### PR TITLE
derper: stun improvements

### DIFF
--- a/src/bin/derper.rs
+++ b/src/bin/derper.rs
@@ -4,7 +4,7 @@
 
 use std::{
     borrow::Cow,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
@@ -42,7 +42,7 @@ struct Cli {
     #[clap(long, default_value_t = false)]
     dev: bool,
     /// Server HTTPS listen address.
-    #[clap(long, short, default_value = "0.0.0.0:443")]
+    #[clap(long, short, default_value = "[::]:443")]
     addr: SocketAddr,
     /// The port on which to serve HTTP. The listener is bound to the same IP (if any) as specified in the -a flag.
     #[clap(long, default_value_t = 80)]
@@ -272,7 +272,7 @@ async fn main() -> Result<()> {
     let mut tasks = JoinSet::new();
 
     if cli.dev {
-        cli.addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), DEV_PORT);
+        cli.addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), DEV_PORT);
         info!(%cli.addr, "Running in dev mode.");
     }
 

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -1804,7 +1804,7 @@ mod tests {
         let _guard = setup_logging();
 
         let mut reports = Vec::new();
-        for _ in 0..3 {
+        for _ in 0..2 {
             let mut client = Client::new(None)
                 .await
                 .context("failed to create netcheck client")?;

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -1807,7 +1807,7 @@ mod tests {
             .await
             .context("failed to create netcheck client")?;
 
-        let stun_servers = vec![("sderp.iroh.computer.", 3478, 0)];
+        let stun_servers = vec![("derp.iroh.computer.", 3478, 0)];
 
         let mut dm = DerpMap::default();
         dm.regions.insert(

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -1804,12 +1804,12 @@ mod tests {
         let _guard = setup_logging();
 
         let mut reports = Vec::new();
-        for _ in 0..20 {
+        for _ in 0..3 {
             let mut client = Client::new(None)
                 .await
                 .context("failed to create netcheck client")?;
 
-            let stun_servers = vec![("derp.iroh.computer.", 3478, 0)];
+            let stun_servers = vec![("sderp.iroh.computer.", 3478, 0)];
 
             let mut dm = DerpMap::default();
             dm.regions.insert(

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -1800,7 +1800,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_iroh_computer_stun() -> Result<()> {
         let _guard = setup_logging();
 

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -1426,7 +1426,7 @@ impl Actor {
 
         let last = self.reports.last.clone();
         let plan = ProbePlan::new(dm, &if_state, last.as_deref());
-        dbg!(&plan);
+
         Ok(ReportState {
             incremental: last.is_some(),
             pc4,
@@ -1799,74 +1799,66 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_iroh_computer_stun() -> Result<()> {
         let _guard = setup_logging();
 
-        let mut reports = Vec::new();
-        for _ in 0..2 {
-            let mut client = Client::new(None)
-                .await
-                .context("failed to create netcheck client")?;
+        let mut client = Client::new(None)
+            .await
+            .context("failed to create netcheck client")?;
 
-            let stun_servers = vec![("sderp.iroh.computer.", 3478, 0)];
+        let stun_servers = vec![("sderp.iroh.computer.", 3478, 0)];
 
-            let mut dm = DerpMap::default();
-            dm.regions.insert(
-                1,
-                DerpRegion {
-                    region_id: 1,
-                    nodes: stun_servers
-                        .into_iter()
-                        .enumerate()
-                        .map(|(i, (host_name, stun_port, derp_port))| DerpNode {
-                            name: format!("default-{}", i),
-                            region_id: 1,
-                            host_name: host_name.into(),
-                            stun_only: true,
-                            stun_port,
-                            ipv4: UseIpv4::None,
-                            ipv6: UseIpv6::None,
-                            derp_port,
-                            stun_test_ip: None,
-                        })
-                        .collect(),
-                    avoid: false,
-                    region_code: "default".into(),
-                },
-            );
-            dbg!(&dm);
+        let mut dm = DerpMap::default();
+        dm.regions.insert(
+            1,
+            DerpRegion {
+                region_id: 1,
+                nodes: stun_servers
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, (host_name, stun_port, derp_port))| DerpNode {
+                        name: format!("default-{}", i),
+                        region_id: 1,
+                        host_name: host_name.into(),
+                        stun_only: true,
+                        stun_port,
+                        ipv4: UseIpv4::None,
+                        ipv6: UseIpv6::None,
+                        derp_port,
+                        stun_test_ip: None,
+                    })
+                    .collect(),
+                avoid: false,
+                region_code: "default".into(),
+            },
+        );
+        dbg!(&dm);
 
-            let r = client
-                .get_report(dm, None, None)
-                .await
-                .context("failed to get netcheck report")?;
-            reports.push(r);
-        }
+        let r = client
+            .get_report(dm, None, None)
+            .await
+            .context("failed to get netcheck report")?;
 
-        dbg!(&reports);
-
-        for r in reports {
-            dbg!(&r);
-            assert!(r.udp, "want UDP");
-            assert_eq!(
-                r.region_latency.len(),
-                1,
-                "expected 1 key in DERPLatency; got {}",
-                r.region_latency.len()
-            );
-            assert!(
-                r.region_latency.get(&1).is_some(),
-                "expected key 1 in DERPLatency; got {:?}",
-                r.region_latency
-            );
-            assert!(r.global_v4.is_some(), "expected globalV4 set");
-            assert_eq!(
-                r.preferred_derp, 1,
-                "preferred_derp = {}; want 1",
-                r.preferred_derp
-            );
-        }
+        dbg!(&r);
+        assert!(r.udp, "want UDP");
+        assert_eq!(
+            r.region_latency.len(),
+            1,
+            "expected 1 key in DERPLatency; got {}",
+            r.region_latency.len()
+        );
+        assert!(
+            r.region_latency.get(&1).is_some(),
+            "expected key 1 in DERPLatency; got {:?}",
+            r.region_latency
+        );
+        assert!(r.global_v4.is_some(), "expected globalV4 set");
+        assert_eq!(
+            r.preferred_derp, 1,
+            "preferred_derp = {}; want 1",
+            r.preferred_derp
+        );
 
         Ok(())
     }

--- a/src/hp/netcheck.rs
+++ b/src/hp/netcheck.rs
@@ -1426,7 +1426,7 @@ impl Actor {
 
         let last = self.reports.last.clone();
         let plan = ProbePlan::new(dm, &if_state, last.as_deref());
-
+        dbg!(&plan);
         Ok(ReportState {
             incremental: last.is_some(),
             pc4,
@@ -1799,7 +1799,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_iroh_computer_stun() -> Result<()> {
         let _guard = setup_logging();
 

--- a/src/net/interfaces.rs
+++ b/src/net/interfaces.rs
@@ -156,10 +156,11 @@ impl State {
             let if_up = ni.is_up();
             let name = ni.iface.name.clone();
             let pfxs: Vec<_> = ni.addrs().collect();
-
+            dbg!(&ni, if_up);
             if if_up {
                 for pfx in &pfxs {
-                    if pfx.addr().is_loopback() {
+                    dbg!(pfx);
+                    if dbg!(pfx.addr().is_loopback()) {
                         continue;
                     }
                     have_v6 |= is_usable_v6(&pfx.addr());

--- a/src/net/interfaces.rs
+++ b/src/net/interfaces.rs
@@ -156,11 +156,9 @@ impl State {
             let if_up = ni.is_up();
             let name = ni.iface.name.clone();
             let pfxs: Vec<_> = ni.addrs().collect();
-            dbg!(&ni, if_up);
             if if_up {
                 for pfx in &pfxs {
-                    dbg!(pfx);
-                    if dbg!(pfx.addr().is_loopback()) {
+                    if pfx.addr().is_loopback() {
                         continue;
                     }
                     have_v6 |= is_usable_v6(&pfx.addr());

--- a/src/net/interfaces.rs
+++ b/src/net/interfaces.rs
@@ -156,6 +156,7 @@ impl State {
             let if_up = ni.is_up();
             let name = ni.iface.name.clone();
             let pfxs: Vec<_> = ni.addrs().collect();
+
             if if_up {
                 for pfx in &pfxs {
                     if pfx.addr().is_loopback() {


### PR DESCRIPTION
- bind to IPv6 by default, so that dual stack allows receiving requests on both IPv4 and IPv6
- use spawn and spawn_blocking in the stun handler