### PR TITLE
request token for provide

### DIFF
--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -29,6 +29,7 @@ once_cell = "1.17.0"
 portable-atomic = "1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quinn = "0.10"
+rand = "0.8"
 range-collections = "0.4.0"
 self_cell = "1.0.1"
 serde = { version = "1", features = ["derive"] }

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -78,6 +78,21 @@ pub async fn run_ticket(
     )
     .await?;
 
+    let request = if ticket.token().is_some() && request.token().is_none() {
+        // we have a ticket, but no token, so we need to add the token to the request
+        match request {
+            AnyGetRequest::Get(get_request) => {
+                AnyGetRequest::Get(get_request.with_token(ticket.token().cloned()))
+            }
+            AnyGetRequest::CustomGet(mut custom_get_request) => {
+                custom_get_request.token = ticket.token().cloned();
+                AnyGetRequest::CustomGet(custom_get_request)
+            }
+        }
+    } else {
+        request
+    };
+
     Ok(run_connection(connection, request))
 }
 

--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -72,9 +72,6 @@ impl FromStr for RequestToken {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "random" {
-            return Ok(Self::generate());
-        }
         let bytes = data_encoding::BASE32_NOPAD.decode(s.to_ascii_uppercase().as_bytes())?;
         RequestToken::new(bytes)
     }

--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -55,6 +55,13 @@ impl RequestToken {
         Ok(Self { bytes })
     }
 
+    /// Generate a random 32 byte request token.
+    pub fn generate() -> Self {
+        Self {
+            bytes: rand::random::<[u8; 32]>().to_vec().into(),
+        }
+    }
+
     /// Returns a reference the token bytes.
     pub fn as_bytes(&self) -> &Bytes {
         &self.bytes
@@ -65,6 +72,9 @@ impl FromStr for RequestToken {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "random" {
+            return Ok(Self::generate());
+        }
         let bytes = data_encoding::BASE32_NOPAD.decode(s.to_ascii_uppercase().as_bytes())?;
         RequestToken::new(bytes)
     }

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -528,9 +528,15 @@ async fn handle_stream<D: BaoMap, E: EventSender>(
         }
     };
 
-    authorization_handler
+    // 3. Authorize the request (may be a no-op)
+    debug!("authorizing request");
+    if let Err(e) = authorization_handler
         .authorize(db.clone(), request.token().cloned(), &request)
-        .await?;
+        .await
+    {
+        writer.notify_transfer_aborted();
+        return Err(e);
+    }
 
     match request {
         Request::Get(request) => handle_get(db, request, writer).await,

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -25,6 +25,15 @@ use super::{
     MAX_RPC_CONNECTIONS, MAX_RPC_STREAMS, RPC_ALPN,
 };
 
+// impl Into<RequestToken> for RequestTokenOptions {
+//     fn into(self) -> RequestToken {
+//         match self {
+//             RequestTokenOptions::Random => RequestToken::generate(),
+//             RequestTokenOptions::Token(token) => token,
+//         }
+//     }
+// }
+
 #[derive(Debug)]
 pub struct ProvideOptions {
     pub addr: SocketAddr,

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -25,15 +25,6 @@ use super::{
     MAX_RPC_CONNECTIONS, MAX_RPC_STREAMS, RPC_ALPN,
 };
 
-// impl Into<RequestToken> for RequestTokenOptions {
-//     fn into(self) -> RequestToken {
-//         match self {
-//             RequestTokenOptions::Random => RequestToken::generate(),
-//             RequestTokenOptions::Token(token) => token,
-//         }
-//     }
-// }
-
 #[derive(Debug)]
 pub struct ProvideOptions {
     pub addr: SocketAddr,

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -240,8 +240,14 @@ impl FromStr for ProviderRpcPort {
 }
 
 #[derive(Debug, Clone)]
-struct TokenAuth {
+pub struct TokenAuth {
     token: Option<RequestToken>,
+}
+
+impl TokenAuth {
+    pub fn new(token: Option<RequestToken>) -> Self {
+        Self { token }
+    }
 }
 
 impl<D> RequestAuthorizationHandler<D> for TokenAuth {
@@ -251,8 +257,9 @@ impl<D> RequestAuthorizationHandler<D> for TokenAuth {
         token: Option<RequestToken>,
         request: &Request,
     ) -> BoxFuture<'static, anyhow::Result<()>> {
+        println!("comparing {:?} to {:?}", token, self.token);
         match &self.token {
-            None => return ().authorize(db, token, request),
+            None => ().authorize(db, token, request),
             Some(expect) => {
                 let expect = expect.clone();
                 async move {

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -18,12 +18,14 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use futures::future::{BoxFuture, Shared};
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt};
-use iroh_bytes::blobs::Collection;
-use iroh_bytes::provider::database::{BaoMap, BaoMapEntry, BaoReadonlyDb};
-use iroh_bytes::provider::RequestAuthorizationHandler;
 use iroh_bytes::{
-    protocol::Closed,
-    provider::{CustomGetHandler, Database, ProvideProgress, Ticket, ValidateProgress},
+    blobs::Collection,
+    protocol::{Closed, RequestToken},
+    provider::{
+        database::{BaoMap, BaoMapEntry, BaoReadonlyDb},
+        CustomGetHandler, Database, ProvideProgress, RequestAuthorizationHandler, Ticket,
+        ValidateProgress,
+    },
     runtime,
     util::{Hash, Progress},
 };
@@ -484,10 +486,10 @@ impl<D: BaoReadonlyDb> Node<D> {
     /// Return a single token containing everything needed to get a hash.
     ///
     /// See [`Ticket`] for more details of how it can be used.
-    pub async fn ticket(&self, hash: Hash) -> Result<Ticket> {
+    pub async fn ticket(&self, hash: Hash, token: Option<RequestToken>) -> Result<Ticket> {
         // TODO: Verify that the hash exists in the db?
         let addrs = self.local_endpoint_addresses().await?;
-        Ticket::new(hash, self.peer_id(), addrs, None)
+        Ticket::new(hash, self.peer_id(), addrs, token)
     }
 
     /// Aborts the node.

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -790,7 +790,7 @@ mod tests {
             .await
             .unwrap();
         let _drop_guard = node.cancel_token().drop_guard();
-        let ticket = node.ticket(hash).await.unwrap();
+        let ticket = node.ticket(hash, None).await.unwrap();
         println!("addrs: {:?}", ticket.addrs());
         assert!(!ticket.addrs().is_empty());
     }

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -8,10 +8,7 @@ use std::{
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
 use futures::{future::BoxFuture, FutureExt};
-use iroh::{
-    commands::provide,
-    node::{Event, Node},
-};
+use iroh::node::{Event, Node, StaticTokenAuthHandler};
 use iroh_net::MagicEndpoint;
 use rand::RngCore;
 use testdir::testdir;
@@ -508,7 +505,7 @@ async fn test_run_ticket() {
     let token = Some(RequestToken::generate());
     let node = Node::builder(db)
         .bind_addr((Ipv4Addr::UNSPECIFIED, 0).into())
-        .custom_auth_handler(provide::TokenAuth::new(token.clone()))
+        .custom_auth_handler(StaticTokenAuthHandler::new(token.clone()))
         .runtime(&rt)
         .spawn()
         .await

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -8,7 +8,10 @@ use std::{
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
 use futures::{future::BoxFuture, FutureExt};
-use iroh::node::{Event, Node};
+use iroh::{
+    commands::provide,
+    node::{Event, Node},
+};
 use iroh_net::MagicEndpoint;
 use rand::RngCore;
 use testdir::testdir;
@@ -502,14 +505,35 @@ async fn test_run_ticket() {
     let rt = test_runtime();
     let readme = Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md");
     let (db, hash) = create_collection(vec![readme.into()]).await.unwrap();
+    let token = Some(RequestToken::generate());
     let node = Node::builder(db)
         .bind_addr((Ipv4Addr::UNSPECIFIED, 0).into())
+        .custom_auth_handler(provide::TokenAuth::new(token.clone()))
         .runtime(&rt)
         .spawn()
         .await
         .unwrap();
     let _drop_guard = node.cancel_token().drop_guard();
-    let ticket = node.ticket(hash, None).await.unwrap();
+
+    let no_token_ticket = node.ticket(hash, None).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(10), async move {
+        let response = get::run_ticket(
+            &no_token_ticket,
+            GetRequest::all(no_token_ticket.hash()).into(),
+            true,
+            None,
+        )
+        .await?;
+
+        let response = aggregate_get_response(response).await;
+        assert!(response.is_err());
+        anyhow::Result::<_>::Ok(())
+    })
+    .await
+    .expect("timeout")
+    .expect("getting without token failed in an unexpected way");
+
+    let ticket = node.ticket(hash, token).await.unwrap();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let response =
             get::run_ticket(&ticket, GetRequest::all(ticket.hash()).into(), true, None).await?;

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -509,7 +509,7 @@ async fn test_run_ticket() {
         .await
         .unwrap();
     let _drop_guard = node.cancel_token().drop_guard();
-    let ticket = node.ticket(hash).await.unwrap();
+    let ticket = node.ticket(hash, None).await.unwrap();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let response =
             get::run_ticket(&ticket, GetRequest::all(ticket.hash()).into(), true, None).await?;


### PR DESCRIPTION
This re-adds request authentication tokens to provide, making it optional, and off by default this go-round. Closes #987 

* supply `--token=random` flag to `iroh provide` to get back old behaviour of random token construction
* supply `--token $BASE_32_ENCODED_TOKEN` to use an external opaque token
* either use of the token flag will require the token for _all_ requests to the provider.

### TODO
* [x] at least one test

### Follow-ups
* [ ] I can't get our CLI to report useful error messages on the get side, would like to investigate better error propagation