### PR TITLE
Remove invalid If-Modified-Since header

### DIFF
--- a/iroh-gateway/src/headers.rs
+++ b/iroh-gateway/src/headers.rs
@@ -61,7 +61,6 @@ pub fn add_cache_control_headers(headers: &mut HeaderMap, metadata: Metadata) {
             HeaderValue::from_str(&lmdt.to_string()).unwrap(),
         );
     } else {
-        headers.insert(LAST_MODIFIED, HeaderValue::from_str("0").unwrap());
         headers.insert(CACHE_CONTROL, VAL_IMMUTABLE_MAX_AGE.clone());
     }
 }


### PR DESCRIPTION
"0" is not a valid value (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified) and for ipfs/ fetches the etag header and the immutable cache control value give the proper caching behavior from browsers.