### PR TITLE
fix: remove usage of unbounded channels

### DIFF
--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -436,6 +436,7 @@ impl Replica {
         let bytes = postcard::to_stdvec(&data)?;
         Ok(bytes.into())
     }
+
     pub fn from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
         let data: ReplicaData = postcard::from_bytes(bytes)?;
         let replica = Self::new(data.namespace);

--- a/iroh/src/sync/content.rs
+++ b/iroh/src/sync/content.rs
@@ -328,6 +328,7 @@ impl Downloader {
             .lock()
             .unwrap()
             .insert(hash, fut.boxed().shared());
+        // TODO: this is potentially blocking inside an async call. figure out a better solution
         if let Err(err) = self.to_actor_tx.send(req) {
             warn!("download actor dropped: {err}");
         }

--- a/iroh/src/sync/live.rs
+++ b/iroh/src/sync/live.rs
@@ -242,6 +242,7 @@ impl Actor {
         doc.on_insert(Box::new(move |origin, entry| {
             // only care for local inserts, otherwise we'd do endless gossip loops
             if let InsertOrigin::Local = origin {
+                // TODO: this is potentially blocking inside an async call. figure out a better solution
                 insert_entry_tx.send((topic, entry)).ok();
             }
         }));


### PR DESCRIPTION
uses flume channels to allow for combined sync and async usage

