### PR TITLE
Make store operations atomic

### DIFF
--- a/iroh-store/Cargo.toml
+++ b/iroh-store/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }
 libipld = "0.14.0"
+rayon = "1.5.3"
 tempfile = "3.3.0"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
 

--- a/iroh-store/Cargo.toml
+++ b/iroh-store/Cargo.toml
@@ -25,7 +25,6 @@ iroh-util = { path = "../iroh-util" }
 multihash = "0.16.3"
 names = { version = "0.14.0", default-features = false }
 opentelemetry = { version = "0.18", features = ["rt-tokio"] }
-parking_lot = "0.12.1"
 rkyv = { version = "0.7.37", features = ["validation"] }
 rocksdb = "0.19.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/iroh-store/Cargo.toml
+++ b/iroh-store/Cargo.toml
@@ -25,6 +25,7 @@ iroh-util = { path = "../iroh-util" }
 multihash = "0.16.3"
 names = { version = "0.14.0", default-features = false }
 opentelemetry = { version = "0.18", features = ["rt-tokio"] }
+parking_lot = "0.12.1"
 rkyv = { version = "0.7.37", features = ["validation"] }
 rocksdb = "0.19.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/iroh-store/src/rpc.rs
+++ b/iroh-store/src/rpc.rs
@@ -30,7 +30,7 @@ impl RpcStore for Store {
     async fn put(&self, req: PutRequest) -> Result<()> {
         let cid = cid_from_bytes(req.cid)?;
         let links = links_from_bytes(req.links)?;
-        let res = self.put(cid, req.blob, links)?;
+        let res = self.spawn(move |x| x.put(cid, req.blob, links)).await?;
 
         info!("store rpc call: put cid {}", cid);
         Ok(res)
@@ -47,50 +47,61 @@ impl RpcStore for Store {
                 Ok((cid, req.blob, links))
             })
             .collect::<Result<Vec<_>>>()?;
-        self.put_many(req)
+        self.spawn(move |x| x.put_many(req)).await
     }
 
     #[tracing::instrument(skip(self))]
     async fn get(&self, req: GetRequest) -> Result<GetResponse> {
         let cid = cid_from_bytes(req.cid)?;
-        if let Some(res) = self.get(&cid)? {
-            Ok(GetResponse {
-                data: Some(BytesMut::from(&res[..]).freeze()),
-            })
-        } else {
-            Ok(GetResponse { data: None })
-        }
+        self.spawn(move |x| {
+            if let Some(res) = x.get(&cid)? {
+                Ok(GetResponse {
+                    data: Some(BytesMut::from(&res[..]).freeze()),
+                })
+            } else {
+                Ok(GetResponse { data: None })
+            }
+        })
+        .await
     }
 
     #[tracing::instrument(skip(self))]
     async fn has(&self, req: HasRequest) -> Result<HasResponse> {
         let cid = cid_from_bytes(req.cid)?;
-        let has = self.has(&cid)?;
-
-        Ok(HasResponse { has })
+        self.spawn(move |self| {
+            let has = self.has(&cid)?;
+            Ok(HasResponse { has })
+        })
+        .await
     }
 
     #[tracing::instrument(skip(self))]
     async fn get_links(&self, req: GetLinksRequest) -> Result<GetLinksResponse> {
         let cid = cid_from_bytes(req.cid)?;
-        if let Some(res) = self.get_links(&cid)? {
-            let links = res.into_iter().map(|cid| cid.to_bytes()).collect();
-            Ok(GetLinksResponse { links })
-        } else {
-            Ok(GetLinksResponse { links: Vec::new() })
-        }
+        self.spawn(move |self| {
+            if let Some(res) = self.get_links(&cid)? {
+                let links = res.into_iter().map(|cid| cid.to_bytes()).collect();
+                Ok(GetLinksResponse { links })
+            } else {
+                Ok(GetLinksResponse { links: Vec::new() })
+            }
+        })
+        .await
     }
 
     #[tracing::instrument(skip(self))]
     async fn get_size(&self, req: GetSizeRequest) -> Result<GetSizeResponse> {
         let cid = cid_from_bytes(req.cid)?;
-        if let Some(size) = self.get_size(&cid).await? {
-            Ok(GetSizeResponse {
-                size: Some(size as u64),
-            })
-        } else {
-            Ok(GetSizeResponse { size: None })
-        }
+        self.spawn(move |self| {
+            if let Some(size) = self.get_size(&cid)? {
+                Ok(GetSizeResponse {
+                    size: Some(size as u64),
+                })
+            } else {
+                Ok(GetSizeResponse { size: None })
+            }
+        })
+        .await
     }
 }
 

--- a/iroh-store/src/rpc.rs
+++ b/iroh-store/src/rpc.rs
@@ -30,7 +30,9 @@ impl RpcStore for Store {
     async fn put(&self, req: PutRequest) -> Result<()> {
         let cid = cid_from_bytes(req.cid)?;
         let links = links_from_bytes(req.links)?;
-        let res = self.spawn(move |x| x.put(cid, req.blob, links)).await?;
+        let res = self
+            .spawn_blocking(move |x| x.put(cid, req.blob, links))
+            .await?;
 
         info!("store rpc call: put cid {}", cid);
         Ok(res)
@@ -47,13 +49,13 @@ impl RpcStore for Store {
                 Ok((cid, req.blob, links))
             })
             .collect::<Result<Vec<_>>>()?;
-        self.spawn(move |x| x.put_many(req)).await
+        self.spawn_blocking(move |x| x.put_many(req)).await
     }
 
     #[tracing::instrument(skip(self))]
     async fn get(&self, req: GetRequest) -> Result<GetResponse> {
         let cid = cid_from_bytes(req.cid)?;
-        self.spawn(move |x| {
+        self.spawn_blocking(move |x| {
             if let Some(res) = x.get(&cid)? {
                 Ok(GetResponse {
                     data: Some(BytesMut::from(&res[..]).freeze()),
@@ -68,7 +70,7 @@ impl RpcStore for Store {
     #[tracing::instrument(skip(self))]
     async fn has(&self, req: HasRequest) -> Result<HasResponse> {
         let cid = cid_from_bytes(req.cid)?;
-        self.spawn(move |self| {
+        self.spawn_blocking(move |self| {
             let has = self.has(&cid)?;
             Ok(HasResponse { has })
         })
@@ -78,7 +80,7 @@ impl RpcStore for Store {
     #[tracing::instrument(skip(self))]
     async fn get_links(&self, req: GetLinksRequest) -> Result<GetLinksResponse> {
         let cid = cid_from_bytes(req.cid)?;
-        self.spawn(move |self| {
+        self.spawn_blocking(move |self| {
             if let Some(res) = self.get_links(&cid)? {
                 let links = res.into_iter().map(|cid| cid.to_bytes()).collect();
                 Ok(GetLinksResponse { links })
@@ -92,7 +94,7 @@ impl RpcStore for Store {
     #[tracing::instrument(skip(self))]
     async fn get_size(&self, req: GetSizeRequest) -> Result<GetSizeResponse> {
         let cid = cid_from_bytes(req.cid)?;
-        self.spawn(move |self| {
+        self.spawn_blocking(move |self| {
             if let Some(size) = self.get_size(&cid)? {
                 Ok(GetSizeResponse {
                     size: Some(size as u64),

--- a/iroh-store/src/store.rs
+++ b/iroh-store/src/store.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
-    thread::available_parallelism,
-};
+use std::{sync::Arc, thread::available_parallelism};
 
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
@@ -13,6 +10,7 @@ use iroh_metrics::{
 };
 use iroh_rpc_client::Client as RpcClient;
 use multihash::Multihash;
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamily, DBPinnableSlice, Direction, IteratorMode, Options,
     WriteBatch, DB as RocksDb,
@@ -248,7 +246,7 @@ impl Store {
         Ok(WriteStore {
             db,
             cf: ColumnFamilies::new(db)?,
-            next_id: self.inner.next_id.write().unwrap(),
+            next_id: self.inner.next_id.write(),
         })
     }
 
@@ -257,7 +255,7 @@ impl Store {
         Ok(ReadStore {
             db,
             cf: ColumnFamilies::new(db)?,
-            _next_id: self.inner.next_id.read().unwrap(),
+            _next_id: self.inner.next_id.read(),
         })
     }
 

--- a/iroh-store/src/store.rs
+++ b/iroh-store/src/store.rs
@@ -268,17 +268,22 @@ impl Store {
     }
 }
 
-/// The local store is fully synchronous and is not Send.
+/// Groups all write operations.
 ///
-/// Due to this, it can store column family handles.
+/// Not Send, so must be used from a single thread.
 ///
-/// All interacion with the database is done through this struct.
+/// All write interacion with the database is done through this struct.
 struct WriteStore<'a> {
     db: &'a RocksDb,
     cf: ColumnFamilies<'a>,
     next_id: RwLockWriteGuard<'a, u64>,
 }
 
+/// Groups all read operations.
+///
+/// Not Send, so must be used from a single thread.
+///
+/// All read interacion with the database is done through this struct.
 struct ReadStore<'a> {
     db: &'a RocksDb,
     cf: ColumnFamilies<'a>,

--- a/iroh-store/src/store.rs
+++ b/iroh-store/src/store.rs
@@ -10,12 +10,12 @@ use iroh_metrics::{
 };
 use iroh_rpc_client::Client as RpcClient;
 use multihash::Multihash;
-use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamily, DBPinnableSlice, Direction, IteratorMode, Options,
     WriteBatch, DB as RocksDb,
 };
 use smallvec::SmallVec;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tokio::task;
 
 use crate::cf::{GraphV0, MetadataV0, CF_BLOBS_V0, CF_GRAPH_V0, CF_ID_V0, CF_METADATA_V0};
@@ -246,7 +246,7 @@ impl Store {
         Ok(WriteStore {
             db,
             cf: ColumnFamilies::new(db)?,
-            next_id: self.inner.next_id.write(),
+            next_id: self.inner.next_id.write().unwrap(),
         })
     }
 
@@ -255,7 +255,7 @@ impl Store {
         Ok(ReadStore {
             db,
             cf: ColumnFamilies::new(db)?,
-            _next_id: self.inner.next_id.read(),
+            _next_id: self.inner.next_id.read().unwrap(),
         })
     }
 


### PR DESCRIPTION
This makes store operations atomic by just using an in memory mutex.

This means that as soon as a db is being opened twice at the same time, it will be corrupted. But that is the case anyway because we are already relying on in process atomicity with the (former) AtomicU64 for the id counter.

I am working on a solution that is using rocksdb transactions on a separate branch, but it seems that this will take a bit longer because I can't get the atomicity test to pass despite using transactions with snapshots.

So this is a stopgap measure that makes our store not break until we sort things out more permanently.

It also implements https://github.com/n0-computer/iroh/issues/426 

Note: I tried using tokio async mutexes, but that gets you into trouble again because LocalStore is not Send.