### PR TITLE
fix(netcheck): Do not read from main Conn sockets

### DIFF
--- a/src/net/ip.rs
+++ b/src/net/ip.rs
@@ -131,7 +131,10 @@ fn is_link_local(ip: IpAddr) -> bool {
     }
 }
 
-/// Converts this address to an IpAddr::V4 if it is an IPv4-mapped IPv6 addresses, otherwise it return self as-is.
+/// Converts IPv4-mappend IPv6 addresses to IPv4.
+///
+/// Converts this address to an [`IpAddr::V4`] if it is an IPv4-mapped IPv6 addresses,
+/// otherwise it return self as-is.
 // TODO: replace with IpAddr::to_canoncial once stabilized.
 pub fn to_canonical(ip: IpAddr) -> IpAddr {
     match ip {


### PR DESCRIPTION
The get_report function is passed the primary Conn sockets so they can
be used to send STUN messages from.  However these sockets should not
be read from directly, Conn already passes through the STUN payloads.
Reading from them directly will lose packets in Conn.

When the sockets are not passed in however we should create them
ourselves, and read from them.  The payloads are now received by the
actor in the same way as otherwise, removing a lot of Option<>s.