### PR TITLE
refactor: replace warp with axum for the test server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,31 +1302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
-dependencies = [
- "base64 0.13.1",
- "bitflags",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1 0.10.5",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,7 +1343,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1333fad8d94b82cab989da428b0b36a3435db3870d85e971a1d6dc0a8576722"
 dependencies = [
- "sha1 0.2.0",
+ "sha1",
 ]
 
 [[package]]
@@ -1626,14 +1650,15 @@ dependencies = [
 name = "iroh-io"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "bytes",
  "futures",
+ "hyper",
  "pin-project",
  "proptest",
  "reqwest",
  "tempfile",
  "tokio",
- "warp",
 ]
 
 [[package]]
@@ -1835,6 +1860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,16 +1897,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -2293,9 +2314,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2303,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7763190f9406839f99e5197afee8c9e759969f7dbfa40ad3b8dbee8757b745b5"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2313,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249061b22e99973da1f5f5f1410284419e283bb60b79255bf5f42a94b66a2e00"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2326,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457c310cfc9cf3f22bc58901cc7f0d3410ac5d6298e432a4f9a6138565cb6df6"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -3070,6 +3091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,12 +3193,6 @@ checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
  "windows-sys 0.42.0",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3283,6 +3304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,17 +3348,6 @@ name = "sha1"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
-
-[[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
 
 [[package]]
 name = "sha2"
@@ -3566,6 +3585,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -3877,6 +3902,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4045,15 +4092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4157,35 +4195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
-]
-
-[[package]]
-name = "warp"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "headers",
- "http",
- "hyper",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project",
- "rustls-pemfile",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/iroh-io/Cargo.toml
+++ b/iroh-io/Cargo.toml
@@ -22,7 +22,8 @@ tokio-io = ["tokio"]
 default = ["tokio-io"]
 
 [dev-dependencies]
+axum = { version = "0.6" }
+hyper = { version = "0.14", features = ["server", "http1"], default-features = false }
 proptest = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "test-util", "macros"] }
-warp = { version = "0.3.5", default-features = false }

--- a/iroh-io/src/http.rs
+++ b/iroh-io/src/http.rs
@@ -64,7 +64,7 @@ impl HttpAdapter {
         to: Option<u64>,
     ) -> Result<reqwest::Response, reqwest::Error> {
         // to is inclusive, commented out because warp is non spec compliant
-        // let to = to.and_then(|x| x.checked_add(1));
+        let to = to.and_then(|x| x.checked_add(1));
         let range = match to {
             Some(to) => format!("bytes={from}-{to}"),
             None => format!("bytes={from}-"),
@@ -164,6 +164,7 @@ pub mod http_adapter {
                             break;
                         }
                     }
+                    // we do not want to rely on the server sending the exact amount of bytes
                     res.truncate(len);
                     Ok(res.freeze())
                 }

--- a/iroh-io/src/lib.rs
+++ b/iroh-io/src/lib.rs
@@ -265,6 +265,76 @@ mod tests {
     #[cfg(feature = "tokio-io")]
     use std::io::Write;
 
+    /// A test server that serves data on a random port, supporting head, get, and range requests
+    #[cfg(feature = "http")]
+    mod test_server {
+        use super::*;
+        use axum::{routing::get, Extension, Router};
+        use hyper::{Body, Request, Response, StatusCode};
+        use std::{net::SocketAddr, ops::Range, sync::Arc};
+
+        pub fn serve(data: Vec<u8>) -> (SocketAddr, impl Future<Output = hyper::Result<()>>) {
+            // Create an Axum router
+            let app = Router::new()
+                .route("/", get(handler))
+                .layer(Extension(Arc::new(data)));
+
+            // Create the server
+            let addr: SocketAddr = SocketAddr::from(([0, 0, 0, 0], 0));
+            let fut = axum::Server::bind(&addr).serve(app.into_make_service());
+
+            // Return the server address and a future that completes when the server is shut down
+            (fut.local_addr(), fut)
+        }
+
+        async fn handler(state: Extension<Arc<Vec<u8>>>, req: Request<Body>) -> Response<Body> {
+            let data = state.0.as_ref();
+            // Check if the request contains a "Range" header
+            if let Some(range_header) = req.headers().get("Range") {
+                if let Ok(range) = parse_range_header(range_header.to_str().unwrap()) {
+                    // Extract the requested range from the data
+                    let start = range.start;
+                    let end = range.end.min(data.len());
+                    let sliced_data = &data[start..end];
+
+                    // Create a partial response with the sliced data
+                    return Response::builder()
+                        .status(StatusCode::PARTIAL_CONTENT)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Length", sliced_data.len())
+                        .header(
+                            "Content-Range",
+                            format!("bytes {}-{}/{}", start, end - 1, data.len()),
+                        )
+                        .body(Body::from(sliced_data.to_vec()))
+                        .unwrap();
+                }
+            }
+
+            // Return the full data if no range header was found
+            Response::new(data.to_owned().into())
+        }
+
+        fn parse_range_header(
+            header_value: &str,
+        ) -> std::result::Result<Range<usize>, &'static str> {
+            let prefix = "bytes=";
+            if header_value.starts_with(prefix) {
+                let range_str = header_value.strip_prefix(prefix).unwrap();
+                if let Some(index) = range_str.find('-') {
+                    let start = range_str[..index]
+                        .parse()
+                        .map_err(|_| "Failed to parse range start")?;
+                    let end: usize = range_str[index + 1..]
+                        .parse()
+                        .map_err(|_| "Failed to parse range end")?;
+                    return Ok(start..end + 1);
+                }
+            }
+            Err("Invalid Range header format")
+        }
+    }
+
     /// mutable style read smoke test, expects a resource containing 0..100u8
     async fn read_mut_smoke(mut file: impl AsyncSliceReader) -> io::Result<()> {
         let expected = (0..100u8).collect::<Vec<_>>();
@@ -493,8 +563,8 @@ mod tests {
             match op {
                 ReadOp::ReadAt(offset, len) => {
                     let data = AsyncSliceReader::read_at(&mut file, offset, len).await?;
-                    current = offset.checked_add(len as u64).unwrap();
                     assert_eq!(&data, &actual[limited_range(offset, len, actual.len())]);
+                    current = offset.checked_add(len as u64).unwrap();
                 }
                 ReadOp::ReadSequential(offset, len) => {
                     let offset = if offset >= 0 {
@@ -503,8 +573,8 @@ mod tests {
                         current.saturating_sub((-offset) as u64)
                     };
                     let data = AsyncSliceReader::read_at(&mut file, offset, len).await?;
-                    current = offset.checked_add(len as u64).unwrap();
                     assert_eq!(&data, &actual[limited_range(offset, len, actual.len())]);
+                    current = offset.checked_add(len as u64).unwrap();
                 }
                 ReadOp::Len => {
                     let len = AsyncSliceReader::len(&mut file).await?;
@@ -529,14 +599,9 @@ mod tests {
 
     #[cfg(feature = "http")]
     #[tokio::test]
+    #[cfg_attr(target_os = "windows", ignore)]
     async fn http_smoke() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.txt");
-        let mut file = std::fs::File::create(&path).unwrap();
-        file.write_all(b"hello world").unwrap();
-        let filter = warp::fs::file(path);
-        let server = warp::serve(filter);
-        let (addr, server) = server.bind_ephemeral(([127, 0, 0, 1], 0));
+        let (addr, server) = test_server::serve(b"hello world".to_vec());
         let url = format!("http://{}", addr);
         println!("serving from {}", url);
         let url = reqwest::Url::parse(&url).unwrap();
@@ -584,18 +649,12 @@ mod tests {
         }
 
         #[cfg(feature = "http")]
+        #[cfg_attr(target_os = "windows", ignore)]
         #[test]
         fn http_read(data in proptest::collection::vec(any::<u8>(), 0..10), ops in random_read_ops(10, 10, 2)) {
-            let dir = tempfile::tempdir().unwrap();
-            let path = dir.path().join("test.txt");
-            let mut file = std::fs::File::create(&path).unwrap();
-            file.write_all(&data).unwrap();
-            let filter = warp::fs::file(path);
             async_test(async move {
                 // create a test server. this has to happen in a tokio runtime
-                let server = warp::serve(filter);
-                // bind to a random port
-                let (addr, server) = server.bind_ephemeral(([127, 0, 0, 1], 0));
+                let (addr, server) = test_server::serve(data.clone());
                 // spawn the server in a background task
                 let server = tokio::spawn(server);
                 // create a resource from the server


### PR DESCRIPTION
this also makes the tests not create a file.

With very friendly and polite support from GPT-4

I had to exclude windows from the range request tests because axum has some issues there. But I think this is OK. The purpose of the test is to make sure we properly deal with range requests etc.