### PR TITLE
fix(iroh-net): remove `transparent` attribute from mapping debug + log bump

### DIFF
--- a/iroh-net/src/portmapper/current_mapping.rs
+++ b/iroh-net/src/portmapper/current_mapping.rs
@@ -11,7 +11,7 @@ use futures::Future;
 use iroh_metrics::inc;
 use std::time::Duration;
 use tokio::{sync::watch, time};
-use tracing::trace;
+use tracing::{trace, debug};
 
 /// This is an implementation detail to facilitate testing.
 pub(super) trait Mapping: std::fmt::Debug + Unpin {
@@ -90,7 +90,7 @@ impl<M: Mapping> CurrentMapping<M> {
     /// Updates the mapping, informing of any changes to the external address. The old mapping is
     /// returned.
     pub(super) fn update(&mut self, mapping: Option<M>) -> Option<M> {
-        trace!("new port mapping {mapping:?}");
+        debug!("new port mapping {mapping:?}");
         let maybe_external_addr = mapping.as_ref().map(|mapping| {
             let (ip, port) = mapping.external();
             SocketAddrV4::new(ip, port.into())

--- a/iroh-net/src/portmapper/current_mapping.rs
+++ b/iroh-net/src/portmapper/current_mapping.rs
@@ -11,7 +11,7 @@ use futures::Future;
 use iroh_metrics::inc;
 use std::time::Duration;
 use tokio::{sync::watch, time};
-use tracing::{trace, debug};
+use tracing::{debug, trace};
 
 /// This is an implementation detail to facilitate testing.
 pub(super) trait Mapping: std::fmt::Debug + Unpin {

--- a/iroh-net/src/portmapper/mapping.rs
+++ b/iroh-net/src/portmapper/mapping.rs
@@ -16,13 +16,10 @@ pub(super) trait PortMapped: std::fmt::Debug + Unpin {
 #[derive(derive_more::Debug)]
 pub enum Mapping {
     /// A UPnP mapping.
-    #[debug(transparent)]
     Upnp(upnp::Mapping),
     /// A PCP mapping.
-    #[debug(transparent)]
     Pcp(pcp::Mapping),
     /// A NAT-PMP mapping.
-    #[debug(transparent)]
     NatPmp(nat_pmp::Mapping),
 }
 


### PR DESCRIPTION
## Description

- Removes the `transparent` attribute from the derived `Debug` implementation for `Mapping`.
- Bump log level where new mapping is logged to `debug`

## Notes & open questions

In hindsight this was the better option all along anyway, since this prints the variant name.
The new log look like this: 
```bash
$ env RUST_LOG=iroh_net::portmapper=debug cargo run doctor port-map upnp 2347
# 2023-08-08T16:44:14.844178Z DEBUG portmapper.service: iroh_net::portmapper: portmap starting
# 2023-08-08T16:44:14.846400Z DEBUG portmapper.service: iroh_net::portmapper: getting a port mapping for 192.168.20.217:2347 -> None
# 2023-08-08T16:44:19.708668Z DEBUG portmapper.service: iroh_net::portmapper::current_mapping: new port mapping Some(Upnp(Mapping { gateway: http://192.168.20.1:58089/ctl/IPConn, external_ip: re.da.ct.ed, external_port: 2347 }))
```
## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
