### PR TITLE
fix(iroh): pass derp map when setting up Node for get

### DIFF
--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -70,8 +70,11 @@ impl GetInteractive {
         let db: iroh::baomap::flat::Store =
             iroh::baomap::flat::Store::load(temp_dir.clone(), temp_dir.clone(), &self.rt).await?;
         // spin up temp node and ask it to download the data for us
-        let provider = iroh::node::Node::builder(db)
-            .collection_parser(IrohCollectionParser)
+        let mut provider = iroh::node::Node::builder(db).collection_parser(IrohCollectionParser);
+        if let Some(ref dm) = self.opts.derp_map {
+            provider = provider.derp_map(dm.clone());
+        }
+        let provider = provider
             .runtime(&iroh_bytes::util::runtime::Handle::from_currrent(1)?)
             .spawn()
             .await?;


### PR DESCRIPTION
## Description

The `get` code path was unable to handle different regions, as the derp map was not set.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
