### PR TITLE
fix(netcheck): Make ICMP ping optional

### DIFF
--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -566,7 +566,13 @@ impl ReportState {
         };
 
         let pinger = if self.plan.has_https_probes() {
-            Some(Pinger::new().await.context("failed to create pinger")?)
+            match Pinger::new().await {
+                Ok(pinger) => Some(pinger),
+                Err(err) => {
+                    debug!("failed to create pinger: {err:#}");
+                    None
+                }
+            }
         } else {
             None
         };

--- a/iroh-net/src/hp/netcheck/probe.rs
+++ b/iroh-net/src/hp/netcheck/probe.rs
@@ -101,6 +101,7 @@ impl ProbePlan {
     pub fn has_https_probes(&self) -> bool {
         self.keys().any(|k| k.ends_with("https"))
     }
+
     /// Generates the probe plan for a `DerpMap`, given the most recent report and
     /// whether IPv6 is configured on an interface.
     pub fn new(dm: &DerpMap, if_state: &interfaces::State, last: Option<&Report>) -> ProbePlan {


### PR DESCRIPTION
On Linux you don't have permission to send ICMP pings by default, so
creating the pinger will fail.  This should not make all of netcheck
fail.