### PR TITLE
feat(p2p): persist identity

### DIFF
--- a/iroh-ctl/src/main.rs
+++ b/iroh-ctl/src/main.rs
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
     // stubbing in metrics
     let prom_registry = Registry::default();
     // TODO: need to register prometheus metrics
-    let metrics_handle = iroh_metrics::init_with_registry(
+    let metrics_handle = iroh_metrics::MetricsHandle::from_registry_with_tracer(
         metrics::metrics_config_with_compile_time_info(metrics_config),
         prom_registry,
     )

--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -73,9 +73,10 @@ async fn main() -> Result<()> {
     let gw_metrics = Metrics::new(&mut prom_registry);
     let handler = Core::new(config, gw_metrics, &mut prom_registry).await?;
 
-    let metrics_handle = iroh_metrics::init_with_registry(metrics_config, prom_registry)
-        .await
-        .expect("failed to initialize metrics");
+    let metrics_handle =
+        iroh_metrics::MetricsHandle::from_registry_with_tracer(metrics_config, prom_registry)
+            .await
+            .expect("failed to initialize metrics");
     let server = handler.server();
     println!("listening on {}", server.local_addr());
     let core_task = tokio::spawn(async move {

--- a/iroh-metrics/src/lib.rs
+++ b/iroh-metrics/src/lib.rs
@@ -30,23 +30,31 @@ impl MetricsHandle {
         opentelemetry::global::shutdown_tracer_provider();
         self.metrics_task.abort();
     }
-}
 
-/// Initialize the tracing and metrics subsystems.
-pub async fn init(cfg: Config) -> Result<MetricsHandle, Box<dyn std::error::Error>> {
-    init_tracer(cfg.clone())?;
-    let metrics_task = init_metrics(cfg, <Registry>::default()).await?;
-    Ok(MetricsHandle { metrics_task })
-}
+    /// Initialize the tracing and metrics subsystems.
+    pub async fn new_with_tracer(cfg: Config) -> Result<Self, Box<dyn std::error::Error>> {
+        init_tracer(cfg.clone())?;
+        let metrics_task = init_metrics(cfg, Registry::default()).await?;
+        Ok(MetricsHandle { metrics_task })
+    }
 
-/// Initialize the tracing and metrics subsystems with custom registry
-pub async fn init_with_registry(
-    cfg: Config,
-    registry: Registry,
-) -> Result<MetricsHandle, Box<dyn std::error::Error>> {
-    init_tracer(cfg.clone())?;
-    let metrics_task = init_metrics(cfg, registry).await?;
-    Ok(MetricsHandle { metrics_task })
+    /// Initialize the tracing and metrics subsystems a with custom registry.
+    pub async fn from_registry_with_tracer(
+        cfg: Config,
+        registry: Registry,
+    ) -> Result<MetricsHandle, Box<dyn std::error::Error>> {
+        init_tracer(cfg.clone())?;
+        Self::from_registry(cfg, registry).await
+    }
+
+    /// Initialize the metrics subsystems with a custom registry.
+    pub async fn from_registry(
+        cfg: Config,
+        registry: Registry,
+    ) -> Result<MetricsHandle, Box<dyn std::error::Error>> {
+        let metrics_task = init_metrics(cfg, registry).await?;
+        Ok(MetricsHandle { metrics_task })
+    }
 }
 
 /// Initialize the metrics subsystem.

--- a/iroh-p2p/src/main.rs
+++ b/iroh-p2p/src/main.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use iroh_p2p::config::{Libp2pConfig, CONFIG_FILE_NAME, ENV_PREFIX};
 use iroh_p2p::{metrics, Libp2pService};
 use iroh_util::{iroh_home_path, make_config};
-use libp2p::identity::{ed25519, Keypair};
 use libp2p::metrics::Metrics;
 use prometheus_client::registry::Registry;
 use tokio::task;
@@ -31,23 +30,10 @@ impl Args {
 /// Starts daemon process
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
-
-    let mut prom_registry = Registry::default();
-    let libp2p_metrics = Metrics::new(&mut prom_registry);
-
     let version = option_env!("IROH_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
-
     println!("Starting iroh-p2p, version {version}");
 
-    // TODO: read keypair from disk
-    // TODO: configurable keypair
-    let net_keypair = {
-        // Keypair not found, generate and save generated keypair
-        let gen_keypair = ed25519::Keypair::generate();
-        // TODO: Save Ed25519 keypair to file
-        Keypair::Ed25519(gen_keypair)
-    };
+    let args = Args::parse();
 
     // TODO: configurable network
     let sources = vec![iroh_home_path(CONFIG_FILE_NAME), args.cfg.clone()];
@@ -63,22 +49,18 @@ async fn main() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let metrics_config = network_config.metrics.clone();
+    let mut prom_registry = Registry::default();
+    let libp2p_metrics = Metrics::new(&mut prom_registry);
+    let metrics_config =
+        metrics::metrics_config_with_compile_time_info(network_config.metrics.clone());
+    iroh_metrics::init_tracer(metrics_config.clone()).expect("failed to initialize tracer");
 
-    let mut p2p_service = Libp2pService::new(
-        network_config,
-        net_keypair,
-        &mut prom_registry,
-        libp2p_metrics,
-    )
-    .await?;
+    let mut p2p_service =
+        Libp2pService::new(network_config, &mut prom_registry, libp2p_metrics).await?;
 
-    let metrics_handle = iroh_metrics::init_with_registry(
-        metrics::metrics_config_with_compile_time_info(metrics_config),
-        prom_registry,
-    )
-    .await
-    .expect("failed to initialize metrics");
+    let metrics_handle = iroh_metrics::MetricsHandle::from_registry(metrics_config, prom_registry)
+        .await
+        .expect("failed to initialize metrics");
 
     // Start services
     let p2p_task = task::spawn(async move {

--- a/iroh-rpc-client/src/store.rs
+++ b/iroh-rpc-client/src/store.rs
@@ -5,7 +5,11 @@ use anyhow::{Context, Result};
 use bytes::Bytes;
 use cid::Cid;
 use futures::Stream;
-use iroh_rpc_types::store::{self, GetLinksRequest, GetRequest, HasRequest, PutRequest};
+use iroh_rpc_types::store::{
+    self, GetLinksRequest, GetP2pIdentityRequest, GetRequest, HasRequest, PutP2pIdentityRequest,
+    PutRequest,
+};
+use libp2p::identity::Keypair;
 use tonic::transport::{Channel, Endpoint};
 use tonic_health::proto::health_client::HealthClient;
 
@@ -83,6 +87,31 @@ impl StoreClient {
                 .collect();
             Ok(Some(links?))
         }
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn get_p2p_identity(&self) -> Result<Option<Keypair>> {
+        let req = iroh_metrics::req::trace_tonic_req(GetP2pIdentityRequest {});
+        let res = self.store.clone().get_p2p_identity(req).await?;
+
+        if let Some(raw) = res.into_inner().keypair {
+            if !raw.is_empty() {
+                let keypair = Keypair::from_protobuf_encoding(&raw)?;
+                return Ok(Some(keypair));
+            }
+        }
+
+        Ok(None)
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn put_p2p_identity(&self, keypair: &Keypair) -> Result<()> {
+        let req = iroh_metrics::req::trace_tonic_req(PutP2pIdentityRequest {
+            keypair: keypair.to_protobuf_encoding()?,
+        });
+        self.store.clone().put_p2p_identity(req).await?;
+
+        Ok(())
     }
 
     #[tracing::instrument(skip(self))]

--- a/iroh-rpc-types/build.rs
+++ b/iroh-rpc-types/build.rs
@@ -4,6 +4,7 @@ fn main() {
         ".p2p.BitswapResponse",
         ".store.PutRequest.blob",
         ".store.GetResponse.data",
+        ".store.GetP2pIdentityResponse.keypair",
     ]);
 
     tonic_build::configure()

--- a/iroh-rpc-types/proto/store.proto
+++ b/iroh-rpc-types/proto/store.proto
@@ -9,6 +9,8 @@ service Store {
   rpc Get(GetRequest) returns (GetResponse) {}
   rpc Has(HasRequest) returns (HasResponse) {}
   rpc GetLinks(GetLinksRequest) returns(GetLinksResponse) {}
+  rpc PutP2pIdentity(PutP2pIdentityRequest) returns (google.protobuf.Empty) {}
+  rpc GetP2pIdentity(GetP2pIdentityRequest) returns (GetP2pIdentityResponse) {}
 }
 
 message PutRequest {
@@ -49,3 +51,14 @@ message GetLinksResponse {
   repeated bytes links = 1;
 }
 
+message PutP2pIdentityRequest {
+  // Serialized keypair
+  bytes keypair = 1;
+}
+
+message GetP2pIdentityRequest {}
+
+message GetP2pIdentityResponse {
+  // Serialized keypair
+  optional bytes keypair = 1;
+}

--- a/iroh-store/src/cf.rs
+++ b/iroh-store/src/cf.rs
@@ -10,8 +10,10 @@ pub const CF_METADATA_V0: &str = "metadata-v0";
 /// Column familty that stores the graph for a blob
 /// - indexed by id (u64)
 pub const CF_GRAPH_V0: &str = "graph-v0";
-/// Column family that stores the mapping multihash to id
+/// Column family that stores the mapping multihash to id.
 pub const CF_ID_V0: &str = "id-v0";
+/// Column family that stores identities.
+pub const CF_IDENTITY_V0: &str = "identity-v0";
 
 // This wrapper type serializes the contained value out-of-line so that newer
 // versions can be viewed as the older version.

--- a/iroh-store/src/main.rs
+++ b/iroh-store/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut prom_registry = Registry::default();
     let store_metrics = Metrics::new(&mut prom_registry);
-    let metrics_handle = iroh_metrics::init_with_registry(
+    let metrics_handle = iroh_metrics::MetricsHandle::from_registry_with_tracer(
         metrics::metrics_config_with_compile_time_info(metrics_config),
         prom_registry,
     )


### PR DESCRIPTION
Stores the p2p identity in the store, such that it is persisted over restarts. If no store is available a temporary identity is created.