### PR TITLE
feat: bitswap client mode

### DIFF
--- a/iroh-bitswap/src/client.rs
+++ b/iroh-bitswap/src/client.rs
@@ -65,7 +65,7 @@ pub struct Client<S: Store> {
     rebroadcast_delay: Duration,
     simulate_dont_haves_on_timeout: bool,
     #[derivative(Debug = "ignore")]
-    blocks_received_cb: Arc<Box<BlocksReceivedCb>>,
+    blocks_received_cb: Option<Arc<Box<BlocksReceivedCb>>>,
     notify: async_broadcast::Sender<Block>,
 }
 
@@ -76,7 +76,7 @@ impl<S: Store> Client<S> {
     pub async fn new(
         network: Network,
         store: S,
-        blocks_received_cb: Box<BlocksReceivedCb>,
+        blocks_received_cb: Option<Box<BlocksReceivedCb>>,
         config: Config,
     ) -> Self {
         let self_id = *network.self_id();

--- a/iroh-bitswap/src/client.rs
+++ b/iroh-bitswap/src/client.rs
@@ -116,7 +116,7 @@ impl<S: Store> Client<S> {
             provider_search_delay: config.provider_search_delay,
             rebroadcast_delay: config.rebroadcast_delay,
             simulate_dont_haves_on_timeout: config.simluate_donthaves_on_timeout,
-            blocks_received_cb: Arc::new(blocks_received_cb),
+            blocks_received_cb: blocks_received_cb.map(Arc::new),
             notify,
         }
     }
@@ -229,7 +229,9 @@ impl<S: Store> Client<S> {
                 error!("failed to broadcast block {}: {:?}", block.cid(), err);
             }
         }
-        (self.blocks_received_cb)(*from, wanted.into_iter().cloned().collect()).await;
+        if let Some(ref cb) = self.blocks_received_cb {
+            (cb)(*from, wanted.into_iter().cloned().collect()).await;
+        }
 
         info!("recv_msg end");
         Ok(())

--- a/iroh-bitswap/src/lib.rs
+++ b/iroh-bitswap/src/lib.rs
@@ -238,9 +238,7 @@ impl<S: Store> Bitswap<S> {
     pub async fn stop(self) -> Result<()> {
         self.network.stop();
         if let Some(server) = self.server {
-            let (a, b) = futures::future::join(self.client.stop(), server.stop()).await;
-            a?;
-            b?;
+            futures::future::try_join(self.client.stop(), server.stop()).await?;
         } else {
             self.client.stop().await?;
         }

--- a/iroh-p2p/src/behaviour.rs
+++ b/iroh-p2p/src/behaviour.rs
@@ -88,9 +88,14 @@ impl NodeBehaviour {
         let pub_key = local_key.public();
         let peer_id = pub_key.to_peer_id();
 
-        let bitswap = if config.bitswap {
+        let bitswap = if config.bitswap_client || config.bitswap_server {
             info!("init bitswap");
-            let bs_config = BitswapConfig::default();
+            // NOTE: server only mode is not implemented yet
+            let bs_config = if config.bitswap_server {
+                BitswapConfig::default()
+            } else {
+                BitswapConfig::default_client_mode()
+            };
             Some(Bitswap::new(peer_id, BitswapStore(rpc_client), bs_config).await)
         } else {
             None

--- a/iroh-p2p/src/behaviour.rs
+++ b/iroh-p2p/src/behaviour.rs
@@ -90,7 +90,7 @@ impl NodeBehaviour {
 
         let bitswap = if config.bitswap_client || config.bitswap_server {
             info!("init bitswap");
-            // NOTE: server only mode is not implemented yet
+            // TODO(dig): server only mode is not implemented yet
             let bs_config = if config.bitswap_server {
                 BitswapConfig::default()
             } else {

--- a/iroh-p2p/src/config.rs
+++ b/iroh-p2p/src/config.rs
@@ -42,8 +42,10 @@ pub struct Libp2pConfig {
     pub bootstrap_peers: Vec<Multiaddr>,
     /// Mdns discovery enabled.
     pub mdns: bool,
-    /// Bitswap discovery enabled.
-    pub bitswap: bool,
+    /// Bitswap server mode enabled.
+    pub bitswap_server: bool,
+    /// Bitswap client mode enabled.
+    pub bitswap_client: bool,
     /// Kademlia discovery enabled.
     pub kademlia: bool,
     /// Autonat holepunching enabled.
@@ -118,7 +120,8 @@ impl Source for Libp2pConfig {
 
         insert_into_config_map(&mut map, "kademlia", self.kademlia);
         insert_into_config_map(&mut map, "autonat", self.autonat);
-        insert_into_config_map(&mut map, "bitswap", self.bitswap);
+        insert_into_config_map(&mut map, "bitswap_client", self.bitswap_client);
+        insert_into_config_map(&mut map, "bitswap_server", self.bitswap_server);
         insert_into_config_map(&mut map, "mdns", self.mdns);
         insert_into_config_map(&mut map, "relay_server", self.relay_server);
         insert_into_config_map(&mut map, "relay_client", self.relay_client);
@@ -166,7 +169,8 @@ impl Default for Libp2pConfig {
             relay_server: true,
             relay_client: true,
             gossipsub: true,
-            bitswap: true,
+            bitswap_client: true,
+            bitswap_server: false,
             max_conns_pending_out: 256,
             max_conns_pending_in: 256,
             max_conns_in: 256,
@@ -307,7 +311,14 @@ mod tests {
         expect.insert("kademlia".to_string(), Value::new(None, default.kademlia));
         expect.insert("autonat".to_string(), Value::new(None, default.autonat));
         expect.insert("mdns".to_string(), Value::new(None, default.mdns));
-        expect.insert("bitswap".to_string(), Value::new(None, default.bitswap));
+        expect.insert(
+            "bitswap_server".to_string(),
+            Value::new(None, default.bitswap_server),
+        );
+        expect.insert(
+            "bitswap_client".to_string(),
+            Value::new(None, default.bitswap_client),
+        );
         expect.insert(
             "relay_server".to_string(),
             Value::new(None, default.relay_server),

--- a/iroh-p2p/src/config.rs
+++ b/iroh-p2p/src/config.rs
@@ -170,7 +170,7 @@ impl Default for Libp2pConfig {
             relay_client: true,
             gossipsub: true,
             bitswap_client: true,
-            bitswap_server: false,
+            bitswap_server: true,
             max_conns_pending_out: 256,
             max_conns_pending_in: 256,
             max_conns_in: 256,


### PR DESCRIPTION
When setting `bitswap_server: false`, there is no serving of blocks happening, only client requests.