### PR TITLE
feat: add `iroh doctor derp accept` and `iroh doctor derp connect` commands for testing derp only data transfers

### DIFF
--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -201,13 +201,13 @@ impl DerpActor {
         }
         let total_bytes = contents.iter().map(|c| c.len() as u64).sum::<u64>();
 
-        const PAYLAOD_SIZE: usize = MAX_PACKET_SIZE - PUBLIC_KEY_LENGTH;
+        const PAYLOAD_SIZE: usize = MAX_PACKET_SIZE - PUBLIC_KEY_LENGTH;
 
         // Split into multiple packets if needed.
         // In almost all cases this will be a single packet.
         // But we have no guarantee that the total size of the contents including
         // length prefix will be smaller than the payload size.
-        for packet in PacketizeIter::<_, PAYLAOD_SIZE>::new(contents) {
+        for packet in PacketizeIter::<_, PAYLOAD_SIZE>::new(contents) {
             match derp_client.send(peer, packet).await {
                 Ok(_) => {
                     inc_by!(MagicsockMetrics, send_derp, total_bytes);

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -222,7 +222,7 @@ impl Cli {
 #[derive(Subcommand, Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum Commands {
-    /// Diagnostic commands for the derp relay protocol.
+    /// Diagnostic commands for the iroh hole punching protocols.
     Doctor {
         /// Commands for doctor - defined in the mod
         #[clap(subcommand)]


### PR DESCRIPTION
## Description

Tried to make this derp-y as possible. And by that I mean, bypasses all of `MagicSock` and `MagicEndpoint`, using the `iroh doctor accept` and `iroh doctor connect` as a framework for the protocol and progress bars.

## Notes & open questions

Some of the adjustments to shoe-horn the `derp::http::Client` into the already established `ProgressBar` work is goofy and wasteful.

We would probably be better off implementing `AsyncWrite` and `AsyncRead` over the `derp::http::Client`, but I was worried about adding too much potentially buggy read / write code here, when we are already dealing with read / write errors inside of `derp` itself. Could be a good future edition, tho.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
