### PR TITLE
refactor: remove ouroboros and replace it with self_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,6 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "os_info",
- "ouroboros",
  "paste",
  "portable-atomic 1.3.2",
  "postcard",
@@ -1643,6 +1642,7 @@ dependencies = [
  "rtnetlink",
  "rustls",
  "rustls-pemfile",
+ "self_cell",
  "serde",
  "serde-error",
  "serdect",
@@ -3256,6 +3256,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c309e515543e67811222dbc9e3dd7e1056279b782e1dacffe4242b718734fb6"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ multibase = { version = "0.9.1", optional = true }
 num_cpus = "1.15.0"
 once_cell = "1.17.0"
 os_info = "3.6.0"
-ouroboros = "0.15.6"
 paste = "1.0.12"
 portable-atomic = "1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
@@ -59,6 +58,7 @@ reqwest = { version = "0.11.14", default-features = false, features = ["rustls-t
 ring = "0.16.20"
 rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
 rustls-pemfile = { version = "1.0.2", optional = true }
+self_cell = "1.0.1"
 serde = { version = "1", features = ["derive"] }
 serde-error = "0.1.2"
 serdect = "0.2.0"


### PR DESCRIPTION
This does not get rid of the ouroboros dependency in bao-tree, just the one directly in iroh. So it does not fix the cargo deny thing.