### PR TITLE
refactoring `derp::Client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "governor",
  "hex",
  "hostname",
+ "http-body",
  "hyper",
  "indicatif",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "governor",
  "hex",
  "hostname",
+ "hyper",
  "indicatif",
  "libc",
  "multibase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ derive_more = "0.99.17"
 dirs-next = "2.0.0"
 ed25519-dalek = { version = "=2.0.0-pre.0", features = ["serde", "rand_core"] }
 flume = "0.10.14"
-hyper = "0.14.25"
+hyper = { version = "0.14.25", features = ["server", "client", "http1"] }
 futures = "0.3.25"
 governor = "0.5.1"
 hex = "0.4.3"
@@ -84,6 +84,7 @@ rand = "0.8"
 testdir = "0.7.2"
 regex = { version = "1.7.1", features = ["std"] }
 nix = "0.26.2"
+http-body = "0.4.5"
 
 [features]
 default = ["cli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ derive_more = "0.99.17"
 dirs-next = "2.0.0"
 ed25519-dalek = { version = "=2.0.0-pre.0", features = ["serde", "rand_core"] }
 flume = "0.10.14"
+hyper = "0.14.25"
 futures = "0.3.25"
 governor = "0.5.1"
 hex = "0.4.3"

--- a/src/hp/derp.rs
+++ b/src/hp/derp.rs
@@ -51,6 +51,8 @@ const MAX_INFO_LEN: usize = 1024 * 1024;
 const KEEP_ALIVE: Duration = Duration::from_secs(60);
 // TODO: what should this be?
 const SERVER_CHANNEL_SIZE: usize = 1024 * 100;
+/// The number of packets buffered for sending per client
+const PER_CLIENT_SEND_QUEUE_DEPTH: usize = 32;
 
 /// ProtocolVersion is bumped whenever there's a wire-incompatiable change.
 ///  - version 1 (zero on wire): consistent box headers, in use by employee dev nodes a bit

--- a/src/hp/derp/client.rs
+++ b/src/hp/derp/client.rs
@@ -4,9 +4,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{bail, ensure, Context, Result};
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
+use super::PER_CLIENT_SEND_QUEUE_DEPTH;
 use super::{
     read_frame,
     types::{ClientInfo, RateLimiter, ServerInfo},
@@ -20,77 +23,31 @@ use super::{
 use crate::hp::key::node::{PublicKey, SecretKey, PUBLIC_KEY_LENGTH};
 
 /// A DERP Client.
-pub struct Client<W, R>
-where
-    W: AsyncWrite + Send + Unpin + 'static, // TODO: static?
-    R: AsyncRead + Unpin,
-{
+pub struct Client {
     /// Server key of the DERP server, not a machine or node key
     server_key: PublicKey,
     /// The public/private keypair
     secret_key: SecretKey,
-    reader: R,
+    reader_task: JoinHandle<Result<()>>,
+    /// The
     // our local addrs
     local_addr: SocketAddr,
-    /// TODO: This is a string in the go impl, using bytes here to make it easier for postcard
-    /// to serialize. 32 is a random number I chose. Need to figure out what the `mesh_key`
-    /// is in practice.
+    /// TODO: This is a string in the go impl, need to make these back into Strings
     mesh_key: Option<[u8; 32]>,
     can_ack_pings: bool,
     is_prober: bool,
 
-    // protected by a mutex in the go impl
-    writer: W,
-    // TODO: maybe write a trait to make working with the rate limiter less gross cause it's currently disgusting
-    rate_limiter: Option<RateLimiter>,
-    /// Once the Client has received an error while receiving (`recv`), it's considered dead & should
-    /// respond to all future attempts to `recv` with an error
-    /// TODO: name?
-    is_dead: AtomicBool,
+    /// Channel on which to communicate to the server. The associated [`mpsc::Receiver`] will close
+    /// if there is ever an error writing to the server.
+    writer_channel: mpsc::Sender<ClientWriterMessage>,
+    /// JoinHandle for the [`ClientWriter`] task
+    writer_task: JoinHandle<Result<()>>,
 }
 
-impl<W, R> Client<W, R>
-where
-    W: AsyncWrite + Unpin + Send,
-    R: AsyncRead + Unpin,
-{
-    async fn recv_server_key(&mut self) -> Result<PublicKey> {
-        recv_server_key(&mut self.reader).await
-    }
+/// A channel on which we recieve messages from the server
+type ReceivedMessages = mpsc::Receiver<ReceivedMessage>;
 
-    async fn parse_server_info(&self, buf: &mut [u8]) -> Result<ServerInfo> {
-        let max_len = NONCE_LEN + MAX_INFO_LEN;
-        let frame_len = buf.len();
-        ensure!(frame_len > NONCE_LEN, "short ServerInfo frame");
-        ensure!(frame_len < max_len, "long ServerInfo frame");
-
-        let msg = self
-            .secret_key
-            .open_from(&self.server_key, buf)
-            .context(format!(
-                "failed to open crypto_box from server key {:?}",
-                self.server_key.as_bytes()
-            ))?;
-        let info: ServerInfo = postcard::from_bytes(&msg)?;
-        Ok(info)
-    }
-
-    async fn send_client_key(&mut self) -> Result<()> {
-        let client_info = ClientInfo {
-            version: PROTOCOL_VERSION,
-            mesh_key: self.mesh_key,
-            can_ack_pings: self.can_ack_pings,
-            is_prober: self.is_prober,
-        };
-        super::send_client_key(
-            &mut self.writer,
-            &self.secret_key,
-            &self.server_key,
-            &client_info,
-        )
-        .await
-    }
-
+impl Client {
     /// Returns a reference to the server's public key.
     pub fn server_public_key(&self) -> PublicKey {
         self.server_key.clone()
@@ -101,8 +58,11 @@ where
     /// Errors if the packet is larger than [`MAX_PACKET_SIZE`]
     // TODO: the rate limiter is only on this method, is it because it's the only method that
     // theoretically sends a bunch of data, or is it an oversight? For example, the `forward_packet` method does not have a rate limiter, but _does_ have a timeout.
-    pub async fn send(&mut self, dstkey: PublicKey, packet: &[u8]) -> Result<()> {
-        send_packet(&mut self.writer, &self.rate_limiter, dstkey, packet).await
+    pub async fn send(&mut self, dstkey: PublicKey, packet: Bytes) -> Result<()> {
+        self.writer_channel
+            .send(ClientWriterMessage::Packet((dstkey, packet)))
+            .await?;
+        Ok(())
     }
 
     /// Used by mesh peers to forward packets.
@@ -113,65 +73,54 @@ where
         &mut self,
         srckey: PublicKey,
         dstkey: PublicKey,
-        packet: &[u8],
+        packet: Bytes,
     ) -> Result<()> {
-        tokio::select! {
-            biased;
-            res = forward_packet(&mut self.writer, srckey, dstkey, packet) => {
-                res
-            }
-            _ = tokio::time::sleep(Duration::from_secs(5)) => {
-                self.write_timeout_fired().await
-            }
-        }
+        self.writer_channel
+            .send(ClientWriterMessage::FwdPacket((srckey, dstkey, packet)))
+            .await?;
+        Ok(())
     }
 
-    async fn write_timeout_fired(&self) -> Result<()> {
-        todo!("shutdown");
+    pub async fn send_ping(&mut self, data: [u8; 8]) -> Result<()> {
+        self.writer_channel
+            .send(ClientWriterMessage::Ping(data))
+            .await?;
+        Ok(())
     }
 
-    pub async fn send_ping(&mut self, data: &[u8; 8]) -> Result<()> {
-        send_ping(&mut self.writer, data).await
-    }
-
-    pub async fn send_pong(&mut self, data: &[u8; 8]) -> Result<()> {
-        send_pong(&mut self.writer, data).await
+    pub async fn send_pong(&mut self, data: [u8; 8]) -> Result<()> {
+        self.writer_channel
+            .send(ClientWriterMessage::Pong(data))
+            .await?;
+        Ok(())
     }
 
     /// Sends a packet that tells the server whether this
     /// client is the user's preferred server. This is only
     /// used in the server for stats.
     pub async fn note_preferred(&mut self, preferred: bool) -> Result<()> {
-        send_note_preferred(&mut self.writer, preferred).await
+        self.writer_channel
+            .send(ClientWriterMessage::NotePreferred(preferred))
+            .await?;
+        Ok(())
     }
 
     /// Sends a request to subscribe to the peer's connection list.
     /// It's a fatal error if the client wasn't created using [`MeshKey`].
     pub async fn watch_connection_changes(&mut self) -> Result<()> {
-        watch_connection_changes(&mut self.writer).await
+        self.writer_channel
+            .send(ClientWriterMessage::WatchConnectionChanges)
+            .await?;
+        Ok(())
     }
 
     /// Asks the server to close the target's TCP connection.
     /// It's a fatal error if the client wasn't created using [`MeshKey`]
     pub async fn close_peer(&mut self, target: PublicKey) -> Result<()> {
-        close_peer(&mut self.writer, target).await
-    }
-
-    async fn set_send_rate_limiter(&mut self, sm: ReceivedMessage) {
-        if let ReceivedMessage::ServerInfo {
-            token_bucket_bytes_per_second,
-            token_bucket_bytes_burst,
-        } = sm
-        {
-            if token_bucket_bytes_per_second == 0 || token_bucket_bytes_burst == 0 {
-                self.rate_limiter = None;
-            } else {
-                self.rate_limiter = Some(
-                    RateLimiter::new(token_bucket_bytes_per_second, token_bucket_bytes_burst)
-                        .unwrap(),
-                );
-            }
-        }
+        self.writer_channel
+            .send(ClientWriterMessage::ClosePeer(target))
+            .await?;
+        Ok(())
     }
 
     async fn local_addr(&self) -> Result<SocketAddr> {
@@ -182,7 +131,91 @@ where
         }
         Ok(self.local_addr)
     }
+}
 
+/// The kinds of messages we can send to the Server
+#[derive(Debug)]
+enum ClientWriterMessage {
+    /// Send a packet (addressed to the [`PublicKey`]) to the server
+    Packet((PublicKey, Bytes)),
+    /// Forward a packet from the src [`PublicKey`] to the dst [`PublicKey`] to the server
+    /// Should only be used for mesh clients.
+    FwdPacket((PublicKey, PublicKey, Bytes)),
+    /// Send a pong to the server
+    Pong([u8; 8]),
+    /// Send a ping to the server
+    Ping([u8; 8]),
+    /// Tell the server whether or not this client is the user's preferred client
+    NotePreferred(bool),
+    /// Subscribe to the server's connection list.
+    /// Should only be used for mesh clients.
+    WatchConnectionChanges,
+    /// Asks the server to close the target's connection.
+    /// Should only be used for mesh clients.
+    ClosePeer(PublicKey),
+    /// Shutdown the writer
+    Shutdown,
+}
+
+/// Call [`ClientWriter::run`] to listen for messages to send to the client.
+/// Should be used by the [`Client`]
+///
+/// Shutsdown when you send a `ClientWriterMessage::Shutdown`, or if there is an error writing to
+/// the server.
+struct ClientWriter<W: AsyncWrite + Unpin + Send + 'static> {
+    recv_msgs: mpsc::Receiver<ClientWriterMessage>,
+    writer: W,
+    rate_limiter: Option<RateLimiter>,
+}
+
+impl<W: AsyncWrite + Unpin + Send + 'static> ClientWriter<W> {
+    async fn run(mut self) -> Result<()> {
+        loop {
+            match self.recv_msgs.recv().await {
+                None => {
+                    bail!("channel unexpectedly closed");
+                }
+                Some(ClientWriterMessage::Packet((key, bytes))) => {
+                    send_packet(&mut self.writer, &self.rate_limiter, key, &bytes).await?;
+                }
+                Some(ClientWriterMessage::FwdPacket((srckey, dstkey, bytes))) => {
+                    tokio::time::timeout(
+                        Duration::from_secs(5),
+                        forward_packet(&mut self.writer, srckey, dstkey, &bytes),
+                    )
+                    .await??;
+                }
+                Some(ClientWriterMessage::Pong(msg)) => {
+                    send_pong(&mut self.writer, &msg).await?;
+                }
+                Some(ClientWriterMessage::Ping(msg)) => {
+                    send_ping(&mut self.writer, &msg).await?;
+                }
+                Some(ClientWriterMessage::NotePreferred(preferred)) => {
+                    send_note_preferred(&mut self.writer, preferred).await?;
+                }
+                Some(ClientWriterMessage::WatchConnectionChanges) => {
+                    watch_connection_changes(&mut self.writer).await?;
+                }
+                Some(ClientWriterMessage::ClosePeer(target)) => {
+                    close_peer(&mut self.writer, target).await?;
+                }
+                Some(ClientWriterMessage::Shutdown) => {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+/// Call [`ClientReader::run`] to send the messages we receive from the server to an associated `ReceivedMessages` channel.
+/// Shuts down if cancelled, or if there is an error reading a message from the server.
+struct ClientReader<R: AsyncRead + Unpin> {
+    reader: R,
+    sender: mpsc::Sender<ReceivedMessages>,
+}
+
+impl<R: AsyncRead + Unpin> ClientReader<R> {
     /// Reads a messages from a DERP server.
     ///
     /// The returned message may alias memory owned by the [`Client`]; if
@@ -190,34 +223,6 @@ where
     ///
     /// Once [`recv`] returns an error, the [`Client`] is dead forever.
     pub async fn recv(&mut self) -> Result<ReceivedMessage> {
-        self.recv_check_error(Duration::from_secs(120)).await
-    }
-
-    async fn recv_check_error(&mut self, timeout_duration: Duration) -> Result<ReceivedMessage> {
-        if self.is_dead.load(Ordering::Relaxed) {
-            bail!("Client is dead");
-        }
-        match self.recv_timeout(timeout_duration).await {
-            Ok(m) => Ok(m),
-            Err(e) => {
-                self.is_dead.swap(true, Ordering::Relaxed);
-                bail!(e);
-            }
-        }
-    }
-
-    async fn recv_timeout(&mut self, timeout_duration: Duration) -> Result<ReceivedMessage> {
-        tokio::select! {
-            biased;
-            res = self.recv_0() => {
-                res
-            } _ = tokio::time::sleep(timeout_duration) => {
-                bail!("recv call exceeded timeout");
-            }
-        }
-    }
-
-    async fn recv_0(&mut self) -> Result<ReceivedMessage> {
         // in practice, quic packets (and thus DERP frames) are under 1.5 KiB
         let mut frame_payload = BytesMut::with_capacity(1024 + 512);
         loop {
@@ -225,21 +230,6 @@ where
                 read_frame(&mut self.reader, MAX_FRAME_SIZE, &mut frame_payload).await?;
 
             match frame_type {
-                FRAME_SERVER_INFO => {
-                    // Server sends this at start-up. Currently unused.
-                    // Just has a JSON messages saying "version: 2",
-                    // but the protocol seems extensible enough as-is without
-                    // needing to wait an RTT to discover the version at startup
-                    // We'd prefer to give the connection to the client (magicsock)
-                    // to start writing as soon as possible.
-                    let server_info = self.parse_server_info(&mut frame_payload).await?;
-                    let received = ReceivedMessage::ServerInfo {
-                        token_bucket_bytes_per_second: server_info.token_bucket_bytes_per_second,
-                        token_bucket_bytes_burst: server_info.token_bucket_bytes_burst,
-                    };
-                    self.set_send_rate_limiter(received.clone()).await;
-                    return Ok(received);
-                }
                 FRAME_KEEP_ALIVE => {
                     // A one-way keep-alive message that doesn't require an ack.
                     // This predated FRAME_PING/FRAME_PONG.
@@ -335,6 +325,7 @@ where
     is_prober: bool,
     server_public_key: Option<PublicKey>,
     can_ack_pings: bool,
+    writer_queue_depth: usize,
 }
 
 impl<W, R> ClientBuilder<W, R>
@@ -352,6 +343,7 @@ where
             is_prober: false,
             server_public_key: None,
             can_ack_pings: false,
+            writer_queue_depth: PER_CLIENT_SEND_QUEUE_DEPTH,
         }
     }
 
@@ -377,21 +369,73 @@ where
         self
     }
 
-    pub async fn build(mut self) -> Result<Client<W, R>>
+    /// Default is [`derp::PER_CLIENT_SEND_QUEUE_DEPTH`]
+    ///
+    /// Will error if the queue depth is set to zero
+    pub fn writer_queue_depth(mut self, depth: usize) -> Result<Self> {
+        if depth == 0 {
+            bail!("cannot set queue to 0, no unbounded channels allowed");
+        }
+        self.writer_queue_depth = depth;
+        Ok(self)
+    }
+
+    async fn server_handshake(&mut self) -> Result<(PublicKey, Option<RateLimiter>)> {
+        let server_key = recv_server_key(&mut self.reader)
+            .await
+            .context("failed to receive server key")?;
+        let client_info = ClientInfo {
+            version: PROTOCOL_VERSION,
+            mesh_key: self.mesh_key,
+            can_ack_pings: self.can_ack_pings,
+            is_prober: self.is_prober,
+        };
+        crate::hp::derp::send_client_key(
+            &mut self.writer,
+            &self.secret_key,
+            &server_key,
+            &client_info,
+        )
+        .await?;
+        let mut buf = BytesMut::new();
+        let (frame_type, _) =
+            crate::hp::derp::read_frame(&mut self.reader, MAX_FRAME_SIZE, &mut buf).await?;
+        assert_eq!(FRAME_SERVER_INFO, frame_type);
+        let msg = self.secret_key.open_from(&server_key, &buf)?;
+        let info: ServerInfo = postcard::from_bytes(&msg)?;
+        if info.version != PROTOCOL_VERSION {
+            bail!(
+                "incompatiable protocol version, expected {PROTOCOL_VERSION}, got {}",
+                info.version
+            );
+        }
+        let rate_limiter = RateLimiter::new(
+            info.token_bucket_bytes_per_second,
+            info.token_bucket_bytes_burst,
+        )?;
+        Ok((server_key, rate_limiter))
+    }
+
+    pub async fn build(mut self) -> Result<Client<R>>
     where
-        W: AsyncWrite + Send + Unpin + 'static,
         R: AsyncRead + Unpin,
     {
-        // TODO: see `Client::server_public_key` todo, but assigning a server_public_key should
-        // probably be removed
-        let server_key = if let Some(key) = self.server_public_key {
-            key
-        } else {
-            recv_server_key(&mut self.reader)
-                .await
-                .context("failed to receive server key")?
-        };
-        let mut client = Client {
+        // exchange information with the server
+        let (server_key, rate_limiter) = self.server_handshake().await?;
+
+        // create task to handle writing to the server
+        let (writer_sender, writer_recv) = mpsc::channel(self.writer_queue_depth);
+        let writer_task = tokio::spawn(async move {
+            let client_writer = ClientWriter {
+                rate_limiter,
+                writer: self.writer,
+                recv_msgs: writer_recv,
+            };
+            client_writer.run().await?;
+            Ok(())
+        });
+
+        Ok(Client {
             server_key,
             secret_key: self.secret_key,
             reader: self.reader,
@@ -399,13 +443,10 @@ where
             mesh_key: self.mesh_key,
             can_ack_pings: self.can_ack_pings,
             is_prober: self.is_prober,
-            writer: self.writer,
-            rate_limiter: None,
+            writer_channel: writer_sender,
+            writer_task,
             is_dead: AtomicBool::new(false),
-        };
-
-        client.send_client_key().await?;
-        Ok(client)
+        })
     }
 }
 

--- a/src/hp/derp/http.rs
+++ b/src/hp/derp/http.rs
@@ -3,4 +3,6 @@ mod server;
 
 pub use client::{Client, ClientError};
 
-pub use server::connection_handler;
+pub use server::derp_connection_handler;
+
+pub(crate) const HTTP_UPGRADE_PROTOCOL: &str = "iroh derp http";

--- a/src/hp/derp/http.rs
+++ b/src/hp/derp/http.rs
@@ -1,3 +1,6 @@
 mod client;
+mod server;
 
 pub use client::{Client, ClientError};
+
+pub use server::connection_handler;

--- a/src/hp/derp/http/server.rs
+++ b/src/hp/derp/http/server.rs
@@ -1,0 +1,213 @@
+use anyhow::Result;
+use futures::future::{BoxFuture, FutureExt};
+use hyper::header::{HeaderValue, UPGRADE};
+use hyper::upgrade::Upgraded;
+use hyper::{Body, Request, Response, StatusCode};
+
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+
+use super::HTTP_UPGRADE_PROTOCOL;
+use crate::hp::derp::{server::ClientConnHandler, types::PacketForwarder};
+
+// The server HTTP handler to do HTTP upgrades
+pub async fn derp_connection_handler<P>(
+    conn_handler: &ClientConnHandler<OwnedReadHalf, OwnedWriteHalf, P>,
+    upgraded: Upgraded,
+) -> Result<()>
+where
+    P: PacketForwarder,
+{
+    // get the underlying TcpStream
+    let parts = match upgraded.downcast::<tokio::net::TcpStream>() {
+        Ok(p) => p,
+        Err(_) => {
+            anyhow::bail!("could not downcast the upgraded connection to a tokio::net::TcpStream")
+        }
+    };
+
+    // split into the reader and writer parts
+    let (reader, writer) = parts.io.into_split();
+
+    // send to the derp server
+    conn_handler.accept(reader, writer).await
+}
+
+type HyperResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+/// Return a closure that takes an http Request, upgrades that connection, and hands it off to the
+/// derp server.
+fn derp_upgrade_fn<P: PacketForwarder>(
+    conn_handler: ClientConnHandler<OwnedReadHalf, OwnedWriteHalf, P>,
+) -> impl Fn(Request<Body>) -> BoxFuture<'static, HyperResult<Response<Body>>> {
+    move |mut req| {
+        // TODO: soooo much cloning. See if there is an alternative
+        let closure_conn_handler = conn_handler.clone();
+        async move {
+            {
+                let mut res = Response::new(Body::empty());
+
+                // Send a 400 to any request that doesn't have
+                // an `Upgrade` header.
+                if !req.headers().contains_key(UPGRADE) {
+                    *res.status_mut() = StatusCode::BAD_REQUEST;
+                    return Ok(res);
+                }
+
+                // Setup a future that will eventually receive the upgraded
+                // connection and talk a new protocol, and spawn the future
+                // into the runtime.
+                //
+                // Note: This can't possibly be fulfilled until the 101 response
+                // is returned below, so it's better to spawn this future instead
+                // waiting for it to complete to then return a response.
+                tokio::task::spawn(async move {
+                    match hyper::upgrade::on(&mut req).await {
+                        Ok(upgraded) => {
+                            if let Err(e) =
+                                derp_connection_handler(&closure_conn_handler, upgraded).await
+                            {
+                                tracing::warn!("server {HTTP_UPGRADE_PROTOCOL} io error: {}", e)
+                            };
+                        }
+                        Err(e) => tracing::warn!("upgrade error: {}", e),
+                    }
+                });
+
+                // Now return a 101 Response saying we agree to the upgrade to the
+                // HTTP_UPGRADE_PROTOCOL
+                *res.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
+                res.headers_mut()
+                    .insert(UPGRADE, HeaderValue::from_static(HTTP_UPGRADE_PROTOCOL));
+                Ok(res)
+            }
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use anyhow::Result;
+    use std::net::SocketAddr;
+
+    use tokio::sync::oneshot;
+
+    use hyper::header::UPGRADE;
+    use hyper::service::{make_service_fn, service_fn};
+    use hyper::upgrade::Upgraded;
+    use hyper::{Body, Client, Request, Server, StatusCode};
+
+    use crate::hp::derp::server::Server as DerpServer;
+    use crate::hp::key::node::{PublicKey, SecretKey};
+
+    /// Handle client-side I/O after HTTP upgraded.
+    async fn derp_client(mut upgraded: Upgraded) -> Result<()> {
+        let secret_key = SecretKey::generate();
+        let got_server_key = crate::hp::derp::client::recv_server_key(&mut upgraded).await?;
+        let client_info = crate::hp::derp::types::ClientInfo {
+            version: crate::hp::derp::PROTOCOL_VERSION,
+            mesh_key: None,
+            can_ack_pings: true,
+            is_prober: true,
+        };
+        crate::hp::derp::send_client_key(&mut upgraded, &secret_key, &got_server_key, &client_info)
+            .await?;
+        let mut buf = bytes::BytesMut::new();
+        let (frame_type, _) =
+            crate::hp::derp::read_frame(&mut upgraded, crate::hp::derp::MAX_FRAME_SIZE, &mut buf)
+                .await?;
+        assert_eq!(crate::hp::derp::FRAME_SERVER_INFO, frame_type);
+        let msg = secret_key.open_from(&got_server_key, &buf)?;
+        let _info: crate::hp::derp::types::ServerInfo = postcard::from_bytes(&msg)?;
+        Ok(())
+    }
+
+    /// Our client HTTP handler to initiate HTTP upgrades.
+    async fn client_upgrade_request(addr: SocketAddr) -> Result<()> {
+        let req = Request::builder()
+            .uri(format!("http://{}/", addr))
+            .header(UPGRADE, HTTP_UPGRADE_PROTOCOL)
+            .body(Body::empty())
+            .unwrap();
+
+        let res = Client::new().request(req).await?;
+        if res.status() != StatusCode::SWITCHING_PROTOCOLS {
+            panic!("Our server didn't upgrade: {}", res.status());
+        }
+
+        match hyper::upgrade::on(res).await {
+            Ok(upgraded) => {
+                if let Err(e) = derp_client(upgraded).await {
+                    eprintln!("client foobar io error: {}", e)
+                };
+            }
+            Err(e) => eprintln!("upgrade error: {}", e),
+        }
+
+        Ok(())
+    }
+
+    struct MockPacketForwarder {}
+
+    impl PacketForwarder for MockPacketForwarder {
+        fn forward_packet(&mut self, srckey: PublicKey, dstkey: PublicKey, packet: bytes::Bytes) {
+            println!("forwarded packet from {srckey:?} to {dstkey:?}: msg: {packet:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_connection_handler() -> Result<()> {
+        // inspired by https://github.com/hyperium/hyper/blob/v0.14.25/examples/upgrades.rs
+
+        let addr = ([127, 0, 0, 1], 0).into();
+
+        // create derp_server
+        let server_key = SecretKey::generate();
+        let derp_server: DerpServer<OwnedReadHalf, OwnedWriteHalf, MockPacketForwarder> =
+            DerpServer::new(server_key, None);
+
+        // create handler that sends new connections to the client
+        let derp_client_handler = derp_server.client_conn_handler();
+
+        // Would love to wrap this in a `make_derp_server_service` function that returns
+        // a `hyper::service::make::MakeServiceFn`, but that's a private struct so I don't think we
+        // can
+        let make_service = make_service_fn(move |_| {
+            let derp_client_handler = derp_client_handler.clone();
+            async { Ok::<_, hyper::Error>(service_fn(derp_upgrade_fn(derp_client_handler))) }
+        });
+
+        let server = Server::bind(&addr).serve(make_service);
+
+        // We need the assigned address for the client to send it messages.
+        let addr = server.local_addr();
+
+        // For this example, a oneshot is used to signal that after 1 request,
+        // the server should be shutdown.
+        let (tx, rx) = oneshot::channel::<()>();
+        let server = server.with_graceful_shutdown(async move {
+            rx.await.ok();
+        });
+
+        // Spawn server on the default executor,
+        // which is usually a thread-pool from tokio default runtime.
+        tokio::task::spawn(async move {
+            if let Err(e) = server.await {
+                eprintln!("server error: {}", e);
+            }
+        });
+
+        // Client requests a HTTP connection upgrade.
+        let request = client_upgrade_request(addr.clone());
+        if let Err(e) = request.await {
+            eprintln!("client error: {}", e);
+        }
+
+        // Complete the oneshot so that the server stops
+        // listening and the process can close down.
+        let _ = tx.send(());
+        Ok(())
+    }
+}

--- a/src/hp/derp/server.rs
+++ b/src/hp/derp/server.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use super::{
     recv_client_key, types::ServerInfo, write_frame, write_frame_timeout, FRAME_SERVER_INFO,
-    FRAME_SERVER_KEY, MAGIC, PROTOCOL_VERSION, SERVER_CHANNEL_SIZE,
+    FRAME_SERVER_KEY, MAGIC, PER_CLIENT_SEND_QUEUE_DEPTH, PROTOCOL_VERSION, SERVER_CHANNEL_SIZE,
 };
 // TODO: skiping `verboseDropKeys` for now
 
@@ -28,9 +28,6 @@ static CONN_NUM: AtomicUsize = AtomicUsize::new(1);
 fn new_conn_num() -> usize {
     CONN_NUM.fetch_add(1, Ordering::Relaxed)
 }
-
-/// The number of packets buffered for sending per client
-const PER_CLIENT_SEND_QUEUE_DEPTH: usize = 32;
 
 pub(crate) const WRITE_TIMEOUT: Duration = Duration::from_secs(2);
 

--- a/src/hp/derp/server.rs
+++ b/src/hp/derp/server.rs
@@ -16,7 +16,7 @@ use crate::hp::key::node::{PublicKey, SecretKey};
 use super::client_conn::ClientConnBuilder;
 use super::{
     clients::Clients,
-    types::{Conn, PacketForwarder, PeerConnState, ServerMessage},
+    types::{PacketForwarder, PeerConnState, ServerMessage},
 };
 use super::{
     recv_client_key, types::ServerInfo, write_frame, write_frame_timeout, FRAME_SERVER_INFO,
@@ -39,9 +39,8 @@ pub(crate) const WRITE_TIMEOUT: Duration = Duration::from_secs(2);
 /// TODO: how small does this have to be before this is considered cheap to clone?
 /// It would make alot of the APIs easier if we could just clone this.
 #[derive(Debug)]
-pub struct Server<C, R, W, P>
+pub struct Server<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,
@@ -60,7 +59,7 @@ where
     /// The DER encoded x509 cert to send after `LetsEncrypt` cert+intermediate.
     meta_cert: Vec<u8>,
     /// Channel on which to communicate to the `ServerActor`
-    server_channel: mpsc::Sender<ServerMessage<C, R, W, P>>,
+    server_channel: mpsc::Sender<ServerMessage<R, W, P>>,
     /// When true, the server has been shutdown.
     closed: bool,
     /// The information we send to the [`client::Client`] about the [`Server`]'s protocol version
@@ -106,9 +105,8 @@ where
     // tcpRtt                       metrics.LabelMap // histogram
 }
 
-impl<C, R, W, P> Server<C, R, W, P>
+impl<R, W, P> Server<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,
@@ -178,7 +176,7 @@ where
 
     /// Create a [`PacketForwarderHandler`], which can add or remove [`PacketForwarder`]s from the
     /// [`Server`].
-    pub fn packet_forwarder_handler(&self) -> PacketForwarderHandler<C, R, W, P> {
+    pub fn packet_forwarder_handler(&self) -> PacketForwarderHandler<R, W, P> {
         PacketForwarderHandler {
             server_channel: self.server_channel.clone(),
         }
@@ -186,7 +184,7 @@ where
 
     /// Create a [`ClientConnHandler`], which can verify connections and add them to the
     /// [`Server`].
-    pub fn client_conn_handler(&self) -> ClientConnHandler<C, R, W, P> {
+    pub fn client_conn_handler(&self) -> ClientConnHandler<R, W, P> {
         ClientConnHandler {
             mesh_key: self.mesh_key.clone(),
             server_channel: self.server_channel.clone(),
@@ -211,19 +209,17 @@ where
 ///
 /// Can be cheaply cloned.
 #[derive(Debug, Clone)]
-pub struct PacketForwarderHandler<C, R, W, P>
+pub struct PacketForwarderHandler<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,
 {
-    server_channel: mpsc::Sender<ServerMessage<C, R, W, P>>,
+    server_channel: mpsc::Sender<ServerMessage<R, W, P>>,
 }
 
-impl<C, R, W, P> PacketForwarderHandler<C, R, W, P>
+impl<R, W, P> PacketForwarderHandler<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,
@@ -247,23 +243,21 @@ where
 ///
 /// Can be cheaply cloned.
 #[derive(Debug, Clone)]
-pub struct ClientConnHandler<C, R, W, P>
+pub struct ClientConnHandler<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,
 {
     mesh_key: Option<[u8; 32]>,
-    server_channel: mpsc::Sender<ServerMessage<C, R, W, P>>,
+    server_channel: mpsc::Sender<ServerMessage<R, W, P>>,
     secret_key: SecretKey,
     write_timeout: Option<Duration>,
     server_info: ServerInfo,
 }
 
-impl<C, R, W, P> ClientConnHandler<C, R, W, P>
+impl<R, W, P> ClientConnHandler<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,
@@ -275,7 +269,7 @@ where
     /// and is unable to verify this one, or if there is some issue communicating with the server.
     ///
     /// The provided [`AsyncReader`] and [`AsyncWriter`] must be already connected to the [`Conn`].
-    pub async fn accept(&self, conn: C, mut reader: R, mut writer: W) -> Result<()> {
+    pub async fn accept(&self, mut reader: R, mut writer: W) -> Result<()> {
         self.send_server_key(&mut writer)
             .await
             .context("unable to send server key to client")?;
@@ -288,7 +282,6 @@ where
         let client_conn_builder = ClientConnBuilder {
             key: client_key,
             conn_num: new_conn_num(),
-            conn,
             reader,
             writer,
             can_mesh: can_mesh(self.mesh_key, client_info.mesh_key),
@@ -343,17 +336,16 @@ where
     }
 }
 
-pub(crate) struct ServerActor<C, R, W, P>
+pub(crate) struct ServerActor<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,
 {
     key: PublicKey,
-    receiver: mpsc::Receiver<ServerMessage<C, R, W, P>>,
+    receiver: mpsc::Receiver<ServerMessage<R, W, P>>,
     /// All clients connected to this server
-    clients: Clients<C>,
+    clients: Clients,
     /// Representation of the mesh network. Keys that are associated with `None` are strictly local
     /// clients.
     client_mesh: HashMap<PublicKey, Option<P>>,
@@ -361,14 +353,13 @@ where
     watchers: HashSet<PublicKey>,
 }
 
-impl<C, R, W, P> ServerActor<C, R, W, P>
+impl<R, W, P> ServerActor<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,
 {
-    pub(crate) fn new(key: PublicKey, receiver: mpsc::Receiver<ServerMessage<C, R, W, P>>) -> Self {
+    pub(crate) fn new(key: PublicKey, receiver: mpsc::Receiver<ServerMessage<R, W, P>>) -> Self {
         Self {
             key,
             receiver,
@@ -609,16 +600,6 @@ mod tests {
     use bytes::BytesMut;
     use tokio::io::DuplexStream;
 
-    struct MockConn {}
-    impl Conn for MockConn {
-        fn close(&self) -> Result<()> {
-            Ok(())
-        }
-        fn local_addr(&self) -> std::net::SocketAddr {
-            "127.0.0.1:3333".parse().unwrap()
-        }
-    }
-
     struct MockPacketForwarder {
         packets: mpsc::Sender<(PublicKey, PublicKey, bytes::Bytes)>,
     }
@@ -640,10 +621,10 @@ mod tests {
         key: PublicKey,
         conn_num: usize,
         server_channel: mpsc::Sender<
-            ServerMessage<MockConn, DuplexStream, DuplexStream, MockPacketForwarder>,
+            ServerMessage<DuplexStream, DuplexStream, MockPacketForwarder>,
         >,
     ) -> (
-        ClientConnBuilder<MockConn, DuplexStream, DuplexStream, MockPacketForwarder>,
+        ClientConnBuilder<DuplexStream, DuplexStream, MockPacketForwarder>,
         DuplexStream,
         DuplexStream,
     ) {
@@ -653,7 +634,6 @@ mod tests {
             ClientConnBuilder {
                 key,
                 conn_num,
-                conn: MockConn {},
                 reader,
                 writer,
                 can_mesh: true,
@@ -672,7 +652,7 @@ mod tests {
 
         // make server actor
         let (server_channel, server_channel_r) = mpsc::channel(20);
-        let server_actor: ServerActor<MockConn, DuplexStream, DuplexStream, MockPacketForwarder> =
+        let server_actor: ServerActor<DuplexStream, DuplexStream, MockPacketForwarder> =
             ServerActor::new(server_key, server_channel_r);
         let done = CancellationToken::new();
         let server_done = done.clone();
@@ -819,17 +799,15 @@ mod tests {
     async fn test_client_conn_handler() -> Result<()> {
         // create client connection handler
         let (server_channel_s, mut server_channel_r) = mpsc::channel(10);
-        let handler =
-            ClientConnHandler::<MockConn, DuplexStream, DuplexStream, MockPacketForwarder> {
-                mesh_key: Some([1u8; 32]),
-                secret_key: SecretKey::generate(),
-                write_timeout: None,
-                server_info: ServerInfo::no_rate_limit(),
-                server_channel: server_channel_s,
-            };
+        let handler = ClientConnHandler::<DuplexStream, DuplexStream, MockPacketForwarder> {
+            mesh_key: Some([1u8; 32]),
+            secret_key: SecretKey::generate(),
+            write_timeout: None,
+            server_info: ServerInfo::no_rate_limit(),
+            server_channel: server_channel_s,
+        };
 
         // create the parts needed for a client
-        let conn = MockConn {};
         let (mut client_reader, server_writer) = tokio::io::duplex(10);
         let (server_reader, mut client_writer) = tokio::io::duplex(10);
         let client_key = SecretKey::generate();
@@ -869,7 +847,7 @@ mod tests {
         });
 
         // attempt to add the connection to the server
-        handler.accept(conn, server_reader, server_writer).await?;
+        handler.accept(server_reader, server_writer).await?;
         client_task.await??;
 
         // ensure we inform the server to create the client from the connection!
@@ -950,7 +928,7 @@ mod tests {
         // create the server!
         let server_key = SecretKey::generate();
         let mesh_key = Some([1u8; 32]);
-        let server: Server<MockConn, DuplexStream, DuplexStream, MockPacketForwarder> =
+        let server: Server<DuplexStream, DuplexStream, MockPacketForwarder> =
             Server::new(server_key, mesh_key.clone());
 
         // create client a and connect it to the server
@@ -958,8 +936,7 @@ mod tests {
         let public_key_a = key_a.public_key();
         let (reader_a, writer_a, mut client_a) = TestClient::new(key_a);
         let handler = server.client_conn_handler();
-        let handler_task =
-            tokio::spawn(async move { handler.accept(MockConn {}, reader_a, writer_a).await });
+        let handler_task = tokio::spawn(async move { handler.accept(reader_a, writer_a).await });
         client_a.accept().await?;
         handler_task.await??;
 
@@ -968,8 +945,7 @@ mod tests {
         let public_key_b = key_b.public_key();
         let (reader_b, writer_b, mut client_b) = TestClient::new(key_b);
         let handler = server.client_conn_handler();
-        let handler_task =
-            tokio::spawn(async move { handler.accept(MockConn {}, reader_b, writer_b).await });
+        let handler_task = tokio::spawn(async move { handler.accept(reader_b, writer_b).await });
         client_b.accept().await?;
         handler_task.await??;
 

--- a/src/hp/derp/server.rs
+++ b/src/hp/derp/server.rs
@@ -242,7 +242,7 @@ where
 /// Created by the [`Server`] by calling [`Server::client_conn_handler`].
 ///
 /// Can be cheaply cloned.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ClientConnHandler<R, W, P>
 where
     R: AsyncRead + Unpin + Send + Sync + 'static,
@@ -332,6 +332,16 @@ where
             let server_mesh_key = self.mesh_key.unwrap();
             let client_mesh_key = client_mesh_key.unwrap();
             server_mesh_key == client_mesh_key
+        }
+    }
+
+    pub fn clone(&self) -> Self {
+        Self {
+            mesh_key: self.mesh_key.clone(),
+            server_channel: self.server_channel.clone(),
+            secret_key: self.secret_key.clone(),
+            write_timeout: self.write_timeout.clone(),
+            server_info: self.server_info.clone(),
         }
     }
 }

--- a/src/hp/derp/types.rs
+++ b/src/hp/derp/types.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::{num::NonZeroU32, time::Instant};
 
 use anyhow::{bail, ensure, Result};
@@ -10,11 +9,6 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use super::client_conn::ClientConnBuilder;
 use super::PROTOCOL_VERSION;
 use crate::hp::key::node::PublicKey;
-
-pub trait Conn: Sync + Send + 'static {
-    fn close(&self) -> Result<()>;
-    fn local_addr(&self) -> SocketAddr;
-}
 
 pub(crate) struct RateLimiter {
     inner: governor::RateLimiter<
@@ -113,9 +107,8 @@ pub trait PacketForwarder: Send + Sync + 'static {
     fn forward_packet(&mut self, srckey: PublicKey, dstkey: PublicKey, packet: Bytes);
 }
 
-pub(crate) enum ServerMessage<C, R, W, P>
+pub(crate) enum ServerMessage<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,
@@ -124,16 +117,15 @@ where
     ClosePeer(PublicKey),
     SendPacket((PublicKey, Packet)),
     SendDiscoPacket((PublicKey, Packet)),
-    CreateClient(ClientConnBuilder<C, R, W, P>),
+    CreateClient(ClientConnBuilder<R, W, P>),
     RemoveClient(PublicKey),
     AddPacketForwarder((PublicKey, P)),
     RemovePacketForwarder(PublicKey),
     Shutdown,
 }
 
-impl<C, R, W, P> std::fmt::Debug for ServerMessage<C, R, W, P>
+impl<R, W, P> std::fmt::Debug for ServerMessage<R, W, P>
 where
-    C: Conn,
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     P: PacketForwarder,

--- a/src/hp/derp/types.rs
+++ b/src/hp/derp/types.rs
@@ -20,16 +20,17 @@ pub(crate) struct RateLimiter {
 }
 
 impl RateLimiter {
-    pub(crate) fn new(bytes_per_second: usize, bytes_burst: usize) -> Result<Self> {
-        ensure!(bytes_per_second != 0);
-        ensure!(bytes_burst != 0);
+    pub(crate) fn new(bytes_per_second: usize, bytes_burst: usize) -> Result<Option<Self>> {
+        if (bytes_per_second == 0 || bytes_burst == 0) {
+            return Ok(None);
+        }
         let bytes_per_second = NonZeroU32::new(u32::try_from(bytes_per_second)?).unwrap();
         let bytes_burst = NonZeroU32::new(u32::try_from(bytes_burst)?).unwrap();
-        Ok(Self {
+        Ok(Some(Self {
             inner: governor::RateLimiter::direct(
                 governor::Quota::per_second(bytes_per_second).allow_burst(bytes_burst),
             ),
-        })
+        }))
     }
 
     pub(crate) fn check_n(&self, n: usize) -> Result<()> {

--- a/src/hp/magicsock/conn.rs
+++ b/src/hp/magicsock/conn.rs
@@ -3215,16 +3215,6 @@ mod tests {
         stun_ip: IpAddr,
     }
 
-    struct MockConn;
-    impl derp::types::Conn for MockConn {
-        fn close(&self) -> Result<()> {
-            Ok(())
-        }
-        fn local_addr(&self) -> SocketAddr {
-            "127.0.0.1:3333".parse().unwrap()
-        }
-    }
-
     struct MockPacketForwarder;
     impl derp::types::PacketForwarder for MockPacketForwarder {
         fn forward_packet(
@@ -3238,12 +3228,8 @@ mod tests {
 
     async fn run_derp_and_stun(stun_ip: IpAddr) -> Result<(DerpMap, impl FnOnce())> {
         // TODO: pass a mesh_key?
-        let d: derp::Server<
-            MockConn,
-            tokio::io::DuplexStream,
-            tokio::io::DuplexStream,
-            MockPacketForwarder,
-        > = derp::Server::new(key::node::SecretKey::generate(), None);
+        let d: derp::Server<tokio::io::DuplexStream, tokio::io::DuplexStream, MockPacketForwarder> =
+            derp::Server::new(key::node::SecretKey::generate(), None);
 
         // TODO: configure DERP server when actually implemented
         // httpsrv := httptest.NewUnstartedServer(derphttp.Handler(d))


### PR DESCRIPTION
- need `ClientReader` `ClilentWriter`, responsible for reading from the server and writing to the server.
- adjust `ClientBuilder` to return `Client` & `mpsc::Sender<ReceivedMessage>`