### PR TITLE
ref(metrics): Document metrics and remove macro_use

### DIFF
--- a/src/hp/magicsock/conn.rs
+++ b/src/hp/magicsock/conn.rs
@@ -28,10 +28,9 @@ use crate::{
         derp::{self, DerpMap, DerpRegion},
         disco, key, netcheck, netmap, portmapper,
     },
-    inc,
     metrics::magicsock::MagicsockMetrics,
+    metrics::{inc, record},
     net::ip::LocalAddresses,
-    record,
     tokio_util::AbortingJoinHandle,
 };
 

--- a/src/hp/magicsock/derp_actor.rs
+++ b/src/hp/magicsock/derp_actor.rs
@@ -16,9 +16,8 @@ use crate::{
         derp::{self, DerpMap, MAX_PACKET_SIZE},
         key::{self, node::PUBLIC_KEY_LENGTH},
     },
-    inc,
     metrics::magicsock::MagicsockMetrics,
-    record,
+    metrics::{inc, record},
 };
 
 use super::conn::{ActorMessage, Inner};

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,9 +6,12 @@
 //!
 //! To enable metrics collection, call `init_metrics()` before starting the service.
 //!
-//! To record a metric, use the `record!` macro with the metric and the value to record.
-//! To increment a metric by 1, use the `inc!` macro with the metric.
-//! To observe a metric, use the `observe!` macro with the metric and the value to observe.
+//! - To record a **gauge** ( or a **counter**), use the [`record`] macro with a value.
+//!   Don't use gauges though.
+//! - To increment a **counter** by 1, use the [`inc`] macro.
+//! - For **histograms** (or **summaries**, but don't use those either) use the [`observe`]
+//!   macro with a value.
+//!
 //! To expose the metrics, start the metrics service with `start_metrics_server()`.
 //!
 //! # Example:
@@ -28,7 +31,6 @@ use hyper::Error;
 #[cfg(feature = "metrics")]
 use std::net::SocketAddr;
 
-#[macro_use]
 mod macros;
 
 /// Expose core types and traits
@@ -40,6 +42,9 @@ mod service;
 
 pub mod iroh;
 pub mod magicsock;
+// Expose the macros in this crate.
+#[allow(unused_imports)]
+pub(crate) use macros::{inc, make_metric_recorders, observe, record};
 
 /// Enables metrics collection, otherwise all inc!, record! & observe! calls are no-ops
 #[cfg(feature = "metrics")]

--- a/src/metrics/core.rs
+++ b/src/metrics/core.rs
@@ -54,13 +54,13 @@ impl Core {
     }
 }
 
-/// Defines the metric trait which provides a common interface for all value based metrics
+/// Interface for all single value based metrics.
 pub trait MetricType {
     /// Returns the name of the metric
     fn name(&self) -> &'static str;
 }
 
-/// Defines the histogram trait which provides a common interface for all  based metrics
+/// Interface for all distribution based metrics.
 pub trait HistogramType {
     /// Returns the name of the metric
     fn name(&self) -> &'static str;
@@ -81,22 +81,31 @@ pub trait MetricsRecorder {
         M: HistogramType + std::fmt::Display;
 }
 
-/// Interface to record metrics
+/// Interface to record metrics.
+///
 /// Helps expose the record interface when using metrics as a library
 pub trait MRecorder {
-    /// Records a value for the metric
+    /// Records a value for the metric.
+    ///
+    /// Recording is for single-value metrics, each recorded metric represents a metric
+    /// value.
     fn record(&self, value: u64);
 }
 
-/// Interface to observe metrics
-/// Helps expose the observe interface when using metrics as a library
+/// Interface to observe metrics.
+///
+/// Helps expose the observe interface when using metrics as a library.
 pub trait MObserver {
-    /// Observes a value for the metric
+    /// Observes a value for the metric.
+    ///
+    /// Observing is for distribution metrics, when multiple observations are combined in a
+    /// single metric value.
     fn observe(&self, value: f64);
 }
 
-// Internal wrapper to record metrics only if the core is enabled
-#[allow(unreachable_patterns)]
+/// Internal wrapper to record metrics only if the core is enabled.
+///
+/// Recording is for single-value metrics, each recorded metric represents a metric value.
 pub(crate) fn record<M>(c: Collector, m: M, v: u64)
 where
     M: MetricType + std::fmt::Display,
@@ -105,13 +114,15 @@ where
         match c {
             Collector::Iroh => CORE.iroh_metrics().record(m, v),
             Collector::Magicsock => CORE.magicsock_metrics().record(m, v),
-            _ => unimplemented!("not enabled/implemented"),
         };
     }
 }
 
-// Internal wrapper to observe metrics only if the core is enabled
-#[allow(unreachable_patterns, dead_code)]
+/// Internal wrapper to observe metrics only if the core is enabled.
+///
+/// Observing is for distribution metrics, when multiple observations are combined in a
+/// single metric value.
+#[allow(dead_code)]
 pub(crate) fn observe<M>(c: Collector, m: M, v: f64)
 where
     M: HistogramType + std::fmt::Display,
@@ -120,7 +131,6 @@ where
         match c {
             Collector::Iroh => CORE.iroh_metrics().observe(m, v),
             Collector::Magicsock => CORE.magicsock_metrics().observe(m, v),
-            _ => unimplemented!("not enabled/implemented"),
         };
     }
 }

--- a/src/metrics/iroh.rs
+++ b/src/metrics/iroh.rs
@@ -1,4 +1,4 @@
-make_metric_recorders! {
+super::make_metric_recorders! {
     Iroh,
     RequestsTotal: Counter: "Total number of requests received",
     BytesSent: Counter: "Number of bytes streamed",

--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -1,4 +1,6 @@
-/// Record a specific metric with a value
+/// Records a new value for a counter or gauge.
+///
+/// Recording is for single-value metrics, each recorded metric represents a metric value.
 #[macro_export]
 macro_rules! record {
     ( $e:expr, $v:expr) => {
@@ -14,8 +16,12 @@ macro_rules! record {
         }
     };
 }
+pub(crate) use record;
 
-/// Increment a specific metric by 1
+/// Increments a counter metric by 1.
+///
+/// Technically you can call this on any single-value metric, but the semantics are for
+/// counters.
 #[macro_export]
 macro_rules! inc {
     ( $e:expr) => {
@@ -31,8 +37,12 @@ macro_rules! inc {
         }
     };
 }
+pub(crate) use inc;
 
-/// Observe a specific metric with a value
+/// Observes a value into a histogram or summary metric.
+///
+/// Observing is for distribution metrics, when multiple observations are combined in a
+/// single metric value.
 #[macro_export]
 macro_rules! observe {
     ( $e:expr, $v:expr) => {
@@ -48,6 +58,7 @@ macro_rules! observe {
         }
     };
 }
+pub(crate) use observe;
 
 /// Generate recorder metrics for a module.
 #[macro_export]
@@ -170,10 +181,11 @@ macro_rules! make_metric_recorders {
             #[derive(Debug, Copy, Clone)]
             pub enum [<$module_name Metrics>] {
                 $(
-                    /// Metric for $name
+                    #[doc = $description]
                     $name,
                 )+
             }
         }
     }
 }
+pub(crate) use make_metric_recorders;

--- a/src/metrics/magicsock.rs
+++ b/src/metrics/magicsock.rs
@@ -1,4 +1,4 @@
-make_metric_recorders! {
+super::make_metric_recorders! {
     Magicsock,
 
     NumDerpConnsAdded:  Counter: "num_derp_conns added",


### PR DESCRIPTION
This improves some documentation by explaining the different metric
types and the difference between record and observe.  It's also a bit
opinionated about metric types.

It also restructures the code a bit to make use of the 2018-edition
macro scoping rules, so macros are not magically available and use can
import them from the metrics module, which gives much better context.