### PR TITLE
fix: don't spam re-connect attempts if something goes wrong when connecting to a derp server

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -101,7 +101,7 @@ fn default_derp_region() -> DerpRegion {
     let default_n0_derp = DerpNode {
         name: "default-1".into(),
         region_id: 1,
-        host_name: "boo-derp.iroh.network".into(),
+        host_name: "derp.iroh.network".into(),
         stun_only: false,
         stun_port: 3478,
         ipv4: UseIpv4::Some("35.175.99.113".parse().unwrap()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,7 +101,7 @@ fn default_derp_region() -> DerpRegion {
     let default_n0_derp = DerpNode {
         name: "default-1".into(),
         region_id: 1,
-        host_name: "derp.iroh.network".into(),
+        host_name: "boo-derp.iroh.network".into(),
         stun_only: false,
         stun_port: 3478,
         ipv4: UseIpv4::Some("35.175.99.113".parse().unwrap()),

--- a/src/hp/derp/http/client.rs
+++ b/src/hp/derp/http/client.rs
@@ -918,7 +918,7 @@ mod tests {
 
         // ensure that the client will bubble up any connection error & not
         // just loop ad infinitum attempting to connect
-        if let Ok(_) = client.recv_detail().await {
+        if (client.recv_detail().await).is_ok() {
             bail!("expected client with bad derp region detail to return with an error");
         }
         Ok(())


### PR DESCRIPTION
Adds test covering issue fixed in #1110 

Fixes bug where the `derp::http:client::recv_detail` method doesn't report back connection errors and instead attempts to reconnect right away. This violates the way the `magicsock::DerpActor` expected the client to be used. It expects to have full control of when we backoff and reconnect.

Adds a test to prove the behavior.