### PR TITLE
change: use DERP port from host_name URL

### DIFF
--- a/iroh-net/examples/magic.rs
+++ b/iroh-net/examples/magic.rs
@@ -52,20 +52,7 @@ async fn main() -> anyhow::Result<()> {
 
     let derp_map = match args.derp_url {
         None => default_derp_map(),
-        Some(url) => {
-            // TODO: This should be done by the DERP client.
-            let derp_port = match url.port() {
-                Some(port) => port,
-                None => match url.scheme() {
-                    "http" => 80,
-                    "https" => 443,
-                    _ => anyhow::bail!(
-                        "Invalid scheme in DERP URL, only http: and https: schemes are supported."
-                    ),
-                },
-            };
-            DerpMap::default_from_node(url, 3478, derp_port, UseIpv4::None, UseIpv6::None)
-        }
+        Some(url) => DerpMap::default_from_node(url, 3478, UseIpv4::None, UseIpv6::None),
     };
 
     let endpoint = MagicEndpoint::builder()

--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -13,7 +13,7 @@ pub fn default_derp_region() -> DerpRegion {
     let default_n0_derp = DerpNode {
         name: "default-1".into(),
         region_id: 1,
-        host_name: "https://derp.iroh.network".parse().unwrap(),
+        url: "https://derp.iroh.network".parse().unwrap(),
         stun_only: false,
         stun_port: 3478,
         ipv4: UseIpv4::Some([35, 175, 99, 113].into()),

--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -18,7 +18,6 @@ pub fn default_derp_region() -> DerpRegion {
         stun_port: 3478,
         ipv4: UseIpv4::Some([35, 175, 99, 113].into()),
         ipv6: UseIpv6::None,
-        derp_port: 443,
         stun_test_ip: None,
     };
     DerpRegion {

--- a/iroh-net/src/hp/derp/http.rs
+++ b/iroh-net/src/hp/derp/http.rs
@@ -80,13 +80,12 @@ mod tests {
             nodes: vec![DerpNode {
                 name: "test_node".to_string(),
                 region_id: 1,
-                host_name: "http://localhost".parse().unwrap(),
+                host_name: format!("http://localhost:{port}").parse().unwrap(),
                 stun_only: false,
                 stun_port: 0,
                 stun_test_ip: None,
                 ipv4: UseIpv4::Some(addr),
                 ipv6: UseIpv6::Disabled,
-                derp_port: port,
             }],
             region_code: "test_region".to_string(),
         };
@@ -221,13 +220,12 @@ mod tests {
             nodes: vec![DerpNode {
                 name: "test_node".to_string(),
                 region_id: 1,
-                host_name: "https://localhost".parse().unwrap(),
+                host_name: format!("https://localhost:{port}").parse().unwrap(),
                 stun_only: false,
                 stun_port: 0,
                 stun_test_ip: None,
                 ipv4: UseIpv4::Some(addr),
                 ipv6: UseIpv6::Disabled,
-                derp_port: port,
             }],
             region_code: "test_region".to_string(),
         };

--- a/iroh-net/src/hp/derp/http.rs
+++ b/iroh-net/src/hp/derp/http.rs
@@ -80,7 +80,7 @@ mod tests {
             nodes: vec![DerpNode {
                 name: "test_node".to_string(),
                 region_id: 1,
-                host_name: format!("http://localhost:{port}").parse().unwrap(),
+                url: format!("http://localhost:{port}").parse().unwrap(),
                 stun_only: false,
                 stun_port: 0,
                 stun_test_ip: None,
@@ -220,7 +220,7 @@ mod tests {
             nodes: vec![DerpNode {
                 name: "test_node".to_string(),
                 region_id: 1,
-                host_name: format!("https://localhost:{port}").parse().unwrap(),
+                url: format!("https://localhost:{port}").parse().unwrap(),
                 stun_only: false,
                 stun_port: 0,
                 stun_test_ip: None,

--- a/iroh-net/src/hp/derp/http/client.rs
+++ b/iroh-net/src/hp/derp/http/client.rs
@@ -683,10 +683,16 @@ impl Client {
                 }
             }
         };
-        let port = if node.derp_port != 0 {
-            node.derp_port
-        } else {
-            443
+        let port = match node.host_name.port() {
+            Some(port) => port,
+            None => match node.host_name.scheme() {
+                "http" => 80,
+                "https" => 443,
+                _ => return Err(ClientError::InvalidUrl(
+                    "Invalid scheme in DERP hostname, only http: and https: schemes are supported."
+                        .into(),
+                )),
+            },
         };
         let dst = format!("{host}:{port}");
         debug!("dialing {}", dst);
@@ -1123,13 +1129,12 @@ mod tests {
             nodes: vec![DerpNode {
                 name: "test_node".to_string(),
                 region_id: 1,
-                host_name: "http://bad.url".parse().unwrap(),
+                host_name: "https://bad.url".parse().unwrap(),
                 stun_only: false,
                 stun_port: 0,
                 stun_test_ip: None,
                 ipv4: UseIpv4::Some("35.175.99.112".parse().unwrap()),
                 ipv6: UseIpv6::Disabled,
-                derp_port: 443,
             }],
             region_code: "test_region".to_string(),
         };

--- a/iroh-net/src/hp/derp/http/client.rs
+++ b/iroh-net/src/hp/derp/http/client.rs
@@ -351,7 +351,7 @@ impl Client {
                 .and_then(|s| rustls::ServerName::try_from(s).ok());
         }
         if let Some(node) = node {
-            if let Some(host) = node.host_name.host_str() {
+            if let Some(host) = node.url.host_str() {
                 return rustls::ServerName::try_from(host).ok();
             }
         }
@@ -380,7 +380,7 @@ impl Client {
             return false;
         }
         if let Some(node) = node {
-            if node.host_name.scheme() == "http" {
+            if node.url.scheme() == "http" {
                 return false;
             }
         }
@@ -664,7 +664,7 @@ impl Client {
             UseIp::Ipv6(UseIpv6::Some(addr)) => addr.into(),
             _ => {
                 let host = node
-                    .host_name
+                    .url
                     .host()
                     .ok_or_else(|| ClientError::InvalidUrl("missing host".into()))?;
                 match host {
@@ -683,9 +683,9 @@ impl Client {
                 }
             }
         };
-        let port = match node.host_name.port() {
+        let port = match node.url.port() {
             Some(port) => port,
-            None => match node.host_name.scheme() {
+            None => match node.url.scheme() {
                 "http" => 80,
                 "https" => 443,
                 _ => return Err(ClientError::InvalidUrl(
@@ -1129,7 +1129,7 @@ mod tests {
             nodes: vec![DerpNode {
                 name: "test_node".to_string(),
                 region_id: 1,
-                host_name: "https://bad.url".parse().unwrap(),
+                url: "https://bad.url".parse().unwrap(),
                 stun_only: false,
                 stun_port: 0,
                 stun_test_ip: None,

--- a/iroh-net/src/hp/derp/http/mesh_clients.rs
+++ b/iroh-net/src/hp/derp/http/mesh_clients.rs
@@ -50,7 +50,7 @@ impl MeshClients {
                 for (_, region) in derp_map.regions.iter() {
                     for node in region.nodes.iter() {
                         // note: `node.host_name` is expected to include the scheme
-                        let mut url = node.host_name.clone();
+                        let mut url = node.url.clone();
                         url.set_path("/derp");
                         urls.push(url);
                     }

--- a/iroh-net/src/hp/derp/map.rs
+++ b/iroh-net/src/hp/derp/map.rs
@@ -27,7 +27,6 @@ impl DerpMap {
     pub fn default_from_node(
         host_name: Url,
         stun_port: u16,
-        derp_port: u16,
         derp_ipv4: UseIpv4,
         derp_ipv6: UseIpv6,
     ) -> Self {
@@ -47,7 +46,6 @@ impl DerpMap {
                     stun_port,
                     ipv4: derp_ipv4,
                     ipv6: derp_ipv6,
-                    derp_port,
                     stun_test_ip: None,
                 }],
                 avoid: false,
@@ -91,7 +89,6 @@ pub struct DerpNode {
     /// If `None`, A record(s) from DNS lookups of HostName are used.
     /// If `Disabled`, IPv6 is not used;
     pub ipv6: UseIpv6,
-    pub derp_port: u16,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/iroh-net/src/hp/derp/map.rs
+++ b/iroh-net/src/hp/derp/map.rs
@@ -41,7 +41,7 @@ impl DerpMap {
                 nodes: vec![DerpNode {
                     name: "default-1".into(),
                     region_id: 1,
-                    url: url,
+                    url,
                     stun_only: !derp_ipv4.is_enabled() && !derp_ipv6.is_enabled(),
                     stun_port,
                     ipv4: derp_ipv4,

--- a/iroh-net/src/hp/derp/map.rs
+++ b/iroh-net/src/hp/derp/map.rs
@@ -25,7 +25,7 @@ impl DerpMap {
 
     /// Creates a new [`DerpMap`] with a single Derp server configured.
     pub fn default_from_node(
-        host_name: Url,
+        url: Url,
         stun_port: u16,
         derp_ipv4: UseIpv4,
         derp_ipv6: UseIpv6,
@@ -41,7 +41,7 @@ impl DerpMap {
                 nodes: vec![DerpNode {
                     name: "default-1".into(),
                     region_id: 1,
-                    host_name,
+                    url: url,
                     stun_only: !derp_ipv4.is_enabled() && !derp_ipv6.is_enabled(),
                     stun_port,
                     ipv4: derp_ipv4,
@@ -77,7 +77,7 @@ pub struct DerpRegion {
 pub struct DerpNode {
     pub name: String,
     pub region_id: u16,
-    pub host_name: Url,
+    pub url: Url,
     pub stun_only: bool,
     pub stun_port: u16,
     pub stun_test_ip: Option<IpAddr>,

--- a/iroh-net/src/hp/magicsock/conn.rs
+++ b/iroh-net/src/hp/magicsock/conn.rs
@@ -2656,7 +2656,7 @@ pub(crate) mod tests {
                         region_id: 1,
                         // In test mode, the DERP client does not validate HTTPS certs, so the host
                         // name is irrelevant, but the port is used.
-                        host_name: format!("https://test-node.invalid:{}", https_addr.port())
+                        url: format!("https://test-node.invalid:{}", https_addr.port())
                             .parse()
                             .unwrap(),
                         stun_only: false,

--- a/iroh-net/src/hp/magicsock/conn.rs
+++ b/iroh-net/src/hp/magicsock/conn.rs
@@ -2654,13 +2654,15 @@ pub(crate) mod tests {
                     nodes: vec![DerpNode {
                         name: "t1".into(),
                         region_id: 1,
-                        host_name: "https://test-node.invalid".parse().unwrap(),
+                        // In test mode, the DERP client does not validate HTTPS certs, so the host
+                        // name is irrelevant, but the port is used.
+                        host_name: format!("https://test-node.invalid:${}", https_addr.port())
+                            .parse()
+                            .unwrap(),
                         stun_only: false,
                         stun_port: stun_addr.port(),
                         ipv4: UseIpv4::Some("127.0.0.1".parse().unwrap()),
                         ipv6: UseIpv6::None,
-
-                        derp_port: https_addr.port(),
                         stun_test_ip: Some(stun_addr.ip()),
                     }],
                     avoid: false,

--- a/iroh-net/src/hp/magicsock/conn.rs
+++ b/iroh-net/src/hp/magicsock/conn.rs
@@ -2656,7 +2656,7 @@ pub(crate) mod tests {
                         region_id: 1,
                         // In test mode, the DERP client does not validate HTTPS certs, so the host
                         // name is irrelevant, but the port is used.
-                        host_name: format!("https://test-node.invalid:${}", https_addr.port())
+                        host_name: format!("https://test-node.invalid:{}", https_addr.port())
                             .parse()
                             .unwrap(),
                         stun_only: false,

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -1788,7 +1788,7 @@ mod tests {
             .await
             .context("failed to create netcheck client")?;
 
-        let stun_servers = vec![("https://derp.iroh.network.", 3478, 0)];
+        let stun_servers = vec![("https://derp.iroh.network.", 3478)];
 
         let mut dm = DerpMap::default();
         dm.regions.insert(
@@ -1798,7 +1798,7 @@ mod tests {
                 nodes: stun_servers
                     .into_iter()
                     .enumerate()
-                    .map(|(i, (host_name, stun_port, derp_port))| DerpNode {
+                    .map(|(i, (host_name, stun_port))| DerpNode {
                         name: format!("default-{}", i),
                         region_id: 1,
                         host_name: host_name.parse().unwrap(),
@@ -1806,7 +1806,6 @@ mod tests {
                         stun_port,
                         ipv4: UseIpv4::None,
                         ipv6: UseIpv6::None,
-                        derp_port,
                         stun_test_ip: None,
                     })
                     .collect(),

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -335,7 +335,7 @@ async fn check_captive_portal(dm: &DerpMap, preferred_derp: Option<u16>) -> Resu
     let node = &dm.regions.get(&preferred_derp).unwrap().nodes[0];
 
     if node
-        .host_name
+        .url
         .host_str()
         .map(|s| s.ends_with(&DOT_INVALID))
         .unwrap_or_default()
@@ -354,7 +354,7 @@ async fn check_captive_portal(dm: &DerpMap, preferred_derp: Option<u16>) -> Resu
     // length is limited; see is_challenge_char in bin/derper for more
     // details.
 
-    let host_name = node.host_name.host_str().unwrap_or_default();
+    let host_name = node.url.host_str().unwrap_or_default();
     let challenge = format!("ts_{}", host_name);
     let portal_url = format!("http://{}/generate_204", host_name);
     let res = client
@@ -453,7 +453,7 @@ async fn get_node_addr(n: &DerpNode, proto: ProbeProto) -> Result<SocketAddr> {
         }
     }
 
-    match n.host_name.host() {
+    match n.url.host() {
         Some(url::Host::Domain(hostname)) => {
             async move {
                 debug!(?proto, %hostname, "Performing DNS lookup for derp addr");
@@ -1801,7 +1801,7 @@ mod tests {
                     .map(|(i, (host_name, stun_port))| DerpNode {
                         name: format!("default-{}", i),
                         region_id: 1,
-                        host_name: host_name.parse().unwrap(),
+                        url: host_name.parse().unwrap(),
                         stun_only: true,
                         stun_port,
                         ipv4: UseIpv4::None,

--- a/iroh-net/src/hp/stun.rs
+++ b/iroh-net/src/hp/stun.rs
@@ -178,7 +178,7 @@ pub mod test {
             let node = DerpNode {
                 name: format!("{region_id}a"),
                 region_id,
-                host_name: format!("http://{region_id}.invalid").parse().unwrap(),
+                url: format!("http://{region_id}.invalid").parse().unwrap(),
                 ipv4,
                 ipv6,
                 stun_port: port,

--- a/iroh-net/src/hp/stun.rs
+++ b/iroh-net/src/hp/stun.rs
@@ -184,7 +184,6 @@ pub mod test {
                 stun_port: port,
                 stun_only: true,
                 stun_test_ip: None,
-                derp_port: 0,
             };
             m.regions.insert(
                 region_id,

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -195,9 +195,9 @@ async fn report(stun_host: Option<String>, stun_port: u16, config: &Config) -> a
 
     let dm = match stun_host {
         Some(host_name) => {
-            let host_name = host_name.parse()?;
+            let url = host_name.parse()?;
             // creating a derp map from host name and stun port
-            DerpMap::default_from_node(host_name, stun_port, UseIpv4::None, UseIpv6::None)
+            DerpMap::default_from_node(url, stun_port, UseIpv4::None, UseIpv6::None)
         }
         None => config.derp_map().expect("derp map not configured"),
     };
@@ -434,10 +434,10 @@ async fn passive_side(connection: quinn::Connection) -> anyhow::Result<()> {
 
 fn configure_local_derp_map() -> DerpMap {
     let stun_port = 3478;
-    let host_name = "http://derp.invalid:3340".parse().unwrap();
+    let url = "http://derp.invalid:3340".parse().unwrap();
     let derp_ipv4 = UseIpv4::Some("127.0.0.1".parse().unwrap());
     let derp_ipv6 = UseIpv6::None;
-    DerpMap::default_from_node(host_name, stun_port, derp_ipv4, derp_ipv6)
+    DerpMap::default_from_node(url, stun_port, derp_ipv4, derp_ipv6)
 }
 
 const DR_DERP_ALPN: [u8; 11] = *b"n0/drderp/1";

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -197,7 +197,7 @@ async fn report(stun_host: Option<String>, stun_port: u16, config: &Config) -> a
         Some(host_name) => {
             let host_name = host_name.parse()?;
             // creating a derp map from host name and stun port
-            DerpMap::default_from_node(host_name, stun_port, 0, UseIpv4::None, UseIpv6::None)
+            DerpMap::default_from_node(host_name, stun_port, UseIpv4::None, UseIpv6::None)
         }
         None => config.derp_map().expect("derp map not configured"),
     };
@@ -434,11 +434,10 @@ async fn passive_side(connection: quinn::Connection) -> anyhow::Result<()> {
 
 fn configure_local_derp_map() -> DerpMap {
     let stun_port = 3478;
-    let host_name = "http://derp.invalid".parse().unwrap();
-    let derp_port = 3340;
+    let host_name = "http://derp.invalid:3340".parse().unwrap();
     let derp_ipv4 = UseIpv4::Some("127.0.0.1".parse().unwrap());
     let derp_ipv6 = UseIpv6::None;
-    DerpMap::default_from_node(host_name, stun_port, derp_port, derp_ipv4, derp_ipv6)
+    DerpMap::default_from_node(host_name, stun_port, derp_ipv4, derp_ipv6)
 }
 
 const DR_DERP_ALPN: [u8; 11] = *b"n0/drderp/1";


### PR DESCRIPTION
Now that `DerpNode::host_name` is an URL, the DERP port can be part of that URL, so we don't need a separate `derp_port` field anymore. 

This makes setting custom DERP config or accepting a DERP server from the command line much simpler, because you need only a single URL string and not multiple options.

It looks a bit weird in the test code because oftenly those use `http://derp.invalid:{port}` now. I think we could just put the full IP in the address also and not set `UseIpv4::Some()`.