### PR TITLE
Add dumb entry point

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "iroh-store",
   "iroh-share",
   "iroh-util",
+  "iroh-entry-point",
   "stores/*",
   "examples",
   "xtask"

--- a/iroh-entry-point/Cargo.toml
+++ b/iroh-entry-point/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "iroh-entry-point"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.66"
+clap = { version = "4.0.9", features = ["derive"] }
+iroh-gateway = {path = "../iroh-gateway"}
+iroh = {path = "../iroh"}
+iroh-metrics = {path = "../iroh-metrics", default-features = false}
+iroh-p2p = {path = "../iroh-p2p", default-features = false, features = ["rpc-mem"]}
+iroh-resolver = {path = "../iroh-resolver"}
+iroh-rpc-client = {path = "../iroh-rpc-client", default-features = false}
+iroh-rpc-types = {path = "../iroh-rpc-types", default-features = false}
+iroh-store = {path = "../iroh-store", default-features = false, features = ["rpc-mem"]}
+iroh-util = {path = "../iroh-util"}
+tokio = "1.21.2"
+
+[[bin]]
+name = "iroh"
+path = "src/main.rs"

--- a/iroh-entry-point/src/main.rs
+++ b/iroh-entry-point/src/main.rs
@@ -1,0 +1,132 @@
+use anyhow::Context;
+use clap::Parser;
+use iroh_util::{iroh_config_path, make_config};
+
+#[derive(Parser, Debug)]
+enum Subcommands {
+    Gateway(iroh_gateway::cli::Args),
+    P2p(iroh_p2p::cli::Args),
+    Store(iroh_store::cli::Args),
+    Cli(iroh::run::Cli),
+}
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(subcommand)]
+    subcommands: Option<Subcommands>,
+}
+
+async fn run_gateway(args: iroh_gateway::cli::Args) -> anyhow::Result<()> {
+    let cfg_path = iroh_config_path(iroh_gateway::config::CONFIG_FILE_NAME)?;
+    let sources = vec![Some(cfg_path), args.cfg.clone()];
+    let mut config = make_config(
+        // default
+        iroh_gateway::config::Config::default(),
+        // potential config files
+        sources,
+        // env var prefix for this config
+        iroh_gateway::config::ENV_PREFIX,
+        // map of present command line arguments
+        args.make_overrides_map(),
+    )
+    .context("invalid config")?;
+    config.metrics = iroh_gateway::metrics::metrics_config_with_compile_time_info(config.metrics);
+    iroh_gateway::run(config).await
+}
+
+async fn run_p2p(args: iroh_p2p::cli::Args) -> anyhow::Result<()> {
+    // TODO: configurable network
+    let cfg_path = iroh_config_path(iroh_p2p::CONFIG_FILE_NAME)?;
+    let sources = vec![Some(cfg_path), args.cfg.clone()];
+    let config = make_config(
+        // default
+        iroh_p2p::Config::default_grpc(),
+        // potential config files
+        sources,
+        // env var prefix for this config
+        iroh_p2p::ENV_PREFIX,
+        // map of present command line arguments
+        args.make_overrides_map(),
+    )
+    .context("invalid config")?;
+    iroh_p2p::run(config)
+}
+
+async fn run_store(args: iroh_store::cli::Args) -> anyhow::Result<()> {
+    let config_path = iroh_config_path(iroh_store::config::CONFIG_FILE_NAME)?;
+    let sources = vec![Some(config_path), args.cfg.clone()];
+    let config_data_path = iroh_store::config::config_data_path(args.path.clone())?;
+    let config = make_config(
+        // default
+        iroh_store::Config::new_grpc(config_data_path),
+        // potential config files
+        sources,
+        // env var prefix for this config
+        iroh_store::config::ENV_PREFIX,
+        // map of present command line arguments
+        args.make_overrides_map(),
+    )
+    .context("invalid config")?;
+    iroh_store::run(config).await
+}
+
+async fn run_cli(args: iroh::run::Cli) -> anyhow::Result<()> {
+    use anyhow::{anyhow, Result};
+    use std::io;
+
+    fn transform_error(r: Result<()>) -> Result<()> {
+        match r {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let io_error = e.root_cause().downcast_ref::<io::Error>();
+                if let Some(io_error) = io_error {
+                    if io_error.kind() == io::ErrorKind::ConnectionRefused {
+                        return Err(anyhow!(
+                            "Connection refused. Are `iroh-p2p` and `iroh-store` running?"
+                        ));
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+
+    // the `run` method exists in two versions:
+    // When using the `testing` feature, the
+    // version of `run` designed for testing purposes using mocked test
+    // fixtures is invoked.
+    // Without the `testing` feature, the version of
+    // `run` that interacts with the real Iroh API is used.
+    let r = args.run().await;
+    let r = transform_error(r);
+    match r {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            eprintln!("Error: {:?}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    if let Some(subcommands) = args.subcommands {
+        match subcommands {
+            Subcommands::Gateway(args) => {
+                run_gateway(args).await?;
+            }
+            Subcommands::P2p(args) => {
+                run_p2p(args).await?;
+            }
+            Subcommands::Store(args) => {
+                run_store(args).await?;
+            }
+            Subcommands::Cli(args) => {
+                run_cli(args).await?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/iroh-gateway/src/lib.rs
+++ b/iroh-gateway/src/lib.rs
@@ -10,4 +10,6 @@ pub mod headers;
 pub mod metrics;
 pub mod response;
 mod rpc;
+mod run;
 pub mod templates;
+pub use run::run;

--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -1,18 +1,11 @@
-use std::sync::Arc;
-
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::Parser;
 use iroh_gateway::{
-    bad_bits::{self, BadBits},
     cli::Args,
     config::{Config, CONFIG_FILE_NAME, ENV_PREFIX},
-    core::Core,
-    metrics,
+    metrics, run,
 };
-use iroh_rpc_client::Client as RpcClient;
 use iroh_util::{iroh_config_path, make_config};
-use tokio::sync::RwLock;
-use tracing::{debug, error};
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
@@ -33,51 +26,5 @@ async fn main() -> Result<()> {
     .unwrap();
     config.metrics = metrics::metrics_config_with_compile_time_info(config.metrics);
     println!("{:#?}", config);
-
-    let metrics_config = config.metrics.clone();
-    let bad_bits = match config.denylist {
-        true => Arc::new(Some(RwLock::new(BadBits::new()))),
-        false => Arc::new(None),
-    };
-    let rpc_addr = config
-        .server_rpc_addr()?
-        .ok_or_else(|| anyhow!("missing gateway rpc addr"))?;
-    let content_loader = RpcClient::new(config.rpc_client.clone()).await?;
-    let handler = Core::new(
-        Arc::new(config),
-        rpc_addr,
-        Arc::clone(&bad_bits),
-        content_loader,
-    )
-    .await?;
-
-    let bad_bits_handle = bad_bits::spawn_bad_bits_updater(Arc::clone(&bad_bits));
-
-    let metrics_handle = iroh_metrics::MetricsHandle::new(metrics_config)
-        .await
-        .expect("failed to initialize metrics");
-
-    #[cfg(unix)]
-    {
-        match iroh_util::increase_fd_limit() {
-            Ok(soft) => debug!("NOFILE limit: soft = {}", soft),
-            Err(err) => error!("Error increasing NOFILE limit: {}", err),
-        }
-    }
-
-    let server = handler.server();
-    println!("listening on {}", server.local_addr());
-    let core_task = tokio::spawn(async move {
-        server.await.unwrap();
-    });
-
-    iroh_util::block_until_sigint().await;
-    core_task.abort();
-
-    metrics_handle.shutdown();
-    if let Some(handle) = bad_bits_handle {
-        handle.abort();
-    }
-
-    Ok(())
+    run(config).await
 }

--- a/iroh-gateway/src/run.rs
+++ b/iroh-gateway/src/run.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+use crate::{
+    bad_bits::{self, BadBits},
+    core::Core,
+};
+use anyhow::{anyhow, Result};
+use iroh_rpc_client::Client as RpcClient;
+use tokio::sync::RwLock;
+use tracing::{debug, error};
+
+pub async fn run(config: crate::config::Config) -> Result<()> {
+    let metrics_config = config.metrics.clone();
+    let bad_bits = match config.denylist {
+        true => Arc::new(Some(RwLock::new(BadBits::new()))),
+        false => Arc::new(None),
+    };
+    let rpc_addr = config
+        .server_rpc_addr()?
+        .ok_or_else(|| anyhow!("missing gateway rpc addr"))?;
+    let content_loader = RpcClient::new(config.rpc_client.clone()).await?;
+    let handler = Core::new(
+        Arc::new(config),
+        rpc_addr,
+        Arc::clone(&bad_bits),
+        content_loader,
+    )
+    .await?;
+
+    let bad_bits_handle = bad_bits::spawn_bad_bits_updater(Arc::clone(&bad_bits));
+
+    let metrics_handle = iroh_metrics::MetricsHandle::new(metrics_config)
+        .await
+        .expect("failed to initialize metrics");
+
+    #[cfg(unix)]
+    {
+        match iroh_util::increase_fd_limit() {
+            Ok(soft) => debug!("NOFILE limit: soft = {}", soft),
+            Err(err) => error!("Error increasing NOFILE limit: {}", err),
+        }
+    }
+
+    let server = handler.server();
+    println!("listening on {}", server.local_addr());
+    let core_task = tokio::spawn(async move {
+        server.await.unwrap();
+    });
+
+    iroh_util::block_until_sigint().await;
+    core_task.abort();
+
+    metrics_handle.shutdown();
+    if let Some(handle) = bad_bits_handle {
+        handle.abort();
+    }
+
+    Ok(())
+}

--- a/iroh-p2p/src/lib.rs
+++ b/iroh-p2p/src/lib.rs
@@ -5,7 +5,9 @@ mod keys;
 pub mod metrics;
 mod node;
 pub mod rpc;
+mod run;
 mod swarm;
+pub use run::run;
 
 pub use self::config::*;
 pub use self::keys::{DiskStorage, Keychain, MemoryStorage};

--- a/iroh-p2p/src/main.rs
+++ b/iroh-p2p/src/main.rs
@@ -1,76 +1,27 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use clap::Parser;
+use iroh_p2p::cli::Args;
 use iroh_p2p::config::{Config, CONFIG_FILE_NAME, ENV_PREFIX};
-use iroh_p2p::{cli::Args, metrics, DiskStorage, Keychain, Node};
+use iroh_p2p::run;
 use iroh_util::{iroh_config_path, make_config};
-use tokio::task;
-use tracing::{debug, error};
 
 /// Starts daemon process
 fn main() -> Result<()> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .max_blocking_threads(2048)
-        .thread_stack_size(16 * 1024 * 1024)
-        .enable_all()
-        .build()
-        .unwrap();
+    let args = Args::parse();
 
-    runtime.block_on(async move {
-        let version = option_env!("IROH_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
-        println!("Starting iroh-p2p, version {version}");
-
-        let args = Args::parse();
-
-        // TODO: configurable network
-        let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
-        let sources = vec![Some(cfg_path), args.cfg.clone()];
-        let network_config = make_config(
-            // default
-            Config::default_grpc(),
-            // potential config files
-            sources,
-            // env var prefix for this config
-            ENV_PREFIX,
-            // map of present command line arguments
-            args.make_overrides_map(),
-        )
-        .context("invalid config")?;
-
-        let metrics_config =
-            metrics::metrics_config_with_compile_time_info(network_config.metrics.clone());
-
-        let metrics_handle = iroh_metrics::MetricsHandle::new(metrics_config)
-            .await
-            .map_err(|e| anyhow!("metrics init failed: {:?}", e))?;
-
-        #[cfg(unix)]
-        {
-            match iroh_util::increase_fd_limit() {
-                Ok(soft) => debug!("NOFILE limit: soft = {}", soft),
-                Err(err) => error!("Error increasing NOFILE limit: {}", err),
-            }
-        }
-
-        let kc = Keychain::<DiskStorage>::new(network_config.key_store_path.clone()).await?;
-        let rpc_addr = network_config
-            .server_rpc_addr()?
-            .ok_or_else(|| anyhow!("missing p2p rpc addr"))?;
-        let mut p2p = Node::new(network_config, rpc_addr, kc).await?;
-
-        // Start services
-        let p2p_task = task::spawn(async move {
-            if let Err(err) = p2p.run().await {
-                error!("{:?}", err);
-            }
-        });
-
-        iroh_util::block_until_sigint().await;
-
-        // Cancel all async services
-        p2p_task.abort();
-        p2p_task.await.ok();
-
-        metrics_handle.shutdown();
-        Ok(())
-    })
+    // TODO: configurable network
+    let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
+    let sources = vec![Some(cfg_path), args.cfg.clone()];
+    let config = make_config(
+        // default
+        Config::default_grpc(),
+        // potential config files
+        sources,
+        // env var prefix for this config
+        ENV_PREFIX,
+        // map of present command line arguments
+        args.make_overrides_map(),
+    )
+    .context("invalid config")?;
+    run(config)
 }

--- a/iroh-p2p/src/run.rs
+++ b/iroh-p2p/src/run.rs
@@ -1,0 +1,56 @@
+use crate::config::Config;
+use crate::{metrics, DiskStorage, Keychain, Node};
+use anyhow::{anyhow, Result};
+use tokio::task;
+use tracing::{debug, error};
+
+pub fn run(network_config: Config) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .max_blocking_threads(2048)
+        .thread_stack_size(16 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async move {
+        let version = option_env!("IROH_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+        println!("Starting iroh-p2p, version {version}");
+
+        let metrics_config =
+            metrics::metrics_config_with_compile_time_info(network_config.metrics.clone());
+
+        let metrics_handle = iroh_metrics::MetricsHandle::new(metrics_config)
+            .await
+            .map_err(|e| anyhow!("metrics init failed: {:?}", e))?;
+
+        #[cfg(unix)]
+        {
+            match iroh_util::increase_fd_limit() {
+                Ok(soft) => debug!("NOFILE limit: soft = {}", soft),
+                Err(err) => error!("Error increasing NOFILE limit: {}", err),
+            }
+        }
+
+        let kc = Keychain::<DiskStorage>::new(network_config.key_store_path.clone()).await?;
+        let rpc_addr = network_config
+            .server_rpc_addr()?
+            .ok_or_else(|| anyhow!("missing p2p rpc addr"))?;
+        let mut p2p = Node::new(network_config, rpc_addr, kc).await?;
+
+        // Start services
+        let p2p_task = task::spawn(async move {
+            if let Err(err) = p2p.run().await {
+                error!("{:?}", err);
+            }
+        });
+
+        iroh_util::block_until_sigint().await;
+
+        // Cancel all async services
+        p2p_task.abort();
+        p2p_task.await.ok();
+
+        metrics_handle.shutdown();
+        Ok(())
+    })
+}

--- a/iroh-store/src/lib.rs
+++ b/iroh-store/src/lib.rs
@@ -3,7 +3,9 @@ pub mod cli;
 pub mod config;
 pub mod metrics;
 pub mod rpc;
+mod run;
 mod store;
+pub use run::run;
 
 pub use crate::config::Config;
 pub use crate::store::Store;

--- a/iroh-store/src/main.rs
+++ b/iroh-store/src/main.rs
@@ -1,20 +1,14 @@
-use anyhow::anyhow;
 use clap::Parser;
 use iroh_store::{
     cli::Args,
     config::{config_data_path, CONFIG_FILE_NAME, ENV_PREFIX},
-    metrics, rpc, Config, Store,
+    run, Config,
 };
-use iroh_util::{block_until_sigint, iroh_config_path, make_config};
-use tracing::{debug, error, info};
+use iroh_util::{iroh_config_path, make_config};
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-
-    let version = env!("CARGO_PKG_VERSION");
-    println!("Starting iroh-store, version {version}");
-
     let config_path = iroh_config_path(CONFIG_FILE_NAME)?;
     let sources = vec![Some(config_path), args.cfg.clone()];
     let config_data_path = config_data_path(args.path.clone())?;
@@ -29,38 +23,5 @@ async fn main() -> anyhow::Result<()> {
         args.make_overrides_map(),
     )
     .unwrap();
-    let metrics_config = config.metrics.clone();
-
-    let metrics_handle = iroh_metrics::MetricsHandle::new(
-        metrics::metrics_config_with_compile_time_info(metrics_config),
-    )
-    .await
-    .expect("failed to initialize metrics");
-
-    #[cfg(unix)]
-    {
-        match iroh_util::increase_fd_limit() {
-            Ok(soft) => debug!("NOFILE limit: soft = {}", soft),
-            Err(err) => error!("Error increasing NOFILE limit: {}", err),
-        }
-    }
-
-    let rpc_addr = config
-        .server_rpc_addr()?
-        .ok_or_else(|| anyhow!("missing store rpc addr"))?;
-    let store = if config.path.exists() {
-        info!("Opening store at {}", config.path.display());
-        Store::open(config).await?
-    } else {
-        info!("Creating store at {}", config.path.display());
-        Store::create(config).await?
-    };
-
-    let rpc_task = tokio::spawn(async move { rpc::new(rpc_addr, store).await.unwrap() });
-
-    block_until_sigint().await;
-    rpc_task.abort();
-    metrics_handle.shutdown();
-
-    Ok(())
+    run(config).await
 }

--- a/iroh-store/src/run.rs
+++ b/iroh-store/src/run.rs
@@ -1,0 +1,44 @@
+use crate::{metrics, rpc, Config, Store};
+use anyhow::anyhow;
+use iroh_util::block_until_sigint;
+use tracing::{debug, error, info};
+
+pub async fn run(config: Config) -> anyhow::Result<()> {
+    let version = env!("CARGO_PKG_VERSION");
+    println!("Starting iroh-store, version {version}");
+
+    let metrics_config = config.metrics.clone();
+
+    let metrics_handle = iroh_metrics::MetricsHandle::new(
+        metrics::metrics_config_with_compile_time_info(metrics_config),
+    )
+    .await
+    .expect("failed to initialize metrics");
+
+    #[cfg(unix)]
+    {
+        match iroh_util::increase_fd_limit() {
+            Ok(soft) => debug!("NOFILE limit: soft = {}", soft),
+            Err(err) => error!("Error increasing NOFILE limit: {}", err),
+        }
+    }
+
+    let rpc_addr = config
+        .server_rpc_addr()?
+        .ok_or_else(|| anyhow!("missing store rpc addr"))?;
+    let store = if config.path.exists() {
+        info!("Opening store at {}", config.path.display());
+        Store::open(config).await?
+    } else {
+        info!("Creating store at {}", config.path.display());
+        Store::create(config).await?
+    };
+
+    let rpc_task = tokio::spawn(async move { rpc::new(rpc_addr, store).await.unwrap() });
+
+    block_until_sigint().await;
+    rpc_task.abort();
+    metrics_handle.shutdown();
+
+    Ok(())
+}

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -37,3 +37,7 @@ iroh-api = { path = "../iroh-api", features = ["testing"] }
 # Unfortunately this also turns on the feature during development, which may be
 # confusing. See the comments in `run.rs` surrounding this.
 iroh = { path = ".", features = ["testing"] }
+
+[[bin]]
+name = "iroh-cli"
+path = "src/main.rs"


### PR DESCRIPTION
This is not really a PR but more a request for discussion with some code attached.

It is **very** dumb. But it would save us from having to publish 4 or 5 binaries.

Instead of `iroh-gateway ...`, you do `iroh gateway ...` etc. Otherwise everything is the same.

Of course you have one fat binary that has stuff you might not need. But I doubt people will care for just trying it out,
and our time might be better used fixing bugs and working on perf than building and publishing so many binaries, at least for the 0.1.0 release...

Here are the sizes:
```
iroh on  rklaehn/iroh-entry-point [$?] via 🦀 v1.63.0 
❯ ls -l target/release/iroh*                            
-rwxr-xr-x  1 rklaehn  staff  42750722 Oct 21 15:29 target/release/iroh // < this would be the only thing we need to publish
-rwxr-xr-x  1 rklaehn  staff  15891990 Oct 21 15:28 target/release/iroh-cli
-rwxr-xr-x  1 rklaehn  staff  19373786 Oct 21 15:28 target/release/iroh-gateway
-rwxr-xr-x  1 rklaehn  staff  24792278 Oct 21 15:29 target/release/iroh-p2p
-rwxr-xr-x  1 rklaehn  staff  20634744 Oct 21 15:28 target/release/iroh-store
```

And the help output:
```
Usage: iroh [COMMAND]

Commands:
  gateway  IPFS gateway
  p2p      Implementation of the p2p part of iroh
  store    Implementation of the storage part of iroh
  cli      A next generation IPFS implementation: https://iroh.computer
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help information
  -V, --version  Print version information
```