### PR TITLE
[feat] HEAD for CIDs + refactoring of handlers

### DIFF
--- a/iroh-gateway/src/bad_bits.rs
+++ b/iroh-gateway/src/bad_bits.rs
@@ -19,7 +19,7 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    let b = hex::decode(&s).unwrap();
+    let b = hex::decode(s).unwrap();
     b[..32].try_into().map_err(de::Error::custom)
 }
 

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -97,6 +97,15 @@ impl<T: ContentLoader + std::marker::Unpin> Client<T> {
     }
 
     #[tracing::instrument(skip(self))]
+    pub async fn retrieve_path_metadata(
+        &self,
+        path: iroh_resolver::resolver::Path,
+    ) -> Result<Out, String> {
+        info!("retrieve path metadata {}", path);
+        self.resolver.resolve(path).await.map_err(|e| e.to_string())
+    }
+
+    #[tracing::instrument(skip(self))]
     pub async fn get_file(
         &self,
         path: iroh_resolver::resolver::Path,
@@ -104,23 +113,19 @@ impl<T: ContentLoader + std::marker::Unpin> Client<T> {
         range: Option<Range<u64>>,
     ) -> Result<(FileResult<T>, Metadata), String> {
         info!("get file {}", path);
-        let res = self
-            .resolver
-            .resolve(path)
-            .await
-            .map_err(|e| e.to_string())?;
-        let metadata = res.metadata().clone();
+        let path_metadata = self.retrieve_path_metadata(path).await?;
+        let metadata = path_metadata.metadata().clone();
         record_ttfb_metrics(start_time, &metadata.source);
 
-        if res.is_dir() {
-            let body = FileResult::Directory(res);
+        if path_metadata.is_dir() {
+            let body = FileResult::Directory(path_metadata);
             Ok((body, metadata))
         } else {
             let mut clip = 0;
             if let Some(range) = &range {
                 clip = range.end as usize;
             }
-            let reader = res
+            let reader = path_metadata
                 .pretty(
                     self.resolver.clone(),
                     OutMetrics { start: start_time },

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -304,7 +304,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             files
                 .iter()
-                .map(|(name, _content)| name.clone())
+                .map(|(name, _content)| name.to_string())
                 .collect::<Vec<_>>()
         );
 

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -1,19 +1,18 @@
 use async_recursion::async_recursion;
 use axum::{
-    body::{self, Body, HttpBody},
+    body::Body,
     error_handling::HandleErrorLayer,
     extract::{Extension, Path, Query},
     http::{header::*, Request as HttpRequest, StatusCode},
     middleware,
     response::IntoResponse,
-    routing::get,
+    routing::{get, head},
     BoxError, Router,
 };
-use bytes::Bytes;
 use futures::TryStreamExt;
 use handlebars::Handlebars;
 use http::Method;
-use iroh_metrics::{core::MRecorder, gateway::GatewayMetrics, get_current_trace_id, inc};
+use iroh_metrics::{core::MRecorder, gateway::GatewayMetrics, inc};
 use iroh_resolver::{
     content_loader::ContentLoader,
     resolver::{CidOrDomain, OutMetrics, UnixfsType},
@@ -28,7 +27,6 @@ use serde_json::{
 use serde_qs;
 use std::{
     collections::HashMap,
-    error::Error,
     fmt::Write,
     ops::Range,
     sync::Arc,
@@ -67,6 +65,7 @@ pub fn get_app_routes<T: ContentLoader + std::marker::Unpin>(state: &Arc<State<T
     Router::new()
         .route("/:scheme/:cid", get(get_handler::<T>))
         .route("/:scheme/:cid/*cpath", get(get_handler::<T>))
+        .route("/:scheme/:cid/*cpath", head(head_handler::<T>))
         .route("/health", get(health_check))
         .route("/icons.css", get(stylesheet_icons))
         .route("/style.css", get(stylesheet_main))
@@ -101,14 +100,24 @@ pub struct GetParams {
     /// specifies the expected format of the response
     format: Option<String>,
     /// specifies the desired filename of the response
-    filename: Option<String>,
+    #[serde(default)]
+    filename: String,
     /// specifies whether the response should be of disposition inline or attachment
-    download: Option<bool>,
+    #[serde(default)]
+    download: bool,
     /// specifies whether the response should render a directory even if index.html is present
     force_dir: Option<bool>,
     /// uri query parameter for handling navigator.registerProtocolHandler Web API requests
     uri: Option<String>,
-    recursive: Option<bool>,
+    #[serde(default)]
+    recursive: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PathParams {
+    scheme: String,
+    cid: String,
+    cpath: Option<String>,
 }
 
 impl GetParams {
@@ -122,108 +131,165 @@ impl GetParams {
     }
 }
 
-#[tracing::instrument(skip(state))]
-pub async fn get_handler<T: ContentLoader + std::marker::Unpin>(
-    Extension(state): Extension<Arc<State<T>>>,
-    Path(params): Path<HashMap<String, String>>,
-    Query(query_params): Query<GetParams>,
-    method: http::Method,
-    http_req: HttpRequest<Body>,
+enum RequestPreprocessingResult {
+    Response(GatewayResponse),
+    FurtherRequest(Box<Request>),
+}
+
+async fn request_preprocessing<T: ContentLoader + std::marker::Unpin>(
+    state: &Arc<State<T>>,
+    path_params: &PathParams,
+    query_params: &GetParams,
     request_headers: HeaderMap,
-) -> Result<GatewayResponse, GatewayError> {
-    inc!(GatewayMetrics::Requests);
-    let start_time = time::Instant::now();
-    // parse path params
-    let scheme = params.get("scheme").unwrap();
-    if scheme != SCHEME_IPFS && scheme != SCHEME_IPNS {
-        return Err(error(
+    response_headers: &mut HeaderMap,
+) -> Result<RequestPreprocessingResult, GatewayError> {
+    if path_params.scheme != SCHEME_IPFS && path_params.scheme != SCHEME_IPNS {
+        return Err(GatewayError::new(
             StatusCode::BAD_REQUEST,
             "invalid scheme, must be ipfs or ipns",
-            &state,
         ));
     }
-    let cid = params.get("cid").unwrap();
-    let cpath = "".to_string();
-    let cpath = params.get("cpath").unwrap_or(&cpath);
-    let query_params_copy = query_params.clone();
+    let cpath = path_params.cpath.as_deref().unwrap_or("");
 
     let uri_param = query_params.uri.clone().unwrap_or_default();
     if !uri_param.is_empty() {
-        return protocol_handler_redirect(uri_param, &state);
+        return protocol_handler_redirect(uri_param, state).map(RequestPreprocessingResult::Response);
     }
-    service_worker_check(&request_headers, cpath.to_string(), &state)?;
-    unsuported_header_check(&request_headers, &state)?;
+    service_worker_check(&request_headers, cpath.to_string(), state)?;
+    unsuported_header_check(&request_headers, state)?;
 
-    if check_bad_bits(&state, cid, cpath).await {
-        return Err(error(StatusCode::GONE, "CID is in the denylist", &state));
+    if check_bad_bits(state, &path_params.cid, cpath).await {
+        return Err(GatewayError::new(
+            StatusCode::GONE,
+            "CID is in the denylist",
+        ));
     }
 
-    let full_content_path = format!("/{}/{}{}", scheme, cid, cpath);
+    let full_content_path = format!("/{}/{}{}", path_params.scheme, path_params.cid, cpath);
     let resolved_path: iroh_resolver::resolver::Path = full_content_path
         .parse()
         .map_err(|e: anyhow::Error| e.to_string())
-        .map_err(|e| error(StatusCode::BAD_REQUEST, &e, &state))?;
+        .map_err(|e| GatewayError::new(StatusCode::BAD_REQUEST, &e))?;
     // TODO: handle 404 or error
     let resolved_cid = resolved_path.root();
 
-    if handle_only_if_cached(&request_headers, &state, resolved_cid).await? {
-        return response(StatusCode::OK, Body::empty(), HeaderMap::new());
+    if handle_only_if_cached(&request_headers, state, resolved_cid).await? {
+        return Ok(RequestPreprocessingResult::Response(GatewayResponse::new(
+            StatusCode::OK,
+            Body::empty(),
+            HeaderMap::new(),
+        )));
     }
 
-    if check_bad_bits(&state, resolved_cid.to_string().as_str(), cpath).await {
-        return Err(error(StatusCode::GONE, "CID is in the denylist", &state));
+    if check_bad_bits(state, resolved_cid.to_string().as_str(), cpath).await {
+        return Err(GatewayError::new(
+            StatusCode::GONE,
+            "CID is in the denylist",
+        ));
     }
 
     // parse query params
-    let format = match get_response_format(&request_headers, query_params.format) {
-        Ok(format) => format,
-        Err(err) => {
-            return Err(error(StatusCode::BAD_REQUEST, &err, &state));
-        }
-    };
+    let format = get_response_format(&request_headers, &query_params.format)
+        .map_err(|err| GatewayError::new(StatusCode::BAD_REQUEST, &err))?;
 
-    let query_file_name = query_params.filename.unwrap_or_default();
-    let download = query_params.download.unwrap_or_default();
-    let recursive = query_params.recursive.unwrap_or_default();
-
-    let mut headers = HeaderMap::new();
-
-    if let Some(resp) = etag_check(&request_headers, resolved_cid, &format, &state) {
-        return Ok(resp);
+    if let Some(resp) = etag_check(&request_headers, resolved_cid, &format, state) {
+        return Ok(RequestPreprocessingResult::Response(resp));
     }
 
     // init headers
-    format.write_headers(&mut headers);
-    add_user_headers(&mut headers, state.config.user_headers().clone());
+    format.write_headers(response_headers);
+    add_user_headers(response_headers, state.config.user_headers().clone());
     let hv = match HeaderValue::from_str(&full_content_path) {
         Ok(hv) => hv,
         Err(err) => {
-            return Err(error(
+            return Err(GatewayError::new(
                 StatusCode::BAD_REQUEST,
                 &format!("invalid header value: {}", err),
-                &state,
             ));
         }
     };
-    headers.insert(&HEADER_X_IPFS_PATH, hv);
+    response_headers.insert(&HEADER_X_IPFS_PATH, hv);
 
     // handle request and fetch data
     let req = Request {
         format,
         cid: resolved_path.root().clone(),
         resolved_path,
-        query_file_name,
-        download,
-        query_params: query_params_copy,
+        query_file_name: query_params.filename.clone(),
+        download: query_params.download,
+        query_params: query_params.clone(),
     };
+    Ok(RequestPreprocessingResult::FurtherRequest(Box::new(req)))
+}
 
-    if recursive {
-        serve_car_recursive(&req, state, headers, start_time).await
-    } else {
-        match req.format {
-            ResponseFormat::Raw => serve_raw(&req, state, headers, &http_req, start_time).await,
-            ResponseFormat::Car => serve_car(&req, state, headers, start_time).await,
-            ResponseFormat::Fs(_) => serve_fs(&req, state, headers, &http_req, start_time).await,
+#[tracing::instrument(skip(state))]
+pub async fn get_handler<T: ContentLoader + std::marker::Unpin>(
+    Extension(state): Extension<Arc<State<T>>>,
+    Path(path_params): Path<PathParams>,
+    Query(query_params): Query<GetParams>,
+    http_req: HttpRequest<Body>,
+    request_headers: HeaderMap,
+) -> Result<GatewayResponse, GatewayError> {
+    inc!(GatewayMetrics::Requests);
+    let start_time = time::Instant::now();
+    let mut response_headers = HeaderMap::new();
+    match request_preprocessing(
+        &state,
+        &path_params,
+        &query_params,
+        request_headers,
+        &mut response_headers,
+    )
+    .await?
+    {
+        RequestPreprocessingResult::Response(gateway_response) => Ok(gateway_response),
+        RequestPreprocessingResult::FurtherRequest(req) => {
+            if query_params.recursive {
+                serve_car_recursive(&req, state, response_headers, start_time).await
+            } else {
+                match req.format {
+                    ResponseFormat::Raw => {
+                        serve_raw(&req, state, response_headers, &http_req, start_time).await
+                    }
+                    ResponseFormat::Car => {
+                        serve_car(&req, state, response_headers, start_time).await
+                    }
+                    ResponseFormat::Fs(_) => {
+                        serve_fs(&req, state, response_headers, &http_req, start_time).await
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[tracing::instrument(skip(state))]
+pub async fn head_handler<T: ContentLoader + std::marker::Unpin>(
+    Extension(state): Extension<Arc<State<T>>>,
+    Path(path_params): Path<PathParams>,
+    Query(query_params): Query<GetParams>,
+    request_headers: HeaderMap,
+) -> Result<GatewayResponse, GatewayError> {
+    inc!(GatewayMetrics::Requests);
+    let mut response_headers = HeaderMap::new();
+    match request_preprocessing(
+        &state,
+        &path_params,
+        &query_params,
+        request_headers,
+        &mut response_headers,
+    )
+    .await?
+    {
+        RequestPreprocessingResult::Response(gateway_response) => Ok(gateway_response),
+        RequestPreprocessingResult::FurtherRequest(req) => {
+            let path_metadata = state
+                .client
+                .retrieve_path_metadata(req.resolved_path)
+                .await
+                .map_err(|e| GatewayError::new(StatusCode::INTERNAL_SERVER_ERROR, &e))?;
+            add_content_length_header(&mut response_headers, path_metadata.metadata().clone());
+            Ok(GatewayResponse::empty(response_headers))
         }
     }
 }
@@ -259,19 +325,17 @@ fn protocol_handler_redirect<T: ContentLoader>(
     let u = match Url::parse(&uri_param) {
         Ok(u) => u,
         Err(e) => {
-            return Err(error(
+            return Err(GatewayError::new(
                 StatusCode::BAD_REQUEST,
                 &format!("invalid uri: {}", e),
-                state,
             ));
         }
     };
     let uri_scheme = u.scheme();
     if uri_scheme != SCHEME_IPFS && uri_scheme != SCHEME_IPNS {
-        return Err(error(
+        return Err(GatewayError::new(
             StatusCode::BAD_REQUEST,
             "invalid uri scheme, must be ipfs or ipns",
-            state,
         ));
     }
     let mut uri_path = u.path().to_string();
@@ -279,7 +343,7 @@ fn protocol_handler_redirect<T: ContentLoader>(
     if uri_query.is_some() {
         let encoded_query = encode(uri_query.unwrap());
         write!(uri_path, "?{}", encoded_query)
-            .map_err(|e| error(StatusCode::BAD_REQUEST, &e.to_string(), state))?;
+            .map_err(|e| GatewayError::new(StatusCode::BAD_REQUEST, &e.to_string()))?;
     }
     let uri_host = u.host().unwrap().to_string();
     let redirect_uri = format!("{}://{}{}", uri_scheme, uri_host, uri_path);
@@ -295,10 +359,9 @@ fn service_worker_check<T: ContentLoader>(
     if request_headers.contains_key(&HEADER_SERVICE_WORKER) {
         let sw = request_headers.get(&HEADER_SERVICE_WORKER).unwrap();
         if sw.to_str().unwrap() == "script" && cpath.is_empty() {
-            return Err(error(
+            return Err(GatewayError::new(
                 StatusCode::BAD_REQUEST,
                 "Service Worker not supported",
-                state,
             ));
         }
     }
@@ -311,10 +374,9 @@ fn unsuported_header_check<T: ContentLoader>(
     state: &State<T>,
 ) -> Result<(), GatewayError> {
     if request_headers.contains_key(&HEADER_X_IPFS_GATEWAY_PREFIX) {
-        return Err(error(
+        return Err(GatewayError::new(
             StatusCode::BAD_REQUEST,
             "Unsupported HTTP header",
-            state,
         ));
     }
     Ok(())
@@ -329,34 +391,24 @@ async fn handle_only_if_cached<T: ContentLoader>(
     if request_headers.contains_key(&HEADER_CACHE_CONTROL) {
         let hv = request_headers.get(&HEADER_CACHE_CONTROL).unwrap();
         if hv.to_str().unwrap() == "only-if-cached" {
-            match cid {
+            return match cid {
+                // ToDo: Race is possible if file would have been deleted immediately after the check
                 CidOrDomain::Cid(cid) => match state.client.has_file_locally(cid).await {
-                    Ok(true) => {
-                        return Ok(true);
-                    }
-                    Ok(false) => {
-                        return Err(error(
-                            StatusCode::PRECONDITION_FAILED,
-                            "File not found in cache",
-                            state,
-                        ));
-                    }
-                    Err(e) => {
-                        return Err(error(
-                            StatusCode::PRECONDITION_FAILED,
-                            &format!("Error checking cache: {}", e),
-                            state,
-                        ));
-                    }
-                },
-                CidOrDomain::Domain(_) => {
-                    return Err(error(
+                    Ok(true) => Ok(true),
+                    Ok(false) => Err(GatewayError::new(
                         StatusCode::PRECONDITION_FAILED,
-                        "Cannot resolve in cache: invalid CID.",
-                        state,
-                    ));
-                }
-            }
+                        "File not found in cache",
+                    )),
+                    Err(e) => Err(GatewayError::new(
+                        StatusCode::PRECONDITION_FAILED,
+                        &format!("Error checking cache: {}", e),
+                    )),
+                },
+                CidOrDomain::Domain(_) => Err(GatewayError::new(
+                    StatusCode::PRECONDITION_FAILED,
+                    "Cannot resolve in cache: invalid CID.",
+                )),
+            };
         }
     }
     Ok(false)
@@ -418,7 +470,7 @@ async fn serve_raw<T: ContentLoader + std::marker::Unpin>(
         .client
         .get_file(req.resolved_path.clone(), start_time, range.clone())
         .await
-        .map_err(|e| error(StatusCode::INTERNAL_SERVER_ERROR, &e, &state))?;
+        .map_err(|e| GatewayError::new(StatusCode::INTERNAL_SERVER_ERROR, &e))?;
 
     match body {
         FileResult::File(body) | FileResult::Raw(body) => {
@@ -442,15 +494,18 @@ async fn serve_raw<T: ContentLoader + std::marker::Unpin>(
                 }
                 add_etag_range(&mut headers, capped_range.clone());
                 add_content_range_headers(&mut headers, capped_range, metadata.size);
-                response(StatusCode::PARTIAL_CONTENT, body, headers)
+                Ok(GatewayResponse::new(
+                    StatusCode::PARTIAL_CONTENT,
+                    body,
+                    headers,
+                ))
             } else {
-                response(StatusCode::OK, body, headers)
+                Ok(GatewayResponse::new(StatusCode::OK, body, headers))
             }
         }
-        FileResult::Directory(_) => Err(error(
+        FileResult::Directory(_) => Err(GatewayError::new(
             StatusCode::INTERNAL_SERVER_ERROR,
             "cannot serve directory as raw",
-            &state,
         )),
     }
 }
@@ -468,7 +523,7 @@ async fn serve_car<T: ContentLoader + std::marker::Unpin>(
         .client
         .get_file(req.resolved_path.clone(), start_time, None)
         .await
-        .map_err(|e| error(StatusCode::INTERNAL_SERVER_ERROR, &e, &state))?;
+        .map_err(|e| GatewayError::new(StatusCode::INTERNAL_SERVER_ERROR, &e))?;
 
     match body {
         FileResult::File(body) | FileResult::Raw(body) => {
@@ -487,12 +542,11 @@ async fn serve_car<T: ContentLoader + std::marker::Unpin>(
                 return Ok(res);
             }
             add_ipfs_roots_headers(&mut headers, metadata);
-            response(StatusCode::OK, body, headers)
+            Ok(GatewayResponse::new(StatusCode::OK, body, headers))
         }
-        FileResult::Directory(_) => Err(error(
+        FileResult::Directory(_) => Err(GatewayError::new(
             StatusCode::INTERNAL_SERVER_ERROR,
             "cannot serve directory as car file",
-            &state,
         )),
     }
 }
@@ -509,7 +563,7 @@ async fn serve_car_recursive<T: ContentLoader + std::marker::Unpin>(
         .clone()
         .get_car_recursive(req.resolved_path.clone(), start_time)
         .await
-        .map_err(|e| error(StatusCode::INTERNAL_SERVER_ERROR, &e, &state))?;
+        .map_err(|e| GatewayError::new(StatusCode::INTERNAL_SERVER_ERROR, &e))?;
 
     let file_name = match req.query_file_name.is_empty() {
         true => format!("{}.car", req.cid),
@@ -525,7 +579,7 @@ async fn serve_car_recursive<T: ContentLoader + std::marker::Unpin>(
         return Ok(res);
     }
     // add_ipfs_roots_headers(&mut headers, metadata);
-    response(StatusCode::OK, body, headers)
+    Ok(GatewayResponse::new(StatusCode::OK, body, headers))
 }
 
 #[tracing::instrument()]
@@ -548,14 +602,14 @@ async fn serve_fs<T: ContentLoader + std::marker::Unpin>(
         .client
         .get_file(req.resolved_path.clone(), start_time, range.clone())
         .await
-        .map_err(|e| error(StatusCode::INTERNAL_SERVER_ERROR, &e, &state))?;
+        .map_err(|e| GatewayError::new(StatusCode::INTERNAL_SERVER_ERROR, &e))?;
 
     add_ipfs_roots_headers(&mut headers, metadata.clone());
     match body {
         FileResult::Directory(res) => {
             let dir_list: anyhow::Result<Vec<_>> = res
                 .unixfs_read_dir(&state.client.resolver, OutMetrics { start: start_time })
-                .map_err(|e| error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string(), &state))?
+                .map_err(|e| GatewayError::new(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?
                 .expect("already known this is a directory")
                 .try_collect()
                 .await;
@@ -565,10 +619,9 @@ async fn serve_fs<T: ContentLoader + std::marker::Unpin>(
                 }
                 Err(e) => {
                     tracing::warn!("failed to read dir: {:?}", e);
-                    Err(error(
+                    Err(GatewayError::new(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "failed to read dir listing",
-                        &state,
                     ))
                 }
             }
@@ -606,15 +659,18 @@ async fn serve_fs<T: ContentLoader + std::marker::Unpin>(
                         }
                         add_etag_range(&mut headers, capped_range.clone());
                         add_content_range_headers(&mut headers, capped_range, metadata.size);
-                        response(StatusCode::PARTIAL_CONTENT, body, headers)
+                        Ok(GatewayResponse::new(
+                            StatusCode::PARTIAL_CONTENT,
+                            body,
+                            headers,
+                        ))
                     } else {
-                        response(StatusCode::OK, body, headers)
+                        Ok(GatewayResponse::new(StatusCode::OK, body, headers))
                     }
                 }
-                None => Err(error(
+                None => Err(GatewayError::new(
                     StatusCode::BAD_REQUEST,
                     "couldn't determine unixfs type",
-                    &state,
                 )),
             }
         }
@@ -635,7 +691,7 @@ async fn serve_fs<T: ContentLoader + std::marker::Unpin>(
             );
             let content_sniffed_mime = body.get_mime();
             add_content_type_headers(&mut headers, &name, content_sniffed_mime);
-            response(StatusCode::OK, body, headers)
+            Ok(GatewayResponse::new(StatusCode::OK, body, headers))
         }
     }
 }
@@ -740,40 +796,11 @@ async fn serve_fs_dir<T: ContentLoader + std::marker::Unpin>(
     let reg = Handlebars::new();
     let dir_template = state.handlebars.get("dir_list").unwrap();
     let res = reg.render_template(dir_template, &template_data).unwrap();
-    response(StatusCode::OK, Body::from(res), headers)
-}
-
-#[tracing::instrument(skip(body))]
-fn response<B>(
-    status_code: StatusCode,
-    body: B,
-    headers: HeaderMap,
-) -> Result<GatewayResponse, GatewayError>
-where
-    B: 'static + HttpBody<Data = Bytes> + Send,
-    <B as HttpBody>::Error: Into<Box<dyn Error + Send + Sync + 'static>>,
-{
-    Ok(GatewayResponse {
-        status_code,
-        body: body::boxed(body),
+    Ok(GatewayResponse::new(
+        StatusCode::OK,
+        Body::from(res),
         headers,
-        trace_id: get_current_trace_id(),
-    })
-}
-
-#[tracing::instrument()]
-fn error<T: ContentLoader>(
-    status_code: StatusCode,
-    message: &str,
-    state: &State<T>,
-) -> GatewayError {
-    inc!(GatewayMetrics::ErrorCount);
-    GatewayError {
-        status_code,
-        message: message.to_string(),
-        trace_id: get_current_trace_id(),
-        method: None,
-    }
+    ))
 }
 
 // #[tracing::instrument()]
@@ -803,20 +830,18 @@ pub async fn middleware_error_handler<T: ContentLoader>(
     }
 
     if err.is::<tower::timeout::error::Elapsed>() {
-        return error(StatusCode::GATEWAY_TIMEOUT, "request timed out", &state);
+        return GatewayError::new(StatusCode::GATEWAY_TIMEOUT, "request timed out");
     }
 
     if err.is::<tower::load_shed::error::Overloaded>() {
-        return error(
+        return GatewayError::new(
             StatusCode::TOO_MANY_REQUESTS,
             "service is overloaded, try again later",
-            &state,
         );
     }
 
-    return error(
+    return GatewayError::new(
         StatusCode::INTERNAL_SERVER_ERROR,
         format!("unhandled internal error: {}", err).as_str(),
-        &state,
     );
 }

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -213,7 +213,11 @@ async fn request_preprocessing<T: ContentLoader + std::marker::Unpin>(
         format,
         cid: resolved_path.root().clone(),
         resolved_path,
-        query_file_name: query_params.filename.as_deref().unwrap_or_default().to_string(),
+        query_file_name: query_params
+            .filename
+            .as_deref()
+            .unwrap_or_default()
+            .to_string(),
         download: query_params.download.unwrap_or_default(),
         query_params: query_params.clone(),
     };

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -153,7 +153,8 @@ async fn request_preprocessing<T: ContentLoader + std::marker::Unpin>(
 
     let uri_param = query_params.uri.clone().unwrap_or_default();
     if !uri_param.is_empty() {
-        return protocol_handler_redirect(uri_param, state).map(RequestPreprocessingResult::Response);
+        return protocol_handler_redirect(uri_param, state)
+            .map(RequestPreprocessingResult::Response);
     }
     service_worker_check(&request_headers, cpath.to_string(), state)?;
     unsuported_header_check(&request_headers, state)?;

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -100,17 +100,14 @@ pub struct GetParams {
     /// specifies the expected format of the response
     format: Option<String>,
     /// specifies the desired filename of the response
-    #[serde(default)]
-    filename: String,
+    filename: Option<String>,
     /// specifies whether the response should be of disposition inline or attachment
-    #[serde(default)]
-    download: bool,
+    download: Option<bool>,
     /// specifies whether the response should render a directory even if index.html is present
     force_dir: Option<bool>,
     /// uri query parameter for handling navigator.registerProtocolHandler Web API requests
     uri: Option<String>,
-    #[serde(default)]
-    recursive: bool,
+    recursive: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -216,8 +213,8 @@ async fn request_preprocessing<T: ContentLoader + std::marker::Unpin>(
         format,
         cid: resolved_path.root().clone(),
         resolved_path,
-        query_file_name: query_params.filename.clone(),
-        download: query_params.download,
+        query_file_name: query_params.filename.as_deref().unwrap_or_default().to_string(),
+        download: query_params.download.unwrap_or_default(),
         query_params: query_params.clone(),
     };
     Ok(RequestPreprocessingResult::FurtherRequest(Box::new(req)))
@@ -245,7 +242,7 @@ pub async fn get_handler<T: ContentLoader + std::marker::Unpin>(
     {
         RequestPreprocessingResult::Response(gateway_response) => Ok(gateway_response),
         RequestPreprocessingResult::FurtherRequest(req) => {
-            if query_params.recursive {
+            if query_params.recursive.unwrap_or_default() {
                 serve_car_recursive(&req, state, response_headers, start_time).await
             } else {
                 match req.format {

--- a/iroh-gateway/src/response.rs
+++ b/iroh-gateway/src/response.rs
@@ -1,10 +1,14 @@
+use axum::body::HttpBody;
 use axum::{
+    body,
     body::BoxBody,
     http::{header::*, HeaderValue, StatusCode},
     response::{IntoResponse, Redirect, Response},
 };
+use bytes::Bytes;
 use iroh_metrics::get_current_trace_id;
 use opentelemetry::trace::TraceId;
+use std::error::Error;
 
 use crate::constants::*;
 
@@ -88,7 +92,7 @@ impl ResponseFormat {
 #[tracing::instrument()]
 pub fn get_response_format(
     request_headers: &HeaderMap,
-    query_format: Option<String>,
+    query_format: &Option<String>,
 ) -> Result<ResponseFormat, String> {
     if let Some(format) = query_format {
         if !format.is_empty() {
@@ -135,15 +139,28 @@ impl IntoResponse for GatewayResponse {
 }
 
 impl GatewayResponse {
+    #[tracing::instrument(skip(body))]
+    pub fn new<B>(status_code: StatusCode, body: B, headers: HeaderMap) -> GatewayResponse
+    where
+        B: 'static + HttpBody<Data = Bytes> + Send,
+        <B as HttpBody>::Error: Into<Box<dyn Error + Send + Sync + 'static>>,
+    {
+        GatewayResponse {
+            status_code,
+            body: body::boxed(body),
+            headers,
+            trace_id: get_current_trace_id(),
+        }
+    }
+
     fn _redirect(to: &str, status_code: StatusCode) -> Self {
         let mut headers = HeaderMap::new();
         headers.insert(LOCATION, HeaderValue::from_str(to).unwrap());
-        GatewayResponse {
-            status_code,
-            body: BoxBody::default(),
-            headers: HeaderMap::new(),
-            trace_id: get_current_trace_id(),
-        }
+        Self::new(status_code, BoxBody::default(), headers)
+    }
+
+    pub fn empty(headers: HeaderMap) -> Self {
+        Self::new(StatusCode::OK, BoxBody::default(), headers)
     }
 
     pub fn redirect(to: &str) -> Self {
@@ -155,12 +172,11 @@ impl GatewayResponse {
     }
 
     pub fn not_modified() -> Self {
-        Self {
-            status_code: StatusCode::NOT_MODIFIED,
-            body: BoxBody::default(),
-            headers: HeaderMap::new(),
-            trace_id: get_current_trace_id(),
-        }
+        Self::new(
+            StatusCode::NOT_MODIFIED,
+            BoxBody::default(),
+            HeaderMap::new(),
+        )
     }
 }
 


### PR DESCRIPTION
Here I've done several things:
- Added HEAD handler that returns `Content-Length` header as in Kubo
- Refactored handlers to make them slightly more idiomatic
- Fixed [bug](https://github.com/n0-computer/iroh/blob/main/iroh-gateway/src/response.rs#L144) that doesn't set Location in redirect
- Applied Clippy to iroh-gateway