### PR TITLE
docs: fix link to install URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Iroh is a protocol for syncing & moving bytes. Bytes of any size, on any device.
 
 ## Using Iroh
 
-Iroh is delivered as a Rust library and a CLI. Run `cargo build` to build the `iroh` CLI. To use iroh in your project, check out https://iroh.computer/install to get started.
+Iroh is delivered as a Rust library and a CLI. Run `cargo build` to build the `iroh` CLI. To use iroh in your project, check out https://iroh.computer/docs/install to get started.
 
 ### As a library
 Disable default features when using `iroh` as a library:


### PR DESCRIPTION
## Description

Fixes a link in the README to correctly point to the documentation.

## Notes & open questions

N/A

## Change checklist

- [ ] Self-review.
- [X] Documentation updates if relevant.
- [ ] Tests if relevant.
