### PR TITLE
feat(gateway): Add about page

### DIFF
--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0/MIT"
 readme = "README.md"
 description = "IPFS gateway"
-repository = "https://github.com/dignifiedquire/iroh"
+repository = "https://github.com/n0-computer/iroh"
 rust-version = "1.63"
 
 [dependencies]

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -69,6 +69,7 @@ pub fn get_app_routes<T: ContentLoader + std::marker::Unpin>(state: &Arc<State<T
         .route("/health", get(health_check))
         .route("/icons.css", get(stylesheet_icons))
         .route("/style.css", get(stylesheet_main))
+        .route("/about", get(about))
         .layer(cors)
         .layer(Extension(Arc::clone(state)))
         .layer(
@@ -299,6 +300,18 @@ pub async fn head_handler<T: ContentLoader + std::marker::Unpin>(
 #[tracing::instrument()]
 pub async fn health_check() -> String {
     "OK".to_string()
+}
+
+#[tracing::instrument]
+pub async fn about() -> String {
+    format!(
+        "{bin} {version}\n\n{description}\n{license}\n{url}",
+        bin = std::env!("CARGO_CRATE_NAME"),
+        version = std::env!("CARGO_PKG_VERSION"),
+        description = std::env!("CARGO_PKG_DESCRIPTION"),
+        license = std::env!("CARGO_PKG_LICENSE"),
+        url = env!("CARGO_PKG_REPOSITORY"),
+    )
 }
 
 async fn stylesheet_main() -> (HeaderMap, &'static str) {

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -69,7 +69,7 @@ pub fn get_app_routes<T: ContentLoader + std::marker::Unpin>(state: &Arc<State<T
         .route("/health", get(health_check))
         .route("/icons.css", get(stylesheet_icons))
         .route("/style.css", get(stylesheet_main))
-        .route("/about", get(about))
+        .route("/info", get(info))
         .layer(cors)
         .layer(Extension(Arc::clone(state)))
         .layer(
@@ -302,12 +302,14 @@ pub async fn health_check() -> String {
     "OK".to_string()
 }
 
+/// Some basic info about the service to respond from a `GET /info` request.
 #[tracing::instrument]
-pub async fn about() -> String {
+pub async fn info() -> String {
     format!(
-        "{bin} {version}\n\n{description}\n{license}\n{url}",
+        "{bin} {version} ({git})\n\n{description}\n{license}\n{url}",
         bin = std::env!("CARGO_CRATE_NAME"),
         version = std::env!("CARGO_PKG_VERSION"),
+        git = git_version::git_version!(),
         description = std::env!("CARGO_PKG_DESCRIPTION"),
         license = std::env!("CARGO_PKG_LICENSE"),
         url = env!("CARGO_PKG_REPOSITORY"),

--- a/iroh-one/Cargo.toml
+++ b/iroh-one/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "Apache-2.0/MIT"
 name = "iroh-one"
 readme = "README.md"
-repository = "https://github.com/dignifiedquire/iroh"
+repository = "https://github.com/n0-computer/iroh"
 version = "0.1.0"
 rust-version = "1.63"
 


### PR DESCRIPTION
Add an about page with a bit of package information.

---

I just found this useful locally as I learn how things work.  Maybe
others like it too.  If not, never mind.