### PR TITLE
switch macos data & config dir to ~/.config/iroh

### DIFF
--- a/iroh-util/src/lib.rs
+++ b/iroh-util/src/lib.rs
@@ -57,12 +57,21 @@ pub async fn block_until_sigint() {
 /// | Platform | Value                                 | Example                          |
 /// | -------- | ------------------------------------- | -------------------------------- |
 /// | Linux    | `$XDG_CONFIG_HOME` or `$HOME`/.config/iroh | /home/alice/.config/iroh              |
-/// | macOS    | `$HOME`/Library/Application Support/iroh   | /Users/Alice/Library/Application Support/iroh |
+/// | macOS    | `$HOME`/.config/iroh   | /Users/Alice/.config/iroh |
 /// | Windows  | `{FOLDERID_RoamingAppData}`/iroh           | C:\Users\Alice\AppData\Roaming\iroh   |
+#[cfg(not(target_os = "macos"))]
 pub fn iroh_config_root() -> Result<PathBuf> {
     let cfg = dirs_next::config_dir()
         .ok_or_else(|| anyhow!("operating environment provides no directory for configuration"))?;
     Ok(cfg.join(&IROH_DIR))
+}
+
+#[cfg(target_os = "macos")]
+pub fn iroh_config_root() -> Result<PathBuf> {
+    let path = dirs_next::home_dir().ok_or_else(|| {
+        anyhow!("operating environment provides no directory for application data")
+    })?;
+    Ok(path.join(format!(".config/{}", &IROH_DIR)))
 }
 
 // Path that leads to a file in the iroh config directory.
@@ -78,13 +87,22 @@ pub fn iroh_config_path(file_name: &str) -> Result<PathBuf> {
 /// | Platform | Value                                         | Example                                  |
 /// | -------- | --------------------------------------------- | ---------------------------------------- |
 /// | Linux    | `$XDG_DATA_HOME`/iroh or `$HOME`/.local/share/iroh | /home/alice/.local/share/iroh                 |
-/// | macOS    | `$HOME`/Library/Application Support/iroh      | /Users/Alice/Library/Application Support/iroh |
+/// | macOS    | `$HOME`/.config/iroh      | /Users/Alice/.config/iroh |
 /// | Windows  | `{FOLDERID_RoamingAppData}/iroh`              | C:\Users\Alice\AppData\Roaming\iroh           |
+#[cfg(not(target_os = "macos"))]
 pub fn iroh_data_root() -> Result<PathBuf> {
     let path = dirs_next::data_dir().ok_or_else(|| {
         anyhow!("operating environment provides no directory for application data")
     })?;
     Ok(path.join(&IROH_DIR))
+}
+
+#[cfg(target_os = "macos")]
+pub fn iroh_data_root() -> Result<PathBuf> {
+    let path = dirs_next::home_dir().ok_or_else(|| {
+        anyhow!("operating environment provides no directory for application data")
+    })?;
+    Ok(path.join(format!(".config/{}", &IROH_DIR)))
 }
 
 /// Path that leads to a file in the iroh data directory.


### PR DESCRIPTION
Alright I've had it.

I'm working on installer scripts for iroh, and on os X "/Users/$USER/Library/Application Support/iroh" is just not a directory I can remember. The experience is shit. Who puts a SPACE in the name of a critical directory!?

But in more concrete terms, our users will need to interact with this directory if we can't automatically load binaries onto their $PATH. having every application under the sun pollute ~/.$APP_NAME isn't sustainable, so I vote we use the default linux location. Checking my own local machine I have the following applications already populating `.config`:

```
/Users/b5/.config
├── configstore
│   └── update-notifier-gatsby-cli.json
├── gatsby
│   ├── config.json
│   └── sites
│       └── fb8c3aad24651584365e9bad287f6c4e
│           ├── developproxy.json
│           ├── developstatusserver.json
│           ├── metadata.json
│           └── telemetryserver.json
├── gscatter
│   └── uid
├── htop
│   └── htoprc
├── iterm2
│   └── AppSupport -> /Users/b5/Library/Application Support/iTerm2
└── xm1
    ├── texmaker.ini
    └── texmakerapp.ini
```

I'm cool to have this one shot down, just want to raise this issue before our release, when it'll take way more work to change.