### PR TITLE
fix(iroh-gateway): add `FileType::Raw` option

### DIFF
--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -494,8 +494,11 @@ async fn serve_fs<T: ContentLoader + std::marker::Unpin>(
             }
         }
         FileResult::Raw(body) => {
+            // todo(arqu): error on no size
+            // todo(arqu): add lazy seeking
             add_cache_control_headers(&mut headers, metadata.clone());
             set_etag_headers(&mut headers, get_etag(&req.cid, Some(req.format.clone())));
+            add_ipfs_roots_headers(&mut headers, metadata);
             let name = add_content_disposition_headers(
                 &mut headers,
                 &req.query_file_name,

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -400,7 +400,6 @@ pub enum OutType {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum UnixfsType {
-    Raw,
     Dir,
     File,
     Symlink,
@@ -963,7 +962,7 @@ impl<T: ContentLoader> Resolver<T> {
             path: root_path,
             size: Some(loaded_cid.data.len() as u64),
             typ: OutType::Raw,
-            unixfs_type: Some(UnixfsType::Raw),
+            unixfs_type: None,
             resolved_path: vec![cid],
             source: loaded_cid.source,
         };


### PR DESCRIPTION
also reverts previous commit that made a bad assumption about allowing `Raw` as a `UnixfsType` in the resolver