### PR TITLE
test(iroh-net): Removed unused stun_test_ip field from DerpNode

### DIFF
--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -39,7 +39,6 @@ pub fn default_na_derp_region() -> DerpRegion {
         stun_port: DEFAULT_DERP_STUN_PORT,
         ipv4: UseIpv4::Some(NA_DERP_IPV4),
         ipv6: UseIpv6::TryDns,
-        stun_test_ip: None,
     };
     DerpRegion {
         region_id: NA_REGION_ID,
@@ -60,7 +59,6 @@ pub fn default_eu_derp_region() -> DerpRegion {
         stun_port: DEFAULT_DERP_STUN_PORT,
         ipv4: UseIpv4::Some(EU_DERP_IPV4),
         ipv6: UseIpv6::TryDns,
-        stun_test_ip: None,
     };
     DerpRegion {
         region_id: EU_REGION_ID,

--- a/iroh-net/src/derp/http.rs
+++ b/iroh-net/src/derp/http.rs
@@ -91,7 +91,6 @@ mod tests {
                 url: format!("http://localhost:{port}").parse().unwrap(),
                 stun_only: false,
                 stun_port: 0,
-                stun_test_ip: None,
                 ipv4: UseIpv4::Some(addr),
                 ipv6: UseIpv6::Disabled,
             }
@@ -235,7 +234,6 @@ mod tests {
                 url: format!("https://localhost:{port}").parse().unwrap(),
                 stun_only: false,
                 stun_port: 0,
-                stun_test_ip: None,
                 ipv4: UseIpv4::Some(addr),
                 ipv6: UseIpv6::Disabled,
             }

--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -1227,7 +1227,6 @@ mod tests {
                 url: "https://bad.url".parse().unwrap(),
                 stun_only: false,
                 stun_port: 0,
-                stun_test_ip: None,
                 ipv4: UseIpv4::Some("35.175.99.112".parse().unwrap()),
                 ipv6: UseIpv6::Disabled,
             }

--- a/iroh-net/src/derp/map.rs
+++ b/iroh-net/src/derp/map.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::HashMap,
     fmt,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{Ipv4Addr, Ipv6Addr},
     sync::Arc,
 };
 
@@ -92,7 +92,6 @@ impl DerpMap {
                     stun_port,
                     ipv4: derp_ipv4,
                     ipv6: derp_ipv6,
-                    stun_test_ip: None,
                 }
                 .into()],
                 avoid: false,
@@ -190,17 +189,20 @@ pub struct DerpNode {
     ///
     /// This name MUST be unique among all configured DERP servers.
     pub name: String,
-    /// The numeric region ID
+    /// The numeric region ID.
     pub region_id: u16,
-    /// The [`Url`] where this derp server can be dialed
+    /// The [`Url`] where this derp server can be dialed.
     #[debug("{}", url)]
     pub url: Url,
-    /// Whether this derp server should only be used for STUN requests
+    /// Whether this derp server should only be used for STUN requests.
+    ///
+    /// This essentially allows you to use a normal STUN server as a DERP node, no DERP
+    /// functionality is used.
     pub stun_only: bool,
-    /// The stun port of the derp server
+    /// The stun port of the derp server.
+    ///
+    /// Setting this to `0` means the default STUN port is used.
     pub stun_port: u16,
-    /// Optional stun-specific IP address
-    pub stun_test_ip: Option<IpAddr>,
     /// Whether to dial this server on IPv4.
     pub ipv4: UseIpv4,
     /// Whether to dial this server on IPv6.

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -481,7 +481,7 @@ pub async fn get_peer_id(connection: &quinn::Connection) -> Result<PublicKey> {
 mod tests {
     use tracing::{info, info_span, Instrument};
 
-    use crate::test_utils::run_derp_and_stun;
+    use crate::test_utils::run_derper;
 
     use super::*;
 
@@ -491,7 +491,7 @@ mod tests {
     #[tokio::test]
     async fn magic_endpoint_connect_close() {
         let _guard = iroh_test::logging::setup();
-        let (derp_map, region_id, _guard) = run_derp_and_stun([127, 0, 0, 1].into()).await.unwrap();
+        let (derp_map, region_id, _guard) = run_derper().await.unwrap();
         let server_secret_key = SecretKey::generate();
         let server_peer_id = server_secret_key.public();
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2541,7 +2541,7 @@ pub(crate) mod tests {
     use tracing_subscriber::{prelude::*, EnvFilter};
 
     use super::*;
-    use crate::{test_utils::run_derp_and_stun, tls, MagicEndpoint};
+    use crate::{test_utils::run_derper, tls, MagicEndpoint};
 
     fn make_transmit(destination: SocketAddr) -> quinn_udp::Transmit {
         quinn_udp::Transmit {
@@ -2659,10 +2659,6 @@ pub(crate) mod tests {
         t.await.unwrap().unwrap();
 
         c.close().await.unwrap();
-    }
-
-    struct Devices {
-        stun_ip: IpAddr,
     }
 
     /// Magicsock plus wrappers for sending packets
@@ -2783,11 +2779,7 @@ pub(crate) mod tests {
     async fn test_two_devices_roundtrip_quinn_magic() -> Result<()> {
         setup_multithreaded_logging();
 
-        let devices = Devices {
-            stun_ip: "127.0.0.1".parse()?,
-        };
-
-        let (derp_map, region, _cleanup) = run_derp_and_stun(devices.stun_ip).await?;
+        let (derp_map, region, _cleanup) = run_derper().await?;
 
         let m1 = MagicStack::new(derp_map.clone()).await?;
         let m2 = MagicStack::new(derp_map.clone()).await?;
@@ -2954,12 +2946,8 @@ pub(crate) mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_two_devices_setup_teardown() -> Result<()> {
         setup_multithreaded_logging();
-        let devices = Devices {
-            stun_ip: "127.0.0.1".parse()?,
-        };
-
         for _ in 0..10 {
-            let (derp_map, _, _cleanup) = run_derp_and_stun(devices.stun_ip).await?;
+            let (derp_map, _, _cleanup) = run_derper().await?;
             println!("setting up magic stack");
             let m1 = MagicStack::new(derp_map.clone()).await?;
             let m2 = MagicStack::new(derp_map.clone()).await?;

--- a/iroh-net/src/netcheck.rs
+++ b/iroh-net/src/netcheck.rs
@@ -915,7 +915,6 @@ mod tests {
                     stun_port,
                     ipv4: UseIpv4::TryDns,
                     ipv6: UseIpv6::TryDns,
-                    stun_test_ip: None,
                 })
                 .map(Arc::new)
                 .collect(),

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -949,16 +949,6 @@ async fn get_derp_addr(n: &DerpNode, proto: ProbeProto) -> Result<SocketAddr> {
     if port == 0 {
         port = DEFAULT_DERP_STUN_PORT;
     }
-    if let Some(ip) = n.stun_test_ip {
-        if proto == ProbeProto::StunIpv4 && ip.is_ipv6() {
-            bail!("STUN test IP set has mismatching protocol");
-        }
-        if proto == ProbeProto::StunIpv6 && ip.is_ipv4() {
-            bail!("STUN test IP set has mismatching protocol");
-        }
-        return Ok(SocketAddr::new(ip, port));
-    }
-
     match proto {
         ProbeProto::StunIpv4 => {
             if let UseIpv4::Some(ip) = n.ipv4 {

--- a/iroh-net/src/stun.rs
+++ b/iroh-net/src/stun.rs
@@ -193,7 +193,6 @@ pub mod test {
                 ipv6,
                 stun_port: port,
                 stun_only: true,
-                stun_test_ip: None,
             };
             DerpRegion {
                 region_id,


### PR DESCRIPTION
## Description

The DerpNode had a field to override the IP address of the STUN server
in testing scenarios.  However we do not use this, it is always the
same address as the derp server, just like in production.

Removing this removes some code complexity.

## Notes & open questions

I believe this was an unused left-over from the wireguard conversion.

## Change checklist

- [x] Self-review.
- [x] ~~Documentation updates if relevant.~~
- [x] Tests if relevant.