### PR TITLE
ref(ci): Deny warnings again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  # RUSTFLAGS: -Dwarnings
+  RUSTFLAGS: -Dwarnings
   MSRV: "1.65"
 
 jobs:


### PR DESCRIPTION
This branch should now be stable enough that we should deny compiler
warnings again.