### PR TITLE
refactor(iroh-net): Always attach tracing spans to spawned tasks

### DIFF
--- a/iroh-net/src/derp/client.rs
+++ b/iroh-net/src/derp/client.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
-use tracing::debug;
+use tracing::{debug, info_span, Instrument};
 
 use super::client_conn::Io;
 use super::PER_CLIENT_SEND_QUEUE_DEPTH;
@@ -500,15 +500,18 @@ where
 
         // create task to handle writing to the server
         let (writer_sender, writer_recv) = mpsc::channel(PER_CLIENT_SEND_QUEUE_DEPTH);
-        let writer_task = tokio::spawn(async move {
-            let client_writer = ClientWriter {
-                rate_limiter,
-                writer: self.writer,
-                recv_msgs: writer_recv,
-            };
-            client_writer.run().await?;
-            Ok(())
-        });
+        let writer_task = tokio::spawn(
+            async move {
+                let client_writer = ClientWriter {
+                    rate_limiter,
+                    writer: self.writer,
+                    recv_msgs: writer_recv,
+                };
+                client_writer.run().await?;
+                Ok(())
+            }
+            .instrument(info_span!("client.writer")),
+        );
 
         let client = Client {
             inner: Arc::new(InnerClient {

--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -17,7 +17,7 @@ use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::Instant;
-use tracing::{debug, info_span, instrument, warn, Instrument};
+use tracing::{debug, info_span, instrument, trace, warn, Instrument};
 use url::Url;
 
 use crate::derp::{
@@ -335,14 +335,14 @@ impl Client {
             // as well
             let mut derp_client_lock = self.inner.derp_client.lock().await;
             if let Some(derp_client) = &*derp_client_lock {
-                debug!("already had connection");
+                trace!("already had connection");
                 return Ok((
                     derp_client.clone(),
                     self.inner.conn_gen.load(Ordering::SeqCst),
                 ));
             }
 
-            debug!("no connection, trying to connect");
+            trace!("no connection, trying to connect");
             let derp_client = tokio::time::timeout(CONNECT_TIMEOUT, self.connect_0())
                 .await
                 .map_err(|_| ClientError::ConnectTimeout)??;
@@ -350,7 +350,7 @@ impl Client {
             let derp_client_clone = derp_client.clone();
             *derp_client_lock = Some(derp_client_clone);
             let conn_gen = self.inner.conn_gen.fetch_add(1, Ordering::SeqCst);
-            debug!("got connection, conn num {conn_gen}");
+            trace!("got connection, conn num {conn_gen}");
             Ok((derp_client, conn_gen))
         }
         .instrument(info_span!("client-connect", %key))
@@ -415,20 +415,20 @@ impl Client {
         true
     }
 
+    #[instrument(level = "debug", skip_all)]
     async fn connect_0(&self) -> Result<DerpClient, ClientError> {
-        debug!("connect_0");
         let url = self.url();
         let is_test_url = url
             .as_ref()
             .map(|url| url.as_str().ends_with(".invalid"))
             .unwrap_or_default();
 
-        debug!("connect_0 url: {:?}, is_test_url: {}", url, is_test_url);
+        debug!("url: {:?}, is_test_url: {}", url, is_test_url);
         let (tcp_stream, derp_node) = if url.is_some() && !is_test_url {
             (self.dial_url().await?, None)
         } else {
             let region = self.current_region().await?;
-            debug!("connect_0 region: {:?}", region);
+            debug!("region: {:?}", region);
             let (tcp_stream, derp_node) = self.dial_region(region).await?;
             (tcp_stream, Some(derp_node))
         };
@@ -474,16 +474,19 @@ impl Client {
                 .handshake(tls_stream)
                 .await
                 .map_err(ClientError::Hyper)?;
-            tokio::spawn(async move {
-                // polling `connection` drives the HTTP exchange
-                // this will poll until we upgrade the connection, but not shutdown the underlying
-                // stream
-                debug!("waiting for connection");
-                if let Err(err) = connection.await {
-                    warn!("client connection error: {:?}", err);
+            tokio::spawn(
+                async move {
+                    // polling `connection` drives the HTTP exchange
+                    // this will poll until we upgrade the connection, but not shutdown the underlying
+                    // stream
+                    debug!("waiting for connection");
+                    if let Err(err) = connection.await {
+                        warn!("client connection error: {:?}", err);
+                    }
+                    debug!("connection done");
                 }
-                debug!("connection done");
-            });
+                .instrument(info_span!("http.conn")),
+            );
             debug!("sending upgrade request");
             request_sender
                 .send_request(req)
@@ -495,16 +498,19 @@ impl Client {
                 .handshake(tcp_stream)
                 .await
                 .map_err(ClientError::Hyper)?;
-            tokio::spawn(async move {
-                // polling `connection` drives the HTTP exchange
-                // this will poll until we upgrade the connection, but not shutdown the underlying
-                // stream
-                debug!("waiting for connection");
-                if let Err(err) = connection.await {
-                    warn!("client connection error: {:?}", err);
+            tokio::spawn(
+                async move {
+                    // polling `connection` drives the HTTP exchange
+                    // this will poll until we upgrade the connection, but not shutdown the underlying
+                    // stream
+                    debug!("waiting for connection");
+                    if let Err(err) = connection.await {
+                        warn!("client connection error: {:?}", err);
+                    }
+                    debug!("connection done");
                 }
-                debug!("connection done");
-            });
+                .instrument(info_span!("http.conn")),
+            );
             debug!("sending upgrade request");
             request_sender
                 .send_request(req)
@@ -1249,11 +1255,14 @@ mod tests {
 
         let (send, recv) = tokio::sync::oneshot::channel();
         // spawn a task to run the mesh client
-        let mesh_task = tokio::spawn(async move {
-            mesh_client
-                .run_mesh_client(packet_forwarder_handler, Some(send))
-                .await
-        });
+        let mesh_task = tokio::spawn(
+            async move {
+                mesh_client
+                    .run_mesh_client(packet_forwarder_handler, Some(send))
+                    .await
+            }
+            .instrument(info_span!("mesh-client")),
+        );
 
         tokio::time::timeout(Duration::from_secs(5), recv).await??;
 

--- a/iroh-net/src/derp/http/server.rs
+++ b/iroh-net/src/derp/http/server.rs
@@ -23,7 +23,7 @@ use tokio::{
 };
 use tokio_rustls_acme::AcmeAcceptor;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, debug_span, error, info, info_span, warn, Instrument};
+use tracing::{debug, error, info, info_span, warn, Instrument};
 
 use super::HTTP_UPGRADE_PROTOCOL;
 use crate::{
@@ -385,7 +385,7 @@ impl ServerState {
                                 {
                                     error!("[{http_str}] derp: failed to handle connection: {e}");
                                 }
-                            }.instrument(debug_span!("handle_connection")));
+                            }.instrument(info_span!("conn")));
                         }
                         Err(err) => {
                             error!("[{http_str}] derp: failed to accept connection: {err}");
@@ -464,17 +464,19 @@ where
                                     derp_connection_handler(&closure_conn_handler, upgraded).await
                                 {
                                     tracing::warn!(
-                                        "server \"{HTTP_UPGRADE_PROTOCOL}\" io error: {:?}",
+                                        "upgrade to \"{HTTP_UPGRADE_PROTOCOL}\": io error: {:?}",
                                         e
                                     );
                                 } else {
-                                    tracing::info!("server \"{HTTP_UPGRADE_PROTOCOL}\" success");
+                                    tracing::info!(
+                                        "upgrade to \"{HTTP_UPGRADE_PROTOCOL}\" success"
+                                    );
                                 };
                             }
                             Err(e) => tracing::warn!("upgrade error: {:?}", e),
                         }
                     }
-                    .instrument(tracing::debug_span!("derp_connection_handler")),
+                    .instrument(tracing::debug_span!("handler")),
                 );
 
                 // Now return a 101 Response saying we agree to the upgrade to the

--- a/iroh-net/src/magicsock/metrics.rs
+++ b/iroh-net/src/magicsock/metrics.rs
@@ -32,6 +32,8 @@ pub struct Metrics {
     pub recv_data_derp: Counter,
     pub recv_data_ipv4: Counter,
     pub recv_data_ipv6: Counter,
+    /// Number of QUIC datagrams received.
+    pub recv_datagrams: Counter,
 
     // Disco packets
     pub send_disco_udp: Counter,
@@ -85,6 +87,7 @@ impl Default for Metrics {
             recv_data_derp: Counter::new("recv_data_derp"),
             recv_data_ipv4: Counter::new("recv_data_ipv4"),
             recv_data_ipv6: Counter::new("recv_data_ipv6"),
+            recv_datagrams: Counter::new("recv_datagrams"),
 
             // Disco packets
             send_disco_udp: Counter::new("disco_send_udp"),

--- a/iroh-net/src/magicsock/udp_actor.rs
+++ b/iroh-net/src/magicsock/udp_actor.rs
@@ -93,7 +93,8 @@ impl UdpActor {
                     match msg {
                         UdpActorMessage::Shutdown => {
                             debug!("shutting down");
-                            break;
+                            // Returning in order to not emit a warning on graceful shutdown
+                            return;
                         }
                     }
                 }

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -30,7 +30,9 @@ use rand::seq::IteratorRandom;
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Instant};
-use tracing::{debug, debug_span, error, info, info_span, instrument, trace, warn, Instrument};
+use tracing::{
+    debug, debug_span, error, info, info_span, instrument, trace, warn, Instrument, Span,
+};
 
 use super::NetcheckMetrics;
 use crate::defaults::DEFAULT_DERP_STUN_PORT;
@@ -258,6 +260,7 @@ impl Actor {
 
                 // Drive the portmapper.
                 pm = &mut port_mapping, if self.outstanding_tasks.port_mapper => {
+                    info!(report=?pm, "Portmapper probe report");
                     self.report.portmap_probe = pm;
                     port_mapping.inner = None;
                     self.outstanding_tasks.port_mapper = false;
@@ -421,16 +424,19 @@ impl Actor {
                 delay=?timeout,
                 "Have enough probe reports, aborting further probes soon",
             );
-            tokio::spawn(async move {
-                time::sleep(timeout).await;
-                // Because we do this after a timeout it is entirely normal that the actor
-                // is no longer there by the time we send this message.
-                reportcheck
-                    .send(Message::AbortProbes)
-                    .await
-                    .map_err(|err| trace!("Failed to abort all probes: {err:#}"))
-                    .ok();
-            });
+            tokio::spawn(
+                async move {
+                    time::sleep(timeout).await;
+                    // Because we do this after a timeout it is entirely normal that the actor
+                    // is no longer there by the time we send this message.
+                    reportcheck
+                        .send(Message::AbortProbes)
+                        .await
+                        .map_err(|err| trace!("Failed to abort all probes: {err:#}"))
+                        .ok();
+                }
+                .instrument(Span::current()),
+            );
         }
 
         if let Some(ipp) = ipp {

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -17,6 +17,7 @@ use iroh_bytes::{protocol::RequestToken, provider::BaoReadonlyDb, util::runtime}
 use iroh_net::{derp::DerpMap, tls::Keypair};
 use quic_rpc::{transport::quinn::QuinnServerEndpoint, ServiceEndpoint};
 use tokio::io::AsyncWriteExt;
+use tracing::{info_span, Instrument};
 
 use crate::config::iroh_data_root;
 
@@ -70,30 +71,33 @@ pub async fn run(rt: &runtime::Handle, path: Option<PathBuf>, opts: ProvideOptio
     // task that will add data to the provider, either from a file or from stdin
     let fut = {
         let provider = provider.clone();
-        tokio::spawn(async move {
-            let (path, tmp_path) = if let Some(path) = path {
-                let absolute = path.canonicalize()?;
-                println!("Adding {} as {}...", path.display(), absolute.display());
-                (absolute, None)
-            } else {
-                // Store STDIN content into a temporary file
-                let (file, path) = tempfile::NamedTempFile::new()?.into_parts();
-                let mut file = tokio::fs::File::from_std(file);
-                let path_buf = path.to_path_buf();
-                // Copy from stdin to the file, until EOF
-                tokio::io::copy(&mut tokio::io::stdin(), &mut file).await?;
-                println!("Adding from stdin...");
-                // return the TempPath to keep it alive
-                (path_buf, Some(path))
-            };
-            // tell the provider to add the data
-            let stream = controller.server_streaming(ProvideRequest { path }).await?;
-            let (hash, entries) = aggregate_add_response(stream).await?;
-            print_add_response(hash, entries);
-            let ticket = provider.ticket(hash).await?.with_token(token);
-            println!("All-in-one ticket: {ticket}");
-            anyhow::Ok(tmp_path)
-        })
+        tokio::spawn(
+            async move {
+                let (path, tmp_path) = if let Some(path) = path {
+                    let absolute = path.canonicalize()?;
+                    println!("Adding {} as {}...", path.display(), absolute.display());
+                    (absolute, None)
+                } else {
+                    // Store STDIN content into a temporary file
+                    let (file, path) = tempfile::NamedTempFile::new()?.into_parts();
+                    let mut file = tokio::fs::File::from_std(file);
+                    let path_buf = path.to_path_buf();
+                    // Copy from stdin to the file, until EOF
+                    tokio::io::copy(&mut tokio::io::stdin(), &mut file).await?;
+                    println!("Adding from stdin...");
+                    // return the TempPath to keep it alive
+                    (path_buf, Some(path))
+                };
+                // tell the provider to add the data
+                let stream = controller.server_streaming(ProvideRequest { path }).await?;
+                let (hash, entries) = aggregate_add_response(stream).await?;
+                print_add_response(hash, entries);
+                let ticket = provider.ticket(hash).await?.with_token(token);
+                println!("All-in-one ticket: {ticket}");
+                anyhow::Ok(tmp_path)
+            }
+            .instrument(info_span!("provider-add")),
+        )
     };
 
     let provider2 = provider.clone();


### PR DESCRIPTION
## Description

This is another commit that keeps fine-tuning our logging.

- Most importantly this consistently attaches spans when tasks are
  spawned.  This threads togehther a lot more context.

- As a general rule spawned tasks get info_span!(), otther spans get
  debug_span!()

- protmapper report is logged on info in reportgen now, just as the
  other sub-reports.

- MagicSock::poll_recv logs number of datagrams on trace now instead
  of info.  This is expected to be a lot.  A new metric is added to
  keep track of this as well.

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates if relevant.~~
- [ ] ~~Tests if relevant.~~