### PR TITLE
X hp deterministic timer tests

### DIFF
--- a/src/hp/magicsock/timer.rs
+++ b/src/hp/magicsock/timer.rs
@@ -82,7 +82,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_timer_success() {
         let val = Arc::new(AtomicBool::new(false));
 
@@ -99,7 +99,7 @@ mod tests {
         assert!(val.load(Ordering::Relaxed));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_timer_abort() {
         let val = Arc::new(AtomicBool::new(false));
 
@@ -115,7 +115,7 @@ mod tests {
         assert!(!val.load(Ordering::Relaxed));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_timer_abort_late() {
         let val = Arc::new(AtomicBool::new(false));
 
@@ -133,7 +133,7 @@ mod tests {
         assert!(val.load(Ordering::Relaxed));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_timer_reset() {
         let val = Arc::new(AtomicBool::new(false));
 


### PR DESCRIPTION
This is using the deterministic timer facility of tokio to make the timer tests more reliable.

https://docs.rs/tokio/latest/tokio/time/fn.pause.html

Not sure if the tests are still worthwhile with this, but before they would occasionally fail because there are no real guarantees with real timers, and time resolution especially on windows is notoriously coarse.

This is relying on the time "auto advancing" https://docs.rs/tokio/latest/tokio/time/fn.pause.html#auto-advance