### PR TITLE
Fix many files bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.7",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2175,9 +2175,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,13 @@ mod tests {
         let num_files = [10, 100, 1000, 10000];
         for num in num_files {
             println!("NUM_FILES: {num}");
-            let file_opts = (0..num).map(|i| (i.to_string(), 10)).collect();
+            let file_opts = (0..num)
+                .map(|i| {
+                    // use a long file name to test large collections
+                    let name = i.to_string().repeat(50);
+                    (name, 10)
+                })
+                .collect();
             transfer_random_data(file_opts).await?;
         }
         Ok(())

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -26,7 +26,7 @@ use quic_rpc::server::RpcChannel;
 use quic_rpc::transport::flume::FlumeConnection;
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use quic_rpc::{RpcClient, RpcServer, ServiceConnection, ServiceEndpoint};
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinError;
 use tokio_util::io::SyncIoBridge;
@@ -749,8 +749,7 @@ async fn transfer_collection(
     )
     .await?;
 
-    let mut data = BytesMut::from(&encoded[..]);
-    writer.write_buf(&mut data).await?;
+    writer.write_all(&encoded).await?;
     for (i, blob) in c.blobs().iter().enumerate() {
         debug!("writing blob {}/{}", i, c.blobs().len());
         tokio::task::yield_now().await;


### PR DESCRIPTION
I made the test fail by making the file name really long.

Made the file name repeat the number multiple times so a radix tree does not optimize the long name away, just in case we do radix trees in the future.