### PR TITLE
impl: cursory metrics & streaming

### DIFF
--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -21,6 +21,7 @@ tracing = "0.1.33"
 metrics = "0.18.1"
 names = { version = "0.13.0", default-features = false }
 git-version = "0.3.5"
+rand = "0.8.5"
 tracing-opentelemetry = "0.17.2"
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -1,16 +1,47 @@
 // this is just a stub for future integration with iroh-gateway
+
 use crate::response::ResponseFormat;
+use axum::body::Body;
+use rand::{prelude::StdRng, Rng, SeedableRng};
+use std::{fs::File, io::Read, path::Path, time::Duration};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Client {}
+
+pub const CHUNK_SIZE: usize = 256;
 
 impl Client {
     pub fn new() -> Self {
         Self {}
     }
 
-    pub async fn get_file(&self, path: &str) -> Result<String, String> {
-        Ok(path.to_string())
+    pub async fn get_file_simulated(&self, _path: &str) -> Result<Body, String> {
+        let (mut sender, body) = Body::channel();
+        // let mut rng = rand::thread_rng();
+        let mut rng: StdRng = SeedableRng::from_entropy();
+
+        tokio::spawn(async move {
+            let test_path = Path::new("test_files/test_big.txt");
+            let mut file = File::open(test_path).unwrap();
+            let mut buf = [0u8; CHUNK_SIZE];
+
+            loop {
+                let n = match file.read(&mut buf) {
+                    Ok(n) => n,
+                    Err(_) => break,
+                };
+                if n == 0 {
+                    break;
+                }
+                sender
+                    .send_data(axum::body::Bytes::from(buf[..n].to_vec()))
+                    .await
+                    .unwrap();
+                tokio::time::sleep(Duration::from_millis(rng.gen_range(0..500))).await;
+            }
+        });
+
+        Ok(body)
     }
 }
 

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -41,11 +41,7 @@ impl Client {
                 increment_counter!(METRICS_CACHE_HIT);
             }
 
-            loop {
-                let n = match file.read(&mut buf) {
-                    Ok(n) => n,
-                    Err(_) => break,
-                };
+            while let Ok(n) = file.read(&mut buf) {
                 if first_block {
                     gauge!(METRICS_TIME_TO_FETCH_FIRST_BLOCK, start_time.elapsed());
                 }

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -1,43 +1,70 @@
 // this is just a stub for future integration with iroh-gateway
 
+use crate::metrics::*;
 use crate::response::ResponseFormat;
 use axum::body::Body;
+use metrics::{counter, gauge, increment_counter};
 use rand::{prelude::StdRng, Rng, SeedableRng};
 use std::{fs::File, io::Read, path::Path, time::Duration};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Client {}
 
-pub const CHUNK_SIZE: usize = 256;
+pub const CHUNK_SIZE: usize = 1024;
 
 impl Client {
     pub fn new() -> Self {
         Self {}
     }
 
-    pub async fn get_file_simulated(&self, _path: &str) -> Result<Body, String> {
+    pub async fn get_file_simulated(
+        &self,
+        _path: &str,
+        start_time: std::time::Instant,
+    ) -> Result<Body, String> {
         let (mut sender, body) = Body::channel();
-        // let mut rng = rand::thread_rng();
         let mut rng: StdRng = SeedableRng::from_entropy();
+
+        // some random latency
+        tokio::time::sleep(Duration::from_millis(rng.gen_range(0..150))).await;
 
         tokio::spawn(async move {
             let test_path = Path::new("test_files/test_big.txt");
             let mut file = File::open(test_path).unwrap();
             let mut buf = [0u8; CHUNK_SIZE];
+            let mut first_block = true;
+            if rng.gen_range(0..250) < 200 {
+                // simulate a cache miss
+                increment_counter!(METRICS_CACHE_MISS);
+            } else {
+                // simulate a cache hit
+                increment_counter!(METRICS_CACHE_HIT);
+            }
 
             loop {
                 let n = match file.read(&mut buf) {
                     Ok(n) => n,
                     Err(_) => break,
                 };
+                if first_block {
+                    gauge!(METRICS_TIME_TO_FETCH_FIRST_BLOCK, start_time.elapsed());
+                }
+                counter!(METRICS_BYTES_FETCHED, n as u64);
+                counter!(METRICS_BYTES_STREAMED, n as u64);
                 if n == 0 {
+                    gauge!(METRICS_TIME_TO_FETCH_FULL_FILE, start_time.elapsed());
+                    gauge!(METRICS_TIME_TO_SERVE_FULL_FILE, start_time.elapsed());
                     break;
                 }
                 sender
                     .send_data(axum::body::Bytes::from(buf[..n].to_vec()))
                     .await
                     .unwrap();
-                tokio::time::sleep(Duration::from_millis(rng.gen_range(0..500))).await;
+                if first_block {
+                    first_block = false;
+                    gauge!(METRICS_TIME_TO_SERVE_FIRST_BLOCK, start_time.elapsed());
+                }
+                tokio::time::sleep(Duration::from_millis(rng.gen_range(0..150))).await;
             }
         });
 

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -81,6 +81,7 @@ async fn get_ipfs(
     Query(query_params): Query<GetParams>,
 ) -> Result<GatewayResponse, GatewayError> {
     increment_counter!(METRICS_CNT_REQUESTS_TOTAL);
+    let start_time = std::time::Instant::now();
     // parse path params
     let cid_param = params.get("cid").unwrap();
     let cid = Cid::try_from(cid_param.clone());
@@ -125,10 +126,10 @@ async fn get_ipfs(
         download,
     };
     match req.format {
-        ResponseFormat::Raw => serve_raw(&req, *client, headers).await,
-        ResponseFormat::Car => serve_car(&req, *client, headers).await,
-        ResponseFormat::Html => serve_html(&req, *client, headers).await,
-        ResponseFormat::Fs => serve_fs(&req, *client, headers).await,
+        ResponseFormat::Raw => serve_raw(&req, *client, headers, start_time).await,
+        ResponseFormat::Car => serve_car(&req, *client, headers, start_time).await,
+        ResponseFormat::Html => serve_html(&req, *client, headers, start_time).await,
+        ResponseFormat::Fs => serve_fs(&req, *client, headers, start_time).await,
     }
 }
 
@@ -137,9 +138,10 @@ async fn serve_raw(
     req: &Request,
     client: Client,
     mut headers: HashMap<String, String>,
+    start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
     let body = client
-        .get_file_simulated(req.full_content_path.as_str())
+        .get_file_simulated(req.full_content_path.as_str(), start_time)
         .await;
     let body = match body {
         Ok(b) => b,
@@ -160,9 +162,10 @@ async fn serve_car(
     req: &Request,
     client: Client,
     mut headers: HashMap<String, String>,
+    start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
     let body = client
-        .get_file_simulated(req.full_content_path.as_str())
+        .get_file_simulated(req.full_content_path.as_str(), start_time)
         .await;
     let body = match body {
         Ok(b) => b,
@@ -183,9 +186,10 @@ async fn serve_html(
     req: &Request,
     client: Client,
     headers: HashMap<String, String>,
+    start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
     let body = client
-        .get_file_simulated(req.full_content_path.as_str())
+        .get_file_simulated(req.full_content_path.as_str(), start_time)
         .await;
     let body = match body {
         Ok(b) => b,
@@ -201,9 +205,10 @@ async fn serve_fs(
     req: &Request,
     client: Client,
     mut headers: HashMap<String, String>,
+    start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
     let body = client
-        .get_file_simulated(req.full_content_path.as_str())
+        .get_file_simulated(req.full_content_path.as_str(), start_time)
         .await;
     let body = match body {
         Ok(b) => b,

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -1,5 +1,5 @@
 use axum::{
-    body::{self, Body, BoxBody},
+    body::{self, BoxBody},
     error_handling::HandleErrorLayer,
     extract::{Extension, Path, Query},
     http::{header::*, StatusCode},
@@ -138,24 +138,21 @@ async fn serve_raw(
     client: Client,
     mut headers: HashMap<String, String>,
 ) -> Result<GatewayResponse, GatewayError> {
-    let body = client.get_file(req.full_content_path.as_str()).await;
+    let body = client
+        .get_file_simulated(req.full_content_path.as_str())
+        .await;
     let body = match body {
         Ok(b) => b,
         Err(e) => {
             return error(StatusCode::INTERNAL_SERVER_ERROR, &e);
         }
     };
-
     set_content_disposition_headers(
         &mut headers,
         format!("{}.bin", req.cid).as_str(),
         DISPOSITION_ATTACHMENT,
     );
-    response(
-        StatusCode::OK,
-        body::boxed(Body::from(body)),
-        headers.clone(),
-    )
+    response(StatusCode::OK, body::boxed(body), headers.clone())
 }
 
 #[tracing::instrument()]
@@ -164,7 +161,9 @@ async fn serve_car(
     client: Client,
     mut headers: HashMap<String, String>,
 ) -> Result<GatewayResponse, GatewayError> {
-    let body = client.get_file(req.full_content_path.as_str()).await;
+    let body = client
+        .get_file_simulated(req.full_content_path.as_str())
+        .await;
     let body = match body {
         Ok(b) => b,
         Err(e) => {
@@ -176,11 +175,7 @@ async fn serve_car(
         format!("{}.car", req.cid).as_str(),
         DISPOSITION_ATTACHMENT,
     );
-    response(
-        StatusCode::OK,
-        body::boxed(Body::from(body)),
-        headers.clone(),
-    )
+    response(StatusCode::OK, body::boxed(body), headers.clone())
 }
 
 #[tracing::instrument()]
@@ -189,18 +184,16 @@ async fn serve_html(
     client: Client,
     headers: HashMap<String, String>,
 ) -> Result<GatewayResponse, GatewayError> {
-    let body = client.get_file(req.full_content_path.as_str()).await;
+    let body = client
+        .get_file_simulated(req.full_content_path.as_str())
+        .await;
     let body = match body {
         Ok(b) => b,
         Err(e) => {
             return error(StatusCode::INTERNAL_SERVER_ERROR, &e);
         }
     };
-    response(
-        StatusCode::OK,
-        body::boxed(Body::from(body)),
-        headers.clone(),
-    )
+    response(StatusCode::OK, body::boxed(body), headers.clone())
 }
 
 #[tracing::instrument()]
@@ -209,7 +202,9 @@ async fn serve_fs(
     client: Client,
     mut headers: HashMap<String, String>,
 ) -> Result<GatewayResponse, GatewayError> {
-    let body = client.get_file(req.full_content_path.as_str()).await;
+    let body = client
+        .get_file_simulated(req.full_content_path.as_str())
+        .await;
     let body = match body {
         Ok(b) => b,
         Err(e) => {
@@ -223,11 +218,7 @@ async fn serve_fs(
         req.download,
     );
     add_content_type_headers(&mut headers, &name);
-    response(
-        StatusCode::OK,
-        body::boxed(Body::from(body)),
-        headers.clone(),
-    )
+    response(StatusCode::OK, body::boxed(body), headers.clone())
 }
 
 #[tracing::instrument()]

--- a/iroh-gateway/src/metrics.rs
+++ b/iroh-gateway/src/metrics.rs
@@ -1,5 +1,5 @@
 use git_version::git_version;
-use metrics::{describe_counter, Unit};
+use metrics::{describe_counter, describe_gauge, Unit};
 
 use opentelemetry::trace::{TraceContextExt, TraceId};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -18,12 +18,64 @@ pub fn metrics_config() -> iroh_metrics::Config {
 }
 
 pub const METRICS_CNT_REQUESTS_TOTAL: &str = "requests_total";
+pub const METRICS_TIME_TO_FETCH_FIRST_BLOCK: &str = "time_to_fetch_first_block";
+pub const METRICS_TIME_TO_FETCH_FULL_FILE: &str = "time_to_fetch_full_file";
+pub const METRICS_TIME_TO_SERVE_FIRST_BLOCK: &str = "time_to_serve_first_block";
+pub const METRICS_TIME_TO_SERVE_FULL_FILE: &str = "time_to_serve_full_file";
+pub const METRICS_CACHE_HIT: &str = "cache_hit";
+pub const METRICS_CACHE_MISS: &str = "cache_miss";
+pub const METRICS_BYTES_STREAMED: &str = "bytes_streamed";
+pub const METRICS_BYTES_FETCHED: &str = "bytes_fetched";
+pub const METRICS_BITRATE_IN: &str = "bitrate_in";
+pub const METRICS_BITRATE_OUT: &str = "bitrate_out";
 
 pub fn register_counters() {
     describe_counter!(
-        "requests_total",
+        METRICS_CNT_REQUESTS_TOTAL,
         Unit::Count,
         "Total number of requests received by the gateway"
+    );
+    describe_gauge!(
+        METRICS_TIME_TO_FETCH_FIRST_BLOCK,
+        Unit::Milliseconds,
+        "Time from start of request to fetching the first block"
+    );
+    describe_gauge!(
+        METRICS_TIME_TO_FETCH_FULL_FILE,
+        Unit::Milliseconds,
+        "Time from start of request to fetching the full file"
+    );
+    describe_gauge!(
+        METRICS_TIME_TO_SERVE_FIRST_BLOCK,
+        Unit::Milliseconds,
+        "Time from start of request to serving the first block"
+    );
+    describe_gauge!(
+        METRICS_TIME_TO_SERVE_FULL_FILE,
+        Unit::Milliseconds,
+        "Time from start of request to serving the full file"
+    );
+    describe_counter!(METRICS_CACHE_HIT, Unit::Count, "Number of cache hits");
+    describe_counter!(METRICS_CACHE_MISS, Unit::Count, "Number of cache misses");
+    describe_counter!(
+        METRICS_BYTES_STREAMED,
+        Unit::Bytes,
+        "Total number of bytes streamed"
+    );
+    describe_counter!(
+        METRICS_BYTES_FETCHED,
+        Unit::Bytes,
+        "Total number of bytes fetched"
+    );
+    describe_gauge!(
+        METRICS_BITRATE_IN,
+        Unit::KilobitsPerSecond,
+        "Bitrate of incoming stream"
+    );
+    describe_gauge!(
+        METRICS_BITRATE_OUT,
+        Unit::KilobitsPerSecond,
+        "Bitrate of outgoing stream"
     );
 }
 


### PR DESCRIPTION
This is 95% simulated (add a ~10-20 kb file in `test_files/test_big.txt` to play with it) but allows us to get some basics in and get metrics pumping to work on the ops side.