### PR TITLE
begin impl Server side of derp, starting with the server side of the client connection

### DIFF
--- a/src/hp/derp.rs
+++ b/src/hp/derp.rs
@@ -10,6 +10,8 @@
 //! Based on tailscale/derp/derp.go
 
 mod client;
+mod client_conn;
+mod conn;
 pub mod http;
 mod map;
 mod server;

--- a/src/hp/derp.rs
+++ b/src/hp/derp.rs
@@ -9,7 +9,7 @@
 //! between very aggressive NATs, firewalls, no IPv6, etc? Well, DERP.
 //! Based on tailscale/derp/derp.go
 
-mod client;
+pub(crate) mod client;
 mod client_conn;
 mod conn;
 pub mod http;

--- a/src/hp/derp.rs
+++ b/src/hp/derp.rs
@@ -22,7 +22,7 @@ pub use self::server::Server;
 
 use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{ensure, Result};
 use bytes::BytesMut;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -86,8 +86,12 @@ const FRAME_FORWARD_PACKET: FrameType = 0x0a;
 const FRAME_RECV_PACKET: FrameType = 0x05;
 /// no payload, no-op (to be replaced with ping/pong)
 const FRAME_KEEP_ALIVE: FrameType = 0x06;
-/// 1 byte paylouad: 0x01 or 0x00 for whether this is client's home node
+/// 1 byte payload: 0x01 or 0x00 for whether this is client's home node
 const FRAME_NOTE_PREFERRED: FrameType = 0x07;
+/// indicates this is the client's home node
+const PREFERRED: u8 = 1u8;
+/// indicates this is NOT the client's home node
+const NOT_PREFERRED: u8 = 0u8;
 
 /// Sent from server to client to signal that a previous sender is no longer connected.
 ///
@@ -155,9 +159,10 @@ async fn read_frame(
     mut buf: &mut BytesMut,
 ) -> Result<(FrameType, usize)> {
     let (frame_type, frame_len) = read_frame_header(&mut reader).await?;
-    if frame_len > max_size {
-        bail!("frame header size {frame_len} exceeds reader limit of {max_size}");
-    }
+    ensure!(
+        frame_len < max_size,
+        "frame header size {frame_len} exceeds reader limit of {max_size}"
+    );
     buf.resize(frame_len, 0u8);
     reader.read_exact(&mut buf).await?;
     Ok((frame_type, frame_len))
@@ -175,15 +180,16 @@ async fn write_frame_header(
 }
 
 /// AsyncWrites a complete frame. Does not flush.
-async fn write_frame(
+async fn write_frame<'a>(
     mut writer: impl AsyncWrite + Unpin,
     frame_type: FrameType,
-    bytes: Vec<&[u8]>,
+    bytes: &[&[u8]],
 ) -> Result<()> {
     let bytes_len: usize = bytes.iter().map(|b| b.len()).sum();
-    if bytes_len > MAX_FRAME_SIZE {
-        bail!("unreasonably large frame write");
-    }
+    ensure!(
+        bytes_len <= MAX_FRAME_SIZE,
+        "unreasonably large frame write"
+    );
     write_frame_header(&mut writer, frame_type, bytes_len).await?;
     for b in bytes {
         writer.write_all(b).await?;
@@ -198,20 +204,14 @@ async fn write_frame(
 async fn write_frame_timeout(
     writer: impl AsyncWrite + Unpin,
     frame_type: FrameType,
-    bytes: Vec<&[u8]>,
-    timeout: Duration,
+    bytes: &[&[u8]],
+    timeout: Option<Duration>,
 ) -> Result<()> {
-    if timeout.is_zero() {
-        return write_frame(writer, frame_type, bytes).await;
-    }
-    tokio::select! {
-        biased;
-        res = write_frame(writer, frame_type, bytes) => {
-            res
-        }
-        _ = tokio::time::sleep(timeout) => {
-            bail!("could not write {} within the deadline {:?}", frame_type, timeout);
-        }
+    if let Some(duration) = timeout {
+        tokio::time::timeout(duration, write_frame(writer, frame_type, bytes)).await??;
+        Ok(())
+    } else {
+        write_frame(writer, frame_type, &bytes).await
     }
 }
 
@@ -229,7 +229,7 @@ mod tests {
         assert_eq!(frame_len, 301);
 
         let expect_buf = b"hello world!";
-        write_frame(&mut writer, FRAME_HEALTH, vec![expect_buf]).await?;
+        write_frame(&mut writer, FRAME_HEALTH, &[expect_buf]).await?;
         writer.flush().await;
         println!("{:?}", reader);
         let mut got_buf = BytesMut::new();

--- a/src/hp/derp/client_conn.rs
+++ b/src/hp/derp/client_conn.rs
@@ -1,45 +1,58 @@
 use std::sync::atomic::AtomicBool;
-use std::time::SystemTime;
+use std::time::Duration;
+use std::time::Instant;
 
-use anyhow::Result;
-use bytes::Bytes;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::mpsc::Receiver;
-use tokio::sync::oneshot::Sender;
+use anyhow::{bail, Context, Result};
+use bytes::{Bytes, BytesMut};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
-use crate::hp::key::node::PublicKey;
+use crate::hp::{
+    disco::looks_like_disco_wrapper,
+    key::node::{PublicKey, PUBLIC_KEY_LENGTH},
+};
 
 use super::client::ClientInfo;
 use super::conn::Conn;
-use super::{write_frame, FRAME_KEEP_ALIVE, FRAME_PEER_GONE, FRAME_PEER_PRESENT, FRAME_PONG};
+use super::{
+    read_frame, write_frame_timeout, FRAME_CLOSE_PEER, FRAME_FORWARD_PACKET, FRAME_KEEP_ALIVE,
+    FRAME_NOTE_PREFERRED, FRAME_PEER_GONE, FRAME_PEER_PRESENT, FRAME_PING, FRAME_PONG,
+    FRAME_RECV_PACKET, FRAME_SEND_PACKET, FRAME_WATCH_CONNS, KEEP_ALIVE, MAX_FRAME_SIZE,
+    MAX_PACKET_SIZE,
+};
 
-type PacketReceiver = Receiver<Packet>;
+type PacketReceiver = mpsc::Receiver<Packet>;
 
 /// A request to write a dataframe to a Client
+#[derive(Debug)]
 struct Packet {
     /// The sender of the packet
     src: PublicKey,
     /// When a packet was put onto a queue before it was sent,
     /// and is used for reporting metrics on the duration of packets
     /// in the queue.
-    enqueued_at: SystemTime,
+    enqueued_at: Instant,
 
     /// The data packet bytes.
     bytes: Bytes,
 }
 
 /// PeerConnState represents whether or not a peer is connected to the server.
+#[derive(Debug)]
 struct PeerConnState {
     peer: PublicKey,
     present: bool,
 }
 
 #[derive(Debug)]
-/// A client's connection to the servber
-struct ClientConn<R, W, C>
+/// A client's connection to the server
+/// A handle?
+/// should have senders here, & be clonable, i think?
+/// should be able to be held by server
+struct ClientConnManager<C>
 where
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
     C: Conn,
 {
     /// Static after construction, process-wide unique counter, incremented each Accept
@@ -47,75 +60,526 @@ where
 
     // TODO: in the go impl, we have a ptr to the server & use that ptr to update stats
     // in rust, we should probably have a stats struct separate from the server that we
-    // can update in different threads
+    // can update in different threads, this may become a series of channels on which to
+    // send updates
     // stats: Stats,
     conn: C,
     key: PublicKey,
     info: ClientInfo,
     /// Sent when connection closes
     // TODO: maybe should be a receiver
-    done: Sender<()>,
+    done: CancellationToken,
     /// Usually ip:port from `SocketAddr`
     remote_addr: String,
     /// zero if remote_addr is not `ip:port`
     remote_ip_port: u16,
-    /// Packets queued to this client
-    send_queue: PacketReceiver,
-    /// Important packets queued to this client
-    disco_send_queue: PacketReceiver,
-    /// Pong replies to send to the client,
-    send_pong_ch: Receiver<[u8; 8]>,
-    /// Write request that a previous sender has disconnected (not used by mesh peers)
-    peer_gone: Receiver<PublicKey>,
-    /// Write request to write `PEER_STATE_CHANGE`
-    mesh_update: Receiver<()>,
     /// When true, the [`ClientInfo`] had the correct mesh token for inter-region routing
     can_mesh: bool,
-    /// Whether more than 1 `ClientConn` for one key is connected
+    /// Whether more than 1 `ClientConnManager` for one key is connected
     is_dup: AtomicBool,
     /// Whether sends to this peer are disabled due to active/active dups
     is_disabled: AtomicBool,
 
     /// Controls how quickly two connections with the same client key can kick
     /// each other off the server by taking ownership of a key
-    // TODO: replace with rate limiter
-    replace_limiter: bool,
+    // TODO: replace with rate limiter, also, this should probably be on the ClientSets, not on
+    // the client itself
+    // replace_limiter: RateLimiter,
 
-    reader: R,
-    connected_at: SystemTime,
-    preferred: bool,
-    writer: W,
-    //// Guarded by s.mu
-    ////
-    //// peerStateChange is used by mesh peers (a set of regional
-    //// DERP servers) and contains records that need to be sent to
-    //// the client for them to update their map of who's connected
-    //// to this node.
-    //peerStateChange []peerConnState
+    /// Instant at which we created the `ClientConnManager`
+    connected_at: Instant,
+
+    reader_handle: JoinHandle<Result<()>>,
+    writer_handle: JoinHandle<Result<()>>,
+
+    /// Channels that allow the ClientConnManager (and the Server) to send
+    /// the client messages. These `Senders` correspond to `Receivers` on the
+    /// [`ClientConnWriter`].
+    client_channels: ClientChannels,
 }
 
-impl<R, W, C> ClientConn<R, W, C>
+/// Channels that the [`ClientConnReader`] needs in order to notify the server
+/// about actions it needs to take on behalf of the client.
+#[derive(Debug)]
+struct ServerChannels {
+    /// Send a notification to the Server to add this client as a watcher
+    add_watcher: mpsc::Sender<PublicKey>,
+    /// Send a notification to the Server to close connections to the given peer
+    close_peer: mpsc::Sender<PublicKey>,
+    /// Send a notification to the server to send this packet to the destination
+    send_queue: mpsc::Sender<(PublicKey, Packet)>,
+    /// Send a notification to the server to forward this pacekt to the destination
+    disco_send_queue: mpsc::Sender<(PublicKey, Packet)>,
+}
+
+/// Channels that the [`ClientConnManager`] uses to communicate with the
+/// [`ClientConnWriter`] to forward the client:
+///  - information about a peer leaving the network (This should only happen for peers that this
+///  client was previously communciating with)
+///  - forwarded packets (if they are mesh client)
+///  - packets sent to this client from another client in the network
+#[derive(Debug)]
+struct ClientChannels {
+    /// Queue of packets intended for the client
+    send_queue: mpsc::Sender<Packet>,
+    /// Queue of important packets intended for the client
+    disco_send_queue: mpsc::Sender<Packet>,
+    /// Notify the client that a previous sender has disconnected (Not used by mesh peers)
+    peer_gone: mpsc::Sender<PublicKey>,
+    /// Send a client (if it is a mesh peer) records that will
+    /// allow the client to update their map of who's connected
+    /// to this node
+    mesh_update: mpsc::Sender<Vec<PeerConnState>>,
+}
+
+impl<C> ClientConnManager<C>
 where
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
     C: Conn,
 {
-    fn set_preferred(&mut self, v: bool) {
+    async fn new<R, W>(
+        key: PublicKey,
+        conn_num: i64,
+        conn: C,
+        reader: R,
+        writer: W,
+        remote_addr: String,
+        remote_ip_port: u16,
+        can_mesh: bool,
+        client_info: ClientInfo,
+        write_timeout: Duration,
+        channel_capacity: usize,
+        server_channels: ServerChannels,
+        shutdown_client: mpsc::Sender<(PublicKey, i64)>,
+    ) -> Result<ClientConnManager<C>>
+    where
+        R: AsyncRead + Unpin + Send + Sync + 'static,
+        W: AsyncWrite + Unpin + Send + Sync + 'static,
+    {
+        let done = CancellationToken::new();
+        let client_id = (key.clone(), conn_num);
+        let (send_queue_s, send_queue_r) = mpsc::channel(channel_capacity);
+
+        let (disco_send_queue_s, disco_send_queue_r) = mpsc::channel(channel_capacity);
+        let (send_pong_s, send_pong_r) = mpsc::channel(channel_capacity);
+        let (peer_gone_s, peer_gone_r) = mpsc::channel(channel_capacity);
+        let (mesh_update_s, mesh_update_r) = mpsc::channel(channel_capacity);
+        let conn_writer = ClientConnWriter {
+            can_mesh,
+            writer,
+            timeout: write_timeout,
+            send_queue: send_queue_r,
+            disco_send_queue: disco_send_queue_r,
+            send_pong: send_pong_r,
+            peer_gone: peer_gone_r,
+            mesh_update_r,
+            mesh_update_s: mesh_update_s.clone(),
+        };
+
+        let conn_reader = ClientConnReader {
+            can_mesh,
+            reader,
+            key: key.clone(),
+            send_pong: send_pong_s,
+            server_channels,
+            preferred: false,
+        };
+
+        // start writer loop
+        let writer_done = done.clone();
+        let writer_shutdown_client = shutdown_client.clone();
+        let writer_client_id = client_id.clone();
+        let writer_handle = tokio::spawn(async move {
+            let res = conn_writer.run(writer_done).await;
+            if let Err(e) = writer_shutdown_client.try_send(writer_client_id.clone()) {
+                tracing::warn!(
+                    "unable to let server know to shut down client {writer_client_id:?}: {e:?}"
+                );
+            }
+            res
+        });
+
+        // start reader loop
+        let reader_done = done.clone();
+        let reader_handle = tokio::spawn(async move {
+            let res = conn_reader.run(reader_done).await;
+            if let Err(e) = shutdown_client.try_send(client_id.clone()) {
+                tracing::warn!(
+                    "unable to let server know to shut down client {client_id:?}: {e:?}"
+                );
+            }
+            res
+        });
+
+        // return client conn to server
+        Ok(ClientConnManager {
+            conn_num,
+            conn,
+            key,
+            remote_addr,
+            remote_ip_port,
+            can_mesh,
+            is_dup: AtomicBool::from(false),
+            is_disabled: AtomicBool::from(false),
+            connected_at: Instant::now(),
+            writer_handle,
+            reader_handle,
+            info: client_info,
+            done,
+            client_channels: ClientChannels {
+                send_queue: send_queue_s,
+                disco_send_queue: disco_send_queue_s,
+                peer_gone: peer_gone_s,
+                mesh_update: mesh_update_s,
+            },
+        })
+    }
+
+    /// Shutdown the `ClientConnManager` reader and writer loops and closes the "actual" connection.
+    ///
+    /// Logs any shutdown errors as warnings.
+    async fn shutdown(self) {
+        self.done.cancel();
+        if let Err(e) = self.writer_handle.await {
+            tracing::warn!(
+                "error closing writer loop for client connection {:?} {}: {e:?}",
+                self.key,
+                self.conn_num
+            );
+        }
+        if let Err(e) = self.reader_handle.await {
+            tracing::warn!(
+                "error closing reader loop for client connection {:?} {}: {e:?}",
+                self.key,
+                self.conn_num
+            );
+        }
+        if let Err(e) = self.conn.close() {
+            tracing::warn!(
+                "error closing connection to client {:?} {}: {e:?}",
+                self.key,
+                self.conn_num
+            );
+        }
+    }
+}
+
+/// Manages all the writes to this client. It periodically sends a `KEEP_ALIVE`
+/// message to the client to keep the connection alive.
+///
+/// Call `run` to start listening for instructions from the
+/// server or from the associated `ClientConnReader`. Once it hits its
+/// first write error or error receiving off a channel, it error an return.
+/// If writes do not complete in the given `timeout`, it will also error.
+///
+/// The `ClientConnWriter` can send the client:
+///  - a KEEP_ALIVE frame
+///  - a PEER_GONE frame, informing the client a peer is gone from the network // TODO: is this
+///  a mesh only thing?
+///  - packets from other peers
+///
+/// If the client is a mesh client, it can also send updates about peers in the mesh.
+#[derive(Debug)]
+pub(crate) struct ClientConnWriter<W: AsyncWrite + Unpin + Send + Sync> {
+    /// Indicates whether this client can mesh
+    can_mesh: bool,
+    /// Writer we use to write to the client
+    writer: W,
+    /// Max time we wait to complete a write to the client
+    timeout: Duration,
+    /// Packets queued to send to the client
+    send_queue: mpsc::Receiver<Packet>,
+    /// Important packets queued to send to the client
+    disco_send_queue: mpsc::Receiver<Packet>,
+    /// Pong replies to send to the client
+    send_pong: mpsc::Receiver<[u8; 8]>,
+    /// Notify the client that a previous sender has disconnected (not used by mesh peers)
+    peer_gone: mpsc::Receiver<PublicKey>,
+    /// Used by mesh peers (a set of regional DERP servers) and contains records
+    /// that need to be sent to the client for them to update their map of who's
+    /// connected to this node
+    /// Notify the client of a peer state change ([`PeerConnState`])
+    mesh_update_r: mpsc::Receiver<Vec<PeerConnState>>,
+    /// Used by `reschedule_mesh_update` to reschedule additional mesh_updates
+    mesh_update_s: mpsc::Sender<Vec<PeerConnState>>,
+}
+
+impl<W> ClientConnWriter<W>
+where
+    W: AsyncWrite + Unpin + Send + Sync,
+{
+    async fn run(mut self, done: CancellationToken) -> Result<()> {
+        let jitter = Duration::from_secs(5);
+        let mut keep_alive = tokio::time::interval(KEEP_ALIVE + jitter);
+        // ticks immediately
+        keep_alive.tick().await;
+        loop {
+            tokio::select! {
+                _ = done.cancelled() => {
+                    return Ok(());
+                }
+                peer = self.peer_gone.recv() => {
+                    let peer = peer.context("Server.peer_gone dropped")?;
+                    self.send_peer_gone(peer).await?;
+                }
+                updates = self.mesh_update_r.recv() => {
+                    let updates = updates.context("Server.mesh_update dropped")?;
+                    self.send_mesh_updates(updates).await?;
+                }
+                packet = self.send_queue.recv() => {
+                    let packet = packet.context("Server.send_queue dropped")?;
+                    self.send_packet(packet).await?;
+                    // TODO: stats
+                    // record `packet.enqueuedAt`
+                }
+                packet = self.disco_send_queue.recv() => {
+                    let packet = packet.context("Server.disco_send_queue dropped")?;
+                    self.send_packet(packet).await?;
+                    // TODO: stats
+                    // record `packet.enqueuedAt`
+                }
+                data = self.send_pong.recv() => {
+                    let data = data.context("ClientConnReader.send_pong dropped")?;
+                    self.send_pong(data).await?;
+                    // TODO: stats
+                    // record `send_pong`
+                }
+                _ = keep_alive.tick() => {
+                    self.send_keep_alive().await?;
+                }
+            }
+            // TODO: golang batches as many writes as are in all the channels
+            // & then flushes when there is no more work to be done at the moment.
+            // refactor to get something similar
+            self.writer.flush().await?;
+        }
+    }
+
+    /// Send  `FRAME_KEEP_ALIVE`, does not flush
+    ///
+    /// Errors if the send does not happen within the `timeout` duration
+    async fn send_keep_alive(&mut self) -> Result<()> {
+        write_frame_timeout(&mut self.writer, FRAME_KEEP_ALIVE, vec![], self.timeout).await
+    }
+
+    /// Send a `pong` frame, does not flush
+    ///
+    /// Errors if the send does not happen within the `timeout` duration
+    async fn send_pong(&mut self, data: [u8; 8]) -> Result<()> {
+        // TODO: stats
+        // c.s.peerGoneFrames.Add(1)
+        write_frame_timeout(&mut self.writer, FRAME_PONG, vec![&data], self.timeout).await
+    }
+
+    /// Sends a peer gone frame, does not flush
+    ///
+    /// Errors if the send does not happen within the `timeout` duration
+    async fn send_peer_gone(&mut self, peer: PublicKey) -> Result<()> {
+        // TODO: stats
+        // c.s.peerGoneFrames.Add(1)
+        write_frame_timeout(
+            &mut self.writer,
+            FRAME_PEER_GONE,
+            vec![peer.as_bytes()],
+            self.timeout,
+        )
+        .await
+    }
+
+    /// Sends a peer present frame, does not flush
+    ///
+    /// Errors if the send does not happen within the `timeout` duration
+    async fn send_peer_present(&mut self, peer: PublicKey) -> Result<()> {
+        write_frame_timeout(
+            &mut self.writer,
+            FRAME_PEER_PRESENT,
+            vec![peer.as_bytes()],
+            self.timeout,
+        )
+        .await
+    }
+
+    // TODO: golang comment:
+    // "Drains as many mesh `PEER_STATE_CHANGE`s entries as possible
+    // into the write buffer WITHOUT flushing or otherwise blocking (as it holds the mutex while
+    // working).
+    // If it can't drain them all, it schedules itself to be called again in the future."
+    /// Send mesh updates for the first 16 (arbitrary #, based on the size that
+    /// the goimpl seems to "want" the `PeerConnState` vector to be) `PeerConnState`
+    /// in the vector. If there are more than 16 entires, it schedules itself for a
+    /// future update.
+    async fn send_mesh_updates(&mut self, mut updates: Vec<PeerConnState>) -> Result<()> {
+        if !self.can_mesh {
+            bail!(
+                "unexpected request to update mesh peers on a connection that is not able to mesh"
+            );
+        }
+        let scheduled_updates: Vec<_> = if updates.len() > 16 {
+            updates.drain(..).collect()
+        } else {
+            updates.drain(..16).collect()
+        };
+        for peer_conn_state in scheduled_updates {
+            if peer_conn_state.present {
+                self.send_peer_present(peer_conn_state.peer).await?;
+            } else {
+                self.send_peer_gone(peer_conn_state.peer).await?;
+            }
+        }
+        if updates.len() != 0 {
+            self.request_mesh_update(updates).await?;
+        }
+        Ok(())
+    }
+
+    // runs in a go routing in the go impl
+    async fn request_mesh_update(&self, updates: Vec<PeerConnState>) -> Result<()> {
+        if !self.can_mesh {
+            bail!(
+                "unexpected request to update mesh peers on a connection that is not able to mesh"
+            );
+        }
+        self.mesh_update_s.send(updates).await?;
+        Ok(())
+    }
+
+    /// Writes contents to the client in a `RECV_PACKET` frame. If `srcKey.is_zero`, it uses the
+    /// old DERPv1 framing format, otherwise uses the DERPv2 framing format. The bytes of contents
+    /// are only valid until this function returns, do not retain the slices.
+    /// Does not flush.
+    async fn send_packet(&mut self, packet: Packet) -> Result<()> {
+        // TODO: stats:
+        // 	defer func() {
+        // // Stats update.
+        // if err != nil {
+        // 	c.s.recordDrop(contents, packet.src, c.key, dropReasonWriteError)
+        // } else {
+        // 	c.s.packetsSent.Add(1)
+        // 	c.s.bytesSent.Add(int64(len(packet.contents)))
+        // }
+        // }()
+        let srckey = packet.src;
+        let contents = packet.bytes;
+        if srckey.is_zero() {
+            // TODO: ensure we handle this correctly on the client side
+            write_frame_timeout(
+                &mut self.writer,
+                FRAME_RECV_PACKET,
+                vec![&contents],
+                self.timeout,
+            )
+            .await
+        } else {
+            write_frame_timeout(
+                &mut self.writer,
+                FRAME_RECV_PACKET,
+                vec![&contents, srckey.as_bytes()],
+                self.timeout,
+            )
+            .await
+        }
+    }
+}
+
+/// Responsible for reading frames from the client, parsing the frames, and sending
+/// the content to the correct location.
+///
+/// The `ClientConnReader` can:
+///     - receive a ping and notify the `ClientConnWriter` to write a pong back
+///     to the client
+///     - notify the server to send a packet to another peer on behalf of the client
+///     - note whether the client is `preferred`  TODO: what is this?
+///
+/// If the `ClientConnReader` `can_mesh` (is a trusted mesh peer), it can also:
+///     - tell the server to add the current client as a watcher TODO: what is a watcher?
+///     - tell the server to close a given peer
+///     - tell the server to forward a packet from another peer.
+struct ClientConnReader<R>
+where
+    R: AsyncRead + Unpin + Send + Sync,
+{
+    /// Indicates whether this client can mesh
+    can_mesh: bool,
+    /// Reader we use to read from the client
+    reader: R,
+    /// PublicKey of this client
+    key: PublicKey,
+    /// Pong replies to sent to the client, processed by the [`ClientConnWriter`]
+    send_pong: mpsc::Sender<[u8; 8]>,
+
+    /// Channels used to communicate with the server about actions
+    /// it needs to take on behalf of the client
+    server_channels: ServerChannels,
+
+    /// TODO: what is this?
+    preferred: bool,
+}
+
+impl<R> ClientConnReader<R>
+where
+    R: AsyncRead + Unpin + Send + Sync,
+{
+    async fn run(mut self, done: CancellationToken) -> Result<()> {
+        tokio::select! {
+            biased;
+            res = self.read() => {
+                res
+            }
+            _ = done.cancelled() => {
+                Ok(())
+            }
+        }
+    }
+
+    /// Read off the `reader`, erroring and returning at the first error
+    async fn read(&mut self) -> Result<()> {
+        let mut buf = BytesMut::new();
+        loop {
+            // TODO: return Ok(()) if EOF error
+            let (frame_type, _frame_len) =
+                read_frame(&mut self.reader, MAX_FRAME_SIZE, &mut buf).await?;
+            // TODO: "note client activity", meaning we update the server that the client with this
+            // public key was the last one to receive data
+            match frame_type {
+                FRAME_NOTE_PREFERRED => {
+                    self.handle_frame_note_preferred(&buf)?;
+                }
+                FRAME_SEND_PACKET => {
+                    self.handle_frame_send_packet(&buf).await?;
+                }
+                FRAME_FORWARD_PACKET => {
+                    self.handle_frame_forward_packet(&buf).await?;
+                }
+                FRAME_WATCH_CONNS => {
+                    self.handle_frame_watch_conns(&buf).await?;
+                }
+                FRAME_CLOSE_PEER => {
+                    self.handle_frame_close_peer(&buf).await?;
+                }
+                FRAME_PING => {
+                    self.handle_frame_ping(&buf).await?;
+                }
+                _ => {
+                    buf.clear();
+                }
+            }
+        }
+    }
+
+    // TODO: what does preferred mean?
+    fn set_preferred(&mut self, v: bool) -> Result<()> {
         if self.preferred == v {
-            return;
+            return Ok(());
         }
         self.preferred = v;
-        // TODO: stats
-        // var homeMove *expvar.Int
-        // if v {
-        // 	c.s.curHomeClients.Add(1)
-        // 	homeMove = &c.s.homeMovesIn
+        // TODO: stats:
+        // 	if v {
+        // c.s.curHomeClients.Add(1)
+        // homeMove = &c.s.homeMovesIn
         // } else {
-        // 	c.s.curHomeClients.Add(-1)
-        // 	homeMove = &c.s.homeMovesOut
+        // c.s.curHomeClients.Add(-1)
+        // homeMove = &c.s.homeMovesOut
         // }
-
-        // // Keep track of varz for home serve moves in/out.  But ignore
+        // 	// Keep track of varz for home serve moves in/out.  But ignore
         // // the initial packet set when a client connects, which we
         // // assume happens within 5 seconds. In any case, just for
         // // graphs, so not important to miss a move. But it shouldn't:
@@ -124,69 +588,168 @@ where
         // if time.Since(c.connectedAt) > 5*time.Second {
         // 	homeMove.Add(1)
         // }
+        Ok(())
     }
 
-    // TODO: stats
-    // // expMovingAverage returns the new moving average given the previous average,
-    // // a new value, and an alpha decay factor.
-    // // https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
-    // func expMovingAverage(prev, newValue, alpha float64) float64 {
-    //   return alpha*newValue + (1-alpha)*prev
-    // }
+    fn handle_frame_note_preferred(&mut self, data: &[u8]) -> Result<()> {
+        if data.len() != 1 {
+            bail!("FRAME_NOTE_PREFERRED content is an unexpected size");
+        }
+        self.set_preferred(data[0] != 0)
+    }
 
-    // TODO: stats
-    // // recordQueueTime updates the average queue duration metric after a packet has been sent.
-    // func (c *sclient) recordQueueTime(enqueuedAt time.Time) {
-    // elapsed := float64(time.Since(enqueuedAt).Milliseconds())
-    // for {
-    // old := atomic.LoadUint64(c.s.avgQueueDuration)
-    // newAvg := expMovingAverage(math.Float64frombits(old), elapsed, 0.1)
-    // if atomic.CompareAndSwapUint64(c.s.avgQueueDuration, old, math.Float64bits(newAvg)) {
-    // break
-    // }
-    // }
-    // }
+    async fn handle_frame_watch_conns(&mut self, data: &[u8]) -> Result<()> {
+        if !data.is_empty() {
+            bail!("FRAME_WATCH_CONNS content is an unexpected size");
+        }
+        if !self.can_mesh {
+            bail!("insufficient permissions");
+        }
+        self.server_channels
+            .add_watcher
+            .send(self.key.clone())
+            .await?;
+        Ok(())
+    }
 
-    fn send_loop(&mut self) -> Result<()> {
+    // assumes ping is 8 bytes
+    async fn handle_frame_ping(&mut self, data: &[u8]) -> Result<()> {
+        if data.len() != 8 {
+            bail!("FRAME_PING unexpected length {}", data.len());
+        }
+        // TODO:stats
+        // c.s.gotPing.Add(1)
+
+        // TODO: add rate limiter
+
+        let data = <[u8; 8]>::try_from(data)?;
+        self.send_pong.send(data).await?;
+        Ok(())
+    }
+
+    async fn handle_frame_close_peer(&self, data: &[u8]) -> Result<()> {
+        if !self.can_mesh {
+            bail!("insufficient permissions");
+        }
+        let key = PublicKey::try_from(data)?;
+        self.server_channels.close_peer.send(key).await?;
+        Ok(())
+    }
+
+    /// Parse the FORWARD_PACKET frame, getting the destination, source, and
+    /// packet content. Then sends the packet to the server, who directs it
+    /// to the destination.
+    ///
+    /// Errors if this client is not a trusted mesh peer, or if the keys cannot
+    /// be parsed correctly, or if the packet is larger than MAX_PACKET_SIZE
+    async fn handle_frame_forward_packet(&self, data: &[u8]) -> Result<()> {
+        if !self.can_mesh {
+            bail!("insufficient permissions");
+        }
+        let (srckey, dstkey, data) = parse_forward_packet(data)?;
+
+        // TODO: stats:
+        // s.packetsRecv.Add(1)
+        // s.bytesRecv.Add(int64(len(contents)))
+        // s.packetsForwaredIn.Add(1)
+
+        let packet = Packet {
+            src: srckey,
+            bytes: Bytes::from(data.to_owned()),
+            enqueued_at: Instant::now(),
+        };
+        self.transfer_packet(dstkey, packet).await
+    }
+
+    /// Parse the SEND_PACKET frame, getting the destination and packet content
+    /// Then sends the packet to the server, who directs it to the destination.
+    ///
+    /// Errors if the key cannot be parsed correctly, or if the packet is
+    /// larger than MAX_PACKET_SIZE
+    async fn handle_frame_send_packet(&self, data: &[u8]) -> Result<()> {
+        let (dstkey, data) = parse_send_packet(data)?;
+        // TODO: stats:
+        // s.packetsRecv.Add(1)
+        // s.bytesRecv.Add(int64(len(contents)))
+        let packet = Packet {
+            src: self.key.clone(),
+            bytes: Bytes::from(data.to_owned()),
+            enqueued_at: Instant::now(),
+        };
+        self.transfer_packet(dstkey, packet).await
+    }
+
+    /// Send the given packet to the server. The server will attempt to
+    /// send the packet to the destination, dropping the packet if the
+    /// destination is not connected, or if the destination client can
+    /// not fit any more messages in its queue.
+    async fn transfer_packet(&self, dstkey: PublicKey, packet: Packet) -> Result<()> {
+        if looks_like_disco_wrapper(&packet.bytes) {
+            self.server_channels
+                .send_queue
+                .send((dstkey, packet))
+                .await
+                .expect("server send_queue dropped");
+        } else {
+            self.server_channels
+                .disco_send_queue
+                .send((dstkey, packet))
+                .await
+                .expect("server disco_send_queue dropped");
+        }
+        Ok(())
+    }
+}
+
+fn parse_forward_packet(data: &[u8]) -> Result<(PublicKey, PublicKey, &[u8])> {
+    if data.len() < PUBLIC_KEY_LENGTH * 2 {
+        bail!("short FORWARD_PACKET frame");
+    }
+
+    let packet_len = data.len() - (PUBLIC_KEY_LENGTH * 2);
+    if packet_len > MAX_PACKET_SIZE {
+        bail!("data packet longer ({packet_len}) than max of {MAX_PACKET_SIZE}");
+    }
+    let srckey = PublicKey::try_from(&data[..PUBLIC_KEY_LENGTH])?;
+    let dstkey = PublicKey::try_from(&data[PUBLIC_KEY_LENGTH..PUBLIC_KEY_LENGTH * 2])?;
+    let data = &data[PUBLIC_KEY_LENGTH * 2..];
+
+    Ok((srckey, dstkey, data))
+}
+
+fn parse_send_packet(data: &[u8]) -> Result<(PublicKey, &[u8])> {
+    if data.len() < PUBLIC_KEY_LENGTH {
+        bail!("short SEND_PACKET frame");
+    }
+    let packet_len = data.len() - PUBLIC_KEY_LENGTH;
+    if packet_len > MAX_PACKET_SIZE {
+        bail!("data packet longer ({packet_len}) than max of {MAX_PACKET_SIZE}");
+    }
+    let dstkey = PublicKey::try_from(&data[..PUBLIC_KEY_LENGTH])?;
+    let data = &data[PUBLIC_KEY_LENGTH..];
+    Ok((dstkey, data))
+}
+
+#[cfg(test)]
+mod tests {
+    super::*;
+
+    #[tokio::test]
+    fn test_client_to_read_manager() -> Result<()> {
+        // set up read manager with reader 
+        // set up channels to send off read manager
+        // send each kind of packet from the client
+        // test that correct messages got to channels
         todo!();
     }
 
-    // TODO: should probably wrap "sends" in a select w/ timeout instead of setting this, as it
-    // doesn't seem to make sense in a rust context
-    fn set_write_deadline(&mut self) {
-        // error is ignored in golang impl
-        let _ = self.conn.set_write_deadline(super::server::WRITE_TIMEOUT);
+    #[tokio::test]
+    fn test_write_manager_to_client() -> Result<()> {
+        // set up writer manager with writer 
+        // set up channels with write info
+        // send each kind of message from the write manager
+        // test that the correct messages got to the writer
+        todo!();
     }
 
-    /// Send  `FRAME_KEEP_ALIVE`
-    // go impl does not flush
-    async fn send_keep_alive(&mut self) -> Result<()> {
-        self.set_write_deadline();
-        write_frame(&mut self.writer, FRAME_KEEP_ALIVE, vec![]).await
-    }
-
-    /// Send a `pong` frame
-    // go impl does not flush
-    async fn send_pong(&mut self, data: &[u8]) -> Result<()> {
-        // TODO: stats
-        // c.s.peerGoneFrames.Add(1)
-        self.set_write_deadline();
-        write_frame(&mut self.writer, FRAME_PONG, vec![data]).await
-    }
-
-    /// Sends a peer gone frame
-    // go impl does not flush
-    async fn send_peer_gone(&mut self, peer: PublicKey) -> Result<()> {
-        // TODO: stats
-        // c.s.peerGoneFrames.Add(1)
-        self.set_write_deadline();
-        write_frame(&mut self.writer, FRAME_PEER_GONE, vec![peer.as_bytes()]).await
-    }
-
-    /// Sends a peer present frame
-    // go impl does not flush
-    async fn send_peer_present(&mut self, peer: PublicKey) -> Result<()> {
-        self.set_write_deadline();
-        write_frame(&mut self.writer, FRAME_PEER_PRESENT, vec![peer.as_bytes()]).await
-    }
 }

--- a/src/hp/derp/client_conn.rs
+++ b/src/hp/derp/client_conn.rs
@@ -1,0 +1,192 @@
+use std::sync::atomic::AtomicBool;
+use std::time::SystemTime;
+
+use anyhow::Result;
+use bytes::Bytes;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::oneshot::Sender;
+
+use crate::hp::key::node::PublicKey;
+
+use super::client::ClientInfo;
+use super::conn::Conn;
+use super::{write_frame, FRAME_KEEP_ALIVE, FRAME_PEER_GONE, FRAME_PEER_PRESENT, FRAME_PONG};
+
+type PacketReceiver = Receiver<Packet>;
+
+/// A request to write a dataframe to a Client
+struct Packet {
+    /// The sender of the packet
+    src: PublicKey,
+    /// When a packet was put onto a queue before it was sent,
+    /// and is used for reporting metrics on the duration of packets
+    /// in the queue.
+    enqueued_at: SystemTime,
+
+    /// The data packet bytes.
+    bytes: Bytes,
+}
+
+/// PeerConnState represents whether or not a peer is connected to the server.
+struct PeerConnState {
+    peer: PublicKey,
+    present: bool,
+}
+
+#[derive(Debug)]
+/// A client's connection to the servber
+struct ClientConn<R, W, C>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    C: Conn,
+{
+    /// Static after construction, process-wide unique counter, incremented each Accept
+    conn_num: i64,
+
+    // TODO: in the go impl, we have a ptr to the server & use that ptr to update stats
+    // in rust, we should probably have a stats struct separate from the server that we
+    // can update in different threads
+    // stats: Stats,
+    conn: C,
+    key: PublicKey,
+    info: ClientInfo,
+    /// Sent when connection closes
+    // TODO: maybe should be a receiver
+    done: Sender<()>,
+    /// Usually ip:port from `SocketAddr`
+    remote_addr: String,
+    /// zero if remote_addr is not `ip:port`
+    remote_ip_port: u16,
+    /// Packets queued to this client
+    send_queue: PacketReceiver,
+    /// Important packets queued to this client
+    disco_send_queue: PacketReceiver,
+    /// Pong replies to send to the client,
+    send_pong_ch: Receiver<[u8; 8]>,
+    /// Write request that a previous sender has disconnected (not used by mesh peers)
+    peer_gone: Receiver<PublicKey>,
+    /// Write request to write `PEER_STATE_CHANGE`
+    mesh_update: Receiver<()>,
+    /// When true, the [`ClientInfo`] had the correct mesh token for inter-region routing
+    can_mesh: bool,
+    /// Whether more than 1 `ClientConn` for one key is connected
+    is_dup: AtomicBool,
+    /// Whether sends to this peer are disabled due to active/active dups
+    is_disabled: AtomicBool,
+
+    /// Controls how quickly two connections with the same client key can kick
+    /// each other off the server by taking ownership of a key
+    // TODO: replace with rate limiter
+    replace_limiter: bool,
+
+    reader: R,
+    connected_at: SystemTime,
+    preferred: bool,
+    writer: W,
+    //// Guarded by s.mu
+    ////
+    //// peerStateChange is used by mesh peers (a set of regional
+    //// DERP servers) and contains records that need to be sent to
+    //// the client for them to update their map of who's connected
+    //// to this node.
+    //peerStateChange []peerConnState
+}
+
+impl<R, W, C> ClientConn<R, W, C>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    C: Conn,
+{
+    fn set_preferred(&mut self, v: bool) {
+        if self.preferred == v {
+            return;
+        }
+        self.preferred = v;
+        // TODO: stats
+        // var homeMove *expvar.Int
+        // if v {
+        // 	c.s.curHomeClients.Add(1)
+        // 	homeMove = &c.s.homeMovesIn
+        // } else {
+        // 	c.s.curHomeClients.Add(-1)
+        // 	homeMove = &c.s.homeMovesOut
+        // }
+
+        // // Keep track of varz for home serve moves in/out.  But ignore
+        // // the initial packet set when a client connects, which we
+        // // assume happens within 5 seconds. In any case, just for
+        // // graphs, so not important to miss a move. But it shouldn't:
+        // // the netcheck/re-STUNs in magicsock only happen about every
+        // // 30 seconds.
+        // if time.Since(c.connectedAt) > 5*time.Second {
+        // 	homeMove.Add(1)
+        // }
+    }
+
+    // TODO: stats
+    // // expMovingAverage returns the new moving average given the previous average,
+    // // a new value, and an alpha decay factor.
+    // // https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+    // func expMovingAverage(prev, newValue, alpha float64) float64 {
+    //   return alpha*newValue + (1-alpha)*prev
+    // }
+
+    // TODO: stats
+    // // recordQueueTime updates the average queue duration metric after a packet has been sent.
+    // func (c *sclient) recordQueueTime(enqueuedAt time.Time) {
+    // elapsed := float64(time.Since(enqueuedAt).Milliseconds())
+    // for {
+    // old := atomic.LoadUint64(c.s.avgQueueDuration)
+    // newAvg := expMovingAverage(math.Float64frombits(old), elapsed, 0.1)
+    // if atomic.CompareAndSwapUint64(c.s.avgQueueDuration, old, math.Float64bits(newAvg)) {
+    // break
+    // }
+    // }
+    // }
+
+    fn send_loop(&mut self) -> Result<()> {
+        todo!();
+    }
+
+    // TODO: should probably wrap "sends" in a select w/ timeout instead of setting this, as it
+    // doesn't seem to make sense in a rust context
+    fn set_write_deadline(&mut self) {
+        // error is ignored in golang impl
+        let _ = self.conn.set_write_deadline(super::server::WRITE_TIMEOUT);
+    }
+
+    /// Send  `FRAME_KEEP_ALIVE`
+    // go impl does not flush
+    async fn send_keep_alive(&mut self) -> Result<()> {
+        self.set_write_deadline();
+        write_frame(&mut self.writer, FRAME_KEEP_ALIVE, vec![]).await
+    }
+
+    /// Send a `pong` frame
+    // go impl does not flush
+    async fn send_pong(&mut self, data: &[u8]) -> Result<()> {
+        // TODO: stats
+        // c.s.peerGoneFrames.Add(1)
+        self.set_write_deadline();
+        write_frame(&mut self.writer, FRAME_PONG, vec![data]).await
+    }
+
+    /// Sends a peer gone frame
+    // go impl does not flush
+    async fn send_peer_gone(&mut self, peer: PublicKey) -> Result<()> {
+        // TODO: stats
+        // c.s.peerGoneFrames.Add(1)
+        self.set_write_deadline();
+        write_frame(&mut self.writer, FRAME_PEER_GONE, vec![peer.as_bytes()]).await
+    }
+
+    /// Sends a peer present frame
+    // go impl does not flush
+    async fn send_peer_present(&mut self, peer: PublicKey) -> Result<()> {
+        self.set_write_deadline();
+        write_frame(&mut self.writer, FRAME_PEER_PRESENT, vec![peer.as_bytes()]).await
+    }
+}

--- a/src/hp/derp/conn.rs
+++ b/src/hp/derp/conn.rs
@@ -1,0 +1,12 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use anyhow::Result;
+
+pub trait Conn {
+    fn close(&self) -> Result<()>;
+    fn local_addr(&self) -> SocketAddr;
+    fn set_deadline(&mut self, duration: Duration) -> Result<()>;
+    fn set_read_deadline(&mut self, duration: Duration) -> Result<()>;
+    fn set_write_deadline(&mut self, duration: Duration) -> Result<()>;
+}

--- a/src/hp/derp/server.rs
+++ b/src/hp/derp/server.rs
@@ -36,7 +36,7 @@ enum DupPolicy {
 
 #[derive(Debug)]
 /// A DERP server.
-pub struct Server<'a, C: Conn> {
+pub struct Server<'a> {
     /// Optionally specifies how long to wait before failing when writing
     /// to a cliet
     write_timeout: Option<Duration>,
@@ -96,7 +96,7 @@ pub struct Server<'a, C: Conn> {
 
     closed: AtomicBool,
     // TODO: how is this used, should it be a `Sender`?
-    net_conns: HashMap<C, Receiver<()>>,
+    // net_conns: HashMap<C, Receiver<()>>,
     clients: HashMap<PublicKey, ClientSet>,
     watchers: HashMap<ClientConn, bool>,
     /// Tracks all clients in the cluster, both locally and to mesh peers.
@@ -114,10 +114,7 @@ pub struct Server<'a, C: Conn> {
     key_of_addr: HashMap<SocketAddr, PublicKey>,
 }
 
-impl<'a, C> Server<'a, C>
-where
-    C: Conn,
-{
+impl<'a> Server<'a> {
     /// replace with builder
     pub fn new(key: SecretKey) -> Self {
         // TODO:
@@ -146,27 +143,27 @@ where
 
     /// Closes the server and waits for the connections to disconnect.
     pub async fn close(self) {
-        let closed = self.closed.load(Ordering::Relaxed);
-        if closed {
-            return;
-        }
-        self.closed.swap(true, Ordering::Relaxed);
-        let mut closed_channels = Vec::new();
+        // let closed = self.closed.load(Ordering::Relaxed);
+        // if closed {
+        //     return;
+        // }
+        // self.closed.swap(true, Ordering::Relaxed);
+        // let mut closed_channels = Vec::new();
 
-        for (net_conn, closed) in self.net_conns.into_iter() {
-            match net_conn.close() {
-                Ok(_) => closed_channels.push(closed),
-                Err(e) => {
-                    tracing::warn!("error closing connection {e:#?}")
-                }
-            }
-        }
+        // for (net_conn, closed) in self.net_conns.into_iter() {
+        //     match net_conn.close() {
+        //         Ok(_) => closed_channels.push(closed),
+        //         Err(e) => {
+        //             tracing::warn!("error closing connection {e:#?}")
+        //         }
+        //     }
+        // }
 
-        for c in closed_channels.into_iter() {
-            if let Err(e) = c.await {
-                tracing::warn!("error while closing connection {e:#?}");
-            }
-        }
+        // for c in closed_channels.into_iter() {
+        //     if let Err(e) = c.await {
+        //         tracing::warn!("error while closing connection {e:#?}");
+        //     }
+        // }
     }
 
     pub fn is_closed(&self) -> bool {
@@ -188,7 +185,7 @@ where
     /// Accept closes `conn`.
     pub fn accept<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         &self,
-        conn: C,
+        // conn: C,
         reader: R,
         writer: W,
         remote_addr: String,
@@ -256,7 +253,7 @@ where
 
     fn accept_0<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         &mut self,
-        conn: C,
+        // conn: C,
         reader: R,
         writer: W,
         remote_addr: String,

--- a/src/hp/derp/server.rs
+++ b/src/hp/derp/server.rs
@@ -1,16 +1,370 @@
-use serde::{Deserialize, Serialize};
+//! based on tailscale/derp/derp_server.go
 
-use crate::hp::key;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::oneshot::Receiver;
+
+use crate::hp::key::node::{PublicKey, SecretKey};
+
+use super::client::ClientInfo;
+use super::conn::Conn;
+
+// TODO: skiping `verboseDropKeys` for now
+
+/// The number of packets buffered for sending
+const PER_CLIENT_SEND_QUEUE_DEPTH: usize = 32;
+
+pub(crate) const WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// A temporary (2021-08-30) mechanism to change the policy
+/// of how duplicate connections for the same key are handled.
+#[derive(Debug)]
+enum DupPolicy {
+    /// A DupPolicy where the last connection to send traffic for a peer
+    /// if the active one.
+    LastWriterIsActive,
+    /// A DupPolicy that detects if peers are trying to send traffic interleaved
+    /// with each other and then disables all of them
+    DisabledFighters,
+}
 
 #[derive(Debug)]
-pub struct Server {}
+/// A DERP server.
+pub struct Server<'a, C: Conn> {
+    /// Optionally specifies how long to wait before failing when writing
+    /// to a cliet
+    write_timeout: Option<Duration>,
+    secret_key: SecretKey,
+    // TODO: what is this?
+    /// "runtime.MemStats.Sys at start (or early-ish)
+    mem_sys_0: u64,
+    // TODO: this is a string in the go impl, I made it a standard length array
+    // of bytes in this impl for ease of serializing. (Postcard cannot estimate
+    // the size of the serialized struct if this field is a `String`). This should
+    // be discussed and worked out.
+    mesh_key: [u8; 32],
+    /// the encoded x509 cert to send after `LetsEncrypt` cert+intermediate
+    meta_cert: &'a [u8],
+    dup_policy: DupPolicy,
+    debug: bool,
 
-impl Server {
-    pub fn new(key: key::node::SecretKey) -> Self {
-        // TODO:
-        Server {}
-    }
+    /// Counters:
+    // TODO: this is the go impl, need to add this in
+    // 	packetsSent, bytesSent       expvar.Int
+    // packetsRecv, bytesRecv       expvar.Int
+    // packetsRecvByKind            metrics.LabelMap
+    // packetsRecvDisco             *expvar.Int
+    // packetsRecvOther             *expvar.Int
+    // _                            align64
+    // packetsDropped               expvar.Int
+    // packetsDroppedReason         metrics.LabelMap
+    // packetsDroppedReasonCounters []*expvar.Int // indexed by dropReason
+    // packetsDroppedType           metrics.LabelMap
+    // packetsDroppedTypeDisco      *expvar.Int
+    // packetsDroppedTypeOther      *expvar.Int
+    // _                            align64
+    // packetsForwardedOut          expvar.Int
+    // packetsForwardedIn           expvar.Int
+    // peerGoneFrames               expvar.Int // number of peer gone frames sent
+    // gotPing                      expvar.Int // number of ping frames from client
+    // sentPong                     expvar.Int // number of pong frames enqueued to client
+    // accepts                      expvar.Int
+    // curClients                   expvar.Int
+    // curHomeClients               expvar.Int // ones with preferred
+    // dupClientKeys                expvar.Int // current number of public keys we have 2+ connections for
+    // dupClientConns               expvar.Int // current number of connections sharing a public key
+    // dupClientConnTotal           expvar.Int // total number of accepted connections when a dup key existed
+    // unknownFrames                expvar.Int
+    // homeMovesIn                  expvar.Int // established clients announce home server moves in
+    // homeMovesOut                 expvar.Int // established clients announce home server moves out
+    // multiForwarderCreated        expvar.Int
+    // multiForwarderDeleted        expvar.Int
+    // removePktForwardOther        expvar.Int
+    // avgQueueDuration             *uint64          // In milliseconds; accessed atomically
+    // tcpRtt                       metrics.LabelMap // histogram
+
+    /// When true, only accept client connections to the DERP server if the `client_key` is a
+    /// known  peer in the network, as specified by a running "tailscaled's client's
+    /// LocalAPI"
+    verify_clients: bool,
+
+    closed: AtomicBool,
+    // TODO: how is this used, should it be a `Sender`?
+    net_conns: HashMap<C, Receiver<()>>,
+    clients: HashMap<PublicKey, ClientSet>,
+    watchers: HashMap<ClientConn, bool>,
+    /// Tracks all clients in the cluster, both locally and to mesh peers.
+    /// If the value is nil, that means the peer is only local (And thus in
+    /// the clients Map, but not remote). If the value is non-nil, it's remote
+    /// (+ maybe also local).
+    clients_mesh: HashMap<PublicKey, PacketForwarder>,
+    /// Tracks which peers have sent to which other peers, and at which
+    /// connection number. This isn't on sclient because it includes intra-region
+    /// forwarded packets as the src.
+    /// src => dst => dst's latest sclient.connNum
+    sent_to: HashMap<PublicKey, HashMap<PublicKey, i64>>,
+
+    /// Maps from netip.AddrPort to a client's public key
+    key_of_addr: HashMap<SocketAddr, PublicKey>,
 }
+
+impl<'a, C> Server<'a, C>
+where
+    C: Conn,
+{
+    /// replace with builder
+    pub fn new(key: SecretKey) -> Self {
+        // TODO:
+        todo!();
+    }
+
+    /// Reports whether the server is configured with a mesh key.
+    pub fn has_mesh_key(&self) -> bool {
+        !self.mesh_key.is_empty()
+    }
+
+    /// Returns the configured mesh key, may be empty.
+    pub fn mesh_key(&self) -> [u8; 32] {
+        self.mesh_key
+    }
+
+    /// Returns the server's private key.
+    pub fn private_key(&self) -> SecretKey {
+        self.secret_key.clone()
+    }
+
+    /// Returns the server's public key.
+    pub fn public_key(&self) -> PublicKey {
+        self.secret_key.verifying_key()
+    }
+
+    /// Closes the server and waits for the connections to disconnect.
+    pub async fn close(self) {
+        let closed = self.closed.load(Ordering::Relaxed);
+        if closed {
+            return;
+        }
+        self.closed.swap(true, Ordering::Relaxed);
+        let mut closed_channels = Vec::new();
+
+        for (net_conn, closed) in self.net_conns.into_iter() {
+            match net_conn.close() {
+                Ok(_) => closed_channels.push(closed),
+                Err(e) => {
+                    tracing::warn!("error closing connection {e:#?}")
+                }
+            }
+        }
+
+        for c in closed_channels.into_iter() {
+            if let Err(e) = c.await {
+                tracing::warn!("error while closing connection {e:#?}");
+            }
+        }
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Relaxed)
+    }
+
+    /// Reports whether the client with the specified key is connected.
+    /// This is used in tests to verify that nodes are connected
+    // TODO: we may not need this
+    fn is_client_connected_for_test(&self, key: PublicKey) -> bool {
+        todo!();
+    }
+
+    /// Adds a new connection to the server and serves it.
+    ///
+    /// The provided [`AsyncReader`] and [`AsyncWriter`] must be already connected to the [`Conn`].
+    /// Accept blocks until the Server is closed or the connection closes on its own.
+    ///
+    /// Accept closes `conn`.
+    pub fn accept<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+        &self,
+        conn: C,
+        reader: R,
+        writer: W,
+        remote_addr: String,
+    ) -> Result<()> {
+        todo!();
+    }
+
+    /// Initializes `Server::meta_cert` with a self-signed x509 cert
+    /// encoding this server's public key and protocol version. "cmd/derp_server
+    /// then sends this after the Let's Encrypt leaf + intermediate certs after
+    /// the ServerHello (encrypted in TLS 1.3, not that is matters much).
+    ///
+    /// Then the client can save a round trime getting that and can start speaking
+    /// DERP right away. (we don't use ALPN because that's sent in the clear and
+    /// we're being paranoid to not look too weird to any middleboxes, given that
+    /// DERP is an ultimate fallback path). But since the post-ServerHello certs
+    /// are encrypted we can have the client also use them as a signal to be able
+    /// to start speaking DERP right away, starting with its identity proof,
+    /// encrypted to the server's public key.
+    ///
+    /// This RTT optimization fails where there's a corp-mandated TLS proxy with
+    /// corp-mandated root certs on employee machines and TLS proxy cleans up
+    /// unnecessary certs. In that case we jsut fall back to the extra RTT.
+    fn init_meta_cert(&self) {
+        todo!();
+    }
+
+    // Returns the server metadata cert that can be sent by the TLS server to
+    // let the client skip a round trip during start-up.
+    pub fn meta_cert(&self) -> &[u8] {
+        self.meta_cert.clone()
+    }
+
+    /// Notes that client c is no authenticated and ready for packets.
+    ///
+    /// If `SCLient::key` is connected more than once, the earlier connection(s)
+    /// are placed in a non-active state where we read from them (primarily to
+    /// observe EOFs/timeouts) but won't send them frames on the assumption
+    /// that they're dead.
+    fn register_client(&mut self, client: ClientConn) {
+        todo!();
+    }
+
+    /// Enqueues a message to all watchers (other DERP nodes in the region or
+    /// trusted clients) that peer's presence changed.
+    fn broadcast_peer_state_change(&mut self, peer: PublicKey, present: bool) {
+        todo!();
+    }
+
+    /// Removes a client from the server
+    fn unregister_client(&mut self, client: ClientConn) {
+        todo!();
+    }
+
+    /// Sends [`PEER_GONE`] frames to parties that `key` has sent to previously
+    /// (whether those sends were from a local client or forward). It must only
+    /// be called after the key has been rmoved from `Server::clients_mesh`.
+    fn not_peer_gone_from_region(&self, key: PublicKey) {
+        todo!();
+    }
+
+    fn add_watcher(&self, client: ClientConn) {
+        todo!();
+    }
+
+    fn accept_0<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+        &mut self,
+        conn: C,
+        reader: R,
+        writer: W,
+        remote_addr: String,
+        conn_num: i64,
+    ) -> Result<()> {
+        todo!();
+    }
+
+    fn note_peer_send(&self, key: PublicKey, dst: ClientConn) {
+        todo!();
+    }
+
+    fn record_drop(
+        &self,
+        packet_bytes: &[u8],
+        srckey: PublicKey,
+        dstkey: PublicKey,
+        reason: DropReason,
+    ) {
+        todo!();
+    }
+
+    fn verify_client(&self, client_key: PublicKey, info: ClientInfo) -> Result<()> {
+        todo!();
+    }
+
+    fn send_server_key<W: AsyncWrite + Unpin>(&self, writer: W) -> Result<()> {
+        todo!();
+    }
+
+    fn note_client_activity(&self, client: ClientConn) {
+        todo!();
+    }
+
+    fn send_server_info<W: AsyncWrite + Unpin>(
+        &self,
+        writer: W,
+        client_key: PublicKey,
+    ) -> Result<()> {
+        todo!();
+    }
+
+    /// Reads the `FRAME_CLIENT_INFO` frame from the client (its proof of identity)
+    /// upon it's initial connection. It should be considered especially untrusted
+    /// at this point.
+    fn recv_client_key<R: AsyncRead + Unpin>(&self, reader: R) -> Result<(PublicKey, ClientInfo)> {
+        todo!();
+    }
+
+    fn recv_packet<R: AsyncRead + Unpin>(
+        &self,
+        reader: R,
+        frame_len: usize,
+    ) -> Result<(PublicKey, &[u8])> {
+        todo!();
+    }
+
+    fn recv_forward_packet<R: AsyncRead + Unpin>(
+        &self,
+        reader: R,
+        frame_len: usize,
+    ) -> Result<(PublicKey, PublicKey, &[u8])> {
+        todo!();
+    }
+
+    pub fn add_packet_forwarder(&self, dst: PublicKey, fwd: PacketForwarder) {
+        todo!();
+    }
+
+    pub fn remove_packet_forwarder(&self, dst: PublicKey, fwd: PacketForwarder) {
+        todo!();
+    }
+
+    pub fn consistency_check() -> Result<()> {
+        todo!();
+    }
+
+    // fn serve_debug_traffic() {
+    //     todo!();
+    // }
+}
+
+#[derive(Debug)]
+enum DropReason {
+    /// Unknown destination PublicKey
+    UnknownDest,
+    /// Unkonwn destination PublicKey on a derp-forwarded packet
+    UnknownDestOnFwd,
+    /// Destination disconnected before we could send
+    Gone,
+    /// Destination queue is full, dropped packet at queue head
+    QueueHead,
+    /// Destination queue is full, dropped packet at queue tail
+    QueueTail,
+    /// OS write failed
+    WriteError,
+    /// The PublicKey is connected 2+ times (active/active, fighting)
+    DupClient,
+}
+
+#[derive(Debug)]
+struct ClientConn {}
+
+#[derive(Debug)]
+struct ClientSet {}
+
+#[derive(Debug)]
+pub struct PacketForwarder {}
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct ServerInfo {

--- a/src/hp/key/node.rs
+++ b/src/hp/key/node.rs
@@ -38,6 +38,14 @@ impl From<[u8; PUBLIC_KEY_LENGTH]> for PublicKey {
     }
 }
 
+impl TryFrom<&[u8]> for PublicKey {
+    type Error = anyhow::Error;
+    fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
+        let value = <[u8; PUBLIC_KEY_LENGTH]>::try_from(value)?;
+        Ok(PublicKey::from(value))
+    }
+}
+
 impl From<PublicKey> for disco::PublicKey {
     fn from(value: PublicKey) -> Self {
         let ed_compressed = curve25519_dalek::edwards::CompressedEdwardsY(*value.0.as_bytes());
@@ -52,6 +60,10 @@ impl From<PublicKey> for disco::PublicKey {
 impl PublicKey {
     pub fn as_bytes(&self) -> &[u8; PUBLIC_KEY_LENGTH] {
         self.0.as_bytes()
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.0.as_bytes() == &[0u8; PUBLIC_KEY_LENGTH]
     }
 }
 

--- a/src/hp/key/node.rs
+++ b/src/hp/key/node.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, hash::Hash};
 pub use ed25519_dalek::{SigningKey, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH};
 
 use super::{disco, disco::NONCE_LEN};
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct PublicKey(ed25519_dalek::VerifyingKey);
@@ -41,7 +41,8 @@ impl From<[u8; PUBLIC_KEY_LENGTH]> for PublicKey {
 impl TryFrom<&[u8]> for PublicKey {
     type Error = anyhow::Error;
     fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
-        let value = <[u8; PUBLIC_KEY_LENGTH]>::try_from(value)?;
+        let value =
+            <[u8; PUBLIC_KEY_LENGTH]>::try_from(value).context("TryFrom slice to PublicKey")?;
         Ok(PublicKey::from(value))
     }
 }


### PR DESCRIPTION
Implement structures that manage the connection from the server to the
client: the `ClientConnManager`, the `ClientConnWriter`, `ClientConnReader`.
When the server "accepts" a connection (`accept` is not yet
implemented), it separates the write and read portions of the
connection. It should create a `ClientConnManager` to interact with the
connection. The `ClientConnManager` runs the `ClientConnWriter` and `ClientConnReader` in a loop.
The `ClientConnWriter` accepts notifications & relayed packets from the server & sends them to the client.
The `ClientConnReader` to reads any notifications or packets it wants
the server to relay from the client, & sends them to be processed in the
server.