### PR TITLE
fix(p2p): Increase the size of the kad mem store

### DIFF
--- a/iroh-p2p/src/behaviour.rs
+++ b/iroh-p2p/src/behaviour.rs
@@ -10,7 +10,7 @@ use libp2p::core::identity::Keypair;
 use libp2p::core::PeerId;
 use libp2p::gossipsub::{Gossipsub, GossipsubConfig, MessageAuthenticity};
 use libp2p::identify::{Identify, IdentifyConfig};
-use libp2p::kad::store::MemoryStore;
+use libp2p::kad::store::{MemoryStore, MemoryStoreConfig};
 use libp2p::kad::{Kademlia, KademliaConfig};
 use libp2p::mdns::TokioMdns as Mdns;
 use libp2p::multiaddr::Protocol;
@@ -62,7 +62,13 @@ impl NodeBehaviour {
             let pub_key = local_key.public();
 
             // TODO: persist to store
-            let store = MemoryStore::new(pub_key.to_peer_id());
+            let mem_store_config = MemoryStoreConfig {
+                // enough for >10gb of unixfs files at the default chunk size
+                max_records: 1024 * 64,
+                max_provided_keys: 1024 * 64,
+                ..Default::default()
+            };
+            let store = MemoryStore::with_config(pub_key.to_peer_id(), mem_store_config);
 
             // TODO: make user configurable
             let mut kad_config = KademliaConfig::default();


### PR DESCRIPTION
This allows adding large files without getting an error. It is a stopgap until we have a persistent kad store.

Before:
```
❯ time cargo run --release -p iroh-ctl -- add --no-wrap test1g  
    Finished release [optimized] target(s) in 0.17s
     Running `target/release/iroh add --no-wrap test1g`
Error: status: Internal, message: "the store cannot contain any more provider records", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Tue, 11 Oct 2022 10:39:21 GMT", "content-length": "0"} }
cargo run --release -p iroh-ctl -- add --no-wrap test1g  0.71s user 0.33s system 7% cpu 13.072 total
```

After:
```
❯ time cargo run --release -p iroh-ctl -- add --no-wrap test1g
    Finished release [optimized] target(s) in 0.18s
     Running `target/release/iroh add --no-wrap test1g`
/ipfs/bafybeiepocidrgivy3uqfh54klmtmfjolx7mceouvt2cggrpkghwsdxzni
cargo run --release -p iroh-ctl -- add --no-wrap test1g  4.75s user 2.29s system 4% cpu 2:53.84 total
```