### PR TITLE
Use base32 encoding for both tickets and peer ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,7 +1593,6 @@ dependencies = [
  "anyhow",
  "backoff",
  "bao-tree",
- "base64 0.21.1",
  "blake3",
  "build-data",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = "1.65"
 anyhow = { version = "1", features = ["backtrace"] }
 backoff = "0.4.0"
 bao-tree = { version = "0.3.1", features = ["tokio_fsm"], default-features = false }
-base64 = "0.21.0"
 blake3 = "1.3.3"
 bytes = { version = "1.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ config = { version = "0.13.1", default-features = false, features = ["toml", "pr
 console = { version = "0.15.5", optional = true }
 crypto_box = { version = "0.9.0-rc.0", features = ["serde", "chacha20"] }
 curve25519-dalek = "=4.0.0-rc.2"
-data-encoding = { version = "2.3.3", optional = true }
+data-encoding = { version = "2.3.3" }
 default-net = "0.14.1"
 der = { version = "0.6", features = ["alloc", "derive"] }
 derive_more = { version = "0.99.17", git = "https://github.com/JelteF/derive_more", features = ["debug", "display", "from", "try_into"] }
@@ -106,7 +106,7 @@ duct = "0.13.6"
 
 [features]
 default = ["cli", "derper", "metrics"]
-cli = ["clap", "console", "indicatif", "data-encoding", "multibase"]
+cli = ["clap", "console", "indicatif", "multibase"]
 derper = ["tokio-rustls", "tokio-rustls-acme", "toml", "rustls-pemfile", "regex"]
 metrics = ["prometheus-client"]
 test = []

--- a/src/provider/ticket.rs
+++ b/src/provider/ticket.rs
@@ -17,7 +17,7 @@ use crate::{Hash, PeerId};
 /// A token containing everything to get a file from the provider.
 ///
 /// It is a single item which can be easily serialized and deserialized.  The [`Display`]
-/// and [`FromStr`] implementations serialize to base64.
+/// and [`FromStr`] implementations serialize to base32.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ticket {
     /// The hash to retrieve.
@@ -66,7 +66,7 @@ impl Ticket {
     }
 }
 
-/// Serializes to base64.
+/// Serializes to base32.
 impl Display for Ticket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let encoded = self.to_bytes();
@@ -76,7 +76,7 @@ impl Display for Ticket {
     }
 }
 
-/// Deserializes from base64.
+/// Deserializes from base32.
 impl FromStr for Ticket {
     type Err = anyhow::Error;
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -123,7 +123,7 @@ impl Debug for PeerId {
     }
 }
 
-/// Serialises the [`PeerId`] to base64.
+/// Serialises the [`PeerId`] to base32.
 ///
 /// [`FromStr`] is capable of deserialising this format.
 impl Display for PeerId {
@@ -137,7 +137,7 @@ impl Display for PeerId {
 /// Error when deserialising a [`PeerId`].
 #[derive(thiserror::Error, Debug)]
 pub enum PeerIdError {
-    /// Error when decoding the base64.
+    /// Error when decoding the base32.
     #[error("decoding: {0}")]
     Base32(#[from] data_encoding::DecodeError),
     /// Error when decoding the public key.
@@ -148,7 +148,7 @@ pub enum PeerIdError {
     DecodingSize,
 }
 
-/// Deserialises the [`PeerId`] from it's base64 encoding.
+/// Deserialises the [`PeerId`] from it's base32 encoding.
 ///
 /// [`Display`] is capable of serialising this format.
 impl FromStr for PeerId {

--- a/src/util.rs
+++ b/src/util.rs
@@ -68,7 +68,10 @@ impl Ord for Hash {
 
 impl Display for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(self.0.as_bytes()))
+        let text = data_encoding::BASE32_NOPAD
+            .encode(self.0.as_bytes())
+            .to_ascii_lowercase();
+        write!(f, "{}", text)
     }
 }
 
@@ -77,7 +80,12 @@ impl FromStr for Hash {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut arr = [0u8; 32];
-        let val = hex::decode(s)?;
+        let val = data_encoding::BASE32_NOPAD.decode(s.to_ascii_uppercase().as_bytes())?; // todo: use a custom error type
+        ensure!(
+            val.len() == 32,
+            "invalid byte length, expected 32, got {}",
+            val.len()
+        );
         ensure!(
             val.len() == 32,
             "invalid byte length, expected 32, got {}",

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
 //! Utility functions and types.
 use anyhow::{ensure, Context, Result};
 use bao_tree::io::{error::EncodeError, sync::encode_ranges_validated};
-use base64::{engine::general_purpose, Engine as _};
 use bytes::Bytes;
 use derive_more::Display;
 use postcard::experimental::max_size::MaxSize;
@@ -18,16 +17,6 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 
 use crate::IROH_BLOCK_SIZE;
-
-/// Encode the given buffer into Base64 URL SAFE without padding.
-pub fn encode(buf: impl AsRef<[u8]>) -> String {
-    general_purpose::URL_SAFE_NO_PAD.encode(buf.as_ref())
-}
-
-/// Decode the given buffer from Base64 URL SAFE without padding.
-pub fn decode(buf: impl AsRef<str>) -> Result<Vec<u8>, base64::DecodeError> {
-    general_purpose::URL_SAFE_NO_PAD.decode(buf.as_ref())
-}
 
 /// Hash type used throught.
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
@@ -79,7 +68,7 @@ impl Ord for Hash {
 
 impl Display for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", encode(self.0.as_bytes()))
+        write!(f, "{}", hex::encode(self.0.as_bytes()))
     }
 }
 
@@ -88,7 +77,7 @@ impl FromStr for Hash {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut arr = [0u8; 32];
-        let val = decode(s)?;
+        let val = hex::decode(s)?;
         ensure!(
             val.len() == 32,
             "invalid byte length, expected 32, got {}",


### PR DESCRIPTION
Not multiformats, just base32 all the time. Use the lower case alphabet and no padding.

Implements https://github.com/n0-computer/iroh/issues/842