### PR TITLE
fix(netcheck): hairpin timeout should wait

### DIFF
--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -784,7 +784,7 @@ impl ReportState {
         let timeout = self.hair_timeout.clone();
         tokio::task::spawn(async move {
             time::sleep(HAIRPIN_CHECK_TIMEOUT).await;
-            timeout.notify_waiters();
+            timeout.notify_one();
         });
     }
 


### PR DESCRIPTION
notify_one makes sure that future waiters are notified right away.
notify_waiters only wakes currently waiting waiters and is too brittle
for us.  we only have one waiter so let's use notify_one for now until
we refactor this to not use Notify.