### PR TITLE
fix(iroh-net): dns fallback to default config

### DIFF
--- a/iroh-net/src/dns.rs
+++ b/iroh-net/src/dns.rs
@@ -1,9 +1,25 @@
+use anyhow::Result;
 use once_cell::sync::Lazy;
-use trust_dns_resolver::TokioAsyncResolver;
+use trust_dns_resolver::{config, AsyncResolver, TokioAsyncResolver};
 
-pub static DNS_RESOLVER: Lazy<TokioAsyncResolver> = Lazy::new(|| {
-    TokioAsyncResolver::tokio_from_system_conf().expect("unable to create DNS resolver")
-});
+pub static DNS_RESOLVER: Lazy<TokioAsyncResolver> =
+    Lazy::new(|| get_resolver().expect("unable to create DNS resolver"));
+
+/// Get resolver to query MX records.
+///
+/// We first try to read the system's resolver from `/etc/resolv.conf`.
+/// This does not work at least on some Androids, therefore we fallback
+/// to the default `ResolverConfig` which uses eg. to google's `8.8.8.8` or `8.8.4.4`.
+fn get_resolver() -> Result<TokioAsyncResolver> {
+    if let Ok(resolver) = AsyncResolver::tokio_from_system_conf() {
+        return Ok(resolver);
+    }
+    let resolver = AsyncResolver::tokio(
+        config::ResolverConfig::default(),
+        config::ResolverOpts::default(),
+    )?;
+    Ok(resolver)
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
On at least iOS the resolve.conf is not available, so need to fallback to a default configuration in that case.

Based on the tested approach in DeltaChat

Fixes #1436

