### PR TITLE
fix sync reconcilation bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,6 +2134,7 @@ dependencies = [
  "proptest",
  "quinn",
  "rand",
+ "rand_chacha",
  "rand_core",
  "redb",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,6 +2126,7 @@ dependencies = [
  "iroh-bytes",
  "iroh-metrics",
  "iroh-net",
+ "iroh-test",
  "once_cell",
  "ouroboros",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,6 +2073,7 @@ dependencies = [
  "quinn-udp",
  "rand",
  "rand_chacha",
+ "rand_core",
  "rcgen",
  "regex",
  "reqwest",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -37,6 +37,7 @@ once_cell = "1.17.0"
 os_info = "3.6.0"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 rand = "0.8"
+rand_core = "0.6.4"
 rcgen = "0.11"
 reqwest = { version = "0.11.19", default-features = false, features = ["rustls-tls"] }
 ring = "0.16.20"

--- a/iroh-net/src/key.rs
+++ b/iroh-net/src/key.rs
@@ -8,6 +8,7 @@ use std::{
     str::FromStr,
 };
 
+use rand_core::CryptoRngCore;
 pub use ed25519_dalek::{Signature, PUBLIC_KEY_LENGTH};
 use ed25519_dalek::{SignatureError, SigningKey, VerifyingKey};
 use once_cell::sync::OnceCell;
@@ -216,10 +217,15 @@ impl SecretKey {
         self.secret.verifying_key().into()
     }
 
-    /// Generate a new [`SecretKey`].
+    /// Generate a new [`SecretKey`] with the default randomness generator.
     pub fn generate() -> Self {
         let mut rng = rand::rngs::OsRng;
-        let secret = SigningKey::generate(&mut rng);
+        Self::generate_with_rng(&mut rng)
+    }
+
+    /// Generate a new [`SecretKey`] with a randomness generator.
+    pub fn generate_with_rng<R: CryptoRngCore + ?Sized>(csprng: &mut R) -> Self {
+        let secret = SigningKey::generate(csprng);
 
         Self {
             secret,

--- a/iroh-net/src/key.rs
+++ b/iroh-net/src/key.rs
@@ -8,10 +8,10 @@ use std::{
     str::FromStr,
 };
 
-use rand_core::CryptoRngCore;
 pub use ed25519_dalek::{Signature, PUBLIC_KEY_LENGTH};
 use ed25519_dalek::{SignatureError, SigningKey, VerifyingKey};
 use once_cell::sync::OnceCell;
+use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 use ssh_key::LineEnding;
 

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -45,6 +45,7 @@ quinn = { version = "0.10", optional = true }
 futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
+iroh-test = { version = "0.5.1", path = "../iroh-test" }
 rand_chacha = "0.3.1"
 tokio = { version = "1", features = ["sync", "macros"] }
 tempfile = "3.4"

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -45,7 +45,7 @@ quinn = { version = "0.10", optional = true }
 futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
-iroh-test = { version = "0.5.1", path = "../iroh-test" }
+iroh-test = { version = "0.6.0-alpha.0", path = "../iroh-test" }
 rand_chacha = "0.3.1"
 tokio = { version = "1", features = ["sync", "macros"] }
 tempfile = "3.4"

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -45,6 +45,7 @@ quinn = { version = "0.10", optional = true }
 futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
+rand_chacha = "0.3.1"
 tokio = { version = "1", features = ["sync", "macros"] }
 tempfile = "3.4"
 proptest = "1.2.0"

--- a/iroh-sync/src/keys.rs
+++ b/iroh-sync/src/keys.rs
@@ -266,7 +266,7 @@ impl Ord for AuthorId {
 /// Utilities for working with byte array identifiers
 // TODO: copy-pasted from iroh-gossip/src/proto/util.rs
 // Unify into iroh-common crate or similar
-mod base32 {
+pub(super) mod base32 {
     /// Convert to a base32 string
     pub fn fmt(bytes: impl AsRef<[u8]>) -> String {
         let mut text = data_encoding::BASE32_NOPAD.encode(bytes.as_ref());

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -286,4 +286,126 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_sync_many_authors() -> Result<()> {
+        let mut rng = rand::thread_rng();
+
+        const NUM_MESSAGES: usize = 1; //20;
+
+        for num_authors in &[2, 3, 4, 5, 10, 20] {
+            println!("Using {num_authors} authors and {NUM_MESSAGES} messages per side");
+
+            let alice_peer_id = SecretKey::generate().public();
+            let bob_peer_id = SecretKey::generate().public();
+            let namespace = Namespace::new(&mut rng);
+
+            let alice_replica_store = store::memory::Store::default();
+            let authors_alice: Vec<_> = (0..*num_authors)
+                .map(|_| alice_replica_store.new_author(&mut rng).unwrap())
+                .collect();
+
+            let alice_replica = alice_replica_store.new_replica(namespace.clone()).unwrap();
+            for i in 0..NUM_MESSAGES {
+                for (author_num, author) in authors_alice.iter().enumerate() {
+                    alice_replica
+                        .hash_and_insert(
+                            format!("hello bob {i}"),
+                            author,
+                            format!("from alice: {author_num}"),
+                        )
+                        .unwrap();
+                }
+            }
+
+            let bob_replica_store = store::memory::Store::default();
+            let authors_bob: Vec<_> = (0..*num_authors)
+                .map(|_| bob_replica_store.new_author(&mut rng).unwrap())
+                .collect();
+            let bob_replica = bob_replica_store.new_replica(namespace.clone()).unwrap();
+            for i in 0..NUM_MESSAGES {
+                for (author_num, author) in authors_bob.iter().enumerate() {
+                    bob_replica
+                        .hash_and_insert(
+                            format!("hello alice {i}"),
+                            author,
+                            format!("from bob: {author_num}"),
+                        )
+                        .unwrap();
+                }
+            }
+
+            assert_eq!(
+                bob_replica_store
+                    .get(bob_replica.namespace(), GetFilter::all())
+                    .unwrap()
+                    .collect::<Result<Vec<_>>>()
+                    .unwrap()
+                    .len(),
+                NUM_MESSAGES * num_authors
+            );
+            assert_eq!(
+                alice_replica_store
+                    .get(alice_replica.namespace(), GetFilter::all())
+                    .unwrap()
+                    .collect::<Result<Vec<_>>>()
+                    .unwrap()
+                    .len(),
+                NUM_MESSAGES * num_authors
+            );
+
+            let (alice, bob) = tokio::io::duplex(64 + NUM_MESSAGES);
+
+            println!("syncing");
+            let (mut alice_reader, mut alice_writer) = tokio::io::split(alice);
+            let replica = alice_replica.clone();
+            let alice_task = tokio::task::spawn(async move {
+                run_alice::<store::memory::Store, _, _>(
+                    &mut alice_writer,
+                    &mut alice_reader,
+                    &replica,
+                    bob_peer_id,
+                )
+                .await
+            });
+
+            let (mut bob_reader, mut bob_writer) = tokio::io::split(bob);
+            let bob_replica_store_task = bob_replica_store.clone();
+            let bob_task = tokio::task::spawn(async move {
+                run_bob::<store::memory::Store, _, _>(
+                    &mut bob_writer,
+                    &mut bob_reader,
+                    bob_replica_store_task,
+                    alice_peer_id,
+                )
+                .await
+            });
+
+            alice_task.await??;
+            bob_task.await??;
+
+            assert_eq!(
+                alice_replica_store
+                    .get(alice_replica.namespace(), GetFilter::all())
+                    .unwrap()
+                    .collect::<Result<Vec<_>>>()
+                    .unwrap()
+                    .len(),
+                2 * NUM_MESSAGES * num_authors,
+                "alice is missing messages"
+            );
+
+            assert_eq!(
+                bob_replica_store
+                    .get(bob_replica.namespace(), GetFilter::all())
+                    .unwrap()
+                    .collect::<Result<Vec<_>>>()
+                    .unwrap()
+                    .len(),
+                2 * NUM_MESSAGES * num_authors,
+                "bob is missing messages"
+            );
+        }
+        Ok(())
+    }
 }

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -288,123 +288,138 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sync_many_authors() -> Result<()> {
+    async fn test_sync_many_authors_memory() -> Result<()> {
+        let alice_store = store::memory::Store::default();
+        let bob_store = store::memory::Store::default();
+        test_sync_many_authors(alice_store, bob_store).await
+    }
+
+    #[tokio::test]
+    async fn test_sync_many_authors_fs() -> Result<()> {
+        let tmpdir = tempfile::tempdir()?;
+        let alice_store = store::fs::Store::new(tmpdir.path().join("a.db"))?;
+        let bob_store = store::fs::Store::new(tmpdir.path().join("b.db"))?;
+        test_sync_many_authors(alice_store, bob_store).await
+    }
+
+    async fn test_sync_many_authors<S: store::Store>(
+        alice_replica_store: S,
+        bob_replica_store: S,
+    ) -> Result<()> {
         let mut rng = rand::thread_rng();
 
-        const NUM_MESSAGES: usize = 1; //20;
+        for num_messages in &[1, 2, 5, 10, 20] {
+            for num_authors in &[2, 3, 4, 5, 10, 20] {
+                println!("Using {num_authors} authors and {num_messages} messages per side");
 
-        for num_authors in &[2, 3, 4, 5, 10, 20] {
-            println!("Using {num_authors} authors and {NUM_MESSAGES} messages per side");
+                let alice_peer_id = SecretKey::generate().public();
+                let bob_peer_id = SecretKey::generate().public();
+                let namespace = Namespace::new(&mut rng);
 
-            let alice_peer_id = SecretKey::generate().public();
-            let bob_peer_id = SecretKey::generate().public();
-            let namespace = Namespace::new(&mut rng);
+                let authors_alice: Vec<_> = (0..*num_authors)
+                    .map(|_| alice_replica_store.new_author(&mut rng).unwrap())
+                    .collect();
 
-            let alice_replica_store = store::memory::Store::default();
-            let authors_alice: Vec<_> = (0..*num_authors)
-                .map(|_| alice_replica_store.new_author(&mut rng).unwrap())
-                .collect();
-
-            let alice_replica = alice_replica_store.new_replica(namespace.clone()).unwrap();
-            for i in 0..NUM_MESSAGES {
-                for (author_num, author) in authors_alice.iter().enumerate() {
-                    alice_replica
-                        .hash_and_insert(
-                            format!("hello bob {i}"),
-                            author,
-                            format!("from alice: {author_num}"),
-                        )
-                        .unwrap();
+                let alice_replica = alice_replica_store.new_replica(namespace.clone()).unwrap();
+                for i in 0..*num_messages {
+                    for (author_num, author) in authors_alice.iter().enumerate() {
+                        alice_replica
+                            .hash_and_insert(
+                                format!("hello bob {i}"),
+                                author,
+                                format!("from alice: {author_num}"),
+                            )
+                            .unwrap();
+                    }
                 }
-            }
 
-            let bob_replica_store = store::memory::Store::default();
-            let authors_bob: Vec<_> = (0..*num_authors)
-                .map(|_| bob_replica_store.new_author(&mut rng).unwrap())
-                .collect();
-            let bob_replica = bob_replica_store.new_replica(namespace.clone()).unwrap();
-            for i in 0..NUM_MESSAGES {
-                for (author_num, author) in authors_bob.iter().enumerate() {
-                    bob_replica
-                        .hash_and_insert(
-                            format!("hello alice {i}"),
-                            author,
-                            format!("from bob: {author_num}"),
-                        )
-                        .unwrap();
+                let authors_bob: Vec<_> = (0..*num_authors)
+                    .map(|_| bob_replica_store.new_author(&mut rng).unwrap())
+                    .collect();
+                let bob_replica = bob_replica_store.new_replica(namespace.clone()).unwrap();
+                for i in 0..*num_messages {
+                    for (author_num, author) in authors_bob.iter().enumerate() {
+                        bob_replica
+                            .hash_and_insert(
+                                format!("hello alice {i}"),
+                                author,
+                                format!("from bob: {author_num}"),
+                            )
+                            .unwrap();
+                    }
                 }
+
+                assert_eq!(
+                    bob_replica_store
+                        .get(bob_replica.namespace(), GetFilter::all())
+                        .unwrap()
+                        .collect::<Result<Vec<_>>>()
+                        .unwrap()
+                        .len(),
+                    num_messages * num_authors
+                );
+                assert_eq!(
+                    alice_replica_store
+                        .get(alice_replica.namespace(), GetFilter::all())
+                        .unwrap()
+                        .collect::<Result<Vec<_>>>()
+                        .unwrap()
+                        .len(),
+                    num_messages * num_authors
+                );
+
+                let (alice, bob) = tokio::io::duplex(64 + num_messages);
+
+                println!("syncing");
+                let (mut alice_reader, mut alice_writer) = tokio::io::split(alice);
+                let replica = alice_replica.clone();
+                let alice_task = tokio::task::spawn(async move {
+                    run_alice::<S, _, _>(
+                        &mut alice_writer,
+                        &mut alice_reader,
+                        &replica,
+                        bob_peer_id,
+                    )
+                    .await
+                });
+
+                let (mut bob_reader, mut bob_writer) = tokio::io::split(bob);
+                let bob_replica_store_task = bob_replica_store.clone();
+                let bob_task = tokio::task::spawn(async move {
+                    run_bob::<S, _, _>(
+                        &mut bob_writer,
+                        &mut bob_reader,
+                        bob_replica_store_task,
+                        alice_peer_id,
+                    )
+                    .await
+                });
+
+                alice_task.await??;
+                bob_task.await??;
+
+                assert_eq!(
+                    alice_replica_store
+                        .get(alice_replica.namespace(), GetFilter::all())
+                        .unwrap()
+                        .collect::<Result<Vec<_>>>()
+                        .unwrap()
+                        .len(),
+                    2 * num_messages * num_authors,
+                    "alice is missing messages"
+                );
+
+                assert_eq!(
+                    bob_replica_store
+                        .get(bob_replica.namespace(), GetFilter::all())
+                        .unwrap()
+                        .collect::<Result<Vec<_>>>()
+                        .unwrap()
+                        .len(),
+                    2 * num_messages * num_authors,
+                    "bob is missing messages"
+                );
             }
-
-            assert_eq!(
-                bob_replica_store
-                    .get(bob_replica.namespace(), GetFilter::all())
-                    .unwrap()
-                    .collect::<Result<Vec<_>>>()
-                    .unwrap()
-                    .len(),
-                NUM_MESSAGES * num_authors
-            );
-            assert_eq!(
-                alice_replica_store
-                    .get(alice_replica.namespace(), GetFilter::all())
-                    .unwrap()
-                    .collect::<Result<Vec<_>>>()
-                    .unwrap()
-                    .len(),
-                NUM_MESSAGES * num_authors
-            );
-
-            let (alice, bob) = tokio::io::duplex(64 + NUM_MESSAGES);
-
-            println!("syncing");
-            let (mut alice_reader, mut alice_writer) = tokio::io::split(alice);
-            let replica = alice_replica.clone();
-            let alice_task = tokio::task::spawn(async move {
-                run_alice::<store::memory::Store, _, _>(
-                    &mut alice_writer,
-                    &mut alice_reader,
-                    &replica,
-                    bob_peer_id,
-                )
-                .await
-            });
-
-            let (mut bob_reader, mut bob_writer) = tokio::io::split(bob);
-            let bob_replica_store_task = bob_replica_store.clone();
-            let bob_task = tokio::task::spawn(async move {
-                run_bob::<store::memory::Store, _, _>(
-                    &mut bob_writer,
-                    &mut bob_reader,
-                    bob_replica_store_task,
-                    alice_peer_id,
-                )
-                .await
-            });
-
-            alice_task.await??;
-            bob_task.await??;
-
-            assert_eq!(
-                alice_replica_store
-                    .get(alice_replica.namespace(), GetFilter::all())
-                    .unwrap()
-                    .collect::<Result<Vec<_>>>()
-                    .unwrap()
-                    .len(),
-                2 * NUM_MESSAGES * num_authors,
-                "alice is missing messages"
-            );
-
-            assert_eq!(
-                bob_replica_store
-                    .get(bob_replica.namespace(), GetFilter::all())
-                    .unwrap()
-                    .collect::<Result<Vec<_>>>()
-                    .unwrap()
-                    .len(),
-                2 * NUM_MESSAGES * num_authors,
-                "bob is missing messages"
-            );
         }
         Ok(())
     }

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -295,6 +295,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_sync_many_authors_memory() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
         let alice_store = store::memory::Store::default();
         let bob_store = store::memory::Store::default();
         test_sync_many_authors(alice_store, bob_store).await
@@ -302,6 +303,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_sync_many_authors_fs() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
         let tmpdir = tempfile::tempdir()?;
         let alice_store = store::fs::Store::new(tmpdir.path().join("a.db"))?;
         let bob_store = store::fs::Store::new(tmpdir.path().join("b.db"))?;

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -350,10 +350,7 @@ mod tests {
         msgs
     }
 
-    async fn test_sync_many_authors<S: Store>(
-        alice_store: S,
-        bob_store: S,
-    ) -> Result<()> {
+    async fn test_sync_many_authors<S: Store>(alice_store: S, bob_store: S) -> Result<()> {
         let num_messages = &[1, 2, 5, 10, 20];
         let num_authors = &[2, 3, 4, 5, 10, 20];
 
@@ -378,7 +375,12 @@ mod tests {
                     &alice_replica,
                     *num_authors,
                     *num_messages,
-                    |author, i| (format!("hello bob {i}"), format!("from alice by {author}: {i}")),
+                    |author, i| {
+                        (
+                            format!("hello bob {i}"),
+                            format!("from alice by {author}: {i}"),
+                        )
+                    },
                 );
                 all_messages.extend_from_slice(&alice_messages);
 
@@ -389,7 +391,12 @@ mod tests {
                     &bob_replica,
                     *num_authors,
                     *num_messages,
-                    |author, i| (format!("hello bob {i}"), format!("from bob by {author}: {i}")),
+                    |author, i| {
+                        (
+                            format!("hello bob {i}"),
+                            format!("from bob by {author}: {i}"),
+                        )
+                    },
                 );
                 all_messages.extend_from_slice(&bob_messages);
 

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -342,7 +342,7 @@ mod tests {
             .get(namespace, GetFilter::all())
             .unwrap()
             .map(|entry| {
-                entry.map(|entry| (entry.author(), entry.key().to_vec(), *entry.content_hash()))
+                entry.map(|entry| (entry.author(), entry.key().to_vec(), entry.content_hash()))
             })
             .collect::<Result<Vec<_>>>()
             .unwrap();

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -168,7 +168,6 @@ pub(super) async fn run_bob<S: store::Store, R: AsyncRead + Unpin, W: AsyncWrite
             }
             Message::Sync(msg) => match replica {
                 Some(ref replica) => {
-                    debug!("run_bob: process message");
                     if let Some(msg) = replica
                         .sync_process_message(msg, other_peer_id)
                         .map_err(Into::into)?

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_stream::StreamExt;
 use tokio_util::codec::{Decoder, Encoder, FramedRead, FramedWrite};
-use tracing::{trace, debug};
+use tracing::{debug, trace};
 
 use crate::{store, NamespaceId, Replica};
 

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -522,13 +522,15 @@ where
         // Process fingerprint messages
         for RangeFingerprint { range, fingerprint } in fingerprints {
             let local_fingerprint = self.store.get_fingerprint(&range, self.limit.as_ref())?;
-
             // Case1 Match, nothing to do
             if local_fingerprint == fingerprint {
                 continue;
             }
 
             // Case2 Recursion Anchor
+            // TODO: This is hugely inefficient and needs to be optimized
+            // For an identity range that includes everything we allocate a vec with all entries of
+            // the replica here.
             let local_values: Vec<_> = self
                 .store
                 .get_range(range.clone(), self.limit.clone())?

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -666,11 +666,12 @@ where
     // pub fn remove(&mut self, k: &K) -> Result<Vec<V>, S::Error> {
     //     self.store.remove(k)
     // }
-    //
-    // /// Returns a refernce to the underlying store.
-    // pub fn store(&self) -> &S {
-    //     &self.store
-    // }
+
+    /// Returns a refernce to the underlying store.
+    #[cfg(test)]
+    pub fn store(&self) -> &S {
+        &self.store
+    }
 }
 
 #[cfg(test)]

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -447,10 +447,10 @@ impl StoreInstance {
     }
 
     fn range_start(&self) -> RecordsId {
-        (self.namespace.as_bytes(), &[0u8; 32], &[][..])
+        (self.namespace.as_bytes(), &[u8::MIN; 32], &[][..])
     }
     fn range_end(&self) -> RecordsId {
-        (self.namespace.as_bytes(), &[255u8; 32], &[][..])
+        (self.namespace.as_bytes(), &[u8::MAX; 32], &[][..])
     }
 }
 

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -678,7 +678,6 @@ impl<'a> RangeLatestIterator<'a> {
                     .open_multimap_table(RECORDS_TABLE)
                     .map_err(anyhow::Error::from)
             },
-            // |record_table| record_table.range(range).map_err(anyhow::Error::from),
             |record_table| range(record_table).map_err(anyhow::Error::from),
             limit,
             filter,

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -8,7 +8,8 @@ use parking_lot::RwLock;
 use rand_core::CryptoRngCore;
 use redb::{
     AccessGuard, Database, MultimapRange, MultimapTableDefinition, MultimapValue,
-    ReadOnlyMultimapTable, ReadTransaction, ReadableMultimapTable, ReadableTable, TableDefinition,
+    ReadOnlyMultimapTable, ReadTransaction, ReadableMultimapTable, ReadableTable, StorageError,
+    TableDefinition,
 };
 
 use crate::{
@@ -444,6 +445,13 @@ impl StoreInstance {
     fn new(namespace: NamespaceId, store: Store) -> Self {
         StoreInstance { namespace, store }
     }
+
+    fn range_start(&self) -> RecordsId {
+        (self.namespace.as_bytes(), &[0u8; 32], &[][..])
+    }
+    fn range_end(&self) -> RecordsId {
+        (self.namespace.as_bytes(), &[255u8; 32], &[][..])
+    }
 }
 
 impl crate::ranger::Store<RecordIdentifier, SignedEntry> for StoreInstance {
@@ -538,119 +546,51 @@ impl crate::ranger::Store<RecordIdentifier, SignedEntry> for StoreInstance {
         range: Range<RecordIdentifier>,
         limit: Option<Range<RecordIdentifier>>,
     ) -> Result<Self::RangeIterator<'_>> {
-        let empty_start = (&[0u8; 32], &[0u8; 32], &[0u8][..]);
-        let empty_end = (&[0u8; 32], &[0u8; 32], &[0u8][..]);
         // identity range: iter1 = all, iter2 = none
         let iter = if range.x() == range.y() {
-            let start = (self.namespace.as_bytes(), &[0u8; 32], &[][..]);
-            let end = (self.namespace.as_bytes(), &[255u8; 32], &[][..]);
+            let start = self.range_start();
+            let end = self.range_end();
             // iterator for all entries in replica
-            let iter = RangeLatestIterator::try_new(
-                self.store.db.begin_read()?,
-                |read_tx| {
-                    read_tx
-                        .open_multimap_table(RECORDS_TABLE)
-                        .map_err(anyhow::Error::from)
-                },
-                |record_table| record_table.range(start..end).map_err(anyhow::Error::from),
+            let iter = RangeLatestIterator::with_range(
+                &self.store.db,
+                |table| table.range(start..end),
                 limit.clone(),
                 RangeFilter::None,
             )?;
             // empty iterator, returns nothing
-            let iter2 = RangeLatestIterator::try_new(
-                self.store.db.begin_read()?,
-                |read_tx| {
-                    read_tx
-                        .open_multimap_table(RECORDS_TABLE)
-                        .map_err(anyhow::Error::from)
-                },
-                |record_table| {
-                    record_table
-                        .range(empty_start..empty_end)
-                        .map_err(anyhow::Error::from)
-                },
-                limit.clone(),
-                RangeFilter::None,
-            )?;
+            let iter2 = RangeLatestIterator::empty(&self.store.db)?;
             iter.chain(iter2)
         // regular range: iter1 = x <= t < y, iter2 = none
         } else if range.x() < range.y() {
-            let range_start = range.x();
-            let range_end = range.y();
-            let start = (
-                range_start.namespace_bytes(),
-                range_start.author_bytes(),
-                range_start.key(),
-            );
-            let end = (
-                range_end.namespace_bytes(),
-                range_end.author_bytes(),
-                range_end.key(),
-            );
+            let start = range.x().as_byte_tuple();
+            let end = range.y().as_byte_tuple();
             // iterator for entries from range.x to range.y
-            let iter = RangeLatestIterator::try_new(
-                self.store.db.begin_read()?,
-                |read_tx| {
-                    read_tx
-                        .open_multimap_table(RECORDS_TABLE)
-                        .map_err(anyhow::Error::from)
-                },
-                |record_table| record_table.range(start..end).map_err(anyhow::Error::from),
+            let iter = RangeLatestIterator::with_range(
+                &self.store.db,
+                |table| table.range(start..end),
                 limit.clone(),
                 RangeFilter::None,
             )?;
             // empty iterator
-            let iter2 = RangeLatestIterator::try_new(
-                self.store.db.begin_read()?,
-                |read_tx| {
-                    read_tx
-                        .open_multimap_table(RECORDS_TABLE)
-                        .map_err(anyhow::Error::from)
-                },
-                |record_table| {
-                    record_table
-                        .range(empty_start..empty_end)
-                        .map_err(anyhow::Error::from)
-                },
-                limit.clone(),
-                RangeFilter::None,
-            )?;
+            let iter2 = RangeLatestIterator::empty(&self.store.db)?;
             iter.chain(iter2)
         // wrap-around range: iter1 = y <= t, iter2 = x >= t
         } else {
-            let start = (self.namespace.as_bytes(), &[0u8; 32], &[][..]);
-            let end = (
-                range.y().namespace_bytes(),
-                range.y().author_bytes(),
-                range.y().key(),
-            );
+            let start = self.range_start();
+            let end = range.y().as_byte_tuple();
             // iterator for entries start to from range.y
-            let iter = RangeLatestIterator::try_new(
-                self.store.db.begin_read()?,
-                |read_tx| {
-                    read_tx
-                        .open_multimap_table(RECORDS_TABLE)
-                        .map_err(anyhow::Error::from)
-                },
-                |record_table| record_table.range(start..end).map_err(anyhow::Error::from),
+            let iter = RangeLatestIterator::with_range(
+                &self.store.db,
+                |table| table.range(start..end),
                 limit.clone(),
                 RangeFilter::None,
             )?;
-            let start = (
-                range.x().namespace_bytes(),
-                range.x().author_bytes(),
-                range.x().key(),
-            );
-            let end = (self.namespace.as_bytes(), &[255u8; 32], &[][..]);
+            let start = range.x().as_byte_tuple();
+            let end = self.range_end();
             // iterator for entries from range.x to end
-            let iter2 = RangeLatestIterator::try_new(
-                self.store.db.begin_read()?,
-                |read_tx| {
-                    read_tx
-                        .open_multimap_table(RECORDS_TABLE)
-                        .map_err(anyhow::Error::from)
-                },
-                |record_table| record_table.range(start..end).map_err(anyhow::Error::from),
+            let iter2 = RangeLatestIterator::with_range(
+                &self.store.db,
+                |table| table.range(start..end),
                 limit.clone(),
                 RangeFilter::None,
             )?;
@@ -717,6 +657,39 @@ pub struct RangeLatestIterator<'a> {
     records: MultimapRange<'this, RecordsId<'static>, RecordsValue<'static>>,
     limit: Option<Range<RecordIdentifier>>,
     filter: RangeFilter,
+}
+
+impl<'a> RangeLatestIterator<'a> {
+    fn with_range(
+        db: &'a Arc<Database>,
+        range: impl for<'this> FnOnce(
+            &'this ReadOnlyMultimapTable<'this, RecordsId<'static>, RecordsValue<'static>>,
+        ) -> Result<
+            MultimapRange<'this, RecordsId<'static>, RecordsValue<'static>>,
+            StorageError,
+        >,
+        limit: Option<Range<RecordIdentifier>>,
+        filter: RangeFilter,
+    ) -> anyhow::Result<Self> {
+        let iter = RangeLatestIterator::try_new(
+            db.begin_read()?,
+            |read_tx| {
+                read_tx
+                    .open_multimap_table(RECORDS_TABLE)
+                    .map_err(anyhow::Error::from)
+            },
+            // |record_table| record_table.range(range).map_err(anyhow::Error::from),
+            |record_table| range(record_table).map_err(anyhow::Error::from),
+            limit,
+            filter,
+        )?;
+        Ok(iter)
+    }
+    fn empty(db: &'a Arc<Database>) -> anyhow::Result<Self> {
+        let start = (&[0u8; 32], &[0u8; 32], &[0u8][..]);
+        let end = (&[0u8; 32], &[0u8; 32], &[0u8][..]);
+        Self::with_range(db, |table| table.range(start..end), None, RangeFilter::None)
+    }
 }
 
 impl std::fmt::Debug for RangeLatestIterator<'_> {

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -496,10 +496,13 @@ impl crate::ranger::Store<RecordIdentifier, SignedEntry> for StoreInstance {
     ) -> Result<Fingerprint> {
         // TODO: optimize?
 
-        let elements = self.get_range(range.clone(), limit.cloned())?;
+        let mut elements: Vec<_> = self
+            .get_range(range.clone(), limit.cloned())?
+            .collect::<Result<_, _>>()?;
+        elements.sort();
+
         let mut fp = Fingerprint::empty();
         for el in elements {
-            let el = el?;
             fp ^= el.0.as_fingerprint();
         }
 
@@ -538,20 +541,28 @@ impl crate::ranger::Store<RecordIdentifier, SignedEntry> for StoreInstance {
         range: Range<RecordIdentifier>,
         limit: Option<Range<RecordIdentifier>>,
     ) -> Result<Self::RangeIterator<'_>> {
-        // TODO: implement inverted range
-        let range_start = range.x();
-        let range_end = range.y();
-
-        let start = (
-            range_start.namespace_bytes(),
-            range_start.author_bytes(),
-            range_start.key(),
-        );
-        let end = (
-            range_end.namespace_bytes(),
-            range_end.author_bytes(),
-            range_end.key(),
-        );
+        let (start, end) = if range.x() == range.y() {
+            let start = (self.namespace.as_bytes(), &[0u8; 32], &[][..]);
+            let end = (self.namespace.as_bytes(), &[255u8; 32], &[][..]);
+            (start, end)
+        } else {
+            let (range_start, range_end) = if range.x() < range.y() {
+                (range.y(), range.x())
+            } else {
+                (range.x(), range.y())
+            };
+            let start = (
+                range_start.namespace_bytes(),
+                range_start.author_bytes(),
+                range_start.key(),
+            );
+            let end = (
+                range_end.namespace_bytes(),
+                range_end.author_bytes(),
+                range_end.key(),
+            );
+            (start, end)
+        };
         let iter = RangeLatestIterator::try_new(
             self.store.db.begin_read()?,
             |read_tx| {

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -494,15 +494,12 @@ impl crate::ranger::Store<RecordIdentifier, SignedEntry> for StoreInstance {
         range: &Range<RecordIdentifier>,
         limit: Option<&Range<RecordIdentifier>>,
     ) -> Result<Fingerprint> {
-        // TODO: optimize?
-
-        let mut elements: Vec<_> = self
-            .get_range(range.clone(), limit.cloned())?
-            .collect::<Result<_, _>>()?;
-        elements.sort();
+        // TODO: optimize
+        let elements = self.get_range(range.clone(), limit.cloned())?;
 
         let mut fp = Fingerprint::empty();
         for el in elements {
+            let el = el?;
             fp ^= el.0.as_fingerprint();
         }
 

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -511,7 +511,6 @@ impl crate::ranger::Store<RecordIdentifier, SignedEntry> for ReplicaStoreInstanc
             fp ^= el.0.as_fingerprint();
             count += 1;
         }
-        println!("get fingerprint for {:?}: {} items", range, count);
         if range.x() == range.y() {
             assert_eq!(count, self.len()?);
         }

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -505,14 +505,9 @@ impl crate::ranger::Store<RecordIdentifier, SignedEntry> for ReplicaStoreInstanc
     ) -> Result<Fingerprint, Self::Error> {
         let elements = self.get_range(range.clone(), limit.cloned())?;
         let mut fp = Fingerprint::empty();
-        let mut count = 0;
         for el in elements {
             let el = el?;
             fp ^= el.0.as_fingerprint();
-            count += 1;
-        }
-        if range.x() == range.y() {
-            assert_eq!(count, self.len()?);
         }
         Ok(fp)
     }

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -505,11 +505,16 @@ impl crate::ranger::Store<RecordIdentifier, SignedEntry> for ReplicaStoreInstanc
     ) -> Result<Fingerprint, Self::Error> {
         let elements = self.get_range(range.clone(), limit.cloned())?;
         let mut fp = Fingerprint::empty();
+        let mut count = 0;
         for el in elements {
             let el = el?;
             fp ^= el.0.as_fingerprint();
+            count += 1;
         }
-
+        println!("get fingerprint for {:?}: {} items", range, count);
+        if range.x() == range.y() {
+            assert_eq!(count, self.len()?);
+        }
         Ok(fp)
     }
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -307,11 +307,11 @@ impl Debug for EntrySignature {
         f.debug_struct("EntrySignature")
             .field(
                 "namespace_signature",
-                &base32::fmt(&self.namespace_signature.to_bytes()),
+                &base32::fmt(self.namespace_signature.to_bytes()),
             )
             .field(
                 "author_signature",
-                &base32::fmt(&self.author_signature.to_bytes()),
+                &base32::fmt(self.author_signature.to_bytes()),
             )
             .finish()
     }

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -488,15 +488,7 @@ impl AsFingerprint for RecordIdentifier {
     }
 }
 
-<<<<<<< HEAD
 impl RangeKey for RecordIdentifier {}
-=======
-impl RangeKey for RecordIdentifier {
-    fn contains(&self, range: &crate::ranger::Range<Self>) -> bool {
-        crate::ranger::contains(self, &range)
-    }
-}
->>>>>>> 762205c9 (try to fix sync reconciliation bug)
 
 impl RecordIdentifier {
     /// Create a new [`RecordIdentifier`].

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -419,11 +419,25 @@ pub struct RecordIdentifier {
 
 impl Debug for RecordIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RecordIdentifier")
-            .field("namespace", &self.namespace)
-            .field("author", &self.author)
-            .field("key", &std::string::String::from_utf8_lossy(&self.key))
-            .finish()
+        /// Convert to a base32 string limited to the first 5 bytes
+        pub fn fmt_short(bytes: impl AsRef<[u8]>) -> String {
+            let len = bytes.as_ref().len().min(5);
+            let mut text = data_encoding::BASE32_NOPAD.encode(&bytes.as_ref()[..len]);
+            text.make_ascii_lowercase();
+            text
+        }
+        write!(
+            f,
+            "RecId({}:{}:{})",
+            fmt_short(self.namespace.as_bytes()),
+            fmt_short(self.author.as_bytes()),
+            &std::string::String::from_utf8_lossy(&self.key)
+        )
+        // f.debug_struct("RecordIdentifier")
+        //     .field("namespace", &self.namespace)
+        //     .field("author", &self.author)
+        //     .field("key", &std::string::String::from_utf8_lossy(&self.key))
+        //     .finish()
     }
 }
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -285,10 +285,25 @@ impl SignedEntry {
 }
 
 /// Signature over an entry.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EntrySignature {
     author_signature: Signature,
     namespace_signature: Signature,
+}
+
+impl Debug for EntrySignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EntrySignature")
+            .field(
+                "namespace_signature",
+                &base32::fmt(&self.namespace_signature.to_bytes()),
+            )
+            .field(
+                "author_signature",
+                &base32::fmt(&self.author_signature.to_bytes()),
+            )
+            .finish()
+    }
 }
 
 impl EntrySignature {
@@ -392,7 +407,7 @@ impl Entry {
 }
 
 /// The indentifier of a record.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Clone, Serialize, Deserialize)]
 pub struct RecordIdentifier {
     /// The key of the record.
     key: Vec<u8>,
@@ -400,6 +415,16 @@ pub struct RecordIdentifier {
     namespace: NamespaceId,
     /// The [`AuthorId`] of the author that wrote this record.
     author: AuthorId,
+}
+
+impl Debug for RecordIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecordIdentifier")
+            .field("namespace", &self.namespace)
+            .field("author", &self.author)
+            .field("key", &std::string::String::from_utf8_lossy(&self.key))
+            .finish()
+    }
 }
 
 impl PartialEq for RecordIdentifier {

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -430,25 +430,11 @@ pub struct RecordIdentifier {
 
 impl Debug for RecordIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        /// Convert to a base32 string limited to the first 5 bytes
-        pub fn fmt_short(bytes: impl AsRef<[u8]>) -> String {
-            let len = bytes.as_ref().len().min(5);
-            let mut text = data_encoding::BASE32_NOPAD.encode(&bytes.as_ref()[..len]);
-            text.make_ascii_lowercase();
-            text
-        }
-        write!(
-            f,
-            "RecId({}:{}:{})",
-            fmt_short(self.namespace.as_bytes()),
-            fmt_short(self.author.as_bytes()),
-            &std::string::String::from_utf8_lossy(&self.key)
-        )
-        // f.debug_struct("RecordIdentifier")
-        //     .field("namespace", &self.namespace)
-        //     .field("author", &self.author)
-        //     .field("key", &std::string::String::from_utf8_lossy(&self.key))
-        //     .finish()
+        f.debug_struct("RecordIdentifier")
+            .field("namespace", &self.namespace)
+            .field("author", &self.author)
+            .field("key", &std::string::String::from_utf8_lossy(&self.key))
+            .finish()
     }
 }
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -212,7 +212,7 @@ impl<S: ranger::Store<RecordIdentifier, SignedEntry>> Replica<S> {
 }
 
 /// A signed entry.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SignedEntry {
     signature: EntrySignature,
     entry: Entry,
@@ -221,6 +221,18 @@ pub struct SignedEntry {
 impl From<SignedEntry> for Entry {
     fn from(value: SignedEntry) -> Self {
         value.entry
+    }
+}
+
+impl PartialOrd for SignedEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.entry.id.partial_cmp(&other.entry.id)
+    }
+}
+
+impl Ord for SignedEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.entry.id.cmp(&other.entry.id)
     }
 }
 
@@ -273,7 +285,7 @@ impl SignedEntry {
 }
 
 /// Signature over an entry.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EntrySignature {
     author_signature: Signature,
     namespace_signature: Signature,
@@ -333,7 +345,7 @@ impl EntrySignature {
 /// An entry is identified by a key, its [`Author`], and the [`Replica`]'s
 /// [`Namespace`]. Its value is the [32-byte BLAKE3 hash](iroh_bytes::Hash)
 /// of the entry's content data, the size of this content data, and a timestamp.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Entry {
     id: RecordIdentifier,
     record: Record,
@@ -380,7 +392,7 @@ impl Entry {
 }
 
 /// The indentifier of a record.
-#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct RecordIdentifier {
     /// The key of the record.
     key: Vec<u8>,
@@ -388,6 +400,34 @@ pub struct RecordIdentifier {
     namespace: NamespaceId,
     /// The [`AuthorId`] of the author that wrote this record.
     author: AuthorId,
+}
+
+impl PartialEq for RecordIdentifier {
+    fn eq(&self, other: &Self) -> bool {
+        self.namespace.eq(&other.namespace)
+            && self.author.eq(&other.author)
+            && self.key.eq(&other.key)
+    }
+}
+
+impl Eq for RecordIdentifier {}
+
+impl PartialOrd for RecordIdentifier {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RecordIdentifier {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.namespace.cmp(&other.namespace) {
+            std::cmp::Ordering::Equal => match self.author.cmp(&other.author) {
+                std::cmp::Ordering::Equal => self.key.cmp(&other.key),
+                res => res,
+            },
+            res => res,
+        }
+    }
 }
 
 impl AsFingerprint for RecordIdentifier {
@@ -463,7 +503,7 @@ impl Deref for Entry {
 }
 
 /// The data part of an entry in a [`Replica`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Record {
     /// Record creation timestamp. Counted as micros since the Unix epoch.
     timestamp: u64,
@@ -533,7 +573,7 @@ mod tests {
     use anyhow::Result;
 
     use crate::{
-        ranger::Range,
+        ranger::{Range, Store as _},
         store::{self, GetFilter},
     };
 
@@ -723,6 +763,30 @@ mod tests {
             .collect::<Result<_>>()?;
         assert_eq!(entries.len(), 12);
 
+        let replica = store.open_replica(&my_replica.namespace())?.unwrap();
+        // Get Range of all should return all latest
+        let entries_second: Vec<_> = replica
+            .inner
+            .read()
+            .peer
+            .store()
+            .get_range(
+                Range::new(RecordIdentifier::default(), RecordIdentifier::default()),
+                None,
+            )
+            .map_err(Into::into)?
+            .collect::<Result<_, _>>()
+            .map_err(Into::into)?;
+
+        assert_eq!(entries_second.len(), 12);
+        assert_eq!(
+            entries,
+            entries_second
+                .into_iter()
+                .map(|(_, x)| x)
+                .collect::<Vec<_>>()
+        );
+
         Ok(())
     }
 
@@ -748,6 +812,9 @@ mod tests {
             assert!(ri0.contains(&range), "start");
             assert!(ri1.contains(&range), "inside");
             assert!(!ri2.contains(&range), "end");
+
+            assert!(ri0 < ri1);
+            assert!(ri1 < ri2);
         }
 
         // Just namespace
@@ -760,6 +827,9 @@ mod tests {
             assert!(ri0.contains(&range), "start");
             assert!(ri1.contains(&range), "inside");
             assert!(!ri2.contains(&range), "end");
+
+            assert!(ri0 < ri1);
+            assert!(ri1 < ri2);
         }
 
         // Just author
@@ -772,6 +842,9 @@ mod tests {
             assert!(ri0.contains(&range), "start");
             assert!(ri1.contains(&range), "inside");
             assert!(!ri2.contains(&range), "end");
+
+            assert!(ri0 < ri1);
+            assert!(ri1 < ri2);
         }
 
         // Just key and namespace
@@ -784,6 +857,26 @@ mod tests {
             assert!(ri0.contains(&range), "start");
             assert!(ri1.contains(&range), "inside");
             assert!(!ri2.contains(&range), "end");
+
+            assert!(ri0 < ri1);
+            assert!(ri1 < ri2);
+        }
+
+        // Mixed
+        {
+            // Ord should prioritize namespace - author - key
+
+            let a0 = a[0].id();
+            let a1 = a[1].id();
+            let n0 = n[0].id();
+            let n1 = n[1].id();
+            let k0 = k[0];
+            let k1 = k[1];
+
+            assert!(RecordIdentifier::new(k0, n0, a0) < RecordIdentifier::new(k1, n1, a1));
+            assert!(RecordIdentifier::new(k1, n0, a0) < RecordIdentifier::new(k0, n1, a0));
+            assert!(RecordIdentifier::new(k0, n0, a1) < RecordIdentifier::new(k1, n0, a1));
+            assert!(RecordIdentifier::new(k0, n1, a1) < RecordIdentifier::new(k1, n1, a1));
         }
     }
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -527,6 +527,11 @@ impl RecordIdentifier {
         out.extend_from_slice(&self.key);
     }
 
+    /// Get this [`RecordIdentifier`] as a tuple of byte slices.
+    pub(crate) fn as_byte_tuple(&self) -> (&[u8; 32], &[u8; 32], &[u8]) {
+        (self.namespace.as_bytes(), self.author.as_bytes(), &self.key)
+    }
+
     /// Get the key of this record.
     pub fn key(&self) -> &[u8] {
         &self.key


### PR DESCRIPTION
## Description

This fixes two bugs:
* Range contains calculation for iroh-sync compound keys was incorrect
* fs store `get_range` implementation (redb) was incorrect for wrap-around ranges

It also contains these refactorings:
* Improve many_authors test to verify all messages are correct
* Simplify the fs store implementation by adding constructor methods to the range iterators
<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
