### PR TITLE
chore(deps): Unify the anyhow version dependency

### DIFF
--- a/iroh-bitswap/Cargo.toml
+++ b/iroh-bitswap/Cargo.toml
@@ -12,7 +12,7 @@ prost-build = "0.11.1"
 
 [dependencies]
 ahash = "0.8.0"
-anyhow = "1.0.65"
+anyhow = "1"
 async-broadcast = "0.4.1"
 async-channel = "1.7.1"
 async-trait = "0.1.57"

--- a/iroh-localops/Cargo.toml
+++ b/iroh-localops/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.25", features = ["signal", "process"]}

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -9,7 +9,7 @@ description = "Implementation of the p2p part of iroh"
 
 [dependencies]
 ahash = "0.8.0"
-anyhow = "1.0"
+anyhow = "1"
 async-stream = "0.3.3"
 async-trait = "0.1.56"
 asynchronous-codec = "0.6.0"

--- a/iroh-rpc-client/Cargo.toml
+++ b/iroh-rpc-client/Cargo.toml
@@ -9,7 +9,7 @@ description = "RPC type client for iroh"
 
 [dependencies]
 
-anyhow = "1.0.57"
+anyhow = "1"
 async-stream = "0.3.3"
 async-trait = "0.1.56"
 bytes = "1.1.0"

--- a/iroh-rpc-types/Cargo.toml
+++ b/iroh-rpc-types/Cargo.toml
@@ -9,7 +9,7 @@ description = "RPC type definitions for iroh"
 
 
 [dependencies]
-anyhow = "1.0.58"
+anyhow = "1"
 async-trait = "0.1.56"
 futures = "0.3.24"
 iroh-metrics = { path = "../iroh-metrics", default-features = false }

--- a/iroh-share/Cargo.toml
+++ b/iroh-share/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/n0-computer/iroh"
 description = "Sharing files with iroh"
 
 [dependencies]
-anyhow = "1.0.58"
+anyhow = "1"
 async-trait = "0.1.56"
 bincode = "1.3.3"
 bytes = "1.1.0"

--- a/iroh-store/Cargo.toml
+++ b/iroh-store/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/n0-computer/iroh"
 description = "Implementation of the storage part of iroh"
 
 [dependencies]
-anyhow = "1.0.57"
+anyhow = "1"
 async-trait = "0.1.56"
 bytecheck = "0.6.7"
 bytes = "1.1.0"

--- a/iroh-util/Cargo.toml
+++ b/iroh-util/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/n0-computer/iroh"
 description = "Utilities for iroh"
 
 [dependencies]
-anyhow = "1.0.57"
+anyhow = "1"
 cid = "0.8.4"
 config = "0.13.1"
 ctrlc = "3.2.2"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -11,7 +11,7 @@ description = "Command line interface for interacting with iroh."
 testing = ["dep:relative-path"]
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1"
 async-stream = "0.3.3"
 clap = { version = "4.0.15", features = ["derive"] }
 config = "0.13.1"

--- a/stores/flatfs/Cargo.toml
+++ b/stores/flatfs/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/n0-computer/iroh"
 description = "Implementation of FlatFS"
 
 [dependencies]
-anyhow = "1.0.57"
+anyhow = "1"
 backoff = "0.4.0"
 ignore = "0.4.18"
 

--- a/stores/rocks/Cargo.toml
+++ b/stores/rocks/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/n0-computer/iroh"
 description = "Implementation of RocksDB based Store"
 
 [dependencies]
-anyhow = "1.0.57"
+anyhow = "1"
 flatfs-store = { path = "../flatfs", optional = true }
 rocksdb = "0.19.0"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1"
 clap = { version = "4.0.9", features = ["derive"] }
 clap_mangen = "0.2.2"
 dirs-next = "2.0.0"


### PR DESCRIPTION
Since iroh is a library, or will be, we should not have too strict a
version requirement, so simply requiring version 1.