### PR TITLE
ref(Conn/PeerMap): Introduce QuicMappedAddress

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -58,6 +58,24 @@ pub struct Options {
 }
 
 /// Create a quinn client endpoint
+///
+/// The *bind_addr* is the address that should be bound locally.  Even though this is an
+/// outgoing connection a socket must be bound and this is explicit.  The main choice to
+/// make here is the address family: IPv4 or IPv6.  Otherwise you normally bind to the
+/// `UNSPECIFIED` address on port `0` thus allowing the kernel to do the right thing.
+///
+/// If *peer_id* is present it will verify during the TLS connection setup that the remote
+/// connected to has the required [`PeerId`], otherwise this will connect to any peer.
+///
+/// The *alpn_protocols* are the list of Application-Layer Protocol Neotiation identifiers
+/// you are happy to accept.
+///
+/// If *keylog* is `true` and the KEYLOGFILE environment variable is present it will be
+/// considered a filename to which the TLS pre-master keys are logged.  This can be useful
+/// to be able to decrypt captured traffic for debugging purposes.
+///
+/// Finally the *derp_map* specifies the DERP servers that can be used to establish this
+/// connection.
 pub async fn make_client_endpoint(
     bind_addr: SocketAddr,
     peer_id: Option<PeerId>,

--- a/src/hp/cfg.rs
+++ b/src/hp/cfg.rs
@@ -148,17 +148,26 @@ pub struct PingResult {
     pub err: Option<String>,
 }
 
+/// A node or peer in the iroh network.
+///
+/// Nodes are primarily identified by their [`Node::key`].
 #[derive(Debug, PartialEq)]
 pub struct Node {
-    // DNS name
-    pub name: Option<String>,
-
+    /// The public key or PeerID, the primary identifier of this node.
     pub key: key::node::PublicKey,
-    /// IP addresses of this Node directly
+    /// DNS name of the peer.
+    pub name: Option<String>,
+    /// Direct IP addresses of this Node.
+    ///
+    /// These are the IP addresses this node is listening on.
     pub addresses: Vec<IpAddr>,
-    // IP+port (public via STUN, and local LANs)
+    /// Endpoints on which we think the node is reachable.
+    ///
+    /// These are populated from STUN results as well as local LAN addresses.
     pub endpoints: Vec<SocketAddr>,
-    /// DERP-in-IP:port ("127.3.3.40:N") endpoint
+    /// DERP-in-IP:port ("127.3.3.40:N") endpoint.
+    ///
+    /// If this nodes expected to be reachable via DERP relaying.
     pub derp: Option<SocketAddr>,
     pub hostinfo: Hostinfo,
     pub created: Instant,

--- a/src/hp/magicsock/conn.rs
+++ b/src/hp/magicsock/conn.rs
@@ -120,7 +120,16 @@ impl Default for Options {
     }
 }
 
-/// Routes UDP packets and actively manages a list of its endpoints.
+/// Iroh connectivity layer.
+///
+/// This is responsible for routing packets to peers based on peer IDs, it will initially
+/// route packets via a derper relay and transparently try and establish a peer-to-peer
+/// connection and upgrade to it.  It will also keep looking for better connections as the
+/// network details of both endpoints change.
+///
+/// It is usually only necessary to use a single [`Conn`] instance in an application, it
+/// means any QUIC endpoints on top will be sharing as much information about peers as
+/// possible.
 #[derive(Clone, Debug)]
 pub struct Conn {
     inner: Arc<Inner>,
@@ -3100,8 +3109,6 @@ impl QuicMappedAddr {
     /// Generates a globally unique fake UDP address.
     ///
     /// This generates and IPv6 Unique Local Address according to RFC 4193.
-    ///
-    /// TODO: Use the subnet to tie an address to a specific `Conn` instance.
     pub(crate) fn generate() -> Self {
         let mut addr = [0u8; 16];
         addr[0] = Self::ADDR_PREFIXL;

--- a/src/hp/magicsock/conn.rs
+++ b/src/hp/magicsock/conn.rs
@@ -149,7 +149,6 @@ impl Deref for Conn {
 pub struct Inner {
     actor_sender: flume::Sender<ActorMessage>,
     /// Sends network messages.
-    // TODO: send transmits *together* with their destination
     network_sender: flume::Sender<Vec<quinn_udp::Transmit>>,
     pub(super) name: String,
     #[debug("on_endpoints: Option<Box<..>>")]

--- a/src/hp/magicsock/endpoint.rs
+++ b/src/hp/magicsock/endpoint.rs
@@ -1,9 +1,8 @@
 use std::{
-    collections::{hash_map, HashMap},
+    collections::HashMap,
     hash::Hash,
     io,
-    net::{IpAddr, Ipv6Addr, SocketAddr},
-    sync::atomic::{AtomicU64, Ordering},
+    net::{IpAddr, SocketAddr},
     time::Duration,
 };
 
@@ -21,7 +20,7 @@ use crate::{
 };
 
 use super::{
-    conn::{ActorMessage, DiscoInfo},
+    conn::{ActorMessage, DiscoInfo, QuicMappedAddr},
     DISCO_PING_INTERVAL, GOOD_ENOUGH_LATENCY, PING_TIMEOUT_DURATION, PONG_HISTORY_COUNT,
     SESSION_ACTIVE_TIMEOUT, TRUST_UDP_ADDR_DURATION, UPGRADE_INTERVAL,
 };
@@ -32,8 +31,8 @@ use super::{
 pub(super) struct Endpoint {
     pub(super) id: usize,
     conn_sender: flume::Sender<ActorMessage>,
-    /// The UDP address we tell wireguard-go we're using
-    pub(super) fake_wg_addr: SocketAddr,
+    /// The UDP address used on the QUIC-layer to address this peer.
+    pub(super) quic_mapped_addr: QuicMappedAddr,
     /// Public key for this node/conection.
     conn_public_key: key::node::PublicKey,
     /// Peer public key (for WireGuard + DERP)
@@ -77,12 +76,12 @@ pub(super) struct Options {
 
 impl Endpoint {
     pub fn new(id: usize, options: Options) -> Self {
-        let fake_wg_addr = init_fake_udp_addr();
+        let quic_mapped_addr = QuicMappedAddr::generate();
 
         Endpoint {
             id,
             conn_sender: options.conn_sender,
-            fake_wg_addr,
+            quic_mapped_addr,
             conn_public_key: options.conn_public_key,
             public_key: options.public_key,
             last_full_ping: None,
@@ -759,11 +758,29 @@ pub struct AddrLatency {
     pub latency: Duration,
 }
 
-/// An index of peerInfos by node (WireGuard) key, disco key, and discovered ip:port endpoints.
+/// Map of the [`Endpoint`] information for all the known peers.
+///
+/// The peers can be looked up by:
+///
+/// - The peer's ID in this map, only useful if you know the ID from an insert or lookup.
+///   This is static and never changes.
+///
+/// - The [`QuicMappedAddr`] which internally identifies the peer to the QUIC stack.  This
+///   is static and never changes.
+///
+/// - The peers's public key, aka `PeerId` or "node_key".  This is static and never changes,
+///   however a peer could be added when this is not yet known.  To set this after creation
+///   use [`PeerMap::store_node_key_mapping`].
+///
+/// - A public socket address on which they are reachable on the internet, known as ip-port.
+///   These come and go as the peer moves around on the internet
+///
+/// An index of peerInfos by node key, QuicMappedAddr, and discovered ip:port endpoints.
 #[derive(Default, Debug)]
 pub(super) struct PeerMap {
     by_node_key: HashMap<key::node::PublicKey, usize>,
     by_ip_port: HashMap<SocketAddr, usize>,
+    by_quic_mapped_addr: HashMap<QuicMappedAddr, usize>,
     by_id: HashMap<usize, Endpoint>,
     next_id: usize,
 }
@@ -807,6 +824,15 @@ impl PeerMap {
             .and_then(|id| self.by_id.get_mut(id))
     }
 
+    pub fn endpoint_for_quic_mapped_addr_mut(
+        &mut self,
+        addr: &QuicMappedAddr,
+    ) -> Option<&mut Endpoint> {
+        self.by_quic_mapped_addr
+            .get(addr)
+            .and_then(|id| self.by_id.get_mut(id))
+    }
+
     pub(super) fn endpoints(&self) -> impl Iterator<Item = (&usize, &Endpoint)> {
         self.by_id.iter()
     }
@@ -815,34 +841,26 @@ impl PeerMap {
         self.by_id.iter_mut()
     }
 
-    pub(super) fn store_node_key_mapping(&mut self, id: usize, public_key: key::node::PublicKey) {
-        if let hash_map::Entry::Vacant(e) = self.by_node_key.entry(public_key) {
-            e.insert(id);
-            // allow lookups by the fake addr
-            let fake_wg_addr = self.by_id(&id).unwrap().fake_wg_addr;
-            self.by_ip_port.insert(fake_wg_addr, id);
-        }
+    /// Sets the node key for a peer if it wasn't known yet.
+    ///
+    /// Since a peer can initially be created before the node key is known, this allows
+    /// setting the node key once it is known.
+    pub(super) fn store_node_key_mapping(&mut self, id: usize, node_key: key::node::PublicKey) {
+        self.by_node_key.entry(node_key).or_insert(id);
     }
 
-    /// Stores endpoint, with a public key.
-    pub(super) fn upsert_endpoint(&mut self, options: Options) -> Option<usize> {
-        if let Some(public_key) = options.public_key.clone() {
-            if !self.by_node_key.contains_key(&public_key) {
-                let id = self.insert_endpoint(options);
-                self.by_node_key.insert(public_key, id);
-                // allow lookups by the fake addr
-                let fake_wg_addr = self.by_id(&id).unwrap().fake_wg_addr;
-                self.by_ip_port.insert(fake_wg_addr, id);
-                return Some(id);
-            }
-        }
-        None
-    }
-
+    /// Inserts a new endpoint into the [`PeerMap`].
     pub(super) fn insert_endpoint(&mut self, options: Options) -> usize {
         let id = self.next_id;
-        let ep = Endpoint::new(id, options);
         self.next_id = self.next_id.wrapping_add(1);
+        let ep = Endpoint::new(id, options);
+
+        // update indices
+        self.by_quic_mapped_addr.insert(ep.quic_mapped_addr, id);
+        if let Some(public_key) = ep.public_key.clone() {
+            self.by_node_key.insert(public_key, id);
+        }
+
         self.by_id.insert(id, ep);
         id
     }
@@ -978,20 +996,6 @@ pub enum DiscoPingPurpose {
     Cli,
     /// Ping to ensure the current route is still valid.
     StayinAlive,
-}
-
-static ADDR_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Generates a globally unique fake UDPAddr.
-pub(super) fn init_fake_udp_addr() -> SocketAddr {
-    let mut addr = [0u8; 16];
-    addr[0] = 0xfd;
-    addr[1] = 0x00;
-
-    let counter = ADDR_COUNTER.fetch_add(1, Ordering::Relaxed);
-    addr[2..10].copy_from_slice(&counter.to_le_bytes());
-
-    SocketAddr::new(IpAddr::V6(Ipv6Addr::from(addr)), 12345)
 }
 
 impl AddrLatency {

--- a/src/hp/netmap.rs
+++ b/src/hp/netmap.rs
@@ -2,6 +2,9 @@
 
 use super::cfg;
 
+/// The local view of the iroh network.
+///
+/// This contains all the peers the local node knows about.
 #[derive(Debug)]
 pub struct NetworkMap {
     pub peers: Vec<cfg::Node>,


### PR DESCRIPTION
This does a little tidying up of the address we tell the QUIC layer to
use to dial a peer:

- It introduces a newtype for it, making it very clear what you are
  working with and avoiding accidentally using it in the wrong place.

- It adds this to the PeerMap, documenting the peer map a bit better.

- It also change the generation of this address a bit: make it an RFC
  compliant Unique Local Address assigning out own Global Id.  This
  should allow more universally detecting if the address leaks.