### PR TITLE
feat: introduce an Api trait and its implementation

### DIFF
--- a/iroh-resolver/Cargo.toml
+++ b/iroh-resolver/Cargo.toml
@@ -16,7 +16,7 @@ prost = "0.11"
 bytes = "1.1.0"
 iroh-rpc-client = { path = "../iroh-rpc-client", default-features = false }
 iroh-util = { path = "../iroh-util", default-features = false }
-tokio = { version = "1" }
+tokio = { version = "1", features = ["fs"] }
 futures = "0.3.21"
 tracing = "0.1.34"
 async-trait = "0.1.53"

--- a/iroh-rpc-client/src/lib.rs
+++ b/iroh-rpc-client/src/lib.rs
@@ -11,5 +11,7 @@ mod store;
 
 pub use crate::client::Client;
 pub use crate::config::Config;
+pub use crate::network::P2pClient;
 #[cfg(feature = "grpc")]
 pub use crate::status::{ServiceStatus, StatusRow, StatusTable};
+pub use crate::store::StoreClient;

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -16,3 +16,6 @@ async-trait = "0.1.53"
 tokio = { version = "1" }
 bytes = "1.1.0"
 libp2p = "0.48"
+tracing = "0.1.34"
+futures = "0.3.21"
+async-stream = "0.3.3"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -7,4 +7,12 @@ readme = "README.md"
 description = "coming soon"
 
 [dependencies]
-
+cid = "0.8.5"
+iroh-resolver = { path = "../iroh-resolver" }
+iroh-rpc-types = { path = "../iroh-rpc-types" }
+iroh-rpc-client = { path = "../iroh-rpc-client" }
+anyhow = "1"
+async-trait = "0.1.53"
+tokio = { version = "1" }
+bytes = "1.1.0"
+libp2p = "0.48"

--- a/iroh/src/api.rs
+++ b/iroh/src/api.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 use cid::Cid;
+use iroh_resolver::resolver::Path as IpfsPath;
 use libp2p::gossipsub::MessageId;
 use libp2p::{Multiaddr, PeerId};
 
@@ -29,8 +30,8 @@ pub trait Accessors<P: P2p, S: Store> {
 
 #[async_trait]
 pub trait GetAdd {
-    async fn get(&self, cid: &Cid, path: &Path) -> Result<()>;
-    async fn add(&self, path: &Path) -> Result<Cid>;
+    async fn get(&self, ipfs_path: &IpfsPath, output_path: Option<&Path>) -> Result<()>;
+    async fn add(&self, path: &Path, recursive: bool, no_wrap: bool) -> Result<Cid>;
 }
 
 impl<T: Accessors<P, S> + GetAdd, P: P2p, S: Store> Api<P, S> for T {}

--- a/iroh/src/api.rs
+++ b/iroh/src/api.rs
@@ -1,0 +1,104 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use cid::Cid;
+use libp2p::gossipsub::MessageId;
+use libp2p::{Multiaddr, PeerId};
+
+pub struct Id {
+    pub peer_id: PeerId,
+    pub listen_addrs: Vec<Multiaddr>,
+    pub local_addrs: Vec<Multiaddr>,
+}
+
+#[derive(Debug)]
+pub enum Ping {
+    PeerId(PeerId),
+    Multiaddr(Multiaddr),
+}
+
+pub trait Api<P: P2p, S: Store>: Main + Accessors<P, S> + GetAdd {}
+
+#[async_trait]
+pub trait Main {
+    async fn version(&self) -> Result<String>;
+}
+
+#[async_trait]
+pub trait Accessors<P: P2p, S: Store> {
+    fn p2p(&self) -> Result<P>;
+    fn store(&self) -> Result<S>;
+}
+
+#[async_trait]
+pub trait GetAdd {
+    // XXX get and add are centered around the filesystem.
+    // We can imagine an underlying version that produces a stream of
+    // Out as well.
+    async fn get(&self, cid: &Cid, path: &Path) -> Result<()>;
+    async fn add(&self, path: &Path) -> Result<Cid>;
+}
+
+impl<T: Main + Accessors<P, S> + GetAdd, P: P2p, S: Store> Api<P, S> for T {}
+
+#[async_trait]
+pub trait P2pConnectDisconnect {
+    async fn connect(&self, peer_id: &PeerId, addrs: &[Multiaddr]) -> Result<()>;
+    async fn disconnect(&self, peer_id: &PeerId) -> Result<()>;
+}
+
+// XXX the std::marker::Sync worries me - it's required to be able to use
+// peers from the implementation of peer_ids
+#[async_trait]
+pub trait P2pId: std::marker::Sync {
+    async fn p2p_version(&self) -> Result<String>;
+    async fn local_peer_id(&self) -> Result<PeerId>;
+    async fn addrs_listen(&self) -> Result<Vec<Multiaddr>>;
+    async fn addrs_local(&self) -> Result<Vec<Multiaddr>>;
+    // can be implemented on the trait itself as it combines others
+    async fn id(&self) -> Result<Id>;
+    // async fn addrs gets a map right now
+    async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>>;
+    async fn peer_ids(&self) -> Result<Vec<PeerId>> {
+        let map = self.peers().await?;
+        Ok(map.into_keys().collect())
+    }
+    async fn ping(&self, ping_args: &[Ping], count: usize) -> Result<()>;
+}
+
+#[async_trait]
+pub trait P2pFetch {
+    async fn fetch_bitswap(&self, cid: &Cid, providers: &[PeerId]) -> Result<Bytes>;
+    async fn fetch_providers(&self, cid: &Cid) -> Result<HashSet<PeerId>>;
+}
+
+#[async_trait]
+pub trait P2pGossipsub {
+    async fn publish(&self, topic: &str, file: Option<&Path>) -> Result<MessageId>;
+    async fn subscribe(&self, topic: &str) -> Result<bool>;
+    async fn unsubscribe(&self, topic: &str) -> Result<bool>;
+}
+
+pub trait P2p: P2pConnectDisconnect + P2pId + P2pFetch + P2pGossipsub {}
+
+impl<T: P2pConnectDisconnect + P2pId + P2pFetch + P2pGossipsub> P2p for T {}
+
+#[async_trait]
+pub trait StoreMain {
+    async fn store_version(&self) -> Result<String>;
+    async fn get_links(&self, cid: &Cid) -> Result<Option<Vec<Cid>>>;
+}
+
+#[async_trait]
+pub trait StoreBlock {
+    async fn block_get(&self, cid: &Cid) -> Result<Option<Bytes>>;
+    async fn block_put(&self, data: &Bytes) -> Result<Cid>;
+    async fn block_has(&self, cid: &Cid) -> Result<bool>;
+}
+
+pub trait Store: StoreMain + StoreBlock {}
+
+impl<T: StoreMain + StoreBlock> Store for T {}

--- a/iroh/src/api.rs
+++ b/iroh/src/api.rs
@@ -43,7 +43,7 @@ pub trait P2pConnectDisconnect {
 }
 
 #[async_trait]
-pub trait P2pId: std::marker::Sync {
+pub trait P2pId: Sync {
     async fn p2p_version(&self) -> Result<String>;
     async fn local_peer_id(&self) -> Result<PeerId>;
     async fn addrs_listen(&self) -> Result<Vec<Multiaddr>>;

--- a/iroh/src/api.rs
+++ b/iroh/src/api.rs
@@ -28,8 +28,8 @@ pub trait Accessors<P: P2p, S: Store> {
     fn store(&self) -> Result<S>;
 }
 
-#[async_trait]
-pub trait GetAdd {
+#[async_trait(?Send)]
+pub trait GetAdd: std::marker::Sync + std::marker::Send {
     async fn get(&self, ipfs_path: &IpfsPath, output_path: Option<&Path>) -> Result<()>;
     async fn add(&self, path: &Path, recursive: bool, no_wrap: bool) -> Result<Cid>;
 }

--- a/iroh/src/api.rs
+++ b/iroh/src/api.rs
@@ -29,7 +29,7 @@ pub trait Accessors<P: P2p, S: Store> {
 }
 
 #[async_trait(?Send)]
-pub trait GetAdd: std::marker::Sync + std::marker::Send {
+pub trait GetAdd {
     async fn get(&self, ipfs_path: &IpfsPath, output_path: Option<&Path>) -> Result<()>;
     async fn add(&self, path: &Path, recursive: bool, no_wrap: bool) -> Result<Cid>;
 }

--- a/iroh/src/clientapi.rs
+++ b/iroh/src/clientapi.rs
@@ -18,9 +18,8 @@ pub struct ClientApi<'a> {
 }
 
 impl<'a> ClientApi<'a> {
-    // what are the Rust conventions for an async new?
-    pub async fn new(client: &'a Client) -> Result<ClientApi<'a>> {
-        Ok(ClientApi { rpc: client })
+    pub fn new(client: &'a Client) -> ClientApi<'a> {
+        ClientApi { rpc: client }
     }
 }
 
@@ -32,7 +31,6 @@ pub struct ClientStore<'a> {
     rpc: &'a StoreClient,
 }
 
-#[async_trait]
 impl<'a> api::Accessors<ClientP2p<'a>, ClientStore<'a>> for ClientApi<'a> {
     fn p2p(&self) -> Result<ClientP2p<'a>> {
         Ok(ClientP2p {
@@ -44,15 +42,6 @@ impl<'a> api::Accessors<ClientP2p<'a>, ClientStore<'a>> for ClientApi<'a> {
         Ok(ClientStore {
             rpc: self.rpc.try_store()?,
         })
-    }
-}
-
-#[async_trait]
-impl<'a> api::Main for ClientApi<'a> {
-    // XXX what's up with version in the existing iroh-cli implementation? is it automatically
-    // implemented by clap? What should it be?
-    async fn version(&self) -> Result<String> {
-        Ok("0.0.0".to_string())
     }
 }
 
@@ -95,7 +84,7 @@ impl<'a> api::P2pId for ClientP2p<'a> {
     }
 
     async fn addrs_listen(&self) -> Result<Vec<Multiaddr>> {
-        let (_peer_id, addrs) = self.rpc.get_listening_addrs().await?;
+        let (_, addrs) = self.rpc.get_listening_addrs().await?;
         Ok(addrs)
     }
 

--- a/iroh/src/clientapi.rs
+++ b/iroh/src/clientapi.rs
@@ -2,12 +2,12 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::api;
+use crate::getadd::{add, get};
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 use cid::Cid;
 use iroh_resolver::resolver::Path as IpfsPath;
-use iroh_resolver::{resolver, unixfs_builder};
 use iroh_rpc_client::{Client, P2pClient, StoreClient};
 use libp2p::{
     gossipsub::{MessageId, TopicHash},
@@ -47,14 +47,14 @@ impl<'a> api::Accessors<ClientP2p<'a>, ClientStore<'a>> for ClientApi<'a> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a> api::GetAdd for ClientApi<'a> {
     async fn get(&self, ipfs_path: &IpfsPath, output: Option<&Path>) -> Result<()> {
-        todo!("awaits integration");
+        get(self.rpc, ipfs_path, output).await
     }
 
     async fn add(&self, path: &Path, recursive: bool, no_wrap: bool) -> Result<Cid> {
-        todo!("awaits integration");
+        add(self.rpc, path, recursive, no_wrap).await
     }
 }
 

--- a/iroh/src/clientapi.rs
+++ b/iroh/src/clientapi.rs
@@ -1,0 +1,187 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use crate::api;
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use cid::Cid;
+use iroh_rpc_client::{Client, P2pClient, StoreClient};
+use libp2p::{
+    gossipsub::{MessageId, TopicHash},
+    Multiaddr, PeerId,
+};
+use tokio::{fs::File, io::stdin, io::AsyncReadExt};
+
+pub struct ClientApi<'a> {
+    rpc: &'a Client,
+}
+
+impl<'a> ClientApi<'a> {
+    // what are the Rust conventions for an async new?
+    pub async fn new(client: &'a Client) -> Result<ClientApi<'a>> {
+        Ok(ClientApi { rpc: client })
+    }
+}
+
+pub struct ClientP2p<'a> {
+    rpc: &'a P2pClient,
+}
+
+pub struct ClientStore<'a> {
+    rpc: &'a StoreClient,
+}
+
+#[async_trait]
+impl<'a> api::Accessors<ClientP2p<'a>, ClientStore<'a>> for ClientApi<'a> {
+    fn p2p(&self) -> Result<ClientP2p<'a>> {
+        Ok(ClientP2p {
+            rpc: self.rpc.try_p2p()?,
+        })
+    }
+
+    fn store(&self) -> Result<ClientStore<'a>> {
+        Ok(ClientStore {
+            rpc: self.rpc.try_store()?,
+        })
+    }
+}
+
+#[async_trait]
+impl<'a> api::Main for ClientApi<'a> {
+    // XXX what's up with version in the existing iroh-cli implementation? is it automatically
+    // implemented by clap? What should it be?
+    async fn version(&self) -> Result<String> {
+        Ok("0.0.0".to_string())
+    }
+}
+
+#[async_trait]
+impl<'a> api::GetAdd for ClientApi<'a> {
+    // XXX this awaits ramfox's work in the resolver
+    async fn get(&self, cid: &Cid, output: &Path) -> Result<()> {
+        todo!("{:?} {:?}", cid, output);
+    }
+
+    async fn add(&self, path: &Path) -> Result<Cid> {
+        todo!("{:?}", path);
+    }
+}
+
+#[async_trait]
+impl<'a> api::P2pConnectDisconnect for ClientP2p<'a> {
+    async fn connect(&self, peer_id: &PeerId, addrs: &[Multiaddr]) -> Result<()> {
+        self.rpc.connect(*peer_id, addrs.to_vec()).await
+    }
+
+    async fn disconnect(&self, peer_id: &PeerId) -> Result<()> {
+        self.rpc.disconnect(*peer_id).await
+    }
+}
+
+#[async_trait]
+impl<'a> api::P2pId for ClientP2p<'a> {
+    async fn p2p_version(&self) -> Result<String> {
+        self.rpc.version().await
+    }
+
+    async fn local_peer_id(&self) -> Result<PeerId> {
+        todo!("Need to port local_peer_id from branch");
+        // self.rpc.try_p2p()?.local_peer_id().await
+    }
+
+    async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>> {
+        self.rpc.get_peers().await
+    }
+
+    async fn addrs_listen(&self) -> Result<Vec<Multiaddr>> {
+        let (_peer_id, addrs) = self.rpc.get_listening_addrs().await?;
+        Ok(addrs)
+    }
+
+    async fn addrs_local(&self) -> Result<Vec<Multiaddr>> {
+        todo!("Need to port external_addresses from branch");
+        // self.rpc.try_p2p()?.external_addresses().await
+    }
+
+    async fn id(&self) -> Result<api::Id> {
+        Ok(api::Id {
+            peer_id: self.local_peer_id().await?,
+            listen_addrs: self.addrs_listen().await?,
+            local_addrs: self.addrs_local().await?,
+        })
+    }
+
+    async fn ping(&self, ping_args: &[api::Ping], count: usize) -> Result<()> {
+        todo!("{:?} {:?}", ping_args, count);
+    }
+}
+
+#[async_trait]
+impl<'a> api::P2pFetch for ClientP2p<'a> {
+    async fn fetch_bitswap(&self, cid: &Cid, providers: &[PeerId]) -> Result<Bytes> {
+        let providers: HashSet<PeerId> = providers.iter().cloned().collect();
+        self.rpc.fetch_bitswap(*cid, providers).await
+    }
+
+    async fn fetch_providers(&self, cid: &Cid) -> Result<HashSet<PeerId>> {
+        self.rpc.fetch_providers(cid).await
+    }
+}
+
+#[async_trait]
+impl<'a> api::P2pGossipsub for ClientP2p<'a> {
+    async fn publish(&self, topic: &str, file: Option<&Path>) -> Result<MessageId> {
+        let mut v: Vec<u8> = Vec::new();
+        if let Some(file) = file {
+            let mut f = File::open(file).await?;
+            f.read_to_end(&mut v).await?;
+        } else {
+            stdin().read_to_end(&mut v).await?;
+        }
+        self.rpc
+            .gossipsub_publish(TopicHash::from_raw(topic), Bytes::from(v))
+            .await
+    }
+
+    async fn subscribe(&self, topic: &str) -> Result<bool> {
+        self.rpc
+            .gossipsub_subscribe(TopicHash::from_raw(topic))
+            .await
+    }
+
+    async fn unsubscribe(&self, topic: &str) -> Result<bool> {
+        self.rpc
+            .gossipsub_unsubscribe(TopicHash::from_raw(topic))
+            .await
+    }
+}
+
+#[async_trait]
+impl<'a> api::StoreMain for ClientStore<'a> {
+    async fn store_version(&self) -> Result<String> {
+        self.rpc.version().await
+    }
+
+    async fn get_links(&self, cid: &Cid) -> Result<Option<Vec<Cid>>> {
+        self.rpc.get_links(*cid).await
+    }
+}
+
+#[async_trait]
+impl<'a> api::StoreBlock for ClientStore<'a> {
+    async fn block_get(&self, cid: &Cid) -> Result<Option<Bytes>> {
+        self.rpc.get(*cid).await
+    }
+
+    async fn block_put(&self, data: &Bytes) -> Result<Cid> {
+        // this awaits ramfox's work in the resolver
+        // would be nice if that work only relied on the store and not
+        // on the full client
+        todo!("not yet")
+    }
+
+    async fn block_has(&self, cid: &Cid) -> Result<bool> {
+        self.rpc.has(*cid).await
+    }
+}

--- a/iroh/src/clientapi.rs
+++ b/iroh/src/clientapi.rs
@@ -6,6 +6,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 use cid::Cid;
+use iroh_resolver::resolver::Path as IpfsPath;
+use iroh_resolver::{resolver, unixfs_builder};
 use iroh_rpc_client::{Client, P2pClient, StoreClient};
 use libp2p::{
     gossipsub::{MessageId, TopicHash},
@@ -47,13 +49,12 @@ impl<'a> api::Accessors<ClientP2p<'a>, ClientStore<'a>> for ClientApi<'a> {
 
 #[async_trait]
 impl<'a> api::GetAdd for ClientApi<'a> {
-    // XXX this awaits ramfox's work in the resolver
-    async fn get(&self, cid: &Cid, output: &Path) -> Result<()> {
-        todo!("{:?} {:?}", cid, output);
+    async fn get(&self, ipfs_path: &IpfsPath, output: Option<&Path>) -> Result<()> {
+        todo!("awaits integration");
     }
 
-    async fn add(&self, path: &Path) -> Result<Cid> {
-        todo!("{:?}", path);
+    async fn add(&self, path: &Path, recursive: bool, no_wrap: bool) -> Result<Cid> {
+        todo!("awaits integration");
     }
 }
 

--- a/iroh/src/clientapi.rs
+++ b/iroh/src/clientapi.rs
@@ -174,7 +174,7 @@ impl<'a> api::StoreBlock for ClientStore<'a> {
         self.rpc.get(*cid).await
     }
 
-    async fn block_put(&self, data: &Bytes) -> Result<Cid> {
+    async fn block_put(&self, _data: &Bytes) -> Result<Cid> {
         // this awaits ramfox's work in the resolver
         // would be nice if that work only relied on the store and not
         // on the full client

--- a/iroh/src/clientapi.rs
+++ b/iroh/src/clientapi.rs
@@ -76,8 +76,7 @@ impl<'a> api::P2pId for ClientP2p<'a> {
     }
 
     async fn local_peer_id(&self) -> Result<PeerId> {
-        todo!("Need to port local_peer_id from branch");
-        // self.rpc.try_p2p()?.local_peer_id().await
+        self.rpc.local_peer_id().await
     }
 
     async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>> {
@@ -90,8 +89,7 @@ impl<'a> api::P2pId for ClientP2p<'a> {
     }
 
     async fn addrs_local(&self) -> Result<Vec<Multiaddr>> {
-        todo!("Need to port external_addresses from branch");
-        // self.rpc.try_p2p()?.external_addresses().await
+        self.rpc.external_addresses().await
     }
 
     async fn id(&self) -> Result<api::Id> {

--- a/iroh/src/getadd.rs
+++ b/iroh/src/getadd.rs
@@ -1,0 +1,132 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use cid::Cid;
+use futures::Stream;
+use futures::StreamExt;
+use iroh_resolver::resolver::Path as IpfsPath;
+use iroh_resolver::{resolver, unixfs_builder};
+use iroh_rpc_client::Client;
+
+pub async fn get(client: &Client, ipfs_path: &IpfsPath, output: Option<&Path>) -> Result<()> {
+    let blocks = get_stream(client.clone(), ipfs_path, output.map(|p| p.to_path_buf()));
+    tokio::pin!(blocks);
+    while let Some(block) = blocks.next().await {
+        let (path, out) = block?;
+        match out {
+            OutType::Dir => {
+                tokio::fs::create_dir_all(path).await?;
+            }
+            OutType::Reader(mut reader) => {
+                if let Some(parent) = path.parent() {
+                    tokio::fs::create_dir_all(parent).await?;
+                }
+                let mut f = tokio::fs::File::create(path).await?;
+                tokio::io::copy(&mut reader, &mut f).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn add(client: &Client, path: &Path, recursive: bool, wrap: bool) -> Result<Cid> {
+    let providing_client = iroh_resolver::unixfs_builder::StoreAndProvideClient {
+        client: Box::new(client),
+    };
+    if path.is_dir() {
+        unixfs_builder::add_dir(Some(&providing_client), path, wrap, recursive).await
+    } else if path.is_file() {
+        unixfs_builder::add_file(Some(&providing_client), path, wrap).await
+    } else {
+        anyhow::bail!("can only add files or directories");
+    }
+}
+
+pub enum OutType<T: resolver::ContentLoader> {
+    Dir,
+    Reader(resolver::OutPrettyReader<T>),
+}
+
+pub fn get_stream<'a>(
+    client: Client,
+    root: &'a IpfsPath,
+    output: Option<PathBuf>,
+) -> impl Stream<Item = Result<(PathBuf, OutType<Client>)>> + 'a {
+    tracing::debug!("get {:?}", root);
+    let resolver = iroh_resolver::resolver::Resolver::new(client);
+    let results = resolver.resolve_recursive_with_paths(root.clone());
+    async_stream::try_stream! {
+        tokio::pin!(results);
+        while let Some(res) = results.next().await {
+            let (path, out) = res?;
+            let path = make_output_path(path, root.clone(), output.clone())?;
+            if out.is_dir() {
+                yield (path, OutType::Dir);
+            } else {
+                let reader = out.pretty(resolver.clone(), Default::default())?;
+                yield (path, OutType::Reader(reader));
+            }
+        }
+    }
+}
+
+// make_output_path adjusts the full path to replace the root with any given output path
+// if it exists
+fn make_output_path(full: IpfsPath, root: IpfsPath, output: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(ref output) = output {
+        let root_str = &root.to_string()[..];
+        let full_as_path = PathBuf::from(full.to_string());
+        let path_str = full_as_path.to_str().context("invalid root path")?;
+        let output_str = output.to_str().context("invalid output path")?;
+        Ok(PathBuf::from(path_str.replace(root_str, output_str)))
+    } else {
+        // returns path as a string
+        Ok(PathBuf::from(full.to_string_without_type()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_make_output_path() {
+        // test with output dir
+        let root =
+            IpfsPath::from_str("/ipfs/QmYbcW4tXLXHWw753boCK8Y7uxLu5abXjyYizhLznq9PUR").unwrap();
+        let full =
+            IpfsPath::from_str("/ipfs/QmYbcW4tXLXHWw753boCK8Y7uxLu5abXjyYizhLznq9PUR/bar.txt")
+                .unwrap();
+        let output = Some(PathBuf::from("foo"));
+        let expect = PathBuf::from("foo/bar.txt");
+        let got = make_output_path(full, root, output).unwrap();
+        assert_eq!(expect, got);
+
+        // test with output filepath
+        let root = resolver::Path::from_str(
+            "/ipfs/QmYbcW4tXLXHWw753boCK8Y7uxLu5abXjyYizhLznq9PUR/bar.txt",
+        )
+        .unwrap();
+        let full = resolver::Path::from_str(
+            "/ipfs/QmYbcW4tXLXHWw753boCK8Y7uxLu5abXjyYizhLznq9PUR/bar.txt",
+        )
+        .unwrap();
+        let output = Some(PathBuf::from("foo/baz.txt"));
+        let expect = PathBuf::from("foo/baz.txt");
+        let got = make_output_path(full, root, output).unwrap();
+        assert_eq!(expect, got);
+
+        // test no output path
+        let root = resolver::Path::from_str("/ipfs/QmYbcW4tXLXHWw753boCK8Y7uxLu5abXjyYizhLznq9PUR")
+            .unwrap();
+        let full = resolver::Path::from_str(
+            "/ipfs/QmYbcW4tXLXHWw753boCK8Y7uxLu5abXjyYizhLznq9PUR/bar.txt",
+        )
+        .unwrap();
+        let output = None;
+        let expect = PathBuf::from("QmYbcW4tXLXHWw753boCK8Y7uxLu5abXjyYizhLznq9PUR/bar.txt");
+        let got = make_output_path(full, root, output).unwrap();
+        assert_eq!(expect, got);
+    }
+}

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -4,5 +4,6 @@ mod clientapi;
 pub use crate::clientapi::ClientApi as Api;
 pub use bytes::Bytes;
 pub use cid::Cid;
+pub use iroh_resolver::resolver::Path as IpfsPath;
 pub use libp2p::gossipsub::MessageId;
 pub use libp2p::{Multiaddr, PeerId};

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod api;
+mod clientapi;
+
+pub use crate::clientapi::ClientApi as Api;
+pub use bytes::Bytes;
+pub use cid::Cid;
+pub use libp2p::gossipsub::MessageId;
+pub use libp2p::{Multiaddr, PeerId};

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 mod clientapi;
+mod getadd;
 
 pub use crate::clientapi::ClientApi as Api;
 pub use bytes::Bytes;

--- a/iroh/src/main.rs
+++ b/iroh/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello world!");
-}


### PR DESCRIPTION
The implementation is a thin wrapper over the RPC client.

This is exposed as a public API and will also be used to implement the CLI in iroh-ctl.

The idea is that the trait can be reimplemented to help test the iroh-ctl later, and it defines clearly what the public API is.

We smooth over the underlying client API somewhat: make `Cid` and `PeerId` into reference arguments, and use `&[]` slices instead of vectors for arguments as well.

In order to implement `ClientApi` I had to expose `P2pClient` and `StoreClient` in `iroh-rpc-client`.
