### PR TITLE
ref: Rename --token to --auth-token for get

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ enum Commands {
         peer: PeerId,
         /// The authentication token to present to the server.
         #[clap(long)]
-        token: String,
+        auth_token: String,
         /// Optional address of the provider, defaults to 127.0.0.1:4433.
         #[clap(long, short)]
         addr: Option<SocketAddr>,
@@ -205,7 +205,7 @@ async fn main() -> Result<()> {
         Commands::Get {
             hash,
             peer,
-            token,
+            auth_token,
             addr,
             out,
         } => {
@@ -217,8 +217,8 @@ async fn main() -> Result<()> {
             if let Some(addr) = addr {
                 opts.addr = addr;
             }
-            let token =
-                AuthToken::from_str(&token).context("Wrong format for authentication token")?;
+            let token = AuthToken::from_str(&auth_token)
+                .context("Wrong format for authentication token")?;
             tokio::select! {
                 biased;
                 res = get_interactive(*hash.as_hash(), opts, token, out) => {


### PR DESCRIPTION
This is consistent with the naming for the provide subcommand and is
more descriptive as well.