### PR TITLE
refactor(`iroh-api`): add takes a `UnixfsEntry` not a `Path`

### DIFF
--- a/iroh-api/Cargo.toml
+++ b/iroh-api/Cargo.toml
@@ -34,4 +34,11 @@ tokio = { version = "1" }
 tracing = "0.1.34"
 
 [dev-dependencies]
+criterion = { version = "0.4.0", features = ["async_tokio"] }
+iroh-rpc-types = { version = "0.1.3", path = "../iroh-rpc-types", default-features = false }
+iroh-store = { version = "0.1.3", path = "../iroh-store", default-features = false }
 tempfile = "3.3.0"
+
+[[bench]]
+name = "add"
+harness = false

--- a/iroh-api/Cargo.toml
+++ b/iroh-api/Cargo.toml
@@ -14,6 +14,7 @@ testing = ["dep:mockall"]
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 async-stream = "0.3.3"
+async-trait = "0.1.53"
 bytes = "1.1.0"
 cid = "0.9"
 config = "0.13.1"

--- a/iroh-api/benches/add.rs
+++ b/iroh-api/benches/add.rs
@@ -1,15 +1,17 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use futures::TryStreamExt;
 use iroh_metrics::config::Config as MetricsConfig;
-use iroh_rpc_client::Client;
-use iroh_rpc_client::Config as RpcClientConfig;
+use iroh_resolver::resolver::Resolver;
+use iroh_rpc_client::{Client, Config as RpcClientConfig};
 use iroh_rpc_types::Addr;
 use iroh_store::{Config as StoreConfig, Store};
 use iroh_unixfs::{
-    builder::Config as UnixfsConfig,
     chunker::{ChunkerConfig, DEFAULT_CHUNKS_SIZE},
+    content_loader::{FullLoader, FullLoaderConfig},
 };
 use tokio::runtime::Runtime;
+
+use iroh_api::{Api, UnixfsConfig, UnixfsEntry};
 
 pub fn add_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("unixfs_add_file");
@@ -44,7 +46,7 @@ pub fn add_benchmark(c: &mut Criterion) {
                     rpc_client: rpc_client.clone(),
                     metrics: MetricsConfig::default(),
                 };
-                let (_task, rpc) = executor.block_on(async {
+                let (_task, client, resolver) = executor.block_on(async {
                     let store = Store::create(config).await.unwrap();
                     let task = executor.spawn(async move {
                         iroh_store::rpc::new(server_addr, store).await.unwrap()
@@ -52,22 +54,32 @@ pub fn add_benchmark(c: &mut Criterion) {
                     // wait for a moment until the transport is setup
                     // TODO: signal this more clearly
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                    let rpc = Client::new(rpc_client).await.unwrap();
-                    (task, rpc)
+                    let client = Client::new(rpc_client).await.unwrap();
+                    let content_loader = FullLoader::new(
+                        client.clone(),
+                        FullLoaderConfig {
+                            http_gateways: Vec::new(),
+                            indexer: None,
+                        },
+                    )
+                    .unwrap();
+                    let resolver = Resolver::new(content_loader);
+
+                    (task, client, resolver)
                 });
                 b.to_async(&executor).iter(|| {
-                    let rpc = rpc.clone();
+                    let api = Api::from_client_and_resolver(client.clone(), resolver.clone());
                     async move {
-                        let stream = iroh_unixfs::builder::add_file(
-                            Some(rpc),
+                        let entry = UnixfsEntry::from_path(
                             path,
                             UnixfsConfig {
                                 wrap: false,
-                                chunker: ChunkerConfig::Fixed(DEFAULT_CHUNKS_SIZE),
+                                chunker: Some(ChunkerConfig::Fixed(DEFAULT_CHUNKS_SIZE)),
                             },
                         )
                         .await
                         .unwrap();
+                        let stream = api.add_stream(entry).await.unwrap();
 
                         let res: Vec<_> = stream.try_collect().await.unwrap();
                         black_box(res)

--- a/iroh-api/benches/add.rs
+++ b/iroh-api/benches/add.rs
@@ -13,7 +13,7 @@ use tokio::runtime::Runtime;
 
 use iroh_api::{Api, UnixfsConfig, UnixfsEntry};
 
-pub fn add_benchmark(c: &mut Criterion) {
+fn add_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("unixfs_add_file");
     for file_size in [
         1024,             //  1 KiB

--- a/iroh-api/src/api.rs
+++ b/iroh-api/src/api.rs
@@ -25,7 +25,7 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::block_store::add_blocks_to_store;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Api {
     client: Client,
     resolver: Resolver<FullLoader>,
@@ -68,7 +68,10 @@ impl Api {
             overrides_map,
         )
         .unwrap();
+        Api::from_config(config).await
+    }
 
+    pub async fn from_config(config: Config) -> Result<Self> {
         let client = Client::new(config.rpc_client).await?;
         let content_loader = FullLoader::new(
             client.clone(),
@@ -91,6 +94,10 @@ impl Api {
         let resolver = Resolver::new(content_loader);
 
         Ok(Self { client, resolver })
+    }
+
+    pub fn from_client_and_resolver(client: Client, resolver: Resolver<FullLoader>) -> Self {
+        Self { client, resolver }
     }
 
     pub async fn provide(&self, cid: Cid) -> Result<()> {

--- a/iroh-api/src/api.rs
+++ b/iroh-api/src/api.rs
@@ -23,7 +23,7 @@ use mockall::automock;
 use relative_path::RelativePathBuf;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-use crate::block_store::add_blocks_to_store;
+use crate::store::add_blocks_to_store;
 
 #[derive(Debug, Clone)]
 pub struct Api {
@@ -163,6 +163,11 @@ impl Api {
         self.client.clone().watch().await.boxed_local()
     }
 
+    /// The `add_stream` method encodes the entry into a DAG and adds
+    /// the resulting blocks to the store. It returns a stream of
+    /// CIDs and the size of the _raw data_ associated with that block.
+    /// If the block does not contain raw data (only link data), the
+    /// size of the block will be 0.
     pub async fn add_stream(
         &self,
         entry: UnixfsEntry,
@@ -180,6 +185,8 @@ impl Api {
         ))
     }
 
+    /// The `add` method encodes the entry into a DAG and adds the resulting
+    /// blocks to the store.
     pub async fn add(&self, entry: UnixfsEntry) -> Result<Cid> {
         let add_events = self.add_stream(entry).await?;
 

--- a/iroh-api/src/api.rs
+++ b/iroh-api/src/api.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use crate::config::{Config, CONFIG_FILE_NAME, ENV_PREFIX};
+use crate::IpfsPath;
 use crate::P2pApi;
-use crate::{AddEvent, IpfsPath};
 use anyhow::{ensure, Context, Result};
 use cid::Cid;
 use futures::stream::LocalBoxStream;
@@ -13,8 +13,7 @@ use iroh_resolver::resolver::Resolver;
 use iroh_rpc_client::Client;
 use iroh_rpc_client::StatusTable;
 use iroh_unixfs::{
-    builder::{self as unixfs_builder, Config as UnixfsConfig},
-    chunker::ChunkerConfig,
+    builder::Entry as UnixfsEntry,
     content_loader::{FullLoader, FullLoaderConfig},
     ResponseClip,
 };
@@ -23,6 +22,8 @@ use iroh_util::{iroh_config_path, make_config};
 use mockall::automock;
 use relative_path::RelativePathBuf;
 use tokio::io::{AsyncRead, AsyncReadExt};
+
+use crate::block_store::add_blocks_to_store;
 
 #[derive(Debug)]
 pub struct Api {
@@ -147,60 +148,6 @@ impl Api {
         Ok(stream.boxed_local())
     }
 
-    pub async fn add_file(
-        &self,
-        path: &Path,
-        wrap: bool,
-        chunker: ChunkerConfig,
-    ) -> Result<LocalBoxStream<'static, Result<AddEvent>>> {
-        let providing_client = unixfs_builder::StoreAndProvideClient {
-            client: self.client.clone(),
-        };
-        let path = path.to_path_buf();
-        let stream = unixfs_builder::add_file(
-            Some(providing_client),
-            &path,
-            UnixfsConfig { wrap, chunker },
-        )
-        .await?;
-
-        Ok(stream.boxed_local())
-    }
-
-    pub async fn add_dir(
-        &self,
-        path: &Path,
-        wrap: bool,
-        chunker: ChunkerConfig,
-    ) -> Result<LocalBoxStream<'static, Result<AddEvent>>> {
-        let providing_client = unixfs_builder::StoreAndProvideClient {
-            client: self.client.clone(),
-        };
-        let path = path.to_path_buf();
-        let stream = unixfs_builder::add_dir(
-            Some(providing_client),
-            &path,
-            UnixfsConfig { wrap, chunker },
-        )
-        .await?;
-
-        Ok(stream.boxed_local())
-    }
-
-    pub async fn add_symlink(
-        &self,
-        path: &Path,
-        wrap: bool,
-    ) -> Result<LocalBoxStream<'static, Result<AddEvent>>> {
-        let providing_client = unixfs_builder::StoreAndProvideClient {
-            client: self.client.clone(),
-        };
-        let path = path.to_path_buf();
-        let stream = unixfs_builder::add_symlink(Some(providing_client), &path, wrap).await?;
-
-        Ok(stream.boxed_local())
-    }
-
     pub async fn check(&self) -> StatusTable {
         self.client.check().await
     }
@@ -211,30 +158,26 @@ impl Api {
 
     pub async fn add_stream(
         &self,
-        path: &Path,
-        wrap: bool,
-        chunker: ChunkerConfig,
-    ) -> Result<LocalBoxStream<'static, Result<AddEvent>>> {
-        if path.is_dir() {
-            self.add_dir(path, wrap, chunker).await
-        } else if path.is_symlink() {
-            self.add_symlink(path, wrap).await
-        } else if path.is_file() {
-            self.add_file(path, wrap, chunker).await
-        } else {
-            anyhow::bail!("can only add files or directories")
-        }
+        entry: UnixfsEntry,
+    ) -> Result<LocalBoxStream<'static, Result<(Cid, u64)>>> {
+        let blocks = match entry {
+            UnixfsEntry::File(f) => f.encode().await?.boxed_local(),
+            UnixfsEntry::Directory(d) => d.encode(),
+            UnixfsEntry::Symlink(s) => Box::pin(async_stream::try_stream! {
+                yield s.encode()?
+            }),
+        };
+
+        Ok(Box::pin(
+            add_blocks_to_store(Some(self.client.clone()), blocks).await,
+        ))
     }
 
-    pub async fn add(&self, path: &Path, wrap: bool, chunker: ChunkerConfig) -> Result<Cid> {
-        let add_events = self.add_stream(path, wrap, chunker).await?;
+    pub async fn add(&self, entry: UnixfsEntry) -> Result<Cid> {
+        let add_events = self.add_stream(entry).await?;
 
         add_events
-            .try_fold(None, |_acc, add_event| async move {
-                match add_event {
-                    AddEvent::ProgressDelta { cid, .. } => Ok(Some(cid)),
-                }
-            })
+            .try_fold(None, |_acc, (cid, _)| async move { Ok(Some(cid)) })
             .await?
             .context("No cid found")
     }

--- a/iroh-api/src/block_store.rs
+++ b/iroh-api/src/block_store.rs
@@ -1,0 +1,118 @@
+use std::{pin::Pin, sync::Arc};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use cid::Cid;
+use futures::{future, stream::TryStreamExt, Stream, StreamExt};
+use iroh_rpc_client::Client;
+use iroh_unixfs::Block;
+
+/// How many chunks to buffer up when adding content.
+const _ADD_PAR: usize = 24;
+
+#[async_trait]
+pub trait Store: 'static + Send + Sync + Clone {
+    async fn has(&self, &cid: Cid) -> Result<bool>;
+    async fn put(&self, cid: Cid, blob: Bytes, links: Vec<Cid>) -> Result<()>;
+    async fn put_many(&self, blocks: Vec<Block>) -> Result<()>;
+}
+
+#[async_trait]
+impl Store for Client {
+    async fn has(&self, cid: Cid) -> Result<bool> {
+        self.try_store()?.has(cid).await
+    }
+
+    async fn put(&self, cid: Cid, blob: Bytes, links: Vec<Cid>) -> Result<()> {
+        self.try_store()?.put(cid, blob, links).await
+    }
+
+    async fn put_many(&self, blocks: Vec<Block>) -> Result<()> {
+        self.try_store()?
+            .put_many(blocks.into_iter().map(|x| x.into_parts()).collect())
+            .await
+    }
+}
+
+#[async_trait]
+impl Store for Arc<tokio::sync::Mutex<std::collections::HashMap<Cid, Bytes>>> {
+    async fn has(&self, cid: Cid) -> Result<bool> {
+        Ok(self.lock().await.contains_key(&cid))
+    }
+    async fn put(&self, cid: Cid, blob: Bytes, _links: Vec<Cid>) -> Result<()> {
+        self.lock().await.insert(cid, blob);
+        Ok(())
+    }
+
+    async fn put_many(&self, blocks: Vec<Block>) -> Result<()> {
+        let mut this = self.lock().await;
+        for block in blocks {
+            this.insert(*block.cid(), block.data().clone());
+        }
+        Ok(())
+    }
+}
+
+use async_stream::stream;
+
+fn add_blocks_to_store_chunked<S: Store>(
+    store: S,
+    mut blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
+) -> impl Stream<Item = Result<(Cid, u64)>> {
+    let mut chunk = Vec::new();
+    let mut chunk_size = 0u64;
+    const MAX_CHUNK_SIZE: u64 = 1024 * 1024 * 16;
+    stream! {
+        while let Some(block) = blocks.next().await {
+            let block = block?;
+            let block_size = block.data().len() as u64;
+            let cid = *block.cid();
+            let raw_data_size = block.raw_data_size().unwrap_or_default();
+            tracing::info!("adding chunk of {} bytes", chunk_size);
+            if chunk_size + block_size > MAX_CHUNK_SIZE {
+                store.put_many(std::mem::take(&mut chunk)).await?;
+                chunk_size = 0;
+            }
+            chunk.push(block);
+            chunk_size += block_size;
+            yield Ok((
+                cid,
+                raw_data_size,
+            ));
+        }
+        // make sure to also send the last chunk!
+        store.put_many(chunk).await?;
+    }
+}
+
+fn _add_blocks_to_store_single<S: Store>(
+    store: Option<S>,
+    blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
+) -> impl Stream<Item = Result<(Cid, u64)>> {
+    blocks
+        .and_then(|x| future::ok(vec![x]))
+        .map(move |blocks| {
+            let store = store.clone();
+            async move {
+                let block = blocks?[0].clone();
+                let raw_data_size = block.raw_data_size().unwrap_or_default();
+                let cid = *block.cid();
+                if let Some(store) = store {
+                    if !store.has(cid).await? {
+                        store.put_many(vec![block]).await?;
+                    }
+                }
+
+                Ok((cid, raw_data_size))
+            }
+        })
+        .buffered(_ADD_PAR)
+}
+
+pub async fn add_blocks_to_store<S: Store>(
+    store: Option<S>,
+    blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
+) -> impl Stream<Item = Result<(Cid, u64)>> {
+    add_blocks_to_store_chunked(store.unwrap(), blocks)
+}

--- a/iroh-api/src/lib.rs
+++ b/iroh-api/src/lib.rs
@@ -1,8 +1,8 @@
 mod api;
-mod block_store;
 mod config;
 mod error;
 mod p2p;
+mod store;
 
 pub mod fs;
 

--- a/iroh-api/src/lib.rs
+++ b/iroh-api/src/lib.rs
@@ -1,4 +1,5 @@
 mod api;
+mod block_store;
 mod config;
 mod error;
 mod p2p;
@@ -20,7 +21,10 @@ pub use bytes::Bytes;
 pub use cid::Cid;
 pub use iroh_resolver::resolver::Path as IpfsPath;
 pub use iroh_rpc_client::{Lookup, ServiceStatus, StatusRow, StatusTable};
-pub use iroh_unixfs::builder::{AddEvent, Config as UnixfsConfig};
+pub use iroh_unixfs::builder::{
+    Config as UnixfsConfig, DirectoryBuilder, Entry as UnixfsEntry, FileBuilder, SymlinkBuilder,
+};
 pub use iroh_unixfs::chunker::{ChunkerConfig, DEFAULT_CHUNKS_SIZE};
+pub use iroh_unixfs::Block;
 pub use libp2p::gossipsub::MessageId;
 pub use libp2p::{Multiaddr, PeerId};

--- a/iroh-api/src/lib.rs
+++ b/iroh-api/src/lib.rs
@@ -11,6 +11,7 @@ pub use crate::api::Api;
 #[cfg(feature = "testing")]
 pub use crate::api::MockApi as Api;
 pub use crate::api::OutType;
+pub use crate::config::Config;
 pub use crate::error::ApiError;
 #[cfg(feature = "testing")]
 pub use crate::p2p::MockP2p as P2pApi;

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -189,8 +189,7 @@ mod tests {
     ) -> (Cid, Vec<Cid>) {
         let store = rpc_client.try_store().unwrap();
         let mut cids = vec![];
-        let mut dir_builder = DirectoryBuilder::new();
-        dir_builder.name(dir);
+        let mut dir_builder = DirectoryBuilder::new().name(dir);
         for (name, content) in files {
             let file = FileBuilder::new()
                 .name(*name)
@@ -198,10 +197,10 @@ mod tests {
                 .build()
                 .await
                 .unwrap();
-            dir_builder.add_file(file);
+            dir_builder = dir_builder.add_file(file);
         }
 
-        let root_dir = dir_builder.build().unwrap();
+        let root_dir = dir_builder.build().await.unwrap();
         let mut parts = root_dir.encode();
         while let Some(part) = parts.next().await {
             let (cid, bytes, links) = part.unwrap().into_parts();

--- a/iroh-resolver/tests/roundtrip.rs
+++ b/iroh-resolver/tests/roundtrip.rs
@@ -28,8 +28,7 @@ type TestDir = BTreeMap<String, TestDirEntry>;
 /// builds an unixfs directory out of a TestDir
 #[async_recursion(?Send)]
 async fn build_directory(name: &str, dir: &TestDir) -> Result<Directory> {
-    let mut builder = DirectoryBuilder::new();
-    builder.name(name);
+    let mut builder = DirectoryBuilder::new().name(name);
     for (name, entry) in dir {
         match entry {
             TestDirEntry::File(content) => {
@@ -38,15 +37,15 @@ async fn build_directory(name: &str, dir: &TestDir) -> Result<Directory> {
                     .content_bytes(content.to_vec())
                     .build()
                     .await?;
-                builder.add_file(file);
+                builder = builder.add_file(file);
             }
             TestDirEntry::Directory(dir) => {
                 let dir = build_directory(name, dir).await?;
-                builder.add_dir(dir)?;
+                builder = builder.add_dir(dir)?;
             }
         }
     }
-    builder.build()
+    builder.build().await
 }
 
 /// builds a TestDir out of a stream of blocks and a resolver

--- a/iroh-share/src/lib.rs
+++ b/iroh-share/src/lib.rs
@@ -136,25 +136,25 @@ mod tests {
 
         let sender = s::Sender::new(9990, &sender_db).await.context("s:new")?;
 
-        let mut dir_builder = DirectoryBuilder::new();
-        dir_builder.name("foo");
-        let file = FileBuilder::new()
+        let file_1 = FileBuilder::new()
             .name("bar.txt")
             .content_bytes(&b"bar"[..])
             .build()
             .await?;
-        dir_builder.add_file(file);
 
         let mut bytes = vec![0u8; 5 * 1024 * 1024 - 8];
         rand::thread_rng().fill_bytes(&mut bytes);
         tokio::fs::write(sender_dir.path().join("baz.txt"), &bytes).await?;
         let f = tokio::fs::File::open(sender_dir.path().join("baz.txt")).await?;
-        let file = FileBuilder::new()
+        let file_2 = FileBuilder::new()
             .name("baz.txt")
             .content_reader(f)
             .build()
             .await?;
-        dir_builder.add_file(file);
+        let dir_builder = DirectoryBuilder::new()
+            .name("foo")
+            .add_file(file_1)
+            .add_file(file_2);
 
         let sender_transfer = sender
             .transfer_from_dir_builder(dir_builder)

--- a/iroh-share/src/sender.rs
+++ b/iroh-share/src/sender.rs
@@ -58,7 +58,7 @@ impl Sender {
         } = self;
 
         let t = Sha256Topic::new(format!("iroh-share-{}", id));
-        let root_dir = dir_builder.build()?;
+        let root_dir = dir_builder.build().await?;
 
         let (done_sender, done_receiver) = oneshot();
 
@@ -157,13 +157,12 @@ impl Sender {
     ) -> Result<Transfer> {
         let name = name.into();
         // wrap in directory to preserve the name
-        let mut root_dir = DirectoryBuilder::new();
         let file = FileBuilder::new()
             .name(name)
             .content_bytes(data)
             .build()
             .await?;
-        root_dir.add_file(file);
+        let root_dir = DirectoryBuilder::new().add_file(file);
 
         self.transfer_from_dir_builder(root_dir).await
     }

--- a/iroh-unixfs/Cargo.toml
+++ b/iroh-unixfs/Cargo.toml
@@ -48,7 +48,3 @@ tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "fs"] }
 
 [build-dependencies]
 prost-build = "0.11.1"
-
-[[bench]]
-name = "unixfs"
-harness = false

--- a/iroh-unixfs/src/builder.rs
+++ b/iroh-unixfs/src/builder.rs
@@ -626,6 +626,7 @@ async fn make_dir_from_path<P: Into<PathBuf>>(path: P, chunker: Chunker) -> Resu
 mod tests {
     use super::*;
     use crate::chunker::DEFAULT_CHUNKS_SIZE;
+    use futures::TryStreamExt;
     use std::io::Write;
 
     #[tokio::test]

--- a/iroh/src/fixture.rs
+++ b/iroh/src/fixture.rs
@@ -4,9 +4,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use futures::StreamExt;
-use iroh_api::{AddEvent, Cid, Lookup, OutType, PeerId};
-use iroh_api::{Api, P2pApi};
-use iroh_api::{ServiceStatus, StatusRow, StatusTable};
+use iroh_api::{Api, Cid, Lookup, OutType, P2pApi, PeerId, ServiceStatus, StatusRow, StatusTable};
 use relative_path::RelativePathBuf;
 
 type GetFixture = fn() -> Api;
@@ -67,11 +65,10 @@ fn fixture_add_file() -> Api {
             Some(StatusRow::new("store", 1, ServiceStatus::Serving)),
         )
     });
-    api.expect_add_stream().returning(|_ipfs_path, _, _| {
+    api.expect_add_stream().returning(|_| {
         let cid = Cid::from_str("QmYbcW4tXLXHWw753boCK8Y7uxLu5abXjyYizhLznq9PUR").unwrap();
-        let add_event = AddEvent::ProgressDelta { cid, size: Some(0) };
 
-        let stream = futures::stream::iter(vec![Ok(add_event)]);
+        let stream = futures::stream::iter(vec![Ok((cid, 0))]);
 
         Ok(Box::pin(stream))
     });
@@ -88,11 +85,10 @@ fn fixture_add_directory() -> Api {
             Some(StatusRow::new("store", 1, ServiceStatus::Serving)),
         )
     });
-    api.expect_add_stream().returning(|_ipfs_path, _, _| {
+    api.expect_add_stream().returning(|_| {
         let cid = Cid::from_str("QmYbcW4tXLXHWw753boCK8Y7uxLu5abXjyYizhLznq9PUR").unwrap();
-        let add_event = AddEvent::ProgressDelta { cid, size: Some(0) };
 
-        Ok(Box::pin(futures::stream::iter(vec![Ok(add_event)])))
+        Ok(Box::pin(futures::stream::iter(vec![Ok((cid, 0))])))
     });
     api.expect_provide().returning(|_| Ok(()));
     api

--- a/iroh/src/run.rs
+++ b/iroh/src/run.rs
@@ -7,7 +7,9 @@ use console::style;
 use crossterm::style::Stylize;
 use futures::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
-use iroh_api::{AddEvent, Api, ChunkerConfig, IpfsPath, ServiceStatus, DEFAULT_CHUNKS_SIZE};
+use iroh_api::{
+    Api, ChunkerConfig, IpfsPath, ServiceStatus, UnixfsConfig, UnixfsEntry, DEFAULT_CHUNKS_SIZE,
+};
 use iroh_metrics::config::Config as MetricsConfig;
 use iroh_util::{human, iroh_config_path, make_config};
 
@@ -255,17 +257,20 @@ async fn add(
     // a while before it starts ending progress reports
     pb.inc(0);
 
-    let mut progress = api.add_stream(path, !no_wrap, chunker).await?;
+    let entry = UnixfsEntry::from_path(
+        path,
+        UnixfsConfig {
+            wrap: !no_wrap,
+            chunker: Some(chunker),
+        },
+    )
+    .await?;
+    let mut progress = api.add_stream(entry).await?;
     let mut cids = Vec::new();
-    while let Some(add_event) = progress.next().await {
-        match add_event? {
-            AddEvent::ProgressDelta { cid, size } => {
-                cids.push(cid);
-                if let Some(size) = size {
-                    pb.inc(size);
-                }
-            }
-        }
+    while let Some(prog) = progress.next().await {
+        let (cid, size) = prog?;
+        cids.push(cid);
+        pb.inc(size);
     }
     pb.finish_and_clear();
 


### PR DESCRIPTION
closes #458 

- [x] re-export builder structs from `iroh-unixfs::builder`
- [x] allow building from a path in `DirectoryBuilder`
- [x] make `builder::Entry` public
- [x] refactor `add` to take an `Entry`
- [x] remove unneeded `add_file`, `add_symlink`, `add_dir` helper functions
- [x] adjust imports/tests/benches
