### PR TITLE
feat(provider): add 'CollectionAdded' Provider event

### DIFF
--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -34,7 +34,7 @@ pub use ticket::Ticket;
 /// Events emitted by the provider informing about the current status.
 #[derive(Debug, Clone)]
 pub enum Event {
-    /// A new collection has been added via an RPC call
+    /// A new collection has been added
     CollectionAdded {
         /// The hash of the added collection
         hash: Hash,

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -34,6 +34,11 @@ pub use ticket::Ticket;
 /// Events emitted by the provider informing about the current status.
 #[derive(Debug, Clone)]
 pub enum Event {
+    /// A new collection has been added via an RPC call
+    CollectionAdded {
+        /// The hash of the added collection
+        hash: Hash,
+    },
     /// A new client connected to the node.
     ClientConnected {
         /// An unique connection id.

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -175,6 +175,7 @@ async fn get_keypair(key: Option<PathBuf>) -> Result<Keypair> {
     }
 }
 
+/// Makes a an RPC endpoint that uses a QUIC transport
 fn make_rpc_endpoint(
     keypair: &Keypair,
     rpc_port: u16,

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -35,7 +35,7 @@ use quic_rpc::{RpcClient, RpcServer, ServiceConnection, ServiceEndpoint};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinError;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 use crate::rpc_protocol::{
     AddrsRequest, AddrsResponse, IdRequest, IdResponse, ListBlobsRequest, ListBlobsResponse,
@@ -585,12 +585,18 @@ impl RpcHandler {
         let data_sources = iroh_bytes::provider::create_data_sources(root)?;
         // create the collection
         // todo: provide feedback for progress
-        let (db, _) = iroh_bytes::provider::collection::create_collection(
+        let (db, hash) = iroh_bytes::provider::collection::create_collection(
             data_sources,
             Progress::new(progress),
         )
         .await?;
         self.inner.db.union_with(db);
+
+        if let Err(e) = self.inner.events.send(Event::ByteProvide(
+            iroh_bytes::provider::Event::CollectionAdded { hash },
+        )) {
+            warn!("failed to send CollectionAdded event: {:?}", e);
+        };
 
         Ok(())
     }
@@ -699,6 +705,8 @@ pub fn make_server_config(
 
 #[cfg(test)]
 mod tests {
+    use futures::StreamExt;
+    use std::collections::HashMap;
     use std::net::Ipv4Addr;
     use std::path::Path;
 
@@ -727,5 +735,73 @@ mod tests {
         let ticket = node.ticket(hash).await.unwrap();
         println!("addrs: {:?}", ticket.addrs());
         assert!(!ticket.addrs().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_node_add_collection_event() {
+        let db = Database::from(HashMap::new());
+        let node = Builder::with_db(db)
+            .bind_addr((Ipv4Addr::UNSPECIFIED, 0).into())
+            .runtime(&test_runtime())
+            .spawn()
+            .await
+            .unwrap();
+
+        let _drop_guard = node.cancel_token().drop_guard();
+
+        let mut events = node.subscribe();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let mut got_hash = None;
+            while let Ok(msg) = events.recv().await {
+                match msg {
+                    Event::ByteProvide(e) => {
+                        if let iroh_bytes::provider::Event::CollectionAdded { hash } = e {
+                            got_hash = Some(hash);
+                            break;
+                        }
+                    }
+                }
+            }
+            tx.send(got_hash.unwrap()).unwrap();
+        });
+
+        let got_hash = tokio::time::timeout(Duration::from_secs(1), async move {
+            let stream = node
+                .controller()
+                .server_streaming(ProvideRequest {
+                    path: Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md"),
+                })
+                .await
+                .unwrap();
+
+            let mut stream = stream;
+
+            while let Some(item) = stream.next().await {
+                match item.unwrap() {
+                    ProvideProgress::AllDone { hash } => {
+                        return Ok(hash);
+                    }
+                    ProvideProgress::Abort(e) => {
+                        anyhow::bail!("Error while adding data: {e}");
+                    }
+                    _ => {}
+                }
+            }
+            anyhow::bail!("stream ended without providing data");
+        })
+        .await
+        .expect("timeout")
+        .expect("get failed");
+
+        match rx.await {
+            Ok(event_hash) => {
+                // assert!(Some(AuthToken::from(vec![1, 2, 3, 4, 5, 6])) == token);
+                assert_eq!(got_hash, event_hash);
+            }
+            Err(e) => {
+                panic!("error receiving token: {:?}", e);
+            }
+        }
     }
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -222,7 +222,7 @@ where
         // the size of this channel must be large because the producer can be on
         // a different thread than the consumer, and can produce a lot of events
         // in a short time
-        let (events_sender, _events_receiver) = broadcast::channel(256);
+        let (events_sender, _events_receiver) = broadcast::channel(512);
         let events = events_sender.clone();
         let cancel_token = CancellationToken::new();
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -770,7 +770,7 @@ mod tests {
                 .await?;
 
             while let Some(item) = stream.next().await {
-                match item.unwrap() {
+                match item? {
                     ProvideProgress::AllDone { hash } => {
                         return Ok(hash);
                     }
@@ -786,7 +786,7 @@ mod tests {
         .context("timeout")?
         .context("get failed")?;
 
-        let event_hash = provide_handle.await?.unwrap();
+        let event_hash = provide_handle.await?.expect("missing collection event");
         assert_eq!(got_hash, event_hash);
 
         Ok(())

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -754,13 +754,10 @@ mod tests {
         tokio::spawn(async move {
             let mut got_hash = None;
             while let Ok(msg) = events.recv().await {
-                match msg {
-                    Event::ByteProvide(e) => {
-                        if let iroh_bytes::provider::Event::CollectionAdded { hash } = e {
-                            got_hash = Some(hash);
-                            break;
-                        }
-                    }
+                if let Event::ByteProvide(iroh_bytes::provider::Event::CollectionAdded { hash }) =
+                    msg
+                {
+                    got_hash = Some(hash);
                 }
             }
             tx.send(got_hash.unwrap()).unwrap();
@@ -796,7 +793,6 @@ mod tests {
 
         match rx.await {
             Ok(event_hash) => {
-                // assert!(Some(AuthToken::from(vec![1, 2, 3, 4, 5, 6])) == token);
                 assert_eq!(got_hash, event_hash);
             }
             Err(e) => {


### PR DESCRIPTION
Need this for iroh.network, which listens to an in-process node for provider collection construction.

I'm piggybacking this to also add a test that does minimal node setup, which should form the basis of writing examples later. Learned many things in the process.