### PR TITLE
Bump bytes minimum version to 1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ abao = { version = "0.2.0", features = ["group_size_16k", "tokio_io"], default-f
 anyhow = { version = "1", features = ["backtrace"] }
 base64 = "0.21.0"
 blake3 = "1.3.3"
-bytes = "1"
+bytes = "1.4"
 clap = { version = "4", features = ["derive"], optional = true }
 console = { version = "0.15.5", optional = true }
 data-encoding = { version = "2.3.3", optional = true }


### PR DESCRIPTION
Adding iroh to a project that already depended on bytes 1.1 fails to compile with:

```
error[E0599]: no function or associated item named `zeroed` found for struct `BytesMut` in the current scope
   --> /home/fabrice/dev/capyloon/api-daemon/third-party/iroh/src/get.rs:273:36
    |
273 |     let mut out_buffer = BytesMut::zeroed(std::cmp::max(
    |                                    ^^^^^^ function or associated item not found in `BytesMut`
```

Because `BytesMut::zeroed()` was introduced in 1.2 . This PR sets the version to 1.4 which is the current stable version for the `bytes` crate.