### PR TITLE
iroh-gateway: Don't send application/octet-stream content-type header

### DIFF
--- a/iroh-gateway/src/constants.rs
+++ b/iroh-gateway/src/constants.rs
@@ -27,8 +27,6 @@ pub static CONTENT_TYPE_IPLD_RAW: HeaderValue =
     HeaderValue::from_static("application/vnd.ipld.raw");
 pub static CONTENT_TYPE_IPLD_CAR: HeaderValue =
     HeaderValue::from_static("application/vnd.ipld.car; version=1");
-pub static CONTENT_TYPE_OCTET_STREAM: HeaderValue =
-    HeaderValue::from_static("application/octet-stream");
 
 // Schemes
 pub static SCHEME_IPFS: &str = "ipfs";

--- a/iroh-gateway/src/headers.rs
+++ b/iroh-gateway/src/headers.rs
@@ -12,10 +12,14 @@ pub fn add_user_headers(headers: &mut HeaderMap, user_headers: HeaderMap) {
 #[tracing::instrument()]
 pub fn add_content_type_headers(headers: &mut HeaderMap, name: &str) {
     let guess = mime_guess::from_path(name);
-    let content_type = guess.first_or_octet_stream().to_string();
-    // todo(arqu): deeper content type checking
-    // todo(arqu): if mime type starts with text/html; strip encoding to let browser detect
-    headers.insert(CONTENT_TYPE, HeaderValue::from_str(&content_type).unwrap());
+    if let Some(content_type) = guess.first() {
+        // todo(arqu): deeper content type checking
+        // todo(arqu): if mime type starts with text/html; strip encoding to let browser detect
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_str(&content_type.to_string()).unwrap(),
+        );
+    }
 }
 
 #[tracing::instrument()]
@@ -201,11 +205,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         let name = "test.RAND_EXT";
         add_content_type_headers(&mut headers, name);
-        assert_eq!(headers.len(), 1);
-        assert_eq!(
-            headers.get(&CONTENT_TYPE).unwrap(),
-            &CONTENT_TYPE_OCTET_STREAM
-        );
+        assert_eq!(headers.len(), 0);
     }
 
     #[test]

--- a/iroh-gateway/src/response.rs
+++ b/iroh-gateway/src/response.rs
@@ -48,7 +48,8 @@ impl ResponseFormat {
                 headers.insert(CACHE_CONTROL, VALUE_NO_CACHE_NO_TRANSFORM.clone());
             }
             ResponseFormat::Fs(_) => {
-                headers.insert(CONTENT_TYPE, CONTENT_TYPE_OCTET_STREAM.clone());
+                // Don't send application/octet-stream in that case, let the
+                // client decide instead.
             }
         }
     }
@@ -233,10 +234,6 @@ mod tests {
         let rf = ResponseFormat::try_from("fs").unwrap();
         let mut headers = HeaderMap::new();
         rf.write_headers(&mut headers);
-        assert_eq!(headers.len(), 1);
-        assert_eq!(
-            headers.get(&CONTENT_TYPE).unwrap(),
-            &CONTENT_TYPE_OCTET_STREAM
-        );
+        assert_eq!(headers.len(), 0);
     }
 }


### PR DESCRIPTION
This fixes https://github.com/n0-computer/iroh/issues/195