### PR TITLE
refactor(netcheck): minor code improvements

### DIFF
--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -519,7 +519,7 @@ impl ReportState {
             if let Some(port_mapper) = port_mapper {
                 port_mapping.inner = Some(Box::pin(async move {
                     match port_mapper.probe().await {
-                        Ok(res) => Some((res.upnp, res.pmp, res.pcp)),
+                        Ok(res) => Some(res),
                         Err(err) => {
                             warn!("skipping port mapping: {:?}", err);
                             None
@@ -624,7 +624,7 @@ impl ReportState {
                 pm = &mut port_mapping => {
                     let mut report = self.report.write().await;
                     match pm {
-                        Some((upnp, pmp, pcp)) => {
+                        Some(portmapper::ProbeResult{upnp, pmp, pcp}) => {
                             report.upnp = Some(upnp);
                             report.pmp = Some(pmp);
                             report.pcp = Some(pcp);

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -693,7 +693,9 @@ impl ReportState {
         }
 
         // abort the rest of the probes
-        debug!("aborting {} probes, already done", probes.len());
+        if !probes.is_empty() {
+            debug!("aborting {} probes, already done", probes.len());
+        }
         drop(probes);
 
         if let Some(hair_pin) = self.wait_hair_check().await {

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -513,7 +513,7 @@ impl ReportState {
         debug!(port_mapper = %port_mapper.is_some(), %skip_external_network, "running report");
         self.report.write().await.os_has_ipv6 = os_has_ipv6().await;
 
-        let do_port_map = port_mapper.is_some();
+        let do_port_map = !skip_external_network && port_mapper.is_some();
         let mut port_mapping = MaybeFuture::default();
         if !skip_external_network {
             if let Some(port_mapper) = port_mapper {
@@ -700,7 +700,7 @@ impl ReportState {
             self.report.write().await.hair_pinning = Some(hair_pin);
         }
 
-        if !skip_external_network && do_port_map {
+        if do_port_map {
             self.wait_port_map.wait().await;
             debug!("port_map done");
         }

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -13,7 +13,7 @@ use std::{
 use anyhow::{anyhow, bail, ensure, Context as _, Result};
 use bytes::Bytes;
 use futures::{
-    stream::{FuturesUnordered, StreamExt},
+    stream::{FusedStream, FuturesUnordered, StreamExt},
     Future, FutureExt,
 };
 use iroh_metrics::{inc, netcheck::NetcheckMetrics};
@@ -485,7 +485,6 @@ struct ReportState {
     /// Doing a lite, follow-up netcheck
     incremental: bool,
     stop_probe: Arc<sync::Notify>,
-    wait_port_map: wg::AsyncWaitGroup,
     /// The report which will be returned.
     report: Arc<RwLock<Report>>,
     got_ep4: Option<SocketAddr>,
@@ -513,7 +512,6 @@ impl ReportState {
         debug!(port_mapper = %port_mapper.is_some(), %skip_external_network, "running report");
         self.report.write().await.os_has_ipv6 = os_has_ipv6().await;
 
-        let do_port_map = !skip_external_network && port_mapper.is_some();
         let mut port_mapping = MaybeFuture::default();
         if !skip_external_network {
             if let Some(port_mapper) = port_mapper {
@@ -615,13 +613,22 @@ impl ReportState {
         tokio::pin!(stun_timer);
         let probes_aborted = self.stop_probe.clone();
 
-        loop {
+        // Probe completion variables. The probe is completed when all parts have finished.
+
+        // portmap probe is considered done if it's not necessary.
+        let mut portmap_done = !port_mapping.inner.is_some();
+        // captive check is considered done if it's not necessary.
+        let mut captive_task_done = !captive_task.inner.is_some();
+        // probes are always done.
+        let mut probes_done = false;
+
+        while !probes_done || !captive_task_done || !portmap_done {
             tokio::select! {
                 _ = &mut stun_timer => {
                     debug!("STUN timer expired");
                     break;
                 },
-                pm = &mut port_mapping => {
+                pm = &mut port_mapping, if port_mapping.inner.is_some() => {
                     let mut report = self.report.write().await;
                     match pm {
                         Some(portmapper::ProbeResult{upnp, pmp, pcp}) => {
@@ -636,8 +643,9 @@ impl ReportState {
                         }
                     }
                     port_mapping.inner = None;
+                    portmap_done = true;
                 }
-                probe_report = probes.next() => {
+                probe_report = probes.next(), if !probes.is_terminated() => {
                     match probe_report {
                         Some(Ok(probe_report)) => {
                             debug!("finished probe: {:?}", probe_report);
@@ -672,14 +680,15 @@ impl ReportState {
                             if self.any_udp().await {
                                 captive_task.inner = None;
                             }
-                            break;
+                            probes_done = true;
                         }
                     }
                 }
-                found = &mut captive_task => {
+                found = &mut captive_task, if captive_task.inner.is_some() => {
                     let mut report = self.report.write().await;
                     report.captive_portal = found;
                     captive_task.inner = None;
+                    captive_task_done = true;
                 }
                 _ = probes_aborted.notified() => {
                     // Saw enough regions.
@@ -687,7 +696,7 @@ impl ReportState {
                     // We can stop the captive portal check since we know that we
                     // got a bunch of STUN responses.
                     captive_task.inner = None;
-                    break;
+                    captive_task_done = true;
                 }
             }
         }
@@ -700,11 +709,6 @@ impl ReportState {
 
         if let Some(hair_pin) = self.wait_hair_check().await {
             self.report.write().await.hair_pinning = Some(hair_pin);
-        }
-
-        if do_port_map {
-            self.wait_port_map.wait().await;
-            debug!("port_map done");
         }
 
         self.stop_timers();
@@ -1404,7 +1408,6 @@ impl Actor {
             pc4_hair: Arc::new(pc4_hair),
             hair_timeout: None,
             stop_probe: Arc::new(sync::Notify::new()),
-            wait_port_map: wg::AsyncWaitGroup::new(),
             report: Default::default(),
             got_ep4: None,
             timers: Default::default(),

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -513,10 +513,10 @@ impl ReportState {
         debug!(port_mapper = %port_mapper.is_some(), %skip_external_network, "running report");
         self.report.write().await.os_has_ipv6 = os_has_ipv6().await;
 
+        let do_port_map = port_mapper.is_some();
         let mut port_mapping = MaybeFuture::default();
         if !skip_external_network {
-            if let Some(ref port_mapper) = port_mapper {
-                let port_mapper = port_mapper.clone();
+            if let Some(port_mapper) = port_mapper {
                 port_mapping.inner = Some(Box::pin(async move {
                     match port_mapper.probe().await {
                         Ok(res) => Some((res.upnp, res.pmp, res.pcp)),
@@ -700,7 +700,7 @@ impl ReportState {
             self.report.write().await.hair_pinning = Some(hair_pin);
         }
 
-        if !skip_external_network && port_mapper.is_some() {
+        if !skip_external_network && do_port_map {
             self.wait_port_map.wait().await;
             debug!("port_map done");
         }


### PR DESCRIPTION
- removes an unnecessary clone
- makes sure the port mapping probe result is used entirely by destructuring it
- changes a log to be emitted only if it's relevant 