### PR TITLE
WIP: isolate test_mesh_network

### DIFF
--- a/iroh-net/src/derp/http/mesh_clients.rs
+++ b/iroh-net/src/derp/http/mesh_clients.rs
@@ -103,19 +103,14 @@ pub enum MeshAddrs {
 #[cfg(test)]
 mod tests {
     use crate::derp::{http::ServerBuilder, ReceivedMessage};
+    use crate::test_utils::setup_logging;
     use anyhow::Result;
-    use tracing_subscriber::{prelude::*, EnvFilter};
 
     use super::*;
 
     #[tokio::test]
     async fn test_mesh_network() -> Result<()> {
-        tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-            .with(EnvFilter::from_default_env())
-            .try_init()
-            .ok();
-
+        let _guard = setup_logging();
         // TODO(ramfox): lower this back down to 10 after a few days with no failures
         for i in 0..50 {
             println!("TEST_MESH_NETWORK: round {i}");


### PR DESCRIPTION
## Description

trying to force a failture on the `test_mesh_network `test and get it to fail, as I'm not getting any failures on my machine or the windows box.

We are going to leave the repetitions at 50 for now, and in a few days if we see no more flakey-ness, I'll set them back down to 10, tracked in issue #1274 

----

Okay, got some failures, described in #1247 

----

closes #1247 

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
