### PR TITLE
Allow to pass custom resolvers

### DIFF
--- a/iroh-gateway/src/bad_bits.rs
+++ b/iroh-gateway/src/bad_bits.rs
@@ -111,6 +111,7 @@ mod tests {
     use super::*;
     use hex_literal::hex;
     use http::StatusCode;
+    use iroh_rpc_client::Client as RpcClient;
     use iroh_rpc_client::Config as RpcClientConfig;
 
     #[tokio::test]
@@ -189,10 +190,12 @@ mod tests {
         config.set_default_headers();
 
         let rpc_addr = "grpc://0.0.0.0:0".parse().unwrap();
+        let content_loader = RpcClient::new(config.rpc_client.clone()).await.unwrap();
         let handler = crate::core::Core::new(
             Arc::new(config),
             rpc_addr,
             Arc::new(Some(RwLock::new(bbits))),
+            content_loader,
         )
         .await
         .unwrap();

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -13,7 +13,7 @@ use futures::TryStreamExt;
 use handlebars::Handlebars;
 use iroh_metrics::{core::MRecorder, gateway::GatewayMetrics, get_current_trace_id, inc};
 use iroh_resolver::{
-    resolver::{CidOrDomain, OutMetrics, UnixfsType},
+    resolver::{CidOrDomain, ContentLoader, OutMetrics, UnixfsType},
     unixfs::Link,
 };
 use serde::{Deserialize, Serialize};
@@ -54,11 +54,11 @@ pub trait StateConfig: std::fmt::Debug + Sync + Send {
     fn user_headers(&self) -> &HeaderMap<HeaderValue>;
 }
 
-pub fn get_app_routes(state: &Arc<State>) -> Router {
+pub fn get_app_routes<T: ContentLoader + std::marker::Unpin>(state: &Arc<State<T>>) -> Router {
     // todo(arqu): ?uri=... https://github.com/ipfs/go-ipfs/pull/7802
     Router::new()
-        .route("/:scheme/:cid", get(get_handler))
-        .route("/:scheme/:cid/*cpath", get(get_handler))
+        .route("/:scheme/:cid", get(get_handler::<T>))
+        .route("/:scheme/:cid/*cpath", get(get_handler::<T>))
         .route("/health", get(health_check))
         .layer(Extension(Arc::clone(state)))
         .layer(
@@ -66,7 +66,7 @@ pub fn get_app_routes(state: &Arc<State>) -> Router {
                 // Handle errors from middleware
                 .layer(Extension(Arc::clone(state)))
                 .layer(CompressionLayer::new())
-                .layer(HandleErrorLayer::new(middleware_error_handler))
+                .layer(HandleErrorLayer::new(middleware_error_handler::<T>))
                 .load_shed()
                 .concurrency_limit(2048)
                 .timeout(Duration::from_secs(60))
@@ -112,8 +112,8 @@ impl GetParams {
 }
 
 #[tracing::instrument(skip(state))]
-pub async fn get_handler(
-    Extension(state): Extension<Arc<State>>,
+pub async fn get_handler<T: ContentLoader + std::marker::Unpin>(
+    Extension(state): Extension<Arc<State<T>>>,
     Path(params): Path<HashMap<String, String>>,
     Query(query_params): Query<GetParams>,
     request_headers: HeaderMap,
@@ -225,9 +225,9 @@ pub async fn health_check() -> String {
 }
 
 #[tracing::instrument()]
-fn protocol_handler_redirect(
+fn protocol_handler_redirect<T: ContentLoader>(
     uri_param: String,
-    state: &State,
+    state: &State<T>,
 ) -> Result<GatewayResponse, GatewayError> {
     let u = match Url::parse(&uri_param) {
         Ok(u) => u,
@@ -260,10 +260,10 @@ fn protocol_handler_redirect(
 }
 
 #[tracing::instrument()]
-fn service_worker_check(
+fn service_worker_check<T: ContentLoader>(
     request_headers: &HeaderMap,
     cpath: String,
-    state: &State,
+    state: &State<T>,
 ) -> Result<(), GatewayError> {
     if request_headers.contains_key(&HEADER_SERVICE_WORKER) {
         let sw = request_headers.get(&HEADER_SERVICE_WORKER).unwrap();
@@ -279,7 +279,10 @@ fn service_worker_check(
 }
 
 #[tracing::instrument()]
-fn unsuported_header_check(request_headers: &HeaderMap, state: &State) -> Result<(), GatewayError> {
+fn unsuported_header_check<T: ContentLoader>(
+    request_headers: &HeaderMap,
+    state: &State<T>,
+) -> Result<(), GatewayError> {
     if request_headers.contains_key(&HEADER_X_IPFS_GATEWAY_PREFIX) {
         return Err(error(
             StatusCode::BAD_REQUEST,
@@ -290,7 +293,7 @@ fn unsuported_header_check(request_headers: &HeaderMap, state: &State) -> Result
     Ok(())
 }
 
-pub async fn check_bad_bits(state: &State, cid: &str, path: &str) -> bool {
+pub async fn check_bad_bits<T: ContentLoader>(state: &State<T>, cid: &str, path: &str) -> bool {
     // check if cid is in the denylist
     if state.bad_bits.is_some() {
         let bad_bits = state.bad_bits.as_ref();
@@ -304,11 +307,11 @@ pub async fn check_bad_bits(state: &State, cid: &str, path: &str) -> bool {
 }
 
 #[tracing::instrument()]
-fn etag_check(
+fn etag_check<T: ContentLoader>(
     request_headers: &HeaderMap,
     resolved_cid: &CidOrDomain,
     format: &ResponseFormat,
-    state: &State,
+    state: &State<T>,
 ) -> Option<GatewayResponse> {
     if request_headers.contains_key("If-None-Match") {
         // todo(arqu): handle dir etags
@@ -326,9 +329,9 @@ fn etag_check(
 }
 
 #[tracing::instrument()]
-async fn serve_raw(
+async fn serve_raw<T: ContentLoader + std::marker::Unpin>(
     req: &Request,
-    state: Arc<State>,
+    state: Arc<State<T>>,
     mut headers: HeaderMap,
     start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
@@ -360,9 +363,9 @@ async fn serve_raw(
 }
 
 #[tracing::instrument()]
-async fn serve_car(
+async fn serve_car<T: ContentLoader + std::marker::Unpin>(
     req: &Request,
-    state: Arc<State>,
+    state: Arc<State<T>>,
     mut headers: HeaderMap,
     start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
@@ -397,9 +400,9 @@ async fn serve_car(
 }
 
 #[tracing::instrument()]
-async fn serve_car_recursive(
+async fn serve_car_recursive<T: ContentLoader + std::marker::Unpin>(
     req: &Request,
-    state: Arc<State>,
+    state: Arc<State<T>>,
     mut headers: HeaderMap,
     start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
@@ -428,9 +431,9 @@ async fn serve_car_recursive(
 
 #[tracing::instrument()]
 #[async_recursion]
-async fn serve_fs(
+async fn serve_fs<T: ContentLoader + std::marker::Unpin>(
     req: &Request,
-    state: Arc<State>,
+    state: Arc<State<T>>,
     mut headers: HeaderMap,
     start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
@@ -496,10 +499,10 @@ async fn serve_fs(
 }
 
 #[tracing::instrument()]
-async fn serve_fs_dir(
+async fn serve_fs_dir<T: ContentLoader + std::marker::Unpin>(
     dir_list: &[Link],
     req: &Request,
-    state: Arc<State>,
+    state: Arc<State<T>>,
     mut headers: HeaderMap,
     start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
@@ -573,7 +576,11 @@ where
 }
 
 #[tracing::instrument()]
-fn error(status_code: StatusCode, message: &str, state: &State) -> GatewayError {
+fn error<T: ContentLoader>(
+    status_code: StatusCode,
+    message: &str,
+    state: &State<T>,
+) -> GatewayError {
     inc!(GatewayMetrics::ErrorCount);
     GatewayError {
         status_code,
@@ -583,8 +590,8 @@ fn error(status_code: StatusCode, message: &str, state: &State) -> GatewayError 
 }
 
 #[tracing::instrument()]
-pub async fn middleware_error_handler(
-    Extension(state): Extension<Arc<State>>,
+pub async fn middleware_error_handler<T: ContentLoader>(
+    Extension(state): Extension<Arc<State<T>>>,
     err: BoxError,
 ) -> impl IntoResponse {
     inc!(GatewayMetrics::FailCount);

--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -9,6 +9,7 @@ use iroh_gateway::{
     core::Core,
     metrics,
 };
+use iroh_rpc_client::Client as RpcClient;
 use iroh_util::{iroh_config_path, make_config};
 use tokio::sync::RwLock;
 use tracing::{debug, error};
@@ -41,7 +42,14 @@ async fn main() -> Result<()> {
     let rpc_addr = config
         .server_rpc_addr()?
         .ok_or_else(|| anyhow!("missing gateway rpc addr"))?;
-    let handler = Core::new(Arc::new(config), rpc_addr, Arc::clone(&bad_bits)).await?;
+    let content_loader = RpcClient::new(config.rpc_client.clone()).await?;
+    let handler = Core::new(
+        Arc::new(config),
+        rpc_addr,
+        Arc::clone(&bad_bits),
+        content_loader,
+    )
+    .await?;
 
     let bad_bits_handle = bad_bits::spawn_bad_bits_updater(Arc::clone(&bad_bits));
 

--- a/iroh-one/Cargo.toml
+++ b/iroh-one/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 anyhow = "1"
 async-trait = "0.1.56"
 axum = "0.5.1"
+cid = "0.8"
 clap = {version = "3.1.14", features = ["derive"]}
 config = "0.13.1"
 futures = "0.3.21"

--- a/iroh-one/src/content_loader.rs
+++ b/iroh-one/src/content_loader.rs
@@ -1,0 +1,70 @@
+/// A content loader implementation for iroh-one.
+use anyhow::Result;
+use async_trait::async_trait;
+use cid::Cid;
+use iroh_resolver::resolver::{parse_links, ContentLoader, LoadedCid, Source, IROH_STORE};
+use iroh_rpc_client::Client as RpcClient;
+use tracing::{debug, trace, warn};
+
+#[derive(Clone, Debug)]
+pub struct RacingLoader {
+    rpc_client: RpcClient,
+}
+
+impl RacingLoader {
+    pub fn new(rpc_client: RpcClient) -> Self {
+        Self { rpc_client }
+    }
+}
+
+#[async_trait]
+impl ContentLoader for RacingLoader {
+    async fn load_cid(&self, cid: &Cid) -> Result<LoadedCid> {
+        // TODO: better strategy
+
+        let cid = *cid;
+        match self.rpc_client.try_store()?.get(cid).await {
+            Ok(Some(data)) => {
+                trace!("retrieved from store");
+                return Ok(LoadedCid {
+                    data,
+                    source: Source::Store(IROH_STORE),
+                });
+            }
+            Ok(None) => {}
+            Err(err) => {
+                warn!("failed to fetch data from store {}: {:?}", cid, err);
+            }
+        }
+        let p2p = self.rpc_client.try_p2p()?;
+        let providers = p2p.fetch_providers(&cid).await?;
+        let bytes = p2p.fetch_bitswap(cid, providers).await?;
+
+        // trigger storage in the background
+        let cloned = bytes.clone();
+        let rpc = self.rpc_client.clone();
+        tokio::spawn(async move {
+            let links = parse_links(&cid, &cloned).unwrap_or_default();
+
+            let len = cloned.len();
+            let links_len = links.len();
+            if let Some(store_rpc) = rpc.store.as_ref() {
+                match store_rpc.put(cid, cloned, links).await {
+                    Ok(_) => debug!("stored {} ({}bytes, {}links)", cid, len, links_len),
+                    Err(err) => {
+                        warn!("failed to store {}: {:?}", cid, err);
+                    }
+                }
+            } else {
+                warn!("failed to store: missing store rpc conn");
+            }
+        });
+
+        trace!("retrieved from p2p");
+
+        Ok(LoadedCid {
+            data: bytes,
+            source: Source::Bitswap,
+        })
+    }
+}

--- a/iroh-one/src/lib.rs
+++ b/iroh-one/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod config;
+pub mod content_loader;
 pub mod mem_p2p;
 pub mod mem_store;
 #[cfg(feature = "uds-gateway")]

--- a/iroh-one/src/main.rs
+++ b/iroh-one/src/main.rs
@@ -10,6 +10,7 @@ use iroh_one::{
     cli::Args,
     config::{Config, CONFIG_FILE_NAME, ENV_PREFIX},
 };
+use iroh_rpc_client::Client as RpcClient;
 use iroh_rpc_types::Addr;
 use iroh_util::{iroh_config_path, make_config};
 #[cfg(feature = "uds-gateway")]
@@ -79,7 +80,16 @@ async fn main() -> Result<()> {
         false => Arc::new(None),
     };
 
-    let shared_state = Core::make_state(Arc::new(config.clone()), Arc::clone(&bad_bits)).await?;
+    // let content_loader = RpcClient::new(config.rpc_client.clone()).await?;
+    let content_loader = iroh_one::content_loader::RacingLoader::new(
+        RpcClient::new(config.rpc_client.clone()).await?,
+    );
+    let shared_state = Core::make_state(
+        Arc::new(config.clone()),
+        Arc::clone(&bad_bits),
+        content_loader,
+    )
+    .await?;
 
     let handler = Core::new_with_state(rpc_addr, Arc::clone(&shared_state)).await?;
 

--- a/iroh-one/src/uds.rs
+++ b/iroh-one/src/uds.rs
@@ -8,6 +8,7 @@ use hyper::{
     server::accept::Accept,
 };
 use iroh_gateway::{core::State, handlers::get_app_routes};
+use iroh_resolver::resolver::ContentLoader;
 use std::path::PathBuf;
 use std::{
     io,
@@ -97,8 +98,8 @@ impl connect_info::Connected<&UnixStream> for UdsConnectInfo {
     }
 }
 
-pub fn uds_server(
-    state: Arc<State>,
+pub fn uds_server<T: ContentLoader + std::marker::Unpin>(
+    state: Arc<State<T>>,
     path: PathBuf,
 ) -> Option<
     Server<


### PR DESCRIPTION
The main change is to switch `iroh-gateway/src/client.rs#Client` to be:
`pub struct Client<T: ContentLoader>` and to sprinkle the generic and
other needed bounds where needed.

`iroh-one/src/content_loader.rs` showcases a custom content loader. For now it's
similar to the regular one without the gateway racing implementation.