### PR TITLE
refactor: extend Iroh client, improve API consistency

### DIFF
--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -93,9 +93,9 @@ pub enum Event {
     },
 }
 
-/// Progress updates for the provide operation.
+/// Progress updates for the add operation.
 #[derive(Debug, Serialize, Deserialize)]
-pub enum ProvideProgress {
+pub enum AddProgress {
     /// An item was found with name `name`, from now on referred to via `id`
     Found {
         /// A new unique id for this entry.
@@ -130,9 +130,9 @@ pub enum ProvideProgress {
     Abort(RpcError),
 }
 
-/// Progress updates for the provide operation.
+/// Progress updates for the get operation.
 #[derive(Debug, Serialize, Deserialize)]
-pub enum ShareProgress {
+pub enum GetProgress {
     /// A new connection was established.
     Connected,
     /// An item was found with hash `hash`, from now on referred to via `id`.

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -27,7 +27,7 @@ pub mod stun;
 pub mod tls;
 pub mod util;
 
-pub use magic_endpoint::MagicEndpoint;
+pub use magic_endpoint::{MagicEndpoint, NodeAddr};
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -31,7 +31,11 @@ pub struct NodeAddr {
 
 impl NodeAddr {
     /// Create a new [`NodeAddr`] from its parts.
-    pub fn from_parts(node_id: PublicKey, derp_region: Option<u16>, endpoints: Vec<SocketAddr>) -> Self {
+    pub fn from_parts(
+        node_id: PublicKey,
+        derp_region: Option<u16>,
+        endpoints: Vec<SocketAddr>,
+    ) -> Self {
         Self {
             node_id,
             derp_region,

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -31,7 +31,7 @@ pub struct NodeAddr {
 
 impl NodeAddr {
     /// Create a new [`NodeAddr`] from its parts.
-    pub fn new(node_id: PublicKey, derp_region: Option<u16>, endpoints: Vec<SocketAddr>) -> Self {
+    pub fn from_parts(node_id: PublicKey, derp_region: Option<u16>, endpoints: Vec<SocketAddr>) -> Self {
         Self {
             node_id,
             derp_region,
@@ -311,7 +311,7 @@ impl MagicEndpoint {
         let addrs = self.local_endpoints().await?;
         let derp = self.my_derp().await;
         let addrs = addrs.into_iter().map(|x| x.addr).collect();
-        Ok(NodeAddr::new(self.peer_id(), derp, addrs))
+        Ok(NodeAddr::from_parts(self.peer_id(), derp, addrs))
     }
 
     /// Get information on all the nodes we have connection information about.

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -4,6 +4,7 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, ensure, Context, Result};
 use quinn_proto::VarInt;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
 
 use crate::{
@@ -18,7 +19,7 @@ use crate::{
 pub use super::magicsock::EndpointInfo as ConnectionInfo;
 
 /// Address information for a node.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NodeAddr {
     /// The node's public key.
     pub node_id: PublicKey,
@@ -26,6 +27,17 @@ pub struct NodeAddr {
     pub derp_region: Option<u16>,
     /// Socket addresses where this node might be reached directly.
     pub endpoints: Vec<SocketAddr>,
+}
+
+impl NodeAddr {
+    /// Create a new [`NodeAddr`] from its parts.
+    pub fn new(node_id: PublicKey, derp_region: Option<u16>, endpoints: Vec<SocketAddr>) -> Self {
+        Self {
+            node_id,
+            derp_region,
+            endpoints,
+        }
+    }
 }
 
 /// Builder for [MagicEndpoint]
@@ -291,6 +303,15 @@ impl MagicEndpoint {
     /// Returns `None` if we are not connected to any DERP region.
     pub async fn my_derp(&self) -> Option<u16> {
         self.msock.my_derp().await
+    }
+
+    /// Get the [`NodeAddr`] for this endpoint.
+    // TODO: We can save an async call by exposing this on the msock.
+    pub async fn my_addr(&self) -> Result<NodeAddr> {
+        let addrs = self.local_endpoints().await?;
+        let derp = self.my_derp().await;
+        let addrs = addrs.into_iter().map(|x| x.addr).collect();
+        Ok(NodeAddr::new(self.peer_id(), derp, addrs))
     }
 
     /// Get information on all the nodes we have connection information about.

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
     let mut stream = doc.get_many(GetFilter::All).await?;
     while let Some(entry) = stream.try_next().await? {
         println!("entry {}", fmt_entry(&entry));
-        let content = doc.read_to_end(&entry).await?;
+        let content = doc.read_to_bytes(&entry).await?;
         println!("  content {}", String::from_utf8(content.to_vec())?)
     }
 

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -14,15 +14,15 @@ async fn main() -> anyhow::Result<()> {
         .spawn()
         .await?;
     let client = node.client();
-    let doc = client.create_doc().await?;
-    let author = client.create_author().await?;
+    let doc = client.docs.create().await?;
+    let author = client.docs.create_author().await?;
     let key = b"hello".to_vec();
     let value = b"world".to_vec();
     doc.set_bytes(author, key.clone(), value).await?;
     let mut stream = doc.get_many(GetFilter::All).await?;
     while let Some(entry) = stream.try_next().await? {
         println!("entry {}", fmt_entry(&entry));
-        let content = doc.get_content_bytes(entry.content_hash()).await?;
+        let content = doc.read_to_end(&entry).await?;
         println!("  content {}", String::from_utf8(content.to_vec())?)
     }
 

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     let client = node.client();
     let doc = client.docs.create().await?;
-    let author = client.docs.create_author().await?;
+    let author = client.authors.create().await?;
     let key = b"hello".to_vec();
     let value = b"world".to_vec();
     doc.set_bytes(author, key.clone(), value).await?;

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -56,9 +56,9 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.node_id());
+    println!("node PeerID:     {}", ticket.node_addr().node_id);
     println!("node listening addresses:");
-    for addr in ticket.addrs() {
+    for addr in ticket.node_addr().endpoints.iter() {
         println!("\t{:?}", addr);
     }
     // print the ticket, containing all the above information

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.peer());
+    println!("node PeerID:     {}", ticket.node_id());
     println!("node listening addresses:");
     for addr in ticket.addrs() {
         println!("\t{:?}", addr);

--- a/iroh/examples/hello-world.rs
+++ b/iroh/examples/hello-world.rs
@@ -37,9 +37,9 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash).await?.with_recursive(false);
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.peer());
+    println!("node PeerID:     {}", ticket.peer().node_id);
     println!("node listening addresses:");
-    for addr in ticket.addrs() {
+    for addr in &ticket.peer().endpoints {
         println!("\t{:?}", addr);
     }
     // print the ticket, containing all the above information

--- a/iroh/examples/hello-world.rs
+++ b/iroh/examples/hello-world.rs
@@ -37,9 +37,9 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash).await?.with_recursive(false);
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.peer().node_id);
+    println!("node PeerID:     {}", ticket.node_addr().node_id);
     println!("node listening addresses:");
-    for addr in &ticket.peer().endpoints {
+    for addr in &ticket.node_addr().endpoints {
         println!("\t{:?}", addr);
     }
     // print the ticket, containing all the above information

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -26,11 +26,12 @@ use crate::rpc_protocol::{
     AuthorCreateRequest, AuthorListRequest, BlobAddPathRequest, BlobGetRequest,
     BlobListCollectionsRequest, BlobListCollectionsResponse, BlobListIncompleteRequest,
     BlobListIncompleteResponse, BlobListRequest, BlobListResponse, BlobReadResponse,
-    BlobValidateRequest, BytesGetRequest, ConnectionInfoResponse, CounterStats, DocCreateRequest,
-    DocGetManyRequest, DocGetOneRequest, DocImportRequest, DocInfoRequest, DocListRequest,
-    DocSetRequest, DocShareRequest, DocStartSyncRequest, DocStopSyncRequest, DocSubscribeRequest,
-    DocTicket, GetProgress, NodeConnectionInfoRequest, NodeConnectionsRequest, NodeShutdownRequest,
-    NodeStatsRequest, NodeStatusRequest, ProviderService, ShareMode, StatusResponse,
+    BlobValidateRequest, BytesGetRequest, CounterStats, DocCreateRequest, DocGetManyRequest,
+    DocGetOneRequest, DocImportRequest, DocInfoRequest, DocListRequest, DocSetRequest,
+    DocShareRequest, DocStartSyncRequest, DocStopSyncRequest, DocSubscribeRequest, DocTicket,
+    GetProgress, NodeConnectionInfoRequest, NodeConnectionInfoResponse, NodeConnectionsRequest,
+    NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest, NodeStatusResponse, ProviderService,
+    ShareMode,
 };
 use crate::sync_engine::{LiveEvent, LiveStatus, PeerSource};
 
@@ -87,7 +88,7 @@ where
 
     /// Get connection information about a node
     pub async fn connection_info(&self, node_id: PublicKey) -> Result<Option<ConnectionInfo>> {
-        let ConnectionInfoResponse { conn_info } = self
+        let NodeConnectionInfoResponse { conn_info } = self
             .rpc
             .rpc(NodeConnectionInfoRequest { node_id })
             .await??;
@@ -95,7 +96,7 @@ where
     }
 
     /// Get status information about a node
-    pub async fn status(&self) -> Result<StatusResponse> {
+    pub async fn status(&self) -> Result<NodeStatusResponse> {
         let response = self.rpc.rpc(NodeStatusRequest).await?;
         Ok(response)
     }
@@ -197,7 +198,7 @@ where
     /// Read all bytes of single blob.
     ///
     /// This allocates a buffer for the full blob. Use only if you know that the blob you're
-    /// reading is small. If not sure, use [Self::reader] and check the size with
+    /// reading is small. If not sure, use [`Self::read`] and check the size with
     /// [`BlobReader::size`] before calling [`BlobReader::read_to_end`].
     pub async fn read_to_end(&self, hash: Hash) -> Result<Bytes> {
         BlobReader::from_rpc(&self.rpc, hash)

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -197,7 +197,7 @@ where
     pub async fn read_to_bytes(&self, hash: Hash) -> Result<Bytes> {
         BlobReader::from_rpc(&self.rpc, hash)
             .await?
-            .read_to_end()
+            .read_to_bytes()
             .await
     }
 
@@ -321,9 +321,9 @@ impl BlobReader {
     }
 
     /// Read all bytes of the blob.
-    pub async fn read_to_end(&mut self) -> anyhow::Result<Bytes> {
+    pub async fn read_to_bytes(&mut self) -> anyhow::Result<Bytes> {
         let mut buf = Vec::with_capacity(self.size() as usize);
-        AsyncReadExt::read_to_end(self, &mut buf).await?;
+        self.read_to_end(&mut buf).await?;
         Ok(buf.into())
     }
 }
@@ -379,10 +379,10 @@ where
     }
 
     /// Read all content of an [`Entry`] into a buffer.
-    pub async fn read_to_end(&self, entry: &Entry) -> Result<Bytes> {
+    pub async fn read_to_bytes(&self, entry: &Entry) -> Result<Bytes> {
         BlobReader::from_rpc(&self.rpc, entry.content_hash())
             .await?
-            .read_to_end()
+            .read_to_bytes()
             .await
     }
 

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -23,7 +23,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use tokio_util::io::StreamReader;
 
 use crate::rpc_protocol::{
-    AuthorCreateRequest, AuthorListRequest, BlobAddPathRequest, BlobGetRequest,
+    AuthorCreateRequest, AuthorListRequest, BlobAddPathRequest, BlobDownloadRequest,
     BlobListCollectionsRequest, BlobListCollectionsResponse, BlobListIncompleteRequest,
     BlobListIncompleteResponse, BlobListRequest, BlobListResponse, BlobReadResponse,
     BlobValidateRequest, BytesGetRequest, CounterStats, DocCreateRequest, DocGetManyRequest,
@@ -234,9 +234,9 @@ where
     }
 
     /// Download a blob from another node and add it to the local database.
-    pub async fn get(
+    pub async fn download(
         &self,
-        req: BlobGetRequest,
+        req: BlobDownloadRequest,
     ) -> Result<impl Stream<Item = Result<GetProgress>>> {
         let stream = self.rpc.server_streaming(req).await?;
         Ok(stream.map_err(anyhow::Error::from))

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -159,16 +159,8 @@ where
         Ok(flatten(stream).map_ok(|res| res.id))
     }
 
-    /// Get a [`Doc`] client for a single document. Return an error if the document cannot be found.
-    pub async fn get(&self, id: NamespaceId) -> Result<Doc<C>> {
-        match self.try_get(id).await? {
-            Some(doc) => Ok(doc),
-            None => Err(anyhow!("Document not found")),
-        }
-    }
-
     /// Get a [`Doc`] client for a single document. Return None if the document cannot be found.
-    pub async fn try_get(&self, id: NamespaceId) -> Result<Option<Doc<C>>> {
+    pub async fn get(&self, id: NamespaceId) -> Result<Option<Doc<C>>> {
         if let Err(_err) = self.rpc.rpc(DocInfoRequest { doc_id: id }).await? {
             return Ok(None);
         }

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -207,7 +207,7 @@ where
     ///
     /// This allocates a buffer for the full blob. Use only if you know that the blob you're
     /// reading is small. If not sure, use [`Self::read`] and check the size with
-    /// [`BlobReader::size`] before calling [`BlobReader::read_to_end`].
+    /// [`BlobReader::size`] before calling [`BlobReader::read_to_bytes`].
     pub async fn read_to_bytes(&self, hash: Hash) -> Result<Bytes> {
         BlobReader::from_rpc(&self.rpc, hash)
             .await?

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -182,7 +182,9 @@ impl<C> BlobsClient<C>
 where
     C: ServiceConnection<ProviderService>,
 {
-    /// Read a single blob as a streaming [`BlobReader`].
+    /// Stream the contents of a a single blob.
+    ///
+    /// Returns a [`BlobReader`], which can report the size of the blob before reading it.
     pub async fn read(&self, hash: Hash) -> Result<BlobReader> {
         BlobReader::from_rpc(&self.rpc, hash).await
     }
@@ -192,7 +194,7 @@ where
     /// This allocates a buffer for the full blob. Use only if you know that the blob you're
     /// reading is small. If not sure, use [`Self::read`] and check the size with
     /// [`BlobReader::size`] before calling [`BlobReader::read_to_end`].
-    pub async fn read_to_end(&self, hash: Hash) -> Result<Bytes> {
+    pub async fn read_to_bytes(&self, hash: Hash) -> Result<Bytes> {
         BlobReader::from_rpc(&self.rpc, hash)
             .await?
             .read_to_end()

--- a/iroh/src/client/quic.rs
+++ b/iroh/src/client/quic.rs
@@ -8,7 +8,7 @@ use std::{
 
 use quic_rpc::transport::quinn::QuinnConnection;
 
-use crate::rpc_protocol::{ProviderRequest, ProviderResponse, ProviderService, VersionRequest};
+use crate::rpc_protocol::{NodeStatusRequest, ProviderRequest, ProviderResponse, ProviderService};
 
 /// TODO: Change to "/iroh-rpc/1"
 pub const RPC_ALPN: [u8; 17] = *b"n0/provider-rpc/1";
@@ -41,10 +41,10 @@ pub async fn connect_raw(rpc_port: u16) -> anyhow::Result<RpcClient> {
     let server_name = "localhost".to_string();
     let connection = QuinnConnection::new(endpoint, addr, server_name);
     let client = RpcClient::new(connection);
-    // Do a version request to check if the server is running.
-    let _version = tokio::time::timeout(Duration::from_secs(1), client.rpc(VersionRequest))
+    // Do a status request to check if the server is running.
+    let _version = tokio::time::timeout(Duration::from_secs(1), client.rpc(NodeStatusRequest))
         .await
-        .context("iroh server is not running")??;
+        .context("Iroh node is not running")??;
     Ok(client)
 }
 fn create_quinn_client(

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -5,20 +5,17 @@ use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 use comfy_table::presets::NOTHING;
 use comfy_table::{Cell, Table};
-use futures::stream::BoxStream;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use human_time::ToHumanTimeString;
-use iroh::client::quic::{Iroh, RpcClient};
+use iroh::client::quic::Iroh;
 use iroh::dial::Ticket;
 use iroh::rpc_protocol::*;
-use iroh_bytes::util::RpcError;
 use iroh_bytes::{protocol::RequestToken, util::runtime, Hash};
+use iroh_net::NodeAddr;
 use iroh_net::{
     key::{PublicKey, SecretKey},
     magic_endpoint::ConnectionInfo,
 };
-use quic_rpc::client::StreamingResponseItemError;
-use quic_rpc::transport::ConnectionErrors;
 
 use crate::commands::sync::fmt_short;
 use crate::config::{ConsoleEnv, NodeConfig};
@@ -82,14 +79,14 @@ impl Cli {
     pub async fn run(self, rt: &runtime::Handle) -> Result<()> {
         match self.command {
             Commands::Console => {
-                let client = iroh::client::quic::connect_raw(self.rpc_args.rpc_port).await?;
+                let iroh = iroh::client::quic::connect(self.rpc_args.rpc_port).await?;
                 let env = ConsoleEnv::for_console()?;
-                repl::run(client, env).await
+                repl::run(&iroh, env).await
             }
             Commands::Rpc(command) => {
-                let client = iroh::client::quic::connect_raw(self.rpc_args.rpc_port).await?;
+                let iroh = iroh::client::quic::connect(self.rpc_args.rpc_port).await?;
                 let env = ConsoleEnv::for_cli()?;
-                command.run(client, env).await
+                command.run(&iroh, env).await
             }
             Commands::Full(command) => {
                 let FullArgs {
@@ -256,10 +253,8 @@ impl FullCommands {
                         rt: rt.clone(),
                         hash,
                         opts: iroh::dial::Options {
-                            addrs,
-                            peer_id: peer,
+                            peer: NodeAddr::new(peer, region, addrs),
                             keylog,
-                            derp_region: region,
                             derp_map: config.derp_map()?,
                             secret_key: SecretKey::generate(),
                         },
@@ -332,28 +327,25 @@ pub enum NodeCommands {
 }
 
 impl NodeCommands {
-    pub async fn run(self, client: RpcClient) -> Result<()> {
+    pub async fn run(self, iroh: &Iroh) -> Result<()> {
         match self {
             Self::Connections => {
-                let connections = client.server_streaming(ConnectionsRequest).await?;
+                let connections = iroh.node.connections().await?;
                 println!("{}", fmt_connections(connections).await);
             }
             Self::Connection { node_id } => {
-                let conn_info = client
-                    .rpc(ConnectionInfoRequest { node_id })
-                    .await??
-                    .conn_info;
+                let conn_info = iroh.node.connection_info(node_id).await?;
                 match conn_info {
                     Some(info) => println!("{}", fmt_connection(info)),
                     None => println!("Not Found"),
                 }
             }
             Self::Shutdown { force } => {
-                client.rpc(ShutdownRequest { force }).await?;
+                iroh.node.shutdown(force).await?;
             }
             Self::Stats => {
-                let response = client.rpc(StatsGetRequest {}).await??;
-                for (name, details) in response.stats.iter() {
+                let stats = iroh.node.stats().await?;
+                for (name, details) in stats.iter() {
                     println!(
                         "{:23} : {:>6}    ({})",
                         name, details.value, details.description
@@ -361,10 +353,10 @@ impl NodeCommands {
                 }
             }
             Self::Status => {
-                let response = client.rpc(StatusRequest).await?;
-
+                let response = iroh.node.status().await?;
                 println!("Listening addresses: {:#?}", response.listen_addrs);
-                println!("PeerID: {}", response.peer_id);
+                println!("Node public key: {}", response.peer_id);
+                println!("Version: {}", response.version);
             }
         }
         Ok(())
@@ -372,13 +364,12 @@ impl NodeCommands {
 }
 
 impl RpcCommands {
-    pub async fn run(self, client: RpcClient, env: ConsoleEnv) -> Result<()> {
-        let iroh = Iroh::new(client.clone());
+    pub async fn run(self, iroh: &Iroh, env: ConsoleEnv) -> Result<()> {
         match self {
-            Self::Node { command } => command.run(client).await,
-            Self::Blob { command } => command.run(client).await,
-            Self::Doc { command } => command.run(&iroh, env).await,
-            Self::Author { command } => command.run(&iroh, env).await,
+            Self::Node { command } => command.run(iroh).await,
+            Self::Blob { command } => command.run(iroh).await,
+            Self::Doc { command } => command.run(iroh, env).await,
+            Self::Author { command } => command.run(iroh, env).await,
         }
     }
 }
@@ -452,7 +443,7 @@ pub enum BlobCommands {
 }
 
 impl BlobCommands {
-    pub async fn run(self, client: RpcClient) -> Result<()> {
+    pub async fn run(self, iroh: &Iroh) -> Result<()> {
         match self {
             Self::Share {
                 hash,
@@ -471,36 +462,36 @@ impl BlobCommands {
                     tracing::info!("output path is {} -> {}", out.display(), absolute.display());
                     *out = absolute;
                 }
-                let (peer, addr, token, derp_region, hash, recursive) =
-                    if let Some(ticket) = ticket.as_ref() {
-                        (
-                            ticket.peer(),
-                            ticket.addrs().to_vec(),
-                            ticket.token(),
-                            ticket.derp_region(),
-                            ticket.hash(),
-                            ticket.recursive(),
-                        )
-                    } else {
-                        (
-                            peer.unwrap(),
-                            addr,
-                            token.as_ref(),
-                            derp_region,
-                            hash.unwrap(),
-                            recursive.unwrap_or_default(),
-                        )
-                    };
-                let mut stream = client
-                    .server_streaming(ShareRequest {
+                let (peer, token, hash, recursive) = if let Some(ticket) = ticket.as_ref() {
+                    (
+                        ticket.peer().clone(),
+                        ticket.token(),
+                        ticket.hash(),
+                        ticket.recursive(),
+                    )
+                } else {
+                    (
+                        NodeAddr::new(peer.unwrap(), derp_region, addr),
+                        token.as_ref(),
+                        hash.unwrap(),
+                        recursive.unwrap_or_default(),
+                    )
+                };
+                let out = match out {
+                    None => ShareLocation::Internal,
+                    Some(path) => ShareLocation::External {
+                        path: path.display().to_string(),
+                        in_place,
+                    },
+                };
+                let mut stream = iroh
+                    .blobs
+                    .get(BlobGetRequest {
                         hash,
                         recursive,
                         peer,
-                        addrs: addr,
-                        derp_region,
                         token: token.cloned(),
-                        out: out.map(|x| x.display().to_string()),
-                        in_place,
+                        out,
                     })
                     .await?;
                 while let Some(item) = stream.next().await {
@@ -509,9 +500,9 @@ impl BlobCommands {
                 }
                 Ok(())
             }
-            Self::List(cmd) => cmd.run(client).await,
-            Self::Validate { repair } => self::validate::run(client, repair).await,
-            Self::Add { path, in_place } => self::add::run(client, path, in_place).await,
+            Self::List(cmd) => cmd.run(iroh).await,
+            Self::Validate { repair } => self::validate::run(iroh, repair).await,
+            Self::Add { path, in_place } => self::add::run(iroh, path, in_place).await,
         }
     }
 }
@@ -557,11 +548,8 @@ fn bold_cell(s: &str) -> Cell {
     Cell::new(s).add_attribute(comfy_table::Attribute::Bold)
 }
 
-async fn fmt_connections<C: ConnectionErrors>(
-    mut infos: BoxStream<
-        'static,
-        Result<Result<ConnectionsResponse, RpcError>, StreamingResponseItemError<C>>,
-    >,
+async fn fmt_connections(
+    mut infos: impl Stream<Item = Result<ConnectionInfo, anyhow::Error>> + Unpin,
 ) -> String {
     let mut table = Table::new();
     table.load_preset(NOTHING).set_header(
@@ -569,7 +557,7 @@ async fn fmt_connections<C: ConnectionErrors>(
             .into_iter()
             .map(bold_cell),
     );
-    while let Some(Ok(Ok(ConnectionsResponse { conn_info }))) = infos.next().await {
+    while let Some(Ok(conn_info)) = infos.next().await {
         let node_id = conn_info.public_key.to_string();
         let region = conn_info
             .derp_region

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -253,7 +253,7 @@ impl FullCommands {
                         rt: rt.clone(),
                         hash,
                         opts: iroh::dial::Options {
-                            peer: NodeAddr::new(peer, region, addrs),
+                            peer: NodeAddr::from_parts(peer, region, addrs),
                             keylog,
                             derp_map: config.derp_map()?,
                             secret_key: SecretKey::generate(),
@@ -471,7 +471,7 @@ impl BlobCommands {
                     )
                 } else {
                     (
-                        NodeAddr::new(peer.unwrap(), derp_region, addr),
+                        NodeAddr::from_parts(peer.unwrap(), derp_region, addr),
                         token.as_ref(),
                         hash.unwrap(),
                         recursive.unwrap_or_default(),

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -81,12 +81,12 @@ impl Cli {
             Commands::Console => {
                 let iroh = iroh::client::quic::connect(self.rpc_args.rpc_port).await?;
                 let env = ConsoleEnv::for_console()?;
-                repl::run(&iroh, env).await
+                repl::run(&iroh, &env).await
             }
             Commands::Rpc(command) => {
                 let iroh = iroh::client::quic::connect(self.rpc_args.rpc_port).await?;
                 let env = ConsoleEnv::for_cli()?;
-                command.run(&iroh, env).await
+                command.run(&iroh, &env).await
             }
             Commands::Full(command) => {
                 let FullArgs {
@@ -364,7 +364,7 @@ impl NodeCommands {
 }
 
 impl RpcCommands {
-    pub async fn run(self, iroh: &Iroh, env: ConsoleEnv) -> Result<()> {
+    pub async fn run(self, iroh: &Iroh, env: &ConsoleEnv) -> Result<()> {
         match self {
             Self::Node { command } => command.run(iroh).await,
             Self::Blob { command } => command.run(iroh).await,

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -355,7 +355,7 @@ impl NodeCommands {
             Self::Status => {
                 let response = iroh.node.status().await?;
                 println!("Listening addresses: {:#?}", response.listen_addrs);
-                println!("Node public key: {}", response.peer_id);
+                println!("Node public key: {}", response.node_id);
                 println!("Version: {}", response.version);
             }
         }
@@ -464,7 +464,7 @@ impl BlobCommands {
                 }
                 let (peer, token, hash, recursive) = if let Some(ticket) = ticket.as_ref() {
                     (
-                        ticket.peer().clone(),
+                        ticket.node_addr().clone(),
                         ticket.token(),
                         ticket.hash(),
                         ticket.recursive(),

--- a/iroh/src/commands/add.rs
+++ b/iroh/src/commands/add.rs
@@ -7,18 +7,13 @@ use std::{
 use anyhow::{Context, Result};
 use futures::{Stream, StreamExt};
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
-use iroh::{client::quic::RpcClient, rpc_protocol::ProvideRequest};
-use iroh_bytes::{provider::ProvideProgress, Hash};
+use iroh::client::quic::Iroh;
+use iroh_bytes::{provider::AddProgress, Hash};
 
-pub async fn run(client: RpcClient, path: PathBuf, in_place: bool) -> Result<()> {
+pub async fn run(iroh: &Iroh, path: PathBuf, in_place: bool) -> Result<()> {
     let absolute = path.canonicalize()?;
     println!("Adding {} as {}...", path.display(), absolute.display());
-    let stream = client
-        .server_streaming(ProvideRequest {
-            path: absolute,
-            in_place,
-        })
-        .await?;
+    let stream = iroh.blobs.add_from_path(absolute, in_place).await?;
     let (hash, entries) = aggregate_add_response(stream).await?;
     print_add_response(hash, entries);
     Ok(())
@@ -31,33 +26,28 @@ pub struct ProvideResponseEntry {
     pub hash: Hash,
 }
 
-pub async fn aggregate_add_response<S, E>(
-    stream: S,
-) -> anyhow::Result<(Hash, Vec<ProvideResponseEntry>)>
-where
-    S: Stream<Item = std::result::Result<ProvideProgress, E>> + Unpin,
-    E: std::error::Error + Send + Sync + 'static,
-{
-    let mut stream = stream;
+pub async fn aggregate_add_response(
+    mut stream: impl Stream<Item = Result<AddProgress>> + Unpin,
+) -> Result<(Hash, Vec<ProvideResponseEntry>)> {
     let mut collection_hash = None;
     let mut collections = BTreeMap::<u64, (String, u64, Option<Hash>)>::new();
     let mut mp = Some(ProvideProgressState::new());
     while let Some(item) = stream.next().await {
         match item? {
-            ProvideProgress::Found { name, id, size } => {
+            AddProgress::Found { name, id, size } => {
                 tracing::trace!("Found({id},{name},{size})");
                 if let Some(mp) = mp.as_mut() {
                     mp.found(name.clone(), id, size);
                 }
                 collections.insert(id, (name, size, None));
             }
-            ProvideProgress::Progress { id, offset } => {
+            AddProgress::Progress { id, offset } => {
                 tracing::trace!("Progress({id}, {offset})");
                 if let Some(mp) = mp.as_mut() {
                     mp.progress(id, offset);
                 }
             }
-            ProvideProgress::Done { hash, id } => {
+            AddProgress::Done { hash, id } => {
                 tracing::trace!("Done({id},{hash:?})");
                 if let Some(mp) = mp.as_mut() {
                     mp.done(id, hash);
@@ -71,7 +61,7 @@ where
                     }
                 }
             }
-            ProvideProgress::AllDone { hash } => {
+            AddProgress::AllDone { hash } => {
                 tracing::trace!("AllDone({hash:?})");
                 if let Some(mp) = mp.take() {
                     mp.all_done();
@@ -79,7 +69,7 @@ where
                 collection_hash = Some(hash);
                 break;
             }
-            ProvideProgress::Abort(e) => {
+            AddProgress::Abort(e) => {
                 if let Some(mp) = mp.take() {
                     mp.error();
                 }

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -9,7 +9,7 @@ use indicatif::{
 };
 use iroh::{
     collection::{Collection, IrohCollectionParser},
-    rpc_protocol::{BlobGetRequest, ShareLocation},
+    rpc_protocol::{BlobDownloadRequest, DownloadLocation},
     util::{io::pathbuf_from_name, progress::ProgressSliceWriter},
 };
 use iroh_bytes::{baomap::range_collections::RangeSet2, provider::GetProgress};
@@ -91,12 +91,12 @@ impl GetInteractive {
         let mut stream = provider
             .client()
             .blobs
-            .get(BlobGetRequest {
+            .download(BlobDownloadRequest {
                 hash: self.hash,
                 recursive: !self.single,
                 peer: self.opts.peer,
                 token: self.token,
-                out: ShareLocation::External {
+                out: DownloadLocation::External {
                     path: out,
                     in_place: true,
                 },

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -9,10 +9,10 @@ use indicatif::{
 };
 use iroh::{
     collection::{Collection, IrohCollectionParser},
-    rpc_protocol::ShareRequest,
+    rpc_protocol::{BlobGetRequest, ShareLocation},
     util::{io::pathbuf_from_name, progress::ProgressSliceWriter},
 };
-use iroh_bytes::{baomap::range_collections::RangeSet2, provider::ShareProgress};
+use iroh_bytes::{baomap::range_collections::RangeSet2, provider::GetProgress};
 use iroh_bytes::{
     get::{
         self,
@@ -89,26 +89,27 @@ impl GetInteractive {
         write(format!("Fetching: {}", hash));
         write(format!("{} Connecting ...", style("[1/3]").bold().dim()));
         let mut stream = provider
-            .controller()
-            .server_streaming(ShareRequest {
+            .client()
+            .blobs
+            .get(BlobGetRequest {
                 hash: self.hash,
                 recursive: !self.single,
-                peer: self.opts.peer_id,
-                addrs: self.opts.addrs,
-                derp_region: self.opts.derp_region,
+                peer: self.opts.peer,
                 token: self.token,
-                in_place: true,
-                out: Some(out),
+                out: ShareLocation::External {
+                    path: out,
+                    in_place: true,
+                },
             })
             .await?;
         let pb = make_download_pb();
         let mut sizes = BTreeMap::new();
         while let Some(x) = stream.next().await {
             match x? {
-                ShareProgress::Connected => {
+                GetProgress::Connected => {
                     write(format!("{} Requesting ...", style("[2/3]").bold().dim()));
                 }
-                ShareProgress::FoundCollection {
+                GetProgress::FoundCollection {
                     total_blobs_size,
                     num_blobs,
                     ..
@@ -119,24 +120,24 @@ impl GetInteractive {
                         total_blobs_size.unwrap_or_default(),
                     )?;
                 }
-                ShareProgress::Found { id, size, .. } => {
+                GetProgress::Found { id, size, .. } => {
                     sizes.insert(id, (size, 0));
                 }
-                ShareProgress::Progress { id, offset } => {
+                GetProgress::Progress { id, offset } => {
                     if let Some((_, current)) = sizes.get_mut(&id) {
                         *current = offset;
                         let total = sizes.values().map(|(_, current)| current).sum::<u64>();
                         pb.set_position(total);
                     }
                 }
-                ShareProgress::Done { id } => {
+                GetProgress::Done { id } => {
                     if let Some((size, current)) = sizes.get_mut(&id) {
                         *current = *size;
                         let total = sizes.values().map(|(_, current)| current).sum::<u64>();
                         pb.set_position(total);
                     }
                 }
-                ShareProgress::NetworkDone {
+                GetProgress::NetworkDone {
                     bytes_read,
                     elapsed,
                     ..
@@ -149,7 +150,7 @@ impl GetInteractive {
                         HumanBytes((bytes_read as f64 / elapsed.as_secs_f64()) as u64)
                     ));
                 }
-                ShareProgress::AllDone => {
+                GetProgress::AllDone => {
                     break;
                 }
                 _ => {}

--- a/iroh/src/commands/repl.rs
+++ b/iroh/src/commands/repl.rs
@@ -10,7 +10,7 @@ use crate::{
     config::{ConsoleEnv, ConsolePaths},
 };
 
-pub async fn run(iroh: &Iroh, env: ConsoleEnv) -> Result<()> {
+pub async fn run(iroh: &Iroh, env: &ConsoleEnv) -> Result<()> {
     println!("{}", "Welcome to the Iroh console!".purple().bold());
     println!("Type `{}` for a list of commands.", "help".bold());
     let mut from_repl = Repl::spawn(env.clone());
@@ -19,7 +19,7 @@ pub async fn run(iroh: &Iroh, env: ConsoleEnv) -> Result<()> {
         tokio::select! {
             biased;
             _ = tokio::signal::ctrl_c() => {},
-            res = cmd.run(iroh, env.clone()) => {
+            res = cmd.run(iroh, env) => {
                 if let Err(err) = res {
                     println!("{} {:?}", "Error:".red().bold(), err)
                 }

--- a/iroh/src/commands/repl.rs
+++ b/iroh/src/commands/repl.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
-use iroh::client::quic::RpcClient;
+use iroh::client::quic::Iroh;
 use rustyline::{error::ReadlineError, Config, DefaultEditor};
 use tokio::sync::{mpsc, oneshot};
 
@@ -10,7 +10,7 @@ use crate::{
     config::{ConsoleEnv, ConsolePaths},
 };
 
-pub async fn run(client: RpcClient, env: ConsoleEnv) -> Result<()> {
+pub async fn run(iroh: &Iroh, env: ConsoleEnv) -> Result<()> {
     println!("{}", "Welcome to the Iroh console!".purple().bold());
     println!("Type `{}` for a list of commands.", "help".bold());
     let mut from_repl = Repl::spawn(env.clone());
@@ -19,7 +19,7 @@ pub async fn run(client: RpcClient, env: ConsoleEnv) -> Result<()> {
         tokio::select! {
             biased;
             _ = tokio::signal::ctrl_c() => {},
-            res = cmd.run(client.clone(), env.clone()) => {
+            res = cmd.run(&iroh, env.clone()) => {
                 if let Err(err) = res {
                     println!("{} {:?}", "Error:".red().bold(), err)
                 }

--- a/iroh/src/commands/repl.rs
+++ b/iroh/src/commands/repl.rs
@@ -19,7 +19,7 @@ pub async fn run(iroh: &Iroh, env: ConsoleEnv) -> Result<()> {
         tokio::select! {
             biased;
             _ = tokio::signal::ctrl_c() => {},
-            res = cmd.run(&iroh, env.clone()) => {
+            res = cmd.run(iroh, env.clone()) => {
                 if let Err(err) = res {
                     println!("{} {:?}", "Error:".red().bold(), err)
                 }

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -270,7 +270,7 @@ impl AuthorCommands {
                 println!("Active author is now {}", fmt_short(author.as_bytes()));
             }
             Self::List => {
-                let mut stream = iroh.docs.list_authors().await?;
+                let mut stream = iroh.authors.list().await?;
                 while let Some(author_id) = stream.try_next().await? {
                     println!("{}", author_id);
                 }
@@ -280,7 +280,7 @@ impl AuthorCommands {
                     bail!("The --switch flag is only supported within the Iroh console.");
                 }
 
-                let author_id = iroh.docs.create_author().await?;
+                let author_id = iroh.authors.create().await?;
                 println!("{}", author_id);
 
                 if switch {

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -314,7 +314,7 @@ async fn print_entry(doc: &Doc, entry: &Entry, content: bool) -> anyhow::Result<
     println!("{}", fmt_entry(entry));
     if content {
         if entry.content_len() < MAX_DISPLAY_CONTENT_LEN {
-            match doc.read_to_end(entry).await {
+            match doc.read_to_bytes(entry).await {
                 Ok(content) => match String::from_utf8(content.into()) {
                     Ok(s) => println!("{s}"),
                     Err(_err) => println!("<invalid UTF-8>"),

--- a/iroh/src/commands/validate.rs
+++ b/iroh/src/commands/validate.rs
@@ -4,12 +4,12 @@ use anyhow::Result;
 use console::{style, Emoji};
 use futures::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use iroh::{client::quic::RpcClient, rpc_protocol::ValidateRequest};
+use iroh::client::quic::Iroh;
 use iroh_bytes::{baomap::ValidateProgress, Hash};
 
-pub async fn run(client: RpcClient, repair: bool) -> Result<()> {
+pub async fn run(iroh: &Iroh, repair: bool) -> Result<()> {
     let mut state = ValidateProgressState::new();
-    let mut response = client.server_streaming(ValidateRequest { repair }).await?;
+    let mut response = iroh.blobs.validate(repair).await?;
 
     while let Some(item) = response.next().await {
         match item? {

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -10,7 +10,7 @@ use anyhow::{ensure, Context, Result};
 use iroh_bytes::protocol::RequestToken;
 use iroh_bytes::Hash;
 use iroh_net::derp::DerpMap;
-use iroh_net::key::{SecretKey};
+use iroh_net::key::SecretKey;
 use iroh_net::NodeAddr;
 use serde::{Deserialize, Serialize};
 

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -205,7 +205,7 @@ mod tests {
         let derp_region = Some(0);
         let ticket = Ticket {
             hash,
-            peer: NodeAddr::new(peer, derp_region, vec![addr]),
+            peer: NodeAddr::from_parts(peer, derp_region, vec![addr]),
             token: Some(token),
             recursive: true,
         };

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -175,6 +175,8 @@ impl FromStr for Ticket {
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+
     use bao_tree::blake3;
 
     use super::*;

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -12,6 +12,7 @@ use iroh_bytes::protocol::RequestToken;
 use iroh_bytes::Hash;
 use iroh_net::derp::DerpMap;
 use iroh_net::key::{PublicKey, SecretKey};
+use iroh_net::NodeAddr;
 use serde::{Deserialize, Serialize};
 
 /// Options for the client
@@ -19,16 +20,12 @@ use serde::{Deserialize, Serialize};
 pub struct Options {
     /// The secret key of the node
     pub secret_key: SecretKey,
-    /// The addresses to connect to
-    pub addrs: Vec<SocketAddr>,
-    /// The peer id to dial
-    pub peer_id: PublicKey,
+    /// The peer to connect to.
+    pub peer: NodeAddr,
     /// Whether to log the SSL keys when `SSLKEYLOGFILE` environment variable is set
     pub keylog: bool,
     /// The configuration of the derp services
     pub derp_map: Option<DerpMap>,
-    /// The DERP region of the node
-    pub derp_region: Option<u16>,
 }
 
 /// Create a new endpoint and dial a peer, returning the connection
@@ -47,10 +44,10 @@ pub async fn dial(opts: Options) -> anyhow::Result<quinn::Connection> {
     let endpoint = endpoint.bind(0).await?;
     endpoint
         .connect(
-            opts.peer_id,
+            opts.peer.node_id,
             &iroh_bytes::protocol::ALPN,
-            opts.derp_region,
-            &opts.addrs,
+            opts.peer.derp_region,
+            &opts.peer.endpoints,
         )
         .await
         .context("failed to connect to provider")
@@ -62,47 +59,40 @@ pub async fn dial(opts: Options) -> anyhow::Result<quinn::Connection> {
 /// and [`FromStr`] implementations serialize to base32.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ticket {
+    /// The provider to get a file from.
+    peer: NodeAddr,
     /// The hash to retrieve.
     hash: Hash,
-    /// The peer ID identifying the provider.
-    peer: PublicKey,
     /// Optional Request token.
     token: Option<RequestToken>,
-    /// The socket addresses the provider is listening on.
-    ///
-    /// This will never be empty.
-    addrs: Vec<SocketAddr>,
     /// True to treat the hash as a collection and retrieve all blobs in it.
     recursive: bool,
-    /// DERP region of the provider
-    derp_region: Option<u16>,
 }
 
 impl Ticket {
     /// Creates a new ticket.
     pub fn new(
+        peer: NodeAddr,
         hash: Hash,
-        peer: PublicKey,
-        addrs: Vec<SocketAddr>,
         token: Option<RequestToken>,
         recursive: bool,
-        derp_region: Option<u16>,
     ) -> Result<Self> {
-        ensure!(!addrs.is_empty(), "addrs list can not be empty");
+        ensure!(!peer.endpoints.is_empty(), "addrs list can not be empty");
         Ok(Self {
             hash,
             peer,
-            addrs,
             token,
             recursive,
-            derp_region,
         })
     }
 
     /// Deserializes from bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let slf: Ticket = postcard::from_bytes(bytes)?;
-        ensure!(!slf.addrs.is_empty(), "Invalid address list in ticket");
+        ensure!(
+            !slf.peer.endpoints.is_empty(),
+            "Invalid address list in ticket"
+        );
         Ok(slf)
     }
 
@@ -116,9 +106,9 @@ impl Ticket {
         self.hash
     }
 
-    /// The [`PublicKey`] of the provider for this ticket.
-    pub fn peer(&self) -> PublicKey {
-        self.peer
+    /// The [`NodeAddr`] of the provider for this ticket.
+    pub fn peer(&self) -> &NodeAddr {
+        &self.peer
     }
 
     /// The [`RequestToken`] for this ticket.
@@ -136,53 +126,43 @@ impl Ticket {
         self.recursive
     }
 
+    /// Get the socket addresses where the provider might be reachable.
+    pub fn addrs(&self) -> &[SocketAddr] {
+        &self.peer.endpoints[..]
+    }
+
+    /// Get the DERP region where the provider might be reachable.
+    pub fn derp_region(&self) -> Option<u16> {
+        self.peer.derp_region
+    }
+
+    /// Get the node ID of the provider.
+    pub fn node_id(&self) -> &PublicKey {
+        &self.peer.node_id
+    }
+
     /// Set recursive to for this ticket
     pub fn with_recursive(self, recursive: bool) -> Self {
         Self { recursive, ..self }
     }
 
-    /// The addresses on which the provider can be reached.
-    ///
-    /// This is guaranteed to be non-empty.
-    pub fn addrs(&self) -> &[SocketAddr] {
-        &self.addrs
-    }
-
-    /// DERP region of the provider
-    pub fn derp_region(&self) -> Option<u16> {
-        self.derp_region
-    }
-
     /// Get the contents of the ticket, consuming it.
-    pub fn into_parts(
-        self,
-    ) -> (
-        Hash,
-        PublicKey,
-        Vec<SocketAddr>,
-        Option<RequestToken>,
-        bool,
-        Option<u16>,
-    ) {
+    pub fn into_parts(self) -> (NodeAddr, Hash, Option<RequestToken>, bool) {
         let Ticket {
-            hash,
             peer,
+            hash,
             token,
-            addrs,
             recursive,
-            derp_region,
         } = self;
-        (hash, peer, addrs, token, recursive, derp_region)
+        (peer, hash, token, recursive)
     }
 
     /// Convert this ticket into a [`Options`], adding the given secret key.
     pub fn as_get_options(&self, secret_key: SecretKey, derp_map: Option<DerpMap>) -> Options {
         Options {
-            peer_id: self.peer,
-            addrs: self.addrs.clone(),
+            peer: self.peer.clone(),
             secret_key,
             keylog: true,
-            derp_region: self.derp_region,
             derp_map,
         }
     }
@@ -225,11 +205,9 @@ mod tests {
         let derp_region = Some(0);
         let ticket = Ticket {
             hash,
-            peer,
-            addrs: vec![addr],
+            peer: NodeAddr::new(peer, derp_region, vec![addr]),
             token: Some(token),
             recursive: true,
-            derp_region,
         };
         let base32 = ticket.to_string();
         println!("Ticket: {base32}");

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -4,14 +4,13 @@
 //! with an empty address list.
 
 use std::fmt::{self, Display};
-use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::{ensure, Context, Result};
 use iroh_bytes::protocol::RequestToken;
 use iroh_bytes::Hash;
 use iroh_net::derp::DerpMap;
-use iroh_net::key::{PublicKey, SecretKey};
+use iroh_net::key::{SecretKey};
 use iroh_net::NodeAddr;
 use serde::{Deserialize, Serialize};
 
@@ -107,7 +106,7 @@ impl Ticket {
     }
 
     /// The [`NodeAddr`] of the provider for this ticket.
-    pub fn peer(&self) -> &NodeAddr {
+    pub fn node_addr(&self) -> &NodeAddr {
         &self.peer
     }
 
@@ -124,21 +123,6 @@ impl Ticket {
     /// True if the ticket is for a collection and should retrieve all blobs in it.
     pub fn recursive(&self) -> bool {
         self.recursive
-    }
-
-    /// Get the socket addresses where the provider might be reachable.
-    pub fn addrs(&self) -> &[SocketAddr] {
-        &self.peer.endpoints[..]
-    }
-
-    /// Get the DERP region where the provider might be reachable.
-    pub fn derp_region(&self) -> Option<u16> {
-        self.peer.derp_region
-    }
-
-    /// Get the node ID of the provider.
-    pub fn node_id(&self) -> &PublicKey {
-        &self.peer.node_id
     }
 
     /// Set recursive to for this ticket

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1119,7 +1119,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
 
     async fn status(self, _: NodeStatusRequest) -> NodeStatusResponse {
         NodeStatusResponse {
-            peer_id: Box::new(self.inner.secret_key.public()),
+            node_id: Box::new(self.inner.secret_key.public()),
             listen_addrs: self
                 .inner
                 .local_endpoint_addresses()
@@ -1466,8 +1466,8 @@ mod tests {
             .unwrap();
         let _drop_guard = node.cancel_token().drop_guard();
         let ticket = node.ticket(hash).await.unwrap();
-        println!("addrs: {:?}", ticket.peer().endpoints);
-        assert!(!ticket.peer().endpoints.is_empty());
+        println!("addrs: {:?}", ticket.node_addr().endpoints);
+        assert!(!ticket.node_addr().endpoints.is_empty());
     }
 
     #[cfg(feature = "mem-db")]

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -25,12 +25,12 @@ use iroh_bytes::baomap::{
 use iroh_bytes::collection::{CollectionParser, NoCollectionParser};
 use iroh_bytes::get::Stats;
 use iroh_bytes::protocol::GetRequest;
-use iroh_bytes::provider::ShareProgress;
+use iroh_bytes::provider::GetProgress;
 use iroh_bytes::util::progress::{FlumeProgressSender, IdGenerator, ProgressSender};
 use iroh_bytes::util::RpcResult;
 use iroh_bytes::{
     protocol::{Closed, Request, RequestToken},
-    provider::{CustomGetHandler, ProvideProgress, RequestAuthorizationHandler},
+    provider::{AddProgress, CustomGetHandler, RequestAuthorizationHandler},
     util::runtime,
     util::Hash,
 };
@@ -42,7 +42,7 @@ use iroh_net::{
     config::Endpoint,
     derp::DerpMap,
     key::{PublicKey, SecretKey},
-    tls, MagicEndpoint,
+    tls, MagicEndpoint, NodeAddr,
 };
 use iroh_sync::store::Store as DocStore;
 use once_cell::sync::OnceCell;
@@ -58,13 +58,12 @@ use tracing::{debug, error, info, trace, warn};
 use crate::dial::Ticket;
 use crate::downloader::Downloader;
 use crate::rpc_protocol::{
-    BytesGetRequest, BytesGetResponse, ConnectionInfoRequest, ConnectionInfoResponse,
-    ConnectionsRequest, ConnectionsResponse, ListBlobsRequest, ListBlobsResponse,
-    ListCollectionsRequest, ListCollectionsResponse, ListIncompleteBlobsRequest,
-    ListIncompleteBlobsResponse, ProvideRequest, ProviderRequest, ProviderResponse,
-    ProviderService, ShareRequest, ShutdownRequest, StatsGetRequest, StatsGetResponse,
-    StatusRequest, StatusResponse, ValidateRequest, VersionRequest, VersionResponse, WatchRequest,
-    WatchResponse,
+    BlobAddPathRequest, BlobGetRequest, BlobListCollectionsRequest, BlobListCollectionsResponse,
+    BlobListIncompleteRequest, BlobListIncompleteResponse, BlobListRequest, BlobListResponse,
+    BlobReadResponse, BlobValidateRequest, BytesGetRequest, ConnectionInfoResponse,
+    ConnectionsResponse, NodeConnectionInfoRequest, NodeConnectionsRequest, NodeShutdownRequest,
+    NodeStatsRequest, NodeStatusRequest, NodeWatchRequest, NodeWatchResponse, ProviderRequest,
+    ProviderResponse, ProviderService, ShareLocation, StatsGetResponse, StatusResponse,
 };
 use crate::sync_engine::{SyncEngine, SYNC_ALPN};
 
@@ -701,14 +700,19 @@ impl<D: ReadableStore, S: DocStore> Node<D, S> {
     /// Return a single token containing everything needed to get a hash.
     ///
     /// See [`Ticket`] for more details of how it can be used.
+    // TODO: We should not assume `recursive: true` as we do currently. Take as argument instead.
     pub async fn ticket(&self, hash: Hash) -> Result<Ticket> {
         // TODO: Verify that the hash exists in the db?
-        let addrs = self.local_endpoint_addresses().await?;
-        let region = self.inner.endpoint.my_derp().await;
-        Ticket::new(hash, self.peer_id(), addrs, None, true, region)
+        let me = self.my_addr().await?;
+        Ticket::new(me, hash, None, true)
     }
 
-    /// Return the DERP region that this provider is connected to
+    /// Return the [`NodeAddr`] for this node.
+    pub async fn my_addr(&self) -> Result<NodeAddr> {
+        self.inner.endpoint.my_addr().await
+    }
+
+    /// Get the DERP region we are connected to.
     pub async fn my_derp(&self) -> Option<u16> {
         self.inner.endpoint.my_derp().await
     }
@@ -772,8 +776,8 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
 
     fn list_blobs(
         self,
-        _msg: ListBlobsRequest,
-    ) -> impl Stream<Item = ListBlobsResponse> + Send + 'static {
+        _msg: BlobListRequest,
+    ) -> impl Stream<Item = BlobListResponse> + Send + 'static {
         use bao_tree::io::fsm::Outboard;
 
         let db = self.inner.db.clone();
@@ -784,15 +788,15 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
                 let hash = entry.hash().into();
                 let size = entry.outboard().await.ok()?.tree().size().0;
                 let path = "".to_owned();
-                Some(ListBlobsResponse { hash, size, path })
+                Some(BlobListResponse { hash, size, path })
             }
         })
     }
 
     fn list_incomplete_blobs(
         self,
-        _msg: ListIncompleteBlobsRequest,
-    ) -> impl Stream<Item = ListIncompleteBlobsResponse> + Send + 'static {
+        _msg: BlobListIncompleteRequest,
+    ) -> impl Stream<Item = BlobListIncompleteResponse> + Send + 'static {
         let db = self.inner.db.clone();
         let local = self.inner.rt.local_pool().clone();
         futures::stream::iter(db.partial_blobs()).filter_map(move |hash| {
@@ -804,7 +808,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
                         "no partial entry found",
                     ));
                 };
-                io::Result::Ok(ListIncompleteBlobsResponse {
+                io::Result::Ok(BlobListIncompleteResponse {
                     hash,
                     size: 0,
                     expected_size: entry.size(),
@@ -816,8 +820,8 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
 
     fn list_collections(
         self,
-        _msg: ListCollectionsRequest,
-    ) -> impl Stream<Item = ListCollectionsResponse> + Send + 'static {
+        _msg: BlobListCollectionsRequest,
+    ) -> impl Stream<Item = BlobListCollectionsResponse> + Send + 'static {
         let db = self.inner.db.clone();
         let local = self.inner.rt.local_pool().clone();
         let roots = db.roots();
@@ -835,7 +839,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
                     })
                     .await
                     .ok()??;
-                Some(ListCollectionsResponse {
+                Some(BlobListCollectionsResponse {
                     hash,
                     total_blobs_count: stats.num_blobs,
                     total_blobs_size: stats.total_blob_size,
@@ -847,7 +851,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
     /// Invoke validate on the database and stream out the result
     fn validate(
         self,
-        _msg: ValidateRequest,
+        _msg: BlobValidateRequest,
     ) -> impl Stream<Item = ValidateProgress> + Send + 'static {
         let (tx, rx) = mpsc::channel(1);
         let tx2 = tx.clone();
@@ -860,13 +864,13 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         tokio_stream::wrappers::ReceiverStream::new(rx)
     }
 
-    fn provide(self, msg: ProvideRequest) -> impl Stream<Item = ProvideProgress> {
+    fn provide(self, msg: BlobAddPathRequest) -> impl Stream<Item = AddProgress> {
         // provide a little buffer so that we don't slow down the sender
         let (tx, rx) = flume::bounded(32);
         let tx2 = tx.clone();
         self.rt().local_pool().spawn_pinned(|| async move {
             if let Err(e) = self.provide0(msg, tx).await {
-                tx2.send_async(ProvideProgress::Abort(e.into())).await.ok();
+                tx2.send_async(AddProgress::Abort(e.into())).await.ok();
             }
         });
         rx.into_stream()
@@ -877,7 +881,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         conn: quinn::Connection,
         hash: Hash,
         recursive: bool,
-        sender: impl ProgressSender<Msg = ShareProgress> + IdGenerator,
+        sender: impl ProgressSender<Msg = GetProgress> + IdGenerator,
     ) -> anyhow::Result<Stats> {
         crate::get::get(
             &self.inner.db,
@@ -896,7 +900,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         hash: Hash,
         recursive: bool,
         stable: bool,
-        progress: impl ProgressSender<Msg = ShareProgress> + IdGenerator,
+        progress: impl ProgressSender<Msg = GetProgress> + IdGenerator,
     ) -> anyhow::Result<()> {
         let db = &self.inner.db;
         let path = PathBuf::from(&out);
@@ -926,7 +930,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
                     let id = progress.new_id();
                     let progress1 = progress.clone();
                     db.export(*hash, path, mode, move |offset| {
-                        Ok(progress1.try_send(ShareProgress::ExportProgress { id, offset })?)
+                        Ok(progress1.try_send(GetProgress::ExportProgress { id, offset })?)
                     })
                     .await?;
                 }
@@ -938,7 +942,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             let id = progress.new_id();
             let entry = db.get(&hash).context("entry not there")?;
             progress
-                .send(ShareProgress::Export {
+                .send(GetProgress::Export {
                     id,
                     hash,
                     target: out,
@@ -947,7 +951,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
                 .await?;
             let progress1 = progress.clone();
             db.export(hash, path, mode, move |offset| {
-                Ok(progress1.try_send(ShareProgress::ExportProgress { id, offset })?)
+                Ok(progress1.try_send(GetProgress::ExportProgress { id, offset })?)
             })
             .await?;
         }
@@ -956,8 +960,8 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
 
     async fn share0(
         self,
-        msg: ShareRequest,
-        progress: impl ProgressSender<Msg = ShareProgress> + IdGenerator,
+        msg: BlobGetRequest,
+        progress: impl ProgressSender<Msg = GetProgress> + IdGenerator,
     ) -> anyhow::Result<()> {
         let local = self.inner.rt.local_pool().clone();
         let hash = msg.hash;
@@ -966,13 +970,13 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             .inner
             .endpoint
             .connect(
-                msg.peer,
+                msg.peer.node_id,
                 &iroh_bytes::protocol::ALPN,
-                msg.derp_region,
-                &msg.addrs,
+                msg.peer.derp_region,
+                &msg.peer.endpoints,
             )
             .await?;
-        progress.send(ShareProgress::Connected).await?;
+        progress.send(GetProgress::Connected).await?;
         let progress2 = progress.clone();
         let progress3 = progress.clone();
         let this = self.clone();
@@ -981,35 +985,32 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         let _export = local.spawn_pinned(move || async move {
             let stats = download.await.unwrap()?;
             progress
-                .send(ShareProgress::NetworkDone {
+                .send(GetProgress::NetworkDone {
                     bytes_written: stats.bytes_written,
                     bytes_read: stats.bytes_read,
                     elapsed: stats.elapsed,
                 })
                 .await?;
-            if let Some(out) = msg.out {
+            if let ShareLocation::External { path, in_place } = msg.out {
                 if let Err(cause) = this
-                    .export(out, hash, msg.recursive, msg.in_place, progress3)
+                    .export(path, hash, msg.recursive, in_place, progress3)
                     .await
                 {
-                    progress.send(ShareProgress::Abort(cause.into())).await?;
+                    progress.send(GetProgress::Abort(cause.into())).await?;
                 }
             }
-            progress.send(ShareProgress::AllDone).await?;
+            progress.send(GetProgress::AllDone).await?;
             anyhow::Ok(())
         });
         Ok(())
     }
 
-    fn share(self, msg: ShareRequest) -> impl Stream<Item = ShareProgress> {
+    fn share(self, msg: BlobGetRequest) -> impl Stream<Item = GetProgress> {
         async move {
             let (sender, receiver) = flume::bounded(1024);
             let sender = FlumeProgressSender::new(sender);
             if let Err(cause) = self.share0(msg, sender.clone()).await {
-                sender
-                    .send(ShareProgress::Abort(cause.into()))
-                    .await
-                    .unwrap();
+                sender.send(GetProgress::Abort(cause.into())).await.unwrap();
             };
             receiver.into_stream()
         }
@@ -1019,8 +1020,8 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
     #[cfg(feature = "iroh-collection")]
     async fn provide0(
         self,
-        msg: ProvideRequest,
-        progress: flume::Sender<ProvideProgress>,
+        msg: BlobAddPathRequest,
+        progress: flume::Sender<AddProgress>,
     ) -> anyhow::Result<()> {
         use crate::collection::{Blob, Collection};
         use futures::TryStreamExt;
@@ -1037,16 +1038,16 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             }
             ImportProgress::Size { id, size } => {
                 let path = names.lock().unwrap().remove(&id)?;
-                Some(ProvideProgress::Found {
+                Some(AddProgress::Found {
                     id,
                     name: path.display().to_string(),
                     size,
                 })
             }
             ImportProgress::OutboardProgress { id, offset } => {
-                Some(ProvideProgress::Progress { id, offset })
+                Some(AddProgress::Progress { id, offset })
             }
-            ImportProgress::OutboardDone { hash, id } => Some(ProvideProgress::Done { hash, id }),
+            ImportProgress::OutboardDone { hash, id } => Some(AddProgress::Done { hash, id }),
             _ => None,
         });
         let root = msg.path;
@@ -1082,7 +1083,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         let collection = Collection::new(blobs, total_blobs_size)?;
         let data = collection.to_bytes()?;
         let hash = self.inner.db.import_bytes(data.into()).await?;
-        progress.send(ProvideProgress::AllDone { hash }).await?;
+        progress.send(AddProgress::AllDone { hash }).await?;
 
         self.inner
             .callbacks
@@ -1097,13 +1098,13 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
     #[cfg(not(feature = "iroh-collection"))]
     async fn provide0(
         self,
-        _msg: ProvideRequest,
-        _progress: flume::Sender<ProvideProgress>,
+        _msg: BlobAddPathRequest,
+        _progress: flume::Sender<AddProgress>,
     ) -> anyhow::Result<()> {
         anyhow::bail!("collections not supported");
     }
 
-    async fn stats(self, _req: StatsGetRequest) -> RpcResult<StatsGetResponse> {
+    async fn stats(self, _req: NodeStatsRequest) -> RpcResult<StatsGetResponse> {
         #[cfg(feature = "metrics")]
         let res = Ok(StatsGetResponse {
             stats: crate::metrics::get_metrics()?,
@@ -1115,12 +1116,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         res
     }
 
-    async fn version(self, _: VersionRequest) -> VersionResponse {
-        VersionResponse {
-            version: env!("CARGO_PKG_VERSION").to_string(),
-        }
-    }
-    async fn status(self, _: StatusRequest) -> StatusResponse {
+    async fn status(self, _: NodeStatusRequest) -> StatusResponse {
         StatusResponse {
             peer_id: Box::new(self.inner.secret_key.public()),
             listen_addrs: self
@@ -1131,7 +1127,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             version: env!("CARGO_PKG_VERSION").to_string(),
         }
     }
-    async fn shutdown(self, request: ShutdownRequest) {
+    async fn shutdown(self, request: NodeShutdownRequest) {
         if request.force {
             info!("hard shutdown requested");
             std::process::exit(0);
@@ -1141,11 +1137,11 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             self.inner.cancel_token.cancel();
         }
     }
-    fn watch(self, _: WatchRequest) -> impl Stream<Item = WatchResponse> {
+    fn watch(self, _: NodeWatchRequest) -> impl Stream<Item = NodeWatchResponse> {
         futures::stream::unfold((), |()| async move {
             tokio::time::sleep(HEALTH_POLL_WAIT).await;
             Some((
-                WatchResponse {
+                NodeWatchResponse {
                     version: env!("CARGO_PKG_VERSION").to_string(),
                 },
                 (),
@@ -1156,7 +1152,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
     fn bytes_get(
         self,
         req: BytesGetRequest,
-    ) -> impl Stream<Item = RpcResult<BytesGetResponse>> + Send + 'static {
+    ) -> impl Stream<Item = RpcResult<BlobReadResponse>> + Send + 'static {
         let (tx, rx) = flume::bounded(RPC_BLOB_GET_CHANNEL_CAP);
         let entry = self.inner.db.get(&req.hash);
         self.inner.rt.local_pool().spawn_pinned(move || async move {
@@ -1167,12 +1163,12 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
 
         async fn read_loop<M: Map>(
             entry: Option<impl MapEntry<M>>,
-            tx: flume::Sender<RpcResult<BytesGetResponse>>,
+            tx: flume::Sender<RpcResult<BlobReadResponse>>,
             chunk_size: usize,
         ) -> anyhow::Result<()> {
             let entry = entry.ok_or_else(|| anyhow!("Blob not found"))?;
             let size = entry.size();
-            tx.send_async(Ok(BytesGetResponse::Entry {
+            tx.send_async(Ok(BlobReadResponse::Entry {
                 size,
                 is_complete: entry.is_complete(),
             }))
@@ -1183,7 +1179,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
                 let chunk = reader.read_at(offset, chunk_size).await?;
                 let len = chunk.len();
                 if !chunk.is_empty() {
-                    tx.send_async(Ok(BytesGetResponse::Data { chunk })).await?;
+                    tx.send_async(Ok(BlobReadResponse::Data { chunk })).await?;
                 }
                 if len < chunk_size {
                     break;
@@ -1199,7 +1195,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
 
     fn connections(
         self,
-        _: ConnectionsRequest,
+        _: NodeConnectionsRequest,
     ) -> impl Stream<Item = RpcResult<ConnectionsResponse>> + Send + 'static {
         // provide a little buffer so that we don't slow down the sender
         let (tx, rx) = flume::bounded(32);
@@ -1223,9 +1219,9 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
 
     async fn connection_info(
         self,
-        req: ConnectionInfoRequest,
+        req: NodeConnectionInfoRequest,
     ) -> RpcResult<ConnectionInfoResponse> {
-        let ConnectionInfoRequest { node_id } = req;
+        let NodeConnectionInfoRequest { node_id } = req;
         let conn_info = self.inner.endpoint.connection_info(node_id).await?;
         Ok(ConnectionInfoResponse { conn_info })
     }
@@ -1247,29 +1243,28 @@ fn handle_rpc_request<
         use ProviderRequest::*;
         debug!("handling rpc request: {}", std::any::type_name::<E>());
         match msg {
-            ListBlobs(msg) => {
+            BlobList(msg) => {
                 chan.server_streaming(msg, handler, RpcHandler::list_blobs)
                     .await
             }
-            ListIncompleteBlobs(msg) => {
+            BlobListIncomplete(msg) => {
                 chan.server_streaming(msg, handler, RpcHandler::list_incomplete_blobs)
                     .await
             }
-            ListCollections(msg) => {
+            BlobListCollections(msg) => {
                 chan.server_streaming(msg, handler, RpcHandler::list_collections)
                     .await
             }
-            Provide(msg) => {
+            BlobAddPath(msg) => {
                 chan.server_streaming(msg, handler, RpcHandler::provide)
                     .await
             }
-            Share(msg) => chan.server_streaming(msg, handler, RpcHandler::share).await,
-            Watch(msg) => chan.server_streaming(msg, handler, RpcHandler::watch).await,
-            Version(msg) => chan.rpc(msg, handler, RpcHandler::version).await,
-            Status(msg) => chan.rpc(msg, handler, RpcHandler::status).await,
-            Shutdown(msg) => chan.rpc(msg, handler, RpcHandler::shutdown).await,
-            Stats(msg) => chan.rpc(msg, handler, RpcHandler::stats).await,
-            Validate(msg) => {
+            BlobGet(msg) => chan.server_streaming(msg, handler, RpcHandler::share).await,
+            NodeWatch(msg) => chan.server_streaming(msg, handler, RpcHandler::watch).await,
+            NodeStatus(msg) => chan.rpc(msg, handler, RpcHandler::status).await,
+            NodeShutdown(msg) => chan.rpc(msg, handler, RpcHandler::shutdown).await,
+            NodeStats(msg) => chan.rpc(msg, handler, RpcHandler::stats).await,
+            BlobValidate(msg) => {
                 chan.server_streaming(msg, handler, RpcHandler::validate)
                     .await
             }
@@ -1355,12 +1350,12 @@ fn handle_rpc_request<
                 })
                 .await
             }
-            Connections(msg) => {
+            NodeConnections(msg) => {
                 chan.server_streaming(msg, handler, RpcHandler::connections)
                     .await
             }
-            ConnectionInfo(msg) => chan.rpc(msg, handler, RpcHandler::connection_info).await,
-            BytesGet(msg) => {
+            NodeConnectionInfo(msg) => chan.rpc(msg, handler, RpcHandler::connection_info).await,
+            BlobRead(msg) => {
                 chan.server_streaming(msg, handler, RpcHandler::bytes_get)
                     .await
             }
@@ -1470,8 +1465,8 @@ mod tests {
             .unwrap();
         let _drop_guard = node.cancel_token().drop_guard();
         let ticket = node.ticket(hash).await.unwrap();
-        println!("addrs: {:?}", ticket.addrs());
-        assert!(!ticket.addrs().is_empty());
+        println!("addrs: {:?}", ticket.peer().endpoints);
+        assert!(!ticket.peer().endpoints.is_empty());
     }
 
     #[cfg(feature = "mem-db")]
@@ -1505,7 +1500,7 @@ mod tests {
         let got_hash = tokio::time::timeout(Duration::from_secs(1), async move {
             let mut stream = node
                 .controller()
-                .server_streaming(ProvideRequest {
+                .server_streaming(BlobAddPathRequest {
                     path: Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md"),
                     in_place: false,
                 })
@@ -1513,10 +1508,10 @@ mod tests {
 
             while let Some(item) = stream.next().await {
                 match item? {
-                    ProvideProgress::AllDone { hash } => {
+                    AddProgress::AllDone { hash } => {
                         return Ok(hash);
                     }
-                    ProvideProgress::Abort(e) => {
+                    AddProgress::Abort(e) => {
                         bail!("Error while adding data: {e}");
                     }
                     _ => {}

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -38,7 +38,7 @@ pub type KeyBytes = [u8; 32];
 
 /// A request to the node to provide the data at the given path
 ///
-/// Will produce a stream of [`ProvideProgress`] messages.
+/// Will produce a stream of [`AddProgress`] messages.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlobAddPathRequest {
     /// The path to the data to provide.
@@ -203,7 +203,7 @@ pub struct NodeConnectionsRequest;
 
 /// A response to a connections request
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ConnectionsResponse {
+pub struct NodeConnectionsResponse {
     /// Information about a connection
     pub conn_info: ConnectionInfo,
 }
@@ -213,7 +213,7 @@ impl Msg<ProviderService> for NodeConnectionsRequest {
 }
 
 impl ServerStreamingMsg<ProviderService> for NodeConnectionsRequest {
-    type Response = RpcResult<ConnectionsResponse>;
+    type Response = RpcResult<NodeConnectionsResponse>;
 }
 
 /// Get connection information about a specific node
@@ -225,13 +225,13 @@ pub struct NodeConnectionInfoRequest {
 
 /// A response to a connection request
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ConnectionInfoResponse {
+pub struct NodeConnectionInfoResponse {
     /// Information about a connection to a node
     pub conn_info: Option<ConnectionInfo>,
 }
 
 impl RpcMsg<ProviderService> for NodeConnectionInfoRequest {
-    type Response = RpcResult<ConnectionInfoResponse>;
+    type Response = RpcResult<NodeConnectionInfoResponse>;
 }
 
 /// A request to shutdown the node
@@ -247,17 +247,17 @@ impl RpcMsg<ProviderService> for NodeShutdownRequest {
 
 /// A request to get information about the identity of the node
 ///
-/// See [`StatusResponse`] for the response.
+/// See [`NodeStatusResponse`] for the response.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NodeStatusRequest;
 
 impl RpcMsg<ProviderService> for NodeStatusRequest {
-    type Response = StatusResponse;
+    type Response = NodeStatusResponse;
 }
 
 /// The response to a version request
 #[derive(Serialize, Deserialize, Debug)]
-pub struct StatusResponse {
+pub struct NodeStatusResponse {
     /// The peer id of the node
     pub peer_id: Box<PublicKey>,
     /// The addresses of the node
@@ -644,7 +644,7 @@ pub enum BlobReadResponse {
 pub struct NodeStatsRequest {}
 
 impl RpcMsg<ProviderService> for NodeStatsRequest {
-    type Response = RpcResult<StatsGetResponse>;
+    type Response = RpcResult<NodeStatsResponse>;
 }
 
 /// Counter stats
@@ -656,9 +656,9 @@ pub struct CounterStats {
     pub description: String,
 }
 
-/// Response to [`StatsGetRequest`]
+/// Response to [`NodeStatsRequest`]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct StatsGetResponse {
+pub struct NodeStatsResponse {
     /// Map of statistics
     pub stats: HashMap<String, CounterStats>,
 }
@@ -707,10 +707,10 @@ pub enum ProviderRequest {
 #[allow(missing_docs, clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize, From, TryInto)]
 pub enum ProviderResponse {
-    NodeStatus(StatusResponse),
-    NodeStats(RpcResult<StatsGetResponse>),
-    NodeConnections(RpcResult<ConnectionsResponse>),
-    NodeConnectionInfo(RpcResult<ConnectionInfoResponse>),
+    NodeStatus(NodeStatusResponse),
+    NodeStats(RpcResult<NodeStatsResponse>),
+    NodeConnections(RpcResult<NodeConnectionsResponse>),
+    NodeConnectionInfo(RpcResult<NodeConnectionInfoResponse>),
     NodeShutdown(()),
     NodeWatch(NodeWatchResponse),
 

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -259,7 +259,7 @@ impl RpcMsg<ProviderService> for NodeStatusRequest {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NodeStatusResponse {
     /// The peer id of the node
-    pub peer_id: Box<PublicKey>,
+    pub node_id: Box<PublicKey>,
     /// The addresses of the node
     pub listen_addrs: Vec<SocketAddr>,
     /// The version of the node

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -62,7 +62,7 @@ impl ServerStreamingMsg<ProviderService> for BlobAddPathRequest {
 
 /// A request to the node to download and share the data specified by the hash.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlobGetRequest {
+pub struct BlobDownloadRequest {
     /// This mandatory field contains the hash of the data to download and share.
     pub hash: Hash,
     /// If this flag is true, the hash is assumed to be a collection and all
@@ -74,12 +74,12 @@ pub struct BlobGetRequest {
     /// the download request.
     pub token: Option<RequestToken>,
     /// This field contains the location to store the data at.
-    pub out: ShareLocation,
+    pub out: DownloadLocation,
 }
 
 /// Location to store a downloaded blob at.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ShareLocation {
+pub enum DownloadLocation {
     /// Store in the node's blob storage directory.
     Internal,
     /// Store at the provided path.
@@ -96,11 +96,11 @@ pub enum ShareLocation {
     },
 }
 
-impl Msg<ProviderService> for BlobGetRequest {
+impl Msg<ProviderService> for BlobDownloadRequest {
     type Pattern = ServerStreaming;
 }
 
-impl ServerStreamingMsg<ProviderService> for BlobGetRequest {
+impl ServerStreamingMsg<ProviderService> for BlobDownloadRequest {
     type Response = GetProgress;
 }
 
@@ -680,7 +680,7 @@ pub enum ProviderRequest {
 
     BlobRead(BytesGetRequest),
     BlobAddPath(BlobAddPathRequest),
-    BlobGet(BlobGetRequest),
+    BlobDownload(BlobDownloadRequest),
     BlobList(BlobListRequest),
     BlobListIncomplete(BlobListIncompleteRequest),
     BlobListCollections(BlobListCollectionsRequest),
@@ -716,7 +716,7 @@ pub enum ProviderResponse {
 
     BlobRead(RpcResult<BlobReadResponse>),
     BlobAddPath(AddProgress),
-    BlobGet(GetProgress),
+    BlobDownload(GetProgress),
     BlobList(BlobListResponse),
     BlobListIncomplete(BlobListIncompleteResponse),
     BlobListCollections(BlobListCollectionsResponse),

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -612,13 +612,15 @@ fn test_provide_get_loop_single(
     let ticket = match_provide_output(&mut provider, num_blobs)?;
     let ticket = Ticket::from_str(&ticket).unwrap();
     let addrs = ticket
-        .addrs()
+        .node_addr()
+        .endpoints
         .iter()
         .map(|x| x.to_string())
         .collect::<Vec<_>>();
-    let peer = ticket.peer().node_id.to_string();
+    let peer = ticket.node_addr().node_id.to_string();
     let region = ticket
-        .derp_region()
+        .node_addr()
+        .derp_region
         .context("should have derp region in ticket")?
         .to_string();
 

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -616,7 +616,7 @@ fn test_provide_get_loop_single(
         .iter()
         .map(|x| x.to_string())
         .collect::<Vec<_>>();
-    let peer = ticket.peer().to_string();
+    let peer = ticket.peer().node_id.to_string();
     let region = ticket
         .derp_region()
         .context("should have derp region in ticket")?

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -146,11 +146,10 @@ async fn empty_files() -> Result<()> {
 /// Create new get options with the given peer id and addresses, using a
 /// randomly generated secret key.
 fn get_options(peer_id: PublicKey, addrs: Vec<SocketAddr>) -> iroh::dial::Options {
+    let peer = iroh_net::NodeAddr::new(peer_id, Some(1), addrs);
     iroh::dial::Options {
         secret_key: SecretKey::generate(),
-        peer_id,
-        addrs,
-        derp_region: Some(1),
+        peer,
         keylog: false,
         derp_map: Some(iroh_net::defaults::default_derp_map()),
     }

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -146,7 +146,7 @@ async fn empty_files() -> Result<()> {
 /// Create new get options with the given peer id and addresses, using a
 /// randomly generated secret key.
 fn get_options(peer_id: PublicKey, addrs: Vec<SocketAddr>) -> iroh::dial::Options {
-    let peer = iroh_net::NodeAddr::new(peer_id, Some(1), addrs);
+    let peer = iroh_net::NodeAddr::from_parts(peer_id, Some(1), addrs);
     iroh::dial::Options {
         secret_key: SecretKey::generate(),
         peer,

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -71,8 +71,8 @@ async fn sync_full_basic() -> Result<()> {
     // node1: create doc and ticket
     let (ticket, doc1) = {
         let iroh = &clients[0];
-        let author = iroh.create_author().await?;
-        let doc = iroh.create_doc().await?;
+        let author = iroh.docs.create_author().await?;
+        let doc = iroh.docs.create().await?;
         let key = b"k1";
         let value = b"v1";
         doc.set_bytes(author, key.to_vec(), value.to_vec()).await?;
@@ -84,8 +84,8 @@ async fn sync_full_basic() -> Result<()> {
     // node2: join in
     let _doc2 = {
         let iroh = &clients[1];
-        let author = iroh.create_author().await?;
-        let doc = iroh.import_doc(ticket.clone()).await?;
+        let author = iroh.docs.create_author().await?;
+        let doc = iroh.docs.import(ticket.clone()).await?;
 
         // wait for remote insert on doc2
         let mut events = doc.subscribe().await?;
@@ -117,7 +117,7 @@ async fn sync_full_basic() -> Result<()> {
     //  node 3 joins & imports the doc from peer 1
     let _doc3 = {
         let iroh = &clients[2];
-        let doc = iroh.import_doc(ticket).await?;
+        let doc = iroh.docs.import(ticket).await?;
 
         // wait for 2 remote inserts
         let mut events = doc.subscribe().await?;
@@ -154,8 +154,8 @@ async fn sync_subscribe_stop() -> Result<()> {
     let node = spawn_node(rt).await?;
     let client = node.client();
 
-    let doc = client.create_doc().await?;
-    let author = client.create_author().await?;
+    let doc = client.docs.create().await?;
+    let author = client.docs.create_author().await?;
     doc.start_sync(vec![]).await?;
 
     let status = doc.status().await?;
@@ -189,7 +189,7 @@ async fn get_latest(doc: &Doc, key: &[u8]) -> anyhow::Result<Vec<u8>> {
         .next()
         .await
         .ok_or_else(|| anyhow!("entry not found"))??;
-    let content = doc.get_content_bytes(entry.content_hash()).await?;
+    let content = doc.read_to_end(&entry).await?;
     Ok(content.to_vec())
 }
 

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -189,7 +189,7 @@ async fn get_latest(doc: &Doc, key: &[u8]) -> anyhow::Result<Vec<u8>> {
         .next()
         .await
         .ok_or_else(|| anyhow!("entry not found"))??;
-    let content = doc.read_to_end(&entry).await?;
+    let content = doc.read_to_bytes(&entry).await?;
     Ok(content.to_vec())
 }
 

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -71,7 +71,7 @@ async fn sync_full_basic() -> Result<()> {
     // node1: create doc and ticket
     let (ticket, doc1) = {
         let iroh = &clients[0];
-        let author = iroh.docs.create_author().await?;
+        let author = iroh.authors.create().await?;
         let doc = iroh.docs.create().await?;
         let key = b"k1";
         let value = b"v1";
@@ -84,7 +84,7 @@ async fn sync_full_basic() -> Result<()> {
     // node2: join in
     let _doc2 = {
         let iroh = &clients[1];
-        let author = iroh.docs.create_author().await?;
+        let author = iroh.authors.create().await?;
         let doc = iroh.docs.import(ticket.clone()).await?;
 
         // wait for remote insert on doc2
@@ -155,7 +155,7 @@ async fn sync_subscribe_stop() -> Result<()> {
     let client = node.client();
 
     let doc = client.docs.create().await?;
-    let author = client.docs.create_author().await?;
+    let author = client.authors.create().await?;
     doc.start_sync(vec![]).await?;
 
     let status = doc.status().await?;


### PR DESCRIPTION
## Description

* Extend Iroh client surface
* Split Iroh client struct into node, blobs, docs
* Use Iroh client in CLI (no more raw RPC calls)
* Improve naming consistency throughout the RPC interface
* Use `iroh_net::NodeAddr` in ticket and get commands
* Improve arguments of `BlobGetRequest`


<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
