### PR TITLE
rework: metrics

### DIFF
--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -19,7 +19,6 @@ tower = { version = "0.4", features = ["util", "timeout", "load-shed", "limit"] 
 mime_guess = "2.0.4"
 iroh-metrics = { path = "../iroh-metrics" }
 tracing = "0.1.33"
-metrics = "0.18.1"
 names = { version = "0.13.0", default-features = false }
 git-version = "0.3.5"
 rand = "0.8.5"
@@ -34,6 +33,7 @@ anyhow = "1"
 futures = "0.3.5"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 iroh-resolver = { path = "../iroh-resolver" }
+prometheus-client = "0.16.0"
 
 [dev-dependencies]
 axum-macros = "0.2.0" # use #[axum_macros::debug_handler] for better error messages on handlers

--- a/iroh-gateway/src/error.rs
+++ b/iroh-gateway/src/error.rs
@@ -2,10 +2,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use metrics::increment_counter;
 use serde_json::json;
-
-use crate::metrics::METRICS_FAIL;
 
 #[derive(Debug)]
 pub struct GatewayError {
@@ -16,7 +13,6 @@ pub struct GatewayError {
 
 impl IntoResponse for GatewayError {
     fn into_response(self) -> Response {
-        increment_counter!(METRICS_FAIL, "code" => self.status_code.as_u16().to_string());
         let body = axum::Json(json!({
             "code": self.status_code.as_u16(),
             "success": false,

--- a/iroh-metrics/Cargo.toml
+++ b/iroh-metrics/Cargo.toml
@@ -13,9 +13,12 @@ tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 tracing-opentelemetry = "0.17.2"
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.10.0", features = ["grpc-sys"] }
+opentelemetry-otlp = { version = "0.10.0", features = ["tonic"] }
 metrics = "0.18.1"
 metrics-util = "0.12"
 metrics-exporter-prometheus = { version = "0.9", features = ["push-gateway"]}
 metrics-exporter-log = "0.4.0"
 tonic = "0.7.2"
+tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread", "process"] }
+prometheus-client = "0.16.0"
+reqwest = "0.11.10"

--- a/iroh-metrics/src/config.rs
+++ b/iroh-metrics/src/config.rs
@@ -35,7 +35,6 @@ impl Config {
             .unwrap_or_else(|_| "http://localhost:4317".to_string());
         let prometheus_gateway_endpoint = std::env::var("IROH_METRICS_PROM_GATEWAY_ENDPOINT")
             .unwrap_or_else(|_| "http://localhost:9091".to_string());
-
         Config {
             service_name,
             instance_id,

--- a/iroh-metrics/src/lib.rs
+++ b/iroh-metrics/src/lib.rs
@@ -2,35 +2,84 @@ pub mod config;
 pub mod req;
 
 use config::Config;
-use metrics_exporter_prometheus::PrometheusBuilder;
 use opentelemetry::{
     global,
     sdk::{propagation::TraceContextPropagator, trace, Resource},
 };
 use opentelemetry_otlp::WithExportConfig;
+use prometheus_client::{encoding::text::encode, registry::Registry};
 use std::env::consts::{ARCH, OS};
 use std::time::Duration;
+use tokio::task::JoinHandle;
+use tracing::log::{debug, warn};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
+pub struct MetricsHandle {
+    metrics_task: JoinHandle<()>,
+}
+
+impl MetricsHandle {
+    /// Shutdown the tracing and metrics subsystems.
+    pub fn shutdown(&self) {
+        opentelemetry::global::shutdown_tracer_provider();
+        self.metrics_task.abort();
+    }
+}
+
 /// Initialize the tracing and metrics subsystems.
-pub fn init(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
-    init_metrics(cfg.clone())?;
-    init_tracer(cfg)
+pub async fn init(cfg: Config) -> Result<MetricsHandle, Box<dyn std::error::Error>> {
+    init_tracer(cfg.clone())?;
+    let metrics_task = init_metrics(cfg, <Registry>::default()).await?;
+    Ok(MetricsHandle { metrics_task })
+}
+
+/// Initialize the tracing and metrics subsystems with custom registry
+pub async fn init_with_registry(
+    cfg: Config,
+    registry: Registry,
+) -> Result<MetricsHandle, Box<dyn std::error::Error>> {
+    init_tracer(cfg.clone())?;
+    let metrics_task = init_metrics(cfg, registry).await?;
+    Ok(MetricsHandle { metrics_task })
 }
 
 /// Initialize the metrics subsystem.
-pub fn init_metrics(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn init_metrics(
+    cfg: Config,
+    registry: Registry,
+) -> Result<JoinHandle<()>, Box<dyn std::error::Error>> {
     if !cfg.debug {
-        let builder = PrometheusBuilder::new().with_push_gateway(
-            format!(
-                "{}/metrics/job/{}/instance/{}",
-                cfg.prometheus_gateway_endpoint, cfg.service_name, cfg.instance_id
-            ),
-            Duration::from_secs(5),
-        )?;
-        builder.install()?;
+        let prom_gateway_uri = format!(
+            "{}/metrics/job/{}/instance/{}",
+            cfg.prometheus_gateway_endpoint, cfg.service_name, cfg.instance_id
+        );
+        let push_client = reqwest::Client::new();
+        return Ok(tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                let mut buff = Vec::new();
+                encode(&mut buff, &registry).unwrap();
+                let res = match push_client.post(&prom_gateway_uri).body(buff).send().await {
+                    Ok(res) => res,
+                    Err(e) => {
+                        warn!("failed to push metrics: {}", e);
+                        continue;
+                    }
+                };
+                match res.status() {
+                    reqwest::StatusCode::OK => {
+                        debug!("pushed metrics to gateway");
+                    }
+                    _ => {
+                        warn!("failed to push metrics to gateway: {:?}", res);
+                        let body = res.text().await.unwrap();
+                        warn!("error body: {}", body);
+                    }
+                }
+            }
+        }));
     }
-    Ok(())
+    Ok(tokio::spawn(async move {}))
 }
 
 /// Initialize the tracing subsystem.
@@ -68,9 +117,4 @@ pub fn init_tracer(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
             .try_init()?;
     }
     Ok(())
-}
-
-/// Shutdown the tracing and metrics subsystems.
-pub fn shutdown_tracing() {
-    opentelemetry::global::shutdown_tracer_provider();
 }

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -35,6 +35,7 @@ tonic = "0.7.2"
 iroh-metrics = { path = "../iroh-metrics" }
 names = { version = "0.13.0", default-features = false }
 git-version = "0.3.5"
+prometheus-client = "0.16.0"
  
 [dependencies.libp2p]
 version = "0.45"
@@ -53,6 +54,7 @@ features = [
   "request-response",
   "websocket",
   "serde",
+  "metrics",
 ] 
 
 [dependencies.multihash]


### PR DESCRIPTION
Does:
- move from `metrics` to `prometheus-client`
- brings us in line with what most others use
- compat with libp2p metrics
- libp2p metrics are flowing now

Breaks:
- current dashboards
- needed to drop old counters
- will have to reduce the noise/chatter, libp2p is vv noisy

To do:
- ~~clean it up a bit~~
- ~~gateway metrics registering should use a sub registry~~
- ~~need to mutex lock all the Arc<State> or something along the lines for the metrics component~~ - not needed as of `prometheus-client = 0.16.0`