### PR TITLE
feat: support lookup names in RPC addrs

### DIFF
--- a/iroh-rpc-client/src/macros.rs
+++ b/iroh-rpc-client/src/macros.rs
@@ -33,6 +33,19 @@ macro_rules! impl_client {
                                 backend: [<$label ClientBackend>]::Grpc { client, health },
                             })
                         }
+                        #[cfg(feature = "grpc")]
+                        Addr::GrpcHttp2Lookup(addr) => {
+                            let conn = Endpoint::new(format!("http://{}", addr))?
+                                .keep_alive_while_idle(true)
+                                .connect_lazy();
+
+                            let client = [<Grpc $label Client>]::new(conn.clone());
+                            let health = HealthClient::new(conn);
+
+                            Ok([<$label Client>] {
+                                backend: [<$label ClientBackend>]::Grpc { client, health },
+                            })
+                        }
                         #[cfg(all(feature = "grpc", unix))]
                         Addr::GrpcUds(path) => {
                             use tokio::net::UnixStream;

--- a/iroh-rpc-types/src/macros.rs
+++ b/iroh-rpc-types/src/macros.rs
@@ -19,6 +19,11 @@ macro_rules! proxy_serve {
                         Ok(())
                     }
 
+                    #[cfg(feature = "grpc")]
+                    $crate::Addr::GrpcHttp2Lookup(name) => {
+                        anyhow::bail!("cannot serve on lookup address: {}", name);
+                    }
+
                     #[cfg(all(feature = "grpc", unix))]
                     $crate::Addr::GrpcUds(path) => {
                         use anyhow::Context;


### PR DESCRIPTION
support addrs like `grpc://example:4444`, which is required for DevOps infrastructure that provides hostname resolution as part of service discovery.

This patch uses the heuristic of being able to resolve to disambiguate between `grpc://foo` the lookup address and `grpc://foo` a path to a unix domain socket file location. In practice this shouldn't be too big a deal, but might get tricky if folks start naming UDS paths after domains 😵 .

I need this to make docker compose examples work, which is a good indication this'll be needed by all modern DevOps deployments