### PR TITLE
fix: avoid 0 divisions

### DIFF
--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -54,7 +54,7 @@ impl Client {
         state
             .metrics
             .bytes_per_sec_out
-            .set(n / start_time.elapsed().as_secs());
+            .set(n / start_time.elapsed().as_secs().max(1));
         state.metrics.bytes_streamed.inc_by(n);
         Ok(res.into())
     }


### PR DESCRIPTION
Obviously these are crappy metrics just to fill in some blanks. We need to disambiguate between cached and non cached responses and segment accordingly.