### PR TITLE
feat: `iroh-ctl status -w` watches the health of each iroh process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "iroh",
   "iroh-bitswap",
   "iroh-car",
+  "iroh-ctl",
   "iroh-rpc-client",
   "iroh-rpc-types",
   "iroh-gateway",

--- a/iroh-ctl/Cargo.toml
+++ b/iroh-ctl/Cargo.toml
@@ -1,3 +1,4 @@
+[package]
 name = "iroh-ctl"
 version = "0.1.0"
 edition = "2021"
@@ -11,6 +12,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 futures = "0.3.5"
 tokio = "1.0"
-tracing = "0.1.35"
+tracing = "0.1.34"
 clap = { version = "3.1.14", features = ["derive"] }
 tonic = "0.7.2"
+iroh-rpc-client = { path = "../iroh-rpc-client" }

--- a/iroh-ctl/Cargo.toml
+++ b/iroh-ctl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iroh-ctl"
 version = "0.1.0"
 edition = "2021"
-authors = ["Friedel Ziegelmayer <me@dignifiedquire.com>"]
+authors = ["Kasey Huizinga <klhuizinga@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/n0-computer/iroh"
 description = "Client for interacting with running iroh processes."

--- a/iroh-ctl/Cargo.toml
+++ b/iroh-ctl/Cargo.toml
@@ -14,5 +14,6 @@ futures = "0.3.5"
 tokio = "1.0"
 tracing = "0.1.34"
 clap = { version = "3.1.14", features = ["derive"] }
+crossterm = "0.23.2"
 tonic = "0.7.2"
 iroh-rpc-client = { path = "../iroh-rpc-client" }

--- a/iroh-ctl/Cargo.toml
+++ b/iroh-ctl/Cargo.toml
@@ -1,0 +1,16 @@
+name = "iroh-ctl"
+version = "0.1.0"
+edition = "2021"
+authors = ["Friedel Ziegelmayer <me@dignifiedquire.com>"]
+license = "Apache-2.0/MIT"
+repository = "https://github.com/n0-computer/iroh"
+description = "Client for interacting with running iroh processes."
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1"
+futures = "0.3.5"
+tokio = "1.0"
+tracing = "0.1.35"
+clap = { version = "3.1.14", features = ["derive"] }
+tonic = "0.7.2"

--- a/iroh-ctl/src/README.md
+++ b/iroh-ctl/src/README.md
@@ -1,0 +1,25 @@
+# iroh-ctl
+
+> Communicate with the different iroh processes
+
+## usage
+
+```
+// Track the status of your different iroh processes
+$ iroh-ctl status --watch
+```
+
+## License
+
+<sup>
+Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
+2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
+</sup>
+
+<br/>
+
+<sub>
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.
+</sub>

--- a/iroh-ctl/src/lib.rs
+++ b/iroh-ctl/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod status;

--- a/iroh-ctl/src/main.rs
+++ b/iroh-ctl/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/iroh-ctl/src/main.rs
+++ b/iroh-ctl/src/main.rs
@@ -1,12 +1,32 @@
-use iroh_rpc_client::{Client, RpcClientConfig};
-use tokio::time::{sleep, Duration};
+mod status;
+
+use clap::{Parser, Subcommand};
+#[derive(Parser, Debug, Clone)]
+#[clap(author, version, about, long_about = None, propagate_version = true)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum Commands {
+    /// status checks the health of the differen processes
+    Status {
+        #[clap(short, long)]
+        /// when true, updates the status table whenever a change in a process's status occurs
+        watch: bool,
+    },
+}
 
 #[tokio::main(flavor = "multi_thread")]
-async fn main() {
-    let client = Client::new(&RpcClientConfig::default()).await.unwrap();
-    loop {
-        let status = client.p2p.check().await.unwrap();
-        println!("health: {:?}", status);
-        sleep(Duration::from_secs(1)).await;
-    }
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Status { watch } => {
+            crate::status::status(watch).await?;
+        }
+    };
+
+    Ok(())
 }

--- a/iroh-ctl/src/main.rs
+++ b/iroh-ctl/src/main.rs
@@ -1,3 +1,12 @@
-fn main() {
-    println!("Hello, world!");
+use iroh_rpc_client::{Client, RpcClientConfig};
+use tokio::time::{sleep, Duration};
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let client = Client::new(&RpcClientConfig::default()).await.unwrap();
+    loop {
+        let status = client.p2p.check().await.unwrap();
+        println!("health: {:?}", status);
+        sleep(Duration::from_secs(1)).await;
+    }
 }

--- a/iroh-ctl/src/main.rs
+++ b/iroh-ctl/src/main.rs
@@ -1,6 +1,7 @@
-mod status;
-
 use clap::{Parser, Subcommand};
+
+use iroh_ctl::status;
+
 #[derive(Parser, Debug, Clone)]
 #[clap(author, version, about, long_about = None, propagate_version = true)]
 struct Cli {

--- a/iroh-ctl/src/status.rs
+++ b/iroh-ctl/src/status.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use futures::StreamExt;
+
+use anyhow::Result;
+use iroh_rpc_client::{Client, RpcClientConfig, ServiceStatus};
+
+pub(crate) async fn status(watch: bool) -> Result<()> {
+    let client = Client::new(&RpcClientConfig::default()).await.unwrap();
+    if watch {
+        let status_stream = client.watch().await;
+        futures::pin_mut!(status_stream);
+        while let Some(s) = status_stream.next().await {
+            print_status_table(s);
+        }
+        Ok(())
+    } else {
+        let s = client.check().await;
+        print_status_table(s);
+        Ok(())
+    }
+}
+
+fn print_status_table(statuses: HashMap<String, ServiceStatus>) {
+    println!("gateway status: {:?}", statuses.get("gateway").unwrap());
+    println!("p2p status: {:?}", statuses.get("p2p").unwrap());
+    println!("store status: {:?}", statuses.get("store").unwrap());
+    println!();
+}

--- a/iroh-ctl/src/status.rs
+++ b/iroh-ctl/src/status.rs
@@ -1,5 +1,12 @@
 use std::collections::HashMap;
+use std::io::{stdout, Write};
 
+use crossterm::terminal::{Clear, ClearType};
+use crossterm::{
+    cursor,
+    style::{self, Attribute, Color, Stylize},
+    QueueableCommand,
+};
 use futures::StreamExt;
 
 use anyhow::Result;
@@ -7,23 +14,101 @@ use iroh_rpc_client::{Client, RpcClientConfig, ServiceStatus};
 
 pub(crate) async fn status(watch: bool) -> Result<()> {
     let client = Client::new(&RpcClientConfig::default()).await.unwrap();
+
+    let mut stdout = stdout();
     if watch {
         let status_stream = client.watch().await;
         futures::pin_mut!(status_stream);
+        stdout.queue(Clear(ClearType::All))?;
         while let Some(s) = status_stream.next().await {
-            print_status_table(s);
+            stdout
+                .queue(cursor::RestorePosition)?
+                .queue(Clear(ClearType::FromCursorUp))?
+                .queue(cursor::MoveTo(0, 1))?;
+            queue_status_table(&stdout, s)?;
+            stdout
+                .queue(cursor::SavePosition)?
+                .queue(style::Print("\n"))?
+                .flush()?;
         }
         Ok(())
     } else {
         let s = client.check().await;
-        print_status_table(s);
+        queue_status_table(&stdout, s)?;
+        stdout.flush()?;
         Ok(())
     }
 }
 
-fn print_status_table(statuses: HashMap<String, ServiceStatus>) {
-    println!("gateway status: {:?}", statuses.get("gateway").unwrap());
-    println!("p2p status: {:?}", statuses.get("p2p").unwrap());
-    println!("store status: {:?}", statuses.get("store").unwrap());
-    println!();
+fn queue_status_table(
+    mut stdout: &std::io::Stdout,
+    statuses: HashMap<String, ServiceStatus>,
+) -> Result<()> {
+    let mut v: Vec<StatusTable> = Vec::new();
+    v.push(StatusTable {
+        name: "gateway".into(),
+        number: 1,
+        status: statuses.get("gateway").unwrap().clone(),
+    });
+
+    v.push(StatusTable {
+        name: "p2p".into(),
+        number: 1,
+        status: statuses.get("p2p").unwrap().clone(),
+    });
+
+    v.push(StatusTable {
+        name: "store".into(),
+        number: 1,
+        status: statuses.get("store").unwrap().clone(),
+    });
+
+    stdout.queue(style::PrintStyledContent(
+        "Process\t\t\tNumber\tStatus\n".attribute(Attribute::Bold),
+    ))?;
+
+    for s in v {
+        stdout
+            .queue(style::Print(format!("{}\t\t\t", s.name)))?
+            .queue(style::Print(format!("{}/1\t", s.number)))?;
+        match s.status {
+            ServiceStatus::Unknown => {
+                stdout.queue(style::PrintStyledContent("Unknown".with(Color::DarkYellow)))?;
+            }
+            ServiceStatus::NotServing => {
+                stdout.queue(style::PrintStyledContent(
+                    "NotServing".with(Color::DarkYellow),
+                ))?;
+            }
+            ServiceStatus::Serving => {
+                stdout.queue(style::PrintStyledContent("Serving".with(Color::Green)))?;
+            }
+            ServiceStatus::ServiceUnknown => {
+                stdout.queue(style::PrintStyledContent(
+                    "Service Unknown".with(Color::DarkYellow),
+                ))?;
+            }
+            ServiceStatus::Down(status) => match status.code() {
+                tonic::Code::Unknown => {
+                    stdout
+                        .queue(style::PrintStyledContent("Down\t".with(Color::DarkYellow)))?
+                        .queue(style::Print("The service has been interupted"))?;
+                }
+                code => {
+                    stdout
+                        .queue(style::PrintStyledContent("Down\t".with(Color::Red)))?
+                        .queue(style::Print(format!("{}\t", code)))?;
+                }
+            },
+        };
+        stdout.queue(style::Print("\n"))?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct StatusTable {
+    name: String,
+    number: usize,
+    status: ServiceStatus,
 }

--- a/iroh-ctl/src/status.rs
+++ b/iroh-ctl/src/status.rs
@@ -20,7 +20,7 @@ pub async fn status(watch: bool) -> Result<()> {
                 .queue(cursor::RestorePosition)?
                 .queue(Clear(ClearType::FromCursorUp))?
                 .queue(cursor::MoveTo(0, 1))?;
-            table.queue_table(&stdout)?;
+            table.queue(&stdout)?;
             stdout
                 .queue(cursor::SavePosition)?
                 .queue(style::Print("\n"))?
@@ -29,7 +29,7 @@ pub async fn status(watch: bool) -> Result<()> {
         Ok(())
     } else {
         let table = client.check().await;
-        table.queue_table(&stdout)?;
+        table.queue(&stdout)?;
         stdout.flush()?;
         Ok(())
     }

--- a/iroh-ctl/src/status.rs
+++ b/iroh-ctl/src/status.rs
@@ -1,11 +1,10 @@
 use std::io::{stdout, Write};
 
-use crossterm::terminal::{Clear, ClearType};
-use crossterm::{cursor, style, QueueableCommand};
-use futures::StreamExt;
-
 use anyhow::Result;
-use iroh_rpc_client::{Client, RpcClientConfig};
+use crossterm::terminal::{Clear, ClearType};
+use crossterm::{cursor, style, style::Stylize, QueueableCommand};
+use futures::StreamExt;
+use iroh_rpc_client::{Client, RpcClientConfig, ServiceStatus, StatusRow, StatusTable};
 
 pub async fn status(watch: bool) -> Result<()> {
     let client = Client::new(&RpcClientConfig::default()).await.unwrap();
@@ -20,7 +19,7 @@ pub async fn status(watch: bool) -> Result<()> {
                 .queue(cursor::RestorePosition)?
                 .queue(Clear(ClearType::FromCursorUp))?
                 .queue(cursor::MoveTo(0, 1))?;
-            table.queue(&stdout)?;
+            queue_table(&table, &stdout)?;
             stdout
                 .queue(cursor::SavePosition)?
                 .queue(style::Print("\n"))?
@@ -29,8 +28,144 @@ pub async fn status(watch: bool) -> Result<()> {
         Ok(())
     } else {
         let table = client.check().await;
-        table.queue(&stdout)?;
+        queue_table(&table, &stdout)?;
         stdout.flush()?;
         Ok(())
+    }
+}
+
+/// queues the table for printing
+/// you must call `writer.flush()` to execute the queue
+pub fn queue_table<W>(table: &StatusTable, mut w: W) -> Result<()>
+where
+    W: Write,
+{
+    w.queue(style::PrintStyledContent(
+        "Process\t\t\tNumber\tStatus\n".bold(),
+    ))?;
+    queue_row(&table.gateway, &mut w)?;
+    queue_row(&table.p2p, &mut w)?;
+    queue_row(&table.store, &mut w)?;
+    Ok(())
+}
+
+// queue queues this row of the StatusRow to be written
+// You must call `writer.flush()` to actually write the content to the writer
+pub fn queue_row<W>(row: &StatusRow, w: &mut W) -> Result<()>
+where
+    W: Write,
+{
+    w.queue(style::Print(format!("{}\t\t\t", row.name())))?
+        .queue(style::Print(format!("{}/1\t", row.number())))?;
+    match row.status() {
+        ServiceStatus::Unknown => {
+            w.queue(style::PrintStyledContent("Unknown".dark_yellow()))?;
+        }
+        ServiceStatus::NotServing => {
+            w.queue(style::PrintStyledContent("Not Serving".dark_yellow()))?;
+        }
+        ServiceStatus::Serving => {
+            w.queue(style::PrintStyledContent("Serving".green()))?;
+        }
+        ServiceStatus::ServiceUnknown => {
+            w.queue(style::PrintStyledContent("Service Unknown".dark_yellow()))?;
+        }
+        ServiceStatus::Down(status) => match status.code() {
+            tonic::Code::Unknown => {
+                w.queue(style::PrintStyledContent("Down".dark_yellow()))?
+                    .queue(style::Print("\tThe service has been interupted"))?;
+            }
+            code => {
+                w.queue(style::PrintStyledContent("Down".red()))?
+                    .queue(style::Print(format!("\t{}", code)))?;
+            }
+        },
+    };
+    w.queue(style::Print("\n"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_table_queue() {
+        let expect = format!("{}gateway\t\t\t1/1\t{}\np2p\t\t\t1/1\t{}\nstore\t\t\t1/1\t{}\tThe service is currently unavailable\n", "Process\t\t\tNumber\tStatus\n".bold(), "Unknown".dark_yellow(), "Serving".green(), "Down".red());
+        let table = StatusTable::new(
+            StatusRow::new("gateway", 1, ServiceStatus::Unknown),
+            StatusRow::new("p2p", 1, ServiceStatus::Serving),
+            StatusRow::new(
+                "store",
+                1,
+                ServiceStatus::Down(tonic::Status::new(tonic::Code::Unavailable, "")),
+            ),
+        );
+
+        let mut got = Vec::new();
+        queue_table(&table, &mut got).unwrap();
+        got.flush().unwrap();
+        let got = String::from_utf8(got).unwrap();
+        assert_eq!(expect, got);
+    }
+
+    #[test]
+    fn status_row_queue() {
+        struct TestCase {
+            row: StatusRow,
+            output: String,
+        }
+
+        let rows = vec![
+            TestCase {
+                row: StatusRow::new("test", 1, ServiceStatus::Unknown),
+                output: format!("test\t\t\t1/1\t{}\n", "Unknown".dark_yellow()),
+            },
+            TestCase {
+                row: StatusRow::new("test", 1, ServiceStatus::NotServing),
+                output: format!("test\t\t\t1/1\t{}\n", "Not Serving".dark_yellow()),
+            },
+            TestCase {
+                row: StatusRow::new("test", 1, ServiceStatus::Serving),
+                output: format!("test\t\t\t1/1\t{}\n", "Serving".green()),
+            },
+            TestCase {
+                row: StatusRow::new("test", 1, ServiceStatus::ServiceUnknown),
+                output: format!("test\t\t\t1/1\t{}\n", "Service Unknown".dark_yellow()),
+            },
+            TestCase {
+                row: StatusRow::new(
+                    "test",
+                    1,
+                    ServiceStatus::Down(tonic::Status::new(tonic::Code::Unknown, "unknown")),
+                ),
+                output: format!(
+                    "test\t\t\t1/1\t{}\tThe service has been interupted\n",
+                    "Down".dark_yellow()
+                ),
+            },
+            TestCase {
+                row: StatusRow::new(
+                    "test",
+                    1,
+                    ServiceStatus::Down(tonic::Status::new(
+                        tonic::Code::Unavailable,
+                        "message text",
+                    )),
+                ),
+                output: format!(
+                    "test\t\t\t1/1\t{}\tThe service is currently unavailable\n",
+                    "Down".red()
+                ),
+            },
+        ];
+
+        for row in rows.into_iter() {
+            let mut got = Vec::new();
+            queue_row(&row.row, &mut got).unwrap();
+            got.flush().unwrap();
+            let got = String::from_utf8(got).unwrap();
+            assert_eq!(row.output, got);
+        }
     }
 }

--- a/iroh-ctl/src/status.rs
+++ b/iroh-ctl/src/status.rs
@@ -1,31 +1,26 @@
-use std::collections::HashMap;
 use std::io::{stdout, Write};
 
 use crossterm::terminal::{Clear, ClearType};
-use crossterm::{
-    cursor,
-    style::{self, Attribute, Color, Stylize},
-    QueueableCommand,
-};
+use crossterm::{cursor, style, QueueableCommand};
 use futures::StreamExt;
 
 use anyhow::Result;
-use iroh_rpc_client::{Client, RpcClientConfig, ServiceStatus};
+use iroh_rpc_client::{Client, RpcClientConfig};
 
-pub(crate) async fn status(watch: bool) -> Result<()> {
+pub async fn status(watch: bool) -> Result<()> {
     let client = Client::new(&RpcClientConfig::default()).await.unwrap();
 
     let mut stdout = stdout();
     if watch {
         let status_stream = client.watch().await;
-        futures::pin_mut!(status_stream);
+        tokio::pin!(status_stream);
         stdout.queue(Clear(ClearType::All))?;
-        while let Some(s) = status_stream.next().await {
+        while let Some(table) = status_stream.next().await {
             stdout
                 .queue(cursor::RestorePosition)?
                 .queue(Clear(ClearType::FromCursorUp))?
                 .queue(cursor::MoveTo(0, 1))?;
-            queue_status_table(&stdout, s)?;
+            table.queue_table(&stdout)?;
             stdout
                 .queue(cursor::SavePosition)?
                 .queue(style::Print("\n"))?
@@ -33,82 +28,9 @@ pub(crate) async fn status(watch: bool) -> Result<()> {
         }
         Ok(())
     } else {
-        let s = client.check().await;
-        queue_status_table(&stdout, s)?;
+        let table = client.check().await;
+        table.queue_table(&stdout)?;
         stdout.flush()?;
         Ok(())
     }
-}
-
-fn queue_status_table(
-    mut stdout: &std::io::Stdout,
-    statuses: HashMap<String, ServiceStatus>,
-) -> Result<()> {
-    let mut v: Vec<StatusTable> = Vec::new();
-    v.push(StatusTable {
-        name: "gateway".into(),
-        number: 1,
-        status: statuses.get("gateway").unwrap().clone(),
-    });
-
-    v.push(StatusTable {
-        name: "p2p".into(),
-        number: 1,
-        status: statuses.get("p2p").unwrap().clone(),
-    });
-
-    v.push(StatusTable {
-        name: "store".into(),
-        number: 1,
-        status: statuses.get("store").unwrap().clone(),
-    });
-
-    stdout.queue(style::PrintStyledContent(
-        "Process\t\t\tNumber\tStatus\n".attribute(Attribute::Bold),
-    ))?;
-
-    for s in v {
-        stdout
-            .queue(style::Print(format!("{}\t\t\t", s.name)))?
-            .queue(style::Print(format!("{}/1\t", s.number)))?;
-        match s.status {
-            ServiceStatus::Unknown => {
-                stdout.queue(style::PrintStyledContent("Unknown".with(Color::DarkYellow)))?;
-            }
-            ServiceStatus::NotServing => {
-                stdout.queue(style::PrintStyledContent(
-                    "NotServing".with(Color::DarkYellow),
-                ))?;
-            }
-            ServiceStatus::Serving => {
-                stdout.queue(style::PrintStyledContent("Serving".with(Color::Green)))?;
-            }
-            ServiceStatus::ServiceUnknown => {
-                stdout.queue(style::PrintStyledContent(
-                    "Service Unknown".with(Color::DarkYellow),
-                ))?;
-            }
-            ServiceStatus::Down(status) => match status.code() {
-                tonic::Code::Unknown => {
-                    stdout
-                        .queue(style::PrintStyledContent("Down\t".with(Color::DarkYellow)))?
-                        .queue(style::Print("The service has been interupted"))?;
-                }
-                code => {
-                    stdout
-                        .queue(style::PrintStyledContent("Down\t".with(Color::Red)))?
-                        .queue(style::Print(format!("{}\t", code)))?;
-                }
-            },
-        };
-        stdout.queue(style::Print("\n"))?;
-    }
-    Ok(())
-}
-
-#[derive(Debug, Clone)]
-pub struct StatusTable {
-    name: String,
-    number: usize,
-    status: ServiceStatus,
 }

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -18,7 +18,10 @@ serde_qs = "0.9.2"
 tower = { version = "0.4", features = ["util", "timeout", "load-shed", "limit"] }
 mime_guess = "2.0.4"
 iroh-metrics = { path = "../iroh-metrics" }
+iroh-rpc-types = { path = "../iroh-rpc-types" }
 tracing = "0.1.33"
+tonic = "0.7.2"
+tonic-health = "0.6.0"
 names = { version = "0.13.0", default-features = false }
 git-version = "0.3.5"
 rand = "0.8.5"

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -31,6 +31,7 @@ use crate::{
     headers::*,
     metrics::{get_current_trace_id, Metrics},
     response::{get_response_format, GatewayResponse, ResponseFormat},
+    rpc,
 };
 
 #[derive(Debug)]
@@ -70,6 +71,7 @@ impl GetParams {
 
 impl Core {
     pub async fn new(config: Config, metrics: Metrics) -> anyhow::Result<Self> {
+        rpc::new(config.rpc.client_config.gateway_addr).await?;
         let rpc_client = RpcClient::new(&config.rpc.client_config).await?;
 
         Ok(Self {

--- a/iroh-gateway/src/lib.rs
+++ b/iroh-gateway/src/lib.rs
@@ -6,3 +6,4 @@ mod error;
 mod headers;
 pub mod metrics;
 mod response;
+mod rpc;

--- a/iroh-gateway/src/rpc.rs
+++ b/iroh-gateway/src/rpc.rs
@@ -1,0 +1,29 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use iroh_rpc_types::gateway::gateway_server;
+use tonic::transport::{NamedService, Server as TonicServer};
+use tonic_health::server::health_reporter;
+
+struct Gateway {}
+
+#[tonic::async_trait]
+impl gateway_server::Gateway for Gateway {}
+
+impl NamedService for Gateway {
+    const NAME: &'static str = "gateway";
+}
+
+pub async fn new(addr: SocketAddr) -> Result<()> {
+    let (mut health_reporter, health_service) = health_reporter();
+    health_reporter
+        .set_serving::<gateway_server::GatewayServer<Gateway>>()
+        .await;
+
+    TonicServer::builder()
+        .add_service(health_service)
+        .add_service(gateway_server::GatewayServer::new(Gateway {}))
+        .serve(addr)
+        .await?;
+    Ok(())
+}

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -32,6 +32,7 @@ iroh-rpc-client = { path = "../iroh-rpc-client" }
 iroh-util = { path = "../iroh-util" }
 rkyv = { version = "0.7.37", features = ["std", "alloc", "validation"] }
 tonic = "0.7.2"
+# tonic-health = { path = "../../tonic/tonic-health" }
 tonic-health = "0.6.0"
 iroh-metrics = { path = "../iroh-metrics" }
 names = { version = "0.13.0", default-features = false }

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -32,6 +32,7 @@ iroh-rpc-client = { path = "../iroh-rpc-client" }
 iroh-util = { path = "../iroh-util" }
 rkyv = { version = "0.7.37", features = ["std", "alloc", "validation"] }
 tonic = "0.7.2"
+tonic-health = "0.6.0"
 iroh-metrics = { path = "../iroh-metrics" }
 names = { version = "0.13.0", default-features = false }
 git-version = "0.3.5"

--- a/iroh-p2p/src/rpc.rs
+++ b/iroh-p2p/src/rpc.rs
@@ -182,7 +182,13 @@ impl p2p_server::P2p for P2p {
 
 pub async fn new(addr: SocketAddr, sender: Sender<RpcMessage>) -> Result<()> {
     let p2p = P2p { sender };
+    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter
+        .set_serving::<p2p_server::P2pServer<P2p>>()
+        .await;
+
     TonicServer::builder()
+        .add_service(health_service)
         .add_service(p2p_server::P2pServer::new(p2p))
         .serve(addr)
         .await?;

--- a/iroh-p2p/src/rpc.rs
+++ b/iroh-p2p/src/rpc.rs
@@ -186,10 +186,11 @@ pub async fn new(addr: SocketAddr, sender: Sender<RpcMessage>) -> Result<()> {
     health_reporter
         .set_serving::<p2p_server::P2pServer<P2p>>()
         .await;
+    let p2p_service = p2p_server::P2pServer::new(p2p);
 
     TonicServer::builder()
         .add_service(health_service)
-        .add_service(p2p_server::P2pServer::new(p2p))
+        .add_service(p2p_service)
         .serve(addr)
         .await?;
     Ok(())

--- a/iroh-rpc-client/Cargo.toml
+++ b/iroh-rpc-client/Cargo.toml
@@ -9,6 +9,7 @@ description = "RPC type client for iroh"
 
 [dependencies]
 async-stream = "0.3.0"
+crossterm = "0.23.2"
 iroh-rpc-types = { path = "../iroh-rpc-types" }
 cid = "0.8.0"
 futures = "0.3.21"

--- a/iroh-rpc-client/Cargo.toml
+++ b/iroh-rpc-client/Cargo.toml
@@ -9,8 +9,7 @@ description = "RPC type client for iroh"
 
 [dependencies]
 async-stream = "0.3.0"
-crossterm = "0.23.2"
-iroh-rpc-types = { path = "../iroh-rpc-types" }
+iroh-rpc-types = { path = "../iroh-rpc-types", features = ["testing"] }
 cid = "0.8.0"
 futures = "0.3.21"
 tokio = { version = "1.0", features = ["sync"] }

--- a/iroh-rpc-client/Cargo.toml
+++ b/iroh-rpc-client/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/n0-computer/iroh"
 description = "RPC type client for iroh"
 
 [dependencies]
+async-stream = "0.3.0"
 iroh-rpc-types = { path = "../iroh-rpc-types" }
 cid = "0.8.0"
 futures = "0.3.21"

--- a/iroh-rpc-client/Cargo.toml
+++ b/iroh-rpc-client/Cargo.toml
@@ -13,6 +13,7 @@ cid = "0.8.0"
 futures = "0.3.21"
 tokio = { version = "1.0", features = ["sync"] }
 tonic = "0.7.2"
+tonic-health = "0.6.0"
 prost = "0.10.3"
 anyhow = "1.0.57"
 bytes = "1.1.0"

--- a/iroh-rpc-client/src/client.rs
+++ b/iroh-rpc-client/src/client.rs
@@ -46,25 +46,24 @@ impl Client {
     pub async fn watch(self) -> impl Stream<Item = StatusTable> {
         stream! {
             let mut status_table: StatusTable = Default::default();
-            yield status_table.clone();
-            let store_status = self.store.watch().await;
-            tokio::pin!(store_status);
-            let p2p_status = self.p2p.watch().await;
-            tokio::pin!(p2p_status);
             let gateway_status = self.gateway.watch().await;
             tokio::pin!(gateway_status);
+            let p2p_status = self.p2p.watch().await;
+            tokio::pin!(p2p_status);
+            let store_status = self.store.watch().await;
+            tokio::pin!(store_status);
             loop {
                 tokio::select! {
-                    Some(status) = store_status.next() => {
-                        status_table.update(status).unwrap() ;
+                    Some(status) = gateway_status.next() => {
+                        status_table.update(status).unwrap();
                         yield status_table.clone();
                     }
                     Some(status) = p2p_status.next() => {
                         status_table.update(status).unwrap();
                         yield status_table.clone();
                     }
-                    Some(status) = gateway_status.next() => {
-                        status_table.update(status).unwrap();
+                    Some(status) = store_status.next() => {
+                        status_table.update(status).unwrap() ;
                         yield status_table.clone();
                     }
                 }
@@ -91,5 +90,119 @@ impl Default for RpcClientConfig {
             p2p_addr: "0.0.0.0:4401".parse().unwrap(),
             store_addr: "0.0.0.0:4402".parse().unwrap(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iroh_rpc_types::test::test_server;
+    use tonic::transport::Server as TonicServer;
+    use tonic_health::{
+        server::{health_reporter, HealthReporter},
+        ServingStatus,
+    };
+
+    use crate::status::{ServiceStatus, StatusRow, StatusTable};
+    use crate::{gateway, network, store};
+
+    struct TestService {}
+    #[tonic::async_trait]
+    impl test_server::Test for TestService {}
+
+    async fn make_service(
+        name: &'static str,
+        addr: SocketAddr,
+    ) -> Result<(HealthReporter, tokio::task::JoinHandle<()>)> {
+        let (mut reporter, service) = health_reporter();
+        reporter
+            .set_serving::<test_server::TestServer<TestService>>()
+            .await;
+
+        let task = tokio::spawn(async move {
+            TonicServer::builder()
+                .add_service(service)
+                .serve(addr)
+                .await
+                .unwrap();
+        });
+        reporter
+            .set_service_status(name, ServingStatus::Serving)
+            .await;
+
+        Ok((reporter, task))
+    }
+
+    #[tokio::test]
+    async fn client_status() {
+        let cfg = RpcClientConfig::default();
+
+        let gateway_name = gateway::NAME;
+        let p2p_name = network::NAME;
+        let store_name = store::NAME;
+        let (mut gateway_reporter, gateway_task) =
+            make_service(gateway_name, cfg.gateway_addr).await.unwrap();
+        let (mut p2p_reporter, p2p_task) = make_service(p2p_name, cfg.p2p_addr).await.unwrap();
+        let (mut store_reporter, store_task) =
+            make_service(store_name, cfg.store_addr).await.unwrap();
+        let client = Client::new(&cfg).await.unwrap();
+
+        // test `check`
+        let mut expect = StatusTable::new(
+            StatusRow::new(gateway_name, 1, ServiceStatus::Serving),
+            StatusRow::new(p2p_name, 1, ServiceStatus::Serving),
+            StatusRow::new(store_name, 1, ServiceStatus::Serving),
+        );
+        let mut got = client.check().await;
+        assert_eq!(expect, got);
+
+        // test `watch`
+        let stream = client.watch().await;
+        tokio::pin!(stream);
+
+        // each status gets reported for the first time in a non-deterministic order
+        stream.next().await.unwrap();
+        stream.next().await.unwrap();
+        got = stream.next().await.unwrap();
+
+        // use display names that are currently hard-wired into `Client`
+        expect.gateway.name = "gateway";
+        expect.p2p.name = "p2p";
+        expect.store.name = "store";
+        assert_eq!(expect, got);
+
+        // update gateway
+        expect
+            .update(StatusRow::new(gateway_name, 1, ServiceStatus::Unknown))
+            .unwrap();
+        gateway_reporter
+            .set_service_status(gateway_name, ServingStatus::Unknown)
+            .await;
+        let got = stream.next().await.unwrap();
+        assert_eq!(expect, got);
+
+        // update p2p
+        expect
+            .update(StatusRow::new(p2p_name, 1, ServiceStatus::NotServing))
+            .unwrap();
+        p2p_reporter
+            .set_service_status(p2p_name, ServingStatus::NotServing)
+            .await;
+        let got = stream.next().await.unwrap();
+        assert_eq!(expect, got);
+
+        // update store
+        expect
+            .update(StatusRow::new(store_name, 1, ServiceStatus::Unknown))
+            .unwrap();
+        store_reporter
+            .set_service_status(store_name, ServingStatus::Unknown)
+            .await;
+        let got = stream.next().await.unwrap();
+        assert_eq!(expect, got);
+
+        gateway_task.abort();
+        p2p_task.abort();
+        store_task.abort();
     }
 }

--- a/iroh-rpc-client/src/client.rs
+++ b/iroh-rpc-client/src/client.rs
@@ -1,18 +1,27 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
+use async_stream::stream;
+use futures::{Stream, StreamExt};
 
+use crate::gateway::GatewayClient;
 use crate::network::P2pClient;
+use crate::status::ServiceStatus;
 use crate::store::StoreClient;
 
 #[derive(Debug, Clone)]
 pub struct Client {
+    pub gateway: GatewayClient,
     pub p2p: P2pClient,
     pub store: StoreClient,
 }
 
 impl Client {
     pub async fn new(cfg: &RpcClientConfig) -> Result<Self> {
+        let gateway = GatewayClient::new(cfg.gateway_addr)
+            .await
+            .context("Could not create gateway rpc client")?;
         let p2p = P2pClient::new(cfg.p2p_addr)
             .await
             .context("Could not create p2p rpc client")?;
@@ -20,7 +29,48 @@ impl Client {
             .await
             .context("Could not create store rpc client")?;
 
-        Ok(Client { p2p, store })
+        Ok(Client {
+            gateway,
+            p2p,
+            store,
+        })
+    }
+
+    pub async fn check(&self) -> HashMap<String, ServiceStatus> {
+        let mut s = HashMap::default();
+        s.insert("store".into(), self.store.check().await);
+        s.insert("p2p".into(), self.p2p.check().await);
+        s.insert("gateway".into(), self.gateway.check().await);
+        s
+    }
+
+    pub async fn watch(self) -> impl Stream<Item = HashMap<String, ServiceStatus>> {
+        stream! {
+            let mut statuses = self.check().await;
+            yield statuses.clone();
+            let store_status = self.store.watch().await;
+            futures::pin_mut!(store_status);
+            let p2p_status = self.p2p.watch().await;
+            futures::pin_mut!(p2p_status);
+            let gateway_status = self.gateway.watch().await;
+            futures::pin_mut!(gateway_status);
+            loop {
+            tokio::select! {
+                Some(status) = store_status.next() => {
+                    statuses.insert("store".into(), status);
+                    yield statuses.clone();
+                }
+                Some(status) = p2p_status.next() => {
+                    statuses.insert("p2p".into(), status);
+                    yield statuses.clone();
+                }
+                Some(status) = gateway_status.next() => {
+                    statuses.insert("gateway".into(), status);
+                    yield statuses.clone();
+                }
+            }
+            }
+        }
     }
 }
 

--- a/iroh-rpc-client/src/gateway.rs
+++ b/iroh-rpc-client/src/gateway.rs
@@ -7,6 +7,10 @@ use tonic_health::proto::health_client::HealthClient;
 
 use crate::status::{self, StatusRow};
 
+// name that the health service registers the gateway client as
+// this is derived from the protobuf definition of a `GatewayServer`
+pub(crate) const NAME: &str = "gateway.Gateway";
+
 #[derive(Debug, Clone)]
 pub struct GatewayClient {
     health: HealthClient<Channel>,
@@ -27,11 +31,11 @@ impl GatewayClient {
 
     #[tracing::instrument(skip(self))]
     pub async fn check(&self) -> StatusRow {
-        status::check(self.health.clone(), "gateway.Gateway").await
+        status::check(self.health.clone(), NAME).await
     }
 
     #[tracing::instrument(skip(self))]
     pub async fn watch(&self) -> impl Stream<Item = StatusRow> {
-        status::watch(self.health.clone(), "gateway.Gateway").await
+        status::watch(self.health.clone(), NAME).await
     }
 }

--- a/iroh-rpc-client/src/gateway.rs
+++ b/iroh-rpc-client/src/gateway.rs
@@ -5,7 +5,7 @@ use futures::Stream;
 use tonic::transport::{Channel, Endpoint};
 use tonic_health::proto::health_client::HealthClient;
 
-use crate::status::{self, ServiceStatus};
+use crate::status::{self, StatusRow};
 
 #[derive(Debug, Clone)]
 pub struct GatewayClient {
@@ -26,12 +26,12 @@ impl GatewayClient {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn check(&self) -> ServiceStatus {
-        status::check(self.health.clone(), "gateway.Gateway".into()).await
+    pub async fn check(&self) -> StatusRow {
+        status::check(self.health.clone(), "gateway.Gateway").await
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn watch(&self) -> impl Stream<Item = ServiceStatus> {
-        status::watch(self.health.clone(), "gateway.Gateway".into()).await
+    pub async fn watch(&self) -> impl Stream<Item = StatusRow> {
+        status::watch(self.health.clone(), "gateway.Gateway").await
     }
 }

--- a/iroh-rpc-client/src/gateway.rs
+++ b/iroh-rpc-client/src/gateway.rs
@@ -1,0 +1,37 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use futures::Stream;
+use tonic::transport::{Channel, Endpoint};
+use tonic_health::proto::health_client::HealthClient;
+
+use crate::status::{self, ServiceStatus};
+
+#[derive(Debug, Clone)]
+pub struct GatewayClient {
+    health: HealthClient<Channel>,
+}
+
+impl GatewayClient {
+    pub async fn new(addr: SocketAddr) -> Result<Self> {
+        let conn = Endpoint::new(format!("http://{}", addr))?
+            .keep_alive_while_idle(true)
+            .connect_lazy();
+
+        let health_client = HealthClient::new(conn);
+
+        Ok(GatewayClient {
+            health: health_client,
+        })
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn check(&self) -> ServiceStatus {
+        status::check(self.health.clone(), "gateway.Gateway".into()).await
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn watch(&self) -> impl Stream<Item = ServiceStatus> {
+        status::watch(self.health.clone(), "gateway.Gateway".into()).await
+    }
+}

--- a/iroh-rpc-client/src/lib.rs
+++ b/iroh-rpc-client/src/lib.rs
@@ -1,6 +1,9 @@
 mod client;
+mod gateway;
 mod network;
+mod status;
 mod store;
 
 pub use crate::client::Client;
 pub use crate::client::RpcClientConfig;
+pub use crate::status::ServiceStatus;

--- a/iroh-rpc-client/src/lib.rs
+++ b/iroh-rpc-client/src/lib.rs
@@ -6,4 +6,4 @@ mod store;
 
 pub use crate::client::Client;
 pub use crate::client::RpcClientConfig;
-pub use crate::status::ServiceStatus;
+pub use crate::status::{ServiceStatus, StatusRow, StatusTable};

--- a/iroh-rpc-client/src/network.rs
+++ b/iroh-rpc-client/src/network.rs
@@ -15,6 +15,10 @@ use tracing::{debug, warn};
 
 use crate::status::{self, StatusRow};
 
+// name that the health service registers the p2p client as
+// this is derived from the protobuf definition of a `P2pServer`
+pub(crate) const NAME: &str = "p2p.P2p";
+
 #[derive(Debug, Clone)]
 pub struct P2pClient {
     p2p: p2p::p2p_client::P2pClient<Channel>,
@@ -114,12 +118,12 @@ impl P2pClient {
 
     #[tracing::instrument(skip(self))]
     pub async fn check(&self) -> StatusRow {
-        status::check(self.health.clone(), "p2p.P2p").await
+        status::check(self.health.clone(), NAME).await
     }
 
     #[tracing::instrument(skip(self))]
     pub async fn watch(&self) -> impl Stream<Item = StatusRow> {
-        status::watch(self.health.clone(), "p2p.P2p").await
+        status::watch(self.health.clone(), NAME).await
     }
 }
 

--- a/iroh-rpc-client/src/network.rs
+++ b/iroh-rpc-client/src/network.rs
@@ -13,7 +13,7 @@ use tonic::transport::{Channel, Endpoint};
 use tonic_health::proto::health_client::HealthClient;
 use tracing::{debug, warn};
 
-use crate::status::{self, ServiceStatus};
+use crate::status::{self, StatusRow};
 
 #[derive(Debug, Clone)]
 pub struct P2pClient {
@@ -113,13 +113,13 @@ impl P2pClient {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn check(&self) -> ServiceStatus {
-        status::check(self.health.clone(), "p2p.P2p".into()).await
+    pub async fn check(&self) -> StatusRow {
+        status::check(self.health.clone(), "p2p.P2p").await
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn watch(&self) -> impl Stream<Item = ServiceStatus> {
-        status::watch(self.health.clone(), "p2p.P2p".into()).await
+    pub async fn watch(&self) -> impl Stream<Item = StatusRow> {
+        status::watch(self.health.clone(), "p2p.P2p").await
     }
 }
 

--- a/iroh-rpc-client/src/network.rs
+++ b/iroh-rpc-client/src/network.rs
@@ -4,20 +4,16 @@ use std::net::SocketAddr;
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use cid::Cid;
+use futures::Stream;
 use iroh_rpc_types::p2p::{
     self, BitswapRequest, ConnectRequest, DisconnectRequest, Empty, Key, Providers,
 };
 use libp2p::{Multiaddr, PeerId};
-use tonic::{
-    codec::Streaming,
-    transport::{Channel, Endpoint},
-};
-
-use tonic_health::proto::{
-    health_check_response::ServingStatus, health_client::HealthClient, HealthCheckRequest,
-    HealthCheckResponse,
-};
+use tonic::transport::{Channel, Endpoint};
+use tonic_health::proto::health_client::HealthClient;
 use tracing::{debug, warn};
+
+use crate::status::{self, ServiceStatus};
 
 #[derive(Debug, Clone)]
 pub struct P2pClient {
@@ -117,17 +113,13 @@ impl P2pClient {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn check(&self) -> Result<ServingStatus> {
-        let req = iroh_metrics::req::trace_tonic_req(HealthCheckRequest { service: "".into() });
-        let res = self.health.clone().check(req).await?.into_inner();
-        Ok(res.status())
+    pub async fn check(&self) -> ServiceStatus {
+        status::check(self.health.clone(), "p2p.P2p".into()).await
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn watch(&self) -> Result<Streaming<HealthCheckResponse>> {
-        let req = iroh_metrics::req::trace_tonic_req(HealthCheckRequest { service: "".into() });
-        let res = self.health.clone().watch(req).await?.into_inner();
-        Ok(res)
+    pub async fn watch(&self) -> impl Stream<Item = ServiceStatus> {
+        status::watch(self.health.clone(), "p2p.P2p".into()).await
     }
 }
 

--- a/iroh-rpc-client/src/status.rs
+++ b/iroh-rpc-client/src/status.rs
@@ -299,7 +299,7 @@ mod tests {
 
         p2p.status = ServiceStatus::Down(tonic::Status::new(tonic::Code::Unavailable, ""));
         let expect = StatusTable::new(gateway, p2p.clone(), store);
-        got.update(p2p.clone()).unwrap();
+        got.update(p2p).unwrap();
         assert_eq!(expect, got);
     }
 }

--- a/iroh-rpc-client/src/status.rs
+++ b/iroh-rpc-client/src/status.rs
@@ -1,0 +1,123 @@
+use async_stream::stream;
+use futures::Stream;
+use tonic::transport::channel::Channel;
+use tonic_health::proto::{
+    health_check_response::ServingStatus, health_client::HealthClient, HealthCheckRequest,
+    HealthCheckResponse,
+};
+
+#[tracing::instrument(skip(health_client))]
+pub async fn check(health_client: HealthClient<Channel>, service: String) -> ServiceStatus {
+    let req = iroh_metrics::req::trace_tonic_req(HealthCheckRequest { service });
+    let res = health_client.clone().check(req).await;
+    match res {
+        Ok(res) => res.into_inner().into(),
+        Err(s) => ServiceStatus::Down(s),
+    }
+}
+
+#[tracing::instrument(skip(health_client))]
+pub async fn watch(
+    health_client: HealthClient<Channel>,
+    service: String,
+) -> impl Stream<Item = ServiceStatus> {
+    stream! {
+        loop {
+            let req = iroh_metrics::req::trace_tonic_req(HealthCheckRequest { service: service.clone() });
+            let res = health_client.clone().watch(req).await;
+            match res {
+                Ok(stream) => {
+                    let mut stream = stream.into_inner();
+                    // loop over the stream, breaking if we get an error or stop receiving messages
+                    loop {
+                        match stream.message().await {
+                            Ok(Some(message)) => yield message.into(),
+                            Ok(None) => {
+                                yield ServiceStatus::Down(tonic::Status::new(tonic::Code::Unavailable, format!("No more health messages from service `{}`", service)));
+                                break;
+                            }
+                            Err(status) => {
+                                yield ServiceStatus::Down(status);
+                                break;
+                            }
+                        }
+                    }
+                },
+                Err(status) => yield ServiceStatus::Down(status)
+            }
+            /// wait before attempting to start a watch stream again
+            tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+        };
+    }
+}
+
+impl std::convert::From<HealthCheckResponse> for ServiceStatus {
+    fn from(h: HealthCheckResponse) -> Self {
+        match h.status() {
+            ServingStatus::Unknown => ServiceStatus::Unknown,
+            ServingStatus::Serving => ServiceStatus::Serving,
+            ServingStatus::NotServing => ServiceStatus::NotServing,
+            ServingStatus::ServiceUnknown => ServiceStatus::ServiceUnknown,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ServiceStatus {
+    ///  Indicates rpc server is in an unknown state
+    Unknown,
+    ///  Indicates service is being created but isn't ready to serve
+    Pending,
+    /// Indicates service is serving data
+    Serving,
+    /// Indicates service is not serving data, but the rpc server is not down
+    NotServing,
+    /// Indicates that the requested service is unknown
+    ServiceUnknown,
+    /// Indicates that the service is down. This ServiceStatus is assigned when
+    /// a `check` or `watch` call has returned an error with `tonic::Status`
+    Down(tonic::Status),
+}
+
+impl std::clone::Clone for ServiceStatus {
+    fn clone(&self) -> Self {
+        match self {
+            ServiceStatus::Down(status) => {
+                ServiceStatus::Down(tonic::Status::new(status.code(), status.message()))
+            }
+            ServiceStatus::Unknown => ServiceStatus::Unknown,
+            ServiceStatus::Pending => ServiceStatus::Pending,
+            ServiceStatus::Serving => ServiceStatus::Serving,
+            ServiceStatus::NotServing => ServiceStatus::NotServing,
+            ServiceStatus::ServiceUnknown => ServiceStatus::ServiceUnknown,
+        }
+    }
+}
+
+// struct WatchStreamResult(std::result::Result<tonic::Response<HealthCheckResponse>, tonic::Status>);
+// struct ServiceStatusResult(Result<ServiceStatus>);
+
+// impl std::convert::From<WatchStreamResult> for ServiceStatusResult {
+//     fn from(res: WatchStreamResult) -> Self {
+//         match res.0 {
+//             Ok(res) => match res.into_inner().status() {
+//                 tonic_health::proto::health_check_response::ServingStatus::Unknown => {
+//                     ServiceStatusResult(Ok(ServiceStatus::Unknown))
+//                 }
+//                 tonic_health::proto::health_check_response::ServingStatus::Serving => {
+//                     ServiceStatusResult(Ok(ServiceStatus::Serving))
+//                 }
+//                 tonic_health::proto::health_check_response::ServingStatus::NotServing => {
+//                     ServiceStatusResult(Ok(ServiceStatus::NotServing))
+//                 }
+//                 tonic_health::proto::health_check_response::ServingStatus::ServiceUnknown => {
+//                     ServiceStatusResult(Err(anyhow!("service unknown")))
+//                 }
+//             },
+//             Err(s) => match s.code() {
+//                 tonic::Code::Unavailable => ServiceStatusResult(Ok(ServiceStatus::Down)),
+//                 _ => ServiceStatusResult(Err(anyhow!("unexpected rpc status {:?}", s))),
+//             },
+//         }
+//     }
+// }

--- a/iroh-rpc-client/src/status.rs
+++ b/iroh-rpc-client/src/status.rs
@@ -66,8 +66,6 @@ impl std::convert::From<HealthCheckResponse> for ServiceStatus {
 pub enum ServiceStatus {
     ///  Indicates rpc server is in an unknown state
     Unknown,
-    ///  Indicates service is being created but isn't ready to serve
-    Pending,
     /// Indicates service is serving data
     Serving,
     /// Indicates service is not serving data, but the rpc server is not down
@@ -86,38 +84,9 @@ impl std::clone::Clone for ServiceStatus {
                 ServiceStatus::Down(tonic::Status::new(status.code(), status.message()))
             }
             ServiceStatus::Unknown => ServiceStatus::Unknown,
-            ServiceStatus::Pending => ServiceStatus::Pending,
             ServiceStatus::Serving => ServiceStatus::Serving,
             ServiceStatus::NotServing => ServiceStatus::NotServing,
             ServiceStatus::ServiceUnknown => ServiceStatus::ServiceUnknown,
         }
     }
 }
-
-// struct WatchStreamResult(std::result::Result<tonic::Response<HealthCheckResponse>, tonic::Status>);
-// struct ServiceStatusResult(Result<ServiceStatus>);
-
-// impl std::convert::From<WatchStreamResult> for ServiceStatusResult {
-//     fn from(res: WatchStreamResult) -> Self {
-//         match res.0 {
-//             Ok(res) => match res.into_inner().status() {
-//                 tonic_health::proto::health_check_response::ServingStatus::Unknown => {
-//                     ServiceStatusResult(Ok(ServiceStatus::Unknown))
-//                 }
-//                 tonic_health::proto::health_check_response::ServingStatus::Serving => {
-//                     ServiceStatusResult(Ok(ServiceStatus::Serving))
-//                 }
-//                 tonic_health::proto::health_check_response::ServingStatus::NotServing => {
-//                     ServiceStatusResult(Ok(ServiceStatus::NotServing))
-//                 }
-//                 tonic_health::proto::health_check_response::ServingStatus::ServiceUnknown => {
-//                     ServiceStatusResult(Err(anyhow!("service unknown")))
-//                 }
-//             },
-//             Err(s) => match s.code() {
-//                 tonic::Code::Unavailable => ServiceStatusResult(Ok(ServiceStatus::Down)),
-//                 _ => ServiceStatusResult(Err(anyhow!("unexpected rpc status {:?}", s))),
-//             },
-//         }
-//     }
-// }

--- a/iroh-rpc-client/src/status.rs
+++ b/iroh-rpc-client/src/status.rs
@@ -1,4 +1,11 @@
+use std::io::Write;
+
+use anyhow::Result;
 use async_stream::stream;
+use crossterm::{
+    style::{self, Stylize},
+    QueueableCommand,
+};
 use futures::Stream;
 use tonic::transport::channel::Channel;
 use tonic_health::proto::{
@@ -7,23 +14,26 @@ use tonic_health::proto::{
 };
 
 #[tracing::instrument(skip(health_client))]
-pub async fn check(health_client: HealthClient<Channel>, service: String) -> ServiceStatus {
-    let req = iroh_metrics::req::trace_tonic_req(HealthCheckRequest { service });
+pub async fn check(health_client: HealthClient<Channel>, service: &'static str) -> StatusRow {
+    let req = iroh_metrics::req::trace_tonic_req(HealthCheckRequest {
+        service: service.to_string(),
+    });
     let res = health_client.clone().check(req).await;
-    match res {
+    let status = match res {
         Ok(res) => res.into_inner().into(),
         Err(s) => ServiceStatus::Down(s),
-    }
+    };
+    StatusRow::new(service, 1, status)
 }
 
 #[tracing::instrument(skip(health_client))]
 pub async fn watch(
     health_client: HealthClient<Channel>,
-    service: String,
-) -> impl Stream<Item = ServiceStatus> {
+    service: &'static str,
+) -> impl Stream<Item = StatusRow> {
     stream! {
         loop {
-            let req = iroh_metrics::req::trace_tonic_req(HealthCheckRequest { service: service.clone() });
+            let req = iroh_metrics::req::trace_tonic_req(HealthCheckRequest { service: service.to_string() });
             let res = health_client.clone().watch(req).await;
             match res {
                 Ok(stream) => {
@@ -31,19 +41,19 @@ pub async fn watch(
                     // loop over the stream, breaking if we get an error or stop receiving messages
                     loop {
                         match stream.message().await {
-                            Ok(Some(message)) => yield message.into(),
+                            Ok(Some(message)) => yield StatusRow::new(service, 1, message.into()),
                             Ok(None) => {
-                                yield ServiceStatus::Down(tonic::Status::new(tonic::Code::Unavailable, format!("No more health messages from service `{}`", service)));
+                                yield StatusRow::new(service, 1, ServiceStatus::Down(tonic::Status::new(tonic::Code::Unavailable, format!("No more health messages from service `{}`", service))));
                                 break;
                             }
                             Err(status) => {
-                                yield ServiceStatus::Down(status);
+                                yield StatusRow::new(service, 1, ServiceStatus::Down(status));
                                 break;
                             }
                         }
                     }
                 },
-                Err(status) => yield ServiceStatus::Down(status)
+                Err(status) => yield StatusRow::new(service, 1, ServiceStatus::Down(status)),
             }
             /// wait before attempting to start a watch stream again
             tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
@@ -88,5 +98,118 @@ impl std::clone::Clone for ServiceStatus {
             ServiceStatus::NotServing => ServiceStatus::NotServing,
             ServiceStatus::ServiceUnknown => ServiceStatus::ServiceUnknown,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StatusRow {
+    name: &'static str,
+    number: usize,
+    status: ServiceStatus,
+}
+
+impl StatusRow {
+    fn new(name: &'static str, number: usize, status: ServiceStatus) -> Self {
+        Self {
+            name,
+            number,
+            status,
+        }
+    }
+
+    // queue_status_table_row queues this row of the StatusRow to be written
+    // You must call `writer.flush()` to actually write the content to the writer
+    fn queue_status_table_row<W>(&self, w: &mut W) -> Result<()>
+    where
+        W: Write,
+    {
+        w.queue(style::Print(format!("{}\t\t\t", self.name)))?
+            .queue(style::Print(format!("{}/1\t", self.number)))?;
+        match &self.status {
+            ServiceStatus::Unknown => {
+                w.queue(style::PrintStyledContent("Unknown".dark_yellow()))?;
+            }
+            ServiceStatus::NotServing => {
+                w.queue(style::PrintStyledContent("NotServing".dark_yellow()))?;
+            }
+            ServiceStatus::Serving => {
+                w.queue(style::PrintStyledContent("Serving".green()))?;
+            }
+            ServiceStatus::ServiceUnknown => {
+                w.queue(style::PrintStyledContent("Service Unknown".dark_yellow()))?;
+            }
+            ServiceStatus::Down(status) => match status.code() {
+                tonic::Code::Unknown => {
+                    w.queue(style::PrintStyledContent("Down\t".dark_yellow()))?
+                        .queue(style::Print("The service has been interupted"))?;
+                }
+                code => {
+                    w.queue(style::PrintStyledContent("Down\t".red()))?
+                        .queue(style::Print(format!("{}\t", code)))?;
+                }
+            },
+        };
+        w.queue(style::Print("\n"))?;
+        Ok(())
+    }
+}
+
+impl Default for StatusRow {
+    fn default() -> Self {
+        Self {
+            name: "",
+            number: 1,
+            status: ServiceStatus::Unknown,
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct StatusTable {
+    gateway: StatusRow,
+    p2p: StatusRow,
+    store: StatusRow,
+}
+
+impl StatusTable {
+    pub fn new(gateway: StatusRow, p2p: StatusRow, store: StatusRow) -> Self {
+        Self {
+            gateway,
+            p2p,
+            store,
+        }
+    }
+
+    pub fn update(&mut self, s: StatusRow) -> Result<()> {
+        match s.name {
+            "gateway" => {
+                self.gateway = s;
+                Ok(())
+            }
+            "p2p" => {
+                self.p2p = s;
+                Ok(())
+            }
+            "store" => {
+                self.store = s;
+                Ok(())
+            }
+            _ => Err(anyhow::anyhow!("unknown service {}", s.name)),
+        }
+    }
+
+    /// queues the table for printing
+    /// you must call `writer.flush()` to execute the queue
+    pub fn queue_table<W>(&self, mut w: W) -> Result<()>
+    where
+        W: Write,
+    {
+        w.queue(style::PrintStyledContent(
+            "Process\t\t\tNumber\tStatus\n".bold(),
+        ))?;
+        self.gateway.queue_status_table_row(&mut w)?;
+        self.p2p.queue_status_table_row(&mut w)?;
+        self.gateway.queue_status_table_row(&mut w)?;
+        Ok(())
     }
 }

--- a/iroh-rpc-client/src/store.rs
+++ b/iroh-rpc-client/src/store.rs
@@ -9,7 +9,7 @@ use iroh_rpc_types::store::{self, GetLinksRequest, GetRequest, HasRequest, PutRe
 use tonic::transport::{Channel, Endpoint};
 use tonic_health::proto::health_client::HealthClient;
 
-use crate::status::{self, ServiceStatus};
+use crate::status::{self, StatusRow};
 
 #[derive(Debug, Clone)]
 pub struct StoreClient {
@@ -79,12 +79,12 @@ impl StoreClient {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn check(&self) -> ServiceStatus {
-        status::check(self.health.clone(), "store.Store".into()).await
+    pub async fn check(&self) -> StatusRow {
+        status::check(self.health.clone(), "store.Store").await
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn watch(&self) -> impl Stream<Item = ServiceStatus> {
-        status::watch(self.health.clone(), "store.Store".into()).await
+    pub async fn watch(&self) -> impl Stream<Item = StatusRow> {
+        status::watch(self.health.clone(), "store.Store").await
     }
 }

--- a/iroh-rpc-client/src/store.rs
+++ b/iroh-rpc-client/src/store.rs
@@ -17,6 +17,10 @@ pub struct StoreClient {
     health: HealthClient<Channel>,
 }
 
+// name that the health service registers the store client as
+// this is derived from the protobuf definition of a `StoreServer`
+pub const NAME: &str = "store.Store";
+
 impl StoreClient {
     pub async fn new(addr: SocketAddr) -> Result<Self> {
         let conn = Endpoint::new(format!("http://{}", addr))?
@@ -80,11 +84,11 @@ impl StoreClient {
 
     #[tracing::instrument(skip(self))]
     pub async fn check(&self) -> StatusRow {
-        status::check(self.health.clone(), "store.Store").await
+        status::check(self.health.clone(), NAME).await
     }
 
     #[tracing::instrument(skip(self))]
     pub async fn watch(&self) -> impl Stream<Item = StatusRow> {
-        status::watch(self.health.clone(), "store.Store").await
+        status::watch(self.health.clone(), NAME).await
     }
 }

--- a/iroh-rpc-client/src/store.rs
+++ b/iroh-rpc-client/src/store.rs
@@ -57,7 +57,7 @@ impl StoreClient {
         let req = iroh_metrics::req::trace_tonic_req(HasRequest {
             cid: cid.to_bytes(),
         });
-        let res = self.0.clone().has(req).await?;
+        let res = self.store.clone().has(req).await?;
         Ok(res.into_inner().has)
     }
 

--- a/iroh-rpc-types/Cargo.toml
+++ b/iroh-rpc-types/Cargo.toml
@@ -19,3 +19,8 @@ prost-types = "0.10.1"
 [build-dependencies]
 prost-build = "0.10.3"
 tonic-build = { version = "0.7.2", features = ["prost"] }
+
+[features]
+# Builds and empty tonic server & client as well as associated protobufs
+# that can be used for testing
+testing = []

--- a/iroh-rpc-types/build.rs
+++ b/iroh-rpc-types/build.rs
@@ -9,7 +9,11 @@ fn main() {
     tonic_build::configure()
         .compile_with_config(
             config,
-            &["proto/p2p.proto", "proto/store.proto"],
+            &[
+                "proto/p2p.proto",
+                "proto/store.proto",
+                "proto/gateway.proto",
+            ],
             &["proto"],
         )
         .unwrap();

--- a/iroh-rpc-types/build.rs
+++ b/iroh-rpc-types/build.rs
@@ -13,6 +13,7 @@ fn main() {
                 "proto/p2p.proto",
                 "proto/store.proto",
                 "proto/gateway.proto",
+                "proto/test.proto",
             ],
             &["proto"],
         )

--- a/iroh-rpc-types/proto/gateway.proto
+++ b/iroh-rpc-types/proto/gateway.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package gateway;
+
+service Gateway {}

--- a/iroh-rpc-types/proto/test.proto
+++ b/iroh-rpc-types/proto/test.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package test;
+
+service Test {}

--- a/iroh-rpc-types/src/gateway.rs
+++ b/iroh-rpc-types/src/gateway.rs
@@ -1,0 +1,1 @@
+tonic::include_proto!("gateway");

--- a/iroh-rpc-types/src/lib.rs
+++ b/iroh-rpc-types/src/lib.rs
@@ -1,3 +1,6 @@
+#[allow(clippy::all)]
 pub mod gateway;
 pub mod p2p;
 pub mod store;
+#[allow(clippy::all)]
+pub mod test;

--- a/iroh-rpc-types/src/lib.rs
+++ b/iroh-rpc-types/src/lib.rs
@@ -2,5 +2,6 @@
 pub mod gateway;
 pub mod p2p;
 pub mod store;
+#[cfg(feature = "testing")]
 #[allow(clippy::all)]
 pub mod test;

--- a/iroh-rpc-types/src/lib.rs
+++ b/iroh-rpc-types/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod gateway;
 pub mod p2p;
 pub mod store;

--- a/iroh-rpc-types/src/test.rs
+++ b/iroh-rpc-types/src/test.rs
@@ -1,0 +1,1 @@
+tonic::include_proto!("test");

--- a/iroh-store/Cargo.toml
+++ b/iroh-store/Cargo.toml
@@ -23,6 +23,7 @@ iroh-rpc-types = { path = "../iroh-rpc-types" }
 iroh-rpc-client = { path = "../iroh-rpc-client" }
 iroh-util = { path = "../iroh-util" }
 tonic = "0.7.2"
+tonic-health = "0.6.0"
 bytes = "1.1.0"
 prometheus-client = "0.16.0"
 iroh-metrics = { path = "../iroh-metrics" }

--- a/iroh-store/src/rpc.rs
+++ b/iroh-store/src/rpc.rs
@@ -8,7 +8,10 @@ use iroh_rpc_types::store::store_server;
 use iroh_rpc_types::store::{
     GetLinksRequest, GetLinksResponse, GetRequest, GetResponse, HasRequest, HasResponse, PutRequest,
 };
-use tonic::{transport::Server as TonicServer, Request, Response, Status};
+use tonic::{
+    transport::{NamedService, Server as TonicServer},
+    Request, Response, Status,
+};
 use tracing::info;
 
 use crate::store::Store;
@@ -90,6 +93,10 @@ impl store_server::Store for Rpc {
             Ok(Response::new(GetLinksResponse { links: Vec::new() }))
         }
     }
+}
+
+impl NamedService for Rpc {
+    const NAME: &'static str = "store";
 }
 
 #[tracing::instrument(skip(store))]


### PR DESCRIPTION
Adds `check` and `watch` methods for the rpc `Client`, that return a `StatusTable` or a stream of `StatusTable`s.

A `StatusTable` is a struct with a set of `StatusRow`s, one for the `gateway`, `p2p`, and `store` rpc servers. This is currently hardcoded as having one "slot" for each process, but in the future should be made more flexible to allow for mulitple `gateway`s, `p2p` nodes, and `store`s.

The status of each row is based on `tonic_health::ServingStatus`, and is received by calling `check` or `watch` on the `HealthServer` of each process. Each rpc server now starts up a `HealthServer` service.

In the future, we may want to implement our own version of `HealthReporter` and `HealthServer`, so we can more finely control and pass through the status of each process.