### PR TITLE
chore: update netsim sims

### DIFF
--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -76,7 +76,7 @@ jobs:
         c='${{ steps.detect_comment_config.outputs.NETSIM_CONFIG }}'
         if [ -z "${c}" ];
         then
-          sudo python3 main.py sims/standard
+          sudo python3 main.py sims/iroh
         else
           echo $c >> custom_sim.json
           sudo python3 main.py custom_sim.json


### PR DESCRIPTION
Instead of the usual suite, we now run iroh on multiple latencies and publish those results. The remaining sims are available by direct config in the comment.