### PR TITLE
Gateway: Fetch recursive DAG as CAR

### DIFF
--- a/iroh-car/src/header.rs
+++ b/iroh-car/src/header.rs
@@ -12,6 +12,10 @@ pub enum CarHeader {
 }
 
 impl CarHeader {
+    pub fn new_v1(roots: Vec<Cid>) -> Self {
+        Self::V1(roots.into())
+    }
+
     pub fn decode(buffer: &[u8]) -> Result<Self, Error> {
         let header: CarHeaderV1 = DagCborCodec
             .decode(buffer)

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -13,7 +13,7 @@ iroh-rpc-types = { path = "../iroh-rpc-types", default-features = false }
 
 cid = "0.8.6"
 
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "process"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "fs"] }
 axum = "0.5.1"
 clap = { version = "4.0.9", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -60,6 +60,8 @@ http-body = "0.4.5"
 
 [dev-dependencies]
 axum-macros = "0.2.0" # use #[axum_macros::debug_handler] for better error messages on handlers
+iroh-store = { path = "../iroh-store" }
+tempfile = "3.3.0"
 
 
 [features]

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -37,6 +37,7 @@ anyhow = "1"
 futures = "0.3.21"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 iroh-resolver = { path = "../iroh-resolver" }
+iroh-car = { path = "../iroh-car" }
 tokio-util = { version = "0.7", features = ["io"] }
 bytes = "1.1.0"
 tower-layer = { version = "0.3" }

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use bytes::Bytes;
 use futures::{StreamExt, TryStream};
 use http::HeaderMap;
+use iroh_car::{CarHeader, CarWriter};
 use iroh_metrics::{
     core::{MObserver, MRecorder},
     gateway::{GatewayHistograms, GatewayMetrics},
@@ -13,7 +14,7 @@ use iroh_metrics::{
 use iroh_resolver::resolver::{
     CidOrDomain, ContentLoader, Metadata, Out, OutMetrics, OutPrettyReader, Resolver, Source,
 };
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncReadExt, AsyncWrite};
 use tokio_util::io::ReaderStream;
 use tracing::{info, warn};
 
@@ -85,22 +86,8 @@ impl<T: ContentLoader + std::marker::Unpin> Client<T> {
             .resolve(path)
             .await
             .map_err(|e| e.to_string())?;
-        record!(
-            GatewayMetrics::TimeToFetchFirstBlock,
-            start_time.elapsed().as_millis() as u64
-        );
         let metadata = res.metadata().clone();
-        if metadata.source == Source::Bitswap {
-            observe!(
-                GatewayHistograms::TimeToFetchFirstBlock,
-                start_time.elapsed().as_millis() as f64
-            );
-        } else {
-            observe!(
-                GatewayHistograms::TimeToFetchFirstBlockCached,
-                start_time.elapsed().as_millis() as f64
-            );
-        }
+        record_ttfb_metrics(start_time, &metadata);
 
         if res.is_dir() {
             let body = FileResult::Directory(res);
@@ -115,6 +102,26 @@ impl<T: ContentLoader + std::marker::Unpin> Client<T> {
 
             Ok((FileResult::File(body), metadata))
         }
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn get_car_recursive(
+        self,
+        path: iroh_resolver::resolver::Path,
+        start_time: std::time::Instant,
+    ) -> Result<axum::body::StreamBody<ReaderStream<tokio::io::DuplexStream>>, String> {
+        info!("get car {}", path);
+        // TODO: Find out what a good buffer size is here.
+        let (writer, reader) = tokio::io::duplex(1024 * 64);
+        let body = axum::body::StreamBody::new(ReaderStream::new(reader));
+        let client = self.clone();
+        tokio::task::spawn(async move {
+            if let Err(e) = fetch_car_recursive(&client.resolver, path, writer, start_time).await {
+                warn!("failed to load recursively: {:?}", e);
+            }
+        });
+
+        Ok(body)
     }
 
     #[tracing::instrument(skip(self))]
@@ -133,22 +140,8 @@ impl<T: ContentLoader + std::marker::Unpin> Client<T> {
             while let Some(res) = res.next().await {
                 match res {
                     Ok(res) => {
-                        record!(
-                            GatewayMetrics::TimeToFetchFirstBlock,
-                            start_time.elapsed().as_millis() as u64
-                        );
                         let metadata = res.metadata().clone();
-                        if metadata.source == Source::Bitswap {
-                            observe!(
-                                GatewayHistograms::TimeToFetchFirstBlock,
-                                start_time.elapsed().as_millis() as f64
-                            );
-                        } else {
-                            observe!(
-                                GatewayHistograms::TimeToFetchFirstBlockCached,
-                                start_time.elapsed().as_millis() as f64
-                            );
-                        }
+                        record_ttfb_metrics(start_time, &metadata);
                         let reader =
                             res.pretty(self.resolver.clone(), OutMetrics { start: start_time });
                         match reader {
@@ -186,4 +179,52 @@ pub struct Request {
     pub content_path: String,
     pub download: bool,
     pub query_params: GetParams,
+}
+
+async fn fetch_car_recursive<T, W>(
+    resolver: &Resolver<T>,
+    path: iroh_resolver::resolver::Path,
+    writer: W,
+    start_time: std::time::Instant,
+) -> Result<(), anyhow::Error>
+where
+    T: ContentLoader,
+    W: AsyncWrite + Send + Unpin,
+{
+    let stream = resolver.resolve_recursive_raw(path);
+    tokio::pin!(stream);
+
+    let root = stream
+        .next()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("root cid not found"))??;
+
+    let header = CarHeader::new_v1(vec![*root.cid()]);
+    let mut writer = CarWriter::new(header, writer);
+    writer.write(*root.cid(), root.content()).await?;
+
+    while let Some(block) = stream.next().await {
+        let block = block?;
+        record_ttfb_metrics(start_time, block.metadata());
+        writer.write(*block.cid(), block.content()).await?;
+    }
+    Ok(())
+}
+
+fn record_ttfb_metrics(start_time: std::time::Instant, metadata: &Metadata) {
+    record!(
+        GatewayMetrics::TimeToFetchFirstBlock,
+        start_time.elapsed().as_millis() as u64
+    );
+    if metadata.source == Source::Bitswap {
+        observe!(
+            GatewayHistograms::TimeToFetchFirstBlock,
+            start_time.elapsed().as_millis() as f64
+        );
+    } else {
+        observe!(
+            GatewayHistograms::TimeToFetchFirstBlockCached,
+            start_time.elapsed().as_millis() as f64
+        );
+    }
 }

--- a/iroh-gateway/src/constants.rs
+++ b/iroh-gateway/src/constants.rs
@@ -31,3 +31,7 @@ pub static CONTENT_TYPE_IPLD_CAR: HeaderValue =
 // Schemes
 pub static SCHEME_IPFS: &str = "ipfs";
 pub static SCHEME_IPNS: &str = "ipns";
+
+// Max number of links to return in a single recursive request.
+// TODO: Make configurable.
+pub static RECURSION_LIMIT: usize = 4096;

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -101,10 +101,51 @@ impl<T: ContentLoader + std::marker::Unpin> Core<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+
     use super::*;
-    use crate::config::Config;
+    use cid::Cid;
+    use futures::{StreamExt, TryStreamExt};
+    use iroh_resolver::unixfs::UnixfsNode;
+    use iroh_resolver::unixfs_builder::{DirectoryBuilder, FileBuilder};
     use iroh_rpc_client::Client as RpcClient;
     use iroh_rpc_client::Config as RpcClientConfig;
+    use iroh_rpc_types::store::StoreClientAddr;
+    use iroh_rpc_types::Addr;
+    use std::io;
+    use tokio_util::io::StreamReader;
+
+    use crate::config::Config;
+
+    async fn spawn_gateway(
+        config: Arc<Config>,
+    ) -> (SocketAddr, RpcClient, tokio::task::JoinHandle<()>) {
+        let rpc_addr = "grpc://0.0.0.0:0".parse().unwrap();
+        let rpc_client = RpcClient::new(config.rpc_client().clone()).await.unwrap();
+        let core = Core::new(config, rpc_addr, Arc::new(None), rpc_client.clone())
+            .await
+            .unwrap();
+        let server = core.server();
+        let addr = server.local_addr();
+        let core_task = tokio::spawn(async move {
+            server.await.unwrap();
+        });
+        (addr, rpc_client, core_task)
+    }
+
+    async fn spawn_store() -> (StoreClientAddr, tokio::task::JoinHandle<()>) {
+        let (server_addr, client_addr) = Addr::new_mem();
+        let store_dir = tempfile::tempdir().unwrap();
+        let config = iroh_store::Config {
+            path: store_dir.path().join("db"),
+            rpc_client: RpcClientConfig::default(),
+            metrics: iroh_metrics::config::Config::default(),
+        };
+        let store = iroh_store::Store::create(config).await.unwrap();
+        let task =
+            tokio::spawn(async move { iroh_store::rpc::new(server_addr, store).await.unwrap() });
+        (client_addr, task)
+    }
 
     #[tokio::test]
     async fn gateway_health() {
@@ -121,16 +162,7 @@ mod tests {
         );
         config.set_default_headers();
 
-        let rpc_addr = "grpc://0.0.0.0:0".parse().unwrap();
-        let content_loader = RpcClient::new(config.rpc_client().clone()).await.unwrap();
-        let handler = Core::new(Arc::new(config), rpc_addr, Arc::new(None), content_loader)
-            .await
-            .unwrap();
-        let server = handler.server();
-        let addr = server.local_addr();
-        let core_task = tokio::spawn(async move {
-            server.await.unwrap();
-        });
+        let (addr, _rpc_client, core_task) = spawn_gateway(Arc::new(config)).await;
 
         let uri = hyper::Uri::builder()
             .scheme("http")
@@ -146,5 +178,111 @@ mod tests {
         assert_eq!(b"OK", &body[..]);
         core_task.abort();
         core_task.await.unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn fetch_car_recursive() {
+        let (store_client_addr, store_task) = spawn_store().await;
+        let mut config = Config::new(
+            false,
+            false,
+            false,
+            0,
+            RpcClientConfig {
+                gateway_addr: None,
+                p2p_addr: None,
+                store_addr: Some(store_client_addr),
+            },
+        );
+        config.set_default_headers();
+
+        let (addr, rpc_client, core_task) = spawn_gateway(Arc::new(config)).await;
+
+        let dir = "demo";
+        let files = [
+            ("hello.txt".to_string(), b"ola".to_vec()),
+            ("world.txt".to_string(), b"mundo".to_vec()),
+        ];
+
+        // add a directory with two files to the store.
+        let (root_cid, all_cids) = {
+            let store = rpc_client.try_store().unwrap();
+            let mut cids = vec![];
+            let mut dir_builder = DirectoryBuilder::new();
+            dir_builder.name(dir);
+            for (name, content) in &files {
+                let mut file = FileBuilder::new();
+                file.name(name).content_bytes(content.clone());
+                dir_builder.add_file(file.build().await.unwrap());
+            }
+
+            let root_dir = dir_builder.build().unwrap();
+            let mut parts = root_dir.encode();
+            while let Some(part) = parts.next().await {
+                let (cid, bytes) = part.unwrap();
+                cids.push(cid);
+                store.put(cid, bytes, vec![]).await.unwrap();
+            }
+            (cids.last().unwrap().clone(), cids)
+        };
+
+        // request the root cid as a recursive car
+        let res = {
+            let client = hyper::Client::new();
+            let uri = hyper::Uri::builder()
+                .scheme("http")
+                .authority(format!("localhost:{}", addr.port()))
+                .path_and_query(format!("/ipfs/{}?recursive=true", root_cid))
+                .build()
+                .unwrap();
+            let req = hyper::Request::builder()
+                .method("GET")
+                .header("accept", "application/vnd.ipld.car")
+                .uri(uri)
+                .body(hyper::Body::empty())
+                .unwrap();
+            client.request(req).await.unwrap()
+        };
+
+        assert_eq!(http::StatusCode::OK, res.status());
+
+        // read the response body into a car reader and map the entries
+        // to UnixFS nodes
+        let body = StreamReader::new(
+            res.into_body()
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string())),
+        );
+        let car_reader = iroh_car::CarReader::new(body).await.unwrap();
+        let (nodes, cids): (Vec<UnixfsNode>, Vec<Cid>) = car_reader
+            .stream()
+            .map(|res| res.unwrap())
+            .map(|(cid, bytes)| (UnixfsNode::decode(&cid, bytes.into()).unwrap(), cid))
+            .unzip()
+            .await;
+
+        // match cids and content
+        assert_eq!(cids.clone().sort(), all_cids.clone().sort());
+        assert_eq!(cids[0], root_cid);
+        assert_eq!(nodes.len(), files.len() + 1);
+        assert_eq!(nodes[0].is_dir(), true);
+        assert_eq!(
+            nodes[0]
+                .links()
+                .map(|link| link.unwrap().name.unwrap().to_string())
+                .collect::<Vec<_>>(),
+            files
+                .iter()
+                .map(|(name, _content)| name.clone())
+                .collect::<Vec<_>>()
+        );
+
+        for (i, node) in nodes[1..].iter().enumerate() {
+            assert_eq!(node, &UnixfsNode::Raw(files[i].1.clone().into()));
+        }
+
+        core_task.abort();
+        core_task.await.unwrap_err();
+        store_task.abort();
+        store_task.await.unwrap_err();
     }
 }

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -101,6 +101,7 @@ impl<T: ContentLoader + std::marker::Unpin> Core<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::net::SocketAddr;
 
     use super::*;
@@ -223,7 +224,7 @@ mod tests {
                 cids.push(cid);
                 store.put(cid, bytes, vec![]).await.unwrap();
             }
-            (cids.last().unwrap().clone(), cids)
+            (*cids.last().unwrap(), cids)
         };
 
         // request the root cid as a recursive car
@@ -261,10 +262,14 @@ mod tests {
             .await;
 
         // match cids and content
-        assert_eq!(cids.clone().sort(), all_cids.clone().sort());
+        assert_eq!(cids.len(), all_cids.len());
+        assert_eq!(
+            HashSet::<_>::from_iter(cids.iter()),
+            HashSet::from_iter(all_cids.iter())
+        );
         assert_eq!(cids[0], root_cid);
         assert_eq!(nodes.len(), files.len() + 1);
-        assert_eq!(nodes[0].is_dir(), true);
+        assert!(nodes[0].is_dir());
         assert_eq!(
             nodes[0]
                 .links()

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -406,12 +406,10 @@ async fn serve_car_recursive<T: ContentLoader + std::marker::Unpin>(
     mut headers: HeaderMap,
     start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
-    // FIXME: actually package as car file
-
     let body = state
         .client
         .clone()
-        .get_file_recursive(req.resolved_path.clone(), start_time)
+        .get_car_recursive(req.resolved_path.clone(), start_time)
         .await
         .map_err(|e| error(StatusCode::INTERNAL_SERVER_ERROR, &e, &state))?;
 

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -623,7 +623,7 @@ impl<T: ContentLoader> Resolver<T> {
         })
     }
 
-    /// Resolve a path recursively and yield the raw bytes plus metadata.
+    /// Resolve a path recursively and supply a closure to resolve cids to outputs.
     #[tracing::instrument(skip(self, resolve))]
     pub fn resolve_recursive_mapped<O, M, F>(
         &self,

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -627,7 +627,6 @@ impl<T: ContentLoader> Resolver<T> {
             cids.push_back(root_block?);
             loop {
                 if let Some(current) = cids.pop_front() {
-                    // let (cid, data) = &current;
                     let links = parse_links(current.cid(), current.content())?;
                     // TODO: configurable limit
                     for link_chunk in links.chunks(8) {
@@ -635,7 +634,7 @@ impl<T: ContentLoader> Resolver<T> {
                             link_chunk.iter().map(|link| {
                                 let this = this.clone();
                                 async move {
-                                    this.load_cid(&link).await.map(|loaded| OutRaw::from_loaded(*link, loaded))
+                                    this.load_cid(link).await.map(|loaded| OutRaw::from_loaded(*link, loaded))
                                 }
                             })
                         ).await;

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -1005,7 +1005,7 @@ impl<T: ContentLoader> Resolver<T> {
     async fn resolve_root(&self, root: &Path) -> Result<(Cid, LoadedCid)> {
         let cid = self.resolve_path_to_cid(root).await?;
         let loaded_cid = self.load_cid(&cid).await?;
-        return Ok((cid, loaded_cid));
+        Ok((cid, loaded_cid))
     }
 
     #[tracing::instrument(skip(self))]


### PR DESCRIPTION
Hi!
I was looking on how to use iroh from other codebases, and a bit of a precursor to a writable gateway, this PR adds functionality to fetch a DAG recursively into a CAR file. This was already stubbed in the gateway but not implemented.

The implementation works similar to the existing recursive loaders. However to save the cost of reserializing, I added a new `OutRaw` struct in the resolver for this (because the `Out` struct in the resolver currently only keeps the deserialized representation for UnixFS nodes). Currently, the nodes are still fully deserialized anyways for link scraping but that would be fixed with #297.

What's still missing is, I think, a configurable upper limit on DAG sizes that can be requested from the Gateway to avoid DoS attacks. Also misses tests, I can add some if the PR seems on the right track to you.