### PR TITLE
fix(iroh-net): use base32 encoding in the derper config for SecretKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +956,9 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "derive_more"
@@ -1645,6 +1683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1746,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1963,6 +2008,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "serde",
+ "serde_with",
  "serdect",
  "socket2 0.5.3",
  "ssh-key",
@@ -3676,6 +3722,35 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "base64 0.21.2",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -71,6 +71,7 @@ zeroize = "1.5"
 clap = { version = "4", features = ["derive"], optional = true }
 regex = { version = "1.7.1", optional = true }
 rustls-pemfile = { version = "1.0.2", optional = true }
+serde_with = { version = "3.3", optional = true }
 toml = { version = "0.7.3", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
@@ -102,7 +103,7 @@ duct = "0.13.6"
 
 [features]
 default = ["metrics"]
-derper = ["clap", "toml", "rustls-pemfile", "regex", "tracing-subscriber"]
+derper = ["clap", "toml", "rustls-pemfile", "regex", "serde_with", "tracing-subscriber"]
 metrics = ["iroh-metrics"]
 
 [[bin]]

--- a/iroh-net/src/bin/derper.rs
+++ b/iroh-net/src/bin/derper.rs
@@ -28,6 +28,7 @@ use iroh_net::{
     key::SecretKey,
     stun,
 };
+use serde_with::{serde_as, DisplayFromStr};
 
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -160,9 +161,11 @@ fn load_secret_key(filename: impl AsRef<Path>) -> Result<rustls::PrivateKey> {
     );
 }
 
+#[serde_as]
 #[derive(Serialize, Deserialize)]
 struct Config {
     /// [`SecretKey`] for this Derper.
+    #[serde_as(as = "DisplayFromStr")]
     secret_key: SecretKey,
     /// Server listen address.
     ///


### PR DESCRIPTION
## Description

This is not a nice config format 😅  `secret_key = [100, 98, 53, 22, 194, 127,  ... ]`


## Notes & open questions

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [x] Tests if relevant.
