### PR TITLE
ref: Change module structure and visibility and require docs

### DIFF
--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -6,12 +6,13 @@ use std::{net::SocketAddr, path::PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use iroh::rpc_protocol::*;
 use iroh_bytes::{cid::Blake3Cid, protocol::RequestToken, provider::Ticket, runtime};
 use iroh_net::tls::{Keypair, PeerId};
 use quic_rpc::transport::quinn::QuinnConnection;
 use quic_rpc::RpcClient;
 
-use crate::{config::Config, rpc_protocol::*};
+use crate::config::Config;
 
 use self::provide::{ProvideOptions, ProviderRpcPort};
 
@@ -168,7 +169,7 @@ pub enum Commands {
         path: Option<PathBuf>,
         #[clap(long, short)]
         /// Listening address to bind to
-        #[clap(long, short, default_value_t = SocketAddr::from(crate::node::DEFAULT_BIND_ADDR))]
+        #[clap(long, short, default_value_t = SocketAddr::from(iroh::node::DEFAULT_BIND_ADDR))]
         addr: SocketAddr,
         /// RPC port, set to "disabled" to disable RPC
         #[clap(long, default_value_t = ProviderRpcPort::Enabled(DEFAULT_RPC_PORT))]

--- a/iroh/src/commands/add.rs
+++ b/iroh/src/commands/add.rs
@@ -7,9 +7,10 @@ use std::{
 use anyhow::{Context, Result};
 use futures::{Stream, StreamExt};
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
+use iroh::rpc_protocol::ProvideRequest;
 use iroh_bytes::{cid::Blake3Cid, provider::ProvideProgress, Hash};
 
-use crate::{commands::make_rpc_client, rpc_protocol::ProvideRequest};
+use crate::commands::make_rpc_client;
 
 pub async fn run(path: PathBuf, rpc_port: u16) -> Result<()> {
     let client = make_rpc_client(rpc_port).await?;

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -63,9 +63,11 @@ pub enum Commands {
         /// Explicitly provided stun host. If provided, this will disable derp and just do stun.
         #[clap(long)]
         stun_host: Option<String>,
+        /// The port of the STUN server.
         #[clap(long, default_value_t = DEFAULT_DERP_STUN_PORT)]
         stun_port: u16,
     },
+    /// Wait for incoming requests from iroh doctor connect
     Accept {
         /// Our own private key, in hex. If not specified, the locally configured key will be used.
         #[clap(long, default_value_t = PrivateKey::Local)]
@@ -83,6 +85,7 @@ pub enum Commands {
         #[clap(long)]
         local_derper: bool,
     },
+    /// Connect to an iroh doctor accept node.
     Connect {
         /// hex peer id of the node to connect to
         dial: String,

--- a/iroh/src/commands/list.rs
+++ b/iroh/src/commands/list.rs
@@ -2,9 +2,8 @@ use anyhow::Result;
 use clap::Subcommand;
 use futures::StreamExt;
 use indicatif::HumanBytes;
+use iroh::rpc_protocol::{ListBlobsRequest, ListCollectionsRequest};
 use iroh_bytes::cid::Blake3Cid;
-
-use crate::rpc_protocol::{ListBlobsRequest, ListCollectionsRequest};
 
 use super::{make_rpc_client, DEFAULT_RPC_PORT};
 

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -6,6 +6,10 @@ use std::{
 };
 
 use anyhow::{ensure, Context, Result};
+use iroh::{
+    node::{Node, StaticTokenAuthHandler},
+    rpc_protocol::{ProvideRequest, ProviderRequest, ProviderResponse, ProviderService},
+};
 use iroh_bytes::{
     protocol::RequestToken,
     provider::{Database, FNAME_PATHS},
@@ -14,11 +18,7 @@ use iroh_bytes::{
 use iroh_net::{hp::derp::DerpMap, tls::Keypair};
 use quic_rpc::{transport::quinn::QuinnServerEndpoint, ServiceEndpoint};
 
-use crate::{
-    config::iroh_data_root,
-    node::{Node, StaticTokenAuthHandler},
-    rpc_protocol::{ProvideRequest, ProviderRequest, ProviderResponse, ProviderService},
-};
+use crate::config::iroh_data_root;
 
 use super::{
     add::{aggregate_add_response, print_add_response},
@@ -186,7 +186,7 @@ fn make_rpc_endpoint(
 ) -> Result<impl ServiceEndpoint<ProviderService>> {
     let rpc_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, rpc_port));
     let rpc_quinn_endpoint = quinn::Endpoint::server(
-        crate::node::make_server_config(
+        iroh::node::make_server_config(
             keypair,
             MAX_RPC_STREAMS,
             MAX_RPC_CONNECTIONS,

--- a/iroh/src/commands/validate.rs
+++ b/iroh/src/commands/validate.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use console::{style, Emoji};
 use futures::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use iroh::rpc_protocol::ValidateRequest;
 use iroh_bytes::{cid::Blake3Cid, provider::ValidateProgress, Hash};
-
-use crate::rpc_protocol::ValidateRequest;
 
 use super::make_rpc_client;
 

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -153,6 +153,7 @@ pub fn iroh_data_root() -> Result<PathBuf> {
 }
 
 /// Path that leads to a file in the iroh data directory.
+#[allow(dead_code)]
 pub fn iroh_data_path(file_name: &Path) -> Result<PathBuf> {
     let path = iroh_data_root()?.join(file_name);
     Ok(path)
@@ -169,6 +170,7 @@ pub fn iroh_data_path(file_name: &Path) -> Result<PathBuf> {
 /// | Linux    | `$XDG_CACHE_HOME`/iroh or `$HOME`/.cache/iroh | /home/.cache/iroh                        |
 /// | macOS    | `$HOME`/Library/Caches/iroh                   | /Users/Alice/Library/Caches/iroh         |
 /// | Windows  | `{FOLDERID_LocalAppData}/iroh`                | C:\Users\Alice\AppData\Roaming\iroh      |
+#[allow(dead_code)]
 pub fn iroh_cache_root() -> Result<PathBuf> {
     if let Some(val) = env::var_os("IROH_CACHE_DIR") {
         return Ok(PathBuf::from(val));
@@ -180,6 +182,7 @@ pub fn iroh_cache_root() -> Result<PathBuf> {
 }
 
 /// Path that leads to a file in the iroh cache directory.
+#[allow(dead_code)]
 pub fn iroh_cache_path(file_name: &Path) -> Result<PathBuf> {
     let path = iroh_cache_root()?.join(file_name);
     Ok(path)

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -1,12 +1,8 @@
 //! Send data over the internet.
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 pub use iroh_bytes as bytes;
 pub use iroh_net as net;
 
 pub mod node;
 pub mod rpc_protocol;
-
-#[cfg(feature = "cli")]
-pub mod commands;
-#[cfg(feature = "cli")]
-pub mod config;

--- a/iroh/src/main.rs
+++ b/iroh/src/main.rs
@@ -2,11 +2,15 @@ use std::{collections::HashMap, time::Duration};
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use iroh::{
+use tracing_subscriber::{prelude::*, EnvFilter};
+
+mod commands;
+mod config;
+
+use crate::{
     commands::{init_metrics_collection, Cli},
     config::{iroh_config_path, Config, CONFIG_FILE_NAME, ENV_PREFIX},
 };
-use tracing_subscriber::{prelude::*, EnvFilter};
 
 fn main() -> Result<()> {
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -158,6 +158,7 @@ where
         }
     }
 
+    /// Configures a custom authorization handler.
     pub fn custom_auth_handler<A2: RequestAuthorizationHandler<D>>(
         self,
         auth_handler: A2,
@@ -435,6 +436,7 @@ struct NodeInner<D> {
 /// Events emitted by the [`Node`] informing about the current status.
 #[derive(Debug, Clone)]
 pub enum Event {
+    /// Events from the iroh-bytes transfer protocol.
     ByteProvide(iroh_bytes::provider::Event),
 }
 
@@ -767,6 +769,10 @@ pub struct StaticTokenAuthHandler {
 }
 
 impl StaticTokenAuthHandler {
+    /// Creates a new handler with provided token.
+    ///
+    /// The single static token provided can be used to authorise all the requests.  If it
+    /// is `None` no authorisation is performed and all requests are allowed.
     pub fn new(token: Option<RequestToken>) -> Self {
         Self { token }
     }


### PR DESCRIPTION
This modifies the modules inside the crate structure and visibility.
Specifically it moves the `config` and `command` modules from the iroh
*crate* into the iroh *binary*.  This could be a little confusing.
This means they are no longer part of the public API of the iroh
crate (and do not need to be documented).

It also fills in a few odd bits of missing doc comments and makes doc
comments required for public APIs on the crate.

When reviewing: the crux are the changes to `main.rs` and `lib.rs`.