### PR TITLE
refactor(iroh-sync): `get_many` and `get_one` method names

### DIFF
--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -226,7 +226,7 @@ mod tests {
 
         assert_eq!(
             bob_replica_store
-                .get(bob_replica.namespace(), GetFilter::All)
+                .get_many(bob_replica.namespace(), GetFilter::All)
                 .unwrap()
                 .collect::<Result<Vec<_>>>()
                 .unwrap()
@@ -235,7 +235,7 @@ mod tests {
         );
         assert_eq!(
             alice_replica_store
-                .get(alice_replica.namespace(), GetFilter::All)
+                .get_many(alice_replica.namespace(), GetFilter::All)
                 .unwrap()
                 .collect::<Result<Vec<_>>>()
                 .unwrap()
@@ -274,7 +274,7 @@ mod tests {
 
         assert_eq!(
             bob_replica_store
-                .get(bob_replica.namespace(), GetFilter::All)
+                .get_many(bob_replica.namespace(), GetFilter::All)
                 .unwrap()
                 .collect::<Result<Vec<_>>>()
                 .unwrap()
@@ -283,7 +283,7 @@ mod tests {
         );
         assert_eq!(
             alice_replica_store
-                .get(alice_replica.namespace(), GetFilter::All)
+                .get_many(alice_replica.namespace(), GetFilter::All)
                 .unwrap()
                 .collect::<Result<Vec<_>>>()
                 .unwrap()
@@ -339,7 +339,7 @@ mod tests {
 
     fn get_messages<S: Store>(store: &S, namespace: NamespaceId) -> Vec<Message> {
         let mut msgs = store
-            .get(namespace, GetFilter::All)
+            .get_many(namespace, GetFilter::All)
             .unwrap()
             .map(|entry| {
                 entry.map(|entry| {

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -46,7 +46,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     ///
     /// Store implementers must ensure that only a single instance of [`Replica`] is created per
     /// namespace. On subsequent calls, a clone of that singleton instance must be returned.
-    ///
+    //
     // TODO: Add close_replica
     fn open_replica(&self, namespace: &NamespaceId) -> Result<Option<Replica<Self::Instance>>>;
 
@@ -66,13 +66,13 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     /// Get an author key from the store.
     fn get_author(&self, author: &AuthorId) -> Result<Option<Author>>;
 
-    /// Iterate over entries of a replica.
+    /// Get an iterator over entries of a replica.
     ///
     /// The [`GetFilter`] has several methods of filtering the returned entries.
-    fn get(&self, namespace: NamespaceId, filter: GetFilter) -> Result<Self::GetIter<'_>>;
+    fn get_many(&self, namespace: NamespaceId, filter: GetFilter) -> Result<Self::GetIter<'_>>;
 
     /// Get an entry by key and author.
-    fn get_by_key_and_author(
+    fn get_one(
         &self,
         namespace: NamespaceId,
         author: AuthorId,

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -21,7 +21,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     /// The specialized instance scoped to a `Namespace`.
     type Instance: ranger::Store<SignedEntry> + PublicKeyStore + Send + Sync + 'static + Clone;
 
-    /// Iterator over entries in the store, returned from [`Self::get`]
+    /// Iterator over entries in the store, returned from [`Self::get_many`]
     type GetIter<'a>: Iterator<Item = Result<SignedEntry>>
     where
         Self: 'a;

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -185,7 +185,11 @@ impl super::Store for Store {
         Ok(replica)
     }
 
-    fn get(&self, namespace: NamespaceId, filter: super::GetFilter) -> Result<Self::GetIter<'_>> {
+    fn get_many(
+        &self,
+        namespace: NamespaceId,
+        filter: super::GetFilter,
+    ) -> Result<Self::GetIter<'_>> {
         match filter {
             super::GetFilter::All => self.get_all(namespace),
             super::GetFilter::Key(key) => self.get_by_key(namespace, key),
@@ -197,7 +201,7 @@ impl super::Store for Store {
         }
     }
 
-    fn get_by_key_and_author(
+    fn get_one(
         &self,
         namespace: NamespaceId,
         author: AuthorId,
@@ -366,8 +370,7 @@ impl crate::ranger::Store<SignedEntry> for StoreInstance {
     }
 
     fn get(&self, id: &RecordIdentifier) -> Result<Option<SignedEntry>> {
-        self.store
-            .get_by_key_and_author(id.namespace(), id.author(), id.key())
+        self.store.get_one(id.namespace(), id.author(), id.key())
     }
 
     fn len(&self) -> Result<usize> {
@@ -623,7 +626,7 @@ mod tests {
         replica.hash_and_insert(&key1, &author, b"v1")?;
         replica.hash_and_insert(&key2, &author, b"v2")?;
         let res = store
-            .get(
+            .get_many(
                 replica.namespace(),
                 GetFilter::AuthorAndPrefix(author.id(), vec![255]),
             )?

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -87,7 +87,11 @@ impl super::Store for Store {
         Ok(replica)
     }
 
-    fn get(&self, namespace: NamespaceId, filter: super::GetFilter) -> Result<Self::GetIter<'_>> {
+    fn get_many(
+        &self,
+        namespace: NamespaceId,
+        filter: super::GetFilter,
+    ) -> Result<Self::GetIter<'_>> {
         match filter {
             super::GetFilter::All => self.get_all(namespace),
             super::GetFilter::Key(key) => self.get_by_key(namespace, key),
@@ -99,7 +103,7 @@ impl super::Store for Store {
         }
     }
 
-    fn get_by_key_and_author(
+    fn get_one(
         &self,
         namespace: NamespaceId,
         author: AuthorId,

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
     let key = b"hello".to_vec();
     let value = b"world".to_vec();
     doc.set_bytes(author, key.clone(), value).await?;
-    let mut stream = doc.get(GetFilter::All).await?;
+    let mut stream = doc.get_many(GetFilter::All).await?;
     while let Some(entry) = stream.try_next().await? {
         println!("entry {}", fmt_entry(&entry));
         let content = doc.get_content_bytes(entry.content_hash()).await?;

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -359,12 +359,12 @@ impl ReplState {
                 prefix,
             } => {
                 let entries = if prefix {
-                    self.store.get(
+                    self.store.get_many(
                         self.doc.namespace(),
                         GetFilter::Prefix(key.as_bytes().to_vec()),
                     )?
                 } else {
-                    self.store.get(
+                    self.store.get_many(
                         self.doc.namespace(),
                         GetFilter::Key(key.as_bytes().to_vec()),
                     )?
@@ -391,8 +391,8 @@ impl ReplState {
             },
             Cmd::Ls { prefix } => {
                 let entries = match prefix {
-                    None => self.store.get(self.doc.namespace(), GetFilter::All)?,
-                    Some(prefix) => self.store.get(
+                    None => self.store.get_many(self.doc.namespace(), GetFilter::All)?,
+                    Some(prefix) => self.store.get_many(
                         self.doc.namespace(),
                         GetFilter::Prefix(prefix.as_bytes().to_vec()),
                     )?,
@@ -462,7 +462,7 @@ impl ReplState {
                                 let mut read = 0;
                                 for i in 0..count {
                                     let key = format!("{}/{}/{}", prefix, t, i);
-                                    let entries = store.get(
+                                    let entries = store.get_many(
                                         doc.namespace(),
                                         GetFilter::Key(key.as_bytes().to_vec()),
                                     )?;
@@ -560,7 +560,7 @@ impl ReplState {
                 }
                 let root = canonicalize_path(&dir_path)?;
                 println!("> exporting {key_prefix} to {root:?}");
-                let entries = self.store.get(
+                let entries = self.store.get_many(
                     self.doc.namespace(),
                     GetFilter::Prefix(key_prefix.as_bytes().to_vec()),
                 )?;
@@ -594,7 +594,7 @@ impl ReplState {
                 // TODO: Fix
                 let entry = self
                     .store
-                    .get(
+                    .get_many(
                         self.doc.namespace(),
                         GetFilter::Key(key.as_bytes().to_vec()),
                     )?

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -15,8 +15,8 @@ use quic_rpc::{RpcClient, ServiceConnection};
 
 use crate::rpc_protocol::{
     AuthorCreateRequest, AuthorListRequest, BytesGetRequest, ConnectionInfoRequest,
-    ConnectionInfoResponse, ConnectionsRequest, CounterStats, DocCreateRequest, DocGetOneRequest,
-    DocGetRequest, DocImportRequest, DocInfoRequest, DocListRequest, DocSetRequest,
+    ConnectionInfoResponse, ConnectionsRequest, CounterStats, DocCreateRequest, DocGetManyRequest,
+    DocGetOneRequest, DocImportRequest, DocInfoRequest, DocListRequest, DocSetRequest,
     DocShareRequest, DocStartSyncRequest, DocStopSyncRequest, DocSubscribeRequest, DocTicket,
     ProviderService, ShareMode, StatsGetRequest,
 };
@@ -184,10 +184,10 @@ where
     }
 
     /// Get entries.
-    pub async fn get(&self, filter: GetFilter) -> Result<impl Stream<Item = Result<Entry>>> {
+    pub async fn get_many(&self, filter: GetFilter) -> Result<impl Stream<Item = Result<Entry>>> {
         let stream = self
             .rpc
-            .server_streaming(DocGetRequest {
+            .server_streaming(DocGetManyRequest {
                 doc_id: self.id,
                 filter,
             })

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -205,7 +205,7 @@ impl DocCommands {
                     }
                 };
 
-                let mut stream = doc.get(filter).await?;
+                let mut stream = doc.get_many(filter).await?;
                 while let Some(entry) = stream.try_next().await? {
                     print_entry(&doc, &entry, content).await?;
                 }
@@ -218,7 +218,7 @@ impl DocCommands {
                 let doc = iroh.get_doc(env.doc(doc)?).await?;
                 let filter = GetFilter::author_prefix(author, prefix);
 
-                let mut stream = doc.get(filter).await?;
+                let mut stream = doc.get_many(filter).await?;
                 while let Some(entry) = stream.try_next().await? {
                     println!("{}", fmt_entry(&entry));
                 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1293,8 +1293,10 @@ fn handle_rpc_request<
                 .await
             }
             DocGet(msg) => {
-                chan.server_streaming(msg, handler, |handler, req| handler.inner.sync.doc_get(req))
-                    .await
+                chan.server_streaming(msg, handler, |handler, req| {
+                    handler.inner.sync.doc_get_many(req)
+                })
+                .await
             }
             DocGetOne(msg) => {
                 chan.rpc(msg, handler, |handler, req| async move {

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -564,24 +564,24 @@ pub struct DocSetResponse {
 
 /// Get entries from a document
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocGetRequest {
+pub struct DocGetManyRequest {
     /// The document id
     pub doc_id: NamespaceId,
     /// Filter entries by this [`GetFilter`]
     pub filter: GetFilter,
 }
 
-impl Msg<ProviderService> for DocGetRequest {
+impl Msg<ProviderService> for DocGetManyRequest {
     type Pattern = ServerStreaming;
 }
 
-impl ServerStreamingMsg<ProviderService> for DocGetRequest {
-    type Response = RpcResult<DocGetResponse>;
+impl ServerStreamingMsg<ProviderService> for DocGetManyRequest {
+    type Response = RpcResult<DocGetManyResponse>;
 }
 
-/// Response to [`DocGetRequest`]
+/// Response to [`DocGetManyRequest`]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocGetResponse {
+pub struct DocGetManyResponse {
     /// The document entry
     pub entry: SignedEntry,
 }
@@ -601,7 +601,7 @@ impl RpcMsg<ProviderService> for DocGetOneRequest {
     type Response = RpcResult<DocGetOneResponse>;
 }
 
-/// Response to [`DocGetRequest`]
+/// Response to [`DocGetOneRequest`]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DocGetOneResponse {
     /// The document entry
@@ -680,7 +680,7 @@ pub enum ProviderRequest {
     DocCreate(DocCreateRequest),
     DocImport(DocImportRequest),
     DocSet(DocSetRequest),
-    DocGet(DocGetRequest),
+    DocGet(DocGetManyRequest),
     DocGetOne(DocGetOneRequest),
     DocStartSync(DocStartSyncRequest),
     DocStopSync(DocStopSyncRequest),
@@ -719,7 +719,7 @@ pub enum ProviderResponse {
     DocCreate(RpcResult<DocCreateResponse>),
     DocImport(RpcResult<DocImportResponse>),
     DocSet(RpcResult<DocSetResponse>),
-    DocGet(RpcResult<DocGetResponse>),
+    DocGet(RpcResult<DocGetManyResponse>),
     DocGetOne(RpcResult<DocGetOneResponse>),
     DocShare(RpcResult<DocShareResponse>),
     DocStartSync(RpcResult<DocStartSyncResponse>),

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -10,12 +10,12 @@ use rand::rngs::OsRng;
 use crate::{
     rpc_protocol::{
         AuthorCreateRequest, AuthorCreateResponse, AuthorListRequest, AuthorListResponse,
-        DocCreateRequest, DocCreateResponse, DocGetOneRequest, DocGetOneResponse, DocGetRequest,
-        DocGetResponse, DocImportRequest, DocImportResponse, DocInfoRequest, DocInfoResponse,
-        DocListRequest, DocListResponse, DocSetRequest, DocSetResponse, DocShareRequest,
-        DocShareResponse, DocStartSyncRequest, DocStartSyncResponse, DocStopSyncRequest,
-        DocStopSyncResponse, DocSubscribeRequest, DocSubscribeResponse, DocTicket, RpcResult,
-        ShareMode,
+        DocCreateRequest, DocCreateResponse, DocGetManyRequest, DocGetManyResponse,
+        DocGetOneRequest, DocGetOneResponse, DocImportRequest, DocImportResponse, DocInfoRequest,
+        DocInfoResponse, DocListRequest, DocListResponse, DocSetRequest, DocSetResponse,
+        DocShareRequest, DocShareResponse, DocStartSyncRequest, DocStartSyncResponse,
+        DocStopSyncRequest, DocStopSyncResponse, DocSubscribeRequest, DocSubscribeResponse,
+        DocTicket, RpcResult, ShareMode,
     },
     sync_engine::{KeepCallback, LiveStatus, PeerSource, SyncEngine},
 };
@@ -182,18 +182,21 @@ impl<S: Store> SyncEngine<S> {
             .map_err(anyhow::Error::from)?;
         let entry = self
             .store
-            .get_by_key_and_author(replica.namespace(), author.id(), &key)?
+            .get_one(replica.namespace(), author.id(), &key)?
             .ok_or_else(|| anyhow!("failed to get entry after insertion"))?;
         Ok(DocSetResponse { entry })
     }
 
-    pub fn doc_get(&self, req: DocGetRequest) -> impl Stream<Item = RpcResult<DocGetResponse>> {
-        let DocGetRequest { doc_id, filter } = req;
+    pub fn doc_get_many(
+        &self,
+        req: DocGetManyRequest,
+    ) -> impl Stream<Item = RpcResult<DocGetManyResponse>> {
+        let DocGetManyRequest { doc_id, filter } = req;
         let (tx, rx) = flume::bounded(ITER_CHANNEL_CAP);
         let store = self.store.clone();
         self.rt.main().spawn_blocking(move || {
-            let ite = store.get(doc_id, filter);
-            let ite = inline_result(ite).map_ok(|entry| DocGetResponse { entry });
+            let ite = store.get_many(doc_id, filter);
+            let ite = inline_result(ite).map_ok(|entry| DocGetManyResponse { entry });
             for entry in ite {
                 if let Err(_err) = tx.send(entry) {
                     break;
@@ -210,9 +213,7 @@ impl<S: Store> SyncEngine<S> {
             key,
         } = req;
         let replica = self.get_replica(&doc_id)?;
-        let entry = self
-            .store
-            .get_by_key_and_author(replica.namespace(), author, key)?;
+        let entry = self.store.get_one(replica.namespace(), author, key)?;
         Ok(DocGetOneResponse { entry })
     }
 }

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -184,7 +184,7 @@ async fn assert_latest(doc: &Doc, key: &[u8], value: &[u8]) {
 async fn get_latest(doc: &Doc, key: &[u8]) -> anyhow::Result<Vec<u8>> {
     let filter = GetFilter::Key(key.to_vec());
     let entry = doc
-        .get(filter)
+        .get_many(filter)
         .await?
         .next()
         .await


### PR DESCRIPTION
## Description

Changes `Store::get` to `Store::get_many` and `Store::get_by_author_and_key` to `Store::get_one`, in the trait and the RPC interface. Much clearer IMO.

Based on #1445

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
