### PR TITLE
refactor(iroh-net): keep `DerpMap` fixed

### DIFF
--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -1,5 +1,4 @@
 //! Default values used in [`iroh-net`][`crate`]
-use std::collections::HashMap;
 
 use crate::derp::{DerpMap, DerpNode, DerpRegion, UseIpv4, UseIpv6};
 
@@ -25,11 +24,7 @@ pub const DEFAULT_DERP_STUN_PORT: u16 = 3478;
 
 /// Get the default [`DerpMap`].
 pub fn default_derp_map() -> DerpMap {
-    DerpMap {
-        regions: HashMap::from_iter(
-            [(1, default_na_derp_region()), (2, default_eu_derp_region())].into_iter(),
-        ),
-    }
+    [default_na_derp_region(), default_eu_derp_region()].into()
 }
 
 /// Get the default [`DerpRegion`] for NA.

--- a/iroh-net/src/derp/http/mesh_clients.rs
+++ b/iroh-net/src/derp/http/mesh_clients.rs
@@ -48,7 +48,7 @@ impl MeshClients {
             MeshAddrs::Addrs(urls) => urls.to_owned(),
             MeshAddrs::DerpMap(derp_map) => {
                 let mut urls = Vec::new();
-                for (_, region) in derp_map.regions.iter() {
+                for region in derp_map.regions() {
                     for node in region.nodes.iter() {
                         // note: `node.host_name` is expected to include the scheme
                         let mut url = node.url.clone();

--- a/iroh-net/src/derp/map.rs
+++ b/iroh-net/src/derp/map.rs
@@ -27,7 +27,7 @@ impl DerpMap {
         ids
     }
 
-    /// Returns an `Iteratore` over all known regions.
+    /// Returns an `Iterator` over all known regions.
     pub fn regions(&self) -> impl Iterator<Item = &DerpRegion> {
         self.regions.values()
     }

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -184,17 +184,12 @@ impl MagicEndpoint {
     ) -> anyhow::Result<Self> {
         let msock = magicsock::MagicSock::new(magicsock::Options {
             port: bind_port,
+            derp_map: Some(derp_map.unwrap_or_default()),
             private_key: keypair.secret().clone().into(),
             callbacks: callbacks.unwrap_or_default(),
         })
         .await?;
         trace!("created magicsock");
-
-        let derp_map = derp_map.unwrap_or_default();
-        msock
-            .set_derp_map(Some(derp_map))
-            .await
-            .context("setting derp map")?;
 
         let endpoint = quinn::Endpoint::new_with_abstract_socket(
             quinn::EndpointConfig::default(),

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -232,13 +232,16 @@ impl Inner {
 
     /// Returns `true` if we have DERP configuration for the given DERP `region`.
     pub(self) async fn has_derp_region(&self, region: u16) -> bool {
-        self.get_derp_region(region).await.is_some()
+        match &*self.derp_map.read().await {
+            None => false,
+            Some(ref derp_map) => derp_map.contains_region(region),
+        }
     }
 
     pub(self) async fn get_derp_region(&self, region: u16) -> Option<DerpRegion> {
         match &*self.derp_map.read().await {
             None => None,
-            Some(ref derp_map) => derp_map.regions.get(&region).cloned(),
+            Some(ref derp_map) => derp_map.get_region(region).cloned(),
         }
     }
 
@@ -1627,8 +1630,7 @@ impl Actor {
             match derp_map
                 .as_ref()
                 .expect("already checked")
-                .regions
-                .get(&derp_num)
+                .get_region(derp_num)
             {
                 Some(dr) => {
                     info!("home is now derp-{} ({})", derp_num, dr.region_code);

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -397,7 +397,7 @@ impl MagicSock {
                     last_endpoints: Vec::new(),
                     last_endpoints_time: None,
                     on_endpoint_refreshed: HashMap::new(),
-                    periodic_re_stun_timer: new_re_stun_timer(),
+                    periodic_re_stun_timer: new_re_stun_timer(false),
                     net_info_last: None,
                     disco_info: HashMap::new(),
                     peer_map: Default::default(),
@@ -1329,7 +1329,7 @@ impl Actor {
                     .expect("sender not go away");
                 return;
             }
-            self.periodic_re_stun_timer = new_re_stun_timer();
+            self.periodic_re_stun_timer = new_re_stun_timer(true);
         }
 
         self.endpoints_update_state
@@ -2323,13 +2323,17 @@ fn get_disco_info<'a>(
     disco_info.get_mut(k).unwrap()
 }
 
-fn new_re_stun_timer() -> time::Interval {
+fn new_re_stun_timer(initial_delay: bool) -> time::Interval {
     // Pick a random duration between 20 and 26 seconds (just under 30s,
     // a common UDP NAT timeout on Linux,etc)
     let mut rng = rand::thread_rng();
     let d: Duration = rng.gen_range(Duration::from_secs(20)..=Duration::from_secs(26));
     debug!("scheduling periodic_stun to run in {}s", d.as_secs());
-    time::interval_at(time::Instant::now() + d, d)
+    if initial_delay {
+        time::interval_at(time::Instant::now() + d, d)
+    } else {
+        time::interval(d)
+    }
 }
 
 /// Initial connection setup.

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -201,12 +201,14 @@ impl DerpActor {
             // Reconnect any DERP region that changed definitions.
             if let Some(old) = old {
                 let derp_map = derp_map.as_ref().unwrap();
-                for (rid, old_def) in old.regions {
-                    if let Some(new_def) = derp_map.regions.get(&rid) {
-                        if &old_def == new_def {
+                for old_def in old.regions() {
+                    let rid = old_def.region_id;
+                    if let Some(new_def) = derp_map.get_region(rid) {
+                        if old_def == new_def {
                             continue;
                         }
                     }
+                    // Clear home derp if this is unknown now
                     if rid == self.conn.my_derp() {
                         self.conn.set_my_derp(0);
                     }
@@ -250,7 +252,7 @@ impl DerpActor {
                 warn!("DERP is disabled");
                 return;
             }
-            if !derp_map.as_ref().unwrap().regions.contains_key(&region_id) {
+            if !derp_map.as_ref().unwrap().contains_region(region_id) {
                 warn!("unknown region id {}", region_id);
                 return;
             }

--- a/iroh-net/src/netcheck.rs
+++ b/iroh-net/src/netcheck.rs
@@ -898,30 +898,27 @@ mod tests {
 
         let stun_servers = vec![("https://derp.iroh.network.", DEFAULT_DERP_STUN_PORT)];
 
-        let mut dm = DerpMap::default();
         let region_id = 1;
-        dm.regions.insert(
+        let dm: DerpMap = [DerpRegion {
             region_id,
-            DerpRegion {
-                region_id,
-                nodes: stun_servers
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, (host_name, stun_port))| DerpNode {
-                        name: format!("default-{}", i),
-                        region_id,
-                        url: host_name.parse().unwrap(),
-                        stun_only: true,
-                        stun_port,
-                        ipv4: UseIpv4::TryDns,
-                        ipv6: UseIpv6::TryDns,
-                        stun_test_ip: None,
-                    })
-                    .collect(),
-                avoid: false,
-                region_code: "default".into(),
-            },
-        );
+            nodes: stun_servers
+                .into_iter()
+                .enumerate()
+                .map(|(i, (host_name, stun_port))| DerpNode {
+                    name: format!("default-{}", i),
+                    region_id,
+                    url: host_name.parse().unwrap(),
+                    stun_only: true,
+                    stun_port,
+                    ipv4: UseIpv4::TryDns,
+                    ipv6: UseIpv6::TryDns,
+                    stun_test_ip: None,
+                })
+                .collect(),
+            avoid: false,
+            region_code: "default".into(),
+        }]
+        .into();
         dbg!(&dm);
 
         let r = client
@@ -960,7 +957,7 @@ mod tests {
         let blackhole = tokio::net::UdpSocket::bind("127.0.0.1:0").await?;
         let stun_addr = blackhole.local_addr()?;
         let mut dm = stun::test::derp_map_of([stun_addr].into_iter());
-        dm.regions.get_mut(&1).unwrap().nodes[0].stun_only = true;
+        dm.get_region_mut(1).unwrap().nodes[0].stun_only = true;
 
         let mut client = Client::new(None).await?;
 

--- a/iroh-net/src/stun.rs
+++ b/iroh-net/src/stun.rs
@@ -175,40 +175,35 @@ pub mod test {
     }
 
     pub fn derp_map_of(stun: impl Iterator<Item = SocketAddr>) -> DerpMap {
-        let mut m = DerpMap::default();
+        stun.enumerate()
+            .map(|(i, addr)| {
+                let region_id = (i + 1) as u16;
+                let host = addr.ip();
+                let port = addr.port();
 
-        for (i, addr) in stun.enumerate() {
-            let region_id = (i + 1) as u16;
-            let host = addr.ip();
-            let port = addr.port();
+                let (ipv4, ipv6) = match host {
+                    IpAddr::V4(v4) => (UseIpv4::Some(v4), UseIpv6::TryDns),
+                    IpAddr::V6(v6) => (UseIpv4::TryDns, UseIpv6::Some(v6)),
+                };
 
-            let (ipv4, ipv6) = match host {
-                IpAddr::V4(v4) => (UseIpv4::Some(v4), UseIpv6::TryDns),
-                IpAddr::V6(v6) => (UseIpv4::TryDns, UseIpv6::Some(v6)),
-            };
-
-            let node = DerpNode {
-                name: format!("{region_id}a"),
-                region_id,
-                url: format!("http://{region_id}.invalid").parse().unwrap(),
-                ipv4,
-                ipv6,
-                stun_port: port,
-                stun_only: true,
-                stun_test_ip: None,
-            };
-            m.regions.insert(
-                region_id,
+                let node = DerpNode {
+                    name: format!("{region_id}a"),
+                    region_id,
+                    url: format!("http://{region_id}.invalid").parse().unwrap(),
+                    ipv4,
+                    ipv6,
+                    stun_port: port,
+                    stun_only: true,
+                    stun_test_ip: None,
+                };
                 DerpRegion {
                     region_id,
                     region_code: "".to_string(),
                     avoid: false,
                     nodes: vec![node],
-                },
-            );
-        }
-
-        m
+                }
+            })
+            .into()
     }
 
     /// Sets up a simple STUN server binding to `0.0.0.0:0`.

--- a/iroh-net/src/test_utils.rs
+++ b/iroh-net/src/test_utils.rs
@@ -147,32 +147,26 @@ pub(crate) async fn run_derp_and_stun(
 
     let (stun_addr, _, stun_drop_guard) = crate::stun::test::serve(stun_ip).await?;
     let region_id = 1;
-    let m = DerpMap {
-        regions: [(
-            1,
-            DerpRegion {
-                region_id,
-                region_code: "test".into(),
-                nodes: vec![DerpNode {
-                    name: "t1".into(),
-                    region_id,
-                    // In test mode, the DERP client does not validate HTTPS certs, so the host
-                    // name is irrelevant, but the port is used.
-                    url: format!("https://test-node.invalid:{}", https_addr.port())
-                        .parse()
-                        .unwrap(),
-                    stun_only: false,
-                    stun_port: stun_addr.port(),
-                    ipv4: UseIpv4::Some("127.0.0.1".parse().unwrap()),
-                    ipv6: UseIpv6::Disabled,
-                    stun_test_ip: Some(stun_addr.ip()),
-                }],
-                avoid: false,
-            },
-        )]
-        .into_iter()
-        .collect(),
-    };
+    let m: DerpMap = [DerpRegion {
+        region_id,
+        region_code: "test".into(),
+        nodes: vec![DerpNode {
+            name: "t1".into(),
+            region_id,
+            // In test mode, the DERP client does not validate HTTPS certs, so the host
+            // name is irrelevant, but the port is used.
+            url: format!("https://test-node.invalid:{}", https_addr.port())
+                .parse()
+                .unwrap(),
+            stun_only: false,
+            stun_port: stun_addr.port(),
+            ipv4: UseIpv4::Some("127.0.0.1".parse().unwrap()),
+            ipv6: UseIpv6::Disabled,
+            stun_test_ip: Some(stun_addr.ip()),
+        }],
+        avoid: false,
+    }]
+    .into();
 
     let (tx, rx) = oneshot::channel();
     tokio::spawn(

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -34,7 +34,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             // TODO(ramfox): this should probably just be a derp map
-            derp_regions: vec![default_na_derp_region(), default_eu_derp_region()],
+            derp_regions: [default_na_derp_region(), default_eu_derp_region()].into(),
         }
     }
 }
@@ -94,12 +94,8 @@ impl Config {
             return None;
         }
 
-        let mut regions = HashMap::new();
-        for region in &self.derp_regions {
-            regions.insert(region.region_id, region.clone());
-        }
-
-        Some(DerpMap { regions })
+        let dm: DerpMap = self.derp_regions.iter().cloned().into();
+        Some(dm)
     }
 }
 


### PR DESCRIPTION
## Description

The `DerpMap` wasn't being changed anyway at runtime, only for initial config.

Closes #1182 

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.

