### PR TITLE
Use boxed dyn callbacks to get rid of some type parameters

### DIFF
--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.65"
 anyhow = { version = "1", features = ["backtrace"] }
 bao-tree = { version = "0.5.0", features = ["tokio_fsm"], default-features = false }
 blake3 = "1.3.3"
+bytes = "1"
 derive_more = { package = "derive_more_preview", version = "0.1.0", features = ["debug", "display", "from", "try_into"] }
 flume = "0.10.14"
 futures = "0.3.25"

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -3,6 +3,7 @@ use std::{
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     path::PathBuf,
     str::FromStr,
+    sync::Arc,
 };
 
 use anyhow::{ensure, Context, Result};
@@ -127,7 +128,7 @@ async fn provide(
     let keypair = get_keypair(key).await?;
 
     let mut builder = Node::builder(db)
-        .custom_auth_handler(StaticTokenAuthHandler::new(opts.request_token))
+        .custom_auth_handler(Arc::new(StaticTokenAuthHandler::new(opts.request_token)))
         .keylog(opts.keylog);
     if let Some(dm) = opts.derp_map {
         builder = builder.derp_map(dm);

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -70,20 +70,18 @@ const ENDPOINT_WAIT: Duration = Duration::from_secs(5);
 /// The returned [`Node`] is awaitable to know when it finishes.  It can be terminated
 /// using [`Node::shutdown`].
 #[derive(Debug)]
-pub struct Builder<D = Database, E = DummyServerEndpoint, C = (), A = ()>
+pub struct Builder<D = Database, E = DummyServerEndpoint>
 where
     D: BaoMap,
     E: ServiceEndpoint<ProviderService>,
-    C: CustomGetHandler<D>,
-    A: RequestAuthorizationHandler,
 {
     bind_addr: SocketAddr,
     keypair: Keypair,
     rpc_endpoint: E,
     db: D,
     keylog: bool,
-    custom_get_handler: C,
-    auth_handler: A,
+    custom_get_handler: Arc<dyn CustomGetHandler>,
+    auth_handler: Arc<dyn RequestAuthorizationHandler>,
     derp_map: Option<DerpMap>,
     rt: Option<runtime::Handle>,
 }
@@ -100,25 +98,20 @@ impl<D: BaoMap> Builder<D> {
             keylog: false,
             derp_map: None,
             rpc_endpoint: Default::default(),
-            custom_get_handler: Default::default(),
-            auth_handler: Default::default(),
+            custom_get_handler: Arc::new(()),
+            auth_handler: Arc::new(()),
             rt: None,
         }
     }
 }
 
-impl<E, C, A, D> Builder<D, E, C, A>
+impl<D, E> Builder<D, E>
 where
     D: BaoReadonlyDb,
     E: ServiceEndpoint<ProviderService>,
-    C: CustomGetHandler<D>,
-    A: RequestAuthorizationHandler,
 {
     /// Configure rpc endpoint, changing the type of the builder to the new endpoint type.
-    pub fn rpc_endpoint<E2: ServiceEndpoint<ProviderService>>(
-        self,
-        value: E2,
-    ) -> Builder<D, E2, C, A> {
+    pub fn rpc_endpoint<E2: ServiceEndpoint<ProviderService>>(self, value: E2) -> Builder<D, E2> {
         // we can't use ..self here because the return type is different
         Builder {
             bind_addr: self.bind_addr,
@@ -139,41 +132,19 @@ where
         self
     }
 
-    /// Configure the custom get handler, changing the type of the builder to the new handler type.
-    pub fn custom_get_handler<C2: CustomGetHandler<D>>(
-        self,
-        custom_handler: C2,
-    ) -> Builder<D, E, C2, A> {
-        // we can't use ..self here because the return type is different
-        Builder {
-            bind_addr: self.bind_addr,
-            keypair: self.keypair,
-            db: self.db,
-            keylog: self.keylog,
-            rpc_endpoint: self.rpc_endpoint,
-            custom_get_handler: custom_handler,
-            auth_handler: self.auth_handler,
-            derp_map: self.derp_map,
-            rt: self.rt,
+    /// Configure the custom get handler.
+    pub fn custom_get_handler(self, custom_get_handler: Arc<dyn CustomGetHandler>) -> Self {
+        Self {
+            custom_get_handler,
+            ..self
         }
     }
 
     /// Configures a custom authorization handler.
-    pub fn custom_auth_handler<A2: RequestAuthorizationHandler>(
-        self,
-        auth_handler: A2,
-    ) -> Builder<D, E, C, A2> {
-        // we can't use ..self here because the return type is different
-        Builder {
-            bind_addr: self.bind_addr,
-            keypair: self.keypair,
-            db: self.db,
-            keylog: self.keylog,
-            rpc_endpoint: self.rpc_endpoint,
-            custom_get_handler: self.custom_get_handler,
+    pub fn custom_auth_handler(self, auth_handler: Arc<dyn RequestAuthorizationHandler>) -> Self {
+        Self {
             auth_handler,
-            derp_map: self.derp_map,
-            rt: self.rt,
+            ..self
         }
     }
 
@@ -303,8 +274,8 @@ where
         handler: RpcHandler<D>,
         rpc: E,
         internal_rpc: impl ServiceEndpoint<ProviderService>,
-        custom_get_handler: C,
-        auth_handler: A,
+        custom_get_handler: Arc<dyn CustomGetHandler>,
+        auth_handler: Arc<dyn RequestAuthorizationHandler>,
         rt: runtime::Handle,
     ) {
         let rpc = RpcServer::new(rpc);

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -75,7 +75,7 @@ where
     D: BaoMap,
     E: ServiceEndpoint<ProviderService>,
     C: CustomGetHandler<D>,
-    A: RequestAuthorizationHandler<D>,
+    A: RequestAuthorizationHandler,
 {
     bind_addr: SocketAddr,
     keypair: Keypair,
@@ -112,7 +112,7 @@ where
     D: BaoReadonlyDb,
     E: ServiceEndpoint<ProviderService>,
     C: CustomGetHandler<D>,
-    A: RequestAuthorizationHandler<D>,
+    A: RequestAuthorizationHandler,
 {
     /// Configure rpc endpoint, changing the type of the builder to the new endpoint type.
     pub fn rpc_endpoint<E2: ServiceEndpoint<ProviderService>>(
@@ -159,7 +159,7 @@ where
     }
 
     /// Configures a custom authorization handler.
-    pub fn custom_auth_handler<A2: RequestAuthorizationHandler<D>>(
+    pub fn custom_auth_handler<A2: RequestAuthorizationHandler>(
         self,
         auth_handler: A2,
     ) -> Builder<D, E, C, A2> {
@@ -778,10 +778,9 @@ impl StaticTokenAuthHandler {
     }
 }
 
-impl<D> RequestAuthorizationHandler<D> for StaticTokenAuthHandler {
+impl RequestAuthorizationHandler for StaticTokenAuthHandler {
     fn authorize(
         &self,
-        _db: D,
         token: Option<RequestToken>,
         _request: &Request,
     ) -> BoxFuture<'static, anyhow::Result<()>> {

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -2,6 +2,7 @@ use std::{
     collections::BTreeMap,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -482,7 +483,7 @@ async fn test_run_ticket() {
     let token = Some(RequestToken::generate());
     let node = Node::builder(db)
         .bind_addr((Ipv4Addr::UNSPECIFIED, 0).into())
-        .custom_auth_handler(StaticTokenAuthHandler::new(token.clone()))
+        .custom_auth_handler(Arc::new(StaticTokenAuthHandler::new(token.clone())))
         .runtime(&rt)
         .spawn()
         .await
@@ -600,21 +601,23 @@ fn readme_path() -> PathBuf {
 }
 
 #[derive(Clone, Debug)]
-struct CollectionCustomHandler;
+struct CollectionCustomHandler {
+    db: Database,
+}
 
-impl CustomGetHandler<Database> for CollectionCustomHandler {
+impl CustomGetHandler for CollectionCustomHandler {
     fn handle(
         &self,
         _token: Option<RequestToken>,
         _data: Bytes,
-        database: Database,
     ) -> BoxFuture<'static, anyhow::Result<GetRequest>> {
+        let db = self.db.clone();
         async move {
             let readme = readme_path();
             let sources = vec![DataSource::new(readme)];
             let (new_db, hash) = create_collection(sources).await?;
             let new_db = new_db.to_inner();
-            database.union_with(new_db);
+            db.union_with(new_db);
             let request = GetRequest::all(hash);
             Ok(request)
         }
@@ -623,15 +626,17 @@ impl CustomGetHandler<Database> for CollectionCustomHandler {
 }
 
 #[derive(Clone, Debug)]
-struct BlobCustomHandler;
+struct BlobCustomHandler {
+    db: Database,
+}
 
-impl CustomGetHandler<Database> for BlobCustomHandler {
+impl CustomGetHandler for BlobCustomHandler {
     fn handle(
         &self,
         _token: Option<RequestToken>,
         _data: Bytes,
-        database: Database,
     ) -> BoxFuture<'static, anyhow::Result<GetRequest>> {
+        let db = self.db.clone();
         async move {
             let readme = readme_path();
             let sources = vec![DataSource::new(readme)];
@@ -639,7 +644,7 @@ impl CustomGetHandler<Database> for BlobCustomHandler {
             let mut new_db = new_db.to_inner();
             new_db.remove(&c_hash);
             let file_hash = *new_db.iter().next().unwrap().0;
-            database.union_with(new_db);
+            db.union_with(new_db);
             let request = GetRequest::single(file_hash);
             println!("{:?}", request);
             Ok(request)
@@ -652,10 +657,10 @@ impl CustomGetHandler<Database> for BlobCustomHandler {
 async fn test_custom_request_blob() {
     let rt = test_runtime();
     let db = Database::default();
-    let node = Node::builder(db)
+    let node = Node::builder(db.clone())
         .bind_addr("127.0.0.1:0".parse().unwrap())
         .runtime(&rt)
-        .custom_get_handler(BlobCustomHandler)
+        .custom_get_handler(Arc::new(BlobCustomHandler { db }))
         .spawn()
         .await
         .unwrap();
@@ -685,10 +690,10 @@ async fn test_custom_request_blob() {
 async fn test_custom_request_collection() {
     let rt = test_runtime();
     let db = Database::default();
-    let node = Node::builder(db)
+    let node = Node::builder(db.clone())
         .bind_addr("127.0.0.1:0".parse().unwrap())
         .runtime(&rt)
-        .custom_get_handler(CollectionCustomHandler)
+        .custom_get_handler(Arc::new(CollectionCustomHandler { db }))
         .spawn()
         .await
         .unwrap();
@@ -744,7 +749,7 @@ async fn test_token_passthrough() -> Result<()> {
     let (db, hash) = create_collection(vec![readme.into()]).await.unwrap();
     let provider = Node::builder(db)
         .bind_addr("0.0.0.0:0".parse().unwrap())
-        .custom_auth_handler(CustomAuthHandler)
+        .custom_auth_handler(Arc::new(CustomAuthHandler))
         .runtime(&rt)
         .spawn()
         .await?;

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -714,10 +714,9 @@ async fn test_custom_request_collection() {
 #[derive(Clone, Debug)]
 struct CustomAuthHandler;
 
-impl<D> RequestAuthorizationHandler<D> for CustomAuthHandler {
+impl RequestAuthorizationHandler for CustomAuthHandler {
     fn authorize(
         &self,
-        _db: D,
         token: Option<RequestToken>,
         _request: &iroh_bytes::protocol::Request,
     ) -> BoxFuture<'static, Result<()>> {


### PR DESCRIPTION
## Description

Get rid of some type parameters where they do not provide much benefit.

We can not get rid of the database parameter, since that has type members for all the futures, and getting rid of this would mean boxing all futures. But for the request authentication handler and the custom get handler we can just box them.

## Notes & open questions

In the builder, should we leave it up to the caller to create an Arc<dyn ...> or do this ourselves? I prefer to let the caller do it
because this is just during setup, and they might have already arced it for some other reason.

## Change checklist

- [x] Self-review.