### PR TITLE
refactor(iroh-bytes): remove handshake and rely on ALPN only for protocol negotiation

### DIFF
--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -74,7 +74,7 @@ pub mod get_response_machine {
     use std::result;
 
     use crate::{
-        protocol::{read_lp, GetRequest, NonEmptyRequestRangeSpecIter, HANDSHAKE_SIZE},
+        protocol::{read_lp, GetRequest, NonEmptyRequestRangeSpecIter},
         tokio_util::ConcatenateSliceWriter,
     };
 
@@ -194,20 +194,13 @@ pub mod get_response_machine {
                 mut writer,
                 request,
             } = self;
-            let mut out_buffer = BytesMut::zeroed(1024);
-
             // 1. Send Handshake
             {
                 debug!("sending handshake");
                 let handshake = Handshake::new();
-                let used = postcard::to_slice(&handshake, &mut out_buffer)?;
-                debug_assert_eq!(
-                    used.len(),
-                    HANDSHAKE_SIZE,
-                    "serialized handshake had unexpected size"
-                );
+                let used = handshake.to_bytes();
                 writer
-                    .write_all(used)
+                    .write_all(&used)
                     .await
                     .map_err(|e| anyhow!("failed to write handshake {:?}", e))?;
             }

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -28,7 +28,7 @@ use tracing::{debug, error};
 pub use crate::util::Hash;
 
 use crate::blobs::Collection;
-use crate::protocol::{write_lp, AnyGetRequest, Handshake, RangeSpecSeq};
+use crate::protocol::{write_lp, AnyGetRequest, RangeSpecSeq};
 use crate::tokio_util::{TrackingReader, TrackingWriter};
 use crate::util::pathbuf_from_name;
 use crate::IROH_BLOCK_SIZE;
@@ -80,14 +80,12 @@ pub mod get_response_machine {
 
     use super::*;
 
-    use anyhow::anyhow;
     use bao_tree::io::{
         fsm::{ResponseDecoderReading, ResponseDecoderReadingNext, ResponseDecoderStart},
         Leaf, Parent,
     };
     use derive_more::From;
     use iroh_io::AsyncSliceWriter;
-    use tokio::io::AsyncWriteExt;
 
     self_cell::self_cell! {
         struct RangesIterInner {
@@ -194,18 +192,7 @@ pub mod get_response_machine {
                 mut writer,
                 request,
             } = self;
-            // 1. Send Handshake
-            {
-                debug!("sending handshake");
-                let handshake = Handshake::new();
-                let used = handshake.to_bytes();
-                writer
-                    .write_all(&used)
-                    .await
-                    .map_err(|e| anyhow!("failed to write handshake {:?}", e))?;
-            }
-
-            // 2. Send Request
+            // 1. Send Request
             {
                 debug!("sending request");
                 // wrap the get request in a request so we can serialize it
@@ -213,7 +200,7 @@ pub mod get_response_machine {
                 write_lp(&mut writer, &request_bytes).await?;
             }
 
-            // 3. Finish writing before expecting a response
+            // 2. Finish writing before expecting a response
             let (mut writer, bytes_written) = writer.into_parts();
             writer.finish().await?;
 
@@ -619,7 +606,7 @@ pub async fn dial(opts: Options) -> anyhow::Result<quinn::Connection> {
         .bind(0)
         .await?;
     endpoint
-        .connect(opts.peer_id, &crate::P2P_ALPN, &opts.addrs)
+        .connect(opts.peer_id, &crate::protocol::ALPN, &opts.addrs)
         .await
         .context("failed to connect to provider")
 }

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -20,7 +20,6 @@ use bao_tree::{ByteNum, ChunkNum};
 use bytes::BytesMut;
 use iroh_net::tls::Keypair;
 use iroh_net::{hp::derp::DerpMap, tls::PeerId};
-use postcard::experimental::max_size::MaxSize;
 use quinn::RecvStream;
 use range_collections::RangeSet2;
 use std::path::{Path, PathBuf};
@@ -75,7 +74,7 @@ pub mod get_response_machine {
     use std::result;
 
     use crate::{
-        protocol::{read_lp, GetRequest, NonEmptyRequestRangeSpecIter},
+        protocol::{read_lp, GetRequest, NonEmptyRequestRangeSpecIter, HANDSHAKE_SIZE},
         tokio_util::ConcatenateSliceWriter,
     };
 
@@ -195,7 +194,7 @@ pub mod get_response_machine {
                 mut writer,
                 request,
             } = self;
-            let mut out_buffer = BytesMut::zeroed(Handshake::POSTCARD_MAX_SIZE);
+            let mut out_buffer = BytesMut::zeroed(1024);
 
             // 1. Send Handshake
             {
@@ -204,7 +203,7 @@ pub mod get_response_machine {
                 let used = postcard::to_slice(&handshake, &mut out_buffer)?;
                 debug_assert_eq!(
                     used.len(),
-                    Handshake::POSTCARD_MAX_SIZE,
+                    HANDSHAKE_SIZE,
                     "serialized handshake had unexpected size"
                 );
                 writer

--- a/iroh-bytes/src/lib.rs
+++ b/iroh-bytes/src/lib.rs
@@ -21,8 +21,6 @@ pub use iroh_net as net;
 
 use bao_tree::BlockSize;
 
-pub const P2P_ALPN: [u8; 9] = *b"n0/iroh/1";
-
 /// Block size used by iroh, 2^4*1024 = 16KiB
 pub const IROH_BLOCK_SIZE: BlockSize = match BlockSize::new(4) {
     Some(bs) => bs,

--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -21,17 +21,49 @@ pub(crate) const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 100;
 /// Protocol version
 pub const VERSION: u64 = 2;
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+/// The magic number, sent in the handshake.
+/// 8 bytes long
+const HANDSHAKE_MAGIC: &str = "IROH💾";
+const HANDSHAKE_MAGIC_LEN: usize = HANDSHAKE_MAGIC.as_bytes().len();
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) struct Handshake {
     pub version: u64,
 }
 
 /// Serialized length of [Handshake].
-pub(crate) const HANDSHAKE_SIZE: usize = 1;
+pub(crate) const HANDSHAKE_SIZE: usize = HANDSHAKE_MAGIC_LEN + 8;
+
+impl Default for Handshake {
+    fn default() -> Self {
+        Self { version: VERSION }
+    }
+}
 
 impl Handshake {
     pub fn new() -> Self {
-        Self { version: VERSION }
+        Self::default()
+    }
+
+    /// Serializes the [Handshake] into its byte representation.
+    pub fn to_bytes(&self) -> [u8; HANDSHAKE_SIZE] {
+        let mut out = [0u8; HANDSHAKE_SIZE];
+        out[..HANDSHAKE_MAGIC_LEN].copy_from_slice(HANDSHAKE_MAGIC.as_bytes());
+        out[HANDSHAKE_MAGIC_LEN..].copy_from_slice(&self.version.to_le_bytes());
+
+        out
+    }
+
+    /// Parse the given bytes into a [Handshake].
+    pub fn from_bytes(source: impl AsRef<[u8]>) -> Result<Self> {
+        let source: &[u8] = source.as_ref();
+        let bytes: [u8; HANDSHAKE_SIZE] = source.try_into()?;
+        ensure!(
+            &bytes[..HANDSHAKE_MAGIC_LEN] == HANDSHAKE_MAGIC.as_bytes(),
+            "invalid magic number"
+        );
+        let version = u64::from_le_bytes(bytes[HANDSHAKE_MAGIC_LEN..].try_into()?);
+        Ok(Handshake { version })
     }
 }
 
@@ -306,9 +338,11 @@ mod tests {
     #[test]
     fn test_handshake_ser() {
         let handshake = Handshake::new();
-        let ser = postcard::to_stdvec(&handshake).unwrap();
+        let ser = handshake.to_bytes();
         assert_eq!(ser.len(), HANDSHAKE_SIZE);
-        let de: Handshake = postcard::from_bytes(&ser).unwrap();
+        let de = Handshake::from_bytes(ser).unwrap();
         assert_eq!(de, handshake);
+
+        assert_eq!(HANDSHAKE_SIZE, 16);
     }
 }

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -11,15 +11,14 @@ use futures::future::{BoxFuture, Either};
 use futures::{Future, FutureExt};
 use iroh_io::{AsyncSliceReaderExt, FileAdapter};
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::AsyncWrite;
 use tracing::{debug, debug_span, warn};
 use tracing_futures::Instrument;
 use walkdir::WalkDir;
 
 use crate::blobs::Collection;
 use crate::protocol::{
-    read_fixed_size, read_lp, write_lp, CustomGetRequest, GetRequest, Handshake, RangeSpec,
-    Request, RequestToken, HANDSHAKE_SIZE, VERSION,
+    read_lp, write_lp, CustomGetRequest, GetRequest, RangeSpec, Request, RequestToken,
 };
 use crate::provider::database::BaoMapEntry;
 use crate::util::{canonicalize_path, Hash, Progress, RpcError};
@@ -310,28 +309,6 @@ pub fn create_data_sources(root: PathBuf) -> anyhow::Result<Vec<DataSource>> {
     })
 }
 
-/// Read and decode the handshake.
-///
-/// Will fail if there is an error while reading, there is a token mismatch, or no valid
-/// handshake was received.
-///
-/// When successful, the reader is still useable after this function and the buffer will be
-/// drained of any handshake data.
-pub async fn read_handshake<R: AsyncRead + Unpin>(reader: R, buffer: &mut BytesMut) -> Result<()> {
-    let payload = read_fixed_size(reader, buffer, HANDSHAKE_SIZE as u64)
-        .await?
-        .context("no valid handshake received")?;
-
-    let handshake = Handshake::from_bytes(&payload)?;
-    ensure!(
-        handshake.version == VERSION,
-        "expected version {} but got {}",
-        VERSION,
-        handshake.version
-    );
-    Ok(())
-}
-
 /// Read the request from the getter.
 ///
 /// Will fail if there is an error while reading, if the reader
@@ -502,21 +479,14 @@ pub async fn handle_connection<
 
 async fn handle_stream<D: BaoMap, E: EventSender>(
     db: D,
-    mut reader: quinn::RecvStream,
+    reader: quinn::RecvStream,
     writer: ResponseWriter<E>,
     custom_get_handler: impl CustomGetHandler<D>,
     authorization_handler: impl RequestAuthorizationHandler<D>,
 ) -> Result<()> {
     let mut in_buffer = BytesMut::with_capacity(1024);
 
-    // 1. Read Handshake
-    debug!("reading handshake");
-    if let Err(e) = read_handshake(&mut reader, &mut in_buffer).await {
-        writer.notify_transfer_aborted();
-        return Err(e);
-    }
-
-    // 2. Decode the request.
+    // 1. Decode the request.
     debug!("reading request");
     let request = match read_request(reader, &mut in_buffer).await {
         Ok(r) => r,
@@ -526,7 +496,7 @@ async fn handle_stream<D: BaoMap, E: EventSender>(
         }
     };
 
-    // 3. Authorize the request (may be a no-op)
+    // 2. Authorize the request (may be a no-op)
     debug!("authorizing request");
     if let Err(e) = authorization_handler
         .authorize(db.clone(), request.token().cloned(), &request)

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -10,7 +10,6 @@ use bytes::{Bytes, BytesMut};
 use futures::future::{BoxFuture, Either};
 use futures::{Future, FutureExt};
 use iroh_io::{AsyncSliceReaderExt, FileAdapter};
-use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::{debug, debug_span, warn};
@@ -20,7 +19,7 @@ use walkdir::WalkDir;
 use crate::blobs::Collection;
 use crate::protocol::{
     read_fixed_size, read_lp, write_lp, CustomGetRequest, GetRequest, Handshake, RangeSpec,
-    Request, RequestToken, VERSION,
+    Request, RequestToken, HANDSHAKE_SIZE, VERSION,
 };
 use crate::provider::database::BaoMapEntry;
 use crate::util::{canonicalize_path, Hash, Progress, RpcError};
@@ -319,7 +318,7 @@ pub fn create_data_sources(root: PathBuf) -> anyhow::Result<Vec<DataSource>> {
 /// When successful, the reader is still useable after this function and the buffer will be
 /// drained of any handshake data.
 pub async fn read_handshake<R: AsyncRead + Unpin>(reader: R, buffer: &mut BytesMut) -> Result<()> {
-    let payload = read_fixed_size(reader, buffer, Handshake::POSTCARD_MAX_SIZE as u64)
+    let payload = read_fixed_size(reader, buffer, HANDSHAKE_SIZE as u64)
         .await?
         .context("no valid handshake received")?;
 

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -322,7 +322,7 @@ pub async fn read_handshake<R: AsyncRead + Unpin>(reader: R, buffer: &mut BytesM
         .await?
         .context("no valid handshake received")?;
 
-    let handshake: Handshake = postcard::from_bytes(&payload)?;
+    let handshake = Handshake::from_bytes(&payload)?;
     ensure!(
         handshake.version == VERSION,
         "expected version {} but got {}",

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -88,7 +88,7 @@ where
     rt: Option<runtime::Handle>,
 }
 
-const PROTOCOLS: [&[u8]; 1] = [&iroh_bytes::P2P_ALPN];
+const PROTOCOLS: [&[u8]; 1] = [&iroh_bytes::protocol::ALPN];
 
 impl<D: BaoMap> Builder<D> {
     /// Creates a new builder for [`Node`] using the given [`Database`].
@@ -354,7 +354,7 @@ where
                             continue;
                         }
                     };
-                    if alpn.as_bytes() == iroh_bytes::P2P_ALPN.as_ref() {
+                    if alpn.as_bytes() == iroh_bytes::protocol::ALPN.as_ref() {
                         let db = handler.inner.db.clone();
                         let events = MappedSender(events.clone());
                         let custom_get_handler = custom_get_handler.clone();

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -778,7 +778,7 @@ async fn test_token_passthrough() -> Result<()> {
             .bind(0)
             .await?;
         endpoint
-            .connect(peer_id, &iroh_bytes::P2P_ALPN, &addrs)
+            .connect(peer_id, &iroh_bytes::protocol::ALPN, &addrs)
             .await
             .context("failed to connect to provider")?;
         let request = GetRequest::all(hash).with_token(token).into();


### PR DESCRIPTION
Closes the simple part of #964.