### PR TITLE
fix(deps): We use the serde feature from Url

### DIFF
--- a/iroh-unixfs/Cargo.toml
+++ b/iroh-unixfs/Cargo.toml
@@ -31,6 +31,7 @@ once_cell.workspace = true
 prost.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "json"] }
+url = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["fs"] }

--- a/iroh-unixfs/src/indexer.rs
+++ b/iroh-unixfs/src/indexer.rs
@@ -6,9 +6,10 @@ use cid::Cid;
 use config::ValueKind;
 use libp2p::{Multiaddr, PeerId};
 use multihash::Multihash;
-use reqwest::{Client, Url};
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tracing::trace;
+use url::Url;
 
 /// Public endpoint of the indexer nodes.
 pub const CID_CONTACT: &str = "https://cid.contact/cid/";


### PR DESCRIPTION
To use the serde feature from Url you must request the feature, which
can only be done by directly depending on the Url crate instead of
pulling it in via reqwest.