### PR TITLE
feat: Add run_ticket to dial all addresses stored in a Ticket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "3a09ac8bb8c16a282264c379dffba707b9c998afc7506009137f3c6136888078"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1179,7 +1179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea993e32c77d87f01236c38f572ecb6c311d592e56a06262a007fd2a6e31253c"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "libc",
  "netlink-packet-core",

--- a/src/get.rs
+++ b/src/get.rs
@@ -134,7 +134,7 @@ impl AsyncRead for DataStream {
 
 /// Gets a collection and all its blobs using a [`Ticket`].
 pub async fn run_ticket<A, B, C, FutA, FutB, FutC>(
-    ticket: Ticket,
+    ticket: &Ticket,
     keylog: bool,
     max_concurrent: u8,
     on_connected: A,
@@ -150,7 +150,7 @@ where
     FutC: Future<Output = Result<DataStream>>,
 {
     let start = Instant::now();
-    let connection = dial_ticket(&ticket, keylog, max_concurrent.into()).await?;
+    let connection = dial_ticket(ticket, keylog, max_concurrent.into()).await?;
     run_connection(
         connection,
         ticket.hash,

--- a/src/get.rs
+++ b/src/get.rs
@@ -249,7 +249,7 @@ where
 }
 
 /// Gets a collection and all its blobs from a provider on the established connection.
-pub async fn run_connection<A, B, C, FutA, FutB, FutC>(
+async fn run_connection<A, B, C, FutA, FutB, FutC>(
     connection: quinn::Connection,
     hash: Hash,
     auth_token: AuthToken,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ mod tests {
         tokio::time::timeout(
             Duration::from_secs(10),
             get::run_ticket(
-                ticket,
+                &ticket,
                 true,
                 16,
                 || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,13 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 pub mod blobs;
 pub mod get;
+pub mod net;
 pub mod progress;
 pub mod protocol;
 pub mod provider;
 pub mod rpc_protocol;
 
-pub mod net;
-
+mod subnet;
 mod tls;
 mod util;
 
@@ -19,7 +19,7 @@ pub use util::Hash;
 #[cfg(test)]
 mod tests {
     use std::{
-        net::SocketAddr,
+        net::{Ipv4Addr, SocketAddr},
         path::{Path, PathBuf},
         sync::{atomic::AtomicUsize, Arc},
         time::Duration,
@@ -489,5 +489,49 @@ mod tests {
         .await
         .expect("timeout")
         .expect("get failed");
+    }
+
+    #[tokio::test]
+    async fn test_run_ticket() {
+        let readme = Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md");
+        let (db, hash) = create_collection(vec![readme.into()]).await.unwrap();
+        let provider = Provider::builder(db)
+            .bind_addr((Ipv4Addr::UNSPECIFIED, 0).into())
+            .spawn()
+            .unwrap();
+        let _drop_guard = provider.cancel_token().drop_guard();
+        let ticket = provider.ticket(hash);
+        let mut on_connected = false;
+        let mut on_collection = false;
+        let mut on_blob = false;
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            get::run_ticket(
+                ticket,
+                true,
+                16,
+                || {
+                    on_connected = true;
+                    async { Ok(()) }
+                },
+                |_| {
+                    on_collection = true;
+                    async { Ok(()) }
+                },
+                |_hash, mut stream, _name| {
+                    on_blob = true;
+                    async move {
+                        io::copy(&mut stream, &mut io::sink()).await?;
+                        Ok(stream)
+                    }
+                },
+            ),
+        )
+        .await
+        .expect("timeout")
+        .expect("get ticket failed");
+        assert!(on_connected);
+        assert!(on_collection);
+        assert!(on_blob);
     }
 }

--- a/src/subnet.rs
+++ b/src/subnet.rs
@@ -1,0 +1,41 @@
+//! Same subnet logic.
+//!
+//! Tiny module because left/right shifting confuses emacs' rust-mode.  So sad.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// Checks if both addresses are on the same subnet given the `prefix_len`.
+pub(crate) fn same_subnet_v4(addr_a: Ipv4Addr, addr_b: Ipv4Addr, prefix_len: u8) -> bool {
+    let mask = u32::MAX << (32 - prefix_len);
+    let a = u32::from(addr_a) & mask;
+    let b = u32::from(addr_b) & mask;
+    a == b
+}
+
+pub(crate) fn same_subnet_v6(addr_a: Ipv6Addr, addr_b: Ipv6Addr, prefix_len: u8) -> bool {
+    let mask = u128::MAX << (128 - prefix_len);
+    let a = u128::from(addr_a) & mask;
+    let b = u128::from(addr_b) & mask;
+    a == b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_same_subnet_v4() {
+        let a = Ipv4Addr::new(192, 168, 0, 5);
+        let b = Ipv4Addr::new(192, 168, 1, 6);
+        assert!(!same_subnet_v4(a, b, 24));
+        assert!(same_subnet_v4(a, b, 16));
+    }
+
+    #[test]
+    fn test_same_subnet_v6() {
+        let a = Ipv6Addr::new(0xfd56, 0x5799, 0xd8f6, 0x3cc, 0x0, 0x0, 0x0, 0x1);
+        let b = Ipv6Addr::new(0xfd56, 0x5799, 0xd8f6, 0x3cd, 0x0, 0x0, 0x0, 0x2);
+        assert!(!same_subnet_v6(a, b, 64));
+        assert!(same_subnet_v6(a, b, 48));
+    }
+}


### PR DESCRIPTION
This adds a new iroh::get::run_ticket call which will dial all the
addresses in a ticket concurrently, up to a specified concurrency
limit.  The first established connection is returned.

This allows much better fetching of a ticket, without having to know
how it is constructed and speeds up connecting.

When dialing an attempt is made to first try addresses which are
considered to be on the same subnet as any local address.

This doesn't yet update main.rs to use this.  Probably best as a
separate PR.