### PR TITLE
ci: self hosted mac runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
       - run:
           no_output_timeout: 20m
           name: Test with << parameters.cargo-args >>
-          command: cargo test << parameters.cargo-args >> -j 2
+          command: cargo test << parameters.cargo-args >> -j 4
       - save-sccache-cache
 
   rustfmt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,17 @@ commands:
             echo 'export PATH="$HOME:~/.cargo/bin:~/.rustup/toolchains/<< pipeline.parameters.nightly-version >>-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:$PATH"' >> $BASH_ENV
             source $BASH_ENV
 
+  setup-sccache-mac:
+    steps:
+      - run:
+          name: Install sccache on mac
+          command: |
+            brew install sccache
+            # This configures Rust to use sccache.
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            # This is the maximum space sccache cache will use on disk.
+            echo 'export "SCCACHE_CACHE_SIZE"="4G"' >> $BASH_ENV
+            sccache --version
 
   setup-sccache:
     steps:
@@ -275,7 +286,7 @@ jobs:
       - checkout
       - setup-env-mac
       - setup-protoc-mac
-      - setup-sccache
+      - setup-sccache-mac
       - restore-sccache-cache
       - run:
           no_output_timeout: 20m
@@ -377,7 +388,7 @@ jobs:
       - checkout
       - setup-env-mac
       - setup-protoc-mac
-      - setup-sccache
+      - setup-sccache-mac
       - restore-sccache-cache
       - aws-cli/setup:
           profile-name: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,11 +80,11 @@ commands:
             echo 'export PATH="$PATH:/root/.cargo/bin"' >> $BASH_ENV
             echo 'export RUSTFLAGS="-C link-dead-code"' >> $BASH_ENV
             source $BASH_ENV
-      # - run:
-      #     name: setup ld
-      #     command: |
-      #       sudo bash -l -c 'echo $(rustc --print sysroot)/lib >> /etc/ld.so.conf'
-      #       sudo bash -l -c 'echo /usr/local/lib >> /etc/ld.so.conf'
+      - run:
+          name: setup ld
+          command: |
+            sudo bash -l -c 'echo $(rustc --print sysroot)/lib >> /etc/ld.so.conf'
+            sudo bash -l -c 'echo /usr/local/lib >> /etc/ld.so.conf'
       #       sudo ldconfig
 
   setup-protoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ commands:
           command: |
             sudo bash -l -c 'echo $(rustc --print sysroot)/lib >> /etc/ld.so.conf'
             sudo bash -l -c 'echo /usr/local/lib >> /etc/ld.so.conf'
-      #       sudo ldconfig
 
   setup-protoc:
     steps:
@@ -375,12 +374,6 @@ jobs:
           os: linux
           arch: aarch64
       - save-sccache-cache
-  
-  runner-test:
-    machine: true
-    resource_class: n0-computer/mac-intel
-    steps:
-      - run: echo "Hi I'm on Runners!"
 
   build_release_osx:
     executor: mac-executor
@@ -429,45 +422,44 @@ workflows:
 
   iroh-ci-cd:
     jobs:
-      # - cargo_fetch
-      # - rustfmt:
-      #     requires:
-      #       - cargo_fetch
-      # - clippy:
-      #     requires:
-      #       - cargo_fetch
-      # - test:
-      #     name: "test_linux_x86_64"
-      #     cargo-args: "--workspace"
-      #     requires:
-      #       - cargo_fetch
-      # - test:
-      #     name: "test_linux_x86_64--no-default-features"
-      #     cargo-args: "--workspace --no-default-features"
-      #     requires:
-      #       - cargo_fetch
-      # - build_release:
-      #     name: "build linux release"
-      #     context: aws_s3
-      #     requires:
-      #       - test_linux_x86_64
-      #       - test_linux_x86_64--no-default-features
-      #     filters:
-      #       branches:
-      #         only: main
+      - cargo_fetch
+      - rustfmt:
+          requires:
+            - cargo_fetch
+      - clippy:
+          requires:
+            - cargo_fetch
+      - test:
+          name: "test_linux_x86_64"
+          cargo-args: "--workspace"
+          requires:
+            - cargo_fetch
+      - test:
+          name: "test_linux_x86_64--no-default-features"
+          cargo-args: "--workspace --no-default-features"
+          requires:
+            - cargo_fetch
+      - build_release:
+          name: "build linux release"
+          context: aws_s3
+          requires:
+            - test_linux_x86_64
+            - test_linux_x86_64--no-default-features
+          filters:
+            branches:
+              only: main
       - test_darwin:
           name: "test_darwin_x86_64"
           cargo-args: "--workspace"
-      # - test_darwin:
-      #     name: "test_darwin_x86_64--no-default-features"
-      #     cargo-args: "--workspace --no-default-features"
-      # - build_release_osx:
-      #     name: "build mac release"
-      #     context: aws_s3
-      #     requires:
-      #       - test_darwin_x86_64
-      #       - test_darwin_x86_64--no-default-features
-      #     filters:
-      #       branches:
-      #         only: main
-      # - runner-test
+      - test_darwin:
+          name: "test_darwin_x86_64--no-default-features"
+          cargo-args: "--workspace --no-default-features"
+      - build_release_osx:
+          name: "build mac release"
+          context: aws_s3
+          requires:
+            - test_darwin_x86_64
+            - test_darwin_x86_64--no-default-features
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,9 @@ jobs:
       - save-sccache-cache
 
   test_darwin:
-    executor: mac-executor
+    # executor: mac-executor
+    machine: true
+    resource_class: n0-computer/mac-intel
     parameters:
       cargo-args:
         description: Addtional arguments for the cargo command
@@ -362,6 +364,12 @@ jobs:
           os: linux
           arch: aarch64
       - save-sccache-cache
+  
+  runner-test:
+    machine: true
+    resource_class: n0-computer/mac-intel
+    steps:
+      - run: echo "Hi I'm on Runners!"
 
   build_release_osx:
     executor: mac-executor
@@ -410,44 +418,45 @@ workflows:
 
   iroh-ci-cd:
     jobs:
-      - cargo_fetch
-      - rustfmt:
-          requires:
-            - cargo_fetch
-      - clippy:
-          requires:
-            - cargo_fetch
-      - test:
-          name: "test_linux_x86_64"
-          cargo-args: "--workspace"
-          requires:
-            - cargo_fetch
-      - test:
-          name: "test_linux_x86_64--no-default-features"
-          cargo-args: "--workspace --no-default-features"
-          requires:
-            - cargo_fetch
-      - build_release:
-          name: "build linux release"
-          context: aws_s3
-          requires:
-            - test_linux_x86_64
-            - test_linux_x86_64--no-default-features
-          filters:
-            branches:
-              only: main
+      # - cargo_fetch
+      # - rustfmt:
+      #     requires:
+      #       - cargo_fetch
+      # - clippy:
+      #     requires:
+      #       - cargo_fetch
+      # - test:
+      #     name: "test_linux_x86_64"
+      #     cargo-args: "--workspace"
+      #     requires:
+      #       - cargo_fetch
+      # - test:
+      #     name: "test_linux_x86_64--no-default-features"
+      #     cargo-args: "--workspace --no-default-features"
+      #     requires:
+      #       - cargo_fetch
+      # - build_release:
+      #     name: "build linux release"
+      #     context: aws_s3
+      #     requires:
+      #       - test_linux_x86_64
+      #       - test_linux_x86_64--no-default-features
+      #     filters:
+      #       branches:
+      #         only: main
       - test_darwin:
           name: "test_darwin_x86_64"
           cargo-args: "--workspace"
-      - test_darwin:
-          name: "test_darwin_x86_64--no-default-features"
-          cargo-args: "--workspace --no-default-features"
-      - build_release_osx:
-          name: "build mac release"
-          context: aws_s3
-          requires:
-            - test_darwin_x86_64
-            - test_darwin_x86_64--no-default-features
-          filters:
-            branches:
-              only: main
+      # - test_darwin:
+      #     name: "test_darwin_x86_64--no-default-features"
+      #     cargo-args: "--workspace --no-default-features"
+      # - build_release_osx:
+      #     name: "build mac release"
+      #     context: aws_s3
+      #     requires:
+      #       - test_darwin_x86_64
+      #       - test_darwin_x86_64--no-default-features
+      #     filters:
+      #       branches:
+      #         only: main
+      # - runner-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,6 +362,7 @@ jobs:
           command: |
             rustup target add aarch64-unknown-linux-gnu
             rustup toolchain install stable-aarch64-unknown-linux-gnu
+            rustup default stable-aarch64-unknown-linux-gnu
       - run:
           name: build aarch64_linux
           command: cargo build --release -v --target aarch64-unknown-linux-gnu
@@ -376,7 +377,9 @@ jobs:
       - save-sccache-cache
 
   build_release_osx:
-    executor: mac-executor
+    #executor: mac-executor
+    machine: true
+    resource_class: n0-computer/mac-intel
     steps:
       - checkout
       - setup-env-mac
@@ -402,6 +405,7 @@ jobs:
           command: |
             rustup target add aarch64-apple-darwin
             rustup toolchain install stable-aarch64-apple-darwin
+            rustup default stable-aarch64-apple-darwin
       - run:
           name: build aarch64_darwin
           no_output_timeout: 20m


### PR DESCRIPTION
I've set up my local box to run builds. 
All builds are now sequential for mac but still:
- it's essentially free
- individual build time down from 40ish min to 7ish min
- total build time down from 40ish min to 15ish min

Will be more congested once we have more PR volume but shouldn't be a biggie for a while. Can always add more boxes.