### PR TITLE
chore: update quic-rpc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ prometheus-client = "0.18"
 proptest = "1"
 prost = "0.11"
 prost-build = "0.11.1"
-quic-rpc = { version = "0.2.2", default-features = false }
+quic-rpc = { version = "0.2.3", default-features = false }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rayon = "1.5.3"

--- a/iroh-rpc-client/src/lib.rs
+++ b/iroh-rpc-client/src/lib.rs
@@ -53,8 +53,7 @@ pub async fn create_server<S: Service>(
             // Ok(Some(RpcServer::new(combined::Channel::new(Some(addr), None))))
         }
         Addr::Irpc(addr) => {
-            let (channel, hyper) = quic_rpc::transport::http2::ServerChannel::new(&addr)?;
-            tokio::spawn(hyper);
+            let channel = quic_rpc::transport::http2::ServerChannel::serve(&addr)?;
             let channel = combined::ServerChannel::new(Some(channel), None);
             let server = RpcServer::new(channel);
             Ok(server)


### PR DESCRIPTION
This should give us better termination and also solve some issues with rpc messages being too large.

It probably allocates needlessly large buffers for each hyper connection, but that is preferable to getting errors. We will get rid of this with a subsequent quic-rpc update.