### PR TITLE
fix: Avoid other output between contents when printing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,11 +97,10 @@ impl OutWriter {
 }
 
 impl OutWriter {
-    pub async fn println(&self, content: impl AsRef<[u8]>) {
+    pub async fn println(&self, mut content: String) {
         let stderr = &mut *self.stderr.lock().await;
-        let mut buf: Vec<u8> = content.as_ref().to_vec();
-        buf.extend(b"\n");
-        stderr.write_all(&buf).await.unwrap();
+        content.push('\n');
+        stderr.write_all(content.as_bytes()).await.unwrap();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,8 +99,9 @@ impl OutWriter {
 impl OutWriter {
     pub async fn println(&self, content: impl AsRef<[u8]>) {
         let stderr = &mut *self.stderr.lock().await;
-        stderr.write_all(content.as_ref()).await.unwrap();
-        stderr.write_all(b"\n").await.unwrap();
+        let mut buf: Vec<u8> = content.as_ref().iter().copied().collect();
+        buf.extend(b"\n");
+        stderr.write_all(&buf).await.unwrap();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ impl OutWriter {
 impl OutWriter {
     pub async fn println(&self, content: impl AsRef<[u8]>) {
         let stderr = &mut *self.stderr.lock().await;
-        let mut buf: Vec<u8> = content.as_ref().iter().copied().collect();
+        let mut buf: Vec<u8> = content.as_ref().to_vec();
         buf.extend(b"\n");
         stderr.write_all(&buf).await.unwrap();
     }


### PR DESCRIPTION
This makes sure the OutWriter writes the newline as part of the same
buffer as the output.  This makes it less likely that the output will
be interrupted between the content and the newline.  E.g. without this
and enabling logging, log messages will be injected between the
content and the newline, making the output garbled.

Unfortunately this isn't entirely correct and is more of a heuristic
because most of our output is small enough that they fit in a single
write.  In the blocking world you'd lock Stderr while printing the
messages, in the tokio world however I don't know how to safely do
this.