### PR TITLE
test(iroh-p2p): test interactions between multiple nodes

### DIFF
--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -67,6 +67,7 @@ features = [
 
 [dev-dependencies]
 criterion = "0.4"
+rand_chacha = "0.3.1"
 
 [features]
 default = ["rpc-grpc", "rpc-mem"]

--- a/iroh-p2p/src/node.rs
+++ b/iroh-p2p/src/node.rs
@@ -1058,20 +1058,21 @@ mod tests {
         Ok(())
     }
 
+    #[derive(Debug)]
     struct TestRunnerBuilder {
-        /// optional listening address for this node, when None, the swarm will connect to a random
-        /// tcp port
+        /// An Optional listening address for this node
+        /// When `None`, the swarm will connect to a random tcp port.
         addr: Option<Multiaddr>,
-        /// listening addresses for the p2p client, when None, the client will communicate over
-        /// a memory rpc channel
+        /// The listening addresses for the p2p client.
+        /// When `None`, the client will communicate over a memory rpc channel
         rpc_addrs: Option<(P2pServerAddr, P2pClientAddr)>,
-        /// when true, allow bootstrapping to the network, otherwise don't provide any addresses
-        /// from which to bootstrap
+        /// When `true`, allow bootstrapping to the network.
+        /// Otherwise, don't provide any addresses from which to bootstrap.
         bootstrap: bool,
-        /// optional seed to use when building a peer_id, when None will use a previously derived
-        /// peer_id 12D3KooWFma2D63TG9ToSiRsjFkoNm2tTihScTBAEdXxinYk5rwE
+        /// An optional seed to use when building a peer_id.
+        /// When `None`, it will use a previously derived peer_id `12D3KooWFma2D63TG9ToSiRsjFkoNm2tTihScTBAEdXxinYk5rwE`.
         seed: Option<ChaCha8Rng>,
-        /// optional keys to tell the node to provide on the dht
+        /// Optional `Keys` the node should provide to the DHT on start up.
         keys: Option<Vec<Key>>,
     }
 
@@ -1202,17 +1203,19 @@ mod tests {
     }
 
     struct TestRunner {
-        /// task for the running p2p node
+        /// The task that runs the p2p node.
         task: JoinHandle<()>,
-        /// rpc client, can use it to communicate with the p2p node
+        /// The RPC client
+        /// Used to communicate with the p2p node.
         client: P2pClient,
-        /// the node's peer_id
+        /// The node's peer_id
         peer_id: PeerId,
-        /// a channel to recieve network events read by the node
+        /// A channel to read the network events received by the node.
         network_events: Receiver<NetworkEvent>,
-        /// listening address for this node
+        /// The listening address for this node.
         addr: Multiaddr,
-        /// multiaddr that is a combination of the listening addr and peer_id
+        /// A multiaddr that is a combination of the listening addr and peer_id.
+        /// This address can be used by another node to dial this peer directly.
         dial_addr: Multiaddr,
     }
 
@@ -1514,7 +1517,7 @@ mod tests {
         // when `start_providing` waits for the record to make it to the dht
         // we can remove this polling
         let providers = tokio::time::timeout(
-            Duration::from_millis(2500),
+            Duration::from_millis(5000),
             poll_for_providers(test_runner_a.client.clone(), &cid),
         )
         .await

--- a/iroh-rpc-client/src/network.rs
+++ b/iroh-rpc-client/src/network.rs
@@ -47,6 +47,13 @@ impl P2pClient {
         Ok(addrs)
     }
 
+    #[tracing::instrument(skip(self))]
+    pub async fn listeners(&self) -> Result<Vec<Multiaddr>> {
+        let res = self.backend.listeners(()).await?;
+        let addrs = addrs_from_bytes(res.addrs)?;
+        Ok(addrs)
+    }
+
     // Fetches a block directly from the network.
     #[tracing::instrument(skip(self))]
     pub async fn fetch_bitswap(
@@ -412,6 +419,13 @@ mod tests {
         }
 
         async fn external_addrs(
+            &self,
+            _request: Request<()>,
+        ) -> Result<tonic::Response<Multiaddrs>, tonic::Status> {
+            todo!()
+        }
+
+        async fn listeners(
             &self,
             _request: Request<()>,
         ) -> Result<tonic::Response<Multiaddrs>, tonic::Status> {

--- a/iroh-rpc-types/proto/p2p.proto
+++ b/iroh-rpc-types/proto/p2p.proto
@@ -8,6 +8,7 @@ service P2p {
   rpc Version(google.protobuf.Empty) returns (VersionResponse) {}
   rpc LocalPeerId(google.protobuf.Empty) returns (PeerIdResponse) {}
   rpc ExternalAddrs(google.protobuf.Empty) returns (Multiaddrs) {}
+  rpc Listeners(google.protobuf.Empty) returns (Multiaddrs) {}
   rpc FetchBitswap(BitswapRequest) returns (BitswapResponse) {}
   rpc FetchProviderDht(Key) returns (stream Providers) {}
   rpc NotifyNewBlocksBitswap(NotifyNewBlocksBitswapRequest) returns (google.protobuf.Empty) {}

--- a/iroh-rpc-types/src/p2p.rs
+++ b/iroh-rpc-types/src/p2p.rs
@@ -28,5 +28,6 @@ proxy!(
     start_providing: Key => () => (),
     stop_providing: Key => () => (),
     local_peer_id: () => PeerIdResponse => PeerIdResponse,
-    external_addrs: () => Multiaddrs => Multiaddrs
+    external_addrs: () => Multiaddrs => Multiaddrs,
+    listeners: () => Multiaddrs => Multiaddrs
 );


### PR DESCRIPTION
covers these `RpcMessages`

- ExternalAddrs
- LocalPeerId
- ProviderRequest
- StartProviding
- StopProviding
- NetListeningAddrs
- NetPeers
- NetConnectByPeerId
- NetConnect
- Gossipsub messages
- FindPeerOnDht
- LookupPeerInfo
- ListenForIdentify
- AddressesOfPeer

The missing tests are for:
- P2pClient::fetch_bitswap
- P2pClient::notify_new_blocks_bitswap
- P2pClient::stop_session_bitswap
- P2pClient::disconnect -> this isn't actually implemented
- P2pClient::shutdown -> this doesn't seem to do anything

The bitswap commands are a bit trickier to fake. I would like to either move on or tackle them in a separate PR.

closes #455 