### PR TITLE
metrics(netcheck): Add the basic netcheck metrics

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -42,6 +42,8 @@ mod service;
 
 pub mod iroh;
 pub mod magicsock;
+pub mod netcheck;
+
 // Expose the macros in this crate.
 #[allow(unused_imports)]
 pub(crate) use macros::{inc, make_metric_recorders, observe, record};

--- a/src/metrics/core.rs
+++ b/src/metrics/core.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use once_cell::sync::Lazy;
 use prometheus_client::{encoding::text::encode, registry::Registry};
 
-use crate::metrics::{iroh, magicsock};
+use crate::metrics::{iroh, magicsock, netcheck};
 
 pub(crate) static CORE: Lazy<Core> = Lazy::new(Core::default);
 
@@ -12,6 +12,7 @@ pub(crate) struct Core {
     registry: Registry,
     iroh_metrics: iroh::Metrics,
     magicsock_metrics: magicsock::Metrics,
+    netcheck_metrics: netcheck::Metrics,
 }
 
 impl Default for Core {
@@ -21,6 +22,7 @@ impl Default for Core {
             enabled: AtomicBool::new(false),
             iroh_metrics: iroh::Metrics::new(&mut reg),
             magicsock_metrics: magicsock::Metrics::new(&mut reg),
+            netcheck_metrics: netcheck::Metrics::new(&mut reg),
             registry: reg,
         }
     }
@@ -37,6 +39,10 @@ impl Core {
 
     pub(crate) fn magicsock_metrics(&self) -> &magicsock::Metrics {
         &self.magicsock_metrics
+    }
+
+    pub(crate) fn netcheck_metrics(&self) -> &netcheck::Metrics {
+        &self.netcheck_metrics
     }
 
     pub(crate) fn encode(&self) -> Result<Vec<u8>, std::io::Error> {
@@ -114,6 +120,7 @@ where
         match c {
             Collector::Iroh => CORE.iroh_metrics().record(m, v),
             Collector::Magicsock => CORE.magicsock_metrics().record(m, v),
+            Collector::Netcheck => CORE.netcheck_metrics().record(m, v),
         };
     }
 }
@@ -131,6 +138,7 @@ where
         match c {
             Collector::Iroh => CORE.iroh_metrics().observe(m, v),
             Collector::Magicsock => CORE.magicsock_metrics().observe(m, v),
+            Collector::Netcheck => CORE.netcheck_metrics().observe(m, v),
         };
     }
 }
@@ -143,4 +151,6 @@ pub enum Collector {
     Iroh,
     /// Magicsock related metrics.
     Magicsock,
+    /// Netcheck related metrics.
+    Netcheck,
 }

--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -3,7 +3,7 @@
 /// Recording is for single-value metrics, each recorded metric represents a metric value.
 #[macro_export]
 macro_rules! record {
-    ( $e:expr, $v:expr) => {
+    ( $e:expr, $v:expr) => {{
         #[cfg(feature = "metrics")]
         {
             use $crate::metrics::core::MRecorder;
@@ -14,7 +14,7 @@ macro_rules! record {
         {
             $e;
         }
-    };
+    }};
 }
 pub(crate) use record;
 
@@ -24,18 +24,20 @@ pub(crate) use record;
 /// counters.
 #[macro_export]
 macro_rules! inc {
-    ( $e:expr) => {
-        #[cfg(feature = "metrics")]
+    ( $e:expr) => {{
         {
-            use $crate::metrics::core::MRecorder;
-            $e.record(1);
+            #[cfg(feature = "metrics")]
+            {
+                use $crate::metrics::core::MRecorder;
+                $e.record(1);
+            }
+            #[cfg(not(feature = "metrics"))]
+            #[allow(path_statements)]
+            {
+                $e;
+            }
         }
-        #[cfg(not(feature = "metrics"))]
-        #[allow(path_statements)]
-        {
-            $e;
-        }
-    };
+    }};
 }
 pub(crate) use inc;
 
@@ -45,7 +47,7 @@ pub(crate) use inc;
 /// single metric value.
 #[macro_export]
 macro_rules! observe {
-    ( $e:expr, $v:expr) => {
+    ( $e:expr, $v:expr) => {{
         #[cfg(feature = "metrics")]
         {
             use $crate::metrics::core::MObserver;
@@ -56,14 +58,14 @@ macro_rules! observe {
         {
             $e;
         }
-    };
+    }};
 }
 pub(crate) use observe;
 
 /// Generate recorder metrics for a module.
 #[macro_export]
 macro_rules! make_metric_recorders {
-    ($module_name:ident, $($name:ident: $type:ident: $description:expr),+) => {
+    ($module_name:ident, $($name:ident: $type:ident: $description:expr $(,)?)+) => {
         paste::paste! {
             #[cfg(feature = "metrics")]
             #[allow(unused_imports)]

--- a/src/metrics/netcheck.rs
+++ b/src/metrics/netcheck.rs
@@ -1,0 +1,12 @@
+super::make_metric_recorders! {
+    Netcheck,
+
+    StunPacketsDropped: Counter: "Incoming STUN packets dropped due to a full receiving queue.",
+    StunPacketsSentIpv4: Counter: "Number of IPv4 STUN packets sent",
+    StunPacketsSentIpv6: Counter: "Number of IPv6 STUN packets sent",
+    StunPacketsRecvIpv4: Counter: "Number of IPv4 STUN packets received",
+    StunPacketsRecvIpv6: Counter: "Number of IPv6 STUN packets received",
+    Reports: Counter: "Number of reports executed by netcheck, including full reports",
+    ReportsFull: Counter: "Number of full reports executed by netcheck",
+    ReportsError: Counter: "Number of executed reports resulting in an error",
+}


### PR DESCRIPTION
This adds the basic metrics to netcheck.  There's probably room for
more.

Also updates the macros to be a bit more ergonomic:

- Allow optional trailing comma on the last item in the metrics
  definition.

- When using metrics start a new scope for the compiler so that we can
  use it anywhere, e.g. also in match statements where the expression
  is followed with a , rather than a ;.

Closes #927