### PR TITLE
fix: cross builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       run: cross check --all --target ${{ matrix.target }}
 
     - name: test
-      run: cross test --all --target ${{ matrix.target }} -- --test-threads=16
+      run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
 
   check_fmt_and_docs:
     name: Checking fmt and docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Cleanup Docker
+      continue-on-error: true
       run: |
         docker kill $(docker ps -q)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,10 @@ jobs:
     - name: Install rust stable
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Cleanup Docker
+      run: |
+        docker kill $(docker ps -q)
+
     - name: Install cross
       # See https://github.com/cross-rs/cross/issues/1222
       run: cargo install cross --git https://github.com/cross-rs/cross
@@ -228,7 +232,7 @@ jobs:
       run: cross check --all --target ${{ matrix.target }}
 
     - name: test
-      run: cross test --all --target ${{ matrix.target }} -- --test-threads=4
+      run: cross test --all --target ${{ matrix.target }} -- --test-threads=16
 
   check_fmt_and_docs:
     name: Checking fmt and docs


### PR DESCRIPTION
Every now and then a cross docker container hangs around (failed job or something gets borked) and it keeps eating up RAM. Worst offender at 75GB for a single lingering container.

This ensures a clean slate and bumps the runners up to a reasonable number, so things should be faster and more stable.