### PR TITLE
docs(iroh-net): deny missing docs and broken links in the crate, except the `derp` mod

### DIFF
--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -13,7 +13,7 @@ pub const DEFAULT_DERP_IPV4: std::net::Ipv4Addr = std::net::Ipv4Addr::new(35, 17
 /// Get the default [`DerpMap`].
 pub fn default_derp_map() -> DerpMap {
     DerpMap {
-        regions: [(1, default_derp_region())].into(),
+        regions: HashMap::from_iter([(1, default_derp_region())].into_iter()),
     }
 }
 

--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -1,13 +1,15 @@
-use std::collections::HashMap;
+//! Default values used in [`iroh-net`][`crate`]
 
 use crate::hp::derp::{DerpMap, DerpNode, DerpRegion, UseIpv4, UseIpv6};
 
+/// Get the default [`DerpMap`].
 pub fn default_derp_map() -> DerpMap {
     DerpMap {
-        regions: HashMap::from_iter([(1, default_derp_region())].into_iter()),
+        regions: [(1, default_derp_region())].into(),
     }
 }
 
+/// Get the default [`DerpRegion`].
 pub fn default_derp_region() -> DerpRegion {
     // The default derper run by number0.
     let default_n0_derp = DerpNode {

--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -1,4 +1,5 @@
 //! Default values used in [`iroh-net`][`crate`]
+use std::collections::HashMap;
 
 use crate::hp::derp::{DerpMap, DerpNode, DerpRegion, UseIpv4, UseIpv6};
 

--- a/iroh-net/src/hp.rs
+++ b/iroh-net/src/hp.rs
@@ -1,3 +1,5 @@
+//! Utilities for hole punching.
+#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod derp;
 mod dns;
 pub mod magicsock;

--- a/iroh-net/src/hp/cfg.rs
+++ b/iroh-net/src/hp/cfg.rs
@@ -18,17 +18,24 @@ pub const DERP_MAGIC_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 3, 3, 40));
 /// An endpoint IPPort and an associated type.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Endpoint {
+    /// The address of the endpoint.
     pub addr: SocketAddr,
+    /// The kind of endpoint.
     pub typ: EndpointType,
 }
 
+/// Type of endpoint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EndpointType {
+    /// Endpoint kind has not been determined yet.
     Unknown,
+    /// Endpoint is bound to a local address.
     Local,
+    /// Endpoint has a publicly reachable address found via STUN.
     Stun,
+    /// Endpoint uses a port mapping in the router.
     Portmapped,
-    /// hard NAT: STUN'ed IPv4 address + local fixed port
+    /// Hard NAT: STUN'ed IPv4 address + local fixed port.
     Stun4LocalPort,
 }
 
@@ -104,11 +111,14 @@ impl NetInfo {
     }
 }
 
+/// The type of link.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LinkType {
+    /// A wired link (ethernet, fiber, etc).
     Wired,
+    /// A WiFi link.
     Wifi,
-    /// LTE, 4G, 3G, etc
+    /// LTE, 4G, 3G, etc.
     Mobile,
 }
 
@@ -125,6 +135,7 @@ pub struct PingResult {
     pub node_ip: Option<IpAddr>,
     /// DNS name base or (possibly not unique) hostname
     pub node_name: Option<String>,
+    /// Perceived latency in seconds.
     pub latency_seconds: Option<f64>,
     /// The ip:port if direct UDP was used. It is not currently set for TSMP pings.
     pub endpoint: Option<SocketAddr>,

--- a/iroh-net/src/hp/key.rs
+++ b/iroh-net/src/hp/key.rs
@@ -1,1 +1,2 @@
+//! The private and public keys of a node.
 pub mod node;

--- a/iroh-net/src/hp/key/node.rs
+++ b/iroh-net/src/hp/key/node.rs
@@ -135,7 +135,7 @@ impl SecretKey {
         crypto_box::ChaChaBox::new(&other.0, &self.0)
     }
 
-    /// Creates a shared secret between the [`SecretKey`] and the given [`PublicKey`], and sealsthe
+    /// Creates a shared secret between the [SecretKey] and the given [PublicKey], and seals the
     /// provided cleartext.
     pub fn seal_to(&self, other: &PublicKey, cleartext: &[u8]) -> Vec<u8> {
         use crypto_box::aead::{Aead, AeadCore, OsRng};

--- a/iroh-net/src/hp/key/node.rs
+++ b/iroh-net/src/hp/key/node.rs
@@ -1,3 +1,5 @@
+//! The private and public keys of a node.
+
 use std::{fmt::Debug, hash::Hash};
 
 use anyhow::{anyhow, ensure, Context, Result};
@@ -9,6 +11,7 @@ pub(crate) const PUBLIC_KEY_LENGTH: usize = KEY_SIZE;
 pub(crate) const SECRET_KEY_LENGTH: usize = KEY_SIZE;
 pub(crate) const NONCE_LEN: usize = 24;
 
+/// Public key of a node.
 #[derive(Clone, Eq)]
 pub struct PublicKey(crypto_box::PublicKey);
 
@@ -65,15 +68,18 @@ impl TryFrom<&[u8]> for PublicKey {
 }
 
 impl PublicKey {
+    /// Borrow the public key as bytes.
     pub fn as_bytes(&self) -> &[u8; PUBLIC_KEY_LENGTH] {
         self.0.as_bytes()
     }
 
+    /// Whether the public key is zero.
     pub fn is_zero(&self) -> bool {
         self.0.as_bytes() == &[0u8; PUBLIC_KEY_LENGTH]
     }
 }
 
+/// The private key of a node.
 #[derive(Clone)]
 pub struct SecretKey(crypto_box::SecretKey);
 
@@ -104,14 +110,17 @@ impl<'de> Deserialize<'de> for SecretKey {
 }
 
 impl SecretKey {
+    /// Generate a random [SecretKey].
     pub fn generate() -> Self {
         Self(crypto_box::SecretKey::generate(&mut rand::rngs::OsRng))
     }
 
+    /// Get the [PublicKey] that corresponds to this [SecretKey].
     pub fn public_key(&self) -> PublicKey {
         self.0.public_key().into()
     }
 
+    /// Serialize the [SecretKey] to bytes.
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()
     }
@@ -126,8 +135,8 @@ impl SecretKey {
         crypto_box::ChaChaBox::new(&other.0, &self.0)
     }
 
-    // Creates a shared secret between the [`SecretKey`] and the given [`PublicKey`], and sealsthe
-    // provided cleartext.
+    /// Creates a shared secret between the [`SecretKey`] and the given [`PublicKey`], and sealsthe
+    /// provided cleartext.
     pub fn seal_to(&self, other: &PublicKey, cleartext: &[u8]) -> Vec<u8> {
         use crypto_box::aead::{Aead, AeadCore, OsRng};
 
@@ -142,8 +151,8 @@ impl SecretKey {
         res
     }
 
-    // Creates a shared secret between the [`SecretKey`] and the given [`PublicKey`], and opens the
-    // `seal`, returning the cleartext.
+    /// Creates a shared secret between the [SecretKey] and the given [PublicKey], and opens the
+    /// `seal`, returning the cleartext.
     pub fn open_from(&self, other: &PublicKey, seal: &[u8]) -> Result<Vec<u8>> {
         let shared_secret = self.shared_secret(other);
 

--- a/iroh-net/src/hp/magicsock/conn.rs
+++ b/iroh-net/src/hp/magicsock/conn.rs
@@ -381,6 +381,7 @@ impl Conn {
         Ok(c)
     }
 
+    /// Retrieve information about known peer's endpoints in the network.
     pub async fn tracked_endpoints(&self) -> Result<Vec<EndpointInfo>> {
         let (s, r) = sync::oneshot::channel();
         self.actor_sender
@@ -390,6 +391,7 @@ impl Conn {
         Ok(res)
     }
 
+    /// Query for the local endpoints discovered during the last endpoint discovery.
     pub async fn local_endpoints(&self) -> Result<Vec<cfg::Endpoint>> {
         let (s, r) = sync::oneshot::channel();
         self.actor_sender
@@ -399,6 +401,7 @@ impl Conn {
         Ok(res)
     }
 
+    /// Get the cached version of the Ipv4 and Ipv6 addrs of the current connection.
     pub fn local_addr(&self) -> Result<(SocketAddr, Option<SocketAddr>)> {
         Ok(*self.local_addrs.read().unwrap())
     }

--- a/iroh-net/src/hp/magicsock/conn.rs
+++ b/iroh-net/src/hp/magicsock/conn.rs
@@ -381,7 +381,7 @@ impl Conn {
         Ok(c)
     }
 
-    /// Retrieve information about known peer's endpoints in the network.
+    /// Retrieve information about known peers' endpoints in the network.
     pub async fn tracked_endpoints(&self) -> Result<Vec<EndpointInfo>> {
         let (s, r) = sync::oneshot::channel();
         self.actor_sender

--- a/iroh-net/src/hp/magicsock/endpoint.rs
+++ b/iroh-net/src/hp/magicsock/endpoint.rs
@@ -1013,7 +1013,7 @@ struct EndpointState {
     /// Contains the TxID for the last incoming ping. This is
     /// used to de-dup incoming pings that we may see on both the raw disco
     /// socket on Linux, and UDP socket. We cannot rely solely on the raw socket
-    /// disco handling due to https://github.com/tailscale/tailscale/issues/7078.
+    /// disco handling due to <https://github.com/tailscale/tailscale/issues/7078>.
     last_got_ping_tx_id: Option<stun::TransactionId>,
 
     /// If non-zero, is the time this endpoint was advertised last via a call-me-maybe disco message.

--- a/iroh-net/src/hp/magicsock/timer.rs
+++ b/iroh-net/src/hp/magicsock/timer.rs
@@ -50,6 +50,7 @@ impl Timer {
         Timer { s, t }
     }
 
+    /// Reset the timer to stop after `d` has passed.
     pub async fn reset(&self, d: Duration) {
         self.s.send(d).await.ok();
     }

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -228,7 +228,7 @@ impl Client {
     /// STUN packets.  This function **will not read from the sockets**, as they may be
     /// receiving other traffic as well, normally they are the sockets carrying the real
     /// traffic.  Thus all stun packets received on those sockets should be passed to
-    /// [`Client::get_msg_sender`] in order for this function to receive the stun
+    /// [Client::receive_stun_packet] in order for this function to receive the stun
     /// responses and function correctly.
     ///
     /// If these are not passed in this will bind sockets for STUN itself, though results

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -70,6 +70,9 @@ const CAPTIVE_PORTAL_DELAY: Duration = Duration::from_millis(200);
 /// Timeout for captive portal checks, must be lower than OVERALL_PROBE_TIMEOUT
 const CAPTIVE_PORTAL_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// A netcheck report.
+///
+/// Can be obtained by calling [Client::get_report].
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct Report {
     /// A UDP STUN round trip completed.

--- a/iroh-net/src/hp/netmap.rs
+++ b/iroh-net/src/hp/netmap.rs
@@ -7,5 +7,6 @@ use super::cfg;
 /// This contains all the peers the local node knows about.
 #[derive(Clone, Debug)]
 pub struct NetworkMap {
+    /// Known peers in the network.
     pub peers: Vec<cfg::Node>,
 }

--- a/iroh-net/src/hp/ping.rs
+++ b/iroh-net/src/hp/ping.rs
@@ -6,6 +6,8 @@ use anyhow::{Context, Result};
 use surge_ping::{Client, Config, IcmpPacket, PingIdentifier, PingSequence, ICMP};
 use tracing::debug;
 
+/// Allows sending ICMP echo requests to a host in order to determine network latency.
+/// Will gracefully handle both ipv4 and ipv6.
 #[derive(Debug, Clone)]
 pub struct Pinger(Arc<Inner>);
 
@@ -23,6 +25,7 @@ struct Inner {
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl Pinger {
+    /// Create a new [Pinger].
     pub async fn new() -> Result<Self> {
         let client_v4 = Client::new(&Config::builder().kind(ICMP::V4).build())
             .context("failed creating IPv4 pinger")?;
@@ -35,6 +38,7 @@ impl Pinger {
         })))
     }
 
+    /// Send a ping request with asociated data, returning the perceived latency.
     pub async fn send(&self, addr: IpAddr, data: &[u8]) -> Result<Duration> {
         let client = match addr {
             IpAddr::V4(_) => &self.0.client_v4,

--- a/iroh-net/src/hp/ping.rs
+++ b/iroh-net/src/hp/ping.rs
@@ -7,7 +7,7 @@ use surge_ping::{Client, Config, IcmpPacket, PingIdentifier, PingSequence, ICMP}
 use tracing::debug;
 
 /// Allows sending ICMP echo requests to a host in order to determine network latency.
-/// Will gracefully handle both ipv4 and ipv6.
+/// Will gracefully handle both IPv4 and IPv6.
 #[derive(Debug, Clone)]
 pub struct Pinger(Arc<Inner>);
 

--- a/iroh-net/src/hp/portmapper.rs
+++ b/iroh-net/src/hp/portmapper.rs
@@ -27,6 +27,7 @@ const AVAILABILITY_TRUST_DURATION: Duration = Duration::from_secs(60 * 10); // 1
 /// Capacity of the channel to communicate with the long-running service.
 const SERVICE_CHANNEL_CAPACITY: usize = 32; // should be plenty
 
+/// Output of a port mapping probe.
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
 #[display("portmap={{ UPnP: {upnp}, PMP: {pmp}, PCP: {pcp} }}")]
 pub struct ProbeOutput {
@@ -39,6 +40,7 @@ pub struct ProbeOutput {
 }
 
 impl ProbeOutput {
+    /// Indicate if all port mapping protocols are available.
     pub fn all_available(&self) -> bool {
         self.upnp && self.pcp && self.pmp
     }

--- a/iroh-net/src/hp/portmapper.rs
+++ b/iroh-net/src/hp/portmapper.rs
@@ -40,7 +40,7 @@ pub struct ProbeOutput {
 }
 
 impl ProbeOutput {
-    /// Indicate if all port mapping protocols are available.
+    /// Indicates if all port mapping protocols are available.
     pub fn all_available(&self) -> bool {
         self.upnp && self.pcp && self.pmp
     }

--- a/iroh-net/src/hp/stun.rs
+++ b/iroh-net/src/hp/stun.rs
@@ -22,7 +22,7 @@ pub enum Error {
     /// STUN request is not a binding request when it should be.
     #[error("not binding")]
     NotBinding,
-    /// STUN packet is not a response when it should.
+    /// STUN packet is not a response when it should be.
     #[error("not success response")]
     NotSuccessResponse,
     /// STUN response has malformed attributes.

--- a/iroh-net/src/hp/stun.rs
+++ b/iroh-net/src/hp/stun.rs
@@ -1,3 +1,5 @@
+//! STUN packets sending and receiving.
+
 use std::net::SocketAddr;
 
 use stun_rs::{

--- a/iroh-net/src/hp/stun.rs
+++ b/iroh-net/src/hp/stun.rs
@@ -19,7 +19,7 @@ pub enum Error {
     /// The STUN message could not be parsed or is otherwise invalid.
     #[error("invalid message")]
     InvalidMessage,
-    /// STUN request is not a binding request when it should.
+    /// STUN request is not a binding request when it should be.
     #[error("not binding")]
     NotBinding,
     /// STUN packet is not a response when it should.

--- a/iroh-net/src/hp/stun.rs
+++ b/iroh-net/src/hp/stun.rs
@@ -11,23 +11,30 @@ pub use stun_rs::{
 
 use crate::net::ip::to_canonical;
 
+/// Errors that can occurr when handling a STUN packet.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// The STUN message could not be parsed or is otherwise invalid.
     #[error("invalid message")]
     InvalidMessage,
+    /// STUN request is not a binding request when it should.
     #[error("not binding")]
     NotBinding,
+    /// STUN packet is not a response when it should.
     #[error("not success response")]
     NotSuccessResponse,
+    /// STUN response has malformed attributes.
     #[error("malformed attributes")]
     MalformedAttrs,
+    /// STUN request didn't end in fingerprint.
     #[error("no fingerprint")]
     NoFingerprint,
+    /// STUN request had bogus fingerprint.
     #[error("invalid fingerprint")]
     InvalidFingerprint,
 }
 
-// Generates a binding request STUN packet.
+/// Generates a binding request STUN packet.
 pub fn request(tx: TransactionId) -> Vec<u8> {
     let fp = Fingerprint::default();
     let msg = StunMessageBuilder::new(methods::BINDING, MessageClass::Request)

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![recursion_limit = "256"]
 
 pub mod defaults;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -1,15 +1,15 @@
 // #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![recursion_limit = "256"]
 
-#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
+#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod defaults;
-#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
+#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod hp;
-#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
+#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod magic_endpoint;
-#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
+#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod net;
-#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
+#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod tls;
 #[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod util;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod defaults;
 #[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod hp;
-#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod magic_endpoint;
 #[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod net;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -3,7 +3,7 @@
 
 #[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod defaults;
-#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod hp;
 #[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod magic_endpoint;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -9,7 +9,7 @@ pub mod hp;
 pub mod magic_endpoint;
 #[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod net;
-#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod tls;
 #[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod util;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -7,7 +7,7 @@ pub mod defaults;
 pub mod hp;
 #[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod magic_endpoint;
-#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod net;
 #[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod tls;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -1,7 +1,7 @@
 // #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![recursion_limit = "256"]
 
-#[allow(missing_docs, rustdoc::broken_intra_doc_links)]
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod defaults;
 #[allow(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod hp;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -1,4 +1,3 @@
-// #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![recursion_limit = "256"]
 
 #[deny(missing_docs, rustdoc::broken_intra_doc_links)]

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -1,11 +1,17 @@
-#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+// #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![recursion_limit = "256"]
 
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod defaults;
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod hp;
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod magic_endpoint;
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod net;
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod tls;
+#[deny(missing_docs, rustdoc::broken_intra_doc_links)]
 pub mod util;
 
 pub use magic_endpoint::MagicEndpoint;

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -153,6 +153,7 @@ fn make_server_config(
     Ok(server_config)
 }
 
+/// An endpoint that leverages a [quinn::Endpoint] backed by a [hp::magicsock::Conn].
 #[derive(Clone, Debug)]
 pub struct MagicEndpoint {
     keypair: Arc<Keypair>,

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -1,3 +1,5 @@
+//! An endpoint that leverages a [quinn::Endpoint] backed by a [hp::magicsock::Conn].
+
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},

--- a/iroh-net/src/net/interfaces.rs
+++ b/iroh-net/src/net/interfaces.rs
@@ -339,7 +339,9 @@ pub async fn default_route_interface() -> Option<String> {
 /// machine using it.
 #[derive(Debug, Clone)]
 pub struct HomeRouter {
+    /// Ip of the router.
     pub gateway: IpAddr,
+    /// Our local Ip if known.
     pub my_ip: Option<IpAddr>,
 }
 

--- a/iroh-net/src/net/interfaces/linux.rs
+++ b/iroh-net/src/net/interfaces/linux.rs
@@ -68,7 +68,7 @@ async fn default_route_proc() -> Result<Option<DefaultRouteDetails>> {
 /// Try find the default route by parsing the "ip route" command output.
 ///
 /// We use this on Android where /proc/net/route can be missing entries or have locked-down
-/// permissions.  See also comments in https://github.com/tailscale/tailscale/pull/666.
+/// permissions.  See also comments in <https://github.com/tailscale/tailscale/pull/666>.
 #[cfg(target_os = "android")]
 pub async fn default_route_android_ip_route() -> Result<Option<DefaultRouteDetails>> {
     use tokio::process::Command;

--- a/iroh-net/src/net/interfaces/windows.rs
+++ b/iroh-net/src/net/interfaces/windows.rs
@@ -6,7 +6,7 @@ use wmi::{query::FilterValue, COMLibrary, WMIConnection};
 
 use super::DefaultRouteDetails;
 
-/// API Docs: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/wmiiprouteprov/win32-ip4routetable
+/// API Docs: <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/wmiiprouteprov/win32-ip4routetable>
 #[derive(Deserialize, Debug)]
 #[allow(non_camel_case_types, non_snake_case)]
 struct Win32_IP4RouteTable {

--- a/iroh-net/src/tls/certificate.rs
+++ b/iroh-net/src/tls/certificate.rs
@@ -1,6 +1,7 @@
 //! X.509 certificate handling.
 //!
 //! This module handles generation, signing, and verification of certificates.
+//! Based on rust-libp2p/transports/tls
 
 use der::{asn1::OctetStringRef, Decode, Encode, Sequence};
 use x509_parser::prelude::*;
@@ -94,17 +95,21 @@ pub struct P2pExtension {
     signature: super::Signature,
 }
 
+/// An error that occurs during certificate generation.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct GenError(#[from] rcgen::RcgenError);
 
+/// An error that occurs during certificate parsing.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct ParseError(#[from] pub(crate) webpki::Error);
 
+/// An error that occurs during signature verification.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct VerificationError(#[from] pub(crate) webpki::Error);
+
 /// Internal function that only parses but does not verify the certificate.
 ///
 /// Useful for testing but unsuitable for production.

--- a/iroh-net/src/tls/certificate.rs
+++ b/iroh-net/src/tls/certificate.rs
@@ -1,7 +1,6 @@
 //! X.509 certificate handling.
 //!
 //! This module handles generation, signing, and verification of certificates.
-//! Based on rust-libp2p/transports/tls
 
 use der::{asn1::OctetStringRef, Decode, Encode, Sequence};
 use x509_parser::prelude::*;

--- a/iroh-net/src/tls/verifier.rs
+++ b/iroh-net/src/tls/verifier.rs
@@ -2,7 +2,6 @@
 //!
 //! This module handles a verification of a client/server certificate chain
 //! and signatures allegedly by the given certificates.
-//! Based on rust-libp2p/transports/tls
 
 use std::sync::Arc;
 

--- a/iroh-net/src/tls/verifier.rs
+++ b/iroh-net/src/tls/verifier.rs
@@ -2,6 +2,7 @@
 //!
 //! This module handles a verification of a client/server certificate chain
 //! and signatures allegedly by the given certificates.
+//! Based on rust-libp2p/transports/tls
 
 use std::sync::Arc;
 

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -1,3 +1,4 @@
+//! Utilities used in [`iroh-net`][`crate`]
 use std::{
     future::Future,
     pin::Pin,
@@ -41,6 +42,7 @@ pub struct CancelOnDrop {
 }
 
 impl CancelOnDrop {
+    /// Create a [`CancelOnDrop`] with a name and a handle to a task.
     pub fn new(task_name: &'static str, handle: tokio::task::AbortHandle) -> Self {
         CancelOnDrop { task_name, handle }
     }
@@ -56,6 +58,7 @@ impl Drop for CancelOnDrop {
 /// Resolves to pending if the inner is `None`.
 #[derive(Debug)]
 pub struct MaybeFuture<T> {
+    /// Future to be polled.
     pub inner: Option<T>,
 }
 

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -1,4 +1,5 @@
 //! Utilities used in [`iroh-net`][`crate`]
+
 use std::{
     future::Future,
     pin::Pin,


### PR DESCRIPTION
the individual `deny` should be moved to the top level once the `derp` is documented
part of #1156 