### PR TITLE
fix: Improve listening addr output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -333,6 +333,9 @@ async fn provide_interactive(
     let provider = builder.spawn()?;
 
     out_writer
+        .println(format!("Listening address: {}", provider.listen_addr()))
+        .await;
+    out_writer
         .println(format!("PeerID: {}", provider.peer_id()))
         .await;
     out_writer

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,9 +332,7 @@ async fn provide_interactive(
     }
     let provider = builder.spawn()?;
 
-    out_writer
-        .println(format!("Listening address: {}", provider.listen_addr()))
-        .await;
+    println!("Listening address: {}", provider.listen_addr());
     out_writer
         .println(format!("PeerID: {}", provider.peer_id()))
         .await;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -172,8 +172,9 @@ impl Builder {
         events: broadcast::Sender<Event>,
         cancel_token: CancellationToken,
     ) {
-        debug!("\nlistening at: {:#?}", server.local_addr().unwrap());
-
+        if let Ok(addr) = server.local_addr() {
+            debug!("listening at: {addr}");
+        }
         loop {
             tokio::select! {
                 biased;


### PR DESCRIPTION
This fixes the log message output which had an extraneous newline in
it and needlessly used debug output.

It also adds the listening address to the normal provider output: This
is universally useful since you can specify addresses with -a but
don't otherwise know which one is used if using OS-allocated ports.
This can also be useful for testing.