### PR TITLE
feat(provider): Allow binding to multiple addresses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -672,7 +672,9 @@ async fn main_impl() -> Result<()> {
             let client = make_rpc_client(rpc_port).await?;
             let response = client.rpc(IdRequest).await?;
 
-            println!("Listening address: {}", response.listen_addr);
+            for addr in response.listen_addrs.iter() {
+                println!("Listening address: {}", addr);
+            }
             println!("PeerID: {}", response.peer_id);
             println!("Auth token: {}", response.auth_token);
             Ok(())
@@ -716,7 +718,7 @@ async fn provide(
 
     let mut builder = provider::Provider::builder(db).keylog(keylog);
     if let Some(addr) = addr {
-        builder = builder.bind_addr(addr);
+        builder = builder.bind_addrs(vec![addr]);
     }
     if let Some(ref encoded) = auth_token {
         let auth_token = AuthToken::from_str(encoded)?;
@@ -732,7 +734,9 @@ async fn provide(
         builder.keypair(keypair).spawn()?
     };
 
-    println!("Listening address: {}", provider.local_address());
+    for addr in provider.local_addresses() {
+        println!("Listening address: {}", addr);
+    }
     println!("PeerID: {}", provider.peer_id());
     println!("Auth token: {}", provider.auth_token());
     println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -718,7 +718,7 @@ async fn provide(
 
     let mut builder = provider::Provider::builder(db).keylog(keylog);
     if let Some(addr) = addr {
-        builder = builder.bind_addrs(vec![addr])?;
+        builder = builder.bind_addrs(vec![addr]);
     }
     if let Some(ref encoded) = auth_token {
         let auth_token = AuthToken::from_str(encoded)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -718,7 +718,7 @@ async fn provide(
 
     let mut builder = provider::Provider::builder(db).keylog(keylog);
     if let Some(addr) = addr {
-        builder = builder.bind_addrs(vec![addr]);
+        builder = builder.bind_addrs(vec![addr])?;
     }
     if let Some(ref encoded) = auth_token {
         let auth_token = AuthToken::from_str(encoded)?;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -159,12 +159,20 @@ impl<E: ServiceEndpoint<ProviderService>> Builder<E> {
         }
     }
 
-    /// Binds the provider service to a different socket.
+    /// Sets the sockets to which the provider service should bind.
     ///
-    /// By default it binds to `127.0.0.1:4433`.
-    pub fn bind_addrs(mut self, addrs: Vec<SocketAddr>) -> Self {
+    /// In case the provider should bind to multiple addresses.  This is needed e.g. when
+    /// you want to bind to both IPv4 and IPv6 at the same time as not all platforms will
+    /// accept IPv4 connections on an IPv6 wildcard address.
+    ///
+    /// By default it binds only to `127.0.0.1:4433`.
+    pub fn bind_addrs(mut self, addrs: Vec<SocketAddr>) -> Result<Self> {
+        ensure!(
+            !addrs.is_empty(),
+            "Provider must bind to at least one socket"
+        );
         self.bind_addrs = addrs;
-        self
+        Ok(self)
     }
 
     /// Uses the given [`Keypair`] for the [`PeerId`] instead of a newly generated one.

--- a/src/rpc_protocol.rs
+++ b/src/rpc_protocol.rs
@@ -130,7 +130,7 @@ pub struct WatchResponse {
 pub struct IdResponse {
     pub peer_id: Box<PeerId>,
     pub auth_token: Box<AuthToken>,
-    pub listen_addr: Box<SocketAddr>,
+    pub listen_addrs: Box<Vec<SocketAddr>>,
     pub version: String,
 }
 


### PR DESCRIPTION
This allows binding the provider to multiple addresses, the common
case is to bind to both IPv4 and IPv6 sockets.  But any suitable
combination is possible.