### PR TITLE
feat(iroh-bytes): remove unneeded u64 length prefix

### DIFF
--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -255,12 +255,6 @@ pub mod fsm {
                     return Err(ConnectedNextError::RequestTooBig);
                 }
 
-                // write u64 length prefix
-                writer
-                    .write_u64_le(request_bytes.len() as u64)
-                    .await
-                    .map_err(ConnectedNextError::from_io)?;
-
                 // write the request itself
                 writer
                     .write_all(&request_bytes)


### PR DESCRIPTION
## Description

we used to write the length prefix here. But this is not needed since we immediately close the stream after writing the request. And since this is a request/response protocol this is unlikely to change.

quinn::ReadStream::read_to_end offers a size limit where we can just use MAX_MESSAGE_SIZE to be on the safe side.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
