### PR TITLE
fix(iroh-one): Wire up mem addresses to each other

### DIFF
--- a/iroh-one/src/main.rs
+++ b/iroh-one/src/main.rs
@@ -48,16 +48,16 @@ async fn main() -> Result<()> {
 
     let (store_rpc, p2p_rpc) = {
         let (store_recv, store_sender) = Addr::new_mem();
-        config.rpc_client.store_addr = Some(store_sender);
-        let store_rpc = iroh_one::mem_store::start(store_recv, config.clone().store).await?;
-
         let (p2p_recv, p2p_sender) = Addr::new_mem();
+        config.rpc_client.store_addr = Some(store_sender);
         config.rpc_client.p2p_addr = Some(p2p_sender);
-        let p2p_rpc = iroh_one::mem_p2p::start(p2p_recv, config.clone().p2p).await?;
+        config.synchronize_subconfigs();
+
+        let store_rpc = iroh_one::mem_store::start(store_recv, config.store.clone()).await?;
+
+        let p2p_rpc = iroh_one::mem_p2p::start(p2p_recv, config.p2p.clone()).await?;
         (store_rpc, p2p_rpc)
     };
-
-    config.synchronize_subconfigs();
 
     config.metrics = metrics::metrics_config_with_compile_time_info(config.metrics);
     println!("{:#?}", config);


### PR DESCRIPTION
This copies the mem-addresses in the config to the bits of config that
are used by the individual services before starting them up.  This
should help them talk to each other a little better.

---

Tested this locally and seems to work, I think?