### PR TITLE
fix(iroh): pass derp-map on get-options

### DIFF
--- a/iroh-bytes/src/provider/ticket.rs
+++ b/iroh-bytes/src/provider/ticket.rs
@@ -8,6 +8,7 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::{ensure, Result};
+use iroh_net::hp::derp::DerpMap;
 use iroh_net::tls::{Keypair, PeerId};
 use serde::{Deserialize, Serialize};
 
@@ -93,13 +94,13 @@ impl Ticket {
         (hash, peer, addrs, token)
     }
 
-    pub fn as_get_options(&self, keypair: Keypair) -> get::Options {
+    pub fn as_get_options(&self, keypair: Keypair, derp_map: Option<DerpMap>) -> get::Options {
         get::Options {
             peer_id: self.peer,
             addrs: self.addrs.clone(),
             keypair,
             keylog: true,
-            derp_map: None,
+            derp_map,
         }
     }
 }

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -70,7 +70,7 @@ impl Cli {
                 let get = if let Some(ticket) = ticket {
                     self::get::GetInteractive {
                         hash: ticket.hash(),
-                        opts: ticket.as_get_options(Keypair::generate()),
+                        opts: ticket.as_get_options(Keypair::generate(), config.derp_map()),
                         token: ticket.token().cloned(),
                         single: false,
                     }

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -492,7 +492,7 @@ async fn test_run_ticket() {
 
     let no_token_ticket = node.ticket(hash, None).await.unwrap();
     tokio::time::timeout(Duration::from_secs(10), async move {
-        let opts = no_token_ticket.as_get_options(Keypair::generate());
+        let opts = no_token_ticket.as_get_options(Keypair::generate(), None);
         let request = GetRequest::all(no_token_ticket.hash()).into();
         let response = run_get_request(opts, request).await;
         assert!(response.is_err());
@@ -507,7 +507,7 @@ async fn test_run_ticket() {
         let request = GetRequest::all(hash)
             .with_token(ticket.token().cloned())
             .into();
-        run_get_request(ticket.as_get_options(Keypair::generate()), request).await
+        run_get_request(ticket.as_get_options(Keypair::generate(), None), request).await
     })
     .await
     .expect("timeout")


### PR DESCRIPTION
The derp map was not properly set when using `get --ticket`, which resulted in issues in the netsim tests, as now derp node was known on the `get` side.