### PR TITLE
chore: Disable uds-gateway feature on windows

### DIFF
--- a/iroh-one/src/cli.rs
+++ b/iroh-one/src/cli.rs
@@ -21,7 +21,7 @@ pub struct Args {
     tracing: bool,
     #[clap(long)]
     denylist: bool,
-    #[cfg(feature = "uds-gateway")]
+    #[cfg(all(feature = "uds-gateway", unix))]
     #[clap(long = "gateway-uds-path")]
     pub gateway_uds_path: Option<PathBuf>,
     /// Path to the store
@@ -52,7 +52,7 @@ impl Args {
         if let Some(path) = self.store_path.clone() {
             map.insert("store.path", path.to_str().unwrap_or("").to_string());
         }
-        #[cfg(feature = "uds-gateway")]
+        #[cfg(all(feature = "uds-gateway", unix))]
         if let Some(path) = self.gateway_uds_path.clone() {
             map.insert("gateway_uds_path", path.to_str().unwrap_or("").to_string());
         }

--- a/iroh-one/src/lib.rs
+++ b/iroh-one/src/lib.rs
@@ -2,5 +2,5 @@ pub mod cli;
 pub mod config;
 pub mod mem_p2p;
 pub mod mem_store;
-#[cfg(feature = "uds-gateway")]
+#[cfg(all(feature = "uds-gateway", unix))]
 pub mod uds;

--- a/iroh-one/src/main.rs
+++ b/iroh-one/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use iroh_gateway::{bad_bits::BadBits, core::Core, metrics};
-#[cfg(feature = "uds-gateway")]
+#[cfg(all(feature = "uds-gateway", unix))]
 use iroh_one::uds;
 use iroh_one::{
     cli::Args,
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
         server.await.unwrap();
     });
 
-    #[cfg(feature = "uds-gateway")]
+    #[cfg(all(feature = "uds-gateway", unix))]
     let uds_server_task = {
         let mut path = tempfile::Builder::new()
             .prefix("iroh")
@@ -135,7 +135,7 @@ async fn main() -> Result<()> {
 
     store_rpc.abort();
     p2p_rpc.abort();
-    #[cfg(feature = "uds-gateway")]
+    #[cfg(all(feature = "uds-gateway", unix))]
     uds_server_task.abort();
     core_task.abort();
 


### PR DESCRIPTION
Perhaps it is even desireable to trigger a compilation failure when
trying to enable the feature on windows.  The downside is that the
`--all-features` argument to cargo would no longer work on windows and
this makes the development experience a lot more painful.  For now
this seems a reasonable compromise.