### PR TITLE
feat(iroh-net): Implement the https probe.

### DIFF
--- a/iroh-net/src/bin/derper.rs
+++ b/iroh-net/src/bin/derper.rs
@@ -231,8 +231,9 @@ struct TlsConfig {
     cert_dir: Option<PathBuf>,
     /// The port on which to serve a response for the captive portal probe over HTTP.
     ///
-    /// The listener is bound to the same IP as specified in the `addr` field. Defaults to 80.
-    /// This field is only read in we are serving the derper over HTTPS. In that case, we must listen for requests for the `/generate_204` over a non-TLS connection.
+    /// The listener is bound to the same IP as specified in the `addr` field. Defaults to
+    /// 80.  This field is only read in we are serving the derper over HTTPS. In that case,
+    /// we must listen for requests for the `/generate_204` over a non-TLS connection.
     captive_portal_port: Option<u16>,
 }
 
@@ -452,7 +453,7 @@ async fn run(
     };
 
     let mut builder = DerpServerBuilder::new(addr)
-        .secret_key(secret_key.map(Into::into))
+        .secret_key(secret_key)
         .mesh_key(mesh_key)
         .headers(headers)
         .tls_config(tls_config.clone())

--- a/iroh-net/src/derp.rs
+++ b/iroh-net/src/derp.rs
@@ -13,6 +13,7 @@ pub(crate) mod client;
 pub(crate) mod client_conn;
 pub(crate) mod clients;
 mod codec;
+pub mod derper;
 pub mod http;
 mod map;
 mod metrics;

--- a/iroh-net/src/derp/derper.rs
+++ b/iroh-net/src/derp/derper.rs
@@ -1,0 +1,492 @@
+//! A full-fledged DERP and STUN server.
+//!
+//! This module provides an API to create a full fledged DERP server.  It is primarily used
+//! by the `derper` binary in this crate.
+
+use std::fmt;
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use futures::stream::{FusedStream, FuturesUnordered};
+use futures::StreamExt;
+use iroh_metrics::inc;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio::task::{JoinError, JoinHandle};
+use tracing::{debug, error, info, info_span, trace, warn, Instrument};
+use url::Url;
+
+use crate::derp::MeshKey;
+use crate::key::SecretKey;
+use crate::stun;
+
+// Module defined in this file.
+use metrics::StunMetrics;
+
+use super::http::TlsAcceptor;
+
+/// Configuration for the full DERP & STUN server.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ServerConfig<EC: fmt::Debug, EA: fmt::Debug = EC> {
+    /// Main listen address.
+    pub addr: IpAddr,
+    /// Configuration for the DERP server, disabled if `None`.
+    pub derp: Option<DerpConfig<EC, EA>>,
+    /// Configuration for the STUN server, disabled if `None`.
+    pub stun: Option<StunConfig>,
+    /// Socket to serve metrics on.
+    pub metrics_addr: Option<SocketAddr>,
+}
+
+impl<EC: fmt::Debug, EA: fmt::Debug> ServerConfig<EC, EA> {
+    /// Creates a new config.
+    pub fn new() -> Self {
+        Self {
+            addr: Ipv6Addr::UNSPECIFIED.into(),
+            derp: None,
+            stun: None,
+            metrics_addr: None,
+        }
+    }
+
+    /// Validates the config for internal consistency.
+    pub fn validate(&self) -> Result<()> {
+        if self.derp.is_none() && self.stun.is_none() {
+            bail!("neither DERP nor STUN server configured");
+        }
+        if let Some(derp) = &self.derp {
+            if let Some(tls) = &derp.tls {
+                if derp.port == tls.http_port {
+                    bail!("derp port conflicts with captive portal port");
+                }
+            }
+        }
+        if let Some(sock) = self.metrics_addr {
+            if sock.ip() == self.addr {
+                bail!("Metrics address conflicts with server address");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Configuration for the DERP server.
+///
+/// This includes the HTTP services hosted by the DERP server.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct DerpConfig<EC: fmt::Debug, EA: fmt::Debug = EC> {
+    /// The port on which the server should listen.
+    ///
+    /// Normally you'd choose `80` if configured without TLS and `443` when configured with
+    /// TLS since the DERP server is an HTTP server.
+    pub port: u16,
+    /// The secret key of the DERP server.
+    pub secret_key: SecretKey,
+    /// TLS configuration, no TLS is used if `None`.
+    pub tls: Option<TlsConfig<EC, EA>>,
+    /// Rate limits, if enabled.
+    pub limits: Option<Limits>,
+    /// Optional DERP mesh configuration.
+    pub mesh: Option<MeshConfig>,
+}
+
+/// Configuration for the STUN server.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct StunConfig {
+    /// The port on which to listen.
+    ///
+    /// Normally you'd chose `3478`, see [`crate::defaults::DEFAULT_DERP_STUN_SERVER`].
+    pub port: u16,
+}
+
+/// TLS configuration for DERP server.
+///
+/// Normally the DERP server accepts connections on HTTPS.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct TlsConfig<EC: fmt::Debug, EA: fmt::Debug = EC> {
+    /// Mode for getting a cert.
+    pub cert: CertConfig<EC, EA>,
+    /// Hostname to use for the certificate, must match the certificate.
+    pub hostname: String,
+    /// The port on which to serve plain text HTTP requests.
+    ///
+    /// Since the captive portal probe has to run over plain text HTTP and TLS is used for
+    /// the main derper this has to be a different port.  Normally you'd choose `80`.
+    pub http_port: u16,
+}
+
+/// Rate limits.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Limits {
+    /// Rate limit for accepting new connection. Unlimited if not set.
+    pub accept_conn_limit: Option<f64>,
+    /// Burst limit for accepting new connection. Unlimited if not set.
+    pub accept_conn_burst: Option<usize>,
+}
+
+/// TLS certificate configuration.
+#[derive(derive_more::Debug)]
+#[non_exhaustive]
+pub enum CertConfig<EC: fmt::Debug, EA: fmt::Debug = EC> {
+    /// Use Let's Encrypt.
+    LetsEncrypt {
+        /// Configuration for Let's Encrypt certificates.
+        #[debug("AcmeConfig")]
+        config: tokio_rustls_acme::AcmeConfig<EC, EA>,
+        /// Whether to use the LetsEncrypt production or staging server.
+        ///
+        /// While in developement, LetsEncrypt prefers you to use the staging
+        /// server. However, the staging server seems to only use `ECDSA` keys. In their
+        /// current set up, you can only get intermediate certificates for `ECDSA` keys if
+        /// you are on their "allowlist". The production server uses `RSA` keys, which allow
+        /// for issuing intermediate certificates in all normal circumstances.  So, to have
+        /// valid certificates, we must use the LetsEncrypt production server.  Read more
+        /// here: <https://letsencrypt.org/certificates/#intermediate-certificates> Default
+        /// is true. This field is ignored if we are not using `cert_mode:
+        /// CertMode::LetsEncrypt`.
+        prod: bool,
+        /// The contact email for the tls certificate.
+        contact: String,
+    },
+    /// Use a static TLS key and certificate chain.
+    Manual {
+        /// The TLS private key.
+        private_key: rustls::PrivateKey,
+        /// The TLS certificate chain.
+        certs: Vec<rustls::Certificate>,
+    },
+}
+
+/// DERP mesh config.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct MeshConfig {
+    /// The PSK mesh key.
+    key: MeshKey,
+    /// The other DERP servers to mesh with.
+    peers: Vec<Url>,
+}
+
+/// A running STUN + DERP server.
+///
+/// This is a full DERP server, including STUN, DERP and various associated HTTP services.
+///
+/// Dropping this will stop the server.
+#[derive(Debug)]
+pub struct Server {
+    addr: SocketAddr,
+    task: JoinHandle<()>,
+}
+
+impl Server {
+    /// Starts the server.
+    pub async fn spawn<EC, EA>(config: ServerConfig<EC, EA>) -> Result<Self>
+    where
+        EC: fmt::Debug,
+        EA: fmt::Debug,
+    {
+        config.validate()?;
+        let supervisor = TaskSupervisor::new();
+        let supervisor_addr = supervisor.addr();
+        let supervisor_task = tokio::spawn(
+            async move {
+                let mut supervisor = supervisor;
+                supervisor.run().await
+            }
+            .instrument(info_span!("supervisor")),
+        );
+        if let Some(stun) = config.stun {
+            let task = tokio::spawn(
+                async move {
+                    serve_stun(config.addr, stun.port).await;
+                    Ok(())
+                }
+                .instrument(info_span!("stun-server", addr = %config.addr, port = stun.port)),
+            );
+            supervisor_addr.add_task(task)?;
+        }
+        if let Some(derp) = config.derp {
+            let (tls_config, headers, captive_portal_port) = if let Some(tls_config) = derp.tls {
+                match tls_config.cert {
+                    CertConfig::LetsEncrypt {
+                        config,
+                        prod,
+                        contact,
+                    } => todo!(),
+                    CertConfig::Manual { private_key, certs } => todo!(),
+                }
+                let config: rustls::ServerConfig = todo!();
+                let acceptor: TlsAcceptor = todo!();
+            };
+            //     let contact = tls_config.contact;
+            //     let is_production = tls_config.prod_tls;
+            //     let (config, acceptor) = tls_config
+            //         .cert
+            //         .gen_server_config(
+            //             cfg.hostname.clone(),
+            //             contact,
+            //             is_production,
+            //             tls_config.cert_dir.unwrap_or_else(|| PathBuf::from(".")),
+            //         )
+            //         .await?;
+            //     let headers: Vec<(&str, &str)> = TLS_HEADERS.into();
+            //     (
+            //         Some(DerpTlsConfig { config, acceptor }),
+            //         headers,
+            //         tls_config
+            //             .captive_portal_port
+            //             .unwrap_or(DEFAULT_CAPTIVE_PORTAL_PORT),
+            //     )
+            // } else {
+            //     (None, Vec::new(), 0)
+            // };
+        }
+        Ok(Self {
+            addr: todo!(),
+            task: supervisor_task,
+        })
+    }
+}
+
+/// An actor which supervises other tasks, with no restarting and one-for-all strategy.
+///
+/// The supervisor itself does no restarting of tasks.  It only terminates all other tasks
+/// when one fails.
+#[derive(Debug)]
+struct TaskSupervisor {
+    addr_tx: mpsc::Sender<SupervisorMessage>,
+    addr_rx: mpsc::Receiver<SupervisorMessage>,
+    tasks: FuturesUnordered<JoinHandle<Result<()>>>,
+}
+
+impl TaskSupervisor {
+    fn new() -> Self {
+        let (addr_tx, addr_rx) = mpsc::channel(16);
+        Self {
+            addr_tx,
+            addr_rx,
+            tasks: FuturesUnordered::new(),
+        }
+    }
+
+    async fn run(&mut self) {
+        // Note this can never fail!
+        loop {
+            tokio::select! {
+                biased;
+                res = self.addr_rx.recv() => {
+                    match res {
+                        Some(msg) => self.handle_msg(msg),
+                        None => {
+                            error!("All senders closed, impossible");
+                            break;
+                        }
+                    }
+                }
+                item = self.tasks.next() => {
+                    match item {
+                        Some(res) => {
+                            self.handle_task_finished(res);
+                            if self.tasks.is_terminated() {
+                                break;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+        debug!("Supervisor finished");
+    }
+
+    fn handle_msg(&mut self, msg: SupervisorMessage) {
+        match msg {
+            SupervisorMessage::AddTask(task) => {
+                self.tasks.push(task);
+            }
+            SupervisorMessage::Abort => {
+                for task in self.tasks.iter() {
+                    task.abort();
+                }
+            }
+        }
+    }
+
+    fn handle_task_finished(&mut self, res: Result<Result<()>, JoinError>) {
+        match res {
+            Ok(Ok(())) => info!("Supervised task gracefully finished, aborting others"),
+            Ok(Err(err)) => error!("Supervised task failed, aborting others.  err: {err}"),
+            Err(err) => {
+                if err.is_cancelled() {
+                    info!("Supervised task cancelled, aborting others");
+                }
+                if err.is_panic() {
+                    // TODO: We just swallow the panic.  Unfortunately we can only resume
+                    // it, which is not (yet?) what we want?  Or maybe it is.
+                    error!("Supervised task paniced, aborting others");
+                }
+            }
+        }
+        for task in self.tasks.iter() {
+            task.abort();
+        }
+    }
+
+    fn addr(&self) -> SupervisorAddr {
+        SupervisorAddr {
+            tx: self.addr_tx.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum SupervisorMessage {
+    AddTask(JoinHandle<Result<()>>),
+    Abort,
+}
+
+#[derive(Debug)]
+struct SupervisorAddr {
+    tx: mpsc::Sender<SupervisorMessage>,
+}
+
+impl SupervisorAddr {
+    fn add_task(
+        &self,
+        task: JoinHandle<Result<()>>,
+    ) -> Result<(), mpsc::error::TrySendError<SupervisorMessage>> {
+        self.tx.try_send(SupervisorMessage::AddTask(task))
+    }
+
+    fn shutdown(&self) -> Result<(), mpsc::error::TrySendError<SupervisorMessage>> {
+        self.tx.try_send(SupervisorMessage::Abort)
+    }
+}
+
+async fn serve_stun(host: IpAddr, port: u16) {
+    match UdpSocket::bind((host, port)).await {
+        Ok(sock) => {
+            let addr = sock.local_addr().expect("socket just bound");
+            info!(%addr, "running STUN server");
+            server_stun_listener(sock).await;
+        }
+        Err(err) => {
+            error!("failed to open STUN listener: {:#?}", err);
+        }
+    }
+}
+
+async fn server_stun_listener(sock: UdpSocket) {
+    let sock = Arc::new(sock);
+    let mut buffer = vec![0u8; 64 << 10];
+    loop {
+        match sock.recv_from(&mut buffer).await {
+            Ok((n, src_addr)) => {
+                inc!(StunMetrics, requests);
+                let pkt = buffer[..n].to_vec();
+                let sock = sock.clone();
+                tokio::spawn(async move {
+                    if !stun::is(&pkt) {
+                        debug!(%src_addr, "STUN: ignoring non stun packet");
+                        inc!(StunMetrics, bad_requests);
+                        return;
+                    }
+                    match tokio::task::spawn_blocking(move || stun::parse_binding_request(&pkt))
+                        .await
+                        .unwrap()
+                    {
+                        Ok(txid) => {
+                            debug!(%src_addr, %txid, "STUN: received binding request");
+                            let res =
+                                tokio::task::spawn_blocking(move || stun::response(txid, src_addr))
+                                    .await
+                                    .unwrap();
+                            match sock.send_to(&res, src_addr).await {
+                                Ok(len) => {
+                                    if len != res.len() {
+                                        warn!(%src_addr, %txid, "STUN: failed to write response sent: {}, but expected {}", len, res.len());
+                                    }
+                                    match src_addr {
+                                        SocketAddr::V4(_) => {
+                                            inc!(StunMetrics, ipv4_success);
+                                        }
+                                        SocketAddr::V6(_) => {
+                                            inc!(StunMetrics, ipv6_success);
+                                        }
+                                    }
+                                    trace!(%src_addr, %txid, "STUN: sent {} bytes", len);
+                                }
+                                Err(err) => {
+                                    inc!(StunMetrics, failures);
+                                    warn!(%src_addr, %txid, "STUN: failed to write response: {:#}", err);
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            inc!(StunMetrics, bad_requests);
+                            warn!(%src_addr, "STUN: invalid binding request: {:?}", err);
+                        }
+                    }
+                });
+            }
+            Err(err) => {
+                inc!(StunMetrics, failures);
+                warn!("STUN: failed to recv: {:?}", err);
+            }
+        }
+    }
+}
+
+mod metrics {
+    use iroh_metrics::{
+        core::{Counter, Metric},
+        struct_iterable::Iterable,
+    };
+
+    /// StunMetrics tracked for the DERPER
+    #[allow(missing_docs)]
+    #[derive(Debug, Clone, Iterable)]
+    pub struct StunMetrics {
+        /*
+         * Metrics about STUN requests over ipv6
+         */
+        /// Number of stun requests made
+        pub requests: Counter,
+        /// Number of successful requests over ipv4
+        pub ipv4_success: Counter,
+        /// Number of successful requests over ipv6
+        pub ipv6_success: Counter,
+
+        /// Number of bad requests, either non-stun packets or incorrect binding request
+        pub bad_requests: Counter,
+        /// Number of failures
+        pub failures: Counter,
+    }
+
+    impl Default for StunMetrics {
+        fn default() -> Self {
+            Self {
+                /*
+                 * Metrics about STUN requests
+                 */
+                requests: Counter::new("Number of STUN requests made to the server."),
+                ipv4_success: Counter::new("Number of successful ipv4 STUN requests served."),
+                ipv6_success: Counter::new("Number of successful ipv6 STUN requests served."),
+                bad_requests: Counter::new("Number of bad requests made to the STUN endpoint."),
+                failures: Counter::new("Number of STUN requests that end in failure."),
+            }
+        }
+    }
+
+    impl Metric for StunMetrics {
+        fn name() -> &'static str {
+            "stun"
+        }
+    }
+}

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2541,7 +2541,7 @@ pub(crate) mod tests {
     use tracing_subscriber::{prelude::*, EnvFilter};
 
     use super::*;
-    use crate::{test_utils::run_derper, tls, MagicEndpoint};
+    use crate::{test_utils::TestDerper, tls, MagicEndpoint};
 
     fn make_transmit(destination: SocketAddr) -> quinn_udp::Transmit {
         quinn_udp::Transmit {
@@ -2779,10 +2779,10 @@ pub(crate) mod tests {
     async fn test_two_devices_roundtrip_quinn_magic() -> Result<()> {
         setup_multithreaded_logging();
 
-        let (derp_map, region, _cleanup) = run_derper().await?;
+        let derper = TestDerper::run().await?;
 
-        let m1 = MagicStack::new(derp_map.clone()).await?;
-        let m2 = MagicStack::new(derp_map.clone()).await?;
+        let m1 = MagicStack::new(derper.derp_map.clone()).await?;
+        let m2 = MagicStack::new(derper.derp_map.clone()).await?;
 
         let cleanup_mesh = mesh_stacks(vec![m1.clone(), m2.clone()]).await?;
 
@@ -2872,7 +2872,7 @@ pub(crate) mod tests {
                     println!("[{}] connecting to {}", a_name, b_addr);
                     let conn = a
                         .endpoint
-                        .connect(b_peer_id, &ALPN, region, &[b_addr])
+                        .connect(b_peer_id, &ALPN, derper.region_id, &[b_addr])
                         .await
                         .with_context(|| format!("[{}] connect", a_name))?;
 
@@ -2947,10 +2947,10 @@ pub(crate) mod tests {
     async fn test_two_devices_setup_teardown() -> Result<()> {
         setup_multithreaded_logging();
         for _ in 0..10 {
-            let (derp_map, _, _cleanup) = run_derper().await?;
+            let derper = TestDerper::run().await?;
             println!("setting up magic stack");
-            let m1 = MagicStack::new(derp_map.clone()).await?;
-            let m2 = MagicStack::new(derp_map.clone()).await?;
+            let m1 = MagicStack::new(derper.derp_map.clone()).await?;
+            let m2 = MagicStack::new(derper.derp_map.clone()).await?;
 
             let cleanup_mesh = mesh_stacks(vec![m1.clone(), m2.clone()]).await?;
 

--- a/iroh-net/src/test_utils.rs
+++ b/iroh-net/src/test_utils.rs
@@ -14,60 +14,87 @@ use crate::key::SecretKey;
 #[derive(Debug)]
 pub(crate) struct CleanupDropGuard(pub(crate) oneshot::Sender<()>);
 
-/// Runs a  DERP server with STUN enabled suitable for tests.
+/// A running DERP server to be used for testing purposes.
 ///
-/// The returned `u16` is the region ID of the DERP server in the returned [`DerpMap`], it
-/// is always `Some` as that is how the [`MagicEndpoint::connect`] API expects it.
+/// The server will also have STUN enabled.
 ///
-/// [`MagicEndpoint::connect`]: crate::magic_endpoint::MagicEndpoint
-pub(crate) async fn run_derper() -> Result<(DerpMap, Option<u16>, CleanupDropGuard)> {
-    // TODO: pass a mesh_key?
+/// Dropping this will terminate the server.
+pub(crate) struct TestDerper {
+    /// The [`DerpMap`] to use this server.
+    pub(crate) derp_map: DerpMap,
+    /// The region ID of this server.
+    ///
+    /// This is an `Option` since that is how the [`MagicEndpoint::connect`] API expects it,
+    /// it will always be `Some`.
+    ///
+    /// [`MagicEndpoint::connect`]: crate::magic_endpoint::MagicEndpoint
+    pub(crate) region_id: Option<u16>,
+    /// The certificate for the DERP server.
+    ///
+    /// This is valid for the URL in the [`derp_map`].
+    ///
+    /// [`derp_map`]: TestDerper::derp_map
+    pub(crate) certificate: rustls::Certificate,
+    /// Drop guard to stop the started server.
+    _drop_guard: oneshot::Sender<()>,
+}
 
-    let server_key = SecretKey::generate();
-    let tls_config = crate::derp::http::make_tls_config();
-    let server = crate::derp::http::ServerBuilder::new("127.0.0.1:0".parse().unwrap())
-        .secret_key(Some(server_key))
-        .tls_config(Some(tls_config))
-        .spawn()
-        .await?;
+impl TestDerper {
+    /// Start a new DERP test server.
+    pub(crate) async fn run() -> Result<Self> {
+        // TODO: pass a mesh_key?
 
-    let https_addr = server.addr();
-    println!("DERP listening on {:?}", https_addr);
+        let server_key = SecretKey::generate();
+        let (tls_config, certificate) = crate::derp::http::make_tls_config();
+        let server = crate::derp::http::ServerBuilder::new("127.0.0.1:0".parse().unwrap())
+            .secret_key(Some(server_key))
+            .tls_config(Some(tls_config))
+            .spawn()
+            .await?;
 
-    let (stun_addr, _, stun_drop_guard) = crate::stun::test::serve(server.addr().ip()).await?;
-    let region_id = 1;
-    let m = DerpMap::from_regions([DerpRegion {
-        region_id,
-        region_code: "test".into(),
-        nodes: vec![DerpNode {
-            name: "t1".into(),
+        let https_addr = server.addr();
+        println!("DERP listening on {:?}", https_addr);
+
+        let (stun_addr, _, stun_drop_guard) = crate::stun::test::serve(server.addr().ip()).await?;
+        let region_id = 1;
+        let derp_map = DerpMap::from_regions([DerpRegion {
             region_id,
-            // In test mode, the DERP client does not validate HTTPS certs, so the host
-            // name is irrelevant, but the port is used.
-            url: format!("https://test-node.invalid:{}", https_addr.port())
-                .parse()
-                .unwrap(),
-            stun_only: false,
-            stun_port: stun_addr.port(),
-            ipv4: UseIpv4::Some("127.0.0.1".parse().unwrap()),
-            ipv6: UseIpv6::Disabled,
-        }
-        .into()],
-        avoid: false,
-    }])
-    .expect("hardcoded");
+            region_code: "test".into(),
+            nodes: vec![DerpNode {
+                name: "t1".into(),
+                region_id,
+                // In test mode, the DERP client does not validate HTTPS certs, so the host
+                // name is irrelevant, but the port is used.
+                url: format!("https://{}:{}", https_addr.ip(), https_addr.port())
+                    .parse()
+                    .unwrap(),
+                stun_only: false,
+                stun_port: stun_addr.port(),
+                ipv4: UseIpv4::Some("127.0.0.1".parse().unwrap()),
+                ipv6: UseIpv6::Disabled,
+            }
+            .into()],
+            avoid: false,
+        }])
+        .expect("hardcoded");
 
-    let (tx, rx) = oneshot::channel();
-    tokio::spawn(
-        async move {
-            let _stun_cleanup = stun_drop_guard; // move into this closure
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(
+            async move {
+                let _stun_cleanup = stun_drop_guard; // move into this closure
 
-            // Wait until we're dropped or receive a message.
-            rx.await.ok();
-            server.shutdown().await;
-        }
-        .instrument(info_span!("derp-stun-cleanup")),
-    );
+                // Wait until we're dropped or receive a message.
+                rx.await.ok();
+                server.shutdown().await;
+            }
+            .instrument(info_span!("derp-stun-cleanup")),
+        );
 
-    Ok((m, Some(region_id), CleanupDropGuard(tx)))
+        Ok(TestDerper {
+            derp_map,
+            region_id: Some(region_id),
+            certificate,
+            _drop_guard: tx,
+        })
+    }
 }


### PR DESCRIPTION
## Description

This is needed to figure out the closest derp server when UDP is
blocked.  Now that we have multiple derp servers we'll start to rely
on this working.

## Notes & open questions

The Initial commit introduces the feature and can be manually tested against a derp server.  However it comes with a failing test.

The 2nd commit breaks things but is aiming at being able to run a full derp server, including the http(s) services in tests:

It moves out the server part of `src/bin/derper.rs` into `src/derp/derper.rs`.  This latter does not try to do anything related to UX or touch the filesystem.  It's configuration is rather different but works from just a struct.  `src/bin/derper.rs` will have to do all the file reading and convert things into the right shape.  This way this PR will also not affect any configuration file formats.

This part is incomplete so far.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
