### PR TITLE
fix(derp): Filter DNS results by address family

### DIFF
--- a/iroh-net/src/hp/derp/http/client.rs
+++ b/iroh-net/src/hp/derp/http/client.rs
@@ -706,11 +706,10 @@ impl Client {
                             .await
                             .map_err(|e| ClientError::Dns(Some(e)))?
                             .iter()
-                            .filter(|addr| match dst_primary {
+                            .find(|addr| match dst_primary {
                                 UseIp::Ipv4(_) => addr.is_ipv4(),
                                 UseIp::Ipv6(_) => addr.is_ipv6(),
-                            })
-                            .next();
+                            });
                         addr.ok_or_else(|| ClientError::Dns(None))?
                     }
                     url::Host::Ipv4(ip) => IpAddr::V4(ip),

--- a/iroh-net/src/hp/derp/http/client.rs
+++ b/iroh-net/src/hp/derp/http/client.rs
@@ -706,6 +706,10 @@ impl Client {
                             .await
                             .map_err(|e| ClientError::Dns(Some(e)))?
                             .iter()
+                            .filter(|addr| match dst_primary {
+                                UseIp::Ipv4(_) => addr.is_ipv4(),
+                                UseIp::Ipv6(_) => addr.is_ipv6(),
+                            })
                             .next();
                         addr.ok_or_else(|| ClientError::Dns(None))?
                     }


### PR DESCRIPTION
## Description

We try dialing the derper via both IPv4 and IPv6.  However when the
derper address is looked up via DNS we need to filter the DNS results
for the corresponding address family otherwise we'll end up dialing
the same derper twice on the same address.

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

Tested by staring at logs.  Can't really wish for more right now.

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.