### PR TITLE
fix: ensure that the root data path exists before creating lock files

### DIFF
--- a/iroh-util/src/lock.rs
+++ b/iroh-util/src/lock.rs
@@ -37,6 +37,7 @@ impl ProgramLock {
 
     /// Try to acquire a lock for this program.
     pub fn acquire(&mut self) -> Result<()> {
+        std::fs::create_dir_all(&crate::iroh_data_root()?)?;
         let file = Rc::new(File::create(&self.path)?);
 
         file_guard::lock(file, Lock::Exclusive, 0, 1)


### PR DESCRIPTION
WIthout that fix, if `$HOME/.local/share/iroh` doesn't exist yet the lock creation fails.

ping @b5 since that may conflict with your work on start/stop.