### PR TITLE
ref(lru-cache): Change lru cache crate to avoid vulnerable dependency

### DIFF
--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -71,9 +71,14 @@ default-features = false
 features = ["std", "multihash-impl", "identity", "sha2"]
 
 [dev-dependencies]
+criterion = "0.3"
+lru = "0.8.1"
 
 [features]
 default = ["rpc-grpc", "rpc-mem"]
 rpc-grpc = ["iroh-rpc-types/grpc", "iroh-rpc-client/grpc", "iroh-metrics/rpc-grpc"]
 rpc-mem = ["iroh-rpc-types/mem", "iroh-rpc-client/mem"]
 
+[[bench]]
+name = "lru_cache"
+harness = false

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -71,7 +71,6 @@ default-features = false
 features = ["std", "multihash-impl", "identity", "sha2"]
 
 [dev-dependencies]
-caches = "0.2.2"
 criterion = "0.4"
 
 [features]

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -14,7 +14,6 @@ async-stream = "0.3.3"
 async-trait = "0.1.56"
 asynchronous-codec = "0.6.0"
 bytes = "1.1.0"
-caches = "0.2.2"
 cid = "0.8.0"
 clap = { version = "4.0.9", features = ["derive"] }
 config = "0.13.1"
@@ -27,6 +26,7 @@ iroh-rpc-client = { path = "../iroh-rpc-client", default-features = false }
 iroh-rpc-types = { path = "../iroh-rpc-types", default-features = false }
 iroh-util = { path = "../iroh-util" }
 lazy_static = "1.4"
+lru = "0.8"
 names = { version = "0.14.0", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
@@ -71,8 +71,8 @@ default-features = false
 features = ["std", "multihash-impl", "identity", "sha2"]
 
 [dev-dependencies]
+caches = "0.2.2"
 criterion = "0.3"
-lru = "0.8.1"
 
 [features]
 default = ["rpc-grpc", "rpc-mem"]

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -72,7 +72,7 @@ features = ["std", "multihash-impl", "identity", "sha2"]
 
 [dev-dependencies]
 caches = "0.2.2"
-criterion = "0.3"
+criterion = "0.4"
 
 [features]
 default = ["rpc-grpc", "rpc-mem"]

--- a/iroh-p2p/benches/lru_cache.rs
+++ b/iroh-p2p/benches/lru_cache.rs
@@ -1,0 +1,239 @@
+//! Test the LRU cache implementation
+//!
+//! # Running the benchmarks
+//!
+//! Install `cargo-criterion`:
+//!
+//! ```shell
+//! cargo install cargo-criterion
+//! ```
+//!
+//! Run the benchmarks:
+//!
+//! ```shell
+//! cargo criterion -p iroh-p2p
+//! ```
+
+use caches::Cache;
+use criterion::{criterion_group, criterion_main, Criterion};
+use libp2p::PeerId;
+
+// The size of the cache to make.  Taken from behaviour::peer_manager::DEFAULT_BAD_PEER_CAP.
+const CACHE_SIZE: usize = 10 * 4096;
+
+fn bench_contains_empty_cache(c: &mut Criterion) {
+    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    let peer = PeerId::random();
+    cache.put(peer, ());
+    for _ in 0..16 {
+        cache.put(PeerId::random(), ());
+    }
+    let missing = PeerId::random();
+    assert!(!cache.contains(&missing));
+
+    c.bench_function("caches: contains almost empty cache", |b| {
+        b.iter(|| {
+            cache.contains(&peer);
+            cache.contains(&missing);
+        })
+    });
+}
+
+fn bench_lru_contains_empty_cache(c: &mut Criterion) {
+    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+    let peer = PeerId::random();
+    cache.push(peer, ());
+    for _ in 0..16 {
+        cache.push(PeerId::random(), ());
+    }
+    let missing = PeerId::random();
+    assert!(!cache.contains(&missing));
+
+    c.bench_function("lru: contains almost empty cache", |b| {
+        b.iter(|| {
+            cache.contains(&peer);
+            cache.contains(&missing);
+        })
+    });
+}
+
+fn bench_contains_full_cache(c: &mut Criterion) {
+    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    let peer = PeerId::random();
+    cache.put(peer, ());
+    for _ in 0..CACHE_SIZE {
+        cache.put(PeerId::random(), ());
+    }
+    let missing = PeerId::random();
+    assert!(!cache.contains(&missing));
+
+    c.bench_function("caches: contains full cache", |b| {
+        b.iter(|| {
+            cache.contains(&peer);
+            cache.contains(&missing);
+        })
+    });
+}
+
+fn bench_lru_contains_full_cache(c: &mut Criterion) {
+    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+    let peer = PeerId::random();
+    cache.push(peer, ());
+    for _ in 0..CACHE_SIZE {
+        cache.push(PeerId::random(), ());
+    }
+    let missing = PeerId::random();
+    assert!(!cache.contains(&missing));
+
+    c.bench_function("lru: contains full cache", |b| {
+        b.iter(|| {
+            cache.contains(&peer);
+            cache.contains(&missing);
+        })
+    });
+}
+
+fn bench_put_empty_cache(c: &mut Criterion) {
+    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
+
+    c.bench_function("caches: put almost empty cache", |b| {
+        b.iter(|| {
+            for i in 0..32 {
+                cache.put(peer_ids[i], ());
+            }
+        })
+    });
+}
+
+fn bench_lru_put_empty_cache(c: &mut Criterion) {
+    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
+
+    c.bench_function("lru: put almost empty cache", |b| {
+        b.iter(|| {
+            for i in 0..32 {
+                cache.push(peer_ids[i], ());
+            }
+        })
+    });
+}
+
+fn bench_put_full_cache(c: &mut Criterion) {
+    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    for _ in 0..CACHE_SIZE {
+        cache.put(PeerId::random(), ());
+    }
+    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
+
+    c.bench_function("caches: put full cache", |b| {
+        b.iter(|| {
+            for i in 0..32 {
+                cache.put(peer_ids[i], ());
+            }
+        })
+    });
+}
+
+fn bench_lru_put_full_cache(c: &mut Criterion) {
+    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+    for _ in 0..CACHE_SIZE {
+        cache.put(PeerId::random(), ());
+    }
+    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
+
+    c.bench_function("lru: put full cache", |b| {
+        b.iter(|| {
+            for i in 0..32 {
+                cache.push(peer_ids[i], ());
+            }
+        })
+    });
+}
+
+fn bench_remove_empty_cache(c: &mut Criterion) {
+    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
+    for peer_id in peer_ids {
+        cache.put(peer_id, ());
+    }
+
+    c.bench_function("caches: remove almost empty cache", |b| {
+        b.iter(|| {
+            for i in 0..16 {
+                cache.remove(&peer_ids[i]);
+            }
+        })
+    });
+}
+
+fn bench_lru_remove_empty_cache(c: &mut Criterion) {
+    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
+    for peer_id in peer_ids {
+        cache.push(peer_id, ());
+    }
+
+    c.bench_function("lru: remove almost empty cache", |b| {
+        b.iter(|| {
+            for i in 0..16 {
+                cache.pop(&peer_ids[i]);
+            }
+        })
+    });
+}
+
+fn bench_remove_full_cache(c: &mut Criterion) {
+    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    for _ in 0..CACHE_SIZE {
+        cache.put(PeerId::random(), ());
+    }
+    let peer_ids: [PeerId; 16] = std::array::from_fn(|_| PeerId::random());
+    for peer_id in peer_ids {
+        cache.put(peer_id, ());
+    }
+
+    c.bench_function("caches: remove full cache", |b| {
+        b.iter(|| {
+            for i in 0..16 {
+                cache.remove(&peer_ids[i]);
+            }
+        })
+    });
+}
+
+fn bench_lru_remove_full_cache(c: &mut Criterion) {
+    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+    for _ in 0..CACHE_SIZE {
+        cache.push(PeerId::random(), ());
+    }
+    let peer_ids: [PeerId; 16] = std::array::from_fn(|_| PeerId::random());
+    for peer_id in peer_ids {
+        cache.push(peer_id, ());
+    }
+
+    c.bench_function("lru: remove full cache", |b| {
+        b.iter(|| {
+            for i in 0..16 {
+                cache.pop(&peer_ids[i]);
+            }
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_contains_empty_cache,
+    bench_contains_full_cache,
+    bench_put_empty_cache,
+    bench_put_full_cache,
+    bench_remove_empty_cache,
+    bench_remove_full_cache,
+    bench_lru_contains_empty_cache,
+    bench_lru_contains_full_cache,
+    bench_lru_put_empty_cache,
+    bench_lru_put_full_cache,
+    bench_lru_remove_empty_cache,
+    bench_lru_remove_full_cache,
+);
+criterion_main!(benches);

--- a/iroh-p2p/benches/lru_cache.rs
+++ b/iroh-p2p/benches/lru_cache.rs
@@ -16,13 +16,7 @@
 //! ```shell
 //! cargo criterion -p iroh-p2p
 //! ```
-//!
-//! # Disabled benches
-//!
-//! The bench functions for the `caches` crate are commented out in order not to require a
-//! dependency on the crate.
 
-// use caches::Cache;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use libp2p::PeerId;
 
@@ -31,30 +25,6 @@ const CACHE_SIZE: usize = 10 * 4096;
 
 fn bench_contains_empty(c: &mut Criterion) {
     let mut group = c.benchmark_group("Contains, almost empty cache");
-    // group.bench_function("caches", |bencher| {
-    //     bencher.iter_batched(
-    //         // setup
-    //         || {
-    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    //             let peer = PeerId::random();
-    //             cache.put(peer, ());
-    //             for _ in 0..16 {
-    //                 cache.put(PeerId::random(), ());
-    //             }
-    //             let missing = PeerId::random();
-    //             assert!(cache.contains(&peer));
-    //             assert!(!cache.contains(&missing));
-    //             (cache, peer, missing)
-    //         },
-    //         // routine
-    //         |(cache, peer, missing)| {
-    //             cache.contains(&peer);
-    //             cache.contains(&missing);
-    //             cache // drop outside of routine
-    //         },
-    //         BatchSize::SmallInput,
-    //     )
-    // });
     group.bench_function("lru", |bencher| {
         bencher.iter_batched(
             // setup
@@ -84,30 +54,6 @@ fn bench_contains_empty(c: &mut Criterion) {
 
 fn bench_contains_full(c: &mut Criterion) {
     let mut group = c.benchmark_group("Contains, full cache");
-    // group.bench_function("caches", |bencher| {
-    //     bencher.iter_batched(
-    //         // setup
-    //         || {
-    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    //             for _ in 0..CACHE_SIZE {
-    //                 cache.put(PeerId::random(), ());
-    //             }
-    //             let peer = PeerId::random();
-    //             cache.put(peer, ());
-    //             let missing = PeerId::random();
-    //             assert!(cache.contains(&peer));
-    //             assert!(!cache.contains(&missing));
-    //             (cache, peer, missing)
-    //         },
-    //         // routine
-    //         |(cache, peer, missing)| {
-    //             cache.contains(&peer);
-    //             cache.contains(&missing);
-    //             cache // drop outside of routine
-    //         },
-    //         BatchSize::LargeInput,
-    //     )
-    // });
     group.bench_function("lru", |bencher| {
         bencher.iter_batched(
             // setup
@@ -137,22 +83,6 @@ fn bench_contains_full(c: &mut Criterion) {
 
 fn bench_put_empty(c: &mut Criterion) {
     let mut group = c.benchmark_group("put, almost empty cache");
-    // group.bench_function("caches", |bencher| {
-    //     bencher.iter_batched(
-    //         // setup
-    //         || {
-    //             let cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    //             let peer_id = PeerId::random();
-    //             (cache, peer_id)
-    //         },
-    //         // routine
-    //         |(mut cache, peer_id)| {
-    //             cache.put(peer_id, ());
-    //             (cache, peer_id) // drop outside of routine
-    //         },
-    //         BatchSize::SmallInput,
-    //     )
-    // });
     group.bench_function("lru", |bencher| {
         bencher.iter_batched(
             // setup
@@ -174,25 +104,6 @@ fn bench_put_empty(c: &mut Criterion) {
 
 fn bench_put_full(c: &mut Criterion) {
     let mut group = c.benchmark_group("put, full cache");
-    // group.bench_function("caches", |bencher| {
-    //     bencher.iter_batched(
-    //         // setup
-    //         || {
-    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    //             for _ in 0..CACHE_SIZE {
-    //                 cache.put(PeerId::random(), ());
-    //             }
-    //             let peer_id = PeerId::random();
-    //             (cache, peer_id)
-    //         },
-    //         // routine
-    //         |(mut cache, peer_id)| {
-    //             cache.put(peer_id, ());
-    //             (cache, peer_id) // drop outside of routine
-    //         },
-    //         BatchSize::LargeInput,
-    //     )
-    // });
     group.bench_function("lru", |bencher| {
         bencher.iter_batched(
             // setup
@@ -217,26 +128,6 @@ fn bench_put_full(c: &mut Criterion) {
 
 fn bench_pop_empty(c: &mut Criterion) {
     let mut group = c.benchmark_group("pop, almost empty cache");
-    // group.bench_function("caches", |benches| {
-    //     benches.iter_batched(
-    //         // setup
-    //         || {
-    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    //             for _ in 0..16 {
-    //                 cache.put(PeerId::random(), ());
-    //             }
-    //             let peer_id = PeerId::random();
-    //             cache.put(peer_id, ());
-    //             (cache, peer_id)
-    //         },
-    //         // routine
-    //         |(mut cache, peer_id)| {
-    //             cache.remove(&peer_id);
-    //             (cache, peer_id) // drop outside of routine
-    //         },
-    //         BatchSize::SmallInput,
-    //     )
-    // });
     group.bench_function("lru", |benches| {
         benches.iter_batched(
             // setup
@@ -261,26 +152,6 @@ fn bench_pop_empty(c: &mut Criterion) {
 }
 fn bench_pop_full(c: &mut Criterion) {
     let mut group = c.benchmark_group("pop, full cache");
-    // group.bench_function("caches", |benches| {
-    //     benches.iter_batched(
-    //         // setup
-    //         || {
-    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    //             for _ in 0..CACHE_SIZE {
-    //                 cache.put(PeerId::random(), ());
-    //             }
-    //             let peer_id = PeerId::random();
-    //             cache.put(peer_id, ());
-    //             (cache, peer_id)
-    //         },
-    //         // routine
-    //         |(mut cache, peer_id)| {
-    //             cache.remove(&peer_id);
-    //             (cache, peer_id) // drop outside of routine
-    //         },
-    //         BatchSize::LargeInput,
-    //     )
-    // });
     group.bench_function("lru", |benches| {
         benches.iter_batched(
             // setup

--- a/iroh-p2p/benches/lru_cache.rs
+++ b/iroh-p2p/benches/lru_cache.rs
@@ -16,8 +16,13 @@
 //! ```shell
 //! cargo criterion -p iroh-p2p
 //! ```
+//!
+//! # Disabled benches
+//!
+//! The bench functions for the `caches` crate are commented out in order not to require a
+//! dependency on the crate.
 
-use caches::Cache;
+// use caches::Cache;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use libp2p::PeerId;
 
@@ -26,30 +31,30 @@ const CACHE_SIZE: usize = 10 * 4096;
 
 fn bench_contains_empty(c: &mut Criterion) {
     let mut group = c.benchmark_group("Contains, almost empty cache");
-    group.bench_function("caches", |bencher| {
-        bencher.iter_batched(
-            // setup
-            || {
-                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-                let peer = PeerId::random();
-                cache.put(peer, ());
-                for _ in 0..16 {
-                    cache.put(PeerId::random(), ());
-                }
-                let missing = PeerId::random();
-                assert!(cache.contains(&peer));
-                assert!(!cache.contains(&missing));
-                (cache, peer, missing)
-            },
-            // routine
-            |(cache, peer, missing)| {
-                cache.contains(&peer);
-                cache.contains(&missing);
-                cache // drop outside of routine
-            },
-            BatchSize::SmallInput,
-        )
-    });
+    // group.bench_function("caches", |bencher| {
+    //     bencher.iter_batched(
+    //         // setup
+    //         || {
+    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    //             let peer = PeerId::random();
+    //             cache.put(peer, ());
+    //             for _ in 0..16 {
+    //                 cache.put(PeerId::random(), ());
+    //             }
+    //             let missing = PeerId::random();
+    //             assert!(cache.contains(&peer));
+    //             assert!(!cache.contains(&missing));
+    //             (cache, peer, missing)
+    //         },
+    //         // routine
+    //         |(cache, peer, missing)| {
+    //             cache.contains(&peer);
+    //             cache.contains(&missing);
+    //             cache // drop outside of routine
+    //         },
+    //         BatchSize::SmallInput,
+    //     )
+    // });
     group.bench_function("lru", |bencher| {
         bencher.iter_batched(
             // setup
@@ -79,30 +84,30 @@ fn bench_contains_empty(c: &mut Criterion) {
 
 fn bench_contains_full(c: &mut Criterion) {
     let mut group = c.benchmark_group("Contains, full cache");
-    group.bench_function("caches", |bencher| {
-        bencher.iter_batched(
-            // setup
-            || {
-                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-                for _ in 0..CACHE_SIZE {
-                    cache.put(PeerId::random(), ());
-                }
-                let peer = PeerId::random();
-                cache.put(peer, ());
-                let missing = PeerId::random();
-                assert!(cache.contains(&peer));
-                assert!(!cache.contains(&missing));
-                (cache, peer, missing)
-            },
-            // routine
-            |(cache, peer, missing)| {
-                cache.contains(&peer);
-                cache.contains(&missing);
-                cache // drop outside of routine
-            },
-            BatchSize::LargeInput,
-        )
-    });
+    // group.bench_function("caches", |bencher| {
+    //     bencher.iter_batched(
+    //         // setup
+    //         || {
+    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    //             for _ in 0..CACHE_SIZE {
+    //                 cache.put(PeerId::random(), ());
+    //             }
+    //             let peer = PeerId::random();
+    //             cache.put(peer, ());
+    //             let missing = PeerId::random();
+    //             assert!(cache.contains(&peer));
+    //             assert!(!cache.contains(&missing));
+    //             (cache, peer, missing)
+    //         },
+    //         // routine
+    //         |(cache, peer, missing)| {
+    //             cache.contains(&peer);
+    //             cache.contains(&missing);
+    //             cache // drop outside of routine
+    //         },
+    //         BatchSize::LargeInput,
+    //     )
+    // });
     group.bench_function("lru", |bencher| {
         bencher.iter_batched(
             // setup
@@ -132,22 +137,22 @@ fn bench_contains_full(c: &mut Criterion) {
 
 fn bench_put_empty(c: &mut Criterion) {
     let mut group = c.benchmark_group("put, almost empty cache");
-    group.bench_function("caches", |bencher| {
-        bencher.iter_batched(
-            // setup
-            || {
-                let cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-                let peer_id = PeerId::random();
-                (cache, peer_id)
-            },
-            // routine
-            |(mut cache, peer_id)| {
-                cache.put(peer_id, ());
-                (cache, peer_id) // drop outside of routine
-            },
-            BatchSize::SmallInput,
-        )
-    });
+    // group.bench_function("caches", |bencher| {
+    //     bencher.iter_batched(
+    //         // setup
+    //         || {
+    //             let cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    //             let peer_id = PeerId::random();
+    //             (cache, peer_id)
+    //         },
+    //         // routine
+    //         |(mut cache, peer_id)| {
+    //             cache.put(peer_id, ());
+    //             (cache, peer_id) // drop outside of routine
+    //         },
+    //         BatchSize::SmallInput,
+    //     )
+    // });
     group.bench_function("lru", |bencher| {
         bencher.iter_batched(
             // setup
@@ -169,25 +174,25 @@ fn bench_put_empty(c: &mut Criterion) {
 
 fn bench_put_full(c: &mut Criterion) {
     let mut group = c.benchmark_group("put, full cache");
-    group.bench_function("caches", |bencher| {
-        bencher.iter_batched(
-            // setup
-            || {
-                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-                for _ in 0..CACHE_SIZE {
-                    cache.put(PeerId::random(), ());
-                }
-                let peer_id = PeerId::random();
-                (cache, peer_id)
-            },
-            // routine
-            |(mut cache, peer_id)| {
-                cache.put(peer_id, ());
-                (cache, peer_id) // drop outside of routine
-            },
-            BatchSize::LargeInput,
-        )
-    });
+    // group.bench_function("caches", |bencher| {
+    //     bencher.iter_batched(
+    //         // setup
+    //         || {
+    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    //             for _ in 0..CACHE_SIZE {
+    //                 cache.put(PeerId::random(), ());
+    //             }
+    //             let peer_id = PeerId::random();
+    //             (cache, peer_id)
+    //         },
+    //         // routine
+    //         |(mut cache, peer_id)| {
+    //             cache.put(peer_id, ());
+    //             (cache, peer_id) // drop outside of routine
+    //         },
+    //         BatchSize::LargeInput,
+    //     )
+    // });
     group.bench_function("lru", |bencher| {
         bencher.iter_batched(
             // setup
@@ -212,26 +217,26 @@ fn bench_put_full(c: &mut Criterion) {
 
 fn bench_pop_empty(c: &mut Criterion) {
     let mut group = c.benchmark_group("pop, almost empty cache");
-    group.bench_function("caches", |benches| {
-        benches.iter_batched(
-            // setup
-            || {
-                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-                for _ in 0..16 {
-                    cache.put(PeerId::random(), ());
-                }
-                let peer_id = PeerId::random();
-                cache.put(peer_id, ());
-                (cache, peer_id)
-            },
-            // routine
-            |(mut cache, peer_id)| {
-                cache.remove(&peer_id);
-                (cache, peer_id) // drop outside of routine
-            },
-            BatchSize::SmallInput,
-        )
-    });
+    // group.bench_function("caches", |benches| {
+    //     benches.iter_batched(
+    //         // setup
+    //         || {
+    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    //             for _ in 0..16 {
+    //                 cache.put(PeerId::random(), ());
+    //             }
+    //             let peer_id = PeerId::random();
+    //             cache.put(peer_id, ());
+    //             (cache, peer_id)
+    //         },
+    //         // routine
+    //         |(mut cache, peer_id)| {
+    //             cache.remove(&peer_id);
+    //             (cache, peer_id) // drop outside of routine
+    //         },
+    //         BatchSize::SmallInput,
+    //     )
+    // });
     group.bench_function("lru", |benches| {
         benches.iter_batched(
             // setup
@@ -256,26 +261,26 @@ fn bench_pop_empty(c: &mut Criterion) {
 }
 fn bench_pop_full(c: &mut Criterion) {
     let mut group = c.benchmark_group("pop, full cache");
-    group.bench_function("caches", |benches| {
-        benches.iter_batched(
-            // setup
-            || {
-                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-                for _ in 0..CACHE_SIZE {
-                    cache.put(PeerId::random(), ());
-                }
-                let peer_id = PeerId::random();
-                cache.put(peer_id, ());
-                (cache, peer_id)
-            },
-            // routine
-            |(mut cache, peer_id)| {
-                cache.remove(&peer_id);
-                (cache, peer_id) // drop outside of routine
-            },
-            BatchSize::LargeInput,
-        )
-    });
+    // group.bench_function("caches", |benches| {
+    //     benches.iter_batched(
+    //         // setup
+    //         || {
+    //             let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+    //             for _ in 0..CACHE_SIZE {
+    //                 cache.put(PeerId::random(), ());
+    //             }
+    //             let peer_id = PeerId::random();
+    //             cache.put(peer_id, ());
+    //             (cache, peer_id)
+    //         },
+    //         // routine
+    //         |(mut cache, peer_id)| {
+    //             cache.remove(&peer_id);
+    //             (cache, peer_id) // drop outside of routine
+    //         },
+    //         BatchSize::LargeInput,
+    //     )
+    // });
     group.bench_function("lru", |benches| {
         benches.iter_batched(
             // setup

--- a/iroh-p2p/benches/lru_cache.rs
+++ b/iroh-p2p/benches/lru_cache.rs
@@ -1,4 +1,7 @@
-//! Test the LRU cache implementation
+//! Test the LRU cache implementation.
+//!
+//! These are a few simple tests of the operations we do on empty and full caches.  Mostly
+//! how populated the cache is doesn't seem to affect things much.
 //!
 //! # Running the benchmarks
 //!
@@ -15,225 +18,294 @@
 //! ```
 
 use caches::Cache;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use libp2p::PeerId;
 
 // The size of the cache to make.  Taken from behaviour::peer_manager::DEFAULT_BAD_PEER_CAP.
 const CACHE_SIZE: usize = 10 * 4096;
 
-fn bench_contains_empty_cache(c: &mut Criterion) {
-    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    let peer = PeerId::random();
-    cache.put(peer, ());
-    for _ in 0..16 {
-        cache.put(PeerId::random(), ());
-    }
-    let missing = PeerId::random();
-    assert!(!cache.contains(&missing));
-
-    c.bench_function("caches: contains almost empty cache", |b| {
-        b.iter(|| {
-            cache.contains(&peer);
-            cache.contains(&missing);
-        })
+fn bench_contains_empty(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Contains, almost empty cache");
+    group.bench_function("caches", |bencher| {
+        bencher.iter_batched(
+            // setup
+            || {
+                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+                let peer = PeerId::random();
+                cache.put(peer, ());
+                for _ in 0..16 {
+                    cache.put(PeerId::random(), ());
+                }
+                let missing = PeerId::random();
+                assert!(cache.contains(&peer));
+                assert!(!cache.contains(&missing));
+                (cache, peer, missing)
+            },
+            // routine
+            |(cache, peer, missing)| {
+                cache.contains(&peer);
+                cache.contains(&missing);
+                cache // drop outside of routine
+            },
+            BatchSize::SmallInput,
+        )
     });
+    group.bench_function("lru", |bencher| {
+        bencher.iter_batched(
+            // setup
+            || {
+                let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+                let peer = PeerId::random();
+                cache.put(peer, ());
+                for _ in 0..16 {
+                    cache.put(PeerId::random(), ());
+                }
+                let missing = PeerId::random();
+                assert!(cache.contains(&peer));
+                assert!(!cache.contains(&missing));
+                (cache, peer, missing)
+            },
+            // routine
+            |(cache, peer, missing)| {
+                cache.contains(&peer);
+                cache.contains(&missing);
+                cache // drop outside of routine
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
 }
 
-fn bench_lru_contains_empty_cache(c: &mut Criterion) {
-    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
-    let peer = PeerId::random();
-    cache.push(peer, ());
-    for _ in 0..16 {
-        cache.push(PeerId::random(), ());
-    }
-    let missing = PeerId::random();
-    assert!(!cache.contains(&missing));
-
-    c.bench_function("lru: contains almost empty cache", |b| {
-        b.iter(|| {
-            cache.contains(&peer);
-            cache.contains(&missing);
-        })
+fn bench_contains_full(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Contains, full cache");
+    group.bench_function("caches", |bencher| {
+        bencher.iter_batched(
+            // setup
+            || {
+                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+                for _ in 0..CACHE_SIZE {
+                    cache.put(PeerId::random(), ());
+                }
+                let peer = PeerId::random();
+                cache.put(peer, ());
+                let missing = PeerId::random();
+                assert!(cache.contains(&peer));
+                assert!(!cache.contains(&missing));
+                (cache, peer, missing)
+            },
+            // routine
+            |(cache, peer, missing)| {
+                cache.contains(&peer);
+                cache.contains(&missing);
+                cache // drop outside of routine
+            },
+            BatchSize::LargeInput,
+        )
     });
+    group.bench_function("lru", |bencher| {
+        bencher.iter_batched(
+            // setup
+            || {
+                let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+                for _ in 0..CACHE_SIZE {
+                    cache.put(PeerId::random(), ());
+                }
+                let peer = PeerId::random();
+                cache.put(peer, ());
+                let missing = PeerId::random();
+                assert!(cache.contains(&peer));
+                assert!(!cache.contains(&missing));
+                (cache, peer, missing)
+            },
+            // routine
+            |(cache, peer, missing)| {
+                cache.contains(&peer);
+                cache.contains(&missing);
+                cache // drop outside of routine
+            },
+            BatchSize::LargeInput,
+        )
+    });
+    group.finish();
 }
 
-fn bench_contains_full_cache(c: &mut Criterion) {
-    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    let peer = PeerId::random();
-    cache.put(peer, ());
-    for _ in 0..CACHE_SIZE {
-        cache.put(PeerId::random(), ());
-    }
-    let missing = PeerId::random();
-    assert!(!cache.contains(&missing));
-
-    c.bench_function("caches: contains full cache", |b| {
-        b.iter(|| {
-            cache.contains(&peer);
-            cache.contains(&missing);
-        })
+fn bench_put_empty(c: &mut Criterion) {
+    let mut group = c.benchmark_group("put, almost empty cache");
+    group.bench_function("caches", |bencher| {
+        bencher.iter_batched(
+            // setup
+            || {
+                let cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+                let peer_id = PeerId::random();
+                (cache, peer_id)
+            },
+            // routine
+            |(mut cache, peer_id)| {
+                cache.put(peer_id, ());
+                (cache, peer_id) // drop outside of routine
+            },
+            BatchSize::SmallInput,
+        )
     });
+    group.bench_function("lru", |bencher| {
+        bencher.iter_batched(
+            // setup
+            || {
+                let cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+                let peer_id = PeerId::random();
+                (cache, peer_id)
+            },
+            // routine
+            |(mut cache, peer_id)| {
+                cache.put(peer_id, ());
+                (cache, peer_id) // drop outside of routine
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
 }
 
-fn bench_lru_contains_full_cache(c: &mut Criterion) {
-    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
-    let peer = PeerId::random();
-    cache.push(peer, ());
-    for _ in 0..CACHE_SIZE {
-        cache.push(PeerId::random(), ());
-    }
-    let missing = PeerId::random();
-    assert!(!cache.contains(&missing));
-
-    c.bench_function("lru: contains full cache", |b| {
-        b.iter(|| {
-            cache.contains(&peer);
-            cache.contains(&missing);
-        })
+fn bench_put_full(c: &mut Criterion) {
+    let mut group = c.benchmark_group("put, full cache");
+    group.bench_function("caches", |bencher| {
+        bencher.iter_batched(
+            // setup
+            || {
+                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+                for _ in 0..CACHE_SIZE {
+                    cache.put(PeerId::random(), ());
+                }
+                let peer_id = PeerId::random();
+                (cache, peer_id)
+            },
+            // routine
+            |(mut cache, peer_id)| {
+                cache.put(peer_id, ());
+                (cache, peer_id) // drop outside of routine
+            },
+            BatchSize::LargeInput,
+        )
     });
+    group.bench_function("lru", |bencher| {
+        bencher.iter_batched(
+            // setup
+            || {
+                let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+                for _ in 0..CACHE_SIZE {
+                    cache.put(PeerId::random(), ());
+                }
+                let peer_id = PeerId::random();
+                (cache, peer_id)
+            },
+            // routine
+            |(mut cache, peer_id)| {
+                cache.put(peer_id, ());
+                (cache, peer_id) // drop outside of routine
+            },
+            BatchSize::LargeInput,
+        )
+    });
+    group.finish();
 }
 
-fn bench_put_empty_cache(c: &mut Criterion) {
-    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
-
-    c.bench_function("caches: put almost empty cache", |b| {
-        b.iter(|| {
-            for i in 0..32 {
-                cache.put(peer_ids[i], ());
-            }
-        })
+fn bench_pop_empty(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pop, almost empty cache");
+    group.bench_function("caches", |benches| {
+        benches.iter_batched(
+            // setup
+            || {
+                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+                for _ in 0..16 {
+                    cache.put(PeerId::random(), ());
+                }
+                let peer_id = PeerId::random();
+                cache.put(peer_id, ());
+                (cache, peer_id)
+            },
+            // routine
+            |(mut cache, peer_id)| {
+                cache.remove(&peer_id);
+                (cache, peer_id) // drop outside of routine
+            },
+            BatchSize::SmallInput,
+        )
     });
+    group.bench_function("lru", |benches| {
+        benches.iter_batched(
+            // setup
+            || {
+                let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+                for _ in 0..16 {
+                    cache.put(PeerId::random(), ());
+                }
+                let peer_id = PeerId::random();
+                cache.put(peer_id, ());
+                (cache, peer_id)
+            },
+            // routine
+            |(mut cache, peer_id)| {
+                cache.pop(&peer_id);
+                (cache, peer_id) // drop outside of routine
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
 }
-
-fn bench_lru_put_empty_cache(c: &mut Criterion) {
-    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
-    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
-
-    c.bench_function("lru: put almost empty cache", |b| {
-        b.iter(|| {
-            for i in 0..32 {
-                cache.push(peer_ids[i], ());
-            }
-        })
+fn bench_pop_full(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pop, full cache");
+    group.bench_function("caches", |benches| {
+        benches.iter_batched(
+            // setup
+            || {
+                let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
+                for _ in 0..CACHE_SIZE {
+                    cache.put(PeerId::random(), ());
+                }
+                let peer_id = PeerId::random();
+                cache.put(peer_id, ());
+                (cache, peer_id)
+            },
+            // routine
+            |(mut cache, peer_id)| {
+                cache.remove(&peer_id);
+                (cache, peer_id) // drop outside of routine
+            },
+            BatchSize::LargeInput,
+        )
     });
-}
-
-fn bench_put_full_cache(c: &mut Criterion) {
-    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    for _ in 0..CACHE_SIZE {
-        cache.put(PeerId::random(), ());
-    }
-    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
-
-    c.bench_function("caches: put full cache", |b| {
-        b.iter(|| {
-            for i in 0..32 {
-                cache.put(peer_ids[i], ());
-            }
-        })
+    group.bench_function("lru", |benches| {
+        benches.iter_batched(
+            // setup
+            || {
+                let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
+                for _ in 0..CACHE_SIZE {
+                    cache.put(PeerId::random(), ());
+                }
+                let peer_id = PeerId::random();
+                cache.put(peer_id, ());
+                (cache, peer_id)
+            },
+            // routine
+            |(mut cache, peer_id)| {
+                cache.pop(&peer_id);
+                (cache, peer_id) // drop outside of routine
+            },
+            BatchSize::LargeInput,
+        )
     });
-}
-
-fn bench_lru_put_full_cache(c: &mut Criterion) {
-    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
-    for _ in 0..CACHE_SIZE {
-        cache.put(PeerId::random(), ());
-    }
-    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
-
-    c.bench_function("lru: put full cache", |b| {
-        b.iter(|| {
-            for i in 0..32 {
-                cache.push(peer_ids[i], ());
-            }
-        })
-    });
-}
-
-fn bench_remove_empty_cache(c: &mut Criterion) {
-    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
-    for peer_id in peer_ids {
-        cache.put(peer_id, ());
-    }
-
-    c.bench_function("caches: remove almost empty cache", |b| {
-        b.iter(|| {
-            for i in 0..16 {
-                cache.remove(&peer_ids[i]);
-            }
-        })
-    });
-}
-
-fn bench_lru_remove_empty_cache(c: &mut Criterion) {
-    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
-    let peer_ids: [PeerId; 32] = std::array::from_fn(|_| PeerId::random());
-    for peer_id in peer_ids {
-        cache.push(peer_id, ());
-    }
-
-    c.bench_function("lru: remove almost empty cache", |b| {
-        b.iter(|| {
-            for i in 0..16 {
-                cache.pop(&peer_ids[i]);
-            }
-        })
-    });
-}
-
-fn bench_remove_full_cache(c: &mut Criterion) {
-    let mut cache = caches::RawLRU::new(CACHE_SIZE).unwrap();
-    for _ in 0..CACHE_SIZE {
-        cache.put(PeerId::random(), ());
-    }
-    let peer_ids: [PeerId; 16] = std::array::from_fn(|_| PeerId::random());
-    for peer_id in peer_ids {
-        cache.put(peer_id, ());
-    }
-
-    c.bench_function("caches: remove full cache", |b| {
-        b.iter(|| {
-            for i in 0..16 {
-                cache.remove(&peer_ids[i]);
-            }
-        })
-    });
-}
-
-fn bench_lru_remove_full_cache(c: &mut Criterion) {
-    let mut cache = lru::LruCache::new(CACHE_SIZE.try_into().unwrap());
-    for _ in 0..CACHE_SIZE {
-        cache.push(PeerId::random(), ());
-    }
-    let peer_ids: [PeerId; 16] = std::array::from_fn(|_| PeerId::random());
-    for peer_id in peer_ids {
-        cache.push(peer_id, ());
-    }
-
-    c.bench_function("lru: remove full cache", |b| {
-        b.iter(|| {
-            for i in 0..16 {
-                cache.pop(&peer_ids[i]);
-            }
-        })
-    });
+    group.finish();
 }
 
 criterion_group!(
     benches,
-    bench_contains_empty_cache,
-    bench_contains_full_cache,
-    bench_put_empty_cache,
-    bench_put_full_cache,
-    bench_remove_empty_cache,
-    bench_remove_full_cache,
-    bench_lru_contains_empty_cache,
-    bench_lru_contains_full_cache,
-    bench_lru_put_empty_cache,
-    bench_lru_put_full_cache,
-    bench_lru_remove_empty_cache,
-    bench_lru_remove_full_cache,
+    bench_contains_empty,
+    bench_contains_full,
+    bench_put_empty,
+    bench_put_full,
+    bench_pop_empty,
+    bench_pop_full,
 );
 criterion_main!(benches);


### PR DESCRIPTION
Change the LRU cache from the caches crate to the lru crate.  This crate is much simpler and does not depend on a vulnerable version of the time crate, resolving our cargo-audit issues.

A benchmark is included showing our use of the LRU cache to have no notable performance difference between both crates.


Closes #375 