### PR TITLE
add timeout for captive portal test

### DIFF
--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -62,7 +62,7 @@ const ENOUGH_REGIONS: usize = 3;
 // Chosen semi-arbitrarily
 const CAPTIVE_PORTAL_DELAY: Duration = Duration::from_millis(200);
 
-// Timeout for captive portal checks, must be lower than OVERALL_PROBE_TIMEOUT
+/// Timeout for captive portal checks, must be lower than OVERALL_PROBE_TIMEOUT
 const CAPTIVE_PORTAL_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Default, Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
...and set stun_only = true for stun.l.google.com since it isn't a derp server

This does not yet fix the test_google_stun test, but at least it fails due to an assertion and not due to a timeout.

The question is how you can figure out from the test result that the stun worked. This is it:

```
Report {
    udp: false,
    ipv6: false,
    ipv4: false,
    ipv6_can_send: false,
    ipv4_can_send: false,
    os_has_ipv6: true,
    icmpv4: false,
    mapping_varies_by_dest_ip: None,
    hair_pinning: None,
    upnp: None,
    pmp: None,
    pcp: None,
    preferred_derp: 0,
    region_latency: {},
    region_v4_latency: {},
    region_v6_latency: {},
    global_v4: None,
    global_v6: None,
    captive_portal: None,
}
```