### PR TITLE
Get rid of MagicEndpoint::dial_peer and refactor dialing in get

### DIFF
--- a/iroh-bytes/src/blobs.rs
+++ b/iroh-bytes/src/blobs.rs
@@ -27,7 +27,7 @@ impl Collection {
         })
     }
 
-    /// Serialize this collection to a std Vec<u8>
+    /// Serialize this collection to a std `Vec<u8>`
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
         Ok(postcard::to_stdvec(self)?)
     }

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -14,6 +14,7 @@ use bao_tree::io::DecodeResponseItem;
 use bao_tree::outboard::PreOrderMemOutboard;
 use bao_tree::{ByteNum, ChunkNum};
 use bytes::BytesMut;
+use iroh_net::tls::Keypair;
 use iroh_net::{hp::derp::DerpMap, tls::PeerId};
 use postcard::experimental::max_size::MaxSize;
 use quinn::RecvStream;
@@ -70,6 +71,7 @@ pub async fn run_ticket(
     derp_map: Option<DerpMap>,
 ) -> Result<get_response_machine::AtInitial> {
     let connection = iroh_net::MagicEndpoint::dial_peer(
+        Keypair::generate(),
         ticket.peer(),
         &crate::P2P_ALPN,
         ticket.addrs(),
@@ -623,6 +625,7 @@ pub async fn run(
     opts: Options,
 ) -> anyhow::Result<get_response_machine::AtInitial> {
     let connection = iroh_net::MagicEndpoint::dial_peer(
+        Keypair::generate(),
         opts.peer_id,
         &crate::P2P_ALPN,
         &opts.addrs,

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -26,7 +26,6 @@ pub use crate::util::Hash;
 
 use crate::blobs::Collection;
 use crate::protocol::{write_lp, AnyGetRequest, Handshake, RangeSpecSeq};
-use crate::provider::Ticket;
 use crate::tokio_util::{TrackingReader, TrackingWriter};
 use crate::util::pathbuf_from_name;
 use crate::IROH_BLOCK_SIZE;
@@ -34,13 +33,15 @@ use crate::IROH_BLOCK_SIZE;
 /// Options for the client
 #[derive(Clone, Debug)]
 pub struct Options {
-    /// The addresses to connect to.
+    /// The keypair of the node
+    pub keypair: Keypair,
+    /// The addresses to connect to
     pub addrs: Vec<SocketAddr>,
-    /// The peer id to expect
+    /// The peer id to dial
     pub peer_id: PeerId,
-    /// Whether to log the SSL keys when `SSLKEYLOGFILE` environment variable is set.
+    /// Whether to log the SSL keys when `SSLKEYLOGFILE` environment variable is set
     pub keylog: bool,
-    /// The configuration of the derp services.
+    /// The configuration of the derp services
     pub derp_map: Option<DerpMap>,
 }
 
@@ -61,26 +62,6 @@ impl Stats {
         let data_len_bit = self.bytes_read * 8;
         data_len_bit as f64 / (1000. * 1000.) / self.elapsed.as_secs_f64()
     }
-}
-
-/// Gets a collection and all its blobs using a [`Ticket`].
-pub async fn run_ticket(
-    ticket: &Ticket,
-    request: AnyGetRequest,
-    keylog: bool,
-    derp_map: Option<DerpMap>,
-) -> Result<get_response_machine::AtInitial> {
-    let connection = iroh_net::MagicEndpoint::dial_peer(
-        Keypair::generate(),
-        ticket.peer(),
-        &crate::P2P_ALPN,
-        ticket.addrs(),
-        derp_map,
-        keylog,
-    )
-    .await?;
-
-    Ok(run_connection(connection, request))
 }
 
 /// Finite state machine for get responses
@@ -619,29 +600,22 @@ pub mod get_response_machine {
     }
 }
 
-/// Dial a peer and run a get request
-pub async fn run(
-    request: AnyGetRequest,
-    opts: Options,
-) -> anyhow::Result<get_response_machine::AtInitial> {
-    let connection = iroh_net::MagicEndpoint::dial_peer(
-        Keypair::generate(),
-        opts.peer_id,
-        &crate::P2P_ALPN,
-        &opts.addrs,
-        opts.derp_map,
-        opts.keylog,
-    )
-    .await?;
-    Ok(run_connection(connection, request))
-}
-
-/// Do a get request and return a stream of responses
-pub fn run_connection(
-    connection: quinn::Connection,
-    request: AnyGetRequest,
-) -> get_response_machine::AtInitial {
-    get_response_machine::AtInitial::new(connection, request)
+/// Create a new endpoint and dial a peer, returning the connection
+///
+/// Note that this will create an entirely new endpoint, so it should be only
+/// used for short lived connections. If you want to connect to multiple peers,
+/// it is preferable to create an endpoint and use `connect` on the endpoint.
+pub async fn dial(opts: Options) -> anyhow::Result<quinn::Connection> {
+    let endpoint = iroh_net::MagicEndpoint::builder()
+        .keypair(opts.keypair)
+        .derp_map(opts.derp_map)
+        .keylog(opts.keylog)
+        .bind(0)
+        .await?;
+    endpoint
+        .connect(opts.peer_id, &crate::P2P_ALPN, &opts.addrs)
+        .await
+        .context("failed to connect to provider")
 }
 
 /// Error when processing a response

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -1,8 +1,12 @@
 //! The client side API
 //!
-//! The main entry point is [`run`]. This function takes callbacks that will
-//! be invoked when blobs or collections are received. It is up to the caller
-//! to store the received data.
+//! To get data, create a connection using the `dial` function or use any quinn
+//! connection that was obtained in another way.
+//!
+//! Create a request describing the data you want to get.
+//!
+//! Then create a state machine using [get_response_machine::AtInitial::new] and
+//! drive it to completion by calling next on each state.
 use std::error::Error;
 use std::fmt::{self, Debug};
 use std::net::SocketAddr;

--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -96,11 +96,21 @@ pub enum Request {
 }
 
 impl Request {
+    /// Gets the request token.
     pub fn token(&self) -> Option<&RequestToken> {
         match self {
             Request::Get(get) => get.token(),
             Request::CustomGet(get) => get.token.as_ref(),
         }
+    }
+
+    /// Sets the request token and returns a new request.
+    pub fn with_token(mut self, value: Option<RequestToken>) -> Self {
+        match &mut self {
+            Request::Get(get) => get.token = value,
+            Request::CustomGet(get) => get.token = value,
+        }
+        self
     }
 }
 

--- a/iroh-bytes/src/provider/ticket.rs
+++ b/iroh-bytes/src/provider/ticket.rs
@@ -8,11 +8,11 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::{ensure, Result};
-use iroh_net::tls::PeerId;
+use iroh_net::tls::{Keypair, PeerId};
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::RequestToken;
-use crate::Hash;
+use crate::{get, Hash};
 
 /// A token containing everything to get a file from the provider.
 ///
@@ -91,6 +91,16 @@ impl Ticket {
             addrs,
         } = self;
         (hash, peer, addrs, token)
+    }
+
+    pub fn get_options(&self, keypair: Keypair) -> get::Options {
+        get::Options {
+            peer_id: self.peer,
+            addrs: self.addrs.clone(),
+            keypair,
+            keylog: true,
+            derp_map: None,
+        }
     }
 }
 

--- a/iroh-bytes/src/provider/ticket.rs
+++ b/iroh-bytes/src/provider/ticket.rs
@@ -93,7 +93,7 @@ impl Ticket {
         (hash, peer, addrs, token)
     }
 
-    pub fn get_options(&self, keypair: Keypair) -> get::Options {
+    pub fn as_get_options(&self, keypair: Keypair) -> get::Options {
         get::Options {
             peer_id: self.peer,
             addrs: self.addrs.clone(),

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -223,8 +223,8 @@ impl Client {
     /// The *stun_conn4* and *stun_conn6* endpoints are bound UDP sockets to use to send out
     /// STUN packets.  This function **will not read from the sockets**, as they may be
     /// receiving other traffic as well, normally they are the sockets carrying the real
-    /// traffic.  Thus all stun packets received on those sockets should be passed to
-    /// [`Client::get_msg_sender`] in order for this function to receive the stun
+    /// traffic. Thus all stun packets received on those sockets should be passed to
+    /// [`Client::receive_stun_packet`] in order for this function to receive the stun
     /// responses and function correctly.
     ///
     /// If these are not passed in this will bind sockets for STUN itself, though results

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -168,40 +168,6 @@ impl MagicEndpoint {
         MagicEndpointBuilder::default()
     }
 
-    /// Connect to a remote endpoint, creating an endpoint on the fly.
-    ///
-    /// The PeerId and the ALPN protocol are required. If you happen to know dialable addresses of
-    /// the remote endpoint, they can be specified and will be used to try and establish a direct
-    /// connection without involving a DERP server. If no addresses are specified, the endpoint
-    /// will try to dial the peer through the configured DERP servers.
-    ///
-    /// If *derp_map* is set, these DERP servers are used to discover the dialed peer by its
-    /// [`PeerId`], help establish the connection being an initial relay for traffic and assist in
-    /// holepunching.
-    ///
-    /// If *keylog* is `true` and the KEYLOGFILE environment variable is present it will be
-    /// considered a filename to which the TLS pre-master keys are logged.  This can be useful
-    /// to be able to decrypt captured traffic for debugging purposes.
-    ///
-    /// Note that this function is a convenience wrapper around [MagicEndpointBuilder] and [Self::connect].
-    /// It should be used in short lived processes that only need to connect to a single peer.
-    /// Otherwise, it is more efficient to create a [MagicEndpoint] and then
-    /// use [Self::connect] to connect to multiple peers.
-    pub async fn dial_peer(
-        keypair: Keypair,
-        peer_id: PeerId,
-        alpn_protocol: &[u8],
-        known_addrs: &[SocketAddr],
-        derp_map: Option<DerpMap>,
-        keylog: bool,
-    ) -> anyhow::Result<quinn::Connection> {
-        let endpoint = MagicEndpoint::bind(keypair, 0, None, derp_map, None, keylog).await?;
-        endpoint
-            .connect(peer_id, alpn_protocol, known_addrs)
-            .await
-            .context("failed to connect to provider")
-    }
-
     /// Create a quinn endpoint backed by a magicsock.
     ///
     /// This is for internal use, the public interface is the [MagicEndpointBuilder] obtained from

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -182,15 +182,20 @@ impl MagicEndpoint {
     /// If *keylog* is `true` and the KEYLOGFILE environment variable is present it will be
     /// considered a filename to which the TLS pre-master keys are logged.  This can be useful
     /// to be able to decrypt captured traffic for debugging purposes.
+    ///
+    /// Note that this function is a convenience wrapper around [MagicEndpointBuilder] and [Self::connect].
+    /// It should be used in short lived processes that only need to connect to a single peer.
+    /// Otherwise, it is more efficient to create a [MagicEndpoint] and then
+    /// use [Self::connect] to connect to multiple peers.
     pub async fn dial_peer(
+        keypair: Keypair,
         peer_id: PeerId,
         alpn_protocol: &[u8],
         known_addrs: &[SocketAddr],
         derp_map: Option<DerpMap>,
         keylog: bool,
     ) -> anyhow::Result<quinn::Connection> {
-        let endpoint =
-            MagicEndpoint::bind(Keypair::generate(), 0, None, derp_map, None, keylog).await?;
+        let endpoint = MagicEndpoint::bind(keypair, 0, None, derp_map, None, keylog).await?;
         endpoint
             .connect(peer_id, alpn_protocol, known_addrs)
             .await

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -6,7 +6,7 @@ use std::{net::SocketAddr, path::PathBuf};
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use iroh_bytes::{cid::Blake3Cid, protocol::RequestToken, provider::Ticket, runtime};
-use iroh_net::tls::PeerId;
+use iroh_net::tls::{Keypair, PeerId};
 use quic_rpc::transport::quinn::QuinnConnection;
 use quic_rpc::RpcClient;
 
@@ -72,6 +72,7 @@ impl Cli {
                         peer_id: peer,
                         keylog: self.keylog,
                         derp_map: config.derp_map(),
+                        keypair: Keypair::generate(),
                     },
                     token,
                     single,

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -10,7 +10,7 @@ use iroh_bytes::{
     cid::Blake3Cid,
     get::{
         self,
-        get_response_machine::{ConnectedNext, EndBlobNext},
+        get_response_machine::{self, ConnectedNext, EndBlobNext},
     },
     protocol::{GetRequest, RangeSpecSeq, Request, RequestToken},
     provider::Ticket,
@@ -19,7 +19,7 @@ use iroh_bytes::{
     Hash,
 };
 use iroh_io::{AsyncSliceWriter, FileAdapter};
-use iroh_net::hp::derp::DerpMap;
+use iroh_net::{hp::derp::DerpMap, tls::Keypair};
 use range_collections::RangeSet2;
 use tokio::sync::mpsc;
 
@@ -66,6 +66,21 @@ impl GetInteractive {
         }
     }
 
+    fn get_options(&self) -> get::Options {
+        match self {
+            GetInteractive::Ticket {
+                ticket,
+                keylog,
+                derp_map,
+            } => get::Options {
+                keylog: *keylog,
+                derp_map: derp_map.clone(),
+                ..ticket.get_options(Keypair::generate())
+            },
+            GetInteractive::Hash { opts, .. } => opts.clone(),
+        }
+    }
+
     fn new_request(&self, query: RangeSpecSeq) -> Request {
         GetRequest::new(self.hash(), query)
             .with_token(self.token().cloned())
@@ -96,14 +111,9 @@ impl GetInteractive {
         let collection_info = Some((1, 0));
 
         let request = self.new_request(query);
-        let response = match self {
-            GetInteractive::Ticket {
-                ticket,
-                keylog,
-                derp_map,
-            } => get::run_ticket(&ticket, request, keylog, derp_map).await?,
-            GetInteractive::Hash { opts, .. } => get::run(request, opts).await?,
-        };
+        let opts = self.get_options();
+        let connection = get::dial(opts).await?;
+        let response = get_response_machine::AtInitial::new(connection, request);
         let connected = response.next().await?;
         write(format!("{} Requesting ...", style("[2/3]").bold().dim()));
         if let Some((count, missing_bytes)) = collection_info {
@@ -190,14 +200,9 @@ impl GetInteractive {
         };
 
         let request = self.new_request(query);
-        let response = match self {
-            GetInteractive::Ticket {
-                ticket,
-                keylog,
-                derp_map,
-            } => get::run_ticket(&ticket, request, keylog, derp_map).await?,
-            GetInteractive::Hash { opts, .. } => get::run(request, opts).await?,
-        };
+        let opts = self.get_options();
+        let connection = get::dial(opts).await?;
+        let response = get_response_machine::AtInitial::new(connection, request);
         let connected = response.next().await?;
         write(format!("{} Requesting ...", style("[2/3]").bold().dim()));
         if let Some((count, missing_bytes)) = collection_info {
@@ -366,14 +371,9 @@ impl GetInteractive {
 
         let pb = make_download_pb();
         let request = self.new_request(query);
-        let response = match self {
-            GetInteractive::Ticket {
-                ticket,
-                keylog,
-                derp_map,
-            } => get::run_ticket(&ticket, request, keylog, derp_map).await?,
-            GetInteractive::Hash { opts, .. } => get::run(request, opts).await?,
-        };
+        let opts = self.get_options();
+        let connection = get::dial(opts).await?;
+        let response = get_response_machine::AtInitial::new(connection, request);
         let connected = response.next().await?;
         write(format!("{} Requesting ...", style("[2/3]").bold().dim()));
         let ConnectedNext::StartRoot(curr) = connected.next().await? else {

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -75,7 +75,7 @@ impl GetInteractive {
             } => get::Options {
                 keylog: *keylog,
                 derp_map: derp_map.clone(),
-                ..ticket.get_options(Keypair::generate())
+                ..ticket.as_get_options(Keypair::generate())
             },
             GetInteractive::Hash { opts, .. } => opts.clone(),
         }

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -110,9 +110,8 @@ impl GetInteractive {
         // collection info, in case we won't get a callback with is_root
         let collection_info = Some((1, 0));
 
-        let request = self.new_request(query);
-        let opts = self.get_options();
-        let connection = get::dial(opts).await?;
+        let request = self.new_request(query).with_token(self.token().cloned());
+        let connection = get::dial(self.get_options()).await?;
         let response = get_response_machine::AtInitial::new(connection, request);
         let connected = response.next().await?;
         write(format!("{} Requesting ...", style("[2/3]").bold().dim()));
@@ -199,9 +198,8 @@ impl GetInteractive {
             Some((collection.len() as u64, 0))
         };
 
-        let request = self.new_request(query);
-        let opts = self.get_options();
-        let connection = get::dial(opts).await?;
+        let request = self.new_request(query).with_token(self.token().cloned());
+        let connection = get::dial(self.get_options()).await?;
         let response = get_response_machine::AtInitial::new(connection, request);
         let connected = response.next().await?;
         write(format!("{} Requesting ...", style("[2/3]").bold().dim()));
@@ -370,9 +368,8 @@ impl GetInteractive {
         };
 
         let pb = make_download_pb();
-        let request = self.new_request(query);
-        let opts = self.get_options();
-        let connection = get::dial(opts).await?;
+        let request = self.new_request(query).with_token(self.token().cloned());
+        let connection = get::dial(self.get_options()).await?;
         let response = get_response_machine::AtInitial::new(connection, request);
         let connected = response.next().await?;
         write(format!("{} Requesting ...", style("[2/3]").bold().dim()));

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -56,7 +56,7 @@ const MAX_STREAMS: u64 = 10;
 const HEALTH_POLL_WAIT: Duration = Duration::from_secs(1);
 
 /// Default bind address for the node.
-/// 11204 is "iroh" in leetspeak https://simple.wikipedia.org/wiki/Leet
+/// 11204 is "iroh" in leetspeak <https://simple.wikipedia.org/wiki/Leet>
 pub const DEFAULT_BIND_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::LOCALHOST, 11204);
 
 /// How long we wait at most for some endpoints to be discovered.

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -492,7 +492,7 @@ async fn test_run_ticket() {
 
     let no_token_ticket = node.ticket(hash, None).await.unwrap();
     tokio::time::timeout(Duration::from_secs(10), async move {
-        let opts = no_token_ticket.get_options(Keypair::generate());
+        let opts = no_token_ticket.as_get_options(Keypair::generate());
         let request = GetRequest::all(no_token_ticket.hash()).into();
         let response = run_get_request(opts, request).await;
         assert!(response.is_err());
@@ -507,7 +507,7 @@ async fn test_run_ticket() {
         let request = GetRequest::all(hash)
             .with_token(ticket.token().cloned())
             .into();
-        run_get_request(ticket.get_options(Keypair::generate()), request).await
+        run_get_request(ticket.as_get_options(Keypair::generate()), request).await
     })
     .await
     .expect("timeout")

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeMap,
-    net::{Ipv4Addr, Ipv6Addr},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -9,7 +9,10 @@ use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
 use futures::{future::BoxFuture, FutureExt};
 use iroh::node::{Event, Node};
-use iroh_net::{tls::Keypair, MagicEndpoint};
+use iroh_net::{
+    tls::{Keypair, PeerId},
+    MagicEndpoint,
+};
 use rand::RngCore;
 use testdir::testdir;
 use tokio::{fs, io::AsyncWriteExt, sync::broadcast};
@@ -117,6 +120,18 @@ async fn empty_files() -> Result<()> {
     transfer_random_data(file_opts, &rt).await
 }
 
+/// Create new get options with the given peer id and addresses, using a
+/// randomly generated keypair.
+fn get_options(peer_id: PeerId, addrs: Vec<SocketAddr>) -> get::Options {
+    get::Options {
+        keypair: Keypair::generate(),
+        peer_id,
+        addrs,
+        keylog: false,
+        derp_map: None,
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn multiple_clients() -> Result<()> {
     let dir: PathBuf = testdir!();
@@ -150,16 +165,11 @@ async fn multiple_clients() -> Result<()> {
 
         tasks.push(rt.local_pool().spawn_pinned(move || {
             async move {
-                let opts = get::Options {
-                    addrs,
-                    peer_id,
-                    keylog: true,
-                    derp_map: None,
-                };
+                let opts = get_options(peer_id, addrs);
                 let expected_data = &content;
                 let expected_name = &name;
-                let response = get::run(GetRequest::all(hash).into(), opts).await?;
-                let (collection, children, _stats) = aggregate_get_response(response).await?;
+                let request = GetRequest::all(hash).into();
+                let (collection, children, _stats) = run_get_request(opts, request).await?;
                 assert_eq!(expected_name, &collection.blobs()[0].name);
                 assert_eq!(&file_hash, &collection.blobs()[0].hash);
                 assert_eq!(expected_data, &children[&0]);
@@ -265,15 +275,9 @@ where
     });
 
     let addrs = node.local_endpoint_addresses().await?;
-    let opts = get::Options {
-        addrs,
-        peer_id: node.peer_id(),
-        keylog: true,
-        derp_map: None,
-    };
-
-    let response = get::run(GetRequest::all(collection_hash).into(), opts).await?;
-    let (collection, children, _stats) = aggregate_get_response(response).await?;
+    let opts = get_options(node.peer_id(), addrs);
+    let request = GetRequest::all(collection_hash).into();
+    let (collection, children, _stats) = run_get_request(opts, request).await?;
     assert_eq!(num_blobs, collection.blobs().len());
     for (i, (name, hash)) in lookup.into_iter().enumerate() {
         let hash = Hash::from(hash);
@@ -385,18 +389,9 @@ async fn test_server_close() {
         }
     });
 
-    let response = get::run(
-        GetRequest::all(hash).into(),
-        get::Options {
-            addrs: node_addr,
-            peer_id,
-            keylog: true,
-            derp_map: None,
-        },
-    )
-    .await
-    .unwrap();
-    let (_collection, _children, _stats) = aggregate_get_response(response).await.unwrap();
+    let opts = get_options(peer_id, node_addr);
+    let request = GetRequest::all(hash).into();
+    let (_collection, _children, _stats) = run_get_request(opts, request).await.unwrap();
 
     // Unwrap the JoinHandle, then the result of the Provider
     tokio::time::timeout(Duration::from_secs(10), supervisor)
@@ -431,19 +426,11 @@ async fn test_blob_reader_partial() -> Result<()> {
     let peer_id = node.peer_id();
 
     let timeout = tokio::time::timeout(std::time::Duration::from_secs(10), async move {
-        let request = get::run(
-            GetRequest::all(hash).into(),
-            get::Options {
-                addrs: node_addr,
-                peer_id,
-                keylog: true,
-                derp_map: None,
-            },
-        )
-        .await
-        .unwrap();
+        let connection = get::dial(get_options(peer_id, node_addr)).await.unwrap();
+        let response =
+            get_response_machine::AtInitial::new(connection, GetRequest::all(hash).into());
         // connect
-        let connected = request.next().await.unwrap();
+        let connected = response.next().await.unwrap();
         // send the request
         let _start = connected.next().await.unwrap();
         // and then just hang
@@ -479,18 +466,9 @@ async fn test_ipv6() {
     let addrs = node.local_endpoint_addresses().await.unwrap();
     let peer_id = node.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
-        let request = get::run(
-            GetRequest::all(hash).into(),
-            get::Options {
-                addrs,
-                peer_id,
-                keylog: true,
-                derp_map: None,
-            },
-        )
-        .await
-        .unwrap();
-        aggregate_get_response(request).await
+        let opts = get_options(peer_id, addrs);
+        let request = GetRequest::all(hash).into();
+        run_get_request(opts, request).await
     })
     .await
     .expect("timeout")
@@ -511,9 +489,8 @@ async fn test_run_ticket() {
     let _drop_guard = node.cancel_token().drop_guard();
     let ticket = node.ticket(hash).await.unwrap();
     tokio::time::timeout(Duration::from_secs(10), async move {
-        let response =
-            get::run_ticket(&ticket, GetRequest::all(ticket.hash()).into(), true, None).await?;
-        aggregate_get_response(response).await
+        let request = GetRequest::all(hash).into();
+        run_get_request(ticket.get_options(Keypair::generate()), request).await
     })
     .await
     .expect("timeout")
@@ -532,10 +509,12 @@ fn validate_children(collection: Collection, children: BTreeMap<u64, Bytes>) -> 
     Ok(())
 }
 
-// helper to aggregate a get response and return all relevant data
-async fn aggregate_get_response(
-    initial: get_response_machine::AtInitial,
+async fn run_get_request(
+    opts: get::Options,
+    request: AnyGetRequest,
 ) -> anyhow::Result<(Collection, BTreeMap<u64, Bytes>, Stats)> {
+    let connection = get::dial(opts).await?;
+    let initial = get_response_machine::AtInitial::new(connection, request);
     use get_response_machine::*;
     let mut items = BTreeMap::new();
     let connected = initial.next().await?;
@@ -589,18 +568,9 @@ async fn test_run_fsm() {
     let addrs = node.local_endpoint_addresses().await.unwrap();
     let peer_id = node.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
-        let connection = MagicEndpoint::dial_peer(
-            Keypair::generate(),
-            peer_id,
-            &iroh_bytes::P2P_ALPN,
-            &addrs,
-            None,
-            true,
-        )
-        .await?;
+        let opts = get_options(peer_id, addrs);
         let request = GetRequest::all(hash).into();
-        let stream = get::run_connection(connection, request);
-        let (collection, children, _) = aggregate_get_response(stream).await?;
+        let (collection, children, _) = run_get_request(opts, request).await?;
         validate_children(collection, children)?;
         anyhow::Ok(())
     })
@@ -680,16 +650,8 @@ async fn test_custom_request_blob() {
             token: None,
             data: Bytes::from(&b"hello"[..]),
         });
-        let response = get::run(
-            request,
-            get::Options {
-                addrs,
-                peer_id,
-                keylog: true,
-                derp_map: None,
-            },
-        )
-        .await?;
+        let connection = get::dial(get_options(peer_id, addrs)).await?;
+        let response = get_response_machine::AtInitial::new(connection, request);
         let connected = response.next().await?;
         let ConnectedNext::StartRoot(start) = connected.next().await? else { panic!() };
         let header = start.next();
@@ -721,17 +683,8 @@ async fn test_custom_request_collection() {
             token: None,
             data: Bytes::from(&b"hello"[..]),
         });
-        let response = get::run(
-            request,
-            get::Options {
-                addrs,
-                peer_id,
-                keylog: true,
-                derp_map: None,
-            },
-        )
-        .await?;
-        let (_collection, items, _stats) = aggregate_get_response(response).await?;
+        let opts = get_options(peer_id, addrs);
+        let (_collection, items, _stats) = run_get_request(opts, request).await?;
         let actual = &items[&0];
         let expected = tokio::fs::read(readme_path()).await?;
         assert_eq!(actual, &expected);
@@ -802,27 +755,18 @@ async fn test_token_passthrough() -> Result<()> {
     let addrs = provider.local_endpoint_addresses().await?;
     let peer_id = provider.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
-        MagicEndpoint::dial_peer(
-            Keypair::generate(),
-            peer_id,
-            &iroh_bytes::P2P_ALPN,
-            &addrs,
-            None,
-            true,
-        )
-        .await?;
+        let endpoint = MagicEndpoint::builder()
+            .keypair(Keypair::generate())
+            .keylog(true)
+            .bind(0)
+            .await?;
+        endpoint
+            .connect(peer_id, &iroh_bytes::P2P_ALPN, &addrs)
+            .await
+            .context("failed to connect to provider")?;
         let request = GetRequest::all(hash).with_token(token).into();
-        let response = get::run(
-            request,
-            get::Options {
-                addrs,
-                peer_id,
-                keylog: true,
-                derp_map: None,
-            },
-        )
-        .await?;
-        let (_collection, items, _stats) = aggregate_get_response(response).await?;
+        let opts = get_options(peer_id, addrs);
+        let (_collection, items, _stats) = run_get_request(opts, request).await?;
         let actual = &items[&0];
         let expected = tokio::fs::read(readme_path()).await?;
         assert_eq!(actual, &expected);

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
 use futures::{future::BoxFuture, FutureExt};
 use iroh::node::{Event, Node};
-use iroh_net::MagicEndpoint;
+use iroh_net::{tls::Keypair, MagicEndpoint};
 use rand::RngCore;
 use testdir::testdir;
 use tokio::{fs, io::AsyncWriteExt, sync::broadcast};
@@ -589,8 +589,15 @@ async fn test_run_fsm() {
     let addrs = node.local_endpoint_addresses().await.unwrap();
     let peer_id = node.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
-        let connection =
-            MagicEndpoint::dial_peer(peer_id, &iroh_bytes::P2P_ALPN, &addrs, None, true).await?;
+        let connection = MagicEndpoint::dial_peer(
+            Keypair::generate(),
+            peer_id,
+            &iroh_bytes::P2P_ALPN,
+            &addrs,
+            None,
+            true,
+        )
+        .await?;
         let request = GetRequest::all(hash).into();
         let stream = get::run_connection(connection, request);
         let (collection, children, _) = aggregate_get_response(stream).await?;
@@ -795,7 +802,15 @@ async fn test_token_passthrough() -> Result<()> {
     let addrs = provider.local_endpoint_addresses().await?;
     let peer_id = provider.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
-        MagicEndpoint::dial_peer(peer_id, &iroh_bytes::P2P_ALPN, &addrs, None, true).await?;
+        MagicEndpoint::dial_peer(
+            Keypair::generate(),
+            peer_id,
+            &iroh_bytes::P2P_ALPN,
+            &addrs,
+            None,
+            true,
+        )
+        .await?;
         let request = GetRequest::all(hash).with_token(token).into();
         let response = get::run(
             request,


### PR DESCRIPTION
there is now only one dial fn, that basically just passes through the options to the MagicEndpoint. This is used no matter if you use tickets or explicitly given peer and addrs.