### PR TITLE
chore(clippy): Place identifiers in format string

### DIFF
--- a/iroh-api/benches/add.rs
+++ b/iroh-api/benches/add.rs
@@ -24,7 +24,7 @@ fn add_benchmark(c: &mut Criterion) {
     {
         let value = vec![8u8; *file_size];
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join(format!("{}.raw", file_size));
+        let path = dir.path().join(format!("{file_size}.raw"));
         std::fs::write(&path, value).unwrap();
 
         group.throughput(criterion::Throughput::Bytes(*file_size as u64));

--- a/iroh-bitswap/src/peer_task_queue.rs
+++ b/iroh-bitswap/src/peer_task_queue.rs
@@ -289,7 +289,7 @@ mod tests {
         // add blocks for all letters
         for letter in shuffled_alphabet {
             let i = alphabet.iter().position(|c| *c == letter).unwrap();
-            println!("{} - {}", letter, i);
+            println!("{letter} - {i}");
             ptq.push_task(
                 partner,
                 Task {
@@ -633,7 +633,7 @@ mod tests {
         let mut targets = Vec::new();
         for i in 0..n {
             let (peer, tasks, _) = ptq.pop_tasks(1).await.unwrap();
-            assert_eq!(tasks.len(), 1, "task {} did not match: {:?}", i, tasks);
+            assert_eq!(tasks.len(), 1, "task {i} did not match: {tasks:?}");
             targets.push(peer);
         }
         assert_eq_unordered(expected, targets);

--- a/iroh-one/src/main.rs
+++ b/iroh-one/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
     };
 
     config.metrics = metrics::metrics_config_with_compile_time_info(config.metrics);
-    println!("{:#?}", config);
+    println!("{config:#?}");
 
     let metrics_config = config.metrics.clone();
 

--- a/iroh-p2p/src/keys.rs
+++ b/iroh-p2p/src/keys.rs
@@ -299,7 +299,7 @@ fn path_is_private_key<P: AsRef<Path>>(path: P) -> bool {
 fn print_algorithm(alg: ssh_key::Algorithm) -> &'static str {
     match alg {
         ssh_key::Algorithm::Ed25519 => "ed25519",
-        _ => panic!("unusupported algorithm {}", alg),
+        _ => panic!("unusupported algorithm {alg}"),
     }
 }
 

--- a/iroh-p2p/src/node.rs
+++ b/iroh-p2p/src/node.rs
@@ -155,7 +155,7 @@ impl<KeyStorage: Storage> Node<KeyStorage> {
 
         for addr in &libp2p_config.listening_multiaddrs {
             Swarm::listen_on(&mut swarm, addr.clone())?;
-            println!("{}", addr);
+            println!("{addr}");
         }
 
         Ok(Node {
@@ -1310,12 +1310,12 @@ mod tests {
                 assert!(!new_providers.is_empty());
 
                 for p in &new_providers {
-                    println!("{}", p);
+                    println!("{p}");
                     providers.push(*p);
                 }
             }
 
-            println!("{:?}", providers);
+            println!("{providers:?}");
             assert!(!providers.is_empty());
             assert!(
                 providers.len() >= DEFAULT_PROVIDER_LIMIT,

--- a/iroh-resolver/src/resolver.rs
+++ b/iroh-resolver/src/resolver.rs
@@ -1178,7 +1178,7 @@ mod tests {
         ];
 
         for test in roundtrip_tests {
-            println!("{}", test);
+            println!("{test}");
             let p: Path = test.parse().unwrap();
             assert_eq!(p.to_string(), test);
         }
@@ -1188,7 +1188,7 @@ mod tests {
             "/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy",
         )];
         for (test_in, test_out) in valid_tests {
-            println!("{}", test_in);
+            println!("{test_in}");
             let p: Path = test_in.parse().unwrap();
             assert_eq!(p.to_string(), test_out);
         }
@@ -1200,7 +1200,7 @@ mod tests {
             "/ipfs/ipfs.io",
         ];
         for test in invalid_tests {
-            println!("{}", test);
+            println!("{test}");
             assert!(test.parse::<Path>().is_err());
         }
     }
@@ -1452,7 +1452,7 @@ mod tests {
                     "hello\n"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_hello_txt);
+                panic!("invalid result: {ipld_hello_txt:?}");
             }
         }
 
@@ -1488,7 +1488,7 @@ mod tests {
                     "hello\n"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_hello_txt);
+                panic!("invalid result: {ipld_hello_txt:?}");
             }
         }
 
@@ -1551,7 +1551,7 @@ mod tests {
                     "world\n"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_bar_txt);
+                panic!("invalid result: {ipld_bar_txt:?}");
             }
         }
     }
@@ -1609,7 +1609,7 @@ mod tests {
             let cr = seek_and_clip(ctx.clone(), &node, resolver.clone(), 1..3).await;
             assert_eq!(read_to_string(cr).await, "el");
         } else {
-            panic!("invalid result: {:?}", ipld_hello_txt);
+            panic!("invalid result: {ipld_hello_txt:?}");
         }
     }
 
@@ -1676,7 +1676,7 @@ mod tests {
                 assert!(content.starts_with("2.0</a>"));
                 assert!(content.ends_with("the Apac"));
             } else {
-                panic!("invalid result: {:?}", ipld_readme);
+                panic!("invalid result: {ipld_readme:?}");
             }
         }
     }
@@ -1845,7 +1845,7 @@ mod tests {
                     "hello\n"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_hello_txt);
+                panic!("invalid result: {ipld_hello_txt:?}");
             }
         }
 
@@ -1888,7 +1888,7 @@ mod tests {
                     "world\n"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_bar_txt);
+                panic!("invalid result: {ipld_bar_txt:?}");
             }
         }
     }
@@ -1952,12 +1952,12 @@ mod tests {
                     .unwrap(),
                 )
                 .await;
-                print!("{}", content);
+                print!("{content}");
                 assert_eq!(content.len(), 426);
                 assert!(content.starts_with("# iroh"));
                 assert!(content.ends_with("</sub>\n\n"));
             } else {
-                panic!("invalid result: {:?}", ipld_readme);
+                panic!("invalid result: {ipld_readme:?}");
             }
         }
     }
@@ -2123,7 +2123,7 @@ mod tests {
                     "hello\n"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_hello_txt);
+                panic!("invalid result: {ipld_hello_txt:?}");
             }
         }
 
@@ -2180,7 +2180,7 @@ mod tests {
                     "world\n"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_bar_txt);
+                panic!("invalid result: {ipld_bar_txt:?}");
             }
         }
 
@@ -2218,7 +2218,7 @@ mod tests {
                     "./bar.txt"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_bar_txt);
+                panic!("invalid result: {ipld_bar_txt:?}");
             }
         }
 
@@ -2256,7 +2256,7 @@ mod tests {
                     "../../hello.txt"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_bar_txt);
+                panic!("invalid result: {ipld_bar_txt:?}");
             }
         }
 
@@ -2294,7 +2294,7 @@ mod tests {
                     "../hello.txt"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_bar_txt);
+                panic!("invalid result: {ipld_bar_txt:?}");
             }
 
             let path = format!("/ipfs/{my_symlink_cid_str}");
@@ -2322,7 +2322,7 @@ mod tests {
                     "../hello.txt"
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_bar_txt);
+                panic!("invalid result: {ipld_bar_txt:?}");
             }
         }
     }
@@ -2388,7 +2388,7 @@ mod tests {
                     "world\n",
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_txt);
+                panic!("invalid result: {ipld_txt:?}");
             }
         }
         // read the directory listing
@@ -2429,7 +2429,7 @@ mod tests {
 
         for i in 1..=10000 {
             tokio::task::yield_now().await; // yield so sessions can be closed
-            let path = format!("/ipfs/{root_cid_str}/{}.txt", i);
+            let path = format!("/ipfs/{root_cid_str}/{i}.txt");
             let ipld_txt = resolver.resolve(path.parse().unwrap()).await.unwrap();
 
             assert!(ipld_txt
@@ -2456,10 +2456,10 @@ mod tests {
                         .unwrap()
                     )
                     .await,
-                    format!("{}\n", i),
+                    format!("{i}\n"),
                 );
             } else {
-                panic!("invalid result: {:?}", ipld_txt);
+                panic!("invalid result: {ipld_txt:?}");
             }
         }
     }

--- a/iroh-resolver/tests/roundtrip.rs
+++ b/iroh-resolver/tests/roundtrip.rs
@@ -167,7 +167,7 @@ async fn symlink_roundtrip_test() -> Result<()> {
     let mut reader = out.pretty(resolver, OutMetrics::default(), None)?;
     let mut t = String::new();
     reader.read_to_string(&mut t).await?;
-    println!("{}", t);
+    println!("{t}");
     assert_eq!(target, t);
     Ok(())
 }
@@ -248,7 +248,7 @@ fn test_hamt_roundtrip_3() {
 async fn test_hamt_roundtrip_large() {
     let mut dir = TestDir::new();
     for i in 0..10000 {
-        dir.insert(format!("file_{}", i), TestDirEntry::File(Bytes::new()));
+        dir.insert(format!("file_{i}"), TestDirEntry::File(Bytes::new()));
     }
     assert!(dir_roundtrip_test(dir, true).await.unwrap());
 }

--- a/iroh-resolver/tests/unixfs.rs
+++ b/iroh-resolver/tests/unixfs.rs
@@ -59,7 +59,7 @@ async fn test_dagger_testdata() -> Result<()> {
 
     for source in sources {
         for param in &params {
-            println!("== {:?} ==", source);
+            println!("== {source:?} ==");
             println!("Degree: {}", param.degree);
             println!("Chunker: {}", param.chunker);
 
@@ -81,7 +81,7 @@ async fn test_dagger_testdata() -> Result<()> {
             let out = resolver.resolve(Path::from_cid(root)).await?;
             let t = read_to_vec(out.pretty(resolver, OutMetrics::default(), None)?).await?;
 
-            println!("Root: {}", root);
+            println!("Root: {root}");
             println!("Len: {}", data.len());
             println!("Elapsed: {}s", start.elapsed().as_secs_f32());
 

--- a/iroh-share/src/main.rs
+++ b/iroh-share/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
             let ticket = sender_transfer.ticket();
             let ticket_bytes = ticket.as_bytes();
             let ticket_str = multibase::encode(multibase::Base::Base64, &ticket_bytes);
-            println!("Ticket:\n{}\n", ticket_str);
+            println!("Ticket:\n{ticket_str}\n");
             sender_transfer.done().await?;
         }
         Commands::Receive { ticket, out } => {
@@ -102,10 +102,10 @@ async fn main() -> Result<()> {
                 while let Some(ev) = progress.next().await {
                     match ev {
                         Ok(ProgressEvent::Piece { index, total }) => {
-                            println!("transferred: {}/{}", index, total);
+                            println!("transferred: {index}/{total}");
                         }
                         Err(e) => {
-                            eprintln!("transfer failed: {}", e);
+                            eprintln!("transfer failed: {e}");
                         }
                     }
                 }

--- a/iroh-share/src/sender.rs
+++ b/iroh-share/src/sender.rs
@@ -57,7 +57,7 @@ impl Sender {
             gossip_task,
         } = self;
 
-        let t = Sha256Topic::new(format!("iroh-share-{}", id));
+        let t = Sha256Topic::new(format!("iroh-share-{id}"));
         let root_dir = dir_builder.build().await?;
 
         let (done_sender, done_receiver) = oneshot();

--- a/iroh-store/benches/rpc.rs
+++ b/iroh-store/benches/rpc.rs
@@ -48,7 +48,7 @@ pub fn put_benchmark(c: &mut Criterion) {
             group.bench_with_input(
                 BenchmarkId::new(
                     "(transport, value_size)",
-                    format!("({:?}, {})", transport, value_size),
+                    format!("({transport:?}, {value_size})"),
                 ),
                 &(key, value),
                 |b, (key, value)| {
@@ -101,7 +101,7 @@ pub fn get_benchmark(c: &mut Criterion) {
             group.bench_with_input(
                 BenchmarkId::new(
                     "(transport, value_size)",
-                    format!("({:?}, {})", transport, value_size),
+                    format!("({transport:?}, {value_size})"),
                 ),
                 &(),
                 |b, _| {

--- a/iroh-unixfs/src/balanced_tree.rs
+++ b/iroh-unixfs/src/balanced_tree.rs
@@ -331,7 +331,7 @@ mod tests {
 
     async fn build_expect(num_chunks: usize, degree: usize) -> Vec<Block> {
         let tree = build_expect_tree(num_chunks, degree).await;
-        println!("{:?}", tree);
+        println!("{tree:?}");
         build_expect_vec_from_tree(tree, num_chunks, degree).await
     }
 
@@ -414,7 +414,7 @@ mod tests {
             let node = node.expect("unexpected error in balanced tree stream");
             let (got_cid, got_bytes, _) = node.into_parts();
             let len = got_bytes.len() as u64;
-            println!("node index {}", i);
+            println!("node index {i}");
             assert_eq!(expect_cid, got_cid);
             assert_eq!(expect_bytes, got_bytes);
             i += 1;

--- a/iroh/src/fixture.rs
+++ b/iroh/src/fixture.rs
@@ -275,6 +275,6 @@ pub fn get_fixture_api() -> Api {
     let fixture_name = env::var("IROH_CTL_FIXTURE").expect("IROH_CTL_FIXTURE must be set");
     let fixture = registry
         .get(&fixture_name)
-        .unwrap_or_else(|| panic!("unknown fixture: {}", fixture_name));
+        .unwrap_or_else(|| panic!("unknown fixture: {fixture_name}"));
     fixture()
 }

--- a/iroh/src/main.rs
+++ b/iroh/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     match r {
         Ok(_) => Ok(()),
         Err(e) => {
-            eprintln!("Error: {:?}", e);
+            eprintln!("Error: {e:?}");
             std::process::exit(1);
         }
     }
@@ -42,7 +42,7 @@ fn transform_error(r: Result<()>) -> Result<()> {
                 return Err(anyhow!(
                     "Connection refused. This command requires a running {} service.\n{}",
                     service,
-                    format!("hint: try 'iroh start {}'", service).yellow(),
+                    format!("hint: try 'iroh start {service}'").yellow(),
                 ));
             }
             Err(e)

--- a/iroh/src/p2p.rs
+++ b/iroh/src/p2p.rs
@@ -57,7 +57,7 @@ impl Display for PeerIdOrAddrArg {
             PeerIdOrAddr::PeerId(p) => p.to_string(),
             PeerIdOrAddr::Multiaddr(a) => a.to_string(),
         };
-        write!(f, "{}", peer_id_or_addr)
+        write!(f, "{peer_id_or_addr}")
     }
 }
 
@@ -65,7 +65,7 @@ pub async fn run_command(p2p: &P2pApi, cmd: &P2p) -> Result<()> {
     match &cmd.command {
         P2pCommands::Connect { addr } => match p2p.connect(&addr.0).await {
             Ok(_) => {
-                println!("Connected to {}!", addr);
+                println!("Connected to {addr}!");
             }
             Err(e) => return Err(e),
         },
@@ -99,7 +99,7 @@ fn display_lookup(l: &Lookup) {
     );
     l.observed_addrs
         .iter()
-        .for_each(|addr| println!("  {}", addr));
+        .for_each(|addr| println!("  {addr}"));
     println!(
         "{} {}",
         "Listening Addresses".bold().dim(),
@@ -107,7 +107,7 @@ fn display_lookup(l: &Lookup) {
     );
     l.listen_addrs
         .iter()
-        .for_each(|addr| println!("  {}", addr));
+        .for_each(|addr| println!("  {addr}"));
     println!(
         "{} {}\n  {}",
         "Protocols".bold().dim(),
@@ -120,7 +120,7 @@ fn display_peers(peers: HashMap<PeerId, Vec<Multiaddr>>) {
     // let mut pid_str: String;
     for (peer_id, addrs) in peers {
         if let Some(addr) = addrs.first() {
-            println!("{}/p2p/{}", addr, peer_id);
+            println!("{addr}/p2p/{peer_id}");
         }
     }
 }

--- a/iroh/src/p2p.rs
+++ b/iroh/src/p2p.rs
@@ -105,9 +105,7 @@ fn display_lookup(l: &Lookup) {
         "Listening Addresses".bold().dim(),
         format!("({}):", l.listen_addrs.len()).bold().dim()
     );
-    l.listen_addrs
-        .iter()
-        .for_each(|addr| println!("  {addr}"));
+    l.listen_addrs.iter().for_each(|addr| println!("  {addr}"));
     println!(
         "{} {}\n  {}",
         "Protocols".bold().dim(),

--- a/iroh/src/run.rs
+++ b/iroh/src/run.rs
@@ -220,7 +220,7 @@ async fn add(
 
     println!(
         "{} Calculating size...",
-        style(format!("[1/{}]", steps)).bold().dim()
+        style(format!("[1/{steps}]")).bold().dim()
     );
 
     let pb = ProgressBar::new_spinner();
@@ -243,7 +243,7 @@ async fn add(
 
     println!(
         "{} Importing content {}...",
-        style(format!("[2/{}]", steps)).bold().dim(),
+        style(format!("[2/{steps}]")).bold().dim(),
         human::format_bytes(total_size)
     );
 
@@ -281,7 +281,7 @@ async fn add(
         let rec_str = if cids.len() == 1 { "record" } else { "records" };
         println!(
             "{} Providing {} {} to the distributed hash table ...",
-            style(format!("[3/{}]", steps)).bold().dim(),
+            style(format!("[3/{steps}]")).bold().dim(),
             cids.len(),
             rec_str,
         );
@@ -299,7 +299,7 @@ async fn add(
         pb.finish_and_clear();
     }
 
-    println!("/ipfs/{}", root);
+    println!("/ipfs/{root}");
 
     Ok(())
 }

--- a/iroh/src/services.rs
+++ b/iroh/src/services.rs
@@ -90,8 +90,8 @@ async fn start_services(api: &Api, services: BTreeSet<&str>) -> Result<()> {
     }
 
     for service in missing_services.iter() {
-        let daemon_name = format!("iroh-{}", service);
-        let log_path = iroh_cache_path(format!("iroh-{}.log", service).as_str())?;
+        let daemon_name = format!("iroh-{service}");
+        let log_path = iroh_cache_path(format!("iroh-{service}.log").as_str())?;
 
         // check if a binary by this name exists
         let bin_path = which::which(&daemon_name).map_err(|_| {
@@ -142,7 +142,7 @@ pub async fn stop(api: &Api, services: &Vec<String>) -> Result<()> {
 
 pub async fn stop_services(api: &Api, services: BTreeSet<&str>) -> Result<()> {
     for service in services {
-        let daemon_name = format!("iroh-{}", service);
+        let daemon_name = format!("iroh-{service}");
         info!("checking daemon {} lock", daemon_name);
         let mut lock = ProgramLock::new(&daemon_name)?;
         match lock.active_pid() {
@@ -156,7 +156,7 @@ pub async fn stop_services(api: &Api, services: BTreeSet<&str>) -> Result<()> {
                         if is_down {
                             println!("{}", "stopped".red());
                         } else {
-                            eprintln!("{}", format!("{} API is still running, but the lock is removed.\nYou may need to manually stop iroh via your operating system", service).red());
+                            eprintln!("{}", format!("{service} API is still running, but the lock is removed.\nYou may need to manually stop iroh via your operating system").red());
                         }
                     }
                     Err(error) => {
@@ -166,7 +166,7 @@ pub async fn stop_services(api: &Api, services: BTreeSet<&str>) -> Result<()> {
             }
             Err(e) => match e {
                 LockError::NoLock(_) => {
-                    eprintln!("{}", format!("{} is already stopped", daemon_name).white());
+                    eprintln!("{}", format!("{daemon_name} is already stopped").white());
                 }
                 LockError::NoSuchProcess(_, _) => {
                     lock.destroy_without_checking().unwrap();
@@ -177,7 +177,7 @@ pub async fn stop_services(api: &Api, services: BTreeSet<&str>) -> Result<()> {
                     );
                 }
                 e => {
-                    eprintln!("{} lock error: {}", daemon_name, e);
+                    eprintln!("{daemon_name} lock error: {e}");
                     continue;
                 }
             },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -63,7 +63,7 @@ enum Commands {
 fn main() {
     let args = Cli::parse();
     if let Err(e) = run_subcommand(args) {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         std::process::exit(-1);
     }
 }
@@ -111,14 +111,14 @@ fn dev_install(build: bool) -> Result<()> {
     let bins = ["iroh", "iroh-one", "iroh-gateway", "iroh-p2p", "iroh-store"];
     let home = dirs_next::home_dir().unwrap();
     for bin in bins {
-        let from = project_root().join(format!("target/release/{}", bin));
+        let from = project_root().join(format!("target/release/{bin}"));
         if !from.try_exists()? {
             bail!(
                 "{} not found, did you run `cargo build --release`?",
                 from.display()
             );
         }
-        let to = home.join(format!(".cargo/bin/{}", bin));
+        let to = home.join(format!(".cargo/bin/{bin}"));
         println!("copying {} to {}", bin, to.display());
         fs::copy(from, to)?;
     }
@@ -197,18 +197,18 @@ fn build_docker(all: bool, build_images: Vec<String>, progress: String) -> Resul
     let commit = current_git_commit()?;
 
     for image in images {
-        println!("building {}:{}", image, commit);
+        println!("building {image}:{commit}");
         let status = Command::new("docker")
             .current_dir(project_root())
             .args([
                 "build",
                 "-t",
-                format!("n0computer/{}:{}", image, commit).as_str(),
+                format!("n0computer/{image}:{commit}").as_str(),
                 "-t",
-                format!("n0computer/{}:latest", image).as_str(),
+                format!("n0computer/{image}:latest").as_str(),
                 "-f",
-                format!("docker/Dockerfile.{}", image).as_str(),
-                format!("--progress={}", progress).as_str(),
+                format!("docker/Dockerfile.{image}").as_str(),
+                format!("--progress={progress}").as_str(),
                 ".",
             ])
             .status()?;
@@ -241,20 +241,20 @@ fn buildx_docker(all: bool, build_images: Vec<String>, platforms: String) -> Res
     // println!("created buildx instance: {}", buildx_instance);
 
     for image in images {
-        println!("building {}:{}", image, commit);
+        println!("building {image}:{commit}");
         let status = Command::new("docker")
             .current_dir(project_root())
             .args([
                 "buildx",
                 "build",
                 "--push",
-                format!("--platform={}", platforms).as_str(),
+                format!("--platform={platforms}").as_str(),
                 "--tag",
-                format!("n0computer/{}:{}", image, commit).as_str(),
+                format!("n0computer/{image}:{commit}").as_str(),
                 "--tag",
-                format!("n0computer/{}:latest", image).as_str(),
+                format!("n0computer/{image}:latest").as_str(),
                 "-f",
-                format!("docker/Dockerfile.{}", image).as_str(),
+                format!("docker/Dockerfile.{image}").as_str(),
                 ".",
             ])
             .status()?;
@@ -287,20 +287,20 @@ fn push_docker(all: bool, images: Vec<String>) -> Result<()> {
     let count = images.len() * 2;
 
     for image in images {
-        println!("pushing {}:{}", image, commit);
+        println!("pushing {image}:{commit}");
         Command::new("docker")
             .current_dir(project_root())
-            .args(["push", format!("n0computer/{}:{}", image, commit).as_str()])
+            .args(["push", format!("n0computer/{image}:{commit}").as_str()])
             .status()?
             .success()
             .then(|| {
                 success_count += 1;
             });
 
-        println!("pushing {}:{}", image, commit);
+        println!("pushing {image}:{commit}");
         Command::new("docker")
             .current_dir(project_root())
-            .args(["push", format!("n0computer/{}:latest", image).as_str()])
+            .args(["push", format!("n0computer/{image}:latest").as_str()])
             .status()?
             .success()
             .then(|| {
@@ -310,7 +310,7 @@ fn push_docker(all: bool, images: Vec<String>) -> Result<()> {
         println!();
     }
 
-    println!("{}/{} tags pushed.", success_count, count);
+    println!("{success_count}/{count} tags pushed.");
     Ok(())
 }
 


### PR DESCRIPTION
Newer clippy wants the identifiers in the format string when
possible.  Boring change but why not.

Closes #661