### PR TITLE
chore: update quic-rpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ prometheus-client = "0.18"
 proptest = "1"
 prost = "0.11"
 prost-build = "0.11.1"
-quic-rpc = { version = "0.2.3", default-features = false }
+quic-rpc = { version = "0.3.0", default-features = false }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rayon = "1.5.3"


### PR DESCRIPTION
This should at least get rid of the errors when receiving empty frames