### PR TITLE
(chore): de-dupe axum

### DIFF
--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.65"
 anyhow = { version = "1", features = ["backtrace"] }
 async-recursion = "1.0.0"
 async-trait = "0.1.56"
-axum = "0.5.15"
+axum = "0.6"
 bytes = "1.1.0"
 cid = "0.9"
 clap = { version = "4.0.9", features = ["derive"] }

--- a/iroh-one/Cargo.toml
+++ b/iroh-one/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.65"
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 async-trait = "0.1.56"
-axum = "0.5.1"
+axum = "0.6"
 bytes = "1.1"
 cid = "0.9"
 clap = {version = "4.0.9", features = ["derive"]}


### PR DESCRIPTION
0.6 is pulled by opentelemetry-otlp -> tonic