### PR TITLE
tests(ipv6): Do not run IPv6 tests if the host doesn't support IPv6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install nightly
+    - name: Install Rust 1.67
       # See https://github.com/cross-rs/cross/issues/1222
       uses: dtolnay/rust-toolchain@1.67
 

--- a/src/hp/magicsock/rebinding_conn.rs
+++ b/src/hp/magicsock/rebinding_conn.rs
@@ -254,6 +254,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_rebinding_conn_send_recv_ipv6() -> Result<()> {
+        if !crate::hp::netcheck::os_has_ipv6().await {
+            return Ok(());
+        }
+        let _guard = setup_logging();
         rebinding_conn_send_recv(Network::Ipv6).await
     }
 

--- a/src/hp/magicsock/rebinding_conn.rs
+++ b/src/hp/magicsock/rebinding_conn.rs
@@ -257,7 +257,6 @@ mod tests {
         if !crate::hp::netcheck::os_has_ipv6().await {
             return Ok(());
         }
-        let _guard = setup_logging();
         rebinding_conn_send_recv(Network::Ipv6).await
     }
 

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -1721,7 +1721,7 @@ async fn recv_stun_once(sock: &UdpSocket, buf: &mut [u8], actor_addr: &ActorAddr
 }
 
 /// Test if IPv6 works at all, or if it's been hard disabled at the OS level.
-async fn os_has_ipv6() -> bool {
+pub(crate) async fn os_has_ipv6() -> bool {
     // TODO: use socket2 to specify binding to ipv6
     let udp = UdpSocket::bind("[::1]:0").await;
     udp.is_ok()


### PR DESCRIPTION
Seems some of the cross environments simply don't do IPv6 at all.  In
that case there's no point in trying IPv6.