### PR TITLE
Add back the get --single functionality that has been lost during a refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
 
     - name: Check MSRV all features
       run: |
-        cargo +$MSRV check --workspace --all-targets --no-default-features
+        cargo +$MSRV check --workspace --all-targets --features cli
 
   cargo_deny:
     name: cargo deny

--- a/src/get.rs
+++ b/src/get.rs
@@ -830,7 +830,7 @@ pub fn get_missing_range(
     name: &str,
     temp_dir: &Path,
     target_dir: &Path,
-) -> io::Result<RangeSpecSeq> {
+) -> io::Result<RangeSet2<ChunkNum>> {
     if target_dir.exists() && !temp_dir.exists() {
         // target directory exists yet does not contain the temp dir
         // refuse to continue
@@ -840,8 +840,7 @@ pub fn get_missing_range(
         ));
     }
     let range = get_missing_range_impl(hash, name, temp_dir, target_dir)?;
-    let spec = RangeSpecSeq::new(vec![range]);
-    Ok(spec)
+    Ok(range)
 }
 
 /// Get missing range for a single file


### PR DESCRIPTION
Not sure if this should even be the same command. Maybe get blob or get-blob? But we have a bit of a feature explosion.

get (hash / ticket) x (collection / blob)

In any case, the single code path is now separate, which makes things simpler. One question I have is how much, if any, progress we should have when getting single or collection to stdout.

If you just get to stdout without redirecting, the stderr progress and stdout content get mixed and will look very confusing...