### PR TITLE
chore: Specify resolver 2 for entire workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "iroh-sync",
   "iroh-test",
 ]
+resolver = "2"
 
 [profile.release]
 debug = true


### PR DESCRIPTION
## Description

All the crates use edition 2021 which use this resolver, but the
workspace itself defaults to resolver 1.  This creates confusion and
it is better to set everything to resolver 2.

## Notes & open questions

This solves the following error since rust 1.72:

cargo-json-read-from-string: warning: some crates are on edition 2021 which defaults to ‘resolver = "2"‘, but virtual workspaces default to ‘resolver = "1"‘
note: to keep the current resolver, specify ‘workspace.resolver = "1"‘ in the workspace root’s manifest
note: to use the edition 2021 resolver, specify ‘workspace.resolver = "2"‘ in the workspace root’s manifest


## Change checklist

- [x] Self-review.
- [x] ~~Documentation updates if relevant.~~
- [x] ~~Tests if relevant.~~