### PR TITLE
Remove dumping packet content in Debug...

### DIFF
--- a/src/hp/magicsock/conn.rs
+++ b/src/hp/magicsock/conn.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    fmt::Debug,
+    fmt::{Debug, self},
     io::{self, IoSliceMut},
     mem::MaybeUninit,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -676,12 +676,21 @@ enum NetworkSource {
     Derp,
 }
 
-#[derive(Debug)]
 struct DerpReadResult {
     region_id: u16,
     src: key::node::PublicKey,
     /// packet data
     buf: BytesMut,
+}
+
+impl fmt::Debug for DerpReadResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DerpReadResult")
+            .field("region_id", &self.region_id)
+            .field("src", &self.src)
+            .field("buf", &self.buf.len())
+            .finish()
+    }
 }
 
 /// Contains fields for an active DERP connection.


### PR DESCRIPTION
...for DerpReadResult and ReceivedMessage::ReceivedPacket

This prevents seeing a giant wall of useless text when running with debug tracing. If we actually need the package contents we can do something more fancy like a hex dump of the first n chars, but I think this is already useful.