### PR TITLE
ref(iroh-net): Use a short format for node PublicKey logging

### DIFF
--- a/iroh-net/src/derp/client.rs
+++ b/iroh-net/src/derp/client.rs
@@ -61,7 +61,7 @@ impl Client {
     ///
     /// Errors if the packet is larger than [`super::MAX_PACKET_SIZE`]
     pub async fn send(&self, dstkey: PublicKey, packet: Bytes) -> Result<()> {
-        debug!("[DERP] -> {:?} ({}b)", dstkey, packet.len());
+        debug!(%dstkey, len=packet.len(), "[DERP] send");
 
         self.inner
             .writer_channel

--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -353,7 +353,7 @@ impl Client {
             debug!("got connection, conn num {conn_gen}");
             Ok((derp_client, conn_gen))
         }
-        .instrument(info_span!("client-connect", ?key))
+        .instrument(info_span!("client-connect", %key))
         .await
     }
 

--- a/iroh-net/src/key/node.rs
+++ b/iroh-net/src/key/node.rs
@@ -1,5 +1,6 @@
 //! The private and public keys of a node.
 
+use std::fmt::Display;
 use std::{fmt::Debug, hash::Hash};
 
 use anyhow::{anyhow, ensure, Context, Result};
@@ -25,6 +26,26 @@ impl From<crate::tls::PeerId> for PublicKey {
 impl Debug for PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "PublicKey({})", hex::encode(self.0.as_bytes()))
+    }
+}
+
+impl PublicKey {
+    /// The number of hex characters to show in [`PublicKey::short_hex`].
+    const SHORT_HEX_LENGTH: usize = 8;
+
+    /// Return a short hex-formatted string of this key.
+    ///
+    /// This is useful for displaying in logs etc.
+    pub fn short_hex(&self) -> String {
+        let bytes = &self.0.as_bytes()[..Self::SHORT_HEX_LENGTH];
+        hex::encode(bytes)
+    }
+}
+
+/// Uses the [`PublicKey::short_hex`] to represent the key.
+impl Display for PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PublicKey({}..)", self.short_hex())
     }
 }
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -281,10 +281,7 @@ impl MagicSock {
     ///
     /// [`Callbacks::on_endpoint`]: crate::magicsock::conn::Callbacks::on_endpoints
     pub async fn new(opts: Options) -> Result<Self> {
-        let name = format!(
-            "magic-{}",
-            hex::encode(&opts.private_key.public_key().as_ref()[..8])
-        );
+        let name = format!("magic-{}", opts.private_key.public_key().short_hex());
         Self::with_name(name.clone(), opts)
             .instrument(info_span!("conn", %name))
             .await
@@ -576,12 +573,12 @@ impl MagicSock {
 
         self.inner.closing.store(true, Ordering::Relaxed);
         self.inner.closed.store(true, Ordering::SeqCst);
-        // c.connCtxCancel()
 
         let mut tasks = self.actor_tasks.lock().await;
+        let task_count = tasks.len();
         let mut i = 0;
         while let Some(task) = tasks.pop() {
-            debug!("waiting for task {}", i);
+            debug!("waiting for task {i}/{task_count}");
             task.await?;
             i += 1;
         }
@@ -1080,7 +1077,7 @@ impl Actor {
             .endpoint_for_ip_port(&SendAddr::Udp(meta.addr))
         {
             None => {
-                warn!("no peer_map state found for {:?}, skipping", meta.addr);
+                warn!(peer=?meta.addr, "no peer_map state found for peer, skipping");
                 return false;
             }
             Some(ep) => {
@@ -1133,10 +1130,7 @@ impl Actor {
         let ep_quic_mapped_addr = match self.peer_map.endpoint_for_node_key(&dm.src) {
             Some(ep) => ep.quic_mapped_addr,
             None => {
-                info!(
-                    "no peer_map state found for {:?} in: {:#?}",
-                    dm.src, self.peer_map
-                );
+                info!(peer=%dm.src, "no peer_map state found for peer");
                 let id = self.peer_map.insert_endpoint(EndpointOptions {
                     conn_sender: self.conn.actor_sender.clone(),
                     conn_public_key: self.conn.public_key.clone(),
@@ -2211,12 +2205,16 @@ impl Actor {
         // remove moribund nodes in the next step below.
         for n in &self.net_map.as_ref().unwrap().peers {
             if self.peer_map.endpoint_for_node_key(&n.key).is_none() {
+                // info!(
+                //     "inserting peer's endpoint {:?} - {:?} {:#?} {:#?}",
+                //     self.inner.public_key, // our own node's public key
+                //     n.key.clone(),         // public key of node endpoint being created
+                //     self.peer_map,         // map of all endpoints we know about
+                //     n,                     // node being added
+                // );
                 info!(
-                    "inserting endpoint {:?} - {:?} {:#?} {:#?}",
-                    self.conn.public_key,
-                    n.key.clone(),
-                    self.peer_map,
-                    n,
+                    peer = %n.key,
+                    "inserting peer's endpoint in PeerMap"
                 );
                 self.peer_map.insert_endpoint(EndpointOptions {
                     conn_sender: self.conn.actor_sender.clone(),

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -243,7 +243,7 @@ impl DerpActor {
         contents: Vec<Bytes>,
         peer: key::node::PublicKey,
     ) {
-        debug!("sending derp region: {} - {:?}", region_id, peer);
+        debug!(region_id, %peer, "sending derp");
         {
             let derp_map = &*self.conn.derp_map.read().await;
             if derp_map.is_none() {
@@ -627,7 +627,7 @@ impl ReaderState {
                 return (ReadResult::Break, ReadAction::None);
             }
         };
-        debug!("derp.recv(derp-{}) received: {:?}", self.region, msg);
+        debug!(region_id=%self.region, ?msg, "derp.recv received");
 
         match msg {
             Err(err) => {


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

This uses the short hex format of the node PublicKey that was used for
the MagicSock logging in all places where we log.  It uses this format
in the Display of the PublicKey to make this convenient.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates if relevant.~~
- [ ] ~~Tests if relevant.~~