### PR TITLE
ref(netcheck): make netcheck a long-running actor

### DIFF
--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -19,7 +19,7 @@ use futures::{
 use rand::seq::IteratorRandom;
 use tokio::{
     net::UdpSocket,
-    sync::{self, broadcast, mpsc, RwLock},
+    sync::{self, broadcast, mpsc, oneshot, RwLock},
     task::JoinSet,
     time::{self, Duration, Instant},
 };
@@ -127,17 +127,38 @@ impl fmt::Display for Report {
     }
 }
 
-/// Generates a netcheck [`Report`].
-/// Client to generate netcheck [`Report`]s.
+/// Client to run netchecks.
 ///
-/// This has an actor inside, but it only runs when [`Client::get_report`] is being called.
-/// While running it expects to be passed received stun packets using
-/// [`Client::get_stun_packet_channel`], the [`crate::hp::magicsock::Conn`] using this client needs to be wired up to
-/// do so.
-#[derive(Debug)]
+/// Creating this creates a netcheck actor which runs in the background.  Most of the time
+/// it is idle unless [`Client::get_report`] is called, which is the main interface.
+///
+/// The [`Client`] struct can be cloned and results multiple handles to the running actor.
+/// If all [`Client`]s are dropped the actor stops running.
+///
+/// While running the netcheck actor expects to be passed all received stun packets using
+/// [`Client::get_stun_packet_channel`], the [`crate::hp::magicsock::Conn`] using this
+/// client needs to be wired up to do so.
+#[derive(Debug, Clone)]
 pub struct Client {
-    msg_sender: mpsc::Sender<ActorMessage>,
-    actor: Actor,
+    /// Channel to send message to the [`Actor`].
+    ///
+    /// If all senders are dropped, in other words all clones of this struct are dropped,
+    /// the actor will terminate.
+    addr: ActorAddr,
+    /// Ensures the actor is terminated when the client is dropped.
+    _drop_guard: Arc<ClientDropGuard>,
+}
+
+#[derive(Debug)]
+struct ClientDropGuard {
+    addr: ActorAddr,
+}
+
+impl Drop for ClientDropGuard {
+    fn drop(&mut self) {
+        // If we can't send the actor is already not running so that's fine.
+        self.addr.blocking_send(ActorMessage::Exit).ok();
+    }
 }
 
 #[derive(Debug)]
@@ -159,12 +180,14 @@ impl Client {
         let last_full = Instant::now();
         let (got_hair_stun, _) = broadcast::channel(1);
 
+        // TODO: consider an instrumented flume channel so we have metrics.
         let (msg_sender, msg_receiver) = mpsc::channel(32);
 
         let dns_resolver = TokioAsyncResolver::tokio_from_system_conf()?;
 
-        let actor = Actor {
+        let mut actor = Actor {
             receiver: msg_receiver,
+            sender: msg_sender,
             reports: Reports {
                 next_full: false,
                 prev: Default::default(),
@@ -176,17 +199,26 @@ impl Client {
             port_mapper,
             got_hair_stun,
             dns_resolver,
+            in_flight_stun_requests: Default::default(),
+            check_run: None,
         };
+        let addr = actor.addr();
+        tokio::spawn(async move { actor.main().await });
 
-        Ok(Client { msg_sender, actor })
+        Ok(Client {
+            addr: addr.clone(),
+            _drop_guard: ClientDropGuard { addr }.into(),
+        })
     }
 
-    /// Returns the sender which can send messages to the actor.
-    ///
-    /// Used by [`crate::hp::magicsock::Conn`] to pass received stun packets to the running
-    /// netcheck actor.
-    pub(crate) fn get_msg_sender(&self) -> mpsc::Sender<ActorMessage> {
-        self.msg_sender.clone()
+    pub(crate) async fn receive_stun_packet(&self, payload: Bytes, src: SocketAddr) -> Result<()> {
+        self.addr
+            .send(ActorMessage::StunPacket {
+                payload,
+                from_addr: src,
+            })
+            .await
+            .map_err(|_| anyhow!("actor no longer running"))
     }
 
     /// Runs a netcheck, returning the report.
@@ -208,102 +240,21 @@ impl Client {
         stun_conn4: Option<Arc<UdpSocket>>,
         stun_conn6: Option<Arc<UdpSocket>>,
     ) -> Result<Arc<Report>> {
-        // If not given  UdpSockets to send stun packets, create them.
-        // TODO: Is failure really fatal?
-        let cancel_token = CancellationToken::new();
-        let stun_conn4 = match stun_conn4 {
-            Some(stun_conn4) => stun_conn4,
-            None => {
-                let addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0));
-                let sock = UdpSocket::bind(addr)
-                    .await
-                    .context("netcheck: failed to bind udp 0.0.0.0:0")?;
-                let sock = Arc::new(sock);
-                Self::spawn_udp_listener(
-                    sock.clone(),
-                    self.msg_sender.clone(),
-                    cancel_token.clone(),
-                );
-                sock
-            }
-        };
-        let stun_conn6 = match stun_conn6 {
-            Some(stun_conn6) => stun_conn6,
-            None => {
-                let addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0));
-                let sock = UdpSocket::bind(addr)
-                    .await
-                    .context("netcheck: failed to bind udp6 [::]:0")?;
-                let sock = Arc::new(sock);
-                Self::spawn_udp_listener(
-                    sock.clone(),
-                    self.msg_sender.clone(),
-                    cancel_token.clone(),
-                );
-                sock
-            }
-        };
-        let _cancel_on_drop = cancel_token.drop_guard();
-
         // TODO: consider if DerpMap should be made to easily clone?  It seems expensive
         // right now.
-        self.actor.run(dm.clone(), stun_conn4, stun_conn6).await
-    }
-
-    /// Spawns a tokio task reading stun packets from the UDP socket.
-    ///
-    /// This is a sync function and does not wait until the task is running.  However this
-    /// is fine since the socket is already bound so packets will not be lost.
-    fn spawn_udp_listener(
-        sock: Arc<UdpSocket>,
-        sender: mpsc::Sender<ActorMessage>,
-        cancel_token: CancellationToken,
-    ) {
-        let span = debug_span!(
-            "stun.listener.udp",
-            local_addr = sock
-                .local_addr()
-                .map(|a| a.to_string())
-                .unwrap_or(String::from("-")),
-        );
-        tokio::spawn(
-            async move {
-                debug!("udp stun socket listener started");
-                // TODO: Can we do better for buffers here?  Probably doesn't matter
-                // much.
-                let mut buf = vec![0u8; 64 << 10];
-                loop {
-                    tokio::select! {
-                        biased;
-                        _ = cancel_token.cancelled() => break,
-                        res = Self::recv_stun_once(&sock, &mut buf, &sender) => {
-                            if let Err(err) = res {
-                                warn!(%err, "stun recv failed");
-                                break;
-                            }
-                        }
-                    }
-                }
-                debug!("udp stun socket listener stopped");
-            }
-            .instrument(span),
-        );
-    }
-
-    /// Receive STUN response from a UDP socket, pass it to the actor.
-    async fn recv_stun_once(
-        sock: &UdpSocket,
-        buf: &mut [u8],
-        sender: &mpsc::Sender<ActorMessage>,
-    ) -> Result<()> {
-        let (count, mut from_addr) = sock
-            .recv_from(buf)
-            .await
-            .context("Error reading from stun socket")?;
-        let payload = &buf[..count];
-        from_addr.set_ip(to_canonical(from_addr.ip()));
-        let msg = ActorMessage::StunPacket(Bytes::from(payload.to_vec()), from_addr);
-        sender.send(msg).await.context("actor stopped")
+        let (tx, rx) = oneshot::channel();
+        self.addr
+            .send(ActorMessage::RunCheck {
+                derp_map: dm.clone(),
+                stun_sock_v4: stun_conn4,
+                stun_sock_v6: stun_conn6,
+                response_tx: tx,
+            })
+            .await?;
+        match rx.await {
+            Ok(res) => res,
+            Err(_) => Err(anyhow!("channel closed, actor awol")),
+        }
     }
 }
 
@@ -546,8 +497,9 @@ struct ReportState {
     last: Option<Arc<Report>>,
 }
 
+// TODO: Can we not make this pub?
 #[derive(Debug)]
-struct Inflight {
+pub(crate) struct Inflight {
     tx: stun::TransactionId,
     start: Instant,
     s: sync::oneshot::Sender<(Duration, SocketAddr)>,
@@ -557,7 +509,7 @@ impl ReportState {
     #[instrument(name = "report_state", skip_all)]
     async fn run(
         mut self,
-        in_flight: sync::mpsc::Sender<Inflight>,
+        actor_addr: ActorAddr,
         dm: DerpMap,
         port_mapper: Option<portmapper::Client>,
         skip_external_network: bool,
@@ -632,14 +584,14 @@ impl ReportState {
                 let node = named_node(&dm, probe.node());
                 ensure!(node.is_some(), "missing named node {}", probe.node());
                 let node = node.unwrap().clone();
-                let in_flight = in_flight.clone();
+                let actor_addr = actor_addr.clone();
                 let pc4 = self.pc4.clone();
                 let pc6 = self.pc6.clone();
                 let report = self.report.clone();
                 let pinger = pinger.clone();
 
                 set.push(Box::pin(async move {
-                    run_probe(report, resolver, pc4, pc6, node, probe, in_flight, pinger).await
+                    run_probe(report, resolver, pc4, pc6, node, probe, actor_addr, pinger).await
                 }));
             }
 
@@ -921,7 +873,7 @@ async fn run_probe(
     pc6: Arc<UdpSocket>,
     node: DerpNode,
     probe: Probe,
-    in_flight: sync::mpsc::Sender<Inflight>,
+    actor_addr: ActorAddr,
     pinger: Option<Pinger>,
 ) -> Result<ProbeReport, ProbeError> {
     if !probe.delay().is_zero() {
@@ -943,12 +895,12 @@ async fn run_probe(
     let sent = Instant::now(); // after DNS lookup above
 
     let (s, r) = sync::oneshot::channel();
-    in_flight
-        .send(Inflight {
+    actor_addr
+        .send(ActorMessage::InFlightStun(Inflight {
             tx: txid,
             start: sent,
             s,
-        })
+        }))
         .await
         .map_err(|e| ProbeError::Transient(e.into(), probe.clone()))?;
     let mut result = ProbeReport::new(probe.clone());
@@ -1106,85 +1058,261 @@ impl ProbeReport {
     }
 }
 
+/// Messages to send to the [`Actor`].
 #[derive(Debug)]
 pub(crate) enum ActorMessage {
-    StunPacket(Bytes, SocketAddr),
+    /// Run a netcheck.
+    ///
+    /// Only one netcheck can be run at a time, trying to run multiple concurrently will
+    /// fail.
+    RunCheck {
+        /// The derp configuration.
+        derp_map: DerpMap,
+        /// Socket to send IPv4 STUN probes from.
+        ///
+        /// Responses are never read from this socket, they must be passed in via the
+        /// [`ActorMessage::StunPacket`] message since the socket is also used to receive
+        /// other packets from in the magicsocket (`Conn`).
+        ///
+        /// If not provided this will attempt to bind a suitable socket itself.
+        stun_sock_v4: Option<Arc<UdpSocket>>,
+        /// Socket to send IPv6 STUN probes from.
+        ///
+        /// Like `stun_sock_v4` but for IPv6.
+        stun_sock_v6: Option<Arc<UdpSocket>>,
+        /// Channel to receive the response.
+        response_tx: oneshot::Sender<Result<Arc<Report>>>,
+    },
+    /// A report produced by [`ReportState`].
+    ReportReady { report: Report, derp_map: DerpMap },
+    /// [`ReportState`] failed to produce a report.
+    ReportAborted,
+    /// An incoming STUN packet to parse.
+    StunPacket {
+        /// The raw UDP payload.
+        payload: Bytes,
+        /// The address this was claimed to be received from.
+        from_addr: SocketAddr,
+    },
+    /// A probe wants to register an in-flight STUN request.
+    InFlightStun(Inflight),
+    /// Terminate the actor.
+    Exit,
+}
+
+/// Sender to the [`Actor`].
+///
+/// Unlike [`Client`] this is the raw channel to send messages over.  Keeping this alive
+/// will not keep the actor alive, which makes this handy to pass to internal tasks.
+#[derive(Debug, Clone)]
+struct ActorAddr {
+    sender: mpsc::Sender<ActorMessage>,
+}
+
+impl ActorAddr {
+    async fn send(&self, msg: ActorMessage) -> Result<(), mpsc::error::SendError<ActorMessage>> {
+        self.sender.send(msg).await
+    }
+
+    fn blocking_send(&self, msg: ActorMessage) -> Result<(), mpsc::error::SendError<ActorMessage>> {
+        self.sender.blocking_send(msg)
+    }
 }
 
 #[derive(Debug)]
 struct Actor {
     /// Actor messages channel.
+    ///
+    /// If there are no more senders the actor stops.
     receiver: mpsc::Receiver<ActorMessage>,
+    /// The sender side of the messages channel.
+    ///
+    /// This allows creating new [`ActorAddr`]s from the actor.
+    sender: mpsc::Sender<ActorMessage>,
+    // /// Channel to signal the actor should terminate.
+    // ///
+    // /// Either sending a message or dropping the sender will terminate the actor.
+    // exit_rx: oneshot::Receiver<()>,
+    /// A collection of previously generated reports.
+    ///
+    /// Sometimes it is useful to look at past reports to decide what to do.
     reports: Reports,
     /// Whether the client should try to reach things other than localhost.
     ///
     /// This is set to true in tests to avoid probing the local LAN's router, etc.
     skip_external_network: bool,
-    /// Whether to run port mapping queries.
+    /// The port mapper client, if those are requested.
+    ///
+    /// The port mapper is responsible for talking to routers via UPnP and the like to try
+    /// and open ports.
     port_mapper: Option<portmapper::Client>,
     got_hair_stun: broadcast::Sender<SocketAddr>,
     dns_resolver: TokioAsyncResolver,
+    /// Information about the currently in-flight STUN requests.
+    ///
+    /// This is used to complete the STUN probe when receiving STUN packets.
+    in_flight_stun_requests: HashMap<stun::TransactionId, Inflight>,
+    /// The response channel if there is a check running.
+    ///
+    /// There can only ever be one check running at a time.  If it is running the response
+    /// channel is stored here.
+    check_run: Option<oneshot::Sender<Result<Arc<Report>>>>,
 }
 
 impl Actor {
-    /// Performs a single netcheck run.
-    ///
-    /// See [`Client::get_report`] for the arguments.
-    #[instrument(name = "get_report", skip_all)]
-    async fn run(
-        &mut self,
-        dm: DerpMap,
-        stun_sock_v4: Arc<UdpSocket>,
-        stun_sock_v6: Arc<UdpSocket>,
-    ) -> Result<Arc<Report>> {
-        let report_state = self
-            .create_report_state(&dm, stun_sock_v4.clone(), stun_sock_v6.clone())
-            .await
-            .context("failed to create ReportState")?;
-        let (in_flight_s, mut in_flight_r) = sync::mpsc::channel(8);
-        let mut running = {
-            let port_mapper = self.port_mapper.clone();
-            let skip_external = self.skip_external_network;
-            let resolver = self.dns_resolver.clone(); // not a cheap clone
-            Box::pin(time::timeout(OVERALL_PROBE_TIMEOUT, async move {
-                report_state
-                    .run(in_flight_s, dm, port_mapper, skip_external, &resolver)
-                    .await
-            }))
-        };
-        let mut in_flight = HashMap::new();
+    /// Returns the channel to send messages to the actor.
+    fn addr(&self) -> ActorAddr {
+        ActorAddr {
+            sender: self.sender.clone(),
+        }
+    }
 
-        loop {
-            tokio::select! {
-                Some(inf) = in_flight_r.recv() => {
-                    in_flight.insert(inf.tx, inf);
+    /// Run the actor.
+    ///
+    /// It will now run and handle messages.  Once the connected [`Client`] (including all
+    /// its clones) is dropped this will terminate.
+    async fn main(&mut self) {
+        debug!("netcheck actor starting");
+        while let Some(msg) = self.receiver.recv().await {
+            match msg {
+                ActorMessage::RunCheck {
+                    derp_map,
+                    stun_sock_v4,
+                    stun_sock_v6,
+                    response_tx,
+                } => {
+                    self.handle_run_check(derp_map, stun_sock_v4, stun_sock_v6, response_tx)
+                        .await;
                 }
-                msg = self.receiver.recv() => {
-                    debug!("incoming stun packet: {:?}", msg);
-                    match msg {
-                        None => bail!("client dropped, abort"),
-                        Some(ActorMessage::StunPacket(pkt, source)) =>
-                            self.receive_stun_packet(&mut in_flight, &pkt, source),
-                    }
+                ActorMessage::ReportReady { report, derp_map } => {
+                    self.handle_report_ready(report, derp_map);
+                    self.in_flight_stun_requests.clear();
                 }
-                res = &mut running => {
-                    match res {
-                        Ok(Ok((report, dm))) => {
-                            let report = self.finish_and_store_report(report, &dm);
-                            return Ok(report)
-                        }
-                        Err(err) => {
-                            warn!("generate report timed out: {:?}", err);
-                            return Err(err.into());
-                        }
-                        Ok(Err(err)) => {
-                            warn!("failed to generate report: {:?}", err);
-                            return Err(err);
-                        }
-                    }
+                ActorMessage::ReportAborted => {
+                    self.in_flight_stun_requests.clear();
+                    self.check_run.take();
                 }
+                ActorMessage::StunPacket { payload, from_addr } => {
+                    // TODO: drop package if no check is running
+                    self.handle_stun_packet(&payload, from_addr);
+                }
+                ActorMessage::InFlightStun(inflight) => {
+                    self.handle_in_flight_stun(inflight);
+                }
+                ActorMessage::Exit => break,
             }
         }
+        debug!("netcheck actor finished");
+    }
+
+    /// Handles the [`ActorMessage::ReportReady`] message.
+    ///
+    /// Finishes the report, sends it to the response channel.
+    fn handle_report_ready(&mut self, report: Report, derp_map: DerpMap) {
+        let report = self.finish_and_store_report(report, &derp_map);
+        if let Some(response_tx) = self.check_run.take() {
+            // If no one want the report anymore just drop it.
+            response_tx.send(Ok(report)).ok();
+        }
+    }
+
+    /// Starts a check run as requested by the [`ActorMessage::RunCheck`] message.
+    async fn handle_run_check(
+        &mut self,
+        derp_map: DerpMap,
+        stun_sock_v4: Option<Arc<UdpSocket>>,
+        stun_sock_v6: Option<Arc<UdpSocket>>,
+        response_tx: oneshot::Sender<Result<Arc<Report>>>,
+    ) {
+        if self.check_run.is_some() {
+            response_tx.send(Err(anyhow!("A check is already running")));
+            return;
+        }
+        match self
+            .start_report_run(derp_map, stun_sock_v4, stun_sock_v6)
+            .await
+        {
+            Ok(()) => {
+                self.check_run.insert(response_tx);
+            }
+            Err(err) => {
+                response_tx.send(Err(err));
+            }
+        }
+    }
+
+    /// Spawns a task running a [`ReportState`] run.
+    ///
+    /// When the run is completed the task sends the result back to this actor.
+    async fn start_report_run(
+        &mut self,
+        derp_map: DerpMap,
+        stun_sock_v4: Option<Arc<UdpSocket>>,
+        stun_sock_v6: Option<Arc<UdpSocket>>,
+    ) -> Result<()> {
+        // TODO: These spawns should not be fatal on failure, see issue #1025
+        let cancel_token = CancellationToken::new();
+        let stun_sock_v4 = match stun_sock_v4 {
+            Some(stun_sock_v4) => stun_sock_v4,
+            None => {
+                let addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0));
+                let sock = UdpSocket::bind(addr)
+                    .await
+                    .context("netcheck: failed to bind udp 0.0.0.0:0")?;
+                let sock = Arc::new(sock);
+                spawn_udp_listener(sock.clone(), self.addr(), cancel_token.clone());
+                sock
+            }
+        };
+        let stun_sock_v6 = match stun_sock_v6 {
+            Some(stun_sock_v6) => stun_sock_v6,
+            None => {
+                let addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0));
+                let sock = UdpSocket::bind(addr)
+                    .await
+                    .context("netcheck: failed to bind udp6 [::]:0")?;
+                let sock = Arc::new(sock);
+                spawn_udp_listener(sock.clone(), self.addr(), cancel_token.clone());
+                sock
+            }
+        };
+
+        let report_state = self
+            .create_report_state(&derp_map, stun_sock_v4, stun_sock_v6)
+            .await
+            .context("failed to create ReportState")?;
+        let port_mapper = self.port_mapper.clone();
+        let skip_external = self.skip_external_network;
+        let resolver = self.dns_resolver.clone(); // not a cheap clone, maybe Arc it
+        let addr = self.addr();
+        tokio::spawn(async move {
+            match time::timeout(
+                OVERALL_PROBE_TIMEOUT,
+                report_state.run(
+                    addr.clone(),
+                    derp_map,
+                    port_mapper,
+                    skip_external,
+                    &resolver,
+                ),
+            )
+            .await
+            {
+                Ok(Ok((report, derp_map))) => {
+                    addr.send(ActorMessage::ReportReady { report, derp_map })
+                        .await;
+                }
+                Err(err) => {
+                    warn!("generate report timed out: {:?}", err);
+                    addr.send(ActorMessage::ReportAborted).await;
+                }
+                Ok(Err(err)) => {
+                    warn!("failed to generate report: {:?}", err);
+                    addr.send(ActorMessage::ReportAborted).await;
+                }
+            }
+        });
+        Ok(())
     }
 
     async fn create_report_state(
@@ -1228,7 +1356,7 @@ impl Actor {
         }
 
         let last = self.reports.last.clone();
-        let plan = ProbePlan::new(dm, &if_state, last.as_deref()).await;
+        let plan = ProbePlan::new(dm, &if_state, last.as_deref());
 
         Ok(ReportState {
             incremental: last.is_some(),
@@ -1249,12 +1377,15 @@ impl Actor {
         })
     }
 
-    fn receive_stun_packet(
-        &self,
-        in_flight: &mut HashMap<stun::TransactionId, Inflight>,
-        pkt: &[u8],
-        src: SocketAddr,
-    ) {
+    /// Handles [`ActorMesage::StunPacket`].
+    ///
+    /// If there are currently no in-flight stun requests registerd this is dropped,
+    /// otherwise forwarded to the probe.
+    fn handle_stun_packet(&mut self, pkt: &[u8], src: SocketAddr) {
+        if self.in_flight_stun_requests.is_empty() {
+            return;
+        }
+
         trace!(%src, "received STUN packet");
 
         // if src.is_ipv4() {
@@ -1271,7 +1402,7 @@ impl Actor {
 
         match stun::parse_response(pkt) {
             Ok((tx, addr_port)) => {
-                if let Some(inf) = in_flight.remove(&tx) {
+                if let Some(inf) = self.in_flight_stun_requests.remove(&tx) {
                     let elapsed = inf.start.elapsed();
                     let _ = inf.s.send((elapsed, addr_port));
                 }
@@ -1288,6 +1419,14 @@ impl Actor {
                 );
             }
         }
+    }
+
+    /// Handles [`ActorMessage::InFlightStun`].
+    ///
+    /// The in-flight request is added to [`Actor::in_flight_stun_requests`] so that
+    /// [`Actor::handle_stun_packet`] can forward packets correctly.
+    fn handle_in_flight_stun(&mut self, inflight: Inflight) {
+        self.in_flight_stun_requests.insert(inflight.tx, inflight);
     }
 
     fn finish_and_store_report(&mut self, report: Report, dm: &DerpMap) -> Arc<Report> {
@@ -1443,6 +1582,61 @@ impl Actor {
     }
 }
 
+/// Spawns a tokio task reading stun packets from the UDP socket.
+///
+/// This is a sync function and does not wait until the task is running.  However this
+/// is fine since the socket is already bound so packets will not be lost.
+fn spawn_udp_listener(
+    sock: Arc<UdpSocket>,
+    actor_addr: ActorAddr,
+    cancel_token: CancellationToken,
+) {
+    let span = debug_span!(
+        "stun.listener.udp",
+        local_addr = sock
+            .local_addr()
+            .map(|a| a.to_string())
+            .unwrap_or(String::from("-")),
+    );
+    tokio::spawn(
+        async move {
+            debug!("udp stun socket listener started");
+            // TODO: Can we do better for buffers here?  Probably doesn't matter
+            // much.
+            let mut buf = vec![0u8; 64 << 10];
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancel_token.cancelled() => break,
+                    res = recv_stun_once(&sock, &mut buf, &actor_addr) => {
+                        if let Err(err) = res {
+                            warn!(%err, "stun recv failed");
+                            break;
+                        }
+                    }
+                }
+            }
+            debug!("udp stun socket listener stopped");
+        }
+        .instrument(span),
+    );
+}
+
+/// Receive STUN response from a UDP socket, pass it to the actor.
+async fn recv_stun_once(sock: &UdpSocket, buf: &mut [u8], actor_addr: &ActorAddr) -> Result<()> {
+    let (count, mut from_addr) = sock
+        .recv_from(buf)
+        .await
+        .context("Error reading from stun socket")?;
+    let payload = &buf[..count];
+    from_addr.set_ip(to_canonical(from_addr.ip()));
+    let msg = ActorMessage::StunPacket {
+        payload: Bytes::from(payload.to_vec()),
+        from_addr,
+    };
+    actor_addr.send(msg).await.context("actor stopped")
+}
+
 /// Test if IPv6 works at all, or if it's been hard disabled at the OS level.
 async fn os_has_ipv6() -> bool {
     // TODO: use socket2 to specify binding to ipv6
@@ -1567,6 +1761,7 @@ mod tests {
             .get_report(&dm, None, None)
             .await
             .context("failed to get netcheck report")?;
+        dbg!(&r);
         assert!(r.udp, "want UDP");
         assert_eq!(
             r.region_latency.len(),

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -192,11 +192,12 @@ impl Client {
         let mut actor = Actor::new(port_mapper)?;
         let addr = actor.addr();
         let task = tokio::spawn(async move { actor.main().await });
+        let drop_guard = ClientDropGuard {
+            task: task.abort_handle(),
+        };
         Ok(Client {
-            addr: addr,
-            _drop_guard: Arc::new(ClientDropGuard {
-                task: task.abort_handle(),
-            }),
+            addr,
+            _drop_guard: Arc::new(drop_guard),
         })
     }
 

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -195,7 +195,7 @@ impl Client {
     pub async fn new(port_mapper: Option<portmapper::Client>) -> Result<Self> {
         let mut actor = Actor::new(port_mapper)?;
         let addr = actor.addr();
-        let task = tokio::spawn(async move { actor.main().await });
+        let task = tokio::spawn(async move { actor.run().await });
         let drop_guard = ClientDropGuard {
             task: task.abort_handle(),
         };
@@ -1218,7 +1218,7 @@ impl Actor {
     ///
     /// It will now run and handle messages.  Once the connected [`Client`] (including all
     /// its clones) is dropped this will terminate.
-    async fn main(&mut self) {
+    async fn run(&mut self) {
         debug!("netcheck actor starting");
         while let Some(msg) = self.receiver.recv().await {
             match msg {
@@ -1240,7 +1240,6 @@ impl Actor {
                     self.current_check_run.take();
                 }
                 ActorMessage::StunPacket { payload, from_addr } => {
-                    // TODO: drop package if no check is running
                     self.handle_stun_packet(&payload, from_addr);
                 }
                 ActorMessage::InFlightStun(inflight) => {

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -136,10 +136,10 @@ impl fmt::Display for Report {
 /// If all [`Client`]s are dropped the actor stops running.
 ///
 /// While running the netcheck actor expects to be passed all received stun packets using
-/// [`Client::get_stun_packet_channel`], the [`crate::hp::magicsock::Conn`] using this
+/// [`Client::receive_stun_packet`], the [`crate::hp::magicsock::Conn`] using this
 /// client needs to be wired up to do so.
 #[derive(Debug, Clone)]
-pub struct Client {
+pub(crate) struct Client {
     /// Channel to send message to the [`Actor`].
     ///
     /// If all senders are dropped, in other words all clones of this struct are dropped,

--- a/src/hp/netcheck/probe.rs
+++ b/src/hp/netcheck/probe.rs
@@ -103,11 +103,7 @@ impl ProbePlan {
     }
     /// Generates the probe plan for a `DerpMap`, given the most recent report and
     /// whether IPv6 is configured on an interface.
-    pub async fn new(
-        dm: &DerpMap,
-        if_state: &interfaces::State,
-        last: Option<&Report>,
-    ) -> ProbePlan {
+    pub fn new(dm: &DerpMap, if_state: &interfaces::State, last: Option<&Report>) -> ProbePlan {
         if last.is_none() || last.unwrap().region_latency.is_empty() {
             return Self::new_initial(dm, if_state);
         }

--- a/src/hp/ping.rs
+++ b/src/hp/ping.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt::Debug, net::IpAddr, sync::Arc, time::Duration};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use surge_ping::{Client, Config, IcmpPacket, PingIdentifier, PingSequence, ICMP};
 use tracing::debug;
 
@@ -24,8 +24,10 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl Pinger {
     pub async fn new() -> Result<Self> {
-        let client_v4 = Client::new(&Config::builder().kind(ICMP::V4).build())?;
-        let client_v6 = Client::new(&Config::builder().kind(ICMP::V6).build())?;
+        let client_v4 = Client::new(&Config::builder().kind(ICMP::V4).build())
+            .context("failed creating IPv4 pinger")?;
+        let client_v6 = Client::new(&Config::builder().kind(ICMP::V6).build())
+            .context("failed creating IPv6 pinger")?;
 
         Ok(Self(Arc::new(Inner {
             client_v4,


### PR DESCRIPTION
This turns the netcheck into a long running actor:

- The `Client` creates the actor which runs in a background tokio task.
- The `Client` can be cloned to get more handles to the netcheck actor.
- Once `Client` is dropped the actor is stopped.
- Now you can always pass stun packets to to netcheck: it manages the state internally.

This last point is the motivation, it simplifies how things are wired up and makes it easier to keep the right state in the netcheck actor where it belongs.  This will also make future changes to netcheck more contained.

It turns the former netcheck actor into more of a full-scale actor.  The `ReportState` is not following this pattern yet.