### PR TITLE
feat: multi-service rpc for iroh-one

### DIFF
--- a/iroh-gateway/src/bad_bits.rs
+++ b/iroh-gateway/src/bad_bits.rs
@@ -196,9 +196,13 @@ mod tests {
                 tracing::error!("Failed to run gateway rpc handler: {}", err);
             }
         });
-        let handler = crate::core::Core::new(Arc::new(config), Arc::new(Some(RwLock::new(bbits))), content_loader)
-            .await
-            .unwrap();
+        let handler = crate::core::Core::new(
+            Arc::new(config),
+            Arc::new(Some(RwLock::new(bbits))),
+            content_loader,
+        )
+        .await
+        .unwrap();
         let server = handler.server();
         let addr = server.local_addr();
         let core_task = tokio::spawn(async move {

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -31,7 +31,7 @@ impl<T: ContentLoader + std::marker::Unpin> Core<T> {
         content_loader: T,
     ) -> anyhow::Result<Self> {
         Ok(Self {
-            state: Self::make_state(config, bad_bits, content_loader).await?
+            state: Self::make_state(config, bad_bits, content_loader).await?,
         })
     }
 

--- a/iroh-gateway/src/lib.rs
+++ b/iroh-gateway/src/lib.rs
@@ -9,5 +9,5 @@ pub mod handlers;
 pub mod headers;
 pub mod metrics;
 pub mod response;
-mod rpc;
+pub mod rpc;
 pub mod templates;

--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -43,12 +43,7 @@ async fn main() -> Result<()> {
         .server_rpc_addr()?
         .ok_or_else(|| anyhow!("missing gateway rpc addr"))?;
     let content_loader = RpcClient::new(config.rpc_client.clone()).await?;
-    let handler = Core::new(
-        Arc::new(config),
-        Arc::clone(&bad_bits),
-        content_loader,
-    )
-    .await?;
+    let handler = Core::new(Arc::new(config), Arc::clone(&bad_bits), content_loader).await?;
 
     // Start the rpc handler.
     tokio::spawn(async move {

--- a/iroh-gateway/src/rpc.rs
+++ b/iroh-gateway/src/rpc.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use iroh_rpc_types::gateway::{Gateway as RpcGateway, GatewayServerAddr, VersionResponse};
+use iroh_rpc_types::gateway::{GatewayGateway as RpcGateway, GatewayServerAddr, VersionResponse};
 
 #[derive(Default)]
 pub struct Gateway {}

--- a/iroh-one/Cargo.toml
+++ b/iroh-one/Cargo.toml
@@ -26,6 +26,7 @@ iroh-rpc-client = {path = "../iroh-rpc-client", default-features = false}
 iroh-rpc-types = {path = "../iroh-rpc-types", default-features = false}
 iroh-store = {path = "../iroh-store", default-features = false, features = ["rpc-mem"]}
 iroh-util = {path = "../iroh-util"}
+paste = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 tempdir = "0.3.7"
 tokio = {version = "1", features = ["macros", "rt-multi-thread", "process"]}

--- a/iroh-one/src/lib.rs
+++ b/iroh-one/src/lib.rs
@@ -3,5 +3,6 @@ pub mod config;
 pub mod content_loader;
 pub mod mem_p2p;
 pub mod mem_store;
+pub mod rpc;
 #[cfg(feature = "uds-gateway")]
 pub mod uds;

--- a/iroh-one/src/main.rs
+++ b/iroh-one/src/main.rs
@@ -89,9 +89,7 @@ async fn main() -> Result<()> {
 
     // Start the rpc handler.
     tokio::spawn(async move {
-        if let Err(err) =
-            iroh_one::rpc::new(gateway_rpc_addr, &config).await
-        {
+        if let Err(err) = iroh_one::rpc::new(gateway_rpc_addr, &config).await {
             tracing::error!("Failed to run gateway rpc handler: {}", err);
         }
     });

--- a/iroh-one/src/rpc.rs
+++ b/iroh-one/src/rpc.rs
@@ -1,0 +1,101 @@
+use crate::config::Config;
+use anyhow::Result;
+use async_trait::async_trait;
+use iroh_rpc_client::{P2pClient, StoreClient};
+use iroh_rpc_types::{
+    gateway_one::{
+        gateway::VersionResponse, p2p::*, store::*, GatewayOneGateway as RpcGateway,
+        GatewayOneP2p as RpcP2p, GatewayOneServerAddr, GatewayOneStore as RpcStore,
+    },
+    p2p::{P2pClientAddr, P2pP2p},
+    store::{StoreClientAddr, StoreStore},
+};
+use std::mem::transmute;
+use paste::paste;
+
+/// This macro generates the implementation for a service trait in iroh-one. This works
+/// by relaying the calls to the "real" client's backend.
+/// Use of `transmute` here is safe because we know the structs are the same, but protobuf
+/// imports are duplicated in each crate instead of being shared.
+macro_rules! relay {
+    ($service:ident, $($func:ident: $req:ty => $res:ty),+) => {
+        paste! {
+            pub struct [<$service:camel One>] {
+                client: [<$service:camel Client>],
+            }
+
+            impl [<$service:camel One>] {
+                pub async fn new(addr: [<$service:camel ClientAddr>]) -> Result<Self> {
+                    let client = [<$service:camel Client>]::new(addr).await?;
+                    Ok(Self { client })
+                }
+            }
+
+            #[async_trait]
+            impl [<Rpc $service:camel>] for [<$service:camel One>] {
+                $(
+                    #[tracing::instrument(skip(self))]
+                    async fn [<$func:snake>](&self, req: $req) -> Result<$res> {
+                        unsafe { transmute(self.client.backend.[<$func:snake>](transmute(req)).await) }
+                    }
+                )+
+            }
+        }
+    }
+}
+
+pub struct GatewayOne {}
+
+impl GatewayOne {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl RpcGateway for GatewayOne {
+    #[tracing::instrument(skip(self))]
+    async fn version(&self, _: ()) -> Result<VersionResponse> {
+        let version = env!("CARGO_PKG_VERSION").to_string();
+        Ok(VersionResponse { version })
+    }
+}
+
+relay!(
+    Store,
+    put: PutRequest => (),
+    get: GetRequest => GetResponse,
+    has: HasRequest => HasResponse,
+    get_links: GetLinksRequest => GetLinksResponse
+);
+
+relay!(
+    P2p,
+    shutdown: () => (),
+    fetch_bitswap: BitswapRequest => BitswapResponse,
+    fetch_provider: Key => Providers,
+    get_listening_addrs: () => GetListeningAddrsResponse,
+    get_peers: () => GetPeersResponse,
+    peer_connect: ConnectRequest => ConnectResponse,
+    peer_disconnect: DisconnectRequest => (),
+    gossipsub_add_explicit_peer: GossipsubPeerIdMsg => (),
+    gossipsub_all_mesh_peers: () => GossipsubPeersResponse,
+    gossipsub_all_peers: () => GossipsubAllPeersResponse,
+    gossipsub_mesh_peers: GossipsubTopicHashMsg => GossipsubPeersResponse,
+    gossipsub_publish: GossipsubPublishRequest => GossipsubPublishResponse,
+    gossipsub_remove_explicit_peer: GossipsubPeerIdMsg => (),
+    gossipsub_subscribe: GossipsubTopicHashMsg => GossipsubSubscribeResponse,
+    gossipsub_topics: () => GossipsubTopicsResponse,
+    gossipsub_unsubscribe: GossipsubTopicHashMsg => GossipsubSubscribeResponse
+);
+
+#[cfg(feature = "grpc")]
+impl iroh_rpc_types::NamedService for GatewayOne {
+    const NAME: &'static str = "gatewayone";
+}
+
+pub async fn new(addr: GatewayOneServerAddr, config: &Config) -> Result<()> {
+    let store = StoreOne::new(config.rpc_client.store_addr.as_ref().unwrap().clone()).await?;
+    let p2p = P2pOne::new(config.rpc_client.p2p_addr.as_ref().unwrap().clone()).await?;
+    iroh_rpc_types::gateway_one::serve(addr, GatewayOne::new(), store, p2p).await
+}

--- a/iroh-p2p/src/rpc.rs
+++ b/iroh-p2p/src/rpc.rs
@@ -23,7 +23,7 @@ use iroh_rpc_types::p2p::{
     GetListeningAddrsResponse, GetPeersResponse, GossipsubAllPeersResponse, GossipsubPeerAndTopics,
     GossipsubPeerIdMsg, GossipsubPeersResponse, GossipsubPublishRequest, GossipsubPublishResponse,
     GossipsubSubscribeResponse, GossipsubTopicHashMsg, GossipsubTopicsResponse, Key as ProviderKey,
-    Multiaddrs, P2p as RpcP2p, P2pServerAddr, PeerIdResponse, Providers, VersionResponse,
+    Multiaddrs, P2pP2p as RpcP2p, P2pServerAddr, PeerIdResponse, Providers, VersionResponse,
 };
 
 struct P2p {

--- a/iroh-rpc-client/src/gateway.rs
+++ b/iroh-rpc-client/src/gateway.rs
@@ -6,7 +6,7 @@ use futures::Stream;
 #[cfg(feature = "grpc")]
 use iroh_rpc_types::gateway::gateway_client::GatewayClient as GrpcGatewayClient;
 use iroh_rpc_types::{
-    gateway::{Gateway, GatewayClientAddr, GatewayClientBackend},
+    gateway::{GatewayClientAddr, GatewayClientBackend, GatewayGateway},
     Addr,
 };
 #[cfg(feature = "grpc")]
@@ -14,7 +14,7 @@ use tonic::transport::Endpoint;
 #[cfg(feature = "grpc")]
 use tonic_health::proto::health_client::HealthClient;
 
-impl_client!(Gateway);
+impl_client!(Gateway: Gateway);
 
 impl GatewayClient {
     #[tracing::instrument(skip(self))]

--- a/iroh-rpc-client/src/lib.rs
+++ b/iroh-rpc-client/src/lib.rs
@@ -13,3 +13,6 @@ pub use crate::client::Client;
 pub use crate::config::Config;
 #[cfg(feature = "grpc")]
 pub use crate::status::{ServiceStatus, StatusRow, StatusTable};
+
+pub use crate::store::StoreClient;
+pub use crate::network::P2pClient;

--- a/iroh-rpc-client/src/lib.rs
+++ b/iroh-rpc-client/src/lib.rs
@@ -14,5 +14,5 @@ pub use crate::config::Config;
 #[cfg(feature = "grpc")]
 pub use crate::status::{ServiceStatus, StatusRow, StatusTable};
 
-pub use crate::store::StoreClient;
 pub use crate::network::P2pClient;
+pub use crate::store::StoreClient;

--- a/iroh-rpc-client/src/network.rs
+++ b/iroh-rpc-client/src/network.rs
@@ -9,7 +9,7 @@ use futures::Stream;
 use iroh_rpc_types::p2p::p2p_client::P2pClient as GrpcP2pClient;
 use iroh_rpc_types::p2p::{
     BitswapRequest, ConnectRequest, DisconnectRequest, GossipsubPeerAndTopics, GossipsubPeerIdMsg,
-    GossipsubPublishRequest, GossipsubTopicHashMsg, Key, P2p, P2pClientAddr, P2pClientBackend,
+    GossipsubPublishRequest, GossipsubTopicHashMsg, Key, P2pClientAddr, P2pClientBackend, P2pP2p,
     Providers,
 };
 use iroh_rpc_types::Addr;
@@ -24,7 +24,7 @@ use tracing::{debug, warn};
 #[cfg(feature = "grpc")]
 use crate::status::{self, StatusRow};
 
-impl_client!(P2p);
+impl_client!(P2p: P2p);
 
 impl P2pClient {
     #[tracing::instrument(skip(self))]

--- a/iroh-rpc-client/src/store.rs
+++ b/iroh-rpc-client/src/store.rs
@@ -8,7 +8,8 @@ use futures::Stream;
 #[cfg(feature = "grpc")]
 use iroh_rpc_types::store::store_client::StoreClient as GrpcStoreClient;
 use iroh_rpc_types::store::{
-    GetLinksRequest, GetRequest, HasRequest, PutRequest, Store, StoreClientAddr, StoreClientBackend,
+    GetLinksRequest, GetRequest, HasRequest, PutRequest, StoreClientAddr, StoreClientBackend,
+    StoreStore,
 };
 use iroh_rpc_types::Addr;
 #[cfg(feature = "grpc")]
@@ -19,7 +20,7 @@ use tonic_health::proto::health_client::HealthClient;
 #[cfg(feature = "grpc")]
 use crate::status::{self, StatusRow};
 
-impl_client!(Store);
+impl_client!(Store: Store);
 
 impl StoreClient {
     #[tracing::instrument(skip(self))]

--- a/iroh-rpc-types/build.rs
+++ b/iroh-rpc-types/build.rs
@@ -11,6 +11,7 @@ fn main() {
         "proto/p2p.proto",
         "proto/store.proto",
         "proto/gateway.proto",
+        "proto/gateway_one.proto",
         "proto/test.proto",
     ];
     let source_dirs = ["proto"];

--- a/iroh-rpc-types/proto/gateway_one.proto
+++ b/iroh-rpc-types/proto/gateway_one.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package gatewayone;
+
+import "google/protobuf/empty.proto";
+
+import "gateway.proto";
+import "store.proto";
+import "p2p.proto";
+
+service Gateway {
+  rpc Version(google.protobuf.Empty) returns (gateway.VersionResponse) {}
+}
+
+service Store {
+  rpc Put(store.PutRequest) returns (google.protobuf.Empty) {}
+  rpc Get(store.GetRequest) returns (store.GetResponse) {}
+  rpc Has(store.HasRequest) returns (store.HasResponse) {}
+  rpc GetLinks(store.GetLinksRequest) returns(store.GetLinksResponse) {}
+}
+
+service P2p {
+  rpc FetchBitswap(p2p.BitswapRequest) returns (p2p.BitswapResponse) {}
+  rpc FetchProvider(p2p.Key) returns (p2p.Providers) {}
+  rpc GetListeningAddrs(google.protobuf.Empty) returns (p2p.GetListeningAddrsResponse) {}
+  rpc GetPeers(google.protobuf.Empty) returns (p2p.GetPeersResponse) {}
+  rpc PeerConnect(p2p.ConnectRequest) returns (p2p.ConnectResponse) {}
+  rpc PeerDisconnect(p2p.DisconnectRequest) returns (google.protobuf.Empty) {}
+  rpc Shutdown(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+
+  rpc GossipsubAddExplicitPeer(p2p.GossipsubPeerIdMsg) returns (google.protobuf.Empty) {}
+  rpc GossipsubAllMeshPeers(google.protobuf.Empty) returns (p2p.GossipsubPeersResponse) {}
+  rpc GossipsubAllPeers(google.protobuf.Empty) returns (p2p.GossipsubAllPeersResponse) {}
+  rpc GossipsubMeshPeers(p2p.GossipsubTopicHashMsg) returns (p2p.GossipsubPeersResponse) {}
+  rpc GossipsubPublish(p2p.GossipsubPublishRequest) returns (p2p.GossipsubPublishResponse) {}
+  rpc GossipsubRemoveExplicitPeer(p2p.GossipsubPeerIdMsg) returns (google.protobuf.Empty) {}
+  rpc GossipsubSubscribe(p2p.GossipsubTopicHashMsg) returns (p2p.GossipsubSubscribeResponse) {}
+  rpc GossipsubTopics(google.protobuf.Empty) returns (p2p.GossipsubTopicsResponse) {}
+  rpc GossipsubUnsubscribe(p2p.GossipsubTopicHashMsg) returns (p2p.GossipsubSubscribeResponse) {}
+}

--- a/iroh-rpc-types/src/gateway.rs
+++ b/iroh-rpc-types/src/gateway.rs
@@ -1,6 +1,8 @@
 include_proto!("gateway");
 
-proxy!(
+proxy!(Gateway,
+(
     Gateway,
     version: () => VersionResponse
+)
 );

--- a/iroh-rpc-types/src/gateway_one.rs
+++ b/iroh-rpc-types/src/gateway_one.rs
@@ -1,0 +1,59 @@
+include_proto!("gatewayone");
+
+#[allow(clippy::all)]
+pub mod gateway {
+    include!(concat!(env!("OUT_DIR"), "/gateway.rs"));
+}
+
+#[allow(clippy::all)]
+pub mod store {
+    include!(concat!(env!("OUT_DIR"), "/store.rs"));
+}
+use crate::gateway_one::store::{
+    GetLinksRequest, GetLinksResponse, GetRequest, GetResponse, HasRequest, HasResponse, PutRequest,
+};
+
+#[allow(clippy::all)]
+pub mod p2p {
+    include!(concat!(env!("OUT_DIR"), "/p2p.rs"));
+}
+use crate::gateway_one::p2p::{
+    BitswapRequest, BitswapResponse, ConnectRequest, ConnectResponse, DisconnectRequest,
+    GetListeningAddrsResponse, GetPeersResponse, GossipsubAllPeersResponse, GossipsubPeerIdMsg,
+    GossipsubPeersResponse, GossipsubPublishRequest, GossipsubPublishResponse,
+    GossipsubSubscribeResponse, GossipsubTopicHashMsg, GossipsubTopicsResponse, Key, Providers,
+};
+
+// Note: Keep in sync with iroh-one/src/rpc.rs
+proxy!(GatewayOne,
+(
+    Gateway,
+    version: () => gateway::VersionResponse
+),
+(
+    Store,
+    put: PutRequest => (),
+    get: GetRequest => GetResponse,
+    has: HasRequest => HasResponse,
+    get_links: GetLinksRequest => GetLinksResponse
+),
+(
+    P2p,
+    shutdown: () => (),
+    fetch_bitswap: BitswapRequest => BitswapResponse,
+    fetch_provider: Key => Providers,
+    get_listening_addrs: () => GetListeningAddrsResponse,
+    get_peers: () => GetPeersResponse,
+    peer_connect: ConnectRequest => ConnectResponse,
+    peer_disconnect: DisconnectRequest => (),
+    gossipsub_add_explicit_peer: GossipsubPeerIdMsg => (),
+    gossipsub_all_mesh_peers: () => GossipsubPeersResponse,
+    gossipsub_all_peers: () => GossipsubAllPeersResponse,
+    gossipsub_mesh_peers: GossipsubTopicHashMsg => GossipsubPeersResponse,
+    gossipsub_publish: GossipsubPublishRequest => GossipsubPublishResponse,
+    gossipsub_remove_explicit_peer: GossipsubPeerIdMsg => (),
+    gossipsub_subscribe: GossipsubTopicHashMsg => GossipsubSubscribeResponse,
+    gossipsub_topics: () => GossipsubTopicsResponse,
+    gossipsub_unsubscribe: GossipsubTopicHashMsg => GossipsubSubscribeResponse
+)
+);

--- a/iroh-rpc-types/src/lib.rs
+++ b/iroh-rpc-types/src/lib.rs
@@ -2,6 +2,7 @@
 mod macros;
 
 pub mod gateway;
+pub mod gateway_one;
 pub mod p2p;
 pub mod store;
 

--- a/iroh-rpc-types/src/p2p.rs
+++ b/iroh-rpc-types/src/p2p.rs
@@ -1,6 +1,7 @@
 include_proto!("p2p");
 
-proxy!(
+proxy!(P2p,
+(
     P2p,
     version: () => VersionResponse,
     local_peer_id: () => PeerIdResponse,
@@ -23,4 +24,5 @@ proxy!(
     gossipsub_subscribe: GossipsubTopicHashMsg => GossipsubSubscribeResponse,
     gossipsub_topics: () => GossipsubTopicsResponse,
     gossipsub_unsubscribe: GossipsubTopicHashMsg => GossipsubSubscribeResponse
+)
 );

--- a/iroh-rpc-types/src/store.rs
+++ b/iroh-rpc-types/src/store.rs
@@ -1,10 +1,12 @@
 include_proto!("store");
 
-proxy!(
+proxy!(Store,
+(
     Store,
     version: () => VersionResponse,
     put: PutRequest => (),
     get: GetRequest => GetResponse,
     has: HasRequest => HasResponse,
     get_links: GetLinksRequest => GetLinksResponse
+)
 );

--- a/iroh-store/src/rpc.rs
+++ b/iroh-store/src/rpc.rs
@@ -6,7 +6,7 @@ use bytes::BytesMut;
 use cid::Cid;
 use iroh_rpc_types::store::{
     GetLinksRequest, GetLinksResponse, GetRequest, GetResponse, HasRequest, HasResponse,
-    PutRequest, Store as RpcStore, StoreServerAddr, VersionResponse,
+    PutRequest, StoreServerAddr, StoreStore as RpcStore, VersionResponse,
 };
 use tracing::info;
 


### PR DESCRIPTION
This patch enables iroh-one rpc control enpoint to serve the same
calls as the independent gateway, store and p2p programs. To that end, 
the following changes are made:
- decouple iroh-one rpc from iroh-gateway rpc.
- create a iroh-one specific grpc definition, with 3 services.
- upddate the rpc macros to support multiple services.