### PR TITLE
WIP new database implementation and format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,9 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "camino"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,3 +3175,7 @@ dependencies = [
  "quote",
  "syn 2.0.11",
 ]
+
+[[patch.unused]]
+name = "tokio"
+version = "1.25.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,9 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.1.5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0269d09622b162b68e1cafea0a70aa6d8f85ae2b0e65b98d583ba9b89bf8adf6"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,8 +162,6 @@ dependencies = [
 [[package]]
 name = "bao-tree"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f475e39fc0ee53faefa68805aa234de8034e1317a7fabd15f4b908db55285396"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde-error",
+ "smallvec",
  "ssh-key",
  "tempfile",
  "testdir",
@@ -2298,6 +2299,9 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,7 +3175,3 @@ dependencies = [
  "quote",
  "syn 2.0.11",
 ]
-
-[[patch.unused]]
-name = "tokio"
-version = "1.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ debug-assertions = false
 opt-level = 3
 panic = 'abort'
 incremental = false
+
+[patch.crates-io]
+bao-tree = { path="../bao-tree" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ walkdir = "2"
 webpki = "0.22"
 x509-parser = "0.14"
 zeroize = "1.5"
-bao-tree = { version = "0.1.5", features = ["tokio_io"], default-features = false, path = "../bao-tree" }
+bao-tree = { version = "0.2.0", features = ["tokio_io"], default-features = false }
 range-collections = "0.4.0"
 smallvec = { version = "1.10.0", features = ["serde", "const_new"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ debug-assertions = false
 opt-level = 3
 panic = 'abort'
 incremental = false
+
+[patch.crates-io]
+tokio = { path = "../tokio/tokio" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ walkdir = "2"
 webpki = "0.22"
 x509-parser = "0.14"
 zeroize = "1.5"
-bao-tree = { version = "0.1.5", features = ["tokio_io"], default-features = false }
+bao-tree = { version = "0.1.5", features = ["tokio_io"], default-features = false, path = "../bao-tree" }
 range-collections = "0.4.0"
 smallvec = { version = "1.10.0", features = ["serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ x509-parser = "0.14"
 zeroize = "1.5"
 bao-tree = { version = "0.1.5", features = ["tokio_io"], default-features = false }
 range-collections = "0.4.0"
+smallvec = { version = "1.10.0", features = ["serde"] }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.63"
 anyhow = { version = "1", features = ["backtrace"] }
 base64 = "0.21.0"
 blake3 = "1.3.3"
-bytes = "1.4"
+bytes = { version = "1.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"], optional = true }
 console = { version = "0.15.5", optional = true }
 data-encoding = { version = "2.3.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,5 +86,5 @@ opt-level = 3
 panic = 'abort'
 incremental = false
 
-[patch.crates-io]
-bao-tree = { path="../bao-tree" }
+# [patch.crates-io]
+# bao-tree = { path="../bao-tree" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ x509-parser = "0.14"
 zeroize = "1.5"
 bao-tree = { version = "0.1.5", features = ["tokio_io"], default-features = false, path = "../bao-tree" }
 range-collections = "0.4.0"
-smallvec = { version = "1.10.0", features = ["serde"] }
+smallvec = { version = "1.10.0", features = ["serde", "const_new"] }
 
 once_cell = { version = "1.17.1", optional = true }
 prometheus-client = { version = "0.18.0", optional = true }
@@ -85,6 +85,3 @@ debug-assertions = false
 opt-level = 3
 panic = 'abort'
 incremental = false
-
-[patch.crates-io]
-tokio = { path = "../tokio/tokio" }

--- a/proptest-regressions/protocol/range_spec.txt
+++ b/proptest-regressions/protocol/range_spec.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7375b003a63bfe725eb4bcb2f266fae6afd9b3c921f9c2018f97daf6ef05a364 # shrinks to ranges = [RangeSet{ChunkNum(0)..ChunkNum(1)}, RangeSet{}]

--- a/proptest-regressions/protocol/range_spec.txt
+++ b/proptest-regressions/protocol/range_spec.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 7375b003a63bfe725eb4bcb2f266fae6afd9b3c921f9c2018f97daf6ef05a364 # shrinks to ranges = [RangeSet{ChunkNum(0)..ChunkNum(1)}, RangeSet{}]
+cc 23322efa46881646f1468137a688e66aee7ec2a3d01895ccad851d442a7828af # shrinks to ranges = [RangeSet{}, RangeSet{ChunkNum(0)..ChunkNum(1)}]

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -34,7 +34,7 @@ impl Collection {
     }
 
     /// Blobs in this collection
-    pub(crate) fn blobs(&self) -> &[Blob] {
+    pub fn blobs(&self) -> &[Blob] {
         &self.blobs
     }
 
@@ -54,12 +54,13 @@ impl Collection {
     }
 }
 
+///
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Blob {
+pub struct Blob {
     /// The name of this blob of data
-    pub(crate) name: String,
+    pub name: String,
     /// The hash of the blob of data
-    pub(crate) hash: Hash,
+    pub hash: Hash,
 }
 
 #[cfg(test)]

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -29,7 +29,7 @@ impl Collection {
     /// Deserialize a collection from a byte slice
     pub fn from_bytes(data: &[u8]) -> Result<Self> {
         let c: Collection =
-            postcard::from_bytes(data).context("failed to serialize Collection data")?;
+            postcard::from_bytes(data).context("failed to deserialize Collection data")?;
         Ok(c)
     }
 

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -38,11 +38,6 @@ impl Collection {
         &self.blobs
     }
 
-    /// Take ownership of the blobs in this collection
-    pub(crate) fn into_inner(self) -> Vec<Blob> {
-        self.blobs
-    }
-
     /// Total size of the raw data referred to by all blobs in this collection
     pub fn total_blobs_size(&self) -> u64 {
         self.total_blobs_size

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -38,6 +38,11 @@ impl Collection {
         &self.blobs
     }
 
+    /// Take ownership of the blobs in this collection
+    pub fn into_inner(self) -> Vec<Blob> {
+        self.blobs
+    }
+
     /// Total size of the raw data referred to by all blobs in this collection
     pub fn total_blobs_size(&self) -> u64 {
         self.total_blobs_size

--- a/src/get.rs
+++ b/src/get.rs
@@ -639,8 +639,7 @@ where
         let serialized = postcard::to_stdvec(&request)?;
         write_lp(&mut writer, &serialized).await?;
     }
-    let bytes_written = writer.bytes_written();
-    let mut writer = writer.into_inner();
+    let (mut writer, bytes_written) = writer.into_parts();
     writer.finish().await?;
     drop(writer);
 
@@ -672,8 +671,7 @@ where
     }
 
     // Shut down the stream
-    let bytes_read = reader.bytes_read();
-    let mut reader = reader.into_inner();
+    let (mut reader, bytes_read) = reader.into_parts();
     if let Some(chunk) = reader.read_chunk(8, false).await? {
         reader.stop(0u8.into()).ok();
         error!("Received unexpected data from the provider: {chunk:?}");

--- a/src/get.rs
+++ b/src/get.rs
@@ -277,7 +277,7 @@ pub fn get_missing_data(
         .blobs()
         .iter()
         .map(|blob| {
-            let paths = FilePaths::new(blob, &temp, &path);
+            let paths = FilePaths::new(blob, temp, path);
             io::Result::Ok(if paths.is_final() {
                 tracing::debug!("Found final file: {:?}", paths.target);
                 // we assume that the file is correct
@@ -433,7 +433,7 @@ impl<U> OnBlobData<U> {
     /// Read the entire blob into a Vec<u8> and then decode it as a Collection
     pub async fn read_collection(&mut self, hash: Hash) -> anyhow::Result<Collection> {
         let data = self.read_blob(hash).await?;
-        Ok(Collection::from_bytes(&data)?)
+        Collection::from_bytes(&data)
     }
 
     /// The ranges we requested
@@ -617,7 +617,7 @@ where
 {
     let start = Instant::now();
     // expect to get blob data in the order they appear in the collection
-    let mut ranges_iter = request.ranges.non_empty_iter();
+    let ranges_iter = request.ranges.non_empty_iter();
     let (writer, reader) = connection.open_bi().await?;
     let mut reader = TrackingReader::new(reader);
     let mut writer = TrackingWriter::new(writer);
@@ -648,7 +648,7 @@ where
     // 3. Read response
     debug!("reading response");
     let mut limit = None;
-    while let Some((offset, query)) = ranges_iter.next() {
+    for (offset, query) in ranges_iter {
         assert!(!query.is_empty());
         if let Some(limit) = limit {
             if offset >= limit {

--- a/src/get.rs
+++ b/src/get.rs
@@ -567,7 +567,7 @@ where
                 let response: Response = postcard::from_bytes(&response_buffer)?;
                 match response.data {
                     // server is sending over a collection of blobs
-                    Res::FoundCollection => {
+                    Res::Found => {
                         // read entire collection data into buffer
                         let data: Bytes = read_bao_encoded(&mut reader, hash, &request.ranges.blob)
                             .await?
@@ -598,13 +598,6 @@ where
                             }
                             reader = blob_reader.into_inner();
                         }
-                    }
-
-                    // unexpected message
-                    Res::Found { .. } => {
-                        // we should only receive `Res::FoundCollection` or `Res::NotFound` from the
-                        // provider at this point in the exchange
-                        bail!("Unexpected message from provider. Ending transfer early.");
                     }
 
                     // data associated with the hash is not found
@@ -647,10 +640,6 @@ async fn handle_blob_response(
         Some(response_buffer) => {
             let response: Response = postcard::from_bytes(&response_buffer)?;
             match response.data {
-                // unexpected message
-                Res::FoundCollection => Err(anyhow!(
-                    "Unexpected message from provider. Ending transfer early."
-                ))?,
                 // blob data not found
                 Res::NotFound => Err(anyhow!("data for {} not found", hash))?,
                 // next blob in collection will be sent over

--- a/src/get.rs
+++ b/src/get.rs
@@ -567,7 +567,7 @@ where
                 let response: Response = postcard::from_bytes(&response_buffer)?;
                 match response.data {
                     // server is sending over a collection of blobs
-                    Res::FoundCollection { .. } => {
+                    Res::FoundCollection => {
                         // read entire collection data into buffer
                         let data: Bytes = read_bao_encoded(&mut reader, hash, &request.ranges.blob)
                             .await?
@@ -648,7 +648,7 @@ async fn handle_blob_response(
             let response: Response = postcard::from_bytes(&response_buffer)?;
             match response.data {
                 // unexpected message
-                Res::FoundCollection { .. } => Err(anyhow!(
+                Res::FoundCollection => Err(anyhow!(
                     "Unexpected message from provider. Ending transfer early."
                 ))?,
                 // blob data not found

--- a/src/get.rs
+++ b/src/get.rs
@@ -7,9 +7,7 @@ use std::fmt::Debug;
 use std::io::{self, Cursor, SeekFrom};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Poll;
 use std::time::{Duration, Instant};
 
 use crate::blobs::{Blob, Collection};
@@ -17,6 +15,7 @@ use crate::protocol::{write_lp, AuthToken, Handshake, RangeSpecSeq, Request};
 use crate::provider::Ticket;
 use crate::subnet::{same_subnet_v4, same_subnet_v6};
 use crate::tls::{self, Keypair, PeerId};
+use crate::tokio_util::{TrackingReader, SeekOptimized, TrackingWriter};
 use crate::util::pathbuf_from_name;
 use crate::IROH_BLOCK_SIZE;
 use anyhow::{anyhow, Context, Result};
@@ -27,11 +26,11 @@ use bao_tree::outboard::PreOrderMemOutboard;
 use bao_tree::{BaoTree, ByteNum, ChunkNum};
 use bytes::BytesMut;
 use default_net::Interface;
-use futures::{ready, Future, StreamExt};
+use futures::{Future, StreamExt};
 use postcard::experimental::max_size::MaxSize;
 use quinn::RecvStream;
 use range_collections::RangeSet2;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
 use tracing::{debug, debug_span, error};
 use tracing_futures::Instrument;
 
@@ -688,236 +687,4 @@ where
             bytes_read,
         },
     ))
-}
-
-#[derive(Debug)]
-struct TrackingReader<R> {
-    inner: R,
-    read: u64,
-}
-
-impl<R> TrackingReader<R> {
-    pub fn new(inner: R) -> Self {
-        Self { inner, read: 0 }
-    }
-
-    pub fn bytes_read(&self) -> u64 {
-        self.read
-    }
-
-    pub fn into_inner(self) -> R {
-        self.inner
-    }
-}
-
-impl<R> AsyncRead for TrackingReader<R>
-where
-    R: AsyncRead + Unpin,
-{
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
-        let this = &mut *self;
-        let filled0 = buf.filled().len();
-        let res = Pin::new(&mut this.inner).poll_read(cx, buf);
-        if let Poll::Ready(Ok(())) = res {
-            let size = buf.filled().len().saturating_sub(filled0);
-            this.read = this.read.saturating_add(size as u64);
-        }
-        res
-    }
-}
-
-struct TrackingWriter<W> {
-    inner: W,
-    written: u64,
-}
-
-impl<W> TrackingWriter<W> {
-    pub fn new(inner: W) -> Self {
-        Self { inner, written: 0 }
-    }
-
-    pub fn bytes_written(&self) -> u64 {
-        self.written
-    }
-
-    pub fn into_inner(self) -> W {
-        self.inner
-    }
-}
-
-impl<W: AsyncWrite + Unpin> AsyncWrite for TrackingWriter<W> {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        let this = &mut *self;
-        let res = Pin::new(&mut this.inner).poll_write(cx, buf);
-        if let Poll::Ready(Ok(size)) = res {
-            this.written = this.written.saturating_add(size as u64);
-        }
-        res
-    }
-
-    fn poll_flush(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
-    }
-
-    fn poll_shutdown(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
-    }
-}
-
-///
-#[derive(Debug)]
-pub struct SeekOptimized<T> {
-    inner: T,
-    state: SeekOptimizedState,
-}
-
-impl<T> SeekOptimized<T> {
-    ///
-    pub fn new(inner: T) -> Self {
-        Self {
-            inner,
-            state: SeekOptimizedState::Unknown,
-        }
-    }
-
-    ///
-    pub fn into_inner(self) -> T {
-        self.inner
-    }
-}
-
-#[derive(Debug)]
-enum SeekOptimizedState {
-    Unknown,
-    Seeking,
-    FakeSeeking(u64),
-    Known(u64),
-}
-
-impl SeekOptimizedState {
-    fn take(&mut self) -> Self {
-        std::mem::replace(self, SeekOptimizedState::Unknown)
-    }
-
-    fn is_seeking(&self) -> bool {
-        match self {
-            SeekOptimizedState::Seeking => true,
-            SeekOptimizedState::FakeSeeking(_) => true,
-            _ => false,
-        }
-    }
-}
-
-impl<T: AsyncRead + Unpin> AsyncRead for SeekOptimized<T> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
-        Poll::Ready(if self.state.is_seeking() {
-            Err(io::Error::new(
-                io::ErrorKind::Other,
-                "cannot read while seeking",
-            ))
-        } else {
-            let before = buf.remaining();
-            ready!(Pin::new(&mut self.inner).poll_read(cx, buf))?;
-            let after = buf.remaining();
-            let read = before - after;
-            if let SeekOptimizedState::Known(offset) = &mut self.state {
-                *offset += read as u64;
-            }
-            Ok(())
-        })
-    }
-}
-
-impl<T: AsyncWrite + Unpin> AsyncWrite for SeekOptimized<T> {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        Poll::Ready(if self.state.is_seeking() {
-            Err(io::Error::new(
-                io::ErrorKind::Other,
-                "cannot write while seeking",
-            ))
-        } else {
-            let result = ready!(Pin::new(&mut self.inner).poll_write(cx, buf))?;
-            if let SeekOptimizedState::Known(offset) = &mut self.state {
-                *offset += result as u64;
-            }
-            Ok(result)
-        })
-    }
-
-    fn poll_flush(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
-    }
-
-    fn poll_shutdown(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
-    }
-}
-
-impl<T: AsyncSeek + Unpin> AsyncSeek for SeekOptimized<T> {
-    fn start_seek(mut self: Pin<&mut Self>, seek_from: SeekFrom) -> io::Result<()> {
-        self.state = match (self.state.take(), seek_from) {
-            (SeekOptimizedState::Known(offset), SeekFrom::Current(0)) => {
-                // somebody wants to know the current position
-                SeekOptimizedState::FakeSeeking(offset)
-            }
-            (SeekOptimizedState::Known(offset), SeekFrom::Start(current)) if offset == current => {
-                // seek to the current position
-                SeekOptimizedState::FakeSeeking(offset)
-            }
-            _ => {
-                // if start_seek fails, we go into unknown state
-                Pin::new(&mut self.inner).start_seek(seek_from)?;
-                SeekOptimizedState::Seeking
-            }
-        };
-        Ok(())
-    }
-
-    fn poll_complete(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<io::Result<u64>> {
-        // if we are in fakeseeking state, intercept the call to the inner
-        if let SeekOptimizedState::FakeSeeking(offset) = self.state {
-            self.state = SeekOptimizedState::Known(offset);
-            return Poll::Ready(Ok(offset));
-        }
-        // in all other cases we have to do the call to the inner
-        //
-        // a tokio file can be busy even when it seems idle, because write ops
-        // are buffered. so we have to poll_complete until it returns Ok.
-        let res = ready!(Pin::new(&mut self.inner).poll_complete(cx))?;
-        if let SeekOptimizedState::Seeking = self.state {
-            self.state = SeekOptimizedState::Known(res);
-        }
-        Poll::Ready(Ok(res))
-    }
 }

--- a/src/get.rs
+++ b/src/get.rs
@@ -420,7 +420,7 @@ impl<U> OnBlobData<U> {
         BaoTree::new(ByteNum(self.size), IROH_BLOCK_SIZE)
     }
 
-    /// Read the entire blob into a Vec<u8>
+    /// Read the entire blob into a `Vec<u8>`
     ///
     /// Make sure to check the size of the blob before calling this.
     pub async fn read_blob(&mut self, hash: Hash) -> anyhow::Result<Vec<u8>> {
@@ -429,7 +429,7 @@ impl<U> OnBlobData<U> {
         Ok(target)
     }
 
-    /// Read the entire blob into a Vec<u8> and then decode it as a Collection
+    /// Read the entire blob into a `Vec<u8>` and then decode it as a Collection
     pub async fn read_collection(&mut self, hash: Hash) -> anyhow::Result<Collection> {
         let data = self.read_blob(hash).await?;
         Collection::from_bytes(&data)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod rpc_protocol;
 mod subnet;
 mod tls;
 mod util;
+mod tokio_util;
 
 pub use tls::{Keypair, PeerId, PeerIdError, PublicKey, SecretKey, Signature};
 pub use util::Hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ mod tests {
             let content = &content;
             let name = &name;
             get::run(
-                hash,
+                Request::all(hash),
                 token,
                 opts,
                 || async { Ok(()) },
@@ -273,7 +273,7 @@ mod tests {
         let expects = Arc::new(expects);
 
         get::run(
-            collection_hash,
+            Request::all(collection_hash),
             provider.auth_token(),
             opts,
             || async { Ok(()) },
@@ -389,7 +389,7 @@ mod tests {
         });
 
         get::run(
-            hash,
+            Request::all(hash),
             auth_token,
             get::Options {
                 addr: provider_addr,
@@ -438,7 +438,7 @@ mod tests {
         let timeout = tokio::time::timeout(
             std::time::Duration::from_secs(10),
             get::run(
-                hash,
+                Request::all(hash),
                 auth_token,
                 get::Options {
                     addr: provider_addr,
@@ -485,7 +485,7 @@ mod tests {
         tokio::time::timeout(
             Duration::from_secs(10),
             get::run(
-                hash,
+                Request::all(hash),
                 auth_token,
                 get::Options {
                     addr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ mod tests {
                     if info.is_root() {
                         let collection = info.read_collection(hash).await?;
                         let actual_name = &collection.blobs()[0].name;
-                        info.set_limit(collection.blobs().len() + 1);
+                        info.set_limit(collection.total_entries() + 1);
                         assert_eq!(expected_name, actual_name);
                     } else {
                         let actual_data = info.read_blob(file_hash).await?;
@@ -287,14 +287,14 @@ mod tests {
                 let expects = expects.clone();
                 async move {
                     if let Some(offset) = data.child_offset() {
-                        let (_, path, hash) = &expects[offset];
+                        let (_, path, hash) = &expects[offset as usize];
                         let expect = tokio::fs::read(&path).await?;
                         let got = data.read_blob(*hash).await?;
                         assert_eq!(expect, got);
                         data.end()
                     } else {
                         let collection = data.read_collection(collection_hash).await?;
-                        data.set_limit(collection.blobs().len() + 1);
+                        data.set_limit(collection.total_entries() + 1);
                         data.end()
                     }
                 }
@@ -403,7 +403,7 @@ mod tests {
             move |mut data| async move {
                 if data.is_root() {
                     let collection = data.read_collection(hash).await?;
-                    data.set_limit(collection.blobs().len() + 1);
+                    data.set_limit(collection.total_entries() + 1);
                     data.user = Some(collection);
                 } else {
                     let hash = data.user.as_ref().unwrap().blobs()[0].hash;
@@ -506,7 +506,7 @@ mod tests {
                 move |mut data| async move {
                     if data.is_root() {
                         let collection = data.read_collection(hash).await?;
-                        data.set_limit(collection.blobs().len() + 1);
+                        data.set_limit(collection.total_entries() + 1);
                         data.user = Some(collection);
                     } else {
                         let hash = data.user.as_ref().unwrap().blobs()[0].hash;
@@ -556,7 +556,7 @@ mod tests {
                     async move {
                         if data.is_root() {
                             let collection = data.read_collection(hash).await?;
-                            data.set_limit(collection.blobs().len() + 1);
+                            data.set_limit(collection.total_entries() + 1);
                             data.user = Some(collection);
                         } else {
                             let hash = data.user.as_ref().unwrap().blobs()[0].hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ mod tests {
                 token,
                 opts,
                 || async { Ok(()) },
-                |_collection| async { Ok(()) },
+                |_data, _collection| async { Ok(()) },
                 |got_hash, mut reader, got_name| async move {
                     assert_eq!(file_hash, got_hash);
                     let mut got = Vec::new();
@@ -277,7 +277,7 @@ mod tests {
             provider.auth_token(),
             opts,
             || async { Ok(()) },
-            |collection| {
+            |_data, collection| {
                 assert_eq!(collection.blobs().len(), num_blobs);
                 async { Ok(()) }
             },
@@ -397,7 +397,7 @@ mod tests {
                 keylog: true,
             },
             || async move { Ok(()) },
-            |_collection| async move { Ok(()) },
+            |_data, _collection| async move { Ok(()) },
             |_hash, mut stream, _name| async move {
                 stream.drain().await?;
                 Ok(stream)
@@ -446,7 +446,7 @@ mod tests {
                     keylog: true,
                 },
                 || async move { Ok(()) },
-                |_collection| async move { Ok(()) },
+                |_data, _collection| async move { Ok(()) },
                 |_hash, stream, _name| async move {
                     // evil: do nothing with the stream!
                     Ok(stream)
@@ -493,7 +493,7 @@ mod tests {
                     keylog: true,
                 },
                 || async move { Ok(()) },
-                |_collection| async move { Ok(()) },
+                |_data, _collection| async move { Ok(()) },
                 |_hash, mut stream, _name| async move {
                     stream.drain().await?;
                     Ok(stream)
@@ -528,7 +528,7 @@ mod tests {
                     on_connected = true;
                     async { Ok(()) }
                 },
-                |_| {
+                |_, _| {
                     on_collection = true;
                     async { Ok(()) }
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ mod tests {
     use tokio::{fs, sync::broadcast};
     use tracing_subscriber::{prelude::*, EnvFilter};
 
-    use crate::protocol::AuthToken;
+    use crate::protocol::{AuthToken, Request};
     use crate::provider::{create_collection, Event, Provider};
     use crate::tls::PeerId;
     use crate::util::Hash;
@@ -522,6 +522,7 @@ mod tests {
             Duration::from_secs(10),
             get::run_ticket(
                 &ticket,
+                Request::all(ticket.hash()),
                 true,
                 16,
                 || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -550,7 +550,10 @@ async fn main_impl() -> Result<()> {
         } => {
             let iroh_data_root = iroh_data_root()?;
             let db = {
-                if iroh_data_root.is_dir() {
+                if !iroh_data_root.is_dir() {
+                    std::fs::create_dir_all(&iroh_data_root)?;
+                }
+                if Database::db_path(&iroh_data_root).exists() {
                     // try to load db
                     Database::load(iroh_data_root.clone(), ValidateMode::None).await?
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -612,7 +612,7 @@ async fn main_impl() -> Result<()> {
                 }
             }
             // persist the db to disk.
-            db.save(&iroh_data_root)?;
+            db.save(&iroh_data_root).await?;
 
             // the future holds a reference to the temp file, so we need to
             // keep it for as long as the provider is running. The drop(fut)

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use indicatif::{
 use iroh::blobs::{Blob, Collection};
 use iroh::get::{get_data_path, get_missing_range, get_missing_ranges, OnBlobData};
 use iroh::protocol::{AuthToken, RangeSpecSeq, Request};
-use iroh::provider::{Database, Provider, Ticket};
+use iroh::provider::{Database, Provider, Ticket, ValidateMode};
 use iroh::rpc_protocol::*;
 use iroh::rpc_protocol::{
     ListRequest, ProvideRequest, ProviderRequest, ProviderResponse, ProviderService, VersionRequest,
@@ -552,10 +552,10 @@ async fn main_impl() -> Result<()> {
             let db = {
                 if iroh_data_root.is_dir() {
                     // try to load db
-                    Database::load(&iroh_data_root).await?
+                    Database::load(iroh_data_root.clone(), ValidateMode::None).await?
                 } else {
                     // directory does not exist, create an empty db
-                    Database::default()
+                    Database::new(iroh_data_root.clone())
                 }
             };
             let key = Some(iroh_data_root.join("keypair"));
@@ -612,7 +612,7 @@ async fn main_impl() -> Result<()> {
                 }
             }
             // persist the db to disk.
-            db.save(&iroh_data_root).await?;
+            db.save(&iroh_data_root)?;
 
             // the future holds a reference to the temp file, so we need to
             // keep it for as long as the provider is running. The drop(fut)

--- a/src/main.rs
+++ b/src/main.rs
@@ -813,11 +813,7 @@ async fn get_interactive(get: GetInteractive, out_dir: Option<PathBuf>) -> Resul
 
     progress!("{} Connecting ...", style("[1/3]").bold().dim());
 
-    let temp_dir = if let Some(ref out) = out_dir {
-        Some(out.join(".iroh-tmp"))
-    } else {
-        None
-    };
+    let temp_dir = out_dir.as_ref().map(|out| out.join(".iroh-tmp"));
     let (query, _) = match (&out_dir, &temp_dir) {
         (Some(out), Some(temp_dir)) => get_missing_data(get.hash(), out, temp_dir)?,
         _ => (RangeSpecSeq::all(), None),
@@ -881,7 +877,7 @@ async fn get_interactive(get: GetInteractive, out_dir: Option<PathBuf>) -> Resul
                 let name = if name.is_empty() {
                     PathBuf::from(hash.to_string())
                 } else {
-                    pathbuf_from_name(&name)
+                    pathbuf_from_name(name)
                 };
                 pb.set_message(format!("Receiving '{}'...", name.display()));
                 pb.reset();

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -11,7 +11,7 @@ use quinn::VarInt;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 mod range_spec;
-pub use range_spec::{RangeSpec, RequestRangeSpec};
+pub use range_spec::{RangeSpec, RangeSpecSeq};
 
 use crate::{
     util::{self, Hash},
@@ -45,12 +45,14 @@ pub struct Request {
     /// blake3 hash
     pub name: Hash,
     /// The range of data to request
-    pub ranges: RequestRangeSpec,
+    ///
+    /// The first element is the parent, all subsequent elements are children.
+    pub ranges: RangeSpecSeq,
 }
 
 impl Request {
     /// Request a blob or collection with specified ranges
-    pub fn new(name: Hash, ranges: RequestRangeSpec) -> Self {
+    pub fn new(name: Hash, ranges: RangeSpecSeq) -> Self {
         Self { name, ranges }
     }
 
@@ -58,7 +60,7 @@ impl Request {
     pub fn all(name: Hash) -> Self {
         Self {
             name,
-            ranges: RequestRangeSpec::all(),
+            ranges: RangeSpecSeq::all(),
         }
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -18,7 +18,7 @@ use crate::util::{self, Hash};
 pub(crate) const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 100;
 
 /// Protocol version
-pub const VERSION: u64 = 1;
+pub const VERSION: u64 = 2;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, MaxSize)]
 pub(crate) struct Handshake {
@@ -59,18 +59,6 @@ impl Request {
             ranges: RangeSpecSeq::all(),
         }
     }
-}
-
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, MaxSize)]
-pub(crate) struct Response {
-    pub data: Res,
-}
-
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, MaxSize)]
-pub(crate) enum Res {
-    NotFound,
-    // If found, a stream of bao data is sent as next message.
-    Found,
 }
 
 /// Write the given data to the provider sink, with a unsigned varint length prefix.

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -73,10 +73,6 @@ pub(crate) enum Res {
     NotFound,
     // If found, a stream of bao data is sent as next message.
     Found,
-    /// Indicates that the given hash referred to a collection of multiple blobs
-    /// A stream of boa data that decodes to a `Collection` is sent as the next message,
-    /// followed by `Res::Found` responses, send in the order indicated in the `Collection`.
-    FoundCollection,
 }
 
 /// Write the given data to the provider sink, with a unsigned varint length prefix.

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -11,7 +11,7 @@ use quinn::VarInt;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 mod range_spec;
-pub(crate) use range_spec::{RangeSpec, RequestRangeSpec};
+pub use range_spec::{RangeSpec, RequestRangeSpec};
 
 use crate::{
     util::{self, Hash},
@@ -39,12 +39,28 @@ impl Handshake {
     }
 }
 
+/// A request
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
-pub(crate) struct Request {
+pub struct Request {
     /// blake3 hash
     pub name: Hash,
-
+    /// The range of data to request
     pub ranges: RequestRangeSpec,
+}
+
+impl Request {
+    /// Request a blob or collection with specified ranges
+    pub fn new(name: Hash, ranges: RequestRangeSpec) -> Self {
+        Self { name, ranges }
+    }
+
+    /// Request a collection and all its children
+    pub fn all(name: Hash) -> Self {
+        Self {
+            name,
+            ranges: RequestRangeSpec::all(),
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, MaxSize)]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -8,7 +8,6 @@ use bao_tree::io::tokio::AsyncResponseDecoder;
 use bytes::{Bytes, BytesMut};
 use postcard::experimental::max_size::MaxSize;
 use quinn::VarInt;
-use range_collections::RangeSet2;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 mod range_spec;
@@ -120,9 +119,14 @@ pub(crate) async fn read_lp(
 pub(crate) async fn read_bao_encoded<R: AsyncRead + Unpin>(
     reader: R,
     hash: Hash,
+    ranges: &RangeSpec,
 ) -> Result<Vec<u8>> {
-    let mut decoder =
-        AsyncResponseDecoder::new(hash.into(), RangeSet2::all(), IROH_BLOCK_SIZE, reader);
+    let mut decoder = AsyncResponseDecoder::new(
+        hash.into(),
+        ranges.to_chunk_ranges(),
+        IROH_BLOCK_SIZE,
+        reader,
+    );
     // we don't know the size yet, so we just allocate a reasonable amount
     let mut decoded = Vec::with_capacity(4096);
     decoder.read_to_end(&mut decoded).await?;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -11,6 +11,8 @@ use quinn::VarInt;
 use range_collections::RangeSet2;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+mod range_spec;
+pub(crate) use range_spec::{RangeSpec, RequestRangeSpec};
 
 use crate::{
     util::{self, Hash},
@@ -38,10 +40,12 @@ impl Handshake {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, MaxSize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub(crate) struct Request {
     /// blake3 hash
     pub name: Hash,
+
+    pub ranges: RequestRangeSpec,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, MaxSize)]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -76,10 +76,7 @@ pub(crate) enum Res {
     /// Indicates that the given hash referred to a collection of multiple blobs
     /// A stream of boa data that decodes to a `Collection` is sent as the next message,
     /// followed by `Res::Found` responses, send in the order indicated in the `Collection`.
-    FoundCollection {
-        /// The size of the raw data we are planning to transfer
-        total_blobs_size: u64,
-    },
+    FoundCollection,
 }
 
 /// Write the given data to the provider sink, with a unsigned varint length prefix.

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -85,14 +85,12 @@ impl fmt::Debug for RangeSpec {
             f.debug_list()
                 .entries(self.to_chunk_ranges().iter())
                 .finish()
+        } else if self.is_all() {
+            write!(f, "all")
+        } else if self.is_empty() {
+            write!(f, "empty")
         } else {
-            if self.is_all() {
-                write!(f, "all")
-            } else if self.is_empty() {
-                write!(f, "empty")
-            } else {
-                f.debug_list().entries(self.0.iter()).finish()
-            }
+            f.debug_list().entries(self.0.iter()).finish()
         }
     }
 }
@@ -260,8 +258,8 @@ mod tests {
         prop::collection::vec((value_range.clone(), value_range), 0..16).prop_map(|v| {
             let mut res = RangeSet2::empty();
             for (a, b) in v {
-                let start = a.min(b) as u64;
-                let end = a.max(b) as u64;
+                let start = a.min(b);
+                let end = a.max(b);
                 res |= RangeSet2::from(ChunkNum(start)..ChunkNum(end));
             }
             res

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -165,7 +165,7 @@ pub struct RequestRangeSpecIter<'a> {
 
 impl<'a> RequestRangeSpecIter<'a> {
     /// True if we are at the end of the iterator
-    /// 
+    ///
     /// This does not mean that the iterator is terminated, it just means that
     /// it will repeat the same value forever.
     pub fn is_at_end(&self) -> bool {
@@ -221,7 +221,7 @@ impl<'a> Iterator for NonEmptyRequestRangeSpecIter<'a> {
                 break Some((count, curr));
             } else if self.inner.is_at_end() {
                 // terminate instead of looping until we run out of u64 values
-                break None
+                break None;
             }
         }
     }

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -10,10 +10,10 @@ use smallvec::{smallvec, SmallVec};
 /// this is a sequence of spans, where the first span is considered false, and each subsequent span is alternating.
 ///
 /// Examples:
-/// The range 10..33 would be encoded as [10, 23]
-/// The empty range would be encoded as the empty array []
-/// A full interval .. would be encoded as [0]
-/// A half open interval 15.. would be encoded as [15]
+/// The range 10..33 would be encoded as `[10, 23]`
+/// The empty range would be encoded as the empty array `[]`
+/// A full interval .. would be encoded as `[0]`
+/// A half open interval 15.. would be encoded as `[15]`
 ///
 /// All values except for the first one must be non-zero. The first value may be zero.
 /// Values are bao chunk numbers, not byte offsets.

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -101,6 +101,9 @@ impl RequestRangeSpec {
     }
 }
 
+/// An infinite iterator of range specs
+///
+/// default is what to use if the children of this RequestRangeSpec are empty.
 pub(crate) struct RequestRangeSpecIter<'a> {
     /// number of times we emit the current value
     count: u64,
@@ -117,14 +120,15 @@ impl<'a> Iterator for RequestRangeSpecIter<'a> {
         loop {
             if self.count > 0 {
                 self.count -= 1;
-                break Some(self.value);
+                break;
             } else if let Some(((count, value), rest)) = self.remaining.split_first() {
                 self.count = *count;
                 self.value = value;
                 self.remaining = rest;
             } else {
-                break Some(self.value);
+                break;
             }
         }
+        Some(self.value)
     }
 }

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -85,7 +85,7 @@ pub struct RequestRangeSpec {
 /// Examples:
 ///
 /// All child ranges: `[(0, [0])]` starting at offset 0, all offsets (see above)
-/// First chunk of all child: `[(0, [0, 1])]` starting at offset 0, chunk range 0..1
+/// First chunk of all children: `[(0, [0, 1])]` starting at offset 0, chunk range 0..1
 /// All of child 1234: `[(1234, [0]), [1, []]]`.
 /// First 33 chunks of child 5678: `[(5678, [0, 33]), (1, [])]`.
 /// Chunks 10 to 30 of child 6789: `[(6789, [10, 20]), (1, [])]`.

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -118,8 +118,8 @@ impl RangeSpecSeq {
     /// An empty range spec sequence
     ///
     /// When iterated, will return an empty range forever
-    pub fn empty() -> Self {
-        Self(SmallVec::new())
+    pub const fn empty() -> Self {
+        Self(SmallVec::new_const())
     }
 
     /// A complete range spec sequence

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -120,6 +120,24 @@ impl RangeSpecSeq {
         Self(SmallVec::new_const())
     }
 
+    /// If this range seq describes a range for a single item, returns the offset
+    /// and range spec for that item
+    pub fn single(&self) -> Option<(u64, &RangeSpec)> {
+        // we got two elements,
+        // the first element starts at offset 0,
+        // and the second element is empty
+        if self.0.len() != 2 {
+            return None;
+        }
+        let (fst_ofs, fst_val) = &self.0[0];
+        let (snd_ofs, snd_val) = &self.0[1];
+        if *fst_ofs == 0 && *snd_ofs == 1 && snd_val.is_empty() {
+            Some((*fst_ofs, fst_val))
+        } else {
+            None
+        }
+    }
+
     /// A complete range spec sequence
     ///
     /// When iterated, will return a full range forever

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -1,0 +1,130 @@
+use bao_tree::ChunkNum;
+use range_collections::RangeSet2;
+use serde::{Deserialize, Serialize};
+use smallvec::{smallvec, SmallVec};
+
+/// A chunk range specification.
+///
+/// this is a sequence of spans, where the first span is considered false, and each subsequent span is alternating.
+///
+/// Examples:
+/// The range 10..33 would be encoded as [10, 23]
+/// The empty range would be encoded as the empty array []
+/// A full interval .. would be encoded as [0]
+/// A half open interval 15.. would be encoded as [15]
+///
+/// All values except for the first one must be non-zero. The first value may be zero.
+/// Values are bao chunk numbers, not byte offsets.
+///
+/// This is a SmallVec so we can avoid allocations for the very common case of a single chunk range.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[repr(transparent)]
+pub(crate) struct RangeSpec(SmallVec<[u64; 2]>);
+
+impl RangeSpec {
+    pub fn empty() -> Self {
+        Self(SmallVec::new())
+    }
+
+    pub fn all() -> Self {
+        Self(smallvec![0])
+    }
+
+    /// Convert a range set from this range spec
+    pub fn to_chunk_ranges(&self) -> RangeSet2<ChunkNum> {
+        // this is zero allocation for single ranges
+        // todo: optimize this in range collections
+        let mut ranges = RangeSet2::empty();
+        let mut current = ChunkNum(0);
+        let mut on = false;
+        for &width in self.0.iter() {
+            let next = current + width;
+            if on {
+                ranges |= RangeSet2::from(current..next);
+            }
+            current = next;
+            on = !on;
+        }
+        if on {
+            ranges |= RangeSet2::from(current..);
+        }
+        ranges
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+pub(crate) struct RequestRangeSpec {
+    /// ranges for the document itself
+    pub blob: RangeSpec,
+    /// sub ranges for the items of this collection, empty means nothing
+    ///
+    /// This is also a sequence of spans, but the value after the span is given by the second argument
+    ///
+    /// Examples:
+    ///
+    /// All child ranges: `[(0, [0])]` starting at offset 0, all offsets (see above)
+    /// First chunk of all child: `[(0, [0, 1])]` starting at offset 0, chunk range 0..1
+    /// All of child 1234: `[(1234, [0]), [1, []]]`.
+    /// First 33 chunks of child 5678: `[(5678, [0, 33]), (1, [])]`.
+    /// Chunks 10 to 30 of child 6789: `[(6789, [10, 20]), (1, [])]`.
+    /// No child ranges: `[]`
+    ///
+    /// This is a smallvec so that we can avoid allocations in the common case of a single child range.
+    pub children: SmallVec<[(u64, RangeSpec); 2]>,
+}
+
+impl RequestRangeSpec {
+    #[allow(dead_code)]
+    pub fn empty() -> Self {
+        Self {
+            blob: RangeSpec::empty(),
+            children: SmallVec::new(),
+        }
+    }
+
+    pub fn all() -> Self {
+        Self {
+            blob: RangeSpec::all(),
+            children: smallvec![(0, RangeSpec::all())],
+        }
+    }
+
+    /// An infinite iterator of range specs
+    ///
+    /// default is what to use if the children of this RequestRangeSpec are empty.
+    pub fn iter<'a>(&'a self, default: &'a RangeSpec) -> RequestRangeSpecIter<'a> {
+        RequestRangeSpecIter {
+            count: 0,
+            value: default,
+            remaining: &self.children,
+        }
+    }
+}
+
+pub(crate) struct RequestRangeSpecIter<'a> {
+    /// number of times we emit the current value
+    count: u64,
+    /// the current value
+    value: &'a RangeSpec,
+    /// remaining ranges
+    remaining: &'a [(u64, RangeSpec)],
+}
+
+impl<'a> Iterator for RequestRangeSpecIter<'a> {
+    type Item = &'a RangeSpec;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.count > 0 {
+                self.count -= 1;
+                break Some(self.value);
+            } else if let Some(((count, value), rest)) = self.remaining.split_first() {
+                self.count = *count;
+                self.value = value;
+                self.remaining = rest;
+            } else {
+                break Some(self.value);
+            }
+        }
+    }
+}

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bao_tree::ChunkNum;
 use range_collections::{RangeSet2, RangeSetRef};
 use serde::{Deserialize, Serialize};
@@ -17,7 +19,7 @@ use smallvec::{smallvec, SmallVec};
 /// Values are bao chunk numbers, not byte offsets.
 ///
 /// This is a SmallVec so we can avoid allocations for the very common case of a single chunk range.
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Deserialize, Serialize, PartialEq, Eq, Clone)]
 #[repr(transparent)]
 pub struct RangeSpec(SmallVec<[u64; 2]>);
 
@@ -74,6 +76,24 @@ impl RangeSpec {
             ranges |= RangeSet2::from(current..);
         }
         ranges
+    }
+}
+
+impl fmt::Debug for RangeSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            f.debug_list()
+                .entries(self.to_chunk_ranges().iter())
+                .finish()
+        } else {
+            if self.is_all() {
+                write!(f, "all")
+            } else if self.is_empty() {
+                write!(f, "empty")
+            } else {
+                f.debug_list().entries(self.0.iter()).finish()
+            }
+        }
     }
 }
 

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -148,7 +148,7 @@ impl RangeSpecSeq {
     }
 
     /// An infinite iterator of range specs
-    pub fn iter<'a>(&'a self) -> RequestRangeSpecIter<'a> {
+    pub fn iter(&self) -> RequestRangeSpecIter<'_> {
         let before_first = self.0.get(0).map(|(c, _)| *c).unwrap_or_default();
         RequestRangeSpecIter {
             current: &EMPTY_RANGE_SPEC,
@@ -160,7 +160,7 @@ impl RangeSpecSeq {
     /// An iterator over non empty range specs
     ///
     /// This iterator is infinite if the range spec is infinite
-    pub fn non_empty_iter<'a>(&'a self) -> impl Iterator<Item = (usize, &'a RangeSpec)> + 'a {
+    pub fn non_empty_iter(&self) -> impl Iterator<Item = (usize, &RangeSpec)> {
         self.iter().enumerate().filter(|(_, r)| !r.is_empty())
     }
 }

--- a/src/provider/database.rs
+++ b/src/provider/database.rs
@@ -583,6 +583,13 @@ impl Database {
         Ok(tokio::task::spawn_blocking(|| Self::load_internal(data_dir, validate)).await??)
     }
 
+    ///
+    pub async fn save(&self, data_dir: impl AsRef<Path>) -> io::Result<()> {
+        let this = self.clone();
+        let data_dir = data_dir.as_ref().to_owned();
+        Ok(tokio::task::spawn_blocking(move || this.save_internal(data_dir)).await??)
+    }
+
     /// Load a database from disk for testing. Synchronous.
     #[cfg(feature = "cli")]
     pub fn load_test(dir: impl AsRef<Path>) -> io::Result<Self> {
@@ -597,7 +604,7 @@ impl Database {
     }
 
     ///
-    pub fn save(&self, data_dir: impl AsRef<Path>) -> io::Result<()> {
+    fn save_internal(&self, data_dir: impl AsRef<Path>) -> io::Result<()> {
         let inner = self.0.read().unwrap();
         inner.save(data_dir)
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -774,7 +774,7 @@ async fn transfer_collection(
             if offset < c.blobs().len() + 1 {
                 tokio::task::yield_now().await;
                 let hash = c.blobs()[offset - 1].hash;
-                let (status, writer1, size) = send_blob(&db, hash, ranges, writer).await?;
+                let (status, writer1, size) = send_blob(db, hash, ranges, writer).await?;
                 writer = writer1;
                 if SentStatus::NotFound == status {
                     writer.finish().await?;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -767,7 +767,7 @@ async fn transfer_collection(
         .blobs()
         .iter()
         .enumerate()
-        .zip(request.ranges.iter(&default))
+        .zip(request.ranges.children.iter(&default))
     {
         debug!("writing blob {}/{}", i, c.blobs().len());
         tokio::task::yield_now().await;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -55,7 +55,7 @@ mod database;
 mod ticket;
 
 #[cfg(cli)]
-pub use database::Snapshot;
+pub use database::SnapshotOld;
 pub use database::{Database, ValidateMode};
 pub use ticket::Ticket;
 
@@ -1050,7 +1050,7 @@ mod tests {
     use tokio::io::AsyncReadExt;
 
     use crate::blobs::Blob;
-    use crate::provider::database::Snapshot;
+    use crate::provider::database::SnapshotOld;
 
     use super::*;
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -798,7 +798,7 @@ async fn transfer_collection(
                     connection_id,
                     request_id,
                     hash,
-                    index: (offset - 1) as u64,
+                    index: offset - 1,
                     size,
                 });
             } else {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -572,7 +572,7 @@ impl RpcHandler {
         // create the collection
         // todo: provide feedback for progress
         let (db, _) = collection::create_collection(data_sources, Progress::new(progress)).await?;
-        self.inner.db.union_with(db);
+        self.inner.db.union_with(db)?;
 
         Ok(())
     }
@@ -1016,7 +1016,7 @@ impl From<&std::path::Path> for DataSource {
 /// Returns a the hash of the collection created by the given list of DataSources
 pub async fn create_collection(data_sources: Vec<DataSource>) -> Result<(Database, Hash)> {
     let (db, hash) = collection::create_collection(data_sources, Progress::none()).await?;
-    Ok((Database::from_blobs(db), hash))
+    Ok((Database::from_blobs(db)?, hash))
 }
 
 /// Create a [`quinn::ServerConfig`] with the given keypair and limits.
@@ -1050,7 +1050,6 @@ mod tests {
     use tokio::io::AsyncReadExt;
 
     use crate::blobs::Blob;
-    use crate::provider::database::SnapshotOld;
 
     use super::*;
 
@@ -1098,7 +1097,7 @@ mod tests {
                 map.insert(hash, BlobOrCollection::Collection { outboard, data });
             }
             let db = Database::new(".".into());
-            db.union_with(map);
+            db.union_with(map).unwrap();
             db
         })
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -734,7 +734,7 @@ async fn transfer_collection(
 ) -> Result<SentStatus> {
     let hash = request.name;
     let CollectionData { data, outboard } = collection;
-    let outboard = PreOrderMemOutboardRef::new(hash.into(), IROH_BLOCK_SIZE, outboard);
+    let outboard = PreOrderMemOutboardRef::new(hash.into(), IROH_BLOCK_SIZE, outboard)?;
 
     let c: Collection = postcard::from_bytes(data)?;
     let _ = events.send(Event::TransferCollectionStarted {
@@ -910,7 +910,7 @@ async fn send_blob<W: AsyncWrite + Unpin + Send + 'static>(
         })) => {
             write_response(&mut writer, buffer, Res::Found).await?;
 
-            let outboard = PreOrderMemOutboardRef::new(name.into(), IROH_BLOCK_SIZE, &outboard);
+            let outboard = PreOrderMemOutboardRef::new(name.into(), IROH_BLOCK_SIZE, &outboard)?;
             let file_reader = tokio::fs::File::open(&path).await?;
             bao_tree::io::tokio::encode_ranges_validated(
                 file_reader,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -749,9 +749,7 @@ async fn transfer_collection(
     write_response(
         &mut writer,
         buffer,
-        Res::FoundCollection {
-            total_blobs_size: c.total_blobs_size(),
-        },
+        Res::FoundCollection,
     )
     .await?;
     // stream the collection data directly to the writer

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -746,12 +746,7 @@ async fn transfer_collection(
 
     // TODO: we should check if the blobs referenced in this container
     // actually exist in this provider before returning `FoundCollection`
-    write_response(
-        &mut writer,
-        buffer,
-        Res::FoundCollection,
-    )
-    .await?;
+    write_response(&mut writer, buffer, Res::Found).await?;
     // stream the collection data directly to the writer
     encode_ranges_validated(
         Cursor::new(data),

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -972,14 +972,15 @@ async fn send_blob<W: AsyncWrite + Unpin + Send + 'static>(
             println!("sending blob {} {}", path.display(), size);
             let outboard = PreOrderMemOutboardRef::new(name.into(), IROH_BLOCK_SIZE, &outboard)?;
             let file_reader = tokio::fs::File::open(&path).await?;
-            bao_tree::io::tokio::encode_ranges_validated(
+            let res = bao_tree::io::tokio::encode_ranges_validated(
                 file_reader,
                 outboard,
                 &ranges.to_chunk_ranges(),
                 &mut writer,
             )
-            .await?;
-            println!("done sending blob {}", path.display());
+            .await;
+            println!("done sending blob {} {:?}", path.display(), res);
+            res?;
 
             Ok((SentStatus::Sent, writer, size))
         }

--- a/src/tokio_util.rs
+++ b/src/tokio_util.rs
@@ -1,0 +1,233 @@
+use std::{task::Poll, io::{self, SeekFrom}, pin::Pin};
+
+use futures::ready;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncSeek};
+
+#[derive(Debug)]
+pub(crate) struct TrackingReader<R> {
+    inner: R,
+    read: u64,
+}
+
+impl<R> TrackingReader<R> {
+    pub fn new(inner: R) -> Self {
+        Self { inner, read: 0 }
+    }
+
+    pub fn bytes_read(&self) -> u64 {
+        self.read
+    }
+
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R> AsyncRead for TrackingReader<R>
+where
+    R: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = &mut *self;
+        let filled0 = buf.filled().len();
+        let res = Pin::new(&mut this.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = res {
+            let size = buf.filled().len().saturating_sub(filled0);
+            this.read = this.read.saturating_add(size as u64);
+        }
+        res
+    }
+}
+
+pub(crate) struct TrackingWriter<W> {
+    inner: W,
+    written: u64,
+}
+
+impl<W> TrackingWriter<W> {
+    pub fn new(inner: W) -> Self {
+        Self { inner, written: 0 }
+    }
+
+    pub fn bytes_written(&self) -> u64 {
+        self.written
+    }
+
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: AsyncWrite + Unpin> AsyncWrite for TrackingWriter<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = &mut *self;
+        let res = Pin::new(&mut this.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(size)) = res {
+            this.written = this.written.saturating_add(size as u64);
+        }
+        res
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+///
+#[derive(Debug)]
+pub(crate) struct SeekOptimized<T> {
+    inner: T,
+    state: SeekOptimizedState,
+}
+
+impl<T> SeekOptimized<T> {
+    ///
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            state: SeekOptimizedState::Unknown,
+        }
+    }
+
+    ///
+    #[allow(dead_code)]
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+#[derive(Debug)]
+enum SeekOptimizedState {
+    Unknown,
+    Seeking,
+    FakeSeeking(u64),
+    Known(u64),
+}
+
+impl SeekOptimizedState {
+    fn take(&mut self) -> Self {
+        std::mem::replace(self, SeekOptimizedState::Unknown)
+    }
+
+    fn is_seeking(&self) -> bool {
+        matches!(self, SeekOptimizedState::Seeking | SeekOptimizedState::FakeSeeking(_))
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for SeekOptimized<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Poll::Ready(if self.state.is_seeking() {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "cannot read while seeking",
+            ))
+        } else {
+            let before = buf.remaining();
+            ready!(Pin::new(&mut self.inner).poll_read(cx, buf))?;
+            let after = buf.remaining();
+            let read = before - after;
+            if let SeekOptimizedState::Known(offset) = &mut self.state {
+                *offset += read as u64;
+            }
+            Ok(())
+        })
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for SeekOptimized<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(if self.state.is_seeking() {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "cannot write while seeking",
+            ))
+        } else {
+            let result = ready!(Pin::new(&mut self.inner).poll_write(cx, buf))?;
+            if let SeekOptimizedState::Known(offset) = &mut self.state {
+                *offset += result as u64;
+            }
+            Ok(result)
+        })
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+impl<T: AsyncSeek + Unpin> AsyncSeek for SeekOptimized<T> {
+    fn start_seek(mut self: Pin<&mut Self>, seek_from: SeekFrom) -> io::Result<()> {
+        self.state = match (self.state.take(), seek_from) {
+            (SeekOptimizedState::Known(offset), SeekFrom::Current(0)) => {
+                // somebody wants to know the current position
+                SeekOptimizedState::FakeSeeking(offset)
+            }
+            (SeekOptimizedState::Known(offset), SeekFrom::Start(current)) if offset == current => {
+                // seek to the current position
+                SeekOptimizedState::FakeSeeking(offset)
+            }
+            _ => {
+                // if start_seek fails, we go into unknown state
+                Pin::new(&mut self.inner).start_seek(seek_from)?;
+                SeekOptimizedState::Seeking
+            }
+        };
+        Ok(())
+    }
+
+    fn poll_complete(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<io::Result<u64>> {
+        // if we are in fakeseeking state, intercept the call to the inner
+        if let SeekOptimizedState::FakeSeeking(offset) = self.state {
+            self.state = SeekOptimizedState::Known(offset);
+            return Poll::Ready(Ok(offset));
+        }
+        // in all other cases we have to do the call to the inner
+        //
+        // a tokio file can be busy even when it seems idle, because write ops
+        // are buffered. so we have to poll_complete until it returns Ok.
+        let res = ready!(Pin::new(&mut self.inner).poll_complete(cx))?;
+        if let SeekOptimizedState::Seeking = self.state {
+            self.state = SeekOptimizedState::Known(res);
+        }
+        Poll::Ready(Ok(res))
+    }
+}

--- a/src/tokio_util.rs
+++ b/src/tokio_util.rs
@@ -55,6 +55,22 @@ where
     }
 }
 
+impl<R> AsyncSeek for TrackingReader<R>
+where
+    R: AsyncSeek + Unpin,
+{
+    fn start_seek(mut self: Pin<&mut Self>, pos: SeekFrom) -> io::Result<()> {
+        Pin::new(&mut self.inner).start_seek(pos)
+    }
+
+    fn poll_complete(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<u64>> {
+        Pin::new(&mut self.inner).poll_complete(cx)
+    }
+}
+
 /// A writer that tracks the number of bytes written
 pub(crate) struct TrackingWriter<W> {
     inner: W,

--- a/src/util.rs
+++ b/src/util.rs
@@ -181,7 +181,7 @@ pub(crate) fn validate_bao<F: Fn(u64)>(
 ) -> result::Result<(), BaoValidationError> {
     let hash = blake3::Hash::from(hash);
     let outboard =
-        bao_tree::outboard::PreOrderMemOutboardRef::new(hash, IROH_BLOCK_SIZE, &outboard);
+        bao_tree::outboard::PreOrderMemOutboardRef::new(hash, IROH_BLOCK_SIZE, &outboard)?;
 
     // do not wrap the data_reader in a BufReader, that is slow wnen seeking
     encode_ranges_validated(

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     fmt::{self, Display},
     io::{self, Read, Seek, Write},
-    path::{Component, Path},
+    path::{Component, Path, PathBuf},
     result,
     str::FromStr,
 };
@@ -239,23 +239,13 @@ pub fn canonicalize_path(path: impl AsRef<Path>) -> anyhow::Result<String> {
     Ok(parts.join("/"))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_hash() {
-        let data = b"hello world";
-        let hash = Hash::new(data);
-
-        let encoded = hash.to_string();
-        assert_eq!(encoded.parse::<Hash>().unwrap(), hash);
+/// Create a pathbuf from a name.
+pub fn pathbuf_from_name(name: &str) -> PathBuf {
+    let mut path = PathBuf::new();
+    for part in name.split('/') {
+        path.push(part);
     }
-
-    #[test]
-    fn test_canonicalize_path() {
-        assert_eq!(canonicalize_path("foo/bar").unwrap(), "foo/bar");
-    }
+    path
 }
 
 pub(crate) struct ProgressReader<R, F: Fn(ProgressReaderUpdate)> {
@@ -319,5 +309,24 @@ impl<T: fmt::Debug + Send + Sync + 'static> Progress<T> {
             progress.send(msg).await?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash() {
+        let data = b"hello world";
+        let hash = Hash::new(data);
+
+        let encoded = hash.to_string();
+        assert_eq!(encoded.parse::<Hash>().unwrap(), hash);
+    }
+
+    #[test]
+    fn test_canonicalize_path() {
+        assert_eq!(canonicalize_path("foo/bar").unwrap(), "foo/bar");
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -282,10 +282,7 @@ fn test_provide_get_loop(path: &Path, input: Input, output: Output) -> Result<()
 
     let home = testdir!();
     let mut provider = make_provider(&path, &input, home, None, None)?;
-    // std::io::copy(
-    //     &mut provider.child.stderr.take().unwrap(),
-    //     &mut std::io::stderr(),
-    // )?;
+    // std::io::copy(&mut provider.child.stderr.take().unwrap(), &mut std::io::stderr())?;
 
     let stdout = provider.child.stdout.take().unwrap();
     let stdout = BufReader::new(stdout);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -282,7 +282,7 @@ fn test_provide_get_loop(path: &Path, input: Input, output: Output) -> Result<()
 
     let home = testdir!();
     let mut provider = make_provider(&path, &input, home, None, None)?;
-    // std::io::copy(&mut provider.child.stderr.take().unwrap(), &mut std::io::stderr())?;
+    std::io::copy(&mut provider.child.stderr.take().unwrap(), &mut std::io::stderr())?;
 
     let stdout = provider.child.stdout.take().unwrap();
     let stdout = BufReader::new(stdout);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -282,7 +282,10 @@ fn test_provide_get_loop(path: &Path, input: Input, output: Output) -> Result<()
 
     let home = testdir!();
     let mut provider = make_provider(&path, &input, home, None, None)?;
-    std::io::copy(&mut provider.child.stderr.take().unwrap(), &mut std::io::stderr())?;
+    // std::io::copy(
+    //     &mut provider.child.stderr.take().unwrap(),
+    //     &mut std::io::stderr(),
+    // )?;
 
     let stdout = provider.child.stdout.take().unwrap();
     let stdout = BufReader::new(stdout);


### PR DESCRIPTION
- no more distinction between blobs and collections, since that is fundamentally flawed
- multiple paths per hash
- inline storage (we need this for the collections)
- lazy outboard cache
- rudimentary db file versioning

Note that this builds on https://github.com/n0-computer/iroh/pull/930 , but the issue itself is very much independent of that. We could also add this to https://github.com/n0-computer/iroh/pull/942 if we wanted to take things slow.

BlobOrCollection is never going to work, since you can add the same data as both blob and collection, and then the current db will break.

E.g. 

- create a collection
- create a second collection with the collection data of the first collection added as a file/blob

Depending on which one you add first, the other just won't work.