### PR TITLE
Chunky add

### DIFF
--- a/iroh-resolver/src/unixfs_builder.rs
+++ b/iroh-resolver/src/unixfs_builder.rs
@@ -10,11 +10,11 @@ use async_recursion::async_recursion;
 use async_trait::async_trait;
 use bytes::Bytes;
 use cid::Cid;
+use futures::stream::TryStreamExt;
 use futures::{future, stream::LocalBoxStream, Stream, StreamExt};
 use iroh_rpc_client::Client;
 use prost::Message;
 use tokio::io::AsyncRead;
-use futures::stream::TryStreamExt;
 
 use crate::{
     balanced_tree::{TreeBuilder, DEFAULT_DEGREE},
@@ -32,7 +32,7 @@ use crate::{
 const DIRECTORY_LINK_LIMIT: usize = 6000;
 
 /// How many chunks to buffer up when adding content.
-const ADD_PAR: usize = 24;
+const _ADD_PAR: usize = 24;
 
 #[derive(Debug, PartialEq)]
 enum DirectoryType {
@@ -648,8 +648,8 @@ fn add_blocks_to_store_chunked<S: Store>(
 ) -> impl Stream<Item = Result<AddEvent>> {
     let mut chunk = Vec::new();
     let mut chunk_size = 0u64;
-    const MAX_CHUNK_SIZE: u64  =1024 * 1024 * 16;
-    let t = stream!{
+    const MAX_CHUNK_SIZE: u64 = 1024 * 1024 * 16;
+    let t = stream! {
         while let Some(block) = blocks.next().await {
             let block = block?;
             let block_size = block.data().len() as u64;
@@ -673,7 +673,7 @@ fn add_blocks_to_store_chunked<S: Store>(
     t
 }
 
-fn add_blocks_to_store_single<S: Store>(
+fn _add_blocks_to_store_single<S: Store>(
     store: Option<S>,
     blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
 ) -> impl Stream<Item = Result<AddEvent>> {
@@ -697,7 +697,7 @@ fn add_blocks_to_store_single<S: Store>(
                 })
             }
         })
-        .buffered(ADD_PAR)
+        .buffered(_ADD_PAR)
 }
 
 pub async fn add_blocks_to_store<S: Store>(

--- a/iroh-resolver/src/unixfs_builder.rs
+++ b/iroh-resolver/src/unixfs_builder.rs
@@ -646,7 +646,6 @@ fn add_blocks_to_store_chunked<S: Store>(
     store: S,
     mut blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
 ) -> impl Stream<Item = Result<AddEvent>> {
-    println!("add_blocks_to_store_chunked");
     let mut chunk = Vec::new();
     let mut chunk_size = 0u64;
     const MAX_CHUNK_SIZE: u64  =1024 * 1024 * 16;

--- a/iroh-resolver/src/unixfs_builder.rs
+++ b/iroh-resolver/src/unixfs_builder.rs
@@ -10,10 +10,11 @@ use async_recursion::async_recursion;
 use async_trait::async_trait;
 use bytes::Bytes;
 use cid::Cid;
-use futures::{stream::LocalBoxStream, Stream, StreamExt};
+use futures::{future, stream::LocalBoxStream, Stream, StreamExt};
 use iroh_rpc_client::Client;
 use prost::Message;
 use tokio::io::AsyncRead;
+use futures::stream::TryStreamExt;
 
 use crate::{
     balanced_tree::{TreeBuilder, DEFAULT_DEGREE},
@@ -496,6 +497,7 @@ pub(crate) fn encode_unixfs_pb(
 pub trait Store: 'static + Send + Sync + Clone {
     async fn has(&self, &cid: Cid) -> Result<bool>;
     async fn put(&self, cid: Cid, blob: Bytes, links: Vec<Cid>) -> Result<()>;
+    async fn put_many(&self, blocks: Vec<Block>) -> Result<()>;
 }
 
 #[async_trait]
@@ -506,6 +508,12 @@ impl Store for Client {
 
     async fn put(&self, cid: Cid, blob: Bytes, links: Vec<Cid>) -> Result<()> {
         self.try_store()?.put(cid, blob, links).await
+    }
+
+    async fn put_many(&self, blocks: Vec<Block>) -> Result<()> {
+        self.try_store()?
+            .put_many(blocks.into_iter().map(|x| x.into_parts()).collect())
+            .await
     }
 }
 
@@ -525,6 +533,13 @@ impl Store for StoreAndProvideClient {
         // we provide after insertion is finished
         // self.client.try_p2p()?.start_providing(&cid).await
     }
+
+    async fn put_many(&self, blocks: Vec<Block>) -> Result<()> {
+        self.client
+            .try_store()?
+            .put_many(blocks.into_iter().map(|x| x.into_parts()).collect())
+            .await
+    }
 }
 
 #[async_trait]
@@ -534,6 +549,14 @@ impl Store for Arc<tokio::sync::Mutex<std::collections::HashMap<Cid, Bytes>>> {
     }
     async fn put(&self, cid: Cid, blob: Bytes, _links: Vec<Cid>) -> Result<()> {
         self.lock().await.insert(cid, blob);
+        Ok(())
+    }
+
+    async fn put_many(&self, blocks: Vec<Block>) -> Result<()> {
+        let mut this = self.lock().await;
+        for block in blocks {
+            this.insert(*block.cid(), block.data().clone());
+        }
         Ok(())
     }
 }
@@ -617,20 +640,55 @@ pub enum AddEvent {
     },
 }
 
-pub async fn add_blocks_to_store<S: Store>(
+use async_stream::stream;
+
+fn add_blocks_to_store_chunked<S: Store>(
+    store: S,
+    mut blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
+) -> impl Stream<Item = Result<AddEvent>> {
+    println!("add_blocks_to_store_chunked");
+    let mut chunk = Vec::new();
+    let mut chunk_size = 0u64;
+    const MAX_CHUNK_SIZE: u64  =1024 * 1024 * 16;
+    let t = stream!{
+        while let Some(block) = blocks.next().await {
+            let block = block?;
+            let block_size = block.data().len() as u64;
+            let cid = *block.cid();
+            if chunk_size + block_size > MAX_CHUNK_SIZE {
+                tracing::info!("adding chunk of {} bytes", chunk_size);
+                store.put_many(chunk.clone()).await?;
+                chunk.clear();
+                chunk_size = 0;
+            } else {
+                chunk_size += block_size;
+            }
+            yield Ok(AddEvent::ProgressDelta {
+                cid,
+                size: block.raw_data_size(),
+            });
+        }
+        // make sure to also send the last chunk!
+        store.put_many(chunk).await?;
+    };
+    t
+}
+
+fn add_blocks_to_store_single<S: Store>(
     store: Option<S>,
     blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
 ) -> impl Stream<Item = Result<AddEvent>> {
     blocks
-        .map(move |block| {
+        .and_then(|x| future::ok(vec![x]))
+        .map(move |blocks| {
             let store = store.clone();
             async move {
-                let block = block?;
+                let block = blocks?[0].clone();
                 let raw_data_size = block.raw_data_size();
-                let (cid, bytes, links) = block.into_parts();
+                let cid = *block.cid();
                 if let Some(store) = store {
                     if !store.has(cid).await? {
-                        store.put(cid, bytes, links).await?;
+                        store.put_many(vec![block]).await?;
                     }
                 }
 
@@ -641,6 +699,13 @@ pub async fn add_blocks_to_store<S: Store>(
             }
         })
         .buffered(ADD_PAR)
+}
+
+pub async fn add_blocks_to_store<S: Store>(
+    store: Option<S>,
+    blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
+) -> impl Stream<Item = Result<AddEvent>> {
+    add_blocks_to_store_chunked(store.unwrap(), blocks)
 }
 
 #[async_recursion(?Send)]

--- a/iroh-rpc-types/proto/store.proto
+++ b/iroh-rpc-types/proto/store.proto
@@ -7,6 +7,7 @@ import "google/protobuf/empty.proto";
 service Store {
   rpc Version(google.protobuf.Empty) returns (VersionResponse) {}
   rpc Put(PutRequest) returns (google.protobuf.Empty) {}
+  rpc PutMany(PutManyRequest) returns (google.protobuf.Empty) {}
   rpc Get(GetRequest) returns (GetResponse) {}
   rpc Has(HasRequest) returns (HasResponse) {}
   rpc GetLinks(GetLinksRequest) returns(GetLinksResponse) {}
@@ -15,6 +16,12 @@ service Store {
 
 message VersionResponse {
   string version = 1;
+}
+
+// this should really be a stream
+// but that would require a rewrite of the proxy! macro
+message PutManyRequest {
+  repeated PutRequest blocks = 1;
 }
 
 message PutRequest {

--- a/iroh-rpc-types/src/store.rs
+++ b/iroh-rpc-types/src/store.rs
@@ -3,7 +3,9 @@ include_proto!("store");
 proxy!(
     Store,
     version: () => VersionResponse => VersionResponse,
+
     put: PutRequest => () => (),
+    put_many: PutManyRequest => () => (),
     get: GetRequest => GetResponse => GetResponse,
     has: HasRequest => HasResponse => HasResponse,
     get_links: GetLinksRequest => GetLinksResponse => GetLinksResponse,

--- a/iroh-store/src/rpc.rs
+++ b/iroh-store/src/rpc.rs
@@ -43,7 +43,7 @@ impl RpcStore for Store {
             let links = links_from_bytes(req.links)?;
             Ok((cid, req.blob, links))
         }).collect::<Result<Vec<_>>>()?;
-        self.put_many(req).await
+        self.put_many(req)
     }
 
     #[tracing::instrument(skip(self))]

--- a/iroh-store/src/rpc.rs
+++ b/iroh-store/src/rpc.rs
@@ -38,11 +38,15 @@ impl RpcStore for Store {
 
     #[tracing::instrument(skip(self, req))]
     async fn put_many(&self, req: PutManyRequest) -> Result<()> {
-        let req = req.blocks.into_iter().map(|req| {
-            let cid = cid_from_bytes(req.cid)?;
-            let links = links_from_bytes(req.links)?;
-            Ok((cid, req.blob, links))
-        }).collect::<Result<Vec<_>>>()?;
+        let req = req
+            .blocks
+            .into_iter()
+            .map(|req| {
+                let cid = cid_from_bytes(req.cid)?;
+                let links = links_from_bytes(req.links)?;
+                Ok((cid, req.blob, links))
+            })
+            .collect::<Result<Vec<_>>>()?;
         self.put_many(req)
     }
 

--- a/iroh-store/src/store.rs
+++ b/iroh-store/src/store.rs
@@ -93,6 +93,13 @@ struct CodeAndId {
     id: u64,
 }
 
+struct ColumnFamilies<'a> {
+    id: &'a ColumnFamily,
+    metadata: &'a ColumnFamily,
+    graph: &'a ColumnFamily,
+    blobs: &'a ColumnFamily,
+}
+
 impl Store {
     /// Creates a new database.
     #[tracing::instrument]
@@ -195,9 +202,16 @@ impl Store {
     where
         L: IntoIterator<Item = Cid>,
     {
+        self.put0(cid, blob, links, &self.cfs()?)
+    }
+
+    fn put0<T: AsRef<[u8]>, L>(&self, cid: Cid, blob: T, links: L, cf: &ColumnFamilies) -> Result<()>
+    where
+        L: IntoIterator<Item = Cid>,
+    {
         inc!(StoreMetrics::PutRequests);
 
-        if self.has(&cid).await? {
+        if self.has0(&cid, cf)? {
             return Ok(());
         }
 
@@ -216,22 +230,17 @@ impl Store {
         let metadata_bytes = rkyv::to_bytes::<_, 1024>(&metadata)?; // TODO: is this the right amount of scratch space?
         let id_key = id_key(&cid);
 
-        let children = self.ensure_id_many(links.into_iter()).await?;
+        let children = self.ensure_id_many(links.into_iter(), cf)?;
 
         let graph = GraphV0 { children };
         let graph_bytes = rkyv::to_bytes::<_, 1024>(&graph)?; // TODO: is this the right amount of scratch space?
-
-        let cf_id = self.cf_id()?;
-        let cf_meta = self.cf_metadata()?;
-        let cf_graph = self.cf_graph()?;
-        let cf_blobs = self.cf_blobs()?;
         let blob_size = blob.as_ref().len();
 
         let mut batch = WriteBatch::default();
-        batch.put_cf(cf_id, id_key, &id_bytes);
-        batch.put_cf(cf_blobs, &id_bytes, blob);
-        batch.put_cf(cf_meta, &id_bytes, metadata_bytes);
-        batch.put_cf(cf_graph, &id_bytes, graph_bytes);
+        batch.put_cf(cf.id, id_key, &id_bytes);
+        batch.put_cf(cf.blobs, &id_bytes, blob);
+        batch.put_cf(cf.metadata, &id_bytes, metadata_bytes);
+        batch.put_cf(cf.graph, &id_bytes, graph_bytes);
         self.db().write(batch)?;
         observe!(StoreHistograms::PutRequests, start.elapsed().as_secs_f64());
         record!(StoreMetrics::PutBytes, blob_size as u64);
@@ -241,22 +250,17 @@ impl Store {
 
 
     #[tracing::instrument(skip(self, blocks))]
-    pub async fn put_many(&self, blocks: impl IntoIterator<Item = (Cid, Bytes, Vec<Cid>)>) -> Result<()>
+    pub fn put_many(&self, blocks: impl IntoIterator<Item = (Cid, Bytes, Vec<Cid>)>) -> Result<()>
     {
-        let cf_id = self.cf_id()?;
-        let cf_meta = self.cf_metadata()?;
-        let cf_graph = self.cf_graph()?;
-        let cf_blobs = self.cf_blobs()?;
+        let cf = self.cfs()?;
 
         let mut batch = WriteBatch::default();
         for (cid, blob, links) in blocks.into_iter() {
-            if self.has(&cid).await? {
+            if self.has0(&cid, &cf)? {
                 return Ok(());
             }
     
             let id = self.next_id();
-    
-            let start = std::time::Instant::now();
     
             let id_bytes = id.to_be_bytes();
     
@@ -269,21 +273,17 @@ impl Store {
             let metadata_bytes = rkyv::to_bytes::<_, 1024>(&metadata)?; // TODO: is this the right amount of scratch space?
             let id_key = id_key(&cid);
     
-            let children = self.ensure_id_many(links.into_iter()).await?;
+            let children = self.ensure_id_many(links.into_iter(), &cf)?;
     
             let graph = GraphV0 { children };
             let graph_bytes = rkyv::to_bytes::<_, 1024>(&graph)?; // TODO: is this the right amount of scratch space?
     
-            let cf_id = self.cf_id()?;
-            let cf_meta = self.cf_metadata()?;
-            let cf_graph = self.cf_graph()?;
-            let cf_blobs = self.cf_blobs()?;
-            let blob_size = blob.as_ref().len();
+            let _blob_size = blob.as_ref().len();
     
-            batch.put_cf(cf_id, id_key, &id_bytes);
-            batch.put_cf(cf_blobs, &id_bytes, blob);
-            batch.put_cf(cf_meta, &id_bytes, metadata_bytes);
-            batch.put_cf(cf_graph, &id_bytes, graph_bytes);
+            batch.put_cf(cf.id, id_key, &id_bytes);
+            batch.put_cf(cf.blobs, &id_bytes, blob);
+            batch.put_cf(cf.metadata, &id_bytes, metadata_bytes);
+            batch.put_cf(cf.graph, &id_bytes, graph_bytes);
         }
 
         self.db().write(batch)?;
@@ -327,11 +327,16 @@ impl Store {
 
     #[tracing::instrument(skip(self))]
     pub async fn get(&self, cid: &Cid) -> Result<Option<DBPinnableSlice<'_>>> {
+        self.get0(cid)
+    }
+
+    fn get0(&self, cid: &Cid) -> Result<Option<DBPinnableSlice<'_>>> {
         inc!(StoreMetrics::GetRequests);
         let start = std::time::Instant::now();
-        let res = match self.get_id(cid).await? {
+        let cf = self.cfs()?;
+        let res = match self.get_id(cid, &cf)? {
             Some(id) => {
-                let maybe_blob = self.get_by_id(id).await?;
+                let maybe_blob = self.get_by_id(id, &cf)?;
                 inc!(StoreMetrics::StoreHit);
                 record!(
                     StoreMetrics::GetBytes,
@@ -350,10 +355,14 @@ impl Store {
 
     #[tracing::instrument(skip(self))]
     pub async fn get_size(&self, cid: &Cid) -> Result<Option<usize>> {
-        match self.get_id(cid).await? {
+        self.get_size0(cid, &self.cfs()?)
+    }
+
+    fn get_size0(&self, cid: &Cid, cf: &ColumnFamilies) -> Result<Option<usize>> {
+        match self.get_id(cid, cf)? {
             Some(id) => {
                 inc!(StoreMetrics::StoreHit);
-                let maybe_size = self.get_size_by_id(id).await?;
+                let maybe_size = self.get_size_by_id(id)?;
                 Ok(maybe_size)
             }
             None => {
@@ -365,12 +374,15 @@ impl Store {
 
     #[tracing::instrument(skip(self))]
     pub async fn has(&self, cid: &Cid) -> Result<bool> {
-        match self.get_id(cid).await? {
+        self.has0(cid, &self.cfs()?)
+    }
+
+    fn has0(&self, cid: &Cid, cf: &ColumnFamilies) -> Result<bool> {
+        match self.get_id(cid, cf)? {
             Some(id) => {
-                let cf_blobs = self.cf_blobs()?;
                 let exists = self
                     .db()
-                    .get_pinned_cf(cf_blobs, id.to_be_bytes())?
+                    .get_pinned_cf(cf.blobs, id.to_be_bytes())?
                     .is_some();
                 Ok(exists)
             }
@@ -380,11 +392,15 @@ impl Store {
 
     #[tracing::instrument(skip(self))]
     pub async fn get_links(&self, cid: &Cid) -> Result<Option<Vec<Cid>>> {
+        self.get_links0(cid, &self.cfs()?)
+    }
+
+    fn get_links0(&self, cid: &Cid, cf: &ColumnFamilies) -> Result<Option<Vec<Cid>>> {
         inc!(StoreMetrics::GetLinksRequests);
         let start = std::time::Instant::now();
-        let res = match self.get_id(cid).await? {
+        let res = match self.get_id(cid, cf)? {
             Some(id) => {
-                let maybe_links = self.get_links_by_id(id).await?;
+                let maybe_links = self.get_links_by_id(id, cf)?;
                 inc!(StoreMetrics::GetLinksHit);
                 Ok(maybe_links)
             }
@@ -400,11 +416,10 @@ impl Store {
         res
     }
 
-    #[tracing::instrument(skip(self))]
-    async fn get_id(&self, cid: &Cid) -> Result<Option<u64>> {
-        let cf_id = self.cf_id()?;
+    #[tracing::instrument(skip(self, cf))]
+    fn get_id(&self, cid: &Cid, cf: &ColumnFamilies) -> Result<Option<u64>> {
         let id_key = id_key(cid);
-        let maybe_id_bytes = self.db().get_pinned_cf(cf_id, id_key)?;
+        let maybe_id_bytes = self.db().get_pinned_cf(cf.id, id_key)?;
         match maybe_id_bytes {
             Some(bytes) => {
                 let arr = bytes[..8].try_into().map_err(|e| anyhow!("{:?}", e))?;
@@ -446,16 +461,15 @@ impl Store {
             }))
     }
 
-    #[tracing::instrument(skip(self))]
-    async fn get_by_id(&self, id: u64) -> Result<Option<DBPinnableSlice<'_>>> {
-        let cf_blobs = self.cf_blobs()?;
-        let maybe_blob = self.db().get_pinned_cf(cf_blobs, id.to_be_bytes())?;
+    #[tracing::instrument(skip(self, cf))]
+    fn get_by_id(&self, id: u64, cf: &ColumnFamilies) -> Result<Option<DBPinnableSlice<'_>>> {
+        let maybe_blob = self.db().get_pinned_cf(cf.blobs, id.to_be_bytes())?;
 
         Ok(maybe_blob)
     }
 
     #[tracing::instrument(skip(self))]
-    async fn get_size_by_id(&self, id: u64) -> Result<Option<usize>> {
+    fn get_size_by_id(&self, id: u64) -> Result<Option<usize>> {
         let cf_blobs = self
             .inner
             .content
@@ -469,17 +483,15 @@ impl Store {
         Ok(maybe_size)
     }
 
-    #[tracing::instrument(skip(self))]
-    async fn get_links_by_id(&self, id: u64) -> Result<Option<Vec<Cid>>> {
-        let cf_graph = self.cf_graph()?;
+    #[tracing::instrument(skip(self, cf))]
+    fn get_links_by_id(&self, id: u64, cf: &ColumnFamilies) -> Result<Option<Vec<Cid>>> {
         let id_bytes = id.to_be_bytes();
         // FIXME: can't use pinned because otherwise this can trigger alignment issues :/
-        match self.db().get_cf(cf_graph, &id_bytes)? {
+        match self.db().get_cf(cf.graph, &id_bytes)? {
             Some(links_id) => {
-                let cf_meta = self.cf_metadata()?;
                 let graph = rkyv::check_archived_root::<GraphV0>(&links_id)
                     .map_err(|e| anyhow!("{:?}", e))?;
-                let keys = graph.children.iter().map(|id| (&cf_meta, id.to_be_bytes()));
+                let keys = graph.children.iter().map(|id| (&cf.metadata, id.to_be_bytes()));
                 let meta = self.db().multi_get_cf(keys);
                 let mut links = Vec::with_capacity(meta.len());
                 for (i, meta) in meta.into_iter().enumerate() {
@@ -503,19 +515,16 @@ impl Store {
     }
 
     /// Takes a list of cids and gives them ids, which are boths stored and then returned.
-    #[tracing::instrument(skip(self, cids))]
-    async fn ensure_id_many<I>(&self, cids: I) -> Result<Vec<u64>>
+    #[tracing::instrument(skip(self, cids, cf))]
+    fn ensure_id_many<I>(&self, cids: I, cf: &ColumnFamilies) -> Result<Vec<u64>>
     where
         I: IntoIterator<Item = Cid>,
     {
-        let cf_id = self.cf_id()?;
-        let cf_meta = self.cf_metadata()?;
-
         let mut ids = Vec::new();
         let mut batch = WriteBatch::default();
         for cid in cids {
             let id_key = id_key(&cid);
-            let id = if let Some(id) = self.db().get_pinned_cf(cf_id, &id_key)? {
+            let id = if let Some(id) = self.db().get_pinned_cf(cf.id, &id_key)? {
                 u64::from_be_bytes(id.as_ref().try_into()?)
             } else {
                 let id = self.next_id();
@@ -526,8 +535,8 @@ impl Store {
                     multihash: cid.hash().to_bytes(),
                 };
                 let metadata_bytes = rkyv::to_bytes::<_, 1024>(&metadata)?; // TODO: is this the right amount of scratch space?
-                batch.put_cf(&cf_id, id_key, &id_bytes);
-                batch.put_cf(&cf_meta, &id_bytes, metadata_bytes);
+                batch.put_cf(&cf.id, id_key, &id_bytes);
+                batch.put_cf(&cf.metadata, &id_bytes, metadata_bytes);
                 id
             };
             ids.push(id);
@@ -545,32 +554,26 @@ impl Store {
         id
     }
 
+    fn cfs(&self) -> Result<ColumnFamilies> {
+        let db = self.db();
+        Ok(ColumnFamilies {
+            id: db
+                .cf_handle(CF_ID_V0)
+                .context("missing column family: id")?,
+            metadata: db
+                .cf_handle(CF_METADATA_V0)
+                .context("missing column family: metadata")?,
+            graph: db
+                .cf_handle(CF_GRAPH_V0)
+                .context("missing column family: graph")?,
+            blobs: db
+                .cf_handle(CF_BLOBS_V0)
+                .context("missing column family: blobs")?,
+        })
+    }
+
     fn db(&self) -> &RocksDb {
         &self.inner.content
-    }
-
-    fn cf_id(&self) -> Result<&ColumnFamily> {
-        self.db()
-            .cf_handle(CF_ID_V0)
-            .context("missing column family: id")
-    }
-
-    fn cf_metadata(&self) -> Result<&ColumnFamily> {
-        self.db()
-            .cf_handle(CF_METADATA_V0)
-            .context("missing column family: metadata")
-    }
-
-    fn cf_blobs(&self) -> Result<&ColumnFamily> {
-        self.db()
-            .cf_handle(CF_BLOBS_V0)
-            .context("missing column family: blobs")
-    }
-
-    fn cf_graph(&self) -> Result<&ColumnFamily> {
-        self.db()
-            .cf_handle(CF_GRAPH_V0)
-            .context("missing column family: graph")
     }
 }
 


### PR DESCRIPTION
I did two things:
- add a bulk put option into the store api and chunked the store interactions
  (so we can take advantage of the fact that DBs like to process stuff in large chunks, and we reduce the overhead of all the indirection and wrapping we have in our code)
- parallelize the hashing of the content

I was able to remove the parallel requests, so I think this does not even benefit from the grpc connection pool all that much.
Ideally I think all apis should be stream based. I tried a long time to find a way through the maze that is the proxy! macro, but I gave up...

Results:
![fast_add](https://user-images.githubusercontent.com/248257/197722623-3c2f2b21-aae7-4fe7-8fd0-c609a8e8d3bb.gif)


