### PR TITLE
Improve error management and reporting when using unix domain sockets

### DIFF
--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -34,8 +34,9 @@ impl Core {
         bad_bits: Arc<Option<RwLock<BadBits>>>,
     ) -> anyhow::Result<Self> {
         tokio::spawn(async move {
-            // TODO: handle error
-            rpc::new(rpc_addr, Gateway::default()).await
+            if let Err(err) = rpc::new(rpc_addr, Gateway::default()).await {
+                tracing::error!("Failed to run gateway rpc handler: {}", err);
+            }
         });
         let rpc_client = RpcClient::new(config.rpc_client().clone()).await?;
         let mut templates = HashMap::new();
@@ -58,8 +59,9 @@ impl Core {
         state: Arc<State>,
     ) -> anyhow::Result<Self> {
         tokio::spawn(async move {
-            // TODO: handle error
-            rpc::new(rpc_addr, Gateway::default()).await
+            if let Err(err) = rpc::new(rpc_addr, Gateway::default()).await {
+                tracing::error!("Failed to run gateway rpc handler: {}", err);
+            }
         });
         Ok(Self { state })
     }

--- a/iroh-one/src/config.rs
+++ b/iroh-one/src/config.rs
@@ -59,11 +59,11 @@ impl Config {
         }
     }
 
-    /// When running in ipfsd mode, the resolver will use memory channels to
+    /// When running in single binary mode, the resolver will use memory channels to
     /// communicate with the p2p and store modules.
     /// The gateway itself is exposing a UDS rpc endpoint to be also usable
     /// as a single entry point for other system services if feature enabled.
-    pub fn default_ipfsd() -> RpcClientConfig {
+    pub fn default_rpc_config() -> RpcClientConfig {
         #[cfg(feature = "uds-gateway")]
         let path: PathBuf = TempDir::new("iroh").unwrap().path().join("ipfsd.http");
 
@@ -92,14 +92,14 @@ impl Default for Config {
     fn default() -> Self {
         #[cfg(feature = "uds-gateway")]
         let gateway_uds_path: PathBuf = TempDir::new("iroh").unwrap().path().join("ipfsd.http");
-        let ipfsd = Self::default_ipfsd();
+        let rpc_client = Self::default_rpc_config();
         let metrics_config = MetricsConfig::default();
         Self {
-            rpc_client: ipfsd.clone(),
+            rpc_client: rpc_client.clone(),
             metrics: metrics_config.clone(),
             gateway: iroh_gateway::config::Config::default(),
-            store: default_store_config(ipfsd.clone(), metrics_config.clone()),
-            p2p: default_p2p_config(ipfsd, metrics_config),
+            store: default_store_config(rpc_client.clone(), metrics_config.clone()),
+            p2p: default_p2p_config(rpc_client, metrics_config),
             #[cfg(feature = "uds-gateway")]
             gateway_uds_path: Some(gateway_uds_path),
         }

--- a/iroh-rpc-types/src/macros.rs
+++ b/iroh-rpc-types/src/macros.rs
@@ -37,6 +37,15 @@ macro_rules! proxy {
                                 anyhow::bail!("cannot bind socket: already exists: {}", path.display());
                             }
                         }
+
+                        // If the parent directory doesn't exist, we'll fail to bind.
+                        // Create a more precise error to recognize that case.
+                        if let Some(parent) = path.parent() {
+                            if !parent.exists() {
+                                anyhow::bail!("socket parent directory doesn't exist: {}", parent.display());
+                            }
+                        }
+
                         // Delete file on close
                         struct UdsGuard(std::path::PathBuf);
                         impl Drop for UdsGuard {


### PR DESCRIPTION
Not perfect but improves the situation around the lines of what is discussed in https://github.com/n0-computer/iroh/issues/223

In general the default configuration is created first, and then overridden by other configuration sources so it's a bit annoying to know if we still use a default value or not, without adding flags to track that. I don't think the added complexity would be warranted.

r? @dignifiedquire 