### PR TITLE
fix: gha disk space hacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
         echo "RELEASE_ARCH=${{ matrix.release-arch }}" >> $GITHUB_ENV
         echo "RELEASE_OS=${{ matrix.release-os }}" >> $GITHUB_ENV
     
+    - name: Claim back some disk space (ubuntu-latest)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
     - name: Install sccache (ubuntu-latest)
       if: matrix.os == 'ubuntu-latest'
       env:


### PR DESCRIPTION
Edit, sadly GHA are very resource constrained and a frequent issue (which is already breaking builds) is running out of disk. Doing some "official hacks" to claim back some more on ubuntu. Will follow along for other platforms as needed.