### PR TITLE
fix: rpc creation no longer blocks the gateway

### DIFF
--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -49,3 +49,4 @@ urlencoding = "2.1.0"
 
 [dev-dependencies]
 axum-macros = "0.2.0" # use #[axum_macros::debug_handler] for better error messages on handlers
+hyper = "0.14.19"

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -30,6 +30,7 @@ opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 time = "0.3.9"
 headers = "0.3.7"
 iroh-rpc-client = { path = "../iroh-rpc-client" }
+hyper = "0.14.19"
 libp2p = "0.45.0"
 iroh-util = { path = "../iroh-util" }
 anyhow = "1"
@@ -49,4 +50,3 @@ urlencoding = "2.1.0"
 
 [dev-dependencies]
 axum-macros = "0.2.0" # use #[axum_macros::debug_handler] for better error messages on handlers
-hyper = "0.14.19"

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -606,6 +606,8 @@ mod tests {
         let res = client.get(uri).await.unwrap();
 
         assert_eq!(StatusCode::OK, res.status());
+        let body = hyper::body::to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(b"OK", &body[..]);
         core_task.abort();
         core_task.await.unwrap_err();
     }

--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -46,8 +46,10 @@ async fn main() -> Result<()> {
             .expect("failed to initialize metrics");
 
     let handler = Core::new(config, gw_metrics).await?;
+    let server = handler.serve();
+    println!("listening on {}", server.local_addr());
     let core_task = tokio::spawn(async move {
-        handler.serve().await;
+        server.await.unwrap();
     });
 
     iroh_util::block_until_sigint().await;


### PR DESCRIPTION
Also, adds `/health` endpoint that returns both status code OK, and string "OK".

closes #106 