### PR TITLE
fix(ci): Call cargo with beta toolchain from env var

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: clippy all features
         run: |
-          cargo +RUSTV clippy --workspace --all-features --all-targets -- -D warnings
+          cargo +$RUSTV clippy --workspace --all-features --all-targets -- -D warnings
 
       - name: Create Issue if clippy failed
         if: ${{ failure() }}


### PR DESCRIPTION
This should be an env var.  Of course.  Debugging ci is just so
painful and slow. :(

Closes #621