### PR TITLE
fix: remove build-data dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.22",
+ "time",
 ]
 
 [[package]]
@@ -381,17 +381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78a6932c88f1d2c29533a3b8a5f5a2f84cc19c3339b431677c3160c5c2e6ca85"
 
 [[package]]
-name = "build-data"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac83c47416b2db78a5a8a45d7d229a730b62806fa41ac6b4dbde6d016798776"
-dependencies = [
- "chrono",
- "safe-lock",
- "safe-regex",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,11 +463,8 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "time 0.1.43",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1703,7 +1689,6 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "backoff",
- "build-data",
  "bytes",
  "clap",
  "crypto_box",
@@ -1712,6 +1697,7 @@ dependencies = [
  "default-net",
  "der",
  "derive_more",
+ "duct",
  "ed25519-dalek",
  "flume",
  "futures",
@@ -1744,7 +1730,7 @@ dependencies = [
  "stun-rs",
  "surge-ping",
  "thiserror",
- "time 0.3.22",
+ "time",
  "tokio",
  "tokio-rustls",
  "tokio-rustls-acme",
@@ -2108,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
+checksum = "53ba502077159ace3aa56c25449a007173a406607a94ef665247246191eb38b1"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -2813,7 +2799,7 @@ checksum = "4954fbc00dcd4d8282c987710e50ba513d351400dbdd00e803a05172a90d8976"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.22",
+ "time",
  "yasna",
 ]
 
@@ -3128,59 +3114,6 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "safe-lock"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077d73db7973cccf63eb4aff1e5a34dc2459baa867512088269ea5f2f4253c90"
-
-[[package]]
-name = "safe-proc-macro2"
-version = "1.0.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "814c536dcd27acf03296c618dab7ad62d28e70abd7ba41d3f34a2ce707a2c666"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "safe-quote"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e530f7831f3feafcd5f1aae406ac205dd998436b4007c8e80f03eca78a88f7"
-dependencies = [
- "safe-proc-macro2",
-]
-
-[[package]]
-name = "safe-regex"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15289bf322e0673d52756a18194167f2378ec1a15fe884af6e2d2cb934822b0"
-dependencies = [
- "safe-regex-macro",
-]
-
-[[package]]
-name = "safe-regex-compiler"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba76fae590a2aa665279deb1f57b5098cbace01a0c5e60e262fcf55f7c51542"
-dependencies = [
- "safe-proc-macro2",
- "safe-quote",
-]
-
-[[package]]
-name = "safe-regex-macro"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c2e96b5c03f158d1b16ba79af515137795f4ad4e8de3f790518aae91f1d127"
-dependencies = [
- "safe-proc-macro2",
- "safe-regex-compiler",
-]
 
 [[package]]
 name = "salsa20"
@@ -3714,16 +3647,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
@@ -3766,11 +3689,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "374442f06ee49c3a28a8fc9f01a2596fed7559c6b99b31279c3261778e77d84f"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -4636,7 +4560,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.22",
+ "time",
 ]
 
 [[package]]
@@ -4645,7 +4569,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.22",
+ "time",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -24,7 +24,6 @@ license-files = [
 [advisories]
 ignore = [
        "RUSTSEC-2020-0168", # mach is unmaintained
-       "RUSTSEC-2020-0071", # time advisory, see #1035
 ]
 
 [sources]

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -84,7 +84,7 @@ tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macr
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
-build-data = "0.1.3"
+duct = "0.13.6"
 
 [features]
 default = ["metrics"]

--- a/iroh-net/build.rs
+++ b/iroh-net/build.rs
@@ -1,6 +1,25 @@
+use std::io;
+
+use duct::cmd;
+
 fn main() {
-    build_data::set_GIT_COMMIT();
-    build_data::set_RUSTC_VERSION();
-    build_data::set_SOURCE_TIMESTAMP();
-    build_data::no_debug_rebuilds();
+    // Git commit
+    println!("cargo:rustc-env=GIT_COMMIT={}", get_git_commit().unwrap());
+
+    // Rustc version
+    println!(
+        "cargo:rustc-env=RUSTC_VERSION={}",
+        get_rustc_version().unwrap()
+    );
+}
+
+fn get_git_commit() -> std::io::Result<String> {
+    cmd!("git", "rev-parse", "HEAD").read()
+}
+
+fn get_rustc_version() -> io::Result<String> {
+    let rustc_var = std::env::var_os("RUSTC")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "RUSTC env var is not set"))?;
+    cmd!(rustc_var, "--version").read()
 }

--- a/iroh-net/src/hp/hostinfo.rs
+++ b/iroh-net/src/hp/hostinfo.rs
@@ -83,6 +83,7 @@ mod tests {
         let info = Hostinfo::default();
         println!("{:#?}", info);
 
+        assert!(!info.git_commit.is_empty());
         assert!(!info.rust_version.is_empty());
     }
 }


### PR DESCRIPTION
Simplifies getting the information we actually need, without using another dependency.

Ref #1035