### PR TITLE
fix(ci): Set the protoc-arch matrix for weekly job

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [beta]
+        protoc-arch: [linux-x86_64]
 
     runs-on: ubuntu-latest
 
@@ -27,7 +28,6 @@ jobs:
           echo "PROTOC_ARCH=${{ matrix.protoc-arch }}" >> $GITHUB_ENV
 
       - name: Install Protoc
-        if: matrix.os != 'windows-latest'
         run: |
           PROTOC_VERSION=3.20.1
           PROTOC_ZIP=protoc-$PROTOC_VERSION-$PROTOC_ARCH.zip


### PR DESCRIPTION
This is used to select the architecture of the protoc compiler to
download.  It doesn't need to be so dynamic in this workflow but
keeping it this way makes it more similar to the main ci workflow and
thus hopefully easier to maintain.

Closes #618 