### PR TITLE
ref(ci): Do not run cargo check separately and test all features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,8 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
       
-    - name: check
-      run: cargo check --all --bins --tests
-      
     - name: tests
-      run: cargo test --all
+      run: cargo test --workspace --all-features --lib --bins --tests
       
   build_and_test_windows:
     name: Build and test (Windows)
@@ -87,15 +84,8 @@ jobs:
     
     - uses: msys2/setup-msys2@v2
 
-    - name: check
-      run: cargo check --all --bins --tests --target ${{ matrix.target }} 
-      
-    - name: check bench
-      if: matrix.rust == 'nightly'
-      run: cargo check --target ${{ matrix.target }} --benches
-
     - name: tests
-      run: cargo test --all  --target ${{ matrix.target }}
+      run: cargo test --workspace --all-features --lib --bins --tests --target ${{ matrix.target }}
 
   build_release:
     name: Build release binaries
@@ -247,6 +237,8 @@ jobs:
       with:
           components: clippy
 
+    # TODO: We have a bunch of platform-dependent code so should
+    #    probably run this job on the full platofrm matrix
     - name: clippy check
       run: cargo clippy --message-format=json --all-features --all-targets
 


### PR DESCRIPTION
The cargo check runs do not help with any speedup, they cost >20s, do
not test anything that's not already covered by other tests.  So
remove them.

Updates the cargo test invocations to:

- Use --workspace instead of deprecated --all.  We don't have a
  workspace crate yet though so could just remove it for now, but this
  is a bit more future-proof I guess.

- Use --all-features since we have no features that are incompatible
  with each other.  Let's keep it that way!

- Select the --lib --bins and --tests targets, --all-targets would
  include the benches which we probably don't want to run as part of the
  main test run, but we don't have any yet so that is also just
  future-proofing.