### PR TITLE
deps: Allow old ed25519-dalek crate in cargo-deny for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,4 +22,6 @@ license-files = [
 ]
 
 [advisories]
-ignore = []
+ignore = [
+       "RUSTSEC-2022-0093",
+]


### PR DESCRIPTION
## Description

This allows the old ed25519-dalek crate in our cargo-deny config for
now.  IIUC the way we use this is not currently a probelm and PR #1352
is aiming to fix this entirely.

This should be reverted as part of #1352.


<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates if relevant.~~
- [ ] ~~Tests if relevant.~~