### PR TITLE
rename StartCollection to StartRoot

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -296,7 +296,7 @@ pub mod get_response_machine {
     #[derive(Debug, From)]
     pub enum ConnectedNext {
         /// First response is a collection
-        StartCollection(AtStartCollection),
+        StartRoot(AtStartRoot),
         /// First response is a child
         StartChild(AtStartChild),
         /// Request is empty
@@ -368,7 +368,7 @@ pub mod get_response_machine {
             Ok(match misc.ranges_iter.next() {
                 Some((offset, ranges)) => {
                     if offset == 0 {
-                        AtStartCollection {
+                        AtStartRoot {
                             reader,
                             ranges,
                             misc,
@@ -392,7 +392,7 @@ pub mod get_response_machine {
 
     /// State of the get response when we start reading a collection
     #[derive(Debug)]
-    pub struct AtStartCollection {
+    pub struct AtStartRoot {
         ranges: RangeSet2<ChunkNum>,
         reader: TrackingReader<quinn::RecvStream>,
         misc: Box<Misc>,
@@ -449,7 +449,7 @@ pub mod get_response_machine {
         }
     }
 
-    impl AtStartCollection {
+    impl AtStartRoot {
         /// The ranges we have requested for the child
         pub fn ranges(&self) -> &RangeSet2<ChunkNum> {
             &self.ranges

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,7 +522,7 @@ mod tests {
         let connected = initial.next().await?;
         // we assume that the request includes the entire collection
         let (mut next, collection) = {
-            let ConnectedNext::StartCollection(sc) = connected.next().await? else {
+            let ConnectedNext::StartRoot(sc) = connected.next().await? else {
                 panic!("request did not include collection");
             };
             let (done, data) = sc.next().concatenate_into_vec().await?;
@@ -657,7 +657,7 @@ mod tests {
             )
             .await?;
             let connected = response.next().await?;
-            let ConnectedNext::StartCollection(start) = connected.next().await? else { panic!() };
+            let ConnectedNext::StartRoot(start) = connected.next().await? else { panic!() };
             let header = start.next();
             let (_, actual) = header.concatenate_into_vec().await?;
             let expected = tokio::fs::read(readme_path()).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -898,7 +898,7 @@ async fn get_to_dir(get: GetInteractive, out_dir: PathBuf) -> Result<()> {
         init_download_progress(count, missing_bytes);
     }
     let (mut next, collection) = match connected.next().await? {
-        ConnectedNext::StartCollection(curr) => {
+        ConnectedNext::StartRoot(curr) => {
             tokio::fs::create_dir_all(&temp_dir)
                 .await
                 .context("unable to create directory {temp_dir}")?;
@@ -1045,7 +1045,7 @@ async fn get_to_stdout(get: GetInteractive) -> Result<()> {
     };
     let connected = response.next().await?;
     progress!("{} Requesting ...", style("[2/3]").bold().dim());
-    let ConnectedNext::StartCollection(curr) = connected.next().await? else {
+    let ConnectedNext::StartRoot(curr) = connected.next().await? else {
         anyhow::bail!("expected a collection");
     };
     let (mut next, collection) = {


### PR DESCRIPTION
because StartCollection implies that it is always a collection, which is not the case when requesting a single blob.

Other alternative names would be StartParent, but in case of a single blob it is also not a parent.

Todo once we agree on the name - update the FSM svg drawing.