### PR TITLE
fix: Remove limits checking in BitswapHandler

### DIFF
--- a/iroh-bitswap/src/lib.rs
+++ b/iroh-bitswap/src/lib.rs
@@ -26,7 +26,7 @@ use libp2p::swarm::{
 use libp2p::{Multiaddr, PeerId};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use self::client::{Client, Config as ClientConfig};
 use self::message::BitswapMessage;
@@ -326,7 +326,7 @@ impl<S: Store> Bitswap<S> {
                 if let PeerState::Connected(old_id) = old_state {
                     if let PeerState::Connected(new_id) = new_state {
                         // TODO: better understand what this means and how to handle it.
-                        warn!(
+                        info!(
                             "Peer {}: detected connection id change: {:?} => {:?}",
                             peer, old_id, new_id
                         );

--- a/iroh-p2p/Cargo.toml
+++ b/iroh-p2p/Cargo.toml
@@ -40,7 +40,7 @@ toml.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 zeroize.workspace = true
- 
+
 [dependencies.libp2p]
 workspace = true
 features = [

--- a/iroh-unixfs/src/builder.rs
+++ b/iroh-unixfs/src/builder.rs
@@ -64,7 +64,7 @@ impl Directory {
         Directory::basic(name, vec![entry])
     }
 
-    fn basic(name: String, entries: Vec<Entry>) -> Self {
+    pub fn basic(name: String, entries: Vec<Entry>) -> Self {
         Directory::Basic(BasicDirectory { name, entries })
     }
 
@@ -161,7 +161,7 @@ enum Content {
 impl Debug for Content {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Content::Reader(_) => write!(f, "Content::Reader(Pin<Box<dyn AsyncRead>>)"),
+            Content::Reader(_) => write!(f, "Content::Reader(Pin<Box<dyn AsyncRead + Send>>)"),
             Content::Path(p) => write!(f, "Content::Path({})", p.display()),
         }
     }
@@ -359,7 +359,7 @@ impl FileBuilder {
         self
     }
 
-    pub fn content_reader<T: tokio::io::AsyncRead + Send + 'static>(mut self, content: T) -> Self {
+    pub fn content_reader<T: AsyncRead + Send + 'static>(mut self, content: T) -> Self {
         self.reader = Some(Box::pin(content));
         self
     }


### PR DESCRIPTION
I was debugging the case when only two nodes are launched, iroh and kubo, the first one trying to download a lot of data from the second one. It just didn't worked and stucked at first blocks.

Seems that bitswap handler implementation has been copied from gossipsub and uses the same inbound substream limiting logic that is possibly not correct for BitSwap.

`inbound_substream` counter never decreases and hit limits very soon, then iroh disconnects from kubo, reconnects and goes into erratic state (worth to debug too).