### PR TITLE
remove some clones from `b5/opaque_auth`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -691,9 +691,7 @@ mod tests {
                 derp_map: None,
             })
             .await?;
-            let request = GetRequest::all(hash)
-                .with_auth_token(auth_token.clone())
-                .into();
+            let request = GetRequest::all(hash).with_auth_token(auth_token).into();
             let stream = get::run_connection(connection, request);
             aggregate_get_response(stream).await?;
             anyhow::Ok(())

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -56,8 +56,8 @@ impl AuthToken {
     }
 
     /// Serializes to bytes.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.bytes.clone()
+    pub fn to_bytes(self) -> Vec<u8> {
+        self.bytes
     }
 }
 
@@ -90,10 +90,10 @@ pub enum Request {
 }
 
 impl Request {
-    pub fn auth_token(&self) -> Option<AuthToken> {
+    pub fn auth_token(&self) -> Option<&AuthToken> {
         match self {
             Request::Get(get) => get.auth_token(),
-            Request::CustomGet(get) => get.auth_token.clone(),
+            Request::CustomGet(get) => get.auth_token.as_ref(),
         }
     }
 }
@@ -155,8 +155,8 @@ impl GetRequest {
         Self { auth_token, ..self }
     }
 
-    pub fn auth_token(&self) -> Option<AuthToken> {
-        self.auth_token.clone()
+    pub fn auth_token(&self) -> Option<&AuthToken> {
+        self.auth_token.as_ref()
     }
 }
 

--- a/src/provider/ticket.rs
+++ b/src/provider/ticket.rs
@@ -70,15 +70,26 @@ impl Ticket {
     }
 
     /// The [`AuthToken`] for this ticket.
-    pub fn auth_token(&self) -> Option<AuthToken> {
-        self.auth_token.clone()
+    pub fn auth_token(&self) -> Option<&AuthToken> {
+        self.auth_token.as_ref()
     }
 
     /// The addresses on which the provider can be reached.
     ///
     /// This is guaranteed to be non-empty.
-    pub fn addrs(&self) -> &[SocketAddr] {
+    pub fn addrs(&self) -> &Vec<SocketAddr> {
         &self.addrs
+    }
+
+    /// Get the contents of the ticket, consuming it.
+    pub fn destructure(self) -> (Hash, PeerId, Vec<SocketAddr>, Option<AuthToken>) {
+        let Ticket {
+            hash,
+            peer,
+            auth_token,
+            addrs,
+        } = self;
+        (hash, peer, addrs, auth_token)
     }
 }
 


### PR DESCRIPTION
You asked about clones in #1109 , so I went `clone` hunting.

- One was not caught by the compiler, no idea why.
- I'm not a fan of functions that clone values in the shadows.. you never know when just a reference is enough and then a clone was made unnecessarily. I changed those to identify places where clones were happening and try to get rid of those.
- In `src/main.rs` there is some code that appears three times and creates a `GetInteractive` "response". I did some refactor  of this code that consumes the ticket and manages to:
  - remove the copy of `hash`
  - remove the clone of `auth_token`
  - remove the copy of `peer_id`
  - remove the clone of `addrs` 
- In `src/protocol.rs` moved the `to_bytes` to consume `self`. There used to be a lint suggesting that `to_<bla>` should consume `self` or be otherwise renamed to `as_<bla>` in any case, this also prevents some clones even if the compiler ended up optimizing those. In the same file, more returning refs instead of internal clones too.
- In `AuthorizationHandler::authorize` this receives both the request and the token. It looks like we could get it from the request? This would further remove clones but answering this needs more conceptual knowledge than I have, so didn't remove it.

**NOTE** This code is not beautiful :nail_care: .  Making it nice (having proper function names, and where they go) is something I can't suggest _yet_

Make of this what you want :grin: 
