### PR TITLE
fix: pass links to store when adding data

### DIFF
--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -220,9 +220,9 @@ mod tests {
             let root_dir = dir_builder.build().unwrap();
             let mut parts = root_dir.encode();
             while let Some(part) = parts.next().await {
-                let (cid, bytes) = part.unwrap();
+                let (cid, bytes, links) = part.unwrap().into_parts();
                 cids.push(cid);
-                store.put(cid, bytes, vec![]).await.unwrap();
+                store.put(cid, bytes, links).await.unwrap();
             }
             (*cids.last().unwrap(), cids)
         };

--- a/iroh-resolver/src/unixfs_builder.rs
+++ b/iroh-resolver/src/unixfs_builder.rs
@@ -675,9 +675,12 @@ mod tests {
         stream: impl Stream<Item = Result<Block>>,
     ) -> Result<(Cid, Resolver<Arc<fnv::FnvHashMap<Cid, Bytes>>>)> {
         tokio::pin!(stream);
-        let items: Vec<_> = stream.try_collect().await?;
-        let root_block = items.last().context("no root")?.clone();
-        let store: fnv::FnvHashMap<Cid, Bytes> = items
+        let blocks: Vec<_> = stream.try_collect().await?;
+        for block in &blocks {
+            block.validate()?;
+        }
+        let root_block = blocks.last().context("no root")?.clone();
+        let store: fnv::FnvHashMap<Cid, Bytes> = blocks
             .into_iter()
             .map(|block| {
                 let (cid, bytes, _) = block.into_parts();

--- a/iroh-resolver/src/unixfs_builder.rs
+++ b/iroh-resolver/src/unixfs_builder.rs
@@ -17,6 +17,7 @@ use tokio::io::AsyncRead;
 use crate::{
     balanced_tree::{TreeBuilder, DEFAULT_DEGREE},
     chunker::{Chunker, DEFAULT_CHUNKS_SIZE, DEFAULT_CHUNK_SIZE_LIMIT},
+    resolver::Block,
     unixfs::{dag_pb, unixfs_pb, DataType, Node, UnixfsNode},
 };
 
@@ -56,7 +57,7 @@ impl Directory {
         }
     }
 
-    pub async fn encode_root(self) -> Result<(Cid, Bytes)> {
+    pub async fn encode_root(self) -> Result<Block> {
         let mut current = None;
         let parts = self.encode();
         tokio::pin!(parts);
@@ -68,7 +69,7 @@ impl Directory {
         current.expect("must not be empty")
     }
 
-    pub fn encode<'a>(self) -> LocalBoxStream<'a, Result<(Cid, Bytes)>> {
+    pub fn encode<'a>(self) -> LocalBoxStream<'a, Result<Block>> {
         async_stream::try_stream! {
             let mut links = Vec::new();
             for entry in self.entries {
@@ -79,9 +80,9 @@ impl Directory {
                         tokio::pin!(parts);
                         let mut root = None;
                         while let Some(part) = parts.next().await {
-                            let (cid, bytes) = part?;
-                            root = Some((cid, bytes.clone()));
-                            yield (cid, bytes);
+                            let block = part?;
+                            root = Some(block.clone());
+                            yield block;
                         }
                          (name, root)
                     }
@@ -91,18 +92,18 @@ impl Directory {
                         tokio::pin!(parts);
                         let mut root = None;
                         while let Some(part) = parts.next().await {
-                            let (cid, bytes) = part?;
-                            root = Some((cid, bytes.clone()));
-                            yield (cid, bytes);
+                            let block = part?;
+                            root = Some(block.clone());
+                            yield block;
                         }
                          (name, root)
                     }
                 };
-                let (cid, bytes) = root.expect("file must not be empty");
+                let root_block = root.expect("file must not be empty");
                 links.push(dag_pb::PbLink {
-                    hash: Some(cid.to_bytes()),
+                    hash: Some(root_block.cid().to_bytes()),
                     name: Some(name),
-                    tsize: Some(bytes.len() as u64),
+                    tsize: Some(root_block.data().len() as u64),
                 });
 
             }
@@ -177,7 +178,7 @@ impl File {
         }
     }
 
-    pub async fn encode_root(self) -> Result<(Cid, Bytes)> {
+    pub async fn encode_root(self) -> Result<Block> {
         let mut current = None;
         let parts = self.encode().await?;
         tokio::pin!(parts);
@@ -189,7 +190,7 @@ impl File {
         current.expect("must not be empty")
     }
 
-    pub async fn encode(self) -> Result<impl Stream<Item = Result<(Cid, Bytes)>>> {
+    pub async fn encode(self) -> Result<impl Stream<Item = Result<Block>>> {
         let reader = match self.content {
             Content::Path(path) => {
                 let f = tokio::fs::File::open(path).await?;
@@ -456,9 +457,9 @@ pub async fn add_file<S: Store>(store: Option<S>, path: &Path, wrap: bool) -> Re
     tokio::pin!(parts);
 
     while let Some(part) = parts.next().await {
-        let (cid, bytes) = part?;
+        let (cid, bytes, links) = part?.into_parts();
         if let Some(ref store) = store {
-            store.put(cid, bytes, vec![]).await?;
+            store.put(cid, bytes, links).await?;
         }
         root = Some(cid);
     }
@@ -492,9 +493,9 @@ pub async fn add_dir<S: Store>(
     tokio::pin!(parts);
 
     while let Some(part) = parts.next().await {
-        let (cid, bytes) = part?;
+        let (cid, bytes, links) = part?.into_parts();
         if let Some(ref store) = store {
-            store.put(cid, bytes, vec![]).await?;
+            store.put(cid, bytes, links).await?;
         }
         root = Some(cid);
     }
@@ -577,14 +578,14 @@ mod tests {
 
         let dir = dir.build()?;
 
-        let (cid_dir, dir_encoded) = dir.encode_root().await?;
-        let decoded_dir = UnixfsNode::decode(&cid_dir, dir_encoded)?;
+        let dir_block = dir.encode_root().await?;
+        let decoded_dir = UnixfsNode::decode(dir_block.cid(), dir_block.data().clone())?;
 
         let links = decoded_dir.links().collect::<Result<Vec<_>>>().unwrap();
         assert_eq!(links[0].name.unwrap(), "bar.txt");
-        assert_eq!(links[0].cid, bar_encoded[0].0);
+        assert_eq!(links[0].cid, *bar_encoded[0].cid());
         assert_eq!(links[1].name.unwrap(), "baz.txt");
-        assert_eq!(links[1].cid, baz_encoded[0].0);
+        assert_eq!(links[1].cid, *baz_encoded[0].cid());
 
         // TODO: check content
         Ok(())
@@ -649,14 +650,14 @@ mod tests {
 
         let dir = dir.build()?;
 
-        let (cid_dir, dir_encoded) = dir.encode_root().await?;
-        let decoded_dir = UnixfsNode::decode(&cid_dir, dir_encoded)?;
+        let dir_block = dir.encode_root().await?;
+        let decoded_dir = UnixfsNode::decode(dir_block.cid(), dir_block.data().clone())?;
 
         let links = decoded_dir.links().collect::<Result<Vec<_>>>().unwrap();
         assert_eq!(links[0].name.unwrap(), "bar.txt");
-        assert_eq!(links[0].cid, bar_encoded[0].0);
+        assert_eq!(links[0].cid, *bar_encoded[0].cid());
         assert_eq!(links[1].name.unwrap(), "baz.txt");
-        assert_eq!(links[1].cid, baz_encoded[0].0);
+        assert_eq!(links[1].cid, *baz_encoded[0].cid());
 
         // TODO: check content
         Ok(())
@@ -671,14 +672,20 @@ mod tests {
 
     /// Read a stream of (cid, block) pairs into an in memory store and return the store and the root cid
     async fn stream_to_resolver(
-        stream: impl Stream<Item = Result<(Cid, Bytes)>>,
+        stream: impl Stream<Item = Result<Block>>,
     ) -> Result<(Cid, Resolver<Arc<fnv::FnvHashMap<Cid, Bytes>>>)> {
         tokio::pin!(stream);
         let items: Vec<_> = stream.try_collect().await?;
-        let (root, _) = items.last().context("no root")?.clone();
-        let store: fnv::FnvHashMap<Cid, Bytes> = items.into_iter().collect();
+        let root_block = items.last().context("no root")?.clone();
+        let store: fnv::FnvHashMap<Cid, Bytes> = items
+            .into_iter()
+            .map(|block| {
+                let (cid, bytes, _) = block.into_parts();
+                (cid, bytes)
+            })
+            .collect();
         let resolver = Resolver::new(Arc::new(store));
-        Ok((root, resolver))
+        Ok((*root_block.cid(), resolver))
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -905,17 +912,17 @@ mod tests {
 
         let dir = dir.build()?;
 
-        let (cid_dir, dir_encoded) = dir.encode_root().await?;
-        let decoded_dir = UnixfsNode::decode(&cid_dir, dir_encoded)?;
+        let dir_block = dir.encode_root().await?;
+        let decoded_dir = UnixfsNode::decode(dir_block.cid(), dir_block.data().clone())?;
 
         let links = decoded_dir.links().collect::<Result<Vec<_>>>().unwrap();
         assert_eq!(links[0].name.unwrap(), "bar.txt");
-        assert_eq!(links[0].cid, bar_encoded[4].0);
+        assert_eq!(links[0].cid, *bar_encoded[4].cid());
         assert_eq!(links[1].name.unwrap(), "baz.txt");
-        assert_eq!(links[1].cid, baz_encoded[8].0);
+        assert_eq!(links[1].cid, *baz_encoded[8].cid());
 
         for (i, encoded) in baz_encoded.iter().enumerate() {
-            let node = UnixfsNode::decode(&encoded.0, encoded.1.clone())?;
+            let node = UnixfsNode::decode(encoded.cid(), encoded.data().clone())?;
             if i == 8 {
                 assert_eq!(node.typ(), Some(DataType::File));
                 assert_eq!(node.links().count(), 8);

--- a/iroh-share/src/sender.rs
+++ b/iroh-share/src/sender.rs
@@ -69,11 +69,10 @@ impl Sender {
             let mut num_parts = 0;
             let mut root_cid = None;
             while let Some(part) = parts.next().await {
-                // TODO: store links in the store
-                let (cid, bytes) = part?;
+                let (cid, bytes, links) = part?.into_parts();
                 num_parts += 1;
                 root_cid = Some(cid);
-                store.put(cid, bytes, vec![]).await?;
+                store.put(cid, bytes, links).await?;
             }
             (root_cid.unwrap(), num_parts)
         };

--- a/iroh-store/src/store.rs
+++ b/iroh-store/src/store.rs
@@ -400,19 +400,24 @@ impl Store {
         let mut ids = Vec::new();
         let mut batch = WriteBatch::default();
         for cid in cids {
-            let id = self.next_id();
-            let id_bytes = id.to_be_bytes();
+            let multihash = cid.hash().to_bytes();
+            let id = if let Some(id) = self.inner.content.get_pinned_cf(cf_id, &multihash)? {
+                u64::from_be_bytes(id.as_ref().try_into()?)
+            } else {
+                let id = self.next_id();
+                let id_bytes = id.to_be_bytes();
 
-            let metadata = Versioned(MetadataV0 {
-                codec: cid.codec(),
-                multihash: cid.hash().to_bytes(),
-            });
-            let metadata_bytes = rkyv::to_bytes::<_, 1024>(&metadata)?; // TODO: is this the right amount of scratch space?
+                let metadata = Versioned(MetadataV0 {
+                    codec: cid.codec(),
+                    multihash,
+                });
+                let metadata_bytes = rkyv::to_bytes::<_, 1024>(&metadata)?; // TODO: is this the right amount of scratch space?
 
-            let multihash = &metadata.0.multihash;
-            // TODO: is it worth to check for existence instead of just writing?
-            batch.put_cf(&cf_id, multihash, &id_bytes);
-            batch.put_cf(&cf_meta, &id_bytes, metadata_bytes);
+                let multihash = &metadata.0.multihash;
+                batch.put_cf(&cf_id, multihash, &id_bytes);
+                batch.put_cf(&cf_meta, &id_bytes, metadata_bytes);
+                id
+            };
             ids.push(id);
         }
         self.inner.content.write(batch)?;


### PR DESCRIPTION
Note that this may lead to decreased performance, since we are doing more work than before. But the store needs this information.

The way links are parsed can be optimized, see #297 . And I am not quite sure if finding links should not be done on the store side. But that is another discussion to be had.

Fixes #287