### PR TITLE
feat: Refactor unixfs

### DIFF
--- a/iroh-api/src/api.rs
+++ b/iroh-api/src/api.rs
@@ -14,7 +14,6 @@ use iroh_rpc_client::{Client, ClientStatus};
 use iroh_unixfs::{
     builder::Entry as UnixfsEntry,
     content_loader::{FullLoader, FullLoaderConfig},
-    ResponseClip,
 };
 use iroh_util::{iroh_config_path, make_config};
 #[cfg(feature = "testing")]
@@ -152,13 +151,13 @@ impl Api {
                 if out.is_dir() {
                     yield (relative_path, OutType::Dir);
                 } else if out.is_symlink() {
-                    let mut reader = out.pretty(resolver.clone(), Default::default(), ResponseClip::NoClip)?;
+                    let mut reader = out.pretty(resolver.clone(), Default::default(), None)?;
                     let mut target = String::new();
                     reader.read_to_string(&mut target).await?;
                     let target = PathBuf::from(target);
                     yield (relative_path, OutType::Symlink(target));
                 } else {
-                    let reader = out.pretty(resolver.clone(), Default::default(), ResponseClip::NoClip)?;
+                    let reader = out.pretty(resolver.clone(), Default::default(), None)?;
                     yield (relative_path, OutType::Reader(Box::new(reader)));
                 }
             }

--- a/iroh-gateway/src/bad_bits.rs
+++ b/iroh-gateway/src/bad_bits.rs
@@ -218,7 +218,7 @@ mod tests {
         let uri = hyper::Uri::builder()
             .scheme("http")
             .authority(format!("localhost:{}", addr.port()))
-            .path_and_query(format!("/ipfs/{}", bad_cid))
+            .path_and_query(format!("/ipfs/{bad_cid}"))
             .build()
             .unwrap();
         let client = hyper::Client::new();
@@ -228,7 +228,7 @@ mod tests {
         let uri = hyper::Uri::builder()
             .scheme("http")
             .authority(format!("localhost:{}", addr.port()))
-            .path_and_query(format!("/ipfs/{}/{}", bad_cid, bad_path))
+            .path_and_query(format!("/ipfs/{bad_cid}/{bad_path}"))
             .build()
             .unwrap();
         let client = hyper::Client::new();
@@ -238,7 +238,7 @@ mod tests {
         let uri = hyper::Uri::builder()
             .scheme("http")
             .authority(format!("localhost:{}", addr.port()))
-            .path_and_query(format!("/ipfs/{}/{}", bad_cid_2, bad_path))
+            .path_and_query(format!("/ipfs/{bad_cid_2}/{bad_path}"))
             .build()
             .unwrap();
         let client = hyper::Client::new();
@@ -249,7 +249,7 @@ mod tests {
         let uri = hyper::Uri::builder()
             .scheme("http")
             .authority(format!("localhost:{}", addr.port()))
-            .path_and_query(format!("/ipfs/{}/{}?format=raw", bad_cid_2, bad_path))
+            .path_and_query(format!("/ipfs/{bad_cid_2}/{bad_path}?format=raw"))
             .build()
             .unwrap();
         let client = hyper::Client::new();
@@ -260,7 +260,7 @@ mod tests {
         let uri = hyper::Uri::builder()
             .scheme("http")
             .authority(format!("localhost:{}", addr.port()))
-            .path_and_query(format!("/ipfs/{}/{}", bad_cid, good_path))
+            .path_and_query(format!("/ipfs/{bad_cid}/{good_path}"))
             .build()
             .unwrap();
         let client = hyper::Client::new();
@@ -270,7 +270,7 @@ mod tests {
         let uri = hyper::Uri::builder()
             .scheme("http")
             .authority(format!("localhost:{}", addr.port()))
-            .path_and_query(format!("/ipfs/{}/{}", bad_cid_2, good_path))
+            .path_and_query(format!("/ipfs/{bad_cid_2}/{good_path}"))
             .build()
             .unwrap();
         let client = hyper::Client::new();
@@ -280,7 +280,7 @@ mod tests {
         let uri = hyper::Uri::builder()
             .scheme("http")
             .authority(format!("localhost:{}", addr.port()))
-            .path_and_query(format!("/ipfs/{}", good_cid))
+            .path_and_query(format!("/ipfs/{good_cid}"))
             .build()
             .unwrap();
         let client = hyper::Client::new();

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -213,7 +213,7 @@ mod tests {
         let store = rpc_client.try_store().unwrap();
         let mut cids = vec![];
         let mut dir_builder = DirectoryBuilder::new().name(dir);
-        for (name, content) in files.into_iter() {
+        for (name, content) in files.iter() {
             let file = FileBuilder::new()
                 .name(name)
                 .content_bytes(content.to_vec())

--- a/iroh-gateway/src/core.rs
+++ b/iroh-gateway/src/core.rs
@@ -38,7 +38,7 @@ impl<T: ContentLoader + Unpin> Core<T> {
     ) -> anyhow::Result<Self> {
         tokio::spawn(async move {
             if let Err(err) = rpc::new(rpc_addr, Gateway::default()).await {
-                tracing::error!("Failed to run gateway rpc handler: {}", err);
+                tracing::error!("Failed to run gateway rpc handler: {err}");
             }
         });
         let mut templates = HashMap::new();
@@ -123,6 +123,8 @@ mod tests {
     use axum::response::Response;
     use cid::Cid;
     use futures::{StreamExt, TryStreamExt};
+    use http::header::CONTENT_RANGE;
+    use http::HeaderValue;
     use hyper::Body;
     use iroh_rpc_client::Client as RpcClient;
     use iroh_rpc_client::Config as RpcClientConfig;
@@ -131,6 +133,9 @@ mod tests {
     use iroh_unixfs::builder::{DirectoryBuilder, FileBuilder};
     use iroh_unixfs::content_loader::{FullLoader, FullLoaderConfig};
     use iroh_unixfs::unixfs::UnixfsNode;
+    use rand::distributions::{Alphanumeric, DistString};
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
     use std::io;
     use tokio_util::io::StreamReader;
 
@@ -142,7 +147,6 @@ mod tests {
         file_cids: Vec<Cid>,
         core_task: tokio::task::JoinHandle<()>,
         store_task: tokio::task::JoinHandle<()>,
-        files: Vec<(String, Vec<u8>)>,
     }
 
     impl TestSetup {
@@ -209,10 +213,10 @@ mod tests {
         let store = rpc_client.try_store().unwrap();
         let mut cids = vec![];
         let mut dir_builder = DirectoryBuilder::new().name(dir);
-        for (name, content) in files {
+        for (name, content) in files.into_iter() {
             let file = FileBuilder::new()
                 .name(name)
-                .content_bytes(content.clone())
+                .content_bytes(content.to_vec())
                 .build()
                 .await
                 .unwrap();
@@ -226,7 +230,8 @@ mod tests {
             cids.push(cid);
             store.put(cid, bytes, links).await.unwrap();
         }
-        (*cids.last().unwrap(), cids)
+        let root = *cids.last().unwrap();
+        (root, cids)
     }
 
     async fn do_request(
@@ -254,7 +259,7 @@ mod tests {
             .unwrap()
     }
 
-    async fn setup_test(redirect_to_subdomains: bool) -> TestSetup {
+    async fn setup_test(redirect_to_subdomains: bool, files: &[(String, Vec<u8>)]) -> TestSetup {
         let (store_client_addr, store_task) = spawn_store().await;
         let mut config = Config::new(
             0,
@@ -269,11 +274,7 @@ mod tests {
         config.redirect_to_subdomain = redirect_to_subdomains;
         let (gateway_addr, rpc_client, core_task) = spawn_gateway(Arc::new(config)).await;
         let dir = "demo";
-        let files = vec![
-            ("hello.txt".to_string(), b"ola".to_vec()),
-            ("world.txt".to_string(), b"mundo".to_vec()),
-        ];
-        let (root_cid, file_cids) = put_directory_with_files(&rpc_client, dir, &files).await;
+        let (root_cid, file_cids) = put_directory_with_files(&rpc_client, dir, files).await;
 
         TestSetup {
             gateway_addr,
@@ -281,7 +282,6 @@ mod tests {
             file_cids,
             core_task,
             store_task,
-            files,
         }
     }
 
@@ -319,7 +319,11 @@ mod tests {
     // TODO(b5) - refactor to return anyhow::Result<()>
     #[tokio::test]
     async fn test_fetch_car_recursive() {
-        let test_setup = setup_test(false).await;
+        let files = &[
+            ("hello.txt".to_string(), b"ola".to_vec()),
+            ("world.txt".to_string(), b"mundo".to_vec()),
+        ];
+        let test_setup = setup_test(false, files).await;
 
         // request the root cid as a recursive car
         let res = do_request(
@@ -351,29 +355,32 @@ mod tests {
             HashSet::from_iter(test_setup.file_cids.iter())
         );
         assert_eq!(cids[0], test_setup.root_cid);
-        assert_eq!(nodes.len(), test_setup.files.len() + 1);
+        assert_eq!(nodes.len(), files.len() + 1);
         assert!(nodes[0].is_dir());
         assert_eq!(
             nodes[0]
                 .links()
                 .map(|link| link.unwrap().name.unwrap().to_string())
                 .collect::<Vec<_>>(),
-            test_setup
-                .files
+            files
                 .iter()
                 .map(|(name, _content)| name.to_string())
                 .collect::<Vec<_>>()
         );
 
         for (i, node) in nodes[1..].iter().enumerate() {
-            assert_eq!(node, &UnixfsNode::Raw(test_setup.files[i].1.clone().into()));
+            assert_eq!(node, &UnixfsNode::Raw(files[i].1.clone().into()));
         }
         test_setup.shutdown().await
     }
 
     #[tokio::test]
     async fn test_head_request_to_file() {
-        let test_setup = setup_test(false).await;
+        let files = &[
+            ("hello.txt".to_string(), b"ola".to_vec()),
+            ("world.txt".to_string(), b"mundo".to_vec()),
+        ];
+        let test_setup = setup_test(false, files).await;
 
         // request the root cid as a recursive car
         let res = do_request(
@@ -396,7 +403,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_gateway_requests() {
-        let test_setup = setup_test(false).await;
+        let files = &[
+            ("hello.txt".to_string(), b"ola".to_vec()),
+            ("world.txt".to_string(), b"mundo".to_vec()),
+        ];
+        let test_setup = setup_test(false, files).await;
 
         // request the root cid as a recursive car
         let res = do_request(
@@ -433,30 +444,117 @@ mod tests {
             HashSet::from_iter(test_setup.file_cids.iter())
         );
         assert_eq!(cids[0], test_setup.root_cid);
-        assert_eq!(nodes.len(), test_setup.files.len() + 1);
+        assert_eq!(nodes.len(), files.len() + 1);
         assert!(nodes[0].is_dir());
         assert_eq!(
             nodes[0]
                 .links()
                 .map(|link| link.unwrap().name.unwrap().to_string())
                 .collect::<Vec<_>>(),
-            test_setup
-                .files
+            files
                 .iter()
                 .map(|(name, _content)| name.to_string())
                 .collect::<Vec<_>>()
         );
 
         for (i, node) in nodes[1..].iter().enumerate() {
-            assert_eq!(node, &UnixfsNode::Raw(test_setup.files[i].1.clone().into()));
+            assert_eq!(node, &UnixfsNode::Raw(files[i].1.clone().into()));
         }
 
         test_setup.shutdown().await
     }
 
     #[tokio::test]
+    async fn test_range_requests() {
+        let files = [(
+            "large.txt".to_string(),
+            Alphanumeric
+                .sample_string(&mut SmallRng::seed_from_u64(42), 8 * 1024 * 1024)
+                .bytes()
+                .collect(),
+        )];
+        let large_file = &files[0].1;
+        let test_setup = setup_test(false, &files).await;
+
+        // -----------------------------
+
+        let res = do_request(
+            "GET",
+            &format!("localhost:{}", test_setup.gateway_addr.port()),
+            "/large.txt",
+            Some(&[
+                ("host", &format!("{}.ipfs.localhost", test_setup.root_cid)),
+                ("range", "bytes=0-1"),
+            ]),
+        )
+        .await;
+
+        assert_eq!(http::StatusCode::PARTIAL_CONTENT, res.status());
+        assert_eq!(
+            HeaderValue::from_str("bytes 0-1/8388608").unwrap(),
+            res.headers().get(CONTENT_RANGE).unwrap()
+        );
+
+        let (body, _) = res.into_body().into_future().await;
+        assert_eq!(body.unwrap().unwrap(), large_file[0..2]);
+
+        // -----------------------------
+
+        let res = do_request(
+            "GET",
+            &format!("localhost:{}", test_setup.gateway_addr.port()),
+            "/large.txt",
+            Some(&[
+                ("host", &format!("{}.ipfs.localhost", test_setup.root_cid)),
+                ("range", "bytes=4000-1000000"),
+            ]),
+        )
+        .await;
+
+        assert_eq!(http::StatusCode::PARTIAL_CONTENT, res.status());
+        assert_eq!(
+            HeaderValue::from_str("bytes 4000-1000000/8388608").unwrap(),
+            res.headers().get(CONTENT_RANGE).unwrap()
+        );
+
+        let content = hyper::body::to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(content.len(), 1000001 - 4000);
+        assert_eq!(content, large_file[4000..1000001]);
+
+        let res = do_request(
+            "GET",
+            &format!("localhost:{}", test_setup.gateway_addr.port()),
+            "/large.txt",
+            Some(&[
+                ("host", &format!("{}.ipfs.localhost", test_setup.root_cid)),
+                ("range", "bytes=0-8388607"),
+            ]),
+        )
+        .await;
+
+        assert_eq!(http::StatusCode::PARTIAL_CONTENT, res.status());
+        assert_eq!(
+            HeaderValue::from_str("bytes 0-8388607/8388608").unwrap(),
+            res.headers().get(CONTENT_RANGE).unwrap()
+        );
+
+        let content = hyper::body::to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(content.len(), large_file.len());
+        assert_eq!(content, large_file);
+
+        test_setup.shutdown().await
+    }
+
+    #[tokio::test]
     async fn test_gateway_redirection() {
-        let test_setup = setup_test(true).await;
+        let test_setup = setup_test(
+            true,
+            &[
+                ("hello.txt".to_string(), b"ola".to_vec()),
+                ("world.txt".to_string(), b"mundo".to_vec()),
+            ],
+        )
+        .await;
 
         // Usual request
         let res = do_request(
@@ -617,7 +715,7 @@ mod tests {
 
         assert_eq!(http::StatusCode::MOVED_PERMANENTLY, res.status());
         assert_eq!(
-            format!("http://{}.ipfs.ipfs.io/world.txt", test_setup.root_cid,),
+            format!("http://{}.ipfs.ipfs.io/world.txt", test_setup.root_cid),
             res.headers().get("Location").unwrap().to_str().unwrap(),
         );
 

--- a/iroh-gateway/src/handler_params.rs
+++ b/iroh-gateway/src/handler_params.rs
@@ -36,7 +36,7 @@ impl GetParams {
         if q.is_empty() {
             q
         } else {
-            format!("?{}", q)
+            format!("?{q}")
         }
     }
 }

--- a/iroh-gateway/src/handlers.rs
+++ b/iroh-gateway/src/handlers.rs
@@ -301,7 +301,7 @@ pub async fn subdomain_handler<T: ContentLoader + Unpin>(
     let path = Path::from_parts(
         parsed_subdomain_url.scheme,
         &inlined_dns_link_to_dns_link(parsed_subdomain_url.cid_or_domain),
-        path_params.content_path.as_deref().unwrap_or(""),
+        path_params.content_path.as_deref().unwrap_or("/"),
     )
     .map_err(|e| GatewayError::new(StatusCode::BAD_REQUEST, &e.to_string()))?;
     handler(

--- a/iroh-gateway/src/headers.rs
+++ b/iroh-gateway/src/headers.rs
@@ -458,7 +458,7 @@ mod tests {
             ),
             Some(ResponseFormat::Raw),
         );
-        let wetag = format!("W/{}", etag);
+        let wetag = format!("W/{etag}");
         let other_etag = get_etag(
             &CidOrDomain::Cid(
                 Cid::try_from("bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4aaaaa")
@@ -466,8 +466,8 @@ mod tests {
             ),
             Some(ResponseFormat::Raw),
         );
-        let other_wetag = format!("W/{}", other_etag);
-        let long_etag = format!("{},{}", other_etag, wetag);
+        let other_wetag = format!("W/{other_etag}");
+        let long_etag = format!("{other_etag},{wetag}");
 
         assert!(etag_matches(any_etag, &etag));
         assert!(etag_matches(&etag, &wetag));

--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
     )
     .unwrap();
     config.metrics = metrics::metrics_config_with_compile_time_info(config.metrics);
-    println!("{:#?}", config);
+    println!("{config:#?}");
 
     let metrics_config = config.metrics.clone();
     let dns_resolver_config = config.dns_resolver.clone();

--- a/iroh-gateway/src/response.rs
+++ b/iroh-gateway/src/response.rs
@@ -33,7 +33,7 @@ impl std::convert::TryFrom<&str> for ResponseFormat {
                 if rf.starts_with("application/vnd.ipld.") {
                     Ok(ResponseFormat::Fs(rf.to_string()))
                 } else {
-                    Err(format!("{}: {}", ERR_UNSUPPORTED_FORMAT, rf))
+                    Err(format!("{ERR_UNSUPPORTED_FORMAT}: {rf}"))
                 }
             }
         }

--- a/iroh-gateway/src/templates.rs
+++ b/iroh-gateway/src/templates.rs
@@ -25,5 +25,5 @@ pub fn icon_class_name(path: &str) -> String {
     } else {
         "_blank"
     };
-    format!("icon-{}", icon)
+    format!("icon-{icon}")
 }

--- a/iroh-resolver/src/dns_resolver.rs
+++ b/iroh-resolver/src/dns_resolver.rs
@@ -80,7 +80,7 @@ impl DnsResolver {
 
     #[tracing::instrument]
     pub async fn resolve_dnslink(&self, url: &str) -> Result<Vec<Path>> {
-        let url = format!("_dnslink.{}.", url);
+        let url = format!("_dnslink.{url}.");
         let records = self.resolve_txt_record(&url).await?;
         let records = records
             .into_iter()

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -93,15 +93,14 @@ impl Path {
             let root = Cid::from_str(cid_or_domain).context("invalid cid")?;
             (PathType::Ipfs, CidOrDomain::Cid(root))
         };
-        let tail = if tail_path != "/" {
-            tail_path
-                .split(&['/', '\\'])
-                .filter(|s| !s.is_empty())
-                .map(String::from)
-                .collect()
-        } else {
-            vec!["".to_string()]
-        };
+        let mut tail = tail_path
+            .split(&['/', '\\'])
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect::<Vec<_>>();
+        if tail_path.ends_with('/') {
+            tail.push("".to_string())
+        }
         Ok(Path { typ, root, tail })
     }
 

--- a/iroh-resolver/tests/unixfs.rs
+++ b/iroh-resolver/tests/unixfs.rs
@@ -8,7 +8,6 @@ use iroh_unixfs::{
     self,
     builder::FileBuilder,
     chunker::{self, Chunker},
-    ResponseClip,
 };
 
 async fn read_fixture(path: impl AsRef<std::path::Path>) -> Result<Vec<u8>> {
@@ -80,9 +79,7 @@ async fn test_dagger_testdata() -> Result<()> {
             let stream = file.encode().await?;
             let (root, resolver) = stream_to_resolver(stream).await?;
             let out = resolver.resolve(Path::from_cid(root)).await?;
-            let t =
-                read_to_vec(out.pretty(resolver, OutMetrics::default(), ResponseClip::NoClip)?)
-                    .await?;
+            let t = read_to_vec(out.pretty(resolver, OutMetrics::default(), None)?).await?;
 
             println!("Root: {}", root);
             println!("Len: {}", data.len());

--- a/iroh-rpc-client/src/lib.rs
+++ b/iroh-rpc-client/src/lib.rs
@@ -69,7 +69,7 @@ pub async fn open_client<S: Service>(addr: Addr<S>) -> anyhow::Result<RpcClient<
             combined::ClientChannel::new(None, Some(client)),
         )),
         Addr::Irpc(uri) => {
-            let uri = format!("http://{}", uri).parse()?;
+            let uri = format!("http://{uri}").parse()?;
             let channel = http2::ClientChannel::new(uri);
             let channel = combined::ClientChannel::new(Some(channel), None);
             Ok(RpcClient::<S, ChannelTypes>::new(channel))

--- a/iroh-share/src/receiver.rs
+++ b/iroh-share/src/receiver.rs
@@ -5,7 +5,7 @@ use futures::{
 };
 use iroh_p2p::NetworkEvent;
 use iroh_resolver::resolver::{Out, OutPrettyReader, OutType, Path, Resolver, UnixfsType};
-use iroh_unixfs::{Link, ResponseClip};
+use iroh_unixfs::Link;
 use libp2p::gossipsub::{GossipsubMessage, MessageId, TopicHash};
 use libp2p::PeerId;
 use tokio::sync::mpsc::{channel, Receiver as ChannelReceiver};
@@ -238,8 +238,7 @@ impl Data {
     }
 
     pub fn pretty(self) -> Result<OutPrettyReader<Loader>> {
-        self.root
-            .pretty(self.resolver, Default::default(), ResponseClip::NoClip)
+        self.root.pretty(self.resolver, Default::default(), None)
     }
 
     pub async fn read_file(&self, link: &Link) -> Result<Data> {

--- a/iroh-store/src/store.rs
+++ b/iroh-store/src/store.rs
@@ -683,8 +683,7 @@ impl<'a> ReadStore<'a> {
         let n_id = self.db.iterator_cf(&cf.id, IteratorMode::Start).count();
         if n_meta != n_id {
             res.push(format!(
-                "non bijective mapping between cid and id. Metadata and id cfs have different lengths: {} != {}",
-                n_meta, n_id
+                "non bijective mapping between cid and id. Metadata and id cfs have different lengths: {n_meta} != {n_id}"
             ));
         }
         Ok(res)

--- a/iroh-unixfs/src/chunker.rs
+++ b/iroh-unixfs/src/chunker.rs
@@ -49,7 +49,7 @@ pub enum ChunkerConfig {
 impl Display for ChunkerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Fixed(chunk_size) => write!(f, "fixed-{}", chunk_size),
+            Self::Fixed(chunk_size) => write!(f, "fixed-{chunk_size}"),
             Self::Rabin => write!(f, "rabin"),
         }
     }

--- a/iroh-unixfs/src/content_loader.rs
+++ b/iroh-unixfs/src/content_loader.rs
@@ -101,7 +101,7 @@ impl GatewayUrl {
                 url
             }
             GatewayUrl::Subdomain(raw) => {
-                format!("https://{}.ipfs.{}?format=raw", cid_str, raw).parse()?
+                format!("https://{cid_str}.ipfs.{raw}?format=raw").parse()?
             }
         };
         Ok(url)

--- a/iroh-unixfs/src/lib.rs
+++ b/iroh-unixfs/src/lib.rs
@@ -8,7 +8,7 @@ pub mod indexer;
 mod types;
 pub mod unixfs;
 
-pub use crate::types::{Block, Link, LinkRef, Links, LoadedCid, PbLinks, ResponseClip, Source};
+pub use crate::types::{Block, Link, LinkRef, Links, LoadedCid, PbLinks, Source};
 
 use std::collections::BTreeSet;
 

--- a/iroh-unixfs/src/types.rs
+++ b/iroh-unixfs/src/types.rs
@@ -79,23 +79,6 @@ impl Block {
     }
 }
 
-/// Holds information if we should clip the response and to what offset
-#[derive(Debug, Clone, Copy)]
-pub enum ResponseClip {
-    NoClip,
-    Clip(usize),
-}
-
-impl From<usize> for ResponseClip {
-    fn from(item: usize) -> Self {
-        if item == 0 {
-            ResponseClip::NoClip
-        } else {
-            ResponseClip::Clip(item)
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Link {
     pub cid: Cid,

--- a/iroh-unixfs/src/unixfs.rs
+++ b/iroh-unixfs/src/unixfs.rs
@@ -18,7 +18,7 @@ use crate::{
     codecs::Codec,
     content_loader::{ContentLoader, LoaderContext},
     hamt::Hamt,
-    types::{Block, Link, LinkRef, Links, PbLinks, ResponseClip},
+    types::{Block, Link, LinkRef, Links, PbLinks},
 };
 
 pub(crate) mod unixfs_pb {
@@ -306,12 +306,12 @@ impl UnixfsNode {
     }
 
     /// If this is a directory or hamt shard, returns a stream that yields all children of it.
-    pub fn as_child_reader<'a, 'b: 'a, C: ContentLoader>(
-        &'a self,
+    pub fn as_child_reader<C: ContentLoader>(
+        &self,
         ctx: LoaderContext,
         loader: C,
         om: OutMetrics,
-    ) -> Result<Option<UnixfsChildStream<'a>>> {
+    ) -> Result<Option<UnixfsChildStream>> {
         match self {
             UnixfsNode::Raw(_)
             | UnixfsNode::RawNode(_)
@@ -339,7 +339,7 @@ impl UnixfsNode {
         ctx: LoaderContext,
         loader: C,
         om: OutMetrics,
-        pos_max: ResponseClip,
+        pos_max: Option<usize>,
     ) -> Result<Option<UnixfsContentReader<C>>> {
         match self {
             UnixfsNode::Raw(_)
@@ -351,7 +351,6 @@ impl UnixfsNode {
                 Ok(Some(UnixfsContentReader::File {
                     root_node: self,
                     pos: 0,
-                    skip_pos: 0,
                     pos_max,
                     current_node: CurrentNodeState::Outer,
                     current_links,
@@ -383,9 +382,9 @@ impl<'a> Debug for UnixfsChildStream<'a> {
             UnixfsChildStream::Hamt {
                 pos, out_metrics, ..
             } =>
-                write!(f, "UnixfsChildStream::Hamt {{ stream: BoxStream<Result<Link>>, pos: {}, out_metrics {:?} }}", pos, out_metrics),
+                write!(f, "UnixfsChildStream::Hamt {{ stream: BoxStream<Result<Link>>, pos: {pos}, out_metrics {out_metrics:?} }}"),
             UnixfsChildStream::Directory { out_metrics, .. } =>
-                write!(f, "UnixfsChildStream::Directory {{ stream: BoxStream<Result<Link>>, out_metrics {:?} }}", out_metrics),
+                write!(f, "UnixfsChildStream::Directory {{ stream: BoxStream<Result<Link>>, out_metrics {out_metrics:?} }}"),
         }
     }
 }
@@ -397,9 +396,7 @@ pub enum UnixfsContentReader<C: ContentLoader> {
         /// Absolute position in bytes
         pos: usize,
         /// Absolute max position in bytes, only used for clipping responses
-        pos_max: ResponseClip,
-        /// Amount of bytes to skip to seek up to pos
-        skip_pos: usize,
+        pos_max: Option<usize>,
         /// Current node being operated on, only used for nested nodes (not the root).
         current_node: CurrentNodeState,
         /// Stack of links left to traverse.
@@ -451,7 +448,6 @@ impl<C: ContentLoader + Unpin + 'static> AsyncRead for UnixfsContentReader<C> {
                 root_node,
                 pos,
                 pos_max,
-                skip_pos,
                 current_node,
                 current_links,
                 loader,
@@ -459,18 +455,17 @@ impl<C: ContentLoader + Unpin + 'static> AsyncRead for UnixfsContentReader<C> {
                 ctx,
             } => {
                 let typ = root_node.typ();
-                let pos_current = *pos;
+                let pos_old = *pos;
                 let poll_res = match root_node {
                     UnixfsNode::Raw(data) => {
-                        let res = poll_read_buf_at_pos(pos, *pos_max, data, buf);
-                        Poll::Ready(res)
+                        read_data_to_buf(pos, *pos_max, &data[*pos..], buf);
+                        Poll::Ready(Ok(()))
                     }
                     UnixfsNode::File(node) => poll_read_file_at(
                         cx,
                         node,
                         loader.clone(),
                         pos,
-                        skip_pos,
                         *pos_max,
                         buf,
                         current_links,
@@ -479,16 +474,16 @@ impl<C: ContentLoader + Unpin + 'static> AsyncRead for UnixfsContentReader<C> {
                     ),
                     UnixfsNode::Symlink(node) => {
                         let data = node.inner.data.as_deref().unwrap_or_default();
-                        let res = poll_read_buf_at_pos(pos, *pos_max, data, buf);
-                        Poll::Ready(res)
+                        read_data_to_buf(pos, *pos_max, &data[*pos..], buf);
+                        Poll::Ready(Ok(()))
                     }
                     _ => Poll::Ready(Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
-                        format!("unsupported Unixfs type for file types: {:?} ", typ),
+                        format!("unsupported Unixfs type for file types: {typ:?} "),
                     ))),
                 };
-                let bytes_read = *pos - pos_current;
-                out_metrics.observe_bytes_read(pos_current, bytes_read);
+                let bytes_read = *pos - pos_old;
+                out_metrics.observe_bytes_read(pos_old, bytes_read);
                 poll_res
             }
         }
@@ -501,63 +496,58 @@ impl<C: ContentLoader + Unpin + 'static> AsyncSeek for UnixfsContentReader<C> {
             UnixfsContentReader::File {
                 root_node,
                 pos,
-                pos_max: _,
-                skip_pos,
-                current_node: _,
-                current_links: _,
-                loader: _,
-                out_metrics: _,
-                ctx: _,
-            } => match position {
-                std::io::SeekFrom::Start(offset) => {
-                    let mut i = offset as usize;
-                    let data_len = root_node.size();
-                    if let Some(data_len) = data_len {
-                        if data_len == 0 {
-                            *pos = 0;
-                            return Ok(());
+                current_node,
+                current_links,
+                ..
+            } => {
+                *current_node = CurrentNodeState::Outer;
+                *current_links = vec![root_node.links_owned().unwrap()];
+                let data_len = root_node.size();
+                match position {
+                    std::io::SeekFrom::Start(offset) => {
+                        let mut i = offset as usize;
+                        if let Some(data_len) = data_len {
+                            if data_len == 0 {
+                                *pos = 0;
+                                return Ok(());
+                            }
+                            i = std::cmp::min(i, data_len - 1);
                         }
-                        i = std::cmp::min(i, data_len - 1);
+                        *pos = i;
                     }
-                    *pos = i;
-                    *skip_pos = i;
-                }
-                std::io::SeekFrom::End(offset) => {
-                    let data_len = root_node.size();
-                    if let Some(data_len) = data_len {
-                        if data_len == 0 {
-                            *pos = 0;
-                            return Ok(());
+                    std::io::SeekFrom::End(offset) => {
+                        if let Some(data_len) = data_len {
+                            if data_len == 0 {
+                                *pos = 0;
+                                return Ok(());
+                            }
+                            let mut i = (data_len as i64 + offset) % data_len as i64;
+                            if i < 0 {
+                                i += data_len as i64;
+                            }
+                            *pos = i as usize;
+                        } else {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::InvalidInput,
+                                "cannot seek from end of unknown length",
+                            ));
                         }
-                        let mut i = (data_len as i64 + offset) % data_len as i64;
-                        if i < 0 {
-                            i += data_len as i64;
+                    }
+                    std::io::SeekFrom::Current(offset) => {
+                        let mut i = *pos as i64 + offset;
+                        i = std::cmp::max(0, i);
+
+                        if let Some(data_len) = data_len {
+                            if data_len == 0 {
+                                *pos = 0;
+                                return Ok(());
+                            }
+                            i = std::cmp::min(i, data_len as i64 - 1);
                         }
                         *pos = i as usize;
-                        *skip_pos = i as usize;
-                    } else {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
-                            "cannot seek from end of unknown length",
-                        ));
                     }
                 }
-                std::io::SeekFrom::Current(offset) => {
-                    let mut i = *pos as i64 + offset;
-                    i = std::cmp::max(0, i);
-
-                    let data_len = root_node.size();
-                    if let Some(data_len) = data_len {
-                        if data_len == 0 {
-                            *pos = 0;
-                            return Ok(());
-                        }
-                        i = std::cmp::min(i, data_len as i64 - 1);
-                    }
-                    *pos = i as usize;
-                    *skip_pos = i as usize;
-                }
-            },
+            }
         }
         Ok(())
     }
@@ -567,73 +557,74 @@ impl<C: ContentLoader + Unpin + 'static> AsyncSeek for UnixfsContentReader<C> {
         _cx: &mut Context<'_>,
     ) -> Poll<std::io::Result<u64>> {
         match &mut *self {
-            UnixfsContentReader::File {
-                root_node: _,
-                pos,
-                pos_max: _,
-                skip_pos: _,
-                current_node: _,
-                current_links: _,
-                loader: _,
-                out_metrics: _,
-                ctx: _,
-            } => Poll::Ready(Ok(*pos as u64)),
+            UnixfsContentReader::File { pos, .. } => Poll::Ready(Ok(*pos as u64)),
         }
     }
 }
 
-pub fn poll_read_buf_at_pos(
+pub fn read_data_to_buf(
     pos: &mut usize,
-    clip: ResponseClip,
+    pos_max: Option<usize>,
     data: &[u8],
     buf: &mut tokio::io::ReadBuf<'_>,
-) -> std::io::Result<()> {
-    let mut pos_max = data.len();
-    if let ResponseClip::Clip(n) = clip {
-        pos_max = n;
-    }
-    if *pos >= data.len() || *pos >= pos_max {
-        return Ok(());
-    }
-    let data_len = data.len() - *pos;
-    let amt = std::cmp::min(data_len, buf.remaining());
-    let amt = std::cmp::min(amt, pos_max - *pos);
-    buf.put_slice(&data[*pos..*pos + amt]);
+) -> usize {
+    let data_to_read = pos_max.map(|pos_max| pos_max - *pos).unwrap_or(data.len());
+    let amt = std::cmp::min(std::cmp::min(data_to_read, buf.remaining()), data.len());
+    buf.put_slice(&data[..amt]);
     *pos += amt;
-
-    Ok(())
+    amt
 }
 
 #[allow(clippy::large_enum_variant)]
 pub enum CurrentNodeState {
+    // Initial state
     Outer,
-    None,
-    Loaded(usize, UnixfsNode),
-    Loading(BoxFuture<'static, Result<UnixfsNode>>),
+    // Need to load next node from the list
+    NextNodeRequested {
+        next_node_offset: usize,
+    },
+    // Node has been loaded and ready to be processed
+    Loaded {
+        node_offset: usize,
+        node_pos: usize,
+        node: UnixfsNode,
+    },
+    // Ongoing loading of the node
+    Loading {
+        node_offset: usize,
+        fut: BoxFuture<'static, Result<UnixfsNode>>,
+    },
 }
 
 impl Debug for CurrentNodeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CurrentNodeState::Outer => write!(f, "CurrentNodeState::Outer"),
-            CurrentNodeState::None => write!(f, "CurrentNodeState::None"),
-            CurrentNodeState::Loaded(pos, n) => {
-                write!(f, "CurrentNodeState::Loaded({:?}, {:?})", pos, n)
+            CurrentNodeState::NextNodeRequested { next_node_offset } => {
+                write!(f, "CurrentNodeState::None ({next_node_offset})")
             }
-            CurrentNodeState::Loading(_) => write!(f, "CurrentNodeState::Loading(Fut)"),
+            CurrentNodeState::Loaded {
+                node_offset,
+                node_pos,
+                node,
+            } => {
+                write!(
+                    f,
+                    "CurrentNodeState::Loaded({node_offset:?}, {node_pos:?}, {node:?})"
+                )
+            }
+            CurrentNodeState::Loading { .. } => write!(f, "CurrentNodeState::Loading(Fut)"),
         }
     }
 }
 
 fn load_next_node<C: ContentLoader + 'static>(
+    next_node_offset: usize,
     current_node: &mut CurrentNodeState,
     current_links: &mut Vec<VecDeque<Link>>,
     loader: C,
     ctx: std::sync::Arc<tokio::sync::Mutex<LoaderContext>>,
 ) -> bool {
-    // Load next node
-
-    // find non empty links
     let links = loop {
         if let Some(last_mut) = current_links.last_mut() {
             if last_mut.is_empty() {
@@ -645,7 +636,7 @@ fn load_next_node<C: ContentLoader + 'static>(
             }
         } else {
             // no links left we are done
-            return true;
+            return false;
         }
     };
 
@@ -659,8 +650,11 @@ fn load_next_node<C: ContentLoader + 'static>(
         Ok(node)
     }
     .boxed();
-    *current_node = CurrentNodeState::Loading(fut);
-    false
+    *current_node = CurrentNodeState::Loading {
+        node_offset: next_node_offset,
+        fut,
+    };
+    true
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -669,43 +663,52 @@ fn poll_read_file_at<C: ContentLoader + 'static>(
     root_node: &Node,
     loader: C,
     pos: &mut usize,
-    skip_pos: &mut usize,
-    pos_max: ResponseClip,
+    pos_max: Option<usize>,
     buf: &mut tokio::io::ReadBuf<'_>,
     current_links: &mut Vec<VecDeque<Link>>,
     current_node: &mut CurrentNodeState,
     ctx: std::sync::Arc<tokio::sync::Mutex<LoaderContext>>,
 ) -> Poll<std::io::Result<()>> {
     loop {
+        if let Some(pos_max) = pos_max {
+            if pos_max <= *pos {
+                return Poll::Ready(Ok(()));
+            }
+        }
         match current_node {
             CurrentNodeState::Outer => {
                 // check for links
                 if root_node.outer.links.is_empty() {
                     // simplest case just one file
                     let data = root_node.inner.data.as_deref().unwrap_or(&[][..]);
-                    let res = poll_read_buf_at_pos(pos, pos_max, data, buf);
-                    return Poll::Ready(res);
+                    read_data_to_buf(pos, pos_max, &data[*pos..], buf);
+                    return Poll::Ready(Ok(()));
                 }
 
                 // read root local data
                 if let Some(ref data) = root_node.inner.data {
                     if *pos < data.len() {
-                        let res = poll_read_buf_at_pos(pos, pos_max, data, buf);
-                        return Poll::Ready(res);
+                        read_data_to_buf(pos, pos_max, &data[*pos..], buf);
+                        return Poll::Ready(Ok(()));
                     }
                 }
-                *current_node = CurrentNodeState::None;
-                if load_next_node(current_node, current_links, loader.clone(), ctx.clone()) {
+                *current_node = CurrentNodeState::NextNodeRequested {
+                    next_node_offset: 0,
+                };
+            }
+            CurrentNodeState::NextNodeRequested { next_node_offset } => {
+                let loaded_next_node = load_next_node(
+                    *next_node_offset,
+                    current_node,
+                    current_links,
+                    loader.clone(),
+                    ctx.clone(),
+                );
+                if !loaded_next_node {
                     return Poll::Ready(Ok(()));
                 }
             }
-            CurrentNodeState::None => {
-                if load_next_node(current_node, current_links, loader.clone(), ctx.clone()) {
-                    return Poll::Ready(Ok(()));
-                }
-            }
-            CurrentNodeState::Loading(fut) => {
-                // Already loading the next node, just wait
+            CurrentNodeState::Loading { node_offset, fut } => {
                 match fut.poll_unpin(cx) {
                     Poll::Pending => {
                         return Poll::Pending;
@@ -714,7 +717,11 @@ fn poll_read_file_at<C: ContentLoader + 'static>(
                         match node.links_owned() {
                             Ok(links) => {
                                 current_links.push(links);
-                                *current_node = CurrentNodeState::Loaded(0, node);
+                                *current_node = CurrentNodeState::Loaded {
+                                    node_offset: *node_offset,
+                                    node_pos: *pos - *node_offset,
+                                    node,
+                                };
                             }
                             Err(e) => {
                                 return Poll::Ready(Err(std::io::Error::new(
@@ -726,7 +733,9 @@ fn poll_read_file_at<C: ContentLoader + 'static>(
                         // TODO: do one read
                     }
                     Poll::Ready(Err(e)) => {
-                        *current_node = CurrentNodeState::None;
+                        *current_node = CurrentNodeState::NextNodeRequested {
+                            next_node_offset: *node_offset,
+                        };
                         return Poll::Ready(Err(std::io::Error::new(
                             std::io::ErrorKind::InvalidData,
                             e.to_string(),
@@ -734,98 +743,48 @@ fn poll_read_file_at<C: ContentLoader + 'static>(
                     }
                 }
             }
-            CurrentNodeState::Loaded(ref mut node_pos, ref mut current_node_inner) => {
-                // already loaded
-                let ty = current_node_inner.typ();
-                match current_node_inner {
-                    UnixfsNode::Raw(data) => {
-                        if node_pos < skip_pos {
-                            if *node_pos + data.len() < *skip_pos {
-                                *skip_pos -= data.len();
-                                *node_pos += data.len();
-                            } else {
-                                *node_pos += *skip_pos - *node_pos;
-                                *skip_pos = 0;
-                            }
-                        }
-
-                        let old = *node_pos;
-                        let mut node_pos_max = data.len();
-                        if let ResponseClip::Clip(n) = pos_max {
-                            if *pos >= n + old {
-                                return Poll::Ready(Ok(()));
-                            }
-                            node_pos_max = (n + old) - *pos;
-                        }
-                        let res = poll_read_buf_at_pos(
-                            node_pos,
-                            ResponseClip::Clip(node_pos_max),
-                            data,
-                            buf,
-                        );
-                        // advance global pos
-                        let amt_read = *node_pos - old;
-                        *pos += amt_read;
-                        if amt_read > 0 {
-                            return Poll::Ready(res);
-                        } else if *node_pos == data.len() {
-                            // finished reading this node
-                            if load_next_node(
-                                current_node,
-                                current_links,
-                                loader.clone(),
-                                ctx.clone(),
-                            ) {
-                                return Poll::Ready(Ok(()));
-                            }
-                        }
+            CurrentNodeState::Loaded {
+                ref node_offset,
+                ref mut node_pos,
+                node: ref mut current_node_inner,
+            } => match current_node_inner {
+                UnixfsNode::Raw(data) => {
+                    if *node_offset + data.len() <= *pos {
+                        *current_node = CurrentNodeState::NextNodeRequested {
+                            next_node_offset: node_offset + data.len(),
+                        };
+                        continue;
                     }
-                    UnixfsNode::File(node) | UnixfsNode::RawNode(node) => {
-                        // read direct node data
-                        if let Some(ref data) = node.inner.data {
-                            if node_pos < skip_pos {
-                                if *node_pos + data.len() < *skip_pos {
-                                    *skip_pos -= data.len();
-                                    *node_pos += data.len();
-                                } else {
-                                    *node_pos += *skip_pos - *node_pos;
-                                    *skip_pos = 0;
-                                }
-                            }
-                            let old = *node_pos;
-                            let mut node_pos_max = data.len();
-                            if let ResponseClip::Clip(n) = pos_max {
-                                if *pos >= n + old {
-                                    return Poll::Ready(Ok(()));
-                                }
-                                node_pos_max = (n + old) - *pos;
-                            }
-                            let res = poll_read_buf_at_pos(
-                                node_pos,
-                                ResponseClip::Clip(node_pos_max),
-                                data,
-                                buf,
-                            );
-                            let amt_read = *node_pos - old;
-                            *pos += amt_read;
-                            if amt_read > 0 {
-                                return Poll::Ready(res);
-                            }
-                        }
-                        // follow links
-                        if load_next_node(current_node, current_links, loader.clone(), ctx.clone())
-                        {
-                            return Poll::Ready(Ok(()));
-                        }
-                    }
-                    _ => {
-                        return Poll::Ready(Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            format!("invalid type nested in chunked file: {:?}", ty),
-                        )));
-                    }
+                    let bytes_read = read_data_to_buf(pos, pos_max, &data[*node_pos..], buf);
+                    *node_pos += bytes_read;
+                    return Poll::Ready(Ok(()));
                 }
-            }
+                UnixfsNode::File(node) | UnixfsNode::RawNode(node) => {
+                    if let Some(ref data) = node.inner.data {
+                        if node_offset + data.len() <= *pos {
+                            *current_node = CurrentNodeState::NextNodeRequested {
+                                next_node_offset: node_offset + data.len(),
+                            };
+                            continue;
+                        }
+                        let bytes_read = read_data_to_buf(pos, pos_max, &data[*node_pos..], buf);
+                        *node_pos += bytes_read;
+                        return Poll::Ready(Ok(()));
+                    }
+                    *current_node = CurrentNodeState::NextNodeRequested {
+                        next_node_offset: *node_offset,
+                    };
+                }
+                _ => {
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "invalid type nested in chunked file: {:?}",
+                            current_node_inner.typ()
+                        ),
+                    )));
+                }
+            },
         }
     }
 }

--- a/iroh/src/doc.rs
+++ b/iroh/src/doc.rs
@@ -70,7 +70,7 @@ with `iroh stop`.
 Daemons provide 'services'. Services work together to fullfill requests.
 There are three services:
 
-  storage  -  a database of IPFS content
+  store    -  a database of IPFS content
   p2p      -  peer-2-peer networking functionality
   gateway  -  bridge the IPFS network to HTTP
 
@@ -89,7 +89,7 @@ pub const STOP_LONG_DESCRIPTION: &str = "
 stop turns local iroh services off by killing daemon processes. There are three
 iroh services, each backed by a daemon:
 
-   storage  -  a database of IPFS content
+   store    -  a database of IPFS content
    p2p      -  peer-2-peer networking functionality
    gateway  -  bridge the IPFS network to HTTP
 


### PR DESCRIPTION
`ResponseClip` has been deleted but it is better to discuss. I did it because its semantics was not obvious, it was used for clipping both entire response and partial responses from `Node` with non-trivial transitions between them.

Worth to note, now `Range` header with value `start-end` translates to rust struct `Range` with values `start` and `end + 1`. `Range` in rust non-inclusive for right bound, it is more convinient.