### PR TITLE
feat: get `NodeInfo`s from the `MagicEndpoint`

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -20,7 +20,7 @@ use crate::{
     tls,
 };
 
-type PeerInfo = super::magicsock::EndpointInfo;
+type NodeInfo = super::magicsock::EndpointInfo;
 
 /// Builder for [MagicEndpoint]
 #[derive(Debug)]
@@ -291,10 +291,10 @@ impl MagicEndpoint {
 
     /// Get information on all the peers we have connection information about.
     ///
-    /// Includes the peer's [`PublicKey`], potential DERP region, it's addresses with any known
+    /// Includes the node's [`PublicKey`], potential DERP region, it's addresses with any known
     /// latency, and its [`ConnectionType`], which let's us know if we are currently communicating
-    /// with that peer over a `Direct` (UDP) or `Relay` (DERP) connection.
-    pub async fn peer_infos(&self) -> anyhow::Result<Vec<PeerInfo>> {
+    /// with that node over a `Direct` (UDP) or `Relay` (DERP) connection.
+    pub async fn node_infos(&self) -> anyhow::Result<Vec<NodeInfo>> {
         self.msock.tracked_endpoints().await
     }
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -292,7 +292,7 @@ impl MagicEndpoint {
     /// Get information on all the peers we have connection information about.
     ///
     /// Includes the node's [`PublicKey`], potential DERP region, it's addresses with any known
-    /// latency, and its [`ConnectionType`], which let's us know if we are currently communicating
+    /// latency, and its [`crate::magicsock::ConnectionType`], which let's us know if we are currently communicating
     /// with that node over a `Direct` (UDP) or `Relay` (DERP) connection.
     pub async fn node_infos(&self) -> anyhow::Result<Vec<NodeInfo>> {
         self.msock.tracked_endpoints().await

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -20,6 +20,8 @@ use crate::{
     tls,
 };
 
+type PeerInfo = super::magicsock::EndpointInfo;
+
 /// Builder for [MagicEndpoint]
 #[derive(Debug)]
 pub struct MagicEndpointBuilder {
@@ -285,6 +287,15 @@ impl MagicEndpoint {
     /// Returns `None` if we are not connected to any DERP region.
     pub async fn my_derp(&self) -> Option<u16> {
         self.msock.my_derp().await
+    }
+
+    /// Get information on all the peers we have connection information about.
+    ///
+    /// Includes the peer's [`PublicKey`], potential DERP region, it's addresses with any known
+    /// latency, and its [`ConnectionType`], which let's us know if we are currently communicating
+    /// with that peer over a `Direct` (UDP) or `Relay` (DERP) connection.
+    pub async fn peer_infos(&self) -> anyhow::Result<Vec<PeerInfo>> {
+        self.msock.tracked_endpoints().await
     }
 
     /// Connect to a remote endpoint.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -68,6 +68,7 @@ mod rebinding_conn;
 mod timer;
 mod udp_actor;
 
+pub use self::endpoint::ConnectionType;
 pub use self::endpoint::EndpointInfo;
 pub use self::metrics::Metrics;
 pub use self::timer::Timer;

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -981,7 +981,7 @@ impl Actor {
     async fn handle_actor_message(&mut self, msg: ActorMessage) -> bool {
         match msg {
             ActorMessage::TrackedEndpoints(s) => {
-                let eps: Vec<_> = self.peer_map.endpoints().map(|(_, ep)| ep.info()).collect();
+                let eps: Vec<_> = self.peer_map.endpoint_infos();
                 let _ = s.send(eps);
             }
             ActorMessage::LocalEndpoints(s) => {

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -1496,15 +1496,15 @@ mod tests {
         let expect = Vec::from([
             EndpointInfo {
                 id: a_endpoint.id,
-                public_key: a_endpoint.public_key.clone(),
+                public_key: a_endpoint.public_key,
                 derp_region: a_endpoint.derp_addr,
-                addrs: Vec::from([(a_socket_addr.clone(), Some(latency))]),
+                addrs: Vec::from([(a_socket_addr, Some(latency))]),
                 conn_type: ConnectionType::Direct(a_socket_addr),
                 latency: Some(latency),
             },
             EndpointInfo {
                 id: b_endpoint.id,
-                public_key: b_endpoint.public_key.clone(),
+                public_key: b_endpoint.public_key,
                 derp_region: b_endpoint.derp_addr,
                 addrs: Vec::new(),
                 conn_type: ConnectionType::Relay(0),
@@ -1512,7 +1512,7 @@ mod tests {
             },
             EndpointInfo {
                 id: c_endpoint.id,
-                public_key: c_endpoint.public_key.clone(),
+                public_key: c_endpoint.public_key,
                 derp_region: c_endpoint.derp_addr,
                 addrs: Vec::new(),
                 conn_type: ConnectionType::Relay(0),
@@ -1520,7 +1520,7 @@ mod tests {
             },
             EndpointInfo {
                 id: d_endpoint.id,
-                public_key: d_endpoint.public_key.clone(),
+                public_key: d_endpoint.public_key,
                 derp_region: d_endpoint.derp_addr,
                 addrs: Vec::from([(d_socket_addr, Some(latency))]),
                 conn_type: ConnectionType::Relay(0),
@@ -1530,20 +1530,20 @@ mod tests {
 
         let peer_map = PeerMap {
             by_node_key: HashMap::from([
-                (a_endpoint.public_key.clone(), a_endpoint.id),
-                (b_endpoint.public_key.clone(), b_endpoint.id),
-                (c_endpoint.public_key.clone(), c_endpoint.id),
-                (d_endpoint.public_key.clone(), d_endpoint.id),
+                (a_endpoint.public_key, a_endpoint.id),
+                (b_endpoint.public_key, b_endpoint.id),
+                (c_endpoint.public_key, c_endpoint.id),
+                (d_endpoint.public_key, d_endpoint.id),
             ]),
             by_ip_port: HashMap::from([
                 (SendAddr::Udp(a_socket_addr), a_endpoint.id),
                 (SendAddr::Udp(d_socket_addr), d_endpoint.id),
             ]),
             by_quic_mapped_addr: HashMap::from([
-                (a_endpoint.quic_mapped_addr.clone(), a_endpoint.id),
-                (b_endpoint.quic_mapped_addr.clone(), b_endpoint.id),
-                (c_endpoint.quic_mapped_addr.clone(), c_endpoint.id),
-                (d_endpoint.quic_mapped_addr.clone(), d_endpoint.id),
+                (a_endpoint.quic_mapped_addr, a_endpoint.id),
+                (b_endpoint.quic_mapped_addr, b_endpoint.id),
+                (c_endpoint.quic_mapped_addr, c_endpoint.id),
+                (d_endpoint.quic_mapped_addr, d_endpoint.id),
             ]),
             by_id: HashMap::from([
                 (a_endpoint.id, a_endpoint),


### PR DESCRIPTION
## Description

Call `MagicEndpoint::node_infos()` to get a `Vec<NodeInfo>`, or list connection information on all nodes we know about.

`NodeInfo` is aliased from `super::magicsock::EndpointInfo`.

```rust
/// The type of connection we have to the node.
#[derive(Debug, Clone, Eq, PartialEq)]
pub enum ConnectionType {
    /// Direct UDP connection
    Direct(SocketAddr),
    /// Relay connection over DERP
    Relay(u16),
    /// We have no verified connection to this peer
    None,
}

/// Details about an Endpoint
#[derive(Debug, Clone, Eq, PartialEq)]
pub struct EndpointInfo {
    /// The id in the peer_map
    pub id: usize,
    /// The public key of the endpoint.
    pub public_key: PublicKey,
    /// Derp region, if available.
    pub derp_region: Option<u16>,
    /// List of addresses at which this node might be reachable, plus any latency information we
    /// have about that address.
    pub addrs: Vec<(SocketAddr, Option<Duration>)>,
    /// The type of connection we have to the peer, either direct or over relay.
    ///
    /// Depending on the expiry time, we may still have a direct connection to the peer
    /// but our best address for the peer may have timed out.
    /// Until we verify that connection, we assume that we may only have a relay
    /// connection to that peer.
    pub conn_type: ConnectionType,
    /// The latency of the `conn_type`.
    pub latency: Option<Duration>,
}

```

## Notes & open questions

Please let me know if the above `EndpointInfo` + `ConnectionType` is enough for our UI and sync purposes!

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
