### PR TITLE
zbase32 encoding for peerid and ticket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,7 @@ dependencies = [
  "walkdir",
  "webpki",
  "x509-parser",
+ "zbase32",
  "zeroize",
 ]
 
@@ -3161,6 +3162,12 @@ checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
  "time",
 ]
+
+[[package]]
+name = "zbase32"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9079049688da5871a7558ddacb7f04958862c703e68258594cb7a862b5e33f"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,7 +1114,6 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "bao-tree",
- "base64 0.21.0",
  "blake3",
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.65"
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 bao-tree = { version = "0.3.1", features = ["tokio_fsm"], default-features = false }
-base64 = "0.21.0"
 blake3 = "1.3.3"
 bytes = { version = "1.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 walkdir = "2"
 webpki = "0.22"
 x509-parser = "0.14"
+zbase32 = "0.1.2"
 zeroize = "1.5"
 [dev-dependencies]
 proptest = "1.0.0"

--- a/src/provider/database.rs
+++ b/src/provider/database.rs
@@ -83,8 +83,7 @@ impl DataPaths {
     }
 }
 
-/// Using base64 you have all those weird characters like + and /.
-/// So we use hex for file names.
+/// We use hex for file names.
 fn format_hash(hash: &Hash) -> String {
     hex::encode(hash.as_ref())
 }

--- a/src/provider/ticket.rs
+++ b/src/provider/ticket.rs
@@ -10,7 +10,6 @@ use std::str::FromStr;
 use anyhow::{ensure, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::util;
 use crate::{Hash, PeerId};
 
 /// A token containing everything to get a file from the provider.
@@ -71,7 +70,7 @@ impl Ticket {
 impl Display for Ticket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let encoded = self.to_bytes();
-        write!(f, "{}", util::encode(encoded))
+        write!(f, "{}", zbase32::encode_full_bytes(&encoded))
     }
 }
 
@@ -80,7 +79,9 @@ impl FromStr for Ticket {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = util::decode(s)?;
+        use anyhow::anyhow;
+        let bytes: Vec<u8> = zbase32::decode_full_bytes_str(s)
+            .map_err(|e| anyhow!("Invalid base32 encoding in ticket {}", e))?;
         let slf = Self::from_bytes(&bytes)?;
         Ok(slf)
     }

--- a/src/provider/ticket.rs
+++ b/src/provider/ticket.rs
@@ -17,7 +17,7 @@ use crate::{Hash, PeerId};
 /// A token containing everything to get a file from the provider.
 ///
 /// It is a single item which can be easily serialized and deserialized.  The [`Display`]
-/// and [`FromStr`] implementations serialize to base64.
+/// and [`FromStr`] implementations serialize to zbase32.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ticket {
     /// The hash to retrieve.
@@ -66,7 +66,7 @@ impl Ticket {
     }
 }
 
-/// Serializes to base64.
+/// Serializes to zbase32.
 impl Display for Ticket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let encoded = self.to_bytes();
@@ -74,7 +74,7 @@ impl Display for Ticket {
     }
 }
 
-/// Deserializes from base64.
+/// Deserializes from zbase32.
 impl FromStr for Ticket {
     type Err = anyhow::Error;
 
@@ -94,7 +94,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ticket_base64_roundtrip() {
+    fn test_ticket_zbase32_roundtrip() {
         let hash = blake3::hash(b"hi there");
         let hash = Hash::from(hash);
         let peer = PeerId::from(Keypair::generate().public());
@@ -104,11 +104,11 @@ mod tests {
             peer,
             addrs: vec![addr],
         };
-        let base64 = ticket.to_string();
-        println!("Ticket: {base64}");
-        println!("{} bytes", base64.len());
+        let zbase32 = ticket.to_string();
+        println!("Ticket: {zbase32}");
+        println!("{} bytes", zbase32.len());
 
-        let ticket2: Ticket = base64.parse().unwrap();
+        let ticket2: Ticket = zbase32.parse().unwrap();
         assert_eq!(ticket2, ticket);
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -17,8 +17,6 @@ pub use ed25519_dalek::{PublicKey, SecretKey, Signature};
 use serde::{Deserialize, Serialize};
 use ssh_key::LineEnding;
 
-use crate::util;
-
 pub(crate) const P2P_ALPN: [u8; 9] = *b"n0/iroh/1";
 
 /// A keypair.
@@ -103,11 +101,15 @@ impl From<PublicKey> for PeerId {
 
 impl Debug for PeerId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "PeerId({})", util::encode(self.0.as_bytes()))
+        write!(
+            f,
+            "PeerId({})",
+            zbase32::encode_full_bytes(self.0.as_bytes())
+        )
     }
 }
 
-/// Serialises the [`PeerId`] to base64.
+/// Serialises the [`PeerId`] to zbase32.
 ///
 /// [`FromStr`] is capable of deserialising this format.
 impl Display for PeerId {
@@ -119,7 +121,7 @@ impl Display for PeerId {
 /// Error when deserialising a [`PeerId`].
 #[derive(thiserror::Error, Debug)]
 pub enum PeerIdError {
-    /// Error when decoding the base64.
+    /// Error when decoding the zbase32.
     #[error("encoding {0}")]
     ZBase32(&'static str),
     /// Error when decoding the public key.
@@ -127,7 +129,7 @@ pub enum PeerIdError {
     Key(#[from] ed25519_dalek::SignatureError),
 }
 
-/// Deserialises the [`PeerId`] from it's base64 encoding.
+/// Deserialises the [`PeerId`] from it's zbase32 encoding.
 ///
 /// [`Display`] is capable of serialising this format.
 impl FromStr for PeerId {


### PR DESCRIPTION
This is how it looks like:

```
Listening address: 127.0.0.1:4433
PeerID: 466i37nghjwagjxct3xodwhe7m6p6zrckam4ddue1n1b3zjzk59y

Adding ../bao/src as /Users/rklaehn/projects_git/bao/src...
- encode.rs: 56.30 KiB
- lib.rs: 3.45 KiB
- decode.rs: 41.88 KiB
Total: 101.63 KiB

Collection: bafkr4icqzz5wdefyexxh3ku37kwae2nplj3mvl25wlst27fnvmo3pqq6ki
All-in-one ticket: rbech65b1nhnm5u7ikp9imynpgziw7ski7q5f3j7x1s4s8pzaexfregzziqxetznpgb1m5rqmhy78n8k9uxi3dnsn6oah4rowoqp4p4s9ayoy9ayyyy7neo
```

Implements https://github.com/n0-computer/iroh/issues/842