### PR TITLE
chore(clippy): Update for rust 1.65

### DIFF
--- a/iroh-bitswap/build.rs
+++ b/iroh-bitswap/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     prost_build::Config::new()
-        .bytes(&[
+        .bytes([
             ".bitswap_pb.Message.Block.data",
             ".bitswap_pb.Message.blocks",
         ])

--- a/iroh-localops/src/process.rs
+++ b/iroh-localops/src/process.rs
@@ -42,7 +42,7 @@ fn daemonize_process(_bin_path: PathBuf, _log_path: PathBuf) -> Result<()> {
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn daemonize_process(bin_path: PathBuf, log_path: PathBuf) -> Result<()> {
-    std::fs::create_dir_all(&log_path.parent().unwrap())?;
+    std::fs::create_dir_all(log_path.parent().unwrap())?;
     // ¯\_(ツ)_/¯
     let status = Command::new("bash")
         .arg("-c")

--- a/iroh-resolver/build.rs
+++ b/iroh-resolver/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     prost_build::Config::new()
-        .bytes(&[".unixfs_pb.Data", ".merkledag_pb.PBNode.Data"])
+        .bytes([".unixfs_pb.Data", ".merkledag_pb.PBNode.Data"])
         .compile_protos(&["src/unixfs.proto", "src/merkledag.proto"], &["src"])
         .unwrap();
 }

--- a/iroh-rpc-types/build.rs
+++ b/iroh-rpc-types/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     let mut config = prost_build::Config::new();
-    config.bytes(&[
+    config.bytes([
         ".p2p.BitswapBlock.data",
         ".p2p.BitswapResponse",
         ".p2p.GossipsubPublishRequest.data",

--- a/iroh-util/src/lib.rs
+++ b/iroh-util/src/lib.rs
@@ -62,7 +62,7 @@ pub async fn block_until_sigint() {
 pub fn iroh_config_root() -> Result<PathBuf> {
     let cfg = dirs_next::config_dir()
         .ok_or_else(|| anyhow!("operating environment provides no directory for configuration"))?;
-    Ok(cfg.join(&IROH_DIR))
+    Ok(cfg.join(IROH_DIR))
 }
 
 // Path that leads to a file in the iroh config directory.
@@ -84,7 +84,7 @@ pub fn iroh_data_root() -> Result<PathBuf> {
     let path = dirs_next::data_dir().ok_or_else(|| {
         anyhow!("operating environment provides no directory for application data")
     })?;
-    Ok(path.join(&IROH_DIR))
+    Ok(path.join(IROH_DIR))
 }
 
 /// Path that leads to a file in the iroh data directory.
@@ -106,7 +106,7 @@ pub fn iroh_cache_root() -> Result<PathBuf> {
     let path = dirs_next::cache_dir().ok_or_else(|| {
         anyhow!("operating environment provides no directory for application data")
     })?;
-    Ok(path.join(&IROH_DIR))
+    Ok(path.join(IROH_DIR))
 }
 
 /// Path that leads to a file in the iroh cache directory.

--- a/iroh-util/src/lock.rs
+++ b/iroh-util/src/lock.rs
@@ -183,7 +183,7 @@ pub fn read_lock_pid(prog_name: &str) -> Result<Pid, LockError> {
 }
 
 fn read_lock(path: &PathBuf) -> Result<Pid, LockError> {
-    let mut file = File::open(&path).map_err(|e| match e.kind() {
+    let mut file = File::open(path).map_err(|e| match e.kind() {
         ErrorKind::NotFound => LockError::NoLock(path.clone()),
         e => LockError::Uncategorized {
             source: anyhow!("{}", e),

--- a/stores/flatfs/src/flatfs.rs
+++ b/stores/flatfs/src/flatfs.rs
@@ -51,7 +51,7 @@ impl Flatfs {
 
         // Make sure the sharding directory exists.
         if !parent_dir.exists() {
-            if let Err(err) = retry(|| fs::create_dir(&parent_dir)) {
+            if let Err(err) = retry(|| fs::create_dir(parent_dir)) {
                 // Directory got already created, that's fine.
                 if err.kind() != io::ErrorKind::AlreadyExists {
                     return Err(err)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -74,7 +74,7 @@ fn dist_binaries() -> Result<()> {
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let status = Command::new(cargo)
         .current_dir(project_root())
-        .args(&["build", "--release"])
+        .args(["build", "--release"])
         .status()?;
 
     if !status.success() {


### PR DESCRIPTION
This applies clippy rules for Rust 1.65.