### PR TITLE
deps: update webpki to rustls-webpki and webpki-roots to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,7 +1799,7 @@ dependencies = [
  "socket2 0.5.3",
  "widestring",
  "windows-sys 0.48.0",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
@@ -3328,9 +3328,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "20b9b67e2ca7dd9e9f9285b759de30ff538aab981abaaf7bc9bd90b84a0126c3"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -3361,8 +3361,8 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.22.6",
- "winreg 0.10.1",
+ "webpki-roots 0.25.2",
+ "winreg",
 ]
 
 [[package]]
@@ -4713,25 +4713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4982,15 +4963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,7 @@ dependencies = [
  "rtnetlink",
  "rustls",
  "rustls-pemfile",
- "rustls-webpki 0.101.4",
+ "rustls-webpki",
  "serde",
  "serde_with",
  "serdect",
@@ -2028,7 +2028,7 @@ dependencies = [
  "trust-dns-resolver",
  "ucd-parse",
  "url",
- "webpki-roots 0.25.2",
+ "webpki-roots",
  "wg",
  "wmi",
  "x509-parser",
@@ -3361,7 +3361,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.2",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3504,7 +3504,7 @@ checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.4",
+ "rustls-webpki",
  "sct",
 ]
 
@@ -3527,16 +3527,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -4244,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls-acme"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550afe930502a9d56f2a753d5958a1fe98e6c698a617d5de8497616286323ea4"
+checksum = "dfb6f50b5523d014ba161512c37457acb16fd8218c883c7152e0a67ab763f2d4"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -4264,7 +4254,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "url",
- "webpki-roots 0.23.1",
+ "webpki-roots",
  "x509-parser",
 ]
 
@@ -4710,15 +4700,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki 0.100.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,6 +2007,7 @@ dependencies = [
  "rtnetlink",
  "rustls",
  "rustls-pemfile",
+ "rustls-webpki 0.101.4",
  "serde",
  "serde_with",
  "serdect",
@@ -2027,8 +2028,7 @@ dependencies = [
  "trust-dns-resolver",
  "ucd-parse",
  "url",
- "webpki",
- "webpki-roots 0.23.1",
+ "webpki-roots 0.25.2",
  "wg",
  "wmi",
  "x509-parser",
@@ -3504,7 +3504,7 @@ checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.3",
+ "rustls-webpki 0.101.4",
  "sct",
 ]
 
@@ -3541,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.3"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -4739,6 +4739,12 @@ checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
  "rustls-webpki 0.100.1",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "wg"

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -58,8 +58,8 @@ tokio-rustls-acme = { version = "0.1" }
 tokio-stream = { version = "0.1", features = ["sync"]}
 ucd-parse = "=0.1.10" # pinned to avoid having to bump MSRV to 1.70 (recursive dep of stun-rs)
 url = { version = "2.4", features = ["serde"] }
-webpki = { version = "0.22", features = ["std"] }
-webpki-roots = "0.23.0"
+webpki = { package = "rustls-webpki", version = "0.101.4", features = ["std"] }
+webpki-roots = "0.25"
 wg = "0.3.1"
 quinn = "0.10"
 quinn-proto = "0.10"

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -38,7 +38,7 @@ os_info = "3.6.0"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 rand = "0.8"
 rcgen = "0.11"
-reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.19", default-features = false, features = ["rustls-tls"] }
 ring = "0.16.20"
 rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
 serde = { version = "1", features = ["derive"] }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -54,7 +54,7 @@ time = "0.3.20"
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "io-std", "signal", "process"] }
 tokio-util = { version = "0.7", features = ["io-util", "io"] }
 tokio-rustls = { version = "0.24" }
-tokio-rustls-acme = { version = "0.1" }
+tokio-rustls-acme = { version = "0.2" }
 tokio-stream = { version = "0.1", features = ["sync"]}
 ucd-parse = "=0.1.10" # pinned to avoid having to bump MSRV to 1.70 (recursive dep of stun-rs)
 url = { version = "2.4", features = ["serde"] }

--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -447,7 +447,7 @@ impl Client {
             debug!("Starting TLS handshake");
             // TODO: review TLS config
             let mut roots = rustls::RootCertStore::empty();
-            roots.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+            roots.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
                 rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
                     ta.subject,
                     ta.spki,


### PR DESCRIPTION
## Description

Replaces [`webpki`](https://github.com/briansmith/webpki) with [`rustls-webpki`](https://github.com/rustls/webpki) as a fix to https://rustsec.org/advisories/RUSTSEC-2023-0052. Updates `reqwest` and `tokio-rustls-acme` to latest versions (which include the same change from `webpki` to `rustls-webpki`).

Also updates `webpki-roots` to the latest version.

## Notes & open questions

Did not do any manual testing. Would hope that CI should catch any incompatiblities.

## Change checklist

- [x] Self-review.
- ~~Documentation updates if relevant.~~
- ~~Tests if relevant.~~
