### PR TITLE
gateway: spec parity

### DIFF
--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -14,7 +14,7 @@ iroh-rpc-types = { path = "../iroh-rpc-types", default-features = false }
 cid = "0.8.6"
 
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "fs"] }
-axum = "0.5.1"
+axum = "0.5.15"
 clap = { version = "4.0.9", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.78"

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -13,7 +13,7 @@ iroh-rpc-types = { path = "../iroh-rpc-types", default-features = false }
 
 cid = "0.8.6"
 
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "fs"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "fs", "io-util"] }
 axum = "0.5.15"
 clap = { version = "4.0.9", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -57,6 +57,7 @@ reqwest = { version = "0.11.10", features = ["rustls-tls"], default-features = f
 hex-literal = "0.3.4"
 hex = "0.4.3"
 http-body = "0.4.5"
+mime_classifier = "0.0.1"
 phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -58,6 +58,7 @@ hex-literal = "0.3.4"
 hex = "0.4.3"
 http-body = "0.4.5"
 mime_classifier = "0.0.1"
+mime = "0.3"
 phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]

--- a/iroh-gateway/src/bad_bits.rs
+++ b/iroh-gateway/src/bad_bits.rs
@@ -177,9 +177,6 @@ mod tests {
         bbits.update(deny_list);
 
         let mut config = Config::new(
-            false,
-            false,
-            false,
             0,
             RpcClientConfig {
                 gateway_addr: None,

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -3,6 +3,7 @@ use std::task::Poll;
 
 use anyhow::Result;
 use bytes::Bytes;
+use cid::Cid;
 use futures::{StreamExt, TryStream};
 use http::HeaderMap;
 use iroh_car::{CarHeader, CarWriter};
@@ -173,6 +174,14 @@ impl<T: ContentLoader + std::marker::Unpin> Client<T> {
         });
 
         Ok(body)
+    }
+}
+
+impl<T: ContentLoader> Client<T> {
+    #[tracing::instrument(skip(self))]
+    pub async fn has_file_locally(&self, cid: &Cid) -> Result<bool> {
+        info!("has cid {}", cid);
+        self.resolver.has_cid(cid).await
     }
 }
 

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -191,7 +191,6 @@ pub struct Request {
     pub cid: CidOrDomain,
     pub resolved_path: iroh_resolver::resolver::Path,
     pub query_file_name: String,
-    pub content_path: String,
     pub download: bool,
     pub query_params: GetParams,
 }

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -16,7 +16,7 @@ use iroh_resolver::resolver::{
     CidOrDomain, ContentLoader, Metadata, Out, OutMetrics, OutPrettyReader, OutType, Resolver,
     Source,
 };
-use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWrite};
 use tokio_util::io::ReaderStream;
 use tracing::{info, warn};
 

--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -258,7 +258,13 @@ mod tests {
             "access-control-allow-methods".to_string(),
             Value::new(None, "GET, PUT, POST, DELETE, HEAD, OPTIONS"),
         );
-        expect.insert("access-control-allow-headers".to_string(), Value::new(None, "if-none-match, accept, cache-control, range, service-worker"));
+        expect.insert(
+            "access-control-allow-headers".to_string(),
+            Value::new(
+                None,
+                "if-none-match, accept, cache-control, range, service-worker",
+            ),
+        );
         expect.insert(
             "cache-control".to_string(),
             Value::new(None, "no-cache, no-transform"),

--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn test_default_headers() {
         let headers = default_headers();
-        assert_eq!(headers.len(), 5);
+        assert_eq!(headers.len(), 4);
         let h = headers.get(&ACCESS_CONTROL_ALLOW_ORIGIN).unwrap();
         assert_eq!(h, "*");
     }
@@ -237,10 +237,6 @@ mod tests {
                 None,
                 "if-none-match, accept, cache-control, range, service-worker",
             ),
-        );
-        expect.insert(
-            "cache-control".to_string(),
-            Value::new(None, "no-cache, no-transform"),
         );
         expect.insert("accept-ranges".to_string(), Value::new(None, "none"));
         let got = collect_headers(&default_headers()).unwrap();

--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -108,18 +108,11 @@ fn default_headers() -> HeaderMap {
     );
     headers.typed_insert(
         [
-            CONTENT_TYPE,
-            CONTENT_DISPOSITION,
-            LAST_MODIFIED,
+            IF_NONE_MATCH,
+            ACCEPT,
             CACHE_CONTROL,
-            ACCEPT_RANGES,
-            ETAG,
+            RANGE,
             HEADER_SERVICE_WORKER.clone(),
-            HEADER_X_IPFS_GATEWAY_PREFIX.clone(),
-            HEADER_X_TRACE_ID.clone(),
-            HEADER_X_CONTENT_TYPE_OPTIONS.clone(),
-            HEADER_X_IPFS_PATH.clone(),
-            HEADER_X_IPFS_ROOTS.clone(),
         ]
         .into_iter()
         .collect::<AccessControlAllowHeaders>(),
@@ -265,7 +258,7 @@ mod tests {
             "access-control-allow-methods".to_string(),
             Value::new(None, "GET, PUT, POST, DELETE, HEAD, OPTIONS"),
         );
-        expect.insert("access-control-allow-headers".to_string(), Value::new(None, "content-type, content-disposition, last-modified, cache-control, accept-ranges, etag, service-worker, x-ipfs-gateway-prefix, x-trace-id, x-content-type-options, x-ipfs-path, x-ipfs-roots"));
+        expect.insert("access-control-allow-headers".to_string(), Value::new(None, "if-none-match, accept, cache-control, range, service-worker"));
         expect.insert(
             "cache-control".to_string(),
             Value::new(None, "no-cache, no-transform"),

--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -103,7 +103,6 @@ fn default_headers() -> HeaderMap {
         .collect::<AccessControlAllowHeaders>(),
     );
     // todo(arqu): remove these once propperly implmented
-    headers.insert(CACHE_CONTROL, VALUE_NO_CACHE_NO_TRANSFORM.clone());
     headers.insert(ACCEPT_RANGES, VALUE_NONE.clone());
     headers
 }

--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -131,7 +131,7 @@ impl Source for Config {
     fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
         let rpc_client = self.rpc_client.collect()?;
         let mut map: Map<String, Value> = Map::new();
-        insert_into_config_map(&mut map, "public_url_base", self.public_url_base);
+        insert_into_config_map(&mut map, "public_url_base", self.public_url_base.clone());
         insert_into_config_map(&mut map, "denylist", self.denylist);
         // Some issue between deserializing u64 & u16, converting this to
         // an signed int fixes the issue
@@ -197,6 +197,10 @@ mod tests {
     fn test_collect() {
         let default = Config::default();
         let mut expect: Map<String, Value> = Map::new();
+        expect.insert(
+            "public_url_base".to_string(),
+            Value::new(None, default.public_url_base.clone()),
+        );
         expect.insert("port".to_string(), Value::new(None, default.port as i64));
         expect.insert("denylist".to_string(), Value::new(None, default.denylist));
         expect.insert(

--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -24,12 +24,6 @@ pub struct Config {
     /// Pretty URL to redirect to
     #[serde(default = "String::new")]
     pub public_url_base: String,
-    /// flag to toggle whether the gateway allows writing/pushing data
-    pub writeable: bool,
-    /// flag to toggle whether the gateway allows fetching data from other nodes or is local only
-    pub fetch: bool,
-    /// flag to toggle whether the gateway enables/utilizes caching
-    pub cache: bool,
     /// default port to listen on
     pub port: u16,
     /// flag to toggle whether the gateway should use denylist on requests
@@ -46,18 +40,9 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(
-        writeable: bool,
-        fetch: bool,
-        cache: bool,
-        port: u16,
-        rpc_client: RpcClientConfig,
-    ) -> Self {
+    pub fn new(port: u16, rpc_client: RpcClientConfig) -> Self {
         Self {
             public_url_base: String::new(),
-            writeable,
-            fetch,
-            cache,
             headers: HeaderMap::new(),
             port,
             rpc_client,
@@ -128,9 +113,6 @@ impl Default for Config {
         let rpc_client = RpcClientConfig::default_grpc();
         let mut t = Self {
             public_url_base: String::new(),
-            writeable: false,
-            fetch: false,
-            cache: false,
             headers: HeaderMap::new(),
             port: DEFAULT_PORT,
             rpc_client,
@@ -150,9 +132,7 @@ impl Source for Config {
     fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
         let rpc_client = self.rpc_client.collect()?;
         let mut map: Map<String, Value> = Map::new();
-        insert_into_config_map(&mut map, "writeable", self.writeable);
-        insert_into_config_map(&mut map, "fetch", self.fetch);
-        insert_into_config_map(&mut map, "cache", self.cache);
+        insert_into_config_map(&mut map, "public_url_base", self.public_url_base);
         insert_into_config_map(&mut map, "denylist", self.denylist);
         // Some issue between deserializing u64 & u16, converting this to
         // an signed int fixes the issue
@@ -211,9 +191,6 @@ mod tests {
     #[test]
     fn default_config() {
         let config = Config::default();
-        assert!(!config.writeable);
-        assert!(!config.fetch);
-        assert!(!config.cache);
         assert_eq!(config.port, DEFAULT_PORT);
     }
 
@@ -221,9 +198,6 @@ mod tests {
     fn test_collect() {
         let default = Config::default();
         let mut expect: Map<String, Value> = Map::new();
-        expect.insert("writeable".to_string(), Value::new(None, default.writeable));
-        expect.insert("fetch".to_string(), Value::new(None, default.fetch));
-        expect.insert("cache".to_string(), Value::new(None, default.cache));
         expect.insert("port".to_string(), Value::new(None, default.port as i64));
         expect.insert("denylist".to_string(), Value::new(None, default.denylist));
         expect.insert(

--- a/iroh-gateway/src/constants.rs
+++ b/iroh-gateway/src/constants.rs
@@ -14,8 +14,6 @@ pub static HEADER_CACHE_CONTROL: HeaderName = HeaderName::from_static("cache-con
 // Common Header Values
 pub static VALUE_XCTO_NOSNIFF: HeaderValue = HeaderValue::from_static("nosniff");
 pub static VALUE_NONE: HeaderValue = HeaderValue::from_static("none");
-pub static VALUE_NO_CACHE_NO_TRANSFORM: HeaderValue =
-    HeaderValue::from_static("no-cache, no-transform");
 pub static VAL_IMMUTABLE_MAX_AGE: HeaderValue =
     HeaderValue::from_static("public, max-age=31536000, immutable");
 

--- a/iroh-gateway/src/constants.rs
+++ b/iroh-gateway/src/constants.rs
@@ -9,6 +9,7 @@ pub static HEADER_X_IPFS_GATEWAY_PREFIX: HeaderName =
     HeaderName::from_static("x-ipfs-gateway-prefix");
 pub static HEADER_X_IPFS_ROOTS: HeaderName = HeaderName::from_static("x-ipfs-roots");
 pub static HEADER_SERVICE_WORKER: HeaderName = HeaderName::from_static("service-worker");
+pub static HEADER_CACHE_CONTROL: HeaderName = HeaderName::from_static("cache-control");
 
 // Common Header Values
 pub static VALUE_XCTO_NOSNIFF: HeaderValue = HeaderValue::from_static("nosniff");

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -194,9 +194,6 @@ mod tests {
     async fn fetch_car_recursive() {
         let (store_client_addr, store_task) = spawn_store().await;
         let mut config = Config::new(
-            false,
-            false,
-            false,
             0,
             RpcClientConfig {
                 gateway_addr: None,

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -163,9 +163,6 @@ mod tests {
     #[tokio::test]
     async fn gateway_health() {
         let mut config = Config::new(
-            false,
-            false,
-            false,
             0,
             RpcClientConfig {
                 gateway_addr: None,

--- a/iroh-gateway/src/error.rs
+++ b/iroh-gateway/src/error.rs
@@ -13,6 +13,7 @@ pub struct GatewayError {
 
 impl IntoResponse for GatewayError {
     fn into_response(self) -> Response {
+        // TODO: handle HEAD request
         let body = axum::Json(json!({
             "code": self.status_code.as_u16(),
             "success": false,

--- a/iroh-gateway/src/error.rs
+++ b/iroh-gateway/src/error.rs
@@ -29,9 +29,7 @@ impl GatewayError {
 impl IntoResponse for GatewayError {
     fn into_response(self) -> Response {
         match self.method {
-            Some(http::Method::HEAD) => {
-                return (self.status_code).into_response();
-            }
+            Some(http::Method::HEAD) => (self.status_code).into_response(),
             _ => {
                 let body = axum::Json(json!({
                     "code": self.status_code.as_u16(),
@@ -39,9 +37,9 @@ impl IntoResponse for GatewayError {
                     "message": self.message,
                     "trace_id": self.trace_id,
                 }));
-                return (self.status_code, body).into_response();
+                (self.status_code, body).into_response()
             }
-        };
+        }
     }
 }
 

--- a/iroh-gateway/src/error.rs
+++ b/iroh-gateway/src/error.rs
@@ -1,3 +1,8 @@
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+};
+
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -9,17 +14,45 @@ pub struct GatewayError {
     pub status_code: StatusCode,
     pub message: String,
     pub trace_id: String,
+    pub method: Option<http::Method>,
+}
+
+impl GatewayError {
+    pub fn with_method(self, method: http::Method) -> Self {
+        Self {
+            method: Some(method),
+            ..self
+        }
+    }
 }
 
 impl IntoResponse for GatewayError {
     fn into_response(self) -> Response {
-        // TODO: handle HEAD request
-        let body = axum::Json(json!({
-            "code": self.status_code.as_u16(),
-            "success": false,
-            "message": self.message,
-            "trace_id": self.trace_id,
-        }));
-        (self.status_code, body).into_response()
+        match self.method {
+            Some(http::Method::HEAD) => {
+                return (self.status_code).into_response();
+            }
+            _ => {
+                let body = axum::Json(json!({
+                    "code": self.status_code.as_u16(),
+                    "success": false,
+                    "message": self.message,
+                    "trace_id": self.trace_id,
+                }));
+                return (self.status_code, body).into_response();
+            }
+        };
     }
 }
+
+impl Display for GatewayError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "gateway_error({}): {})",
+            &self.status_code, &self.message
+        )
+    }
+}
+
+impl Error for GatewayError {}

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -161,7 +161,7 @@ pub async fn get_handler<T: ContentLoader + std::marker::Unpin>(
         .map_err(|e| error(StatusCode::BAD_REQUEST, &e, &state))?;
     let resolved_cid = resolved_path.root();
 
-    if handle_only_if_cached(&request_headers, &state, &resolved_cid).await? {
+    if handle_only_if_cached(&request_headers, &state, resolved_cid).await? {
         return response(StatusCode::OK, Body::empty(), HeaderMap::new());
     }
 

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -72,7 +72,7 @@ pub fn get_app_routes<T: ContentLoader + std::marker::Unpin>(state: &Arc<State<T
                 .layer(CompressionLayer::new())
                 .layer(HandleErrorLayer::new(middleware_error_handler::<T>))
                 .load_shed()
-                .concurrency_limit(2048)
+                .concurrency_limit(2048*1024)
                 .timeout(Duration::from_secs(60))
                 .into_inner(),
         )

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -91,7 +91,6 @@ pub fn get_app_routes<T: ContentLoader + std::marker::Unpin>(state: &Arc<State<T
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct GetParams {
-    // todo(arqu): swap this for ResponseFormat
     /// specifies the expected format of the response
     format: Option<String>,
     /// specifies the desired filename of the response
@@ -200,7 +199,7 @@ pub async fn get_handler<T: ContentLoader + std::marker::Unpin>(
         Err(err) => {
             return Err(error(
                 StatusCode::BAD_REQUEST,
-                &format!("invalid header: {}", err),
+                &format!("invalid header value: {}", err),
                 &state,
             ));
         }
@@ -438,6 +437,7 @@ async fn serve_car<T: ContentLoader + std::marker::Unpin>(
     mut headers: HeaderMap,
     start_time: std::time::Instant,
 ) -> Result<GatewayResponse, GatewayError> {
+    // TODO: handle car versions
     // FIXME: we currently only retrieve full cids
     let (body, metadata) = state
         .client

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -554,7 +554,9 @@ async fn serve_fs<T: ContentLoader + std::marker::Unpin>(
                             HeaderValue::from_str("inode/symlink").unwrap(),
                         );
                     } else {
-                        add_content_type_headers(&mut headers, &name);
+                        // todo(arqu): get a sample of the file to do content type detection
+                        let body_sample = "".as_bytes();
+                        add_content_type_headers(&mut headers, &name, body_sample);
                     }
                     response(StatusCode::OK, body, headers)
                 }

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -382,15 +382,18 @@ fn etag_check<T: ContentLoader>(
     state: &State<T>,
 ) -> Option<GatewayResponse> {
     if request_headers.contains_key("If-None-Match") {
-        // todo(arqu): handle dir etags
-        let cid_etag = get_etag(resolved_cid, Some(format.clone()));
         let inm = request_headers
             .get("If-None-Match")
             .unwrap()
             .to_str()
             .unwrap();
-        if etag_matches(inm, &cid_etag) {
-            return Some(GatewayResponse::not_modified());
+        if !inm.is_empty() {
+            // todo(arqu): handle dir etags
+            let cid_etag = get_etag(resolved_cid, Some(format.clone()));
+
+            if etag_matches(inm, &cid_etag) {
+                return Some(GatewayResponse::not_modified());
+            }
         }
     }
     None

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -558,8 +558,8 @@ async fn serve_fs<T: ContentLoader + std::marker::Unpin>(
                             HeaderValue::from_str("inode/symlink").unwrap(),
                         );
                     } else {
-                        let body_sample = body.get_sample();
-                        add_content_type_headers(&mut headers, &name, body_sample.as_slice());
+                        let content_sniffed_mime = body.get_mime();
+                        add_content_type_headers(&mut headers, &name, content_sniffed_mime);
                     }
                     response(StatusCode::OK, body, headers)
                 }
@@ -604,7 +604,7 @@ async fn serve_fs_dir<T: ContentLoader + std::marker::Unpin>(
             .unwrap_or_default()
     });
     if !force_dir && has_index {
-        if !req.resolved_path.is_dir() {
+        if !req.resolved_path.is_dir_like_path() {
             let redirect_path = format!(
                 "{}/{}",
                 req.resolved_path,
@@ -623,7 +623,7 @@ async fn serve_fs_dir<T: ContentLoader + std::marker::Unpin>(
 
     let mut template_data: Map<String, Json> = Map::new();
     let mut root_path = req.resolved_path.clone();
-    if !root_path.is_dir() {
+    if !root_path.is_dir_like_path() {
         root_path.push("");
     }
 

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -554,9 +554,8 @@ async fn serve_fs<T: ContentLoader + std::marker::Unpin>(
                             HeaderValue::from_str("inode/symlink").unwrap(),
                         );
                     } else {
-                        // todo(arqu): get a sample of the file to do content type detection
-                        let body_sample = "".as_bytes();
-                        add_content_type_headers(&mut headers, &name, body_sample);
+                        let body_sample = body.get_sample();
+                        add_content_type_headers(&mut headers, &name, body_sample.as_slice());
                     }
                     response(StatusCode::OK, body, headers)
                 }

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -604,7 +604,7 @@ async fn serve_fs_dir<T: ContentLoader + std::marker::Unpin>(
             .unwrap_or_default()
     });
     if !force_dir && has_index {
-        if !req.resolved_path.is_dir_like_path() {
+        if !req.resolved_path.has_trailing_slash() {
             let redirect_path = format!(
                 "{}/{}",
                 req.resolved_path,
@@ -623,7 +623,7 @@ async fn serve_fs_dir<T: ContentLoader + std::marker::Unpin>(
 
     let mut template_data: Map<String, Json> = Map::new();
     let mut root_path = req.resolved_path.clone();
-    if !root_path.is_dir_like_path() {
+    if !root_path.has_trailing_slash() {
         root_path.push("");
     }
 

--- a/iroh-gateway/src/headers.rs
+++ b/iroh-gateway/src/headers.rs
@@ -12,23 +12,15 @@ pub fn add_user_headers(headers: &mut HeaderMap, user_headers: HeaderMap) {
 #[tracing::instrument()]
 pub fn add_content_type_headers(headers: &mut HeaderMap, name: &str, body_sample: &[u8]) {
     let guess = mime_guess::from_path(name);
-    let mut content_type = String::new();
+    let mut content_type: String;
     if let Some(ct) = guess.first() {
         content_type = ct.to_string();
     } else {
-        // todo(arqu): deeper content type checking
-        let classifier = mime_classifier::MimeClassifier::new();
-        let context = mime_classifier::LoadContext::Browsing;
-        let no_sniff_flag = mime_classifier::NoSniffFlag::Off;
-        let apache_bug_flag = mime_classifier::ApacheBugFlag::Off;
-        let supplied_type = None;
-        let computed_type = classifier.classify(
-            context,
-            no_sniff_flag,
-            apache_bug_flag,
-            &supplied_type,
-            body_sample,
-        );
+        content_type = sniff_content_type(body_sample);
+    }
+
+    if content_type.starts_with("text/") {
+        content_type.push_str("; charset=utf-8");
     }
 
     if content_type.starts_with("text/html") {
@@ -38,6 +30,24 @@ pub fn add_content_type_headers(headers: &mut HeaderMap, name: &str, body_sample
     if !content_type.is_empty() {
         headers.insert(CONTENT_TYPE, HeaderValue::from_str(&content_type).unwrap());
     }
+}
+
+#[tracing::instrument()]
+fn sniff_content_type(body_sample: &[u8]) -> String {
+    let classifier = mime_classifier::MimeClassifier::new();
+    let context = mime_classifier::LoadContext::Browsing;
+    let no_sniff_flag = mime_classifier::NoSniffFlag::Off;
+    let apache_bug_flag = mime_classifier::ApacheBugFlag::On;
+    let supplied_type = None;
+    let computed_type = classifier.classify(
+        context,
+        no_sniff_flag,
+        apache_bug_flag,
+        &supplied_type,
+        body_sample,
+    );
+
+    computed_type.to_string()
 }
 
 #[tracing::instrument()]
@@ -218,13 +228,17 @@ mod tests {
         assert_eq!(headers.len(), 1);
         assert_eq!(
             headers.get(&CONTENT_TYPE).unwrap(),
-            &"text/plain".to_string()
+            &"text/plain; charset=utf-8".to_string()
         );
 
         let mut headers = HeaderMap::new();
         let name = "test.RAND_EXT";
         add_content_type_headers(&mut headers, name, body.as_bytes());
-        assert_eq!(headers.len(), 0);
+        assert_eq!(headers.len(), 1);
+        assert_eq!(
+            headers.get(&CONTENT_TYPE).unwrap(),
+            &"text/plain; charset=utf-8".to_string()
+        );
     }
 
     #[test]

--- a/iroh-gateway/src/headers.rs
+++ b/iroh-gateway/src/headers.rs
@@ -26,10 +26,10 @@ pub fn add_content_type_headers(headers: &mut HeaderMap, name: &str) {
 pub fn add_content_disposition_headers(
     headers: &mut HeaderMap,
     filename: &str,
-    content_path: &str,
+    content_path: &iroh_resolver::resolver::Path,
     should_download: bool,
 ) -> String {
-    let mut name = get_filename(content_path);
+    let mut name = get_filename(&content_path.to_string());
     if !filename.is_empty() {
         name = filename.to_string();
     }
@@ -212,9 +212,12 @@ mod tests {
         // inline
         let mut headers = HeaderMap::new();
         let filename = "test.txt";
-        let content_path = "QmSomeCid";
+        let content_path: iroh_resolver::resolver::Path =
+            "/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy"
+                .parse()
+                .unwrap();
         let download = false;
-        let name = add_content_disposition_headers(&mut headers, filename, content_path, download);
+        let name = add_content_disposition_headers(&mut headers, filename, &content_path, download);
         assert_eq!(headers.len(), 1);
         assert_eq!(
             headers.get(&CONTENT_DISPOSITION).unwrap(),
@@ -225,9 +228,12 @@ mod tests {
         // attachment
         let mut headers = HeaderMap::new();
         let filename = "test.txt";
-        let content_path = "QmSomeCid";
+        let content_path: iroh_resolver::resolver::Path =
+            "/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy"
+                .parse()
+                .unwrap();
         let download = true;
-        let name = add_content_disposition_headers(&mut headers, filename, content_path, download);
+        let name = add_content_disposition_headers(&mut headers, filename, &content_path, download);
         assert_eq!(headers.len(), 1);
         assert_eq!(
             headers.get(&CONTENT_DISPOSITION).unwrap(),
@@ -238,18 +244,27 @@ mod tests {
         // no filename & no content path filename
         let mut headers = HeaderMap::new();
         let filename = "";
-        let content_path = "QmSomeCid";
+        let content_path: iroh_resolver::resolver::Path =
+            "/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy"
+                .parse()
+                .unwrap();
         let download = true;
-        let name = add_content_disposition_headers(&mut headers, filename, content_path, download);
+        let name = add_content_disposition_headers(&mut headers, filename, &content_path, download);
         assert_eq!(headers.len(), 1);
-        assert_eq!(name, "QmSomeCid");
+        assert_eq!(
+            name,
+            "bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy"
+        );
 
         // no filename & with content path filename
         let mut headers = HeaderMap::new();
         let filename = "";
-        let content_path = "QmSomeCid/folder/test.txt";
+        let content_path: iroh_resolver::resolver::Path =
+            "/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy/folder/test.txt"
+                .parse()
+                .unwrap();
         let download = true;
-        let name = add_content_disposition_headers(&mut headers, filename, content_path, download);
+        let name = add_content_disposition_headers(&mut headers, filename, &content_path, download);
         assert_eq!(headers.len(), 1);
         assert_eq!(name, "test.txt");
     }

--- a/iroh-gateway/src/headers.rs
+++ b/iroh-gateway/src/headers.rs
@@ -56,6 +56,7 @@ pub fn set_content_disposition_headers(headers: &mut HeaderMap, filename: &str, 
 pub fn add_cache_control_headers(headers: &mut HeaderMap, metadata: Metadata) {
     if metadata.path.typ() == PathType::Ipns {
         let lmdt: OffsetDateTime = time::SystemTime::now().into();
+        // TODO: better last modified headers based on actual dns ttls
         headers.insert(
             LAST_MODIFIED,
             HeaderValue::from_str(&lmdt.to_string()).unwrap(),

--- a/iroh-gateway/src/response.rs
+++ b/iroh-gateway/src/response.rs
@@ -45,7 +45,6 @@ impl ResponseFormat {
                 headers.insert(CONTENT_TYPE, CONTENT_TYPE_IPLD_CAR.clone());
                 headers.insert(&HEADER_X_CONTENT_TYPE_OPTIONS, VALUE_XCTO_NOSNIFF.clone());
                 headers.insert(ACCEPT_RANGES, VALUE_NONE.clone());
-                headers.insert(CACHE_CONTROL, VALUE_NO_CACHE_NO_TRANSFORM.clone());
             }
             ResponseFormat::Fs(_) => {
                 // Don't send application/octet-stream in that case, let the

--- a/iroh-gateway/src/response.rs
+++ b/iroh-gateway/src/response.rs
@@ -197,7 +197,7 @@ mod tests {
         let rf = ResponseFormat::try_from("car").unwrap();
         let mut headers = HeaderMap::new();
         rf.write_headers(&mut headers);
-        assert_eq!(headers.len(), 4);
+        assert_eq!(headers.len(), 3);
         assert_eq!(headers.get(&CONTENT_TYPE).unwrap(), &CONTENT_TYPE_IPLD_CAR);
         assert_eq!(
             headers.get(&HEADER_X_CONTENT_TYPE_OPTIONS).unwrap(),

--- a/iroh-gateway/src/response.rs
+++ b/iroh-gateway/src/response.rs
@@ -91,22 +91,15 @@ pub fn get_response_format(
 ) -> Result<ResponseFormat, String> {
     if let Some(format) = query_format {
         if !format.is_empty() {
-            match ResponseFormat::try_from(format.as_str()) {
-                Ok(format) => {
-                    return Ok(format);
-                }
-                Err(_) => {}
+            if let Ok(format) = ResponseFormat::try_from(format.as_str()) {
+                return Ok(format);
             }
         }
     }
 
     match ResponseFormat::try_from_headers(request_headers) {
-        Ok(format) => {
-            return Ok(format);
-        }
-        Err(_) => {
-            return Ok(ResponseFormat::Fs(String::new()));
-        }
+        Ok(format) => Ok(format),
+        Err(_) => Ok(ResponseFormat::Fs(String::new())),
     }
 }
 

--- a/iroh-one/src/content_loader.rs
+++ b/iroh-one/src/content_loader.rs
@@ -67,4 +67,8 @@ impl ContentLoader for RacingLoader {
             source: Source::Bitswap,
         })
     }
+
+    async fn has_cid(&self, cid: &Cid) -> Result<bool> {
+        Ok(self.rpc_client.try_store()?.has(*cid).await?)
+    }
 }

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -111,7 +111,7 @@ impl Path {
     }
 
     pub fn is_dir(&self) -> bool {
-        self.tail.len() > 0 && self.tail.last().unwrap().eq("")
+        !self.tail.is_empty() && self.tail.last().unwrap().is_empty()
     }
 
     pub fn push(&mut self, str: impl AsRef<str>) {
@@ -121,13 +121,13 @@ impl Path {
     pub fn to_string_without_type(&self) -> String {
         let mut s = format!("{}", self.root);
         for part in &self.tail {
-            if part == "" {
+            if part.is_empty() {
                 continue;
             }
             s.push_str(&format!("/{}", part)[..]);
         }
         if self.is_dir() {
-            s.push_str("/");
+            s.push('/');
         }
         s
     }
@@ -153,7 +153,7 @@ impl Display for Path {
         write!(f, "/{}/{}", self.typ.as_str(), self.root)?;
 
         for part in &self.tail {
-            if part == "" {
+            if part.is_empty() {
                 continue;
             }
             write!(f, "/{}", part)?;
@@ -1239,13 +1239,11 @@ mod tests {
         let dir_test = "/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy/";
         let non_dir_path: Path = non_dir_test.parse().unwrap();
         let dir_path: Path = dir_test.parse().unwrap();
-        assert!(non_dir_path.tail().len() == 0);
+        assert!(non_dir_path.tail().is_empty());
         assert!(dir_path.tail().len() == 1);
-        assert!(dir_path.tail()[0] == "");
+        assert!(dir_path.tail()[0].is_empty());
 
         assert!(non_dir_path.to_string() == non_dir_test);
-        println!("dir_path: {}", dir_path.to_string());
-        println!("dir_test: {}", dir_test);
         assert!(dir_path.to_string() == dir_test);
         assert!(dir_path.is_dir());
         assert!(!non_dir_path.is_dir());

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -110,7 +110,8 @@ impl Path {
         &self.tail
     }
 
-    pub fn is_dir(&self) -> bool {
+    // used only for string path manipulation
+    pub fn is_dir_like_path(&self) -> bool {
         !self.tail.is_empty() && self.tail.last().unwrap().is_empty()
     }
 
@@ -126,7 +127,7 @@ impl Path {
             }
             s.push_str(&format!("/{}", part)[..]);
         }
-        if self.is_dir() {
+        if self.is_dir_like_path() {
             s.push('/');
         }
         s
@@ -159,7 +160,7 @@ impl Display for Path {
             write!(f, "/{}", part)?;
         }
 
-        if self.is_dir() {
+        if self.is_dir_like_path() {
             write!(f, "/")?;
         }
 
@@ -1245,8 +1246,8 @@ mod tests {
 
         assert!(non_dir_path.to_string() == non_dir_test);
         assert!(dir_path.to_string() == dir_test);
-        assert!(dir_path.is_dir());
-        assert!(!non_dir_path.is_dir());
+        assert!(dir_path.is_dir_like_path());
+        assert!(!non_dir_path.is_dir_like_path());
     }
 
     fn make_ipld() -> Ipld {

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -111,7 +111,7 @@ impl Path {
     }
 
     // used only for string path manipulation
-    pub fn is_dir_like_path(&self) -> bool {
+    pub fn has_trailing_slash(&self) -> bool {
         !self.tail.is_empty() && self.tail.last().unwrap().is_empty()
     }
 
@@ -127,7 +127,7 @@ impl Path {
             }
             s.push_str(&format!("/{}", part)[..]);
         }
-        if self.is_dir_like_path() {
+        if self.has_trailing_slash() {
             s.push('/');
         }
         s
@@ -160,7 +160,7 @@ impl Display for Path {
             write!(f, "/{}", part)?;
         }
 
-        if self.is_dir_like_path() {
+        if self.has_trailing_slash() {
             write!(f, "/")?;
         }
 
@@ -1246,8 +1246,8 @@ mod tests {
 
         assert!(non_dir_path.to_string() == non_dir_test);
         assert!(dir_path.to_string() == dir_test);
-        assert!(dir_path.is_dir_like_path());
-        assert!(!non_dir_path.is_dir_like_path());
+        assert!(dir_path.has_trailing_slash());
+        assert!(!non_dir_path.has_trailing_slash());
     }
 
     fn make_ipld() -> Ipld {

--- a/iroh-share/src/p2p_node.rs
+++ b/iroh-share/src/p2p_node.rs
@@ -107,6 +107,10 @@ impl ContentLoader for Loader {
             source: Source::Bitswap,
         })
     }
+
+    async fn has_cid(&self, cid: &Cid) -> Result<bool> {
+        Ok(self.client.try_store()?.has(*cid).await?)
+    }
 }
 
 impl P2pNode {


### PR DESCRIPTION
Tackles https://github.com/n0-computer/iroh/issues/277

Closes: 
- https://github.com/n0-computer/iroh/issues/230
- https://github.com/n0-computer/iroh/issues/103
- https://github.com/n0-computer/iroh/issues/197
- https://github.com/n0-computer/iroh/issues/98
- https://github.com/n0-computer/iroh/issues/89

Various other QoL fixes, most of the `ETag` support (missing dir etags), `HEAD` request handling (missing a small bit to be done), ensures headers, params etc are in line with spec.

Remainder of work will continue to be tracked on the tracker issue.