### PR TITLE
feat: metrics for iroh-gossip and iroh-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
  "futures",
  "genawaiter",
  "indexmap 2.0.0",
+ "iroh-metrics",
  "iroh-net",
  "once_cell",
  "postcard",

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -21,6 +21,7 @@ rand = { version = "0.8.5", features = ["std_rng"] }
 rand_core = "0.6.4"
 serde = { version = "1.0.164", features = ["derive"] }
 tracing = "0.1.37"
+iroh-metrics = { path = "../iroh-metrics", version = "0.5.0" }
 
 # net dependencies (optional)
 futures = { version = "0.3.25", optional = true }

--- a/iroh-gossip/src/lib.rs
+++ b/iroh-gossip/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
+pub mod metrics;
 #[cfg(feature = "net")]
 pub mod net;
 pub mod proto;

--- a/iroh-gossip/src/metrics.rs
+++ b/iroh-gossip/src/metrics.rs
@@ -1,0 +1,49 @@
+//! Metrics for iroh-gossip
+
+use iroh_metrics::{
+    core::{Counter, Metric},
+    struct_iterable::Iterable,
+};
+
+/// Enum of metrics for the module
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Iterable)]
+pub struct Metrics {
+    pub msgs_ctrl_sent: Counter,
+    pub msgs_ctrl_recv: Counter,
+    pub msgs_data_sent: Counter,
+    pub msgs_data_recv: Counter,
+    pub msgs_data_sent_size: Counter,
+    pub msgs_data_recv_size: Counter,
+    pub msgs_ctrl_sent_size: Counter,
+    pub msgs_ctrl_recv_size: Counter,
+    pub neighbor_up: Counter,
+    pub neighbor_down: Counter,
+    // pub topics_joined: Counter,
+    // pub topics_left: Counter,
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            msgs_ctrl_sent: Counter::new("Number of control messages sent"),
+            msgs_ctrl_recv: Counter::new("Number of control messages received"),
+            msgs_data_sent: Counter::new("Number of data messages sent"),
+            msgs_data_recv: Counter::new("Number of data messages received"),
+            msgs_data_sent_size: Counter::new("Total size of all data messages sent"),
+            msgs_data_recv_size: Counter::new("Total size of all data messages received"),
+            msgs_ctrl_sent_size: Counter::new("Total size of all control messages sent"),
+            msgs_ctrl_recv_size: Counter::new("Total size of all control messages received"),
+            neighbor_up: Counter::new("Number of times we connected to a peer"),
+            neighbor_down: Counter::new("Number of times we disconnected from a peer"),
+            // topics_joined: Counter::new("Number of times we joined a topic"),
+            // topics_left: Counter::new("Number of times we left a topic"),
+        }
+    }
+}
+
+impl Metric for Metrics {
+    fn name() -> &'static str {
+        "Iroh Gossip"
+    }
+}

--- a/iroh-gossip/src/proto/plumtree.rs
+++ b/iroh-gossip/src/proto/plumtree.rs
@@ -134,6 +134,9 @@ impl Gossip {
             round: self.round.next(),
         }
     }
+    pub fn content_len(&self) -> usize {
+        self.content.len()
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/iroh-gossip/src/proto/state.rs
+++ b/iroh-gossip/src/proto/state.rs
@@ -12,8 +12,10 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::proto::{topic, Config, PeerAddress};
+use iroh_metrics::{inc, inc_by};
 
 use super::PeerData;
+use crate::metrics::Metrics;
 
 /// The identifier for a topic
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Ord, PartialOrd, Deserialize)]
@@ -84,6 +86,28 @@ impl FromStr for TopicId {
 pub struct Message<PA> {
     topic: TopicId,
     message: topic::Message<PA>,
+}
+
+impl<PA> Message<PA> {
+    /// Get the kind of this message
+    pub fn kind(&self) -> MessageKind {
+        self.message.kind()
+    }
+}
+
+/// Whether this is a control or data message
+pub enum MessageKind {
+    /// A data message and its payload size.
+    Data,
+    /// A control message.
+    Control,
+}
+
+impl<PA: Serialize> Message<PA> {
+    /// Get the encoded size of this message
+    pub fn size(&self) -> postcard::Result<usize> {
+        postcard::experimental::serialized_size(&self)
+    }
 }
 
 /// A timer to be registered into the runtime
@@ -234,6 +258,8 @@ impl<PA: PeerAddress, R: Rng + Clone> State<PA, R> {
         event: InEvent<PA>,
         now: Instant,
     ) -> impl Iterator<Item = OutEvent<PA>> + '_ {
+        track_in_event(&event);
+
         let event: InEventMapped<PA> = event.into();
 
         // todo: add command to leave a topic
@@ -296,6 +322,9 @@ impl<PA: PeerAddress, R: Rng + Clone> State<PA, R> {
             }
         }
 
+        // track metrics
+        track_out_events(&self.outbox);
+
         self.outbox.drain(..)
     }
 }
@@ -325,5 +354,60 @@ fn handle_out_event<PA: PeerAddress>(
             }
         }
         topic::OutEvent::PeerData(peer, data) => outbox.push(OutEvent::PeerData(peer, data)),
+    }
+}
+
+fn track_out_events<PA: Serialize>(events: &[OutEvent<PA>]) {
+    for event in events {
+        match event {
+            OutEvent::SendMessage(_to, message) => match message.kind() {
+                MessageKind::Data => {
+                    inc!(Metrics, msgs_data_sent);
+                    inc_by!(
+                        Metrics,
+                        msgs_data_sent_size,
+                        message.size().unwrap_or(0) as u64
+                    );
+                }
+                MessageKind::Control => {
+                    inc!(Metrics, msgs_ctrl_sent);
+                    inc_by!(
+                        Metrics,
+                        msgs_ctrl_sent_size,
+                        message.size().unwrap_or(0) as u64
+                    );
+                }
+            },
+            OutEvent::EmitEvent(_topic, event) => match event {
+                super::Event::NeighborUp(_peer) => inc!(Metrics, neighbor_up),
+                super::Event::NeighborDown(_peer) => inc!(Metrics, neighbor_down),
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+}
+
+fn track_in_event<PA: Serialize>(event: &InEvent<PA>) {
+    match event {
+        InEvent::RecvMessage(_from, message) => match message.kind() {
+            MessageKind::Data => {
+                inc!(Metrics, msgs_data_recv);
+                inc_by!(
+                    Metrics,
+                    msgs_data_recv_size,
+                    message.size().unwrap_or(0) as u64
+                );
+            }
+            MessageKind::Control => {
+                inc!(Metrics, msgs_ctrl_recv);
+                inc_by!(
+                    Metrics,
+                    msgs_ctrl_recv_size,
+                    message.size().unwrap_or(0) as u64
+                );
+            }
+        },
+        _ => {}
     }
 }

--- a/iroh-gossip/src/proto/topic.rs
+++ b/iroh-gossip/src/proto/topic.rs
@@ -12,8 +12,11 @@ use rand::Rng;
 use rand_core::SeedableRng;
 use serde::{Deserialize, Serialize};
 
-use super::hyparview::{self, InEvent as SwarmIn};
 use super::plumtree::{self, InEvent as GossipIn};
+use super::{
+    hyparview::{self, InEvent as SwarmIn},
+    state::MessageKind,
+};
 use super::{PeerAddress, PeerData};
 
 /// Input event to the topic state handler.
@@ -94,6 +97,19 @@ pub enum Message<PA> {
     Swarm(hyparview::Message<PA>),
     /// A message of the gossip broadcast layer
     Gossip(plumtree::Message),
+}
+
+impl<PA> Message<PA> {
+    /// Get the kind of this message
+    pub fn kind(&self) -> MessageKind {
+        match self {
+            Message::Swarm(_) => MessageKind::Control,
+            Message::Gossip(message) => match message {
+                plumtree::Message::Gossip(_) => MessageKind::Data,
+                _ => MessageKind::Control,
+            },
+        }
+    }
 }
 
 /// An event to be emitted to the application for a particular topic.

--- a/iroh/src/sync.rs
+++ b/iroh/src/sync.rs
@@ -15,6 +15,8 @@ pub const SYNC_ALPN: &[u8] = b"/iroh-sync/1";
 
 mod content;
 mod live;
+pub mod metrics;
+
 pub use content::*;
 pub use live::*;
 

--- a/iroh/src/sync/metrics.rs
+++ b/iroh/src/sync/metrics.rs
@@ -1,0 +1,45 @@
+use iroh_metrics::{
+    core::{Counter, Metric},
+    struct_iterable::Iterable,
+};
+
+/// Metrics for iroh-sync
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Iterable)]
+pub struct Metrics {
+    pub new_entries_local: Counter,
+    pub new_entries_remote: Counter,
+    pub new_entries_local_size: Counter,
+    pub new_entries_remote_size: Counter,
+    pub download_bytes_total: Counter,
+    pub download_time_total: Counter,
+    pub downloads_success: Counter,
+    pub downloads_error: Counter,
+    pub downloads_notfound: Counter,
+    pub initial_sync_success: Counter,
+    pub initial_sync_failed: Counter,
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            new_entries_local: Counter::new("Number of document entries added locally"),
+            new_entries_remote: Counter::new("Number of document entries added by peers"),
+            new_entries_local_size: Counter::new("Total size of entry contents added locally"),
+            new_entries_remote_size: Counter::new("Total size of entry contents added by peers"),
+            download_bytes_total: Counter::new("Total number of content bytes downloaded"),
+            download_time_total: Counter::new("Total time in ms spent downloading content bytes"),
+            downloads_success: Counter::new("Total number of successfull downloads"),
+            downloads_error: Counter::new("Total number of downloads failed with error"),
+            downloads_notfound: Counter::new("Total number of downloads failed with not found"),
+            initial_sync_success: Counter::new("Number of successfull initial syncs "),
+            initial_sync_failed: Counter::new("Number of failed initial syncs"),
+        }
+    }
+}
+
+impl Metric for Metrics {
+    fn name() -> &'static str {
+        "iroh-sync"
+    }
+}


### PR DESCRIPTION
## Description

This PR adds metrics for iroh-gossip and iroh-sync. The commit on iroh-gossip should move to #1149 but this will happen not today to keep things easy for the demo.

Also adds a `stats` command to the repl to display current metrics.

![foo](https://github.com/n0-computer/iroh/assets/43627/ddb89129-e621-4772-9244-9260ecdc5e82)


## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] ~~Tests if relevant.~~
