### PR TITLE
feat(docs): Check rustdoc more strictly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.65"
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Docs
-      run: cargo doc --workspace --all-features --no-deps
+      run: cargo doc --workspace --all-features --no-deps --document-private-items
 
   clippy_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Docs
-      run: cargo doc
+      run: cargo doc --workspace --all-features --no-deps
 
   clippy_check:
     runs-on: ubuntu-latest

--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -22,7 +22,7 @@ pub(crate) const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 100;
 pub const ALPN: [u8; 13] = *b"/iroh-bytes/2";
 
 /// Maximum size of a request token, matches a browser cookie max size:
-/// https://datatracker.ietf.org/doc/html/rfc2109#section-6.3
+/// <https://datatracker.ietf.org/doc/html/rfc2109#section-6.3>.
 const MAX_REQUEST_TOKEN_SIZE: usize = 4096;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, From)]

--- a/iroh-net/src/bin/derper.rs
+++ b/iroh-net/src/bin/derper.rs
@@ -158,7 +158,7 @@ struct Config {
     private_key: key::node::SecretKey,
     /// Server listen address.
     ///
-    /// Defaults to [::]:443.
+    /// Defaults to `[::]:443`.
     ///
     /// If the port address is 443, the derper will issue a warning if it is started
     /// without a `tls` config.

--- a/iroh-net/src/bin/derper.rs
+++ b/iroh-net/src/bin/derper.rs
@@ -158,7 +158,7 @@ struct Config {
     private_key: key::node::SecretKey,
     /// Server listen address.
     ///
-    /// Defaults to `[::]:443`.
+    /// Defaults to [::]:443.
     ///
     /// If the port address is 443, the derper will issue a warning if it is started
     /// without a `tls` config.

--- a/iroh-net/src/hp/derp/types.rs
+++ b/iroh-net/src/hp/derp/types.rs
@@ -69,7 +69,7 @@ pub(crate) struct ClientInfo {
     /// Optionally specifies a pre-shared key used by trusted clients.
     /// It's required to subscribe to the connection list and forward
     /// packets. It's empty for regular users.
-    /// TODO: this is a string in the go-impl, using an Option<array> here
+    /// TODO: this is a string in the go-impl, using an `Option<array>` here
     /// to satisfy postcard's `MaxSize` trait
     pub(crate) mesh_key: Option<MeshKey>,
     /// Whether the client declares it's able to ack pings

--- a/iroh-net/src/hp/magicsock/conn.rs
+++ b/iroh-net/src/hp/magicsock/conn.rs
@@ -2370,6 +2370,8 @@ impl Display for SendAddr {
 }
 
 /// A simple iterator to group [`Transmit`]s by destination.
+///
+/// [`Transmit`]: quinn_udp::Transmit
 struct TransmitIter<'a> {
     transmits: &'a [quinn_udp::Transmit],
     offset: usize,

--- a/iroh-net/src/hp/magicsock/derp_actor.rs
+++ b/iroh-net/src/hp/magicsock/derp_actor.rs
@@ -749,7 +749,7 @@ pub(super) struct PacketizeIter<I: Iterator, const N: usize> {
 
 impl<I: Iterator, const N: usize> PacketizeIter<I, N> {
     /// Create a new new PacketizeIter from something that can be turned into an
-    /// iterator of slices, like a Vec<Bytes>.
+    /// iterator of slices, like a `Vec<Bytes>`.
     pub(super) fn new(iter: impl IntoIterator<IntoIter = I>) -> Self {
         Self {
             iter: iter.into_iter().peekable(),

--- a/iroh-net/src/hp/magicsock/endpoint.rs
+++ b/iroh-net/src/hp/magicsock/endpoint.rs
@@ -878,7 +878,7 @@ pub struct AddrLatency {
 ///
 /// - The peers's public key, aka `PeerId` or "node_key".  This is static and never changes,
 ///   however a peer could be added when this is not yet known.  To set this after creation
-///   use [`PeerMap::store_node_key_mapping`].
+///   use [`PeerMap::set_node_key_for_ip_port`].
 ///
 /// - A public socket address on which they are reachable on the internet, known as ip-port.
 ///   These come and go as the peer moves around on the internet

--- a/iroh-net/src/hp/netcheck.rs
+++ b/iroh-net/src/hp/netcheck.rs
@@ -1180,7 +1180,7 @@ struct Actor {
 impl Actor {
     /// Creates a new actor.
     ///
-    /// This does not start the actor, see [`Actor::main`] for this.  You should not
+    /// This does not start the actor, see [`Actor::run`] for this.  You should not
     /// normally create this directly but rather create a [`Client`].
     fn new(port_mapper: Option<portmapper::Client>) -> Result<Self> {
         // TODO: consider an instrumented flume channel so we have metrics.
@@ -1426,7 +1426,7 @@ impl Actor {
         }
     }
 
-    /// Handles [`ActorMesage::StunPacket`].
+    /// Handles [`ActorMessage::StunPacket`].
     ///
     /// If there are currently no in-flight stun requests registerd this is dropped,
     /// otherwise forwarded to the probe.


### PR DESCRIPTION
This makes our docs checking a bit stricter:

- rustdoc warnings are now fatal in ci.
- we test docs of the entire workspace...
- we test private items as well

This includes the fixes needed to make this all work.