### PR TITLE
chore(ci): ensure external contributors don't fail CI on report dumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
 
     - name: test
       run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
-
+  
   check_fmt_and_docs:
     timeout-minutes: 30
     name: Checking fmt and docs
@@ -383,6 +383,7 @@ jobs:
         python3 reports_csv.py --metro --integration --commit ${{ env.LAST_COMMIT_SHA }} > report_metro_integration.txt
 
     - name: Dump report
+      if: ${{ github.repository == 'n0-computer/iroh' }}
       run: |
         export AWS_ACCESS_KEY_ID=${{secrets.S3_ACCESS_KEY_ID}}
         export AWS_SECRET_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
 
     - name: test
       run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
-  
+
   check_fmt_and_docs:
     timeout-minutes: 30
     name: Checking fmt and docs

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -10,7 +10,7 @@ on:
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
-  MSRV: "1.63"
+  MSRV: "1.66"
 
 jobs:
   netsim:


### PR DESCRIPTION
## Description

Detects if we're running netsim from a fork and doesn't dump reports.
Closes https://github.com/n0-computer/iroh/issues/1297

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
