### PR TITLE
WIP: impl `derp::client` mod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6690c370453db30743b373a60ba498fc0d6d83b11f4abfd87a84a075db5dd4"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -92,7 +92,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.19",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -120,12 +120,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
- "futures-lite",
 ]
 
 [[package]]
@@ -153,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -220,9 +219,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bincode"
@@ -392,7 +391,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.45",
+ "time 0.1.43",
  "wasm-bindgen",
  "winapi",
 ]
@@ -410,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -425,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -438,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -476,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "const_format"
@@ -553,6 +552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -632,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -647,19 +655,32 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -712,10 +733,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "der-parser"
-version = "8.1.0"
+name = "der"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
+checksum = "bc302fd9b18d66834a6f092d10ea85489c0ca8ad6b7304092135fab171d853cd"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -788,7 +819,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
 dependencies = [
- "der",
+ "der 0.6.1",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -796,11 +827,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf420a7ec85d98495b0c34aa4a58ca117f982ffbece111aeb545160148d7010"
+checksum = "be522bee13fa6d8059f4903a4084aa3bd50725e18150202f0238deb615cd6371"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.1",
  "serde",
  "signature",
 ]
@@ -840,7 +871,7 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
+ "der 0.6.1",
  "digest 0.10.6",
  "ff",
  "generic-array",
@@ -946,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
+checksum = "54b2f3c51e4dd999930845da5d10a48775b8fe4ca9f4f9ec1f9161f334da5dfe"
 
 [[package]]
 name = "flume"
@@ -1042,21 +1073,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1094,12 @@ name = "futures-task"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -1127,6 +1149,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
+name = "governor"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c390a940a5d157878dd057c78680a33ce3415bcd05b4799509ea44210914b4d5"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "quanta",
+ "rand",
+ "smallvec",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1389,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
  "windows-sys 0.45.0",
@@ -1433,11 +1473,12 @@ dependencies = [
  "curve25519-dalek 4.0.0-rc.1",
  "data-encoding",
  "default-net",
- "der",
+ "der 0.6.1",
  "derive_more",
  "ed25519-dalek",
  "flume",
  "futures",
+ "governor",
  "hex",
  "hostname",
  "indicatif",
@@ -1484,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -1496,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
@@ -1583,6 +1624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1750,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e21fbb6f3d253a14df90eb0000a6066780a15dd901a7519ce02d77a94985b"
+checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
 dependencies = [
  "bytes",
  "futures",
@@ -1774,6 +1824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1838,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "ntapi"
@@ -2010,12 +2072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pem"
@@ -2070,9 +2126,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
+checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2080,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
+checksum = "a81186863f3d0a27340815be8f2078dd8050b14cd71913db9fbda795e5f707d7"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2090,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
+checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2103,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
+checksum = "5e3b284b1f13a20dc5ebc90aff59a51b8d7137c221131b52a7260c08cbc1cc80"
 dependencies = [
  "once_cell",
  "pest",
@@ -2150,9 +2206,9 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.6.1",
+ "pkcs8 0.9.0",
+ "spki 0.6.0",
  "zeroize",
 ]
 
@@ -2162,8 +2218,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+dependencies = [
+ "der 0.7.0",
+ "spki 0.7.0",
 ]
 
 [[package]]
@@ -2328,6 +2394,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quic-rpc"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,6 +2554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,7 +2570,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.19",
+ "time 0.3.20",
  "yasna",
 ]
 
@@ -2517,15 +2608,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -2602,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b3896c9b7790b70a9aa314a30e4ae114200992a19c96cbe0ca6070edd32ab8"
+checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
 dependencies = [
  "byteorder",
  "digest 0.10.6",
@@ -2613,7 +2695,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "signature",
  "subtle",
@@ -2670,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
@@ -2728,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safe-lock"
@@ -2811,9 +2893,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -2832,9 +2914,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
  "subtle",
  "zeroize",
 ]
@@ -2911,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -2922,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3005,9 +3087,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3035,7 +3117,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+dependencies = [
+ "base64ct",
+ "der 0.7.0",
 ]
 
 [[package]]
@@ -3116,9 +3208,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3185,16 +3277,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3208,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "testdir"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23029d5d16b0351859485c6849252f00bf0ebc98098a9efd954853c3533720c7"
+checksum = "c31eb500f7513b559ed7e0652894268dbe8ef27b6241b783ce274f4741eae137"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3222,18 +3313,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3252,20 +3343,19 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "serde",
@@ -3281,9 +3371,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -3305,9 +3395,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3320,7 +3410,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3548,9 +3638,9 @@ checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -3628,12 +3718,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3645,9 +3729,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"
@@ -3957,7 +4041,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.19",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -3979,7 +4063,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
- "time 0.3.19",
+ "time 0.3.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ ed25519-dalek = { version = "=2.0.0-pre.0", features = ["serde", "rand_core"] }
 flume = "0.10.14"
 futures = "0.3.25"
 hex = "0.4.0"
+governor = "0.5.1"
 hostname = "0.3.1"
 indicatif = { version = "0.17", features = ["tokio"], optional = true }
 libc = "0.2.139"

--- a/src/hp/derp.rs
+++ b/src/hp/derp.rs
@@ -29,7 +29,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 /// including its on-wire framing overhead)
 const MAX_PACKET_SIZE: usize = 64 * 1024;
 
-const MAX_FRAME_SIZE: usize = 10 * 1024 * 1024;
+const MAX_FRAME_SIZE: usize = 1024 * 1024;
 
 /// The DERP magic number, sent in the FRAME_SERVER_KEY frame
 /// upon initial connection
@@ -170,7 +170,7 @@ async fn read_frame(
     if frame_len > max_size {
         bail!("frame header size {frame_len} exceeds reader limit of {max_size}");
     }
-
+    // TODO: this is weird and wrong
     reader.read_exact(&mut bytes).await?;
     Ok((frame_type, frame_len))
 }

--- a/src/hp/derp/client.rs
+++ b/src/hp/derp/client.rs
@@ -1,7 +1,210 @@
 //! based on tailscale/derp/derp_client.go
+use std::sync::Arc;
 use std::time::Duration;
 
-use crate::hp::key;
+use anyhow::{bail, Context, Result};
+use bytes::BytesMut;
+use postcard::experimental::max_size::MaxSize;
+use serde::{Deserialize, Serialize};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
+    sync::Mutex,
+};
+
+use super::{
+    read_frame, server::ServerInfo, write_frame, write_frame_header, FrameType, FRAME_CLIENT_INFO,
+    FRAME_FORWARD_PACKET, FRAME_PING, FRAME_PONG, FRAME_SEND_PACKET, MAGIC, MAX_PACKET_SIZE,
+    PROTOCOL_VERSION,
+};
+use crate::hp::{
+    derp::{FRAME_SERVER_KEY, MAX_INFO_LEN, NONCE_LEN},
+    key::{self, node::PublicKey},
+    magicsock::Conn,
+};
+
+const SERVER_KEY_FRAME_MAX_SIZE: u32 = 1024;
+
+/// A DERP Client.
+/// TODO: static????
+struct Client<W: AsyncWrite + Send + Unpin + 'static, R: AsyncRead + Unpin> {
+    /// Server key of the DERP server, not a machine or node key
+    server_key: key::node::PublicKey,
+    /// TODO: maybe change to "secret_key" to match `key::node::SecretKey` naming
+    private_key: key::node::SecretKey,
+    /// public key associated with `private_key`
+    public_key: key::node::PublicKey,
+    conn: Conn,
+    reader: R,
+    /// TODO: This is a string in the go impl, using bytes here to make it easier for postcard
+    /// to serialize. 32 is a random number I chose. Need to figure out what the `mesh_key`
+    /// is in practice.
+    mesh_key: [u8; 32],
+    can_ack_pings: bool,
+    is_prober: bool,
+
+    // mutex lock to protect the writer
+    writer: Arc<Mutex<W>>,
+    // TODO: wtf is this:
+    // rate: rate.Limiter
+    /// bytes to discard on next Recv
+    peeked: usize,
+    /// sticky (set by Recv)
+    /// TODO: temporarily a string until I figure out what this is in practice
+    read_err: String,
+}
+
+/// TODO: ClientBuilder
+
+impl<W: AsyncWrite + Send + Unpin + 'static, R: AsyncRead + Unpin> Client<W, R> {
+    // TODO: for something relatively straight forward, this is pretty hard to follow
+    // TODO: also, should Client.server_key be an option?
+    async fn recv_server_key(&mut self) -> Result<()> {
+        // expecting MAGIC followed by 32 bytes that contain the server key
+        let magic_len = MAGIC.len();
+        let mut buf = BytesMut::with_capacity(magic_len + 32);
+        let (frame_type, frame_len) =
+            read_frame(&mut self.reader, SERVER_KEY_FRAME_MAX_SIZE, &mut buf).await?;
+        let buffer_len = u32::try_from(buf.len())?;
+        if frame_len < buffer_len
+            || frame_type != FRAME_SERVER_KEY
+            || buf[..magic_len] != MAGIC.bytes().collect::<Vec<_>>()[..]
+        {
+            bail!("invalid server greeting");
+        }
+        let key: [u8; 32] = buf[magic_len..magic_len + 32].try_into()?;
+        self.server_key = key::node::PublicKey::from(key);
+        Ok(())
+    }
+
+    async fn parse_server_info(&self, buf: &mut [u8]) -> Result<ServerInfo> {
+        // TODO: should NONCE_LEN just be usize?
+        let max_len = NONCE_LEN as usize + MAX_INFO_LEN;
+        let frame_len = buf.len();
+        if frame_len < NONCE_LEN as usize {
+            bail!("short ServerInfo frame");
+        }
+        if frame_len > max_len {
+            bail!("long ServerInfo frame");
+        }
+
+        let msg = self
+            .private_key
+            .open_from(&self.public_key, buf)
+            .context(format!(
+                "failed to open crypto_box from server key {:?}",
+                self.server_key.as_bytes()
+            ))?;
+        let info: ServerInfo = postcard::from_bytes(&msg)?;
+        Ok(info)
+    }
+
+    async fn send_client_key(&mut self) -> Result<()> {
+        let mut buf = BytesMut::zeroed(ClientInfo::POSTCARD_MAX_SIZE);
+        let msg = postcard::to_slice(
+            &ClientInfo {
+                version: PROTOCOL_VERSION,
+                mesh_key: self.mesh_key,
+                can_ack_pings: self.can_ack_pings,
+                is_prober: self.is_prober,
+            },
+            &mut buf,
+        )?;
+        let mut msg = self.private_key.seal_to(&self.public_key, msg);
+        // TODO: doing bufs all over the place...
+        let mut buf: Vec<u8> = self.public_key.as_bytes().to_vec();
+        buf.append(&mut msg);
+        let mut writer = self.writer.lock().await;
+        write_frame(&mut *writer, FRAME_CLIENT_INFO, &buf).await
+    }
+
+    /// Returns a reference to the server's public key.
+    pub fn server_public_key(&self) -> PublicKey {
+        self.server_key.clone()
+    }
+
+    /// Sends a packet to the node identified by `dstkey`
+    ///
+    /// Errors if the packet is larger than [`MAX_PACKET_SIZE`]
+    pub async fn send(&mut self, dstkey: PublicKey, packet: &[u8]) -> Result<()> {
+        if packet.len() > MAX_PACKET_SIZE {
+            bail!("packet too big: {}", packet.len());
+        }
+        let frame_len = u32::try_from(key::node::KEY_SIZE + packet.len())?;
+        {
+            let mut writer = self.writer.lock().await;
+            // TODO: rate limiter
+            write_frame_header(&mut *writer, FRAME_SEND_PACKET, frame_len).await?;
+            writer.write_all(dstkey.as_bytes()).await?;
+            writer.write_all(packet).await?;
+            writer.flush().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn forward_packet(
+        &self,
+        srckey: PublicKey,
+        dstkey: PublicKey,
+        packet: &[u8],
+    ) -> Result<()> {
+        if packet.len() > MAX_PACKET_SIZE {
+            bail!("packet too big: {}", packet.len());
+        }
+
+        let frame_len = u32::try_from(key::node::KEY_SIZE + packet.len())?;
+        let writer = Arc::clone(&self.writer);
+        let write_task = tokio::spawn(async move {
+            let mut writer = writer.lock().await;
+            write_frame_header(&mut *writer, FRAME_FORWARD_PACKET, frame_len).await?;
+            writer.write_all(srckey.as_bytes()).await?;
+            writer.write_all(dstkey.as_bytes()).await?;
+            writer.flush().await?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        match tokio::time::timeout(Duration::from_secs(5), write_task).await {
+            Ok(res) => res?,
+            Err(_) => self.write_timeout_fired().await,
+        }
+    }
+
+    async fn write_timeout_fired(&self) -> Result<()> {
+        self.conn.close().await
+    }
+
+    pub async fn send_ping(&self, data: [u8; 8]) -> Result<()> {
+        self.send_ping_or_pong(FRAME_PING, data).await
+    }
+
+    pub async fn send_pong(&self, data: [u8; 8]) -> Result<()> {
+        self.send_ping_or_pong(FRAME_PONG, data).await
+    }
+
+    async fn send_ping_or_pong(&self, frame_type: FrameType, data: [u8; 8]) -> Result<()> {
+        let mut writer = self.writer.lock().await;
+        write_frame_header(&mut *writer, frame_type, 8).await?;
+        writer.write_all(&data).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, MaxSize)]
+pub(crate) struct ClientInfo {
+    /// The DERP protocol version that the client was built with.
+    /// See [`PROTOCOL_VERSION`].
+    version: usize,
+    /// Optionally specifies a pre-shared key used by trusted clients.
+    /// It's required to subscribe to the connection list and forward
+    /// packets. It's empty for regular users.
+    /// TODO: this is a string in the go-impl, using an array here
+    /// to satisfy postcard's `MaxSize` trait
+    mesh_key: [u8; 32],
+    /// Whether the client declares it's able to ack pings
+    can_ack_pings: bool,
+    /// Whether this client is a prober.
+    is_prober: bool,
+}
 
 #[derive(Debug, Clone)]
 pub enum ReceivedMessage {

--- a/src/hp/derp/client.rs
+++ b/src/hp/derp/client.rs
@@ -1,24 +1,29 @@
 //! based on tailscale/derp/derp_client.go
-use std::sync::Arc;
 use std::time::Duration;
+use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::{bail, Context, Result};
 use bytes::BytesMut;
 use governor::RateLimiter;
 use postcard::experimental::max_size::MaxSize;
+use quinn::AsyncUdpSocket;
 use serde::{Deserialize, Serialize};
 use tokio::{
-    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     sync::Mutex,
 };
 
 use super::{
-    read_frame, server::ServerInfo, write_frame, write_frame_header, FrameType, FRAME_CLIENT_INFO,
-    FRAME_FORWARD_PACKET, FRAME_PING, FRAME_PONG, FRAME_SEND_PACKET, MAGIC, MAX_PACKET_SIZE,
-    PROTOCOL_VERSION,
+    read_frame, read_frame_header, server::ServerInfo, write_frame, write_frame_header, FrameType,
+    FRAME_CLIENT_INFO, FRAME_CLOSE_PEER, FRAME_FORWARD_PACKET, FRAME_HEALTH, FRAME_NOTE_PREFERRED,
+    FRAME_PEER_GONE, FRAME_PING, FRAME_PONG, FRAME_RESTARTING, FRAME_SEND_PACKET,
+    FRAME_SERVER_INFO, FRAME_WATCH_CONNS, MAGIC, MAX_PACKET_SIZE, PROTOCOL_VERSION,
 };
 use crate::hp::{
-    derp::{FRAME_SERVER_KEY, MAX_INFO_LEN, NONCE_LEN},
+    derp::{
+        FRAME_KEEP_ALIVE, FRAME_PEER_PRESENT, FRAME_RECV_PACKET, FRAME_SERVER_KEY, MAX_FRAME_SIZE,
+        MAX_INFO_LEN, NONCE_LEN,
+    },
     key::{self, node::PublicKey},
     magicsock::Conn,
 };
@@ -28,8 +33,7 @@ const SERVER_KEY_FRAME_MAX_SIZE: u32 = 1024;
 /// A DERP Client.
 struct Client<W, R, S, C, MW = governor::middleware::NoOpMiddleware>
 where
-    /// TODO: static????
-    W: AsyncWrite + Send + Unpin + 'static,
+    W: AsyncWrite + Send + Unpin + 'static, // TODO: static?
     R: AsyncRead + Unpin,
     S: governor::state::DirectStateStore<Key = governor::state::direct::NotKeyed>,
     C: governor::clock::Clock,
@@ -54,11 +58,9 @@ where
     writer: Arc<Mutex<W>>,
     // TODO: maybe write a trait to make working with the rate limiter less gross cause it's currently disgusting
     rate_limiter: Option<Arc<RateLimiter<governor::state::direct::NotKeyed, S, C, MW>>>,
-    /// bytes to discard on next Recv
-    peeked: usize,
     /// sticky (set by Recv)
-    /// TODO: temporarily a string until I figure out what this is in practice
-    read_err: String,
+    /// TODO: temporarily a string until I figure out what to do about cloning errors
+    recv_err: Arc<Mutex<Option<String>>>,
 }
 
 /// TODO: ClientBuilder
@@ -155,7 +157,7 @@ where
                 match rate_limiter.check_n(std::num::NonZeroU32::new(frame_len).unwrap()) {
                     Ok(_) => {}
                     Err(_) => {
-                        tracing::warn!("droping send: rate limit reached");
+                        tracing::warn!("dropping send: rate limit reached");
                         return Ok(());
                     }
                 }
@@ -214,6 +216,226 @@ where
         writer.flush().await?;
         Ok(())
     }
+
+    /// Sends a packet that tells the server whether this
+    /// client is the user's preferred server. This is only
+    /// used in the server for stats.
+    pub async fn note_preferred(&self, preferred: bool) -> Result<()> {
+        let byte = {
+            if preferred {
+                [0x00]
+            } else {
+                [0x01]
+            }
+        };
+        let mut writer = self.writer.lock().await;
+        write_frame_header(&mut *writer, FRAME_NOTE_PREFERRED, 1).await?;
+        writer.write(&byte).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+
+    /// Sends a request to subscribe to the peer's connection list.
+    /// It's a fatal error if the client wasn't created using [`MeshKey`].
+    pub async fn watch_connection_changes(&self) -> Result<()> {
+        let mut writer = self.writer.lock().await;
+        write_frame_header(&mut *writer, FRAME_WATCH_CONNS, 0).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+
+    /// Asks the server to close the target's TCP connection.
+    /// It's a fatal error if the client wasn't created using [`MeshKey`]
+    pub async fn close_peer(&self, target: PublicKey) -> Result<()> {
+        let mut writer = self.writer.lock().await;
+        write_frame(&mut *writer, FRAME_CLOSE_PEER, target.as_bytes()).await?;
+        Ok(())
+    }
+
+    async fn set_send_rate_limiter(&mut self, sm: ReceivedMessage) {
+        if let ReceivedMessage::ServerInfo {
+            token_bucket_bytes_per_second,
+            ..
+        } = sm
+        {
+            if token_bucket_bytes_per_second == 0 {
+                self.rate_limiter = None;
+            } else {
+                // make a new rate_limiter & add it to the client
+                todo!("the rate limiter stuff is a mess, figure it out");
+            }
+        }
+    }
+
+    async fn local_addr(&self) -> Result<SocketAddr> {
+        {
+            let recv_err = self.recv_err.lock().await;
+            if let Some(e) = &*recv_err {
+                bail!(e.clone());
+            }
+        }
+        Ok(self.conn.local_addr()?)
+    }
+
+    /// Reads a messages from a DERP server.
+    ///
+    /// The returned message may alias memory owned by the [`Client`]; if
+    /// should only be accessed until the next call to [`Client`].
+    ///
+    /// Once [`recv`] returns an error, the [`Client`] is dead forever.
+    pub async fn recv(&self) -> Result<ReceivedMessage> {
+        self.recv_check_error(Duration::from_secs(120)).await
+    }
+
+    async fn recv_check_error(&self, timeout: Duration) -> Result<ReceivedMessage> {
+        {
+            let recv_err = self.recv_err.lock().await;
+            if let Some(err) = &*recv_err {
+                bail!(err.clone());
+            }
+        }
+        match self.recv_timeout(timeout).await {
+            Ok(m) => Ok(m),
+            Err(e) => {
+                let mut recv_err = self.recv_err.lock().await;
+                // if it's errored on a simultaneous call to `recv` alread, just
+                // return the other error
+                if let Some(err) = &*recv_err {
+                    bail!(err.clone());
+                } else {
+                    *recv_err = Some(e.to_string());
+                    bail!(e);
+                }
+            }
+        }
+    }
+
+    async fn recv_timeout(&self, timeout: Duration) -> Result<ReceivedMessage> {
+        todo!();
+    }
+
+    async fn recv_0(&mut self) -> Result<ReceivedMessage> {
+        let mut frame_payload = BytesMut::with_capacity(4 * 1024);
+        loop {
+            let (frame_type, frame_len) = read_frame_header(&mut self.reader).await?;
+            if frame_len as usize > MAX_FRAME_SIZE {
+                bail!("unexpectedly large frame of {} bytes returned", frame_len);
+            }
+            let mut read_total = 0;
+            loop {
+                let read = self.reader.read(&mut frame_payload).await?;
+                if read == 0 {
+                    break;
+                }
+                read_total += read;
+            }
+            if read_total != frame_len as usize {
+                bail!(
+                    "unexpected number of bytes sent in frame, said {}, received {}",
+                    frame_len,
+                    read_total
+                );
+            }
+
+            match frame_type {
+                FRAME_SERVER_INFO => {
+                    // Server sends this at start-up. Currently unused.
+                    // Just has a JSON messages saying "version: 2",
+                    // but the protocol seems extensible enough as-is without
+                    // needing to wait an RTT to discover the version at startup
+                    // We'd prefer to give the connection to the client (magicsock)
+                    // to start writing as soon as possible.
+                    let server_info = self.parse_server_info(&mut frame_payload).await?;
+                    let received = ReceivedMessage::ServerInfo {
+                        token_bucket_bytes_per_second: server_info.token_bucket_bytes_per_second,
+                        token_bucket_bytes_burst: server_info.token_bucket_bytes_burst,
+                    };
+                    self.set_send_rate_limiter(received.clone()).await;
+                    return Ok(received);
+                }
+                FRAME_KEEP_ALIVE => {
+                    // A one-way keep-alive message that doesn't require an ack.
+                    // This predated FRAME_PING/FRAME_PONG.
+                    return Ok(ReceivedMessage::KeepAlive);
+                }
+                FRAME_PEER_GONE => {
+                    if (frame_len as usize) < crypto_box::KEY_SIZE {
+                        tracing::warn!(
+                            "unexpected: dropping short PEER_GONE frame from DERP server"
+                        );
+                        continue;
+                    }
+                    let key = get_key_from_slice(&frame_payload[..])?;
+                    return Ok(ReceivedMessage::PeerGone(PublicKey::from(key)));
+                }
+                FRAME_PEER_PRESENT => {
+                    if (frame_len as usize) < crypto_box::KEY_SIZE {
+                        tracing::warn!(
+                            "unexpected: dropping short PEER_PRESENT frame from DERP server"
+                        );
+                        continue;
+                    }
+                    let key = get_key_from_slice(&frame_payload[..])?;
+                    return Ok(ReceivedMessage::PeerPresent(PublicKey::from(key)));
+                }
+                FRAME_RECV_PACKET => {
+                    if (frame_len as usize) < crypto_box::KEY_SIZE {
+                        tracing::warn!("unexpected: dropping short packet from DERP server");
+                        continue;
+                    }
+                    let key = get_key_from_slice(&frame_payload[..])?;
+                    let packet = ReceivedMessage::ReceivedPacket {
+                        source: key,
+                        data: frame_payload[crypto_box::KEY_SIZE..].to_vec(),
+                    };
+                    return Ok(packet);
+                }
+                FRAME_PING => {
+                    if frame_len < 8 {
+                        tracing::warn!("unexpected: dropping short PING frame");
+                        continue;
+                    }
+                    let ping = <[u8; 8]>::try_from(&frame_payload[..8])?;
+                    return Ok(ReceivedMessage::Ping(ping));
+                }
+                FRAME_PONG => {
+                    if frame_len < 8 {
+                        tracing::warn!("unexpected: dropping short PONG frame");
+                        continue;
+                    }
+                    let pong = <[u8; 8]>::try_from(&frame_payload[..8])?;
+                    return Ok(ReceivedMessage::Pong(pong));
+                }
+                FRAME_HEALTH => {
+                    let problem = Some(String::from_utf8_lossy(&frame_payload).into());
+                    return Ok(ReceivedMessage::Health { problem });
+                }
+                FRAME_RESTARTING => {
+                    if frame_len < 8 {
+                        tracing::warn!("unexpected: dropping short server restarting frame");
+                        continue;
+                    }
+                    let reconnect_in = <[u8; 4]>::try_from(&frame_payload[..4])?;
+                    let try_for = <[u8; 4]>::try_from(&frame_payload[4..8])?;
+                    let reconnect_in =
+                        Duration::from_millis(u32::from_be_bytes(reconnect_in) as u64);
+                    let try_for = Duration::from_millis(u32::from_be_bytes(try_for) as u64);
+                    return Ok(ReceivedMessage::ServerRestarting {
+                        reconnect_in,
+                        try_for,
+                    });
+                }
+                _ => {
+                    frame_payload.clear();
+                }
+            }
+        }
+    }
+}
+
+// errors if `frame_len` is less than the expected key size
+fn get_key_from_slice(payload: &[u8]) -> Result<PublicKey> {
+    Ok(<[u8; crypto_box::KEY_SIZE]>::try_from(payload)?.into())
 }
 
 #[derive(Serialize, Deserialize, MaxSize)]

--- a/src/hp/derp/server.rs
+++ b/src/hp/derp/server.rs
@@ -9,3 +9,10 @@ impl Server {
         Server {}
     }
 }
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ServerInfo {
+    pub(crate) version: usize,
+    pub(crate) token_bucket_bytes_per_second: usize,
+    pub(crate) token_bucket_bytes_burst: usize,
+}

--- a/src/hp/derp/server.rs
+++ b/src/hp/derp/server.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::hp::key;
 
 #[derive(Debug)]

--- a/src/hp/disco.rs
+++ b/src/hp/disco.rs
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_extraction() {
-        let sender_key = key::node::SecretKey::generate(&mut rand::rngs::OsRng);
+        let sender_key = key::node::SecretKey::generate();
         let sender_node_key: key::node::PublicKey = sender_key.verifying_key().into();
         let msg = Message::Ping(Ping {
             tx_id: stun::TransactionId::default(),

--- a/src/hp/key/disco.rs
+++ b/src/hp/key/disco.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use anyhow::{anyhow, ensure, Result};
 
 pub const PUBLIC_RAW_LEN: usize = 32;
-const NONCE_LEN: usize = 24;
+pub(crate) const NONCE_LEN: usize = 24;
 pub const SECRET_RAW_LEN: usize = 32;
 
 /// Public key for a discovery.

--- a/src/hp/key/node.rs
+++ b/src/hp/key/node.rs
@@ -140,3 +140,9 @@ impl From<SecretKey> for disco::SecretKey {
         disco::SecretKey::from(value.0.to_bytes())
     }
 }
+
+impl From<SecretKey> for crate::tls::Keypair {
+    fn from(value: SecretKey) -> Self {
+        value.0.into()
+    }
+}

--- a/src/hp/key/node.rs
+++ b/src/hp/key/node.rs
@@ -5,8 +5,6 @@ pub use ed25519_dalek::{SigningKey, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH};
 use super::{disco, disco::NONCE_LEN};
 use anyhow::{anyhow, ensure, Result};
 
-pub(crate) const KEY_SIZE: usize = 32;
-
 #[derive(Clone, PartialEq, Eq)]
 pub struct PublicKey(ed25519_dalek::VerifyingKey);
 
@@ -116,12 +114,6 @@ impl SecretKey {
 impl Debug for SecretKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "SecretKey({})", hex::encode(self.0.to_bytes()))
-    }
-}
-
-impl AsRef<[u8]> for SecretKey {
-    fn as_ref(&self) -> &[u8] {
-        &self.0.to_bytes()
     }
 }
 

--- a/src/hp/key/node.rs
+++ b/src/hp/key/node.rs
@@ -1,8 +1,11 @@
 use std::{fmt::Debug, hash::Hash};
 
-pub use ed25519_dalek::{SigningKey as SecretKey, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH};
+pub use ed25519_dalek::{SigningKey, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH};
 
-use super::disco;
+use super::{disco, disco::NONCE_LEN};
+use anyhow::{anyhow, ensure, Result};
+
+pub(crate) const KEY_SIZE: usize = 32;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct PublicKey(ed25519_dalek::VerifyingKey);
@@ -48,8 +51,100 @@ impl From<PublicKey> for disco::PublicKey {
     }
 }
 
+impl PublicKey {
+    pub fn as_bytes(&self) -> &[u8; PUBLIC_KEY_LENGTH] {
+        self.0.as_bytes()
+    }
+}
+
+#[derive(Clone)]
+pub struct SecretKey(ed25519_dalek::SigningKey);
+
+impl SecretKey {
+    pub fn generate() -> Self {
+        Self(ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng))
+    }
+
+    pub fn verifying_key(&self) -> PublicKey {
+        self.0.verifying_key().into()
+    }
+
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.to_bytes()
+    }
+
+    fn shared_secret(&self, other: &PublicKey) -> crypto_box::ChaChaBox {
+        let public_key = crypto_box::PublicKey::from(*other.as_bytes());
+        let secret_key = crypto_box::SecretKey::from(self.to_bytes());
+        crypto_box::ChaChaBox::new(&public_key, &secret_key)
+    }
+
+    // Creates a shared secret between the [`SecretKey`] and the given [`PublicKey`], and sealsthe
+    // provided cleartext.
+    pub fn seal_to(&self, other: &PublicKey, cleartext: &[u8]) -> Vec<u8> {
+        use crypto_box::aead::{Aead, AeadCore, OsRng};
+
+        let shared_secret = self.shared_secret(other);
+        let nonce = crypto_box::ChaChaBox::generate_nonce(&mut OsRng);
+        let ciphertext = shared_secret
+            .encrypt(&nonce, cleartext)
+            .expect("encryption failed");
+
+        let mut res = nonce.to_vec();
+        res.extend(ciphertext);
+        res
+    }
+
+    // Creates a shared secret between the [`SecretKey`] and the given [`PublicKey`], and opens the
+    // `seal`, returning the cleartext.
+    pub fn open_from(&self, other: &PublicKey, seal: &[u8]) -> Result<Vec<u8>> {
+        let shared_secret = self.shared_secret(other);
+
+        use crypto_box::aead::Aead;
+        ensure!(seal.len() > NONCE_LEN, "too short");
+
+        let (nonce, ciphertext) = seal.split_at(NONCE_LEN);
+        let nonce: [u8; NONCE_LEN] = nonce.try_into().unwrap();
+        let cleartext = shared_secret
+            .decrypt(&nonce.into(), ciphertext)
+            .map_err(|e| anyhow!("decryption failed: {:?}", e))?;
+
+        Ok(cleartext)
+    }
+}
+
+impl Debug for SecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SecretKey({})", hex::encode(self.0.to_bytes()))
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0.to_bytes()
+    }
+}
+
+impl Hash for SecretKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.to_bytes().hash(state)
+    }
+}
+
+impl From<ed25519_dalek::SigningKey> for SecretKey {
+    fn from(key: ed25519_dalek::SigningKey) -> Self {
+        Self(key)
+    }
+}
+
+impl From<[u8; SECRET_KEY_LENGTH]> for SecretKey {
+    fn from(value: [u8; SECRET_KEY_LENGTH]) -> Self {
+        Self(ed25519_dalek::SigningKey::from_bytes(&value))
+    }
+}
+
 impl From<SecretKey> for disco::SecretKey {
     fn from(value: SecretKey) -> Self {
-        disco::SecretKey::from(value.to_bytes())
+        disco::SecretKey::from(value.0.to_bytes())
     }
 }

--- a/src/hp/magicsock/conn.rs
+++ b/src/hp/magicsock/conn.rs
@@ -3336,7 +3336,7 @@ mod tests {
     }
 
     async fn run_derp_and_stun(stun_ip: IpAddr) -> Result<(DerpMap, impl FnOnce())> {
-        let d = derp::Server::new(key::node::SecretKey::generate(&mut rand::rngs::OsRng));
+        let d = derp::Server::new(key::node::SecretKey::generate());
 
         // TODO: configure DERP server when actually implemented
         // httpsrv := httptest.NewUnstartedServer(derphttp.Handler(d))
@@ -3392,7 +3392,7 @@ mod tests {
 
     impl MagicStack {
         async fn new(derp_map: DerpMap) -> Result<Self> {
-            let key = key::node::SecretKey::generate(&mut rand::rngs::OsRng);
+            let key = key::node::SecretKey::generate();
             Self::with_key(key, derp_map).await
         }
 

--- a/src/hp/magicsock/rebinding_conn.rs
+++ b/src/hp/magicsock/rebinding_conn.rs
@@ -371,7 +371,7 @@ mod tests {
     use anyhow::Result;
 
     fn wrap_socket(conn: impl AsyncUdpSocket) -> Result<(quinn::Endpoint, key::node::SecretKey)> {
-        let key = key::node::SecretKey::generate(&mut rand::rngs::OsRng);
+        let key = key::node::SecretKey::generate();
         let tls_server_config =
             tls::make_server_config(&key.clone().into(), vec![tls::P2P_ALPN.to_vec()], false)?;
         let server_config = quinn::ServerConfig::with_crypto(Arc::new(tls_server_config));


### PR DESCRIPTION
some general notes about this first attempt (aka "this mess"):

- golang impl uses u32 everywhere, including sending the frame length on the wire.  I assuming we should continue to only use 4 bytes for the frame length, but then we should probably convert to `usize` when we get it, so that we have fewer `as usize`'s littered throughout the code. But I haven't done this yet.

- from looking at the surrounding code that imports the derp client, it looks like we need to be able to use this in many threads. So I've wrapped any "shared data" in an `Arc<Mutex>`

- I don't understand why the go code only wrapped the `writer` in a mutex lock and not the `reader` as well. I followed the same pattern, because maybe I don't understand this yet?

- the rate limiter is gross and maybe we wrap this in a trait so we don't have to drag around the underlying `governor` traits in our client implementation. Updating the rate limiter is also not fully implemented. Because I'm mad at how gross it is & also I needed to stop spending time on it & move on.

- this `recv_err` nonsense is so ugly, god help me. After we encounter an error reading while running `recv`, the go impl wants us to return the same error anytime we call `recv` again on the client. (The client is "dead" after the first error). However, most errors in rust aren't clonable, so currently I'm storing the error as a `String` that I've pulled from the error itself. There has got to be a better way to do this, other than the nonsense I've implemented, no?