### PR TITLE
fix: convert v0 -> v1 before base32 conversion

### DIFF
--- a/iroh-resolver/src/content_loader.rs
+++ b/iroh-resolver/src/content_loader.rs
@@ -83,22 +83,19 @@ impl GatewayUrl {
         }
     }
 
-    pub fn as_url(&self, cid: &Cid) -> Url {
-        let cid_str = cid
-            .into_v1()
-            .unwrap()
-            .to_string_of_base(Base::Base32Lower)
-            .unwrap();
-        match self {
+    pub fn as_url(&self, cid: &Cid) -> Result<Url> {
+        let cid_str = cid.into_v1()?.to_string_of_base(Base::Base32Lower)?;
+        let url = match self {
             GatewayUrl::Full(raw) => {
                 let mut url = raw.join(&cid_str).unwrap();
                 url.set_query(Some("format=raw"));
                 url
             }
-            GatewayUrl::Subdomain(raw) => format!("https://{}.ipfs.{}?format=raw", cid_str, raw)
-                .parse()
-                .unwrap(),
-        }
+            GatewayUrl::Subdomain(raw) => {
+                format!("https://{}.ipfs.{}?format=raw", cid_str, raw).parse()?
+            }
+        };
+        Ok(url)
     }
 }
 
@@ -165,7 +162,7 @@ impl FullLoader {
     async fn fetch_gateway(&self, cid: &Cid) -> Result<Option<LoadedCid>> {
         match self.next_gateway().await {
             Some(url) => {
-                let response = reqwest::get(url.as_url(cid)).await?;
+                let response = reqwest::get(url.as_url(cid)?).await?;
                 // Filter out non http 200 responses.
                 if !response.status().is_success() {
                     return Err(anyhow!("unexpected http status"));

--- a/iroh-resolver/src/content_loader.rs
+++ b/iroh-resolver/src/content_loader.rs
@@ -84,7 +84,11 @@ impl GatewayUrl {
     }
 
     pub fn as_url(&self, cid: &Cid) -> Url {
-        let cid_str = cid.to_string_of_base(Base::Base32Lower).unwrap();
+        let cid_str = cid
+            .into_v1()
+            .unwrap()
+            .to_string_of_base(Base::Base32Lower)
+            .unwrap();
         match self {
             GatewayUrl::Full(raw) => {
                 let mut url = raw.join(&cid_str).unwrap();


### PR DESCRIPTION
fixes #511

turns out you can't go straight from v0 -> base32 v1, which makes sense, but is irritating. Better than the alternative of silently converting into cidv1 I guess.

Anyway, fixes the gateway