### PR TITLE
fix(iroh-one): use default store path when no --store-path flag present

### DIFF
--- a/iroh-one/src/config.rs
+++ b/iroh-one/src/config.rs
@@ -6,6 +6,7 @@ use iroh_metrics::config::Config as MetricsConfig;
 use iroh_p2p::Libp2pConfig;
 use iroh_rpc_client::Config as RpcClientConfig;
 use iroh_rpc_types::Addr;
+use iroh_store::config::config_data_path;
 use iroh_util::insert_into_config_map;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -88,7 +89,8 @@ impl Default for Config {
         let gateway_uds_path: PathBuf = TempDir::new("iroh").unwrap().path().join("ipfsd.http");
         let rpc_client = Self::default_rpc_config();
         let metrics_config = MetricsConfig::default();
-        let store_config = default_store_config(rpc_client.clone(), metrics_config.clone());
+        let store_config =
+            default_store_config(None, rpc_client.clone(), metrics_config.clone()).unwrap();
         let key_store_path = iroh_util::iroh_data_root().unwrap();
         Self {
             rpc_client: rpc_client.clone(),
@@ -103,14 +105,16 @@ impl Default for Config {
 }
 
 fn default_store_config(
+    store_path: Option<PathBuf>,
     ipfsd: RpcClientConfig,
     metrics: iroh_metrics::config::Config,
-) -> iroh_store::config::Config {
-    iroh_store::config::Config {
-        path: PathBuf::new(),
+) -> Result<iroh_store::config::Config> {
+    let path = config_data_path(store_path)?;
+    Ok(iroh_store::config::Config {
+        path,
         rpc_client: ipfsd,
         metrics,
-    }
+    })
 }
 
 fn default_p2p_config(


### PR DESCRIPTION
use store exported path in iroh-one.

closes #255, closes #309. cc @fabricedesre