### PR TITLE
fix(sync): properly drop rpc subscriptions, add doc status

### DIFF
--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 
 pub use iroh_bytes::{baomap::ValidateProgress, provider::ProvideProgress, util::RpcResult};
 
-use crate::sync::{LiveEvent, PeerSource};
+use crate::sync::{LiveEvent, LiveStatus, PeerSource};
 
 /// A 32-byte key or token
 pub type KeyBytes = [u8; 32];
@@ -343,7 +343,7 @@ impl Msg<ProviderService> for DocSubscribeRequest {
 }
 
 impl ServerStreamingMsg<ProviderService> for DocSubscribeRequest {
-    type Response = DocSubscribeResponse;
+    type Response = RpcResult<DocSubscribeResponse>;
 }
 
 /// Response to [`DocSubscribeRequest`]
@@ -473,7 +473,10 @@ impl RpcMsg<ProviderService> for DocInfoRequest {
 /// Response to [`DocInfoRequest`]
 // TODO: actually provide info
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocInfoResponse {}
+pub struct DocInfoResponse {
+    /// Live sync status
+    pub status: LiveStatus,
+}
 
 /// Start to sync a doc with peers.
 #[derive(Serialize, Deserialize, Debug)]
@@ -670,7 +673,7 @@ pub enum ProviderResponse {
     DocShare(RpcResult<DocShareResponse>),
     DocStartSync(RpcResult<DocStartSyncResponse>),
     DocStopSync(RpcResult<DocStopSyncResponse>),
-    DocSubscribe(DocSubscribeResponse),
+    DocSubscribe(RpcResult<DocSubscribeResponse>),
 
     BytesGet(RpcResult<BytesGetResponse>),
 

--- a/iroh/src/sync/rpc.rs
+++ b/iroh/src/sync/rpc.rs
@@ -79,7 +79,7 @@ impl<S: Store> SyncEngine<S> {
     pub async fn doc_info(&self, req: DocInfoRequest) -> RpcResult<DocInfoResponse> {
         let _replica = self.get_replica(&req.doc_id)?;
         let status = self.live.status(req.doc_id).await?;
-        let status = status.unwrap_or_else(|| LiveStatus {
+        let status = status.unwrap_or(LiveStatus {
             active: false,
             subscriptions: 0,
         });

--- a/iroh/src/sync/rpc.rs
+++ b/iroh/src/sync/rpc.rs
@@ -7,16 +7,19 @@ use iroh_sync::{store::Store, sync::Namespace};
 use itertools::Itertools;
 use rand::rngs::OsRng;
 
-use crate::rpc_protocol::{
-    AuthorCreateRequest, AuthorCreateResponse, AuthorListRequest, AuthorListResponse,
-    DocCreateRequest, DocCreateResponse, DocGetRequest, DocGetResponse, DocImportRequest,
-    DocImportResponse, DocInfoRequest, DocInfoResponse, DocListRequest, DocListResponse,
-    DocSetRequest, DocSetResponse, DocShareRequest, DocShareResponse, DocStartSyncRequest,
-    DocStartSyncResponse, DocStopSyncRequest, DocStopSyncResponse, DocSubscribeRequest,
-    DocSubscribeResponse, DocTicket, RpcResult, ShareMode,
+use crate::{
+    rpc_protocol::{
+        AuthorCreateRequest, AuthorCreateResponse, AuthorListRequest, AuthorListResponse,
+        DocCreateRequest, DocCreateResponse, DocGetRequest, DocGetResponse, DocImportRequest,
+        DocImportResponse, DocInfoRequest, DocInfoResponse, DocListRequest, DocListResponse,
+        DocSetRequest, DocSetResponse, DocShareRequest, DocShareResponse, DocStartSyncRequest,
+        DocStartSyncResponse, DocStopSyncRequest, DocStopSyncResponse, DocSubscribeRequest,
+        DocSubscribeResponse, DocTicket, RpcResult, ShareMode,
+    },
+    sync::KeepCallback,
 };
 
-use super::{engine::SyncEngine, PeerSource};
+use super::{engine::SyncEngine, LiveStatus, PeerSource};
 
 /// Capacity for the flume channels to forward sync store iterators to async RPC streams.
 const ITER_CHANNEL_CAP: usize = 64;
@@ -74,9 +77,13 @@ impl<S: Store> SyncEngine<S> {
     }
 
     pub async fn doc_info(&self, req: DocInfoRequest) -> RpcResult<DocInfoResponse> {
-        let replica = self.get_replica(&req.doc_id)?;
-        self.start_sync(replica.namespace(), vec![]).await?;
-        Ok(DocInfoResponse {})
+        let _replica = self.get_replica(&req.doc_id)?;
+        let status = self.live.status(req.doc_id).await?;
+        let status = status.unwrap_or_else(|| LiveStatus {
+            active: false,
+            subscriptions: 0,
+        });
+        Ok(DocInfoResponse { status })
     }
 
     pub async fn doc_share(&self, req: DocShareRequest) -> RpcResult<DocShareResponse> {
@@ -100,19 +107,31 @@ impl<S: Store> SyncEngine<S> {
     pub async fn doc_subscribe(
         &self,
         req: DocSubscribeRequest,
-    ) -> impl Stream<Item = DocSubscribeResponse> {
+    ) -> impl Stream<Item = RpcResult<DocSubscribeResponse>> {
         let (s, r) = flume::bounded(64);
-        self.live
-            .subscribe(req.doc_id, move |event| {
+        let res = self
+            .live
+            .subscribe(req.doc_id, {
                 let s = s.clone();
-                async move {
-                    s.send_async(DocSubscribeResponse { event }).await.ok();
+                move |event| {
+                    let s = s.clone();
+                    async move {
+                        // Send event over the channel, unsubscribe if the channel is closed.
+                        match s.send_async(Ok(DocSubscribeResponse { event })).await {
+                            Err(_err) => KeepCallback::Drop,
+                            Ok(()) => KeepCallback::Keep,
+                        }
+                    }
+                    .boxed()
                 }
-                .boxed()
             })
-            .await
-            .unwrap(); // TODO: handle error
-
+            .await;
+        match res {
+            Err(err) => {
+                s.send_async(Err(err.into())).await.ok();
+            }
+            Ok(_token) => {}
+        };
         r.into_stream()
     }
 

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -146,6 +146,35 @@ async fn sync_full_basic() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn sync_subscribe_stop() -> Result<()> {
+    setup_logging();
+    let rt = test_runtime();
+    let node = spawn_node(rt).await?;
+    let client = node.client();
+
+    let doc = client.create_doc().await?;
+    let author = client.create_author().await?;
+    doc.start_sync(vec![]).await?;
+
+    let status = doc.status().await?;
+    assert_eq!(status.active, true);
+    assert_eq!(status.subscriptions, 0);
+
+    let sub = doc.subscribe().await?;
+    let status = doc.status().await?;
+    assert_eq!(status.subscriptions, 1);
+    drop(sub);
+
+    doc.set_bytes(author, b"x".to_vec(), b"x".to_vec()).await?;
+    let status = doc.status().await?;
+    assert_eq!(status.subscriptions, 0);
+
+    node.shutdown();
+
+    Ok(())
+}
+
 async fn assert_latest(doc: &Doc, key: &[u8], value: &[u8]) {
     let content = get_latest(doc, key).await.unwrap();
     assert_eq!(content, value.to_vec());

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -158,7 +158,7 @@ async fn sync_subscribe_stop() -> Result<()> {
     doc.start_sync(vec![]).await?;
 
     let status = doc.status().await?;
-    assert_eq!(status.active, true);
+    assert!(status.active);
     assert_eq!(status.subscriptions, 0);
 
     let sub = doc.subscribe().await?;


### PR DESCRIPTION
## Description

So far in #1333, if a RPC or in-memory client called `doc.subscribe()` the event callback would never be dropped, even if the client did drop the event stream. This PR fixes this, by having the event callbacks return whether the callback should stay active or not. We can't use the removal token here, because calling `LiveSync::unsubscribe` from within the event callback would deadlock the actor.

Also adds a a `LiveStatus` to the doc info RPC call. For now only contains the number of subscribers. More info, e.g. on peers, can come later.

## Notes & open questions

* As of #1333 and unchanged by this PR: `doc.subscribe` will fail for documents that are not in the `LiveSync` (they are added via `doc.import` or `doc.start_sync`). This is unfortunate, because you'd often want to setup a subscription before starting sync, to catch all events.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
