### PR TITLE
draft/playing around: put and get IPLD resources in gateway

### DIFF
--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -39,6 +39,7 @@ bytes = "1.1.0"
 tower-layer = { version = "0.3" }
 tower-http = { version = "0.1", features = ["trace"] }
 http = "0.2"
+libipld = "0.13.1"
 
 [dev-dependencies]
 axum-macros = "0.2.0" # use #[axum_macros::debug_handler] for better error messages on handlers

--- a/iroh-gateway/README.md
+++ b/iroh-gateway/README.md
@@ -21,6 +21,6 @@ A rust implementation of an IPFS gateway.
 
 | Endpoint                          | Flag                                       | Description                                                                             | Default    |
 |-----------------------------------|--------------------------------------------|-----------------------------------------------------------------------------------------|------------|
-| `/ipfs/:cid` & `/ipfs/:cid/:path` | `?format={"", "fs", "raw", "car", "html"}` | Specifies the serving format & content-type                                             | `""/fs`    |
+| `/ipfs/:cid` & `/ipfs/:cid/:path` | `?format={"", "fs", "raw", "car", "json", "cbor", "html"}` | Specifies the serving format & content-type                                             | `""/fs`    |
 |                                   | `?filename=DESIRED_FILE_NAME`              | Specifies a filename for the attachment                                                 | `{cid}.bin` |
 |                                   | `?download={true, false}`                  | Sets content-disposition to attachment, browser prompts to save file instead of loading | `false`    |

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -1,9 +1,13 @@
-use std::sync::Arc;
-
 use axum::body::StreamBody;
+use bytes::Bytes;
+use cid::multihash::{Code, MultihashDigest};
+use cid::Cid;
 use iroh_resolver::resolver::CidOrDomain;
 use iroh_resolver::resolver::OutPrettyReader;
 use iroh_resolver::resolver::Resolver;
+use libipld::codec::Encode;
+use libipld::{Ipld, IpldCodec};
+use std::sync::Arc;
 use tokio_util::io::ReaderStream;
 use tracing::info;
 
@@ -21,6 +25,69 @@ impl Client {
     pub fn new(rpc_client: &iroh_rpc_client::Client) -> Self {
         Self {
             resolver: Resolver::new(rpc_client.clone()),
+        }
+    }
+
+    #[tracing::instrument(skip(rpc_client))]
+    pub async fn put_raw(
+        &self,
+        blob: Bytes,
+        rpc_client: &iroh_rpc_client::Client,
+    ) -> Result<Cid, String> {
+        let digest = Code::Blake3_256.digest(&blob);
+        let cid = Cid::new_v1(IpldCodec::Raw.into(), digest);
+        rpc_client
+            .store
+            .put(cid, blob, vec![])
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(cid)
+    }
+
+    #[tracing::instrument(skip(rpc_client))]
+    pub async fn put_ipld(
+        &self,
+        input: Ipld,
+        rpc_client: &iroh_rpc_client::Client,
+    ) -> Result<Cid, String> {
+        let codec = IpldCodec::DagCbor;
+        let mut blob = Vec::new();
+        input.encode(codec, &mut blob).map_err(|e| e.to_string())?;
+        let digest = Code::Blake3_256.digest(&blob);
+        let cid = Cid::new_v1(codec.into(), digest);
+        let mut links = vec![];
+        input.references(&mut links);
+        rpc_client
+            .store
+            .put(cid, blob.into(), links)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(cid)
+    }
+
+    #[tracing::instrument]
+    pub async fn get_ipld(
+        &self,
+        path: &str,
+        start_time: std::time::Instant,
+        state: Arc<State>,
+    ) -> Result<Ipld, String> {
+        state.metrics.cache_miss.inc();
+        let p: iroh_resolver::resolver::Path =
+            path.parse().map_err(|e: anyhow::Error| e.to_string())?;
+        // todo(arqu): this is wrong but currently don't have access to the data stream
+        state
+            .metrics
+            .ttf_block
+            .set(start_time.elapsed().as_millis() as u64);
+        state
+            .metrics
+            .hist_ttfb
+            .observe(start_time.elapsed().as_millis() as f64);
+        let res = self.resolver.resolve(p).await.map_err(|e| e.to_string())?;
+        match res.into_ipld() {
+            Some(ipld) => Ok(ipld),
+            None => Err("This node cannot be represented as IPLD".into()),
         }
     }
 

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -173,7 +173,7 @@ async fn post_ipfs(
 ) -> Result<GatewayResponse, GatewayError> {
     state.metrics.requests_total.inc();
     let input_format = InputFormat::from_headers(&request_headers)
-        .map_err(|err| error(StatusCode::BAD_REQUEST, &err, &state))?;
+        .map_err(|err| error(StatusCode::BAD_REQUEST, err, &state))?;
     let cid = match input_format {
         InputFormat::Raw => state.client.put_raw(body, &state.rpc_client).await,
         InputFormat::DagJson | InputFormat::DagCbor => {

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -154,10 +154,10 @@ impl Out {
     /// Get a reference to the content as an IPLD node, if applicable.
     pub fn ipld(&self) -> Option<&Ipld> {
         match &self.content {
-            OutContent::DagPb(ipld, _) => Some(&ipld),
-            OutContent::DagCbor(ipld, _) => Some(&ipld),
-            OutContent::DagJson(ipld, _) => Some(&ipld),
-            OutContent::Raw(ipld, _) => Some(&ipld),
+            OutContent::DagPb(ipld, _) => Some(ipld),
+            OutContent::DagCbor(ipld, _) => Some(ipld),
+            OutContent::DagJson(ipld, _) => Some(ipld),
+            OutContent::Raw(ipld, _) => Some(ipld),
             OutContent::Unixfs(_) => None,
         }
     }

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -151,6 +151,28 @@ impl Out {
         self.content.typ()
     }
 
+    /// Get a reference to the content as an IPLD node, if applicable.
+    pub fn ipld(&self) -> Option<&Ipld> {
+        match &self.content {
+            OutContent::DagPb(ipld, _) => Some(&ipld),
+            OutContent::DagCbor(ipld, _) => Some(&ipld),
+            OutContent::DagJson(ipld, _) => Some(&ipld),
+            OutContent::Raw(ipld, _) => Some(&ipld),
+            OutContent::Unixfs(_) => None,
+        }
+    }
+
+    /// Convert into an IPLD node, if applicable.
+    pub fn into_ipld(self) -> Option<Ipld> {
+        match self.content {
+            OutContent::DagPb(ipld, _) => Some(ipld),
+            OutContent::DagCbor(ipld, _) => Some(ipld),
+            OutContent::DagJson(ipld, _) => Some(ipld),
+            OutContent::Raw(ipld, _) => Some(ipld),
+            OutContent::Unixfs(_) => None,
+        }
+    }
+
     /// Returns an iterator over the content of this directory.
     /// Only if this is of type `unixfs` and a directory.
     pub fn unixfs_read_dir(&self) -> Option<impl Iterator<Item = Result<LinkRef<'_>>>> {


### PR DESCRIPTION
Hi @dignifiedquire  :wave: and iroh team,

I've been (quietly) following along iroh developments out of interest, and like it a lot :) today I had some spare time and played around a bit with the codebase to get a feeling for it.

I ended up implementing putting and getting IPLD nodes into the store through the gateway in either cbor or json encoding.

I do not know (and certainly don't expect) if you're interested in PRs at this stage of the project, especially without prior coordination.  I have also just seen that @Arqu is working on some refactoring on the gateway. But feel free to have a look at the changes (I really loved how simple and straightforward this turned out, as I said, I was just mocking around a bit). If this aligns with the direction, I could update it after #87 is merged. I wouldn't mind either if this PR was not fitting atm :slightly_smiling_face: 

Also, I haven't digged into the existing specs – I just playing around. It works great though already with this very simple implementation, you can follow links through the resolver:
```
$ curl localhost:9050/ipfs -X POST -H "content-type: application/json" -d '{"hello":"world"}'
bafyr4iahzl6dyblh5gjfk5lo46xkkfk7fvxhyot4636rdglz3n5tayegd4
$ curl localhost:9050/ipfs -X POST -H "content-type: application/json" -d '{"link":{"/":"bafyr4iahzl6dyblh5gjfk5lo46xkkfk7fvxhyot4636rdglz3n5tayegd4"}}'
bafyr4ihjzsnn2mxvprhq5lvupmirvtgyg26xflnimnkadunch5cc6tbun4
$ curl localhost:9050/ipfs/bafyr4ihjzsnn2mxvprhq5lvupmirvtgyg26xflnimnkadunch5cc6tbun4/link/hello?format=json
"world"
```

Oh, and likely there should be access control for putting content.

Thanks,
Franz