### PR TITLE
Write some basic documentation for the various iroh crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Iroh is a next-generation implementation of the Interplanetary File System ([IPF
 IPFS is a networking protocol for exchanging _content-addressed_ blocks of immutable data. “Content-addressed” means referring to data by the *hash of its content*, which makes the reference unique and verifiable. These two properties make it possible to get data from *any* node in the network that speaks the IPFS protocol, including IPFS content being served by other implementations of IPFS.
 
 This repo is a common core for three distributions of iroh:
+
 - **Iroh Cloud:** core features of iroh split into configurable microservices, optimized for running at datacenter scale.
 - **Iroh One:** A select set of iroh cloud features packaged as a single binary for simplified deployment.
 - **Iroh Mobile:** iOS & Android libraries that bring efficient data distribution to mobile apps.
@@ -13,7 +14,14 @@ This repo is a common core for three distributions of iroh:
 
 Iroh has yet to publish a release. We are targeting the end of October 2022 for an initial version, which will coincide with the launch of a proper web site & documentation. Before iroh's first release we're in build-from-source and read-source-to-understand-how-it-works territory.
 
-In the meantime, there's a [quickstart guide](./quickstart.md) if you'd like to get a feel for running an iroh cloud gateway. 
+In the meantime, there's a [quickstart guide](./quickstart.md) if you'd like to get a feel for running an iroh cloud gateway.
+
+## Building
+
+To build Iroh, you need a recent version of Rust installed. [Rustup](https://rustup.rs/) is the recommended way to do that.
+
+You also need a recent version of the [Protobuf compiler](https://github.com/protocolbuffers/protobuf#protocol-compiler-installation).
+Download it from the [Protobuf Releases page](https://github.com/protocolbuffers/protobuf/releases); you need to get the `protoc-` release for your platform. To install, make sure the `protoc` compiler is on your path. If you get errors during build about `experimental_allow_proto3_optional` or inability to import `/google/protobuf/empty.proto` you're likely using a version of the compiler that's too old.
 
 ## Benchmarks
 

--- a/iroh-bitswap/README.md
+++ b/iroh-bitswap/README.md
@@ -1,7 +1,11 @@
 # iroh-p2p
 
-> Implementation of the IPFS bitswap protocol.
+This contains an implementation of the [IPFS bitswap
+protocol](https://docs.ipfs.tech/concepts/bitswap/). It sends blocks of data to
+other peers in the IPFS network who want them, and receives blocks requested by
+the client from the network.
 
+It is part of [iroh](https://github.com/n0-computer/iroh).
 
 ## License
 

--- a/iroh-car/README.md
+++ b/iroh-car/README.md
@@ -1,8 +1,14 @@
 # iroh-car
 
-> [CAR file](https://ipld.io/specs/transport/car/) support for iroh.
+[CAR file](https://ipld.io/specs/transport/car/) support for iroh. "CAR" stands
+for Content Addressable aRchives. A CAR file typically contains a serialized
+representation of an [IPLD
+DAG](https://docs.ipfs.tech/concepts/merkle-dag/#merkle-directed-acyclic-graphs-dags),
+though is general enough to contain arbitrary IPLD blocks.
 
 Currently supports only [v1](https://ipld.io/specs/transport/car/carv1/).
+
+It is part of [iroh](https://github.com/n0-computer/iroh).
 
 ## License
 

--- a/iroh-ctl/README.md
+++ b/iroh-ctl/README.md
@@ -1,8 +1,14 @@
-# iroh-share
+# iroh-ctl
 
-This provides an application that lets you easily share files accross devices
-using [iroh](https://github.com/n0-computer/iroh) and
-[IPFS](https://ipfs.tech/).
+This contains the implementation of a command-line tool for controlling
+[iroh](https://github.com/n0-computer/iroh).
+
+## usage
+
+```
+// Track the status of your different iroh processes
+$ iroh-ctl status --watch
+```
 
 ## License
 
@@ -18,4 +24,3 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
 </sub>
-

--- a/iroh-gateway/README.md
+++ b/iroh-gateway/README.md
@@ -1,6 +1,9 @@
 # Iroh Gateway
 
-A rust implementation of an IPFS gateway.
+A Rust implementation of an [IPFS
+gateway](https://docs.ipfs.tech/concepts/ipfs-gateway/) based on
+[iroh](https://github.com/n0-computer/iroh). An IPFS gateway allows you to
+access content on the IPFS network over HTTP.
 
 ## Running / Building
 

--- a/iroh-gateway/src/headers.rs
+++ b/iroh-gateway/src/headers.rs
@@ -61,7 +61,6 @@ pub fn add_cache_control_headers(headers: &mut HeaderMap, metadata: Metadata) {
             HeaderValue::from_str(&lmdt.to_string()).unwrap(),
         );
     } else {
-        headers.insert(LAST_MODIFIED, HeaderValue::from_str("0").unwrap());
         headers.insert(CACHE_CONTROL, VAL_IMMUTABLE_MAX_AGE.clone());
     }
 }

--- a/iroh-metrics/README.md
+++ b/iroh-metrics/README.md
@@ -1,6 +1,7 @@
 # Iroh Metrics
 
-The metrics collection interface for iroh services.
+The metrics collection interface for
+[iroh](https://github.com/n0-computer/iroh) services.
 
 ## ENV Variables
 

--- a/iroh-one/README.md
+++ b/iroh-one/README.md
@@ -1,6 +1,11 @@
 # Iroh One
 
-Single binary of iroh services (gateway, p2p, store) communicating via mem channels.
+Single binary of [iroh](https://github.com/n0-computer/iroh) services
+([gateway](https://github.com/n0-computer/iroh/tree/main/iroh-gateway),
+[p2p](https://github.com/n0-computer/iroh/tree/main/iroh-p2p),
+[store](https://github.com/n0-computer/iroh/tree/main/iroh-store))
+communicating via mem channels. This is an alternative to deploying the iroh
+services as micro services.
 
 ## Running / Building
 

--- a/iroh-p2p/README.md
+++ b/iroh-p2p/README.md
@@ -1,7 +1,8 @@
 # iroh-p2p
 
-> P2P networking for iroh.
-
+P2P networking for [iroh](https://github.com/n0-computer/iroh). This implements
+an [IPFS node](https://docs.ipfs.tech/concepts/nodes/). The IPFS network
+consists of a collection of nodes.
 
 ## How to run
 

--- a/iroh-resolver/README.md
+++ b/iroh-resolver/README.md
@@ -1,7 +1,15 @@
 # iroh-resolver
 
-> Resolver for iroh.
+Resolver for [iroh](https://github.com/n0-computer/iroh). It retrieves data
+associated with an IPFS CID from the [iroh
+store](https://github.com/n0-computer/iroh/tree/main/iroh-store), or if not
+available, uses [iroh
+p2p](https://github.com/n0-computer/iroh/tree/main/iroh-p2p) to retrieve it
+from the IPFS network. 
 
+This crate also provides a way to take a directory of files, or a single file,
+and chunk it into smaller parts that can be stored, and assemble them back
+together again.
 
 ## License
 

--- a/iroh-rpc-client/README.md
+++ b/iroh-rpc-client/README.md
@@ -1,0 +1,28 @@
+# iroh-rpc-client
+
+[iroh](https://github.com/n0-computer/iroh) services internally communicate via
+RPC, using the [gRPC protocol](https://grpc.io/) and [protocol
+buffers](https://developers.google.com/protocol-buffers). This crate provides
+an RPC client that can be used to talk to an [iroh
+gateway](https://github.com/n0-computer/iroh/tree/main/iroh-gateway), an [iroh
+p2p node](https://github.com/n0-computer/iroh/tree/main/iroh-p2p), and the
+[iroh store](https://github.com/n0-computer/iroh/tree/main/iroh-store). 
+
+The types that define the RPC protocol are maintained in
+[iroh-rpc-types](https://github.com/n0-computer/iroh/tree/main/iroh-rpc-types).
+
+## License
+
+<sup>
+Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
+2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
+</sup>
+
+<br/>
+
+<sub>
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.
+</sub>
+

--- a/iroh-rpc-types/README.md
+++ b/iroh-rpc-types/README.md
@@ -1,0 +1,24 @@
+# iroh-rpc-types
+
+This crate defines types for use by the
+[iroh-rpc-client](https://github.com/n0-computer/iroh/tree/main/iroh-rpc-client),
+which is used for [iroh](https://github.com/n0-computer/iroh) services to
+communicate internally via RPC. The protocol used is [gRPC](https://grpc.io/).
+This crate defines the gRPC types in the form of [Protocol
+Buffers](https://developers.google.com/protocol-buffers). It uses the [Tonic
+framework](https://github.com/hyperium/tonic) to expose the gRPC types to Rust.
+
+## License
+
+<sup>
+Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
+2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
+</sup>
+
+<br/>
+
+<sub>
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.
+</sub>

--- a/iroh-store/README.md
+++ b/iroh-store/README.md
@@ -1,7 +1,7 @@
 # iroh-store
 
-> Storage for iroh.
-
+Storage for [iroh](https://github.com/n0-computer/iroh). This provides an gRPC
+API for storing IPFS data in a [RocksDB database](http://rocksdb.org/).
 
 ## How to run
 

--- a/iroh-util/README.md
+++ b/iroh-util/README.md
@@ -1,13 +1,7 @@
-# iroh-ctl
+# iroh-util
 
-> Communicate with the different iroh processes
-
-## usage
-
-```
-// Track the status of your different iroh processes
-$ iroh-ctl status --watch
-```
+Utility functions for [iroh](https://github.com/n0-computer/iroh). This
+provides shared functionality to be used in other iroh crates.
 
 ## License
 
@@ -23,3 +17,4 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
 </sub>
+


### PR DESCRIPTION
When I was going through the iroh crates I noticed that the readmes were rather minimal or absent. Now each iroh crate (except `iroh` itself which is still empty) contains a basic README with some explanation of what's going on on. This is to the best of my knowledge, so this is also a way to test my knowledge - please comment where I'm wrong to improve my understanding.
