### PR TITLE
ci: GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
         type: string
         default: ""
     environment:
-      RUST_LOG: debug
+      RUST_LOG: error
     steps:
       - set-env-path
       - setup-protoc
@@ -288,7 +288,7 @@ jobs:
         type: string
         default: ""
     environment:
-      RUST_LOG: debug
+      RUST_LOG: error
     steps:
       - checkout
       - setup-env-mac
@@ -319,7 +319,7 @@ jobs:
   clippy:
     executor: docker-executor
     environment:
-      RUST_LOG: debug
+      RUST_LOG: warn
     steps:
       - set-env-path
       - setup-protoc
@@ -348,13 +348,13 @@ jobs:
           profile-name: default
       - run:
           name: build x86_64 release
-          command: cargo build --release -v
+          command: cargo build --profile ci -v
       - push-to-s3:
-          path: ./target/release/
+          path: ./target/ci/
           os: linux
           arch: amd64
       - push-to-s3-latest:
-          path: ./target/release/
+          path: ./target/ci/
           os: linux
           arch: amd64
       - save-sccache-cache
@@ -375,13 +375,13 @@ jobs:
           profile-name: default
       - run:
           name: build aarch64 release
-          command: cargo build --release -v
+          command: cargo build --profile ci -v
       - push-to-s3:
-          path: ./target/release/
+          path: ./target/ci/
           os: linux
           arch: aarch64
       - push-to-s3-latest:
-          path: ./target/release/
+          path: ./target/ci/
           os: linux
           arch: aarch64
       - save-sccache-cache
@@ -403,13 +403,13 @@ jobs:
       - run:
           name: build x86_64_darwin
           no_output_timeout: 20m
-          command: cargo build --release -v
+          command: cargo build --profile ci -v
       - push-to-s3:
-          path: ./target/release/
+          path: ./target/ci/
           os: darwin
           arch: x86_64
       - push-to-s3-latest:
-          path: ./target/release/
+          path: ./target/ci/
           os: darwin
           arch: x86_64
       - run:
@@ -421,13 +421,13 @@ jobs:
       - run:
           name: build aarch64_darwin
           no_output_timeout: 20m
-          command: cargo build --release -v --target aarch64-apple-darwin
+          command: cargo build --profile ci -v --target aarch64-apple-darwin
       - push-to-s3:
-          path: ./target/aarch64-apple-darwin/release/
+          path: ./target/aarch64-apple-darwin/ci/
           os: darwin
           arch: aarch64
       - push-to-s3-latest:
-          path: ./target/aarch64-apple-darwin/release/
+          path: ./target/aarch64-apple-darwin/ci/
           os: darwin
           arch: aarch64
       - save-sccache-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,28 @@ jobs:
           name: Run cargo clippy (default features)
           command: cargo clippy --all --all-targets -- -D warnings
       - save-sccache-cache
+  
+  audit:
+    executor: docker-executor
+    environment:
+      RUST_LOG: warn
+    steps:
+      - set-env-path
+      - setup-protoc
+      - *restore-workspace
+      - *restore-cache
+      - setup-sccache
+      - restore-sccache-cache
+      - run:
+          name: Install cargo audit
+          command: cargo install --force cargo-audit
+      - run:
+          name: Generate lock file
+          command: cargo generate-lockfile
+      - run:
+          name: Run cargo audit (default features)
+          command: cargo audit
+      - save-sccache-cache
 
   build_release_x86_64:
     executor: default
@@ -443,6 +465,9 @@ workflows:
           requires:
             - cargo_fetch
       - clippy:
+          requires:
+            - cargo_fetch
+      - audit:
           requires:
             - cargo_fetch
       - test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        rust: [nightly, stable]
+        rust: [stable]
         experimental: [false]
         include:
           - os: ubuntu-latest
@@ -28,11 +29,9 @@ jobs:
             release-os: darwin
             release-arch: x86_64
           - os: windows-latest
-            rust: stable
             sccache-path: "%LOCALAPPDATA%\\sccache"
             release-os: windows
             release-arch: amd64
-            experimental: true
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache
@@ -130,53 +129,43 @@ jobs:
         command: check
         args: --all --bins --tests --examples
 
-    - name: check bench
-      uses: actions-rs/cargo@v1
-      if: matrix.rust == 'nightly'
-      with:
-        command:  check
-        args: --benches
-
     - name: tests
       uses: actions-rs/cargo@v1
+      timeout-minutes: 30
       with:
         command: test
-        args: --all -j 2
+        args: --all -j 4
 
     - name: clipy
       uses: actions-rs/cargo@v1
       if: matrix.os == 'ubuntu-latest' && matrix.rust=='stable'
       with:
           command: clippy
-          args: --all --tests --benches -- -D warnings
+          args: --all --tests --benches --all-targets -- -D warnings
 
     - name: build release
       uses: actions-rs/cargo@v1
       if: matrix.rust=='stable' && github.ref_name=='main'
       with:
         command: build
-        args: --release
+        args: --profile ci
     
-    - name: Get current iroh-gateway version
-      id: ig_version
-      if: matrix.os != 'windows-latest' && matrix.rust=='stable' && github.ref_name=='main'
-      uses: dante-signal31/rust-app-version@v1.0.0
+    - name: Install rust toolchain
+      uses: actions-rs/toolchain@v1
+      if: matrix.rust=='stable' && matrix.os == 'macOS-latest' && github.ref_name=='main'
       with:
-         cargo_toml_folder: iroh-gateway/
+        profile: minimal
+        override: true
+        default: true
+        toolchain: ${{ matrix.rust }}
+        target: aarch64-apple-darwin
     
-    - name: Get current iroh-p2p version
-      id: ip2p_version
-      if: matrix.os != 'windows-latest' && matrix.rust=='stable' && github.ref_name=='main'
-      uses: dante-signal31/rust-app-version@v1.0.0
+    - name: build release
+      uses: actions-rs/cargo@v1
+      if: matrix.rust=='stable' && matrix.os == 'macOS-latest' && github.ref_name=='main'
       with:
-         cargo_toml_folder: iroh-p2p/
-    
-    - name: Get current iroh-store version
-      id: istore_version
-      if: matrix.os != 'windows-latest' && matrix.rust=='stable' && github.ref_name=='main'
-      uses: dante-signal31/rust-app-version@v1.0.0
-      with:
-         cargo_toml_folder: iroh-store/
+        command: build
+        args: --profile ci --target aarch64-apple-darwin
 
     - name: Setup awscli on mac
       if: matrix.os == 'macos-latest' && matrix.rust=='stable' && github.ref_name=='main'
@@ -198,19 +187,21 @@ jobs:
           echo "AWS_SECRET_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}" >> $GITHUB_ENV
           echo "AWS_DEFAULT_REGION=us-west-2" >> $GITHUB_ENV
 
-    # - name: push release
-    #   if: matrix.os != 'windows-latest' && matrix.rust=='stable' && github.ref_name=='main'
-    #   run: |
-    #     aws s3 cp ./target/release/iroh-gateway s3://vorc/iroh-gateway-${RELEASE_OS}-${RELEASE_ARCH}-${{ steps.ig_version.outputs.app_version }}-${GITHUB_SHA::7} --no-progress
-    #     aws s3 cp ./target/release/iroh-p2p s3://vorc/iroh-p2p-${RELEASE_OS}-${RELEASE_ARCH}-${{ steps.ip2p_version.outputs.app_version }}-${GITHUB_SHA::7} --no-progress
-    #     aws s3 cp ./target/release/iroh-store s3://vorc/iroh-store-${RELEASE_OS}-${RELEASE_ARCH}-${{ steps.istore_version.outputs.app_version }}-${GITHUB_SHA::7} --no-progress
+    - name: push release
+      if: matrix.os == 'macOS-latest' && matrix.rust=='stable' && github.ref_name=='main'
+      run: |
+        aws s3 cp ./target/ci/iroh-gateway s3://vorc/iroh-gateway-${RELEASE_OS}-${RELEASE_ARCH}-${GITHUB_SHA::7} --no-progress
+        aws s3 cp ./target/ci/iroh-p2p s3://vorc/iroh-p2p-${RELEASE_OS}-${RELEASE_ARCH}-${GITHUB_SHA::7} --no-progress
+        aws s3 cp ./target/ci/iroh-store s3://vorc/iroh-store-${RELEASE_OS}-${RELEASE_ARCH}-${GITHUB_SHA::7} --no-progress
+        aws s3 cp ./target/ci/iroh s3://vorc/iroh-${RELEASE_OS}-${RELEASE_ARCH}-${GITHUB_SHA::7} --no-progress
 
-    # - name: push release latest
-    #   if: matrix.os != 'windows-latest' && matrix.rust=='stable' && github.ref_name=='main'
-    #   run: |
-    #     aws s3 cp ./target/release/iroh-gateway s3://vorc/iroh-gateway-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
-    #     aws s3 cp ./target/release/iroh-p2p s3://vorc/iroh-p2p-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
-    #     aws s3 cp ./target/release/iroh-store s3://vorc/iroh-store-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
+    - name: push release latest
+      if: matrix.os != 'macOS-latest' && matrix.rust=='stable' && github.ref_name=='main'
+      run: |
+        aws s3 cp ./target/ci/iroh-gateway s3://vorc/iroh-gateway-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
+        aws s3 cp ./target/ci/iroh-p2p s3://vorc/iroh-p2p-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
+        aws s3 cp ./target/ci/iroh-store s3://vorc/iroh-store-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
+        aws s3 cp ./target/ci/iroh s3://vorc/iroh-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
     
     - name: Print sccache stats
       run: sccache --show-stats

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,10 @@ resolver = "2"
 [patch.crates-io]
 libp2p = { git = "https://github.com/dignifiedquire/rust-libp2p", branch = "iroh-0-49" }
 # libp2p = { path = "../rust-libp2p" }
+
+[profile.ci]
+inherits = 'release'
+lto = true
+panic = 'abort'
+incremental = false
+codegen-units = 8

--- a/iroh-bitswap/src/peer_task_queue.rs
+++ b/iroh-bitswap/src/peer_task_queue.rs
@@ -177,15 +177,12 @@ impl<T: Topic, D: Data, TM: TaskMerger<T, D>> PeerTaskQueue<T, D, TM> {
     pub async fn tasks_done(&self, peer: PeerId, tasks: &[Task<T, D>]) {
         let mut this = self.inner.lock().await;
 
-        match this.peer_queue.remove(&peer) {
-            Some(mut peer_tracker) => {
-                // tell the peer what was done
-                for task in tasks {
-                    peer_tracker.task_done(task);
-                }
-                this.peer_queue.push(peer, peer_tracker);
+        if let Some(mut peer_tracker) = this.peer_queue.remove(&peer) {
+            // tell the peer what was done
+            for task in tasks {
+                peer_tracker.task_done(task);
             }
-            None => {}
+            this.peer_queue.push(peer, peer_tracker);
         }
     }
 

--- a/iroh-gateway/src/templates.rs
+++ b/iroh-gateway/src/templates.rs
@@ -20,6 +20,10 @@ pub fn icon_class_name(path: &str) -> String {
         .extension()
         .and_then(OsStr::to_str)
         .unwrap_or("");
-    let icon = KNOWN_ICONS.contains(ext).then(|| ext).unwrap_or("_blank");
+    let icon = if KNOWN_ICONS.contains(ext) {
+        ext
+    } else {
+        "_blank"
+    };
     format!("icon-{}", icon)
 }


### PR DESCRIPTION
Fixes builds, adds mac releases (x86_64 and arm64) and enables windows builds (admittedly failing now but a good reminder to resolve it).

Also adds cargo-audit closing out: https://github.com/n0-computer/iroh/issues/8

Post merge I'll make the mac tests/builds mandatory.
Once we clean up cargo audit and windows build those will be mandatory too. 
Keeping the ubuntu tests on GH Actions just because.