### PR TITLE
[WIP] feat: Add iroh-sync and integrate with gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.9.0",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1717,7 @@ dependencies = [
  "iroh-io",
  "iroh-metrics",
  "iroh-net",
+ "iroh-sync",
  "multibase",
  "nix",
  "num_cpus",
@@ -1845,6 +1904,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-sync"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "bytes",
+ "crossbeam",
+ "ed25519-dalek",
+ "hex",
+ "iroh-bytes",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rand_core",
+ "serde",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2071,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,7 +2206,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375f3ee1fb90dfabed4754a4ebb0137553162655757cd2a91cdca88d8f7c7672"
+checksum = "7fe57d23bb00e29afe80e401729cb5cf2d14d64814397529cdc4fdb2a8e6bc6e"
 dependencies = [
  "blake3",
  "bytes",
@@ -332,9 +332,9 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "blake3"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199c42ab6972d92c9f8995f086273d25c42fc0f7b2a1fcefba465c1352d25ba5"
+checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.6"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
@@ -490,7 +490,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
+checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
 
 [[package]]
 name = "const_format"
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "core-foundation"
@@ -707,17 +707,17 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -758,7 +758,7 @@ dependencies = [
  "dlopen2",
  "libc",
  "memalloc",
- "netlink-packet-core 0.5.0",
+ "netlink-packet-core",
  "netlink-packet-route",
  "netlink-sys",
  "once_cell",
@@ -800,26 +800,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "git+https://github.com/JelteF/derive_more#60ed1e7247e7cb085b57c309fade3bde29791017"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "0.99.17"
-source = "git+https://github.com/JelteF/derive_more#60ed1e7247e7cb085b57c309fade3bde29791017"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.25",
- "unicode-xid",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -839,7 +820,7 @@ checksum = "10c89e23c2ccd1af6fae76cbe614c135e5640837f5e868f0995549f1762db62d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
  "unicode-xid",
 ]
 
@@ -884,7 +865,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1035,14 +1016,14 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "erased-serde"
@@ -1195,7 +1176,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1748,11 +1729,11 @@ dependencies = [
  "bytes",
  "clap",
  "data-encoding",
- "derive_more",
+ "derive_more_preview",
  "ed25519-dalek",
  "futures",
  "genawaiter",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "iroh-net",
  "once_cell",
  "postcard",
@@ -1865,12 +1846,12 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.4",
+ "rustix 0.38.3",
  "windows-sys 0.48.0",
 ]
 
@@ -2075,17 +2056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "netlink-packet-core"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
-dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
-]
-
-[[package]]
 name = "netlink-packet-route"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,7 +2065,7 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "libc",
- "netlink-packet-core 0.5.0",
+ "netlink-packet-core",
  "netlink-packet-utils",
 ]
 
@@ -2113,14 +2083,14 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842c6770fc4bb33dd902f41829c61ef872b8e38de1405aa0b938b27b8fba12c3"
+checksum = "26305d12193227ef7b8227e7d61ae4eaf174607f79bd8eeceff07aacaefde497"
 dependencies = [
  "bytes",
  "futures",
  "log",
- "netlink-packet-core 0.7.0",
+ "netlink-packet-core",
  "netlink-sys",
  "thiserror",
  "tokio",
@@ -2485,7 +2455,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2516,7 +2486,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2613,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.0"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d220334a184db82b31b83f5ff093e3315280fb2b6bbc032022b2304a509aab7a"
+checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
 name = "positioned-io"
@@ -2736,18 +2706,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prometheus-client"
-version = "0.21.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
+checksum = "78c2f43e8969d51935d2a7284878ae053ba30034cd563f673cde37ba5205685e"
 dependencies = [
  "dtoa",
  "itoa",
@@ -3012,19 +2982,19 @@ checksum = "68bf53dad9b6086826722cdc99140793afd9f62faa14a1ad07eb4f955e7a7216"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "89089e897c013b3deb627116ae56a6955a72b8bed395c9526af31c9fe528b484"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.2",
- "regex-syntax 0.7.4",
+ "regex-automata 0.3.0",
+ "regex-syntax 0.7.3",
 ]
 
 [[package]]
@@ -3038,20 +3008,14 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "fa250384981ea14565685dea16a9ccc4d1c541a13f82b9c168572264d1df8c56"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.3",
 ]
-
-[[package]]
-name = "regex-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96ede7f386ba6e910092e7ccdc04176cface62abebea07ed6b46d870ed95ca2"
 
 [[package]]
 name = "regex-syntax"
@@ -3061,9 +3025,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "reqwest"
@@ -3182,7 +3146,7 @@ checksum = "ed7d42da676fdf7e470e2502717587dd1089d8b48d9d1b846dcc3c01072858cb"
 dependencies = [
  "futures",
  "log",
- "netlink-packet-core 0.5.0",
+ "netlink-packet-core",
  "netlink-packet-route",
  "netlink-packet-utils",
  "netlink-proto",
@@ -3238,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -3251,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
 dependencies = [
  "log",
  "ring",
@@ -3417,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
 dependencies = [
  "serde_derive",
 ]
@@ -3435,20 +3399,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.102"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -3684,7 +3648,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3750,9 +3714,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3836,22 +3800,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3866,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "serde",
@@ -3884,9 +3848,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -3934,7 +3898,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -4087,7 +4051,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -4208,18 +4172,19 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-parse"
-version = "0.1.12"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212c59636157b18c2f57eed2799e6606c52fc49c6a11685ffb0d08f06e55f428"
+checksum = "fc2d0556a998f4c55500ce1730901ba32bafbe820068cbdc091421525d61253b"
 dependencies = [
- "regex-lite",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unarray"
@@ -4367,7 +4332,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
@@ -4401,7 +4366,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4681,9 +4646,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe57d23bb00e29afe80e401729cb5cf2d14d64814397529cdc4fdb2a8e6bc6e"
+checksum = "375f3ee1fb90dfabed4754a4ebb0137553162655757cd2a91cdca88d8f7c7672"
 dependencies = [
  "blake3",
  "bytes",
@@ -332,9 +332,9 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "blake3"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
+checksum = "199c42ab6972d92c9f8995f086273d25c42fc0f7b2a1fcefba465c1352d25ba5"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
  "serde",
 ]
@@ -490,7 +490,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
+checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "const_format"
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "core-foundation"
@@ -707,17 +707,17 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -758,7 +758,7 @@ dependencies = [
  "dlopen2",
  "libc",
  "memalloc",
- "netlink-packet-core",
+ "netlink-packet-core 0.5.0",
  "netlink-packet-route",
  "netlink-sys",
  "once_cell",
@@ -800,7 +800,26 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "git+https://github.com/JelteF/derive_more#60ed1e7247e7cb085b57c309fade3bde29791017"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "0.99.17"
+source = "git+https://github.com/JelteF/derive_more#60ed1e7247e7cb085b57c309fade3bde29791017"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -820,7 +839,7 @@ checksum = "10c89e23c2ccd1af6fae76cbe614c135e5640837f5e868f0995549f1762db62d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "unicode-xid",
 ]
 
@@ -865,7 +884,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1016,14 +1035,14 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
@@ -1176,7 +1195,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1214,6 +1233,22 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
+
+[[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "futures-core",
+ "genawaiter-macro",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
 
 [[package]]
 name = "generic-array"
@@ -1716,6 +1751,7 @@ dependencies = [
  "derive_more",
  "ed25519-dalek",
  "futures",
+ "genawaiter",
  "indexmap 1.9.3",
  "iroh-net",
  "once_cell",
@@ -1829,12 +1865,12 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.3",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -2039,6 +2075,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
 name = "netlink-packet-route"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,7 +2095,7 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "libc",
- "netlink-packet-core",
+ "netlink-packet-core 0.5.0",
  "netlink-packet-utils",
 ]
 
@@ -2066,14 +2113,14 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26305d12193227ef7b8227e7d61ae4eaf174607f79bd8eeceff07aacaefde497"
+checksum = "842c6770fc4bb33dd902f41829c61ef872b8e38de1405aa0b938b27b8fba12c3"
 dependencies = [
  "bytes",
  "futures",
  "log",
- "netlink-packet-core",
+ "netlink-packet-core 0.7.0",
  "netlink-sys",
  "thiserror",
  "tokio",
@@ -2438,7 +2485,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2469,7 +2516,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2566,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
+checksum = "d220334a184db82b31b83f5ff093e3315280fb2b6bbc032022b2304a509aab7a"
 
 [[package]]
 name = "positioned-io"
@@ -2689,18 +2736,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prometheus-client"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c2f43e8969d51935d2a7284878ae053ba30034cd563f673cde37ba5205685e"
+checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
 dependencies = [
  "dtoa",
  "itoa",
@@ -2965,19 +3012,19 @@ checksum = "68bf53dad9b6086826722cdc99140793afd9f62faa14a1ad07eb4f955e7a7216"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89089e897c013b3deb627116ae56a6955a72b8bed395c9526af31c9fe528b484"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.0",
- "regex-syntax 0.7.3",
+ "regex-automata 0.3.2",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -2991,14 +3038,20 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa250384981ea14565685dea16a9ccc4d1c541a13f82b9c168572264d1df8c56"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f96ede7f386ba6e910092e7ccdc04176cface62abebea07ed6b46d870ed95ca2"
 
 [[package]]
 name = "regex-syntax"
@@ -3008,9 +3061,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
@@ -3129,7 +3182,7 @@ checksum = "ed7d42da676fdf7e470e2502717587dd1089d8b48d9d1b846dcc3c01072858cb"
 dependencies = [
  "futures",
  "log",
- "netlink-packet-core",
+ "netlink-packet-core 0.5.0",
  "netlink-packet-route",
  "netlink-packet-utils",
  "netlink-proto",
@@ -3185,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -3198,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.3"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
@@ -3364,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.166"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
@@ -3382,20 +3435,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.166"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -3631,7 +3684,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3697,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3783,22 +3836,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3813,9 +3866,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
  "serde",
@@ -3831,9 +3884,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]
@@ -3881,7 +3934,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4034,7 +4087,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4155,19 +4208,18 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-parse"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2d0556a998f4c55500ce1730901ba32bafbe820068cbdc091421525d61253b"
+checksum = "212c59636157b18c2f57eed2799e6606c52fc49c6a11685ffb0d08f06e55f428"
 dependencies = [
- "once_cell",
- "regex",
+ "regex-lite",
 ]
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unarray"
@@ -4315,7 +4367,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -4349,7 +4401,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4629,9 +4681,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-gossip"
+version = "0.4.1"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "bytes",
+ "clap",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek",
+ "futures",
+ "indexmap 1.9.3",
+ "iroh-net",
+ "postcard",
+ "quinn",
+ "rand",
+ "rand_core",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "iroh-io"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,7 @@ dependencies = [
  "futures",
  "indexmap 1.9.3",
  "iroh-net",
+ "once_cell",
  "postcard",
  "quinn",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "git+https://github.com/JelteF/derive_more#60ed1e7247e7cb085b57c309fade3bde29791017"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "0.99.17"
+source = "git+https://github.com/JelteF/derive_more#60ed1e7247e7cb085b57c309fade3bde29791017"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+ "unicode-xid",
+]
+
+[[package]]
 name = "derive_more_preview"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,14 +1725,17 @@ dependencies = [
  "clap",
  "config",
  "console",
+ "data-encoding",
  "derive_more_preview",
  "dirs-next",
  "duct",
+ "ed25519-dalek",
  "flume",
  "futures",
  "hex",
  "indicatif",
  "iroh-bytes",
+ "iroh-gossip",
  "iroh-io",
  "iroh-metrics",
  "iroh-net",
@@ -1721,6 +1743,7 @@ dependencies = [
  "multibase",
  "nix",
  "num_cpus",
+ "once_cell",
  "postcard",
  "quic-rpc",
  "quinn",
@@ -1735,6 +1758,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "url",
  "walkdir",
 ]
 
@@ -1911,6 +1935,7 @@ dependencies = [
  "blake3",
  "bytes",
  "crossbeam",
+ "derive_more",
  "ed25519-dalek",
  "hex",
  "iroh-bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "iroh-bytes",
   "iroh-gossip",
   "iroh-metrics",
+  "iroh-sync",
 ]
 
 [profile.optimized-release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "iroh",
   "iroh-net",
   "iroh-bytes",
+  "iroh-gossip",
   "iroh-metrics",
 ]
 

--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -172,7 +172,7 @@ impl GetRequest {
 }
 
 /// Write the given data to the provider sink, with a unsigned varint length prefix.
-pub(crate) async fn write_lp<W: AsyncWrite + Unpin>(writer: &mut W, data: &[u8]) -> Result<()> {
+pub async fn write_lp<W: AsyncWrite + Unpin>(writer: &mut W, data: &[u8]) -> Result<()> {
     ensure!(
         data.len() < MAX_MESSAGE_SIZE,
         "sending message is too large"
@@ -193,7 +193,7 @@ pub(crate) async fn write_lp<W: AsyncWrite + Unpin>(writer: &mut W, data: &[u8])
 ///
 /// The message as raw bytes.  If the end of the stream is reached and there is no partial
 /// message, returns `None`.
-pub(crate) async fn read_lp(
+pub async fn read_lp(
     mut reader: impl AsyncRead + Unpin,
     buffer: &mut BytesMut,
 ) -> Result<Option<Bytes>> {

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "iroh-gossip"
+version = "0.4.1"
+edition = "2021"
+readme = "README.md"
+description = "gossip messages over broadcast trees"
+license = "MIT/Apache-2.0"
+authors = ["n0 team"]
+repository = "https://github.com/n0-computer/iroh-sync"
+
+[dependencies]
+# proto dependencies (required)
+anyhow = { version = "1", features = ["backtrace"] }
+blake3 = "1.3.3"
+bytes = { version = "1.4.0", features = ["serde"] }
+data-encoding = "2.4.0"
+derive_more = { version = "0.99.17", git = "https://github.com/JelteF/derive_more", features = ["debug", "display", "from", "try_into", "add"] }
+ed25519-dalek = { version = "=2.0.0-rc.2", features = ["serde", "rand_core"] }
+indexmap = "1.9.3"
+rand = { version = "0.8.5", features = ["std_rng"] }
+rand_core = "0.6.4"
+serde = { version = "1.0.164", features = ["derive"] }
+tracing = "0.1.37"
+
+# net dependencies (optional)
+futures = { version = "0.3.25", optional = true }
+iroh-net = { path = "../iroh-net", optional = true }
+quinn = { version = "0.10", optional = true }
+tokio = { version = "1", optional = true, features = ["io-util", "sync", "rt", "macros", "net", "fs"] }
+postcard = { version = "1", optional = true, default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
+tokio-util = { version = "0.7.8", optional = true, features = ["codec"] }
+
+[dev-dependencies]
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "4", features = ["derive"] }
+url = "2.4.0"
+
+[features]
+default = ["net"]
+net = ["futures", "iroh-net", "quinn", "tokio", "postcard", "tokio-util"]

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -29,6 +29,7 @@ quinn = { version = "0.10", optional = true }
 tokio = { version = "1", optional = true, features = ["io-util", "sync", "rt", "macros", "net", "fs"] }
 postcard = { version = "1", optional = true, default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 tokio-util = { version = "0.7.8", optional = true, features = ["codec"] }
+once_cell = "1.18.0"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -38,3 +39,7 @@ url = "2.4.0"
 [features]
 default = ["net"]
 net = ["futures", "iroh-net", "quinn", "tokio", "postcard", "tokio-util"]
+
+[[example]]
+name = "chat"
+required-features = ["net"]

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -15,7 +15,7 @@ blake3 = "1.3.3"
 bytes = { version = "1.4.0", features = ["serde"] }
 data-encoding = "2.4.0"
 derive_more = { version = "0.99.17", git = "https://github.com/JelteF/derive_more", features = ["debug", "display", "from", "try_into", "add"] }
-ed25519-dalek = { version = "=2.0.0-rc.2", features = ["serde", "rand_core"] }
+ed25519-dalek = { version = "=2.0.0-rc.3", features = ["serde", "rand_core"] }
 indexmap = "1.9.3"
 rand = { version = "0.8.5", features = ["std_rng"] }
 rand_core = "0.6.4"

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -14,9 +14,9 @@ anyhow = { version = "1", features = ["backtrace"] }
 blake3 = "1.3.3"
 bytes = { version = "1.4.0", features = ["serde"] }
 data-encoding = "2.4.0"
-derive_more = { version = "0.99.17", git = "https://github.com/JelteF/derive_more", features = ["debug", "display", "from", "try_into", "add"] }
+derive_more = { package = "derive_more_preview", version = "0.1.0", features = ["add", "debug", "display", "from", "try_into"] }
 ed25519-dalek = { version = "=2.0.0-rc.3", features = ["serde", "rand_core"] }
-indexmap = "1.9.3"
+indexmap = "2.0.0"
 rand = { version = "0.8.5", features = ["std_rng"] }
 rand_core = "0.6.4"
 serde = { version = "1.0.164", features = ["derive"] }

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1", optional = true, features = ["io-util", "sync", "rt", "
 postcard = { version = "1", optional = true, default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 tokio-util = { version = "0.7.8", optional = true, features = ["codec"] }
 once_cell = "1.18.0"
+genawaiter = { version = "0.99.1", default-features = false, features = ["futures03"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/iroh-gossip/README.md
+++ b/iroh-gossip/README.md
@@ -1,0 +1,19 @@
+# iroh-gossip
+
+
+# License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+   http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this project by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -1,0 +1,229 @@
+//! Chat over iroh-gossip
+//!
+//! This broadcasts signed messages over iroh-gossip and verifies
+//! signatures on received messages.
+//!
+//! To connect to a swarm, you need to share a DERP server and know at least
+//! one other peer's peer id.
+//!
+//! By default a new peer id is created when starting the example. To reuse your identity,
+//! set the `--secret-key` CLI flag with the secret printed on a previous invocation.
+//!
+//! You can use this with a local DERP server. To do so, run
+//! `cargo run --bin derper -- --dev`
+//! and then set the `-d http://localhost:3340` flag on this example.
+
+use std::{collections::HashMap, net::SocketAddr};
+
+use bytes::Bytes;
+use clap::Parser;
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use iroh_gossip::{
+    net::{GossipHandle, GOSSIP_ALPN},
+    proto::{Event, TopicId},
+};
+use iroh_net::{
+    defaults::default_derp_map,
+    hp::derp::{DerpMap, UseIpv4, UseIpv6},
+    magic_endpoint::accept_conn,
+    tls::{Keypair, PeerId},
+    MagicEndpoint,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[clap(short, long)]
+    secret_key: Option<String>,
+    #[clap(short, long)]
+    topic: String,
+    #[clap(short, long)]
+    derp_server: Option<Url>,
+    #[clap(short, long)]
+    peers: Vec<PeerId>,
+    #[clap(short, long)]
+    name: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+
+    let keypair = match args.secret_key {
+        None => Keypair::generate(),
+        Some(key) => parse_secret(&key)?,
+    };
+    println!("our secret key: {}", fmt_secret(&keypair));
+
+    // configure our derp map
+    // TODO: this should be a one-liner
+    let derp_map = match args.derp_server {
+        None => default_derp_map(),
+        Some(url) => {
+            let derp_port = match url.port() {
+                Some(port) => port,
+                None => match url.scheme() {
+                    "http" => 80,
+                    "https" => 443,
+                    _ => anyhow::bail!(
+                        "Invalid scheme in DERP URL, only http: and https: schemes are supported."
+                    ),
+                },
+            };
+            DerpMap::default_from_node(url, 3478, derp_port, UseIpv4::None, UseIpv6::None)
+        }
+    };
+
+    // init a peerid -> name hashmap
+    let mut names = HashMap::new();
+
+    // build our magic endpoint
+    let endpoint = MagicEndpoint::builder()
+        .keypair(keypair)
+        .alpns(vec![GOSSIP_ALPN.to_vec()])
+        .derp_map(Some(derp_map))
+        .bind(SocketAddr::new([127, 0, 0, 1].into(), 0))
+        .await?;
+    println!("> listening as {}", endpoint.peer_id());
+
+    // create the gossip protocol
+    let gossip = GossipHandle::from_endpoint(endpoint.clone(), Default::default());
+
+    // spawn our endpoint loop that forwards incoming connections to the gossiper
+    tokio::spawn(endpoint_loop(endpoint.clone(), gossip.clone()));
+
+    // join the topic with the peers provided
+    let topic: TopicId = blake3::hash(args.topic.as_bytes()).into();
+    println!("> joining topic {topic} on peers {:?}", args.peers);
+    gossip.join(topic, args.peers).await?;
+    println!("> joined! now send some gossip...");
+
+    // broadcast our name, if set
+    if let Some(name) = args.name {
+        names.insert(endpoint.peer_id(), name.clone());
+        let message =
+            SignedMessage::sign_and_encode(endpoint.keypair(), &Message::AboutMe { name })?;
+        gossip.broadcast(topic, message).await?;
+    }
+
+    // subscribe and print loop
+    tokio::spawn(subscribe_loop(gossip.clone(), topic, names));
+
+    // spawn an input thread that reads stdin
+    // not using tokio here because they recommend this for "technical reasons"
+    let (line_tx, mut line_rx) = tokio::sync::mpsc::channel(1);
+    std::thread::spawn(move || input_loop(line_tx));
+
+    // broadcast each line we type
+    while let Some(text) = line_rx.recv().await {
+        let message =
+            SignedMessage::sign_and_encode(endpoint.keypair(), &Message::Message { text })?;
+        gossip.broadcast(topic, message).await?;
+    }
+
+    Ok(())
+}
+
+async fn subscribe_loop(
+    gossip: GossipHandle,
+    topic: TopicId,
+    mut names: HashMap<PeerId, String>,
+) -> anyhow::Result<()> {
+    let mut stream = gossip.subscribe(topic).await?;
+    loop {
+        let event = stream.recv().await?;
+        if let Event::Received(data) = event {
+            let (from, message) = SignedMessage::verify_and_decode(&data)?;
+            match message {
+                Message::AboutMe { name } => {
+                    names.insert(from, name.clone());
+                    println!("> {} is now known as {}", fmt_peer_id(&from), name);
+                }
+                Message::Message { text } => {
+                    let name = names
+                        .get(&from)
+                        .map_or_else(|| fmt_peer_id(&from), String::to_string);
+                    println!("{}: {}", name, text);
+                }
+            }
+        }
+    }
+}
+
+async fn endpoint_loop(endpoint: MagicEndpoint, gossip: GossipHandle) -> anyhow::Result<()> {
+    while let Some(conn) = endpoint.accept().await {
+        let (peer_id, alpn, conn) = accept_conn(conn).await?;
+        match alpn.as_bytes() {
+            GOSSIP_ALPN => gossip.handle_connection(conn).await?,
+            _ => println!("> ignoring connection from {peer_id}: unsupported ALPN protocol"),
+        }
+    }
+    Ok(())
+}
+
+fn input_loop(line_tx: tokio::sync::mpsc::Sender<String>) -> anyhow::Result<()> {
+    let mut buffer = String::new();
+    let stdin = std::io::stdin(); // We get `Stdin` here.
+    loop {
+        stdin.read_line(&mut buffer)?;
+        line_tx.blocking_send(buffer.clone())?;
+        buffer.clear();
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct SignedMessage {
+    from: PeerId,
+    data: Bytes,
+    signature: Signature,
+}
+
+impl SignedMessage {
+    pub fn verify_and_decode(bytes: &[u8]) -> anyhow::Result<(PeerId, Message)> {
+        let signed_message: Self = postcard::from_bytes(bytes)?;
+        let key: VerifyingKey = signed_message.from.into();
+        key.verify_strict(&signed_message.data, &signed_message.signature)?;
+        let message: Message = postcard::from_bytes(&signed_message.data)?;
+        Ok((signed_message.from, message))
+    }
+
+    pub fn sign_and_encode(keypair: &Keypair, message: &Message) -> anyhow::Result<Bytes> {
+        let data: Bytes = postcard::to_stdvec(&message)?.into();
+        let signature = keypair.secret().sign(&data);
+        let from: PeerId = keypair.public().into();
+        let signed_message = Self {
+            from,
+            data,
+            signature,
+        };
+        let encoded = postcard::to_stdvec(&signed_message)?;
+        Ok(encoded.into())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+enum Message {
+    AboutMe { name: String },
+    Message { text: String },
+}
+
+fn fmt_peer_id(input: &PeerId) -> String {
+    let text = format!("{}", input);
+    format!("{}…{}", &text[..5], &text[(text.len() - 2)..])
+}
+
+fn fmt_secret(keypair: &Keypair) -> String {
+    let mut text = data_encoding::BASE32_NOPAD.encode(&keypair.secret().to_bytes());
+    text.make_ascii_lowercase();
+    text
+}
+fn parse_secret(secret: &str) -> anyhow::Result<Keypair> {
+    let bytes: [u8; 32] = data_encoding::BASE32_NOPAD
+        .decode(secret.to_ascii_uppercase().as_bytes())?
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("Invalid secret"))?;
+    let key = SigningKey::from_bytes(&bytes);
+    Ok(key.into())
+}

--- a/iroh-gossip/src/lib.rs
+++ b/iroh-gossip/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod proto;
+
+#[cfg(feature = "net")]
+pub mod net;

--- a/iroh-gossip/src/net/mod.rs
+++ b/iroh-gossip/src/net/mod.rs
@@ -1,0 +1,719 @@
+use std::{collections::HashMap, fmt, sync::Arc, time::Instant};
+
+use anyhow::{anyhow, Context};
+use bytes::{Bytes, BytesMut};
+use iroh_net::{magic_endpoint::get_peer_id, tls::PeerId, MagicEndpoint};
+use rand::rngs::StdRng;
+use rand_core::SeedableRng;
+use tokio::{
+    sync::{broadcast, mpsc, oneshot},
+    task::JoinHandle,
+};
+use tracing::{debug, warn};
+
+use self::util::{read_message, write_message, Dialer, Timers};
+use crate::proto::{self, TopicId};
+
+mod util;
+
+/// ALPN protocol name
+pub const GOSSIP_ALPN: &[u8] = b"n0/iroh-gossip/0";
+/// Maximum message size is limited to 1024 bytes for now.
+pub(crate) const MAX_MESSAGE_SIZE: usize = 1024;
+/// Channel capacity for topic subscription broadcast channels (one per topic)
+const SUBSCRIBE_ALL_CAP: usize = 64;
+/// Channel capacity for all subscription broadcast channels (single)
+const SUBSCRIBE_TOPIC_CAP: usize = 64;
+/// Channel capacity for the send queue (one per connection)
+const SEND_QUEUE_CAP: usize = 64;
+/// Channel capacity for the ToActor message queue (single)
+const TO_ACTOR_CAP: usize = 64;
+/// Channel capacity for the InEvent message queue (single)
+const IN_EVENT_CAP: usize = 1024;
+
+pub type InEvent = proto::InEvent<PeerId>;
+pub type OutEvent = proto::OutEvent<PeerId>;
+pub type Event = proto::Event<PeerId>;
+pub type Command = proto::Command<PeerId>;
+pub type Timer = proto::Timer<PeerId>;
+pub type ProtoMessage = proto::Message<PeerId>;
+
+/// Publish and subscribe on gossiping topics.
+///
+/// Each topic is a separate broadcast tree with separate memberships.
+///
+/// A topic has to be joined before you can publish or subscribe on the topic.
+/// To join the swarm for a topic, you have to know the [PeerId] of at least one peer that also joined the topic.
+///
+/// Messages published on the swarm will be delivered to all peers that joined the swarm for that
+/// topic. You will also be relaying (gossiping) messages published by other peers.
+///
+/// With the default settings, the protocol will maintain up to 5 peer connections per topic.
+///
+/// While the GossipHandle is created from a [MagicEndpoint], it does not accept connections
+/// itself. You should run an accept loop on the MagicEndpoint yourself, check the ALPN protocol of incoming
+/// connections, and if the ALPN protocol equals [GOSSIP_ALPN], forward the connection to the
+/// gossip actor through [Self::handle_connection].
+///
+/// The gossip actor will, however, initiate new connections to other peers by itself.
+#[derive(Clone)]
+pub struct GossipHandle {
+    to_actor_tx: mpsc::Sender<ToActor>,
+    _actor_handle: Arc<JoinHandle<anyhow::Result<()>>>,
+}
+
+impl GossipHandle {
+    /// Spawn a gossip actor and get a handle for it
+    pub fn from_endpoint(endpoint: MagicEndpoint, config: proto::Config) -> Self {
+        let peer_id = endpoint.peer_id();
+        let dialer = Dialer::new(endpoint);
+        Self::new(dialer, peer_id, config)
+    }
+
+    fn new(dialer: Dialer, peer_id: PeerId, config: proto::Config) -> Self {
+        let state = proto::State::new(peer_id, config, rand::rngs::StdRng::from_entropy());
+        let (to_actor_tx, to_actor_rx) = mpsc::channel(TO_ACTOR_CAP);
+        let (in_event_tx, in_event_rx) = mpsc::channel(IN_EVENT_CAP);
+        let actor = GossipActor {
+            state,
+            dialer,
+            to_actor_rx,
+            in_event_rx,
+            in_event_tx,
+            conns: Default::default(),
+            conn_send_tx: Default::default(),
+            pending_sends: Default::default(),
+            timers: Timers::new(),
+            subscribers_all: None,
+            subscribers_topic: Default::default(),
+        };
+        let actor_handle = tokio::spawn(async move {
+            if let Err(err) = actor.run().await {
+                warn!("GossipActor closed with error: {err:?}");
+                Err(err)
+            } else {
+                Ok(())
+            }
+        });
+        Self {
+            _actor_handle: Arc::new(actor_handle),
+            to_actor_tx,
+        }
+    }
+
+    /// Join a topic
+    ///
+    /// The returned future completes immediately if we have active peer connections for this
+    /// topic, and otherwise waits for at least one peer connection to be established successfully.
+    /// Note that there is no timeout attached, so this can stall indefinitely. Usually you will
+    /// want to add a timeout yourself.
+    pub async fn join(&self, topic: TopicId, known_peers: Vec<PeerId>) -> anyhow::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.send(ToActor::Join(topic, known_peers, tx)).await?;
+        rx.await?
+    }
+
+    /// Broadcast a message on a topic
+    ///
+    /// Does not join the topic automatically, so you have to call [Self::join] yourself
+    /// for messages to be broadcast to peers.
+    pub async fn broadcast(&self, topic: TopicId, message: Bytes) -> anyhow::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.send(ToActor::Broadcast(topic, message, tx)).await?;
+        rx.await??;
+        Ok(())
+    }
+
+    /// Subscribe to messages and event notifications for a topic.
+    ///
+    /// Does not join the topic automatically, so you have to call [Self::join] yourself
+    /// to actually receive messages.
+    pub async fn subscribe(&self, topic: TopicId) -> anyhow::Result<broadcast::Receiver<Event>> {
+        let (tx, rx) = oneshot::channel();
+        self.send(ToActor::Subscribe(topic, tx)).await?;
+        let res = rx.await.map_err(|_| anyhow!("subscribe_tx dropped"))??;
+        Ok(res)
+    }
+
+    /// Subscribe to all events published on topics that you joined.
+    pub async fn subscribe_all(&self) -> anyhow::Result<broadcast::Receiver<(TopicId, Event)>> {
+        let (tx, rx) = oneshot::channel();
+        self.send(ToActor::SubscribeAll(tx)).await?;
+        let res = rx.await.map_err(|_| anyhow!("subscribe_tx dropped"))??;
+        Ok(res)
+    }
+
+    /// Pass an incoming [quinn::Connection] to the gossip actor.
+    ///
+    /// Make sure to check the ALPN protocol yourself before passing the connection.
+    pub async fn handle_connection(&self, conn: quinn::Connection) -> anyhow::Result<()> {
+        let peer_id = get_peer_id(&conn).await?;
+        self.send(ToActor::ConnIncoming(peer_id, ConnOrigin::Accept, conn))
+            .await?;
+        Ok(())
+    }
+
+    async fn send(&self, event: ToActor) -> anyhow::Result<()> {
+        self.to_actor_tx
+            .send(event)
+            .await
+            .map_err(|_| anyhow!("gossip actor dropped"))
+    }
+}
+
+/// Whether a connection is initiated by us (Dial) or by the remote peer (Accept)
+#[derive(Debug)]
+enum ConnOrigin {
+    Accept,
+    Dial,
+}
+
+/// Input messages for the [GossipActor]
+enum ToActor {
+    ConnIncoming(PeerId, ConnOrigin, quinn::Connection),
+    Join(TopicId, Vec<PeerId>, oneshot::Sender<anyhow::Result<()>>),
+    Broadcast(TopicId, Bytes, oneshot::Sender<anyhow::Result<()>>),
+    Subscribe(
+        TopicId,
+        oneshot::Sender<anyhow::Result<broadcast::Receiver<Event>>>,
+    ),
+    SubscribeAll(oneshot::Sender<anyhow::Result<broadcast::Receiver<(TopicId, Event)>>>),
+}
+
+impl fmt::Debug for ToActor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ToActor::ConnIncoming(peer_id, origin, _conn) => {
+                write!(f, "ConnIncoming({peer_id:?}, {origin:?})")
+            }
+            ToActor::Join(topic, peers, _reply) => write!(f, "Join({topic:?}, {peers:?})"),
+            ToActor::Broadcast(topic, message, _reply) => {
+                write!(f, "Broadcast({topic:?}, bytes<{}>)", message.len())
+            }
+            ToActor::Subscribe(topic, _reply) => write!(f, "Subscribe({topic:?})"),
+            ToActor::SubscribeAll(_reply) => write!(f, "SubscribeAll"),
+        }
+    }
+}
+
+/// Actor that sends and handles messages between the connection and main state loops
+struct GossipActor {
+    /// Protocol state
+    state: proto::State<PeerId, StdRng>,
+    /// Dial machine to connect to peers
+    dialer: Dialer,
+    /// Input messages to the actor
+    to_actor_rx: mpsc::Receiver<ToActor>,
+    /// Input events to the state (emitted from the connection loops)
+    in_event_tx: mpsc::Sender<InEvent>,
+    /// Sender for the state input (cloned into the connection loops)
+    in_event_rx: mpsc::Receiver<InEvent>,
+    /// Queued timers
+    timers: Timers<Timer>,
+    /// Currently opened quinn conections to peers
+    conns: HashMap<PeerId, quinn::Connection>,
+    /// Channels to send outbound messages into the connection loops
+    conn_send_tx: HashMap<PeerId, mpsc::Sender<ProtoMessage>>,
+    /// Queued messages that were to be sent before a dial completed
+    pending_sends: HashMap<PeerId, Vec<ProtoMessage>>,
+    /// Broadcast senders for active topic subscriptions from the application
+    subscribers_topic: HashMap<TopicId, broadcast::Sender<Event>>,
+    /// Broadcast senders for wildcard subscriptions from the application
+    subscribers_all: Option<broadcast::Sender<(TopicId, Event)>>,
+}
+
+impl GossipActor {
+    pub async fn run(mut self) -> anyhow::Result<()> {
+        let me = *self.state.endpoint();
+        loop {
+            tokio::select! {
+                biased;
+                msg = self.to_actor_rx.recv() => {
+                    match msg {
+                        Some(msg) => self.handle_to_actor_msg(msg, Instant::now()).await?,
+                        None => {
+                            debug!(me = ?me, "all gossip handles dropped, stop gossip actor");
+                            break;
+                        }
+                    }
+                },
+                (peer_id, res) = self.dialer.next() => {
+                    match res {
+                        Ok(conn) => {
+                            debug!(me = ?me, peer = ?peer_id, "dial successfull");
+                            self.handle_to_actor_msg(ToActor::ConnIncoming(peer_id, ConnOrigin::Dial, conn), Instant::now()).await.context("dialer.next -> conn -> handle_to_actor_msg")?;
+                        }
+                        Err(err) => {
+                            // TODO: Remove pending messages?
+                            warn!(me = ?me, peer = ?peer_id, "dial failed: {err}");
+                            self.handle_in_event(InEvent::PeerDisconnected(peer_id), Instant::now()).await.context(format!("dialer.next -> err {err} -> handle_in_event PeerDisconnected{peer_id:?}"))?
+                        }
+                    }
+                }
+                event = self.in_event_rx.recv() => {
+                    match event {
+                        Some(event) => {
+                            self.handle_in_event(event, Instant::now()).await.context("in_event_rx.recv -> handle_in_event")?;
+                        }
+                        None => unreachable!()
+                    }
+                }
+                drain = self.timers.wait_and_drain() => {
+                    let now = Instant::now();
+                    for (_instant, timer) in drain {
+                        self.handle_in_event(InEvent::TimerExpired(timer), now).await.context("timers.drain_expired -> handle_in_event")?;
+                    }
+                    self.timers.reset();
+                }
+
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_to_actor_msg(&mut self, msg: ToActor, now: Instant) -> anyhow::Result<()> {
+        let me = *self.state.endpoint();
+        debug!(me = ?me, "handle to_actor  {msg:?}");
+        match msg {
+            ToActor::ConnIncoming(peer_id, origin, conn) => {
+                self.conns.insert(peer_id, conn.clone());
+                self.dialer.abort_dial(&peer_id);
+                let (send_tx, send_rx) = mpsc::channel(SEND_QUEUE_CAP);
+                self.conn_send_tx.insert(peer_id, send_tx.clone());
+
+                // Spawn a task for this connection
+                let in_event_tx = self.in_event_tx.clone();
+                tokio::spawn(async move {
+                    debug!(me = ?me, peer = ?peer_id, "connection established, start loop");
+                    match connection_loop(peer_id, conn, origin, send_rx, &in_event_tx).await {
+                        Ok(()) => {
+                            debug!(me = ?me, peer = ?peer_id, "connection closed without error")
+                        }
+                        Err(err) => {
+                            debug!(me = ?me, peer = ?peer_id, "connection closed with error {err:?}")
+                        }
+                    }
+                    in_event_tx
+                        .send(InEvent::PeerDisconnected(peer_id))
+                        .await
+                        .ok();
+                });
+
+                // Forward queued pending sends
+                if let Some(send_queue) = self.pending_sends.remove(&peer_id) {
+                    for msg in send_queue {
+                        send_tx.send(msg).await?;
+                    }
+                }
+            }
+            ToActor::Join(topic_id, peers, reply) => {
+                for peer_id in peers.iter() {
+                    self.handle_in_event(InEvent::Command(topic_id, Command::Join(*peer_id)), now)
+                        .await?;
+                }
+                if self.state.has_active_peers(&topic_id) {
+                    // If the active_view contains at least one peer, reply now
+                    reply.send(Ok(())).ok();
+                } else {
+                    // Otherwise, wait for any peer to come up as neighbor.
+                    let sub = self.subscribe(topic_id);
+                    tokio::spawn(async move {
+                        let res = wait_for_neighbor_up(sub).await;
+                        reply.send(res).ok();
+                    });
+                }
+            }
+            ToActor::Broadcast(topic_id, message, reply) => {
+                self.handle_in_event(InEvent::Command(topic_id, Command::Broadcast(message)), now)
+                    .await?;
+                reply.send(Ok(())).ok();
+            }
+            ToActor::Subscribe(topic_id, reply) => {
+                let rx = self.subscribe(topic_id);
+                reply.send(Ok(rx)).ok();
+            }
+            ToActor::SubscribeAll(reply) => {
+                let rx = self.subscribe_all();
+                reply.send(Ok(rx)).ok();
+            }
+        };
+        Ok(())
+    }
+
+    async fn handle_in_event(&mut self, event: InEvent, now: Instant) -> anyhow::Result<()> {
+        let me = *self.state.endpoint();
+        debug!(me = ?me, "handle in_event  {event:?}");
+        let out = self.state.handle(event, now);
+        for event in out {
+            debug!(me = ?me, "handle out_event {event:?}");
+            match event {
+                OutEvent::SendMessage(peer_id, message) => {
+                    if let Some(send) = self.conn_send_tx.get(&peer_id) {
+                        send.send(message)
+                            .await
+                            .with_context(|| format!("conn_send[{peer_id:?}] dropped"))?;
+                    } else {
+                        debug!(me = ?me, peer = ?peer_id, "dial");
+                        self.dialer.queue_dial(peer_id, GOSSIP_ALPN);
+                        // TODO: Enforce max length
+                        self.pending_sends.entry(peer_id).or_default().push(message);
+                    }
+                }
+                OutEvent::EmitEvent(topic_id, event) => {
+                    if let Some(sender) = self.subscribers_all.as_mut() {
+                        if let Err(_event) = sender.send((topic_id, event.clone())) {
+                            self.subscribers_all = None;
+                        }
+                    }
+                    if let Some(sender) = self.subscribers_topic.get(&topic_id) {
+                        // Only error case is that all [broadcast::Receivers] have been dropped.
+                        // If so, remove the sender as well.
+                        if let Err(_event) = sender.send(event) {
+                            self.subscribers_topic.remove(&topic_id);
+                        }
+                    }
+                }
+                OutEvent::ScheduleTimer(delay, timer) => {
+                    self.timers.insert(now + delay, timer);
+                }
+                OutEvent::DisconnectPeer(peer) => {
+                    if let Some(conn) = self.conns.remove(&peer) {
+                        conn.close(0u8.into(), b"close from disconnect");
+                    }
+                    self.conn_send_tx.remove(&peer);
+                    self.pending_sends.remove(&peer);
+                    self.dialer.abort_dial(&peer);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn subscribe_all(&mut self) -> broadcast::Receiver<(TopicId, Event)> {
+        if let Some(tx) = self.subscribers_all.as_mut() {
+            tx.subscribe()
+        } else {
+            let (tx, rx) = broadcast::channel(SUBSCRIBE_ALL_CAP);
+            self.subscribers_all = Some(tx);
+            rx
+        }
+    }
+
+    fn subscribe(&mut self, topic_id: TopicId) -> broadcast::Receiver<Event> {
+        if let Some(tx) = self.subscribers_topic.get(&topic_id) {
+            tx.subscribe()
+        } else {
+            let (tx, rx) = broadcast::channel(SUBSCRIBE_TOPIC_CAP);
+            self.subscribers_topic.insert(topic_id, tx);
+            rx
+        }
+    }
+}
+
+async fn wait_for_neighbor_up(mut sub: broadcast::Receiver<Event>) -> anyhow::Result<()> {
+    loop {
+        match sub.recv().await {
+            Ok(Event::NeighborUp(_neighbor)) => break Ok(()),
+            Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
+            Err(broadcast::error::RecvError::Closed) => {
+                break Err(anyhow!("Failed to join swarm: Gossip actor dropped"))
+            }
+        }
+    }
+}
+
+async fn connection_loop(
+    from: PeerId,
+    conn: quinn::Connection,
+    origin: ConnOrigin,
+    mut send_rx: mpsc::Receiver<ProtoMessage>,
+    in_event_tx: &mpsc::Sender<InEvent>,
+) -> anyhow::Result<()> {
+    let (mut send, mut recv) = match origin {
+        ConnOrigin::Accept => conn.accept_bi().await?,
+        ConnOrigin::Dial => conn.open_bi().await?,
+    };
+    let mut send_buf = BytesMut::new();
+    let mut recv_buf = BytesMut::new();
+    loop {
+        tokio::select! {
+            biased;
+            msg = send_rx.recv() => {
+                match msg {
+                    None => break,
+                    Some(msg) =>  write_message(&mut send, &mut send_buf, &msg).await?,
+                }
+            }
+
+            msg = read_message(&mut recv, &mut recv_buf) => {
+                let msg = msg?;
+                match msg {
+                    None => break,
+                    Some(msg) => in_event_tx.send(InEvent::RecvMessage(from, msg)).await?
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::{net::SocketAddr, time::Duration};
+
+    use iroh_net::{hp::derp::DerpMap, MagicEndpoint};
+    use tokio::spawn;
+    use tokio_util::sync::CancellationToken;
+    use tracing::info;
+
+    use super::*;
+
+    async fn create_endpoint(derp_map: DerpMap) -> anyhow::Result<MagicEndpoint> {
+        MagicEndpoint::builder()
+            .alpns(vec![GOSSIP_ALPN.to_vec()])
+            .derp_map(Some(derp_map))
+            .bind(SocketAddr::new([127, 0, 0, 1].into(), 0))
+            .await
+    }
+
+    async fn endpoint_loop(
+        endpoint: MagicEndpoint,
+        gossip: GossipHandle,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()> {
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => break,
+                conn = endpoint.accept() => match conn {
+                    None => break,
+                    Some(conn) => gossip.handle_connection(conn.await?).await?
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn gossip_net_smoke() {
+        util::setup_logging();
+        let (derp_map, cleanup) = util::run_derp_and_stun([127, 0, 0, 1].into())
+            .await
+            .unwrap();
+
+        let ep1 = create_endpoint(derp_map.clone()).await.unwrap();
+        let ep2 = create_endpoint(derp_map.clone()).await.unwrap();
+        let ep3 = create_endpoint(derp_map.clone()).await.unwrap();
+
+        let go1 = GossipHandle::from_endpoint(ep1.clone(), Default::default());
+        let go2 = GossipHandle::from_endpoint(ep2.clone(), Default::default());
+        let go3 = GossipHandle::from_endpoint(ep3.clone(), Default::default());
+        debug!("peer1 {:?}", ep1.peer_id());
+        debug!("peer2 {:?}", ep2.peer_id());
+        debug!("peer3 {:?}", ep3.peer_id());
+        let pi1 = ep1.peer_id();
+
+        let cancel = CancellationToken::new();
+        let tasks = [
+            spawn(endpoint_loop(ep1, go1.clone(), cancel.clone())),
+            spawn(endpoint_loop(ep2, go3.clone(), cancel.clone())),
+            spawn(endpoint_loop(ep3, go2.clone(), cancel.clone())),
+        ];
+
+        let topic: TopicId = blake3::hash(b"foobar").into();
+        go2.join(topic, vec![pi1]).await.unwrap();
+        go3.join(topic, vec![pi1]).await.unwrap();
+        go1.join(topic, vec![]).await.unwrap();
+
+        let pub1 = spawn(async move {
+            for i in 0..10 {
+                let message = format!("hi{}", i);
+                info!("go1 broadcast: {message:?}");
+                go1.broadcast(topic, message.into_bytes().into())
+                    .await
+                    .unwrap();
+                tokio::time::sleep(Duration::from_micros(1)).await;
+            }
+        });
+
+        let sub2 = spawn(async move {
+            let mut stream = go2.subscribe(topic).await.unwrap();
+            let mut recv = vec![];
+            loop {
+                let ev = stream.recv().await.unwrap();
+                info!("go2 event: {ev:?}");
+                if let Event::Received(msg) = ev {
+                    recv.push(msg);
+                }
+                if recv.len() == 10 {
+                    return recv;
+                }
+            }
+        });
+
+        let sub3 = spawn(async move {
+            let mut stream = go3.subscribe(topic).await.unwrap();
+            let mut recv = vec![];
+            loop {
+                let ev = stream.recv().await.unwrap();
+                info!("go3 event: {ev:?}");
+                if let Event::Received(msg) = ev {
+                    recv.push(msg);
+                }
+                if recv.len() == 10 {
+                    return recv;
+                }
+            }
+        });
+
+        pub1.await.unwrap();
+        let recv2 = sub2.await.unwrap();
+        let recv3 = sub3.await.unwrap();
+
+        let expected: Vec<Bytes> = (0..10)
+            .map(|i| Bytes::from(format!("hi{i}").into_bytes()))
+            .collect();
+        assert_eq!(recv2, expected);
+        assert_eq!(recv3, expected);
+
+        cancel.cancel();
+        for t in tasks {
+            t.await.unwrap().unwrap();
+        }
+        cleanup().await;
+    }
+
+    // This is copied from iroh-net/src/hp/magicsock/conn.rs
+    // TODO: Move into a public test_utils module in iroh-net?
+    mod util {
+        use std::net::{IpAddr, SocketAddr};
+
+        use anyhow::Result;
+        use futures::future::BoxFuture;
+        use iroh_net::hp::{
+            derp::{DerpMap, DerpNode, DerpRegion, UseIpv4, UseIpv6},
+            stun::{is, parse_binding_request, response},
+        };
+        use tokio::sync::oneshot;
+        use tracing::debug;
+        use tracing_subscriber::{prelude::*, EnvFilter};
+
+        pub fn setup_logging() {
+            tracing_subscriber::registry()
+                .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+                .with(EnvFilter::from_default_env())
+                .try_init()
+                .ok();
+        }
+
+        pub async fn run_derp_and_stun(
+            stun_ip: IpAddr,
+        ) -> Result<(DerpMap, impl FnOnce() -> BoxFuture<'static, ()>)> {
+            // TODO: pass a mesh_key?
+
+            let server_key = iroh_net::hp::key::node::SecretKey::generate();
+            let server =
+                iroh_net::hp::derp::http::ServerBuilder::new("127.0.0.1:0".parse().unwrap())
+                    .secret_key(Some(server_key))
+                    .tls_config(None)
+                    .spawn()
+                    .await?;
+
+            let http_addr = server.addr();
+            println!("DERP listening on {:?}", http_addr);
+
+            let (stun_addr, stun_cleanup) = serve(stun_ip).await?;
+            let m = DerpMap {
+                regions: [(
+                    1,
+                    DerpRegion {
+                        region_id: 1,
+                        region_code: "test".into(),
+                        nodes: vec![DerpNode {
+                            name: "t1".into(),
+                            region_id: 1,
+                            host_name: "http://127.0.0.1".parse().unwrap(),
+                            stun_only: false,
+                            stun_port: stun_addr.port(),
+                            ipv4: UseIpv4::Some("127.0.0.1".parse().unwrap()),
+                            ipv6: UseIpv6::None,
+
+                            derp_port: http_addr.port(),
+                            stun_test_ip: Some(stun_addr.ip()),
+                        }],
+                        avoid: false,
+                    },
+                )]
+                .into_iter()
+                .collect(),
+            };
+
+            let cleanup = move || {
+                Box::pin(async move {
+                    stun_cleanup.send(()).unwrap();
+                    server.shutdown().await;
+                }) as BoxFuture<'static, ()>
+            };
+
+            Ok((m, cleanup))
+        }
+
+        /// Sets up a simple STUN server.
+        ///
+        /// The returned [`oneshot::Sender`] can be used to stop the server, either drop it or
+        /// send a message on it.
+        pub async fn serve(ip: IpAddr) -> anyhow::Result<(SocketAddr, oneshot::Sender<()>)> {
+            let pc = tokio::net::UdpSocket::bind((ip, 0)).await?;
+            let mut addr = pc.local_addr()?;
+            match addr.ip() {
+                IpAddr::V4(ip) => {
+                    if ip.octets() == [0, 0, 0, 0] {
+                        addr.set_ip("127.0.0.1".parse().unwrap());
+                    }
+                }
+                _ => unreachable!("using ipv4"),
+            }
+
+            println!("listening on {}", addr);
+            let (s, r) = oneshot::channel();
+            tokio::task::spawn(async move {
+                run_stun(pc, r).await;
+            });
+
+            Ok((addr, s))
+        }
+
+        async fn run_stun(pc: tokio::net::UdpSocket, mut done: oneshot::Receiver<()>) {
+            let mut buf = vec![0u8; 64 << 10];
+            loop {
+                debug!("stun read loop");
+                tokio::select! {
+                    _ = &mut done => {
+                        debug!("shutting down");
+                        break;
+                    }
+                    res = pc.recv_from(&mut buf) => match res {
+                        Ok((n, addr)) => {
+                            debug!("stun read packet {}bytes from {}", n, addr);
+                            let pkt = &buf[..n];
+                            if !is(pkt) {
+                                debug!("stun received non STUN pkt");
+                                continue;
+                            }
+                            if let Ok(txid) = parse_binding_request(pkt) {
+                                debug!("stun received binding request");
+                                let res = response(txid, addr);
+                                if let Err(err) = pc.send_to(&res, addr).await {
+                                    eprintln!("STUN server write failed: {:?}", err);
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            eprintln!("failed to read: {:?}", err);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iroh-gossip/src/net/mod.rs
+++ b/iroh-gossip/src/net/mod.rs
@@ -502,7 +502,7 @@ async fn connection_loop(
 
 #[cfg(test)]
 mod test {
-    use std::{net::SocketAddr, time::Duration};
+    use std::time::Duration;
 
     use iroh_net::{hp::derp::DerpMap, MagicEndpoint};
     use tokio::spawn;
@@ -515,7 +515,7 @@ mod test {
         MagicEndpoint::builder()
             .alpns(vec![GOSSIP_ALPN.to_vec()])
             .derp_map(Some(derp_map))
-            .bind(SocketAddr::new([127, 0, 0, 1].into(), 0))
+            .bind(0)
             .await
     }
 
@@ -662,8 +662,9 @@ mod test {
                     .spawn()
                     .await?;
 
-            let http_addr = server.addr();
-            println!("DERP listening on {:?}", http_addr);
+            let derp_addr = server.addr();
+            let derp_port = derp_addr.port();
+            println!("DERP listening on {:?}", derp_addr);
 
             let (stun_addr, stun_cleanup) = serve(stun_ip).await?;
             let m = DerpMap {
@@ -675,13 +676,11 @@ mod test {
                         nodes: vec![DerpNode {
                             name: "t1".into(),
                             region_id: 1,
-                            host_name: "http://127.0.0.1".parse().unwrap(),
+                            url: format!("http://127.0.0.1:{derp_port}").parse().unwrap(),
                             stun_only: false,
                             stun_port: stun_addr.port(),
                             ipv4: UseIpv4::Some("127.0.0.1".parse().unwrap()),
                             ipv6: UseIpv6::None,
-
-                            derp_port: http_addr.port(),
                             stun_test_ip: Some(stun_addr.ip()),
                         }],
                         avoid: false,

--- a/iroh-gossip/src/net/mod.rs
+++ b/iroh-gossip/src/net/mod.rs
@@ -398,7 +398,7 @@ impl GossipActor {
         let me = *self.state.endpoint();
         debug!(me = ?me, "handle in_event  {event:?}");
         if let InEvent::PeerDisconnected(peer) = &event {
-            self.conn_send_tx.remove(&peer);
+            self.conn_send_tx.remove(peer);
         }
         let out = self.state.handle(event, now);
         for event in out {

--- a/iroh-gossip/src/net/util.rs
+++ b/iroh-gossip/src/net/util.rs
@@ -1,0 +1,170 @@
+use std::{collections::HashMap, io, pin::Pin, time::Instant};
+
+use anyhow::{anyhow, bail, ensure, Context, Result};
+use bytes::{Bytes, BytesMut};
+use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
+use iroh_net::{tls::PeerId, MagicEndpoint};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    time::{sleep_until, Sleep},
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::proto::util::TimerMap;
+
+use super::{ProtoMessage, MAX_MESSAGE_SIZE};
+
+/// Write a [ProtoMessage] as a length-prefixed, postcard-encoded message.
+pub async fn write_message<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    buffer: &mut BytesMut,
+    frame: &ProtoMessage,
+) -> Result<()> {
+    let len = postcard::experimental::serialized_size(&frame)?;
+    ensure!(len < MAX_MESSAGE_SIZE);
+    buffer.clear();
+    buffer.resize(len, 0u8);
+    let slice = postcard::to_slice(&frame, buffer)?;
+    writer.write_u32(len as u32).await?;
+    writer.write_all(slice).await?;
+    Ok(())
+}
+
+/// Read a length-prefixed message and decode as [[ProtoMessage]];
+pub async fn read_message(
+    reader: impl AsyncRead + Unpin,
+    buffer: &mut BytesMut,
+) -> Result<Option<ProtoMessage>> {
+    match read_lp(reader, buffer).await? {
+        None => Ok(None),
+        Some(data) => {
+            let message = postcard::from_bytes(&data)?;
+            Ok(Some(message))
+        }
+    }
+}
+
+/// Reads a length prefixed message.
+///
+/// # Returns
+///
+/// The message as raw bytes.  If the end of the stream is reached and there is no partial
+/// message, returns `None`.
+pub async fn read_lp(
+    mut reader: impl AsyncRead + Unpin,
+    buffer: &mut BytesMut,
+) -> Result<Option<Bytes>> {
+    let size = match reader.read_u32().await {
+        Ok(size) => size,
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let mut reader = reader.take(size as u64);
+    let size = usize::try_from(size).context("frame larger than usize")?;
+    if size > MAX_MESSAGE_SIZE {
+        bail!("Incoming message exceeds MAX_MESSAGE_SIZE");
+    }
+    buffer.reserve(size);
+    loop {
+        let r = reader.read_buf(buffer).await?;
+        if r == 0 {
+            break;
+        }
+    }
+    Ok(Some(buffer.split_to(size).freeze()))
+}
+
+pub type DialFuture = BoxFuture<'static, (PeerId, anyhow::Result<quinn::Connection>)>;
+
+/// Dial peers and maintain a queue of pending dials
+///
+/// This wraps a [MagicEndpoint], connects to peers through the endpoint, stores
+/// the pending connect futures and emits finished connect results.
+pub struct Dialer {
+    endpoint: MagicEndpoint,
+    pending: FuturesUnordered<DialFuture>,
+    pending_peers: HashMap<PeerId, CancellationToken>,
+}
+impl Dialer {
+    pub fn new(endpoint: MagicEndpoint) -> Self {
+        Self {
+            endpoint,
+            pending: Default::default(),
+            pending_peers: Default::default(),
+        }
+    }
+    pub fn queue_dial(&mut self, peer_id: PeerId, alpn_protocol: &'static [u8]) {
+        if self.is_pending(&peer_id) {
+            return;
+        }
+        let cancel = CancellationToken::new();
+        self.pending_peers.insert(peer_id, cancel.clone());
+        let endpoint = self.endpoint.clone();
+        let fut = async move {
+            let res = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => Err(anyhow!("Cancelled")),
+                res = endpoint.connect(peer_id, alpn_protocol, &[]) => res
+            };
+            (peer_id, res)
+        }
+        .boxed();
+        self.pending.push(fut.boxed());
+    }
+
+    pub fn abort_dial(&mut self, peer_id: &PeerId) {
+        if let Some(cancel) = self.pending_peers.remove(peer_id) {
+            cancel.cancel();
+        }
+    }
+
+    pub fn is_pending(&self, peer: &PeerId) -> bool {
+        self.pending_peers.contains_key(peer)
+    }
+
+    pub async fn next(&mut self) -> (PeerId, anyhow::Result<quinn::Connection>) {
+        match self.pending_peers.is_empty() {
+            false => {
+                let (peer_id, res) = self.pending.next().await.unwrap();
+                self.pending_peers.remove(&peer_id);
+                (peer_id, res)
+            }
+            true => futures::future::pending().await,
+        }
+    }
+}
+
+pub struct Timers<T> {
+    next: Option<(Instant, Pin<Box<Sleep>>)>,
+    map: TimerMap<T>,
+}
+impl<T> Timers<T> {
+    pub fn new() -> Self {
+        Self {
+            next: None,
+            map: TimerMap::new(),
+        }
+    }
+    /// Insert a new entry at the specified instant
+    pub fn insert(&mut self, instant: Instant, item: T) {
+        self.map.insert(instant, item);
+        self.reset();
+    }
+
+    pub fn reset(&mut self) {
+        self.next = self
+            .map
+            .first()
+            .map(|(instant, _)| (*instant, Box::pin(sleep_until((*instant).into()))))
+    }
+
+    pub async fn wait_and_drain(&mut self) -> impl Iterator<Item = (Instant, T)> {
+        match self.next.as_mut() {
+            Some((instant, sleep)) => {
+                sleep.await;
+                self.map.drain_until(instant)
+            }
+            None => futures::future::pending().await,
+        }
+    }
+}

--- a/iroh-gossip/src/net/util.rs
+++ b/iroh-gossip/src/net/util.rs
@@ -142,7 +142,7 @@ impl<T> Timers<T> {
     pub fn new() -> Self {
         Self {
             next: None,
-            map: TimerMap::new(),
+            map: TimerMap::default(),
         }
     }
     /// Insert a new entry at the specified instant

--- a/iroh-gossip/src/proto/hyparview.rs
+++ b/iroh-gossip/src/proto/hyparview.rs
@@ -361,10 +361,9 @@ where
 
     fn insert_peer_info(&mut self, peer_info: PeerInfo<PA>, io: &mut impl IO<PA>) {
         let old = self.peer_data.remove(&peer_info.id);
-        if let Some(old) = old {
-            if old != peer_info.data {
-                io.push(OutEvent::PeerData(peer_info.id, peer_info.data.clone()));
-            }
+        let same = matches!(old, Some(old) if old == peer_info.data);
+        if !same {
+            io.push(OutEvent::PeerData(peer_info.id, peer_info.data.clone()));
         }
         self.peer_data.insert(peer_info.id, peer_info.data);
     }

--- a/iroh-gossip/src/proto/hyparview.rs
+++ b/iroh-gossip/src/proto/hyparview.rs
@@ -1,0 +1,567 @@
+//! Implementation of the HyParView membership protocol
+//!
+//! The implementation is based on [this paper][paper] by Joao Leitao, Jose Pereira, Luıs Rodrigues
+//! and the [example implementation][impl] by Bartosz Sypytkowski
+//!
+//! [paper]: https://asc.di.fct.unl.pt/~jleitao/pdf/dsn07-leitao.pdf
+//! [impl]: https://gist.github.com/Horusiath/84fac596101b197da0546d1697580d99
+
+use std::{
+    collections::HashSet,
+    hash::Hash,
+    time::{Duration, Instant},
+};
+
+use derive_more::{From, Sub};
+use rand::rngs::ThreadRng;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use super::{util::IndexSet, PeerAddress, IO};
+
+#[derive(Debug)]
+pub enum InEvent<PA> {
+    RecvMessage(PA, Message<PA>),
+    TimerExpired(Timer<PA>),
+    PeerDisconnected(PA),
+    RequestJoin(PA),
+}
+
+pub enum OutEvent<PA> {
+    SendMessage(PA, Message<PA>),
+    ScheduleTimer(Duration, Timer<PA>),
+    DisconnectPeer(PA),
+    EmitEvent(Event<PA>),
+}
+
+#[derive(Clone, Debug)]
+pub enum Event<PA> {
+    NeighborUp(PA),
+    NeighborDown(PA),
+}
+
+#[derive(Clone, Debug)]
+pub enum Timer<PA> {
+    DoShuffle,
+    PendingNeighborRequest(PA),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum Message<PA> {
+    /// Sent to a peer if you want to join the swarm
+    Join,
+    /// When receiving Join, ForwardJoin is forwarded to the peer's ActiveView to introduce the
+    /// new member.
+    ForwardJoin(ForwardJoin<PA>),
+    /// A shuffle request is sent occasionally to re-shuffle the PassiveView with contacts from
+    /// other peers.
+    Shuffle(Shuffle<PA>),
+    /// Peers reply to Shuffle requests with a random subset of their PassiveView.
+    ShuffleReply(ShuffleReply<PA>),
+    /// Request to add sender to an active view of recipient. If `highPriority` is set, it cannot
+    /// be denied.
+    Neighbor(Neighbor),
+    /// Request to disconnect from a peer.
+    /// If `alive` is true, the other peer is not shutting down, so it should be added to the
+    /// passive set.
+    /// If `respond` is true, the peer should answer the disconnect request before shutting down
+    /// the connection.
+    Disconnect(Disconnect),
+}
+
+#[derive(From, Sub, Eq, PartialEq, Clone, Debug, Copy, Serialize, Deserialize)]
+pub struct Ttl(pub u16);
+impl Ttl {
+    pub fn expired(&self) -> bool {
+        *self == Ttl(0)
+    }
+    pub fn next(&self) -> Ttl {
+        Ttl(self.0.saturating_sub(1))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ForwardJoin<PA> {
+    peer: PA,
+    ttl: Ttl,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Shuffle<PA> {
+    origin: PA,
+    nodes: Vec<PA>,
+    ttl: Ttl,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ShuffleReply<PA> {
+    nodes: Vec<PA>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub enum Priority {
+    High,
+    Low,
+}
+
+impl<PA: Hash + Eq> FromIterator<PA> for ShuffleReply<PA> {
+    fn from_iter<I: IntoIterator<Item = PA>>(nodes: I) -> Self {
+        Self {
+            nodes: HashSet::<PA>::from_iter(nodes.into_iter())
+                .into_iter()
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Neighbor {
+    priority: Priority,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Disconnect {
+    alive: Alive,
+    respond: Respond,
+}
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub active_view_capacity: usize,
+    pub passive_view_capacity: usize,
+    pub active_random_walk_length: Ttl,
+    pub passive_random_walk_length: Ttl,
+    pub shuffle_random_walk_length: Ttl,
+    pub shuffle_active_view_count: usize,
+    pub shuffle_passive_view_count: usize,
+    pub shuffle_interval: Duration,
+
+    /// Timeout after which a Neighbor request is considered failed
+    pub neighbor_request_timeout: Duration,
+}
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            active_view_capacity: 5,
+            passive_view_capacity: 30,
+            active_random_walk_length: Ttl(6),
+            passive_random_walk_length: Ttl(3),
+            shuffle_random_walk_length: Ttl(6),
+            shuffle_active_view_count: 3,
+            shuffle_passive_view_count: 4,
+            shuffle_interval: Duration::from_secs(60),
+            neighbor_request_timeout: Duration::from_millis(500),
+        }
+    }
+}
+
+pub type Respond = bool;
+pub type Alive = bool;
+
+#[derive(Default, Debug, Clone)]
+pub struct Stats {
+    total_connections: usize,
+}
+
+#[derive(Debug)]
+pub struct State<PA, RG = ThreadRng> {
+    me: PA,
+    pub(crate) active_view: IndexSet<PA>,
+    pub(crate) passive_view: IndexSet<PA>,
+    config: Config,
+    shuffle_scheduled: bool,
+    rng: RG,
+    stats: Stats,
+    pending_neighbor_requests: HashSet<PA>,
+}
+
+impl<PA, RG> State<PA, RG>
+where
+    PA: PeerAddress,
+    RG: Rng,
+{
+    pub fn new(me: PA, config: Config, rng: RG) -> Self {
+        Self {
+            me,
+            active_view: IndexSet::new(),
+            passive_view: IndexSet::new(),
+            config,
+            shuffle_scheduled: false,
+            rng,
+            stats: Stats::default(),
+            pending_neighbor_requests: Default::default(),
+        }
+    }
+
+    pub fn handle(&mut self, event: InEvent<PA>, now: Instant, io: &mut impl IO<PA>) {
+        match event {
+            InEvent::RecvMessage(from, message) => self.handle_message(from, message, now, io),
+            InEvent::TimerExpired(timer) => match timer {
+                Timer::DoShuffle => self.handle_shuffle_timer(io),
+                Timer::PendingNeighborRequest(peer) => self.handle_pending_neighbor_timer(peer, io),
+            },
+            InEvent::PeerDisconnected(peer) => self.handle_disconnect(peer, io),
+            InEvent::RequestJoin(peer) => self.handle_join(peer, io),
+        }
+
+        // this will only happen on the first call
+        if !self.shuffle_scheduled {
+            io.push(OutEvent::ScheduleTimer(
+                self.config.shuffle_interval,
+                Timer::DoShuffle,
+            ));
+            self.shuffle_scheduled = true;
+        }
+    }
+
+    pub fn active_view(&self) -> impl Iterator<Item = &PA> {
+        self.active_view.iter()
+    }
+
+    pub fn passive_view(&self) -> impl Iterator<Item = &PA> {
+        self.passive_view.iter()
+    }
+
+    fn handle_message(
+        &mut self,
+        from: PA,
+        message: Message<PA>,
+        now: Instant,
+        io: &mut impl IO<PA>,
+    ) {
+        let is_disconnect = matches!(message, Message::Disconnect(Disconnect { .. }));
+        if !is_disconnect && !self.active_view.contains(&from) {
+            self.stats.total_connections += 1;
+        }
+        match message {
+            Message::Join => self.on_join(from, now, io),
+            Message::ForwardJoin(details) => self.on_forward_join(from, details, now, io),
+            Message::Shuffle(details) => self.on_shuffle(from, details, io),
+            Message::ShuffleReply(details) => self.on_shuffle_reply(details),
+            Message::Neighbor(details) => self.on_neighbor(from, details, now, io),
+            Message::Disconnect(details) => self.on_disconnect(from, details, io),
+        }
+
+        // Disconnect from passive nodes right after receiving a message.
+        if !is_disconnect && !self.active_view.contains(&from) {
+            io.push(OutEvent::DisconnectPeer(from));
+        }
+    }
+
+    fn handle_join(&mut self, peer: PA, io: &mut impl IO<PA>) {
+        io.push(OutEvent::SendMessage(peer, Message::Join));
+    }
+
+    fn handle_disconnect(&mut self, peer: PA, io: &mut impl IO<PA>) {
+        self.on_disconnect(
+            peer,
+            Disconnect {
+                alive: true,
+                respond: false,
+            },
+            io,
+        );
+    }
+
+    fn on_join(&mut self, peer: PA, now: Instant, io: &mut impl IO<PA>) {
+        // "A node that receives a join request will start by adding the new
+        // node to its active view, even if it has to drop a random node from it. (6)"
+        self.add_active(peer, Priority::High, now, io);
+        // "The contact node c will then send to all other nodes in its active view a ForwardJoin
+        // request containing the new node identifier. Associated to the join procedure,
+        // there are two configuration parameters, named Active Random Walk Length (ARWL),
+        // that specifies the maximum number of hops a ForwardJoin request is propagated,
+        // and Passive Random Walk Length (PRWL), that specifies at which point in the walk the node
+        // is inserted in a passive view. To use these parameters, the ForwardJoin request carries
+        // a “time to live” field that is initially set to ARWL and decreased at every hop. (7)"
+        let ttl = self.config.active_random_walk_length;
+        for node in self.active_view.iter_without(&peer) {
+            let message = Message::ForwardJoin(ForwardJoin { peer, ttl });
+            io.push(OutEvent::SendMessage(*node, message));
+        }
+    }
+
+    fn on_forward_join(
+        &mut self,
+        sender: PA,
+        message: ForwardJoin<PA>,
+        now: Instant,
+        io: &mut impl IO<PA>,
+    ) {
+        // "i) If the time to live is equal to zero or if the number of nodes in p’s active view is equal to one,
+        // it will add the new node to its active view (7)"
+        if message.ttl.expired() || self.active_view.len() <= 1 {
+            self.add_active(message.peer, Priority::High, now, io);
+        }
+        // "ii) If the time to live is equal to PRWL, p will insert the new node into its passive view"
+        else if message.ttl == self.config.passive_random_walk_length {
+            self.add_passive(message.peer);
+        }
+        // "iii) The time to live field is decremented."
+        // "iv) If, at this point, n has not been inserted
+        // in p’s active view, p will forward the request to a random node in its active view
+        // (different from the one from which the request was received)."
+        if !self.active_view.contains(&message.peer) {
+            match self
+                .active_view
+                .pick_random_without(&[&sender], &mut self.rng)
+            {
+                None => {
+                    // TODO: I think this is unreachable!() but will have to check, maybe decrease
+                    // to warn
+                    unreachable!("no peers in active view but also did not add this node on forward join, this should not happen");
+                }
+                Some(next) => {
+                    let message = Message::ForwardJoin(ForwardJoin {
+                        peer: message.peer,
+                        ttl: message.ttl.next(),
+                    });
+                    io.push(OutEvent::SendMessage(*next, message));
+                }
+            }
+        }
+    }
+
+    fn on_neighbor(&mut self, from: PA, details: Neighbor, now: Instant, io: &mut impl IO<PA>) {
+        self.pending_neighbor_requests.remove(&from);
+        // "A node q that receives a high priority neighbor request will always accept the request, even
+        // if it has to drop a random member from its active view (again, the member that is dropped will
+        // receive a Disconnect notification). If a node q receives a low priority Neighbor request, it will
+        // only accept the request if it has a free slot in its active view, otherwise it will refuse the request."
+        match details.priority {
+            Priority::High => {
+                self.add_active(from, Priority::High, now, io);
+            }
+            Priority::Low if !self.active_is_full() => {
+                self.add_active(from, Priority::Low, now, io);
+            }
+            _ => {}
+        }
+    }
+
+    fn on_shuffle(&mut self, from: PA, shuffle: Shuffle<PA>, io: &mut impl IO<PA>) {
+        if shuffle.ttl.expired() {
+            let len = shuffle.nodes.len();
+            for node in shuffle.nodes {
+                self.add_passive(node);
+            }
+            let nodes = self.passive_view.shuffled_max(len, &mut self.rng);
+            let message = Message::ShuffleReply(ShuffleReply::from_iter(nodes));
+            io.push(OutEvent::SendMessage(shuffle.origin, message));
+        } else if let Some(node) = self
+            .active_view
+            .pick_random_without(&[&shuffle.origin, &from], &mut self.rng)
+        {
+            let message = Message::Shuffle(Shuffle {
+                origin: shuffle.origin,
+                nodes: shuffle.nodes,
+                ttl: shuffle.ttl.next(),
+            });
+            io.push(OutEvent::SendMessage(*node, message));
+        }
+    }
+
+    fn on_shuffle_reply(&mut self, message: ShuffleReply<PA>) {
+        for node in message.nodes {
+            self.add_passive(node);
+        }
+    }
+
+    fn on_disconnect(&mut self, peer: PA, details: Disconnect, io: &mut impl IO<PA>) {
+        self.pending_neighbor_requests.remove(&peer);
+        self.remove_active(&peer, details.respond, io);
+        if details.alive {
+            self.add_passive(peer);
+        } else {
+            self.passive_view.remove(&peer);
+        }
+    }
+
+    fn handle_shuffle_timer(&mut self, io: &mut impl IO<PA>) {
+        if let Some(node) = self.active_view.pick_random(&mut self.rng) {
+            let active = self.active_view.shuffled_without_max(
+                &[node],
+                self.config.shuffle_active_view_count,
+                &mut self.rng,
+            );
+            let passive = self.passive_view.shuffled_without_max(
+                &[node],
+                self.config.shuffle_passive_view_count,
+                &mut self.rng,
+            );
+            let mut nodes = Vec::new();
+            nodes.extend(active);
+            nodes.extend(passive);
+            let message = Shuffle {
+                origin: self.me,
+                nodes,
+                ttl: self.config.shuffle_random_walk_length,
+            };
+            io.push(OutEvent::SendMessage(*node, Message::Shuffle(message)));
+        }
+        io.push(OutEvent::ScheduleTimer(
+            self.config.shuffle_interval,
+            Timer::DoShuffle,
+        ));
+    }
+
+    fn passive_is_full(&self) -> bool {
+        self.passive_view.len() >= self.config.passive_view_capacity
+    }
+
+    fn active_is_full(&self) -> bool {
+        self.active_view.len() >= self.config.active_view_capacity
+    }
+
+    /// Add a peer to the passive view.
+    ///
+    /// If the passive view is full, it will first remove a random peer and then insert the new peer.
+    /// If a peer is currently in the active view it will not be added.
+    fn add_passive(&mut self, peer: PA) {
+        if self.active_view.contains(&peer) || self.passive_view.contains(&peer) || peer == self.me
+        {
+            return;
+        }
+        if self.passive_is_full() {
+            self.passive_view.remove_random(&mut self.rng);
+        }
+        self.passive_view.insert(peer);
+    }
+
+    /// Remove a peer from the active view.
+    ///
+    /// If respond is true, a Disconnect message will be sent to the peer.
+    fn remove_active(&mut self, peer: &PA, respond: Respond, io: &mut impl IO<PA>) -> Option<PA> {
+        self.active_view.get_index_of(peer).map(|idx| {
+            let removed_peer = self
+                .remove_active_by_index(idx, respond, RemovalReason::Disconnect, io)
+                .unwrap();
+
+            self.refill_active_from_passive(&[&removed_peer], io);
+
+            removed_peer
+        })
+    }
+
+    fn refill_active_from_passive(&mut self, skip_peers: &[&PA], io: &mut impl IO<PA>) {
+        if self.active_view.len() + self.pending_neighbor_requests.len()
+            >= self.config.active_view_capacity
+        {
+            return;
+        }
+        // "When a node p suspects that one of the nodes present in its active view has failed
+        // (by either disconnecting or blocking), it selects a random node q from its passive view and
+        // attempts to establish a TCP connection with q. If the connection fails to establish,
+        // node q is considered failed and removed from p’s passive view; another node q′ is selected
+        // at random and a new attempt is made. The procedure is repeated until a connection is established
+        // with success." (p7)
+        let mut skip_peers = skip_peers.to_vec();
+        skip_peers.extend(self.pending_neighbor_requests.iter());
+
+        if let Some(node) = self
+            .passive_view
+            .pick_random_without(&skip_peers, &mut self.rng)
+        {
+            let priority = match self.active_view.is_empty() {
+                true => Priority::High,
+                false => Priority::Low,
+            };
+            let message = Message::Neighbor(Neighbor { priority });
+            io.push(OutEvent::SendMessage(*node, message));
+            // schedule a timer that checks if the node replied with a neighbor message,
+            // otherwise try again with another passive node.
+            io.push(OutEvent::ScheduleTimer(
+                self.config.neighbor_request_timeout,
+                Timer::PendingNeighborRequest(*node),
+            ));
+            self.pending_neighbor_requests.insert(*node);
+        };
+    }
+
+    fn handle_pending_neighbor_timer(&mut self, peer: PA, io: &mut impl IO<PA>) {
+        if self.pending_neighbor_requests.remove(&peer) {
+            self.passive_view.remove(&peer);
+            self.refill_active_from_passive(&[], io);
+        }
+    }
+
+    fn remove_active_by_index(
+        &mut self,
+        peer_index: usize,
+        respond: Respond,
+        reason: RemovalReason,
+        io: &mut impl IO<PA>,
+    ) -> Option<PA> {
+        if let Some(peer) = self.active_view.remove_index(peer_index) {
+            if respond {
+                let message = Message::Disconnect(Disconnect {
+                    alive: true,
+                    respond: false,
+                });
+                io.push(OutEvent::SendMessage(peer, message));
+            }
+            io.push(OutEvent::DisconnectPeer(peer));
+            io.push(OutEvent::EmitEvent(Event::NeighborDown(peer)));
+            self.add_passive(peer);
+            debug!(peer = ?self.me, other = ?peer, "removed from active view, reason: {reason:?}");
+            Some(peer)
+        } else {
+            None
+        }
+    }
+
+    /// Remove a random peer from the active view.
+    fn free_random_slot_in_active_view(&mut self, io: &mut impl IO<PA>) {
+        if let Some(index) = self.active_view.pick_random_index(&mut self.rng) {
+            self.remove_active_by_index(index, true, RemovalReason::Random, io);
+        }
+    }
+
+    /// Add a peer to the active view.
+    ///
+    /// If the active view is currently full, a random peer will be removed first.
+    /// Sends a Neighbor message to the peer. If high_priority is true, the peer
+    /// may not deny the Neighbor request.
+    fn add_active(
+        &mut self,
+        peer: PA,
+        priority: Priority,
+        _now: Instant,
+        io: &mut impl IO<PA>,
+    ) -> bool {
+        if self.active_view.contains(&peer) || peer == self.me {
+            return true;
+        }
+        match (priority, self.active_is_full()) {
+            (Priority::High, is_full) => {
+                if is_full {
+                    self.free_random_slot_in_active_view(io);
+                }
+                self.add_active_unchecked(peer, Priority::High, io);
+                true
+            }
+            (Priority::Low, false) => {
+                self.add_active_unchecked(peer, Priority::Low, io);
+                true
+            }
+            (Priority::Low, true) => false,
+        }
+    }
+
+    fn add_active_unchecked(&mut self, peer: PA, priority: Priority, io: &mut impl IO<PA>) {
+        self.passive_view.remove(&peer);
+        self.active_view.insert(peer);
+        debug!(peer = ?self.me, other = ?peer, "add to active view");
+
+        let message = Message::Neighbor(Neighbor { priority });
+        io.push(OutEvent::SendMessage(peer, message));
+        io.push(OutEvent::EmitEvent(Event::NeighborUp(peer)));
+    }
+}
+
+#[derive(Debug)]
+enum RemovalReason {
+    Disconnect,
+    Random,
+}

--- a/iroh-gossip/src/proto/mod.rs
+++ b/iroh-gossip/src/proto/mod.rs
@@ -1,6 +1,6 @@
 use std::{fmt, hash::Hash};
 
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 pub mod hyparview;
 pub mod plumtree;
@@ -13,3 +13,17 @@ pub use topic::{Command, Config, Event, IO};
 
 pub trait PeerAddress: Hash + Eq + Copy + fmt::Debug + Serialize + DeserializeOwned {}
 impl<T> PeerAddress for T where T: Hash + Eq + Copy + fmt::Debug + Serialize + DeserializeOwned {}
+
+pub type PeerData = bytes::Bytes;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PeerInfo<PA> {
+    pub id: PA,
+    pub data: PeerData,
+}
+
+impl<PA> From<(PA, PeerData)> for PeerInfo<PA> {
+    fn from((id, data): (PA, PeerData)) -> Self {
+        Self { id, data }
+    }
+}

--- a/iroh-gossip/src/proto/mod.rs
+++ b/iroh-gossip/src/proto/mod.rs
@@ -1,0 +1,15 @@
+use std::{fmt, hash::Hash};
+
+use serde::{de::DeserializeOwned, Serialize};
+
+pub mod hyparview;
+pub mod plumtree;
+pub mod state;
+pub mod topic;
+pub(crate) mod util;
+
+pub use state::{InEvent, Message, OutEvent, State, Timer, TopicId};
+pub use topic::{Command, Config, Event, IO};
+
+pub trait PeerAddress: Hash + Eq + Copy + fmt::Debug + Serialize + DeserializeOwned {}
+impl<T> PeerAddress for T where T: Hash + Eq + Copy + fmt::Debug + Serialize + DeserializeOwned {}

--- a/iroh-gossip/src/proto/mod.rs
+++ b/iroh-gossip/src/proto/mod.rs
@@ -6,7 +6,7 @@ pub mod hyparview;
 pub mod plumtree;
 pub mod state;
 pub mod topic;
-pub(crate) mod util;
+pub mod util;
 
 pub use state::{InEvent, Message, OutEvent, State, Timer, TopicId};
 pub use topic::{Command, Config, Event, IO};

--- a/iroh-gossip/src/proto/plumtree.rs
+++ b/iroh-gossip/src/proto/plumtree.rs
@@ -109,7 +109,7 @@ pub enum Message {
     IHave(Vec<IHave>),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Gossip {
     id: MessageId,
     round: Round,
@@ -122,6 +122,15 @@ impl Gossip {
             content: self.content,
             round: self.round.next(),
         }
+    }
+}
+impl fmt::Debug for Gossip {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Gossip")
+            .field("id", &self.id)
+            .field("round", &self.round)
+            .field("content", &format!("<{}>", self.content.len()))
+            .finish()
     }
 }
 

--- a/iroh-gossip/src/proto/plumtree.rs
+++ b/iroh-gossip/src/proto/plumtree.rs
@@ -1,0 +1,453 @@
+//! Implementation of the Plumtree epidemic broadcast tree protocol
+//!
+//! The implementation is based on [this paper][paper] by Joao Leitao, Jose Pereira, Luıs Rodrigues
+//! and the [example implementation][impl] by Bartosz Sypytkowski
+//!
+//! [paper]: https://asc.di.fct.unl.pt/~jleitao/pdf/srds07-leitao.pdf
+//! [impl]: https://gist.github.com/Horusiath/84fac596101b197da0546d1697580d99
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    fmt,
+    hash::Hash,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use derive_more::{Add, From, Sub};
+use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
+
+use super::{PeerAddress, IO};
+
+pub enum InEvent<PA> {
+    RecvMessage(PA, Message),
+    Broadcast(Bytes),
+    TimerExpired(Timer),
+    NeighborUp(PA),
+    NeighborDown(PA),
+    PeerDisconnected(PA),
+}
+
+pub enum OutEvent<PA> {
+    SendMessage(PA, Message),
+    ScheduleTimer(Duration, Timer),
+    EmitEvent(Event),
+}
+
+#[derive(Clone, Debug)]
+pub enum Timer {
+    SendGraft(MessageId),
+    DispatchLazyPush,
+}
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    Received(Bytes),
+}
+
+/// A message identifier, which is the message content's blake3 hash
+#[derive(Serialize, Deserialize, Clone, Copy, Eq)]
+pub struct MessageId([u8; 32]);
+
+impl From<blake3::Hash> for MessageId {
+    fn from(hash: blake3::Hash) -> Self {
+        Self(hash.into())
+    }
+}
+
+impl std::hash::Hash for MessageId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.0);
+    }
+}
+
+impl PartialEq for MessageId {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl fmt::Display for MessageId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut text = data_encoding::BASE32_NOPAD.encode(&self.0);
+        text.make_ascii_lowercase();
+        write!(f, "{}", text)
+    }
+}
+impl fmt::Debug for MessageId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut text = data_encoding::BASE32_NOPAD.encode(&self.0);
+        text.make_ascii_lowercase();
+        write!(f, "{}…{}", &text[..5], &text[(text.len() - 2)..])
+    }
+}
+
+#[derive(
+    From, Add, Sub, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Debug, Hash,
+)]
+pub struct Round(u16);
+
+impl Round {
+    pub fn next(&self) -> Round {
+        Round(self.0 + 1)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum Message {
+    /// When receiving Gossip, emit as event and forward full message to eager peer
+    /// and (after a delay) message IDs to lazy peers.
+    Gossip(Gossip),
+    /// When receiving Prune, move the peer from the eager to the lazy set
+    Prune,
+    /// When receiving Graft, move the peer to the eager set and send the full content for the
+    /// included message ID.
+    Graft(Graft),
+    /// When receiving IHave, do nothing initially, and request the messages for the included
+    /// message IDs after some time if they aren't pushed eagerly to us.
+    IHave(Vec<IHave>),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Gossip {
+    id: MessageId,
+    round: Round,
+    content: Bytes,
+}
+impl Gossip {
+    pub fn next_round(self) -> Gossip {
+        Gossip {
+            id: self.id,
+            content: self.content,
+            round: self.round.next(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IHave {
+    id: MessageId,
+    round: Round,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Graft {
+    id: Option<MessageId>,
+    round: Round,
+}
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub graft_timeout_1: Duration,
+    pub graft_timeout_2: Duration,
+    pub dispatch_timeout: Duration,
+    pub optimization_threshold: Round,
+}
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            graft_timeout_1: Duration::from_millis(80),
+            graft_timeout_2: Duration::from_secs(40),
+            dispatch_timeout: Duration::from_millis(50),
+            optimization_threshold: Round(7),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Stats {
+    pub payload_messages_received: u64,
+    pub control_messages_received: u64,
+    pub max_last_delivery_hop: u16,
+}
+
+#[derive(Debug)]
+pub struct State<PA> {
+    me: PA,
+    config: Config,
+
+    pub(crate) eager_push_peers: HashSet<PA>,
+    pub(crate) lazy_push_peers: HashSet<PA>,
+
+    lazy_push_queue: HashMap<PA, Vec<IHave>>,
+
+    missing_messages: HashMap<MessageId, VecDeque<(PA, Round)>>,
+    received_messages: IndexSet<MessageId>,
+    cache: HashMap<MessageId, Gossip>,
+
+    graft_timer_scheduled: HashSet<MessageId>,
+    dispatch_timer_scheduled: bool,
+
+    pub(crate) stats: Stats,
+}
+
+impl<PA: PeerAddress> State<PA> {
+    pub fn new(me: PA, config: Config) -> Self {
+        Self {
+            me,
+            eager_push_peers: Default::default(),
+            lazy_push_peers: Default::default(),
+            lazy_push_queue: Default::default(),
+            config,
+            missing_messages: Default::default(),
+            received_messages: Default::default(),
+            graft_timer_scheduled: Default::default(),
+            cache: Default::default(),
+            dispatch_timer_scheduled: false,
+            stats: Default::default(),
+        }
+    }
+
+    // TODO: optimization step from the paper
+
+    pub fn handle(&mut self, event: InEvent<PA>, io: &mut impl IO<PA>) {
+        match event {
+            InEvent::RecvMessage(from, message) => self.handle_message(from, message, io),
+            InEvent::Broadcast(data) => self.do_broadcast(data, io),
+            InEvent::NeighborUp(peer) => self.on_neighbor_up(peer),
+            InEvent::NeighborDown(peer) => self.on_neighbor_down(peer),
+            InEvent::PeerDisconnected(peer) => self.on_neighbor_down(peer),
+            InEvent::TimerExpired(timer) => match timer {
+                Timer::DispatchLazyPush => self.on_dispatch_timer(io),
+                Timer::SendGraft(id) => {
+                    self.on_send_graft_timer(id, io);
+                }
+            },
+        }
+    }
+
+    pub fn stats(&self) -> &Stats {
+        &self.stats
+    }
+
+    fn handle_message(&mut self, sender: PA, message: Message, io: &mut impl IO<PA>) {
+        if matches!(message, Message::Gossip(_)) {
+            self.stats.payload_messages_received += 1;
+        } else {
+            self.stats.control_messages_received += 1;
+        }
+        match message {
+            Message::Gossip(details) => self.on_gossip(sender, details, io),
+            Message::Prune => self.on_prune(sender),
+            Message::IHave(details) => self.on_ihave(sender, details, io),
+            Message::Graft(details) => self.on_graft(sender, details, io),
+        }
+    }
+
+    /// Dispatches messages from lazy queue over to lazy peers.
+    fn on_dispatch_timer(&mut self, io: &mut impl IO<PA>) {
+        for (peer, list) in self.lazy_push_queue.drain() {
+            io.push(OutEvent::SendMessage(peer, Message::IHave(list)));
+        }
+
+        self.dispatch_timer_scheduled = false;
+    }
+
+    /// Send a gossip message.
+    /// Will be pushed in full to eager peers.
+    /// Pushing the message ids to the lazy peers is delayed by a timer.
+    fn do_broadcast(&mut self, data: Bytes, io: &mut impl IO<PA>) {
+        let id = blake3::hash(&data).into();
+        let message = Gossip {
+            id,
+            round: Round(0),
+            content: data,
+        };
+        self.received_messages.insert(id);
+        self.cache.insert(id, message.clone());
+        let me = self.me;
+        self.eager_push(message.clone(), &me, io);
+        self.lazy_push(message, &me, io);
+    }
+
+    fn on_gossip(&mut self, sender: PA, message: Gossip, io: &mut impl IO<PA>) {
+        // if we already received this message: move peer to lazy set
+        // and notify peer about this.
+        if self.received_messages.contains(&message.id) {
+            self.add_lazy(sender);
+            io.push(OutEvent::SendMessage(sender, Message::Prune));
+        // otherwise store the message, emit to application and forward to peers
+        } else {
+            // insert the message in the list of received messages
+            self.received_messages.insert(message.id);
+
+            // increase the round for forwarding the message, and add to cache
+            // to reply to Graft messages later
+            // TODO: use an LRU cache for self.cache
+            // TODO: add callback/event to application to get missing messages that were received before?
+            let message = message.next_round();
+            self.cache.insert(message.id, message.clone());
+
+            // push the message to our peers
+            self.eager_push(message.clone(), &sender, io);
+            self.lazy_push(message.clone(), &sender, io);
+
+            // cleanup places where we track missing messages
+            self.graft_timer_scheduled.remove(&message.id);
+            let previous_ihaves = self.missing_messages.remove(&message.id);
+            // do the optimization step from the paper
+            if let Some(previous_ihaves) = previous_ihaves {
+                self.optimize_tree(&sender, &message, previous_ihaves, io);
+            }
+
+            // emit event to application
+            io.push(OutEvent::EmitEvent(Event::Received(message.content)));
+
+            self.stats.max_last_delivery_hop =
+                self.stats.max_last_delivery_hop.max(message.round.0);
+        }
+    }
+
+    fn optimize_tree(
+        &mut self,
+        sender: &PA,
+        message: &Gossip,
+        previous_ihaves: VecDeque<(PA, Round)>,
+        io: &mut impl IO<PA>,
+    ) {
+        let round = message.round;
+        let best_ihave = previous_ihaves
+            .iter()
+            .min_by(|(_froma, ra), (_fromb, rb)| ra.cmp(rb))
+            .copied();
+
+        if let Some((ihave_node, ihave_round)) = best_ihave {
+            if (ihave_round < round) && (round - ihave_round) >= self.config.optimization_threshold
+            {
+                let message = Message::Graft(Graft {
+                    id: None,
+                    round: ihave_round,
+                });
+                io.push(OutEvent::SendMessage(ihave_node, message));
+                io.push(OutEvent::SendMessage(*sender, Message::Prune));
+            }
+        }
+    }
+
+    fn on_prune(&mut self, sender: PA) {
+        self.add_lazy(sender);
+    }
+
+    // "When a node receives a IHAVE message, it simply marks the corresponding message as missing
+    // It then starts a timer, with a predefined timeout value, and waits for the missing message to be
+    // received via eager push before the timer expires. The timeout value is a protocol parameter
+    // that should be configured considering the diameter of the overlay and a target maximum recovery latency, defined
+    // by the application requirements. This is a parameter that should be statically configured at deployment time." (p8)
+    fn on_ihave(&mut self, sender: PA, ihaves: Vec<IHave>, io: &mut impl IO<PA>) {
+        for ihave in ihaves {
+            if !self.received_messages.contains(&ihave.id) {
+                self.missing_messages
+                    .entry(ihave.id)
+                    .or_default()
+                    .push_back((sender, ihave.round));
+
+                if !self.graft_timer_scheduled.contains(&ihave.id) {
+                    self.graft_timer_scheduled.insert(ihave.id);
+                    io.push(OutEvent::ScheduleTimer(
+                        self.config.graft_timeout_1,
+                        Timer::SendGraft(ihave.id),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn on_send_graft_timer(&mut self, id: MessageId, io: &mut impl IO<PA>) {
+        if self.received_messages.contains(&id) {
+            return;
+        }
+        let entry = self
+            .missing_messages
+            .get_mut(&id)
+            .and_then(|entries| entries.pop_front());
+        if let Some((peer, round)) = entry {
+            self.add_eager(peer);
+            let message = Message::Graft(Graft {
+                id: Some(id),
+                round,
+            });
+            io.push(OutEvent::SendMessage(peer, message));
+
+            // "when a GRAFT message is sent, another timer is started to expire after a certain timeout,
+            // to ensure that the message will be requested to another neighbor if it is not received
+            // meanwhile. This second timeout value should be smaller that the first, in the order of
+            // an average round trip time to a neighbor." (p9)
+            io.push(OutEvent::ScheduleTimer(
+                self.config.graft_timeout_2,
+                Timer::SendGraft(id),
+            ));
+        }
+    }
+
+    fn on_graft(&mut self, sender: PA, details: Graft, io: &mut impl IO<PA>) {
+        self.add_eager(sender);
+        if let Some(id) = details.id {
+            if let Some(message) = self.cache.get(&id) {
+                io.push(OutEvent::SendMessage(
+                    sender,
+                    Message::Gossip(message.clone()),
+                ));
+            }
+        }
+    }
+
+    fn on_neighbor_up(&mut self, peer: PA) {
+        self.add_eager(peer);
+    }
+
+    // "When a neighbor is detected to leave the overlay, it is simple removed from the membership.
+    // Furthermore, the record of IHAVE messages sent from failed members is deleted from the missing history" (p9)
+    fn on_neighbor_down(&mut self, peer: PA) {
+        self.missing_messages.retain(|_message_id, ihaves| {
+            ihaves.retain(|(ihave_peer, _round)| *ihave_peer != peer);
+            !ihaves.is_empty()
+        });
+        self.eager_push_peers.remove(&peer);
+        self.lazy_push_peers.remove(&peer);
+    }
+
+    /// Moves peer into eager set.
+    fn add_eager(&mut self, peer: PA) {
+        self.eager_push_peers.insert(peer);
+        self.lazy_push_peers.remove(&peer);
+    }
+
+    /// Moves peer into lazy set.
+    fn add_lazy(&mut self, peer: PA) {
+        self.eager_push_peers.remove(&peer);
+        self.lazy_push_peers.insert(peer);
+    }
+
+    /// Immediatelly sends message to eager peers.
+    fn eager_push(&mut self, gossip: Gossip, sender: &PA, io: &mut impl IO<PA>) {
+        for peer in self
+            .eager_push_peers
+            .iter()
+            .filter(|peer| **peer != self.me && *peer != sender)
+        {
+            io.push(OutEvent::SendMessage(
+                *peer,
+                Message::Gossip(gossip.clone()),
+            ));
+        }
+    }
+
+    /// Puts lazy message announcements on top of the queue which will be consumed into batched
+    /// IHave message once dispatch trigger activates (it's cyclic operation).
+    fn lazy_push(&mut self, gossip: Gossip, sender: &PA, io: &mut impl IO<PA>) {
+        for peer in self.lazy_push_peers.iter().filter(|x| *x != sender) {
+            self.lazy_push_queue.entry(*peer).or_default().push(IHave {
+                id: gossip.id,
+                round: gossip.round,
+            });
+        }
+        if !self.dispatch_timer_scheduled {
+            io.push(OutEvent::ScheduleTimer(
+                self.config.dispatch_timeout,
+                Timer::DispatchLazyPush,
+            ));
+            self.dispatch_timer_scheduled = true;
+        }
+    }
+}

--- a/iroh-gossip/src/proto/state.rs
+++ b/iroh-gossip/src/proto/state.rs
@@ -14,6 +14,24 @@ use super::PeerData;
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Ord, PartialOrd, Deserialize)]
 pub struct TopicId([u8; 32]);
 
+impl TopicId {
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for TopicId {
+    fn from(value: [u8; 32]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&[u8; 32]> for TopicId {
+    fn from(value: &[u8; 32]) -> Self {
+        Self(*value)
+    }
+}
+
 impl From<blake3::Hash> for TopicId {
     fn from(value: blake3::Hash) -> Self {
         Self(value.into())

--- a/iroh-gossip/src/proto/state.rs
+++ b/iroh-gossip/src/proto/state.rs
@@ -1,0 +1,220 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    time::{Duration, Instant},
+};
+
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+use crate::proto::{topic, Config, PeerAddress};
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Ord, PartialOrd, Deserialize)]
+pub struct TopicId([u8; 32]);
+
+impl From<blake3::Hash> for TopicId {
+    fn from(value: blake3::Hash) -> Self {
+        Self(value.into())
+    }
+}
+
+impl fmt::Display for TopicId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut text = data_encoding::BASE32_NOPAD.encode(&self.0);
+        text.make_ascii_lowercase();
+        write!(f, "{}", text)
+    }
+}
+impl fmt::Debug for TopicId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut text = data_encoding::BASE32_NOPAD.encode(&self.0);
+        text.make_ascii_lowercase();
+        write!(f, "{}…{}", &text[..5], &text[(text.len() - 2)..])
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Message<PA> {
+    topic: TopicId,
+    message: topic::Message<PA>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Timer<PA> {
+    topic: TopicId,
+    timer: topic::Timer<PA>,
+}
+
+/// Input event to the state handler.
+#[derive(Clone, Debug)]
+pub enum InEvent<PA> {
+    /// Message received from the network.
+    RecvMessage(PA, Message<PA>),
+    /// Execute a command from the application.
+    Command(TopicId, topic::Command<PA>),
+    /// Trigger a previously scheduled timer.
+    TimerExpired(Timer<PA>),
+    /// Peer disconnected on the network level.
+    PeerDisconnected(PA),
+}
+
+#[derive(Debug, Clone)]
+pub enum OutEvent<PA> {
+    /// Send a message on the network
+    SendMessage(PA, Message<PA>),
+    /// Emit an event to the application.
+    EmitEvent(TopicId, topic::Event<PA>),
+    /// Schedule a timer. The runtime is responsible for sending an [InEvent::TimerExpired]
+    /// after the duration.
+    ScheduleTimer(Duration, Timer<PA>),
+    /// Close the connection to a peer on the network level.
+    DisconnectPeer(PA),
+}
+
+type ConnsMap<PA> = HashMap<PA, HashSet<TopicId>>;
+type Outbox<PA> = Vec<OutEvent<PA>>;
+
+enum InEventMapped<PA> {
+    PeerDisconnected(PA),
+    TopicEvent(TopicId, topic::InEvent<PA>),
+}
+
+impl<PA> From<InEvent<PA>> for InEventMapped<PA> {
+    fn from(event: InEvent<PA>) -> InEventMapped<PA> {
+        match event {
+            InEvent::RecvMessage(from, Message { topic, message }) => {
+                Self::TopicEvent(topic, topic::InEvent::RecvMessage(from, message))
+            }
+            InEvent::Command(topic, command) => {
+                Self::TopicEvent(topic, topic::InEvent::Command(command))
+            }
+            InEvent::TimerExpired(Timer { topic, timer }) => {
+                Self::TopicEvent(topic, topic::InEvent::TimerExpired(timer))
+            }
+            InEvent::PeerDisconnected(peer) => Self::PeerDisconnected(peer),
+        }
+    }
+}
+
+pub struct State<PA, R> {
+    me: PA,
+    config: Config,
+    rng: R,
+    states: HashMap<TopicId, topic::State<PA, R>>,
+    outbox: Outbox<PA>,
+    conns: ConnsMap<PA>,
+}
+
+impl<PA: PeerAddress, R: Rng + Clone> State<PA, R> {
+    pub fn new(me: PA, config: Config, rng: R) -> Self {
+        Self {
+            me,
+            config,
+            rng,
+            states: Default::default(),
+            outbox: Default::default(),
+            conns: Default::default(),
+        }
+    }
+
+    pub fn endpoint(&self) -> &PA {
+        &self.me
+    }
+
+    pub fn state(&self, topic: &TopicId) -> Option<&topic::State<PA, R>> {
+        self.states.get(topic)
+    }
+
+    pub fn state_mut(&mut self, topic: &TopicId) -> Option<&mut topic::State<PA, R>> {
+        self.states.get_mut(topic)
+    }
+
+    pub fn has_active_peers(&self, topic: &TopicId) -> bool {
+        self.state(topic)
+            .map(|s| s.has_active_peers())
+            .unwrap_or(false)
+    }
+
+    pub fn handle(
+        &mut self,
+        event: InEvent<PA>,
+        now: Instant,
+    ) -> impl Iterator<Item = OutEvent<PA>> + '_ {
+        let event: InEventMapped<PA> = event.into();
+
+        // todo: add command to leave a topic
+        match event {
+            InEventMapped::TopicEvent(topic, event) => {
+                // when receiving messages, update our conn map to take note that this topic state may want
+                // to keep this connection
+                // TODO: this is a lot of hashmap lookups, maybe there's ways to optimize?
+                if let topic::InEvent::RecvMessage(from, _message) = &event {
+                    self.conns.entry(*from).or_default().insert(topic);
+                }
+                // when receiving a join command, initialize state if it doesn't exist
+                if let topic::InEvent::Command(topic::Command::Join(_peer)) = event {
+                    if let std::collections::hash_map::Entry::Vacant(e) = self.states.entry(topic) {
+                        e.insert(topic::State::with_rng(
+                            self.me,
+                            self.config.clone(),
+                            self.rng.clone(),
+                        ));
+                    }
+                }
+                if let std::collections::hash_map::Entry::Vacant(e) = self.states.entry(topic) {
+                    e.insert(topic::State::with_rng(
+                        self.me,
+                        self.config.clone(),
+                        self.rng.clone(),
+                    ));
+                }
+
+                // pass the event to the state handler
+                if let Some(state) = self.states.get_mut(&topic) {
+                    let out = state.handle(event, now);
+                    for event in out {
+                        handle_out_event(topic, event, &mut self.conns, &mut self.outbox);
+                    }
+                }
+            }
+            // when a peer disconnected on the network level, forward event to all states
+            InEventMapped::PeerDisconnected(peer) => {
+                for (topic, state) in self.states.iter_mut() {
+                    let out = state.handle(topic::InEvent::PeerDisconnected(peer), now);
+                    for event in out {
+                        handle_out_event(*topic, event, &mut self.conns, &mut self.outbox);
+                    }
+                }
+            }
+        }
+
+        self.outbox.drain(..)
+    }
+}
+
+fn handle_out_event<PA: PeerAddress>(
+    topic: TopicId,
+    event: topic::OutEvent<PA>,
+    conns: &mut ConnsMap<PA>,
+    outbox: &mut Outbox<PA>,
+) {
+    match event {
+        topic::OutEvent::SendMessage(to, message) => {
+            outbox.push(OutEvent::SendMessage(to, Message { topic, message }))
+        }
+        topic::OutEvent::EmitEvent(event) => outbox.push(OutEvent::EmitEvent(topic, event)),
+        topic::OutEvent::ScheduleTimer(delay, timer) => {
+            outbox.push(OutEvent::ScheduleTimer(delay, Timer { topic, timer }))
+        }
+        topic::OutEvent::DisconnectPeer(peer) => {
+            let empty = conns
+                .get_mut(&peer)
+                .map(|list| list.remove(&topic) && list.is_empty())
+                .unwrap_or(false);
+            if empty {
+                conns.remove(&peer);
+                outbox.push(OutEvent::DisconnectPeer(peer));
+            }
+        }
+    }
+}

--- a/iroh-gossip/src/proto/topic.rs
+++ b/iroh-gossip/src/proto/topic.rs
@@ -1,0 +1,827 @@
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+use bytes::Bytes;
+use derive_more::From;
+use rand::Rng;
+use rand_core::SeedableRng;
+use serde::{Deserialize, Serialize};
+
+use super::hyparview::{self, InEvent as SwarmIn};
+use super::plumtree::{self, InEvent as GossipIn};
+use super::PeerAddress;
+
+/// Input event to the state handler.
+#[derive(Clone, Debug)]
+pub enum InEvent<PA> {
+    /// Message received from the network.
+    RecvMessage(PA, Message<PA>),
+    /// Execute a command from the application.
+    Command(Command<PA>),
+    /// Trigger a previously scheduled timer.
+    TimerExpired(Timer<PA>),
+    /// Peer disconnected on the network level.
+    PeerDisconnected(PA),
+}
+
+/// An output event from the state handler.
+#[derive(Debug)]
+pub enum OutEvent<PA> {
+    /// Send a message on the network
+    SendMessage(PA, Message<PA>),
+    /// Emit an event to the application.
+    EmitEvent(Event<PA>),
+    /// Schedule a timer. The runtime is responsible for sending an [InEvent::TimerExpired]
+    /// after the duration.
+    ScheduleTimer(Duration, Timer<PA>),
+    /// Close the connection to a peer on the network level.
+    DisconnectPeer(PA),
+}
+
+impl<PA> From<hyparview::OutEvent<PA>> for OutEvent<PA> {
+    fn from(event: hyparview::OutEvent<PA>) -> Self {
+        use hyparview::OutEvent::*;
+        match event {
+            SendMessage(to, message) => Self::SendMessage(to, message.into()),
+            ScheduleTimer(delay, timer) => Self::ScheduleTimer(delay, timer.into()),
+            DisconnectPeer(peer) => Self::DisconnectPeer(peer),
+            EmitEvent(event) => Self::EmitEvent(event.into()),
+        }
+    }
+}
+
+impl<PA> From<plumtree::OutEvent<PA>> for OutEvent<PA> {
+    fn from(event: plumtree::OutEvent<PA>) -> Self {
+        use plumtree::OutEvent::*;
+        match event {
+            SendMessage(to, message) => Self::SendMessage(to, message.into()),
+            ScheduleTimer(delay, timer) => Self::ScheduleTimer(delay, timer.into()),
+            EmitEvent(event) => Self::EmitEvent(event.into()),
+        }
+    }
+}
+
+pub trait IO<PA: Clone> {
+    fn push(&mut self, event: impl Into<OutEvent<PA>>);
+}
+
+#[derive(From, Debug, Serialize, Deserialize, Clone)]
+pub enum Message<PA> {
+    Swarm(hyparview::Message<PA>),
+    Gossip(plumtree::Message),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Event<PA> {
+    NeighborUp(PA),
+    NeighborDown(PA),
+    Received(Bytes),
+}
+
+impl<PA> From<hyparview::Event<PA>> for Event<PA> {
+    fn from(value: hyparview::Event<PA>) -> Self {
+        match value {
+            hyparview::Event::NeighborUp(peer) => Self::NeighborUp(peer),
+            hyparview::Event::NeighborDown(peer) => Self::NeighborDown(peer),
+        }
+    }
+}
+
+impl<PA> From<plumtree::Event> for Event<PA> {
+    fn from(value: plumtree::Event) -> Self {
+        match value {
+            plumtree::Event::Received(peer) => Self::Received(peer),
+        }
+    }
+}
+
+#[derive(Clone, From, Debug)]
+pub enum Timer<PA> {
+    Swarm(hyparview::Timer<PA>),
+    Gossip(plumtree::Timer),
+}
+
+#[derive(Clone, Debug)]
+pub enum Command<PA> {
+    Join(PA),
+    Broadcast(Bytes),
+}
+
+impl<PA: Clone> IO<PA> for VecDeque<OutEvent<PA>> {
+    fn push(&mut self, event: impl Into<OutEvent<PA>>) {
+        self.push_back(event.into())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct Config {
+    pub membership: hyparview::Config,
+    pub broadcast: plumtree::Config,
+}
+
+/// The topic state maintains the swarm membership and broadcast tree for a particular topic.
+#[derive(Debug)]
+pub struct State<PA, R> {
+    me: PA,
+    pub(crate) swarm: hyparview::State<PA, R>,
+    pub(crate) gossip: plumtree::State<PA>,
+    outbox: VecDeque<OutEvent<PA>>,
+    stats: Stats,
+}
+
+impl<PA: PeerAddress> State<PA, rand::rngs::StdRng> {
+    /// Initialize the local state with the default random number generator.
+    pub fn new(me: PA, config: Config) -> Self {
+        Self::with_rng(me, config, rand::rngs::StdRng::from_entropy())
+    }
+}
+
+impl<PA, R> State<PA, R> {
+    /// The address of your local endpoint.
+    pub fn endpoint(&self) -> &PA {
+        &self.me
+    }
+}
+
+impl<PA: PeerAddress, R: Rng> State<PA, R> {
+    /// Initialize the local state with a custom random number generator.
+    pub fn with_rng(me: PA, config: Config, rng: R) -> Self {
+        Self {
+            swarm: hyparview::State::new(me, config.membership, rng),
+            gossip: plumtree::State::new(me, config.broadcast),
+            me,
+            outbox: VecDeque::new(),
+            stats: Stats::default(),
+        }
+    }
+
+    /// Handle an incoming event.
+    ///
+    /// Returns an iterator of outgoing events that must be processed by the application.
+    pub fn handle(
+        &mut self,
+        event: InEvent<PA>,
+        now: Instant,
+    ) -> impl Iterator<Item = OutEvent<PA>> + '_ {
+        let io = &mut self.outbox;
+        // Process the event, store out events in outbox.
+        match event {
+            InEvent::Command(command) => match command {
+                Command::Join(peer) => self.swarm.handle(SwarmIn::RequestJoin(peer), now, io),
+                Command::Broadcast(data) => self.gossip.handle(GossipIn::Broadcast(data), io),
+            },
+            InEvent::RecvMessage(from, message) => {
+                self.stats.messages_received += 1;
+                match message {
+                    Message::Swarm(message) => {
+                        self.swarm
+                            .handle(SwarmIn::RecvMessage(from, message), now, io)
+                    }
+                    Message::Gossip(message) => {
+                        self.gossip.handle(GossipIn::RecvMessage(from, message), io)
+                    }
+                }
+            }
+            InEvent::TimerExpired(timer) => match timer {
+                Timer::Swarm(timer) => self.swarm.handle(SwarmIn::TimerExpired(timer), now, io),
+                Timer::Gossip(timer) => self.gossip.handle(GossipIn::TimerExpired(timer), io),
+            },
+            InEvent::PeerDisconnected(peer) => {
+                self.swarm.handle(SwarmIn::PeerDisconnected(peer), now, io);
+                self.gossip.handle(GossipIn::PeerDisconnected(peer), io);
+            }
+        }
+
+        // Forward NeigborUp and NeighborDown events from hyparview to plumtree
+        let mut io = VecDeque::new();
+        for event in self.outbox.iter() {
+            match event {
+                OutEvent::EmitEvent(Event::NeighborUp(peer)) => {
+                    self.gossip.handle(GossipIn::NeighborUp(*peer), &mut io)
+                }
+                OutEvent::EmitEvent(Event::NeighborDown(peer)) => {
+                    self.gossip.handle(GossipIn::NeighborDown(*peer), &mut io)
+                }
+                _ => {}
+            }
+        }
+        // Note that this is a no-op because plumtree::handle(NeighborUp | NeighborDown)
+        // above does not emit any OutEvents.
+        self.outbox.extend(io.drain(..));
+
+        // Update sent message counter
+        self.stats.messages_sent += self
+            .outbox
+            .iter()
+            .filter(|event| matches!(event, OutEvent::SendMessage(_, _)))
+            .count();
+
+        self.outbox.drain(..)
+    }
+
+    pub fn stats(&self) -> &Stats {
+        &self.stats
+    }
+
+    pub fn has_active_peers(&self) -> bool {
+        !self.swarm.active_view.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Stats {
+    pub messages_sent: usize,
+    pub messages_received: usize,
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        collections::{BTreeMap, HashMap, HashSet, VecDeque},
+        env,
+        time::{Duration, Instant},
+    };
+
+    use bytes::Bytes;
+    use rand::Rng;
+    use rand_core::SeedableRng;
+    use tracing::{debug, warn};
+    use tracing_subscriber::{prelude::*, EnvFilter};
+
+    use super::{Command, Config, Event, InEvent, OutEvent, PeerAddress, State, Timer};
+    use crate::proto::util::TimerMap;
+
+    fn setup_logging() {
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+            .with(EnvFilter::from_default_env())
+            .try_init()
+            .ok();
+    }
+
+    #[test]
+    fn hyparview_smoke() {
+        setup_logging();
+        // Create a network with 4 nodes and active_view_capacity 2
+        let mut config = Config::default();
+        config.membership.active_view_capacity = 2;
+        let mut network = Network::new(Instant::now());
+        for i in 0..4 {
+            network.push(State::new(i, config.clone()));
+        }
+
+        // Do some joins between nodes 0,1,2
+        network.command(0, Command::Join(1));
+        network.command(0, Command::Join(2));
+        network.command(1, Command::Join(2));
+        network.ticks(10);
+
+        // Confirm emitted events
+        let actual = network.events_sorted();
+        let expected = sort(vec![
+            (0, Event::NeighborUp(1)),
+            (0, Event::NeighborUp(2)),
+            (1, Event::NeighborUp(2)),
+            (1, Event::NeighborUp(0)),
+            (2, Event::NeighborUp(0)),
+            (2, Event::NeighborUp(1)),
+        ]);
+        assert_eq!(actual, expected);
+
+        // Confirm active connections
+        assert_eq!(network.conns(), vec![(0, 1), (0, 2), (1, 2)]);
+
+        // Now let node 3 join node 0.
+        // Node 0 is full, so it will disconnect from either node 1 or node 2.
+        network.command(3, Command::Join(0));
+        network.ticks(8);
+
+        // Confirm emitted events. There's two options because whether node 0 disconnects from
+        // node 1 or node 2 is random.
+        let actual = network.events_sorted();
+        eprintln!("actual {actual:?}");
+        let expected1 = sort(vec![
+            (3, Event::NeighborUp(0)),
+            (0, Event::NeighborUp(3)),
+            (0, Event::NeighborDown(1)),
+            (1, Event::NeighborDown(0)),
+        ]);
+        let expected2 = sort(vec![
+            (3, Event::NeighborUp(0)),
+            (0, Event::NeighborUp(3)),
+            (0, Event::NeighborDown(2)),
+            (2, Event::NeighborDown(0)),
+        ]);
+        assert!((actual == expected1) || (actual == expected2));
+
+        // Confirm active connections.
+        if actual == expected1 {
+            assert_eq!(network.conns(), vec![(0, 2), (0, 3), (1, 2)]);
+        } else {
+            assert_eq!(network.conns(), vec![(0, 1), (0, 3), (1, 2)]);
+        }
+        assert!(assert_synchronous_active(&network));
+    }
+
+    #[test]
+    fn plumtree_smoke() {
+        setup_logging();
+        let config = Config::default();
+        let mut network = Network::new(Instant::now());
+        let broadcast_ticks = 12;
+        let join_ticks = 12;
+        // build a network with 6 nodes
+        for i in 0..6 {
+            network.push(State::new(i, config.clone()));
+        }
+
+        // connect nodes 1 and 2 to node 0
+        (1..3).for_each(|i| network.command(i, Command::Join(0)));
+        // connect nodes 4 and 5 to node 3
+        (4..6).for_each(|i| network.command(i, Command::Join(3)));
+        // run ticks and drain events
+        network.ticks(join_ticks);
+        let _ = network.events();
+        assert!(assert_synchronous_active(&network));
+
+        // now broadcast a first message
+        network.command(1, Command::Broadcast(b"hi1".to_vec().into()));
+        network.ticks(broadcast_ticks);
+        let events = network.events();
+        let received = events.filter(|x| matches!(x, (_, Event::Received(_))));
+        // message should be received by two other nodes
+        assert_eq!(received.count(), 2);
+        assert!(assert_synchronous_active(&network));
+
+        // now connect the two sections of the swarm
+        network.command(2, Command::Join(5));
+        network.ticks(join_ticks);
+        let _ = network.events();
+        report_round_distribution(&network);
+
+        // now broadcast again
+        network.command(1, Command::Broadcast(b"hi2".to_vec().into()));
+        network.ticks(broadcast_ticks);
+        let events = network.events();
+        let received = events.filter(|x| matches!(x, (_, Event::Received(_))));
+        // message should be received by all 5 other nodes
+        assert_eq!(received.count(), 5);
+        assert!(assert_synchronous_active(&network));
+        report_round_distribution(&network);
+    }
+
+    fn read_var(name: &str, default: usize) -> usize {
+        env::var(name)
+            .unwrap_or_else(|_| default.to_string())
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn big_multiple_sender() {
+        setup_logging();
+        let mut gossip_config = Config::default();
+        gossip_config.broadcast.optimization_threshold = (read_var("OPTIM", 7) as u16).into();
+        let config = SimulatorConfig {
+            peers_count: read_var("PEERS", 100),
+            ..Default::default()
+        };
+        let rounds = read_var("ROUNDS", 10);
+        let mut simulator = Simulator::new(config, gossip_config);
+        simulator.init();
+        simulator.bootstrap();
+        for i in 0..rounds {
+            let from = i + 1;
+            let message = format!("m{i}").into_bytes().into();
+            simulator.gossip_round(from, message)
+        }
+        simulator.report_round_sums();
+    }
+
+    #[test]
+    fn big_single_sender() {
+        setup_logging();
+        let mut gossip_config = Config::default();
+        gossip_config.broadcast.optimization_threshold = (read_var("OPTIM", 7) as u16).into();
+        let config = SimulatorConfig {
+            peers_count: read_var("PEERS", 100),
+            ..Default::default()
+        };
+        let rounds = read_var("ROUNDS", 10);
+        let mut simulator = Simulator::new(config, gossip_config);
+        simulator.init();
+        simulator.bootstrap();
+        for i in 0..rounds {
+            let from = 2;
+            let message = format!("m{i}").into_bytes().into();
+            simulator.gossip_round(from, message)
+        }
+        simulator.report_round_sums();
+    }
+
+    fn report_round_distribution<PA: PeerAddress, R: Rng>(network: &Network<PA, R>) {
+        let mut eager_distrib: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut lazy_distrib: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut active_distrib: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut passive_distrib: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut payload_recv = 0;
+        let mut control_recv = 0;
+        for state in network.peers.iter() {
+            let stats = state.gossip.stats();
+            *eager_distrib
+                .entry(state.gossip.eager_push_peers.len())
+                .or_default() += 1;
+            *lazy_distrib
+                .entry(state.gossip.lazy_push_peers.len())
+                .or_default() += 1;
+            *active_distrib
+                .entry(state.swarm.active_view().count())
+                .or_default() += 1;
+            *passive_distrib
+                .entry(state.swarm.passive_view().count())
+                .or_default() += 1;
+            payload_recv += stats.payload_messages_received;
+            control_recv += stats.control_messages_received;
+        }
+        // eprintln!("distributions {round_distrib:?}");
+        eprintln!("payload_recv {payload_recv} control_recv {control_recv}");
+        eprintln!("eager_distrib {eager_distrib:?}");
+        eprintln!("lazy_distrib {lazy_distrib:?}");
+        eprintln!("active_distrib {active_distrib:?}");
+        eprintln!("passive_distrib {passive_distrib:?}");
+    }
+
+    const TICK_DURATION: Duration = Duration::from_millis(10);
+    const DEFAULT_LATENCY: Duration = TICK_DURATION.saturating_mul(3);
+
+    /// Test network implementation.
+    /// Stores events in VecDeques and processes on ticks.
+    /// Timers are checked after each tick. The local time is increased with TICK_DURATION before
+    /// each tick.
+    /// Note: Panics when sending to an unknown peer.
+    struct Network<PA, R> {
+        start: Instant,
+        time: Instant,
+        tick_duration: Duration,
+        inqueues: Vec<VecDeque<InEvent<PA>>>,
+        peers: Vec<State<PA, R>>,
+        peers_by_address: HashMap<PA, usize>,
+        conns: HashSet<ConnId<PA>>,
+        events: VecDeque<(PA, Event<PA>)>,
+        timers: TimerMap<(usize, Timer<PA>)>,
+        transport: TimerMap<(usize, InEvent<PA>)>,
+        latencies: HashMap<ConnId<PA>, Duration>,
+    }
+    impl<PA, R> Network<PA, R> {
+        pub fn new(time: Instant) -> Self {
+            Self {
+                start: time,
+                time,
+                tick_duration: TICK_DURATION,
+                inqueues: Default::default(),
+                peers: Default::default(),
+                peers_by_address: Default::default(),
+                conns: Default::default(),
+                events: Default::default(),
+                timers: TimerMap::new(),
+                transport: TimerMap::new(),
+                latencies: HashMap::new(),
+            }
+        }
+    }
+
+    fn push_back<PA: Eq + std::hash::Hash>(
+        inqueues: &mut [VecDeque<InEvent<PA>>],
+        peer_pos: usize,
+        event: InEvent<PA>,
+    ) {
+        inqueues.get_mut(peer_pos).unwrap().push_back(event);
+    }
+
+    impl<PA: PeerAddress + Ord, R: Rng> Network<PA, R> {
+        pub fn push(&mut self, peer: State<PA, R>) {
+            let idx = self.inqueues.len();
+            self.inqueues.push(VecDeque::new());
+            self.peers_by_address.insert(*peer.endpoint(), idx);
+            self.peers.push(peer);
+        }
+
+        pub fn events(&mut self) -> impl Iterator<Item = (PA, Event<PA>)> + '_ {
+            self.events.drain(..)
+        }
+
+        pub fn events_sorted(&mut self) -> Vec<(PA, Event<PA>)> {
+            sort(self.events().collect())
+        }
+
+        pub fn conns(&self) -> Vec<(PA, PA)> {
+            sort(self.conns.iter().cloned().map(Into::into).collect())
+        }
+
+        pub fn command(&mut self, peer: PA, command: Command<PA>) {
+            debug!(?peer, "~~ COMMAND {command:?}");
+            let idx = *self.peers_by_address.get(&peer).unwrap();
+            push_back(&mut self.inqueues, idx, InEvent::Command(command));
+        }
+
+        pub fn ticks(&mut self, n: usize) {
+            (0..n).for_each(|_| self.tick())
+        }
+
+        pub fn get_tick(&self) -> u32 {
+            ((self.time - self.start) / self.tick_duration.as_millis() as u32).as_millis() as u32
+        }
+
+        pub fn tick(&mut self) {
+            self.time += self.tick_duration;
+
+            // process timers
+            for (_time, (idx, timer)) in self.timers.drain_until(&self.time) {
+                push_back(&mut self.inqueues, idx, InEvent::TimerExpired(timer));
+            }
+
+            // move messages
+            for (_time, (peer, event)) in self.transport.drain_until(&self.time) {
+                push_back(&mut self.inqueues, peer, event);
+            }
+
+            // process inqueues: let peer handle all incoming events
+            let mut messages_sent = 0;
+            for (idx, queue) in self.inqueues.iter_mut().enumerate() {
+                let state = self.peers.get_mut(idx).unwrap();
+                let peer = *state.endpoint();
+                while let Some(event) = queue.pop_front() {
+                    if let InEvent::RecvMessage(from, _message) = &event {
+                        self.conns.insert((*from, peer).into());
+                    }
+                    debug!(peer = ?peer, "IN  {event:?}");
+                    let out = state.handle(event, self.time);
+                    for event in out {
+                        debug!(peer = ?peer, "OUT {event:?}");
+                        match event {
+                            OutEvent::SendMessage(to, message) => {
+                                let to_idx = *self.peers_by_address.get(&to).unwrap();
+                                let latency = latency_between(&mut self.latencies, &peer, &to);
+                                self.transport.insert(
+                                    self.time + latency,
+                                    (to_idx, InEvent::RecvMessage(peer, message)),
+                                );
+                                messages_sent += 1;
+                            }
+                            OutEvent::ScheduleTimer(latency, timer) => {
+                                self.timers.insert(self.time + latency, (idx, timer));
+                            }
+                            OutEvent::DisconnectPeer(to) => {
+                                debug!(peer = ?peer, other = ?to, "disconnect");
+                                let to_idx = *self.peers_by_address.get(&to).unwrap();
+                                let latency = latency_between(&mut self.latencies, &peer, &to)
+                                    + Duration::from_nanos(1);
+                                if self.conns.remove(&(peer, to).into()) {
+                                    self.transport.insert(
+                                        self.time + latency,
+                                        (to_idx, InEvent::PeerDisconnected(peer)),
+                                    );
+                                }
+                            }
+                            OutEvent::EmitEvent(event) => {
+                                debug!(peer = ?peer, "emit   {event:?}");
+                                self.events.push_back((peer, event));
+                            }
+                        }
+                    }
+                }
+            }
+            debug!(
+                tick = self.get_tick(),
+                "~~ TICK (messages sent: {messages_sent})"
+            );
+        }
+    }
+    fn latency_between<PA: PeerAddress>(
+        _latencies: &mut HashMap<ConnId<PA>, Duration>,
+        _a: &PA,
+        _b: &PA,
+    ) -> Duration {
+        DEFAULT_LATENCY
+    }
+
+    fn assert_synchronous_active<PA: PeerAddress, R>(network: &Network<PA, R>) -> bool {
+        for state in network.peers.iter() {
+            let peer = *state.endpoint();
+            for other in state.swarm.active_view.iter() {
+                let other_idx = network.peers_by_address.get(other).unwrap();
+                let other_state = &network.peers.get(*other_idx).unwrap().swarm.active_view;
+                if !other_state.contains(&peer) {
+                    warn!(peer = ?peer, other = ?other, "missing active_view peer in other");
+                    return false;
+                }
+            }
+            for other in state.gossip.eager_push_peers.iter() {
+                let other_idx = network.peers_by_address.get(other).unwrap();
+                let other_state = &network
+                    .peers
+                    .get(*other_idx)
+                    .unwrap()
+                    .gossip
+                    .eager_push_peers;
+                if !other_state.contains(&peer) {
+                    warn!(peer = ?peer, other = ?other, "missing eager_push peer in other");
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    type PeerId = usize;
+    struct Simulator {
+        gossip_config: Config,
+        network: Network<PeerId, rand::rngs::StdRng>,
+        config: SimulatorConfig,
+        round_stats: Vec<RoundStats>,
+    }
+    struct SimulatorConfig {
+        peers_count: usize,
+        bootstrap_count: usize,
+        bootstrap_ticks: usize,
+        join_ticks: usize,
+        warmup_ticks: usize,
+        round_max_ticks: usize,
+    }
+    #[derive(Debug, Default)]
+    struct RoundStats {
+        ticks: usize,
+        rmr: f32,
+        ldh: u16,
+    }
+    impl Default for SimulatorConfig {
+        fn default() -> Self {
+            Self {
+                peers_count: 100,
+                bootstrap_count: 5,
+                bootstrap_ticks: 50,
+                join_ticks: 1,
+                warmup_ticks: 300,
+                round_max_ticks: 200,
+            }
+        }
+    }
+    impl Simulator {
+        pub fn new(config: SimulatorConfig, gossip_config: Config) -> Self {
+            Self {
+                gossip_config,
+                config,
+                network: Network::new(Instant::now()),
+                round_stats: Default::default(),
+            }
+        }
+        pub fn init(&mut self) {
+            for i in 0..self.config.peers_count {
+                let rng = rand::rngs::StdRng::seed_from_u64(i as u64);
+                self.network
+                    .push(State::with_rng(i, self.gossip_config.clone(), rng.clone()));
+            }
+        }
+        pub fn bootstrap(&mut self) {
+            for i in 1..self.config.bootstrap_count {
+                self.network.command(i, Command::Join(0));
+            }
+            self.network.ticks(self.config.bootstrap_ticks);
+            let _ = self.network.events();
+
+            for i in self.config.bootstrap_count..self.config.peers_count {
+                let contact = i % self.config.bootstrap_count;
+                self.network.command(i, Command::Join(contact));
+                self.network.ticks(self.config.join_ticks);
+                let _ = self.network.events();
+            }
+            self.network.ticks(self.config.warmup_ticks);
+            let _ = self.network.events();
+        }
+
+        pub fn gossip_round(&mut self, from: PeerId, message: Bytes) {
+            let prev_total_payload_counter = self.total_payload_messages();
+            let mut expected: HashSet<usize> = HashSet::from_iter(
+                self.network
+                    .peers
+                    .iter()
+                    .map(|p| *p.endpoint())
+                    .filter(|p| *p != from),
+            );
+            let expected_len = expected.len() as u64;
+            self.network
+                .command(from, Command::Broadcast(message.clone()));
+
+            let mut tick = 0;
+            loop {
+                if expected.is_empty() {
+                    break;
+                }
+                if tick > self.config.round_max_ticks {
+                    break;
+                }
+                tick += 1;
+                self.network.tick();
+                let events = self.network.events();
+                let received: HashSet<_> = events
+                    .filter(|(_peer, event)| matches!(event,  Event::Received(recv) if recv == &message))
+                    .map(|(peer, _msg)| peer)
+                    .collect();
+                for peer in received.iter() {
+                    expected.remove(peer);
+                }
+                // eprintln!(
+                //     "tick {tick:3} received {:5} remaining {:5} ",
+                //     received.len(),
+                //     expected.len(),
+                // );
+            }
+
+            assert!(expected.is_empty(), "all nodes received the broadcast");
+            let payload_counter = self.total_payload_messages() - prev_total_payload_counter;
+            let rmr = (payload_counter as f32 / (expected_len as f32 - 1.)) - 1.;
+            let ldh = self.max_ldh();
+            let stats = RoundStats {
+                ticks: tick,
+                rmr,
+                ldh,
+            };
+            self.round_stats.push(stats);
+            self.reset_stats()
+        }
+
+        fn report_round_sums(&self) {
+            let len = self.round_stats.len();
+            let mut rmr = 0.;
+            let mut ldh = 0.;
+            let mut ticks = 0.;
+            for round in self.round_stats.iter() {
+                rmr += round.rmr;
+                ldh += round.ldh as f32;
+                ticks += round.ticks as f32;
+            }
+            rmr /= len as f32;
+            ldh /= len as f32;
+            ticks /= len as f32;
+            eprintln!(
+                "average over {} rounds with {} peers: RMR {rmr:.2} LDH {ldh:.2} ticks {ticks:.2}",
+                self.round_stats.len(),
+                self.network.peers.len(),
+            );
+            eprintln!("RMR = Relative Message Redundancy, LDH = Last Delivery Hop");
+        }
+
+        fn reset_stats(&mut self) {
+            for state in self.network.peers.iter_mut() {
+                state.gossip.stats = Default::default();
+            }
+        }
+
+        fn max_ldh(&self) -> u16 {
+            let mut max = 0;
+            for state in self.network.peers.iter() {
+                let stats = state.gossip.stats();
+                max = max.max(stats.max_last_delivery_hop);
+            }
+            max
+        }
+
+        fn total_payload_messages(&self) -> u64 {
+            let mut sum = 0;
+            for state in self.network.peers.iter() {
+                let stats = state.gossip.stats();
+                sum += stats.payload_messages_received;
+            }
+            sum
+        }
+    }
+
+    /// Helper struct for active connections. A sorted tuple.
+    #[derive(Debug, Clone, PartialOrd, Ord, Eq, PartialEq, Hash)]
+    pub struct ConnId<PA>([PA; 2]);
+    impl<PA: Ord> ConnId<PA> {
+        pub fn new(a: PA, b: PA) -> Self {
+            let mut conn = [a, b];
+            conn.sort();
+            Self(conn)
+        }
+    }
+    impl<PA: Ord> From<(PA, PA)> for ConnId<PA> {
+        fn from((a, b): (PA, PA)) -> Self {
+            Self::new(a, b)
+        }
+    }
+    impl<PA: Copy> From<ConnId<PA>> for (PA, PA) {
+        fn from(conn: ConnId<PA>) -> (PA, PA) {
+            (conn.0[0], conn.0[1])
+        }
+    }
+
+    fn sort<T: Ord + Clone>(items: Vec<T>) -> Vec<T> {
+        let mut sorted = items;
+        sorted.sort();
+        sorted
+    }
+}

--- a/iroh-gossip/src/proto/topic.rs
+++ b/iroh-gossip/src/proto/topic.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::VecDeque,
+    fmt,
     time::{Duration, Instant},
 };
 
@@ -77,11 +78,20 @@ pub enum Message<PA> {
     Gossip(plumtree::Message),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Event<PA> {
     NeighborUp(PA),
     NeighborDown(PA),
     Received(Bytes),
+}
+impl<PA: fmt::Debug> fmt::Debug for Event<PA> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Received(msg) => write!(f, "Received(<{}>)", msg.len()),
+            Self::NeighborUp(peer) => write!(f, "NeighborUp({peer:?})"),
+            Self::NeighborDown(peer) => write!(f, "NeighborDown({peer:?})"),
+        }
+    }
 }
 
 impl<PA> From<hyparview::Event<PA>> for Event<PA> {
@@ -107,10 +117,19 @@ pub enum Timer<PA> {
     Gossip(plumtree::Timer),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum Command<PA> {
     Join(PA),
     Broadcast(Bytes),
+}
+
+impl<PA: fmt::Debug> fmt::Debug for Command<PA> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Join(peer) => write!(f, "Join({peer:?})"),
+            Self::Broadcast(msg) => write!(f, "Broadcast(<{}>)", msg.len()),
+        }
+    }
 }
 
 impl<PA: Clone> IO<PA> for VecDeque<OutEvent<PA>> {

--- a/iroh-gossip/src/proto/util.rs
+++ b/iroh-gossip/src/proto/util.rs
@@ -19,10 +19,13 @@ pub struct IndexSet<T> {
     inner: indexmap::IndexSet<T>,
 }
 
-impl<T> IndexSet<T>
-where
-    T: Hash + Eq + PartialEq,
-{
+impl<T: Hash + Eq + PartialEq> Default for IndexSet<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Hash + Eq + PartialEq> IndexSet<T> {
     pub fn new() -> Self {
         Self {
             inner: indexmap::IndexSet::new(),

--- a/iroh-gossip/src/proto/util.rs
+++ b/iroh-gossip/src/proto/util.rs
@@ -1,0 +1,173 @@
+use rand::{
+    seq::{IteratorRandom, SliceRandom},
+    Rng,
+};
+use std::{
+    collections::BTreeMap,
+    hash::Hash,
+    time::{Duration, Instant},
+};
+
+/// A hash set where the iteration order of the values is independent of their
+/// hash values.
+///
+/// This is wrapper around [indexmap::IndexSet] that limits the removal API to
+/// always do shift_remove (preserving the order of other elements) and adds a
+/// couple of utility methods to randomly select elements from the set.
+#[derive(Default, Debug, Clone)]
+pub struct IndexSet<T> {
+    inner: indexmap::IndexSet<T>,
+}
+
+impl<T> IndexSet<T>
+where
+    T: Hash + Eq + PartialEq,
+{
+    pub fn new() -> Self {
+        Self {
+            inner: indexmap::IndexSet::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+    pub fn insert(&mut self, value: T) -> bool {
+        self.inner.insert(value)
+    }
+
+    pub fn contains(&self, value: &T) -> bool {
+        self.inner.contains(value)
+    }
+
+    pub fn get_index_of(&self, value: &T) -> Option<usize> {
+        self.inner.get_index_of(value)
+    }
+
+    /// Remove a random element from the set.
+    pub fn remove_random<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Option<T> {
+        self.pick_random_index(rng)
+            .and_then(|idx| self.inner.shift_remove_index(idx))
+    }
+
+    /// Pick a random element from the set.
+    pub fn pick_random<R: Rng + ?Sized>(&self, rng: &mut R) -> Option<&T> {
+        self.pick_random_index(rng)
+            .and_then(|idx| self.inner.get_index(idx))
+    }
+
+    /// Pick a random element from the set, but not any of the elements in `without`.
+    pub fn pick_random_without<R: Rng + ?Sized>(&self, without: &[&T], rng: &mut R) -> Option<&T> {
+        self.iter().filter(|x| !without.contains(x)).choose(rng)
+    }
+
+    /// Pick a random index for an element in the set.
+    pub fn pick_random_index<R: Rng + ?Sized>(&self, rng: &mut R) -> Option<usize> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(rng.gen_range(0..self.inner.len()))
+        }
+    }
+
+    /// Remove an element from the set, while keeping the order of the other elements.
+    pub fn remove(&mut self, value: &T) -> Option<T> {
+        self.inner.shift_remove_full(value).map(|(_i, v)| v)
+    }
+
+    /// Remove an element from the set by its index.
+    pub fn remove_index(&mut self, index: usize) -> Option<T> {
+        self.inner.shift_remove_index(index)
+    }
+
+    /// Create an iterator over the set in the order of insertion.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.inner.iter()
+    }
+
+    /// Create an iterator over the set in the order of insertion, while skipping the element in
+    /// `without`.
+    pub fn iter_without<'a>(&'a self, value: &'a T) -> impl Iterator<Item = &'a T> {
+        self.iter().filter(move |x| *x != value)
+    }
+}
+
+impl<T> IndexSet<T>
+where
+    T: Hash + Eq + Clone,
+{
+    /// Create a vector of all elements in the set in random order.
+    pub fn shuffled<R: Rng + ?Sized>(&self, rng: &mut R) -> Vec<T> {
+        let mut items: Vec<_> = self.inner.iter().cloned().collect();
+        items.shuffle(rng);
+        items
+    }
+
+    /// Create a vector of all elements in the set in random order, and shorten to
+    /// the first `len` elements after shuffling.
+    pub fn shuffled_max<R: Rng + ?Sized>(&self, len: usize, rng: &mut R) -> Vec<T> {
+        let mut items = self.shuffled(rng);
+        items.truncate(len);
+        items
+    }
+
+    /// Create a vector of the elements in the set in random order while omitting
+    /// the elements in `without`.
+    pub fn shuffled_without<R: Rng + ?Sized>(&self, without: &[&T], rng: &mut R) -> Vec<T> {
+        let mut items = self
+            .inner
+            .iter()
+            .filter(|x| !without.contains(x))
+            .cloned()
+            .collect::<Vec<_>>();
+        items.shuffle(rng);
+        items
+    }
+
+    /// Create a vector of the elements in the set in random order while omitting
+    /// the elements in `without`, and shorten to the first `len` elements.
+    pub fn shuffled_without_max<R: Rng + ?Sized>(
+        &self,
+        without: &[&T],
+        len: usize,
+        rng: &mut R,
+    ) -> Vec<T> {
+        let mut items = self.shuffled_without(without, rng);
+        items.truncate(len);
+        items
+    }
+}
+
+/// A BtreeMap with Instant as key. Allows to process expired items.
+pub struct TimerMap<T>(BTreeMap<Instant, Vec<T>>);
+
+impl<T> TimerMap<T> {
+    /// Create a new, empty TimerMap
+    pub fn new() -> Self {
+        Self(Default::default())
+    }
+    /// Insert a new entry at the specified instant
+    pub fn insert(&mut self, instant: Instant, item: T) {
+        let entry = self.0.entry(instant).or_default();
+        entry.push(item);
+    }
+
+    /// Remove and return all entries before and equal to `from`
+    pub fn drain_until(&mut self, from: &Instant) -> impl Iterator<Item = (Instant, T)> {
+        let split_point = *from + Duration::from_nanos(1);
+        let later_half = self.0.split_off(&split_point);
+        let expired = std::mem::replace(&mut self.0, later_half);
+        expired
+            .into_iter()
+            .flat_map(|(t, v)| v.into_iter().map(move |v| (t, v)))
+    }
+
+    /// Get a reference to the earliest entry in the TimerMap
+    pub fn first(&self) -> Option<(&Instant, &Vec<T>)> {
+        self.0.iter().next()
+    }
+}

--- a/iroh-gossip/src/proto/util.rs
+++ b/iroh-gossip/src/proto/util.rs
@@ -14,7 +14,7 @@ use std::{
 /// This is wrapper around [indexmap::IndexSet] that limits the removal API to
 /// always do shift_remove (preserving the order of other elements) and adds a
 /// couple of utility methods to randomly select elements from the set.
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct IndexSet<T> {
     inner: indexmap::IndexSet<T>,
 }

--- a/iroh-gossip/src/proto/util.rs
+++ b/iroh-gossip/src/proto/util.rs
@@ -171,3 +171,9 @@ impl<T> TimerMap<T> {
         self.0.iter().next()
     }
 }
+
+impl<T> Default for TimerMap<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/iroh-net/src/hp/cfg.rs
+++ b/iroh-net/src/hp/cfg.rs
@@ -8,7 +8,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::key;
+use super::{key, portmapper};
 
 /// Fake WireGuard endpoint IP address that means to
 /// use DERP. When used (in the Node.DERP field), the port number of

--- a/iroh-net/src/hp/cfg.rs
+++ b/iroh-net/src/hp/cfg.rs
@@ -6,7 +6,9 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 
-use super::{key, portmapper};
+use serde::{Deserialize, Serialize};
+
+use super::key;
 
 /// Fake WireGuard endpoint IP address that means to
 /// use DERP. When used (in the Node.DERP field), the port number of
@@ -16,7 +18,7 @@ use super::{key, portmapper};
 pub const DERP_MAGIC_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 3, 3, 40));
 
 /// An endpoint IPPort and an associated type.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Endpoint {
     /// The address of the endpoint.
     pub addr: SocketAddr,
@@ -25,7 +27,7 @@ pub struct Endpoint {
 }
 
 /// Type of endpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EndpointType {
     /// Endpoint kind has not been determined yet.
     Unknown,

--- a/iroh-net/src/tls.rs
+++ b/iroh-net/src/tls.rs
@@ -98,7 +98,7 @@ impl From<SecretKey> for Keypair {
 ///
 /// The [`PeerId`] implements both `Display` and `FromStr` which can be used to
 /// (de)serialise to human-readable and relatively safely transferrable strings.
-#[derive(Clone, PartialEq, Eq, Copy, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Copy, Serialize, Deserialize, Hash)]
 pub struct PeerId(PublicKey);
 
 impl From<PublicKey> for PeerId {

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "iroh-sync"
+version = "0.1.0"
+edition = "2021"
+readme = "README.md"
+description = "Iroh sync"
+license = "MIT/Apache-2.0"
+authors = ["n0 team"]
+repository = "https://github.com/n0-computer/iroh"
+
+[dependencies]
+anyhow = "1.0.71"
+blake3 = "1.3.3"
+crossbeam = "0.8.2"
+ed25519-dalek = { version = "2.0.0-rc.2", features = ["serde", "rand_core"] }
+iroh-bytes = { path = "../iroh-bytes", version = "0.4" }
+once_cell = "1.18.0"
+rand = "0.8.5"
+rand_core = "0.6.4"
+serde = { version = "1.0.164", features = ["derive"] }
+url = "2.4.0"
+bytes = "1.4.0"
+parking_lot = "0.12.1"
+hex = "0.4"
+
+[dev-dependencies]
+tokio = { version = "1.28.2", features = ["sync", "macros"] }

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/n0-computer/iroh"
 anyhow = "1.0.71"
 blake3 = "1.3.3"
 crossbeam = "0.8.2"
+derive_more = { version = "0.99.17", git = "https://github.com/JelteF/derive_more", features = ["debug", "display", "from", "try_into"] }
 ed25519-dalek = { version = "2.0.0-rc.2", features = ["serde", "rand_core"] }
 iroh-bytes = { path = "../iroh-bytes", version = "0.4" }
 once_cell = "1.18.0"

--- a/iroh-sync/LICENSE-APACHE
+++ b/iroh-sync/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/iroh-sync/LICENSE-MIT
+++ b/iroh-sync/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2023
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/iroh-sync/README.md
+++ b/iroh-sync/README.md
@@ -1,0 +1,19 @@
+# iroh-sync
+
+
+# License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+   http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this project by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.

--- a/iroh-sync/src/lib.rs
+++ b/iroh-sync/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod ranger;
+pub mod sync;

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -160,7 +160,7 @@ impl<K, V> MessagePart<K, V> {
     pub fn values(&self) -> Option<&[(K, V)]> {
         match self {
             MessagePart::RangeFingerprint(_) => None,
-            MessagePart::RangeItem(RangeItem { values, .. }) => Some(&values),
+            MessagePart::RangeItem(RangeItem { values, .. }) => Some(values),
         }
     }
 }
@@ -180,7 +180,7 @@ where
 {
     /// Construct the initial message.
     fn init<S: Store<K, V>>(store: &S, limit: Option<&Range<K>>) -> Self {
-        let x = store.get_first().clone();
+        let x = store.get_first();
         let range = Range::new(x.clone(), x);
         let fingerprint = store.get_fingerprint(&range, limit);
         let part = MessagePart::RangeFingerprint(RangeFingerprint { range, fingerprint });
@@ -332,7 +332,7 @@ where
         };
 
         loop {
-            if filter(&next.0) {
+            if filter(next.0) {
                 return Some(next);
             }
 
@@ -432,7 +432,7 @@ where
                     self.store
                         .get_range(range.clone(), self.limit.clone())
                         .into_iter()
-                        .filter(|(k, _)| values.iter().find(|(vk, _)| &vk == k).is_none())
+                        .filter(|(k, _)| !values.iter().any(|(vk, _)| &vk == k))
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),
                 )
@@ -816,7 +816,7 @@ mod tests {
                     hex::encode(&self.key)
                 };
                 f.debug_struct("Multikey")
-                    .field("author", &hex::encode(&self.author))
+                    .field("author", &hex::encode(self.author))
                     .field("key", &key)
                     .finish()
             }
@@ -1236,8 +1236,8 @@ mod tests {
 
     #[test]
     fn test_div_ceil() {
-        assert_eq!(div_ceil(1, 1), 1 / 1);
-        assert_eq!(div_ceil(2, 1), 2 / 1);
+        assert_eq!(div_ceil(1, 1), 1);
+        assert_eq!(div_ceil(2, 1), 2);
         assert_eq!(div_ceil(4, 2), 4 / 2);
 
         assert_eq!(div_ceil(3, 2), 2);

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -1,0 +1,1246 @@
+//! Implementation of Set Reconcilliation based on
+//! "Range-Based Set Reconciliation" by Aljoscha Meyer.
+//!
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Serialize};
+
+/// Stores a range.
+///
+/// There are three possibilities
+/// - x, x: All elements in a set, denoted with
+/// - [x, y): x < y: Includes x, but not y
+/// - S \ [y, x) y < x: Includes x, but not y.
+/// This means that ranges are "wrap around" conceptually.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
+pub struct Range<K> {
+    x: K,
+    y: K,
+}
+
+impl<K> Range<K> {
+    pub fn x(&self) -> &K {
+        &self.x
+    }
+
+    pub fn y(&self) -> &K {
+        &self.y
+    }
+
+    pub fn new(x: K, y: K) -> Self {
+        Range { x, y }
+    }
+
+    pub fn map<X>(self, f: impl FnOnce(K, K) -> (X, X)) -> Range<X> {
+        let (x, y) = f(self.x, self.y);
+        Range { x, y }
+    }
+}
+
+impl<K> From<(K, K)> for Range<K> {
+    fn from((x, y): (K, K)) -> Self {
+        Range { x, y }
+    }
+}
+
+pub trait RangeKey: Sized + Ord + Debug {
+    /// Is this key inside the range?
+    fn contains(&self, range: &Range<Self>) -> bool {
+        contains(self, range)
+    }
+}
+
+/// Default implementation of `contains` for `Ord` types.
+pub fn contains<T: Ord>(t: &T, range: &Range<T>) -> bool {
+    match range.x().cmp(range.y()) {
+        Ordering::Equal => true,
+        Ordering::Less => range.x() <= t && t < range.y(),
+        Ordering::Greater => range.x() <= t || t < range.y(),
+    }
+}
+
+impl RangeKey for &str {}
+impl RangeKey for &[u8] {}
+
+#[derive(Copy, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Fingerprint(pub [u8; 32]);
+
+impl Debug for Fingerprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Fp({})", blake3::Hash::from(self.0).to_hex())
+    }
+}
+
+impl Fingerprint {
+    /// The fingerprint of the empty set
+    pub fn empty() -> Self {
+        Fingerprint::new(&[][..])
+    }
+
+    pub fn new<T: AsFingerprint>(val: T) -> Self {
+        val.as_fingerprint()
+    }
+}
+
+pub trait AsFingerprint {
+    fn as_fingerprint(&self) -> Fingerprint;
+}
+
+impl<T: AsRef<[u8]>> AsFingerprint for T {
+    fn as_fingerprint(&self) -> Fingerprint {
+        Fingerprint(blake3::hash(self.as_ref()).into())
+    }
+}
+
+impl std::ops::BitXorAssign for Fingerprint {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        for (a, b) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *a ^= b;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RangeFingerprint<K> {
+    #[serde(bound(
+        serialize = "Range<K>: Serialize",
+        deserialize = "Range<K>: Deserialize<'de>"
+    ))]
+    pub range: Range<K>,
+    /// The fingerprint of `range`.
+    pub fingerprint: Fingerprint,
+}
+
+/// Transfers items inside a range to the other participant.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RangeItem<K, V> {
+    /// The range out of which the elements are.
+    #[serde(bound(
+        serialize = "Range<K>: Serialize",
+        deserialize = "Range<K>: Deserialize<'de>"
+    ))]
+    pub range: Range<K>,
+    #[serde(bound(
+        serialize = "K: Serialize, V: Serialize",
+        deserialize = "K: Deserialize<'de>, V: Deserialize<'de>"
+    ))]
+    pub values: Vec<(K, V)>,
+    /// If false, requests to send local items in the range.
+    /// Otherwise not.
+    pub have_local: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum MessagePart<K, V> {
+    #[serde(bound(
+        serialize = "RangeFingerprint<K>: Serialize",
+        deserialize = "RangeFingerprint<K>: Deserialize<'de>"
+    ))]
+    RangeFingerprint(RangeFingerprint<K>),
+    #[serde(bound(
+        serialize = "RangeItem<K, V>: Serialize",
+        deserialize = "RangeItem<K, V>: Deserialize<'de>"
+    ))]
+    RangeItem(RangeItem<K, V>),
+}
+
+impl<K, V> MessagePart<K, V> {
+    pub fn is_range_fingerprint(&self) -> bool {
+        matches!(self, MessagePart::RangeFingerprint(_))
+    }
+
+    pub fn is_range_item(&self) -> bool {
+        matches!(self, MessagePart::RangeItem(_))
+    }
+
+    pub fn values(&self) -> Option<&[(K, V)]> {
+        match self {
+            MessagePart::RangeFingerprint(_) => None,
+            MessagePart::RangeItem(RangeItem { values, .. }) => Some(&values),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Message<K, V> {
+    #[serde(bound(
+        serialize = "MessagePart<K, V>: Serialize",
+        deserialize = "MessagePart<K, V>: Deserialize<'de>"
+    ))]
+    parts: Vec<MessagePart<K, V>>,
+}
+
+impl<K, V> Message<K, V>
+where
+    K: RangeKey + Clone + Default + AsFingerprint,
+{
+    /// Construct the initial message.
+    fn init<S: Store<K, V>>(store: &S, limit: Option<&Range<K>>) -> Self {
+        let x = store.get_first().clone();
+        let range = Range::new(x.clone(), x);
+        let fingerprint = store.get_fingerprint(&range, limit);
+        let part = MessagePart::RangeFingerprint(RangeFingerprint { range, fingerprint });
+        Message { parts: vec![part] }
+    }
+
+    pub fn parts(&self) -> &[MessagePart<K, V>] {
+        &self.parts
+    }
+}
+
+pub trait Store<K, V>: Sized + Default
+where
+    K: RangeKey + Clone + Default + AsFingerprint,
+{
+    /// Get a the first key (or the default if none is available).
+    fn get_first(&self) -> K;
+    fn get(&self, key: &K) -> Option<&V>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
+    /// Calculate the fingerprint of the given range.
+    fn get_fingerprint(&self, range: &Range<K>, limit: Option<&Range<K>>) -> Fingerprint;
+
+    /// Insert the given key value pair.
+    fn put(&mut self, k: K, v: V);
+
+    type RangeIterator<'a>: Iterator<Item = (&'a K, &'a V)>
+    where
+        Self: 'a,
+        K: 'a,
+        V: 'a;
+
+    /// Returns all items in the given range
+    fn get_range<'a>(&'a self, range: Range<K>, limit: Option<Range<K>>)
+        -> Self::RangeIterator<'a>;
+    fn remove(&mut self, key: &K) -> Option<V>;
+
+    type AllIterator<'a>: Iterator<Item = (&'a K, &'a V)>
+    where
+        Self: 'a,
+        K: 'a,
+        V: 'a;
+    fn all(&self) -> Self::AllIterator<'_>;
+}
+
+#[derive(Debug)]
+pub struct SimpleStore<K, V> {
+    data: BTreeMap<K, V>,
+}
+
+impl<K, V> Default for SimpleStore<K, V> {
+    fn default() -> Self {
+        SimpleStore {
+            data: BTreeMap::default(),
+        }
+    }
+}
+
+impl<K, V> Store<K, V> for SimpleStore<K, V>
+where
+    K: RangeKey + Clone + Default + AsFingerprint,
+{
+    fn get_first(&self) -> K {
+        if let Some((k, _)) = self.data.first_key_value() {
+            k.clone()
+        } else {
+            Default::default()
+        }
+    }
+
+    fn get(&self, key: &K) -> Option<&V> {
+        self.data.get(key)
+    }
+
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Calculate the fingerprint of the given range.
+    fn get_fingerprint(&self, range: &Range<K>, limit: Option<&Range<K>>) -> Fingerprint {
+        let elements = self.get_range(range.clone(), limit.cloned());
+        let mut fp = Fingerprint::empty();
+        for el in elements {
+            fp ^= el.0.as_fingerprint();
+        }
+
+        fp
+    }
+
+    /// Insert the given key value pair.
+    fn put(&mut self, k: K, v: V) {
+        self.data.insert(k, v);
+    }
+
+    type RangeIterator<'a> = SimpleRangeIterator<'a, K, V>
+        where K: 'a, V: 'a;
+    /// Returns all items in the given range
+    fn get_range<'a>(
+        &'a self,
+        range: Range<K>,
+        limit: Option<Range<K>>,
+    ) -> Self::RangeIterator<'a> {
+        // TODO: this is not very efficient, optimize depending on data structure
+        let iter = self.data.iter();
+
+        SimpleRangeIterator { iter, range, limit }
+    }
+
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.data.remove(key)
+    }
+
+    type AllIterator<'a> = std::collections::btree_map::Iter<'a, K, V>
+    where K: 'a,
+          V: 'a;
+
+    fn all(&self) -> Self::AllIterator<'_> {
+        self.data.iter()
+    }
+}
+
+#[derive(Debug)]
+pub struct SimpleRangeIterator<'a, K: 'a, V: 'a> {
+    iter: std::collections::btree_map::Iter<'a, K, V>,
+    range: Range<K>,
+    limit: Option<Range<K>>,
+}
+
+impl<'a, K, V> Iterator for SimpleRangeIterator<'a, K, V>
+where
+    K: RangeKey,
+{
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut next = self.iter.next()?;
+
+        let filter = |x: &K| {
+            let r = x.contains(&self.range);
+            if let Some(ref limit) = self.limit {
+                r && x.contains(limit)
+            } else {
+                r
+            }
+        };
+
+        loop {
+            if filter(&next.0) {
+                return Some(next);
+            }
+
+            next = self.iter.next()?;
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Peer<K, V, S: Store<K, V> = SimpleStore<K, V>>
+where
+    K: RangeKey + Clone + Default + AsFingerprint,
+{
+    store: S,
+    /// Up to how many values to send immediately, before sending only a fingerprint.
+    max_set_size: usize,
+    /// `k` in the protocol, how many splits to generate. at least 2
+    split_factor: usize,
+    limit: Option<Range<K>>,
+
+    _phantom: PhantomData<V>, // why???
+}
+
+impl<K, V, S> Default for Peer<K, V, S>
+where
+    K: RangeKey + Clone + Default + AsFingerprint,
+    S: Store<K, V> + Default,
+{
+    fn default() -> Self {
+        Peer {
+            store: S::default(),
+            max_set_size: 1,
+            split_factor: 2,
+            limit: None,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<K, V, S> Peer<K, V, S>
+where
+    K: PartialEq + RangeKey + Clone + Default + Debug + AsFingerprint,
+    V: Clone + Debug,
+    S: Store<K, V> + Default,
+{
+    pub fn with_limit(limit: Range<K>) -> Self {
+        Peer {
+            store: S::default(),
+            max_set_size: 1,
+            split_factor: 2,
+            limit: Some(limit),
+            _phantom: Default::default(),
+        }
+    }
+}
+impl<K, V, S> Peer<K, V, S>
+where
+    K: PartialEq + RangeKey + Clone + Default + Debug + AsFingerprint,
+    V: Clone + Debug,
+    S: Store<K, V>,
+{
+    /// Generates the initial message.
+    pub fn initial_message(&self) -> Message<K, V> {
+        Message::init(&self.store, self.limit.as_ref())
+    }
+
+    /// Processes an incoming message and produces a response.
+    /// If terminated, returns `None`
+    pub fn process_message(&mut self, message: Message<K, V>) -> Option<Message<K, V>> {
+        let mut out = Vec::new();
+
+        // TODO: can these allocs be avoided?
+        let mut items = Vec::new();
+        let mut fingerprints = Vec::new();
+        for part in message.parts {
+            match part {
+                MessagePart::RangeItem(item) => {
+                    items.push(item);
+                }
+                MessagePart::RangeFingerprint(fp) => {
+                    fingerprints.push(fp);
+                }
+            }
+        }
+
+        // Process item messages
+        for RangeItem {
+            range,
+            values,
+            have_local,
+        } in items
+        {
+            let diff: Option<Vec<_>> = if have_local {
+                None
+            } else {
+                Some(
+                    self.store
+                        .get_range(range.clone(), self.limit.clone())
+                        .into_iter()
+                        .filter(|(k, _)| values.iter().find(|(vk, _)| &vk == k).is_none())
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                )
+            };
+
+            // Store incoming values
+            for (k, v) in values {
+                self.store.put(k, v);
+            }
+
+            if let Some(diff) = diff {
+                if !diff.is_empty() {
+                    out.push(MessagePart::RangeItem(RangeItem {
+                        range,
+                        values: diff,
+                        have_local: true,
+                    }));
+                }
+            }
+        }
+
+        // Process fingerprint messages
+        for RangeFingerprint { range, fingerprint } in fingerprints {
+            let local_fingerprint = self.store.get_fingerprint(&range, self.limit.as_ref());
+
+            // Case1 Match, nothing to do
+            if local_fingerprint == fingerprint {
+                continue;
+            }
+
+            // Case2 Recursion Anchor
+            let local_values: Vec<_> = self
+                .store
+                .get_range(range.clone(), self.limit.clone())
+                .collect();
+            if local_values.len() <= 1 || fingerprint == Fingerprint::empty() {
+                let values = local_values
+                    .into_iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                out.push(MessagePart::RangeItem(RangeItem {
+                    range,
+                    values,
+                    have_local: false,
+                }));
+            } else {
+                // Case3 Recurse
+                // Create partition
+                // m0 = x < m1 < .. < mk = y, with k>= 2
+                // such that [ml, ml+1) is nonempty
+                let mut ranges = Vec::with_capacity(self.split_factor);
+                let chunk_len = div_ceil(local_values.len(), self.split_factor);
+
+                // Select the first index, for which the key is larger than the x of the range.
+                let mut start_index = local_values
+                    .iter()
+                    .position(|(k, _)| range.x() <= k)
+                    .unwrap_or(0);
+                let max_len = local_values.len();
+                for i in 0..self.split_factor {
+                    let s_index = start_index;
+                    let start = (s_index * chunk_len) % max_len;
+                    let e_index = s_index + 1;
+                    let end = (e_index * chunk_len) % max_len;
+
+                    let (x, y) = if i == 0 {
+                        // first
+                        (range.x(), local_values[end].0)
+                    } else if i == self.split_factor - 1 {
+                        // last
+                        (local_values[start].0, range.y())
+                    } else {
+                        // regular
+                        (local_values[start].0, local_values[end].0)
+                    };
+                    let range = Range::new(x.clone(), y.clone());
+                    ranges.push(range);
+                    start_index += 1;
+                }
+
+                for range in ranges.into_iter() {
+                    let chunk: Vec<_> = self
+                        .store
+                        .get_range(range.clone(), self.limit.clone())
+                        .collect();
+                    // Add either the fingerprint or the item set
+                    let fingerprint = self.store.get_fingerprint(&range, self.limit.as_ref());
+                    if chunk.len() > self.max_set_size {
+                        out.push(MessagePart::RangeFingerprint(RangeFingerprint {
+                            range,
+                            fingerprint,
+                        }));
+                    } else {
+                        let values = chunk
+                            .into_iter()
+                            .map(|(k, v)| {
+                                let k: K = k.clone();
+                                let v: V = v.clone();
+                                (k, v)
+                            })
+                            .collect();
+                        out.push(MessagePart::RangeItem(RangeItem {
+                            range,
+                            values,
+                            have_local: false,
+                        }));
+                    }
+                }
+            }
+        }
+
+        // If we have any parts, return a message
+        if !out.is_empty() {
+            Some(Message { parts: out })
+        } else {
+            None
+        }
+    }
+
+    /// Insert a key value pair.
+    pub fn put(&mut self, k: K, v: V) {
+        self.store.put(k, v);
+    }
+
+    pub fn get(&self, k: &K) -> Option<&V> {
+        self.store.get(k)
+    }
+
+    /// Remove the given key.
+    pub fn remove(&mut self, k: &K) -> Option<V> {
+        self.store.remove(k)
+    }
+
+    /// List all existing key value pairs.
+    pub fn all(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.store.all()
+    }
+
+    /// Returns a refernce to the underlying store.
+    pub fn store(&self) -> &S {
+        &self.store
+    }
+}
+
+/// Sadly https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil is still unstable..
+fn div_ceil(a: usize, b: usize) -> usize {
+    debug_assert!(a != 0);
+    debug_assert!(b != 0);
+
+    a / b + (a % b != 0) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    use super::*;
+
+    #[test]
+    fn test_paper_1() {
+        let alice_set = [("ape", 1), ("eel", 1), ("fox", 1), ("gnu", 1)];
+        let bob_set = [
+            ("bee", 1),
+            ("cat", 1),
+            ("doe", 1),
+            ("eel", 1),
+            ("fox", 1),
+            ("hog", 1),
+        ];
+
+        let res = sync(None, &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 2, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 2, "B -> A message count");
+
+        // Initial message
+        assert_eq!(res.alice_to_bob[0].parts.len(), 1);
+        assert!(res.alice_to_bob[0].parts[0].is_range_fingerprint());
+
+        // Response from Bob - recurse once
+        assert_eq!(res.bob_to_alice[0].parts.len(), 2);
+        assert!(res.bob_to_alice[0].parts[0].is_range_fingerprint());
+        assert!(res.bob_to_alice[0].parts[1].is_range_fingerprint());
+
+        // Last response from Alice
+        assert_eq!(res.alice_to_bob[1].parts.len(), 3);
+        assert!(res.alice_to_bob[1].parts[0].is_range_item());
+        assert!(res.alice_to_bob[1].parts[1].is_range_fingerprint());
+        assert!(res.alice_to_bob[1].parts[2].is_range_item());
+
+        // Last response from Bob
+        assert_eq!(res.bob_to_alice[1].parts.len(), 2);
+        assert!(res.bob_to_alice[1].parts[0].is_range_item());
+        assert!(res.bob_to_alice[1].parts[1].is_range_item());
+    }
+
+    #[test]
+    fn test_paper_2() {
+        let alice_set = [
+            ("ape", 1),
+            ("bee", 1),
+            ("cat", 1),
+            ("doe", 1),
+            ("eel", 1),
+            ("fox", 1), // the only value being sent
+            ("gnu", 1),
+            ("hog", 1),
+        ];
+        let bob_set = [
+            ("ape", 1),
+            ("bee", 1),
+            ("cat", 1),
+            ("doe", 1),
+            ("eel", 1),
+            ("gnu", 1),
+            ("hog", 1),
+        ];
+
+        let res = sync(None, &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 3, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 2, "B -> A message count");
+    }
+
+    #[test]
+    fn test_paper_3() {
+        let alice_set = [
+            ("ape", 1),
+            ("bee", 1),
+            ("cat", 1),
+            ("doe", 1),
+            ("eel", 1),
+            ("fox", 1),
+            ("gnu", 1),
+            ("hog", 1),
+        ];
+        let bob_set = [("ape", 1), ("cat", 1), ("eel", 1), ("gnu", 1)];
+
+        let res = sync(None, &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 3, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 2, "B -> A message count");
+    }
+
+    #[test]
+    fn test_limits() {
+        let alice_set = [("ape", 1), ("bee", 1), ("cat", 1)];
+        let bob_set = [("ape", 1), ("cat", 1), ("doe", 1)];
+
+        // No Limit
+        let res = sync(None, &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 3, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 2, "B -> A message count");
+
+        // With Limit: just ape
+        let limit = ("ape", "bee").into();
+        let res = sync(Some(limit), &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 1, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 0, "B -> A message count");
+
+        // With Limit: just bee, cat
+        let limit = ("bee", "doe").into();
+        let res = sync(Some(limit), &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 2, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 1, "B -> A message count");
+    }
+
+    #[test]
+    fn test_prefixes_simple() {
+        let alice_set = [("/foo/bar", 1), ("/foo/baz", 1), ("/foo/cat", 1)];
+        let bob_set = [("/foo/bar", 1), ("/alice/bar", 1), ("/alice/baz", 1)];
+
+        // No Limit
+        let res = sync(None, &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 2, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 2, "B -> A message count");
+
+        // With Limit: just /alice
+        let limit = ("/alice", "/b").into();
+        let res = sync(Some(limit), &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 1, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 1, "B -> A message count");
+    }
+
+    #[test]
+    fn test_prefixes_empty_alice() {
+        let alice_set = [];
+        let bob_set = [("/foo/bar", 1), ("/alice/bar", 1), ("/alice/baz", 1)];
+
+        // No Limit
+        let res = sync(None, &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 1, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 1, "B -> A message count");
+
+        // With Limit: just /alice
+        let limit = ("/alice", "/b").into();
+        let res = sync(Some(limit), &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 1, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 1, "B -> A message count");
+    }
+
+    #[test]
+    fn test_prefixes_empty_bob() {
+        let alice_set = [("/foo/bar", 1), ("/foo/baz", 1), ("/foo/cat", 1)];
+        let bob_set = [];
+
+        // No Limit
+        let res = sync(None, &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 2, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 1, "B -> A message count");
+
+        // With Limit: just /alice
+        let limit = ("/alice", "/b").into();
+        let res = sync(Some(limit), &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 1, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 0, "B -> A message count");
+    }
+
+    #[test]
+    fn test_multikey() {
+        #[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        struct Multikey {
+            author: [u8; 4],
+            key: Vec<u8>,
+        }
+
+        impl RangeKey for Multikey {
+            fn contains(&self, range: &Range<Self>) -> bool {
+                let author = range.x().author.cmp(&range.y().author);
+                let key = range.x().key.cmp(&range.y().key);
+
+                match (author, key) {
+                    (Ordering::Equal, Ordering::Equal) => {
+                        // All
+                        true
+                    }
+                    (Ordering::Equal, Ordering::Less) => {
+                        // Regular, based on key
+                        range.x().key <= self.key && self.key < range.y().key
+                    }
+                    (Ordering::Equal, Ordering::Greater) => {
+                        // Reverse, based on key
+                        range.x().key <= self.key || self.key < range.y().key
+                    }
+                    (Ordering::Less, Ordering::Equal) => {
+                        // Regular, based on author
+                        range.x().author <= self.author && self.author < range.y().author
+                    }
+                    (Ordering::Greater, Ordering::Equal) => {
+                        // Reverse, based on key
+                        range.x().author <= self.author || self.author < range.y().author
+                    }
+                    (Ordering::Less, Ordering::Less) => {
+                        // Regular, key and author
+                        range.x().key <= self.key
+                            && self.key < range.y().key
+                            && range.x().author <= self.author
+                            && self.author < range.y().author
+                    }
+                    (Ordering::Greater, Ordering::Greater) => {
+                        // Reverse, key and author
+                        (range.x().key <= self.key || self.key < range.y().key)
+                            && (range.x().author <= self.author || self.author < range.y().author)
+                    }
+                    (Ordering::Less, Ordering::Greater) => {
+                        // Regular author, Reverse key
+                        (range.x().key <= self.key || self.key < range.y().key)
+                            && (range.x().author <= self.author && self.author < range.y().author)
+                    }
+                    (Ordering::Greater, Ordering::Less) => {
+                        // Regular key, Reverse author
+                        (range.x().key <= self.key && self.key < range.y().key)
+                            && (range.x().author <= self.author || self.author < range.y().author)
+                    }
+                }
+            }
+        }
+
+        impl Debug for Multikey {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let key = if let Ok(key) = std::str::from_utf8(&self.key) {
+                    key.to_string()
+                } else {
+                    hex::encode(&self.key)
+                };
+                f.debug_struct("Multikey")
+                    .field("author", &hex::encode(&self.author))
+                    .field("key", &key)
+                    .finish()
+            }
+        }
+        impl AsFingerprint for Multikey {
+            fn as_fingerprint(&self) -> Fingerprint {
+                let mut hasher = blake3::Hasher::new();
+                hasher.update(&self.author);
+                hasher.update(&self.key);
+                Fingerprint(hasher.finalize().into())
+            }
+        }
+
+        impl Multikey {
+            fn new(author: [u8; 4], key: impl AsRef<[u8]>) -> Self {
+                Multikey {
+                    author,
+                    key: key.as_ref().to_vec(),
+                }
+            }
+        }
+        let author_a = [1u8; 4];
+        let author_b = [2u8; 4];
+        let alice_set = [
+            (Multikey::new(author_a, "ape"), 1),
+            (Multikey::new(author_a, "bee"), 1),
+            (Multikey::new(author_b, "bee"), 1),
+            (Multikey::new(author_a, "doe"), 1),
+        ];
+        let bob_set = [
+            (Multikey::new(author_a, "ape"), 1),
+            (Multikey::new(author_a, "bee"), 1),
+            (Multikey::new(author_a, "cat"), 1),
+            (Multikey::new(author_b, "cat"), 1),
+        ];
+
+        // No limit
+        let res = sync(None, &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 2, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 2, "B -> A message count");
+        res.assert_alice_set(
+            "no limit",
+            &[
+                (Multikey::new(author_a, "ape"), 1),
+                (Multikey::new(author_a, "bee"), 1),
+                (Multikey::new(author_b, "bee"), 1),
+                (Multikey::new(author_a, "doe"), 1),
+                (Multikey::new(author_a, "cat"), 1),
+                (Multikey::new(author_b, "cat"), 1),
+            ],
+        );
+
+        res.assert_bob_set(
+            "no limit",
+            &[
+                (Multikey::new(author_a, "ape"), 1),
+                (Multikey::new(author_a, "bee"), 1),
+                (Multikey::new(author_b, "bee"), 1),
+                (Multikey::new(author_a, "doe"), 1),
+                (Multikey::new(author_a, "cat"), 1),
+                (Multikey::new(author_b, "cat"), 1),
+            ],
+        );
+
+        // Only author_a
+        let limit = Range::new(Multikey::new(author_a, ""), Multikey::new(author_b, ""));
+        let res = sync(Some(limit), &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 2, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 1, "B -> A message count");
+        res.assert_alice_set(
+            "only author_a",
+            &[
+                (Multikey::new(author_a, "ape"), 1),
+                (Multikey::new(author_a, "bee"), 1),
+                (Multikey::new(author_b, "bee"), 1),
+                (Multikey::new(author_a, "doe"), 1),
+                (Multikey::new(author_a, "cat"), 1),
+            ],
+        );
+
+        res.assert_bob_set(
+            "only author_a",
+            &[
+                (Multikey::new(author_a, "ape"), 1),
+                (Multikey::new(author_a, "bee"), 1),
+                (Multikey::new(author_a, "cat"), 1),
+                (Multikey::new(author_b, "cat"), 1),
+                (Multikey::new(author_a, "doe"), 1),
+            ],
+        );
+
+        // All authors, but only cat
+        let limit = Range::new(
+            Multikey::new(author_a, "cat"),
+            Multikey::new(author_a, "doe"),
+        );
+        let res = sync(Some(limit), &alice_set, &bob_set);
+        assert_eq!(res.alice_to_bob.len(), 1, "A -> B message count");
+        assert_eq!(res.bob_to_alice.len(), 1, "B -> A message count");
+
+        res.assert_alice_set(
+            "only cat",
+            &[
+                (Multikey::new(author_a, "ape"), 1),
+                (Multikey::new(author_a, "bee"), 1),
+                (Multikey::new(author_b, "bee"), 1),
+                (Multikey::new(author_a, "doe"), 1),
+                (Multikey::new(author_a, "cat"), 1),
+                (Multikey::new(author_b, "cat"), 1),
+            ],
+        );
+
+        res.assert_bob_set(
+            "only cat",
+            &[
+                (Multikey::new(author_a, "ape"), 1),
+                (Multikey::new(author_a, "bee"), 1),
+                (Multikey::new(author_a, "cat"), 1),
+                (Multikey::new(author_b, "cat"), 1),
+            ],
+        );
+    }
+
+    struct SyncResult<K, V>
+    where
+        K: RangeKey + Clone + Default + AsFingerprint,
+    {
+        alice: Peer<K, V>,
+        bob: Peer<K, V>,
+        alice_to_bob: Vec<Message<K, V>>,
+        bob_to_alice: Vec<Message<K, V>>,
+    }
+
+    impl<K, V> SyncResult<K, V>
+    where
+        K: RangeKey + Clone + Default + AsFingerprint + Debug,
+        V: Debug,
+    {
+        fn print_messages(&self) {
+            let len = std::cmp::max(self.alice_to_bob.len(), self.bob_to_alice.len());
+            for i in 0..len {
+                if let Some(msg) = self.alice_to_bob.get(i) {
+                    println!("A -> B:");
+                    print_message(msg);
+                }
+                if let Some(msg) = self.bob_to_alice.get(i) {
+                    println!("B -> A:");
+                    print_message(msg);
+                }
+            }
+        }
+    }
+
+    impl<K, V> SyncResult<K, V>
+    where
+        K: Debug + RangeKey + Clone + Default + AsFingerprint,
+        V: Debug + Clone + PartialEq,
+    {
+        fn assert_alice_set(&self, ctx: &str, expected: &[(K, V)]) {
+            dbg!(self.alice.all().collect::<Vec<_>>());
+            for (k, v) in expected {
+                assert_eq!(
+                    self.alice.store.get(k),
+                    Some(v),
+                    "{}: (alice) missing key {:?}",
+                    ctx,
+                    k
+                );
+            }
+            assert_eq!(expected.len(), self.alice.store.len(), "{}: (alice)", ctx);
+        }
+
+        fn assert_bob_set(&self, ctx: &str, expected: &[(K, V)]) {
+            dbg!(self.bob.all().collect::<Vec<_>>());
+
+            for (k, v) in expected {
+                assert_eq!(
+                    self.bob.store.get(k),
+                    Some(v),
+                    "{}: (bob) missing key {:?}",
+                    ctx,
+                    k
+                );
+            }
+            assert_eq!(expected.len(), self.bob.store.len(), "{}: (bob)", ctx);
+        }
+    }
+
+    fn print_message<K, V>(msg: &Message<K, V>)
+    where
+        K: Debug,
+        V: Debug,
+    {
+        for part in &msg.parts {
+            match part {
+                MessagePart::RangeFingerprint(RangeFingerprint { range, fingerprint }) => {
+                    println!(
+                        "  RangeFingerprint({:?}, {:?}, {:?})",
+                        range.x(),
+                        range.y(),
+                        fingerprint
+                    );
+                }
+                MessagePart::RangeItem(RangeItem {
+                    range,
+                    values,
+                    have_local,
+                }) => {
+                    println!(
+                        "  RangeItem({:?} | {:?}) (local?: {})\n  {:?}",
+                        range.x(),
+                        range.y(),
+                        have_local,
+                        values,
+                    );
+                }
+            }
+        }
+    }
+
+    fn sync<K, V>(
+        limit: Option<Range<K>>,
+        alice_set: &[(K, V)],
+        bob_set: &[(K, V)],
+    ) -> SyncResult<K, V>
+    where
+        K: PartialEq + RangeKey + Clone + Default + Debug + AsFingerprint,
+        V: Clone + Debug + PartialEq,
+    {
+        println!("Using Limit: {:?}", limit);
+        let mut expected_set_alice = BTreeMap::new();
+        let mut expected_set_bob = BTreeMap::new();
+
+        let mut alice = if let Some(limit) = limit.clone() {
+            Peer::<K, V>::with_limit(limit)
+        } else {
+            Peer::<K, V>::default()
+        };
+        for (k, v) in alice_set {
+            alice.put(k.clone(), v.clone());
+
+            let include = if let Some(ref limit) = limit {
+                k.contains(limit)
+            } else {
+                true
+            };
+            if include {
+                expected_set_bob.insert(k.clone(), v.clone());
+            }
+            // alices things are always in alices store
+            expected_set_alice.insert(k.clone(), v.clone());
+        }
+
+        let mut bob = if let Some(limit) = limit.clone() {
+            Peer::<K, V>::with_limit(limit)
+        } else {
+            Peer::<K, V>::default()
+        };
+        for (k, v) in bob_set {
+            bob.put(k.clone(), v.clone());
+            let include = if let Some(ref limit) = limit {
+                k.contains(limit)
+            } else {
+                true
+            };
+            if include {
+                expected_set_alice.insert(k.clone(), v.clone());
+            }
+            // bobs things are always in bobs store
+            expected_set_bob.insert(k.clone(), v.clone());
+        }
+
+        let mut alice_to_bob = Vec::new();
+        let mut bob_to_alice = Vec::new();
+        let initial_message = alice.initial_message();
+
+        let mut next_to_bob = Some(initial_message);
+        let mut rounds = 0;
+        while let Some(msg) = next_to_bob.take() {
+            assert!(rounds < 100, "too many rounds");
+            rounds += 1;
+            alice_to_bob.push(msg.clone());
+
+            if let Some(msg) = bob.process_message(msg) {
+                bob_to_alice.push(msg.clone());
+                next_to_bob = alice.process_message(msg);
+            }
+        }
+        let res = SyncResult {
+            alice,
+            bob,
+            alice_to_bob,
+            bob_to_alice,
+        };
+        res.print_messages();
+
+        let alice_now: Vec<_> = res.alice.all().collect();
+        assert_eq!(
+            expected_set_alice.iter().collect::<Vec<_>>(),
+            alice_now,
+            "alice"
+        );
+
+        let bob_now: Vec<_> = res.bob.all().collect();
+        assert_eq!(expected_set_bob.iter().collect::<Vec<_>>(), bob_now, "bob");
+
+        // Check that values were never sent twice
+        let mut alice_sent = BTreeMap::new();
+        for msg in &res.alice_to_bob {
+            for part in &msg.parts {
+                if let Some(values) = part.values() {
+                    for (key, value) in values {
+                        assert!(
+                            alice_sent.insert(key.clone(), value.clone()).is_none(),
+                            "alice: duplicate {:?} - {:?}",
+                            key,
+                            value
+                        );
+                    }
+                }
+            }
+        }
+
+        let mut bob_sent = BTreeMap::new();
+        for msg in &res.bob_to_alice {
+            for part in &msg.parts {
+                if let Some(values) = part.values() {
+                    for (key, value) in values {
+                        assert!(
+                            bob_sent.insert(key.clone(), value.clone()).is_none(),
+                            "bob: duplicate {:?} - {:?}",
+                            key,
+                            value
+                        );
+                    }
+                }
+            }
+        }
+
+        res
+    }
+
+    #[test]
+    fn store_get_range() {
+        let mut store = SimpleStore::<&'static str, usize>::default();
+        let set = [
+            ("bee", 1),
+            ("cat", 1),
+            ("doe", 1),
+            ("eel", 1),
+            ("fox", 1),
+            ("hog", 1),
+        ];
+        for (k, v) in &set {
+            store.put(*k, *v);
+        }
+
+        let all: Vec<_> = store
+            .get_range(Range::new("", ""), None)
+            .into_iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        assert_eq!(&all, &set[..]);
+
+        let regular: Vec<_> = store
+            .get_range(("bee", "eel").into(), None)
+            .into_iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        assert_eq!(&regular, &set[..3]);
+
+        // empty start
+        let regular: Vec<_> = store
+            .get_range(("", "eel").into(), None)
+            .into_iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        assert_eq!(&regular, &set[..3]);
+
+        let regular: Vec<_> = store
+            .get_range(("cat", "hog").into(), None)
+            .into_iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        assert_eq!(&regular, &set[1..5]);
+
+        let excluded: Vec<_> = store
+            .get_range(("fox", "bee").into(), None)
+            .into_iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+
+        assert_eq!(excluded[0].0, "fox");
+        assert_eq!(excluded[1].0, "hog");
+        assert_eq!(excluded.len(), 2);
+
+        let excluded: Vec<_> = store
+            .get_range(("fox", "doe").into(), None)
+            .into_iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+
+        assert_eq!(excluded.len(), 4);
+        assert_eq!(excluded[0].0, "bee");
+        assert_eq!(excluded[1].0, "cat");
+        assert_eq!(excluded[2].0, "fox");
+        assert_eq!(excluded[3].0, "hog");
+
+        // Limit
+        let all: Vec<_> = store
+            .get_range(("", "").into(), Some(("bee", "doe").into()))
+            .into_iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        assert_eq!(&all, &set[..2]);
+    }
+
+    #[test]
+    fn test_div_ceil() {
+        assert_eq!(div_ceil(1, 1), 1 / 1);
+        assert_eq!(div_ceil(2, 1), 2 / 1);
+        assert_eq!(div_ceil(4, 2), 4 / 2);
+
+        assert_eq!(div_ceil(3, 2), 2);
+        assert_eq!(div_ceil(5, 3), 2);
+    }
+}

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -1,0 +1,789 @@
+// Names and concepts are roughly based on Willows design at the moment:
+//
+// https://hackmd.io/DTtck8QOQm6tZaQBBtTf7w
+//
+// This is going to change!
+
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, HashMap},
+    fmt::{Debug, Display},
+    str::FromStr,
+    sync::Arc,
+    time::SystemTime,
+};
+
+use parking_lot::RwLock;
+
+use bytes::Bytes;
+use ed25519_dalek::{Signature, SignatureError, Signer, SigningKey, VerifyingKey};
+use iroh_bytes::Hash;
+use rand_core::CryptoRngCore;
+use serde::{Deserialize, Serialize};
+
+use crate::ranger::{AsFingerprint, Fingerprint, Peer, Range, RangeKey};
+
+pub type ProtocolMessage = crate::ranger::Message<RecordIdentifier, SignedEntry>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Author {
+    priv_key: SigningKey,
+    id: AuthorId,
+}
+
+impl Display for Author {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Author({})", hex::encode(self.priv_key.to_bytes()))
+    }
+}
+
+impl Author {
+    pub fn new<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Self {
+        let priv_key = SigningKey::generate(rng);
+        let id = AuthorId(priv_key.verifying_key());
+
+        Author { priv_key, id }
+    }
+
+    pub fn id(&self) -> &AuthorId {
+        &self.id
+    }
+
+    pub fn sign(&self, msg: &[u8]) -> Signature {
+        self.priv_key.sign(msg)
+    }
+
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+        self.id.verify(msg, signature)
+    }
+}
+
+#[derive(Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct AuthorId(VerifyingKey);
+
+impl Debug for AuthorId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AuthorId({})", hex::encode(self.0.as_bytes()))
+    }
+}
+
+impl AuthorId {
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+        self.0.verify_strict(msg, signature)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Namespace {
+    priv_key: SigningKey,
+    id: NamespaceId,
+}
+
+impl Display for Namespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Namespace({})", hex::encode(self.priv_key.to_bytes()))
+    }
+}
+
+impl FromStr for Namespace {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let priv_key: [u8; 32] = hex::decode(s).map_err(|_| ())?.try_into().map_err(|_| ())?;
+        let priv_key = SigningKey::from_bytes(&priv_key);
+        let id = NamespaceId(priv_key.verifying_key());
+        Ok(Namespace { priv_key, id })
+    }
+}
+
+impl FromStr for Author {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let priv_key: [u8; 32] = hex::decode(s).map_err(|_| ())?.try_into().map_err(|_| ())?;
+        let priv_key = SigningKey::from_bytes(&priv_key);
+        let id = AuthorId(priv_key.verifying_key());
+        Ok(Author { priv_key, id })
+    }
+}
+
+impl Namespace {
+    pub fn new<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Self {
+        let priv_key = SigningKey::generate(rng);
+        let id = NamespaceId(priv_key.verifying_key());
+
+        Namespace { priv_key, id }
+    }
+
+    pub fn id(&self) -> &NamespaceId {
+        &self.id
+    }
+
+    pub fn sign(&self, msg: &[u8]) -> Signature {
+        self.priv_key.sign(msg)
+    }
+
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+        self.id.verify(msg, signature)
+    }
+}
+
+#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct NamespaceId(VerifyingKey);
+
+impl Display for NamespaceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NamespaceId({})", hex::encode(self.0.as_bytes()))
+    }
+}
+
+impl Debug for NamespaceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NamespaceId({})", hex::encode(self.0.as_bytes()))
+    }
+}
+
+impl NamespaceId {
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+        self.0.verify_strict(msg, signature)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+}
+
+/// Manages the replicas and authors for an instance.
+#[derive(Debug, Clone, Default)]
+pub struct ReplicaStore {
+    replicas: Arc<RwLock<HashMap<NamespaceId, Replica>>>,
+    authors: Arc<RwLock<HashMap<AuthorId, Author>>>,
+}
+
+impl ReplicaStore {
+    pub fn get_replica(&self, namespace: &NamespaceId) -> Option<Replica> {
+        let replicas = &*self.replicas.read();
+        replicas.get(namespace).cloned()
+    }
+
+    pub fn get_author(&self, author: &AuthorId) -> Option<Author> {
+        let authors = &*self.authors.read();
+        authors.get(author).cloned()
+    }
+
+    pub fn new_author<R: CryptoRngCore + ?Sized>(&self, rng: &mut R) -> Author {
+        let author = Author::new(rng);
+        self.authors.write().insert(*author.id(), author.clone());
+        author
+    }
+
+    pub fn new_replica(&self, namespace: Namespace) -> Replica {
+        let replica = Replica::new(namespace);
+        self.replicas
+            .write()
+            .insert(replica.namespace(), replica.clone());
+        replica
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Replica {
+    inner: Arc<RwLock<InnerReplica>>,
+}
+
+#[derive(Debug)]
+struct InnerReplica {
+    namespace: Namespace,
+    peer: Peer<RecordIdentifier, SignedEntry, Store>,
+    content: HashMap<Hash, Bytes>,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Store {
+    /// Stores records by identifier + timestamp
+    records: BTreeMap<RecordIdentifier, BTreeMap<u64, SignedEntry>>,
+}
+
+impl Store {
+    pub fn latest(&self) -> impl Iterator<Item = (&RecordIdentifier, &SignedEntry)> {
+        self.records.iter().filter_map(|(k, values)| {
+            let (_, v) = values.last_key_value()?;
+            Some((k, v))
+        })
+    }
+}
+
+impl crate::ranger::Store<RecordIdentifier, SignedEntry> for Store {
+    /// Get a the first key (or the default if none is available).
+    fn get_first(&self) -> RecordIdentifier {
+        self.records
+            .first_key_value()
+            .map(|(k, _)| k.clone())
+            .unwrap_or_default()
+    }
+
+    fn get(&self, key: &RecordIdentifier) -> Option<&SignedEntry> {
+        self.records
+            .get(key)
+            .and_then(|values| values.last_key_value())
+            .map(|(_, v)| v)
+    }
+
+    fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    fn get_fingerprint(
+        &self,
+        range: &Range<RecordIdentifier>,
+        limit: Option<&Range<RecordIdentifier>>,
+    ) -> Fingerprint {
+        let elements = self.get_range(range.clone(), limit.cloned());
+        let mut fp = Fingerprint::empty();
+        for el in elements {
+            fp ^= el.0.as_fingerprint();
+        }
+
+        fp
+    }
+
+    fn put(&mut self, k: RecordIdentifier, v: SignedEntry) {
+        // TODO: propagate error/not insertion?
+        if v.verify().is_ok() {
+            let timestamp = v.entry().record().timestamp();
+            // TODO: verify timestamp is "reasonable"
+
+            self.records.entry(k).or_default().insert(timestamp, v);
+        }
+    }
+
+    type RangeIterator<'a> = RangeIterator<'a>;
+    fn get_range<'a>(
+        &'a self,
+        range: Range<RecordIdentifier>,
+        limit: Option<Range<RecordIdentifier>>,
+    ) -> Self::RangeIterator<'a> {
+        RangeIterator {
+            iter: self.records.iter(),
+            range: Some(range),
+            limit,
+        }
+    }
+
+    fn remove(&mut self, key: &RecordIdentifier) -> Option<SignedEntry> {
+        self.records
+            .remove(key)
+            .and_then(|mut v| v.last_entry().map(|e| e.remove_entry().1))
+    }
+
+    type AllIterator<'a> = RangeIterator<'a>;
+
+    fn all(&self) -> Self::AllIterator<'_> {
+        RangeIterator {
+            iter: self.records.iter(),
+            range: None,
+            limit: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RangeIterator<'a> {
+    iter: std::collections::btree_map::Iter<'a, RecordIdentifier, BTreeMap<u64, SignedEntry>>,
+    range: Option<Range<RecordIdentifier>>,
+    limit: Option<Range<RecordIdentifier>>,
+}
+
+impl<'a> RangeIterator<'a> {
+    fn matches(&self, x: &RecordIdentifier) -> bool {
+        let range = self.range.as_ref().map(|r| x.contains(r)).unwrap_or(true);
+        let limit = self.limit.as_ref().map(|r| x.contains(r)).unwrap_or(true);
+        range && limit
+    }
+}
+
+impl<'a> Iterator for RangeIterator<'a> {
+    type Item = (&'a RecordIdentifier, &'a SignedEntry);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut next = self.iter.next()?;
+        loop {
+            if self.matches(&next.0) {
+                let (k, values) = next;
+                let (_, v) = values.last_key_value()?;
+                return Some((k, v));
+            }
+
+            next = self.iter.next()?;
+        }
+    }
+}
+
+impl Replica {
+    pub fn new(namespace: Namespace) -> Self {
+        Replica {
+            inner: Arc::new(RwLock::new(InnerReplica {
+                namespace,
+                peer: Peer::default(),
+                content: HashMap::default(),
+            })),
+        }
+    }
+
+    pub fn get_content(&self, hash: &Hash) -> Option<Bytes> {
+        self.inner.read().content.get(hash).cloned()
+    }
+
+    // TODO: not horrible
+    pub fn all(&self) -> Vec<(RecordIdentifier, SignedEntry)> {
+        self.inner
+            .read()
+            .peer
+            .all()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+
+    /// Inserts a new record at the given key.
+    pub fn insert(&self, key: impl AsRef<[u8]>, author: &Author, data: impl Into<Bytes>) {
+        let mut inner = self.inner.write();
+
+        let id = RecordIdentifier::new(key, inner.namespace.id(), author.id());
+        let data: Bytes = data.into();
+        let record = Record::from_data(&data, inner.namespace.id());
+
+        // Store content
+        inner.content.insert(*record.content_hash(), data);
+
+        // Store signed entries
+        let entry = Entry::new(id.clone(), record);
+        let signed_entry = entry.sign(&inner.namespace, author);
+        inner.peer.put(id, signed_entry);
+    }
+
+    /// Gets all entries matching this key and author.
+    pub fn get_latest(&self, key: impl AsRef<[u8]>, author: &AuthorId) -> Option<SignedEntry> {
+        let inner = self.inner.read();
+        inner
+            .peer
+            .get(&RecordIdentifier::new(key, &inner.namespace.id(), author))
+            .cloned()
+    }
+
+    /// Returns all versions of the matching documents.
+    pub fn get_all<'a, 'b: 'a>(
+        &'a self,
+        key: impl AsRef<[u8]> + 'b,
+        author: &AuthorId,
+    ) -> GetAllIter<'a> {
+        let guard: parking_lot::lock_api::RwLockReadGuard<_, _> = self.inner.read();
+        let record_id = RecordIdentifier::new(key, guard.namespace.id(), author);
+        GetAllIter {
+            records: parking_lot::lock_api::RwLockReadGuard::map(guard, move |inner| {
+                &inner.peer.store().records
+            }),
+            record_id,
+            index: 0,
+        }
+    }
+
+    pub fn sync_initial_message(&self) -> crate::ranger::Message<RecordIdentifier, SignedEntry> {
+        self.inner.read().peer.initial_message()
+    }
+
+    pub fn sync_process_message(
+        &self,
+        message: crate::ranger::Message<RecordIdentifier, SignedEntry>,
+    ) -> Option<crate::ranger::Message<RecordIdentifier, SignedEntry>> {
+        self.inner.write().peer.process_message(message)
+    }
+
+    pub fn namespace(&self) -> NamespaceId {
+        *self.inner.read().namespace.id()
+    }
+}
+
+#[derive(Debug)]
+pub struct GetAllIter<'a> {
+    // Oh my god, rust why u do this to me?
+    records: parking_lot::lock_api::MappedRwLockReadGuard<
+        'a,
+        parking_lot::RawRwLock,
+        BTreeMap<RecordIdentifier, BTreeMap<u64, SignedEntry>>,
+    >,
+    record_id: RecordIdentifier,
+    /// Current iteration index.
+    index: usize,
+}
+
+impl<'a> Iterator for GetAllIter<'a> {
+    type Item = SignedEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let values = self.records.get(&self.record_id)?;
+
+        let (_, res) = values.iter().nth(self.index)?;
+        self.index += 1;
+        Some(res.clone()) // :( I give up
+    }
+}
+
+/// A signed entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedEntry {
+    signature: EntrySignature,
+    entry: Entry,
+}
+
+impl SignedEntry {
+    pub fn from_entry(entry: Entry, namespace: &Namespace, author: &Author) -> Self {
+        let signature = EntrySignature::from_entry(&entry, namespace, author);
+        SignedEntry { signature, entry }
+    }
+
+    pub fn verify(&self) -> Result<(), SignatureError> {
+        self.signature
+            .verify(&self.entry, &self.entry.id.namespace, &self.entry.id.author)
+    }
+
+    pub fn signature(&self) -> &EntrySignature {
+        &self.signature
+    }
+
+    pub fn entry(&self) -> &Entry {
+        &self.entry
+    }
+}
+
+/// Signature over an entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntrySignature {
+    author_signature: Signature,
+    namespace_signature: Signature,
+}
+
+impl EntrySignature {
+    pub fn from_entry(entry: &Entry, namespace: &Namespace, author: &Author) -> Self {
+        // TODO: this should probably include a namespace prefix
+        // namespace in the cryptographic sense.
+        let bytes = entry.to_vec();
+        let namespace_signature = namespace.sign(&bytes);
+        let author_signature = author.sign(&bytes);
+
+        EntrySignature {
+            author_signature,
+            namespace_signature,
+        }
+    }
+
+    pub fn verify(
+        &self,
+        entry: &Entry,
+        namespace: &NamespaceId,
+        author: &AuthorId,
+    ) -> Result<(), SignatureError> {
+        let bytes = entry.to_vec();
+        namespace.verify(&bytes, &self.namespace_signature)?;
+        author.verify(&bytes, &self.author_signature)?;
+
+        Ok(())
+    }
+}
+
+/// A single entry in a replica.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Entry {
+    id: RecordIdentifier,
+    record: Record,
+}
+
+impl Entry {
+    pub fn new(id: RecordIdentifier, record: Record) -> Self {
+        Entry { id, record }
+    }
+
+    pub fn id(&self) -> &RecordIdentifier {
+        &self.id
+    }
+
+    pub fn record(&self) -> &Record {
+        &self.record
+    }
+
+    /// Serialize this entry into its canonical byte representation used for signing.
+    pub fn into_vec(&self, out: &mut Vec<u8>) {
+        self.id.as_bytes(out);
+        self.record.as_bytes(out);
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.into_vec(&mut out);
+        out
+    }
+
+    pub fn sign(self, namespace: &Namespace, author: &Author) -> SignedEntry {
+        SignedEntry::from_entry(self, namespace, author)
+    }
+}
+
+/// The indentifier of a record.
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RecordIdentifier {
+    /// The key of the record.
+    key: Vec<u8>,
+    /// The namespace this record belongs to.
+    namespace: NamespaceId,
+    /// The author that wrote this record.
+    author: AuthorId,
+}
+
+impl AsFingerprint for RecordIdentifier {
+    fn as_fingerprint(&self) -> crate::ranger::Fingerprint {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.namespace.as_bytes());
+        hasher.update(self.author.as_bytes());
+        hasher.update(&self.key);
+        Fingerprint(hasher.finalize().into())
+    }
+}
+
+impl PartialOrd for NamespaceId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for NamespaceId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_bytes().cmp(other.0.as_bytes())
+    }
+}
+
+impl PartialOrd for AuthorId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AuthorId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_bytes().cmp(other.0.as_bytes())
+    }
+}
+
+impl RangeKey for RecordIdentifier {
+    fn contains(&self, range: &crate::ranger::Range<Self>) -> bool {
+        // For now we just do key inclusion and check if namespace and author match
+        if self.namespace != range.x().namespace || self.namespace != range.y().namespace {
+            return false;
+        }
+        if self.author != range.x().author || self.author != range.y().author {
+            return false;
+        }
+
+        let mapped_range = range.clone().map(|x, y| (x.key, y.key));
+        crate::ranger::contains(&self.key, &mapped_range)
+    }
+}
+
+impl RecordIdentifier {
+    pub fn new(key: impl AsRef<[u8]>, namespace: &NamespaceId, author: &AuthorId) -> Self {
+        RecordIdentifier {
+            key: key.as_ref().to_vec(),
+            namespace: *namespace,
+            author: *author,
+        }
+    }
+
+    pub fn as_bytes(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(self.namespace.as_bytes());
+        out.extend_from_slice(self.author.as_bytes());
+        out.extend_from_slice(&self.key);
+    }
+
+    pub fn key(&self) -> &[u8] {
+        &self.key
+    }
+
+    pub fn namespace(&self) -> &NamespaceId {
+        &self.namespace
+    }
+
+    pub fn author(&self) -> &AuthorId {
+        &self.author
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Record {
+    /// Record creation timestamp. Counted as micros since the Unix epoch.
+    timestamp: u64,
+    /// Length of the data referenced by `hash`.
+    len: u64,
+    hash: Hash,
+}
+
+impl Record {
+    pub fn new(timestamp: u64, len: u64, hash: Hash) -> Self {
+        Record {
+            timestamp,
+            len,
+            hash,
+        }
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    pub fn content_len(&self) -> u64 {
+        self.len
+    }
+
+    pub fn content_hash(&self) -> &Hash {
+        &self.hash
+    }
+
+    pub fn from_data(data: impl AsRef<[u8]>, namespace: &NamespaceId) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time drift")
+            .as_micros() as u64;
+        let data = data.as_ref();
+        let len = data.len() as u64;
+        // Salted hash
+        // TODO: do we actually want this?
+        // TODO: this should probably use a namespace prefix if used
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(namespace.as_bytes());
+        hasher.update(data);
+        let hash = hasher.finalize();
+
+        Self::new(timestamp, len, hash.into())
+    }
+
+    pub fn as_bytes(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.timestamp.to_be_bytes());
+        out.extend_from_slice(&self.len.to_be_bytes());
+        out.extend_from_slice(self.hash.as_ref());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basics() {
+        let mut rng = rand::thread_rng();
+        let alice = Author::new(&mut rng);
+        let myspace = Namespace::new(&mut rng);
+
+        let record_id = RecordIdentifier::new("/my/key", myspace.id(), alice.id());
+        let record = Record::from_data(b"this is my cool data", myspace.id());
+        let entry = Entry::new(record_id, record);
+        let signed_entry = entry.sign(&myspace, &alice);
+        signed_entry.verify().expect("failed to verify");
+
+        let my_replica = Replica::new(myspace);
+        for i in 0..10 {
+            my_replica.insert(format!("/{i}"), &alice, format!("{i}: hello from alice"));
+        }
+
+        for i in 0..10 {
+            let res = my_replica.get_latest(format!("/{i}"), alice.id()).unwrap();
+            let len = format!("{i}: hello from alice").as_bytes().len() as u64;
+            assert_eq!(res.entry().record().content_len(), len);
+            res.verify().expect("invalid signature");
+        }
+
+        // Test multiple records for the same key
+        my_replica.insert("/cool/path", &alice, "round 1");
+        let entry = my_replica.get_latest("/cool/path", alice.id()).unwrap();
+        let content = my_replica
+            .get_content(entry.entry().record().content_hash())
+            .unwrap();
+        assert_eq!(&content[..], b"round 1");
+
+        // Second
+
+        my_replica.insert("/cool/path", &alice, "round 2");
+        let entry = my_replica.get_latest("/cool/path", alice.id()).unwrap();
+        let content = my_replica
+            .get_content(entry.entry().record().content_hash())
+            .unwrap();
+        assert_eq!(&content[..], b"round 2");
+
+        // Get All
+        let entries: Vec<_> = my_replica.get_all("/cool/path", alice.id()).collect();
+        assert_eq!(entries.len(), 2);
+        let content = my_replica
+            .get_content(entries[0].entry().record().content_hash())
+            .unwrap();
+        assert_eq!(&content[..], b"round 1");
+        let content = my_replica
+            .get_content(entries[1].entry().record().content_hash())
+            .unwrap();
+        assert_eq!(&content[..], b"round 2");
+    }
+
+    #[test]
+    fn test_replica_sync() {
+        let alice_set = ["ape", "eel", "fox", "gnu"];
+        let bob_set = ["bee", "cat", "doe", "eel", "fox", "hog"];
+
+        let mut rng = rand::thread_rng();
+        let author = Author::new(&mut rng);
+        let myspace = Namespace::new(&mut rng);
+        let mut alice = Replica::new(myspace.clone());
+        for el in &alice_set {
+            alice.insert(el, &author, el.as_bytes());
+        }
+
+        let mut bob = Replica::new(myspace);
+        for el in &bob_set {
+            bob.insert(el, &author, el.as_bytes());
+        }
+
+        sync(&author, &mut alice, &mut bob, &alice_set, &bob_set);
+    }
+
+    fn sync(
+        author: &Author,
+        alice: &mut Replica,
+        bob: &mut Replica,
+        alice_set: &[&str],
+        bob_set: &[&str],
+    ) {
+        // Sync alice - bob
+        let mut next_to_bob = Some(alice.sync_initial_message());
+        let mut rounds = 0;
+        while let Some(msg) = next_to_bob.take() {
+            assert!(rounds < 100, "too many rounds");
+            rounds += 1;
+            if let Some(msg) = bob.sync_process_message(msg) {
+                next_to_bob = alice.sync_process_message(msg);
+            }
+        }
+
+        // Check result
+        for el in alice_set {
+            alice.get_latest(el, author.id()).unwrap();
+            bob.get_latest(el, author.id()).unwrap();
+        }
+
+        for el in bob_set {
+            alice.get_latest(el, author.id()).unwrap();
+            bob.get_latest(el, author.id()).unwrap();
+        }
+    }
+}

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -46,7 +46,7 @@ impl Author {
     }
 
     pub fn from_bytes(bytes: &[u8; 32]) -> Self {
-        SigningKey::from_bytes(&bytes).into()
+        SigningKey::from_bytes(bytes).into()
     }
 
     pub fn id(&self) -> &AuthorId {
@@ -358,7 +358,7 @@ impl<'a> Iterator for RangeIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let mut next = self.iter.next()?;
         loop {
-            if self.matches(&next.0) {
+            if self.matches(next.0) {
                 let (k, values) = next;
                 let (_, v) = values.last_key_value()?;
                 return Some((k, v));
@@ -441,7 +441,7 @@ impl Replica {
         let inner = self.inner.read();
         inner
             .peer
-            .get(&RecordIdentifier::new(key, &inner.namespace.id(), author))
+            .get(&RecordIdentifier::new(key, inner.namespace.id(), author))
             .cloned()
     }
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -24,6 +24,7 @@ iroh-io = { version = "0.2.1" }
 iroh-net = { path = "../iroh-net" }
 iroh-bytes = { path = "../iroh-bytes" }
 iroh-sync = { path = "../iroh-sync" }
+iroh-gossip = { path = "../iroh-gossip" }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quic-rpc = { version = "0.6", default-features = false, features = ["flume-transport"] }
 quinn = "0.10"
@@ -50,11 +51,18 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 # Metrics
 iroh-metrics = { path = "../iroh-metrics", optional = true }
 
+# Examples
+once_cell = { version = "1.18.0", optional = true }
+ed25519-dalek = { version = "=2.0.0-rc.3", features = ["serde", "rand_core"], optional = true }
+data-encoding = { version = "2.3.3", optional = true }
+url = { version = "2.4.0", optional = true }
+
 [features]
 default = ["cli", "metrics"]
 cli = ["clap", "config", "console", "dirs-next", "hex", "indicatif", "multibase", "num_cpus", "quic-rpc/quinn-transport", "tempfile", "tokio/rt-multi-thread", "tracing-subscriber"]
 metrics = ["iroh-metrics"]
 test = []
+example-sync = ["cli", "ed25519-dalek", "data-encoding", "url", "once_cell"]
 
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
@@ -74,3 +82,6 @@ postcard = "1"
 name = "iroh"
 required-features = ["cli"]
 
+[[example]]
+name = "sync"
+required-features = ["example-sync"]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -23,10 +23,12 @@ futures = "0.3.25"
 iroh-io = { version = "0.2.1" }
 iroh-net = { path = "../iroh-net" }
 iroh-bytes = { path = "../iroh-bytes" }
-iroh-metrics = { path = "../iroh-metrics", optional = true }
+iroh-sync = { path = "../iroh-sync" }
+postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quic-rpc = { version = "0.6", default-features = false, features = ["flume-transport"] }
 quinn = "0.10"
 range-collections = { version = "0.4.0" }
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["io-util", "rt"] }
 tokio-util = { version = "0.7", features = ["io-util", "io"] }
@@ -42,14 +44,15 @@ hex = { version = "0.4.3", optional = true }
 indicatif = { version = "0.17", features = ["tokio"], optional = true }
 multibase = { version = "0.9.1", optional = true }
 num_cpus = { version = "1.15.0", optional = true }
-postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"], optional = true }
 tempfile = { version = "3.4", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
+# Metrics
+iroh-metrics = { path = "../iroh-metrics", optional = true }
 
 [features]
 default = ["cli", "metrics"]
-cli = ["clap", "config", "console", "dirs-next", "hex", "indicatif", "multibase", "num_cpus", "postcard", "quic-rpc/quinn-transport", "tempfile", "tokio/rt-multi-thread", "tracing-subscriber"]
+cli = ["clap", "config", "console", "dirs-next", "hex", "indicatif", "multibase", "num_cpus", "quic-rpc/quinn-transport", "tempfile", "tokio/rt-multi-thread", "tracing-subscriber"]
 metrics = ["iroh-metrics"]
 test = []
 
@@ -59,7 +62,6 @@ blake3 = "1.3.3"
 bytes = "1"
 duct = "0.13.6"
 nix = "0.26.2"
-rand = "0.8"
 regex = { version = "1.7.1", features = ["std"] }
 testdir = "0.8"
 tokio = { version = "1", features = ["macros", "io-util", "rt"] }

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -1,0 +1,347 @@
+//! Live edit a p2p document
+//!
+//! By default a new peer id is created when starting the example. To reuse your identity,
+//! set the `--private-key` CLI flag with the private key printed on a previous invocation.
+//!
+//! You can use this with a local DERP server. To do so, run
+//! `cargo run --bin derper -- --dev`
+//! and then set the `-d http://localhost:3340` flag on this example.
+
+use std::{fmt, str::FromStr};
+
+use anyhow::bail;
+use clap::Parser;
+use ed25519_dalek::SigningKey;
+use iroh::sync::{LiveSync, PeerSource, SYNC_ALPN};
+use iroh_gossip::{
+    net::{GossipHandle, GOSSIP_ALPN},
+    proto::TopicId,
+};
+use iroh_net::{
+    defaults::{default_derp_map, DEFAULT_DERP_STUN_PORT},
+    hp::derp::{DerpMap, UseIpv4, UseIpv6},
+    magic_endpoint::get_alpn,
+    tls::Keypair,
+    MagicEndpoint,
+};
+use iroh_sync::sync::{Author, Namespace, Replica, ReplicaStore, SignedEntry};
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use url::Url;
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// Private key to derive our peer id from
+    #[clap(long)]
+    private_key: Option<String>,
+    /// Set a custom DERP server. By default, the DERP server hosted by n0 will be used.
+    #[clap(short, long)]
+    derp: Option<Url>,
+    /// Disable DERP completeley
+    #[clap(long)]
+    no_derp: bool,
+    /// Set your nickname
+    #[clap(short, long)]
+    name: Option<String>,
+    /// Set the bind port for our socket. By default, a random port will be used.
+    #[clap(short, long, default_value = "0")]
+    bind_port: u16,
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Parser, Debug)]
+enum Command {
+    Open { doc_name: String },
+    Join { ticket: String },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+    run(args).await
+}
+
+async fn run(args: Args) -> anyhow::Result<()> {
+    // parse or generate our keypair
+    let keypair = match args.private_key {
+        None => Keypair::generate(),
+        Some(key) => parse_keypair(&key)?,
+    };
+    println!("> our private key: {}", fmt_secret(&keypair));
+
+    // configure our derp map
+    let derp_map = match (args.no_derp, args.derp) {
+        (false, None) => Some(default_derp_map()),
+        (false, Some(url)) => Some(derp_map_from_url(url)?),
+        (true, None) => None,
+        (true, Some(_)) => bail!("You cannot set --no-derp and --derp at the same time"),
+    };
+    println!("> using DERP servers: {}", fmt_derp_map(&derp_map));
+
+    // init a cell that will hold our gossip handle to be used in endpoint callbacks
+    let gossip_cell: OnceCell<GossipHandle> = OnceCell::new();
+    // init a channel that will emit once the initial endpoints of our local node are discovered
+    let (initial_endpoints_tx, mut initial_endpoints_rx) = mpsc::channel(1);
+
+    // build our magic endpoint
+    let gossip_cell_clone = gossip_cell.clone();
+    let endpoint = MagicEndpoint::builder()
+        .keypair(keypair.clone())
+        .alpns(vec![GOSSIP_ALPN.to_vec(), SYNC_ALPN.to_vec()])
+        .derp_map(derp_map)
+        .on_endpoints(Box::new(move |endpoints| {
+            // send our updated endpoints to the gossip protocol to be sent as PeerData to peers
+            if let Some(gossip) = gossip_cell_clone.get() {
+                gossip.update_endpoints(endpoints).ok();
+            }
+            // trigger oneshot on the first endpoint update
+            initial_endpoints_tx.try_send(endpoints.to_vec()).ok();
+        }))
+        .bind(args.bind_port)
+        .await?;
+    println!("> our peer id: {}", endpoint.peer_id());
+
+    // wait for a first endpoint update so that we know about at least one of our addrs
+    let initial_endpoints = initial_endpoints_rx.recv().await.unwrap();
+    // println!("> our endpoints: {initial_endpoints:?}");
+
+    let (topic, peers) = match &args.command {
+        Command::Open { doc_name } => {
+            let topic: TopicId = blake3::hash(doc_name.as_bytes()).into();
+            println!(
+                "> opening document {doc_name} as namespace {} and waiting for peers to join us...",
+                fmt_hash(topic.as_bytes())
+            );
+            (topic, vec![])
+        }
+        Command::Join { ticket } => {
+            let Ticket { topic, peers } = Ticket::from_str(ticket)?;
+            println!("> joining topic {topic} and connecting to {peers:?}",);
+            (topic, peers)
+        }
+    };
+
+    let our_ticket = {
+        // add our local endpoints to the ticket and print it for others to join
+        let addrs = initial_endpoints.iter().map(|ep| ep.addr).collect();
+        let mut peers = peers.clone();
+        peers.push(PeerSource {
+            peer_id: endpoint.peer_id(),
+            addrs,
+        });
+        Ticket { peers, topic }
+    };
+    println!("> ticket to join us: {our_ticket}");
+
+    // create the gossip protocol
+    let gossip = {
+        let gossip = GossipHandle::from_endpoint(endpoint.clone(), Default::default());
+        // insert the gossip handle into the gossip cell to be used in the endpoint callbacks above
+        gossip_cell.set(gossip.clone()).unwrap();
+        // pass our initial peer println to the gossip protocol
+        gossip.update_endpoints(&initial_endpoints)?;
+        gossip
+    };
+
+    // create the sync doc and store
+    let (store, author, doc) = create_document(topic, &keypair)?;
+
+    // spawn our endpoint loop that forwards incoming connections
+    tokio::spawn(endpoint_loop(
+        endpoint.clone(),
+        gossip.clone(),
+        store.clone(),
+    ));
+
+    // spawn an input thread that reads stdin
+    // not using tokio here because they recommend this for "technical reasons"
+    let (line_tx, mut line_rx) = tokio::sync::mpsc::channel::<String>(1);
+    std::thread::spawn(move || input_loop(line_tx));
+
+    // create the live syncer
+    let mut sync_handle = LiveSync::spawn(endpoint.clone(), gossip.clone(), doc.clone(), peers);
+
+    // do some logging
+    doc.on_insert(Box::new(move |origin, entry| {
+        println!("> insert from {origin:?}: {}", fmt_entry(&entry));
+    }));
+
+    // process stdin lines
+    println!("> read to accept commands: set <key> <value> | get <key> | ls | exit");
+    while let Some(text) = line_rx.recv().await {
+        let mut parts = text.split(' ');
+        match [parts.next(), parts.next(), parts.next()] {
+            [Some("set"), Some(key), Some(value)] => {
+                let key = key.to_string();
+                let value = value.to_string();
+                doc.insert(&key, &author, value);
+            }
+            [Some("get"), Some(key), None] => {
+                // TODO: we need a way to get all filtered by key from all authors
+                let mut entries = doc
+                    .all()
+                    .into_iter()
+                    .filter_map(|(id, entry)| (id.key() == key.as_bytes()).then(|| entry));
+                while let Some(entry) = entries.next() {
+                    println!("{} -> {}", fmt_entry(&entry), fmt_content(&doc, &entry));
+                }
+            }
+            [Some("ls"), None, None] => {
+                let all = doc.all();
+                println!("> {} entries", all.len());
+                for (_id, entry) in all {
+                    println!("{} -> {}", fmt_entry(&entry), fmt_content(&doc, &entry));
+                }
+            }
+            [Some("exit"), None, None] => {
+                let res = sync_handle.cancel().await?;
+                println!("syncer closed with {res:?}");
+                break;
+            }
+            _ => println!("> invalid command"),
+        }
+    }
+
+    Ok(())
+}
+
+fn create_document(
+    topic: TopicId,
+    keypair: &Keypair,
+) -> anyhow::Result<(ReplicaStore, Author, Replica)> {
+    let author = Author::from(keypair.secret().clone());
+    let namespace = Namespace::from_bytes(topic.as_bytes());
+    let store = ReplicaStore::default();
+    let doc = store.new_replica(namespace);
+    Ok((store, author, doc))
+}
+
+async fn endpoint_loop(
+    endpoint: MagicEndpoint,
+    gossip: GossipHandle,
+    replica_store: ReplicaStore,
+) -> anyhow::Result<()> {
+    while let Some(mut conn) = endpoint.accept().await {
+        let alpn = get_alpn(&mut conn).await?;
+        println!("> incoming connection with alpn {alpn}");
+        // let (peer_id, alpn, conn) = accept_conn(conn).await?;
+        let res = match alpn.as_bytes() {
+            GOSSIP_ALPN => gossip.handle_connection(conn.await?).await,
+            SYNC_ALPN => iroh::sync::handle_connection(conn, replica_store.clone()).await,
+            _ => Err(anyhow::anyhow!(
+                "ignoring connection: unsupported ALPN protocol"
+            )),
+        };
+        if let Err(err) = res {
+            tracing::error!("connection for {alpn} errored: {err:?}");
+        }
+    }
+    Ok(())
+}
+
+fn input_loop(line_tx: tokio::sync::mpsc::Sender<String>) -> anyhow::Result<()> {
+    let mut buffer = String::new();
+    let stdin = std::io::stdin(); // We get `Stdin` here.
+    loop {
+        stdin.read_line(&mut buffer)?;
+        line_tx.blocking_send(buffer.trim().to_string())?;
+        buffer.clear();
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Ticket {
+    topic: TopicId,
+    peers: Vec<PeerSource>,
+}
+impl Ticket {
+    /// Deserializes from bytes.
+    fn from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        postcard::from_bytes(bytes).map_err(Into::into)
+    }
+    /// Serializes to bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_stdvec(self).expect("postcard::to_stdvec is infallible")
+    }
+}
+
+/// Serializes to base32.
+impl fmt::Display for Ticket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let encoded = self.to_bytes();
+        let mut text = data_encoding::BASE32_NOPAD.encode(&encoded);
+        text.make_ascii_lowercase();
+        write!(f, "{text}")
+    }
+}
+
+/// Deserializes from base32.
+impl FromStr for Ticket {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = data_encoding::BASE32_NOPAD.decode(s.to_ascii_uppercase().as_bytes())?;
+        let slf = Self::from_bytes(&bytes)?;
+        Ok(slf)
+    }
+}
+
+// helpers
+
+fn fmt_entry(entry: &SignedEntry) -> String {
+    let id = entry.entry().id();
+    let key = std::str::from_utf8(id.key()).unwrap_or("<bad key>");
+    let hash = entry.entry().record().content_hash();
+    let author = fmt_hash(id.author().as_bytes());
+    let fmt_hash = fmt_hash(hash.as_bytes());
+    format!("@{author}: {key} = {fmt_hash}")
+}
+fn fmt_content(doc: &Replica, entry: &SignedEntry) -> String {
+    let hash = entry.entry().record().content_hash();
+    let content = doc.get_content(hash);
+    let content = content
+        .map(|content| String::from_utf8(content.into()).unwrap())
+        .unwrap_or_else(|| "<missing content>".into());
+    content
+}
+fn fmt_hash(hash: &[u8]) -> String {
+    let mut text = data_encoding::BASE32_NOPAD.encode(hash);
+    text.make_ascii_lowercase();
+    format!("{}…{}", &text[..5], &text[(text.len() - 2)..])
+}
+fn fmt_secret(keypair: &Keypair) -> String {
+    let mut text = data_encoding::BASE32_NOPAD.encode(&keypair.secret().to_bytes());
+    text.make_ascii_lowercase();
+    text
+}
+fn parse_keypair(secret: &str) -> anyhow::Result<Keypair> {
+    let bytes: [u8; 32] = data_encoding::BASE32_NOPAD
+        .decode(secret.to_ascii_uppercase().as_bytes())?
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("Invalid secret"))?;
+    let key = SigningKey::from_bytes(&bytes);
+    Ok(key.into())
+}
+fn fmt_derp_map(derp_map: &Option<DerpMap>) -> String {
+    match derp_map {
+        None => "None".to_string(),
+        Some(map) => {
+            let regions = map.regions.iter().map(|(id, region)| {
+                let nodes = region.nodes.iter().map(|node| node.url.to_string());
+                (*id, nodes.collect::<Vec<_>>())
+            });
+            format!("{:?}", regions.collect::<Vec<_>>())
+        }
+    }
+}
+fn derp_map_from_url(url: Url) -> anyhow::Result<DerpMap> {
+    Ok(DerpMap::default_from_node(
+        url,
+        DEFAULT_DERP_STUN_PORT,
+        UseIpv4::None,
+        UseIpv6::None,
+    ))
+}

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -9,7 +9,7 @@
 
 use std::{fmt, str::FromStr};
 
-use anyhow::bail;
+use anyhow::{anyhow, bail};
 use clap::Parser;
 use ed25519_dalek::SigningKey;
 use iroh::sync::{LiveSync, PeerSource, SYNC_ALPN};
@@ -81,32 +81,45 @@ async fn run(args: Args) -> anyhow::Result<()> {
     };
     println!("> using DERP servers: {}", fmt_derp_map(&derp_map));
 
-    // init a cell that will hold our gossip handle to be used in endpoint callbacks
-    let gossip_cell: OnceCell<GossipHandle> = OnceCell::new();
-    // init a channel that will emit once the initial endpoints of our local node are discovered
-    let (initial_endpoints_tx, mut initial_endpoints_rx) = mpsc::channel(1);
-
     // build our magic endpoint
-    let gossip_cell_clone = gossip_cell.clone();
-    let endpoint = MagicEndpoint::builder()
-        .keypair(keypair.clone())
-        .alpns(vec![GOSSIP_ALPN.to_vec(), SYNC_ALPN.to_vec()])
-        .derp_map(derp_map)
-        .on_endpoints(Box::new(move |endpoints| {
-            // send our updated endpoints to the gossip protocol to be sent as PeerData to peers
-            if let Some(gossip) = gossip_cell_clone.get() {
-                gossip.update_endpoints(endpoints).ok();
-            }
-            // trigger oneshot on the first endpoint update
-            initial_endpoints_tx.try_send(endpoints.to_vec()).ok();
-        }))
-        .bind(args.bind_port)
-        .await?;
-    println!("> our peer id: {}", endpoint.peer_id());
+    let (endpoint, gossip, initial_endpoints) = {
+        // init a cell that will hold our gossip handle to be used in endpoint callbacks
+        let gossip_cell: OnceCell<GossipHandle> = OnceCell::new();
+        // init a channel that will emit once the initial endpoints of our local node are discovered
+        let (initial_endpoints_tx, mut initial_endpoints_rx) = mpsc::channel(1);
 
-    // wait for a first endpoint update so that we know about at least one of our addrs
-    let initial_endpoints = initial_endpoints_rx.recv().await.unwrap();
-    // println!("> our endpoints: {initial_endpoints:?}");
+        let endpoint = MagicEndpoint::builder()
+            .keypair(keypair.clone())
+            .alpns(vec![GOSSIP_ALPN.to_vec(), SYNC_ALPN.to_vec()])
+            .derp_map(derp_map)
+            .on_endpoints({
+                let gossip_cell = gossip_cell.clone();
+                Box::new(move |endpoints| {
+                    // send our updated endpoints to the gossip protocol to be sent as PeerData to peers
+                    if let Some(gossip) = gossip_cell.get() {
+                        gossip.update_endpoints(endpoints).ok();
+                    }
+                    // trigger oneshot on the first endpoint update
+                    initial_endpoints_tx.try_send(endpoints.to_vec()).ok();
+                })
+            })
+            .bind(args.bind_port)
+            .await?;
+
+        // create the gossip protocol
+        let gossip = {
+            let gossip = GossipHandle::from_endpoint(endpoint.clone(), Default::default());
+            // insert the gossip handle into the gossip cell to be used in the endpoint callbacks above
+            gossip_cell.set(gossip.clone()).unwrap();
+            gossip
+        };
+        // wait for a first endpoint update so that we know about at least one of our addrs
+        let initial_endpoints = initial_endpoints_rx.recv().await.unwrap();
+        // pass our initial endpoints to the gossip protocol
+        gossip.update_endpoints(&initial_endpoints)?;
+        (endpoint, gossip, initial_endpoints)
+    };
+    println!("> our peer id: {}", endpoint.peer_id());
 
     let (topic, peers) = match &args.command {
         Command::Open { doc_name } => {
@@ -124,6 +137,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
         }
     };
 
+    // println!("> our endpoints: {initial_endpoints:?}");
     let our_ticket = {
         // add our local endpoints to the ticket and print it for others to join
         let addrs = initial_endpoints.iter().map(|ep| ep.addr).collect();
@@ -135,16 +149,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
         Ticket { peers, topic }
     };
     println!("> ticket to join us: {our_ticket}");
-
-    // create the gossip protocol
-    let gossip = {
-        let gossip = GossipHandle::from_endpoint(endpoint.clone(), Default::default());
-        // insert the gossip handle into the gossip cell to be used in the endpoint callbacks above
-        gossip_cell.set(gossip.clone()).unwrap();
-        // pass our initial peer println to the gossip protocol
-        gossip.update_endpoints(&initial_endpoints)?;
-        gossip
-    };
 
     // create the sync doc and store
     let (store, author, doc) = create_document(topic, &keypair)?;
@@ -162,7 +166,8 @@ async fn run(args: Args) -> anyhow::Result<()> {
     std::thread::spawn(move || input_loop(line_tx));
 
     // create the live syncer
-    let mut sync_handle = LiveSync::spawn(endpoint.clone(), gossip.clone(), doc.clone(), peers);
+    let sync_handle = LiveSync::spawn(endpoint.clone(), gossip.clone());
+    sync_handle.sync_doc(doc.clone(), peers.clone()).await?;
 
     // do some logging
     doc.on_insert(Box::new(move |origin, entry| {
@@ -172,15 +177,18 @@ async fn run(args: Args) -> anyhow::Result<()> {
     // process stdin lines
     println!("> read to accept commands: set <key> <value> | get <key> | ls | exit");
     while let Some(text) = line_rx.recv().await {
-        let mut parts = text.split(' ');
-        match [parts.next(), parts.next(), parts.next()] {
-            [Some("set"), Some(key), Some(value)] => {
-                let key = key.to_string();
-                let value = value.to_string();
+        let cmd = match Cmd::from_str(&text) {
+            Ok(cmd) => cmd,
+            Err(err) => {
+                println!("> failed to parse command: {}", err);
+                continue;
+            }
+        };
+        match cmd {
+            Cmd::Set { key, value } => {
                 doc.insert(&key, &author, value);
             }
-            [Some("get"), Some(key), None] => {
-                // TODO: we need a way to get all filtered by key from all authors
+            Cmd::Get { key } => {
                 let mut entries = doc
                     .all()
                     .into_iter()
@@ -189,23 +197,46 @@ async fn run(args: Args) -> anyhow::Result<()> {
                     println!("{} -> {}", fmt_entry(&entry), fmt_content(&doc, &entry));
                 }
             }
-            [Some("ls"), None, None] => {
+            Cmd::Ls => {
                 let all = doc.all();
                 println!("> {} entries", all.len());
                 for (_id, entry) in all {
                     println!("{} -> {}", fmt_entry(&entry), fmt_content(&doc, &entry));
                 }
             }
-            [Some("exit"), None, None] => {
+            Cmd::Exit => {
                 let res = sync_handle.cancel().await?;
                 println!("syncer closed with {res:?}");
                 break;
             }
-            _ => println!("> invalid command"),
         }
     }
 
     Ok(())
+}
+
+pub enum Cmd {
+    Set { key: String, value: String },
+    Get { key: String },
+    Ls,
+    Exit,
+}
+impl FromStr for Cmd {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split(' ');
+        match [parts.next(), parts.next(), parts.next()] {
+            [Some("set"), Some(key), Some(value)] => Ok(Self::Set {
+                key: key.into(),
+                value: value.into(),
+            }),
+            [Some("get"), Some(key), None] => Ok(Self::Get { key: key.into() }),
+            [Some("ls"), None, None] => Ok(Self::Ls),
+            [Some("exit"), None, None] => Ok(Self::Exit),
+            _ => Err(anyhow!("invalid command")),
+        }
+    }
 }
 
 fn create_document(
@@ -236,7 +267,7 @@ async fn endpoint_loop(
             )),
         };
         if let Err(err) = res {
-            tracing::error!("connection for {alpn} errored: {err:?}");
+            println!("> connection for {alpn} closed, reason: {err}");
         }
     }
     Ok(())
@@ -294,16 +325,16 @@ impl FromStr for Ticket {
 fn fmt_entry(entry: &SignedEntry) -> String {
     let id = entry.entry().id();
     let key = std::str::from_utf8(id.key()).unwrap_or("<bad key>");
-    let hash = entry.entry().record().content_hash();
     let author = fmt_hash(id.author().as_bytes());
-    let fmt_hash = fmt_hash(hash.as_bytes());
-    format!("@{author}: {key} = {fmt_hash}")
+    let hash = entry.entry().record().content_hash();
+    let hash = fmt_hash(hash.as_bytes());
+    format!("@{author}: {key} = {hash}")
 }
 fn fmt_content(doc: &Replica, entry: &SignedEntry) -> String {
     let hash = entry.entry().record().content_hash();
     let content = doc.get_content(hash);
     let content = content
-        .map(|content| String::from_utf8(content.into()).unwrap())
+        .map(|content| String::from_utf8(content.into()).unwrap_or_else(|_| "<bad content>".into()))
         .unwrap_or_else(|| "<missing content>".into());
     content
 }

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -6,6 +6,7 @@ pub use iroh_net as net;
 
 pub mod node;
 pub mod rpc_protocol;
+#[allow(missing_docs)]
 pub mod sync;
 pub mod util;
 

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -6,6 +6,7 @@ pub use iroh_net as net;
 
 pub mod node;
 pub mod rpc_protocol;
+pub mod sync;
 pub mod util;
 
 /// Expose metrics module

--- a/iroh/src/sync.rs
+++ b/iroh/src/sync.rs
@@ -1,0 +1,234 @@
+use std::net::SocketAddr;
+
+use anyhow::{bail, ensure, Result};
+use bytes::BytesMut;
+use iroh_net::{hp::derp::DerpMap, tls::PeerId, MagicEndpoint};
+use iroh_sync::sync::{NamespaceId, Replica, ReplicaStore};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+pub const SYNC_ALPN: &[u8] = b"n0/iroh-sync/1";
+
+/// Sync Protocol
+///
+/// - Init message: signals which namespace is being synced
+/// - N Sync messages
+///
+/// On any error and on success the substream is closed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum Message {
+    Init {
+        /// Namespace to sync
+        namespace: NamespaceId,
+        /// Initial message
+        message: iroh_sync::sync::ProtocolMessage,
+    },
+    Sync(iroh_sync::sync::ProtocolMessage),
+}
+
+pub async fn run(
+    namespace: String,
+    author: String,
+    addrs: Vec<SocketAddr>,
+    peer: PeerId,
+    derp_map: Option<DerpMap>,
+) -> Result<()> {
+    let namespace: iroh_sync::sync::Namespace = namespace
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid namespace"))?;
+    let author: iroh_sync::sync::Author = author
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid author"))?;
+    println!("Syncing {} with peer {}", namespace.id(), peer);
+    let keylog = false;
+
+    let alice = iroh_sync::sync::Replica::new(namespace.clone());
+
+    alice.insert("alice-is-cool", &author, "alice");
+
+    let endpoint = MagicEndpoint::builder()
+        .keylog(keylog)
+        .derp_map(derp_map)
+        .bind(0)
+        .await?;
+
+    let connection = endpoint.connect(peer, SYNC_ALPN, &addrs).await?;
+    println!("Connected to {}", peer);
+
+    let (mut send_stream, mut recv_stream) = connection.open_bi().await?;
+
+    run_alice(&mut send_stream, &mut recv_stream, &alice).await?;
+
+    println!("sync finished");
+    for (key, value) in alice.all() {
+        println!(
+            "got {:?}\n{:?}\n {:?}\n",
+            std::str::from_utf8(key.key()),
+            key,
+            value
+        );
+    }
+
+    Ok(())
+}
+
+/// Runs the initiator side of the sync protocol.
+async fn run_alice<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    reader: &mut R,
+    alice: &Replica,
+) -> Result<()> {
+    let mut buffer = BytesMut::with_capacity(1024);
+
+    // Init message
+
+    let init_message = Message::Init {
+        namespace: alice.namespace(),
+        message: alice.sync_initial_message(),
+    };
+    let msg_bytes = postcard::to_stdvec(&init_message)?;
+    iroh_bytes::protocol::write_lp(writer, &msg_bytes).await?;
+
+    // Sync message loop
+
+    while let Some(read) = iroh_bytes::protocol::read_lp(&mut *reader, &mut buffer).await? {
+        println!("read {}", read.len());
+        let msg = postcard::from_bytes(&read)?;
+        match msg {
+            Message::Init { .. } => {
+                bail!("unexpected message: init");
+            }
+            Message::Sync(msg) => {
+                if let Some(msg) = alice.sync_process_message(msg) {
+                    send_sync_message(writer, msg).await?;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn handle_connection(
+    connecting: quinn::Connecting,
+    replica_store: ReplicaStore,
+) -> Result<()> {
+    let connection = connecting.await?;
+    let (mut send_stream, mut recv_stream) = connection.accept_bi().await?;
+
+    run_bob(&mut send_stream, &mut recv_stream, replica_store).await?;
+    send_stream.finish().await?;
+
+    println!("done");
+
+    Ok(())
+}
+
+/// Runs the receiver side of the sync protocol.
+async fn run_bob<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    reader: &mut R,
+    replica_store: ReplicaStore,
+) -> Result<()> {
+    let mut buffer = BytesMut::with_capacity(1024);
+
+    let mut replica = None;
+    while let Some(read) = iroh_bytes::protocol::read_lp(&mut *reader, &mut buffer).await? {
+        println!("read {}", read.len());
+        let msg = postcard::from_bytes(&read)?;
+
+        match msg {
+            Message::Init { namespace, message } => {
+                ensure!(replica.is_none(), "double init message");
+
+                match replica_store.get_replica(&namespace) {
+                    Some(r) => {
+                        println!("starting sync for {}", namespace);
+                        if let Some(msg) = r.sync_process_message(message) {
+                            send_sync_message(writer, msg).await?;
+                        } else {
+                            break;
+                        }
+                        replica = Some(r);
+                    }
+                    None => {
+                        // TODO: this should be possible.
+                        bail!("unable to synchronize unknown namespace: {}", namespace);
+                    }
+                }
+            }
+            Message::Sync(msg) => match replica {
+                Some(ref replica) => {
+                    if let Some(msg) = replica.sync_process_message(msg) {
+                        send_sync_message(writer, msg).await?;
+                    } else {
+                        break;
+                    }
+                }
+                None => {
+                    bail!("unexpected sync message without init");
+                }
+            },
+        }
+    }
+
+    Ok(())
+}
+
+async fn send_sync_message<W: AsyncWrite + Unpin>(
+    stream: &mut W,
+    msg: iroh_sync::sync::ProtocolMessage,
+) -> Result<()> {
+    let msg_bytes = postcard::to_stdvec(&Message::Sync(msg))?;
+    iroh_bytes::protocol::write_lp(stream, &msg_bytes).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use iroh_sync::sync::Namespace;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_sync_simple() -> Result<()> {
+        let mut rng = rand::thread_rng();
+
+        let replica_store = ReplicaStore::default();
+        // For now uses same author on both sides.
+        let author = replica_store.new_author(&mut rng);
+        let namespace = Namespace::new(&mut rng);
+        let bob_replica = replica_store.new_replica(namespace.clone());
+        bob_replica.insert("hello alice", &author, "from bob");
+
+        let alice_replica = Replica::new(namespace.clone());
+        alice_replica.insert("hello bob", &author, "from alice");
+
+        assert_eq!(bob_replica.all().len(), 1);
+        assert_eq!(alice_replica.all().len(), 1);
+
+        let (alice, bob) = tokio::io::duplex(64);
+
+        let (mut alice_reader, mut alice_writer) = tokio::io::split(alice);
+        let replica = alice_replica.clone();
+        let alice_task = tokio::task::spawn(async move {
+            run_alice(&mut alice_writer, &mut alice_reader, &replica).await
+        });
+
+        let (mut bob_reader, mut bob_writer) = tokio::io::split(bob);
+        let bob_replica_store = replica_store.clone();
+        let bob_task = tokio::task::spawn(async move {
+            run_bob(&mut bob_writer, &mut bob_reader, bob_replica_store).await
+        });
+
+        alice_task.await??;
+        bob_task.await??;
+
+        assert_eq!(bob_replica.all().len(), 2);
+        assert_eq!(alice_replica.all().len(), 2);
+
+        Ok(())
+    }
+}

--- a/iroh/src/sync.rs
+++ b/iroh/src/sync.rs
@@ -83,7 +83,7 @@ pub async fn connect_and_sync(
         .await
         .context("dial_and_sync")?;
     let (mut send_stream, mut recv_stream) = connection.open_bi().await?;
-    let res = run_alice(&mut send_stream, &mut recv_stream, &doc).await;
+    let res = run_alice(&mut send_stream, &mut recv_stream, doc).await;
     debug!("sync with peer {}: finish {:?}", peer_id, res);
     res
 }

--- a/iroh/src/sync/live.rs
+++ b/iroh/src/sync/live.rs
@@ -1,0 +1,281 @@
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+
+use crate::sync::connect_and_sync;
+use anyhow::{anyhow, Context};
+use futures::{
+    future::{BoxFuture, Shared},
+    stream::FuturesUnordered,
+    FutureExt, TryFutureExt,
+};
+use iroh_gossip::{
+    net::{Event, GossipHandle},
+    proto::TopicId,
+};
+use iroh_net::{tls::PeerId, MagicEndpoint};
+use iroh_sync::sync::{InsertOrigin, Replica, SignedEntry};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    sync::{broadcast, mpsc},
+    task::JoinError,
+};
+use tokio_stream::StreamExt;
+use tracing::error;
+
+const CHANNEL_CAP: usize = 8;
+
+/// The address to connect to a peer
+/// TODO: Move into iroh-net
+/// TODO: Make an enum and support DNS resolution
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PeerSource {
+    pub peer_id: PeerId,
+    pub addrs: Vec<SocketAddr>,
+    // derp_region: usize
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Op {
+    Put(SignedEntry),
+}
+
+#[derive(Debug)]
+enum SyncState {
+    Running,
+    Finished,
+    Failed(anyhow::Error),
+}
+
+#[derive(Debug)]
+pub enum ToActor {
+    Shutdown,
+}
+
+/// Handle to a running live sync actor
+#[derive(Debug, Clone)]
+pub struct LiveSync {
+    to_actor_tx: mpsc::Sender<ToActor>,
+    task: Shared<BoxFuture<'static, Result<(), Arc<JoinError>>>>,
+}
+
+impl LiveSync {
+    pub fn spawn(
+        endpoint: MagicEndpoint,
+        gossip: GossipHandle,
+        doc: Replica,
+        initial_peers: Vec<PeerSource>,
+    ) -> Self {
+        let (to_actor_tx, to_actor_rx) = mpsc::channel(CHANNEL_CAP);
+        let mut actor = Actor::new(endpoint, gossip, doc, initial_peers, to_actor_rx);
+        let task = tokio::spawn(async move { actor.run().await });
+        let handle = LiveSync {
+            to_actor_tx,
+            task: task.map_err(Arc::new).boxed().shared(),
+        };
+        handle
+    }
+
+    /// Cancel the live sync.
+    pub async fn cancel(&mut self) -> anyhow::Result<()> {
+        self.to_actor_tx.send(ToActor::Shutdown).await?;
+        self.task.clone().await?;
+        Ok(())
+    }
+}
+
+// TODO: Right now works with a single doc. Can quite easily be extended to work on a set of
+// replicas. Then the handle above could have a
+// `join_doc(doc: Replica, initial_peers: Vec<PeerSource)`
+// method to send new replicas to the actor. Will be more efficient than spawning an actor per
+// document likely.
+// TODO: Also add `handle_connection` to the replica and track incoming sync requests here too.
+// Currently peers might double-sync in both directions.
+#[derive(Debug)]
+struct Actor {
+    replica: Replica,
+    endpoint: MagicEndpoint,
+    initial_peers: Vec<PeerSource>,
+    gossip_stream: GossipStream,
+    to_actor_rx: mpsc::Receiver<ToActor>,
+    insert_entry_rx: mpsc::UnboundedReceiver<SignedEntry>,
+    sync_state: HashMap<PeerId, SyncState>,
+    gossip: GossipHandle,
+    running_sync_tasks: FuturesUnordered<tokio::task::JoinHandle<(PeerId, anyhow::Result<()>)>>,
+}
+
+impl Actor {
+    pub fn new(
+        endpoint: MagicEndpoint,
+        gossip: GossipHandle,
+        replica: Replica,
+        initial_peers: Vec<PeerSource>,
+        to_actor_rx: mpsc::Receiver<ToActor>,
+    ) -> Self {
+        // TODO: instead of an unbounded channel, we'd want a FIFO ring buffer likely
+        // (we have to send from the blocking Replica::on_insert callback, so we need a channel
+        // with nonblocking sending, so either unbounded or ringbuffer like)
+        let (insert_tx, insert_rx) = mpsc::unbounded_channel();
+        // let (to_actor_tx, to_actor_rx) = mpsc::channel(CHANNEL_CAP);
+        // setup replica insert notifications.
+        replica.on_insert(Box::new(move |origin, entry| {
+            // only care for local inserts, otherwise we'd do endless gossip loops
+            if let InsertOrigin::Local = origin {
+                insert_tx.send(entry.clone()).ok();
+            }
+        }));
+
+        // setup a gossip subscripion
+        let peer_ids: Vec<PeerId> = initial_peers.iter().map(|p| p.peer_id.clone()).collect();
+        let topic: TopicId = replica.namespace().as_bytes().into();
+        let gossip_subscription = GossipStream::new(gossip.clone(), topic, peer_ids);
+
+        Self {
+            gossip,
+            replica,
+            endpoint,
+            gossip_stream: gossip_subscription,
+            insert_entry_rx: insert_rx,
+            to_actor_rx,
+            sync_state: Default::default(),
+            running_sync_tasks: Default::default(),
+            initial_peers,
+        }
+    }
+    pub async fn run(&mut self) {
+        if let Err(err) = self.run_inner().await {
+            error!("live sync failed: {err:?}");
+        }
+    }
+
+    async fn run_inner(&mut self) -> anyhow::Result<()> {
+        // add addresses of initial peers to our endpoint address book
+        for peer in &self.initial_peers {
+            self.endpoint
+                .add_known_addrs(peer.peer_id, &peer.addrs)
+                .await?;
+        }
+        // trigger initial sync with initial peers
+        for peer in self.initial_peers.clone().iter().map(|p| p.peer_id) {
+            self.sync_with_peer(peer);
+        }
+        loop {
+            tokio::select! {
+                biased;
+                msg = self.to_actor_rx.recv() => {
+                    match msg {
+                        // received shutdown signal, or livesync handle was dropped: break loop and
+                        // exit
+                        Some(ToActor::Shutdown) | None => break,
+                    }
+                }
+                // new gossip message
+                event = self.gossip_stream.next() => {
+                    if let Err(err) = self.on_gossip_event(event?) {
+                        error!("Failed to process gossip event: {err:?}");
+                    }
+                },
+                entry = self.insert_entry_rx.recv() => {
+                    let entry = entry.ok_or_else(|| anyhow!("insert_rx returned None"))?;
+                    self.on_insert_entry(entry).await?;
+                }
+                Some(res) = self.running_sync_tasks.next() => {
+                    let (peer, res) = res.context("task sync_with_peer paniced")?;
+                    self.on_sync_finished(peer, res);
+
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn sync_with_peer(&mut self, peer: PeerId) {
+        // Check if we synced and only start sync if not yet synced
+        // sync_with_peer is triggered on NeighborUp events, so might trigger repeatedly for the
+        // same peers.
+        // TODO: Track finished time and potentially re-run sync
+        if let Some(_state) = self.sync_state.get(&peer) {
+            return;
+        };
+        self.sync_state.insert(peer, SyncState::Running);
+        let task = {
+            let endpoint = self.endpoint.clone();
+            let replica = self.replica.clone();
+            tokio::spawn(async move {
+                println!("> connect and sync with {peer}");
+                let res = connect_and_sync(&endpoint, &replica, peer, &[]).await;
+                println!("> sync with {peer} done: {res:?}");
+                (peer, res)
+            })
+        };
+        self.running_sync_tasks.push(task);
+    }
+
+    fn on_sync_finished(&mut self, peer: PeerId, res: anyhow::Result<()>) {
+        let state = match res {
+            Ok(_) => SyncState::Finished,
+            Err(err) => SyncState::Failed(err),
+        };
+        self.sync_state.insert(peer, state);
+    }
+
+    fn on_gossip_event(&mut self, event: Event) -> anyhow::Result<()> {
+        match event {
+            // We received a gossip message. Try to insert it into our replica.
+            Event::Received(data) => {
+                let op: Op = postcard::from_bytes(&data)?;
+                match op {
+                    Op::Put(entry) => {
+                        self.replica.insert_remote_entry(entry)?;
+                    }
+                }
+            }
+            // A new neighbor appeared in the gossip swarm. Try to sync with it directly.
+            // [Self::sync_with_peer] will check to not resync with peers synced previously in the
+            // same session. TODO: Maybe this is too broad and leads to too many sync requests.
+            Event::NeighborUp(peer) => {
+                self.sync_with_peer(peer);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// A new entry was inserted locally. Broadcast a gossip message.
+    async fn on_insert_entry(&mut self, entry: SignedEntry) -> anyhow::Result<()> {
+        let op = Op::Put(entry);
+        let topic: TopicId = self.replica.namespace().as_bytes().into();
+        self.gossip
+            .broadcast(topic, postcard::to_stdvec(&op)?.into())
+            .await?;
+        Ok(())
+    }
+}
+
+// TODO: If this is the API surface we want move to iroh-gossip/src/net and make this be
+// GossipHandle::subscribe
+#[derive(Debug)]
+pub enum GossipStream {
+    Joining(GossipHandle, TopicId, Vec<PeerId>),
+    Running(broadcast::Receiver<Event>),
+}
+
+impl GossipStream {
+    pub fn new(gossip: GossipHandle, topic: TopicId, peers: Vec<PeerId>) -> Self {
+        Self::Joining(gossip, topic, peers)
+    }
+    pub async fn next(&mut self) -> anyhow::Result<Event> {
+        loop {
+            match self {
+                Self::Joining(gossip, topic, peers) => {
+                    // TODO: avoid the clone
+                    gossip.join(*topic, peers.clone()).await?;
+                    let sub = gossip.subscribe(*topic).await?;
+                    *self = Self::Running(sub);
+                }
+                Self::Running(sub) => {
+                    let ret = sub.recv().await.map_err(|e| e.into());
+                    return ret;
+                }
+            }
+        }
+    }
+}

--- a/iroh/src/sync/live.rs
+++ b/iroh/src/sync/live.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use crate::sync::connect_and_sync;
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Result};
 use futures::{
     future::{BoxFuture, Shared},
-    stream::FuturesUnordered,
+    stream::{BoxStream, FuturesUnordered, StreamExt},
     FutureExt, TryFutureExt,
 };
 use iroh_gossip::{
@@ -14,11 +14,7 @@ use iroh_gossip::{
 use iroh_net::{tls::PeerId, MagicEndpoint};
 use iroh_sync::sync::{InsertOrigin, Replica, SignedEntry};
 use serde::{Deserialize, Serialize};
-use tokio::{
-    sync::{broadcast, mpsc},
-    task::JoinError,
-};
-use tokio_stream::StreamExt;
+use tokio::{sync::mpsc, task::JoinError};
 use tracing::error;
 
 const CHANNEL_CAP: usize = 8;
@@ -47,6 +43,10 @@ enum SyncState {
 
 #[derive(Debug)]
 pub enum ToActor {
+    SyncDoc {
+        doc: Replica,
+        initial_peers: Vec<PeerSource>,
+    },
     Shutdown,
 }
 
@@ -58,15 +58,14 @@ pub struct LiveSync {
 }
 
 impl LiveSync {
-    pub fn spawn(
-        endpoint: MagicEndpoint,
-        gossip: GossipHandle,
-        doc: Replica,
-        initial_peers: Vec<PeerSource>,
-    ) -> Self {
+    pub fn spawn(endpoint: MagicEndpoint, gossip: GossipHandle) -> Self {
         let (to_actor_tx, to_actor_rx) = mpsc::channel(CHANNEL_CAP);
-        let mut actor = Actor::new(endpoint, gossip, doc, initial_peers, to_actor_rx);
-        let task = tokio::spawn(async move { actor.run().await });
+        let mut actor = Actor::new(endpoint, gossip, to_actor_rx);
+        let task = tokio::spawn(async move {
+            if let Err(err) = actor.run().await {
+                error!("live sync failed: {err:?}");
+            }
+        });
         let handle = LiveSync {
             to_actor_tx,
             task: task.map_err(Arc::new).boxed().shared(),
@@ -75,207 +74,203 @@ impl LiveSync {
     }
 
     /// Cancel the live sync.
-    pub async fn cancel(&mut self) -> anyhow::Result<()> {
+    pub async fn cancel(&self) -> Result<()> {
         self.to_actor_tx.send(ToActor::Shutdown).await?;
         self.task.clone().await?;
         Ok(())
     }
+
+    pub async fn sync_doc(&self, doc: Replica, initial_peers: Vec<PeerSource>) -> Result<()> {
+        self.to_actor_tx
+            .send(ToActor::SyncDoc { doc, initial_peers })
+            .await?;
+        Ok(())
+    }
 }
 
-// TODO: Right now works with a single doc. Can quite easily be extended to work on a set of
-// replicas. Then the handle above could have a
-// `join_doc(doc: Replica, initial_peers: Vec<PeerSource)`
-// method to send new replicas to the actor. Will be more efficient than spawning an actor per
-// document likely.
 // TODO: Also add `handle_connection` to the replica and track incoming sync requests here too.
 // Currently peers might double-sync in both directions.
-#[derive(Debug)]
 struct Actor {
-    replica: Replica,
     endpoint: MagicEndpoint,
-    initial_peers: Vec<PeerSource>,
-    gossip_stream: GossipStream,
-    to_actor_rx: mpsc::Receiver<ToActor>,
-    insert_entry_rx: mpsc::UnboundedReceiver<SignedEntry>,
-    sync_state: HashMap<PeerId, SyncState>,
     gossip: GossipHandle,
-    running_sync_tasks: FuturesUnordered<tokio::task::JoinHandle<(PeerId, anyhow::Result<()>)>>,
+
+    docs: HashMap<TopicId, Replica>,
+    subscription: BoxStream<'static, Result<(TopicId, Event)>>,
+    sync_state: HashMap<(TopicId, PeerId), SyncState>,
+
+    to_actor_rx: mpsc::Receiver<ToActor>,
+    insert_entry_tx: mpsc::UnboundedSender<(TopicId, SignedEntry)>,
+    insert_entry_rx: mpsc::UnboundedReceiver<(TopicId, SignedEntry)>,
+
+    pending_syncs: FuturesUnordered<BoxFuture<'static, (TopicId, PeerId, Result<()>)>>,
+    pending_joins: FuturesUnordered<BoxFuture<'static, (TopicId, Result<()>)>>,
 }
 
 impl Actor {
     pub fn new(
         endpoint: MagicEndpoint,
         gossip: GossipHandle,
-        replica: Replica,
-        initial_peers: Vec<PeerSource>,
         to_actor_rx: mpsc::Receiver<ToActor>,
     ) -> Self {
         // TODO: instead of an unbounded channel, we'd want a FIFO ring buffer likely
         // (we have to send from the blocking Replica::on_insert callback, so we need a channel
         // with nonblocking sending, so either unbounded or ringbuffer like)
         let (insert_tx, insert_rx) = mpsc::unbounded_channel();
-        // let (to_actor_tx, to_actor_rx) = mpsc::channel(CHANNEL_CAP);
-        // setup replica insert notifications.
-        replica.on_insert(Box::new(move |origin, entry| {
-            // only care for local inserts, otherwise we'd do endless gossip loops
-            if let InsertOrigin::Local = origin {
-                insert_tx.send(entry.clone()).ok();
-            }
-        }));
-
-        // setup a gossip subscripion
-        let peer_ids: Vec<PeerId> = initial_peers.iter().map(|p| p.peer_id.clone()).collect();
-        let topic: TopicId = replica.namespace().as_bytes().into();
-        let gossip_subscription = GossipStream::new(gossip.clone(), topic, peer_ids);
+        let sub = gossip.clone().subscribe_all().boxed();
 
         Self {
             gossip,
-            replica,
+            // replica,
             endpoint,
-            gossip_stream: gossip_subscription,
+            // gossip_stream: gossip_subscription,
             insert_entry_rx: insert_rx,
+            insert_entry_tx: insert_tx,
             to_actor_rx,
             sync_state: Default::default(),
-            running_sync_tasks: Default::default(),
-            initial_peers,
-        }
-    }
-    pub async fn run(&mut self) {
-        if let Err(err) = self.run_inner().await {
-            error!("live sync failed: {err:?}");
+            pending_syncs: Default::default(),
+            // initial_peers,
+            pending_joins: Default::default(),
+            docs: Default::default(),
+            subscription: sub,
         }
     }
 
-    async fn run_inner(&mut self) -> anyhow::Result<()> {
-        // add addresses of initial peers to our endpoint address book
-        for peer in &self.initial_peers {
-            self.endpoint
-                .add_known_addrs(peer.peer_id, &peer.addrs)
-                .await?;
-        }
-        // trigger initial sync with initial peers
-        for peer in self.initial_peers.clone().iter().map(|p| p.peer_id) {
-            self.sync_with_peer(peer);
-        }
+    async fn run(&mut self) -> Result<()> {
         loop {
             tokio::select! {
                 biased;
                 msg = self.to_actor_rx.recv() => {
                     match msg {
-                        // received shutdown signal, or livesync handle was dropped: break loop and
-                        // exit
+                        // received shutdown signal, or livesync handle was dropped:
+                        // break loop and exit
                         Some(ToActor::Shutdown) | None => break,
+                        Some(ToActor::SyncDoc { doc, initial_peers }) => self.insert_doc(doc, initial_peers).await?,
                     }
                 }
                 // new gossip message
-                event = self.gossip_stream.next() => {
-                    if let Err(err) = self.on_gossip_event(event?) {
+                Some(event) = self.subscription.next() => {
+                    let (topic, event) = event?;
+                    if let Err(err) = self.on_gossip_event(topic, event) {
                         error!("Failed to process gossip event: {err:?}");
                     }
                 },
                 entry = self.insert_entry_rx.recv() => {
-                    let entry = entry.ok_or_else(|| anyhow!("insert_rx returned None"))?;
-                    self.on_insert_entry(entry).await?;
+                    let (topic, entry) = entry.ok_or_else(|| anyhow!("insert_rx returned None"))?;
+                    self.on_insert_entry(topic, entry).await?;
                 }
-                Some(res) = self.running_sync_tasks.next() => {
-                    let (peer, res) = res.context("task sync_with_peer paniced")?;
-                    self.on_sync_finished(peer, res);
+                Some((topic, peer, res)) = self.pending_syncs.next() => {
+                    // let (topic, peer, res) = res.context("task sync_with_peer paniced")?;
+                    self.on_sync_finished(topic, peer, res);
 
+                }
+                Some((topic, res)) = self.pending_joins.next() => {
+                    if let Err(err) = res {
+                        error!("failed to join {topic:?}: {err:?}");
+                    }
+                    // TODO: maintain some join state
                 }
             }
         }
         Ok(())
     }
 
-    fn sync_with_peer(&mut self, peer: PeerId) {
+    fn sync_with_peer(&mut self, topic: TopicId, peer: PeerId) {
+        let Some(doc) = self.docs.get(&topic) else {
+            return;
+        };
         // Check if we synced and only start sync if not yet synced
         // sync_with_peer is triggered on NeighborUp events, so might trigger repeatedly for the
         // same peers.
         // TODO: Track finished time and potentially re-run sync
-        if let Some(_state) = self.sync_state.get(&peer) {
+        if let Some(_state) = self.sync_state.get(&(topic, peer)) {
             return;
         };
-        self.sync_state.insert(peer, SyncState::Running);
+        // TODO: fixme (doc_id, peer)
+        self.sync_state.insert((topic, peer), SyncState::Running);
         let task = {
             let endpoint = self.endpoint.clone();
-            let replica = self.replica.clone();
-            tokio::spawn(async move {
+            let doc = doc.clone();
+            async move {
                 println!("> connect and sync with {peer}");
-                let res = connect_and_sync(&endpoint, &replica, peer, &[]).await;
+                let res = connect_and_sync(&endpoint, &doc, peer, &[]).await;
                 println!("> sync with {peer} done: {res:?}");
-                (peer, res)
-            })
+                (topic, peer, res)
+            }
+            .boxed()
         };
-        self.running_sync_tasks.push(task);
+        self.pending_syncs.push(task);
     }
 
-    fn on_sync_finished(&mut self, peer: PeerId, res: anyhow::Result<()>) {
+    async fn insert_doc(&mut self, doc: Replica, initial_peers: Vec<PeerSource>) -> Result<()> {
+        let peer_ids: Vec<PeerId> = initial_peers.iter().map(|p| p.peer_id.clone()).collect();
+        let topic: TopicId = doc.namespace().as_bytes().into();
+        // join gossip for the topic to receive and send message
+        // let gossip = self.gossip.clone();
+        self.pending_joins.push({
+            let peer_ids = peer_ids.clone();
+            let gossip = self.gossip.clone();
+            async move {
+                let res = gossip.join(topic, peer_ids).await;
+                (topic, res)
+            }
+            .boxed()
+        });
+        // setup replica insert notifications.
+        let insert_entry_tx = self.insert_entry_tx.clone();
+        doc.on_insert(Box::new(move |origin, entry| {
+            // only care for local inserts, otherwise we'd do endless gossip loops
+            if let InsertOrigin::Local = origin {
+                insert_entry_tx.send((topic, entry.clone())).ok();
+            }
+        }));
+        self.docs.insert(topic, doc);
+        // add addresses of initial peers to our endpoint address book
+        for peer in &initial_peers {
+            self.endpoint
+                .add_known_addrs(peer.peer_id, &peer.addrs)
+                .await?;
+        }
+        // trigger initial sync with initial peers
+        for peer in peer_ids {
+            self.sync_with_peer(topic, peer);
+        }
+        Ok(())
+    }
+
+    fn on_sync_finished(&mut self, topic: TopicId, peer: PeerId, res: Result<()>) {
         let state = match res {
             Ok(_) => SyncState::Finished,
             Err(err) => SyncState::Failed(err),
         };
-        self.sync_state.insert(peer, state);
+        self.sync_state.insert((topic, peer), state);
     }
 
-    fn on_gossip_event(&mut self, event: Event) -> anyhow::Result<()> {
+    fn on_gossip_event(&mut self, topic: TopicId, event: Event) -> Result<()> {
+        let Some(doc) = self.docs.get(&topic) else {
+            return Err(anyhow!("Missing doc for {topic:?}"));
+        };
         match event {
             // We received a gossip message. Try to insert it into our replica.
             Event::Received(data) => {
                 let op: Op = postcard::from_bytes(&data)?;
                 match op {
-                    Op::Put(entry) => {
-                        self.replica.insert_remote_entry(entry)?;
-                    }
+                    Op::Put(entry) => doc.insert_remote_entry(entry)?,
                 }
             }
             // A new neighbor appeared in the gossip swarm. Try to sync with it directly.
             // [Self::sync_with_peer] will check to not resync with peers synced previously in the
             // same session. TODO: Maybe this is too broad and leads to too many sync requests.
-            Event::NeighborUp(peer) => {
-                self.sync_with_peer(peer);
-            }
+            Event::NeighborUp(peer) => self.sync_with_peer(topic, peer),
             _ => {}
         }
         Ok(())
     }
 
     /// A new entry was inserted locally. Broadcast a gossip message.
-    async fn on_insert_entry(&mut self, entry: SignedEntry) -> anyhow::Result<()> {
+    async fn on_insert_entry(&mut self, topic: TopicId, entry: SignedEntry) -> Result<()> {
         let op = Op::Put(entry);
-        let topic: TopicId = self.replica.namespace().as_bytes().into();
-        self.gossip
-            .broadcast(topic, postcard::to_stdvec(&op)?.into())
-            .await?;
+        let message = postcard::to_stdvec(&op)?.into();
+        self.gossip.broadcast(topic, message).await?;
         Ok(())
-    }
-}
-
-// TODO: If this is the API surface we want move to iroh-gossip/src/net and make this be
-// GossipHandle::subscribe
-#[derive(Debug)]
-pub enum GossipStream {
-    Joining(GossipHandle, TopicId, Vec<PeerId>),
-    Running(broadcast::Receiver<Event>),
-}
-
-impl GossipStream {
-    pub fn new(gossip: GossipHandle, topic: TopicId, peers: Vec<PeerId>) -> Self {
-        Self::Joining(gossip, topic, peers)
-    }
-    pub async fn next(&mut self) -> anyhow::Result<Event> {
-        loop {
-            match self {
-                Self::Joining(gossip, topic, peers) => {
-                    // TODO: avoid the clone
-                    gossip.join(*topic, peers.clone()).await?;
-                    let sub = gossip.subscribe(*topic).await?;
-                    *self = Self::Running(sub);
-                }
-                Self::Running(sub) => {
-                    let ret = sub.recv().await.map_err(|e| e.into());
-                    return ret;
-                }
-            }
-        }
     }
 }

--- a/iroh/src/sync/live.rs
+++ b/iroh/src/sync/live.rs
@@ -15,7 +15,7 @@ use iroh_net::{tls::PeerId, MagicEndpoint};
 use iroh_sync::sync::{InsertOrigin, Replica, SignedEntry};
 use serde::{Deserialize, Serialize};
 use tokio::{sync::mpsc, task::JoinError};
-use tracing::error;
+use tracing::{debug, error};
 
 const CHANNEL_CAP: usize = 8;
 
@@ -120,15 +120,12 @@ impl Actor {
 
         Self {
             gossip,
-            // replica,
             endpoint,
-            // gossip_stream: gossip_subscription,
             insert_entry_rx: insert_rx,
             insert_entry_tx: insert_tx,
             to_actor_rx,
             sync_state: Default::default(),
             pending_syncs: Default::default(),
-            // initial_peers,
             pending_joins: Default::default(),
             docs: Default::default(),
             subscription: sub,
@@ -191,9 +188,9 @@ impl Actor {
             let endpoint = self.endpoint.clone();
             let doc = doc.clone();
             async move {
-                println!("> connect and sync with {peer}");
+                debug!("sync with {peer}");
                 let res = connect_and_sync(&endpoint, &doc, peer, &[]).await;
-                println!("> sync with {peer} done: {res:?}");
+                debug!("> synced with {peer}: {res:?}");
                 (topic, peer, res)
             }
             .boxed()
@@ -202,7 +199,7 @@ impl Actor {
     }
 
     async fn insert_doc(&mut self, doc: Replica, initial_peers: Vec<PeerSource>) -> Result<()> {
-        let peer_ids: Vec<PeerId> = initial_peers.iter().map(|p| p.peer_id.clone()).collect();
+        let peer_ids: Vec<PeerId> = initial_peers.iter().map(|p| p.peer_id).collect();
         let topic: TopicId = doc.namespace().as_bytes().into();
         // join gossip for the topic to receive and send message
         // let gossip = self.gossip.clone();
@@ -220,7 +217,7 @@ impl Actor {
         doc.on_insert(Box::new(move |origin, entry| {
             // only care for local inserts, otherwise we'd do endless gossip loops
             if let InsertOrigin::Local = origin {
-                insert_entry_tx.send((topic, entry.clone())).ok();
+                insert_entry_tx.send((topic, entry)).ok();
             }
         }));
         self.docs.insert(topic, doc);


### PR DESCRIPTION
This PR starts with a rebase of #1127 on top of #1149

The main addition so far is `iroh/src/sync/live.rs` which integrates iroh-sync and iroh-gossip to provide live synchronization of a iroh-sync document among peers.
There's also an example in `iroh/examples/sync.rs` that showcases live editing a document with peers.

There is no integration yet with `iroh-bytes` which also means that the content of entries inserted by peers is missing (only the hash is there). Integration with iroh-bytes will be next.

Also there's lots of TODOs in the code. 

~~And something seems to be off for the initial sync (that actually uses iroh-sync). It does not work reliably right now, looking into debugging next.~~ a commit was missing, now fixed