### PR TITLE
refactor: improve path handling in iroh dir

### DIFF
--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -778,7 +778,7 @@ fn create_secret_key(private_key: PrivateKey) -> anyhow::Result<SecretKey> {
             SecretKey::from(bytes)
         }
         PrivateKey::Local => {
-            let path = IrohPaths::Keypair.env_path()?;
+            let path = IrohPaths::Keypair.with_env()?;
             if path.exists() {
                 let bytes = std::fs::read(&path)?;
                 let keypair = Keypair::try_from_openssh(bytes)?;

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::config::{iroh_config_path, iroh_data_root, Config, CONFIG_FILE_NAME, ENV_PREFIX};
+use crate::config::{iroh_config_path, Config, IrohPaths, CONFIG_FILE_NAME, ENV_PREFIX};
 
 use anyhow::Context;
 use clap::Subcommand;
@@ -778,8 +778,7 @@ fn create_secret_key(private_key: PrivateKey) -> anyhow::Result<SecretKey> {
             SecretKey::from(bytes)
         }
         PrivateKey::Local => {
-            let iroh_data_root = iroh_data_root()?;
-            let path = iroh_data_root.join("keypair");
+            let path = IrohPaths::Keypair.env_path()?;
             if path.exists() {
                 let bytes = std::fs::read(&path)?;
                 let keypair = Keypair::try_from_openssh(bytes)?;

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -49,12 +49,14 @@ pub async fn run(
         );
     }
 
-    let blob_dir = IrohPaths::BaoFlatStore.env_path()?;
+    let blob_dir = IrohPaths::BaoFlatStoreComplete.with_env()?;
+    let partial_blob_dir = IrohPaths::BaoFlatStorePartial.with_env()?;
     tokio::fs::create_dir_all(&blob_dir).await?;
-    let db = flat::Store::load(&blob_dir, &blob_dir, rt)
+    tokio::fs::create_dir_all(&partial_blob_dir).await?;
+    let db = flat::Store::load(&blob_dir, &partial_blob_dir, rt)
         .await
         .with_context(|| format!("Failed to load iroh database from {}", blob_dir.display()))?;
-    let key = Some(IrohPaths::Keypair.env_path()?);
+    let key = Some(IrohPaths::Keypair.with_env()?);
     let token = opts.request_token.clone();
     let provider = provide(db.clone(), rt, key, opts).await?;
     let controller = provider.controller();

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -24,6 +24,7 @@ pub const CONFIG_FILE_NAME: &str = "iroh.config.toml";
 pub const ENV_PREFIX: &str = "IROH";
 
 /// Paths to files or directory within the [`iroh_data_root`] used by Iroh.
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum IrohPaths {
     /// Path to the node's private key for the [`iroh_net::PeerId`].
     Keypair,
@@ -253,5 +254,21 @@ mod tests {
         let config = Config::load::<String, String>(&[][..], "__FOO", Default::default()).unwrap();
 
         assert_eq!(config.derp_regions.len(), 2);
+    }
+
+    #[test]
+    fn test_iroh_paths_parse_roundtrip() {
+        let kinds = [
+            IrohPaths::BaoFlatStoreComplete,
+            IrohPaths::BaoFlatStorePartial,
+            IrohPaths::Keypair,
+        ];
+        for iroh_path in &kinds {
+            let root = PathBuf::from("/tmp");
+            let path = root.join(iroh_path);
+            let fname = path.file_name().unwrap().to_str().unwrap();
+            let parsed = IrohPaths::from_str(fname).unwrap();
+            assert_eq!(*iroh_path, parsed);
+        }
     }
 }


### PR DESCRIPTION
## Description

Currently the handling of paths and files within the IROH_DATA_DIR was a bit ad-hoc. This adds an enum in `config.rs` to only use well-defined paths.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] ~~Tests if relevant~~.
