### PR TITLE
refactor(iroh-sync): store `RecordIdentifier` as bytes

### DIFF
--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -577,7 +577,7 @@ impl Debug for RecordIdentifier {
         f.debug_struct("RecordIdentifier")
             .field("namespace", &self.namespace())
             .field("author", &self.author())
-            .field("key", &std::string::String::from_utf8_lossy(&self.key()))
+            .field("key", &std::string::String::from_utf8_lossy(self.key()))
             .finish()
     }
 }


### PR DESCRIPTION
## Description

Builds on #1445. Had an idea - we can make the `RecordIdentifier` be a newtype wrapper around `Bytes`. With this we can expose the `RecordIdentifier` directly as a simple continous byte slice.

I'm not too sure if we gain much over the previous form – Maybe some performance when cloning oftenly. And @rklaehn wanted to have a simple byte representation for store improvements. 

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
