### PR TITLE
Remove resolver dependency from p2p

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "1.1.0"
 bytesize = "1.1.0"
 par-stream = { version = "0.10.2", default-features = false, features = ["runtime-tokio"] }
 indicatif = "0.17.0"
+iroh-util = { path = "../iroh-util" }
 
 [features]
 default = []

--- a/examples/src/bin/importer.rs
+++ b/examples/src/bin/importer.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
         .try_par_map_unordered(None, move |(cid, data)| {
             move || {
                 let data = Bytes::from(data);
-                if iroh_resolver::verify_hash(&cid, &data) == Some(false) {
+                if iroh_util::verify_hash(&cid, &data) == Some(false) {
                     bail!("invalid hash {:?}", cid);
                 }
                 let links = iroh_resolver::parse_links(&cid, &data).unwrap_or_default();

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -36,7 +36,6 @@ dirs = "4.0.0"
 toml = "0.5.9"
 zeroize = "1.4"
 ssh-key = { version = "0.4.2", features = ["ed25519", "std", "rand_core"], default-features = false }
-iroh-resolver = { path = "../iroh-resolver", default-features = false }
 rand = "0.8.5"
 async-stream = "0.3.3"
 tempfile = "3.3.0"
@@ -75,6 +74,6 @@ tokio = { version = "1" }
 
 [features]
 default = ["rpc-grpc", "rpc-mem"]
-rpc-grpc = ["iroh-rpc-types/grpc", "iroh-rpc-client/grpc", "iroh-metrics/rpc-grpc", "iroh-resolver/rpc-grpc"]
-rpc-mem = ["iroh-rpc-types/mem", "iroh-rpc-client/mem", "iroh-resolver/rpc-mem"]
+rpc-grpc = ["iroh-rpc-types/grpc", "iroh-rpc-client/grpc", "iroh-metrics/rpc-grpc"]
+rpc-mem = ["iroh-rpc-types/mem", "iroh-rpc-client/mem"]
 

--- a/iroh-p2p/src/node.rs
+++ b/iroh-p2p/src/node.rs
@@ -339,7 +339,7 @@ impl<KeyStorage: Storage> Node<KeyStorage> {
                     BitswapEvent::OutboundQueryCompleted { id, result } => match result {
                         BitswapQueryResult::Want(WantResult::Ok { sender, cid, data }) => {
                             info!("got block {} from {}", cid, sender);
-                            match iroh_resolver::resolver::verify_hash(&cid, &data) {
+                            match iroh_util::verify_hash(&cid, &data) {
                                 Some(true) => {
                                     let b = Block::new(data, cid);
                                     if let Some(chan) = self.bitswap_queries.remove(&id) {

--- a/iroh-resolver/Cargo.toml
+++ b/iroh-resolver/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
 iroh-store = { path = "../iroh-store", default-features = false }
 iroh-rpc-types = { path = "../iroh-rpc-types", default-features = false }
 iroh-car = { path = "../iroh-car" }
+iroh-util = { path = "../iroh-util", default-features = false }
 
 [build-dependencies]
 prost-build = "0.11.1"

--- a/iroh-resolver/src/lib.rs
+++ b/iroh-resolver/src/lib.rs
@@ -5,4 +5,4 @@ pub mod resolver;
 pub mod unixfs;
 pub mod unixfs_builder;
 
-pub use crate::resolver::{parse_links, verify_hash};
+pub use crate::resolver::parse_links;

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -9,7 +9,6 @@ use std::time::Instant;
 use anyhow::{anyhow, bail, ensure, Context as _, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
-use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
 use futures::Stream;
 use iroh_metrics::resolver::Metrics;
@@ -820,14 +819,6 @@ pub fn parse_links(cid: &Cid, bytes: &[u8]) -> Result<Vec<Cid>> {
     Ok(links)
 }
 
-/// Verifies that the provided bytes hash to the given multihash.
-pub fn verify_hash(cid: &Cid, bytes: &[u8]) -> Option<bool> {
-    Code::try_from(cid.hash().code()).ok().map(|code| {
-        let calculated_hash = code.digest(bytes);
-        &calculated_hash == cid.hash()
-    })
-}
-
 #[tracing::instrument]
 async fn resolve_dnslink(url: &str) -> Result<Vec<Path>> {
     let url = format!("_dnslink.{}.", url);
@@ -960,7 +951,7 @@ mod tests {
             let digest = Code::Blake3_256.digest(&bytes);
             let c = Cid::new_v1(codec.into(), digest);
 
-            assert_eq!(verify_hash(&c, &bytes), Some(true));
+            assert_eq!(iroh_util::verify_hash(&c, &bytes), Some(true));
         }
     }
 

--- a/iroh-util/Cargo.toml
+++ b/iroh-util/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/n0-computer/iroh"
 description = "Utilities for iroh"
 
 [dependencies]
+cid = "0.8.4"
 ctrlc = "3.2.2"
 futures = "0.3.21"
 anyhow = "1.0.57"

--- a/iroh-util/src/lib.rs
+++ b/iroh-util/src/lib.rs
@@ -9,6 +9,10 @@ use std::{
 };
 
 use anyhow::Result;
+use cid::{
+    multihash::{Code, MultihashDigest},
+    Cid,
+};
 use config::{Config, ConfigError, Environment, File, Map, Source, Value, ValueKind};
 use dirs::home_dir;
 use tracing::debug;
@@ -138,6 +142,14 @@ where
     debug!("make_config:\n{:#?}\n", cfg);
     let cfg: T = cfg.try_deserialize()?;
     Ok(cfg)
+}
+
+/// Verifies that the provided bytes hash to the given multihash.
+pub fn verify_hash(cid: &Cid, bytes: &[u8]) -> Option<bool> {
+    Code::try_from(cid.hash().code()).ok().map(|code| {
+        let calculated_hash = code.digest(bytes);
+        &calculated_hash == cid.hash()
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The dependency is causing issues when working on a 'all in one' daemon using memory channels
for rpc: we end up with a circular dependency: resolver -> p2p -> resolver.
Since the only use is the 'verify_hash()' function, this patch moves it to the
iroh_util crate and updates the call sites accordingly.