### PR TITLE
ci: cancel workflows when a new commit is pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings


### PR DESCRIPTION
## Description

This should help with load on our test runners. Copied from https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre

## Notes & open questions

How fast will this cancel the jobs on our own boxes? No idea how that works really...

## Change checklist

- [x] Self-review.