### PR TITLE
Fast bao tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,11 +243,13 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.5.2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ca1e4d36dce793d56ed016f22662a337d31f6407996e9ad2ec3c7bdc79a45c"
 dependencies = [
- "blake3",
  "bytes",
  "futures",
+ "iroh-blake3",
  "iroh-io",
  "positioned-io",
  "range-collections",
@@ -327,18 +329,6 @@ name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
-
-[[package]]
-name = "blake3"
-version = "1.4.1"
-source = "git+https://github.com/rklaehn/BLAKE3.git?branch=more-guts#c8b199b0a6d6dd7fd60ad9a977a4582979c8569e"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
-]
 
 [[package]]
 name = "block-buffer"
@@ -1634,7 +1624,6 @@ version = "0.5.1"
 dependencies = [
  "anyhow",
  "bao-tree",
- "blake3",
  "bytes",
  "clap",
  "config",
@@ -1677,12 +1666,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-blake3"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9446c3ff33feef14809b17e90178caa73bf184ed5054337485a0b002bc7197e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "iroh-bytes"
 version = "0.5.0"
 dependencies = [
  "anyhow",
  "bao-tree",
- "blake3",
  "bytes",
  "data-encoding",
  "derive_more",
@@ -1714,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d7af75c35274d15ec2347363e268fcebc2a5d1a975bc9d87384c5232b5cace"
+checksum = "e9c47e66a8ee652d554f00e085a0a6559b6c029036aab918a412aad1541b3fea"
 dependencies = [
  "bytes",
  "futures",
@@ -2929,9 +2930,9 @@ dependencies = [
 
 [[package]]
 name = "range-collections"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2151d0cda6f7cee2de547749cccca65dffbe1a292a1176fd914083acd21190ff"
+checksum = "9242e3fdeb51584ea4295232d89c29cfc919f5b70660d02ee32edacb075c2469"
 dependencies = [
  "binary-merge",
  "inplace-vec-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,8 +244,6 @@ dependencies = [
 [[package]]
 name = "bao-tree"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300ecc0fc879f191300741b6e7de87d3303e843f2d6e1ff9f33f2eadd3f857ec"
 dependencies = [
  "blake3",
  "bytes",
@@ -333,15 +331,13 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 [[package]]
 name = "blake3"
 version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199c42ab6972d92c9f8995f086273d25c42fc0f7b2a1fcefba465c1352d25ba5"
+source = "git+https://github.com/rklaehn/BLAKE3.git?branch=more-guts#c8b199b0a6d6dd7fd60ad9a977a4582979c8569e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,3 @@ debug-assertions = false
 opt-level = 3
 panic = 'abort'
 incremental = false
-
-[patch.crates-io]
-bao-tree = { path = "../bao-tree" }
-blake3 = { git = "https://github.com/rklaehn/BLAKE3.git", branch = "more-guts" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ debug-assertions = false
 opt-level = 3
 panic = 'abort'
 incremental = false
+
+[patch.crates-io]
+bao-tree = { path = "../bao-tree" }
+blake3 = { git = "https://github.com/rklaehn/BLAKE3.git", branch = "more-guts" }

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -13,8 +13,7 @@ rust-version = "1.66"
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-bao-tree = { version = "0.5.0", features = ["tokio_fsm"], default-features = false }
-blake3 = "1.3.3"
+bao-tree = { version = "0.6.0", features = ["tokio_fsm"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
 data-encoding = "2.3.3"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into"] }

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::sync::Arc;
 
 use anyhow::{ensure, Context, Result};
+use bao_tree::blake3;
 use bao_tree::io::fsm::{encode_ranges_validated, Outboard};
 use bytes::{Bytes, BytesMut};
 use futures::future::BoxFuture;

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -1,5 +1,6 @@
 //! Utility functions and types.
 use anyhow::Result;
+use bao_tree::blake3;
 use postcard::experimental::max_size::MaxSize;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, result, str::FromStr};

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -14,8 +14,7 @@ rust-version = "1.66"
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-bao-tree = { version = "0.5.0", features = ["tokio_fsm"], default-features = false }
-blake3 = "1.3.3"
+bao-tree = { version = "0.6.0", features = ["tokio_fsm"], default-features = false }
 bytes = "1"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into"] }
 flume = "0.10.14"
@@ -63,7 +62,6 @@ test = []
 
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-blake3 = "1.3.3"
 bytes = "1"
 duct = "0.13.6"
 nix = "0.26.2"

--- a/iroh/src/collection.rs
+++ b/iroh/src/collection.rs
@@ -79,6 +79,7 @@ pub struct Blob {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bao_tree::blake3;
 
     #[test]
     fn roundtrip_blob() {

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result};
+use bao_tree::blake3;
 use bao_tree::{io::outboard::PreOrderMemOutboard, ByteNum, ChunkNum};
 use console::style;
 use indicatif::{
@@ -87,7 +88,7 @@ impl GetInteractive {
             std::fs::OpenOptions::new()
                 .write(true)
                 .create(true)
-                .open(&data_path_2)
+                .open(data_path_2)
         })
         .await?;
         tracing::debug!("piping data to {:?} and {:?}", data_path, outboard_path);
@@ -99,7 +100,7 @@ impl GetInteractive {
                 std::fs::OpenOptions::new()
                     .write(true)
                     .create(true)
-                    .open(&outboard_path)
+                    .open(outboard_path)
             })
             .await?;
             Some(outboard_file)
@@ -219,7 +220,7 @@ impl GetInteractive {
                     std::fs::OpenOptions::new()
                         .write(true)
                         .create(true)
-                        .open(&data_path_2)
+                        .open(data_path_2)
                 })
                 .await?;
                 tracing::debug!("piping data to {data_path:?} and {outboard_path:?}");
@@ -231,7 +232,7 @@ impl GetInteractive {
                         std::fs::OpenOptions::new()
                             .write(true)
                             .create(true)
-                            .open(&outboard_path)
+                            .open(outboard_path)
                     })
                     .await?;
                     Some(outboard_file)

--- a/iroh/src/database/flat.rs
+++ b/iroh/src/database/flat.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, RwLock};
 use std::{fmt, io, result};
 
 use anyhow::Context;
+use bao_tree::blake3;
 use bao_tree::io::outboard::{PostOrderMemOutboard, PreOrderMemOutboard};
 use bytes::Bytes;
 use futures::future::BoxFuture;

--- a/iroh/src/database/mem.rs
+++ b/iroh/src/database/mem.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 
+use bao_tree::blake3;
 use bao_tree::io::fsm::Outboard;
 use bao_tree::io::outboard::PreOrderMemOutboard;
 use bytes::Bytes;

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -209,6 +209,7 @@ impl FromStr for Ticket {
 
 #[cfg(test)]
 mod tests {
+    use bao_tree::blake3;
     use iroh_net::tls::Keypair;
 
     use super::*;

--- a/iroh/src/util/io.rs
+++ b/iroh/src/util/io.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path};
 use std::{io::Write, path::PathBuf, result};
 use thiserror::Error;
 
+use bao_tree::blake3;
 use bao_tree::io::sync::encode_ranges_validated;
 use bao_tree::io::{
     sync::{ReadAt, Size},

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Context, Result};
+use bao_tree::blake3;
 use duct::{cmd, ReaderHandle};
 use iroh::bytes::Hash;
 use iroh::dial::Ticket;

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -29,6 +29,7 @@ use testdir::testdir;
 use tokio::{fs, io::AsyncWriteExt, sync::mpsc};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
+use bao_tree::blake3;
 use iroh_bytes::{
     collection::{CollectionParser, CollectionStats, LinkStream},
     get::{fsm, fsm::ConnectedNext, Stats},


### PR DESCRIPTION
## Description

Use the newly published iroh-blake3 and bao-tree to get much faster hashing of 16kb subtrees. Factor of 4 improvement due to SIMD use in blake3.

Ideally we would move back to upstream blake3 eventually, once https://github.com/BLAKE3-team/BLAKE3/pull/329 is merged.

To make the switch and the subsequent switch back easier I removed the dependency on blake3 and instead reexported our forked blake3 as blake3 in bao-tree.

## Notes & open questions

Is there a nicer way to do all this reexport business?

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
