### PR TITLE
docs: Add docs to RPC protocol

### DIFF
--- a/iroh/src/commands/list.rs
+++ b/iroh/src/commands/list.rs
@@ -38,16 +38,18 @@ impl Commands {
                 let mut response = client.server_streaming(ListCollectionsRequest).await?;
                 while let Some(collection) = response.next().await {
                     let collection = collection?;
+                    let total_blobs_count = collection.total_blobs_count.unwrap_or_default();
+                    let total_blobs_size = collection.total_blobs_size.unwrap_or_default();
                     println!(
                         "{}: {} {} ({})",
                         collection.hash,
-                        collection.total_blobs_count,
-                        if collection.total_blobs_count > 1 {
+                        total_blobs_count,
+                        if total_blobs_count > 1 {
                             "blobs"
                         } else {
                             "blob"
                         },
-                        HumanBytes(collection.total_blobs_size),
+                        HumanBytes(total_blobs_size),
                     );
                 }
             }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -669,8 +669,8 @@ impl<D: BaoMap + BaoReadonlyDb, C: CollectionParser> RpcHandler<D, C> {
                     .ok()??;
                 Some(ListCollectionsResponse {
                     hash,
-                    total_blobs_count: stats.num_blobs.unwrap_or_default(),
-                    total_blobs_size: stats.total_blob_size.unwrap_or_default(),
+                    total_blobs_count: stats.num_blobs,
+                    total_blobs_size: stats.total_blob_size,
                 })
             }
         })

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -28,8 +28,9 @@ pub use iroh_bytes::provider::{ProvideProgress, ValidateProgress};
 pub struct ProvideRequest {
     /// The path to the data to provide.
     ///
-    /// This should be an absolute path.
-    /// The node and the cli should be on the same filesystem.
+    /// This should be an absolute path valid for the file system on which
+    /// the node runs. Usually the cli will run on the same machine as the
+    /// node, so this should be an absolute path on the cli machine.
     pub path: PathBuf,
 }
 
@@ -78,7 +79,7 @@ impl ServerStreamingMsg<ProviderService> for ListBlobsRequest {
 
 /// List all collections
 ///
-///
+/// Lists all collections that have been explicitly added to the database.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListCollectionsRequest;
 
@@ -128,7 +129,9 @@ impl RpcMsg<ProviderService> for ShutdownRequest {
     type Response = ();
 }
 
-/// A request to get the id of the node
+/// A request to get information about the identity of the node
+///
+/// See [`IdResponse`] for the response.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IdRequest;
 

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -5,6 +5,8 @@
 //! This file contains request messages, response messages and definitions of
 //! the interaction pattern. Some requests like version and shutdown have a single
 //! response, while others like provide have a stream of responses.
+//!
+//! Note that this is subject to change. The RPC protocol is not yet stable.
 use std::{net::SocketAddr, path::PathBuf};
 
 use derive_more::{From, TryInto};
@@ -86,9 +88,13 @@ pub struct ListCollectionsResponse {
     /// Hash of the collection
     pub hash: Hash,
     /// Number of children in the collection
-    pub total_blobs_count: u64,
+    ///
+    /// This is an optional field, because the data is not always available.
+    pub total_blobs_count: Option<u64>,
     /// Total size of the raw data referred to by all links
-    pub total_blobs_size: u64,
+    ///
+    /// This is an optional field, because the data is not always available.
+    pub total_blobs_size: Option<u64>,
 }
 
 impl Msg<ProviderService> for ListCollectionsRequest {


### PR DESCRIPTION
## Description

Just add some basic docs to the RPC protocol so it does not look so naked in docs.rs. Let's not bikeshed this too much - it is going to change a lot.