### PR TITLE
fix(iroh): handle connection refused errors with pretty messages again

### DIFF
--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -29,6 +29,7 @@ indicatif.workspace = true
 iroh-api.workspace = true
 iroh-localops.workspace = true
 iroh-metrics.workspace = true
+iroh-rpc-client.workspace = true
 iroh-util.workspace = true
 iroh-unixfs.workspace = true
 relative-path = { workspace = true, optional = true }


### PR DESCRIPTION
Bring back this message when nothings running:
```
$ iroh get foo
Error: Connection refused. Are services running?
hint: see 'iroh start' for more on starting services
```

Also pick up a neat little refactor that drops inner match statements