### PR TITLE
ref: micro-optimise by reserving buffer size

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -93,6 +93,7 @@ pub(crate) async fn read_lp(
     };
     let mut reader = reader.take(size);
     let size = usize::try_from(size).context("frame larger than usize")?;
+    buffer.reserve(size);
     loop {
         let r = reader.read_buf(buffer).await?;
         if r == 0 {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::str::FromStr;
 
 use abao::decode::AsyncSliceDecoder;
-use anyhow::{ensure, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use bytes::{Bytes, BytesMut};
 use postcard::experimental::max_size::MaxSize;
 use quinn::VarInt;
@@ -92,6 +92,9 @@ pub(crate) async fn read_lp(
     };
     let mut reader = reader.take(size);
     let size = usize::try_from(size).context("frame larger than usize")?;
+    if size > MAX_MESSAGE_SIZE {
+        bail!("Incoming message exceeds MAX_MESSAGE_SIZE");
+    }
     buffer.reserve(size);
     loop {
         let r = reader.read_buf(buffer).await?;


### PR DESCRIPTION
Before going into the loop we may as well make sure to reserve enough
space for the entire buffer.  Otherwise we could be allocating
multiple times.

This does not change the total allocated size.