### PR TITLE
iroh-sync API cleanup & docs

### DIFF
--- a/iroh-sync/src/keys.rs
+++ b/iroh-sync/src/keys.rs
@@ -1,0 +1,280 @@
+//! Keys used in iroh-sync
+
+use std::{cmp::Ordering, fmt, str::FromStr};
+
+use ed25519_dalek::{Signature, SignatureError, Signer, SigningKey, VerifyingKey};
+use rand_core::CryptoRngCore;
+use serde::{Deserialize, Serialize};
+
+/// Author key to insert entries in a [`Replica`]
+///
+/// Internally, an author is a [`SigningKey`] which is used to sign entries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Author {
+    priv_key: SigningKey,
+}
+impl Author {
+    /// Create a new author with a random key.
+    pub fn new<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Self {
+        let priv_key = SigningKey::generate(rng);
+        Author { priv_key }
+    }
+
+    /// Create an author from a byte array.
+    pub fn from_bytes(bytes: &[u8; 32]) -> Self {
+        SigningKey::from_bytes(bytes).into()
+    }
+
+    /// Returns the Author byte representation.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.priv_key.to_bytes()
+    }
+
+    /// Returns the AuthorId byte representation.
+    pub fn id_bytes(&self) -> [u8; 32] {
+        self.priv_key.verifying_key().to_bytes()
+    }
+
+    /// Get the [`AuthorId`] for this author.
+    pub fn id(&self) -> AuthorId {
+        AuthorId(self.priv_key.verifying_key())
+    }
+
+    /// Sign a message with this author key.
+    pub fn sign(&self, msg: &[u8]) -> Signature {
+        self.priv_key.sign(msg)
+    }
+
+    /// Strictly verify a signature on a message with this author's public key.
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+        self.priv_key.verify_strict(msg, signature)
+    }
+}
+
+/// Identifier for an [`Author`]
+///
+/// This is the corresponding [`VerifyingKey`] for an author. It is used as an identifier, and can
+/// be used to verify [`Signature`]s.
+#[derive(Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct AuthorId(VerifyingKey);
+
+impl AuthorId {
+    /// Verify that a signature matches the `msg` bytes and was created with this the [`Author`]
+    /// that corresponds to this [`AuthorId`].
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+        self.0.verify_strict(msg, signature)
+    }
+
+    /// Get the byte representation of this [`AuthorId`].
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+
+    /// Construct an `AuthorId` from a slice of bytes.
+    ///
+    /// # Warning
+    ///
+    /// The caller is responsible for ensuring that the bytes passed into this method actually
+    /// represent a valid [`ed25591`] curve point. This will never fail for bytes returned from
+    /// [`Self::as_bytes`].
+    pub fn from_bytes(bytes: &[u8; 32]) -> anyhow::Result<Self> {
+        Ok(AuthorId(VerifyingKey::from_bytes(bytes)?))
+    }
+}
+
+/// Namespace key of a [`Replica`].
+///
+/// Holders of this key can insert new entries into a [`Replica`].
+/// Internally, a namespace is a [`SigningKey`] which is used to sign entries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Namespace {
+    priv_key: SigningKey,
+}
+
+impl Namespace {
+    /// Create a new namespace with a random key.
+    pub fn new<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Self {
+        let priv_key = SigningKey::generate(rng);
+
+        Namespace { priv_key }
+    }
+
+    /// Create a namespace from a byte array.
+    pub fn from_bytes(bytes: &[u8; 32]) -> Self {
+        SigningKey::from_bytes(bytes).into()
+    }
+
+    /// Returns the namespace byte representation.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.priv_key.to_bytes()
+    }
+
+    /// Returns the [`NamespaceId`] byte representation.
+    pub fn id_bytes(&self) -> [u8; 32] {
+        self.priv_key.verifying_key().to_bytes()
+    }
+
+    /// Get the [`NamespaceId`] for this namespace.
+    pub fn id(&self) -> NamespaceId {
+        NamespaceId(self.priv_key.verifying_key())
+    }
+
+    /// Sign a message with this namespace key.
+    pub fn sign(&self, msg: &[u8]) -> Signature {
+        self.priv_key.sign(msg)
+    }
+
+    /// Strictly verify a signature on a message with this namespaces's public key.
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+        self.priv_key.verify_strict(msg, signature)
+    }
+}
+
+/// Identifier for a [`Namespace`]
+///
+/// This is the corresponding [`VerifyingKey`] for an author. It is used as an identifier, and can
+/// be used to verify [`Signature`]s.
+#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct NamespaceId(VerifyingKey);
+
+impl NamespaceId {
+    /// Verify that a signature matches the `msg` bytes and was created with this the [`Author`]
+    /// that corresponds to this [`NamespaceId`].
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+        self.0.verify_strict(msg, signature)
+    }
+
+    /// Get the byte representation of this [`NamespaceId`].
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+
+    /// Construct a `NamespaceId` from a slice of bytes.
+    ///
+    /// # Warning
+    ///
+    /// The caller is responsible for ensuring that the bytes passed into this method actually
+    /// represent a valid [`ed25591`] curve point. This will never fail for bytes returned from
+    /// [`Self::as_bytes`].
+    pub fn from_bytes(bytes: &[u8; 32]) -> anyhow::Result<Self> {
+        Ok(NamespaceId(VerifyingKey::from_bytes(bytes)?))
+    }
+}
+
+impl fmt::Display for Author {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Author({})", hex::encode(self.priv_key.to_bytes()))
+    }
+}
+
+impl fmt::Display for Namespace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Namespace({})", hex::encode(self.priv_key.to_bytes()))
+    }
+}
+
+impl fmt::Display for AuthorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0.as_bytes()))
+    }
+}
+
+impl fmt::Display for NamespaceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0.as_bytes()))
+    }
+}
+
+impl fmt::Debug for NamespaceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NamespaceId({})", hex::encode(self.0.as_bytes()))
+    }
+}
+
+impl fmt::Debug for AuthorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AuthorId({})", hex::encode(self.0.as_bytes()))
+    }
+}
+
+impl FromStr for Author {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let priv_key: [u8; 32] = hex::decode(s).map_err(|_| ())?.try_into().map_err(|_| ())?;
+        let priv_key = SigningKey::from_bytes(&priv_key);
+
+        Ok(Author { priv_key })
+    }
+}
+
+impl FromStr for Namespace {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let priv_key: [u8; 32] = hex::decode(s).map_err(|_| ())?.try_into().map_err(|_| ())?;
+        let priv_key = SigningKey::from_bytes(&priv_key);
+
+        Ok(Namespace { priv_key })
+    }
+}
+
+impl FromStr for AuthorId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let pub_key: [u8; 32] = hex::decode(s)?
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("failed to parse: invalid key length"))?;
+        let pub_key = VerifyingKey::from_bytes(&pub_key)?;
+        Ok(AuthorId(pub_key))
+    }
+}
+
+impl FromStr for NamespaceId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let pub_key: [u8; 32] = hex::decode(s)?
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("failed to parse: invalid key length"))?;
+        let pub_key = VerifyingKey::from_bytes(&pub_key)?;
+        Ok(NamespaceId(pub_key))
+    }
+}
+
+impl From<SigningKey> for Author {
+    fn from(priv_key: SigningKey) -> Self {
+        Self { priv_key }
+    }
+}
+
+impl From<SigningKey> for Namespace {
+    fn from(priv_key: SigningKey) -> Self {
+        Self { priv_key }
+    }
+}
+
+impl PartialOrd for NamespaceId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for NamespaceId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_bytes().cmp(other.0.as_bytes())
+    }
+}
+
+impl PartialOrd for AuthorId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AuthorId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_bytes().cmp(other.0.as_bytes())
+    }
+}

--- a/iroh-sync/src/keys.rs
+++ b/iroh-sync/src/keys.rs
@@ -6,7 +6,7 @@ use ed25519_dalek::{Signature, SignatureError, Signer, SigningKey, VerifyingKey}
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
-/// Author key to insert entries in a [`Replica`]
+/// Author key to insert entries in a [`crate::Replica`]
 ///
 /// Internally, an author is a [`SigningKey`] which is used to sign entries.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -70,21 +70,19 @@ impl AuthorId {
         self.0.as_bytes()
     }
 
-    /// Construct an `AuthorId` from a slice of bytes.
+    /// Create from a slice of bytes.
     ///
-    /// # Warning
-    ///
-    /// The caller is responsible for ensuring that the bytes passed into this method actually
-    /// represent a valid [`ed25591`] curve point. This will never fail for bytes returned from
-    /// [`Self::as_bytes`].
+    /// Will return an error if the input bytes do not represent a valid [`ed25519_dalek`]
+    /// curve point. Will never fail for a byte array returned from [`Self::as_bytes`].
+    /// See [`VerifyingKey::from_bytes`] for details.
     pub fn from_bytes(bytes: &[u8; 32]) -> anyhow::Result<Self> {
         Ok(AuthorId(VerifyingKey::from_bytes(bytes)?))
     }
 }
 
-/// Namespace key of a [`Replica`].
+/// Namespace key of a [`crate::Replica`].
 ///
-/// Holders of this key can insert new entries into a [`Replica`].
+/// Holders of this key can insert new entries into a [`crate::Replica`].
 /// Internally, a namespace is a [`SigningKey`] which is used to sign entries.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Namespace {
@@ -149,13 +147,11 @@ impl NamespaceId {
         self.0.as_bytes()
     }
 
-    /// Construct a `NamespaceId` from a slice of bytes.
+    /// Create from a slice of bytes.
     ///
-    /// # Warning
-    ///
-    /// The caller is responsible for ensuring that the bytes passed into this method actually
-    /// represent a valid [`ed25591`] curve point. This will never fail for bytes returned from
-    /// [`Self::as_bytes`].
+    /// Will return an error if the input bytes do not represent a valid [`ed25519_dalek`]
+    /// curve point. Will never fail for a byte array returned from [`Self::as_bytes`].
+    /// See [`VerifyingKey::from_bytes`] for details.
     pub fn from_bytes(bytes: &[u8; 32]) -> anyhow::Result<Self> {
         Ok(NamespaceId(VerifyingKey::from_bytes(bytes)?))
     }

--- a/iroh-sync/src/lib.rs
+++ b/iroh-sync/src/lib.rs
@@ -6,3 +6,4 @@ pub mod metrics;
 mod ranger;
 pub mod store;
 pub mod sync;
+mod keys;

--- a/iroh-sync/src/lib.rs
+++ b/iroh-sync/src/lib.rs
@@ -1,41 +1,8 @@
+//! Set reconciliation for multi-dimensional key-value stores
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+
 #[cfg(feature = "metrics")]
 pub mod metrics;
-pub mod ranger;
+mod ranger;
 pub mod store;
 pub mod sync;
-
-use iroh_metrics::{
-    core::{Counter, Metric},
-    struct_iterable::Iterable,
-};
-
-/// Metrics for iroh-sync
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Iterable)]
-pub struct Metrics {
-    pub new_entries_local: Counter,
-    pub new_entries_remote: Counter,
-    pub new_entries_local_size: Counter,
-    pub new_entries_remote_size: Counter,
-    pub initial_sync_success: Counter,
-    pub initial_sync_failed: Counter,
-}
-
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            new_entries_local: Counter::new("Number of document entries added locally"),
-            new_entries_remote: Counter::new("Number of document entries added by peers"),
-            new_entries_local_size: Counter::new("Total size of entry contents added locally"),
-            new_entries_remote_size: Counter::new("Total size of entry contents added by peers"),
-            initial_sync_success: Counter::new("Number of successfull initial syncs "),
-            initial_sync_failed: Counter::new("Number of failed initial syncs"),
-        }
-    }
-}
-
-impl Metric for Metrics {
-    fn name() -> &'static str {
-        "iroh-sync"
-    }
-}

--- a/iroh-sync/src/lib.rs
+++ b/iroh-sync/src/lib.rs
@@ -1,4 +1,32 @@
-//! Set reconciliation for multi-dimensional key-value stores
+//! Multi-dimensional key-value documents with an efficient synchronization protocol
+//!
+//! The crate operates on [Replicas](Replica). A replica contains an unlimited number of
+//! [Entrys][Entry]. Each entry is identified by a key, its author, and the replica's
+//! namespace. Its value is the [32-byte BLAKE3 hash](iroh_bytes::Hash)
+//! of the entry's content data, the size of this content data, and a timestamp.
+//! The content data itself is not stored or transfered through a replica.
+//!
+//! All entries in a replica are signed with two keypairs:
+//!
+//! * The [Namespace] key, as a token of write capability. The public key is the [NamespaceId], which
+//!   also serves as the unique identifier for a replica.
+//! * The [Author] key, as a proof of authorship. Any number of authors may be created, and an
+//!   their semantic meaning is application-specific. The public key of an author is the [AuthorId].
+//!
+//! Replicas can be synchronized between peers by exchanging messages. The synchronization algorithm
+//! is based on a technique called *range-based set reconciliation*, based on [this paper][paper] by
+//! Aljoscha Meyer:
+//!
+//! > Range-based set reconciliation is a simple approach to efficiently computing the union of two
+//! sets over a network, based on recursively partitioning the sets and comparing fingerprints of
+//! the partitions to probabilistically detect whether a partition requires further work.
+//!
+//! The crate exposes a [generic storage interface](store::Store) with
+//! [in-memory](store::memory::Store) and [persistent, file-based](store::fs::Store)
+//! implementations. The latter makes use of [`redb`], an embedded key-value store, and persists
+//! the whole store with all replicas to a single file.
+//!
+//! [paper]: https://arxiv.org/abs/2212.13567
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 mod keys;
@@ -7,3 +35,6 @@ pub mod metrics;
 mod ranger;
 pub mod store;
 pub mod sync;
+
+pub use keys::*;
+pub use sync::*;

--- a/iroh-sync/src/lib.rs
+++ b/iroh-sync/src/lib.rs
@@ -1,9 +1,9 @@
 //! Set reconciliation for multi-dimensional key-value stores
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
+mod keys;
 #[cfg(feature = "metrics")]
 pub mod metrics;
 mod ranger;
 pub mod store;
 pub mod sync;
-mod keys;

--- a/iroh-sync/src/metrics.rs
+++ b/iroh-sync/src/metrics.rs
@@ -1,3 +1,5 @@
+//! Metrics for iroh-sync
+
 use iroh_metrics::{
     core::{Counter, Metric},
     struct_iterable::Iterable,

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -402,23 +402,25 @@ where
     }
 }
 
-// TODO: with_limit is unused, remove?
-// impl<K, V, S> Peer<K, V, S>
-// where
-//     K: PartialEq + RangeKey + Clone + Default + Debug + AsFingerprint,
-//     V: Clone + Debug,
-//     S: Store<K, V> + Default,
-// {
-//     fn with_limit(limit: Range<K>) -> Self {
-//         Peer {
-//             store: S::default(),
-//             max_set_size: 1,
-//             split_factor: 2,
-//             limit: Some(limit),
-//             _phantom: Default::default(),
-//         }
-//     }
-// }
+// currently unused outside of tests
+#[cfg(test)]
+impl<K, V, S> Peer<K, V, S>
+where
+    K: PartialEq + RangeKey + Clone + Default + Debug + AsFingerprint,
+    V: Clone + Debug,
+    S: Store<K, V> + Default,
+{
+    fn with_limit(limit: Range<K>) -> Self {
+        Peer {
+            store: S::default(),
+            max_set_size: 1,
+            split_factor: 2,
+            limit: Some(limit),
+            _phantom: Default::default(),
+        }
+    }
+}
+
 impl<K, V, S> Peer<K, V, S>
 where
     K: PartialEq + RangeKey + Clone + Default + Debug + AsFingerprint,
@@ -613,19 +615,20 @@ where
         self.store.put(k, v)
     }
 
-    // TODO: these are unused, remove?
+    /// List all existing key value pairs.
+    // currently unused outside of tests
+    #[cfg(test)]
+    pub fn all(&self) -> Result<impl Iterator<Item = Result<(K, V), S::Error>> + '_, S::Error> {
+        self.store.all()
+    }
+
+    // /// Get the entry for the given key.
     // pub fn get(&self, k: &K) -> Result<Option<V>, S::Error> {
     //     self.store.get(k)
     // }
-    //
     // /// Remove the given key.
     // pub fn remove(&mut self, k: &K) -> Result<Vec<V>, S::Error> {
     //     self.store.remove(k)
-    // }
-    //
-    // /// List all existing key value pairs.
-    // pub fn all(&self) -> Result<impl Iterator<Item = Result<(K, V), S::Error>> + '_, S::Error> {
-    //     self.store.all()
     // }
     //
     // /// Returns a refernce to the underlying store.

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -402,22 +402,23 @@ where
     }
 }
 
-impl<K, V, S> Peer<K, V, S>
-where
-    K: PartialEq + RangeKey + Clone + Default + Debug + AsFingerprint,
-    V: Clone + Debug,
-    S: Store<K, V> + Default,
-{
-    pub fn with_limit(limit: Range<K>) -> Self {
-        Peer {
-            store: S::default(),
-            max_set_size: 1,
-            split_factor: 2,
-            limit: Some(limit),
-            _phantom: Default::default(),
-        }
-    }
-}
+// TODO: with_limit is unused, remove?
+// impl<K, V, S> Peer<K, V, S>
+// where
+//     K: PartialEq + RangeKey + Clone + Default + Debug + AsFingerprint,
+//     V: Clone + Debug,
+//     S: Store<K, V> + Default,
+// {
+//     fn with_limit(limit: Range<K>) -> Self {
+//         Peer {
+//             store: S::default(),
+//             max_set_size: 1,
+//             split_factor: 2,
+//             limit: Some(limit),
+//             _phantom: Default::default(),
+//         }
+//     }
+// }
 impl<K, V, S> Peer<K, V, S>
 where
     K: PartialEq + RangeKey + Clone + Default + Debug + AsFingerprint,
@@ -612,24 +613,25 @@ where
         self.store.put(k, v)
     }
 
-    pub fn get(&self, k: &K) -> Result<Option<V>, S::Error> {
-        self.store.get(k)
-    }
-
-    /// Remove the given key.
-    pub fn remove(&mut self, k: &K) -> Result<Vec<V>, S::Error> {
-        self.store.remove(k)
-    }
-
-    /// List all existing key value pairs.
-    pub fn all(&self) -> Result<impl Iterator<Item = Result<(K, V), S::Error>> + '_, S::Error> {
-        self.store.all()
-    }
-
-    /// Returns a refernce to the underlying store.
-    pub fn store(&self) -> &S {
-        &self.store
-    }
+    // TODO: these are unused, remove?
+    // pub fn get(&self, k: &K) -> Result<Option<V>, S::Error> {
+    //     self.store.get(k)
+    // }
+    //
+    // /// Remove the given key.
+    // pub fn remove(&mut self, k: &K) -> Result<Vec<V>, S::Error> {
+    //     self.store.remove(k)
+    // }
+    //
+    // /// List all existing key value pairs.
+    // pub fn all(&self) -> Result<impl Iterator<Item = Result<(K, V), S::Error>> + '_, S::Error> {
+    //     self.store.all()
+    // }
+    //
+    // /// Returns a refernce to the underlying store.
+    // pub fn store(&self) -> &S {
+    //     &self.store
+    // }
 }
 
 /// Sadly <https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil> is still unstable..

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -18,8 +18,18 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     /// The specialized instance scoped to a `Namespace`.
     type Instance: ranger::Store<RecordIdentifier, SignedEntry> + Send + Sync + 'static + Clone;
 
-    /// The iterator returned from [`Self::get`].
+    /// Iterator over entries in the store, returned from [`Self::get`]
     type GetIter<'a>: Iterator<Item = Result<SignedEntry>>
+    where
+        Self: 'a;
+
+    /// Iterator over replicas in the store, returned from [`Self::list_replicas`]
+    type NamespaceIter<'a>: Iterator<Item = Result<NamespaceId>>
+    where
+        Self: 'a;
+
+    /// Iterator over authors in the store, returned from [`Self::list_replicas`]
+    type AuthorsIter<'a>: Iterator<Item = Result<Author>>
     where
         Self: 'a;
 
@@ -27,8 +37,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     fn new_replica(&self, namespace: Namespace) -> Result<Replica<Self::Instance>>;
 
     /// List all replicas in this store.
-    // TODO: return iterator
-    fn list_replicas(&self) -> Result<Vec<NamespaceId>>;
+    fn list_namespaces(&self) -> Result<Self::NamespaceIter<'_>>;
 
     /// Open a replica from this store.
     ///
@@ -43,7 +52,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
 
     /// List all author keys in this store.
     // TODO: return iterator
-    fn list_authors(&self) -> Result<Vec<Author>>;
+    fn list_authors(&self) -> Result<Self::AuthorsIter<'_>>;
 
     /// Get an author key from the store.
     fn get_author(&self, author: &AuthorId) -> Result<Option<Author>>;

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -23,12 +23,12 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     where
         Self: 'a;
 
-    /// Iterator over replicas in the store, returned from [`Self::list_replicas`]
+    /// Iterator over replica namespaces in the store, returned from [`Self::list_namespaces`]
     type NamespaceIter<'a>: Iterator<Item = Result<NamespaceId>>
     where
         Self: 'a;
 
-    /// Iterator over authors in the store, returned from [`Self::list_replicas`]
+    /// Iterator over authors in the store, returned from [`Self::list_authors`]
     type AuthorsIter<'a>: Iterator<Item = Result<Author>>
     where
         Self: 'a;

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -36,7 +36,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     /// Create a new replica for `namespace` and persist in this store.
     fn new_replica(&self, namespace: Namespace) -> Result<Replica<Self::Instance>>;
 
-    /// List all replicas in this store.
+    /// List all replica namespaces in this store.
     fn list_namespaces(&self) -> Result<Self::NamespaceIter<'_>>;
 
     /// Open a replica from this store.
@@ -51,7 +51,6 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     fn new_author<R: CryptoRngCore + ?Sized>(&self, rng: &mut R) -> Result<Author>;
 
     /// List all author keys in this store.
-    // TODO: return iterator
     fn list_authors(&self) -> Result<Self::AuthorsIter<'_>>;
 
     /// Get an author key from the store.
@@ -59,8 +58,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
 
     /// Iterate over entries of a replica.
     ///
-    /// Returns an iterator. The [`GetFilter`] has several methods of filtering the returned
-    /// entries.
+    /// The [`GetFilter`] has several methods of filtering the returne entries.
     fn get(&self, namespace: NamespaceId, filter: GetFilter) -> Result<Self::GetIter<'_>>;
 
     /// Gets the single latest entry for the specified key and author.

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -30,14 +30,24 @@ type ReplicaRecordsOwned =
 impl super::Store for Store {
     type Instance = ReplicaStoreInstance;
     type GetIter<'a> = GetIter<'a>;
+    type AuthorsIter<'a> = std::vec::IntoIter<Result<Author>>;
+    type NamespaceIter<'a> = std::vec::IntoIter<Result<NamespaceId>>;
 
     fn open_replica(&self, namespace: &NamespaceId) -> Result<Option<Replica<Self::Instance>>> {
         let replicas = &*self.replicas.read();
         Ok(replicas.get(namespace).cloned())
     }
 
-    fn list_replicas(&self) -> Result<Vec<NamespaceId>> {
-        Ok(self.replicas.read().keys().cloned().collect())
+    fn list_namespaces(&self) -> Result<Self::NamespaceIter<'_>> {
+        // TODO: avoid collect?
+        Ok(self
+            .replicas
+            .read()
+            .keys()
+            .cloned()
+            .map(|n| Ok(n))
+            .collect::<Vec<_>>()
+            .into_iter())
     }
 
     fn get_author(&self, author: &AuthorId) -> Result<Option<Author>> {
@@ -51,8 +61,16 @@ impl super::Store for Store {
         Ok(author)
     }
 
-    fn list_authors(&self) -> Result<Vec<Author>> {
-        Ok(self.authors.read().values().cloned().collect())
+    fn list_authors(&self) -> Result<Self::AuthorsIter<'_>> {
+        // TODO: avoid collect?
+        Ok(self
+            .authors
+            .read()
+            .values()
+            .cloned()
+            .map(|n| Ok(n))
+            .collect::<Vec<_>>()
+            .into_iter())
     }
 
     fn new_replica(&self, namespace: Namespace) -> Result<Replica<ReplicaStoreInstance>> {

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -45,7 +45,7 @@ impl super::Store for Store {
             .read()
             .keys()
             .cloned()
-            .map(|n| Ok(n))
+            .map(Ok)
             .collect::<Vec<_>>()
             .into_iter())
     }
@@ -68,7 +68,7 @@ impl super::Store for Store {
             .read()
             .values()
             .cloned()
-            .map(|n| Ok(n))
+            .map(Ok)
             .collect::<Vec<_>>()
             .into_iter())
     }

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -322,6 +322,10 @@ impl EntrySignature {
 }
 
 /// A single entry in a replica.
+///
+/// An entry is identified by a key, its author, and the replica's
+/// namespace. Its value is the [32-byte BLAKE3 hash](iroh_bytes::Hash)
+/// of the entry's content data, the size of this content data, and a timestamp.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Entry {
     id: RecordIdentifier,
@@ -463,6 +467,7 @@ pub struct Record {
     timestamp: u64,
     /// Length of the data referenced by `hash`.
     len: u64,
+    /// Hash of the content data.
     hash: Hash,
 }
 
@@ -481,12 +486,12 @@ impl Record {
         self.timestamp
     }
 
-    /// Get the length of the data to which this record's content hash refers to.
+    /// Get the length of the data addressed by this record's content hash.
     pub fn content_len(&self) -> u64 {
         self.len
     }
 
-    /// Get the content hash of this record.
+    /// Get the hash of the content data of this record.
     pub fn content_hash(&self) -> &Hash {
         &self.hash
     }

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -6,13 +6,7 @@
 //
 // This is going to change!
 
-use std::{
-    cmp::Ordering,
-    fmt::{Debug, Display},
-    str::FromStr,
-    sync::Arc,
-    time::SystemTime,
-};
+use std::{fmt::Debug, sync::Arc, time::SystemTime};
 
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
@@ -21,268 +15,18 @@ use iroh_metrics::{inc, inc_by};
 
 use parking_lot::{Mutex, RwLock};
 
-use ed25519_dalek::{Signature, SignatureError, Signer, SigningKey, VerifyingKey};
+use ed25519_dalek::{Signature, SignatureError};
 use iroh_bytes::Hash;
-use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
 use crate::ranger::{self, AsFingerprint, Fingerprint, Peer, RangeKey};
+
+pub use crate::keys::*;
 
 /// Protocol message for the set reconciliation protocol
 ///
 /// Can be serialized to bytes with [serde] to transfer between peers.
 pub type ProtocolMessage = crate::ranger::Message<RecordIdentifier, SignedEntry>;
-
-/// Author key to insert entries in a [`Replica`]
-///
-/// Internally, an author is a [`SigningKey`] which is used to sign entries.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Author {
-    priv_key: SigningKey,
-}
-
-impl Display for Author {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Author({})", hex::encode(self.priv_key.to_bytes()))
-    }
-}
-
-impl Author {
-    /// Create a new author with a random key.
-    pub fn new<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Self {
-        let priv_key = SigningKey::generate(rng);
-
-        Author { priv_key }
-    }
-
-    /// Create an author from a byte array.
-    pub fn from_bytes(bytes: &[u8; 32]) -> Self {
-        SigningKey::from_bytes(bytes).into()
-    }
-
-    /// Returns the Author byte representation.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        self.priv_key.to_bytes()
-    }
-
-    /// Returns the AuthorId byte representation.
-    pub fn id_bytes(&self) -> [u8; 32] {
-        self.priv_key.verifying_key().to_bytes()
-    }
-
-    /// Get the [`AuthorId`] for this author.
-    pub fn id(&self) -> AuthorId {
-        AuthorId(self.priv_key.verifying_key())
-    }
-
-    /// Sign a message with this author key.
-    pub fn sign(&self, msg: &[u8]) -> Signature {
-        self.priv_key.sign(msg)
-    }
-
-    /// Strictly verify a signature on a message with this author's public key.
-    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
-        self.priv_key.verify_strict(msg, signature)
-    }
-}
-
-/// Identifier for an [`Author`]
-///
-/// This is the corresponding [`VerifyingKey`] for an author. It is used as an identifier, and can
-/// be used to verify [`Signature`]s.
-#[derive(Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub struct AuthorId(VerifyingKey);
-
-impl Debug for AuthorId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "AuthorId({})", hex::encode(self.0.as_bytes()))
-    }
-}
-
-impl Display for AuthorId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(self.0.as_bytes()))
-    }
-}
-
-impl AuthorId {
-    /// Verify that a signature matches the `msg` bytes and was created with this the [`Author`]
-    /// that corresponds to this [`AuthorId`].
-    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
-        self.0.verify_strict(msg, signature)
-    }
-
-    /// Get the byte representation of this [`AuthorId`].
-    pub fn as_bytes(&self) -> &[u8; 32] {
-        self.0.as_bytes()
-    }
-
-    /// Construct an `AuthorId` from a slice of bytes.
-    ///
-    /// # Warning
-    ///
-    /// The caller is responsible for ensuring that the bytes passed into this method actually
-    /// represent a valid [`ed25591`] curve point. This will never fail for bytes returned from
-    /// [`Self::as_bytes`].
-    pub fn from_bytes(bytes: &[u8; 32]) -> anyhow::Result<Self> {
-        Ok(AuthorId(VerifyingKey::from_bytes(bytes)?))
-    }
-}
-
-/// Namespace key of a [`Replica`].
-///
-/// Holders of this key can insert new entries into a [`Replica`].
-/// Internally, a namespace is a [`SigningKey`] which is used to sign entries.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Namespace {
-    priv_key: SigningKey,
-}
-
-impl Display for Namespace {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Namespace({})", hex::encode(self.priv_key.to_bytes()))
-    }
-}
-
-impl FromStr for Namespace {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let priv_key: [u8; 32] = hex::decode(s).map_err(|_| ())?.try_into().map_err(|_| ())?;
-        let priv_key = SigningKey::from_bytes(&priv_key);
-
-        Ok(Namespace { priv_key })
-    }
-}
-
-impl FromStr for Author {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let priv_key: [u8; 32] = hex::decode(s).map_err(|_| ())?.try_into().map_err(|_| ())?;
-        let priv_key = SigningKey::from_bytes(&priv_key);
-
-        Ok(Author { priv_key })
-    }
-}
-
-impl FromStr for AuthorId {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let pub_key: [u8; 32] = hex::decode(s)?
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("failed to parse: invalid key length"))?;
-        let pub_key = VerifyingKey::from_bytes(&pub_key)?;
-        Ok(AuthorId(pub_key))
-    }
-}
-
-impl FromStr for NamespaceId {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let pub_key: [u8; 32] = hex::decode(s)?
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("failed to parse: invalid key length"))?;
-        let pub_key = VerifyingKey::from_bytes(&pub_key)?;
-        Ok(NamespaceId(pub_key))
-    }
-}
-
-impl From<SigningKey> for Author {
-    fn from(priv_key: SigningKey) -> Self {
-        Self { priv_key }
-    }
-}
-
-impl From<SigningKey> for Namespace {
-    fn from(priv_key: SigningKey) -> Self {
-        Self { priv_key }
-    }
-}
-
-impl Namespace {
-    /// Create a new namespace with a random key.
-    pub fn new<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Self {
-        let priv_key = SigningKey::generate(rng);
-
-        Namespace { priv_key }
-    }
-
-    /// Create a namespace from a byte array.
-    pub fn from_bytes(bytes: &[u8; 32]) -> Self {
-        SigningKey::from_bytes(bytes).into()
-    }
-
-    /// Returns the namespace byte representation.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        self.priv_key.to_bytes()
-    }
-
-    /// Returns the [`NamespaceId`] byte representation.
-    pub fn id_bytes(&self) -> [u8; 32] {
-        self.priv_key.verifying_key().to_bytes()
-    }
-
-    /// Get the [`NamespaceId`] for this namespace.
-    pub fn id(&self) -> NamespaceId {
-        NamespaceId(self.priv_key.verifying_key())
-    }
-
-    /// Sign a message with this namespace key.
-    pub fn sign(&self, msg: &[u8]) -> Signature {
-        self.priv_key.sign(msg)
-    }
-
-    /// Strictly verify a signature on a message with this namespaces's public key.
-    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
-        self.priv_key.verify_strict(msg, signature)
-    }
-}
-
-/// Identifier for a [`Namespace`]
-///
-/// This is the corresponding [`VerifyingKey`] for an author. It is used as an identifier, and can
-/// be used to verify [`Signature`]s.
-#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub struct NamespaceId(VerifyingKey);
-
-impl Display for NamespaceId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(self.0.as_bytes()))
-    }
-}
-
-impl Debug for NamespaceId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "NamespaceId({})", hex::encode(self.0.as_bytes()))
-    }
-}
-
-impl NamespaceId {
-    /// Verify that a signature matches the `msg` bytes and was created with this the [`Author`]
-    /// that corresponds to this [`NamespaceId`].
-    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), SignatureError> {
-        self.0.verify_strict(msg, signature)
-    }
-
-    /// Get the byte representation of this [`NamespaceId`].
-    pub fn as_bytes(&self) -> &[u8; 32] {
-        self.0.as_bytes()
-    }
-
-    /// Construct a `NamespaceId` from a slice of bytes.
-    ///
-    /// # Warning
-    ///
-    /// The caller is responsible for ensuring that the bytes passed into this method actually
-    /// represent a valid [`ed25591`] curve point. This will never fail for bytes returned from
-    /// [`Self::as_bytes`].
-    pub fn from_bytes(bytes: &[u8; 32]) -> anyhow::Result<Self> {
-        Ok(NamespaceId(VerifyingKey::from_bytes(bytes)?))
-    }
-}
 
 /// Byte represenation of a `PeerId` from `iroh-net`
 // TODO: PeerId is in iroh-net which iroh-sync doesn't depend on. Add iroh-common crate with `PeerId`.
@@ -642,30 +386,6 @@ impl AsFingerprint for RecordIdentifier {
         hasher.update(self.author.as_bytes());
         hasher.update(&self.key);
         Fingerprint(hasher.finalize().into())
-    }
-}
-
-impl PartialOrd for NamespaceId {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for NamespaceId {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.as_bytes().cmp(other.0.as_bytes())
-    }
-}
-
-impl PartialOrd for AuthorId {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for AuthorId {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.as_bytes().cmp(other.0.as_bytes())
     }
 }
 

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -1,10 +1,7 @@
 use indicatif::HumanBytes;
 use iroh::node::Node;
 use iroh_bytes::util::runtime;
-use iroh_sync::{
-    store::{GetFilter, KeyFilter},
-    sync::SignedEntry,
-};
+use iroh_sync::{store::GetFilter, sync::SignedEntry};
 use tokio_stream::StreamExt;
 
 #[tokio::main]
@@ -22,13 +19,7 @@ async fn main() -> anyhow::Result<()> {
     let key = b"hello".to_vec();
     let value = b"world".to_vec();
     doc.set_bytes(author, key.clone(), value).await?;
-    let mut stream = doc
-        .get(GetFilter {
-            latest: true,
-            key: KeyFilter::All,
-            author: None,
-        })
-        .await?;
+    let mut stream = doc.get(GetFilter::latest()).await?;
     while let Some(entry) = stream.try_next().await? {
         println!("entry {}", fmt_entry(&entry));
         let content = doc.get_content_bytes(&entry).await?;

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use futures::{Stream, StreamExt, TryStreamExt};
 use iroh_bytes::Hash;
-use iroh_sync::store::{GetFilter, KeyFilter};
+use iroh_sync::store::{GetFilter};
 use iroh_sync::sync::{AuthorId, NamespaceId, SignedEntry};
 use quic_rpc::{RpcClient, ServiceConnection};
 
@@ -135,11 +135,7 @@ where
     }
 
     pub async fn get_latest(&self, author_id: AuthorId, key: Vec<u8>) -> Result<SignedEntry> {
-        let filter = GetFilter {
-            key: KeyFilter::Key(key),
-            author: Some(author_id),
-            latest: true,
-        };
+        let filter = GetFilter::latest().with_key(key).with_author(author_id);
         let mut stream = self.get(filter).await?;
         let entry = stream
             .next()

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use futures::{Stream, StreamExt, TryStreamExt};
 use iroh_bytes::Hash;
-use iroh_sync::store::{GetFilter};
+use iroh_sync::store::GetFilter;
 use iroh_sync::sync::{AuthorId, NamespaceId, SignedEntry};
 use quic_rpc::{RpcClient, ServiceConnection};
 

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -6,7 +6,7 @@ use iroh::{
     sync::PeerSource,
 };
 use iroh_sync::{
-    store::{GetFilter},
+    store::GetFilter,
     sync::{AuthorId, NamespaceId, SignedEntry},
 };
 use quic_rpc::transport::quinn::QuinnConnection;

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -2,8 +2,8 @@ use clap::Parser;
 use futures::TryStreamExt;
 use indicatif::HumanBytes;
 use iroh::{
-    rpc_protocol::{DocTicket, ShareMode},
     client::quic::Iroh,
+    rpc_protocol::{DocTicket, ShareMode},
     sync::PeerSource,
 };
 use iroh_sync::{

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -2,19 +2,16 @@ use clap::Parser;
 use futures::TryStreamExt;
 use indicatif::HumanBytes;
 use iroh::{
-    rpc_protocol::{DocTicket, ProviderRequest, ProviderResponse, ShareMode},
+    rpc_protocol::{DocTicket, ShareMode},
+    client::quic::Iroh,
     sync::PeerSource,
 };
 use iroh_sync::{
     store::GetFilter,
     sync::{AuthorId, NamespaceId, SignedEntry},
 };
-use quic_rpc::transport::quinn::QuinnConnection;
 
 use super::RpcClient;
-
-// TODO: It is a bit unfortunate that we have to drag the generics all through. Maybe box the conn?
-pub type Iroh = iroh::client::Iroh<QuinnConnection<ProviderResponse, ProviderRequest>>;
 
 const MAX_DISPLAY_CONTENT_LEN: u64 = 1024 * 1024;
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -347,7 +347,6 @@ where
         gossip_cell.set(gossip.clone()).unwrap();
 
         // spawn the sync engine
-        // TODO: Remove once persistence is merged
         let downloader = Downloader::new(rt.clone(), endpoint.clone(), self.db.clone());
         let sync = SyncEngine::spawn(
             rt.clone(),
@@ -607,8 +606,6 @@ impl<D: ReadableStore, S: DocStore> Node<D, S> {
     /// Returns a new builder for the [`Node`].
     ///
     /// Once the done with the builder call [`Builder::spawn`] to create the node.
-    ///
-    /// TODO: remove blobs_path argument once peristence branch is merged
     pub fn builder(bao_store: D, doc_store: S) -> Builder<D, S> {
         Builder::with_db_and_store(bao_store, doc_store)
     }

--- a/iroh/src/sync/live.rs
+++ b/iroh/src/sync/live.rs
@@ -37,8 +37,7 @@ use tracing::{debug, error, info, warn};
 const CHANNEL_CAP: usize = 8;
 
 /// The address to connect to a peer
-/// TODO: Move into iroh-net
-/// TODO: Make an enum and support DNS resolution
+// TODO: Move into iroh-net
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PeerSource {
     /// The peer id (required)
@@ -48,9 +47,6 @@ pub struct PeerSource {
     /// Derp region for this peer
     pub derp_region: Option<u16>,
 }
-
-// /// A SyncId is a 32 byte array which is both a [`NamespaceId`] and a [`TopicId`].
-// pub struct SyncId([u8; 32]);
 
 impl PeerSource {
     /// Deserializes from bytes.
@@ -298,7 +294,6 @@ impl<S: store::Store> LiveSync<S> {
     }
 }
 
-// TODO: Also add `handle_connection` to the replica and track incoming sync requests here too.
 // Currently peers might double-sync in both directions.
 struct Actor<S: store::Store, B: baomap::Store> {
     endpoint: MagicEndpoint,


### PR DESCRIPTION
## Description

This PR has a couple of cleanups to `iroh-sync`.
* Adds `deny(missing_docs)`, adds a lot of docs, reduces the public API surface a bit, and a few minor changes to support this
* Adds high-level docs to the `iroh-sync` crate
* Moves `Author`, `AuthorId`, `Namespace` and `NamespaceId` to a new `keys` module
* make `list_namespaces` (was `list_replicas`) and `list_authors` return iterators. the implementations still `collect()` internally, but the surface is fixed. proper fix will need the self-referential dance again.

In a yet-to-be written commit, I'd move the exports from the `sync` and `keys` module to the top level.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
