### PR TITLE
chore(ci): disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,4 @@ codecov:
   notify:
     require_ci_to_pass: false
     after_n_builds: 1
-  comment: false
+comment: false


### PR DESCRIPTION
Apparently the flag is root level. VV confusing config file/options.