### PR TITLE
[WIP] feat(iroh-sync): download from peer that informed us about a change

### DIFF
--- a/iroh-net/src/tls.rs
+++ b/iroh-net/src/tls.rs
@@ -118,6 +118,11 @@ impl PeerId {
         let key = PublicKey::from_bytes(bytes)?;
         Ok(PeerId(key))
     }
+
+    /// Get the peer id as a byte array.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.to_bytes()
+    }
 }
 
 impl From<PublicKey> for PeerId {

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -924,7 +924,7 @@ mod tests {
             rounds += 1;
             println!("round {}", rounds);
             if let Some(msg) = bob.sync_process_message(msg, None).map_err(Into::into)? {
-                next_to_bob = alice.sync_process_message(msg, None).map_err(Into::into);
+                next_to_bob = alice.sync_process_message(msg, None).map_err(Into::into)?;
             }
         }
 

--- a/iroh/src/download.rs
+++ b/iroh/src/download.rs
@@ -20,7 +20,7 @@ use tokio_stream::StreamExt;
 use tracing::{debug, error, warn};
 
 // TODO: Move metrics to iroh-bytes metrics
-use crate::sync::metrics::Metrics;
+use crate::metrics::Metrics;
 // TODO: Will be replaced by proper persistent DB once
 // https://github.com/n0-computer/iroh/pull/1320 is merged
 use crate::database::flat::writable::WritableFileDatabase;

--- a/iroh/src/download.rs
+++ b/iroh/src/download.rs
@@ -20,7 +20,7 @@ use tokio_stream::StreamExt;
 use tracing::{debug, error, warn};
 
 // TODO: Move metrics to iroh-bytes metrics
-use super::sync::metrics::Metrics;
+use crate::sync::metrics::Metrics;
 // TODO: Will be replaced by proper persistent DB once
 // https://github.com/n0-computer/iroh/pull/1320 is merged
 use crate::database::flat::writable::WritableFileDatabase;

--- a/iroh/src/download.rs
+++ b/iroh/src/download.rs
@@ -1,0 +1,347 @@
+//! Download queue
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+use futures::{
+    future::{BoxFuture, LocalBoxFuture, Shared},
+    stream::FuturesUnordered,
+    FutureExt,
+};
+use iroh_bytes::util::Hash;
+use iroh_gossip::net::util::Dialer;
+use iroh_metrics::{inc, inc_by};
+use iroh_net::{tls::PeerId, MagicEndpoint};
+use tokio::sync::oneshot;
+use tokio_stream::StreamExt;
+use tracing::{debug, error, warn};
+
+// TODO: Move metrics to iroh-bytes metrics
+use super::sync::metrics::Metrics;
+// TODO: Will be replaced by proper persistent DB once
+// https://github.com/n0-computer/iroh/pull/1320 is merged
+use crate::database::flat::writable::WritableFileDatabase;
+
+/// Future for the completion of a download request
+pub type DownloadFuture = Shared<BoxFuture<'static, Option<(Hash, u64)>>>;
+
+/// A download queue for iroh-bytes
+///
+/// Spawns a background task that handles connecting to peers and performing get requests.
+///
+/// TODO: Move to iroh-bytes or replace with corresponding feature from iroh-bytes once available
+/// TODO: Support retries and backoff - become a proper queue...
+/// TODO: Download requests send via synchronous flume::Sender::send. Investigate if we want async
+/// here. We currently use [`Downloader::push`] from [`iroh_sync::Replica::on_insert`] callbacks,
+/// which are sync, thus we need a sync method on the Downloader to push new download requests.
+#[derive(Debug, Clone)]
+pub struct Downloader {
+    pending_downloads: Arc<Mutex<HashMap<Hash, DownloadFuture>>>,
+    to_actor_tx: flume::Sender<DownloadRequest>,
+}
+
+impl Downloader {
+    /// Create a new downloader
+    pub fn new(
+        rt: iroh_bytes::util::runtime::Handle,
+        endpoint: MagicEndpoint,
+        db: WritableFileDatabase,
+    ) -> Self {
+        let (tx, rx) = flume::bounded(64);
+        // spawn the actor on a local pool
+        // the local pool is required because WritableFileDatabase::download_single
+        // returns a future that is !Send
+        rt.local_pool().spawn_pinned(move || async move {
+            let mut actor = DownloadActor::new(endpoint, db, rx);
+            if let Err(err) = actor.run().await {
+                error!("download actor failed with error {err:?}");
+            }
+        });
+        Self {
+            pending_downloads: Arc::new(Mutex::new(HashMap::new())),
+            to_actor_tx: tx,
+        }
+    }
+
+    /// Add a new download request to the download queue.
+    ///
+    /// Note: This method takes only [`PeerId`]s and will attempt to connect to those peers. For
+    /// this to succeed, you need to add addresses for these peers to the magic endpoint's
+    /// addressbook yourself. See [`MagicEndpoint::add_known_addrs`].
+    pub fn push(&self, hash: Hash, peers: Vec<PeerId>) {
+        let (reply, reply_rx) = oneshot::channel();
+        let req = DownloadRequest { hash, peers, reply };
+
+        // TODO: this is potentially blocking inside an async call. figure out a better solution
+        if let Err(err) = self.to_actor_tx.send(req) {
+            warn!("download actor dropped: {err}");
+        }
+
+        if self.pending_downloads.lock().unwrap().get(&hash).is_none() {
+            let pending_downloads = self.pending_downloads.clone();
+            let fut = async move {
+                let res = reply_rx.await;
+                pending_downloads.lock().unwrap().remove(&hash);
+                res.ok().flatten()
+            };
+            self.pending_downloads
+                .lock()
+                .unwrap()
+                .insert(hash, fut.boxed().shared());
+        }
+    }
+
+    /// Returns a future that completes once the blob for `hash` has been downloaded, or all queued
+    /// requests for that blob have failed.
+    ///
+    /// NOTE: This does not start the download itself. Use [`Self::push`] for that.
+    pub fn finished(&self, hash: &Hash) -> DownloadFuture {
+        match self.pending_downloads.lock().unwrap().get(hash) {
+            Some(fut) => fut.clone(),
+            None => futures::future::ready(None).boxed().shared(),
+        }
+    }
+}
+
+type DownloadReply = oneshot::Sender<Option<(Hash, u64)>>;
+type PendingDownloadsFutures =
+    FuturesUnordered<LocalBoxFuture<'static, (PeerId, Hash, anyhow::Result<Option<(Hash, u64)>>)>>;
+
+#[derive(Debug)]
+struct DownloadRequest {
+    hash: Hash,
+    peers: Vec<PeerId>,
+    reply: DownloadReply,
+}
+
+#[derive(Debug)]
+struct DownloadActor {
+    dialer: Dialer,
+    db: WritableFileDatabase,
+    conns: HashMap<PeerId, quinn::Connection>,
+    replies: HashMap<Hash, VecDeque<DownloadReply>>,
+    pending_download_futs: PendingDownloadsFutures,
+    queue: DownloadQueue,
+    rx: flume::Receiver<DownloadRequest>,
+}
+impl DownloadActor {
+    fn new(
+        endpoint: MagicEndpoint,
+        db: WritableFileDatabase,
+        rx: flume::Receiver<DownloadRequest>,
+    ) -> Self {
+        Self {
+            rx,
+            db,
+            dialer: Dialer::new(endpoint),
+            replies: Default::default(),
+            conns: Default::default(),
+            pending_download_futs: Default::default(),
+            queue: Default::default(),
+        }
+    }
+    pub async fn run(&mut self) -> anyhow::Result<()> {
+        loop {
+            tokio::select! {
+                req = self.rx.recv_async() => match req {
+                    Err(_) => return Ok(()),
+                    Ok(req) => self.on_download_request(req).await
+                },
+                (peer, conn) = self.dialer.next() => match conn {
+                    Ok(conn) => {
+                        debug!("connection to {peer} established");
+                        self.conns.insert(peer, conn);
+                        self.on_peer_ready(peer);
+                    },
+                    Err(err) => self.on_peer_fail(&peer, err),
+                },
+                Some((peer, hash, res)) = self.pending_download_futs.next() => match res {
+                    Ok(Some((hash, size))) => {
+                        self.queue.on_success(hash, peer);
+                        self.reply(hash, Some((hash, size)));
+                        self.on_peer_ready(peer);
+                    }
+                    Ok(None) => {
+                        self.on_not_found(&peer, hash);
+                        self.on_peer_ready(peer);
+                    }
+                    Err(err) => self.on_peer_fail(&peer, err),
+                }
+            }
+        }
+    }
+
+    fn reply(&mut self, hash: Hash, res: Option<(Hash, u64)>) {
+        for reply in self.replies.remove(&hash).into_iter().flatten() {
+            reply.send(res).ok();
+        }
+    }
+
+    fn on_peer_fail(&mut self, peer: &PeerId, err: anyhow::Error) {
+        warn!("download from {peer} failed: {err}");
+        for hash in self.queue.on_peer_fail(peer) {
+            self.reply(hash, None);
+        }
+        self.conns.remove(peer);
+    }
+
+    fn on_not_found(&mut self, peer: &PeerId, hash: Hash) {
+        self.queue.on_not_found(hash, *peer);
+        if self.queue.has_no_candidates(&hash) {
+            self.reply(hash, None);
+        }
+    }
+
+    fn on_peer_ready(&mut self, peer: PeerId) {
+        if let Some(hash) = self.queue.try_next_for_peer(peer) {
+            self.start_download_unchecked(peer, hash);
+        } else {
+            self.conns.remove(&peer);
+        }
+    }
+
+    fn start_download_unchecked(&mut self, peer: PeerId, hash: Hash) {
+        let conn = self.conns.get(&peer).unwrap().clone();
+        let blobs = self.db.clone();
+        let fut = async move {
+            let start = Instant::now();
+            let res = blobs.download_single(conn, hash).await;
+            // record metrics
+            let elapsed = start.elapsed().as_millis();
+            match &res {
+                Ok(Some((_hash, len))) => {
+                    inc!(Metrics, downloads_success);
+                    inc_by!(Metrics, download_bytes_total, *len);
+                    inc_by!(Metrics, download_time_total, elapsed as u64);
+                }
+                Ok(None) => inc!(Metrics, downloads_notfound),
+                Err(_) => inc!(Metrics, downloads_error),
+            }
+            (peer, hash, res)
+        };
+        self.pending_download_futs.push(fut.boxed_local());
+    }
+
+    async fn on_download_request(&mut self, req: DownloadRequest) {
+        let DownloadRequest { peers, hash, reply } = req;
+        if self.db.has(&hash) {
+            let size = self.db.get_size(&hash).await.unwrap();
+            reply.send(Some((hash, size))).ok();
+            return;
+        }
+        self.replies.entry(hash).or_default().push_back(reply);
+        for peer in peers {
+            self.queue.push_candidate(hash, peer);
+            // TODO: Don't dial all peers instantly.
+            if self.conns.get(&peer).is_none() && !self.dialer.is_pending(&peer) {
+                self.dialer.queue_dial(peer, &iroh_bytes::protocol::ALPN);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct DownloadQueue {
+    candidates_by_hash: HashMap<Hash, VecDeque<PeerId>>,
+    candidates_by_peer: HashMap<PeerId, VecDeque<Hash>>,
+    running_by_hash: HashMap<Hash, PeerId>,
+    running_by_peer: HashMap<PeerId, Hash>,
+}
+
+impl DownloadQueue {
+    pub fn push_candidate(&mut self, hash: Hash, peer: PeerId) {
+        self.candidates_by_hash
+            .entry(hash)
+            .or_default()
+            .push_back(peer);
+        self.candidates_by_peer
+            .entry(peer)
+            .or_default()
+            .push_back(hash);
+    }
+
+    pub fn try_next_for_peer(&mut self, peer: PeerId) -> Option<Hash> {
+        let mut next = None;
+        for (idx, hash) in self.candidates_by_peer.get(&peer)?.iter().enumerate() {
+            if !self.running_by_hash.contains_key(hash) {
+                next = Some((idx, *hash));
+                break;
+            }
+        }
+        if let Some((idx, hash)) = next {
+            self.running_by_hash.insert(hash, peer);
+            self.running_by_peer.insert(peer, hash);
+            self.candidates_by_peer.get_mut(&peer).unwrap().remove(idx);
+            if let Some(peers) = self.candidates_by_hash.get_mut(&hash) {
+                peers.retain(|p| p != &peer);
+            }
+            self.ensure_no_empty(hash, peer);
+            return Some(hash);
+        } else {
+            None
+        }
+    }
+
+    pub fn has_no_candidates(&self, hash: &Hash) -> bool {
+        self.candidates_by_hash.get(hash).is_none() && self.running_by_hash.get(&hash).is_none()
+    }
+
+    pub fn on_success(&mut self, hash: Hash, peer: PeerId) -> Option<(PeerId, Hash)> {
+        let peer2 = self.running_by_hash.remove(&hash);
+        debug_assert_eq!(peer2, Some(peer));
+        self.running_by_peer.remove(&peer);
+        self.try_next_for_peer(peer).map(|hash| (peer, hash))
+    }
+
+    pub fn on_peer_fail(&mut self, peer: &PeerId) -> Vec<Hash> {
+        let mut failed = vec![];
+        for hash in self
+            .candidates_by_peer
+            .remove(peer)
+            .map(|hashes| hashes.into_iter())
+            .into_iter()
+            .flatten()
+        {
+            if let Some(peers) = self.candidates_by_hash.get_mut(&hash) {
+                peers.retain(|p| p != peer);
+                if peers.is_empty() && self.running_by_hash.get(&hash).is_none() {
+                    failed.push(hash);
+                }
+            }
+        }
+        if let Some(hash) = self.running_by_peer.remove(&peer) {
+            self.running_by_hash.remove(&hash);
+            if self.candidates_by_hash.get(&hash).is_none() {
+                failed.push(hash);
+            }
+        }
+        failed
+    }
+
+    pub fn on_not_found(&mut self, hash: Hash, peer: PeerId) {
+        let peer2 = self.running_by_hash.remove(&hash);
+        debug_assert_eq!(peer2, Some(peer));
+        self.running_by_peer.remove(&peer);
+        self.ensure_no_empty(hash, peer);
+    }
+
+    fn ensure_no_empty(&mut self, hash: Hash, peer: PeerId) {
+        if self
+            .candidates_by_peer
+            .get(&peer)
+            .map_or(false, |hashes| hashes.is_empty())
+        {
+            self.candidates_by_peer.remove(&peer);
+        }
+        if self
+            .candidates_by_hash
+            .get(&hash)
+            .map_or(false, |peers| peers.is_empty())
+        {
+            self.candidates_by_hash.remove(&hash);
+        }
+    }
+}

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -8,6 +8,7 @@ pub use iroh_net as net;
 pub mod collection;
 pub mod database;
 pub mod dial;
+pub mod download;
 pub mod node;
 pub mod rpc_protocol;
 #[allow(missing_docs)]

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -10,6 +10,11 @@ pub struct Metrics {
     pub requests_total: Counter,
     pub bytes_sent: Counter,
     pub bytes_received: Counter,
+    pub download_bytes_total: Counter,
+    pub download_time_total: Counter,
+    pub downloads_success: Counter,
+    pub downloads_error: Counter,
+    pub downloads_notfound: Counter,
 }
 
 impl Default for Metrics {
@@ -18,6 +23,11 @@ impl Default for Metrics {
             requests_total: Counter::new("Total number of requests received"),
             bytes_sent: Counter::new("Number of bytes streamed"),
             bytes_received: Counter::new("Number of bytes received"),
+            download_bytes_total: Counter::new("Total number of content bytes downloaded"),
+            download_time_total: Counter::new("Total time in ms spent downloading content bytes"),
+            downloads_success: Counter::new("Total number of successfull downloads"),
+            downloads_error: Counter::new("Total number of downloads failed with error"),
+            downloads_notfound: Counter::new("Total number of downloads failed with not found"),
         }
     }
 }

--- a/iroh/src/sync.rs
+++ b/iroh/src/sync.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use anyhow::{bail, ensure, Context, Result};
 use bytes::BytesMut;
-use iroh_net::{tls::PeerId, MagicEndpoint, magic_endpoint::get_peer_id};
+use iroh_net::{magic_endpoint::get_peer_id, tls::PeerId, MagicEndpoint};
 use iroh_sync::{
     store,
     sync::{NamespaceId, Replica},
@@ -146,7 +146,9 @@ pub async fn run_bob<S: store::Store, R: AsyncRead + Unpin, W: AsyncWrite + Unpi
                 match replica_store.get_replica(&namespace)? {
                     Some(r) => {
                         debug!("starting sync for {}", namespace);
-                        if let Some(msg) = r.sync_process_message(message, peer).map_err(Into::into)? {
+                        if let Some(msg) =
+                            r.sync_process_message(message, peer).map_err(Into::into)?
+                        {
                             send_sync_message(writer, msg).await?;
                         } else {
                             break;
@@ -161,7 +163,10 @@ pub async fn run_bob<S: store::Store, R: AsyncRead + Unpin, W: AsyncWrite + Unpi
             }
             Message::Sync(msg) => match replica {
                 Some(ref replica) => {
-                    if let Some(msg) = replica.sync_process_message(msg, peer).map_err(Into::into)? {
+                    if let Some(msg) = replica
+                        .sync_process_message(msg, peer)
+                        .map_err(Into::into)?
+                    {
                         send_sync_message(writer, msg).await?;
                     } else {
                         break;
@@ -237,8 +242,13 @@ mod tests {
         let (mut alice_reader, mut alice_writer) = tokio::io::split(alice);
         let replica = alice_replica.clone();
         let alice_task = tokio::task::spawn(async move {
-            run_alice::<store::memory::Store, _, _>(&mut alice_writer, &mut alice_reader, &replica, None)
-                .await
+            run_alice::<store::memory::Store, _, _>(
+                &mut alice_writer,
+                &mut alice_reader,
+                &replica,
+                None,
+            )
+            .await
         });
 
         let (mut bob_reader, mut bob_writer) = tokio::io::split(bob);
@@ -248,7 +258,7 @@ mod tests {
                 &mut bob_writer,
                 &mut bob_reader,
                 bob_replica_store_task,
-                None
+                None,
             )
             .await
         });

--- a/iroh/src/sync.rs
+++ b/iroh/src/sync.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use anyhow::{bail, ensure, Context, Result};
 use bytes::BytesMut;
-use iroh_net::{tls::PeerId, MagicEndpoint};
+use iroh_net::{tls::PeerId, MagicEndpoint, magic_endpoint::get_peer_id};
 use iroh_sync::{
     store,
     sync::{NamespaceId, Replica},
@@ -54,7 +54,7 @@ pub async fn connect_and_sync<S: store::Store>(
         .await
         .context("dial_and_sync")?;
     let (mut send_stream, mut recv_stream) = connection.open_bi().await?;
-    let res = run_alice::<S, _, _>(&mut send_stream, &mut recv_stream, doc).await;
+    let res = run_alice::<S, _, _>(&mut send_stream, &mut recv_stream, doc, Some(peer_id)).await;
     debug!("sync with peer {}: finish {:?}", peer_id, res);
     res
 }
@@ -64,7 +64,9 @@ pub async fn run_alice<S: store::Store, R: AsyncRead + Unpin, W: AsyncWrite + Un
     writer: &mut W,
     reader: &mut R,
     alice: &Replica<S::Instance>,
+    peer: Option<PeerId>,
 ) -> Result<()> {
+    let peer = peer.map(|peer| peer.to_bytes());
     let mut buffer = BytesMut::with_capacity(1024);
 
     // Init message
@@ -86,7 +88,7 @@ pub async fn run_alice<S: store::Store, R: AsyncRead + Unpin, W: AsyncWrite + Un
                 bail!("unexpected message: init");
             }
             Message::Sync(msg) => {
-                if let Some(msg) = alice.sync_process_message(msg).map_err(Into::into)? {
+                if let Some(msg) = alice.sync_process_message(msg, peer).map_err(Into::into)? {
                     send_sync_message(writer, msg).await?;
                 } else {
                     break;
@@ -105,9 +107,16 @@ pub async fn handle_connection<S: store::Store>(
 ) -> Result<()> {
     let connection = connecting.await?;
     debug!("> connection established!");
+    let peer_id = get_peer_id(&connection).await?;
     let (mut send_stream, mut recv_stream) = connection.accept_bi().await?;
 
-    run_bob(&mut send_stream, &mut recv_stream, replica_store).await?;
+    run_bob(
+        &mut send_stream,
+        &mut recv_stream,
+        replica_store,
+        Some(peer_id),
+    )
+    .await?;
     send_stream.finish().await?;
 
     debug!("done");
@@ -120,7 +129,9 @@ pub async fn run_bob<S: store::Store, R: AsyncRead + Unpin, W: AsyncWrite + Unpi
     writer: &mut W,
     reader: &mut R,
     replica_store: S,
+    peer: Option<PeerId>,
 ) -> Result<()> {
+    let peer = peer.map(|peer| peer.to_bytes());
     let mut buffer = BytesMut::with_capacity(1024);
 
     let mut replica = None;
@@ -135,7 +146,7 @@ pub async fn run_bob<S: store::Store, R: AsyncRead + Unpin, W: AsyncWrite + Unpi
                 match replica_store.get_replica(&namespace)? {
                     Some(r) => {
                         debug!("starting sync for {}", namespace);
-                        if let Some(msg) = r.sync_process_message(message).map_err(Into::into)? {
+                        if let Some(msg) = r.sync_process_message(message, peer).map_err(Into::into)? {
                             send_sync_message(writer, msg).await?;
                         } else {
                             break;
@@ -150,7 +161,7 @@ pub async fn run_bob<S: store::Store, R: AsyncRead + Unpin, W: AsyncWrite + Unpi
             }
             Message::Sync(msg) => match replica {
                 Some(ref replica) => {
-                    if let Some(msg) = replica.sync_process_message(msg).map_err(Into::into)? {
+                    if let Some(msg) = replica.sync_process_message(msg, peer).map_err(Into::into)? {
                         send_sync_message(writer, msg).await?;
                     } else {
                         break;
@@ -226,7 +237,7 @@ mod tests {
         let (mut alice_reader, mut alice_writer) = tokio::io::split(alice);
         let replica = alice_replica.clone();
         let alice_task = tokio::task::spawn(async move {
-            run_alice::<store::memory::Store, _, _>(&mut alice_writer, &mut alice_reader, &replica)
+            run_alice::<store::memory::Store, _, _>(&mut alice_writer, &mut alice_reader, &replica, None)
                 .await
         });
 
@@ -237,6 +248,7 @@ mod tests {
                 &mut bob_writer,
                 &mut bob_reader,
                 bob_replica_store_task,
+                None
             )
             .await
         });

--- a/iroh/src/sync/content.rs
+++ b/iroh/src/sync/content.rs
@@ -1,20 +1,12 @@
 use std::{
-    collections::{HashMap, VecDeque},
     io,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
-    time::Instant,
+    sync::Arc,
 };
 
 use anyhow::Result;
 use bytes::Bytes;
-use futures::{
-    future::{BoxFuture, LocalBoxFuture, Shared},
-    stream::FuturesUnordered,
-    FutureExt,
-};
 use iroh_bytes::util::Hash;
-use iroh_gossip::net::util::Dialer;
 use iroh_io::{AsyncSliceReader, AsyncSliceReaderExt};
 use iroh_metrics::{inc, inc_by};
 use iroh_net::{tls::PeerId, MagicEndpoint};
@@ -22,12 +14,13 @@ use iroh_sync::{
     store::{self, Store as _},
     sync::{Author, InsertOrigin, Namespace, OnInsertCallback, PeerIdBytes, Replica, SignedEntry},
 };
-use tokio::{io::AsyncRead, sync::oneshot};
-use tokio_stream::StreamExt;
-use tracing::{debug, error, warn};
+use tokio::io::AsyncRead;
 
 use super::metrics::Metrics;
-use crate::database::flat::{writable::WritableFileDatabase, Database};
+use crate::{
+    database::flat::{writable::WritableFileDatabase, Database},
+    download::Downloader,
+};
 
 #[derive(Debug, Copy, Clone)]
 pub enum DownloadMode {
@@ -253,12 +246,12 @@ impl BlobStore {
 
     pub fn start_download(&self, hash: Hash, peers: Vec<PeerId>) {
         if !self.db.has(&hash) {
-            self.downloader.start_download(hash, peers);
+            self.downloader.push(hash, peers);
         }
     }
 
     pub async fn get_bytes(&self, hash: &Hash) -> anyhow::Result<Option<Bytes>> {
-        self.downloader.wait_for_download(hash).await;
+        self.downloader.finished(hash).await;
         let Some(entry) = self.db().get(hash) else {
             return Ok(None)
         };
@@ -267,7 +260,7 @@ impl BlobStore {
     }
 
     pub async fn get_reader(&self, hash: &Hash) -> anyhow::Result<Option<impl AsyncSliceReader>> {
-        self.downloader.wait_for_download(hash).await;
+        self.downloader.finished(hash).await;
         let Some(entry) = self.db().get(hash) else {
             return Ok(None)
         };
@@ -283,313 +276,3 @@ impl BlobStore {
         self.db.put_reader(data).await
     }
 }
-
-pub type DownloadReply = oneshot::Sender<Option<(Hash, u64)>>;
-pub type DownloadFuture = Shared<BoxFuture<'static, Option<(Hash, u64)>>>;
-
-#[derive(Debug)]
-pub struct DownloadRequest {
-    hash: Hash,
-    peers: Vec<PeerId>,
-    reply: DownloadReply,
-}
-
-/// A download queue
-///
-/// Spawns a background task that handles connecting to peers and performing get requests.
-///
-/// TODO: Queued downloads are pushed into an unbounded channel. Maybe make it bounded instead.
-/// We want the start_download() method to be sync though because it is used
-/// from sync on_insert callbacks on the replicas.
-/// TODO: Move to iroh-bytes or replace with corresponding feature from iroh-bytes once available
-#[derive(Debug, Clone)]
-pub struct Downloader {
-    pending_downloads: Arc<Mutex<HashMap<Hash, DownloadFuture>>>,
-    to_actor_tx: flume::Sender<DownloadRequest>,
-}
-
-impl Downloader {
-    pub fn new(
-        rt: iroh_bytes::util::runtime::Handle,
-        endpoint: MagicEndpoint,
-        blobs: WritableFileDatabase,
-    ) -> Self {
-        let (tx, rx) = flume::bounded(64);
-        // spawn the actor on a local pool
-        // the local pool is required because WritableFileDatabase::download_single
-        // returns a future that is !Send
-        rt.local_pool().spawn_pinned(move || async move {
-            let mut actor = DownloadActor::new(endpoint, blobs, rx);
-            if let Err(err) = actor.run().await {
-                error!("download actor failed with error {err:?}");
-            }
-        });
-        Self {
-            pending_downloads: Arc::new(Mutex::new(HashMap::new())),
-            to_actor_tx: tx,
-        }
-    }
-
-    pub fn wait_for_download(&self, hash: &Hash) -> DownloadFuture {
-        match self.pending_downloads.lock().unwrap().get(hash) {
-            Some(fut) => fut.clone(),
-            None => futures::future::ready(None).boxed().shared(),
-        }
-    }
-
-    pub fn start_download(&self, hash: Hash, peers: Vec<PeerId>) {
-        let (reply, reply_rx) = oneshot::channel();
-        let req = DownloadRequest { hash, peers, reply };
-        if self.pending_downloads.lock().unwrap().get(&hash).is_none() {
-            let pending_downloads = self.pending_downloads.clone();
-            let fut = async move {
-                let res = reply_rx.await;
-                pending_downloads.lock().unwrap().remove(&hash);
-                res.ok().flatten()
-            };
-            self.pending_downloads
-                .lock()
-                .unwrap()
-                .insert(hash, fut.boxed().shared());
-        }
-        // TODO: this is potentially blocking inside an async call. figure out a better solution
-        if let Err(err) = self.to_actor_tx.send(req) {
-            warn!("download actor dropped: {err}");
-        }
-    }
-}
-
-type PendingDownloadsFutures =
-    FuturesUnordered<LocalBoxFuture<'static, (PeerId, Hash, anyhow::Result<Option<(Hash, u64)>>)>>;
-
-#[derive(Debug)]
-pub struct DownloadActor {
-    dialer: Dialer,
-    db: WritableFileDatabase,
-    conns: HashMap<PeerId, quinn::Connection>,
-    replies: HashMap<Hash, VecDeque<DownloadReply>>,
-    pending_download_futs: PendingDownloadsFutures,
-    queue: DownloadQueue,
-    rx: flume::Receiver<DownloadRequest>,
-}
-impl DownloadActor {
-    fn new(
-        endpoint: MagicEndpoint,
-        db: WritableFileDatabase,
-        rx: flume::Receiver<DownloadRequest>,
-    ) -> Self {
-        Self {
-            rx,
-            db,
-            dialer: Dialer::new(endpoint),
-            replies: Default::default(),
-            conns: Default::default(),
-            pending_download_futs: Default::default(),
-            queue: Default::default(),
-        }
-    }
-    pub async fn run(&mut self) -> anyhow::Result<()> {
-        loop {
-            tokio::select! {
-                req = self.rx.recv_async() => match req {
-                    Err(_) => return Ok(()),
-                    Ok(req) => self.on_download_request(req).await
-                },
-                (peer, conn) = self.dialer.next() => match conn {
-                    Ok(conn) => {
-                        debug!("connection to {peer} established");
-                        self.conns.insert(peer, conn);
-                        self.on_peer_ready(peer);
-                    },
-                    Err(err) => self.on_peer_fail(&peer, err),
-                },
-                Some((peer, hash, res)) = self.pending_download_futs.next() => match res {
-                    Ok(Some((hash, size))) => {
-                        self.queue.on_success(hash, peer);
-                        self.reply(hash, Some((hash, size)));
-                        self.on_peer_ready(peer);
-                    }
-                    Ok(None) => {
-                        self.on_not_found(&peer, hash);
-                        self.on_peer_ready(peer);
-                    }
-                    Err(err) => self.on_peer_fail(&peer, err),
-                }
-            }
-        }
-    }
-
-    fn reply(&mut self, hash: Hash, res: Option<(Hash, u64)>) {
-        for reply in self.replies.remove(&hash).into_iter().flatten() {
-            reply.send(res).ok();
-        }
-    }
-
-    fn on_peer_fail(&mut self, peer: &PeerId, err: anyhow::Error) {
-        warn!("download from {peer} failed: {err}");
-        for hash in self.queue.on_peer_fail(peer) {
-            self.reply(hash, None);
-        }
-        self.conns.remove(peer);
-    }
-
-    fn on_not_found(&mut self, peer: &PeerId, hash: Hash) {
-        self.queue.on_not_found(hash, *peer);
-        if self.queue.has_no_candidates(&hash) {
-            self.reply(hash, None);
-        }
-    }
-
-    fn on_peer_ready(&mut self, peer: PeerId) {
-        if let Some(hash) = self.queue.try_next_for_peer(peer) {
-            self.start_download_unchecked(peer, hash);
-        } else {
-            self.conns.remove(&peer);
-        }
-    }
-
-    fn start_download_unchecked(&mut self, peer: PeerId, hash: Hash) {
-        let conn = self.conns.get(&peer).unwrap().clone();
-        let blobs = self.db.clone();
-        let fut = async move {
-            let start = Instant::now();
-            let res = blobs.download_single(conn, hash).await;
-            // record metrics
-            let elapsed = start.elapsed().as_millis();
-            match &res {
-                Ok(Some((_hash, len))) => {
-                    inc!(Metrics, downloads_success);
-                    inc_by!(Metrics, download_bytes_total, *len);
-                    inc_by!(Metrics, download_time_total, elapsed as u64);
-                }
-                Ok(None) => inc!(Metrics, downloads_notfound),
-                Err(_) => inc!(Metrics, downloads_error),
-            }
-            (peer, hash, res)
-        };
-        self.pending_download_futs.push(fut.boxed_local());
-    }
-
-    async fn on_download_request(&mut self, req: DownloadRequest) {
-        let DownloadRequest { peers, hash, reply } = req;
-        if self.db.has(&hash) {
-            let size = self.db.get_size(&hash).await.unwrap();
-            reply.send(Some((hash, size))).ok();
-            return;
-        }
-        self.replies.entry(hash).or_default().push_back(reply);
-        for peer in peers {
-            self.queue.push_candidate(hash, peer);
-            // TODO: Don't dial all peers instantly.
-            if self.conns.get(&peer).is_none() && !self.dialer.is_pending(&peer) {
-                self.dialer.queue_dial(peer, &iroh_bytes::protocol::ALPN);
-            }
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct DownloadQueue {
-    candidates_by_hash: HashMap<Hash, VecDeque<PeerId>>,
-    candidates_by_peer: HashMap<PeerId, VecDeque<Hash>>,
-    running_by_hash: HashMap<Hash, PeerId>,
-    running_by_peer: HashMap<PeerId, Hash>,
-}
-
-impl DownloadQueue {
-    pub fn push_candidate(&mut self, hash: Hash, peer: PeerId) {
-        self.candidates_by_hash
-            .entry(hash)
-            .or_default()
-            .push_back(peer);
-        self.candidates_by_peer
-            .entry(peer)
-            .or_default()
-            .push_back(hash);
-    }
-
-    pub fn try_next_for_peer(&mut self, peer: PeerId) -> Option<Hash> {
-        let mut next = None;
-        for (idx, hash) in self.candidates_by_peer.get(&peer)?.iter().enumerate() {
-            if !self.running_by_hash.contains_key(hash) {
-                next = Some((idx, *hash));
-                break;
-            }
-        }
-        if let Some((idx, hash)) = next {
-            self.running_by_hash.insert(hash, peer);
-            self.running_by_peer.insert(peer, hash);
-            self.candidates_by_peer.get_mut(&peer).unwrap().remove(idx);
-            if let Some(peers) = self.candidates_by_hash.get_mut(&hash) {
-                peers.retain(|p| p != &peer);
-            }
-            self.ensure_no_empty(hash, peer);
-            return Some(hash);
-        } else {
-            None
-        }
-    }
-
-    pub fn has_no_candidates(&self, hash: &Hash) -> bool {
-        self.candidates_by_hash.get(hash).is_none() && self.running_by_hash.get(&hash).is_none()
-    }
-
-    pub fn on_success(&mut self, hash: Hash, peer: PeerId) -> Option<(PeerId, Hash)> {
-        let peer2 = self.running_by_hash.remove(&hash);
-        debug_assert_eq!(peer2, Some(peer));
-        self.running_by_peer.remove(&peer);
-        self.try_next_for_peer(peer).map(|hash| (peer, hash))
-    }
-
-    pub fn on_peer_fail(&mut self, peer: &PeerId) -> Vec<Hash> {
-        let mut failed = vec![];
-        for hash in self
-            .candidates_by_peer
-            .remove(peer)
-            .map(|hashes| hashes.into_iter())
-            .into_iter()
-            .flatten()
-        {
-            if let Some(peers) = self.candidates_by_hash.get_mut(&hash) {
-                peers.retain(|p| p != peer);
-                if peers.is_empty() && self.running_by_hash.get(&hash).is_none() {
-                    failed.push(hash);
-                }
-            }
-        }
-        if let Some(hash) = self.running_by_peer.remove(&peer) {
-            self.running_by_hash.remove(&hash);
-            if self.candidates_by_hash.get(&hash).is_none() {
-                failed.push(hash);
-            }
-        }
-        failed
-    }
-
-    pub fn on_not_found(&mut self, hash: Hash, peer: PeerId) {
-        let peer2 = self.running_by_hash.remove(&hash);
-        debug_assert_eq!(peer2, Some(peer));
-        self.running_by_peer.remove(&peer);
-        self.ensure_no_empty(hash, peer);
-    }
-
-    fn ensure_no_empty(&mut self, hash: Hash, peer: PeerId) {
-        if self
-            .candidates_by_peer
-            .get(&peer)
-            .map_or(false, |hashes| hashes.is_empty())
-        {
-            self.candidates_by_peer.remove(&peer);
-        }
-        if self
-            .candidates_by_hash
-            .get(&hash)
-            .map_or(false, |peers| peers.is_empty())
-        {
-            self.candidates_by_hash.remove(&hash);
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {}

--- a/iroh/src/sync/live.rs
+++ b/iroh/src/sync/live.rs
@@ -288,10 +288,10 @@ impl<S: store::Store> Actor<S> {
         };
         match event {
             // We received a gossip message. Try to insert it into our replica.
-            Event::Received(data, _prev_peer) => {
+            Event::Received(data, prev_peer) => {
                 let op: Op = postcard::from_bytes(&data)?;
                 match op {
-                    Op::Put(entry) => doc.insert_remote_entry(entry)?,
+                    Op::Put(entry) => doc.insert_remote_entry(entry, Some(prev_peer.to_bytes()))?,
                 }
             }
             // A new neighbor appeared in the gossip swarm. Try to sync with it directly.

--- a/iroh/src/sync/metrics.rs
+++ b/iroh/src/sync/metrics.rs
@@ -11,11 +11,6 @@ pub struct Metrics {
     pub new_entries_remote: Counter,
     pub new_entries_local_size: Counter,
     pub new_entries_remote_size: Counter,
-    pub download_bytes_total: Counter,
-    pub download_time_total: Counter,
-    pub downloads_success: Counter,
-    pub downloads_error: Counter,
-    pub downloads_notfound: Counter,
     pub initial_sync_success: Counter,
     pub initial_sync_failed: Counter,
 }
@@ -27,11 +22,6 @@ impl Default for Metrics {
             new_entries_remote: Counter::new("Number of document entries added by peers"),
             new_entries_local_size: Counter::new("Total size of entry contents added locally"),
             new_entries_remote_size: Counter::new("Total size of entry contents added by peers"),
-            download_bytes_total: Counter::new("Total number of content bytes downloaded"),
-            download_time_total: Counter::new("Total time in ms spent downloading content bytes"),
-            downloads_success: Counter::new("Total number of successfull downloads"),
-            downloads_error: Counter::new("Total number of downloads failed with error"),
-            downloads_notfound: Counter::new("Total number of downloads failed with not found"),
             initial_sync_success: Counter::new("Number of successfull initial syncs "),
             initial_sync_failed: Counter::new("Number of failed initial syncs"),
         }


### PR DESCRIPTION
## Description

Try to download content from the peer that informed us about a change. During set reconciliation that is the peer we're talking to, during gossip it's the next peer in the graph (so not the sender of the message but the peer which forwarded the message to us). 

This is not finished and waiting for a better downloader which will come soon, but might be interesting to try out now still.

## Notes & open questions

* We'll want some infrastructure to easily extend this to download from other peers too if both author and informer failed
* The downloader will definitely need to support retries after timeouts, because right now you will easily get a gossip message before the other peer downloaded the content themselves

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
