### PR TITLE
feat: Add support for an in-memory store to iroh-embed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,6 @@ debug = false
 debug-assertions = false
 opt-level = 3
 panic = 'abort'
-
 incremental = false
 
 [profile.docker]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ iroh-car = { version = "0.2.0", path = "./iroh-car" }
 iroh-embed = { version = "0.2.0", path = "./iroh-embed" }
 iroh-gateway = { version = "0.2.0", path = "./iroh-gateway" }
 iroh-localops = { version = "0.2.0", path = "./iroh-localops" }
+iroh-memstore = { version = "0.2.0", path = "./iroh-memstore" }
 iroh-metrics = { version = "0.2.0", path = "./iroh-metrics" }
 iroh-one = { version = "0.2.0", path = "./iroh-one" }
 iroh-p2p = { version = "0.2.0", path = "./iroh-p2p" }
@@ -183,6 +184,7 @@ debug = false
 debug-assertions = false
 opt-level = 3
 panic = 'abort'
+
 incremental = false
 
 [profile.docker]

--- a/examples/embed/src/main.rs
+++ b/examples/embed/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use futures_util::StreamExt;
 use iroh_api::{IpfsPath, OutType};
-use iroh_embed::{IrohBuilder, Libp2pConfig, P2pService, RocksStoreService};
+use iroh_embed::{IrohBuilder, IrohService, Libp2pConfig, P2pService, RocksStoreService};
 use testdir::testdir;
 
 #[tokio::main(flavor = "multi_thread")]

--- a/iroh-embed/Cargo.toml
+++ b/iroh-embed/Cargo.toml
@@ -10,9 +10,11 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 futures.workspace = true
 iroh-api.workspace = true
 iroh-gateway.workspace = true
+iroh-memstore.workspace = true
 iroh-metrics.workspace = true
 iroh-one.workspace = true
 iroh-p2p.workspace = true
@@ -21,6 +23,7 @@ iroh-rpc-client.workspace = true
 iroh-rpc-types.workspace = true
 iroh-store.workspace = true
 iroh-unixfs.workspace = true
+quic-rpc.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "json"] }
 tokio.workspace = true
 

--- a/iroh-embed/src/lib.rs
+++ b/iroh-embed/src/lib.rs
@@ -35,11 +35,11 @@ use anyhow::{bail, Result};
 use async_trait::async_trait;
 use iroh_rpc_client::Config as RpcClientConfig;
 use iroh_rpc_types::store::StoreService;
+use iroh_rpc_types::Addr;
 use quic_rpc::Service;
 
 pub use iroh_api::Api;
 pub use iroh_p2p::Libp2pConfig;
-use iroh_rpc_types::Addr;
 pub use iroh_unixfs::indexer::IndexerUrl;
 pub use reqwest::Url;
 

--- a/iroh-embed/src/p2p.rs
+++ b/iroh-embed/src/p2p.rs
@@ -97,7 +97,7 @@ mod tests {
     use testdir::testdir;
     use tokio::time;
 
-    use crate::RocksStoreService;
+    use crate::{IrohService, RocksStoreService};
 
     use super::*;
 

--- a/iroh-embed/src/store.rs
+++ b/iroh-embed/src/store.rs
@@ -42,7 +42,7 @@ impl IrohService<StoreService> for RocksStoreService {
     }
 
     // TODO: This should be graceful termination.
-    async fn stop(mut self: Box<Self>) -> Result<()> {
+    async fn stop(mut self) -> Result<()> {
         // This dummy task will be aborted by Drop.
         let fut = futures::future::ready(());
         let dummy_task = tokio::spawn(fut);
@@ -92,7 +92,7 @@ impl IrohService<StoreService> for MemStoreService {
         self.addr.clone()
     }
 
-    async fn stop(self: Box<Self>) -> Result<()> {
+    async fn stop(self) -> Result<()> {
         let join = self.handle.shutdown();
         join.await.context("Waiting for MemStore task to finish")?;
         Ok(())
@@ -117,7 +117,6 @@ mod tests {
         let store = RocksStoreService::new(dir).await.unwrap();
         assert!(marker.exists());
 
-        let store = Box::new(store);
         let fut = store.stop();
         let ret = time::timeout(Duration::from_millis(500), fut).await;
 
@@ -133,7 +132,6 @@ mod tests {
 
         assert!(!version.is_empty());
 
-        let store = Box::new(store);
         store.stop().await.unwrap();
         let res = client.version().await;
 

--- a/iroh-memstore/src/lib.rs
+++ b/iroh-memstore/src/lib.rs
@@ -157,6 +157,8 @@ impl MemStore {
         Ok(())
     }
 
+    // async fn handle_rpc<S, M>(request: M, sink: )
+
     async fn handle_put(
         &mut self,
         request: PutRequest,

--- a/iroh-memstore/src/lib.rs
+++ b/iroh-memstore/src/lib.rs
@@ -157,8 +157,6 @@ impl MemStore {
         Ok(())
     }
 
-    // async fn handle_rpc<S, M>(request: M, sink: )
-
     async fn handle_put(
         &mut self,
         request: PutRequest,


### PR DESCRIPTION
This allows using the in-memory store provided by the iroh-memstore crate.

Possibly the stores should be behind features, but I don't think this is worth it yet.

Note this also doesn't convert the `P2pService` to use the `IrohService` trait.  It could, I'm a bit undecided on whether to do so or not.  So please let me know your preferences.

Also note that I didn't implement `Drop` for the `MemStoreService`.  I'm now regretting doing this originally.  Tokio tasks also keep running if you drop the handle.

Finally I'm still on the fence about the naming of the `*Service::new` methods, I much prefer the naming in `iroh-memstore` which uses `::spawn` instead of `::new` to signal this is spawning a task.  I'd be happy to rename those, but possibly as a separate API.

----

This PR depends on the `flub/memstore` branch and targets it.  That PR is only in draft, though I think there's nothing wrong with having this PR being approved before.  I'll just sit around a bit before being merged.