### PR TITLE
Update opentelemetry to 0.18

### DIFF
--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -26,8 +26,8 @@ tracing = "0.1.33"
 names = { version = "0.14.0", default-features = false }
 git-version = "0.3.5"
 rand = "0.8.5"
-tracing-opentelemetry = "0.17.2"
-opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
+tracing-opentelemetry = "0.18"
+opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 time = "0.3.9"
 headers = "0.3.7"
 hyper = "0.14.19"

--- a/iroh-metrics/Cargo.toml
+++ b/iroh-metrics/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/n0-computer/iroh"
 tracing = "0.1.33"
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
-tracing-opentelemetry = "0.17.2"
-opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.10.0", features = ["tonic"] }
+tracing-opentelemetry = "0.18"
+opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.11.0", features = ["tonic"] }
 metrics = "0.20.1"
 metrics-util = "0.14"
 metrics-exporter-prometheus = { version = "0.11", features = ["push-gateway"]}

--- a/iroh-store/Cargo.toml
+++ b/iroh-store/Cargo.toml
@@ -24,8 +24,8 @@ iroh-rpc-client = { path = "../iroh-rpc-client", default-features = false }
 iroh-util = { path = "../iroh-util" }
 bytes = "1.1.0"
 iroh-metrics = { path = "../iroh-metrics", default-features = false, features=["store"] }
-tracing-opentelemetry = "0.17.2"
-opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
+tracing-opentelemetry = "0.18"
+opentelemetry = { version = "0.18", features = ["rt-tokio"] }
 names = { version = "0.14.0", default-features = false }
 git-version = "0.3.5"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
opentelemetry was pulling in tonic 0.6.2 while iroh uses the latest 0.8. With this update we don't have a 2 versions of tonic in the build anymore.