### PR TITLE
ref: Enable backtrace support in anyhow

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.63"
 publish = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 bytes = "1.1.0"
 bytesize = "1.1.0"
 clap = { version = "4.0.9", features = ["derive"] }

--- a/iroh-api/Cargo.toml
+++ b/iroh-api/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/n0-computer/iroh"
 testing = ["dep:mockall"]
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-stream = "0.3.3"
 bytes = "1.1.0"
 cid = "0.9"

--- a/iroh-bitswap/Cargo.toml
+++ b/iroh-bitswap/Cargo.toml
@@ -13,7 +13,7 @@ prost-build = "0.11.1"
 
 [dependencies]
 ahash = "0.8.0"
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-broadcast = "0.4.1"
 async-channel = "1.7.1"
 async-trait = "0.1.57"

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/n0-computer/iroh"
 rust-version = "1.63"
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-recursion = "1.0.0"
 async-trait = "0.1.56"
 axum = "0.5.15"

--- a/iroh-localops/Cargo.toml
+++ b/iroh-localops/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/n0-computer/iroh"
 description = "Iroh specific process management."
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26", features = ["signal", "process"]}

--- a/iroh-one/Cargo.toml
+++ b/iroh-one/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.3"
 rust-version = "1.63"
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-trait = "0.1.56"
 axum = "0.5.1"
 bytes = "1.1"

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.63"
 
 [dependencies]
 ahash = "0.8.0"
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-stream = "0.3.3"
 async-trait = "0.1.56"
 asynchronous-codec = "0.6.0"

--- a/iroh-resolver/Cargo.toml
+++ b/iroh-resolver/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-channel = "1.7.1"
 async-recursion = "1.0.0"
 async-stream = "0.3.3"

--- a/iroh-rpc-client/Cargo.toml
+++ b/iroh-rpc-client/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.63"
 
 [dependencies]
 
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-stream = "0.3.3"
 async-trait = "0.1.56"
 bytes = "1.1.0"

--- a/iroh-rpc-types/Cargo.toml
+++ b/iroh-rpc-types/Cargo.toml
@@ -9,7 +9,7 @@ description = "RPC type definitions for iroh"
 rust-version = "1.63"
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-trait = "0.1.56"
 futures = "0.3.24"
 iroh-metrics = { version = "0.1.3", path = "../iroh-metrics", default-features = false }

--- a/iroh-share/Cargo.toml
+++ b/iroh-share/Cargo.toml
@@ -9,7 +9,7 @@ description = "Sharing files with iroh"
 rust-version = "1.63"
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-trait = "0.1.56"
 bincode = "1.3.3"
 bytes = "1.1.0"

--- a/iroh-store/Cargo.toml
+++ b/iroh-store/Cargo.toml
@@ -9,7 +9,7 @@ description = "Implementation of the storage part of iroh"
 rust-version = "1.63"
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 ahash = "0.8.0"
 async-trait = "0.1.56"
 bytecheck = "0.6.7"

--- a/iroh-util/Cargo.toml
+++ b/iroh-util/Cargo.toml
@@ -9,7 +9,7 @@ description = "Utilities for iroh"
 rust-version = "1.63"
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 cid = "0.9"
 config = "0.13.1"
 ctrlc = "3.2.2"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 testing = ["dep:relative-path"]
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 async-stream = "0.3.3"
 clap = { version = "4.0.15", features = ["derive"] }
 config = "0.13.1"

--- a/iroh/tests/cli_tests.rs
+++ b/iroh/tests/cli_tests.rs
@@ -4,6 +4,7 @@
 #[test]
 fn add_directory_without_r_fails_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "add_directory")
         .case("tests/cmd/add_directory_without_r_fails.trycmd")
         .run();
@@ -12,6 +13,7 @@ fn add_directory_without_r_fails_test() {
 #[test]
 fn add_directory_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "add_directory")
         .case("tests/cmd/add_directory.trycmd")
         .run();
@@ -20,6 +22,7 @@ fn add_directory_test() {
 #[test]
 fn add_file_missing_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "add_file")
         .case("tests/cmd/add_file_missing.trycmd")
         .run();
@@ -28,6 +31,7 @@ fn add_file_missing_test() {
 #[test]
 fn add_file_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "add_file")
         .case("tests/cmd/add_file.trycmd")
         .run();
@@ -36,6 +40,7 @@ fn add_file_test() {
 #[test]
 fn get_cid_directory_overwrite_explicit_failure_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get")
         .case("tests/cmd/get_cid_directory_overwrite_explicit_failure.trycmd")
         .run();
@@ -44,6 +49,7 @@ fn get_cid_directory_overwrite_explicit_failure_test() {
 #[test]
 fn get_cid_directory_overwrite_failure_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get")
         .case("tests/cmd/get_cid_directory_overwrite_failure.trycmd")
         .run();
@@ -52,6 +58,7 @@ fn get_cid_directory_overwrite_failure_test() {
 #[test]
 fn get_cid_explicit_output_path_success_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get")
         .case("tests/cmd/get_cid_explicit_output_path_success.trycmd")
         .run();
@@ -60,6 +67,7 @@ fn get_cid_explicit_output_path_success_test() {
 #[test]
 fn get_cid_success_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get")
         .case("tests/cmd/get_cid_success.trycmd")
         .run();
@@ -68,6 +76,7 @@ fn get_cid_success_test() {
 #[tokio::test]
 async fn get_unwrapped_file_overwrite_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get_unwrapped_file")
         .case("tests/cmd/get_unwrapped_file_overwrite.trycmd")
         .run();
@@ -76,6 +85,7 @@ async fn get_unwrapped_file_overwrite_test() {
 #[tokio::test]
 async fn get_failure_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get")
         .case("tests/cmd/get_failure.trycmd")
         .run();
@@ -84,6 +94,7 @@ async fn get_failure_test() {
 #[test]
 fn get_ipfs_path_success_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get")
         .case("tests/cmd/get_ipfs_path_success.trycmd")
         .run();
@@ -92,6 +103,7 @@ fn get_ipfs_path_success_test() {
 #[test]
 fn get_tail_success_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get_unwrapped_file")
         .case("tests/cmd/get_tail_success.trycmd")
         .run();
@@ -100,6 +112,7 @@ fn get_tail_success_test() {
 #[test]
 fn get_unwrapped_file_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get_unwrapped_file")
         .case("tests/cmd/get_unwrapped_file.trycmd")
         .run();
@@ -108,6 +121,7 @@ fn get_unwrapped_file_test() {
 #[test]
 fn get_wrapped_file_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get_wrapped_file")
         .case("tests/cmd/get_wrapped_file.trycmd")
         .run();
@@ -116,6 +130,7 @@ fn get_wrapped_file_test() {
 #[tokio::test]
 async fn get_unwrapped_symlink_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get_unwrapped_symlink")
         .case("tests/cmd/get_unwrapped_symlink.trycmd")
         .run();
@@ -124,6 +139,7 @@ async fn get_unwrapped_symlink_test() {
 #[tokio::test]
 async fn get_wrapped_symlink_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "get_wrapped_symlink")
         .case("tests/cmd/get_wrapped_symlink.trycmd")
         .run();
@@ -132,6 +148,7 @@ async fn get_wrapped_symlink_test() {
 #[test]
 fn lookup_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "lookup")
         .case("tests/cmd/lookup.trycmd")
         .run();
@@ -140,6 +157,7 @@ fn lookup_test() {
 #[test]
 fn version_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .case("tests/cmd/version.trycmd")
         .insert_var("[VERSION]", std::env::var("CARGO_PKG_VERSION").unwrap())
         .unwrap();
@@ -148,6 +166,7 @@ fn version_test() {
 #[test]
 fn start_status_stop_test() {
     trycmd::TestCases::new()
+        .env("RUST_BACKTRACE", "0")
         .env("IROH_CTL_FIXTURE", "start_status_stop")
         .case("tests/cmd/start_status_stop.trycmd")
         .run();

--- a/stores/flatfs/Cargo.toml
+++ b/stores/flatfs/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.63"
 publish = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 backoff = "0.4.0"
 ignore = "0.4.18"
 

--- a/stores/rocks/Cargo.toml
+++ b/stores/rocks/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.63"
 publish = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 flatfs-store = { path = "../flatfs", optional = true }
 rocksdb = "0.19.0"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 rust-version = "1.63"
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 clap = { version = "4.0.9", features = ["derive"] }
 clap_mangen = "0.2.2"
 dirs-next = "2.0.0"


### PR DESCRIPTION
This enables backtrace support in anyhow, allowing backtraces to be
enabled when setting RUST_BACKTRACE=1.  This is useful when trying to
find the source of an error.