### PR TITLE
fix(cli): Respect the --cfg flag

### DIFF
--- a/iroh-api/src/api.rs
+++ b/iroh-api/src/api.rs
@@ -39,12 +39,12 @@ impl Api {
         overrides_map: HashMap<String, String>,
     ) -> Result<Self> {
         let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
-        let sources = vec![Some(cfg_path.as_path()), config_path];
+        let sources = [Some(cfg_path.as_path()), config_path];
         let config = make_config(
             // default
             Config::default(),
             // potential config files
-            sources,
+            &sources,
             // env var prefix for this config
             ENV_PREFIX,
             // map of present command line arguments

--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -23,12 +23,12 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
-    let sources = vec![Some(cfg_path.as_path()), args.cfg.as_deref()];
+    let sources = [Some(cfg_path.as_path()), args.cfg.as_deref()];
     let mut config = make_config(
         // default
         Config::default(),
         // potential config files
-        sources,
+        &sources,
         // env var prefix for this config
         ENV_PREFIX,
         // map of present command line arguments

--- a/iroh-one/src/main.rs
+++ b/iroh-one/src/main.rs
@@ -25,12 +25,12 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
-    let sources = vec![Some(cfg_path.as_path()), args.cfg.as_deref()];
+    let sources = [Some(cfg_path.as_path()), args.cfg.as_deref()];
     let mut config = make_config(
         // default
         Config::default(),
         // potential config files
-        sources,
+        &sources,
         // env var prefix for this config
         ENV_PREFIX,
         // map of present command line arguments

--- a/iroh-p2p/src/main.rs
+++ b/iroh-p2p/src/main.rs
@@ -27,12 +27,12 @@ fn main() -> Result<()> {
 
         // TODO: configurable network
         let cfg_path = iroh_config_path(CONFIG_FILE_NAME)?;
-        let sources = vec![Some(cfg_path.as_path()), args.cfg.as_deref()];
+        let sources = [Some(cfg_path.as_path()), args.cfg.as_deref()];
         let network_config = make_config(
             // default
             Config::default_grpc(),
             // potential config files
-            sources,
+            &sources,
             // env var prefix for this config
             ENV_PREFIX,
             // map of present command line arguments

--- a/iroh-store/src/main.rs
+++ b/iroh-store/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
     println!("Starting iroh-store, version {version}");
 
     let config_path = iroh_config_path(CONFIG_FILE_NAME)?;
-    let sources = vec![Some(config_path.as_path()), args.cfg.as_deref()];
+    let sources = &[Some(config_path.as_path()), args.cfg.as_deref()];
     let config_data_path = config_data_path(args.path.clone())?;
     let config = make_config(
         // default

--- a/iroh-util/Cargo.toml
+++ b/iroh-util/Cargo.toml
@@ -23,5 +23,8 @@ thiserror = "1.0"
 toml = "0.5.9"
 tracing = "0.1.34"
 
+[dev-dependencies]
+testdir = "0.6.0"
+
 [target.'cfg(unix)'.dev-dependencies]
 nix = "0.25"

--- a/iroh-util/src/lib.rs
+++ b/iroh-util/src/lib.rs
@@ -153,7 +153,7 @@ impl Source for MetricsSource {
 /// a metrics field, eg, `IROH_CONFIG_METRICS.SERVICE_NAME`, but only if your environment allows it
 pub fn make_config<T, S, V>(
     default: T,
-    file_paths: Vec<Option<&Path>>,
+    file_paths: &[Option<&Path>],
     env_prefix: &str,
     flag_overrides: HashMap<S, V>,
 ) -> Result<T>
@@ -166,7 +166,7 @@ where
     let mut builder = Config::builder().add_source(default);
 
     // layer on config options from files
-    for path in file_paths.into_iter().flatten() {
+    for path in file_paths.iter().flatten() {
         if path.exists() {
             let p = path.to_str().ok_or_else(|| anyhow::anyhow!("empty path"))?;
             builder = builder.add_source(File::with_name(p));

--- a/iroh-util/tests/config.rs
+++ b/iroh-util/tests/config.rs
@@ -179,7 +179,7 @@ fn test_make_config() {
         || {
             let got = make_config(
                 TestConfig::new(),
-                vec![
+                &[
                     Some(&PathBuf::from(CONFIG_A)),
                     Some(&PathBuf::from(CONFIG_B)),
                     None,

--- a/iroh/src/run.rs
+++ b/iroh/src/run.rs
@@ -85,12 +85,12 @@ enum Commands {
 impl Cli {
     pub async fn run(&self) -> Result<()> {
         let config_path = iroh_config_path(CONFIG_FILE_NAME)?;
-        let sources = vec![self.cfg.as_deref(), Some(config_path.as_path())];
+        let sources = [Some(config_path.as_path()), self.cfg.as_deref()];
         let config = make_config(
             // default
             Config::new(),
             // potential config files
-            sources,
+            &sources,
             // env var prefix for this config
             ENV_PREFIX,
             // map of present command line arguments

--- a/iroh/src/run.rs
+++ b/iroh/src/run.rs
@@ -85,8 +85,7 @@ enum Commands {
 impl Cli {
     pub async fn run(&self) -> Result<()> {
         let config_path = iroh_config_path(CONFIG_FILE_NAME)?;
-        // TODO(b5): allow suppliying some sort of config flag. maybe --config-cli?
-        let sources = vec![Some(config_path.as_path())];
+        let sources = vec![self.cfg.as_deref(), Some(config_path.as_path())];
         let config = make_config(
             // default
             Config::new(),


### PR DESCRIPTION
Use the --cfg flag to load the configuration file for `iroh`.

This does not affect the config files for any of the managed
processes like iroh-p2p etc.

This flag was not used before.

Also optimises the make_config call a little by taking a slice
rather than a Vec.  And assert and document the priority order.