### PR TITLE
feat: p2p api service calls with a p2p-specific error, better feedback

### DIFF
--- a/iroh-api/Cargo.toml
+++ b/iroh-api/Cargo.toml
@@ -28,6 +28,7 @@ async-stream = "0.3.3"
 mockall = { version = "0.11.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 relative-path = "1.7.2"
+thiserror = "1.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/iroh-api/src/error.rs
+++ b/iroh-api/src/error.rs
@@ -1,0 +1,27 @@
+use std::io;
+use thiserror::Error as ThisError;
+// use std::error::Error;
+use anyhow::{anyhow, Error};
+
+/// LockError is the set of known program lock errors
+#[derive(ThisError, Debug)]
+pub enum ApiError<'a> {
+    #[error("Can't connect to {service}. Is the service running?")]
+    ConnectionRefused { service: &'a str },
+    /// catchall error type
+    #[error("{source}")]
+    Uncategorized {
+        #[from]
+        source: anyhow::Error,
+    },
+}
+
+pub fn map_service_error(service: &'static str, e: Error) -> Error {
+    let io_error = e.root_cause().downcast_ref::<io::Error>();
+    if let Some(io_error) = io_error {
+        if io_error.kind() == io::ErrorKind::ConnectionRefused {
+            return anyhow!(ApiError::ConnectionRefused { service });
+        }
+    }
+    e
+}

--- a/iroh-api/src/lib.rs
+++ b/iroh-api/src/lib.rs
@@ -1,6 +1,7 @@
 mod api;
 mod api_ext;
 mod config;
+mod error;
 mod p2p;
 
 #[cfg(feature = "testing")]
@@ -18,3 +19,4 @@ pub use iroh_resolver::unixfs_builder::AddEvent;
 pub use iroh_rpc_client::{Lookup, ServiceStatus, StatusRow, StatusTable};
 pub use libp2p::gossipsub::MessageId;
 pub use libp2p::{Multiaddr, PeerId};
+pub use crate::error::ApiError;

--- a/iroh-api/src/lib.rs
+++ b/iroh-api/src/lib.rs
@@ -8,6 +8,7 @@ mod p2p;
 pub use crate::api::MockApi;
 pub use crate::api::{Api, Iroh, OutType};
 pub use crate::api_ext::ApiExt;
+pub use crate::error::ApiError;
 #[cfg(feature = "testing")]
 pub use crate::p2p::MockP2p;
 pub use crate::p2p::P2p as P2pApi;
@@ -19,4 +20,3 @@ pub use iroh_resolver::unixfs_builder::AddEvent;
 pub use iroh_rpc_client::{Lookup, ServiceStatus, StatusRow, StatusTable};
 pub use libp2p::gossipsub::MessageId;
 pub use libp2p::{Multiaddr, PeerId};
-pub use crate::error::ApiError;


### PR DESCRIPTION
Work into handling errors related to services that are down. p2p subsytem gets it's own specific error feedback + hint, and clean up the boilerplate error for connection refusal cases we don't specifically handle:

<img width="969" alt="Screen Shot 2022-10-23 at 12 28 37 PM" src="https://user-images.githubusercontent.com/1154390/197403981-9e481379-e68a-4b43-8c7a-d00b8ef8c544.png">


related to #399 