### PR TITLE
ref: disable to unused code

### DIFF
--- a/src/hp/hostinfo.rs
+++ b/src/hp/hostinfo.rs
@@ -8,7 +8,7 @@ use super::cfg::NetInfo;
 
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const RUST_VERSION: &str = env!("RUSTC_VERSION");
-const SOURCE_TIMESTAMP: &str = env!("SOURCE_TIMESTAMP");
+// const SOURCE_TIMESTAMP: &str = env!("SOURCE_TIMESTAMP");
 const GIT_COMMIT: &str = env!("GIT_COMMIT");
 
 /// Contains a summary of the host we are running on.

--- a/src/hp/hostinfo.rs
+++ b/src/hp/hostinfo.rs
@@ -8,7 +8,6 @@ use super::cfg::NetInfo;
 
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const RUST_VERSION: &str = env!("RUSTC_VERSION");
-// const SOURCE_TIMESTAMP: &str = env!("SOURCE_TIMESTAMP");
 const GIT_COMMIT: &str = env!("GIT_COMMIT");
 
 /// Contains a summary of the host we are running on.

--- a/src/hp/magicsock/conn.rs
+++ b/src/hp/magicsock/conn.rs
@@ -44,11 +44,11 @@ use super::{
     HEARTBEAT_INTERVAL,
 };
 
-/// How many packets writes can be queued up the DERP client to write on the wire before we start
-/// dropping.
-///
-/// TODO: this is currently arbitrary. Figure out something better?
-const BUFFERED_DERP_WRITES_BEFORE_DROP: usize = 32;
+// /// How many packets writes can be queued up the DERP client to write on the wire before we start
+// /// dropping.
+// ///
+// /// TODO: this is currently arbitrary. Figure out something better?
+// const BUFFERED_DERP_WRITES_BEFORE_DROP: usize = 32;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(super) enum CurrentPortFate {
@@ -615,11 +615,7 @@ impl AsyncUdpSocket for Conn {
                         NetworkReadResult::Error(err) => {
                             return Poll::Ready(Err(err));
                         }
-                        NetworkReadResult::Ok {
-                            source,
-                            bytes,
-                            meta,
-                        } => {
+                        NetworkReadResult::Ok { bytes, meta } => {
                             buf_out[..bytes.len()].copy_from_slice(&bytes);
                             *meta_out = meta;
                             trace!(
@@ -672,18 +668,18 @@ impl AsyncUdpSocket for Conn {
 enum NetworkReadResult {
     Error(io::Error),
     Ok {
-        source: NetworkSource,
+        // source: NetworkSource,
         meta: quinn_udp::RecvMeta,
         bytes: BytesMut,
     },
 }
 
-#[derive(Debug)]
-enum NetworkSource {
-    Ipv4,
-    Ipv6,
-    Derp,
-}
+// #[derive(Debug)]
+// enum NetworkSource {
+//     Ipv4,
+//     Ipv6,
+//     Derp,
+// }
 
 #[derive(derive_more::Debug)]
 struct DerpReadResult {
@@ -965,14 +961,14 @@ impl Actor {
                                 match network {
                                     Network::Ipv4 => {
                                         let _ = self.derp_recv_sender.send_async(NetworkReadResult::Ok {
-                                            source: NetworkSource::Ipv4,
+                                            // source: NetworkSource::Ipv4,
                                             bytes,
                                             meta,
                                         }).await;
                                     }
                                     Network::Ipv6 => {
                                         let _ = self.derp_recv_sender.send_async(NetworkReadResult::Ok {
-                                            source: NetworkSource::Ipv6,
+                                            // source: NetworkSource::Ipv6,
                                             bytes,
                                             meta,
                                         }).await;
@@ -1169,7 +1165,7 @@ impl Actor {
         // 	stats.UpdateRxPhysical(ep.nodeAddr, ipp, dm.n)
         // }
         Some(NetworkReadResult::Ok {
-            source: NetworkSource::Derp,
+            // source: NetworkSource::Derp,
             bytes: dm.buf,
             meta,
         })

--- a/src/hp/magicsock/conn.rs
+++ b/src/hp/magicsock/conn.rs
@@ -44,12 +44,6 @@ use super::{
     HEARTBEAT_INTERVAL,
 };
 
-// /// How many packets writes can be queued up the DERP client to write on the wire before we start
-// /// dropping.
-// ///
-// /// TODO: this is currently arbitrary. Figure out something better?
-// const BUFFERED_DERP_WRITES_BEFORE_DROP: usize = 32;
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(super) enum CurrentPortFate {
     Keep,
@@ -615,15 +609,20 @@ impl AsyncUdpSocket for Conn {
                         NetworkReadResult::Error(err) => {
                             return Poll::Ready(Err(err));
                         }
-                        NetworkReadResult::Ok { bytes, meta } => {
+                        NetworkReadResult::Ok {
+                            bytes,
+                            meta,
+                            source,
+                        } => {
                             buf_out[..bytes.len()].copy_from_slice(&bytes);
                             *meta_out = meta;
                             trace!(
-                                "[QUINN] <- {} ({}b) ({}) ({:?})",
+                                "[QUINN] <- {} ({}b) ({}) ({:?}, {:?})",
                                 meta_out.addr,
                                 meta_out.len,
                                 self.name,
-                                meta_out.dst_ip
+                                meta_out.dst_ip,
+                                source
                             );
                         }
                     }
@@ -668,18 +667,18 @@ impl AsyncUdpSocket for Conn {
 enum NetworkReadResult {
     Error(io::Error),
     Ok {
-        // source: NetworkSource,
+        source: NetworkSource,
         meta: quinn_udp::RecvMeta,
         bytes: BytesMut,
     },
 }
 
-// #[derive(Debug)]
-// enum NetworkSource {
-//     Ipv4,
-//     Ipv6,
-//     Derp,
-// }
+#[derive(Debug)]
+enum NetworkSource {
+    Ipv4,
+    Ipv6,
+    Derp,
+}
 
 #[derive(derive_more::Debug)]
 struct DerpReadResult {
@@ -961,14 +960,14 @@ impl Actor {
                                 match network {
                                     Network::Ipv4 => {
                                         let _ = self.derp_recv_sender.send_async(NetworkReadResult::Ok {
-                                            // source: NetworkSource::Ipv4,
+                                            source: NetworkSource::Ipv4,
                                             bytes,
                                             meta,
                                         }).await;
                                     }
                                     Network::Ipv6 => {
                                         let _ = self.derp_recv_sender.send_async(NetworkReadResult::Ok {
-                                            // source: NetworkSource::Ipv6,
+                                            source: NetworkSource::Ipv6,
                                             bytes,
                                             meta,
                                         }).await;
@@ -1165,7 +1164,7 @@ impl Actor {
         // 	stats.UpdateRxPhysical(ep.nodeAddr, ipp, dm.n)
         // }
         Some(NetworkReadResult::Ok {
-            // source: NetworkSource::Derp,
+            source: NetworkSource::Derp,
             bytes: dm.buf,
             meta,
         })

--- a/src/hp/magicsock/endpoint.rs
+++ b/src/hp/magicsock/endpoint.rs
@@ -180,43 +180,44 @@ impl Endpoint {
         false
     }
 
-    // /// Starts a ping for the "ping" command.
-    // /// `res` is value to call cb with, already partially filled.
-    // pub async fn cli_ping<F>(&mut self, mut res: cfg::PingResult, cb: F)
-    // where
-    //     F: Fn(cfg::PingResult) -> BoxFuture<'static, ()> + Send + Sync + 'static,
-    // {
-    //     if self.expired {
-    //         res.err = Some("endpoint expired".to_string());
-    //         cb(res);
-    //         return;
-    //     }
+    /// Starts a ping for the "ping" command.
+    /// `res` is value to call cb with, already partially filled.
+    #[allow(unused)]
+    pub async fn cli_ping<F>(&mut self, mut res: cfg::PingResult, cb: F)
+    where
+        F: Fn(cfg::PingResult) -> BoxFuture<'static, ()> + Send + Sync + 'static,
+    {
+        if self.expired {
+            res.err = Some("endpoint expired".to_string());
+            cb(res);
+            return;
+        }
 
-    //     self.pending_cli_pings.push(PendingCliPing {
-    //         res,
-    //         cb: Box::new(cb),
-    //     });
+        self.pending_cli_pings.push(PendingCliPing {
+            res,
+            cb: Box::new(cb),
+        });
 
-    //     let now = Instant::now();
-    //     let (udp_addr, derp_addr) = self.addr_for_send(&now);
-    //     if let Some(derp_addr) = derp_addr {
-    //         self.start_ping(derp_addr, now, DiscoPingPurpose::Cli).await;
-    //     }
-    //     if let Some(udp_addr) = udp_addr {
-    //         if self.is_best_addr_valid(now) {
-    //             // Already have an active session, so just ping the address we're using.
-    //             // Otherwise "tailscale ping" results to a node on the local network
-    //             // can look like they're bouncing between, say 10.0.0.0/9 and the peer's
-    //             // IPv6 address, both 1ms away, and it's random who replies first.
-    //             self.start_ping(udp_addr, now, DiscoPingPurpose::Cli).await;
-    //         } else {
-    //             let eps: Vec<_> = self.endpoint_state.keys().cloned().collect();
-    //             for ep in eps {
-    //                 self.start_ping(ep, now, DiscoPingPurpose::Cli).await;
-    //             }
-    //         }
-    //     }
-    // }
+        let now = Instant::now();
+        let (udp_addr, derp_addr) = self.addr_for_send(&now);
+        if let Some(derp_addr) = derp_addr {
+            self.start_ping(derp_addr, now, DiscoPingPurpose::Cli).await;
+        }
+        if let Some(udp_addr) = udp_addr {
+            if self.is_best_addr_valid(now) {
+                // Already have an active session, so just ping the address we're using.
+                // Otherwise "tailscale ping" results to a node on the local network
+                // can look like they're bouncing between, say 10.0.0.0/9 and the peer's
+                // IPv6 address, both 1ms away, and it's random who replies first.
+                self.start_ping(udp_addr, now, DiscoPingPurpose::Cli).await;
+            } else {
+                let eps: Vec<_> = self.endpoint_state.keys().cloned().collect();
+                for ep in eps {
+                    self.start_ping(ep, now, DiscoPingPurpose::Cli).await;
+                }
+            }
+        }
+    }
 
     fn ping_timeout(&mut self, txid: stun::TransactionId) {
         if let Some(sp) = self.sent_ping.remove(&txid) {


### PR DESCRIPTION
This makes cargo check warning-free which is much nicer to work with.

I'd be happy to just remove it as well.  Just don't know this code yet really.