### PR TITLE
fix: Do not send duplicate NotFound responses

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -452,7 +452,6 @@ async fn transfer_collection(
         let (status, writer1) = send_blob(db.clone(), blob.hash, writer, buffer).await?;
         writer = writer1;
         if SentStatus::NotFound == status {
-            write_response(&mut writer, buffer, Res::NotFound).await?;
             writer.finish().await?;
             return Ok(status);
         }


### PR DESCRIPTION
The code was accidentally sending this response twice.  send_blob()
already sends NotFound, and it seems like it belongs more there.