### PR TITLE
iroh-rpc-types: Rewrite error handling story

### DIFF
--- a/iroh-rpc-client/src/network.rs
+++ b/iroh-rpc-client/src/network.rs
@@ -161,12 +161,12 @@ impl P2pClient {
                 peer_id: peer_id.to_bytes(),
                 addrs: addrs.iter().map(|a| a.to_vec()).collect(),
             };
-            self.backend.peer_connect(req).await
+            self.backend.peer_connect(req).await.map_err(anyhow::Error::from)
         } else {
             let req = ConnectByPeerIdRequest {
                 peer_id: peer_id.to_bytes(),
             };
-            self.backend.peer_connect_by_peer_id(req).await
+            self.backend.peer_connect_by_peer_id(req).await.map_err(anyhow::Error::from)
         }
     }
 

--- a/iroh-rpc-types/Cargo.toml
+++ b/iroh-rpc-types/Cargo.toml
@@ -9,7 +9,6 @@ description = "RPC type definitions for iroh"
 
 
 [dependencies]
-anyhow = "1.0.58"
 async-trait = "0.1.56"
 futures = "0.3.24"
 iroh-metrics = { path = "../iroh-metrics", default-features = false }
@@ -17,6 +16,7 @@ paste = "1.0.7"
 prost = "0.11"
 prost-types = "0.11.1"
 serde_with = "2.0.0"
+thiserror = "1.0"
 tokio = { version = "1", features = ["net", "sync"] }
 tokio-stream = { version = "0.1.9", optional = true, features = ["net"] }
 tonic = { version = "0.8", optional = true }

--- a/iroh-rpc-types/src/addr.rs
+++ b/iroh-rpc-types/src/addr.rs
@@ -4,9 +4,10 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, bail};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::error::Error;
 
 #[derive(SerializeDisplay, DeserializeFromStr, Clone)]
 pub enum Addr<T = ()> {
@@ -70,12 +71,12 @@ impl<T> Debug for Addr<T> {
 }
 
 impl<T> FromStr for Addr<T> {
-    type Err = anyhow::Error;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[cfg(feature = "mem")]
         if s == "mem" {
-            bail!("memory addresses can not be serialized or deserialized");
+            return Err(Error::MemAddrSerde);
         }
 
         #[cfg(feature = "grpc")]
@@ -96,7 +97,7 @@ impl<T> FromStr for Addr<T> {
             }
         }
 
-        Err(anyhow!("invalid addr: {}", s))
+        Err(Error::InvalidAddr(s.to_string()))
     }
 }
 

--- a/iroh-rpc-types/src/error.rs
+++ b/iroh-rpc-types/src/error.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("memory addresses can not be serialized or deserialized")]
+    MemAddrSerde,
+
+    #[error("Invalid addr: {}", .0)]
+    InvalidAddr(String),
+
+    #[error("cannot bind socket to directory: {}", .0.display())]
+    SocketToDir(PathBuf),
+
+    #[error("cannot bind socket: already exists: {}", .0.display())]
+    SocketExists(PathBuf),
+
+    #[error("socket parent directory doesn't exist: {}", .0.display())]
+    SocketParentDirDoesNotExist(PathBuf),
+
+    #[error("Failed to bind to {}", .0.display())]
+    FailedToBind(PathBuf, #[source] std::io::Error),
+
+    #[error(transparent)]
+    TonicTransport(#[from] tonic::transport::Error),
+
+    #[error(transparent)]
+    TonicStatus(#[from] tonic::Status),
+
+    #[error(transparent)]
+    TokioOneshotRecv(#[from] tokio::sync::oneshot::error::RecvError),
+
+    #[error("Send failed")]
+    SendFailed,
+
+    #[error("Invalid Response")]
+    InvalidResponse,
+
+    // TODO: Why do we need this?
+    #[error("{}", .0)]
+    Str(String),
+}

--- a/iroh-rpc-types/src/lib.rs
+++ b/iroh-rpc-types/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod macros;
 
+pub mod error;
 pub mod gateway;
 pub mod p2p;
 pub mod store;

--- a/iroh-rpc-types/src/p2p.rs
+++ b/iroh-rpc-types/src/p2p.rs
@@ -7,7 +7,7 @@ proxy!(
     fetch_bitswap: BitswapRequest => BitswapResponse => BitswapResponse,
     fetch_provider_dht: Key =>
         std::pin::Pin<Box<dyn futures::Stream<Item = Result<Providers, tonic::Status>> + Send>> =>
-        std::pin::Pin<Box<dyn futures::Stream<Item = anyhow::Result<Providers>> + Send>> [FetchProviderDhtStream],
+        std::pin::Pin<Box<dyn futures::Stream<Item = Result<Providers, crate::error::Error>> + Send>> [FetchProviderDhtStream],
     stop_session_bitswap: StopSessionBitswapRequest => () => (),
     notify_new_blocks_bitswap: NotifyNewBlocksBitswapRequest => () => (),
     get_listening_addrs: () => GetListeningAddrsResponse =>  GetListeningAddrsResponse,


### PR DESCRIPTION
Part of #491 

This removes `anyhow` from the crate and replaces it with `thiserror`.

There's one TODO left, because there's a `String` somewhere used as error type, which is not nice. But for the first step, this might suffice.
