### PR TITLE
fix: Output writing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use indicatif::{
 };
 use iroh::protocol::AuthToken;
 use iroh::provider::Ticket;
-use tokio::io::AsyncWriteExt;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 use iroh::{get, provider, Hash, Keypair, PeerId};
@@ -84,11 +83,7 @@ enum Commands {
 macro_rules! progress {
     // Match a format string followed by any number of arguments
     ($fmt:expr $(, $args:expr)*) => {{
-        // Use the `format!` macro to format the string with the arguments
-        let mut message = format!($fmt $(, $args)*);
-        // Print the formatted string to the console with a newline
-        message.push('\n');
-        tokio::io::stderr().write_all(message.as_ref()).await.unwrap();
+        eprintln!($fmt $(, $args)*);
     }};
 }
 


### PR DESCRIPTION
This simply delegates to eprintln! for writing output.  This ensures
writes happen more synchronously and the flaky integration tests are
fixed.

While in theory these are blocking operations on the async executor,
this is acceptable because:

- We already use println!() without any problems.  Arguably this is
  more of an issue since we also write data to stdout but it isn't
  because we don't do that at the same time.

- We print a small number of messages, not large amounts of data.  Any
  blocking from this will be small.

- This acquires a sync mutex while writing, that's fine because it is
  acquired and released in the same chunk of async code and not held
  across await points.  This is unlikely to block much as only main
  writes and only one write happens at a time.

- When logging via tracing is enabled this will also end up logging on
  here and will compete for the lock.  This is slightly higher
  contention but doesn't really interfere with the logging here.