### PR TITLE
docs: beef up readme, add quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,26 @@
 
 Iroh is a next-generation implementation of the Interplanetary File System ([IPFS](https://ipfs.io)) for Cloud & Mobile platforms.
 
-IPFS is a networking protocol for exchanging _content-addressed_ blocks of immutable data. “Content-addressed” means referring to data by the *hash of its content*, which makes the reference unique and verifiable. These two properties make it possible to get data from *any* node in the network that speaks the IPFS protocol, including IPFS content being served by other implementations of the protocol.
+IPFS is a networking protocol for exchanging _content-addressed_ blocks of immutable data. “Content-addressed” means referring to data by the *hash of its content*, which makes the reference unique and verifiable. These two properties make it possible to get data from *any* node in the network that speaks the IPFS protocol, including IPFS content being served by other implementations of IPFS.
 
-- Iroh Cloud is an IPFS implementation purpose-built for running at scale on datacenter-grade infrastructure.
-- Iroh Mobile is an IPFS library for iOS & Android app development. Both libraries are operating system specific, written in Rust and wrapped in native language APIs. 
+This repo is a common core for three distributions of iroh:
+- **Iroh Cloud:** core features of iroh split into configurable microservices, optimized for running at datacenter scale.
+- **Iroh One:** A select set of iroh cloud features packaged as a single binary for simplified deployment.
+- **Iroh Mobile:** iOS & Android libraries that bring efficient data distribution to mobile apps.
 
-Iroh has yet to publish a release. We're targeting the end of October 2022 for an initial version.
+## Project Status: Early Days
 
-Iroh is built & maintained by [number 0](https://n0.computer).
+Iroh has yet to publish a release. We are targeting the end of October 2022 for an initial version, which will coincide with the launch of a proper web site & documentation. Before iroh's first release we're in build-from-source and read-source-to-understand-how-it-works territory.
+
+In the meantime, there's a [quickstart guide](./quickstart.md) if you'd like to get a feel for running an iroh cloud gateway. 
+
+## Benchmarks
+
+A full suite of automated benchmarks is in the works. [this talk](https://www.youtube.com/watch?v=qPBR2K2X6cs&t=161s) goes into some early numbers.
+
+## Who's behind this?
+
+Iroh is built & maintained by [number 0](https://n0.computer). We're a founder-backed startup hell-bent on building efficient distributed systems software.
 
 ## License
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -11,17 +11,17 @@ This guide will walk you through running iroh cloud on your local machine, using
 we’ve prepped a bash file one-liner for you:
 
 ```bash
-$ curl -fsSL http://sh.iroh.computer/setup.sh | sh -s -- quickstart
+$ curl -fsSL https://sh.iroh.computer/setup.sh | sh -s -- quickstart
 ```
 
-Running stuff from the internet directly on your terminal is generally a bad idea. Feel free to read through the script first 😄 by dropping the pipe `|` character and everything after it to print `[setup.sh](http://setup.sh)` to your terminal. The setup script takes a bit of time to fetch precompiled binaries. Once up and running you should see terminal output that looks like this:
+Running stuff from the internet directly on your terminal is generally a bad idea. Feel free to read through the script first 😄 by dropping the pipe `|` character and everything after it to print `[setup.sh](https://sh.iroh.computer/setup.sh)` to your terminal. The setup script takes a bit of time to fetch precompiled binaries. Once up and running you should see terminal output that looks like this:
 
 ```
-$ curl -fsSL http://sh.iroh.computer/setup.sh | sh-s--quickstart
-Fetching http: //vorc.gekko.sh:9055/bin/iroh-gateway/darwin/aarch64/latest
-Fetching http://vorc.gekko.sh:9055/bin/iroh-p2p/darwin/aarch64/latest
-Fetching http://vorc.gekko.sh:9055/bin/iroh-store/darwin/aarch64/latest
-Fetching http://vorc.gekko.sh:9055/bin/iroh-ctl/darwin/aarch64/latest
+$ curl -fsSL https://sh.iroh.computer/setup.sh | sh-s--quickstart
+Fetching https://vorc.iroh.computer/bin/iroh-gateway/darwin/aarch64/latest
+Fetching https://vorc.iroh.computer/bin/iroh-p2p/darwin/aarch64/latest
+Fetching https://vorc.iroh.computer/bin/iroh-store/darwin/aarch64/latest
+Fetching https://vorc.iroh.computer/bin/iroh-ctl/darwin/aarch64/latest
 starting iroh-store.
 iroh-store started
 view logs at ~/.iroh/log/iroh-store.log
@@ -37,7 +37,7 @@ you can run iroh-ctl from ~/.iroh/bin/iroh-ctl
 ```
 
 
-🚧 *currently [setup.sh](http://setup.sh) writes everything to `$HOME/.iroh`, Iroh cloud will be switching to use [standard directories](https://dirs.dev/) for config, cache, and application data. See [issue #142](https://github.com/n0-computer/iroh/issues/142) for more detail:*
+🚧 *currently [setup.sh](https://sh.iroh.computer/setup.sh) writes everything to `$HOME/.iroh`, Iroh cloud will be switching to use [standard directories](https://dirs.dev/) for config, cache, and application data. See [issue #142](https://github.com/n0-computer/iroh/issues/142) for more detail:*
 
 ## 2. Using the gateway
 
@@ -62,7 +62,7 @@ This indicates all three services are running & healthy.
 This setup script includes a few options, which you can see by replacing `quickstart` with `-h`:
 
 ```bash
-$ curl -fsSL http://sh.iroh.computer/setup.sh | sh -s -- -h
+$ curl -fsSL https://sh.iroh.computer/setup.sh | sh -s -- -h
 iroh quickstart
 
 USAGE:
@@ -81,13 +81,13 @@ FLAGS:
 The help text includes a reference to a `stop` command. Let’s run that:
 
 ```bash
-$ curl -fsSL http://sh.iroh.computer/setup.sh | sh -s -- stop
+$ curl -fsSL https://sh.iroh.computer/setup.sh | sh -s -- stop
 ```
 
 You should see output looking like this:
 
 ```
-$ curl -fsSL http://sh.iroh.computer/setup.sh | sh -s -- stop
+$ curl -fsSL https://sh.iroh.computer/setup.sh | sh -s -- stop
 stopping iroh-gateway...
 stopping iroh-p2p...
 stopping iroh-store...

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,0 +1,94 @@
+# Quickstart: Gateway
+
+This guide will walk you through running iroh cloud on your local machine, using the default configuration of a gateway backed by a p2p and store service. Once a gateway is up & running we’ll use it to fetch content from the IPFS network by requesting content from a web browser.
+
+
+⚠️ *The quickstart script currently only works for macOS & linux*
+
+
+## 1. Run Iroh locally
+
+we’ve prepped a bash file one-liner for you:
+
+```bash
+$ curl -fsSL http://sh.iroh.computer/setup.sh | sh -s -- quickstart
+```
+
+Running stuff from the internet directly on your terminal is generally a bad idea. Feel free to read through the script first 😄 by dropping the pipe `|` character and everything after it to print `[setup.sh](http://setup.sh)` to your terminal. The setup script takes a bit of time to fetch precompiled binaries. Once up and running you should see terminal output that looks like this:
+
+```
+$ curl -fsSL http://sh.iroh.computer/setup.sh | sh-s--quickstart
+Fetching http: //vorc.gekko.sh:9055/bin/iroh-gateway/darwin/aarch64/latest
+Fetching http://vorc.gekko.sh:9055/bin/iroh-p2p/darwin/aarch64/latest
+Fetching http://vorc.gekko.sh:9055/bin/iroh-store/darwin/aarch64/latest
+Fetching http://vorc.gekko.sh:9055/bin/iroh-ctl/darwin/aarch64/latest
+starting iroh-store.
+iroh-store started
+view logs at ~/.iroh/log/iroh-store.log
+starting iroh-p2p.
+iroh-p2p started
+view logs at ~/.iroh/log/iroh-p2p.log
+starting iroh-gateway.
+iroh-gateway started
+view logs at ~/.iroh/loq/iroh-gatewau.log
+iroh started
+iroh-gateway available at http: //localhost:9050
+you can run iroh-ctl from ~/.iroh/bin/iroh-ctl
+```
+
+
+🚧 *currently [setup.sh](http://setup.sh) writes everything to `$HOME/.iroh`, Iroh cloud will be switching to use [standard directories](https://dirs.dev/) for config, cache, and application data. See [issue #142](https://github.com/n0-computer/iroh/issues/142) for more detail:*
+
+## 2. Using the gateway
+
+Open a web browser and visit [`http://127.0.0.1:9050/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?filename=test.jpg`](http://127.0.0.1:9050/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?filename=test.jpg) . If working, you should see a funny looking “cat”. If so, congrats! You’ve used iroh to load something from the public IPFS network. If you reload this page that same content will be served from a local cache instead of hitting the network again. Feel free to experiment with other IPFS content!
+
+## 3. Hello `iroh-ctl`
+
+Run `~/.iroh/bin/iroh-ctl status` to get a summary of the health of your iroh cloud services. You should see something like:
+
+```
+~/.iroh/bin/iroh-ctl status
+Process     Number    Status
+gateway     1/1       Serving
+p2p         1/1       Serving
+store       1/1       Serving
+```
+
+This indicates all three services are running & healthy.
+
+## 4. Stopping iroh
+
+This setup script includes a few options, which you can see by replacing `quickstart` with `-h`:
+
+```bash
+$ curl -fsSL http://sh.iroh.computer/setup.sh | sh -s -- -h
+iroh quickstart
+
+USAGE:
+    ./iroh.sh [COMMANDS] [FLAGS] [OPTIONS]
+
+COMMANDS:
+    init          Initialize iroh
+    start         Start iroh services
+    stop          Stop iroh services
+    quickstart    Init iroh and start services
+
+FLAGS:
+    -h, --help              Prints help information
+```
+
+The help text includes a reference to a `stop` command. Let’s run that:
+
+```bash
+$ curl -fsSL http://sh.iroh.computer/setup.sh | sh -s -- stop
+```
+
+You should see output looking like this:
+
+```
+$ curl -fsSL http://sh.iroh.computer/setup.sh | sh -s -- stop
+stopping iroh-gateway...
+stopping iroh-p2p...
+stopping iroh-store...
+```

--- a/quickstart.md
+++ b/quickstart.md
@@ -30,7 +30,7 @@ iroh-p2p started
 view logs at ~/.iroh/log/iroh-p2p.log
 starting iroh-gateway.
 iroh-gateway started
-view logs at ~/.iroh/loq/iroh-gatewau.log
+view logs at ~/.iroh/log/iroh-gateway.log
 iroh started
 iroh-gateway available at http: //localhost:9050
 you can run iroh-ctl from ~/.iroh/bin/iroh-ctl


### PR DESCRIPTION
we're not ready to launch a full docs site yet, so let's add a bit more to the readme, and move the quickstart guide into the repo while we work toward a release

closes #208, closes #210