### PR TITLE
fix: stop preventing any directory or file `foo` from existing in the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /iroh_gateway/test_files/*
 .env
 Cargo.lock
-foo


### PR DESCRIPTION
This tripped up some test fixtures I wrote where I had inadvertently created a directory `foo` and hadn't realized they were never actually checked in. Was a bit of a headscratcher we want to prevent in the future.