### PR TITLE
Use the new bao-tree crate instead of abao

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,13 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.1.0"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ecf476d1f9591cb8543bdd6ab4595e64d6d89c8dc445d902326975d08aa0db"
 dependencies = [
  "blake3",
  "bytes",
  "futures",
- "hex",
  "ouroboros",
  "range-collections",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "abao"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +44,12 @@ checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "anyhow"
@@ -84,7 +96,7 @@ checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -96,7 +108,7 @@ checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -118,6 +130,18 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "bao-tree"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+ "bytes",
+ "genawaiter",
+ "ouroboros",
+ "range-collections",
+ "smallvec",
 ]
 
 [[package]]
@@ -149,6 +173,12 @@ name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
+name = "binary-merge"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
 name = "bincode"
@@ -295,10 +325,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
- "proc-macro-error",
+ "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -450,7 +480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -497,10 +527,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ef71ddb5b3a1f53dee24817c8f70dfa1cb29e804c18d88c228d4bc9c86ee3b9"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -513,7 +543,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -566,7 +596,7 @@ checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -615,7 +645,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -654,7 +684,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -772,7 +802,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -803,6 +833,36 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "genawaiter-macro",
+ "genawaiter-proc-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "genawaiter-proc-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
+dependencies = [
+ "proc-macro-error 0.4.12",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -906,6 +966,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inplace-vec-builder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +999,7 @@ version = "0.3.0"
 dependencies = [
  "abao",
  "anyhow",
+ "bao-tree",
  "base64 0.21.0",
  "blake3",
  "bytes",
@@ -953,6 +1023,7 @@ dependencies = [
  "quic-rpc",
  "quinn",
  "rand 0.7.3",
+ "range-collections",
  "rcgen",
  "regex",
  "ring",
@@ -1286,6 +1357,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "ouroboros"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
+dependencies = [
+ "Inflector",
+ "proc-macro-error 1.0.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,7 +1465,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1440,7 +1534,7 @@ checksum = "fc4b01218787dd4420daf63875163a787a78294ad48a24e9f6fa8c6507759a79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1451,14 +1545,40 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr 0.4.12",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr",
+ "proc-macro-error-attr 1.0.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+ "syn-mid",
  "version_check",
 ]
 
@@ -1474,10 +1594,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.51"
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
@@ -1585,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1673,6 +1799,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-collections"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2151d0cda6f7cee2de547749cccca65dffbe1a292a1176fd914083acd21190ff"
+dependencies = [
+ "binary-merge",
+ "inplace-vec-builder",
+ "ref-cast",
+ "smallvec",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1840,26 @@ dependencies = [
  "getrandom 0.2.8",
  "redox_syscall",
  "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43faa91b1c8b36841ee70e97188a869d37ae21759da6846d4be66de5bf7b12c"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -1986,7 +2144,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2161,6 +2319,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,7 +2348,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -2260,7 +2440,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2343,7 +2523,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2406,7 +2586,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2559,7 +2739,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -2581,7 +2761,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2821,6 +3001,6 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ecf476d1f9591cb8543bdd6ab4595e64d6d89c8dc445d902326975d08aa0db"
+checksum = "9133b967344eadaeab97ae14c43794f59b4ab489a963481f94f3d7684919ae18"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,19 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
-name = "abao"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daa0989489b05a455a9707adbbbc17443edf7bbc902ce499cd3b84148d68a40"
-dependencies = [
- "arrayref",
- "arrayvec",
- "blake3",
- "futures",
- "tokio",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,7 +956,6 @@ dependencies = [
 name = "iroh"
 version = "0.3.0"
 dependencies = [
- "abao",
  "anyhow",
  "bao-tree",
  "base64 0.21.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9133b967344eadaeab97ae14c43794f59b4ab489a963481f94f3d7684919ae18"
+checksum = "f475e39fc0ee53faefa68805aa234de8034e1317a7fabd15f4b908db55285396"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.7",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2317,9 +2317,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,10 +138,12 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "bytes",
- "genawaiter",
+ "futures",
+ "hex",
  "ouroboros",
  "range-collections",
  "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -325,7 +327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.107",
@@ -527,7 +529,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ef71ddb5b3a1f53dee24817c8f70dfa1cb29e804c18d88c228d4bc9c86ee3b9"
 dependencies = [
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.107",
@@ -748,9 +750,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -763,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -773,15 +775,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -790,15 +792,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -807,21 +809,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -833,36 +835,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "genawaiter-macro",
- "genawaiter-proc-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
-
-[[package]]
-name = "genawaiter-proc-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
-dependencies = [
- "proc-macro-error 0.4.12",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -1373,7 +1345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.107",
@@ -1545,40 +1517,14 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
-dependencies = [
- "proc-macro-error-attr 0.4.12",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr 1.0.4",
+ "proc-macro-error-attr",
  "proc-macro2",
  "quote",
  "syn 1.0.107",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "syn-mid",
  "version_check",
 ]
 
@@ -1592,12 +1538,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -2327,17 +2267,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tempfile = "3.4"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["io-util", "io"] }
+tokio-util = { version = "0.7" }
 tracing = "0.1"
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/n0-computer/iroh"
 rust-version = "1.63"
 
 [dependencies]
-abao = { version = "0.2.0", features = ["group_size_16k", "tokio_io"], default-features = false }
+# abao = { version = "0.2.0", features = ["group_size_16k", "tokio_io"], default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 base64 = "0.21.0"
 blake3 = "1.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,7 @@ walkdir = "2"
 webpki = "0.22"
 x509-parser = "0.14"
 zeroize = "1.5"
-# bao-tree = { path = "../bao-tree" }
-bao-tree = { version = "0.1.3", features = ["tokio_io"], default-features = false }
+bao-tree = { version = "0.1.5", features = ["tokio_io"], default-features = false }
 range-collections = "0.4.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ webpki = "0.22"
 x509-parser = "0.14"
 zeroize = "1.5"
 # bao-tree = { path = "../bao-tree" }
-bao-tree = { version = "0.1.2", features = ["tokio_io"], default-features = false }
+bao-tree = { version = "0.1.3", features = ["tokio_io"], default-features = false }
 range-collections = "0.4.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,8 @@ walkdir = "2"
 webpki = "0.22"
 x509-parser = "0.14"
 zeroize = "1.5"
-bao-tree = { path = "../bao-tree" }
+# bao-tree = { path = "../bao-tree" }
+bao-tree = { version = "0.1.2", features = ["tokio_io"], default-features = false }
 range-collections = "0.4.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ walkdir = "2"
 webpki = "0.22"
 x509-parser = "0.14"
 zeroize = "1.5"
+bao-tree = { path = "../bao-tree" }
+range-collections = "0.4.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -70,7 +70,7 @@ mod tests {
     fn roundtrip_blob() {
         let b = Blob {
             name: "test".to_string(),
-            hash: abao::Hash::from_hex(
+            hash: blake3::Hash::from_hex(
                 "3aa61c409fd7717c9d9c639202af2fae470c0ef669be7ba2caea5779cb534e9d",
             )
             .unwrap()

--- a/src/get.rs
+++ b/src/get.rs
@@ -18,7 +18,7 @@ use crate::subnet::{same_subnet_v4, same_subnet_v6};
 use crate::tls::{self, Keypair, PeerId};
 use crate::IROH_BLOCK_SIZE;
 use anyhow::{anyhow, bail, Context, Result};
-use bao_tree::r#async::AsyncResponseDecoder;
+use bao_tree::tokio_io::AsyncResponseDecoder;
 use bytes::BytesMut;
 use default_net::Interface;
 use futures::{Future, StreamExt};

--- a/src/get.rs
+++ b/src/get.rs
@@ -14,6 +14,7 @@ use crate::protocol::{
     read_bao_encoded, read_lp, write_lp, AuthToken, Handshake, Request, Res, Response,
 };
 use crate::tls::{self, Keypair, PeerId};
+use crate::IROH_BLOCK_SIZE;
 use anyhow::{anyhow, bail, Context, Result};
 use bao_tree::ChunkNum;
 use bytes::BytesMut;
@@ -104,14 +105,14 @@ impl Stats {
 /// We guarantee that the data is correct by incrementally verifying a hash
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct DataStream(bao_tree::bao_tree::r#async::AsyncResponseDecoder<quinn::RecvStream>);
+pub struct DataStream(bao_tree::r#async::AsyncResponseDecoder<quinn::RecvStream>);
 
 impl DataStream {
     fn new(inner: quinn::RecvStream, hash: Hash) -> Self {
-        let decoder = bao_tree::bao_tree::r#async::AsyncResponseDecoder::new(
+        let decoder = bao_tree::r#async::AsyncResponseDecoder::new(
             hash.into(),
             RangeSet2::from(ChunkNum(0)..),
-            4,
+            IROH_BLOCK_SIZE,
             inner,
         );
         DataStream(decoder)

--- a/src/get.rs
+++ b/src/get.rs
@@ -18,7 +18,7 @@ use crate::subnet::{same_subnet_v4, same_subnet_v6};
 use crate::tls::{self, Keypair, PeerId};
 use crate::IROH_BLOCK_SIZE;
 use anyhow::{anyhow, bail, Context, Result};
-use bao_tree::tokio_io::AsyncResponseDecoder;
+use bao_tree::io::tokio::AsyncResponseDecoder;
 use bytes::BytesMut;
 use default_net::Interface;
 use futures::{Future, StreamExt};

--- a/src/get.rs
+++ b/src/get.rs
@@ -18,7 +18,7 @@ use crate::subnet::{same_subnet_v4, same_subnet_v6};
 use crate::tls::{self, Keypair, PeerId};
 use crate::IROH_BLOCK_SIZE;
 use anyhow::{anyhow, bail, Context, Result};
-use bao_tree::ChunkNum;
+use bao_tree::r#async::AsyncResponseDecoder;
 use bytes::BytesMut;
 use default_net::Interface;
 use futures::{Future, StreamExt};
@@ -108,16 +108,12 @@ impl Stats {
 /// We guarantee that the data is correct by incrementally verifying a hash
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct DataStream(bao_tree::r#async::AsyncResponseDecoder<quinn::RecvStream>);
+pub struct DataStream(AsyncResponseDecoder<quinn::RecvStream>);
 
 impl DataStream {
     fn new(inner: quinn::RecvStream, hash: Hash) -> Self {
-        let decoder = bao_tree::r#async::AsyncResponseDecoder::new(
-            hash.into(),
-            RangeSet2::from(ChunkNum(0)..),
-            IROH_BLOCK_SIZE,
-            inner,
-        );
+        let decoder =
+            AsyncResponseDecoder::new(hash.into(), RangeSet2::all(), IROH_BLOCK_SIZE, inner);
         DataStream(decoder)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ mod tests {
         tokio::fs::write(&path, content).await?;
         // hash of the transfer file
         let data = tokio::fs::read(&path).await?;
-        let (_, expect_hash) = abao::encode::outboard(&data);
+        let expect_hash = blake3::hash(&data);
         let expect_name = filename.to_string();
 
         let (db, hash) =
@@ -207,7 +207,7 @@ mod tests {
             let name = name.into();
             let path = dir.join(name.clone());
             // get expected hash of file
-            let (_, hash) = abao::encode::outboard(&data);
+            let hash = blake3::hash(&data);
             let hash = Hash::from(hash);
 
             tokio::fs::write(&path, data).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,13 @@ mod util;
 pub use tls::{Keypair, PeerId, PeerIdError, PublicKey, SecretKey, Signature};
 pub use util::Hash;
 
+use bao_tree::BlockSize;
+
+pub(crate) const IROH_BLOCK_SIZE: BlockSize = match BlockSize::new(4) {
+    Some(bs) => bs,
+    None => panic!(),
+};
+
 #[cfg(test)]
 mod tests {
     use std::{

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,6 @@ use std::io;
 use std::str::FromStr;
 
 use anyhow::{bail, ensure, Context, Result};
-use bao_tree::ChunkNum;
 use bytes::{Bytes, BytesMut};
 use postcard::experimental::max_size::MaxSize;
 use quinn::VarInt;
@@ -119,7 +118,7 @@ pub(crate) async fn read_bao_encoded<R: AsyncRead + Unpin>(
 ) -> Result<Vec<u8>> {
     let mut decoder = bao_tree::r#async::AsyncResponseDecoder::new(
         hash.into(),
-        RangeSet2::from(ChunkNum(0)..),
+        RangeSet2::all(),
         IROH_BLOCK_SIZE,
         reader,
     );

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::str::FromStr;
 
 use anyhow::{bail, ensure, Context, Result};
+use bao_tree::tokio_io::AsyncResponseDecoder;
 use bytes::{Bytes, BytesMut};
 use postcard::experimental::max_size::MaxSize;
 use quinn::VarInt;
@@ -116,12 +117,8 @@ pub(crate) async fn read_bao_encoded<R: AsyncRead + Unpin>(
     reader: R,
     hash: Hash,
 ) -> Result<Vec<u8>> {
-    let mut decoder = bao_tree::r#async::AsyncResponseDecoder::new(
-        hash.into(),
-        RangeSet2::all(),
-        IROH_BLOCK_SIZE,
-        reader,
-    );
+    let mut decoder =
+        AsyncResponseDecoder::new(hash.into(), RangeSet2::all(), IROH_BLOCK_SIZE, reader);
     // we don't know the size yet, so we just allocate a reasonable amount
     let mut decoded = Vec::with_capacity(4096);
     decoder.read_to_end(&mut decoded).await?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,6 @@ use std::fmt::Display;
 use std::io;
 use std::str::FromStr;
 
-use abao::decode::AsyncSliceDecoder;
 use anyhow::{bail, ensure, Context, Result};
 use bao_tree::ChunkNum;
 use bytes::{Bytes, BytesMut};
@@ -13,7 +12,10 @@ use range_collections::RangeSet2;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-use crate::util::{self, Hash};
+use crate::{
+    util::{self, Hash},
+    IROH_BLOCK_SIZE,
+};
 
 /// Maximum message size is limited to 100MiB for now.
 const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 100;
@@ -115,10 +117,10 @@ pub(crate) async fn read_bao_encoded<R: AsyncRead + Unpin>(
     reader: R,
     hash: Hash,
 ) -> Result<Vec<u8>> {
-    let mut decoder = bao_tree::bao_tree::r#async::AsyncResponseDecoder::new(
+    let mut decoder = bao_tree::r#async::AsyncResponseDecoder::new(
         hash.into(),
         RangeSet2::from(ChunkNum(0)..),
-        4,
+        IROH_BLOCK_SIZE,
         reader,
     );
     // we don't know the size yet, so we just allocate a reasonable amount

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::str::FromStr;
 
 use anyhow::{bail, ensure, Context, Result};
-use bao_tree::tokio_io::AsyncResponseDecoder;
+use bao_tree::io::tokio::AsyncResponseDecoder;
 use bytes::{Bytes, BytesMut};
 use postcard::experimental::max_size::MaxSize;
 use quinn::VarInt;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{ensure, Context, Result};
-use bao_tree::iter::encode_validated;
+use bao_tree::io::encode_validated;
 use bao_tree::outboard::{PostOrderMemOutboard, PreOrderMemOutboard};
 use bytes::{Bytes, BytesMut};
 use futures::future::{BoxFuture, Shared};
@@ -728,7 +728,7 @@ async fn transfer_collection(
         .unwrap();
     let mut encoded = Vec::with_capacity(encoded_size);
     let outboard = PreOrderMemOutboard::new(hash.into(), IROH_BLOCK_SIZE, outboard.to_vec());
-    bao_tree::iter::encode_validated(Cursor::new(data), outboard, &mut encoded)?;
+    bao_tree::io::encode_validated(Cursor::new(data), outboard, &mut encoded)?;
 
     // let mut extractor = SliceExtractor::new_outboard(
     //     std::io::Cursor::new(&data[..]),
@@ -1016,7 +1016,7 @@ fn compute_outboard(
     // this reduces the number of io ops and also the number of progress reports
     let mut reader = BufReader::with_capacity(1024 * 1024, reader);
 
-    let hash = bao_tree::BaoTree::outboard_post_order_io(
+    let hash = bao_tree::io::outboard_post_order(
         &mut reader,
         size,
         IROH_BLOCK_SIZE,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -49,7 +49,7 @@ use crate::rpc_protocol::{
     WatchResponse,
 };
 use crate::tls::{self, Keypair, PeerId};
-use crate::util::{canonicalize_path, Hash, Progress, ProgressReader, ProgressUpdate};
+use crate::util::{canonicalize_path, Hash, Progress, ProgressReader, ProgressReaderUpdate};
 use crate::IROH_BLOCK_SIZE;
 
 mod database;
@@ -992,13 +992,9 @@ fn compute_outboard(
         .context("outboard too large to fit in memory")?;
     let mut outboard = Vec::with_capacity(outboard_size);
 
-    // copy the file into the encoder. Data will be skipped by the encoder in outboard mode.
-    // let outboard_cursor = std::io::Cursor::new(&mut outboard);
-    // let mut encoder = abao::encode::Encoder::new_outboard(outboard_cursor);
-
     // wrap the reader in a progress reader, so we can report progress.
     let reader = ProgressReader::new(file, |p| {
-        if let ProgressUpdate::Progress(offset) = p {
+        if let ProgressReaderUpdate::Progress(offset) = p {
             progress(offset);
         }
     });

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{ensure, Context, Result};
 use bao_tree::io::sync::encode_ranges_validated;
-use bao_tree::outboard::{PostOrderMemOutboard, PreOrderMemOutboard, PreOrderMemOutboardRef};
+use bao_tree::outboard::{PostOrderMemOutboard, PreOrderMemOutboardRef};
 use bytes::{Bytes, BytesMut};
 use futures::future::{BoxFuture, Shared};
 use futures::{stream, FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt};
@@ -885,8 +885,7 @@ async fn send_blob<W: AsyncWrite + Unpin + Send + 'static>(
         })) => {
             write_response(&mut writer, buffer, Res::Found).await?;
 
-            let outboard =
-                PreOrderMemOutboard::new(name.into(), IROH_BLOCK_SIZE, outboard.to_vec());
+            let outboard = PreOrderMemOutboardRef::new(name.into(), IROH_BLOCK_SIZE, &outboard);
             let file_reader = tokio::fs::File::open(&path).await?;
             bao_tree::io::tokio::encode_ranges_validated(
                 file_reader,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -18,7 +18,6 @@ use std::task::Poll;
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
-use abao::encode::SliceExtractor;
 use anyhow::{ensure, Context, Result};
 use bao_tree::bao_tree::iter::{encode_ranges_validated, encode_validated};
 use bao_tree::bao_tree::outboard::PreOrderMemOutboard;
@@ -1317,7 +1316,7 @@ mod tests {
 
     #[test]
     fn test_ticket_base64_roundtrip() {
-        let (_encoded, hash) = abao::encode::encode(b"hi there");
+        let hash = blake3::hash(b"hi there");
         let hash = Hash::from(hash);
         let peer = PeerId::from(Keypair::generate().public());
         let addr = SocketAddr::from_str("127.0.0.1:1234").unwrap();
@@ -1340,7 +1339,7 @@ mod tests {
     async fn test_create_collection() -> Result<()> {
         let dir: PathBuf = testdir!();
         let mut expect_blobs = vec![];
-        let (_, hash) = abao::encode::outboard(vec![]);
+        let hash = blake3::hash(&[]);
         let hash = Hash::from(hash);
 
         // DataSource::File

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{ensure, Context, Result};
-use bao_tree::io::encode_ranges_validated;
+use bao_tree::io::sync::encode_ranges_validated;
 use bao_tree::outboard::{PostOrderMemOutboard, PreOrderMemOutboard, PreOrderMemOutboardRef};
 use bytes::{Bytes, BytesMut};
 use futures::future::{BoxFuture, Shared};
@@ -888,7 +888,7 @@ async fn send_blob<W: AsyncWrite + Unpin + Send + 'static>(
             let outboard =
                 PreOrderMemOutboard::new(name.into(), IROH_BLOCK_SIZE, outboard.to_vec());
             let file_reader = tokio::fs::File::open(&path).await?;
-            bao_tree::tokio_io::encode_ranges_validated(
+            bao_tree::io::tokio::encode_ranges_validated(
                 file_reader,
                 outboard,
                 &RangeSet2::all(),
@@ -1001,7 +1001,7 @@ fn compute_outboard(
     let mut reader = BufReader::with_capacity(1024 * 1024, reader);
 
     let hash =
-        bao_tree::io::outboard_post_order(&mut reader, size, IROH_BLOCK_SIZE, &mut outboard)?;
+        bao_tree::io::sync::outboard_post_order(&mut reader, size, IROH_BLOCK_SIZE, &mut outboard)?;
     let ob = PostOrderMemOutboard::load(hash, Cursor::new(&outboard), IROH_BLOCK_SIZE)?.flip();
     tracing::debug!("done. hash for {} is {hash}", path.display());
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -193,14 +193,15 @@ pub(crate) fn validate_bao<F: Fn(u64)>(
     Ok(())
 }
 
-// little util that discards data but prints progress every 1MB
+/// little util that discards data but prints progress every 1MB
 struct DevNull<F>(u64, F);
 
 impl<F: Fn(u64)> Write for DevNull<F> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        const NOTIFY_EVERY: u64 = 1024 * 1024;
         let prev = self.0;
         let curr = prev + buf.len() as u64;
-        if prev % 1000000 != curr % 1000000 {
+        if prev % NOTIFY_EVERY != curr % NOTIFY_EVERY {
             (self.1)(curr);
         }
         self.0 = curr;

--- a/src/util.rs
+++ b/src/util.rs
@@ -209,7 +209,7 @@ pub(crate) fn validate_bao<F: Fn(u64)>(
     }
 
     // do not wrap the data_reader in a BufReader, that is slow wnen seeking
-    bao_tree::iter::encode_validated(data_reader, outboard, DevNull(0, progress))?;
+    bao_tree::io::encode_validated(data_reader, outboard, DevNull(0, progress))?;
     Ok(())
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -170,10 +170,6 @@ pub(crate) enum BaoValidationError {
     IoError(io::Error),
     /// The data failed to validate
     EncodeError(EncodeError),
-    // /// The hash of the data does not match the hash of the outboard.
-    // HashMismatch,
-    // /// The size of the data does not match the size of the outboard.
-    // SizeMismatch,
 }
 
 impl From<EncodeError> for BaoValidationError {
@@ -273,13 +269,13 @@ mod tests {
     }
 }
 
-pub(crate) struct ProgressReader<R, F: Fn(ProgressUpdate)> {
+pub(crate) struct ProgressReader<R, F: Fn(ProgressReaderUpdate)> {
     inner: R,
     offset: u64,
     cb: F,
 }
 
-impl<R: Read, F: Fn(ProgressUpdate)> ProgressReader<R, F> {
+impl<R: Read, F: Fn(ProgressReaderUpdate)> ProgressReader<R, F> {
     pub fn new(inner: R, cb: F) -> Self {
         Self {
             inner,
@@ -289,22 +285,22 @@ impl<R: Read, F: Fn(ProgressUpdate)> ProgressReader<R, F> {
     }
 }
 
-impl<R: Read, F: Fn(ProgressUpdate)> Read for ProgressReader<R, F> {
+impl<R: Read, F: Fn(ProgressReaderUpdate)> Read for ProgressReader<R, F> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let read = self.inner.read(buf)?;
         self.offset += read as u64;
-        (self.cb)(ProgressUpdate::Progress(self.offset));
+        (self.cb)(ProgressReaderUpdate::Progress(self.offset));
         Ok(read)
     }
 }
 
-impl<R, F: Fn(ProgressUpdate)> Drop for ProgressReader<R, F> {
+impl<R, F: Fn(ProgressReaderUpdate)> Drop for ProgressReader<R, F> {
     fn drop(&mut self) {
-        (self.cb)(ProgressUpdate::Done);
+        (self.cb)(ProgressReaderUpdate::Done);
     }
 }
 
-pub(crate) enum ProgressUpdate {
+pub(crate) enum ProgressReaderUpdate {
     Progress(u64),
     Done,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 //! Utility functions and types.
 use anyhow::{ensure, Context, Result};
-use bao_tree::{error::EncodeError, io::encode_ranges_validated};
+use bao_tree::io::{error::EncodeError, sync::encode_ranges_validated};
 use base64::{engine::general_purpose, Engine as _};
 use bytes::Bytes;
 use derive_more::Display;


### PR DESCRIPTION
What this gives us:

- async wherever you want (it is pretty easy to implement in bao-tree)
  note: I still think that we should not do async everywhere, but we can if we want!
- verified encoding, so validation errors get caught on the server side
- configurable block size, currently set to 4 (= 1024 * 2^4)

and most notably:

- querying for multiple ranges in a single request