### PR TITLE
refactor: remove BlobOrCollection

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -117,10 +117,16 @@ impl CustomGetHandler for () {
 }
 
 /// A [`Database`] entry.
+///
+/// This is either stored externally in the file system, or internally in the database.
+/// Collections are always stored internally for now.
+///
+/// Internally stored entries are stored in the iroh home directory when the database is
+/// persisted.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BlobOrCollection {
+pub enum DbEntry {
     /// A blob.
-    Blob {
+    External {
         /// The bao outboard data.
         outboard: Bytes,
         /// Path to the original data, which must not change while in use.
@@ -134,40 +140,38 @@ pub enum BlobOrCollection {
         size: u64,
     },
     /// A collection.
-    Collection {
-        /// The bao outboard data of the serialised [`Collection`].
+    Internal {
+        /// The bao outboard data.
         outboard: Bytes,
-        /// The serialised [`Collection`].
+        /// The inline data.
         data: Bytes,
     },
 }
 
-impl BlobOrCollection {
-    pub(crate) fn is_blob(&self) -> bool {
-        matches!(self, BlobOrCollection::Blob { .. })
+impl DbEntry {
+    pub(crate) fn is_external(&self) -> bool {
+        matches!(self, DbEntry::External { .. })
     }
 
     pub(crate) fn blob_path(&self) -> Option<&Path> {
         match self {
-            BlobOrCollection::Blob { path, .. } => Some(path),
-            BlobOrCollection::Collection { .. } => None,
+            DbEntry::External { path, .. } => Some(path),
+            DbEntry::Internal { .. } => None,
         }
     }
 
     pub(crate) fn outboard(&self) -> &Bytes {
         match self {
-            BlobOrCollection::Blob { outboard, .. } => outboard,
-            BlobOrCollection::Collection { outboard, .. } => outboard,
+            DbEntry::External { outboard, .. } => outboard,
+            DbEntry::Internal { outboard, .. } => outboard,
         }
     }
 
     /// A reader for the data
     async fn data_reader(&self) -> io::Result<Either<Cursor<Bytes>, tokio::fs::File>> {
         Ok(match self {
-            BlobOrCollection::Blob { path, .. } => {
-                Either::Right(tokio::fs::File::open(path).await?)
-            }
-            BlobOrCollection::Collection { data, .. } => Either::Left(Cursor::new(data.clone())),
+            DbEntry::External { path, .. } => Either::Right(tokio::fs::File::open(path).await?),
+            DbEntry::Internal { data, .. } => Either::Left(Cursor::new(data.clone())),
         })
     }
 
@@ -177,8 +181,8 @@ impl BlobOrCollection {
     /// For blobs it is the blob size.
     pub fn size(&self) -> u64 {
         match self {
-            BlobOrCollection::Blob { size, .. } => *size,
-            BlobOrCollection::Collection { data, .. } => data.len() as u64,
+            DbEntry::External { size, .. } => *size,
+            DbEntry::Internal { data, .. } => data.len() as u64,
         }
     }
 }
@@ -625,7 +629,7 @@ impl RpcHandler {
         let items = self
             .inner
             .db
-            .blobs()
+            .external()
             .map(|(hash, path, size)| ListBlobsResponse { hash, path, size });
         futures::stream::iter(items)
     }
@@ -634,15 +638,17 @@ impl RpcHandler {
         self,
         _msg: ListCollectionsRequest,
     ) -> impl Stream<Item = ListCollectionsResponse> + Send + 'static {
-        let items = self
-            .inner
-            .db
-            .collections()
-            .map(|(hash, collection)| ListCollectionsResponse {
-                hash,
-                total_blobs_count: collection.blobs.len(),
-                total_blobs_size: collection.total_blobs_size,
-            });
+        // collections are always stored internally, so we take everything that is stored internally
+        // and try to parse it as a collection
+        let items = self.inner.db.internal().filter_map(|(hash, collection)| {
+            Collection::from_bytes(&collection)
+                .ok()
+                .map(|collection| ListCollectionsResponse {
+                    hash,
+                    total_blobs_count: collection.blobs.len(),
+                    total_blobs_size: collection.total_blobs_size,
+                })
+        });
         futures::stream::iter(items)
     }
 
@@ -1117,7 +1123,7 @@ async fn send_blob<W: AsyncWrite + Unpin + Send + 'static>(
     writer: &mut W,
 ) -> Result<(SentStatus, u64)> {
     match db.get(&name) {
-        Some(BlobOrCollection::Blob {
+        Some(DbEntry::External {
             outboard,
             path,
             size,
@@ -1274,7 +1280,7 @@ mod tests {
                 });
                 map.insert(
                     hash,
-                    BlobOrCollection::Blob {
+                    DbEntry::External {
                         outboard,
                         size,
                         path,
@@ -1288,7 +1294,7 @@ mod tests {
                 let (outboard, hash) = bao_tree::outboard(&data, IROH_BLOCK_SIZE);
                 let outboard = Bytes::from(outboard);
                 let hash = Hash::from(hash);
-                map.insert(hash, BlobOrCollection::Collection { outboard, data });
+                map.insert(hash, DbEntry::Internal { outboard, data });
             }
             let db = Database::default();
             db.union_with(map);
@@ -1357,7 +1363,7 @@ mod tests {
 
         let collection = {
             let c = db.get(&hash).unwrap();
-            if let BlobOrCollection::Collection { data, .. } = c {
+            if let DbEntry::Internal { data, .. } = c {
                 Collection::from_bytes(&data)?
             } else {
                 panic!("expected hash to correspond with a `Collection`, found `Blob` instead");

--- a/src/provider/collection.rs
+++ b/src/provider/collection.rs
@@ -20,7 +20,7 @@ use crate::rpc_protocol::ProvideProgress;
 use crate::util::{Progress, ProgressReader, ProgressReaderUpdate};
 use crate::{Hash, IROH_BLOCK_SIZE};
 
-use super::{BlobOrCollection, DataSource};
+use super::{DataSource, DbEntry};
 
 /// Creates a collection blob and returns all blobs in a hashmap.
 ///
@@ -29,7 +29,7 @@ use super::{BlobOrCollection, DataSource};
 pub(super) async fn create_collection(
     data_sources: Vec<DataSource>,
     progress: Progress<ProvideProgress>,
-) -> Result<(HashMap<Hash, BlobOrCollection>, Hash)> {
+) -> Result<(HashMap<Hash, DbEntry>, Hash)> {
     let mut outboards = compute_all_outboards(data_sources, progress.clone()).await?;
 
     // TODO: Don't sort on async runtime?
@@ -50,7 +50,7 @@ pub(super) async fn create_collection(
         debug_assert!(outboard.len() >= 8, "outboard must at least contain size");
         map.insert(
             hash,
-            BlobOrCollection::Blob {
+            DbEntry::External {
                 outboard,
                 path,
                 size,
@@ -69,7 +69,7 @@ pub(super) async fn create_collection(
     let hash = Hash::from(hash);
     map.insert(
         hash,
-        BlobOrCollection::Collection {
+        DbEntry::Internal {
             outboard: Bytes::from(outboard),
             data: Bytes::from(data.to_vec()),
         },


### PR DESCRIPTION
The distinction is now just whether something is stored internally or externally.

This is the smallest possible thing I can think of that removes the flawed concept of BlobOrCollection. The next step will be making the db fully generic with pluggable storage, but that is a much bigger effort.