### PR TITLE
Verify content fetched from racing http gateways

### DIFF
--- a/iroh-resolver/src/content_loader.rs
+++ b/iroh-resolver/src/content_loader.rs
@@ -161,11 +161,21 @@ impl FullLoader {
     async fn fetch_gateway(&self, cid: &Cid) -> Result<Option<LoadedCid>> {
         match self.next_gateway().await {
             Some(url) => {
-                let data = reqwest::get(url.as_url(cid)).await?.bytes().await?;
-                Ok(Some(LoadedCid {
-                    data,
-                    source: Source::Http(url.as_string()),
-                }))
+                let response = reqwest::get(url.as_url(cid)).await?;
+                // Filter out non http 200 responses.
+                if !response.status().is_success() {
+                    return Ok(None);
+                }
+                let data = response.bytes().await?;
+                // Make sure the content is not tampered with.
+                if iroh_util::verify_hash(cid, &data) == Some(true) {
+                    Ok(Some(LoadedCid {
+                        data,
+                        source: Source::Http(url.as_string()),
+                    }))
+                } else {
+                    Ok(None)
+                }
             }
             None => Ok(None),
         }

--- a/iroh-resolver/src/content_loader.rs
+++ b/iroh-resolver/src/content_loader.rs
@@ -164,7 +164,7 @@ impl FullLoader {
                 let response = reqwest::get(url.as_url(cid)).await?;
                 // Filter out non http 200 responses.
                 if !response.status().is_success() {
-                    return Ok(None);
+                    return Err(anyhow!("unexpected http status"));
                 }
                 let data = response.bytes().await?;
                 // Make sure the content is not tampered with.
@@ -174,7 +174,7 @@ impl FullLoader {
                         source: Source::Http(url.as_string()),
                     }))
                 } else {
-                    Ok(None)
+                    Err(anyhow!("invalid CID hash"))
                 }
             }
             None => Ok(None),


### PR DESCRIPTION
While doing some local network fetching, I encountered this error: `curl http://localhost:9050/ipfs/CID` failed to return the expected content but returned that:

```html
<html>
<head><title>504 Gateway Time-out</title></head>
<body>
<center><h1>504 Gateway Time-out</h1></center>
<hr><center>openresty</center>
</body>
</html>
```
This is a combination of 2 errors:
- Failure to verify the CID hash since that's not the expected content!
- Failure to consider non 2xx response from gateways as errors.

This patch fixes both, and we now get the timeout from the local gateway as expected:
```shell
curl http://localhost:9050/ipfs/bafkreibimdxekc6ebparbv3pp2hrcfzib7m42ysvzis3djdlumflidnkky
{"code":504,"message":"request timed out","success":false}
```



