### PR TITLE
fix: default off metrics & tracing

### DIFF
--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -23,8 +23,10 @@ struct Args {
     fetch: Option<bool>,
     #[clap(short, long)]
     cache: Option<bool>,
-    #[clap(long = "no-metrics")]
-    no_metrics: bool,
+    #[clap(long = "metrics")]
+    metrics: bool,
+    #[clap(long = "tracing")]
+    tracing: bool,
     #[clap(long)]
     cfg: Option<PathBuf>,
 }
@@ -44,7 +46,8 @@ impl Args {
         if let Some(cache) = self.cache {
             map.insert("cache", cache.to_string());
         }
-        map.insert("metrics.debug", self.no_metrics.to_string());
+        map.insert("metrics.collect", self.metrics.to_string());
+        map.insert("metrics.tracing", self.tracing.to_string());
         map
     }
 }

--- a/iroh-metrics/src/config.rs
+++ b/iroh-metrics/src/config.rs
@@ -14,8 +14,10 @@ pub struct Config {
     pub version: String,
     /// The environment of the service.
     pub service_env: String,
-    /// Flag to enable debug mode.
-    pub debug: bool,
+    /// Flag to enable metrics collection.
+    pub collect: bool,
+    /// Flag to enable tracing collection.
+    pub tracing: bool,
     /// The endpoint of the trace collector.
     pub collector_endpoint: String,
     /// The endpoint of the prometheus push gateway.
@@ -35,7 +37,8 @@ impl Source for Config {
         insert_into_config_map(&mut map, "build", self.build.clone());
         insert_into_config_map(&mut map, "version", self.version.clone());
         insert_into_config_map(&mut map, "service_env", self.service_env.clone());
-        insert_into_config_map(&mut map, "debug", self.debug);
+        insert_into_config_map(&mut map, "collect", self.collect);
+        insert_into_config_map(&mut map, "tracing", self.tracing);
         insert_into_config_map(
             &mut map,
             "collector_endpoint",
@@ -73,7 +76,8 @@ impl Default for Config {
             build: "unknown".to_string(),
             version: "unknown".to_string(),
             service_env: "dev".to_string(),
-            debug: false,
+            collect: false,
+            tracing: false,
             collector_endpoint: "http://localhost:4317".to_string(),
             prom_gateway_endpoint: "http://localhost:9091".to_string(),
         }
@@ -109,7 +113,8 @@ mod tests {
             "service_env".to_string(),
             Value::new(None, cfg.service_env.clone()),
         );
-        expect.insert("debug".to_string(), Value::new(None, cfg.debug));
+        expect.insert("collect".to_string(), Value::new(None, cfg.collect));
+        expect.insert("tracing".to_string(), Value::new(None, cfg.tracing));
         expect.insert(
             "collector_endpoint".to_string(),
             Value::new(None, cfg.collector_endpoint.clone()),

--- a/iroh-metrics/src/lib.rs
+++ b/iroh-metrics/src/lib.rs
@@ -63,7 +63,7 @@ pub async fn init_metrics(
     cfg: Config,
     registry: Registry,
 ) -> Result<JoinHandle<()>, Box<dyn std::error::Error>> {
-    if !cfg.debug {
+    if cfg.collect {
         let prom_gateway_uri = format!(
             "{}/metrics/job/{}/instance/{}",
             cfg.prom_gateway_endpoint, cfg.service_name, cfg.instance_id
@@ -102,7 +102,7 @@ pub fn init_tracer(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
     let log_subscriber = fmt::layer()
         .pretty()
         .with_filter(EnvFilter::from_default_env());
-    if cfg.debug {
+    if !cfg.tracing {
         tracing_subscriber::registry().with(log_subscriber).init();
     } else {
         global::set_text_map_propagator(TraceContextPropagator::new());

--- a/iroh-p2p/src/main.rs
+++ b/iroh-p2p/src/main.rs
@@ -13,8 +13,10 @@ use tracing::error;
 #[derive(Parser, Debug, Clone)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    #[clap(long = "no-metrics")]
-    no_metrics: bool,
+    #[clap(long = "metrics")]
+    metrics: bool,
+    #[clap(long = "tracing")]
+    tracing: bool,
     #[clap(long)]
     cfg: Option<PathBuf>,
 }
@@ -22,7 +24,8 @@ struct Args {
 impl Args {
     fn make_overrides_map(&self) -> HashMap<String, String> {
         let mut map = HashMap::new();
-        map.insert("metrics.debug".to_string(), self.no_metrics.to_string());
+        map.insert("metrics.collect".to_string(), self.metrics.to_string());
+        map.insert("metrics.tracing".to_string(), self.tracing.to_string());
         map
     }
 }

--- a/iroh-p2p/src/node.rs
+++ b/iroh-p2p/src/node.rs
@@ -812,7 +812,6 @@ mod tests {
         let mut prom_registry = Registry::default();
         let mut network_config = Config::default_with_rpc(rpc_client_addr.clone());
         network_config.libp2p.listening_multiaddr = addr;
-        network_config.metrics.debug = true;
 
         let kc = Keychain::<MemoryStorage>::new();
         let mut p2p = Node::new(network_config, rpc_server_addr, kc, &mut prom_registry).await?;

--- a/iroh-share/src/p2p_node.rs
+++ b/iroh-share/src/p2p_node.rs
@@ -150,7 +150,7 @@ impl P2pNode {
             path: db_path.to_path_buf(),
             rpc_client: rpc_store_client_config,
             metrics: iroh_metrics::config::Config {
-                debug: true, // disable tracing by default
+                tracing: false, // disable tracing by default
                 ..Default::default()
             },
         };

--- a/iroh-store/src/main.rs
+++ b/iroh-store/src/main.rs
@@ -18,8 +18,10 @@ struct Args {
     /// Path to the store
     #[clap(long, short)]
     path: Option<PathBuf>,
-    #[clap(long = "no-metrics")]
-    no_metrics: bool,
+    #[clap(long = "metrics")]
+    metrics: bool,
+    #[clap(long = "tracing")]
+    tracing: bool,
     /// Path to the config file
     #[clap(long)]
     cfg: Option<PathBuf>,
@@ -31,7 +33,8 @@ impl Args {
         if let Some(path) = self.path.clone() {
             map.insert("path".to_string(), path.to_str().unwrap_or("").to_string());
         }
-        map.insert("metrics.debug".to_string(), self.no_metrics.to_string());
+        map.insert("metrics.collect".to_string(), self.metrics.to_string());
+        map.insert("metrics.tracing".to_string(), self.tracing.to_string());
         map
     }
 }


### PR DESCRIPTION
We can now turn tracing and metrics on independently. 
Also by default now they are off and the expectations is you will know what you're doing if you do want to set it up.

Remains to be able to toggle this at compile time too.

Closes https://github.com/n0-computer/iroh/issues/114 & tracks the compile time config at https://github.com/n0-computer/iroh/issues/149