### PR TITLE
Add iroh-one to CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
           profile-name: default
       - run:
           name: build aarch64 release
-          command: cargo build --release -v
+          command: cargo build --release -v --features=uds-gateway
       - push-to-s3:
           path: ./target/release/
           os: linux
@@ -405,7 +405,7 @@ jobs:
       - run:
           name: build x86_64_darwin
           no_output_timeout: 20m
-          command: cargo build --release -v
+          command: cargo build --release -v --features=uds-gateway
       - push-to-s3:
           path: ./target/release/
           os: darwin
@@ -423,7 +423,7 @@ jobs:
       - run:
           name: build aarch64_darwin
           no_output_timeout: 20m
-          command: cargo build --release -v --target aarch64-apple-darwin
+          command: cargo build --release -v --target aarch64-apple-darwin --features=uds-gateway
       - push-to-s3:
           path: ./target/aarch64-apple-darwin/release/
           os: darwin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,7 @@ commands:
               aws s3 cp <<parameters.path>>iroh-p2p s3://vorc/iroh-p2p-<<parameters.os>>-<<parameters.arch>>-${CIRCLE_SHA1::7} --no-progress
               aws s3 cp <<parameters.path>>iroh-store s3://vorc/iroh-store-<<parameters.os>>-<<parameters.arch>>-${CIRCLE_SHA1::7} --no-progress
               aws s3 cp <<parameters.path>>iroh-ctl s3://vorc/iroh-ctl-<<parameters.os>>-<<parameters.arch>>-${CIRCLE_SHA1::7} --no-progress
+              aws s3 cp <<parameters.path>>iroh-one s3://vorc/iroh-one-<<parameters.os>>-<<parameters.arch>>-${CIRCLE_SHA1::7} --no-progress
 
   push-to-s3-latest:
     parameters:
@@ -217,6 +218,7 @@ commands:
               aws s3 cp <<parameters.path>>iroh-p2p s3://vorc/iroh-p2p-<<parameters.os>>-<<parameters.arch>>-latest --no-progress
               aws s3 cp <<parameters.path>>iroh-store s3://vorc/iroh-store-<<parameters.os>>-<<parameters.arch>>-latest --no-progress
               aws s3 cp <<parameters.path>>iroh-ctl s3://vorc/iroh-ctl-<<parameters.os>>-<<parameters.arch>>-latest --no-progress
+              aws s3 cp <<parameters.path>>iroh-one s3://vorc/iroh-one-<<parameters.os>>-<<parameters.arch>>-latest --no-progress
 
 jobs:
   cargo_fetch:
@@ -348,7 +350,7 @@ jobs:
           profile-name: default
       - run:
           name: build x86_64 release
-          command: cargo build --release -v
+          command: cargo build --release -v --features=uds-gateway
       - push-to-s3:
           path: ./target/release/
           os: linux


### PR DESCRIPTION
- build with the 'uds-gateway' feature to catch build errors.
- push the iroh-one binary to S3.

Ping @Arqu 