### PR TITLE
refactor: ignore clippy warnings for generated code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ jobs:
       - restore-sccache-cache
       - run:
           name: Run cargo clippy (default features)
-          command: cargo clippy --all --all-targets -- -A clippy::derive-partial-eq-without-eq -D warnings
+          command: cargo clippy --all --all-targets -- -D warnings
       - save-sccache-cache
 
   build_release_x86_64:

--- a/iroh-bitswap/src/behaviour.rs
+++ b/iroh-bitswap/src/behaviour.rs
@@ -91,7 +91,7 @@ pub struct Bitswap {
     config: BitswapConfig,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct BitswapConfig {
     pub session: SessionConfig,
 }
@@ -144,7 +144,7 @@ impl Bitswap {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
 pub enum HandlerEvent {
     Upgrade,

--- a/iroh-bitswap/src/message.rs
+++ b/iroh-bitswap/src/message.rs
@@ -10,13 +10,14 @@ use crate::error::BitswapError;
 use crate::prefix::Prefix;
 
 mod pb {
+    #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/bitswap_pb.rs"));
 }
 
 /// Priority of a wanted block.
 pub type Priority = i32;
 
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct Wantlist {
     /// Wanted blocks.
     want_blocks: AHashMap<Cid, Priority>,
@@ -112,7 +113,7 @@ impl Wantlist {
 }
 
 /// A bitswap message.
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct BitswapMessage {
     wantlist: Wantlist,
     /// List of blocks to send.
@@ -120,13 +121,15 @@ pub struct BitswapMessage {
     block_presences: Vec<BlockPresence>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockPresence {
     pub cid: Cid,
     pub typ: BlockPresenceType,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive,
+)]
 #[repr(i32)]
 pub enum BlockPresenceType {
     Have = 0,

--- a/iroh-bitswap/src/session.rs
+++ b/iroh-bitswap/src/session.rs
@@ -21,7 +21,7 @@ pub struct SessionManager {
     config: Config,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     /// Limit of how many providers are concurrently dialed.
     pub dial_concurrency_factor_providers: NonZeroU8,

--- a/iroh-car/src/header.rs
+++ b/iroh-car/src/header.rs
@@ -5,7 +5,7 @@ use ipld_cbor::DagCborCodec;
 use crate::error::Error;
 
 /// A car header.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CarHeader {
     V1(CarHeaderV1),
@@ -53,7 +53,7 @@ impl CarHeader {
 }
 
 /// CAR file header version 1.
-#[derive(Debug, Clone, Default, ipld::DagCbor, PartialEq)]
+#[derive(Debug, Clone, Default, ipld::DagCbor, PartialEq, Eq)]
 pub struct CarHeaderV1 {
     #[ipld]
     pub roots: Vec<Cid>,

--- a/iroh-gateway/src/response.rs
+++ b/iroh-gateway/src/response.rs
@@ -8,7 +8,7 @@ use crate::constants::*;
 
 pub const ERR_UNSUPPORTED_FORMAT: &str = "unsuported format";
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResponseFormat {
     Raw,
     Car,

--- a/iroh-metrics/src/config.rs
+++ b/iroh-metrics/src/config.rs
@@ -2,7 +2,7 @@ use config::{ConfigError, Map, Source, Value};
 use iroh_util::insert_into_config_map;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
     /// The name of the service. Should be the same as the Cargo package name.
     pub service_name: String,

--- a/iroh-metrics/src/lib.rs
+++ b/iroh-metrics/src/lib.rs
@@ -146,7 +146,7 @@ pub fn get_current_trace_id() -> TraceId {
         .trace_id()
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum Collector {
     #[cfg(feature = "gateway")]
     Gateway,

--- a/iroh-p2p/src/config.rs
+++ b/iroh-p2p/src/config.rs
@@ -32,7 +32,7 @@ pub const DEFAULT_BOOTSTRAP: &[&str] = &[
 // "/ip4/104.131.131.82/udp/4001/quic/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ", // mars.i.ipfs.io
 
 /// Libp2p config for the node.
-#[derive(PartialEq, Debug, Clone, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
 pub struct Libp2pConfig {
     /// Local address.
     pub listening_multiaddr: Multiaddr,

--- a/iroh-resolver/src/chunker.rs
+++ b/iroh-resolver/src/chunker.rs
@@ -10,7 +10,7 @@ pub const DEFAULT_CHUNKS_SIZE: usize = 1024 * 256;
 /// Chunks are limited to 1MiB by default
 pub const DEFAULT_CHUNK_SIZE_LIMIT: usize = 1024 * 1024;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Chunker {
     /// Chunker that splits the given content
     FixedSize { chunk_size: usize },

--- a/iroh-resolver/src/unixfs.rs
+++ b/iroh-resolver/src/unixfs.rs
@@ -21,10 +21,12 @@ use crate::{
 };
 
 pub(crate) mod unixfs_pb {
+    #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/unixfs_pb.rs"));
 }
 
 pub(crate) mod dag_pb {
+    #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/merkledag_pb.rs"));
 }
 

--- a/iroh-share/src/p2p_node.rs
+++ b/iroh-share/src/p2p_node.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::Receiver;
 use tokio::{sync::Mutex, task::JoinHandle};
 use tracing::{error, warn};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ticket {
     pub peer_id: PeerId,
     pub addrs: Vec<Multiaddr>,

--- a/stores/flatfs/src/flatfs.rs
+++ b/stores/flatfs/src/flatfs.rs
@@ -241,7 +241,7 @@ impl Flatfs {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KvStats {
     pub key: String,
     pub size: u64,


### PR DESCRIPTION
Also, as per
https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq derive `Eq` in any public struct that also impls `PartialEq`.