### PR TITLE
fix: update bao-tree dependency to get rid of ouroboros in dependency…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,12 +35,6 @@ checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "aliasable"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "android_system_properties"
@@ -222,15 +210,15 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0087d7a5fd51c1f1daaf1d5978f52146020642a54d9dd169f70196aeca167da1"
+checksum = "941faf14993d0a71a924921abfdb0b028b1e8c160720f8a9b47fb64b0e56f5dc"
 dependencies = [
  "blake3",
  "bytes",
  "futures",
- "ouroboros",
  "range-collections",
+ "self_cell",
  "smallvec",
  "tokio",
 ]
@@ -2135,29 +2123,6 @@ checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "ouroboros"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
-dependencies = [
- "aliasable",
- "ouroboros_macro",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
-dependencies = [
- "Inflector",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.65"
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 backoff = "0.4.0"
-bao-tree = { version = "0.3.1", features = ["tokio_fsm"], default-features = false }
+bao-tree = { version = "0.3.2", features = ["tokio_fsm"], default-features = false }
 blake3 = "1.3.3"
 bytes = { version = "1.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"], optional = true }


### PR DESCRIPTION
… tree

bao-tree still uses ouroboros in the tokio-io optional feature, but no longer in non optional features or in tokio-fsm, which is the one we use.