### PR TITLE
fix: use absolute paths everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.5",
+ "spin 0.9.6",
 ]
 
 [[package]]
@@ -2016,9 +2016,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
 dependencies = [
  "lock_api",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,8 +374,9 @@ async fn main_impl() -> Result<()> {
             // task that will add data to the provider, either from a file or from stdin
             let fut = tokio::spawn(async move {
                 let (path, tmp_path) = if let Some(path) = path {
-                    println!("Adding {}...", path.display());
-                    (path, None)
+                    let absolute = path.canonicalize()?;
+                    println!("Adding {} as {}...", path.display(), absolute.display());
+                    (absolute, None)
                 } else {
                     // Store STDIN content into a temporary file
                     let (file, path) = tempfile::NamedTempFile::new()?.into_parts();
@@ -445,9 +446,10 @@ async fn main_impl() -> Result<()> {
         }
         Commands::Add { path, rpc_port } => {
             let client = make_rpc_client(rpc_port).await?;
-            println!("Adding {}...", path.display());
+            let absolute = path.canonicalize()?;
+            println!("Adding {} as {}...", path.display(), absolute.display());
             let ProvideResponse { hash, entries } =
-                client.rpc(ProvideRequest { path: path.clone() }).await??;
+                client.rpc(ProvideRequest { path: absolute }).await??;
             print_add_response(hash, entries);
             Ok(())
         }


### PR DESCRIPTION
Otherwise it is not possible to add things if the add cli has a different $PATH than the daemon.

Fixes #834