### PR TITLE
ref(tests): consistent test module naming

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -399,7 +399,7 @@ pub async fn get_peer_id(connection: &quinn::Connection) -> anyhow::Result<PeerI
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use futures::future::BoxFuture;
 
     use super::{accept_conn, MagicEndpoint};


### PR DESCRIPTION
All other modules are called "tests".  There is one more "test" module
but it provides helpers and not tests.  Might move some time move some
time as well but doing that right now would give merge conflicts with
another of my PRs...