### PR TITLE
Connection error

### DIFF
--- a/iroh/src/main.rs
+++ b/iroh/src/main.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::Parser;
+use std::io;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
@@ -10,5 +11,30 @@ async fn main() -> Result<()> {
     // fixtures is invoked.
     // Without the `testing` feature, the version of
     // `run` that interacts with the real Iroh API is used.
-    cli.run().await
+    let r = cli.run().await;
+    let r = transform_error(r);
+    match r {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            eprintln!("Error: {:?}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn transform_error(r: Result<()>) -> Result<()> {
+    match r {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let io_error = e.root_cause().downcast_ref::<io::Error>();
+            if let Some(io_error) = io_error {
+                if io_error.kind() == io::ErrorKind::ConnectionRefused {
+                    return Err(anyhow!(
+                        "Connection refused. Are `iroh-p2p` and `iroh-store` running?"
+                    ));
+                }
+            }
+            Err(e)
+        }
+    }
 }

--- a/iroh/src/run.rs
+++ b/iroh/src/run.rs
@@ -162,8 +162,8 @@ async fn add(api: &impl Api, path: &Path, no_wrap: bool, recursive: bool) -> Res
     pb.inc(0);
 
     let mut progress = api.add_stream(path, !no_wrap).await?;
-    while let Some(Ok(add_event)) = progress.next().await {
-        match add_event {
+    while let Some(add_event) = progress.next().await {
+        match add_event? {
             AddEvent::ProgressDelta(size) => {
                 pb.inc(size);
             }

--- a/iroh/src/run.rs
+++ b/iroh/src/run.rs
@@ -6,7 +6,7 @@ use crate::doc;
 use crate::fixture::get_fixture_api;
 use crate::p2p::{run_command as run_p2p_command, P2p};
 use crate::size::size_stream;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use futures::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};

--- a/iroh/src/run.rs
+++ b/iroh/src/run.rs
@@ -6,7 +6,7 @@ use crate::doc;
 use crate::fixture::get_fixture_api;
 use crate::p2p::{run_command as run_p2p_command, P2p};
 use crate::size::size_stream;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 use futures::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};


### PR DESCRIPTION
I broke the error handling in `iroh add` by inadvertently swallowing an error. This PR fixes this and introduces a `transform_error` strategy which looks for the root cause and tries to create a better error message as in #355
