### PR TITLE
chore: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Iroh is delivered as a Rust library and a CLI. Run `cargo build` to build the `i
 
 ### As a library
 Disable default features when using `iroh` as a library:
-`iroh = { version: "...", default-features = false }`
+`iroh = { version = "...", default-features = false }`
 
 This removes dependencies that are only relevant when using `iroh` as a cli.
 

--- a/iroh/README.md
+++ b/iroh/README.md
@@ -14,7 +14,7 @@ Because iroh builds the CLI by default, you should disable `default-features` wh
 
 ```toml
 [dependencies]
-iroh = { version: "...", default-features = false }
+iroh = { version = "...", default-features = false }
 ```
 
 ## Running Examples


### PR DESCRIPTION
## Description
Use an `=` instead of `:` when importing the iroh crate

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
