### PR TITLE
feat(iroh-net): Nat-PMP probes and mappings

### DIFF
--- a/iroh-net/src/portmapper.rs
+++ b/iroh-net/src/portmapper.rs
@@ -20,7 +20,6 @@ use current_mapping::CurrentMapping;
 mod current_mapping;
 mod mapping;
 mod metrics;
-#[allow(unused)]
 mod nat_pmp;
 mod pcp;
 mod upnp;
@@ -216,7 +215,7 @@ struct Probe {
     last_upnp_gateway_addr: Option<(upnp::Gateway, Instant)>,
     /// Last time PCP was seen.
     last_pcp: Option<Instant>,
-    /// Last time PMP was seen.
+    /// Last time NAT-PMP was seen.
     last_nat_pmp: Option<Instant>,
 }
 
@@ -271,7 +270,7 @@ impl Probe {
                 Box::pin(async {
                     nat_pmp::probe_available(local_ip, gateway)
                         .await
-                        .then(|| Instant::now())
+                        .then(Instant::now)
                 })
             }),
         };

--- a/iroh-net/src/portmapper.rs
+++ b/iroh-net/src/portmapper.rs
@@ -20,6 +20,8 @@ use current_mapping::CurrentMapping;
 mod current_mapping;
 mod mapping;
 mod metrics;
+#[allow(unused)]
+mod nat_pmp;
 mod pcp;
 mod upnp;
 
@@ -38,20 +40,20 @@ const UNAVAILABILITY_TRUST_DURATION: Duration = Duration::from_secs(5);
 
 /// Output of a port mapping probe.
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
-#[display("portmap={{ UPnP: {upnp}, PMP: {pmp}, PCP: {pcp} }}")]
+#[display("portmap={{ UPnP: {upnp}, PMP: {nat_pmp}, PCP: {pcp} }}")]
 pub struct ProbeOutput {
     /// If UPnP can be considered available.
     pub upnp: bool,
     /// If PCP can be considered available.
     pub pcp: bool,
     /// If PMP can be considered available.
-    pub pmp: bool,
+    pub nat_pmp: bool,
 }
 
 impl ProbeOutput {
     /// Indicates if all port mapping protocols are available.
     pub fn all_available(&self) -> bool {
-        self.upnp && self.pcp && self.pmp
+        self.upnp && self.pcp && self.nat_pmp
     }
 }
 
@@ -214,8 +216,8 @@ struct Probe {
     last_upnp_gateway_addr: Option<(upnp::Gateway, Instant)>,
     /// Last time PCP was seen.
     last_pcp: Option<Instant>,
-    // TODO(@divma): PMP placeholder.
-    last_pmp: Option<Instant>,
+    /// Last time PMP was seen.
+    last_nat_pmp: Option<Instant>,
 }
 
 impl Default for Probe {
@@ -224,7 +226,7 @@ impl Default for Probe {
             last_probe: Instant::now() - AVAILABILITY_TRUST_DURATION,
             last_upnp_gateway_addr: None,
             last_pcp: None,
-            last_pmp: None,
+            last_nat_pmp: None,
         }
     }
 }
@@ -237,11 +239,11 @@ impl Probe {
         local_ip: Ipv4Addr,
         gateway: Ipv4Addr,
     ) -> Probe {
-        let ProbeOutput { upnp, pcp, pmp: _ } = output;
+        let ProbeOutput { upnp, pcp, nat_pmp } = output;
         let Config {
             enable_upnp,
             enable_pcp,
-            enable_nat_pmp: _,
+            enable_nat_pmp,
         } = config;
         let mut upnp_probing_task = util::MaybeFuture {
             inner: (enable_upnp && !upnp).then(|| {
@@ -264,7 +266,15 @@ impl Probe {
             }),
         };
 
-        let pmp_probing_task = async { None };
+        let mut nat_pmp_probing_task = util::MaybeFuture {
+            inner: (enable_nat_pmp && !nat_pmp).then(|| {
+                Box::pin(async {
+                    nat_pmp::probe_available(local_ip, gateway)
+                        .await
+                        .then(|| Instant::now())
+                })
+            }),
+        };
 
         if upnp_probing_task.inner.is_some() {
             inc!(Metrics, upnp_probes);
@@ -272,23 +282,21 @@ impl Probe {
 
         let mut upnp_done = upnp_probing_task.inner.is_none();
         let mut pcp_done = pcp_probing_task.inner.is_none();
-        let mut pmp_done = true;
-
-        tokio::pin!(pmp_probing_task);
+        let mut nat_pmp_done = nat_pmp_probing_task.inner.is_none();
 
         let mut probe = Probe::default();
 
-        while !upnp_done || !pcp_done || !pmp_done {
+        while !upnp_done || !pcp_done || !nat_pmp_done {
             tokio::select! {
                 last_upnp_gateway_addr = &mut upnp_probing_task, if !upnp_done => {
                     trace!("tick: upnp probe ready");
                     probe.last_upnp_gateway_addr = last_upnp_gateway_addr;
                     upnp_done = true;
                 },
-                last_pmp = &mut pmp_probing_task, if !pmp_done => {
-                    trace!("tick: pmp probe ready");
-                    probe.last_pmp = last_pmp;
-                    pmp_done = true;
+                last_nat_pmp = &mut nat_pmp_probing_task, if !nat_pmp_done => {
+                    trace!("tick: nat_pmp probe ready");
+                    probe.last_nat_pmp = last_nat_pmp;
+                    nat_pmp_done = true;
                 },
                 last_pcp = &mut pcp_probing_task, if !pcp_done => {
                     trace!("tick: pcp probe ready");
@@ -318,10 +326,13 @@ impl Probe {
             .map(|last_probed| *last_probed + AVAILABILITY_TRUST_DURATION > now)
             .unwrap_or_default();
 
-        // not probing for now
-        let pmp = false;
+        let nat_pmp = self
+            .last_nat_pmp
+            .as_ref()
+            .map(|last_probed| *last_probed + AVAILABILITY_TRUST_DURATION > now)
+            .unwrap_or_default();
 
-        ProbeOutput { upnp, pcp, pmp }
+        ProbeOutput { upnp, pcp, nat_pmp }
     }
 
     /// Updates a probe with the `Some` values of another probe that is _assumed_ newer.
@@ -330,7 +341,7 @@ impl Probe {
             last_probe,
             last_upnp_gateway_addr,
             last_pcp,
-            last_pmp,
+            last_nat_pmp,
         } = probe;
         if last_upnp_gateway_addr.is_some() {
             inc!(Metrics, upnp_available);
@@ -359,8 +370,8 @@ impl Probe {
             inc!(Metrics, pcp_available);
             self.last_pcp = last_pcp;
         }
-        if last_pmp.is_some() {
-            self.last_pmp = last_pmp;
+        if last_nat_pmp.is_some() {
+            self.last_nat_pmp = last_nat_pmp;
         }
 
         self.last_probe = last_probe;
@@ -571,7 +582,7 @@ impl Service {
                 Err(e) => return debug!("can't get mapping: {e}"),
             };
 
-            let ProbeOutput { upnp, pcp, pmp: _ } = self.full_probe.output();
+            let ProbeOutput { upnp, pcp, nat_pmp } = self.full_probe.output();
 
             debug!("getting a port mapping for {local_ip}:{local_port} -> {external_addr:?}");
             let recently_probed =
@@ -582,6 +593,10 @@ impl Service {
             // 2. if no service was available, fallback to upnp if enabled
             self.mapping_task = if pcp || (!recently_probed && self.config.enable_pcp) {
                 let task = mapping::Mapping::new_pcp(local_ip, local_port, gateway, external_addr);
+                Some(tokio::spawn(task).into())
+            } else if nat_pmp || (!recently_probed && self.config.enable_nat_pmp) {
+                let task =
+                    mapping::Mapping::new_nat_pmp(local_ip, local_port, gateway, external_addr);
                 Some(tokio::spawn(task).into())
             } else if upnp || self.config.enable_upnp {
                 let external_port = external_addr.map(|(_addr, port)| port);

--- a/iroh-net/src/portmapper/mapping.rs
+++ b/iroh-net/src/portmapper/mapping.rs
@@ -21,6 +21,7 @@ pub enum Mapping {
     /// A PCP mapping.
     #[debug(transparent)]
     Pcp(pcp::Mapping),
+    /// A NAT-PMP mapping.
     #[debug(transparent)]
     NatPmp(nat_pmp::Mapping),
 }
@@ -66,10 +67,7 @@ impl Mapping {
         match self {
             Mapping::Upnp(m) => m.release().await,
             Mapping::Pcp(m) => m.release().await,
-            Mapping::NatPmp(m) => {
-                // TODO(@divma): do
-                anyhow::bail!("unimplemented");
-            }
+            Mapping::NatPmp(m) => m.release().await,
         }
     }
 }

--- a/iroh-net/src/portmapper/mapping.rs
+++ b/iroh-net/src/portmapper/mapping.rs
@@ -39,6 +39,7 @@ impl Mapping {
             .map(Self::Pcp)
     }
 
+    /// Create a new NAT-PMP mapping.
     pub(crate) async fn new_nat_pmp(
         local_ip: Ipv4Addr,
         local_port: NonZeroU16,

--- a/iroh-net/src/portmapper/mapping.rs
+++ b/iroh-net/src/portmapper/mapping.rs
@@ -45,9 +45,14 @@ impl Mapping {
         gateway: Ipv4Addr,
         external_addr: Option<(Ipv4Addr, NonZeroU16)>,
     ) -> Result<Self> {
-        nat_pmp::Mapping::new(local_ip, local_port, gateway, external_addr)
-            .await
-            .map(Self::NatPmp)
+        nat_pmp::Mapping::new(
+            local_ip,
+            local_port,
+            gateway,
+            external_addr.map(|(_addr, port)| port),
+        )
+        .await
+        .map(Self::NatPmp)
     }
 
     /// Create a new UPnP mapping.

--- a/iroh-net/src/portmapper/nat_pmp.rs
+++ b/iroh-net/src/portmapper/nat_pmp.rs
@@ -1,0 +1,139 @@
+use std::{net::Ipv4Addr, num::NonZeroU16, time::Duration};
+
+use tracing::{debug, trace};
+
+use self::protocol::{MapProtocol, Request, Response};
+
+mod protocol;
+
+/// Port to use when acting as a server. This is the one we direct requests to.
+pub const SERVER_PORT: u16 = 5351;
+
+/// Tailscale uses the recommended port mapping lifetime for PMP, which is 2 hours. So we assume a
+/// half lifetime of 1h. See <https://datatracker.ietf.org/doc/html/rfc6886#section-3.3>
+const MAPPING_REQUESTED_LIFETIME_SECONDS: u32 = 60 * 60;
+
+#[derive(Debug)]
+pub struct Mapping {
+    external_port: NonZeroU16,
+    external_addr: Ipv4Addr,
+    lifetime_seconds: u32,
+}
+
+impl Mapping {
+    pub async fn new(
+        local_ip: Ipv4Addr,
+        local_port: NonZeroU16,
+        gateway: Ipv4Addr,
+        preferred_external_address: Option<(Ipv4Addr, NonZeroU16)>,
+    ) -> anyhow::Result<Self> {
+        let socket = tokio::net::UdpSocket::bind((local_ip, 0)).await?;
+        socket.connect((gateway, SERVER_PORT)).await?;
+
+        let (preferred_external_address, preferred_external_port) = match preferred_external_address
+        {
+            Some((ip, port)) => (Some(ip), Some(port.into())),
+            None => (None, None),
+        };
+        let local_port: u16 = local_port.into();
+        let req = Request::Mapping {
+            proto: MapProtocol::UDP,
+            local_port,
+            external_port: preferred_external_port.unwrap_or_default(),
+            lifetime_seconds: MAPPING_REQUESTED_LIFETIME_SECONDS,
+        };
+
+        socket.send(&req.encode()).await?;
+        let mut buffer = vec![0; Response::MAX_SIZE];
+        let read = tokio::time::timeout(RECV_TIMEOUT, socket.recv(&mut buffer)).await??;
+        let response = Response::decode(&buffer[..read])?;
+
+        // pre-create the mapping since we have most info ready
+        let (external_port, lifetime_seconds) = match response {
+            Response::PortMap {
+                proto: MapProtocol::UDP,
+                epoch_time,
+                private_port,
+                external_port,
+                lifetime_seconds,
+            } if private_port == local_port => (external_port, lifetime_seconds),
+            _ => anyhow::bail!("server returned unexpected response for mapping request"),
+        };
+
+        let external_port = external_port
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("received 0 port from server as external port"))?;
+
+        // now send the second response to get the external address
+        let req = Request::ExternalAddress;
+        socket.send(&req.encode()).await?;
+        let mut buffer = vec![0; Response::MAX_SIZE];
+        let read = tokio::time::timeout(RECV_TIMEOUT, socket.recv(&mut buffer)).await??;
+        let response = Response::decode(&buffer[..read])?;
+        let external_addr = match response {
+            Response::PublicAddress {
+                epoch_time,
+                public_ip,
+            } => public_ip,
+            _ => anyhow::bail!("server returned unexpected response for mapping request"),
+        };
+
+        Ok(Mapping {
+            external_port,
+            external_addr,
+            lifetime_seconds,
+        })
+    }
+}
+
+impl super::mapping::PortMapped for Mapping {
+    fn external(&self) -> (Ipv4Addr, NonZeroU16) {
+        (self.external_addr, self.external_port)
+    }
+
+    fn half_lifetime(&self) -> Duration {
+        Duration::from_secs((self.lifetime_seconds / 2).into())
+    }
+}
+
+/// Timeout to receive a response from a NAT-PMP server.
+const RECV_TIMEOUT: Duration = Duration::from_millis(500);
+
+pub async fn probe_available(local_ip: Ipv4Addr, gateway: Ipv4Addr) -> bool {
+    debug!("starting probe");
+    match probe_available_fallible(local_ip, gateway).await {
+        Ok(response) => {
+            trace!("probe response: {response:?}");
+            match response {
+                Response::PublicAddress { .. } => true,
+                _ => {
+                    debug!("server returned an unexpected response type for probe");
+                    // missbehaving server is not useful
+                    false
+                }
+            }
+        }
+        Err(e) => {
+            debug!("probe failed: {e}");
+            false
+        }
+    }
+}
+
+async fn probe_available_fallible(
+    local_ip: Ipv4Addr,
+    gateway: Ipv4Addr,
+) -> anyhow::Result<Response> {
+    // create the socket and send the request
+    let socket = tokio::net::UdpSocket::bind((local_ip, 0)).await?;
+    socket.connect((gateway, SERVER_PORT)).await?;
+    let req = Request::ExternalAddress;
+    socket.send(&req.encode()).await?;
+
+    // wait for the response and decode it
+    let mut buffer = vec![0; Response::MAX_SIZE];
+    let read = tokio::time::timeout(RECV_TIMEOUT, socket.recv(&mut buffer)).await??;
+    let response = Response::decode(&buffer[..read])?;
+
+    Ok(response)
+}

--- a/iroh-net/src/portmapper/nat_pmp.rs
+++ b/iroh-net/src/portmapper/nat_pmp.rs
@@ -43,7 +43,7 @@ impl super::mapping::PortMapped for Mapping {
 }
 
 impl Mapping {
-    /// Attempt to registed a new mapping with the NAT-PMP server on the provided gateway.
+    /// Attempt to register a new mapping with the NAT-PMP server on the provided gateway.
     pub async fn new(
         local_ip: Ipv4Addr,
         local_port: NonZeroU16,

--- a/iroh-net/src/portmapper/nat_pmp.rs
+++ b/iroh-net/src/portmapper/nat_pmp.rs
@@ -84,6 +84,10 @@ impl Mapping {
             lifetime_seconds,
         })
     }
+
+    pub(crate) async fn release(self) -> anyhow::Result<()> {
+        anyhow::bail!("unimplemented")
+    }
 }
 
 impl super::mapping::PortMapped for Mapping {

--- a/iroh-net/src/portmapper/nat_pmp.rs
+++ b/iroh-net/src/portmapper/nat_pmp.rs
@@ -55,7 +55,7 @@ impl Mapping {
         socket.connect((gateway, protocol::SERVER_PORT)).await?;
 
         let req = Request::Mapping {
-            proto: MapProtocol::UDP,
+            proto: MapProtocol::Udp,
             local_port: local_port.into(),
             external_port: external_port.map(Into::into).unwrap_or_default(),
             lifetime_seconds: MAPPING_REQUESTED_LIFETIME_SECONDS,
@@ -70,7 +70,7 @@ impl Mapping {
 
         let (external_port, lifetime_seconds) = match response {
             Response::PortMap {
-                proto: MapProtocol::UDP,
+                proto: MapProtocol::Udp,
                 epoch_time: _,
                 private_port,
                 external_port,
@@ -105,7 +105,7 @@ impl Mapping {
             external_addr,
             lifetime_seconds,
             local_ip,
-            local_port: local_port.into(),
+            local_port,
             gateway,
         })
     }
@@ -128,7 +128,7 @@ impl Mapping {
         socket.connect((gateway, protocol::SERVER_PORT)).await?;
 
         let req = Request::Mapping {
-            proto: MapProtocol::UDP,
+            proto: MapProtocol::Udp,
             local_port: local_port.into(),
             external_port: 0,
             lifetime_seconds: 0,

--- a/iroh-net/src/portmapper/nat_pmp/protocol.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol.rs
@@ -1,0 +1,31 @@
+//! Definitions and utilities to interact with a NAT-PMP server.
+
+mod request;
+mod response;
+
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+// PCP and NAT-PMP share same ports, reasigned by IANA from the older version to the new one. See
+// <https://datatracker.ietf.org/doc/html/rfc6887#section-19>
+
+pub use request::*;
+pub use response::*;
+
+/// Nat Version according to [RFC 6887 Version Negotiation](https://datatracker.ietf.org/doc/html/rfc6887#section-9).
+/// TODO(@divma): real link
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum Version {
+    NatPmp = 0,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum Opcode {
+    // 3.2.  Determining the External Address
+    DetermineExternalAddress = 0,
+    // 3.3.  Requesting a Mapping
+    MapUdp = 1,
+    // 3.3.  Requesting a Mapping
+    MapTcp = 2,
+}

--- a/iroh-net/src/portmapper/nat_pmp/protocol.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol.rs
@@ -11,21 +11,27 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 pub use request::*;
 pub use response::*;
 
-/// Nat Version according to [RFC 6887 Version Negotiation](https://datatracker.ietf.org/doc/html/rfc6887#section-9).
-/// TODO(@divma): real link
+/// Port to use when acting as a server. This is the one we direct requests to.
+pub const SERVER_PORT: u16 = 5351;
+
+/// Nat Version according to [RFC 6886 Transition to Port Control Protocol](https://datatracker.ietf.org/doc/html/rfc6886#section-1.1).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Version {
+    /// NAT-PMP version
     NatPmp = 0,
 }
 
+/// Opcode accepted by a NAT-PMP server.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Opcode {
-    // 3.2.  Determining the External Address
+    /// Determine the external address of the gateway.
+    ///
+    /// See [RFC 6886 Determining the External Address](https://datatracker.ietf.org/doc/html/rfc6886#section-3.2).
     DetermineExternalAddress = 0,
-    // 3.3.  Requesting a Mapping
+    /// Get a UDP Mapping.
+    ///
+    /// See [RFC 6886 Requesting a Mapping](https://datatracker.ietf.org/doc/html/rfc6886#section-3.3).
     MapUdp = 1,
-    // 3.3.  Requesting a Mapping
-    MapTcp = 2,
 }

--- a/iroh-net/src/portmapper/nat_pmp/protocol.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol.rs
@@ -5,7 +5,7 @@ mod response;
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
-// PCP and NAT-PMP share same ports, reasigned by IANA from the older version to the new one. See
+// PCP and NAT-PMP share same ports, reassigned by IANA from the older version to the new one. See
 // <https://datatracker.ietf.org/doc/html/rfc6887#section-19>
 
 pub use request::*;

--- a/iroh-net/src/portmapper/nat_pmp/protocol/request.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol/request.rs
@@ -1,0 +1,53 @@
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+use super::{Opcode, Version};
+
+/// A NAT-PCP Request.
+#[derive(Debug)]
+pub enum Request {
+    ExternalAddress,
+    Mapping {
+        proto: MapProtocol,
+        local_port: u16,
+        external_port: u16,
+        lifetime_seconds: u32,
+    },
+}
+
+/// Protocol for which a port mapping is requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum MapProtocol {
+    UDP = 1,
+    TCP = 2,
+}
+
+impl Request {
+    pub fn encode(&self) -> Vec<u8> {
+        match self {
+            Request::ExternalAddress => vec![
+                Version::NatPmp.into(),
+                Opcode::DetermineExternalAddress.into(),
+            ],
+            Request::Mapping {
+                proto,
+                local_port,
+                external_port,
+                lifetime_seconds,
+            } => {
+                let opcode = match proto {
+                    MapProtocol::UDP => Opcode::MapUdp,
+                    MapProtocol::TCP => Opcode::MapTcp,
+                };
+                let mut buf = vec![Version::NatPmp.into(), opcode.into()];
+                // reserved
+                buf.push(0);
+                buf.push(0);
+                buf.extend_from_slice(&local_port.to_be_bytes());
+                buf.extend_from_slice(&external_port.to_be_bytes());
+                buf.extend_from_slice(&lifetime_seconds.to_be_bytes());
+                buf
+            }
+        }
+    }
+}

--- a/iroh-net/src/portmapper/nat_pmp/protocol/request.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol/request.rs
@@ -28,7 +28,7 @@ pub enum Request {
 #[repr(u8)]
 pub enum MapProtocol {
     /// UDP mapping.
-    UDP = 1,
+    Udp = 1,
 }
 
 impl Request {
@@ -46,7 +46,7 @@ impl Request {
                 lifetime_seconds,
             } => {
                 let opcode = match proto {
-                    MapProtocol::UDP => Opcode::MapUdp,
+                    MapProtocol::Udp => Opcode::MapUdp,
                 };
                 let mut buf = vec![Version::NatPmp.into(), opcode.into()];
                 buf.push(0); // reserved
@@ -64,7 +64,7 @@ impl Request {
         match opcode {
             Opcode::DetermineExternalAddress => Request::ExternalAddress,
             Opcode::MapUdp => Request::Mapping {
-                proto: MapProtocol::UDP,
+                proto: MapProtocol::Udp,
                 local_port: rng.gen(),
                 external_port: rng.gen(),
                 lifetime_seconds: rng.gen(),
@@ -93,7 +93,7 @@ impl Request {
                 let lifetime_bytes: [u8; 4] = buf[8..12].try_into().unwrap();
                 let lifetime_seconds = u32::from_be_bytes(lifetime_bytes);
                 Request::Mapping {
-                    proto: MapProtocol::UDP,
+                    proto: MapProtocol::Udp,
                     local_port,
                     external_port,
                     lifetime_seconds,

--- a/iroh-net/src/portmapper/nat_pmp/protocol/request.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol/request.rs
@@ -1,28 +1,38 @@
+//! A NAT-PCP request encoding and decoding.
+
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use super::{Opcode, Version};
 
 /// A NAT-PCP Request.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Request {
+    /// Request to determine the gateway's external address.
     ExternalAddress,
+    /// Request to register a mapping with the NAT-PCP server.
     Mapping {
+        /// Protocol to use for this mapping.
         proto: MapProtocol,
+        /// Local port to map.
         local_port: u16,
+        /// Preferred external port.
         external_port: u16,
+        /// Requested lifetime in seconds for the mapping.
         lifetime_seconds: u32,
     },
 }
 
 /// Protocol for which a port mapping is requested.
+// NOTE: spec defines TCP as well, which we don't need.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum MapProtocol {
+    /// UDP mapping.
     UDP = 1,
-    TCP = 2,
 }
 
 impl Request {
+    /// Encode this [`Request`].
     pub fn encode(&self) -> Vec<u8> {
         match self {
             Request::ExternalAddress => vec![
@@ -37,17 +47,83 @@ impl Request {
             } => {
                 let opcode = match proto {
                     MapProtocol::UDP => Opcode::MapUdp,
-                    MapProtocol::TCP => Opcode::MapTcp,
                 };
                 let mut buf = vec![Version::NatPmp.into(), opcode.into()];
-                // reserved
-                buf.push(0);
-                buf.push(0);
+                buf.push(0); // reserved
+                buf.push(0); // reserved
                 buf.extend_from_slice(&local_port.to_be_bytes());
                 buf.extend_from_slice(&external_port.to_be_bytes());
                 buf.extend_from_slice(&lifetime_seconds.to_be_bytes());
                 buf
             }
         }
+    }
+
+    #[cfg(test)]
+    fn random<R: rand::Rng>(opcode: super::Opcode, rng: &mut R) -> Self {
+        match opcode {
+            Opcode::DetermineExternalAddress => Request::ExternalAddress,
+            Opcode::MapUdp => Request::Mapping {
+                proto: MapProtocol::UDP,
+                local_port: rng.gen(),
+                external_port: rng.gen(),
+                lifetime_seconds: rng.gen(),
+            },
+        }
+    }
+
+    #[cfg(test)]
+    #[track_caller]
+    fn decode(buf: &[u8]) -> Self {
+        let _version: Version = buf[0].try_into().unwrap();
+        let opcode: super::Opcode = buf[1].try_into().unwrap();
+        // check if this is a mapping request, or an external address request
+        match opcode {
+            Opcode::DetermineExternalAddress => Request::ExternalAddress,
+            Opcode::MapUdp => {
+                // buf[2] reserved
+                // buf[3] reserved
+
+                let local_port_bytes = buf[4..6].try_into().expect("slice has the right size");
+                let local_port = u16::from_be_bytes(local_port_bytes);
+
+                let external_port_bytes = buf[6..8].try_into().expect("slice has the right size");
+                let external_port = u16::from_be_bytes(external_port_bytes);
+
+                let lifetime_bytes: [u8; 4] = buf[8..12].try_into().unwrap();
+                let lifetime_seconds = u32::from_be_bytes(lifetime_bytes);
+                Request::Mapping {
+                    proto: MapProtocol::UDP,
+                    local_port,
+                    external_port,
+                    lifetime_seconds,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_encode_decode_addr_request() {
+        let mut gen = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+
+        let request = Request::random(super::Opcode::DetermineExternalAddress, &mut gen);
+        let encoded = request.encode();
+        assert_eq!(request, Request::decode(&encoded));
+    }
+
+    #[test]
+    fn test_encode_decode_map_request() {
+        let mut gen = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+
+        let request = Request::random(super::Opcode::MapUdp, &mut gen);
+        let encoded = request.encode();
+        assert_eq!(request, Request::decode(&encoded));
     }
 }

--- a/iroh-net/src/portmapper/nat_pmp/protocol/response.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol/response.rs
@@ -147,7 +147,7 @@ impl Response {
                 }
             }
             Opcode::MapUdp => {
-                let proto = MapProtocol::UDP;
+                let proto = MapProtocol::Udp;
 
                 let epoch_bytes = buf[4..8].try_into().expect("slice has the right len");
                 let epoch_time = u32::from_be_bytes(epoch_bytes);
@@ -185,7 +185,7 @@ impl Response {
                 }
             }
             Opcode::MapUdp => Response::PortMap {
-                proto: MapProtocol::UDP,
+                proto: MapProtocol::Udp,
                 epoch_time: rng.gen(),
                 private_port: rng.gen(),
                 external_port: rng.gen(),

--- a/iroh-net/src/portmapper/nat_pmp/protocol/response.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol/response.rs
@@ -1,0 +1,156 @@
+use std::net::Ipv4Addr;
+
+use num_enum::TryFromPrimitive;
+
+use super::{MapProtocol, Opcode, Version};
+
+#[derive(Debug)]
+pub enum Response {
+    PublicAddress {
+        epoch_time: u32,
+        public_ip: Ipv4Addr,
+    },
+    PortMap {
+        proto: MapProtocol,
+        epoch_time: u32,
+        private_port: u16,
+        external_port: u16,
+        lifetime_seconds: u32,
+    },
+}
+
+// 3.5.  Result Codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
+#[repr(u16)]
+pub enum ResultCode {
+    Success = 0,
+    // TODO(@divma): responses having this error have a different packet format. annoying
+    UnsupportedVersion = 1,
+    /// Functionality is suported but not allowerd: e.g. box supports mapping, but user has turned
+    /// feature off.
+    NotAuthorizedOrRefused = 2,
+    /// Netfork failures, e.g. NAT box itself has not obtained a DHCP lease.
+    NetworkFailure = 3,
+    /// NAT box cannot create any more mappings at this time.
+    OutOfResources = 4,
+    UnsupportedOpcode = 5,
+}
+
+/// Errors that can occur when decoding a [`Response`] from a server.
+// TODO(@divma): copy docs instead of refer?
+#[derive(Debug, derive_more::Display, thiserror::Error)]
+pub enum Error {
+    /// Request is too short or is otherwise malformed.
+    #[display("Response is malformed")]
+    Malformed,
+    /// The [`RESPONSE_INDICATOR`] is not present.
+    #[display("Packet does not appear to be a response")]
+    NotAResponse,
+    /// See [`InvalidOpcode`].
+    #[display("Invalid Opcode received")]
+    InvalidOpcode,
+    /// See [`InvalidVersion`].
+    #[display("Invalid version received")]
+    InvalidVersion,
+    /// See [`InvalidResultCode`].
+    #[display("Invalid result code received")]
+    InvalidResultCode,
+    UnsupportedVersion,
+    NotAuthorizedOrRefused,
+    NetworkFailure,
+    OutOfResources,
+    UnsupportedOpcode,
+}
+
+impl Response {
+    /// Minimum size of an encoded [`Response`] sent by a server to this client.
+    pub const MIN_SIZE: usize = // parts of a public ip response
+        1 + // version
+        1 + // opcode
+        2 + // result code
+        4 + // epoch time
+        4; // lifetime
+
+    /// Minimum size of an encoded [`Response`] sent by a server to this client.
+    pub const MAX_SIZE: usize = // parts of mapping response
+        1 + // version
+        1 + // opcode
+        2 + // result code
+        4 + // epoch time
+        2 + // private port
+        2 + // public port 
+        4; // lifetime
+
+    /// Indicator ORd into the [`Opcode`] to indicate a response packet.
+    pub const INDICATOR: u8 = 1u8 << 7;
+
+    pub fn decode(buf: &[u8]) -> Result<Self, Error> {
+        if buf.len() < Self::MIN_SIZE || buf.len() > Self::MAX_SIZE {
+            return Err(Error::Malformed);
+        }
+        let _: Version = buf[0].try_into().map_err(|_| Error::InvalidVersion)?;
+        let opcode = buf[1];
+        if opcode & Self::INDICATOR != Self::INDICATOR {
+            return Err(Error::NotAResponse);
+        }
+        let opcode: Opcode = (opcode & !Self::INDICATOR)
+            .try_into()
+            .map_err(|_| Error::InvalidOpcode)?;
+
+        let result_bytes =
+            u16::from_be_bytes(buf[2..4].try_into().expect("slice has the right len"));
+        let result_code = result_bytes
+            .try_into()
+            .map_err(|_| Error::InvalidResultCode)?;
+
+        match result_code {
+            ResultCode::Success => Ok(()),
+            ResultCode::UnsupportedVersion => Err(Error::UnsupportedVersion),
+            ResultCode::NotAuthorizedOrRefused => Err(Error::NotAuthorizedOrRefused),
+            ResultCode::NetworkFailure => Err(Error::NetworkFailure),
+            ResultCode::OutOfResources => Err(Error::OutOfResources),
+            ResultCode::UnsupportedOpcode => Err(Error::UnsupportedOpcode),
+        }?;
+
+        let response = match opcode {
+            Opcode::DetermineExternalAddress => {
+                let epoch_bytes = buf[4..8].try_into().expect("slice has the right len");
+                let epoch_time = u32::from_be_bytes(epoch_bytes);
+                let ip_bytes: [u8; 4] = buf[8..12].try_into().expect("slice has the right len");
+                Response::PublicAddress {
+                    epoch_time,
+                    public_ip: ip_bytes.into(),
+                }
+            }
+            other @ (Opcode::MapUdp | Opcode::MapTcp) => {
+                let proto = if other == Opcode::MapUdp {
+                    MapProtocol::UDP
+                } else {
+                    MapProtocol::TCP
+                };
+
+                let epoch_bytes = buf[4..8].try_into().expect("slice has the right len");
+                let epoch_time = u32::from_be_bytes(epoch_bytes);
+
+                let private_port_bytes = buf[8..10].try_into().expect("slice has the right len");
+                let private_port = u16::from_be_bytes(private_port_bytes);
+
+                let external_port_bytes = buf[10..12].try_into().expect("slice has the right len");
+                let external_port = u16::from_be_bytes(external_port_bytes);
+
+                let lifetime_bytes = buf[12..16].try_into().expect("slice has the right len");
+                let lifetime_seconds = u32::from_be_bytes(lifetime_bytes);
+
+                Response::PortMap {
+                    proto,
+                    epoch_time,
+                    private_port,
+                    external_port,
+                    lifetime_seconds,
+                }
+            }
+        };
+
+        Ok(response)
+    }
+}

--- a/iroh-net/src/portmapper/nat_pmp/protocol/response.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol/response.rs
@@ -78,7 +78,7 @@ impl Response {
         2 + // result code
         4 + // epoch time
         2 + // private port
-        2 + // public port 
+        2 + // public port
         4; // lifetime
 
     /// Indicator ORd into the [`Opcode`] to indicate a response packet.
@@ -122,12 +122,8 @@ impl Response {
                     public_ip: ip_bytes.into(),
                 }
             }
-            other @ (Opcode::MapUdp | Opcode::MapTcp) => {
-                let proto = if other == Opcode::MapUdp {
-                    MapProtocol::UDP
-                } else {
-                    MapProtocol::TCP
-                };
+            Opcode::MapUdp => {
+                let proto = MapProtocol::UDP;
 
                 let epoch_bytes = buf[4..8].try_into().expect("slice has the right len");
                 let epoch_time = u32::from_be_bytes(epoch_bytes);

--- a/iroh-net/src/portmapper/nat_pmp/protocol/response.rs
+++ b/iroh-net/src/portmapper/nat_pmp/protocol/response.rs
@@ -56,7 +56,7 @@ pub enum Error {
     /// Request is too short or is otherwise malformed.
     #[display("Response is malformed")]
     Malformed,
-    /// The [`RESPONSE_INDICATOR`] is not present.
+    /// The [`Response::RESPONSE_INDICATOR`] is not present.
     #[display("Packet does not appear to be a response")]
     NotAResponse,
     /// The received opcode is not recognized.

--- a/iroh-net/src/portmapper/pcp/protocol.rs
+++ b/iroh-net/src/portmapper/pcp/protocol.rs
@@ -10,7 +10,7 @@ pub use opcode_data::*;
 pub use request::*;
 pub use response::*;
 
-// PCP and NAT-PMP share same ports, reasigned by IANA from the older version to the new one. See
+// PCP and NAT-PMP share same ports, reassigned by IANA from the older version to the new one. See
 // <https://datatracker.ietf.org/doc/html/rfc6887#section-19>
 
 /// Port to use when acting as a server. This is the one we direct requests to.

--- a/iroh-net/src/portmapper/upnp.rs
+++ b/iroh-net/src/portmapper/upnp.rs
@@ -38,16 +38,6 @@ pub struct Mapping {
     external_port: NonZeroU16,
 }
 
-impl super::mapping::PortMapped for Mapping {
-    fn external(&self) -> (Ipv4Addr, NonZeroU16) {
-        (self.external_ip, self.external_port)
-    }
-
-    fn half_lifetime(&self) -> Duration {
-        HALF_LIFETIME
-    }
-}
-
 impl Mapping {
     pub(crate) async fn new(
         local_addr: Ipv4Addr,
@@ -109,6 +99,12 @@ impl Mapping {
             external_port,
         })
     }
+
+    pub fn half_lifetime(&self) -> Duration {
+        HALF_LIFETIME
+    }
+
+    /// Releases the mapping.
     pub(crate) async fn release(self) -> Result<()> {
         let Mapping {
             gateway,
@@ -119,6 +115,11 @@ impl Mapping {
             .remove_port(igd::PortMappingProtocol::UDP, external_port.into())
             .await?;
         Ok(())
+    }
+
+    /// Returns the external gateway ip and port that can be used to contact this node.
+    pub fn external(&self) -> (Ipv4Addr, NonZeroU16) {
+        (self.external_ip, self.external_port)
     }
 }
 

--- a/iroh-net/src/portmapper/upnp.rs
+++ b/iroh-net/src/portmapper/upnp.rs
@@ -38,6 +38,16 @@ pub struct Mapping {
     external_port: NonZeroU16,
 }
 
+impl super::mapping::PortMapped for Mapping {
+    fn external(&self) -> (Ipv4Addr, NonZeroU16) {
+        (self.external_ip, self.external_port)
+    }
+
+    fn half_lifetime(&self) -> Duration {
+        HALF_LIFETIME
+    }
+}
+
 impl Mapping {
     pub(crate) async fn new(
         local_addr: Ipv4Addr,
@@ -99,12 +109,6 @@ impl Mapping {
             external_port,
         })
     }
-
-    pub fn half_lifetime(&self) -> Duration {
-        HALF_LIFETIME
-    }
-
-    /// Releases the mapping.
     pub(crate) async fn release(self) -> Result<()> {
         let Mapping {
             gateway,
@@ -115,11 +119,6 @@ impl Mapping {
             .remove_port(igd::PortMappingProtocol::UDP, external_port.into())
             .await?;
         Ok(())
-    }
-
-    /// Returns the external gateway ip and port that can be used to contact this node.
-    pub fn external(&self) -> (Ipv4Addr, NonZeroU16) {
-        (self.external_ip, self.external_port)
     }
 }
 

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -122,10 +122,13 @@ pub enum Commands {
         /// Whether to enable PCP.
         #[clap(long)]
         enable_pcp: bool,
+        /// Whether to enable NAT-PMP.
+        #[clap(long)]
+        enable_nat_pmp: bool,
     },
     /// Attempt to get a port mapping to the given local port.
     PortMap {
-        /// Protocol to use for port mapping. One of ["upnp", "pcp"].
+        /// Protocol to use for port mapping. One of ["upnp", "nat_pmp", "pcp"].
         protocol: String,
         /// Local port to get a mapping.
         local_port: NonZeroU16,
@@ -612,9 +615,10 @@ async fn port_map(protocol: &str, local_port: NonZeroU16, timeout: Duration) -> 
     // create the config that enables exlusively the required protocol
     let mut enable_upnp = false;
     let mut enable_pcp = false;
-    let enable_nat_pmp = false;
+    let mut enable_nat_pmp = false;
     match protocol.to_ascii_lowercase().as_ref() {
         "upnp" => enable_upnp = true,
+        "nat_pmp" => enable_nat_pmp = true,
         "pcp" => enable_pcp = true,
         other => anyhow::bail!("Unknown port mapping protocol {other}"),
     }
@@ -835,11 +839,12 @@ pub async fn run(command: Commands, config: &Config) -> anyhow::Result<()> {
         Commands::PortMapProbe {
             enable_upnp,
             enable_pcp,
+            enable_nat_pmp,
         } => {
             let config = portmapper::Config {
                 enable_upnp,
                 enable_pcp,
-                enable_nat_pmp: false,
+                enable_nat_pmp,
             };
 
             port_map_probe(config).await


### PR DESCRIPTION
## Description

- Doctor command port getting a port mapping accepts nat pmp.
- Implement nat pmp protocol's requests and responses for udp mappings and external address queries with their encoding + decoding + tests.
- Connect new mapping protocol with the rest
- Correct some docs.

## Notes & open questions

Suggested way of trying:
### A Mapping
```bash
env RUST_LOG=trace cargo run doctor port-map nat_pmp 2446
```
### A probe
```bash
env RUST_LOG=trace cargo run doctor port-map-probe --enable-nat-pmp
```

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
