### PR TITLE
feat(sync): emit event when entry content is downloaded from peers

### DIFF
--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -235,6 +235,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
         endpoint.clone(),
         gossip.clone(),
         docs.clone(),
+        db.clone(),
         downloader,
     );
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -354,6 +354,7 @@ where
             endpoint.clone(),
             gossip.clone(),
             self.docs,
+            self.db.clone(),
             downloader,
         );
 

--- a/iroh/src/sync/live.rs
+++ b/iroh/src/sync/live.rs
@@ -601,7 +601,7 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
 
                 // A new entry was inserted from initial sync or gossip. Queue downloading the
                 // content.
-                let content_status = if let Some(_bao_entry) = self.bao_store.get(&hash) {
+                let content_status = if self.bao_store.get(&hash).is_some() {
                     ContentStatus::Ready
                 } else {
                     if let Some(from) = from {

--- a/iroh/src/sync/live.rs
+++ b/iroh/src/sync/live.rs
@@ -142,6 +142,7 @@ pub type OnLiveEventCallback =
 
 /// Events informing about actions of the live sync progres.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum LiveEvent {
     /// A local insertion.
     InsertLocal {
@@ -388,7 +389,7 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                     if let Some((topic, hash)) = res {
                         if let Some(subs) = self.event_subscriptions.get(&topic) {
                             let event = LiveEvent::ContentReady { hash };
-                            notify_all(&subs, event).await;
+                            notify_all(subs, event).await;
                         }
                     }
 
@@ -590,7 +591,7 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                     let event = LiveEvent::InsertLocal {
                         entry: entry.clone(),
                     };
-                    notify_all(&subs, event).await;
+                    notify_all(subs, event).await;
                 }
             }
             InsertOrigin::Sync(peer_id) => {
@@ -622,7 +623,7 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                         entry: entry.clone(),
                         content_status,
                     };
-                    notify_all(&subs, event).await;
+                    notify_all(subs, event).await;
                 }
             }
         }


### PR DESCRIPTION
## Description

Adds `LiveEvent`s when the content of an entry is downloaded. Also adds availability status of content to the live events.
Now the end-to-end sync test passes without any `sleep`!

## Notes & open questions

* I wasn't sure if the entry `RecordIdentifier` should be included in the event, or only the content `Hash`. Right now the PR does the latter, but could easily switch to the former if it makes it more usable.
* The `SyncEngine` now doesn't do anything over the `LiveSync`. We might want to unify the two structs.  But would do in a seperate PR.
* We might want to add more events later


## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
