### PR TITLE
ref(ci): Do not use fail-fast strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     name: Build and test (Nix)
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         name: [ubuntu-latest, macOS-arm-latest]
         rust: [nightly, stable]
@@ -62,6 +63,7 @@ jobs:
     name: Build and test (Windows)
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         name: [windows-latest]
         rust: [nightly, stable]


### PR DESCRIPTION
We have flaky tests on platforms.  It's best to let them all run on
all platforms so we see all failures and have more debugging tools.