### PR TITLE
ref(tests): Clean up various bits in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "testdir"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fc921e7c4ad1aedb3484811514f3e5cd187886e0bbf1302c175f7578ef552"
+checksum = "48b7965698cfb3d1ac1e6e54b4b45f5caa9e89bda223c8cf723d9cf53d7cefa7"
 dependencies = [
  "anyhow",
  "backtrace",

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -47,7 +47,7 @@ walkdir = "2"
 http-body = "0.4.5"
 proptest = "1.0.0"
 rand = "0.8"
-testdir = "0.7.2"
+testdir = "0.8"
 tempfile = "3.4"
 tokio = { version = "1", features = ["macros", "test-util"] }
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -58,7 +58,7 @@ duct = "0.13.6"
 nix = "0.26.2"
 rand = "0.8"
 regex = { version = "1.7.1", features = ["std"] }
-testdir = "0.7.2"
+testdir = "0.8"
 tokio = { version = "1", features = ["macros", "io-util", "rt"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 walkdir = "2"


### PR DESCRIPTION
- Bump testdir to 0.8, we use multiple testdir!() calls inside a
  single test while expecting to get the same directory.  This was not
  the case but now in 0.8 it is.

- When transferring folders do not use testdir!() directly but a
  subdirectory.  Using testdir!() directly ends up including e.g. the
  iroh_data_dir which should not really be included.

- Simplify make_provider to not require home, all callers used
  testdir!() for that anyway.

- Simplify match_provide_output since it did not use Input anyway.

- Fix test_provide_get_loop to not go put the path inside
  $CARGO_MANIFEST_DIR/tests/fixtures since we do not store any test
  fixtures.  We create all of them on the fly and put them inside
  testdir!().  I think we were always testing this with an empty
  directory before?

- Improve assert_matches_line to not hide the errors from the reader.
  This is the error that is propagated from duct in case the provider
  fails, hiding this is rather confusing.  Improves the error messages
  emitted there too by e.g. showing the failing regex instead of just
  say "EOF, *shrug*".