### PR TITLE
integrate patched quinn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,11 +183,11 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+checksum = "30ff05a702273012438132f449575dbc804e27b2f3cbe3069aa237d26c98fa33"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.1.0",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -195,6 +195,34 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time 0.3.20",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive 0.4.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.20",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
 ]
 
 [[package]]
@@ -1124,11 +1152,25 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
+dependencies = [
+ "asn1-rs 0.3.1",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -2068,7 +2110,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-dns-resolver",
  "walkdir",
- "webpki",
+ "webpki 0.22.0",
  "wg",
  "wmi",
  "x509-parser 0.14.0",
@@ -2511,11 +2553,20 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e20717fa0541f39bd146692035c37bedfa532b3e5071b35761082407546b2a"
+dependencies = [
+ "asn1-rs 0.3.1",
+]
+
+[[package]]
+name = "oid-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
 ]
 
 [[package]]
@@ -2652,16 +2703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
-dependencies = [
- "base64 0.21.0",
- "serde",
 ]
 
 [[package]]
@@ -3065,7 +3106,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3083,7 +3124,7 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3224,7 +3265,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
- "pem 1.1.1",
+ "pem",
  "ring",
  "time 0.3.20",
  "yasna",
@@ -3236,7 +3277,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
- "pem 1.1.1",
+ "pem",
  "ring",
  "time 0.3.20",
  "yasna",
@@ -3498,7 +3539,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3515,8 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-acme"
-version = "0.6.0"
-source = "git+https://github.com/dignifiedquire/rustls-acme?branch=rustls-21#8c400a7ae15ae0634792738dbac0b5ffe36f37aa"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1469e26c5a3b0ce28fa635f61bc4a1c678dfcb7248ad2fc717318bfc3d9d6a9d"
 dependencies = [
  "async-h1",
  "async-io",
@@ -3527,7 +3569,7 @@ dependencies = [
  "futures-rustls",
  "http-types",
  "log",
- "pem 2.0.1",
+ "pem",
  "pin-project",
  "rcgen 0.9.3",
  "ring",
@@ -3539,8 +3581,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
- "webpki-roots 0.23.0",
- "x509-parser 0.15.0",
+ "webpki-roots 0.21.1",
+ "x509-parser 0.13.2",
 ]
 
 [[package]]
@@ -4419,7 +4461,7 @@ checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls 0.20.8",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -4905,6 +4947,16 @@ dependencies = [
 
 [[package]]
 name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -4915,20 +4967,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.23.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
- "rustls-webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -5245,17 +5297,17 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.14.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+checksum = "9fb9bace5b5589ffead1afb76e43e34cff39cd0f3ce7e170ae0c29e53b88eb1c"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.3.1",
  "base64 0.13.1",
  "data-encoding",
- "der-parser",
+ "der-parser 7.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.4.0",
  "rusticata-macros",
  "thiserror",
  "time 0.3.20",
@@ -5263,16 +5315,17 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.15.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab0c2f54ae1d92f4fcb99c0b7ccf0b1e3451cbd395e5f115ccbdbcb18d4f634"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
+ "base64 0.13.1",
  "data-encoding",
- "der-parser",
+ "der-parser 8.2.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
  "time 0.3.20",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,27 +183,11 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "asn1-rs"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ff05a702273012438132f449575dbc804e27b2f3cbe3069aa237d26c98fa33"
-dependencies = [
- "asn1-rs-derive 0.1.0",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror",
- "time 0.3.20",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
 dependencies = [
- "asn1-rs-derive 0.4.0",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -211,18 +195,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time 0.3.20",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
 ]
 
 [[package]]
@@ -1160,25 +1132,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
-dependencies = [
- "asn1-rs 0.3.1",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
- "asn1-rs 0.5.2",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1564,13 +1522,12 @@ dependencies = [
 
 [[package]]
 name = "futures-rustls"
-version = "0.22.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
+checksum = "35bd3cf68c183738046838e300353e4716c674dc5e56890de4826801a6622a28"
 dependencies = [
  "futures-io",
- "rustls 0.20.8",
- "webpki 0.22.0",
+ "rustls 0.21.1",
 ]
 
 [[package]]
@@ -1910,7 +1867,7 @@ dependencies = [
  "hyper",
  "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2085,9 +2042,9 @@ dependencies = [
  "postcard",
  "proptest",
  "quic-rpc",
- "quinn 0.10.0",
- "quinn-proto 0.10.0",
- "quinn-udp 0.4.0",
+ "quinn",
+ "quinn-proto",
+ "quinn-udp",
  "rand 0.8.5",
  "range-collections",
  "rcgen 0.10.0",
@@ -2111,7 +2068,7 @@ dependencies = [
  "thiserror",
  "time 0.3.20",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
  "tokio-stream",
  "tokio-util",
  "toml",
@@ -2120,7 +2077,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-dns-resolver",
  "walkdir",
- "webpki 0.22.0",
+ "webpki",
  "wg",
  "wmi",
  "x509-parser 0.14.0",
@@ -2563,20 +2520,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e20717fa0541f39bd146692035c37bedfa532b3e5071b35761082407546b2a"
-dependencies = [
- "asn1-rs 0.3.1",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
- "asn1-rs 0.5.2",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2713,6 +2661,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "pem"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.0",
+ "serde",
 ]
 
 [[package]]
@@ -3076,14 +3034,13 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d453504fc3e456160ae3b9ebe4d83c1f6477af167aa9b67e2d7bf11a096f179d"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=feat-quinn-010#20679f938d1c257cb51d64f46ba39cc46c580a73"
 dependencies = [
  "bincode",
  "flume",
  "futures",
  "pin-project",
- "quinn 0.9.3",
+ "quinn",
  "serde",
  "tokio",
  "tokio-serde",
@@ -3105,56 +3062,19 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto 0.9.3",
- "quinn-udp 0.3.2",
- "rustc-hash",
- "rustls 0.20.8",
- "thiserror",
- "tokio",
- "tracing",
- "webpki 0.22.0",
-]
-
-[[package]]
-name = "quinn"
 version = "0.10.0"
 source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#47205e0a4b09e1583e1c7b50db24930d00f527d4"
 dependencies = [
  "bytes",
  "pin-project-lite",
- "quinn-proto 0.10.0",
- "quinn-udp 0.4.0",
+ "quinn-proto",
+ "quinn-udp",
  "rustc-hash",
  "rustls 0.21.1",
  "thiserror",
  "tokio",
  "tracing",
- "webpki 0.22.0",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
-dependencies = [
- "bytes",
- "rand 0.8.5",
- "ring",
- "rustc-hash",
- "rustls 0.20.8",
- "rustls-native-certs",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -3172,20 +3092,7 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki 0.22.0",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
-dependencies = [
- "libc",
- "quinn-proto 0.9.3",
- "socket2 0.4.9",
- "tracing",
- "windows-sys 0.42.0",
+ "webpki",
 ]
 
 [[package]]
@@ -3326,7 +3233,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
- "pem",
+ "pem 1.1.1",
  "ring",
  "time 0.3.20",
  "yasna",
@@ -3338,7 +3245,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
- "pem",
+ "pem 1.1.1",
  "ring",
  "time 0.3.20",
  "yasna",
@@ -3454,7 +3361,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3600,7 +3507,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -3609,6 +3516,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
+ "log",
  "ring",
  "rustls-webpki",
  "sct",
@@ -3617,8 +3525,7 @@ dependencies = [
 [[package]]
 name = "rustls-acme"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be93c9190b1c62d16f99512f86c2b171667c675806452f744669bd5e1ec6ae"
+source = "git+https://github.com/dignifiedquire/rustls-acme?branch=rustls-21#8c400a7ae15ae0634792738dbac0b5ffe36f37aa"
 dependencies = [
  "async-h1",
  "async-io",
@@ -3629,11 +3536,11 @@ dependencies = [
  "futures-rustls",
  "http-types",
  "log",
- "pem",
+ "pem 2.0.1",
  "pin-project",
  "rcgen 0.9.3",
  "ring",
- "rustls 0.20.8",
+ "rustls 0.21.1",
  "serde",
  "serde_json",
  "smol",
@@ -3641,8 +3548,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
- "webpki-roots 0.21.1",
- "x509-parser 0.13.2",
+ "webpki-roots 0.23.0",
+ "x509-parser 0.15.0",
 ]
 
 [[package]]
@@ -4521,7 +4428,17 @@ checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls 0.20.8",
  "tokio",
- "webpki 0.22.0",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
 ]
 
 [[package]]
@@ -4997,16 +4914,6 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -5017,20 +4924,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
- "webpki 0.22.0",
+ "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]
@@ -5347,17 +5254,17 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9bace5b5589ffead1afb76e43e34cff39cd0f3ce7e170ae0c29e53b88eb1c"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
- "asn1-rs 0.3.1",
+ "asn1-rs",
  "base64 0.13.1",
  "data-encoding",
- "der-parser 7.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.4.0",
+ "oid-registry",
  "rusticata-macros",
  "thiserror",
  "time 0.3.20",
@@ -5365,17 +5272,16 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+checksum = "bab0c2f54ae1d92f4fcb99c0b7ccf0b1e3451cbd395e5f115ccbdbcb18d4f634"
 dependencies = [
- "asn1-rs 0.5.2",
- "base64 0.13.1",
+ "asn1-rs",
  "data-encoding",
- "der-parser 8.2.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.6.1",
+ "oid-registry",
  "rusticata-macros",
  "thiserror",
  "time 0.3.20",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
 dependencies = [
- "async-lock 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-lock",
  "async-task",
  "concurrent-queue",
  "fastrand",
@@ -261,7 +261,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
 dependencies = [
- "async-lock 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-lock",
  "autocfg",
  "blocking",
  "futures-lite",
@@ -276,7 +276,7 @@ dependencies = [
  "async-channel",
  "async-executor",
  "async-io",
- "async-lock 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-lock",
  "blocking",
  "futures-lite",
  "once_cell",
@@ -304,7 +304,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
- "async-lock 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-lock",
  "autocfg",
  "cfg-if",
  "concurrent-queue",
@@ -328,14 +328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-lock"
-version = "2.7.0"
-source = "git+https://github.com/smol-rs/async-lock?branch=notgull/block-lock#301ebaeec77637f07af190bb367b0c6c5c1ad8aa"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "async-net"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,7 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
 dependencies = [
  "async-io",
- "async-lock 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-lock",
  "autocfg",
  "blocking",
  "cfg-if",
@@ -374,7 +366,7 @@ dependencies = [
  "async-channel",
  "async-global-executor",
  "async-io",
- "async-lock 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-lock",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -566,7 +558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
 dependencies = [
  "async-channel",
- "async-lock 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-lock",
  "async-task",
  "atomic-waker",
  "fastrand",
@@ -2005,7 +1997,6 @@ name = "iroh"
 version = "0.4.1"
 dependencies = [
  "anyhow",
- "async-lock 2.7.0 (git+https://github.com/smol-rs/async-lock?branch=notgull/block-lock)",
  "backoff",
  "bao-tree",
  "base64 0.21.0",
@@ -3063,7 +3054,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 [[package]]
 name = "quinn"
 version = "0.10.0"
-source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#47205e0a4b09e1583e1c7b50db24930d00f527d4"
+source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#da41e0ab8b85a1ba7dda317f098a9c2c257f4412"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -3080,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.10.0"
-source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#47205e0a4b09e1583e1c7b50db24930d00f527d4"
+source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#da41e0ab8b85a1ba7dda317f098a9c2c257f4412"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -3098,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.4.0"
-source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#47205e0a4b09e1583e1c7b50db24930d00f527d4"
+source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#da41e0ab8b85a1ba7dda317f098a9c2c257f4412"
 dependencies = [
  "bytes",
  "libc",
@@ -3963,7 +3954,7 @@ dependencies = [
  "async-executor",
  "async-fs",
  "async-io",
- "async-lock 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-lock",
  "async-net",
  "async-process",
  "blocking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,13 +1261,13 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1569,7 +1569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
 dependencies = [
  "futures-io",
- "rustls",
+ "rustls 0.20.8",
  "webpki 0.22.0",
 ]
 
@@ -1908,7 +1908,7 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls",
 ]
@@ -2085,9 +2085,9 @@ dependencies = [
  "postcard",
  "proptest",
  "quic-rpc",
- "quinn",
- "quinn-proto",
- "quinn-udp",
+ "quinn 0.10.0",
+ "quinn-proto 0.10.0",
+ "quinn-udp 0.4.0",
  "rand 0.8.5",
  "range-collections",
  "rcgen 0.10.0",
@@ -2095,7 +2095,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rtnetlink",
- "rustls",
+ "rustls 0.21.1",
  "rustls-acme",
  "rustls-pemfile",
  "serde",
@@ -2207,9 +2207,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -3083,7 +3083,7 @@ dependencies = [
  "flume",
  "futures",
  "pin-project",
- "quinn",
+ "quinn 0.9.3",
  "serde",
  "tokio",
  "tokio-serde",
@@ -3111,10 +3111,27 @@ checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
 dependencies = [
  "bytes",
  "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
+ "quinn-proto 0.9.3",
+ "quinn-udp 0.3.2",
  "rustc-hash",
- "rustls",
+ "rustls 0.20.8",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.10.0"
+source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#47205e0a4b09e1583e1c7b50db24930d00f527d4"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto 0.10.0",
+ "quinn-udp 0.4.0",
+ "rustc-hash",
+ "rustls 0.21.1",
  "thiserror",
  "tokio",
  "tracing",
@@ -3131,7 +3148,25 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.20.8",
+ "rustls-native-certs",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.10.0"
+source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#47205e0a4b09e1583e1c7b50db24930d00f527d4"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.21.1",
  "rustls-native-certs",
  "slab",
  "thiserror",
@@ -3147,10 +3182,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
  "libc",
- "quinn-proto",
+ "quinn-proto 0.9.3",
  "socket2 0.4.9",
  "tracing",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.4.0"
+source = "git+http://github.com/dignifiedquire/quinn?branch=feat-bytes-transmit#47205e0a4b09e1583e1c7b50db24930d00f527d4"
+dependencies = [
+ "bytes",
+ "libc",
+ "socket2 0.4.9",
+ "tracing",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3401,7 +3448,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3532,9 +3579,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.18"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -3557,10 +3604,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-acme"
-version = "0.5.3"
+name = "rustls"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6278bb5bc46005985f2f154e06696896ea548dd3cf49d6eb3d84878fff31d5b9"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-acme"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01be93c9190b1c62d16f99512f86c2b171667c675806452f744669bd5e1ec6ae"
 dependencies = [
  "async-h1",
  "async-io",
@@ -3575,7 +3633,7 @@ dependencies = [
  "pin-project",
  "rcgen 0.9.3",
  "ring",
- "rustls",
+ "rustls 0.20.8",
  "serde",
  "serde_json",
  "smol",
@@ -3606,6 +3664,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -4451,7 +4519,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki 0.22.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ tempfile = "3.4"
 thiserror = "1"
 time = "0.3.20"
 tokio = { version = "1", features = ["full"] }
-tokio-rustls = { version = "0.23.4", optional = true }
+tokio-rustls = { version = "0.24", optional = true }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["io-util", "io"] }
 toml = { version = "0.7.3", optional = true }
@@ -136,3 +136,5 @@ ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek", b
 quinn = { git = "http://github.com/dignifiedquire/quinn", branch = "feat-bytes-transmit" }
 quinn-udp = { git = "http://github.com/dignifiedquire/quinn", branch = "feat-bytes-transmit" }
 quinn-proto = { git = "http://github.com/dignifiedquire/quinn", branch = "feat-bytes-transmit" }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "feat-quinn-010" }
+rustls-acme = { git = "https://github.com/dignifiedquire/rustls-acme", branch = "rustls-21" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ regex = { version = "1.7.1", optional = true }
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls"] }
 ring = "0.16.20"
 rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
-rustls-acme = { version = "0.6", optional = true, features = ["tokio"] }
+rustls-acme = { version = "0.7", optional = true, features = ["tokio"] }
 rustls-pemfile = { version = "1.0.2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde-error = "0.1.2"
@@ -136,4 +136,3 @@ quinn = { git = "http://github.com/dignifiedquire/quinn", branch = "feat-bytes-t
 quinn-udp = { git = "http://github.com/dignifiedquire/quinn", branch = "feat-bytes-transmit" }
 quinn-proto = { git = "http://github.com/dignifiedquire/quinn", branch = "feat-bytes-transmit" }
 quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "feat-quinn-010" }
-rustls-acme = { git = "https://github.com/dignifiedquire/rustls-acme", branch = "rustls-21" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,16 +44,16 @@ os_info = "3.6.0"
 portable-atomic = "1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quic-rpc = { version = "0.5", default-features = false, features = ["quinn-transport", "flume-transport"] }
-quinn = "0.9"
-quinn-proto = "0.9"
-quinn-udp = "0.3"
+quinn = "0.10"
+quinn-proto = "0.10"
+quinn-udp = "0.4"
 rand = "0.8"
 rcgen = "0.10"
 regex = { version = "1.7.1", optional = true }
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls"] }
 ring = "0.16.20"
-rustls = { version = "0.20.8", default-features = false, features = ["dangerous_configuration"] }
-rustls-acme = { version = "0.5.2", optional = true, features = ["tokio"] }
+rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
+rustls-acme = { version = "0.6", optional = true, features = ["tokio"] }
 rustls-pemfile = { version = "1.0.2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde-error = "0.1.2"
@@ -129,3 +129,10 @@ incremental = false
 [patch.crates-io]
 crypto_box = { git = "https://github.com/RustCrypto/nacl-compat", branch = "master" }
 ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek", branch = "main" }
+
+# quinn = { path = "../quinn/quinn" }
+# quinn-udp = { path = "../quinn/quinn-udp" }
+# quinn-proto = { path = "../quinn/quinn-proto" }
+quinn = { git = "http://github.com/dignifiedquire/quinn", branch = "feat-bytes-transmit" }
+quinn-udp = { git = "http://github.com/dignifiedquire/quinn", branch = "feat-bytes-transmit" }
+quinn-proto = { git = "http://github.com/dignifiedquire/quinn", branch = "feat-bytes-transmit" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ x509-parser = "0.14"
 zeroize = "1.5"
 bao-tree = { version = "0.1.5", features = ["tokio_io"], default-features = false }
 range-collections = "0.4.0"
-async-lock = { git = "https://github.com/smol-rs/async-lock", branch = "notgull/block-lock" }
 surge-ping = "0.8.0"
 
 

--- a/src/get.rs
+++ b/src/get.rs
@@ -81,7 +81,7 @@ pub async fn make_client_endpoint(
         quinn::EndpointConfig::default(),
         None,
         conn.clone(),
-        quinn::TokioRuntime,
+        Arc::new(quinn::TokioRuntime),
     )?;
 
     let mut transport_config = quinn::TransportConfig::default();

--- a/src/hp/derp/client.rs
+++ b/src/hp/derp/client.rs
@@ -72,7 +72,7 @@ impl<R: AsyncRead + Unpin> Client<R> {
     /// Sends a packet to the node identified by `dstkey`
     ///
     /// Errors if the packet is larger than [`MAX_PACKET_SIZE`]
-    pub async fn send(&self, dstkey: PublicKey, packet: Vec<u8>) -> Result<()> {
+    pub async fn send(&self, dstkey: PublicKey, packet: Bytes) -> Result<()> {
         debug!("[DERP] -> {:?} ({}b)", dstkey, packet.len());
 
         self.inner
@@ -307,7 +307,7 @@ impl<R: AsyncRead + Unpin> Client<R> {
 #[derive(Debug)]
 enum ClientWriterMessage {
     /// Send a packet (addressed to the [`PublicKey`]) to the server
-    Packet((PublicKey, Vec<u8>)),
+    Packet((PublicKey, Bytes)),
     /// Forward a packet from the src [`PublicKey`] to the dst [`PublicKey`] to the server
     /// Should only be used for mesh clients.
     FwdPacket((PublicKey, PublicKey, Bytes)),

--- a/src/hp/derp/http.rs
+++ b/src/hp/derp/http.rs
@@ -14,7 +14,7 @@ mod tests {
     use std::net::{Ipv4Addr, SocketAddr};
 
     use anyhow::Result;
-    use bytes::BytesMut;
+    use bytes::{Bytes, BytesMut};
     use hyper::server::conn::Http;
     use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
     use tokio::net::TcpListener;
@@ -129,7 +129,7 @@ mod tests {
         client_b.ping().await?;
 
         println!("sending message from a to b");
-        let msg = b"hi there, client b!".to_vec();
+        let msg = Bytes::from_static(b"hi there, client b!");
         client_a.send(b_key.clone(), msg.clone()).await?;
         println!("waiting for message from a on b");
         let (got_key, got_msg) = b_recv.recv().await.expect("expected message from client_a");
@@ -137,7 +137,7 @@ mod tests {
         assert_eq!(msg, got_msg);
 
         println!("sending message from b to a");
-        let msg = b"right back at ya, client b!".to_vec();
+        let msg = Bytes::from_static(b"right back at ya, client b!");
         client_b.send(a_key.clone(), msg.clone()).await?;
         println!("waiting for message b on a");
         let (got_key, got_msg) = a_recv.recv().await.expect("expected message from client_b");

--- a/src/hp/derp/http/client.rs
+++ b/src/hp/derp/http/client.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use bytes::Bytes;
 use futures::future::BoxFuture;
 use hyper::{header::UPGRADE, Body, Request};
 use rand::Rng;
@@ -597,7 +598,7 @@ impl Client {
     ///
     /// If there is an error sending the packet, it closes the underlying derp connection before
     /// returning.
-    pub async fn send(&self, dst_key: key::node::PublicKey, b: Vec<u8>) -> Result<(), ClientError> {
+    pub async fn send(&self, dst_key: key::node::PublicKey, b: Bytes) -> Result<(), ClientError> {
         debug!("send");
         let (client, _) = self.connect().await?;
         if let Err(_) = client.send(dst_key, b).await {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -214,7 +214,7 @@ impl<E: ServiceEndpoint<ProviderService>> Builder<E> {
             quinn::EndpointConfig::default(),
             Some(server_config),
             conn.clone(),
-            quinn::TokioRuntime,
+            Arc::new(quinn::TokioRuntime),
         )?;
         let (events_sender, _events_receiver) = broadcast::channel(8);
         let events = events_sender.clone();

--- a/src/tls/certificate.rs
+++ b/src/tls/certificate.rs
@@ -258,6 +258,7 @@ impl P2pCertificate<'_> {
             RSA_PKCS1_SHA1 => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
             ECDSA_SHA1_Legacy => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
             Unknown(_) => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
+            _ => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
         };
         let spki = &self.certificate.tbs_certificate.subject_pki;
         let key = signature::UnparsedPublicKey::new(

--- a/src/tls/verifier.rs
+++ b/src/tls/verifier.rs
@@ -3,16 +3,17 @@
 //! This module handles a verification of a client/server certificate chain
 //! and signatures allegedly by the given certificates.
 
+use std::sync::Arc;
+
 use super::{certificate, PeerId};
 use rustls::{
     cipher_suite::{
         TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
     },
     client::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
-    internal::msgs::handshake::DigitallySignedStruct,
     server::{ClientCertVerified, ClientCertVerifier},
-    Certificate, DistinguishedNames, SignatureScheme, SupportedCipherSuite,
-    SupportedProtocolVersion,
+    Certificate, CertificateError, DigitallySignedStruct, DistinguishedName, PeerMisbehaved,
+    SignatureScheme, SupportedCipherSuite, SupportedProtocolVersion,
 };
 
 /// The protocol versions supported by this verifier.
@@ -91,8 +92,8 @@ impl ServerCertVerifier for Libp2pCertificateVerifier {
             // the certificate matches the peer ID they intended to connect to,
             // and MUST abort the connection if there is a mismatch.
             if remote_peer_id != &peer_id {
-                return Err(rustls::Error::PeerMisbehavedError(
-                    "Wrong peer ID in p2p extension".to_string(),
+                return Err(rustls::Error::PeerMisbehaved(
+                    PeerMisbehaved::BadCertChainExtensions,
                 ));
             }
         }
@@ -135,8 +136,8 @@ impl ClientCertVerifier for Libp2pCertificateVerifier {
         true
     }
 
-    fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
-        Some(vec![])
+    fn client_auth_root_subjects(&self) -> &[DistinguishedName] {
+        &[][..]
     }
 
     fn verify_client_cert(
@@ -209,8 +210,8 @@ impl From<certificate::ParseError> for rustls::Error {
     fn from(certificate::ParseError(e): certificate::ParseError) -> Self {
         use webpki::Error::*;
         match e {
-            BadDer => rustls::Error::InvalidCertificateEncoding,
-            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {e}")),
+            BadDer => rustls::Error::InvalidCertificate(CertificateError::BadEncoding),
+            e => rustls::Error::InvalidCertificate(CertificateError::Other(Arc::new(e))),
         }
     }
 }
@@ -218,11 +219,13 @@ impl From<certificate::VerificationError> for rustls::Error {
     fn from(certificate::VerificationError(e): certificate::VerificationError) -> Self {
         use webpki::Error::*;
         match e {
-            InvalidSignatureForPublicKey => rustls::Error::InvalidCertificateSignature,
-            UnsupportedSignatureAlgorithm | UnsupportedSignatureAlgorithmForPublicKey => {
-                rustls::Error::InvalidCertificateSignatureType
+            InvalidSignatureForPublicKey => {
+                rustls::Error::InvalidCertificate(CertificateError::BadSignature)
             }
-            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {e}")),
+            UnsupportedSignatureAlgorithm | UnsupportedSignatureAlgorithmForPublicKey => {
+                rustls::Error::InvalidCertificate(CertificateError::BadSignature)
+            }
+            e => rustls::Error::InvalidCertificate(CertificateError::Other(Arc::new(e))),
         }
     }
 }


### PR DESCRIPTION
This includes updating to `rustls 0.21` and `quinn@0.10`

The actual patch being used is: https://github.com/quinn-rs/quinn/pull/1545

Missing 

- [x] a version of quic-rpc that is compatible: https://github.com/n0-computer/quic-rpc/pull/46
- [x] rustls-acme: https://github.com/FlorianUekermann/rustls-acme/issues/39 https://github.com/FlorianUekermann/rustls-acme/pull/40