### PR TITLE
feat: remove AuthToken

### DIFF
--- a/src/provider/ticket.rs
+++ b/src/provider/ticket.rs
@@ -10,7 +10,6 @@ use std::str::FromStr;
 use anyhow::{ensure, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::protocol::AuthToken;
 use crate::util;
 use crate::{Hash, PeerId};
 
@@ -30,24 +29,12 @@ pub struct Ticket {
     ///
     /// This will never be empty.
     addrs: Vec<SocketAddr>,
-    /// The authentication token with permission to retrieve the hash.
-    token: AuthToken,
 }
 
 impl Ticket {
-    pub(super) fn new(
-        hash: Hash,
-        peer: PeerId,
-        addrs: Vec<SocketAddr>,
-        token: AuthToken,
-    ) -> Result<Self> {
+    pub(super) fn new(hash: Hash, peer: PeerId, addrs: Vec<SocketAddr>) -> Result<Self> {
         ensure!(!addrs.is_empty(), "addrs list can not be empty");
-        Ok(Self {
-            hash,
-            peer,
-            addrs,
-            token,
-        })
+        Ok(Self { hash, peer, addrs })
     }
 
     /// Deserializes from bytes.
@@ -77,11 +64,6 @@ impl Ticket {
     /// This is guaranteed to be non-empty.
     pub fn addrs(&self) -> &[SocketAddr] {
         &self.addrs
-    }
-
-    /// The authentication token for this ticket.
-    pub fn token(&self) -> AuthToken {
-        self.token
     }
 }
 
@@ -116,12 +98,10 @@ mod tests {
         let hash = Hash::from(hash);
         let peer = PeerId::from(Keypair::generate().public());
         let addr = SocketAddr::from_str("127.0.0.1:1234").unwrap();
-        let token = AuthToken::generate();
         let ticket = Ticket {
             hash,
             peer,
             addrs: vec![addr],
-            token,
         };
         let base64 = ticket.to_string();
         println!("Ticket: {base64}");

--- a/src/rpc_protocol.rs
+++ b/src/rpc_protocol.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 use std::{net::SocketAddr, path::PathBuf};
 
-use crate::{protocol::AuthToken, util::RpcError, Hash, PeerId};
+use crate::{util::RpcError, Hash, PeerId};
 use derive_more::{From, TryInto};
 use quic_rpc::{
     message::{Msg, RpcMsg, ServerStreaming, ServerStreamingMsg},
@@ -129,7 +129,6 @@ pub struct WatchResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IdResponse {
     pub peer_id: Box<PeerId>,
-    pub auth_token: Box<AuthToken>,
     pub listen_addr: Box<SocketAddr>,
     pub version: String,
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -464,7 +464,6 @@ fn match_provide_output<T: Read>(
         reader,
         r"Listening address: [\d.:]*"; 1,
         r"PeerID: [_\w\d-]*"; 1,
-        r"Auth token: [\w\d]*"; 1,
         r""; 1,
         r"Adding .*"; 1,
         r"- \S*: \d*.?\d*? ?[BKMGT]i?B?"; num_blobs,


### PR DESCRIPTION
This simplifies the protocol, and now that we have the request extension, it is possible to reimplement this in userspace. 

When we upgrade deltachat to the version without this, it should be easy enough to factor out a small library that users can easily use if they want this functionality. 