### PR TITLE
Always delete an UDS file before binding it

### DIFF
--- a/iroh-rpc-types/src/macros.rs
+++ b/iroh-rpc-types/src/macros.rs
@@ -54,6 +54,14 @@ macro_rules! proxy {
                             }
                         }
 
+                        // We still need to remove the file before binding, because the above
+                        // guard won't run in some situations:
+                        // - crash
+                        // - Android start/stop
+                        // - device power loss
+                        // ...
+                        let _ = std::fs::remove_file(&path);
+
                         let uds = UnixListener::bind(&path)
                             .with_context(|| format!("failed to bind to {}", path.display()))?;
                         let _guard = UdsGuard(path.clone().into());


### PR DESCRIPTION
The RAII struct `UdsGuard` works well when the binary terminates normally but this is unfortunately not always the case:
- crashes.
- on Android, daemons restarted by the init system.
- power loss on mobile devices.

To avoid these failures, this patch forces the deletion before trying to bind the socket. This means that we don't really need the `UdsGuard` anymore -  let me know if I should also remove it. cc @dignifiedquire 