### PR TITLE
feat: disable bailing out when temp dir is missing

### DIFF
--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -241,6 +241,12 @@ pub enum Commands {
         #[clap(long)]
         region: Option<u16>,
         /// Directory in which to save the file(s), defaults to writing to STDOUT
+        ///
+        /// If the directory exists and contains a partial download, the download will
+        /// be resumed.
+        ///
+        /// Otherwise, all files in the collection will be overwritten. Other files
+        /// in the directory will be left untouched.
         #[clap(long, short)]
         out: Option<PathBuf>,
         #[clap(conflicts_with_all = &["hash", "peer", "addrs", "token"])]

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -462,11 +462,9 @@ pub fn get_missing_range(
 ) -> std::io::Result<RangeSet2<ChunkNum>> {
     if target_dir.exists() && !temp_dir.exists() {
         // target directory exists yet does not contain the temp dir
-        // refuse to continue
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Target directory exists but does not contain temp directory",
-        ));
+        // we can not resume a partial download, so we just assume that
+        // the user wants to start from scratch
+        return Ok(RangeSet2::all());
     }
     let range = get_missing_range_impl(hash, name, temp_dir, target_dir)?;
     Ok(range)
@@ -527,11 +525,12 @@ pub fn get_missing_ranges(
     hash: Hash,
     target_dir: &Path,
     temp_dir: &Path,
-) -> anyhow::Result<(RangeSpecSeq, Option<Collection>)> {
+) -> std::io::Result<(RangeSpecSeq, Option<Collection>)> {
     if target_dir.exists() && !temp_dir.exists() {
-        // target directory exists yet does not contain the temp dir
-        // refuse to continue
-        anyhow::bail!("Target directory exists but does not contain temp directory");
+        // the target directory exists, but does not contain the temp directory
+        // that would allow us to resume a partial download, so we just assume that
+        // the user wants to start from scratch
+        return Ok((RangeSpecSeq::all(), None));
     }
     // try to load the collection from the temp directory
     //


### PR DESCRIPTION
## Description

Note that this will lead to the download being repeated from scratch even if the data is already there. We can change that
later. Basically once you get the collection you would have to repeat the step of trying to figure out what is missing, and
then send another request.

## Notes & open questions

- Is this behaviour OK?
- we should probably rethink single blob downloads. They were added as an afterthought, but now it seems they are being used more often.

## Change checklist

- [x] Self-review.