### PR TITLE
fix(iroh-net): split packets on send

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1184,14 +1184,13 @@ impl Actor {
     fn split_packets(transmits: Vec<quinn_udp::Transmit>) -> Vec<Bytes> {
         let mut res = Vec::with_capacity(transmits.len());
         for transmit in transmits {
+            let contents = transmit.contents;
             if let Some(segment_size) = transmit.segment_size {
-                let len = transmit.contents.len();
-                for min in (0..len).step_by(segment_size) {
-                    let max = (min + segment_size).min(len);
-                    res.push(transmit.contents.slice(min..max));
+                for chunk in contents.chunks(segment_size) {
+                    res.push(contents.slice_ref(chunk));
                 }
             } else {
-                res.push(transmit.contents);
+                res.push(contents);
             }
         }
         res


### PR DESCRIPTION
this seems to be the safest way to fix possible GSO/GRO issues on all platforms (Linux and ???) that support them.

## Description

This is a fix for the possible issues described in https://github.com/n0-computer/iroh/issues/1357 that does the simplest possible thing - just split up the packets before sending them to the derper.

Note that we still get GRO/GSO when we have a direct connection. And since the stream to the derper is a byte stream, unless we flush after each send this should still be rather efficient. The only downside is that the derper has to deal with more individual packets.

## Notes & open questions

Does this fix the issue?

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
