### PR TITLE
ci(android): Use the real android targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,8 @@ jobs:
     - name: Install nightly
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        # See https://github.com/cross-rs/cross/issues/1222
+        toolchain: 1.67
         override: true
 
     - name: Install cross

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,8 @@ jobs:
       matrix:
         target:
           - i686-unknown-linux-gnu
-          - arm-linux-androideabi
+          - armv7-linux-androideabi
+          - aarch64-linux-android
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This changes the cross-compiling targets to use those that are used by
the real android phones.