### PR TITLE
fix: use the uds-gateway feature only to control the http uds endpoint

### DIFF
--- a/iroh-one/Cargo.toml
+++ b/iroh-one/Cargo.toml
@@ -27,9 +27,9 @@ iroh-rpc-types = {path = "../iroh-rpc-types", default-features = false}
 iroh-store = {path = "../iroh-store", default-features = false, features = ["rpc-mem"]}
 iroh-util = {path = "../iroh-util"}
 serde = {version = "1.0", features = ["derive"]}
+tempdir = "0.3.7"
 tokio = {version = "1", features = ["macros", "rt-multi-thread", "process"]}
 tracing = "0.1.33"
-tempdir = "0.3.7"
 
 [dev-dependencies]
 axum-macros = "0.2.0" # use #[axum_macros::debug_handler] for better error messages on handlers
@@ -39,4 +39,6 @@ http = "0.2"
 default = ["rpc-mem", "rpc-grpc"]
 rpc-grpc = ["iroh-rpc-types/grpc", "iroh-rpc-client/grpc", "iroh-metrics/rpc-grpc"]
 rpc-mem = ["iroh-rpc-types/mem", "iroh-rpc-client/mem"]
+# uds-gateway controls whether http over uds is enabled. This is independent of the
+# rpc-grpc control endpoint.
 uds-gateway = []

--- a/iroh-one/README.md
+++ b/iroh-one/README.md
@@ -15,7 +15,7 @@ Single binary of iroh services (gateway, p2p, store) communicating via mem chann
 
 ### Features
 
-- `uds-gateway` - enables the usage and binding of the gateway over UDS.
+- `uds-gateway` - enables the usage and binding of the http gateway over UDS.
 
 ### Reference
 

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1.4"
 iroh-bitswap = { path = "../iroh-bitswap" }
 iroh-rpc-types = { path = "../iroh-rpc-types", default-features = false }
 iroh-rpc-client = { path = "../iroh-rpc-client", default-features = false }
-tokio = { version = "1", features = ["time", "sync", "macros"] }
+tokio = { version = "1", features = ["fs", "time", "sync", "macros"] }
 ahash = "0.7.6"
 tracing = "0.1.34"
 clap = { version = "3.1.14", features = ["derive"] }


### PR DESCRIPTION
The current code also turns off the grpc control endpoint, but we need to keep it available in all configurations.

The fix in iroh-p2p/Cargo.toml makes it possible to build iroh-one or iroh-p2p without building the whole workspace.