### PR TITLE
fix(unixfs) Fix unixfs roundtrip bug

### DIFF
--- a/iroh-resolver/src/unixfs.rs
+++ b/iroh-resolver/src/unixfs.rs
@@ -522,19 +522,22 @@ fn load_next_node<T: ContentLoader + 'static>(
     loader: T,
 ) -> bool {
     // Load next node
-    if current_links.is_empty() {
-        // no links left we are done
-        return true;
-    }
-    if current_links.last().unwrap().is_empty() {
-        // remove emtpy
-        current_links.pop();
-    }
 
-    let links = current_links.last_mut().unwrap();
-    if links.is_empty() {
-        return true;
-    }
+    // find non empty links
+    let links = loop {
+        if let Some(last_mut) = current_links.last_mut() {
+            if last_mut.is_empty() {
+                // ignore empty links
+                current_links.pop();
+            } else {
+                // found non empty links
+                break last_mut;
+            }
+        } else {
+            // no links left we are done
+            return true;
+        }
+    };
 
     let link = links.pop_front().unwrap();
 

--- a/iroh-resolver/src/unixfs_builder.rs
+++ b/iroh-resolver/src/unixfs_builder.rs
@@ -682,7 +682,6 @@ mod tests {
     }
 
     // test is ignored because it currently fails
-    #[ignore]
     #[tokio::test]
     async fn test_builder_roundtrip_complex_tree_1() -> Result<()> {
         // fill with random data so we get distinct cids for all blocks
@@ -709,7 +708,6 @@ mod tests {
     }
 
     // test is ignored because it currently fails
-    #[ignore]
     #[tokio::test]
     async fn test_builder_roundtrip_128m() -> Result<()> {
         // fill with random data so we get distinct cids for all blocks


### PR DESCRIPTION
There was an issue when the tree was at least 3 levels deep, and there were two empty/expended link lists above the current position. Fixes https://github.com/n0-computer/beetle/issues/174, so the two ignored tests are now enabled.