### PR TITLE
feat: Support `eth` domains

### DIFF
--- a/iroh-gateway/src/bad_bits.rs
+++ b/iroh-gateway/src/bad_bits.rs
@@ -112,7 +112,7 @@ mod tests {
     use hex_literal::hex;
     use http::StatusCode;
     use iroh_resolver::content_loader::{FullLoader, FullLoaderConfig, GatewayUrl};
-    use iroh_resolver::dns_resolver::DnsResolverConfig;
+    use iroh_resolver::dns_resolver::Config as DnsResolverConfig;
     use iroh_rpc_client::{Client as RpcClient, Config as RpcClientConfig};
 
     #[tokio::test]

--- a/iroh-gateway/src/bad_bits.rs
+++ b/iroh-gateway/src/bad_bits.rs
@@ -112,6 +112,7 @@ mod tests {
     use hex_literal::hex;
     use http::StatusCode;
     use iroh_resolver::content_loader::{FullLoader, FullLoaderConfig, GatewayUrl};
+    use iroh_resolver::dns_resolver::DnsResolverConfig;
     use iroh_rpc_client::{Client as RpcClient, Config as RpcClientConfig};
 
     #[tokio::test]
@@ -205,6 +206,7 @@ mod tests {
             rpc_addr,
             Arc::new(Some(RwLock::new(bbits))),
             content_loader,
+            DnsResolverConfig::default(),
         )
         .await
         .unwrap();

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -13,6 +13,7 @@ use iroh_metrics::{
     gateway::{GatewayHistograms, GatewayMetrics},
     observe, record,
 };
+use iroh_resolver::dns_resolver::DnsResolverConfig;
 use iroh_resolver::{
     content_loader::ContentLoader,
     resolver::{
@@ -90,9 +91,9 @@ impl<T: ContentLoader + std::marker::Unpin> http_body::Body for PrettyStreamBody
 }
 
 impl<T: ContentLoader + std::marker::Unpin> Client<T> {
-    pub fn new(rpc_client: &T) -> Self {
+    pub fn new(rpc_client: &T, dns_resolver_config: DnsResolverConfig) -> Self {
         Self {
-            resolver: Resolver::new(rpc_client.clone()),
+            resolver: Resolver::with_dns_resolver(rpc_client.clone(), dns_resolver_config),
         }
     }
 

--- a/iroh-gateway/src/client.rs
+++ b/iroh-gateway/src/client.rs
@@ -13,7 +13,7 @@ use iroh_metrics::{
     gateway::{GatewayHistograms, GatewayMetrics},
     observe, record,
 };
-use iroh_resolver::dns_resolver::DnsResolverConfig;
+use iroh_resolver::dns_resolver::Config;
 use iroh_resolver::{
     content_loader::ContentLoader,
     resolver::{
@@ -91,7 +91,7 @@ impl<T: ContentLoader + std::marker::Unpin> http_body::Body for PrettyStreamBody
 }
 
 impl<T: ContentLoader + std::marker::Unpin> Client<T> {
-    pub fn new(rpc_client: &T, dns_resolver_config: DnsResolverConfig) -> Self {
+    pub fn new(rpc_client: &T, dns_resolver_config: Config) -> Self {
         Self {
             resolver: Resolver::with_dns_resolver(rpc_client.clone(), dns_resolver_config),
         }

--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -6,7 +6,7 @@ use headers::{
     AccessControlAllowHeaders, AccessControlAllowMethods, AccessControlAllowOrigin, HeaderMapExt,
 };
 use iroh_metrics::config::Config as MetricsConfig;
-use iroh_resolver::dns_resolver::DnsResolverConfig;
+use iroh_resolver::dns_resolver::Config as DnsResolverConfig;
 use iroh_rpc_client::Config as RpcClientConfig;
 use iroh_rpc_types::{gateway::GatewayServerAddr, Addr};
 use iroh_util::insert_into_config_map;

--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -6,6 +6,7 @@ use headers::{
     AccessControlAllowHeaders, AccessControlAllowMethods, AccessControlAllowOrigin, HeaderMapExt,
 };
 use iroh_metrics::config::Config as MetricsConfig;
+use iroh_resolver::dns_resolver::DnsResolverConfig;
 use iroh_rpc_client::Config as RpcClientConfig;
 use iroh_rpc_types::{gateway::GatewayServerAddr, Addr};
 use iroh_util::insert_into_config_map;
@@ -29,10 +30,13 @@ pub struct Config {
     /// flag to toggle whether the gateway should use denylist on requests
     pub use_denylist: bool,
     /// URL of gateways to be used by the racing resolver.
-    /// strings can either be urls or subdomain gateway roots
+    /// Strings can either be urls or subdomain gateway roots
     /// values without https:// prefix are treated as subdomain gateways (eg: dweb.link)
     /// values with are treated as IPFS path gateways (eg: https://ipfs.io)
     pub http_resolvers: Option<Vec<String>>,
+    /// Separate resolvers for particular TLDs
+    #[serde(default = "DnsResolverConfig::default")]
+    pub dns_resolver: DnsResolverConfig,
     /// Indexer node to use.
     pub indexer_endpoint: Option<String>,
     /// rpc addresses for the gateway & addresses for the rpc client to dial
@@ -54,6 +58,7 @@ impl Config {
             port,
             rpc_client,
             http_resolvers: None,
+            dns_resolver: DnsResolverConfig::default(),
             indexer_endpoint: None,
             metrics: MetricsConfig::default(),
             use_denylist: false,
@@ -123,6 +128,7 @@ impl Default for Config {
             port: DEFAULT_PORT,
             rpc_client,
             http_resolvers: None,
+            dns_resolver: DnsResolverConfig::default(),
             indexer_endpoint: None,
             metrics: MetricsConfig::default(),
             use_denylist: false,

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -2,7 +2,7 @@ use axum::Router;
 use iroh_resolver::content_loader::ContentLoader;
 use iroh_rpc_types::gateway::GatewayServerAddr;
 
-use iroh_resolver::dns_resolver::DnsResolverConfig;
+use iroh_resolver::dns_resolver::Config as DnsResolverConfig;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
 

--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -39,6 +39,7 @@ async fn main() -> Result<()> {
     println!("{:#?}", config);
 
     let metrics_config = config.metrics.clone();
+    let dns_resolver_config = config.dns_resolver.clone();
     let bad_bits = match config.use_denylist {
         true => Arc::new(Some(RwLock::new(BadBits::new()))),
         false => Arc::new(None),
@@ -70,6 +71,7 @@ async fn main() -> Result<()> {
         rpc_addr,
         Arc::clone(&bad_bits),
         content_loader,
+        dns_resolver_config,
     )
     .await?;
 

--- a/iroh-one/src/main.rs
+++ b/iroh-one/src/main.rs
@@ -91,6 +91,7 @@ async fn main() -> Result<()> {
         Arc::new(config.clone()),
         Arc::clone(&bad_bits),
         content_loader,
+        config.gateway.dns_resolver,
     )
     .await?;
 

--- a/iroh-resolver/Cargo.toml
+++ b/iroh-resolver/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = "1.0.87"
 tokio = { version = "1", features = ["fs"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1.34"
-trust-dns-resolver = { version = "0.22.0", features = ["dns-over-https-rustls", "tokio-runtime"] }
+trust-dns-resolver = { version = "0.22.0", features = ["dns-over-https-rustls", "serde-config", "tokio-runtime"] }
 unsigned-varint = "0.7.1"
 
 [dev-dependencies]

--- a/iroh-resolver/Cargo.toml
+++ b/iroh-resolver/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = "1.0.87"
 tokio = { version = "1", features = ["fs"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1.34"
-trust-dns-resolver = { version = "0.22.0", features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.22.0", features = ["dns-over-https-rustls", "tokio-runtime"] }
 unsigned-varint = "0.7.1"
 
 [dev-dependencies]

--- a/iroh-resolver/src/dns_resolver.rs
+++ b/iroh-resolver/src/dns_resolver.rs
@@ -1,0 +1,114 @@
+use crate::resolver::Path;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
+use trust_dns_resolver::config::{NameServerConfigGroup, ResolverConfig, ResolverOpts};
+use trust_dns_resolver::{AsyncResolver, TokioAsyncResolver};
+
+#[derive(Debug)]
+pub struct DnsResolver {
+    default_resolver: TokioAsyncResolver,
+    domain_resolvers: HashMap<String, TokioAsyncResolver>,
+}
+
+impl DnsResolver {
+    pub fn new() -> DnsResolver {
+        let mut domain_resolvers = HashMap::new();
+
+        let eth_resolver_config = ResolverConfig::from_parts(
+            None,
+            vec![],
+            NameServerConfigGroup::from_ips_https(
+                &[
+                    IpAddr::V4(Ipv4Addr::new(104, 18, 165, 219)),
+                    IpAddr::V4(Ipv4Addr::new(104, 18, 166, 219)),
+                ],
+                443,
+                "resolver.cloudflare-eth.com".to_string(),
+                true,
+            ),
+        );
+        let eth_resolver =
+            AsyncResolver::tokio(eth_resolver_config, ResolverOpts::default()).unwrap();
+
+        domain_resolvers.insert("eth".to_string(), eth_resolver);
+        DnsResolver {
+            default_resolver: AsyncResolver::tokio(
+                ResolverConfig::default(),
+                ResolverOpts::default(),
+            )
+            .unwrap(),
+            domain_resolvers,
+        }
+    }
+
+    #[tracing::instrument]
+    pub async fn resolve_dnslink(&self, url: &str) -> Result<Vec<Path>> {
+        let url = format!("_dnslink.{}.", url);
+        let records = self.resolve_txt_record(&url).await?;
+        let records = records
+            .into_iter()
+            .filter(|r| r.starts_with("dnslink="))
+            .map(|r| {
+                let p = r.trim_start_matches("dnslink=").trim();
+                p.parse()
+            })
+            .collect::<Result<_>>()?;
+        Ok(records)
+    }
+
+    pub async fn resolve_txt_record(&self, url: &str) -> Result<Vec<String>> {
+        // Construct a new Resolver with default configuration options
+        let tld = url.split('.').filter(|s| !s.is_empty()).last();
+        let resolver = tld
+            .and_then(|tld| self.domain_resolvers.get(tld))
+            .unwrap_or(&self.default_resolver);
+        let txt_response = resolver.txt_lookup(url).await?;
+        let out = txt_response.into_iter().map(|r| r.to_string()).collect();
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DnsResolver;
+    use crate::resolver::PathType;
+
+    #[tokio::test]
+    async fn test_resolve_txt_record() {
+        let resolver = DnsResolver::new();
+        let result = resolver
+            .resolve_txt_record("_dnslink.ipfs.io.")
+            .await
+            .unwrap();
+        assert!(!result.is_empty());
+        assert_eq!(result[0], "dnslink=/ipns/website.ipfs.io");
+
+        let result = resolver
+            .resolve_txt_record("_dnslink.website.ipfs.io.")
+            .await
+            .unwrap();
+        assert!(!result.is_empty());
+        assert!(&result[0].starts_with("dnslink=/ipfs"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_dnslink() {
+        let resolver = DnsResolver::new();
+        let result = resolver.resolve_dnslink("ipfs.io").await.unwrap();
+        assert!(!result.is_empty());
+        assert_eq!(result[0], "/ipns/website.ipfs.io".parse().unwrap());
+
+        let result = resolver.resolve_dnslink("website.ipfs.io").await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].typ(), PathType::Ipfs);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_eth_domain() {
+        let resolver = DnsResolver::new();
+        let result = resolver.resolve_dnslink("ipfs.eth").await.unwrap();
+        assert!(!result.is_empty());
+        assert_eq!(result[0].typ(), PathType::Ipfs);
+    }
+}

--- a/iroh-resolver/src/dns_resolver.rs
+++ b/iroh-resolver/src/dns_resolver.rs
@@ -6,7 +6,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use trust_dns_resolver::config::{NameServerConfigGroup, ResolverConfig, ResolverOpts};
 use trust_dns_resolver::{AsyncResolver, TokioAsyncResolver};
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DnsResolverConfig {
     /// Mapping from TLD to the specific instance of resolver
     tld_resolvers: Option<HashMap<String, ResolverConfig>>,

--- a/iroh-resolver/src/dns_resolver.rs
+++ b/iroh-resolver/src/dns_resolver.rs
@@ -1,10 +1,12 @@
-use crate::resolver::Path;
-use anyhow::Result;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use trust_dns_resolver::config::{NameServerConfigGroup, ResolverConfig, ResolverOpts};
 use trust_dns_resolver::{AsyncResolver, TokioAsyncResolver};
+
+use crate::resolver::Path;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Config {

--- a/iroh-resolver/src/dns_resolver.rs
+++ b/iroh-resolver/src/dns_resolver.rs
@@ -7,22 +7,23 @@ use trust_dns_resolver::config::{NameServerConfigGroup, ResolverConfig, Resolver
 use trust_dns_resolver::{AsyncResolver, TokioAsyncResolver};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-pub struct DnsResolverConfig {
+pub struct Config {
     /// Mapping from TLD to the specific instance of resolver
     tld_resolvers: Option<HashMap<String, ResolverConfig>>,
 }
 
-impl DnsResolverConfig {
+impl Config {
     pub fn empty() -> Self {
-        DnsResolverConfig {
+        Config {
             tld_resolvers: None,
         }
     }
 }
 
-impl Default for DnsResolverConfig {
+impl Default for Config {
     fn default() -> Self {
-        DnsResolverConfig {
+        Config {
+            /// Documentation on .eth TLD lives on https://eth.link/
             tld_resolvers: Some(HashMap::from_iter(vec![(
                 "eth".to_string(),
                 ResolverConfig::from_parts(
@@ -51,7 +52,7 @@ pub struct DnsResolver {
 
 impl DnsResolver {
     /// Creates resolver from its config
-    pub fn from_config(dns_resolver_config: DnsResolverConfig) -> DnsResolver {
+    pub fn from_config(dns_resolver_config: Config) -> DnsResolver {
         let tld_resolvers = dns_resolver_config
             .tld_resolvers
             .map(|dns_resolver_config| {
@@ -107,7 +108,7 @@ impl DnsResolver {
 
 impl Default for DnsResolver {
     fn default() -> Self {
-        DnsResolver::from_config(DnsResolverConfig::default())
+        DnsResolver::from_config(Config::default())
     }
 }
 

--- a/iroh-resolver/src/lib.rs
+++ b/iroh-resolver/src/lib.rs
@@ -2,7 +2,7 @@ pub mod balanced_tree;
 pub mod chunker;
 pub mod codecs;
 pub mod content_loader;
-pub(crate) mod dns_resolver;
+pub mod dns_resolver;
 pub mod hamt;
 pub mod indexer;
 pub mod resolver;

--- a/iroh-resolver/src/lib.rs
+++ b/iroh-resolver/src/lib.rs
@@ -2,6 +2,7 @@ pub mod balanced_tree;
 pub mod chunker;
 pub mod codecs;
 pub mod content_loader;
+pub(crate) mod dns_resolver;
 pub mod hamt;
 pub mod indexer;
 pub mod resolver;

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -23,8 +23,6 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tracing::{debug, trace, warn};
 
-use crate::dns_resolver::{Config, DnsResolver};
-
 use iroh_metrics::{
     core::{MObserver, MRecorder},
     gateway::{GatewayHistograms, GatewayMetrics},
@@ -34,6 +32,7 @@ use iroh_metrics::{
 
 use crate::codecs::Codec;
 use crate::content_loader::ContentLoader;
+use crate::dns_resolver::{Config, DnsResolver};
 use crate::unixfs::{
     poll_read_buf_at_pos, DataType, Link, UnixfsChildStream, UnixfsContentReader, UnixfsNode,
 };

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -23,7 +23,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tracing::{debug, trace, warn};
 
-use crate::dns_resolver::{DnsResolver, DnsResolverConfig};
+use crate::dns_resolver::{Config, DnsResolver};
 
 use iroh_metrics::{
     core::{MObserver, MRecorder},
@@ -737,10 +737,10 @@ struct InnerLoaderContext {
 
 impl<T: ContentLoader> Resolver<T> {
     pub fn new(loader: T) -> Self {
-        Self::with_dns_resolver(loader, DnsResolverConfig::default())
+        Self::with_dns_resolver(loader, Config::default())
     }
 
-    pub fn with_dns_resolver(loader: T, dns_resolver_config: DnsResolverConfig) -> Self {
+    pub fn with_dns_resolver(loader: T, dns_resolver_config: Config) -> Self {
         let (session_closer_s, session_closer_r) = async_channel::bounded(2048);
         let loader_thread = loader.clone();
         let worker = tokio::task::spawn(async move {


### PR DESCRIPTION
This PR does two things:
- Moved DNS resolver to dedicated struct and reused it instead of creation every time
- Added `resolver.cloudflare-eth.com` resolver for `.eth` domains as in Kubo for making possible to resolve Etherium domains. Ip addresses of resolver are hardcoded for avoiding excessive round-trip.