### PR TITLE
feat: Move --keylog to common flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "abao",
  "anyhow",


### PR DESCRIPTION
All subcommands take this option, so repeating it like that is a bit
silly.  Move it to the toplevel.