### PR TITLE
feat: race a http gateway with p2p in iroh-one's content loader

### DIFF
--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -268,16 +268,15 @@ fn record_ttfb_metrics(start_time: std::time::Instant, source: &Source) {
         GatewayMetrics::TimeToFetchFirstBlock,
         start_time.elapsed().as_millis() as u64
     );
-    if *source == Source::Bitswap {
-        observe!(
-            GatewayHistograms::TimeToFetchFirstBlock,
-            start_time.elapsed().as_millis() as f64
-        );
-    } else {
-        observe!(
+    match *source {
+        Source::Store(_) => observe!(
             GatewayHistograms::TimeToFetchFirstBlockCached,
             start_time.elapsed().as_millis() as f64
-        );
+        ),
+        _ => observe!(
+            GatewayHistograms::TimeToFetchFirstBlock,
+            start_time.elapsed().as_millis() as f64
+        ),
     }
 }
 

--- a/iroh-one/Cargo.toml
+++ b/iroh-one/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 anyhow = "1"
 async-trait = "0.1.56"
 axum = "0.5.1"
+bytes = "1.1"
 cid = "0.8"
 clap = {version = "4.0.9", features = ["derive"]}
 config = "0.13.1"
@@ -26,6 +27,7 @@ iroh-rpc-client = {path = "../iroh-rpc-client", default-features = false}
 iroh-rpc-types = {path = "../iroh-rpc-types", default-features = false}
 iroh-store = {path = "../iroh-store", default-features = false, features = ["rpc-mem"]}
 iroh-util = {path = "../iroh-util"}
+reqwest = {version = "0.11", features = ["rustls-tls"], default-features = false}
 serde = {version = "1.0", features = ["derive"]}
 tempdir = "0.3.7"
 tokio = {version = "1", features = ["macros", "rt-multi-thread", "process"]}

--- a/iroh-one/src/config.rs
+++ b/iroh-one/src/config.rs
@@ -27,6 +27,8 @@ pub struct Config {
     /// Path for the UDS socket for the gateway.
     #[cfg(feature = "uds-gateway")]
     pub gateway_uds_path: Option<PathBuf>,
+    /// URL of the gateway used by the racing resolver.
+    pub resolver_gateway: Option<String>,
     /// Gateway specific configuration.
     pub gateway: iroh_gateway::config::Config,
     /// Store specific configuration.
@@ -46,6 +48,7 @@ impl Config {
         p2p: iroh_p2p::config::Config,
         rpc_client: RpcClientConfig,
         #[cfg(feature = "uds-gateway")] gateway_uds_path: Option<PathBuf>,
+        resolver_gateway: Option<String>,
     ) -> Self {
         Self {
             gateway,
@@ -55,6 +58,7 @@ impl Config {
             metrics: MetricsConfig::default(),
             #[cfg(feature = "uds-gateway")]
             gateway_uds_path,
+            resolver_gateway,
         }
     }
 
@@ -100,6 +104,7 @@ impl Default for Config {
             p2p: default_p2p_config(rpc_client, metrics_config, key_store_path),
             #[cfg(feature = "uds-gateway")]
             gateway_uds_path: Some(gateway_uds_path),
+            resolver_gateway: None,
         }
     }
 }
@@ -151,6 +156,10 @@ impl Source for Config {
                 uds_path.to_str().unwrap().to_string(),
             );
         }
+        if let Some(resolver_gateway) = &self.resolver_gateway {
+            insert_into_config_map(&mut map, "resolver_gateway", resolver_gateway.clone());
+        }
+
         Ok(map)
     }
 }

--- a/iroh-one/src/main.rs
+++ b/iroh-one/src/main.rs
@@ -84,6 +84,7 @@ async fn main() -> Result<()> {
     // let content_loader = RpcClient::new(config.rpc_client.clone()).await?;
     let content_loader = iroh_one::content_loader::RacingLoader::new(
         RpcClient::new(config.rpc_client.clone()).await?,
+        config.resolver_gateway.clone(),
     );
     let shared_state = Core::make_state(
         Arc::new(config.clone()),


### PR DESCRIPTION
This adds to iroh-one a new optional configuration item: resolver_gateway
If resolver_gateway is set, the resolver will race the p2p node with fetching a raw block from the gateway.

A new source is also introduced to classify blocks coming from a gateway out from those fetched from p2p or store. Hits from the gateway are considered as not cached for telemetry purposes.

ping @b5 