### PR TITLE
feature: make get-ticket just a way to use get

### DIFF
--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -68,13 +68,14 @@ impl Cli {
                 single,
             } => {
                 let get = if let Some(ticket) = ticket {
-                    self::get::GetInteractive::Ticket {
-                        ticket,
-                        keylog: self.keylog,
-                        derp_map: config.derp_map(),
+                    self::get::GetInteractive {
+                        hash: ticket.hash(),
+                        opts: ticket.as_get_options(Keypair::generate()),
+                        token: ticket.token().cloned(),
+                        single: false,
                     }
                 } else if let (Some(peer), Some(hash)) = (peer, hash) {
-                    self::get::GetInteractive::Hash {
+                    self::get::GetInteractive {
                         hash: *hash.as_hash(),
                         opts: iroh_bytes::get::Options {
                             addrs,

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -366,10 +366,16 @@ fn test_provide_get_loop(path: &Path, input: Input, output: Output) -> Result<()
     let cmd = if let Some(ref out) = out {
         cmd(
             iroh_bin(),
-            ["get-ticket", &all_in_one, "--out", out.to_str().unwrap()],
+            [
+                "get",
+                "--ticket",
+                &all_in_one,
+                "--out",
+                out.to_str().unwrap(),
+            ],
         )
     } else {
-        cmd(iroh_bin(), ["get-ticket", &all_in_one])
+        cmd(iroh_bin(), ["get", "--ticket", &all_in_one])
     }
     .stdout_capture()
     .stderr_capture();


### PR DESCRIPTION
you can either use get --ticket <ticket> or get --peer..., but it is all handled by the get subcommand.

The args are configured so that you get decent error messages when misusing. E.g.

```
❯ cargo run get --ticket ebim463bsc4cl3t5vkn7vlacngxvu5wkv5o3fzj5psw2whnxyipfeigxxvopirxcngbsl3eol4a5hchk7tpvzdcwc6qy42equqon2n2w7yaagacsjt2rhzg3amambkabqtsnwayaycuadc7e3mbq --peer 266vz5cg4juygjpmrzpqdu4i5l6n6xemkyl2ddtiscsbzxjxk37a
error: the argument '--ticket <TICKET>' cannot be used with '--peer <PEER>'
```

The netsim test failure is because netsim is using iroh get-ticket instead of iroh get --ticket. I got a branch of chuck where this is corrected. Just replace `get-ticket` with `get --ticket`