### PR TITLE
remove some stale refs from docs so cargo doc works

### DIFF
--- a/src/hp/derp/server.rs
+++ b/src/hp/derp/server.rs
@@ -61,7 +61,7 @@ where
     server_channel: mpsc::Sender<ServerMessage<R, W, P>>,
     /// When true, the server has been shutdown.
     closed: bool,
-    /// The information we send to the [`client::Client`] about the [`Server`]'s protocol version
+    /// The information we send to the client about the [`Server`]'s protocol version
     /// and required rate limiting (if any)
     server_info: ServerInfo,
     /// Server loop handler
@@ -286,7 +286,7 @@ where
     /// some read or write error to the connection,  if the server is meant to verify clients,
     /// and is unable to verify this one, or if there is some issue communicating with the server.
     ///
-    /// The provided [`AsyncReader`] and [`AsyncWriter`] must be already connected to the [`Conn`].
+    /// The provided [`AsyncRead`] and [`AsyncWrite`] must be already connected to the connection.
     pub async fn accept(&self, mut reader: R, mut writer: W) -> Result<()> {
         debug!("accept: start");
         self.send_server_key(&mut writer)

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -107,7 +107,7 @@ pub struct Report {
 
     /// ip:port of global IPv4
     pub global_v4: Option<SocketAddr>,
-    /// [ip]:port of global IPv6
+    /// `[ip]:port` of global IPv6
     pub global_v6: Option<SocketAddr>,
 
     /// CaptivePortal is set when we think there's a captive portal that is


### PR DESCRIPTION
I like to use cargo doc to get an overview of the code.