### PR TITLE
chore: Enable CI on merge_group trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
         echo "LAST_COMMIT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" >> ${GITHUB_ENV}
         echo "HEAD_REF=${{ github.event.pull_request.head.ref }}" >> ${GITHUB_ENV}
     - name: Setup Environment (Push)  
-      if: ${{ github.event_name == 'push' }}  
+      if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}  
       shell: bash  
       run: |  
         echo "LAST_COMMIT_SHA=$(git rev-parse --short ${GITHUB_SHA})" >> ${GITHUB_ENV}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build_and_test_nix:
+    timeout-minutes: 30
     name: Build and test (Nix)
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -72,6 +73,7 @@ jobs:
       run: cargo test --workspace --all-features --doc
       
   build_and_test_windows:
+    timeout-minutes: 30
     name: Build and test (Windows)
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -111,6 +113,7 @@ jobs:
       run: cargo test --workspace --lib --bins --tests --target ${{ matrix.target }}
 
   build_release:
+    timeout-minutes: 60
     name: Build release binaries
     runs-on: ${{ matrix.runner }}
     continue-on-error: false
@@ -209,6 +212,7 @@ jobs:
         aws s3 cp ./target/optimized-release/derper s3://vorc/derper-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
 
   cross:
+    timeout-minutes: 30
     name: Cross compile
     runs-on: [self-hosted, linux, X64]
     strategy:
@@ -244,6 +248,7 @@ jobs:
       run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
 
   check_fmt_and_docs:
+    timeout-minutes: 30
     name: Checking fmt and docs
     runs-on: ubuntu-latest
     steps:
@@ -260,6 +265,7 @@ jobs:
       run: cargo doc --workspace --all-features --no-deps --document-private-items
 
   clippy_check:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -279,6 +285,7 @@ jobs:
       run: cargo clippy --workspace --all-targets
 
   msrv:
+    timeout-minutes: 30
     name: Minimal Supported Rust Version
     runs-on: ubuntu-latest
     steps:
@@ -292,6 +299,7 @@ jobs:
         cargo +$MSRV check --workspace --all-targets --features cli
 
   cargo_deny:
+    timeout-minutes: 30
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
@@ -303,6 +311,7 @@ jobs:
           command-arguments: "-Dwarnings"
 
   netsim-integration-tests:
+    timeout-minutes: 30
     name: Run network simulations/benchmarks
     runs-on: [self-hosted, linux, X64]
     steps:

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   netsim:
+    timeout-minutes: 60
     name: Run network simulations/benchmarks
     if: >-
       (github.event_name == 'issue_comment' &&


### PR DESCRIPTION
## Description

This is required for CI jobs to run in the merge queue.  And if CI
doesn't run in the merge queue it will never have green CI to merge.

See docs for more info:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

It also needs to update the netsim-custom code that extracts the commit hash.

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates if relevant.~~
- [ ] ~~Tests if relevant.~~