### PR TITLE
chore: run cargo-doc on CI and fix some errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
       run: |
         cargo clippy --workspace --all-features --all-targets -- -D warnings
 
+    - name: docs
+      run: |
+        cargo doc --workspace --all-features --no-deps --document-private-items -- -Dwarnings
+
     - name: tests
       timeout-minutes: 30
       run: |

--- a/iroh-bitswap/src/peer_task_queue.rs
+++ b/iroh-bitswap/src/peer_task_queue.rs
@@ -1,4 +1,4 @@
-//! Based on https://github.com/ipfs/go-peertaskqueue.
+//! Based on <https://github.com/ipfs/go-peertaskqueue>.
 
 use std::{fmt::Debug, sync::Arc};
 

--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -32,7 +32,7 @@ pub struct Config {
     /// URL of gateways to be used by the racing resolver.
     /// Strings can either be urls or subdomain gateway roots
     /// values without https:// prefix are treated as subdomain gateways (eg: dweb.link)
-    /// values with are treated as IPFS path gateways (eg: https://ipfs.io)
+    /// values with are treated as IPFS path gateways (eg: <https://ipfs.io>)
     pub http_resolvers: Option<Vec<String>>,
     /// Separate resolvers for particular TLDs
     #[serde(default = "DnsResolverConfig::default")]

--- a/iroh-p2p/src/behaviour/event.rs
+++ b/iroh-p2p/src/behaviour/event.rs
@@ -7,6 +7,8 @@ use libp2p::{
 use super::peer_manager::PeerManagerEvent;
 
 /// Event type which is emitted from the [`NodeBehaviour`].
+///
+/// [`NodeBehaviour`]: crate::behaviour::NodeBehaviour
 #[derive(Debug)]
 pub enum Event {
     Ping(PingEvent),

--- a/iroh-p2p/src/config.rs
+++ b/iroh-p2p/src/config.rs
@@ -21,7 +21,7 @@ pub const ENV_PREFIX: &str = "IROH_P2P";
 
 /// Default bootstrap nodes
 ///
-/// Based on https://github.com/ipfs/go-ipfs-config/blob/master/bootstrap_peers.go#L17.
+/// Based on <https://github.com/ipfs/go-ipfs-config/blob/master/bootstrap_peers.go#L17>.
 pub const DEFAULT_BOOTSTRAP: &[&str] = &[
     "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
     "/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",

--- a/iroh-resolver/src/balanced_tree.rs
+++ b/iroh-resolver/src/balanced_tree.rs
@@ -11,7 +11,7 @@ use crate::unixfs::{dag_pb, unixfs_pb, DataType, Node, UnixfsNode};
 use crate::unixfs_builder::encode_unixfs_pb;
 
 /// Default degree number for balanced tree, taken from unixfs specs
-/// https://github.com/ipfs/specs/blob/main/UNIXFS.md#layout
+/// <https://github.com/ipfs/specs/blob/main/UNIXFS.md#layout>
 pub const DEFAULT_DEGREE: usize = 174;
 
 #[derive(Debug, PartialEq, Eq)]

--- a/iroh-resolver/src/codecs.rs
+++ b/iroh-resolver/src/codecs.rs
@@ -1,4 +1,4 @@
-/// Multicodecs, as defined in https://github.com/multiformats/multicodec/blob/master/table.csv.
+/// Multicodecs, as defined in <https://github.com/multiformats/multicodec/blob/master/table.csv>.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive, Hash,
 )]

--- a/iroh-resolver/src/indexer.rs
+++ b/iroh-resolver/src/indexer.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use tracing::trace;
 
 /// API connection to the indexer nodes, as implemented in
-/// https://github.com/filecoin-project/storetheindex.
+/// <https://github.com/filecoin-project/storetheindex>.
 #[derive(Debug, Clone)]
 pub struct Indexer {
     endpoint: Url,


### PR DESCRIPTION
This enables running cargo-doc on CI and fixes the current errors and
warnings it has.