### PR TITLE
fix: correctly map memory channels

### DIFF
--- a/iroh-car/Cargo.toml
+++ b/iroh-car/Cargo.toml
@@ -19,6 +19,5 @@ tokio = { version = "1.0.1", features = ["io-util"] }
 
 [dev-dependencies]
 tokio = { version = "1.0.1", features = ["macros", "sync", "rt", "fs", "io-util"] }
-async-channel = "1.6.1"
 
 [features]

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/n0-computer/iroh"
 description = "Implementation of the p2p part of iroh"
 
 [dependencies]
-async-channel = "1.6.1"
 asynchronous-codec = "0.6.0"
 async-trait = "0.1.56"
 anyhow = "1.0"
@@ -37,6 +36,7 @@ dirs = "4.0.0"
 toml = "0.5.9"
 zeroize = "1.4"
 ssh-key = { version = "0.4.2", features = ["ed25519", "std", "rand_core"], default-features = false }
+iroh-resolver = { path = "../iroh-resolver", default-features = false }
 rand = "0.8.5"
 async-stream = "0.3.3"
 tempfile = "3.3.0"
@@ -75,6 +75,6 @@ tokio = { version = "1.0.1" }
 
 [features]
 default = ["rpc-grpc", "rpc-mem"]
-rpc-grpc = ["iroh-rpc-types/grpc", "iroh-rpc-client/grpc", "iroh-metrics/rpc-grpc"]
-rpc-mem = ["iroh-rpc-types/mem", "iroh-rpc-client/mem"]
+rpc-grpc = ["iroh-rpc-types/grpc", "iroh-rpc-client/grpc", "iroh-metrics/rpc-grpc", "iroh-resolver/rpc-grpc"]
+rpc-mem = ["iroh-rpc-types/mem", "iroh-rpc-client/mem", "iroh-resolver/rpc-mem"]
 

--- a/iroh-p2p/src/behaviour.rs
+++ b/iroh-p2p/src/behaviour.rs
@@ -155,13 +155,7 @@ impl NodeBehaviour {
     }
 
     /// Send a block to a peer over bitswap
-    #[allow(dead_code)]
-    pub fn send_block(
-        &mut self,
-        peer_id: &PeerId,
-        cid: Cid,
-        data: Bytes,
-    ) -> Result<(), Box<dyn Error>> {
+    pub fn send_block(&mut self, peer_id: &PeerId, cid: Cid, data: Bytes) -> Result<()> {
         self.bitswap.send_block(peer_id, cid, data);
         Ok(())
     }

--- a/iroh-rpc-client/Cargo.toml
+++ b/iroh-rpc-client/Cargo.toml
@@ -27,7 +27,6 @@ config = "0.13.1"
 tonic = { version = "0.7.2", optional = true }
 tonic-health = { version = "0.6.0", optional = true }
 async-trait = "0.1.56"
-async-channel = "1.6.1"
 tower = { version = "0.4.13", optional = true }
 paste = "1.0.7"
 

--- a/iroh-rpc-client/src/macros.rs
+++ b/iroh-rpc-client/src/macros.rs
@@ -54,8 +54,8 @@ macro_rules! impl_client {
                             })
                         }
                         #[cfg(feature = "mem")]
-                        Addr::Mem(s, r) => Ok([<$label Client>] {
-                            backend: [<$label ClientBackend>]::Mem(s, r),
+                        Addr::Mem(s) => Ok([<$label Client>] {
+                            backend: [<$label ClientBackend>]::Mem(s),
                         }),
                     }
                 }

--- a/iroh-rpc-types/Cargo.toml
+++ b/iroh-rpc-types/Cargo.toml
@@ -18,8 +18,7 @@ iroh-metrics = { path = "../iroh-metrics", default-features = false }
 
 tonic = { version = "0.7.2", optional = true }
 tonic-health = { version = "0.6.0", optional = true }
-async-channel = "1.6.1"
-tokio = { version = "1", optional = true, features = ["net"] }
+tokio = { version = "1", features = ["net", "sync"] }
 tokio-stream = { version = "0.1.9", optional = true, features = ["net"] }
 paste = "1.0.7"
 
@@ -35,7 +34,7 @@ grpc = [
   "tonic-build",
   "tonic-health",
   "iroh-metrics/rpc-grpc",
-  "tokio", "tokio-stream"
+  "tokio-stream"
 ]
 # Memory based transport
 mem = []

--- a/iroh-share/Cargo.toml
+++ b/iroh-share/Cargo.toml
@@ -22,7 +22,6 @@ tokio = { version = "1" }
 libp2p = { version = "0.47", default-features = false, features = ["gossipsub"] }
 serde = { version = "1", features = ["derive"] }
 futures = "0.3.21"
-async-channel = "1.6.1"
 bytes = "1.1.0"
 cid = { version = "0.8.5", features = ["serde-codec"] }
 async-trait = "0.1.56"
@@ -32,6 +31,7 @@ multibase = "0.9.1"
 tempfile = "3.3"
 tracing-subscriber = "0.3.14"
 rand = "0.8.5"
+tokio-stream = "0.1.9"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/iroh-store/benches/rpc.rs
+++ b/iroh-store/benches/rpc.rs
@@ -72,7 +72,6 @@ pub fn put_benchmark(c: &mut Criterion) {
 
                     let config = Config {
                         path: dir.path().join("db"),
-                        rpc_addr: server_addr.clone(),
                         rpc_client: rpc_client.clone(),
                         metrics: MetricsConfig::default(),
                     };
@@ -80,9 +79,7 @@ pub fn put_benchmark(c: &mut Criterion) {
                     let (_task, rpc) = executor.block_on(async {
                         let store = Store::create(config, metrics).await.unwrap();
                         let task = executor.spawn(async move {
-                            iroh_store::rpc::new(server_addr.clone(), store)
-                                .await
-                                .unwrap()
+                            iroh_store::rpc::new(server_addr, store).await.unwrap()
                         });
                         // wait for a moment until the transport is setup
                         // TODO: signal this more clearly
@@ -130,7 +127,6 @@ pub fn get_benchmark(c: &mut Criterion) {
 
                     let config = Config {
                         path: dir.path().join("db"),
-                        rpc_addr: server_addr.clone(),
                         rpc_client: rpc_client.clone(),
                         metrics: MetricsConfig::default(),
                     };
@@ -138,9 +134,7 @@ pub fn get_benchmark(c: &mut Criterion) {
                     let (_task, rpc) = executor.block_on(async {
                         let store = Store::create(config, metrics).await.unwrap();
                         let task = executor.spawn(async move {
-                            iroh_store::rpc::new(server_addr.clone(), store)
-                                .await
-                                .unwrap()
+                            iroh_store::rpc::new(server_addr, store).await.unwrap()
                         });
                         // wait for a moment until the transport is setup
                         // TODO: signal this more clearly

--- a/iroh-store/benches/store.rs
+++ b/iroh-store/benches/store.rs
@@ -5,7 +5,6 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use iroh_metrics::config::Config as MetricsConfig;
 use iroh_metrics::store::Metrics;
 use iroh_rpc_client::Config as RpcClientConfig;
-use iroh_rpc_types::Addr;
 use iroh_store::{Config, Store};
 use tokio::runtime::Runtime;
 
@@ -26,10 +25,8 @@ pub fn put_benchmark(c: &mut Criterion) {
                 let executor = Runtime::new().unwrap();
                 let dir = tempfile::tempdir().unwrap();
                 let rpc_client = RpcClientConfig::default();
-                let (rpc_addr, _) = Addr::new_mem();
                 let config = Config {
                     path: dir.path().into(),
-                    rpc_addr,
                     rpc_client,
                     metrics: MetricsConfig::default(),
                 };
@@ -57,10 +54,8 @@ pub fn get_benchmark(c: &mut Criterion) {
                 let executor = Runtime::new().unwrap();
                 let dir = tempfile::tempdir().unwrap();
                 let rpc_client = RpcClientConfig::default();
-                let (rpc_addr, _) = Addr::new_mem();
                 let config = Config {
                     path: dir.path().into(),
-                    rpc_addr,
                     rpc_client,
                     metrics: MetricsConfig::default(),
                 };

--- a/iroh-store/src/main.rs
+++ b/iroh-store/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use anyhow::anyhow;
 use clap::Parser;
 use iroh_metrics::store::Metrics;
 use iroh_store::{
@@ -65,7 +66,9 @@ async fn main() -> anyhow::Result<()> {
     .await
     .expect("failed to initialize metrics");
 
-    let rpc_addr = config.rpc_addr.clone();
+    let rpc_addr = config
+        .server_rpc_addr()?
+        .ok_or_else(|| anyhow!("missing store rpc addr"))?;
     let store = if config.path.exists() {
         info!("Opening store at {}", config.path.display());
         Store::open(config, store_metrics).await?

--- a/iroh-store/src/store.rs
+++ b/iroh-store/src/store.rs
@@ -435,7 +435,6 @@ mod tests {
 
     use iroh_metrics::config::Config as MetricsConfig;
     use iroh_rpc_client::Config as RpcClientConfig;
-    use iroh_rpc_types::Addr;
 
     use cid::multihash::{Code, MultihashDigest};
     const RAW: u64 = 0x55;
@@ -444,10 +443,8 @@ mod tests {
     async fn test_basics() {
         let dir = tempfile::tempdir().unwrap();
         let rpc_client = RpcClientConfig::default();
-        let (rpc_addr, _) = Addr::new_mem();
         let config = Config {
             path: dir.path().into(),
-            rpc_addr,
             rpc_client,
             metrics: MetricsConfig::default(),
         };
@@ -486,10 +483,8 @@ mod tests {
     async fn test_reopen() {
         let dir = tempfile::tempdir().unwrap();
         let rpc_client = RpcClientConfig::default();
-        let (rpc_addr, _) = Addr::new_mem();
         let config = Config {
             path: dir.path().into(),
-            rpc_addr,
             rpc_client,
             metrics: MetricsConfig::default(),
         };


### PR DESCRIPTION
When sending parallel queries through the rpc transport,
they were not properly mapped to the responses before.

Fixes #165