### PR TITLE
`iroh p2p peers`: command to list peers

### DIFF
--- a/iroh-api/src/lib.rs
+++ b/iroh-api/src/lib.rs
@@ -20,4 +20,3 @@ pub use iroh_resolver::unixfs_builder::AddEvent;
 pub use iroh_rpc_client::{Lookup, ServiceStatus, StatusRow, StatusTable};
 pub use libp2p::gossipsub::MessageId;
 pub use libp2p::{Multiaddr, PeerId};
-pub use crate::error::ApiError;

--- a/iroh-api/src/lib.rs
+++ b/iroh-api/src/lib.rs
@@ -20,3 +20,4 @@ pub use iroh_resolver::unixfs_builder::AddEvent;
 pub use iroh_rpc_client::{Lookup, ServiceStatus, StatusRow, StatusTable};
 pub use libp2p::gossipsub::MessageId;
 pub use libp2p::{Multiaddr, PeerId};
+pub use crate::error::ApiError;

--- a/iroh-api/src/p2p.rs
+++ b/iroh-api/src/p2p.rs
@@ -1,4 +1,5 @@
 use crate::error::map_service_error;
+use std::collections::HashMap;
 use anyhow::Result;
 use async_trait::async_trait;
 use iroh_rpc_client::{Lookup, P2pClient};
@@ -28,6 +29,7 @@ pub trait P2p: Sync {
     async fn lookup_local(&self) -> Result<Lookup>;
     async fn lookup(&self, addr: &PeerIdOrAddr) -> Result<Lookup>;
     async fn connect(&self, addr: &PeerIdOrAddr) -> Result<()>;
+    async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>>;
 }
 
 #[async_trait]
@@ -68,6 +70,10 @@ impl P2p for ClientP2p {
             }
         }
         .map_err(|e| map_service_error("p2p", e))
+    }
+
+    async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>> {
+        self.client.get_peers().await
     }
 }
 

--- a/iroh-api/src/p2p.rs
+++ b/iroh-api/src/p2p.rs
@@ -1,11 +1,11 @@
 use crate::error::map_service_error;
-use std::collections::HashMap;
 use anyhow::Result;
 use async_trait::async_trait;
 use iroh_rpc_client::{Lookup, P2pClient};
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 #[cfg(feature = "testing")]
 use mockall::automock;
+use std::collections::HashMap;
 
 pub struct ClientP2p {
     client: P2pClient,
@@ -73,7 +73,10 @@ impl P2p for ClientP2p {
     }
 
     async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>> {
-        self.client.get_peers().await
+        self.client
+            .get_peers()
+            .await
+            .map_err(|e| map_service_error("p2p", e))
     }
 }
 

--- a/iroh/src/doc.rs
+++ b/iroh/src/doc.rs
@@ -123,3 +123,19 @@ Network's Distributed Hash Table (DHT) before connecting to the node. When
 provided with a multiaddress, the connection is dialed directly.
 
 Providing no <ADDR> argument will return your local node information.";
+
+pub const P2P_PEERS_LONG_DESCRIPTION: &str = "
+'p2p peers' lists the set of peer addresses this node is currently connected to.
+The address format is a multiaddress, or 'multiaddr' for short. For example:
+
+  /ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
+
+The last element after the '/' is the Peer Identifier or 'PeerID'. Either the 
+PeerID or the entire multiaddr can be given to the 'p2p lookup' command
+for additional details about the peer. For example:
+
+  > iroh p2p lookup QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
+  > iroh p2p lookup /ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
+
+For more info on multiaddrs see https://iroh.computer/docs/concepts#multiaddr.
+";

--- a/iroh/src/p2p.rs
+++ b/iroh/src/p2p.rs
@@ -97,12 +97,10 @@ observed addresses: {:?}
 }
 
 fn display_peers(peers: HashMap<PeerId, Vec<Multiaddr>>) {
-    let mut pid_str: String;
+    // let mut pid_str: String;
     for (peer_id, addrs) in peers {
-        pid_str = peer_id.to_string();
-        if pid_str.len() < 52 {
-            pid_str.push_str(&" ".repeat(52 - pid_str.len()));
+        if let Some(addr) = addrs.first() {
+            println!("{}/{}", addr, peer_id);
         }
-        println!("{}\t{} addresses", pid_str, addrs.len());
     }
 }

--- a/iroh/src/p2p.rs
+++ b/iroh/src/p2p.rs
@@ -2,7 +2,7 @@ use crate::doc;
 use anyhow::{Error, Result};
 use clap::{Args, Subcommand};
 use iroh_api::{Lookup, Multiaddr, P2pApi, PeerId, PeerIdOrAddr};
-use std::{fmt::Display, str::FromStr, collections::HashMap};
+use std::{collections::HashMap, fmt::Display, str::FromStr};
 
 #[derive(Args, Debug, Clone)]
 #[clap(about = "Peer-2-peer commands")]
@@ -29,8 +29,9 @@ pub enum P2pCommands {
         /// multiaddress or peer ID
         addr: Option<PeerIdOrAddrArg>,
     },
-    #[clap(about = "List known peers")]
-    Peers {}
+    #[clap(about = "List connected peers")]
+    #[clap(after_help = doc::P2P_PEERS_LONG_DESCRIPTION)]
+    Peers {},
 }
 
 #[derive(Debug, Clone)]
@@ -73,8 +74,8 @@ pub async fn run_command(p2p: &impl P2pApi, cmd: &P2p) -> Result<()> {
                 None => p2p.lookup_local().await?,
             };
             display_lookup(&lookup);
-        },
-        P2pCommands::Peers {  } => {
+        }
+        P2pCommands::Peers {} => {
             let peers = p2p.peers().await?;
             display_peers(peers);
         }
@@ -96,7 +97,7 @@ observed addresses: {:?}
 }
 
 fn display_peers(peers: HashMap<PeerId, Vec<Multiaddr>>) {
-    let mut pid_str:String;
+    let mut pid_str: String;
     for (peer_id, addrs) in peers {
         pid_str = peer_id.to_string();
         if pid_str.len() < 52 {


### PR DESCRIPTION
```
$ iroh p2p peers --help
List connected peers

Usage: iroh p2p peers

Options:
  -h, --help     Print help information
  -V, --version  Print version information


'p2p peers' lists the set of peer addresses this node is currently connected to.
The address format is a multiaddress, or 'multiaddr' for short. For example:

  /ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ

The last element after the '/' is the Peer Identifier or 'PeerID'. Either the
PeerID or the entire multiaddr can be given to the 'p2p lookup' command
for additional details about the peer. For example:

  > iroh p2p lookup QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
  > iroh p2p lookup /ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ

For more info on multiaddrs see https://iroh.computer/docs/concepts#multiaddr.
```

builds on #402