### PR TITLE
feat(iroh-sync) include timestamps in the sync and remove history

### DIFF
--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -226,7 +226,7 @@ mod tests {
 
         assert_eq!(
             bob_replica_store
-                .get(bob_replica.namespace(), GetFilter::all())
+                .get(bob_replica.namespace(), GetFilter::All)
                 .unwrap()
                 .collect::<Result<Vec<_>>>()
                 .unwrap()
@@ -235,7 +235,7 @@ mod tests {
         );
         assert_eq!(
             alice_replica_store
-                .get(alice_replica.namespace(), GetFilter::all())
+                .get(alice_replica.namespace(), GetFilter::All)
                 .unwrap()
                 .collect::<Result<Vec<_>>>()
                 .unwrap()
@@ -274,7 +274,7 @@ mod tests {
 
         assert_eq!(
             bob_replica_store
-                .get(bob_replica.namespace(), GetFilter::all())
+                .get(bob_replica.namespace(), GetFilter::All)
                 .unwrap()
                 .collect::<Result<Vec<_>>>()
                 .unwrap()
@@ -283,7 +283,7 @@ mod tests {
         );
         assert_eq!(
             alice_replica_store
-                .get(alice_replica.namespace(), GetFilter::all())
+                .get(alice_replica.namespace(), GetFilter::All)
                 .unwrap()
                 .collect::<Result<Vec<_>>>()
                 .unwrap()
@@ -339,7 +339,7 @@ mod tests {
 
     fn get_messages<S: Store>(store: &S, namespace: NamespaceId) -> Vec<Message> {
         let mut msgs = store
-            .get(namespace, GetFilter::all())
+            .get(namespace, GetFilter::All)
             .unwrap()
             .map(|entry| {
                 entry.map(|entry| (entry.author(), entry.key().to_vec(), entry.content_hash()))

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -219,7 +219,9 @@ where
 
     /// Returns all items in the given range
     fn get_range(&self, range: Range<K>) -> Result<Self::RangeIterator<'_>, Self::Error>;
-    fn remove(&mut self, key: &K) -> Result<Vec<V>, Self::Error>;
+
+    /// Remove an entry from the store.
+    fn remove(&mut self, key: &K) -> Result<Option<V>, Self::Error>;
 
     type AllIterator<'a>: Iterator<Item = Result<(K, V), Self::Error>>
     where
@@ -300,10 +302,8 @@ where
         })
     }
 
-    fn remove(&mut self, key: &K) -> Result<Vec<V>, Self::Error> {
-        // No versions stored
-
-        let res = self.data.remove(key).into_iter().collect();
+    fn remove(&mut self, key: &K) -> Result<Option<V>, Self::Error> {
+        let res = self.data.remove(key);
         Ok(res)
     }
 

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -1206,8 +1206,7 @@ mod tests {
         #[strategy(test_set())] contents: BTreeMap<String, ()>,
         #[strategy(test_range())] range: Range<String>,
     ) {
-        let (expected, actual) =
-            store_get_ranges_test::<SimpleStore<_, _>, _, _>(contents.clone(), range.clone());
+        let (expected, actual) = store_get_ranges_test::<SimpleStore<_, _>, _, _>(contents, range);
         prop_assert_eq!(expected, actual);
     }
 }

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -48,7 +48,14 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     fn open_replica(&self, namespace: &NamespaceId) -> Result<Option<Replica<Self::Instance>>>;
 
     /// Create a new author key and persist it in the store.
-    fn new_author<R: CryptoRngCore + ?Sized>(&self, rng: &mut R) -> Result<Author>;
+    fn new_author<R: CryptoRngCore + ?Sized>(&self, rng: &mut R) -> Result<Author> {
+        let author = Author::new(rng);
+        self.import_author(author.clone())?;
+        Ok(author)
+    }
+
+    /// Import an author key pair.
+    fn import_author(&self, author: Author) -> Result<()>;
 
     /// List all author keys in this store.
     fn list_authors(&self) -> Result<Self::AuthorsIter<'_>>;

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -68,6 +68,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     /// The [`GetFilter`] has several methods of filtering the returned entries.
     fn get(&self, namespace: NamespaceId, filter: GetFilter) -> Result<Self::GetIter<'_>>;
 
+    /// Get an entry by key and author.
     fn get_by_key_and_author(
         &self,
         namespace: NamespaceId,
@@ -79,7 +80,9 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
 /// Filter a get query onto a namespace
 #[derive(Debug, Serialize, Deserialize)]
 pub enum GetFilter {
+    /// Filter by author
     Author(AuthorId),
+    /// Filter by key
     Key(KeyFilter),
 }
 
@@ -101,25 +104,23 @@ impl GetFilter {
     }
 
     /// Set the key filter.
-    pub fn with_key_filter(mut self, key_filter: KeyFilter) -> Self {
-        self = Self::Key(key_filter);
-        self
+    pub fn with_key_filter(self, key_filter: KeyFilter) -> Self {
+        Self::Key(key_filter)
     }
 
     /// Filter by exact key match.
-    pub fn with_key(mut self, key: impl AsRef<[u8]>) -> Self {
+    pub fn with_key(self, key: impl AsRef<[u8]>) -> Self {
         self.with_key_filter(KeyFilter::Key(key.as_ref().to_vec()))
     }
 
     /// Filter by prefix key match.
-    pub fn with_prefix(mut self, prefix: impl AsRef<[u8]>) -> Self {
+    pub fn with_prefix(self, prefix: impl AsRef<[u8]>) -> Self {
         self.with_key_filter(KeyFilter::Prefix(prefix.as_ref().to_vec()))
     }
 
     /// Filter by author.
-    pub fn with_author(mut self, author: AuthorId) -> Self {
-        self = GetFilter::Author(author);
-        self
+    pub fn with_author(self, author: AuthorId) -> Self {
+        GetFilter::Author(author)
     }
 }
 

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -97,3 +97,15 @@ impl Default for GetFilter {
         Self::All
     }
 }
+
+impl GetFilter {
+    /// Create a [`GetFilter`] from author and prefix options.
+    pub fn author_prefix(author: Option<AuthorId>, prefix: Option<impl AsRef<[u8]>>) -> Self {
+        match (author, prefix) {
+            (None, None) => Self::All,
+            (Some(author), None) => Self::Author(author),
+            (None, Some(prefix)) => Self::Prefix(prefix.as_ref().to_vec()),
+            (Some(author), Some(prefix)) => Self::AuthorAndPrefix(author, prefix.as_ref().to_vec()),
+        }
+    }
+}

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -80,57 +80,20 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
 /// Filter a get query onto a namespace
 #[derive(Debug, Serialize, Deserialize)]
 pub enum GetFilter {
+    /// No filter, list all entries
+    All,
+    /// Filter for exact key match
+    Key(Vec<u8>),
+    /// Filter for key prefix
+    Prefix(Vec<u8>),
     /// Filter by author
     Author(AuthorId),
-    /// Filter by key
-    Key(KeyFilter),
+    /// Filter by key prefix and author
+    AuthorAndPrefix(AuthorId, Vec<u8>),
 }
 
 impl Default for GetFilter {
     fn default() -> Self {
-        Self::all()
+        Self::All
     }
-}
-
-impl GetFilter {
-    /// Create a new get filter.
-    pub fn new() -> Self {
-        GetFilter::Key(KeyFilter::All)
-    }
-
-    /// No filter, iterate over all entries.
-    pub fn all() -> Self {
-        Self::new()
-    }
-
-    /// Set the key filter.
-    pub fn with_key_filter(self, key_filter: KeyFilter) -> Self {
-        Self::Key(key_filter)
-    }
-
-    /// Filter by exact key match.
-    pub fn with_key(self, key: impl AsRef<[u8]>) -> Self {
-        self.with_key_filter(KeyFilter::Key(key.as_ref().to_vec()))
-    }
-
-    /// Filter by prefix key match.
-    pub fn with_prefix(self, prefix: impl AsRef<[u8]>) -> Self {
-        self.with_key_filter(KeyFilter::Prefix(prefix.as_ref().to_vec()))
-    }
-
-    /// Filter by author.
-    pub fn with_author(self, author: AuthorId) -> Self {
-        GetFilter::Author(author)
-    }
-}
-
-/// Filter the keys in a namespace
-#[derive(Debug, Serialize, Deserialize)]
-pub enum KeyFilter {
-    /// No filter, list all entries
-    All,
-    /// Filter for entries starting with a prefix
-    Prefix(Vec<u8>),
-    /// Filter for exact key match
-    Key(Vec<u8>),
 }

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -5,7 +5,6 @@ use std::{cmp::Ordering, collections::HashMap, path::Path, sync::Arc};
 use anyhow::{bail, Result};
 use ouroboros::self_referencing;
 use parking_lot::RwLock;
-use rand_core::CryptoRngCore;
 use redb::{
     AccessGuard, Database, MultimapRange, MultimapTableDefinition, MultimapValue,
     ReadOnlyMultimapTable, ReadTransaction, ReadableMultimapTable, ReadableTable, StorageError,
@@ -180,10 +179,9 @@ impl super::Store for Store {
         Ok(Some(author))
     }
 
-    fn new_author<R: CryptoRngCore + ?Sized>(&self, rng: &mut R) -> Result<Author> {
-        let author = Author::new(rng);
-        self.insert_author(author.clone())?;
-        Ok(author)
+    fn import_author(&self, author: Author) -> Result<()> {
+        self.insert_author(author)?;
+        Ok(())
     }
 
     fn list_authors(&self) -> Result<Self::AuthorsIter<'_>> {

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -304,9 +304,7 @@ fn increment_by_one(value: &mut [u8]) -> bool {
     false
 }
 
-fn prefix_range_end<'a>(
-    value: &'a RecordsId<'a>,
-) -> Option<([u8; 32], [u8; 32], Vec<u8>)> {
+fn prefix_range_end<'a>(value: &'a RecordsId<'a>) -> Option<([u8; 32], [u8; 32], Vec<u8>)> {
     let mut namespace = *value.0;
     let mut author = *value.1;
     let mut prefix = value.2.to_vec();

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -247,15 +247,14 @@ impl Store {
         let mut author2 = *author;
         // move to next possible author, which marks the end of the range
         // TODO: is there a better way to define the range end?
-        for i in 0..32 {
-            if author2[32 - i] != 255 {
-                author2[32 - i] += 1;
+        for char in author2.iter_mut().rev() {
+            if *char != 255 {
+                *char += 1;
                 break;
             }
         }
         let end = (namespace.as_bytes(), &author2, &[][..]);
-        RangeIterator::with_range(&self.db, |table| table.range(start..end), RangeFilter::None)?;
-        todo!()
+        RangeIterator::with_range(&self.db, |table| table.range(start..end), RangeFilter::None)
     }
 
     fn get_by_author_and_prefix(
@@ -276,8 +275,7 @@ impl Store {
             }
         }
         let end = (namespace.as_bytes(), author, &end_prefix[..]);
-        RangeIterator::with_range(&self.db, |table| table.range(start..end), RangeFilter::None)?;
-        todo!()
+        RangeIterator::with_range(&self.db, |table| table.range(start..end), RangeFilter::None)
     }
 
     fn get_by_prefix(

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -219,7 +219,7 @@ impl super::Store for Store {
         };
         let (timestamp, namespace_sig, author_sig, len, hash) = record.value();
 
-        let record = Record::new(timestamp, len, hash.into());
+        let record = Record::new(len, hash.into());
         let id = RecordIdentifier::new(key, namespace, author, timestamp);
         let entry = Entry::new(id, record);
         let entry_signature = EntrySignature::from_parts(namespace_sig, author_sig);
@@ -460,8 +460,8 @@ impl crate::ranger::Store<RecordIdentifier, SignedEntry> for StoreInstance {
             let key = (k.namespace_bytes(), k.author_bytes(), k.key());
             let record = records_table.remove(key)?;
             record.map(|record| {
-                let (timestamp, namespace_sig, author_sig, len, hash) = record.value();
-                let record = Record::new(timestamp, len, hash.into());
+                let (_timestamp, namespace_sig, author_sig, len, hash) = record.value();
+                let record = Record::new(len, hash.into());
                 let entry = Entry::new(k.clone(), record);
                 let entry_signature = EntrySignature::from_parts(namespace_sig, author_sig);
                 SignedEntry::new(entry_signature, entry)
@@ -568,7 +568,7 @@ impl Iterator for RangeIterator<'_> {
                 };
                 if fields.filter.matches(&id) {
                     // TODO: remove timestamp
-                    let record = Record::new(timestamp, len, hash.into());
+                    let record = Record::new(len, hash.into());
                     let entry = Entry::new(id.clone(), record);
                     let entry_signature = EntrySignature::from_parts(namespace_sig, author_sig);
                     let signed_entry = SignedEntry::new(entry_signature, entry);
@@ -612,7 +612,7 @@ mod tests {
                 RecordIdentifier::new_current(format!("hello-{i}"), namespace.id(), author.id());
             let entry = Entry::new(
                 id.clone(),
-                Record::from_data(id.timestamp(), format!("world-{i}"), namespace.id()),
+                Record::from_data(format!("world-{i}"), namespace.id()),
             );
             let entry = SignedEntry::from_entry(entry, &namespace, &author);
             wrapper.put(id, entry)?;
@@ -629,7 +629,7 @@ mod tests {
                 RecordIdentifier::new_current(format!("hello-{i}"), namespace.id(), author.id());
             let entry = Entry::new(
                 id.clone(),
-                Record::from_data(id.timestamp(), format!("world-{i}-2"), namespace.id()),
+                Record::from_data(format!("world-{i}-2"), namespace.id()),
             );
             let entry = SignedEntry::from_entry(entry, &namespace, &author);
             wrapper.put(id.clone(), entry)?;

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -263,10 +263,8 @@ impl Store {
         let start = (namespace.as_bytes(), author, prefix.as_ref());
         let mut end_prefix = prefix.as_ref().to_vec();
         let mut end_author = *author;
-        if !increment_by_one(&mut end_prefix) {
-            if !increment_by_one(&mut end_author) {
-                bail!("Invalid AuthorId")
-            }
+        if !increment_by_one(&mut end_prefix) && !increment_by_one(&mut end_author) {
+            bail!("Invalid AuthorId")
         }
         let end = (namespace.as_bytes(), &end_author, &end_prefix[..]);
         RangeIterator::with_range(&self.db, |table| table.range(start..end), RangeFilter::None)
@@ -608,7 +606,7 @@ mod tests {
 
         let author = store.new_author(&mut rand::thread_rng())?;
         let namespace = Namespace::new(&mut rand::thread_rng());
-        let replica = store.new_replica(namespace.clone())?;
+        let replica = store.new_replica(namespace)?;
 
         // test author prefix relation for all-255 keys
         let key1 = vec![255, 255];

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -244,7 +244,7 @@ impl Store {
     fn get_by_author(&self, namespace: NamespaceId, author: AuthorId) -> Result<RangeIterator<'_>> {
         let author = author.as_bytes();
         let start = (namespace.as_bytes(), author, &[][..]);
-        let end = increment_by_one_if_possible(&start);
+        let end = prefix_range_end(&start);
         RangeIterator::with_range(
             &self.db,
             |table| match end {
@@ -263,7 +263,7 @@ impl Store {
     ) -> Result<RangeIterator<'_>> {
         let author = author.as_bytes();
         let start = (namespace.as_bytes(), author, prefix.as_ref());
-        let end = increment_by_one_if_possible(&start);
+        let end = prefix_range_end(&start);
         RangeIterator::with_range(
             &self.db,
             |table| match end {
@@ -304,7 +304,7 @@ fn increment_by_one(value: &mut [u8]) -> bool {
     false
 }
 
-fn increment_by_one_if_possible<'a>(
+fn prefix_range_end<'a>(
     value: &'a RecordsId<'a>,
 ) -> Option<([u8; 32], [u8; 32], Vec<u8>)> {
     let mut namespace = *value.0;

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -567,7 +567,6 @@ impl Iterator for RangeIterator<'_> {
                     Err(err) => return Some(Err(err)),
                 };
                 if fields.filter.matches(&id) {
-                    // TODO: remove timestamp
                     let record = Record::new(len, hash.into());
                     let entry = Entry::new(id.clone(), record);
                     let entry_signature = EntrySignature::from_parts(namespace_sig, author_sig);

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -8,7 +8,6 @@ use std::{
 
 use anyhow::{bail, Result};
 use parking_lot::{RwLock, RwLockReadGuard};
-use rand_core::CryptoRngCore;
 
 use crate::{
     ranger::{AsFingerprint, Fingerprint, Range},
@@ -55,10 +54,9 @@ impl super::Store for Store {
         Ok(authors.get(author).cloned())
     }
 
-    fn new_author<R: CryptoRngCore + ?Sized>(&self, rng: &mut R) -> Result<Author> {
-        let author = Author::new(rng);
+    fn import_author(&self, author: Author) -> Result<()> {
         self.authors.write().insert(author.id(), author.clone());
-        Ok(author)
+        Ok(())
     }
 
     fn list_authors(&self) -> Result<Self::AuthorsIter<'_>> {

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -58,7 +58,7 @@ impl super::Store for Store {
     }
 
     fn import_author(&self, author: Author) -> Result<()> {
-        self.authors.write().insert(author.id(), author.clone());
+        self.authors.write().insert(author.id(), author);
         Ok(())
     }
 

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -118,10 +118,9 @@ pub struct EntryIterator<'a>(StoreRangeIterator<'a>);
 impl<'a> Iterator for EntryIterator<'a> {
     type Item = Result<SignedEntry>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|res| {
-            res.map(|(_id, entry)| entry)
-                .map_err(|_| unreachable!("never errors"))
-        })
+        self.0
+            .next()
+            .map(|res| Ok(res.map(|(_id, entry)| entry).expect("never errors")))
     }
 }
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -135,7 +135,7 @@ impl<S: ranger::Store<RecordIdentifier, SignedEntry>> Replica<S> {
         drop(inner);
 
         if let Some(sender) = self.on_insert_sender.read().as_ref() {
-            sender.send((InsertOrigin::Local, entry)).ok();
+            sender.send(origin).ok();
         }
 
         #[cfg(feature = "metrics")]

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -110,7 +110,7 @@ impl<S: ranger::Store<RecordIdentifier, SignedEntry>> Replica<S> {
         let record = Record::from_hash(hash, len);
 
         // Store signed entries
-        let entry = Entry::new(id.clone(), record);
+        let entry = Entry::new(id, record);
         let signed_entry = entry.sign(&self.inner.read().namespace, author);
         self.insert_entry(signed_entry, InsertOrigin::Local)
     }
@@ -934,7 +934,7 @@ mod tests {
         let entry = {
             let timestamp = 2;
             let id = RecordIdentifier::new(key, namespace.id(), author.id(), timestamp);
-            let record = Record::from_data(&value);
+            let record = Record::from_data(value);
             Entry::new(id, record).sign(&namespace, &author)
         };
 
@@ -949,12 +949,12 @@ mod tests {
         let entry2 = {
             let timestamp = 1;
             let id = RecordIdentifier::new(key, namespace.id(), author.id(), timestamp);
-            let record = Record::from_data(&value);
+            let record = Record::from_data(value);
             Entry::new(id, record).sign(&namespace, &author)
         };
 
         replica
-            .insert_entry(entry2.clone(), InsertOrigin::Local)
+            .insert_entry(entry2, InsertOrigin::Local)
             .unwrap();
         let res = store
             .get_by_key_and_author(namespace.id(), author.id(), key)?

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -135,7 +135,7 @@ impl<S: ranger::Store<RecordIdentifier, SignedEntry>> Replica<S> {
         drop(inner);
 
         if let Some(sender) = self.on_insert_sender.read().as_ref() {
-            sender.send(origin).ok();
+            sender.send((origin.clone(), entry)).ok();
         }
 
         #[cfg(feature = "metrics")]

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -953,9 +953,7 @@ mod tests {
             Entry::new(id, record).sign(&namespace, &author)
         };
 
-        replica
-            .insert_entry(entry2, InsertOrigin::Local)
-            .unwrap();
+        replica.insert_entry(entry2, InsertOrigin::Local).unwrap();
         let res = store
             .get_by_key_and_author(namespace.id(), author.id(), key)?
             .unwrap();

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -696,7 +696,7 @@ mod tests {
 
         for i in 0..10 {
             let res = store
-                .get_latest_by_key_and_author(my_replica.namespace(), alice.id(), format!("/{i}"))?
+                .get_by_key_and_author(my_replica.namespace(), alice.id(), format!("/{i}"))?
                 .unwrap();
             let len = format!("{i}: hello from alice").as_bytes().len() as u64;
             assert_eq!(res.entry().record().content_len(), len);
@@ -708,14 +708,14 @@ mod tests {
             .hash_and_insert("/cool/path", &alice, "round 1")
             .map_err(Into::into)?;
         let _entry = store
-            .get_latest_by_key_and_author(my_replica.namespace(), alice.id(), "/cool/path")?
+            .get_by_key_and_author(my_replica.namespace(), alice.id(), "/cool/path")?
             .unwrap();
         // Second
         my_replica
             .hash_and_insert("/cool/path", &alice, "round 2")
             .map_err(Into::into)?;
         let _entry = store
-            .get_latest_by_key_and_author(my_replica.namespace(), alice.id(), "/cool/path")?
+            .get_by_key_and_author(my_replica.namespace(), alice.id(), "/cool/path")?
             .unwrap();
 
         // Get All by author
@@ -738,23 +738,23 @@ mod tests {
             .collect::<Result<_>>()?;
         assert_eq!(entries.len(), 2);
 
-        // Get latest by key
-        let entries: Vec<_> = store
-            .get(
-                my_replica.namespace(),
-                GetFilter::latest().with_key(b"/cool/path"),
-            )?
-            .collect::<Result<_>>()?;
-        assert_eq!(entries.len(), 1);
-
-        // Get latest by prefix
-        let entries: Vec<_> = store
-            .get(
-                my_replica.namespace(),
-                GetFilter::latest().with_prefix(b"/cool"),
-            )?
-            .collect::<Result<_>>()?;
-        assert_eq!(entries.len(), 1);
+        // // Get latest by key
+        // let entries: Vec<_> = store
+        //     .get(
+        //         my_replica.namespace(),
+        //         GetFilter::latest().with_key(b"/cool/path"),
+        //     )?
+        //     .collect::<Result<_>>()?;
+        // assert_eq!(entries.len(), 1);
+        //
+        // // Get latest by prefix
+        // let entries: Vec<_> = store
+        //     .get(
+        //         my_replica.namespace(),
+        //         GetFilter::latest().with_prefix(b"/cool"),
+        //     )?
+        //     .collect::<Result<_>>()?;
+        // assert_eq!(entries.len(), 1);
 
         // Get All
         let entries: Vec<_> = store
@@ -762,11 +762,11 @@ mod tests {
             .collect::<Result<_>>()?;
         assert_eq!(entries.len(), 12);
 
-        // Get All latest
-        let entries: Vec<_> = store
-            .get(my_replica.namespace(), GetFilter::latest())?
-            .collect::<Result<_>>()?;
-        assert_eq!(entries.len(), 11);
+        // // Get All latest
+        // let entries: Vec<_> = store
+        //     .get(my_replica.namespace(), GetFilter::latest())?
+        //     .collect::<Result<_>>()?;
+        // assert_eq!(entries.len(), 11);
 
         // insert record from different author
         let _entry = my_replica
@@ -803,23 +803,23 @@ mod tests {
             .collect::<Result<_>>()?;
         assert_eq!(entries.len(), 3);
 
-        // Get latest by key
-        let entries: Vec<_> = store
-            .get(
-                my_replica.namespace(),
-                GetFilter::latest().with_key(b"/cool/path"),
-            )?
-            .collect::<Result<_>>()?;
-        assert_eq!(entries.len(), 2);
+        // // Get latest by key
+        // let entries: Vec<_> = store
+        //     .get(
+        //         my_replica.namespace(),
+        //         GetFilter::latest().with_key(b"/cool/path"),
+        //     )?
+        //     .collect::<Result<_>>()?;
+        // assert_eq!(entries.len(), 2);
 
-        // Get latest by prefix
-        let entries: Vec<_> = store
-            .get(
-                my_replica.namespace(),
-                GetFilter::latest().with_prefix(b"/cool"),
-            )?
-            .collect::<Result<_>>()?;
-        assert_eq!(entries.len(), 2);
+        // // Get latest by prefix
+        // let entries: Vec<_> = store
+        //     .get(
+        //         my_replica.namespace(),
+        //         GetFilter::latest().with_prefix(b"/cool"),
+        //     )?
+        //     .collect::<Result<_>>()?;
+        // assert_eq!(entries.len(), 2);
 
         // Get all by prefix
         let entries: Vec<_> = store
@@ -836,11 +836,11 @@ mod tests {
             .collect::<Result<_>>()?;
         assert_eq!(entries.len(), 13);
 
-        // Get All latest
-        let entries: Vec<_> = store
-            .get(my_replica.namespace(), GetFilter::latest())?
-            .collect::<Result<_>>()?;
-        assert_eq!(entries.len(), 12);
+        // // Get All latest
+        // let entries: Vec<_> = store
+        //     .get(my_replica.namespace(), GetFilter::latest())?
+        //     .collect::<Result<_>>()?;
+        // assert_eq!(entries.len(), 12);
 
         let replica = store.open_replica(&my_replica.namespace())?.unwrap();
         // Get Range of all should return all latest
@@ -952,10 +952,10 @@ mod tests {
             let k0 = k[0];
             let k1 = k[1];
 
-            assert!(RecordIdentifier::new(k0, n0, a0) < RecordIdentifier::new(k1, n1, a1));
-            assert!(RecordIdentifier::new(k1, n0, a0) < RecordIdentifier::new(k0, n1, a0));
-            assert!(RecordIdentifier::new(k0, n0, a1) < RecordIdentifier::new(k1, n0, a1));
-            assert!(RecordIdentifier::new(k0, n1, a1) < RecordIdentifier::new(k1, n1, a1));
+            assert!(RecordIdentifier::new_current(k0, n0, a0) < RecordIdentifier::new_current(k1, n1, a1));
+            assert!(RecordIdentifier::new_current(k1, n0, a0) < RecordIdentifier::new_current(k0, n1, a0));
+            assert!(RecordIdentifier::new_current(k0, n0, a1) < RecordIdentifier::new_current(k1, n0, a1));
+            assert!(RecordIdentifier::new_current(k0, n1, a1) < RecordIdentifier::new_current(k1, n1, a1));
         }
     }
 
@@ -1042,13 +1042,13 @@ mod tests {
 
         // Check result
         for el in alice_set {
-            alice_store.get_latest_by_key_and_author(alice.namespace(), author.id(), el)?;
-            bob_store.get_latest_by_key_and_author(bob.namespace(), author.id(), el)?;
+            alice_store.get_by_key_and_author(alice.namespace(), author.id(), el)?;
+            bob_store.get_by_key_and_author(bob.namespace(), author.id(), el)?;
         }
 
         for el in bob_set {
-            alice_store.get_latest_by_key_and_author(alice.namespace(), author.id(), el)?;
-            bob_store.get_latest_by_key_and_author(bob.namespace(), author.id(), el)?;
+            alice_store.get_by_key_and_author(alice.namespace(), author.id(), el)?;
+            bob_store.get_by_key_and_author(bob.namespace(), author.id(), el)?;
         }
         Ok(())
     }

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -534,7 +534,7 @@ impl RecordIdentifier {
         out.extend_from_slice(self.namespace.as_bytes());
         out.extend_from_slice(self.author.as_bytes());
         out.extend_from_slice(&self.key);
-        out.extend(&self.timestamp.to_be_bytes())
+        out.extend_from_slice(&self.timestamp.to_be_bytes())
     }
 
     /// Get this [`RecordIdentifier`] as a tuple of byte slices.
@@ -630,7 +630,6 @@ impl Record {
 
     /// Serialize this record into a mutable byte array.
     pub(crate) fn as_bytes(&self, out: &mut Vec<u8>) {
-        // Note: the timestamp is not serialized as it is transmitted through the key
         out.extend_from_slice(&self.len.to_be_bytes());
         out.extend_from_slice(self.hash.as_ref());
     }

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
     let key = b"hello".to_vec();
     let value = b"world".to_vec();
     doc.set_bytes(author, key.clone(), value).await?;
-    let mut stream = doc.get(GetFilter::latest()).await?;
+    let mut stream = doc.get(GetFilter::All).await?;
     while let Some(entry) = stream.try_next().await? {
         println!("entry {}", fmt_entry(&entry));
         let content = doc.get_content_bytes(entry.content_hash()).await?;

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -366,7 +366,7 @@ impl ReplState {
                 } else {
                     self.store.get(
                         self.doc.namespace(),
-                        GetFilter::Prefix(key.as_bytes().to_vec()),
+                        GetFilter::Key(key.as_bytes().to_vec()),
                     )?
                 };
                 for entry in entries {

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -562,7 +562,7 @@ impl ReplState {
                 println!("> exporting {key_prefix} to {root:?}");
                 let entries = self.store.get(
                     self.doc.namespace(),
-                    GetFilter::Prefix(&key_prefix.as_bytes().to_vec()),
+                    GetFilter::Prefix(key_prefix.as_bytes().to_vec()),
                 )?;
                 let mut checked_dirs = HashSet::new();
                 for entry in entries {

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -359,11 +359,15 @@ impl ReplState {
                 prefix,
             } => {
                 let entries = if prefix {
-                    self.store
-                        .get(self.doc.namespace(), GetFilter::all().with_prefix(key))?
+                    self.store.get(
+                        self.doc.namespace(),
+                        GetFilter::Prefix(key.as_bytes().to_vec()),
+                    )?
                 } else {
-                    self.store
-                        .get(self.doc.namespace(), GetFilter::all().with_key(key))?
+                    self.store.get(
+                        self.doc.namespace(),
+                        GetFilter::Prefix(key.as_bytes().to_vec()),
+                    )?
                 };
                 for entry in entries {
                     let entry = entry?;
@@ -387,10 +391,11 @@ impl ReplState {
             },
             Cmd::Ls { prefix } => {
                 let entries = match prefix {
-                    None => self.store.get(self.doc.namespace(), GetFilter::all())?,
-                    Some(prefix) => self
-                        .store
-                        .get(self.doc.namespace(), GetFilter::all().with_prefix(prefix))?,
+                    None => self.store.get(self.doc.namespace(), GetFilter::All)?,
+                    Some(prefix) => self.store.get(
+                        self.doc.namespace(),
+                        GetFilter::Prefix(prefix.as_bytes().to_vec()),
+                    )?,
                 };
                 let mut count = 0;
                 for entry in entries {
@@ -457,8 +462,10 @@ impl ReplState {
                                 let mut read = 0;
                                 for i in 0..count {
                                     let key = format!("{}/{}/{}", prefix, t, i);
-                                    let entries = store
-                                        .get(doc.namespace(), GetFilter::all().with_key(key))?;
+                                    let entries = store.get(
+                                        doc.namespace(),
+                                        GetFilter::Key(key.as_bytes().to_vec()),
+                                    )?;
                                     for entry in entries {
                                         let entry = entry?;
                                         let _content = fmt_content_simple(&doc, &entry);
@@ -555,7 +562,7 @@ impl ReplState {
                 println!("> exporting {key_prefix} to {root:?}");
                 let entries = self.store.get(
                     self.doc.namespace(),
-                    GetFilter::latest().with_prefix(&key_prefix),
+                    GetFilter::Prefix(&key_prefix.as_bytes().to_vec()),
                 )?;
                 let mut checked_dirs = HashSet::new();
                 for entry in entries {
@@ -587,7 +594,10 @@ impl ReplState {
                 // TODO: Fix
                 let entry = self
                     .store
-                    .get(self.doc.namespace(), GetFilter::latest().with_key(&key))?
+                    .get(
+                        self.doc.namespace(),
+                        GetFilter::Key(key.as_bytes().to_vec()),
+                    )?
                     .next();
                 if let Some(entry) = entry {
                     let entry = entry?;

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -310,7 +310,7 @@ pub fn fmt_short(hash: impl AsRef<[u8]>) -> String {
 }
 
 async fn print_entry(doc: &Doc, entry: &Entry, content: bool) -> anyhow::Result<()> {
-    println!("{}", fmt_entry(&entry));
+    println!("{}", fmt_entry(entry));
     if content {
         if entry.content_len() < MAX_DISPLAY_CONTENT_LEN {
             match doc.get_content_bytes(entry.content_hash()).await {

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -1,9 +1,9 @@
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use futures::{StreamExt, TryStreamExt};
 use indicatif::HumanBytes;
 use iroh::{
-    client::quic::Iroh,
+    client::quic::{Doc, Iroh},
     rpc_protocol::{DocTicket, ShareMode},
     sync_engine::LiveEvent,
 };
@@ -79,11 +79,6 @@ pub enum DocCommands {
         /// Filter by author.
         #[clap(short, long)]
         author: Option<AuthorId>,
-        /// If true, old entries will be included. By default only the latest value for each key is
-        /// shown.
-        #[clap(short, long)]
-        old: bool,
-
         /// Also print the content for each entry (but only if smaller than 1MB and valid UTf-8)
         #[clap(short, long)]
         content: bool,
@@ -100,10 +95,6 @@ pub enum DocCommands {
         /// Filter by author.
         #[clap(short, long)]
         author: Option<AuthorId>,
-        /// If true, old entries will be included. By default only the latest value for each key is
-        /// shown.
-        #[clap(short, long)]
-        old: bool,
         /// Optional key prefix (parsed as UTF-8 string)
         prefix: Option<String>,
     },
@@ -195,62 +186,44 @@ impl DocCommands {
                 key,
                 prefix,
                 author,
-                old,
                 content,
             } => {
                 let doc = iroh.get_doc(env.doc(doc)?).await?;
-                let mut filter = match old {
-                    true => GetFilter::all(),
-                    false => GetFilter::latest(),
-                };
-                if let Some(author) = author {
-                    filter = filter.with_author(author);
-                };
-                let filter = match prefix {
-                    true => filter.with_prefix(key),
-                    false => filter.with_key(key),
+                let key = key.as_bytes().to_vec();
+                let filter = match (author, prefix) {
+                    (None, false) => GetFilter::Key(key),
+                    (None, true) => GetFilter::Prefix(key),
+                    (Some(author), false) => {
+                        let entry = doc
+                            .get_one(author, key)
+                            .await?
+                            .ok_or_else(|| anyhow!("Entry not found"))?;
+                        print_entry(&doc, &entry, content).await?;
+                        return Ok(());
+                    }
+                    (Some(author), true) => GetFilter::AuthorAndPrefix(author, key),
                 };
 
                 let mut stream = doc.get(filter).await?;
                 while let Some(entry) = stream.try_next().await? {
-                    println!("{}", fmt_entry(&entry));
-                    if content {
-                        if entry.content_len() < MAX_DISPLAY_CONTENT_LEN {
-                            match doc.get_content_bytes(entry.content_hash()).await {
-                                Ok(content) => match String::from_utf8(content.into()) {
-                                    Ok(s) => println!("{s}"),
-                                    Err(_err) => println!("<invalid UTF-8>"),
-                                },
-                                Err(err) => println!("<failed to get content: {err}>"),
-                            }
-                        } else {
-                            println!(
-                                "<skipping content with len {}: too large to print>",
-                                HumanBytes(entry.content_len())
-                            )
-                        }
-                    }
-                    println!();
+                    print_entry(&doc, &entry, content).await?;
                 }
             }
             Self::Keys {
                 doc,
-                old,
                 prefix,
                 author,
             } => {
                 let doc = iroh.get_doc(env.doc(doc)?).await?;
-                let filter = match old {
-                    true => GetFilter::all(),
-                    false => GetFilter::latest(),
+                let filter = match (author, prefix) {
+                    (None, None) => GetFilter::All,
+                    (None, Some(prefix)) => GetFilter::Prefix(prefix.as_bytes().to_vec()),
+                    (Some(author), None) => GetFilter::Author(author),
+                    (Some(author), Some(prefix)) => {
+                        GetFilter::AuthorAndPrefix(author, prefix.as_bytes().to_vec())
+                    }
                 };
-                let mut filter = match prefix {
-                    Some(prefix) => filter.with_prefix(prefix),
-                    None => filter,
-                };
-                if let Some(author) = author {
-                    filter = filter.with_author(author);
-                };
+
                 let mut stream = doc.get(filter).await?;
                 while let Some(entry) = stream.try_next().await? {
                     println!("{}", fmt_entry(&entry));
@@ -334,4 +307,25 @@ pub fn fmt_short(hash: impl AsRef<[u8]>) -> String {
     let mut text = data_encoding::BASE32_NOPAD.encode(&hash.as_ref()[..5]);
     text.make_ascii_lowercase();
     format!("{}…", &text)
+}
+
+async fn print_entry(doc: &Doc, entry: &Entry, content: bool) -> anyhow::Result<()> {
+    println!("{}", fmt_entry(&entry));
+    if content {
+        if entry.content_len() < MAX_DISPLAY_CONTENT_LEN {
+            match doc.get_content_bytes(entry.content_hash()).await {
+                Ok(content) => match String::from_utf8(content.into()) {
+                    Ok(s) => println!("{s}"),
+                    Err(_err) => println!("<invalid UTF-8>"),
+                },
+                Err(err) => println!("<failed to get content: {err}>"),
+            }
+        } else {
+            println!(
+                "<skipping content with len {}: too large to print>",
+                HumanBytes(entry.content_len())
+            )
+        }
+    }
+    Ok(())
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1261,6 +1261,12 @@ fn handle_rpc_request<
                 chan.server_streaming(msg, handler, |handler, req| handler.inner.sync.doc_get(req))
                     .await
             }
+            DocGetOne(msg) => {
+                chan.rpc(msg, handler, |handler, req| async move {
+                    handler.inner.sync.doc_get_one(req).await
+                })
+                .await
+            }
             DocStartSync(msg) => {
                 chan.rpc(msg, handler, |handler, req| async move {
                     handler.inner.sync.doc_start_sync(req).await

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -545,6 +545,28 @@ pub struct DocGetResponse {
     pub entry: SignedEntry,
 }
 
+/// Get entries from a document
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocGetOneRequest {
+    /// The document id
+    pub doc_id: NamespaceId,
+    /// Key
+    pub key: Vec<u8>,
+    /// Author
+    pub author: AuthorId,
+}
+
+impl RpcMsg<ProviderService> for DocGetOneRequest {
+    type Response = RpcResult<DocGetOneResponse>;
+}
+
+/// Response to [`DocGetRequest`]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocGetOneResponse {
+    /// The document entry
+    pub entry: Option<SignedEntry>,
+}
+
 /// Get the bytes for a hash
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BytesGetRequest {
@@ -618,6 +640,7 @@ pub enum ProviderRequest {
     DocImport(DocImportRequest),
     DocSet(DocSetRequest),
     DocGet(DocGetRequest),
+    DocGetOne(DocGetOneRequest),
     DocStartSync(DocStartSyncRequest),
     DocStopSync(DocStopSyncRequest),
     DocShare(DocShareRequest),
@@ -653,6 +676,7 @@ pub enum ProviderResponse {
     DocImport(RpcResult<DocImportResponse>),
     DocSet(RpcResult<DocSetResponse>),
     DocGet(RpcResult<DocGetResponse>),
+    DocGetOne(RpcResult<DocGetOneResponse>),
     DocShare(RpcResult<DocShareResponse>),
     DocStartSync(RpcResult<DocStartSyncResponse>),
     DocStopSync(RpcResult<DocStopSyncResponse>),

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -623,7 +623,7 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                 match op {
                     Op::Put(entry) => {
                         debug!(peer = ?prev_peer, topic = ?topic, "received entry via gossip");
-                        replica.insert_remote_entry(entry, *prev_peer.as_bytes())?
+                        replica.insert_remote_entry(entry, *prev_peer.as_bytes()).map_err(Into::into)?
                     }
                 }
             }

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -623,7 +623,9 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                 match op {
                     Op::Put(entry) => {
                         debug!(peer = ?prev_peer, topic = ?topic, "received entry via gossip");
-                        replica.insert_remote_entry(entry, *prev_peer.as_bytes()).map_err(Into::into)?
+                        replica
+                            .insert_remote_entry(entry, *prev_peer.as_bytes())
+                            .map_err(Into::into)?
                     }
                 }
             }

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -10,11 +10,12 @@ use rand::rngs::OsRng;
 use crate::{
     rpc_protocol::{
         AuthorCreateRequest, AuthorCreateResponse, AuthorListRequest, AuthorListResponse,
-        DocCreateRequest, DocCreateResponse, DocGetRequest, DocGetResponse, DocImportRequest,
-        DocImportResponse, DocInfoRequest, DocInfoResponse, DocListRequest, DocListResponse,
-        DocSetRequest, DocSetResponse, DocShareRequest, DocShareResponse, DocStartSyncRequest,
-        DocStartSyncResponse, DocStopSyncRequest, DocStopSyncResponse, DocSubscribeRequest,
-        DocSubscribeResponse, DocTicket, RpcResult, ShareMode,
+        DocCreateRequest, DocCreateResponse, DocGetOneRequest, DocGetOneResponse, DocGetRequest,
+        DocGetResponse, DocImportRequest, DocImportResponse, DocInfoRequest, DocInfoResponse,
+        DocListRequest, DocListResponse, DocSetRequest, DocSetResponse, DocShareRequest,
+        DocShareResponse, DocStartSyncRequest, DocStartSyncResponse, DocStopSyncRequest,
+        DocStopSyncResponse, DocSubscribeRequest, DocSubscribeResponse, DocTicket, RpcResult,
+        ShareMode,
     },
     sync_engine::{KeepCallback, LiveStatus, PeerSource, SyncEngine},
 };
@@ -181,7 +182,7 @@ impl<S: Store> SyncEngine<S> {
             .map_err(Into::into)?;
         let entry = self
             .store
-            .get_latest_by_key_and_author(replica.namespace(), author.id(), &key)?
+            .get_by_key_and_author(replica.namespace(), author.id(), &key)?
             .ok_or_else(|| anyhow!("failed to get entry after insertion"))?;
         Ok(DocSetResponse { entry })
     }
@@ -200,6 +201,19 @@ impl<S: Store> SyncEngine<S> {
             }
         });
         rx.into_stream()
+    }
+
+    pub async fn doc_get_one(&self, req: DocGetOneRequest) -> RpcResult<DocGetOneResponse> {
+        let DocGetOneRequest {
+            doc_id,
+            author,
+            key,
+        } = req;
+        let replica = self.get_replica(&doc_id)?;
+        let entry = self
+            .store
+            .get_by_key_and_author(replica.namespace(), author, &key)?;
+        Ok(DocGetOneResponse { entry })
     }
 }
 

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -212,7 +212,7 @@ impl<S: Store> SyncEngine<S> {
         let replica = self.get_replica(&doc_id)?;
         let entry = self
             .store
-            .get_by_key_and_author(replica.namespace(), author, &key)?;
+            .get_by_key_and_author(replica.namespace(), author, key)?;
         Ok(DocGetOneResponse { entry })
     }
 }

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -182,7 +182,7 @@ async fn assert_latest(doc: &Doc, key: &[u8], value: &[u8]) {
 }
 
 async fn get_latest(doc: &Doc, key: &[u8]) -> anyhow::Result<Vec<u8>> {
-    let filter = GetFilter::latest().with_key(key);
+    let filter = GetFilter::Key(key.to_vec());
     let entry = doc
         .get(filter)
         .await?


### PR DESCRIPTION
(PR text updated by @Frando)

## Description

This is needed, to ensure both sides will end up with the actual latest version. Also stops storing old versions, as they are not used anymore, and things get very complicated otherwise.

This leads to a couple of changes (all in this PR):

* The store always overwrites if an entry with identical (`namespace`, `author`, `key`) and later timestamp than current is inserted
* The `GetFilter` doesn't have `latest` option anymore and is now a enum
* RPC gets `get_one` to select an entry by author and key

## Notes & open questions

* This change should inform our docs and discussion about author sharing: Using the same author privatekey on different nodes now would mean that concurrent writes while offline would result in the older of the entries (by wall clock time) being deleted and lost without recovery after sync. This means, I think, that author keys should not be shared between devices, and profile identity has to be established across author keys on an upper layer or within the app.

* We don't support deletes in iroh bytes yet, but with this change we definitely have to. After an update (overwrite) the old blob currently is still persisted but lost in space without any reference to its hash.

TODOs:
* Review method naming on `store` trait. Maybe  ~~`get`~~ `get_range` and ~~`get_by_key_and_author`~~`get`?
* More tests