### PR TITLE
feat: switch to libp2p@0.45

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ members = [
   "iroh-util",
   "stores/*"
 ]
+
+[patch.crates-io]
+# TODO: switch to crates.io once 0.45 is released
+# libp2p = { git = "https://github.com/libp2p/rust-libp2p", branch = "master" }
+# TODO: switch to master once the PR gets merged
+libp2p = { git = "https://github.com/dignifiedquire/rust-libp2p", branch = "fix-dns-clone" }

--- a/iroh-bitswap/Cargo.toml
+++ b/iroh-bitswap/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.0", features = ["sync"] }
 bytes = "1.1.0"
 cid = "0.8.0"
 futures = "0.3.5"
-libp2p = { version = "0.44", default-features = false }
+libp2p = { version = "0.45", default-features = false }
 multihash = "0.16.0"
 prost = "0.10"
 thiserror = "1.0.20"
@@ -26,7 +26,7 @@ tracing = "0.1.34"
 [dev-dependencies]
 criterion = "0.3.5"
 env_logger = "0.9"
-libp2p = { version = "0.44", features = ["yamux", "noise", "tcp-tokio"], default-features = false }
+libp2p = { version = "0.45", features = ["yamux", "noise", "tcp-tokio"], default-features = false }
 tokio = { version = "1.0", features = ["macros", "net", "rt"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -28,7 +28,7 @@ opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 time = "0.3.9"
 headers = "0.3.7"
 iroh-rpc-client = { path = "../iroh-rpc-client" }
-libp2p = "0.44.0"
+libp2p = "0.45.0"
 iroh-util = { path = "../iroh-util" }
 anyhow = "1"
 futures = "0.3.5"

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -37,7 +37,7 @@ names = { version = "0.13.0", default-features = false }
 git-version = "0.3.5"
  
 [dependencies.libp2p]
-version = "0.44"
+version = "0.45"
 default-features = false
 features = [
   "gossipsub",

--- a/iroh-rpc-client/Cargo.toml
+++ b/iroh-rpc-client/Cargo.toml
@@ -16,6 +16,6 @@ tonic = "0.7.2"
 prost = "0.10.3"
 anyhow = "1.0.57"
 bytes = "1.1.0"
-libp2p = "0.44.0"
+libp2p = "0.45.0"
 iroh-metrics = { path = "../iroh-metrics" }
 tracing = "0.1.34"

--- a/iroh-rpc-types/Cargo.toml
+++ b/iroh-rpc-types/Cargo.toml
@@ -9,7 +9,7 @@ description = "RPC type definitions for iroh"
 
 
 [dependencies]
-libp2p = { version = "0.44.0", features = ["serde"] }
+libp2p = { version = "0.45.0", features = ["serde"] }
 cid = { version = "0.8.0", features = ["serde-codec"] }
 futures = "0.3.5"
 tonic = "0.7.2"


### PR DESCRIPTION
Depends on my fork, because it needs https://github.com/libp2p/rust-libp2p/pull/2658