### PR TITLE
feat(ticket): Ensure a ticket always has at least one address

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -153,8 +153,8 @@ where
     let connection = dial_ticket(ticket, keylog, max_concurrent.into()).await?;
     run_connection(
         connection,
-        ticket.hash,
-        ticket.token,
+        ticket.hash(),
+        ticket.token(),
         start,
         on_connected,
         on_collection,
@@ -171,7 +171,7 @@ async fn dial_ticket(
     // Sort the interfaces to make sure local ones are at the front of the list.
     let interfaces = default_net::get_interfaces();
     let (mut addrs, other_addrs) = ticket
-        .addrs
+        .addrs()
         .iter()
         .partition::<Vec<_>, _>(|addr| is_same_subnet(addr, &interfaces));
     addrs.extend(other_addrs);
@@ -180,7 +180,7 @@ async fn dial_ticket(
         .map(|addr| {
             let opts = Options {
                 addr,
-                peer_id: Some(ticket.peer),
+                peer_id: Some(ticket.peer()),
                 keylog,
             };
             dial_peer(opts)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,7 +500,7 @@ mod tests {
             .spawn()
             .unwrap();
         let _drop_guard = provider.cancel_token().drop_guard();
-        let ticket = provider.ticket(hash);
+        let ticket = provider.ticket(hash).unwrap();
         let mut on_connected = false;
         let mut on_collection = false;
         let mut on_blob = false;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1166,7 +1166,7 @@ pub struct Ticket {
 
 impl Ticket {
     fn new(hash: Hash, peer: PeerId, addrs: Vec<SocketAddr>, token: AuthToken) -> Result<Self> {
-        ensure!(!addrs.is_empty(), "Invalid address list in ticket");
+        ensure!(!addrs.is_empty(), "Ticket has no address");
         Ok(Self {
             hash,
             peer,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -7,13 +7,11 @@
 //! You can monitor what is happening in the provider using [`Provider::subscribe`].
 //!
 //! To shut down the provider, call [`Provider::shutdown`].
-use std::fmt::{self, Display};
 use std::future::Future;
 use std::io::{BufReader, Read};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::str::FromStr;
 use std::task::Poll;
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
@@ -28,7 +26,6 @@ use quic_rpc::server::RpcChannel;
 use quic_rpc::transport::flume::FlumeConnection;
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use quic_rpc::{RpcClient, RpcServer, ServiceConnection, ServiceEndpoint};
-use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinError;
@@ -50,11 +47,15 @@ use crate::rpc_protocol::{
     WatchResponse,
 };
 use crate::tls::{self, Keypair, PeerId};
-use crate::util::{self, canonicalize_path, Hash, Progress, ProgressReader, ProgressReaderUpdate};
+use crate::util::{canonicalize_path, Hash, Progress, ProgressReader, ProgressReaderUpdate};
+
 mod database;
+mod ticket;
+
 pub use database::Database;
 #[cfg(cli)]
 pub use database::Snapshot;
+pub use ticket::Ticket;
 
 const MAX_CONNECTIONS: u32 = 1024;
 const MAX_STREAMS: u64 = 10;
@@ -1146,89 +1147,6 @@ async fn write_response<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
-/// A token containing everything to get a file from the provider.
-///
-/// It is a single item which can be easily serialized and deserialized.  The [`Display`]
-/// and [`FromStr`] implementations serialize to base64.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Ticket {
-    /// The hash to retrieve.
-    hash: Hash,
-    /// The peer ID identifying the provider.
-    peer: PeerId,
-    /// The socket addresses the provider is listening on.
-    ///
-    /// This will never be empty.
-    addrs: Vec<SocketAddr>,
-    /// The authentication token with permission to retrieve the hash.
-    token: AuthToken,
-}
-
-impl Ticket {
-    fn new(hash: Hash, peer: PeerId, addrs: Vec<SocketAddr>, token: AuthToken) -> Result<Self> {
-        ensure!(!addrs.is_empty(), "addrs list can not be empty");
-        Ok(Self {
-            hash,
-            peer,
-            addrs,
-            token,
-        })
-    }
-
-    /// Deserializes from bytes.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let slf: Ticket = postcard::from_bytes(bytes)?;
-        ensure!(!slf.addrs.is_empty(), "Invalid address list in ticket");
-        Ok(slf)
-    }
-
-    /// Serializes to bytes.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        postcard::to_stdvec(self).expect("postcard::to_stdvec is infallible")
-    }
-
-    /// The hash of the item this ticket can retrieve.
-    pub fn hash(&self) -> Hash {
-        self.hash
-    }
-
-    /// The [`PeerId`] of the provider for this ticket.
-    pub fn peer(&self) -> PeerId {
-        self.peer
-    }
-
-    /// The addresses on which the provider can be reached.
-    ///
-    /// This is guaranteed to be non-empty.
-    pub fn addrs(&self) -> &[SocketAddr] {
-        &self.addrs
-    }
-
-    /// The authentication token for this ticket.
-    pub fn token(&self) -> AuthToken {
-        self.token
-    }
-}
-
-/// Serializes to base64.
-impl Display for Ticket {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let encoded = self.to_bytes();
-        write!(f, "{}", util::encode(encoded))
-    }
-}
-
-/// Deserializes from base64.
-impl FromStr for Ticket {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = util::decode(s)?;
-        let slf = Self::from_bytes(&bytes)?;
-        Ok(slf)
-    }
-}
-
 /// Create a [`quinn::ServerConfig`] with the given keypair and limits.
 pub fn make_server_config(
     keypair: &Keypair,
@@ -1329,27 +1247,6 @@ mod tests {
             let db2 = db2.to_inner();
             prop_assert_eq!(db, db2);
         }
-    }
-
-    #[test]
-    fn test_ticket_base64_roundtrip() {
-        let (_encoded, hash) = abao::encode::encode(b"hi there");
-        let hash = Hash::from(hash);
-        let peer = PeerId::from(Keypair::generate().public());
-        let addr = SocketAddr::from_str("127.0.0.1:1234").unwrap();
-        let token = AuthToken::generate();
-        let ticket = Ticket {
-            hash,
-            peer,
-            addrs: vec![addr],
-            token,
-        };
-        let base64 = ticket.to_string();
-        println!("Ticket: {base64}");
-        println!("{} bytes", base64.len());
-
-        let ticket2: Ticket = base64.parse().unwrap();
-        assert_eq!(ticket2, ticket);
     }
 
     #[tokio::test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1166,7 +1166,7 @@ pub struct Ticket {
 
 impl Ticket {
     fn new(hash: Hash, peer: PeerId, addrs: Vec<SocketAddr>, token: AuthToken) -> Result<Self> {
-        ensure!(!addrs.is_empty(), "Ticket has no address");
+        ensure!(!addrs.is_empty(), "addrs list can not be empty");
         Ok(Self {
             hash,
             peer,

--- a/src/provider/ticket.rs
+++ b/src/provider/ticket.rs
@@ -1,3 +1,8 @@
+//! The ticket type for the provider.
+//!
+//! This is in it's own module to enforce the invariant that you can not construct a ticket
+//! with an empty address list.
+
 use std::fmt;
 use std::net::SocketAddr;
 use std::str::FromStr;

--- a/src/provider/ticket.rs
+++ b/src/provider/ticket.rs
@@ -3,7 +3,7 @@
 //! This is in it's own module to enforce the invariant that you can not construct a ticket
 //! with an empty address list.
 
-use std::fmt;
+use std::fmt::{self, Display};
 use std::net::SocketAddr;
 use std::str::FromStr;
 
@@ -86,7 +86,7 @@ impl Ticket {
 }
 
 /// Serializes to base64.
-impl fmt::Display for Ticket {
+impl Display for Ticket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let encoded = self.to_bytes();
         write!(f, "{}", util::encode(encoded))

--- a/src/provider/ticket.rs
+++ b/src/provider/ticket.rs
@@ -1,0 +1,128 @@
+use std::fmt;
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use anyhow::{ensure, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::AuthToken;
+use crate::util;
+use crate::{Hash, PeerId};
+
+/// A token containing everything to get a file from the provider.
+
+/// A token containing everything to get a file from the provider.
+///
+/// It is a single item which can be easily serialized and deserialized.  The [`Display`]
+/// and [`FromStr`] implementations serialize to base64.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Ticket {
+    /// The hash to retrieve.
+    hash: Hash,
+    /// The peer ID identifying the provider.
+    peer: PeerId,
+    /// The socket addresses the provider is listening on.
+    ///
+    /// This will never be empty.
+    addrs: Vec<SocketAddr>,
+    /// The authentication token with permission to retrieve the hash.
+    token: AuthToken,
+}
+
+impl Ticket {
+    pub(super) fn new(
+        hash: Hash,
+        peer: PeerId,
+        addrs: Vec<SocketAddr>,
+        token: AuthToken,
+    ) -> Result<Self> {
+        ensure!(!addrs.is_empty(), "addrs list can not be empty");
+        Ok(Self {
+            hash,
+            peer,
+            addrs,
+            token,
+        })
+    }
+
+    /// Deserializes from bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let slf: Ticket = postcard::from_bytes(bytes)?;
+        ensure!(!slf.addrs.is_empty(), "Invalid address list in ticket");
+        Ok(slf)
+    }
+
+    /// Serializes to bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_stdvec(self).expect("postcard::to_stdvec is infallible")
+    }
+
+    /// The hash of the item this ticket can retrieve.
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    /// The [`PeerId`] of the provider for this ticket.
+    pub fn peer(&self) -> PeerId {
+        self.peer
+    }
+
+    /// The addresses on which the provider can be reached.
+    ///
+    /// This is guaranteed to be non-empty.
+    pub fn addrs(&self) -> &[SocketAddr] {
+        &self.addrs
+    }
+
+    /// The authentication token for this ticket.
+    pub fn token(&self) -> AuthToken {
+        self.token
+    }
+}
+
+/// Serializes to base64.
+impl fmt::Display for Ticket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let encoded = self.to_bytes();
+        write!(f, "{}", util::encode(encoded))
+    }
+}
+
+/// Deserializes from base64.
+impl FromStr for Ticket {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = util::decode(s)?;
+        let slf = Self::from_bytes(&bytes)?;
+        Ok(slf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tls::Keypair;
+
+    use super::*;
+
+    #[test]
+    fn test_ticket_base64_roundtrip() {
+        let (_encoded, hash) = abao::encode::encode(b"hi there");
+        let hash = Hash::from(hash);
+        let peer = PeerId::from(Keypair::generate().public());
+        let addr = SocketAddr::from_str("127.0.0.1:1234").unwrap();
+        let token = AuthToken::generate();
+        let ticket = Ticket {
+            hash,
+            peer,
+            addrs: vec![addr],
+            token,
+        };
+        let base64 = ticket.to_string();
+        println!("Ticket: {base64}");
+        println!("{} bytes", base64.len());
+
+        let ticket2: Ticket = base64.parse().unwrap();
+        assert_eq!(ticket2, ticket);
+    }
+}


### PR DESCRIPTION
This makes it impossible to have a ticket with an empty address list.
It makes the fields of the ticket private and also makes creating the
ticket fallible.  Both are probably good things for the public API and
the latter e.g. allows us to add further checks like ensure the hash
really exists.