### PR TITLE
fix(iroh-p2p): ensure `providers` stream closes

### DIFF
--- a/iroh-p2p/src/node.rs
+++ b/iroh-p2p/src/node.rs
@@ -1676,7 +1676,7 @@ mod tests {
             // when `start_providing` waits for the record to make it to the dht
             // we can remove this polling
             let providers = tokio::time::timeout(
-                Duration::from_millis(5000),
+                Duration::from_secs(7),
                 poll_for_providers(test_runner_a.client.clone(), &cid),
             )
             .await

--- a/iroh-p2p/src/node.rs
+++ b/iroh-p2p/src/node.rs
@@ -51,7 +51,6 @@ pub enum NetworkEvent {
     PeerDisconnected(PeerId),
     Gossipsub(GossipsubEvent),
     CancelLookupQuery(PeerId),
-    RoutingTableUpdate(PeerId),
 }
 
 #[derive(Debug, Clone)]
@@ -512,129 +511,114 @@ impl<KeyStorage: Storage> Node<KeyStorage> {
             Event::Kademlia(e) => {
                 libp2p_metrics().record(&e);
 
-                // TODO(ramfox): potentially refactor back to one type of kad event
-                match e {
-                    KademliaEvent::OutboundQueryProgressed {
-                        id, result, step, ..
-                    } => {
-                        match result {
-                            QueryResult::GetProviders(Ok(p)) => {
-                                match p {
-                                    GetProvidersOk::FoundProviders { key, providers } => {
-                                        let swarm = self.swarm.behaviour_mut();
-                                        if let Some(kad) = swarm.kad.as_mut() {
-                                            debug!(
-                                                "provider results for {:?} last: {}",
-                                                key, step.last
-                                            );
+                if let KademliaEvent::OutboundQueryProgressed {
+                    id, result, step, ..
+                } = e
+                {
+                    match result {
+                        QueryResult::GetProviders(Ok(p)) => {
+                            match p {
+                                GetProvidersOk::FoundProviders { key, providers } => {
+                                    let swarm = self.swarm.behaviour_mut();
+                                    if let Some(kad) = swarm.kad.as_mut() {
+                                        debug!(
+                                            "provider results for {:?} last: {}",
+                                            key, step.last
+                                        );
 
-                                            // Filter out bad providers.
-                                            let providers: HashSet<_> = providers
-                                                .into_iter()
-                                                .filter(|provider| {
-                                                    let is_bad =
-                                                        swarm.peer_manager.is_bad_peer(provider);
-                                                    if is_bad {
-                                                        inc!(P2PMetrics::SkippedPeerKad);
-                                                    }
-                                                    !is_bad
-                                                })
-                                                .collect();
+                                        // Filter out bad providers.
+                                        let providers: HashSet<_> = providers
+                                            .into_iter()
+                                            .filter(|provider| {
+                                                let is_bad =
+                                                    swarm.peer_manager.is_bad_peer(provider);
+                                                if is_bad {
+                                                    inc!(P2PMetrics::SkippedPeerKad);
+                                                }
+                                                !is_bad
+                                            })
+                                            .collect();
 
-                                            self.providers.handle_get_providers_ok(
-                                                id, step.last, key, providers, kad,
-                                            );
-                                        }
-                                    }
-                                    GetProvidersOk::FinishedWithNoAdditionalRecord { .. } => {
-                                        let swarm = self.swarm.behaviour_mut();
-                                        if let Some(kad) = swarm.kad.as_mut() {
-                                            debug!(
-                                                "FinishedWithNoAdditionalRecord for query {:#?}",
-                                                id
-                                            );
-                                            self.providers.handle_no_additional_records(id, kad);
-                                        }
+                                        self.providers.handle_get_providers_ok(
+                                            id, step.last, key, providers, kad,
+                                        );
                                     }
                                 }
-                            }
-                            QueryResult::GetProviders(Err(error)) => {
-                                if let Some(kad) = self.swarm.behaviour_mut().kad.as_mut() {
-                                    self.providers.handle_get_providers_error(id, error, kad);
-                                }
-                            }
-                            QueryResult::Bootstrap(Ok(BootstrapOk {
-                                peer,
-                                num_remaining,
-                            })) => {
-                                debug!(
-                                    "kad bootstrap done {:?}, remaining: {}",
-                                    peer, num_remaining
-                                );
-                            }
-                            QueryResult::Bootstrap(Err(e)) => {
-                                warn!("kad bootstrap error: {:?}", e);
-                            }
-                            QueryResult::GetClosestPeers(Ok(GetClosestPeersOk { key, peers })) => {
-                                debug!("GetClosestPeers ok {:?}", key);
-                                if let Some((peer_id, channels)) =
-                                    self.find_on_dht_queries.remove(&key)
-                                {
-                                    let have_peer = peers.contains(&peer_id);
-                                    // if this is not the last step we will have more chances to find
-                                    // the peer
-                                    if !have_peer && !step.last {
-                                        return Ok(());
+                                GetProvidersOk::FinishedWithNoAdditionalRecord { .. } => {
+                                    let swarm = self.swarm.behaviour_mut();
+                                    if let Some(kad) = swarm.kad.as_mut() {
+                                        debug!(
+                                            "FinishedWithNoAdditionalRecord for query {:#?}",
+                                            id
+                                        );
+                                        self.providers.handle_no_additional_records(id, kad);
                                     }
-                                    let res = move || {
-                                        if have_peer {
-                                            Ok(())
-                                        } else {
-                                            Err(anyhow!(
-                                                "Failed to find peer {:?} on the DHT",
-                                                peer_id
-                                            ))
-                                        }
-                                    };
-                                    tokio::task::spawn(async move {
-                                        for chan in channels.into_iter() {
-                                            chan.send(res()).ok();
-                                        }
-                                    });
                                 }
-                            }
-                            QueryResult::GetClosestPeers(Err(GetClosestPeersError::Timeout {
-                                key,
-                                ..
-                            })) => {
-                                debug!("GetClosestPeers Timeout: {:?}", key);
-                                if let Some((peer_id, channels)) =
-                                    self.find_on_dht_queries.remove(&key)
-                                {
-                                    tokio::task::spawn(async move {
-                                        for chan in channels.into_iter() {
-                                            chan.send(Err(anyhow!(
-                                                "Failed to find peer {:?} on the DHT: Timeout",
-                                                peer_id
-                                            )))
-                                            .ok();
-                                        }
-                                    });
-                                }
-                            }
-                            other => {
-                                debug!("Libp2p => Unhandled Kademlia query result: {:?}", other)
                             }
                         }
-                    }
-                    KademliaEvent::RoutingUpdated {
-                        peer, is_new_peer, ..
-                    } => {
-                        if is_new_peer {
-                            self.emit_network_event(NetworkEvent::RoutingTableUpdate(peer));
+                        QueryResult::GetProviders(Err(error)) => {
+                            if let Some(kad) = self.swarm.behaviour_mut().kad.as_mut() {
+                                self.providers.handle_get_providers_error(id, error, kad);
+                            }
+                        }
+                        QueryResult::Bootstrap(Ok(BootstrapOk {
+                            peer,
+                            num_remaining,
+                        })) => {
+                            debug!(
+                                "kad bootstrap done {:?}, remaining: {}",
+                                peer, num_remaining
+                            );
+                        }
+                        QueryResult::Bootstrap(Err(e)) => {
+                            warn!("kad bootstrap error: {:?}", e);
+                        }
+                        QueryResult::GetClosestPeers(Ok(GetClosestPeersOk { key, peers })) => {
+                            debug!("GetClosestPeers ok {:?}", key);
+                            if let Some((peer_id, channels)) = self.find_on_dht_queries.remove(&key)
+                            {
+                                let have_peer = peers.contains(&peer_id);
+                                // if this is not the last step we will have more chances to find
+                                // the peer
+                                if !have_peer && !step.last {
+                                    return Ok(());
+                                }
+                                let res = move || {
+                                    if have_peer {
+                                        Ok(())
+                                    } else {
+                                        Err(anyhow!("Failed to find peer {:?} on the DHT", peer_id))
+                                    }
+                                };
+                                tokio::task::spawn(async move {
+                                    for chan in channels.into_iter() {
+                                        chan.send(res()).ok();
+                                    }
+                                });
+                            }
+                        }
+                        QueryResult::GetClosestPeers(Err(GetClosestPeersError::Timeout {
+                            key,
+                            ..
+                        })) => {
+                            debug!("GetClosestPeers Timeout: {:?}", key);
+                            if let Some((peer_id, channels)) = self.find_on_dht_queries.remove(&key)
+                            {
+                                tokio::task::spawn(async move {
+                                    for chan in channels.into_iter() {
+                                        chan.send(Err(anyhow!(
+                                            "Failed to find peer {:?} on the DHT: Timeout",
+                                            peer_id
+                                        )))
+                                        .ok();
+                                    }
+                                });
+                            }
+                        }
+                        other => {
+                            debug!("Libp2p => Unhandled Kademlia query result: {:?}", other)
                         }
                     }
-                    _ => {}
                 }
             }
             Event::Identify(e) => {
@@ -1357,7 +1341,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_two_nodes() -> Result<()> {
-        let mut test_runner_a = TestRunnerBuilder::new().no_bootstrap().build().await?;
+        let test_runner_a = TestRunnerBuilder::new().no_bootstrap().build().await?;
         // peer_id 12D3KooWLo6JTNKXfjkZtKf8ooLQoXVXUEeuu4YDY3CYqK6rxHXt
         let test_runner_b = TestRunnerBuilder::new()
             .no_bootstrap()
@@ -1376,26 +1360,6 @@ mod tests {
         // have any information about our observed addresses
         assert!(lookup_a.observed_addrs.is_empty());
         assert_lookup(lookup_a, test_runner_a.peer_id, &test_runner_a.addr)?;
-
-        // ensure we remove the lookup query if we error while attempting to
-        // identify a peer id
-        let res = test_runner_a.client.lookup(peer_id_b, None).await;
-        assert!(res.is_err());
-
-        let mut found_cancel = false;
-        while let Some(event) = test_runner_a.network_events.recv().await {
-            if let NetworkEvent::CancelLookupQuery(p) = event {
-                assert_eq!(peer_id_b, p);
-                found_cancel = true;
-                break;
-            }
-        }
-
-        if !found_cancel {
-            panic!(
-                "expected to find a `NetworkEvent::CancelLookupQuery` on a failing `lookup` call"
-            );
-        }
 
         // connect
         test_runner_a.client.connect(peer_id_b, addrs_b).await?;
@@ -1604,102 +1568,100 @@ mod tests {
 
     #[tokio::test]
     async fn test_dht() -> Result<()> {
-        for _ in 0..10 {
-            // set up three nodes
-            // two connect to one
-            // try to connect via id
-            let cid: Cid = "bafkreieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq"
-                .parse()
-                .unwrap();
+        // set up three nodes
+        // two connect to one
+        // try to connect via id
+        let cid: Cid = "bafkreieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq"
+            .parse()
+            .unwrap();
 
-            let test_runner_a = TestRunnerBuilder::new().no_bootstrap().build().await?;
-            println!("peer_a: {:?}", test_runner_a.peer_id);
+        let test_runner_a = TestRunnerBuilder::new().no_bootstrap().build().await?;
+        println!("peer_a: {:?}", test_runner_a.peer_id);
 
-            // peer_id 12D3KooWLo6JTNKXfjkZtKf8ooLQoXVXUEeuu4YDY3CYqK6rxHXt
-            let mut test_runner_b = TestRunnerBuilder::new()
-                .no_bootstrap()
-                .with_seed(ChaCha8Rng::from_seed([0; 32]))
-                .build()
-                .await?;
-            let addrs = vec![test_runner_b.addr.clone()];
+        // peer_id 12D3KooWLo6JTNKXfjkZtKf8ooLQoXVXUEeuu4YDY3CYqK6rxHXt
+        let mut test_runner_b = TestRunnerBuilder::new()
+            .no_bootstrap()
+            .with_seed(ChaCha8Rng::from_seed([0; 32]))
+            .build()
+            .await?;
+        let addrs = vec![test_runner_b.addr.clone()];
 
-            println!("peer_b: {:?}", test_runner_b.peer_id);
+        println!("peer_b: {:?}", test_runner_b.peer_id);
 
-            let test_runner_c = TestRunnerBuilder::new()
-                .no_bootstrap()
-                .with_seed(ChaCha8Rng::from_seed([1; 32]))
-                .build()
-                .await?;
+        let test_runner_c = TestRunnerBuilder::new()
+            .no_bootstrap()
+            .with_seed(ChaCha8Rng::from_seed([1; 32]))
+            .build()
+            .await?;
 
-            println!("peer_c: {:?}", test_runner_c.peer_id);
+        println!("peer_c: {:?}", test_runner_c.peer_id);
 
-            // connect a and c to b
-            test_runner_a
-                .client
-                .connect(test_runner_b.peer_id, addrs.clone())
-                .await?;
+        // connect a and c to b
+        test_runner_a
+            .client
+            .connect(test_runner_b.peer_id, addrs.clone())
+            .await?;
 
-            // expect a network event showing a & b have connected
-            match test_runner_b.network_events.recv().await {
-                Some(NetworkEvent::PeerConnected(peer_id)) => {
-                    assert_eq!(test_runner_a.peer_id, peer_id);
-                }
-                Some(n) => {
-                    anyhow::bail!("unexpected network event: {:?}", n);
-                }
-                None => {
-                    anyhow::bail!("expected NetworkEvent::PeerConnected, received no event");
-                }
-            };
+        // expect a network event showing a & b have connected
+        match test_runner_b.network_events.recv().await {
+            Some(NetworkEvent::PeerConnected(peer_id)) => {
+                assert_eq!(test_runner_a.peer_id, peer_id);
+            }
+            Some(n) => {
+                anyhow::bail!("unexpected network event: {:?}", n);
+            }
+            None => {
+                anyhow::bail!("expected NetworkEvent::PeerConnected, received no event");
+            }
+        };
 
-            test_runner_c
-                .client
-                .connect(test_runner_b.peer_id, addrs.clone())
-                .await?;
+        test_runner_c
+            .client
+            .connect(test_runner_b.peer_id, addrs.clone())
+            .await?;
 
-            // expect a network event showing b & c have connected
-            match test_runner_b.network_events.recv().await {
-                Some(NetworkEvent::PeerConnected(peer_id)) => {
-                    assert_eq!(test_runner_c.peer_id, peer_id);
-                }
-                Some(n) => {
-                    anyhow::bail!("unexpected network event: {:?}", n);
-                }
-                None => {
-                    anyhow::bail!("expected NetworkEvent::PeerConnected, received no event");
-                }
-            };
+        // expect a network event showing b & c have connected
+        match test_runner_b.network_events.recv().await {
+            Some(NetworkEvent::PeerConnected(peer_id)) => {
+                assert_eq!(test_runner_c.peer_id, peer_id);
+            }
+            Some(n) => {
+                anyhow::bail!("unexpected network event: {:?}", n);
+            }
+            None => {
+                anyhow::bail!("expected NetworkEvent::PeerConnected, received no event");
+            }
+        };
 
-            // c start providing
-            test_runner_c.client.start_providing(&cid).await?;
+        // c start providing
+        test_runner_c.client.start_providing(&cid).await?;
 
-            // when `start_providing` waits for the record to make it to the dht
-            // we can remove this polling
-            let providers = tokio::time::timeout(
-                Duration::from_secs(7),
-                poll_for_providers(test_runner_a.client.clone(), &cid),
-            )
-            .await
-            .context("timed out before finding providers for the given cid")??;
+        // when `start_providing` waits for the record to make it to the dht
+        // we can remove this polling
+        let providers = tokio::time::timeout(
+            Duration::from_secs(6),
+            poll_for_providers(test_runner_a.client.clone(), &cid),
+        )
+        .await
+        .context("timed out before finding providers for the given cid")??;
 
-            assert!(providers.len() == 1);
-            assert!(providers.get(0).unwrap().contains(&test_runner_c.peer_id));
+        assert!(providers.len() == 1);
+        assert!(providers.get(0).unwrap().contains(&test_runner_c.peer_id));
 
-            // c stop providing
-            test_runner_c.client.stop_providing(&cid).await?;
+        // c stop providing
+        test_runner_c.client.stop_providing(&cid).await?;
 
-            // a fetch providers dht should not get any providers
-            let stream = test_runner_a.client.fetch_providers_dht(&cid).await?;
-            let providers: Vec<_> = stream.try_collect().await.unwrap();
+        // a fetch providers dht should not get any providers
+        let stream = test_runner_a.client.fetch_providers_dht(&cid).await?;
+        let providers: Vec<_> = stream.try_collect().await.unwrap();
 
-            assert!(providers.is_empty());
+        assert!(providers.is_empty());
 
-            // try to connect a to c using only peer_id
-            test_runner_a
-                .client
-                .connect(test_runner_c.peer_id, vec![])
-                .await?;
-        }
+        // try to connect a to c using only peer_id
+        test_runner_a
+            .client
+            .connect(test_runner_c.peer_id, vec![])
+            .await?;
         Ok(())
     }
 

--- a/iroh-p2p/src/providers.rs
+++ b/iroh-p2p/src/providers.rs
@@ -163,6 +163,21 @@ impl Providers {
         }
     }
 
+    pub fn handle_no_additional_records(&mut self, id: QueryId, kad: &mut Kademlia<MemoryStore>) {
+        let mut key = None;
+        for (k, q) in self.current_queries.iter() {
+            if q.query_id == id {
+                key = Some(k.clone());
+                break;
+            }
+        }
+        if let Some(key) = key {
+            self.current_queries.remove(&key);
+            // we freed a spot, poll for advancing queries
+            self.poll(kad);
+        }
+    }
+
     pub fn handle_get_providers_error(
         &mut self,
         id: QueryId,


### PR DESCRIPTION
Also implements final p2p unit test to close #455
Bug fix fixes the flakey dht tests #518

Some notes:
- Before we could get to fixing the flakiness, the test was hanging due to a bug in the `Providers` query manager. To summarize the issue: we weren't reacting to `GetProvidersOk::FinishedWithNoAdditionalRecord` events, which indicate no more records were found. Because this event was never handled, we never removed the `Query` from the `providers` Set, and so the stream of providers never closed, causing the `test_dht` test to hang.

- To test reliability, I looped the `test_dht` 10 times for my initial commits, but removed the loop it once things stabilized.

- I did a whole pass where the node emitted an event whenever the kbuckets were updated, and used that event to ensure everything was "in place" before attempting to `StartProviding` and `fetch_providers_dht`. However... this made things less reliable! So I removed it. It also would have potentially added a lot of "noise" to the `network_event` stream.

- The only thing that actually stabilized the test (when attempting multiple loops)... was increasing the timeout by 1 second. I'm not sure how to feel about this.

- In order to test the `CancelListenForIdentify`, I had to add a `NetworkEvent` that would emit after this cancellation happens. There was no other way I could think of that would allow us to inspect the node itself without breaking the borrow checker. This event would only ever be emitted due to a user action (manually attempting to lookup a peer), so I'm not concerned about it polluting the event space.