### PR TITLE
feat: Remove Request.id from the protocol

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -157,7 +157,7 @@ where
     // 2. Send Request
     {
         debug!("sending request");
-        let req = Request { id: 1, name: hash };
+        let req = Request { name: hash };
 
         let used = postcard::to_slice(&req, &mut out_buffer)?;
         write_lp(&mut writer, used).await?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -37,14 +37,12 @@ impl Handshake {
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, MaxSize)]
 pub(crate) struct Request {
-    pub id: u64,
     /// blake3 hash
     pub name: Hash,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub(crate) struct Response {
-    pub id: u64,
     pub data: Res,
 }
 


### PR DESCRIPTION
Since we now only issue a single request per stream this field was not
used.  Using it in the provider to identify requests would introduce
complexity and overhead for the bookkeeping of request IDs.  Instead
remove the field from the protocol.

The provider still has a use-case for identifying which request events
relate to.  It now uses the QUIC stream ID for this, but does not
promise so on an API-level.  This also simplifies the events since
this new request_id is always known, while previously it was only
known after having decoded the request message.