### PR TITLE
X hp disco fix

### DIFF
--- a/src/hp/derp/client.rs
+++ b/src/hp/derp/client.rs
@@ -621,11 +621,13 @@ pub(crate) async fn send_packets<W: AsyncWrite + Unpin>(
             len
         );
     }
-    tracing::trace!("send derp packets {} {}", transmits.len(), total_len);
-    const PAYLAOD_SIZE: usize = MAX_PACKET_SIZE - PUBLIC_KEY_LENGTH;
-    for packet in PacketizeIter::<_, PAYLAOD_SIZE>::new(transmits) {
-        // rate limit for each packet, but exit early if the rate limit is exceeded.
-        // it is unlikely to recover that quickly.
+    // disco packets must be sent as-is
+    if transmits.len() == 1
+        && transmits[0]
+            .as_ref()
+            .starts_with(crate::hp::disco::MAGIC.as_bytes())
+    {
+        let packet = transmits[0].as_ref();
         if let Some(rate_limiter) = rate_limiter {
             let frame_len = PUBLIC_KEY_LENGTH + packet.len();
             if rate_limiter.check_n(frame_len).is_err() {
@@ -639,6 +641,26 @@ pub(crate) async fn send_packets<W: AsyncWrite + Unpin>(
             &[dstkey.as_bytes(), packet.as_ref()],
         )
         .await?;
+    } else {
+        tracing::trace!("send derp packets {} {}", transmits.len(), total_len);
+        const PAYLAOD_SIZE: usize = MAX_PACKET_SIZE - PUBLIC_KEY_LENGTH;
+        for packet in PacketizeIter::<_, PAYLAOD_SIZE>::new(transmits) {
+            // rate limit for each packet, but exit early if the rate limit is exceeded.
+            // it is unlikely to recover that quickly.
+            if let Some(rate_limiter) = rate_limiter {
+                let frame_len = PUBLIC_KEY_LENGTH + packet.len();
+                if rate_limiter.check_n(frame_len).is_err() {
+                    tracing::warn!("dropping send: rate limit reached");
+                    return Ok(());
+                }
+            }
+            write_frame(
+                &mut writer,
+                FrameType::SendPacket,
+                &[dstkey.as_bytes(), packet.as_ref()],
+            )
+            .await?;
+        }
     }
     writer.flush().await?;
     Ok(())
@@ -783,6 +805,16 @@ impl PacketSplitIter {
     /// Returns an error if the packet is too big.
     pub fn new(bytes: Bytes) -> Self {
         Self { bytes }
+    }
+
+    #[cfg(test)]
+    pub fn split(packet: Bytes) -> std::io::Result<Vec<Bytes>> {
+        let mut iter = Self::new(packet);
+        let mut result = Vec::new();
+        while let Some(item) = iter.next() {
+            result.push(item?);
+        }
+        Ok(result)
     }
 
     fn fail(&mut self) -> Option<std::io::Result<Bytes>> {

--- a/src/hp/derp/client_conn.rs
+++ b/src/hp/derp/client_conn.rs
@@ -734,6 +734,8 @@ fn parse_send_packet(data: &[u8]) -> Result<(PublicKey, &[u8])> {
 
 #[cfg(test)]
 mod tests {
+    use crate::hp::derp::client::PacketSplitIter;
+
     use super::*;
     use anyhow::bail;
     use std::sync::Arc;
@@ -810,9 +812,10 @@ mod tests {
         let msg = server_channel_r.recv().await.unwrap();
         match msg {
             ServerMessage::SendPacket((got_target, packet)) => {
+                let payload = PacketSplitIter::split(packet.bytes)?;
                 assert_eq!(target, got_target);
                 assert_eq!(key, packet.src);
-                assert_eq!(&data[..], &packet.bytes);
+                assert_eq!(&data[..], &payload[0]);
             }
             m => {
                 bail!("expected ServerMessage::SendPacket, got {m:?}");


### PR DESCRIPTION
We now add a length prefix to all packets. We also added this length prefix
to disco packets, meaning that they were no longer disco packets.

In principle I think this is a good thing - you can now transmit any byte
string, including the disco magic string, as a normal packet without it
being accidentally recognized as a disco packet.

But a proper fix for this would involve looking through the code base for
places where the magic byte is used and replacing these with a dedicated
path for disco messages. I tried it, but wasn't sure I got them all.