### PR TITLE
feat(iroh-net): implement `HomeRouter` detection

### DIFF
--- a/iroh-net/src/net/interfaces.rs
+++ b/iroh-net/src/net/interfaces.rs
@@ -369,7 +369,7 @@ impl HomeRouter {
         bsd::likely_home_router()
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "window"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
     fn get_default_gateway() -> Option<IpAddr> {
         let gateway = default_net::get_default_gateway().ok()?;
         Some(gateway.ip_addr)

--- a/iroh-net/src/net/interfaces.rs
+++ b/iroh-net/src/net/interfaces.rs
@@ -26,11 +26,13 @@ use crate::net::ip::{is_loopback, is_private_v6, is_up};
     target_os = "macos",
     target_os = "ios"
 ))]
-use self::bsd::default_route;
+use self::bsd::{default_route, likely_home_router};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use self::linux::default_route;
 #[cfg(target_os = "windows")]
 use self::windows::default_route;
+
+use super::ip::is_private;
 
 /// Represents a network interface.
 #[derive(Debug)]
@@ -335,6 +337,51 @@ pub async fn default_route_interface() -> Option<String> {
     DefaultRouteDetails::new().await.map(|v| v.interface_name)
 }
 
+/// Likely IPs of the residentla router, and the ip address of the current
+/// machine using it.
+#[derive(Debug, Clone)]
+pub struct HomeRouter {
+    pub gateway: IpAddr,
+    pub my_ip: Option<IpAddr>,
+}
+
+impl HomeRouter {
+    /// Returns the likely IP of the residential router, which will always
+    /// be a private address, if found.
+    /// In addition, it returns the IP address of the current machine on
+    /// the LAN using that gateway.
+    /// This is used as the destination for UPnP, NAT-PMP, PCP, etc queries.
+    pub async fn new() -> Option<Self> {
+        let gateway = likely_home_router().await?;
+        let mut my_ip = None;
+
+        let ifaces = default_net::interface::get_interfaces();
+        for iface in ifaces {
+            let iface = Interface { iface };
+
+            // Skip interaces that are up
+            if !iface.is_up() {
+                continue;
+            }
+
+            for addr in iface.addrs() {
+                // Match the IP type to the gateway.
+                let both_ipv4 = gateway.is_ipv4() && addr.addr().is_ipv4();
+                let both_ipv6 = gateway.is_ipv6() && addr.addr().is_ipv6();
+                if !both_ipv4 && !both_ipv6 {
+                    continue;
+                }
+
+                if is_private(&gateway) && is_private(&addr.addr()) {
+                    my_ip = Some(addr.addr());
+                }
+            }
+        }
+
+        Some(HomeRouter { gateway, my_ip })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -345,5 +392,11 @@ mod tests {
             .await
             .expect("missing default route");
         println!("default_route: {:#?}", default_route);
+    }
+
+    #[tokio::test]
+    async fn test_likely_home_router() {
+        let home_router = HomeRouter::new().await.expect("missing home router");
+        println!("home router: {:#?}", home_router);
     }
 }

--- a/iroh-net/src/net/interfaces/bsd.rs
+++ b/iroh-net/src/net/interfaces/bsd.rs
@@ -26,7 +26,7 @@ pub async fn default_route() -> Option<DefaultRouteDetails> {
     })
 }
 
-pub async fn likely_home_router() -> Option<IpAddr> {
+pub fn likely_home_router() -> Option<IpAddr> {
     let rib = fetch_routing_table()?;
     let msgs = parse_routing_table(&rib)?;
     for rm in msgs {

--- a/iroh-net/src/net/interfaces/linux.rs
+++ b/iroh-net/src/net/interfaces/linux.rs
@@ -1,13 +1,10 @@
 //! Linux-specific network interfaces implementations.
 
-use std::net::Ipv4Addr;
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use anyhow::{anyhow, Result};
 #[cfg(not(target_os = "android"))]
 use futures::TryStreamExt;
 use tokio::fs::File;
-use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 use super::DefaultRouteDetails;
 
@@ -26,157 +23,7 @@ pub async fn default_route() -> Option<DefaultRouteDetails> {
     res.ok().flatten()
 }
 
-static PROC_NET_ROUTE_ERR: AtomicBool = AtomicBool::new(false);
 const PROC_NET_ROUTE_PATH: &str = "/proc/net/route";
-/// The max number of lines to read from /proc/net/route looking for a default route.
-const MAX_PROC_NET_ROUTE_READ: usize = 1000;
-
-/// Parses 10.0.0.1 out of:
-///
-/// ```norun
-/// $ cat /proc/net/route
-/// Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT
-/// ens18   00000000        0100000A        0003    0       0       0       00000000        0       0       0
-/// ens18   0000000A        00000000        0001    0       0       0       0000FFFF        0       0       0
-/// ```
-pub async fn likely_home_router() -> Option<Ipv4Addr> {
-    if PROC_NET_ROUTE_ERR.load(Ordering::Relaxed) {
-        // If we failed to read /proc/net/route previously, don't keep trying.
-        // But if we're on Android, go into the Android path.
-        #[cfg(target_os = "android")]
-        return likely_home_router_android();
-        #[cfg(not(target_os = "android"))]
-        return None;
-    }
-    let file = File::open(PROC_NET_ROUTE_PATH).await.ok()?;
-
-    match parse_proc_net_home_router(file).await {
-        Ok(ip) => ip,
-        Err(err) => {
-            tracing::debug!("failed to read /proc/net/route: {:?}", err);
-
-            PROC_NET_ROUTE_ERR.store(true, Ordering::Relaxed);
-            #[cfg(target_os = "android")]
-            return likely_home_router_android();
-            #[cfg(not(target_os = "android"))]
-            return None;
-        }
-    }
-}
-
-async fn parse_proc_net_home_router<R: AsyncRead + Unpin>(source: R) -> Result<Option<Ipv4Addr>> {
-    let mut line_num = 0;
-    let mut reader = BufReader::new(source).lines();
-
-    while let Some(line) = reader.next_line().await? {
-        line_num += 1;
-
-        if line_num == 1 {
-            // Skip header line.
-            continue;
-        }
-        if line_num > MAX_PROC_NET_ROUTE_READ {
-            anyhow::bail!("/proc/net too long");
-        }
-
-        let mut fields = line.split_ascii_whitespace();
-        let Some(gateway_hex) = fields.nth(2) else {
-            continue;
-        };
-        let Some(flags_hex) = fields.next() else {
-            continue;
-        };
-
-        let mut flags_bytes = [0u8; 2];
-        if hex::decode_to_slice(flags_hex, &mut flags_bytes).is_err() {
-            continue;
-        }
-        let flags = u16::from_be_bytes(flags_bytes);
-
-        let mut gateway_bytes = [0u8; 4];
-        if hex::decode_to_slice(gateway_hex, &mut gateway_bytes).is_err() {
-            continue;
-        }
-        let gateway = u32::from_le_bytes(gateway_bytes);
-
-        dbg!(gateway);
-        dbg!(flags);
-
-        if dbg!(flags & (libc::RTF_UP | libc::RTF_GATEWAY))
-            != dbg!(libc::RTF_UP | libc::RTF_GATEWAY)
-        {
-            continue;
-        }
-
-        let ip = Ipv4Addr::from(gateway);
-        if ip.is_private() {
-            return Ok(Some(ip));
-        }
-    }
-    // if errors.Is(err, errStopReading) {
-    // 	err = nil
-    // }
-    // if err != nil {
-    // 	procNetRouteErr.Store(true)
-    // 	if runtime.GOOS == "android" {
-    // 		return likelyHomeRouterIPAndroid()
-    // 	}
-    // 	log.Printf("interfaces: failed to read /proc/net/route: %v", err)
-    // }
-    // if ret.IsValid() {
-    // 	return ret, true
-    // }
-    // if lineNum >= maxProcNetRouteRead {
-    // 	// If we went over our line limit without finding an answer, assume
-    // 	// we're a big fancy Linux router (or at least not a home system)
-    // 	// and set the error bit so we stop trying this in the future (and wasting CPU).
-    // 	// See https://github.com/tailscale/tailscale/issues/7621.
-    // 	//
-    // 	// Remember that "likelyHomeRouterIP" exists purely to find the port
-    // 	// mapping service (UPnP, PMP, PCP) often present on a home router. If we hit
-    // 	// the route (line) limit without finding an answer, we're unlikely to ever
-    // 	// find one in the future.
-    // 	procNetRouteErr.Store(true)
-    // }
-    Ok(None)
-}
-
-/// Android apps don't have permission to read /proc/net/route, at
-/// least on Google devices and the Android emulator.
-#[cfg(target_os = "android")]
-async fn likely_home_router_android() -> Option<Ipv4Addr> {
-    // cmd := exec.Command("/system/bin/ip", "route", "show", "table", "0")
-    // out, err := cmd.StdoutPipe()
-    // if err != nil {
-    // 	return
-    // }
-    // if err := cmd.Start(); err != nil {
-    // 	log.Printf("interfaces: running /system/bin/ip: %v", err)
-    // 	return
-    // }
-    // // Search for line like "default via 10.0.2.2 dev radio0 table 1016 proto static mtu 1500 "
-    // lineread.Reader(out, func(line []byte) error {
-    // 	const pfx = "default via "
-    // 	if !mem.HasPrefix(mem.B(line), mem.S(pfx)) {
-    // 		return nil
-    // 	}
-    // 	line = line[len(pfx):]
-    // 	sp := bytes.IndexByte(line, ' ')
-    // 	if sp == -1 {
-    // 		return nil
-    // 	}
-    // 	ipb := line[:sp]
-    // 	if ip, err := netip.ParseAddr(string(ipb)); err == nil && ip.Is4() {
-    // 		ret = ip
-    // 		log.Printf("interfaces: found Android default route %v", ip)
-    // 	}
-    // 	return nil
-    // })
-    // cmd.Process.Kill()
-    // cmd.Wait()
-    // return ret, ret.IsValid()
-    None
-}
 
 async fn default_route_proc() -> Result<Option<DefaultRouteDetails>> {
     const ZERO_ADDR: &str = "00000000";
@@ -351,22 +198,5 @@ mod tests {
             assert!(!route.interface_name.is_empty());
             assert!(route.interface_index > 0);
         }
-    }
-
-    #[tokio::test]
-    async fn test_parse_proc_net_home_router() {
-        let source = r#"Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT
-ens18   00000000        0100000A        0003    0       0       0       00000000        0       0       0
-ens18   0000000A        00000000        0001    0       0       0       0000FFFF        0       0       0
-"#;
-
-        let expected: Ipv4Addr = "10.0.0.1".parse().unwrap();
-        assert_eq!(
-            parse_proc_net_home_router(std::io::Cursor::new(source))
-                .await
-                .unwrap()
-                .unwrap(),
-            expected,
-        );
     }
 }


### PR DESCRIPTION
- [x] bsd/macos using manual impl because of  https://github.com/shellrow/default-net/issues/34
- [x] linux (using `default_net`)
- [x] windows (using `default_net`)