### PR TITLE
fixes for issues found during the 0.1.2 release

### DIFF
--- a/iroh-bitswap/src/metrics.rs
+++ b/iroh-bitswap/src/metrics.rs
@@ -1,9 +1,15 @@
-use git_version::git_version;
 use iroh_metrics::config::Config as MetricsConfig;
 
 pub fn metrics_config_with_compile_time_info(cfg: MetricsConfig) -> MetricsConfig {
     // compile time configuration
     cfg.with_service_name(env!("CARGO_PKG_NAME").to_string())
-        .with_build(git_version!().to_string())
+        .with_build(
+            git_version::git_version!(
+                prefix = "git:",
+                cargo_prefix = "cargo:",
+                fallback = "unknown"
+            )
+            .to_string(),
+        )
         .with_version(env!("CARGO_PKG_VERSION").to_string())
 }

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -309,7 +309,11 @@ pub async fn info() -> String {
         "{bin} {version} ({git})\n\n{description}\n{license}\n{url}",
         bin = std::env!("CARGO_CRATE_NAME"),
         version = std::env!("CARGO_PKG_VERSION"),
-        git = git_version::git_version!(),
+        git = git_version::git_version!(
+            prefix = "git:",
+            cargo_prefix = "cargo:",
+            fallback = "unknown"
+        ),
         description = std::env!("CARGO_PKG_DESCRIPTION"),
         license = std::env!("CARGO_PKG_LICENSE"),
         url = env!("CARGO_PKG_REPOSITORY"),

--- a/iroh-gateway/src/metrics.rs
+++ b/iroh-gateway/src/metrics.rs
@@ -1,9 +1,15 @@
-use git_version::git_version;
 use iroh_metrics::config::Config as MetricsConfig;
 
 pub fn metrics_config_with_compile_time_info(cfg: MetricsConfig) -> MetricsConfig {
     // compile time configuration
     cfg.with_service_name(env!("CARGO_PKG_NAME").to_string())
-        .with_build(git_version!().to_string())
+        .with_build(
+            git_version::git_version!(
+                prefix = "git:",
+                cargo_prefix = "cargo:",
+                fallback = "unknown"
+            )
+            .to_string(),
+        )
         .with_version(env!("CARGO_PKG_VERSION").to_string())
 }

--- a/iroh-p2p/src/metrics.rs
+++ b/iroh-p2p/src/metrics.rs
@@ -1,9 +1,15 @@
-use git_version::git_version;
 use iroh_metrics::config::Config as MetricsConfig;
 
 pub fn metrics_config_with_compile_time_info(cfg: MetricsConfig) -> MetricsConfig {
     // compile time configuration
     cfg.with_service_name(env!("CARGO_PKG_NAME").to_string())
-        .with_build(git_version!().to_string())
+        .with_build(
+            git_version::git_version!(
+                prefix = "git:",
+                cargo_prefix = "cargo:",
+                fallback = "unknown"
+            )
+            .to_string(),
+        )
         .with_version(env!("CARGO_PKG_VERSION").to_string())
 }

--- a/iroh-p2p/src/node.rs
+++ b/iroh-p2p/src/node.rs
@@ -1402,7 +1402,8 @@ mod tests {
             "/meshsub/1.0.0",
         ];
         let expected_protocol_version = "ipfs/0.1.0";
-        let expected_agent_version = "iroh/0.1.1";
+        let expected_agent_version =
+            format!("iroh/{}", std::env::var("CARGO_PKG_VERSION").unwrap());
 
         assert_eq!(expected_peer_id, got.peer_id);
         assert!(got.listen_addrs.contains(expected_addr));

--- a/iroh-resolver/Cargo.toml
+++ b/iroh-resolver/Cargo.toml
@@ -8,6 +8,11 @@ repository = "https://github.com/n0-computer/iroh"
 description = "Implementation of path resolution for iroh"
 rust-version = "1.63"
 
+exclude = [
+  "tests/**",
+  "fixtures/**",
+]
+
 [dependencies]
 anyhow = "1"
 async-channel = "1.7.1"

--- a/iroh-store/src/metrics.rs
+++ b/iroh-store/src/metrics.rs
@@ -1,9 +1,15 @@
-use git_version::git_version;
 use iroh_metrics::config::Config as MetricsConfig;
 
 pub fn metrics_config_with_compile_time_info(cfg: MetricsConfig) -> MetricsConfig {
     // compile time configuration
     cfg.with_service_name(env!("CARGO_PKG_NAME").to_string())
-        .with_build(git_version!().to_string())
+        .with_build(
+            git_version::git_version!(
+                prefix = "git:",
+                cargo_prefix = "cargo:",
+                fallback = "unknown"
+            )
+            .to_string(),
+        )
         .with_version(env!("CARGO_PKG_VERSION").to_string())
 }

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -1,9 +1,15 @@
-use git_version::git_version;
 use iroh_metrics::config::Config as MetricsConfig;
 
 pub fn metrics_config_with_compile_time_info(cfg: MetricsConfig) -> MetricsConfig {
     // compile time configuration
     cfg.with_service_name(env!("CARGO_PKG_NAME").to_string())
-        .with_build(git_version!().to_string())
+        .with_build(
+            git_version::git_version!(
+                prefix = "git:",
+                cargo_prefix = "cargo:",
+                fallback = "unknown"
+            )
+            .to_string(),
+        )
         .with_version(env!("CARGO_PKG_VERSION").to_string())
 }

--- a/iroh/tests/cli_tests.rs
+++ b/iroh/tests/cli_tests.rs
@@ -141,7 +141,8 @@ fn lookup_test() {
 fn version_test() {
     trycmd::TestCases::new()
         .case("tests/cmd/version.trycmd")
-        .run();
+        .insert_var("[VERSION]", std::env::var("CARGO_PKG_VERSION").unwrap())
+        .unwrap();
 }
 
 #[test]

--- a/iroh/tests/cmd/version.trycmd
+++ b/iroh/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ We can get the version with `--version`:
 
 ```
 $ iroh --version
-iroh 0.1.1
+iroh [VERSION]
 
 ```
 
@@ -10,7 +10,7 @@ We can also get it with `-V`:
 
 ```
 $ iroh -V
-iroh 0.1.1
+iroh [VERSION]
 
 ```
 


### PR DESCRIPTION
- fix #447 which prevents crates depending on the published crates in some cases
- fix hardcoded version information in tests