### PR TITLE
ref(api): Switch argument from PathBuf to &Path

### DIFF
--- a/iroh-api/src/api.rs
+++ b/iroh-api/src/api.rs
@@ -39,7 +39,7 @@ impl Api {
         overrides_map: HashMap<String, String>,
     ) -> Result<Self> {
         let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
-        let sources = vec![Some(cfg_path), config_path.map(PathBuf::from)];
+        let sources = vec![Some(cfg_path.as_path()), config_path];
         let config = make_config(
             // default
             Config::default(),

--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
-    let sources = vec![Some(cfg_path), args.cfg.clone()];
+    let sources = vec![Some(cfg_path.as_path()), args.cfg.as_deref()];
     let mut config = make_config(
         // default
         Config::default(),

--- a/iroh-one/src/main.rs
+++ b/iroh-one/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
-    let sources = vec![Some(cfg_path), args.cfg.clone()];
+    let sources = vec![Some(cfg_path.as_path()), args.cfg.as_deref()];
     let mut config = make_config(
         // default
         Config::default(),

--- a/iroh-p2p/src/main.rs
+++ b/iroh-p2p/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
 
         // TODO: configurable network
         let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
-        let sources = vec![Some(cfg_path), args.cfg.clone()];
+        let sources = vec![Some(cfg_path.as_path()), args.cfg.as_deref()];
         let network_config = make_config(
             // default
             Config::default_grpc(),

--- a/iroh-store/src/main.rs
+++ b/iroh-store/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
     println!("Starting iroh-store, version {version}");
 
     let config_path = iroh_config_path(CONFIG_FILE_NAME)?;
-    let sources = vec![Some(config_path), args.cfg.clone()];
+    let sources = vec![Some(config_path.as_path()), args.cfg.as_deref()];
     let config_data_path = config_data_path(args.path.clone())?;
     let config = make_config(
         // default

--- a/iroh-util/src/lib.rs
+++ b/iroh-util/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::RefCell,
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -153,7 +153,7 @@ impl Source for MetricsSource {
 /// a metrics field, eg, `IROH_CONFIG_METRICS.SERVICE_NAME`, but only if your environment allows it
 pub fn make_config<T, S, V>(
     default: T,
-    file_paths: Vec<Option<PathBuf>>,
+    file_paths: Vec<Option<&Path>>,
     env_prefix: &str,
     flag_overrides: HashMap<S, V>,
 ) -> Result<T>

--- a/iroh-util/tests/config.rs
+++ b/iroh-util/tests/config.rs
@@ -180,8 +180,8 @@ fn test_make_config() {
             let got = make_config(
                 TestConfig::new(),
                 vec![
-                    Some(PathBuf::from(CONFIG_A)),
-                    Some(PathBuf::from(CONFIG_B)),
+                    Some(&PathBuf::from(CONFIG_A)),
+                    Some(&PathBuf::from(CONFIG_B)),
                     None,
                 ],
                 "IROH_TEST_CONFIG",

--- a/iroh/src/run.rs
+++ b/iroh/src/run.rs
@@ -85,7 +85,7 @@ impl Cli {
     pub async fn run(&self) -> Result<()> {
         let config_path = iroh_config_path(CONFIG_FILE_NAME)?;
         // TODO(b5): allow suppliying some sort of config flag. maybe --config-cli?
-        let sources = vec![Some(config_path)];
+        let sources = vec![Some(config_path.as_path())];
         let config = make_config(
             // default
             Config::new(),


### PR DESCRIPTION
Changes the file_paths argument of make_config to take &Path
references.  It is not using this allocation and instead only using it
a &Path.  Many callers also had to explicitly allocate this.

---

I started by simplifying the user-facing API by turning it into a
PathBuf, but after checking how this was used that's just a pointless
allocation.  So instead this does the slightly more complex thing.