### PR TITLE
feat: methods to check if a hash is complete or partial

### DIFF
--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -30,6 +30,12 @@ pub trait MapEntry<D: Map>: Clone + Send + Sync + 'static {
     fn hash(&self) -> blake3::Hash;
     /// The size of the entry.
     fn size(&self) -> u64;
+    /// Returns `true` if the entry is complete.
+    ///
+    /// Note that this does not actually verify if the bytes on disk are complete, it only checks
+    /// if the entry is among the partial or complete section of the [`Map`]. To verify if all
+    /// bytes are actually available on disk, use [`MapEntry::available_ranges`].
+    fn is_complete(&self) -> bool;
     /// Compute the available ranges.
     ///
     /// Depending on the implementation, this may be an expensive operation.
@@ -66,6 +72,11 @@ pub trait Map: Clone + Send + Sync + 'static {
     /// This function should not block to perform io. The knowledge about
     /// existing entries must be present in memory.
     fn get(&self, hash: &Hash) -> Option<Self::Entry>;
+
+    /// Return true if the `hash` is present in the set of complete entries of the store.
+    fn contains_complete(&self, hash: &Hash) -> bool;
+    /// Return true if the `hash` is present in the set of partial entries of the store.
+    fn contains_partial(&self, hash: &Hash) -> bool;
 }
 
 /// A partial entry

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -19,6 +19,17 @@ use tokio::sync::mpsc;
 pub use bao_tree;
 pub use range_collections;
 
+/// The availability status of an entry in a store.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum EntryStatus {
+    /// The entry is completely available.
+    Complete,
+    /// The entry is partially available.
+    Partial,
+    /// The entry is not in the store.
+    NotFound,
+}
+
 /// An entry for one hash in a bao collection
 ///
 /// The entry has the ability to provide you with an (outboard, data)
@@ -73,10 +84,11 @@ pub trait Map: Clone + Send + Sync + 'static {
     /// existing entries must be present in memory.
     fn get(&self, hash: &Hash) -> Option<Self::Entry>;
 
-    /// Return true if the `hash` is present in the set of complete entries of the store.
-    fn contains_complete(&self, hash: &Hash) -> bool;
-    /// Return true if the `hash` is present in the set of partial entries of the store.
-    fn contains_partial(&self, hash: &Hash) -> bool;
+    /// Find out if the data behind a `hash` is complete, partial, or not present.
+    ///
+    /// Note that this does not actually verify the on-disc data, but only checks in which section
+    /// of the store the entry is present.
+    fn contains(&self, hash: &Hash) -> EntryStatus;
 }
 
 /// A partial entry

--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -138,8 +138,8 @@ use futures::future::Either;
 use futures::{Future, FutureExt};
 use iroh_bytes::baomap::range_collections::RangeSet2;
 use iroh_bytes::baomap::{
-    self, ExportMode, ImportMode, ImportProgress, Map, MapEntry, PartialMap, PartialMapEntry,
-    ReadableStore, ValidateProgress,
+    self, EntryStatus, ExportMode, ImportMode, ImportProgress, Map, MapEntry, PartialMap,
+    PartialMapEntry, ReadableStore, ValidateProgress,
 };
 use iroh_bytes::util::progress::{IdGenerator, ProgressSender};
 use iroh_bytes::{Hash, IROH_BLOCK_SIZE};
@@ -600,8 +600,8 @@ impl Map for Store {
                 hex::encode(entry.uuid)
             );
             Some(Entry {
-                is_complete: false,
                 hash: blake3::Hash::from(*hash),
+                is_complete: false,
                 entry: EntryData {
                     data: Either::Right((data_path, entry.size)),
                     outboard: Either::Right(outboard_path),
@@ -613,14 +613,15 @@ impl Map for Store {
         }
     }
 
-    fn contains_complete(&self, hash: &Hash) -> bool {
+    fn contains(&self, hash: &Hash) -> EntryStatus {
         let state = self.0.state.read().unwrap();
-        state.complete.contains_key(hash)
-    }
-
-    fn contains_partial(&self, hash: &Hash) -> bool {
-        let state = self.0.state.read().unwrap();
-        state.partial.contains_key(hash)
+        if state.complete.contains_key(hash) {
+            EntryStatus::Complete
+        } else if state.partial.contains_key(hash) {
+            EntryStatus::Partial
+        } else {
+            EntryStatus::NotFound
+        }
     }
 }
 

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -24,6 +24,7 @@ use futures::future::BoxFuture;
 use futures::FutureExt;
 use iroh_bytes::baomap;
 use iroh_bytes::baomap::range_collections::RangeSet2;
+use iroh_bytes::baomap::EntryStatus;
 use iroh_bytes::baomap::ExportMode;
 use iroh_bytes::baomap::ImportMode;
 use iroh_bytes::baomap::ImportProgress;
@@ -307,14 +308,15 @@ impl Map for Store {
         }
     }
 
-    fn contains_complete(&self, hash: &Hash) -> bool {
+    fn contains(&self, hash: &Hash) -> EntryStatus {
         let state = self.0.state.read().unwrap();
-        state.complete.contains_key(hash)
-    }
-
-    fn contains_partial(&self, hash: &Hash) -> bool {
-        let state = self.0.state.read().unwrap();
-        state.partial.contains_key(hash)
+        if state.complete.contains_key(hash) {
+            EntryStatus::Complete
+        } else if state.partial.contains_key(hash) {
+            EntryStatus::Partial
+        } else {
+            EntryStatus::NotFound
+        }
     }
 }
 

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -204,7 +204,7 @@ pub struct Entry {
     hash: blake3::Hash,
     outboard: PreOrderOutboard<MemFile>,
     data: MemFile,
-    is_complete: bool
+    is_complete: bool,
 }
 
 impl MapEntry<Store> for Entry {
@@ -289,7 +289,7 @@ impl Map for Store {
                     data: outboard.data.clone().into(),
                 },
                 data: data.clone().into(),
-                is_complete: true
+                is_complete: true,
             })
         } else if let Some((data, outboard)) = state.partial.get(hash) {
             Some(Entry {
@@ -300,7 +300,7 @@ impl Map for Store {
                     data: outboard.data.clone().into(),
                 },
                 data: data.clone().into(),
-                is_complete: false
+                is_complete: false,
             })
         } else {
             None

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -23,8 +23,8 @@ use futures::{
 };
 use iroh_bytes::{
     baomap::{
-        self, range_collections::RangeSet2, ExportMode, ImportMode, ImportProgress, Map, MapEntry,
-        PartialMap, PartialMapEntry, ReadableStore, ValidateProgress,
+        self, range_collections::RangeSet2, EntryStatus, ExportMode, ImportMode, ImportProgress,
+        Map, MapEntry, PartialMap, PartialMapEntry, ReadableStore, ValidateProgress,
     },
     util::progress::{IdGenerator, ProgressSender},
     Hash, IROH_BLOCK_SIZE,
@@ -192,12 +192,11 @@ impl Map for Store {
         })
     }
 
-    fn contains_complete(&self, hash: &Hash) -> bool {
-        self.0.contains_key(hash)
-    }
-
-    fn contains_partial(&self, _hash: &Hash) -> bool {
-        false
+    fn contains(&self, hash: &Hash) -> EntryStatus {
+        match self.0.contains_key(hash) {
+            true => EntryStatus::Complete,
+            false => EntryStatus::NotFound,
+        }
     }
 }
 

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -173,6 +173,10 @@ impl MapEntry<Store> for Entry {
     fn data_reader(&self) -> BoxFuture<'_, io::Result<Bytes>> {
         futures::future::ok(self.data.clone()).boxed()
     }
+
+    fn is_complete(&self) -> bool {
+        true
+    }
 }
 
 impl Map for Store {
@@ -186,6 +190,14 @@ impl Map for Store {
             outboard: o.clone(),
             data: d.clone(),
         })
+    }
+
+    fn contains_complete(&self, hash: &Hash) -> bool {
+        self.0.contains_key(hash)
+    }
+
+    fn contains_partial(&self, _hash: &Hash) -> bool {
+        false
     }
 }
 
@@ -267,6 +279,11 @@ impl MapEntry<Store> for PartialEntry {
     }
 
     fn data_reader(&self) -> BoxFuture<'_, io::Result<Bytes>> {
+        // this is unreachable, since PartialEntry can not be created
+        unreachable!()
+    }
+
+    fn is_complete(&self) -> bool {
         // this is unreachable, since PartialEntry can not be created
         unreachable!()
     }


### PR DESCRIPTION
## Description

This adds the methods `contains_complete` and `contains_partial` to `baomap::Map`, and `is_complete` to `baomap::Map::Entry`.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- ~~Tests if relevant.~~
