### PR TITLE
feat(iroh-bytes): add initial query request

### DIFF
--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -295,6 +295,15 @@ pub mod fsm {
                     postcard::from_bytes::<GetRequest>(&response)
                         .map_err(ConnectedNextError::PostcardDe)?
                 }
+                Request::Query(_) => {
+                    // todo: take the query request out of the state machine entirely
+                    // the state machine is really for get requests and custom get requests,
+                    // not for query requests
+                    return Err(ConnectedNextError::Io(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "query request not supported",
+                    )));
+                }
             };
             let hash = request.hash;
             let ranges_iter = RangesIter::new(request.ranges);


### PR DESCRIPTION
## Description

This adds a new request type that allows the requester to get availability information about a blob or collection without having to download the data.

## Notes & open questions

Merge this before implementing so we keep the protocol stable?

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
