### PR TITLE
feat: Send all the things

### DIFF
--- a/iroh-api/src/store.rs
+++ b/iroh-api/src/store.rs
@@ -57,7 +57,7 @@ impl Store for Arc<tokio::sync::Mutex<std::collections::HashMap<Cid, Bytes>>> {
 
 fn add_blocks_to_store_chunked<S: Store>(
     store: S,
-    mut blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
+    mut blocks: Pin<Box<dyn Stream<Item = Result<Block>> + Send>>,
 ) -> impl Stream<Item = Result<(Cid, u64)>> {
     let mut chunk = Vec::new();
     let mut chunk_size = 0u64;
@@ -87,7 +87,7 @@ fn add_blocks_to_store_chunked<S: Store>(
 
 pub async fn add_blocks_to_store<S: Store>(
     store: Option<S>,
-    blocks: Pin<Box<dyn Stream<Item = Result<Block>>>>,
+    blocks: Pin<Box<dyn Stream<Item = Result<Block>> + Send>>,
 ) -> impl Stream<Item = Result<(Cid, u64)>> {
     add_blocks_to_store_chunked(store.unwrap(), blocks)
 }

--- a/iroh-unixfs/src/balanced_tree.rs
+++ b/iroh-unixfs/src/balanced_tree.rs
@@ -33,7 +33,7 @@ impl TreeBuilder {
 
     pub fn stream_tree(
         &self,
-        chunks: impl Stream<Item = std::io::Result<Bytes>>,
+        chunks: impl Stream<Item = std::io::Result<Bytes>> + Send,
     ) -> impl Stream<Item = Result<Block>> {
         match self {
             TreeBuilder::Balanced { degree } => stream_balanced_tree(chunks, *degree),
@@ -48,7 +48,7 @@ struct LinkInfo {
 }
 
 fn stream_balanced_tree(
-    in_stream: impl Stream<Item = std::io::Result<Bytes>>,
+    in_stream: impl Stream<Item = std::io::Result<Bytes>> + Send,
     degree: usize,
 ) -> impl Stream<Item = Result<Block>> {
     try_stream! {

--- a/iroh-unixfs/src/chunker.rs
+++ b/iroh-unixfs/src/chunker.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use bytes::Bytes;
-use futures::{stream::LocalBoxStream, Stream};
+use futures::{stream::BoxStream, Stream};
 use tokio::io::AsyncRead;
 
 mod fixed;
@@ -92,8 +92,8 @@ impl From<ChunkerConfig> for Chunker {
 }
 
 pub enum ChunkerStream<'a> {
-    Fixed(LocalBoxStream<'a, io::Result<Bytes>>),
-    Rabin(LocalBoxStream<'a, io::Result<Bytes>>),
+    Fixed(BoxStream<'a, io::Result<Bytes>>),
+    Rabin(BoxStream<'a, io::Result<Bytes>>),
 }
 
 impl<'a> Debug for ChunkerStream<'a> {
@@ -127,7 +127,7 @@ impl<'a> Stream for ChunkerStream<'a> {
 }
 
 impl Chunker {
-    pub fn chunks<'a, R: AsyncRead + Unpin + 'a>(self, source: R) -> ChunkerStream<'a> {
+    pub fn chunks<'a, R: AsyncRead + Unpin + Send + 'a>(self, source: R) -> ChunkerStream<'a> {
         match self {
             Self::Fixed(chunker) => ChunkerStream::Fixed(chunker.chunks(source)),
             Self::Rabin(chunker) => ChunkerStream::Rabin(chunker.chunks(source)),

--- a/iroh-unixfs/src/chunker/fixed.rs
+++ b/iroh-unixfs/src/chunker/fixed.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use bytes::{Bytes, BytesMut};
-use futures::{stream::LocalBoxStream, StreamExt};
+use futures::{stream::BoxStream, StreamExt};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 /// Default size for chunks.
@@ -27,10 +27,10 @@ impl Fixed {
         Self { chunk_size }
     }
 
-    pub fn chunks<'a, R: AsyncRead + Unpin + 'a>(
+    pub fn chunks<'a, R: AsyncRead + Unpin + Send + 'a>(
         self,
         mut source: R,
-    ) -> LocalBoxStream<'a, io::Result<Bytes>> {
+    ) -> BoxStream<'a, io::Result<Bytes>> {
         let chunk_size = self.chunk_size;
         async_stream::stream! {
             let mut buffer = BytesMut::with_capacity(chunk_size);
@@ -70,7 +70,7 @@ impl Fixed {
                 }
             }
         }
-        .boxed_local()
+        .boxed()
     }
 }
 

--- a/iroh-unixfs/src/chunker/rabin.rs
+++ b/iroh-unixfs/src/chunker/rabin.rs
@@ -3,7 +3,7 @@
 use std::io;
 
 use bytes::{Bytes, BytesMut};
-use futures::{stream::LocalBoxStream, StreamExt};
+use futures::{stream::BoxStream, StreamExt};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 /// Rabin fingerprinting based chunker.
@@ -46,10 +46,10 @@ impl Rabin {
         }
     }
 
-    pub fn chunks<'a, R: AsyncRead + Unpin + 'a>(
+    pub fn chunks<'a, R: AsyncRead + Unpin + Send + 'a>(
         self,
         mut source: R,
-    ) -> LocalBoxStream<'a, io::Result<Bytes>> {
+    ) -> BoxStream<'a, io::Result<Bytes>> {
         async_stream::stream! {
             let target_size = 3 * self.config.max_size;
             let mut buf = BytesMut::with_capacity(target_size);
@@ -142,7 +142,7 @@ impl Rabin {
                 let _ = buf.split_to(cur_idx);
             }
         }
-        .boxed_local()
+        .boxed()
     }
 }
 

--- a/iroh/src/fixture.rs
+++ b/iroh/src/fixture.rs
@@ -51,7 +51,7 @@ fn fixture_get() -> Api {
                 OutType::Reader(Box::new(std::io::Cursor::new("hello"))),
             )),
         ])
-        .boxed_local())
+        .boxed())
     });
     api
 }
@@ -104,7 +104,7 @@ fn fixture_get_wrapped_file() -> Api {
                 OutType::Reader(Box::new(std::io::Cursor::new("hello"))),
             )),
         ])
-        .boxed_local())
+        .boxed())
     });
     api
 }
@@ -116,7 +116,7 @@ fn fixture_get_unwrapped_file() -> Api {
             RelativePathBuf::from_path("").unwrap(),
             OutType::Reader(Box::new(std::io::Cursor::new("hello"))),
         ))])
-        .boxed_local())
+        .boxed())
     });
     api
 }
@@ -131,7 +131,7 @@ fn fixture_get_wrapped_symlink() -> Api {
                 OutType::Symlink(PathBuf::from("target/path/foo.txt")),
             )),
         ])
-        .boxed_local())
+        .boxed())
     });
     api
 }
@@ -143,7 +143,7 @@ fn fixture_get_unwrapped_symlink() -> Api {
             RelativePathBuf::from_path("").unwrap(),
             OutType::Symlink(PathBuf::from("target/path/foo.txt")),
         ))])
-        .boxed_local())
+        .boxed())
     });
     api
 }


### PR DESCRIPTION
Implements #616

There does not seem to be any fundamental reason why the API stuff has to be non send. Just that we did not do the effort to add Send in a few places.

We might want to DRY the trait bounds at some point...