### PR TITLE
ref(ci): Do not output clippy in json format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
           components: clippy
 
     - name: clippy check
-      run: cargo clippy --message-format=json --all-features --all-targets
+      run: cargo clippy --all-features --all-targets
 
   msrv:
     name: Minimal Supported Rust Version


### PR DESCRIPTION
Sounds like we don't use this format and that makes the failures more
readable for humans.