### PR TITLE
adjust ci test run order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
-        rust: [nightly, stable]
+        os: [macOS-latest, ubuntu-latest]
+        rust: [stable, nightly]
 
     steps:
     - name: Checkout
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        rust: [nightly, stable]
+        rust: [stable, nightly]
         target:
           - x86_64-pc-windows-gnu
           -  x86_64-pc-windows-msvc


### PR DESCRIPTION
any thoughts on this?

I feel like I'm missing information whenever the tests fail on nightly before seeing if it passed on stable.