### PR TITLE
chore: add dev-install xtask

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
-private = true
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,4 +10,6 @@ private = true
 anyhow = "1.0"
 clap = { version = "4.0.9", features = ["derive"] }
 clap_mangen = "0.2.2"
+dirs-next = "2.0.0"
 iroh = { path = "../iroh" }
+which = "4.3.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,4 +12,3 @@ clap = { version = "4.0.9", features = ["derive"] }
 clap_mangen = "0.2.2"
 dirs-next = "2.0.0"
 iroh = { path = "../iroh" }
-which = "4.3.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -59,13 +59,13 @@ fn dev_install(build: bool) -> Result<()> {
     if build {
         dist().unwrap();
     }
-    let bins = vec!["iroh", "iroh-one", "iroh-gateway", "iroh-p2p", "iroh-store"];
+    let bins = ["iroh", "iroh-one", "iroh-gateway", "iroh-p2p", "iroh-store"];
     let home = dirs_next::home_dir().unwrap();
     for bin in bins {
         let from = project_root().join(format!("target/release/{}", bin));
         let to = home.join(format!(".cargo/bin/{}", bin));
-        println!("copying {} to {}", bin, to.to_str().unwrap());
-        fs::copy(from, to).unwrap();
+        println!("copying {} to {}", bin, to.display());
+        fs::copy(from, to)?;
     }
     Ok(())
 }
@@ -79,20 +79,6 @@ fn dist_binaries() -> Result<()> {
 
     if !status.success() {
         Err(anyhow::anyhow!("cargo build failed"))?;
-    }
-
-    let dst = project_root().join("target/release/iroh");
-
-    fs::copy(&dst, dist_dir().join("iroh"))?;
-
-    if which::which("strip").is_ok() {
-        eprintln!("stripping the binary");
-        let status = Command::new("strip").arg(&dst).status()?;
-        if !status.success() {
-            Err(anyhow::anyhow!("strip failed"))?;
-        }
-    } else {
-        eprintln!("no `strip` utility found")
     }
 
     Ok(())


### PR DESCRIPTION
fixes `private` config in the `xtask` crate (should be `publish = false`).

Adds new `cargo xtask dev-install` that'll copy all binaries to `$HOME/.cargo/bin/`, which is useful while I'm working on `iroh start`.

Optionally run `cargo xtask dev-install --build` to run a build of all binaries first