### PR TITLE
Remove GrpcUds code path

### DIFF
--- a/iroh-gateway/src/config.rs
+++ b/iroh-gateway/src/config.rs
@@ -79,8 +79,6 @@ impl Config {
                 match addr {
                     #[cfg(feature = "rpc-grpc")]
                     Addr::GrpcHttp2(addr) => Ok(Addr::GrpcHttp2(*addr)),
-                    #[cfg(all(feature = "rpc-grpc", unix))]
-                    Addr::GrpcUds(path) => Ok(Addr::GrpcUds(path.clone())),
                     #[cfg(feature = "rpc-mem")]
                     Addr::Mem(_) => bail!("can not derive rpc_addr for mem addr"),
                     _ => bail!("invalid rpc_addr"),

--- a/iroh-p2p/src/config.rs
+++ b/iroh-p2p/src/config.rs
@@ -221,8 +221,6 @@ impl Config {
                 match addr {
                     #[cfg(feature = "rpc-grpc")]
                     Addr::GrpcHttp2(addr) => Ok(Addr::GrpcHttp2(*addr)),
-                    #[cfg(all(feature = "rpc-grpc", unix))]
-                    Addr::GrpcUds(path) => Ok(Addr::GrpcUds(path.clone())),
                     #[cfg(feature = "rpc-mem")]
                     Addr::Mem(_) => bail!("can not derive rpc_addr for mem addr"),
                     _ => bail!("invalid rpc_addr"),

--- a/iroh-p2p/src/node.rs
+++ b/iroh-p2p/src/node.rs
@@ -1073,23 +1073,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(all(feature = "rpc-grpc", unix))]
-    #[tokio::test]
-    async fn test_fetch_providers_uds_dht() -> Result<()> {
-        let dir = tempfile::tempdir()?;
-        let file = dir.path().join("cool.iroh");
-
-        let server_addr = P2pServerAddr::GrpcUds(file.clone());
-        let client_addr = P2pClientAddr::GrpcUds(file);
-        fetch_providers(
-            "/ip4/0.0.0.0/tcp/5002".parse().unwrap(),
-            server_addr,
-            client_addr,
-        )
-        .await?;
-        Ok(())
-    }
-
     #[cfg(feature = "rpc-mem")]
     #[tokio::test]
     async fn test_fetch_providers_mem_dht() -> Result<()> {

--- a/iroh-rpc-client/src/macros.rs
+++ b/iroh-rpc-client/src/macros.rs
@@ -46,27 +46,6 @@ macro_rules! impl_client {
                                 backend: [<$label ClientBackend>]::Grpc { client, health },
                             })
                         }
-                        #[cfg(all(feature = "grpc", unix))]
-                        Addr::GrpcUds(path) => {
-                            use tokio::net::UnixStream;
-                            use tonic::transport::Uri;
-
-                            let path = std::sync::Arc::new(path);
-                            // dummy addr
-                            let conn = Endpoint::new("http://[..]:50051")?
-                                .keep_alive_while_idle(true)
-                                .connect_with_connector_lazy(tower::service_fn(move |_: Uri| {
-                                    let path = path.clone();
-                                    UnixStream::connect(path.as_ref().clone())
-                                }));
-
-                            let client = [<Grpc $label Client>]::new(conn.clone());
-                            let health = HealthClient::new(conn);
-
-                            Ok([<$label Client>] {
-                                backend: [<$label ClientBackend>]::Grpc { client, health },
-                            })
-                        }
                         #[cfg(feature = "mem")]
                         Addr::Mem(s) => Ok([<$label Client>] {
                             backend: [<$label ClientBackend>]::Mem(s),

--- a/iroh-rpc-types/src/macros.rs
+++ b/iroh-rpc-types/src/macros.rs
@@ -24,55 +24,6 @@ macro_rules! proxy_serve {
                         anyhow::bail!("cannot serve on lookup address: {}", name);
                     }
 
-                    #[cfg(all(feature = "grpc", unix))]
-                    $crate::Addr::GrpcUds(path) => {
-                        use anyhow::Context;
-                        use tokio::net::UnixListener;
-                        use tokio_stream::wrappers::UnixListenerStream;
-
-                        let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
-                        health_reporter
-                            .set_serving::<[<$label:lower _server>]::[<$label Server>]<T>>()
-                            .await;
-
-                        if path.exists() {
-                            if path.is_dir() {
-                                anyhow::bail!("cannot bind socket to directory: {}", path.display());
-                            } else {
-                                anyhow::bail!("cannot bind socket: already exists: {}", path.display());
-                            }
-                        }
-
-                        // If the parent directory doesn't exist, we'll fail to bind.
-                        // Create a more precise error to recognize that case.
-                        if let Some(parent) = path.parent() {
-                            if !parent.exists() {
-                                anyhow::bail!("socket parent directory doesn't exist: {}", parent.display());
-                            }
-                        }
-
-                        // Delete file on close
-                        struct UdsGuard(std::path::PathBuf);
-                        impl Drop for UdsGuard {
-                            fn drop(&mut self) {
-                                let _ = std::fs::remove_file(&self.0);
-                            }
-                        }
-
-                        let uds = UnixListener::bind(&path)
-                            .with_context(|| format!("failed to bind to {}", path.display()))?;
-                        let _guard = UdsGuard(path.clone().into());
-
-                        let uds_stream = UnixListenerStream::new(uds);
-
-                        tonic::transport::Server::builder()
-                            .add_service(health_service)
-                            .add_service([<$label:lower _server>]::[<$label Server>]::new(source))
-                            .serve_with_incoming(uds_stream)
-                            .await?;
-
-                        Ok(())
-                    }
                     #[cfg(feature = "mem")]
                     $crate::Addr::Mem(mut receiver) => {
                         while let Some((msg, sender)) = receiver.recv().await {

--- a/iroh-store/benches/rpc.rs
+++ b/iroh-store/benches/rpc.rs
@@ -19,7 +19,6 @@ const VALUES: [usize; 4] = [32, 256, 1024, 256 * 1024];
 enum Transport {
     GrpcHttp2,
     #[cfg(unix)]
-    GrpcUds,
     Mem,
 }
 
@@ -31,12 +30,6 @@ impl Transport {
                 "grpc://127.0.0.1:4001".parse().unwrap(),
                 None,
             ),
-            #[cfg(unix)]
-            Transport::GrpcUds => {
-                let dir = tempfile::tempdir().unwrap();
-                let file = dir.path().join("iroh-store.uds");
-                (Addr::GrpcUds(file.clone()), Addr::GrpcUds(file), Some(dir))
-            }
             Transport::Mem => {
                 let (a, b) = Addr::new_mem();
                 (a, b, None)
@@ -49,7 +42,7 @@ pub fn put_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("rpc_store_put");
 
     #[cfg(unix)]
-    let addrs = [Transport::GrpcHttp2, Transport::GrpcUds, Transport::Mem];
+    let addrs = [Transport::GrpcHttp2, Transport::Mem];
     #[cfg(not(unix))]
     let addrs = [Transport::GrpcHttp2, Transport::Mem];
     for transport in addrs.into_iter() {
@@ -109,7 +102,7 @@ pub fn put_benchmark(c: &mut Criterion) {
 pub fn get_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("rpc_store_get");
     #[cfg(unix)]
-    let addrs = [Transport::GrpcHttp2, Transport::GrpcUds, Transport::Mem];
+    let addrs = [Transport::GrpcHttp2, Transport::Mem];
     #[cfg(not(unix))]
     let addrs = [Transport::GrpcHttp2, Transport::Mem];
     for transport in addrs.into_iter() {

--- a/iroh-store/src/config.rs
+++ b/iroh-store/src/config.rs
@@ -62,8 +62,6 @@ impl Config {
                 match addr {
                     #[cfg(feature = "rpc-grpc")]
                     Addr::GrpcHttp2(addr) => Ok(Addr::GrpcHttp2(*addr)),
-                    #[cfg(all(feature = "rpc-grpc", unix))]
-                    Addr::GrpcUds(path) => Ok(Addr::GrpcUds(path.clone())),
                     #[cfg(feature = "rpc-mem")]
                     Addr::Mem(_) => bail!("can not derive rpc_addr for mem addr"),
                     _ => bail!("invalid rpc_addr"),


### PR DESCRIPTION
Maybe we will add it again, but this complicates switching the RPC.

Note that only removes the Grpc UDS, not the gateway UDS code path.