### PR TITLE
feat: Improve content propagation in sync

### DIFF
--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 blake3 = { package = "iroh-blake3", version = "1.4.3"}
 bytes = { version = "1.4.0", features = ["serde"] }
 data-encoding = "2.4.0"
-derive_more = { version = "1.0.0-beta.1", features = ["add", "debug", "display", "from", "try_into"] }
+derive_more = { version = "1.0.0-beta.1", features = ["add", "debug", "display", "from", "try_into", "into"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 indexmap = "2.0"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -203,8 +203,8 @@ async fn subscribe_loop(gossip: Gossip, topic: TopicId) -> anyhow::Result<()> {
     let mut stream = gossip.subscribe(topic).await?;
     loop {
         let event = stream.recv().await?;
-        if let Event::Received(data, _prev_peer) = event {
-            let (from, message) = SignedMessage::verify_and_decode(&data)?;
+        if let Event::Received(msg) = event {
+            let (from, message) = SignedMessage::verify_and_decode(&msg.content)?;
             match message {
                 Message::AboutMe { name } => {
                     names.insert(from, name.clone());

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -1,8 +1,7 @@
 //! Networking for the `iroh-gossip` protocol
 
 use std::{
-    collections::HashMap, fmt, future::Future, net::SocketAddr, sync::Arc, task::Poll,
-    time::Instant,
+    collections::HashMap, future::Future, net::SocketAddr, sync::Arc, task::Poll, time::Instant,
 };
 
 use anyhow::{anyhow, Context};
@@ -55,16 +54,16 @@ type ProtoMessage = proto::Message<PublicKey>;
 /// Each topic is a separate broadcast tree with separate memberships.
 ///
 /// A topic has to be joined before you can publish or subscribe on the topic.
-/// To join the swarm for a topic, you have to know the [PublicKey] of at least one peer that also joined the topic.
+/// To join the swarm for a topic, you have to know the [`PublicKey`] of at least one peer that also joined the topic.
 ///
 /// Messages published on the swarm will be delivered to all peers that joined the swarm for that
 /// topic. You will also be relaying (gossiping) messages published by other peers.
 ///
 /// With the default settings, the protocol will maintain up to 5 peer connections per topic.
 ///
-/// Even though the [`Gossip`] is created from a [MagicEndpoint], it does not accept connections
+/// Even though the [`Gossip`] is created from a [`MagicEndpoint`], it does not accept connections
 /// itself. You should run an accept loop on the MagicEndpoint yourself, check the ALPN protocol of incoming
-/// connections, and if the ALPN protocol equals [GOSSIP_ALPN], forward the connection to the
+/// connections, and if the ALPN protocol equals [`GOSSIP_ALPN`], forward the connection to the
 /// gossip actor through [Self::handle_connection].
 ///
 /// The gossip actor will, however, initiate new connections to other peers by itself.
@@ -156,7 +155,7 @@ impl Gossip {
 
     /// Broadcast a message on a topic to all peers in the swarm.
     ///
-    /// This does not join the topic automatically, so you have to call [Self::join] yourself
+    /// This does not join the topic automatically, so you have to call [`Self::join`] yourself
     /// for messages to be broadcast to peers.
     pub async fn broadcast(&self, topic: TopicId, message: Bytes) -> anyhow::Result<()> {
         let (tx, rx) = oneshot::channel();
@@ -166,9 +165,9 @@ impl Gossip {
         Ok(())
     }
 
-    /// Broadcast a message on a topic to the immediate neigborrs.
+    /// Broadcast a message on a topic to the immediate neighbors.
     ///
-    /// This does not join the topic automatically, so you have to call [Self::join] yourself
+    /// This does not join the topic automatically, so you have to call [`Self::join`] yourself
     /// for messages to be broadcast to peers.
     pub async fn broadcast_neighbors(&self, topic: TopicId, message: Bytes) -> anyhow::Result<()> {
         let (tx, rx) = oneshot::channel();
@@ -180,7 +179,7 @@ impl Gossip {
 
     /// Subscribe to messages and event notifications for a topic.
     ///
-    /// Does not join the topic automatically, so you have to call [Self::join] yourself
+    /// Does not join the topic automatically, so you have to call [`Self::join`] yourself
     /// to actually receive messages.
     pub async fn subscribe(&self, topic: TopicId) -> anyhow::Result<broadcast::Receiver<Event>> {
         let (tx, rx) = oneshot::channel();
@@ -191,7 +190,7 @@ impl Gossip {
 
     /// Subscribe to all events published on topics that you joined.
     ///
-    /// Note that this method takes self by value. Usually you would clone the [Gossip] handle.
+    /// Note that this method takes self by value. Usually you would clone the [`Gossip`] handle.
     /// before.
     pub fn subscribe_all(self) -> impl Stream<Item = anyhow::Result<(TopicId, Event)>> {
         Gen::new(|co| async move {
@@ -214,7 +213,7 @@ impl Gossip {
         }
     }
 
-    /// Pass an incoming [quinn::Connection] to the gossip actor.
+    /// Handle an incoming [`quinn::Connection`].
     ///
     /// Make sure to check the ALPN protocol yourself before passing the connection.
     pub async fn handle_connection(&self, conn: quinn::Connection) -> anyhow::Result<()> {
@@ -300,46 +299,37 @@ enum ConnOrigin {
 }
 
 /// Input messages for the gossip [`Actor`].
+#[derive(derive_more::Debug)]
 enum ToActor {
     /// Handle a new QUIC connection, either from accept (external to the actor) or from connect
     /// (happens internally in the actor).
-    ConnIncoming(PublicKey, ConnOrigin, quinn::Connection),
+    ConnIncoming(PublicKey, ConnOrigin, #[debug(skip)] quinn::Connection),
     /// Join a topic with a list of peers. Reply with oneshot once at least one peer joined.
-    Join(TopicId, Vec<PublicKey>, oneshot::Sender<anyhow::Result<()>>),
+    Join(
+        TopicId,
+        Vec<PublicKey>,
+        #[debug(skip)] oneshot::Sender<anyhow::Result<()>>,
+    ),
     /// Leave a topic, send disconnect messages and drop all state.
     Quit(TopicId),
     /// Broadcast a message on a topic.
-    Broadcast(TopicId, Bytes, Scope, oneshot::Sender<anyhow::Result<()>>),
+    Broadcast(
+        TopicId,
+        #[debug("<{}b>", _1.len())] Bytes,
+        Scope,
+        #[debug(skip)] oneshot::Sender<anyhow::Result<()>>,
+    ),
     /// Subscribe to a topic. Return oneshot which resolves to a broadcast receiver for events on a
     /// topic.
     Subscribe(
         TopicId,
-        oneshot::Sender<anyhow::Result<broadcast::Receiver<Event>>>,
+        #[debug(skip)] oneshot::Sender<anyhow::Result<broadcast::Receiver<Event>>>,
     ),
     /// Subscribe to a topic. Return oneshot which resolves to a broadcast receiver for events on a
     /// topic.
-    SubscribeAll(oneshot::Sender<anyhow::Result<broadcast::Receiver<(TopicId, Event)>>>),
-}
-
-impl fmt::Debug for ToActor {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ToActor::ConnIncoming(peer_id, origin, _conn) => {
-                write!(f, "ConnIncoming({peer_id:?}, {origin:?})")
-            }
-            ToActor::Join(topic, peers, _reply) => write!(f, "Join({topic:?}, {peers:?})"),
-            ToActor::Quit(topic) => write!(f, "Quit({topic:?})"),
-            ToActor::Broadcast(topic, message, scope, _reply) => {
-                write!(
-                    f,
-                    "Broadcast({topic:?}, {scope:?}, bytes<{}>)",
-                    message.len()
-                )
-            }
-            ToActor::Subscribe(topic, _reply) => write!(f, "Subscribe({topic:?})"),
-            ToActor::SubscribeAll(_reply) => write!(f, "SubscribeAll"),
-        }
-    }
+    SubscribeAll(
+        #[debug(skip)] oneshot::Sender<anyhow::Result<broadcast::Receiver<(TopicId, Event)>>>,
+    ),
 }
 
 /// Actor that sends and handles messages between the connection and main state loops
@@ -388,7 +378,7 @@ impl Actor {
                 },
                 _ = self.on_endpoints_rx.changed() => {
                     let info = IrohInfo::from_endpoint(&self.endpoint).await?;
-                    let peer_data = postcard::to_stdvec(&info)?;
+                    let peer_data = Bytes::from(postcard::to_stdvec(&info)?);
                     self.handle_in_event(InEvent::UpdatePeerData(peer_data.into()), Instant::now()).await?;
                 }
                 (peer_id, res) = self.dialer.next_conn() => {

--- a/iroh-gossip/src/proto.rs
+++ b/iroh-gossip/src/proto.rs
@@ -58,6 +58,7 @@ pub mod util;
 #[cfg(test)]
 mod tests;
 
+pub use plumtree::Scope;
 pub use state::{InEvent, Message, OutEvent, State, Timer, TopicId};
 pub use topic::{Command, Config, Event, IO};
 
@@ -106,7 +107,7 @@ mod test {
             assert_synchronous_active, report_round_distribution, sort, Network, Simulator,
             SimulatorConfig,
         },
-        TopicId,
+        Scope, TopicId,
     };
 
     #[test]
@@ -215,10 +216,14 @@ mod test {
         assert!(assert_synchronous_active(&network));
 
         // now broadcast a first message
-        network.command(1, t, Command::Broadcast(b"hi1".to_vec().into()));
+        network.command(
+            1,
+            t,
+            Command::Broadcast(b"hi1".to_vec().into(), Scope::Swarm),
+        );
         network.ticks(broadcast_ticks);
         let events = network.events();
-        let received = events.filter(|x| matches!(x, (_, _, Event::Received(_, _))));
+        let received = events.filter(|x| matches!(x, (_, _, Event::Received(_))));
         // message should be received by two other nodes
         assert_eq!(received.count(), 2);
         assert!(assert_synchronous_active(&network));
@@ -230,10 +235,14 @@ mod test {
         report_round_distribution(&network);
 
         // now broadcast again
-        network.command(1, t, Command::Broadcast(b"hi2".to_vec().into()));
+        network.command(
+            1,
+            t,
+            Command::Broadcast(b"hi2".to_vec().into(), Scope::Swarm),
+        );
         network.ticks(broadcast_ticks);
         let events = network.events();
-        let received = events.filter(|x| matches!(x, (_, _, Event::Received(_, _))));
+        let received = events.filter(|x| matches!(x, (_, _, Event::Received(_))));
         // message should be received by all 5 other nodes
         assert_eq!(received.count(), 5);
         assert!(assert_synchronous_active(&network));

--- a/iroh-gossip/src/proto.rs
+++ b/iroh-gossip/src/proto.rs
@@ -80,7 +80,20 @@ impl<T> PeerIdentity for T where T: Hash + Eq + Copy + fmt::Debug + Serialize + 
 ///
 /// Implementations may use these bytes to supply addresses or other information needed to connect
 /// to a peer that is not included in the peer's [`PeerIdentity`].
-pub type PeerData = bytes::Bytes;
+#[derive(
+    derive_more::Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    PartialEq,
+    Eq,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::Deref,
+    Default,
+)]
+#[debug("PeerData({}b)", self.0.len())]
+pub struct PeerData(bytes::Bytes);
 
 /// PeerInfo contains a peer's identifier and the opaque peer data as provided by the implementer.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/iroh-gossip/src/proto/plumtree.rs
+++ b/iroh-gossip/src/proto/plumtree.rs
@@ -94,6 +94,8 @@ pub struct GossipEvent<PI> {
     pub delivered_from: PI,
     /// The broadcast scope of the message
     pub scope: Scope,
+    /// The distance in hops that the message travelled from the original author.
+    pub distance: u16,
 }
 
 impl<PI> GossipEvent<PI> {
@@ -102,6 +104,7 @@ impl<PI> GossipEvent<PI> {
             content: message.content.clone(),
             scope: message.scope,
             delivered_from: from,
+            distance: message.round.0,
         }
     }
 }
@@ -725,6 +728,7 @@ mod test {
                 content,
                 delivered_from: 3,
                 scope: Scope::Swarm,
+                distance: 6,
             })));
             io
         };
@@ -773,6 +777,7 @@ mod test {
                 content,
                 delivered_from: 3,
                 scope: Scope::Swarm,
+                distance: 9,
             })));
             io
         };
@@ -809,6 +814,7 @@ mod test {
                 content,
                 delivered_from: 2,
                 scope: Scope::Swarm,
+                distance: 1,
             })));
             io
         };

--- a/iroh-gossip/src/proto/plumtree.rs
+++ b/iroh-gossip/src/proto/plumtree.rs
@@ -423,7 +423,6 @@ impl<PI: PeerIdentity> State<PI> {
             scope,
         };
         let me = self.me;
-        // TODO: Do we want to lazy push neighbor messages as well?
         if let Scope::Swarm = scope {
             self.received_messages
                 .insert(id, (), now + self.config.message_id_retention);

--- a/iroh-gossip/src/proto/plumtree.rs
+++ b/iroh-gossip/src/proto/plumtree.rs
@@ -41,7 +41,7 @@ impl MessageId {
 pub enum InEvent<PI> {
     /// A [`Message`] was received from the peer.
     RecvMessage(PI, Message),
-    /// Broadcast the contained payload to the full swarm.
+    /// Broadcast the contained payload to the given scope.
     Broadcast(Bytes, Scope),
     /// A timer has expired.
     TimerExpired(Timer),
@@ -92,7 +92,7 @@ pub struct GossipEvent<PI> {
     /// The peer that we received the gossip message from. Note that this is not the peer that
     /// originally broadcasted the message, but the peer before us in the gossiping path.
     pub delivered_from: PI,
-    /// The broadcast scope of the message
+    /// The broadcast scope of the message.
     pub scope: Scope,
     /// The distance in hops that the message travelled from the original author.
     pub distance: u16,
@@ -147,12 +147,12 @@ pub struct Gossip {
     /// Message contents.
     #[debug("<{}b>", content.len())]
     content: Bytes,
-    /// Scope to publish to
+    /// Scope to broadcast to.
     scope: Scope,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Copy)]
 /// The broadcast scope of a gossip message.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Copy)]
 pub enum Scope {
     /// The message is broadcast to all peers in the swarm.
     Swarm,

--- a/iroh-gossip/src/proto/plumtree.rs
+++ b/iroh-gossip/src/proto/plumtree.rs
@@ -169,10 +169,7 @@ pub enum DeliveryScope {
 impl DeliveryScope {
     /// Whether this message was directly received from its publisher.
     pub fn is_direct(&self) -> bool {
-        match self {
-            Self::Neighbors | Self::Swarm(Round(0)) => true,
-            _ => false,
-        }
+        matches!(self, Self::Neighbors | Self::Swarm(Round(0)))
     }
 }
 

--- a/iroh-gossip/src/proto/tests.rs
+++ b/iroh-gossip/src/proto/tests.rs
@@ -336,7 +336,7 @@ impl Simulator {
             let events = self.network.events();
             let received: HashSet<_> = events
                 .filter(
-                    |(_peer, _topic, event)| matches!(event,  Event::Received(recv) if recv.content == &message),
+                    |(_peer, _topic, event)| matches!(event,  Event::Received(recv) if recv.content == message),
                 )
                 .map(|(peer, _topic, _msg)| peer)
                 .collect();

--- a/iroh-gossip/src/proto/tests.rs
+++ b/iroh-gossip/src/proto/tests.rs
@@ -10,6 +10,8 @@ use rand::Rng;
 use rand_core::SeedableRng;
 use tracing::{debug, warn};
 
+use crate::proto::Scope;
+
 use super::{
     util::TimerMap, Command, Config, Event, InEvent, OutEvent, PeerIdentity, State, Timer, TopicId,
 };
@@ -315,8 +317,11 @@ impl Simulator {
                 .filter(|p| *p != from),
         );
         let expected_len = expected.len() as u64;
-        self.network
-            .command(from, TOPIC, Command::Broadcast(message.clone()));
+        self.network.command(
+            from,
+            TOPIC,
+            Command::Broadcast(message.clone(), Scope::Swarm),
+        );
 
         let mut tick = 0;
         loop {
@@ -331,7 +336,7 @@ impl Simulator {
             let events = self.network.events();
             let received: HashSet<_> = events
                 .filter(
-                    |(_peer, _topic, event)| matches!(event,  Event::Received(recv, _) if recv == &message),
+                    |(_peer, _topic, event)| matches!(event,  Event::Received(recv) if recv.content == &message),
                 )
                 .map(|(peer, _topic, _msg)| peer)
                 .collect();

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -268,9 +268,12 @@ where
     /// Processes an incoming message and produces a response.
     /// If terminated, returns `None`
     ///
-    /// `validate_cb` is called before an entry received from the remote is inserted into the store.
+    /// `validate_cb` is called for each incoming entry received from the remote.
     /// It must return true if the entry is valid and should be stored, and false otherwise
     /// (which means the entry will be dropped and not stored).
+    ///
+    /// `content_status_cb` is called for each outgoing entry about to be sent to the remote.
+    /// It must return a [`ContentStatus`], which will be sent to the remote with the entry.
     pub fn process_message<F, F2>(
         &mut self,
         message: Message<E>,

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -8,6 +8,8 @@ use std::marker::PhantomData;
 
 use serde::{Deserialize, Serialize};
 
+use crate::ContentStatus;
+
 /// Store entries that can be fingerprinted and put into ranges.
 pub trait RangeEntry: Debug + Clone + PartialOrd {
     /// The key for this entry, to be used in ranges.
@@ -126,7 +128,7 @@ pub struct RangeItem<E: RangeEntry> {
     ))]
     pub range: Range<E::Key>,
     #[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
-    pub values: Vec<E>,
+    pub values: Vec<(E, ContentStatus)>,
     /// If false, requests to send local items in the range.
     /// Otherwise not.
     pub have_local: bool,
@@ -155,7 +157,7 @@ impl<E: RangeEntry> MessagePart<E> {
         matches!(self, MessagePart::RangeItem(_))
     }
 
-    pub fn values(&self) -> Option<&[E]> {
+    pub fn values(&self) -> Option<&[(E, ContentStatus)]> {
         match self {
             MessagePart::RangeFingerprint(_) => None,
             MessagePart::RangeItem(RangeItem { values, .. }) => Some(values),
@@ -269,13 +271,15 @@ where
     /// `validate_cb` is called before an entry received from the remote is inserted into the store.
     /// It must return true if the entry is valid and should be stored, and false otherwise
     /// (which means the entry will be dropped and not stored).
-    pub fn process_message<F>(
+    pub fn process_message<F, F2>(
         &mut self,
         message: Message<E>,
         validate_cb: F,
+        content_status_cb: F2,
     ) -> Result<Option<Message<E>>, S::Error>
     where
-        F: Fn(&S, &E) -> bool,
+        F: Fn(&S, &E, ContentStatus) -> bool,
+        F2: Fn(&S, &E) -> ContentStatus,
     {
         let mut out = Vec::new();
 
@@ -308,7 +312,10 @@ where
                         .get_range(range.clone())?
                         .filter_map(|existing| match existing {
                             Ok(existing) => {
-                                if !values.iter().any(|entry| existing.key() == entry.key()) {
+                                if !values
+                                    .iter()
+                                    .any(|(entry, _)| existing.key() == entry.key())
+                                {
                                     Some(Ok(existing))
                                 } else {
                                     None
@@ -316,13 +323,19 @@ where
                             }
                             Err(err) => Some(Err(err)),
                         })
+                        .map(|entry| {
+                            entry.map(|entry| {
+                                let content_status = content_status_cb(&self.store, &entry);
+                                (entry, content_status)
+                            })
+                        })
                         .collect::<Result<_, _>>()?,
                 )
             };
 
             // Store incoming values
-            for entry in values {
-                if validate_cb(&self.store, &entry) {
+            for (entry, content_status) in values {
+                if validate_cb(&self.store, &entry, content_status) {
                     self.store.put(entry)?;
                 }
             }
@@ -355,9 +368,16 @@ where
                 .get_range(range.clone())?
                 .collect::<Result<_, _>>()?;
             if local_values.len() <= 1 || fingerprint == Fingerprint::empty() {
+                let values = local_values
+                    .into_iter()
+                    .map(|entry| {
+                        let content_status = content_status_cb(&self.store, &entry);
+                        (entry, content_status)
+                    })
+                    .collect::<Vec<_>>();
                 out.push(MessagePart::RangeItem(RangeItem {
                     range,
-                    values: local_values,
+                    values,
                     have_local: false,
                 }));
             } else {
@@ -443,7 +463,15 @@ where
                             fingerprint,
                         }));
                     } else {
-                        let values = chunk.into_iter().collect::<Result<_, _>>()?;
+                        let values = chunk
+                            .into_iter()
+                            .map(|entry| {
+                                entry.map(|entry| {
+                                    let content_status = content_status_cb(&self.store, &entry);
+                                    (entry, content_status)
+                                })
+                            })
+                            .collect::<Result<_, _>>()?;
                         out.push(MessagePart::RangeItem(RangeItem {
                             range,
                             values,
@@ -843,14 +871,14 @@ mod tests {
 
         let validate_alice: ValidateCb<&str, i32> = Box::new({
             let alice_validate_set = alice_validate_set.clone();
-            move |_, e| {
+            move |_, e, _| {
                 alice_validate_set.borrow_mut().push(*e);
                 false
             }
         });
         let validate_bob: ValidateCb<&str, i32> = Box::new({
             let bob_validate_set = bob_validate_set.clone();
-            move |_, e| {
+            move |_, e, _| {
                 bob_validate_set.borrow_mut().push(*e);
                 false
             }
@@ -974,15 +1002,15 @@ mod tests {
         }
     }
 
-    type ValidateCb<K, V> = Box<dyn Fn(&SimpleStore<K, V>, &(K, V)) -> bool>;
+    type ValidateCb<K, V> = Box<dyn Fn(&SimpleStore<K, V>, &(K, V), ContentStatus) -> bool>;
 
     fn sync<K, V>(alice_set: &[(K, V)], bob_set: &[(K, V)]) -> SyncResult<K, V>
     where
         K: RangeKey + PartialEq + Clone + Default + Debug,
         V: Debug + Clone + PartialOrd,
     {
-        let alice_validate_cb: ValidateCb<K, V> = Box::new(|_, _| true);
-        let bob_validate_cb: ValidateCb<K, V> = Box::new(|_, _| true);
+        let alice_validate_cb: ValidateCb<K, V> = Box::new(|_, _, _| true);
+        let bob_validate_cb: ValidateCb<K, V> = Box::new(|_, _, _| true);
         sync_with_validate_cb_and_assert(alice_set, bob_set, &alice_validate_cb, &bob_validate_cb)
     }
 
@@ -995,8 +1023,8 @@ mod tests {
     where
         K: RangeKey + PartialEq + Clone + Default + Debug,
         V: Debug + Clone + PartialOrd,
-        F1: Fn(&SimpleStore<K, V>, &(K, V)) -> bool,
-        F2: Fn(&SimpleStore<K, V>, &(K, V)) -> bool,
+        F1: Fn(&SimpleStore<K, V>, &(K, V), ContentStatus) -> bool,
+        F2: Fn(&SimpleStore<K, V>, &(K, V), ContentStatus) -> bool,
     {
         let mut expected_set_alice = BTreeMap::new();
         let mut expected_set_bob = BTreeMap::new();
@@ -1038,7 +1066,7 @@ mod tests {
         for msg in &res.alice_to_bob {
             for part in &msg.parts {
                 if let Some(values) = part.values() {
-                    for e in values {
+                    for (e, _) in values {
                         assert!(
                             alice_sent.insert(e.key(), e).is_none(),
                             "alice: duplicate {:?}",
@@ -1053,7 +1081,7 @@ mod tests {
         for msg in &res.bob_to_alice {
             for part in &msg.parts {
                 if let Some(values) = part.values() {
-                    for e in values {
+                    for (e, _) in values {
                         assert!(
                             bob_sent.insert(e.key(), e).is_none(),
                             "bob: duplicate {:?}",
@@ -1077,8 +1105,8 @@ mod tests {
     where
         K: RangeKey + PartialEq + Clone + Default + Debug,
         V: Debug + Clone + PartialOrd,
-        F1: Fn(&SimpleStore<K, V>, &(K, V)) -> bool,
-        F2: Fn(&SimpleStore<K, V>, &(K, V)) -> bool,
+        F1: Fn(&SimpleStore<K, V>, &(K, V), ContentStatus) -> bool,
+        F2: Fn(&SimpleStore<K, V>, &(K, V), ContentStatus) -> bool,
     {
         let mut alice_to_bob = Vec::new();
         let mut bob_to_alice = Vec::new();
@@ -1091,9 +1119,14 @@ mod tests {
             rounds += 1;
             alice_to_bob.push(msg.clone());
 
-            if let Some(msg) = bob.process_message(msg, &bob_validate_cb).unwrap() {
+            if let Some(msg) = bob
+                .process_message(msg, &bob_validate_cb, |_, _| ContentStatus::Complete)
+                .unwrap()
+            {
                 bob_to_alice.push(msg.clone());
-                next_to_bob = alice.process_message(msg, &alice_validate_cb).unwrap();
+                next_to_bob = alice
+                    .process_message(msg, &alice_validate_cb, |_, _| ContentStatus::Complete)
+                    .unwrap();
             }
         }
         SyncResult {

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -923,13 +923,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
                 // optimistically check if the peer could do the request right away
                 match self.get_peer_connection_for_download(&peer_id) {
                     Some(conn) => {
-                        return self.start_download(
-                            kind,
-                            peer_id,
-                            conn,
-                            remaining_retries,
-                            intents,
-                        )
+                        return self.start_download(kind, peer_id, conn, remaining_retries, intents)
                     }
                     None => Some(peer_id),
                 }
@@ -1008,7 +1002,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             intents,
             remaining_retries,
             delay_key,
-            next_peer
+            next_peer,
         };
         debug!(?kind, ?info, "request scheduled");
         self.scheduled_requests.insert(kind, info);

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -940,17 +940,20 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         remaining_retries: u8,
         next_peer: Option<PeerInfo>,
         intents: HashMap<Id, oneshot::Sender<DownloadResult>>,
-        is_retry: bool
+        is_retry: bool,
     ) {
         // this is simply INITIAL_REQUEST_DELAY * attempt_num where attempt_num (as an ordinal
         // number) is maxed at INITIAL_RETRY_COUNT
         let delay = match (is_retry, next_peer) {
             // The next peer has the Provider role, which means we assume it can provide the hash.
             // Thus, start the download immediately.
-            (false, Some(PeerInfo {
-                role: PeerRole::Provider,
-                ..
-            })) => std::time::Duration::ZERO,
+            (
+                false,
+                Some(PeerInfo {
+                    role: PeerRole::Provider,
+                    ..
+                }),
+            ) => std::time::Duration::ZERO,
             // We either have no next peer yet or the next peer only has the Candidate role, thus
             // delay the request.
             _ => {

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -656,13 +656,13 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             .get_candidates(hash)
             .filter_map(|(peer_id, role)| {
                 let peer = PeerInfo::new(*peer_id, *role);
-                if let Some(info) = self.peers.get(&peer_id) {
+                if let Some(info) = self.peers.get(peer_id) {
                     info.conn.as_ref()?;
                     let req_count = info.active_requests();
                     // filter out peers at capacity
                     let has_capacity = !self.concurrency_limits.peer_at_request_capacity(req_count);
                     has_capacity.then_some((peer, ConnState::Connected(req_count)))
-                } else if self.dialer.is_pending(&peer_id) {
+                } else if self.dialer.is_pending(peer_id) {
                     Some((peer, ConnState::Dialing))
                 } else {
                     Some((peer, ConnState::NotConnected))

--- a/iroh/src/downloader/test.rs
+++ b/iroh/src/downloader/test.rs
@@ -46,7 +46,9 @@ async fn smoke_test() {
     let kind = DownloadKind::Blob {
         hash: Hash::new([0u8; 32]),
     };
-    let handle = downloader.queue(kind.clone(), vec![peer]).await;
+    let handle = downloader
+        .queue(kind.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .await;
     // wait for the download result to be reported
     handle.await.expect("should report success");
     // verify that the peer was dialed
@@ -73,7 +75,9 @@ async fn deduplication() {
     };
     let mut handles = Vec::with_capacity(10);
     for _ in 0..10 {
-        let h = downloader.queue(kind.clone(), vec![peer]).await;
+        let h = downloader
+            .queue(kind.clone(), vec![(peer, PeerRole::Candidate).into()])
+            .await;
         handles.push(h);
     }
     assert!(
@@ -103,16 +107,24 @@ async fn cancellation() {
     let kind_1 = DownloadKind::Blob {
         hash: Hash::new([0u8; 32]),
     };
-    let handle_a = downloader.queue(kind_1.clone(), vec![peer]).await;
-    let handle_b = downloader.queue(kind_1.clone(), vec![peer]).await;
+    let handle_a = downloader
+        .queue(kind_1.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .await;
+    let handle_b = downloader
+        .queue(kind_1.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .await;
     downloader.cancel(handle_a).await;
 
     // create a request with two intents and cancel them both
     let kind_2 = DownloadKind::Blob {
         hash: Hash::new([1u8; 32]),
     };
-    let handle_c = downloader.queue(kind_2.clone(), vec![peer]).await;
-    let handle_d = downloader.queue(kind_2.clone(), vec![peer]).await;
+    let handle_c = downloader
+        .queue(kind_2.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .await;
+    let handle_d = downloader
+        .queue(kind_2.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .await;
     downloader.cancel(handle_c).await;
     downloader.cancel(handle_d).await;
 
@@ -148,7 +160,9 @@ async fn max_concurrent_requests() {
         let kind = DownloadKind::Blob {
             hash: Hash::new([i; 32]),
         };
-        let h = downloader.queue(kind.clone(), vec![peer]).await;
+        let h = downloader
+            .queue(kind.clone(), vec![(peer, PeerRole::Candidate).into()])
+            .await;
         expected_history.push((kind, peer));
         handles.push(h);
     }
@@ -191,9 +205,49 @@ async fn max_concurrent_requests_per_peer() {
         let kind = DownloadKind::Blob {
             hash: Hash::new([i; 32]),
         };
-        let h = downloader.queue(kind.clone(), vec![peer]).await;
+        let h = downloader
+            .queue(kind.clone(), vec![(peer, PeerRole::Candidate).into()])
+            .await;
         handles.push(h);
     }
 
     futures::future::join_all(handles).await;
+}
+
+/// Tests that providers are preferred over candidates.
+#[tokio::test]
+async fn peer_role_provider() {
+    let dialer = dialer::TestingDialer::default();
+    let getter = getter::TestingGetter::default();
+    let concurrency_limits = ConcurrencyLimits::default();
+
+    let mut downloader =
+        Downloader::spawn_for_test(dialer.clone(), getter.clone(), concurrency_limits);
+
+    let peer_candidate1 = SecretKey::from_bytes(&[0u8; 32]).public();
+    let peer_candidate2 = SecretKey::from_bytes(&[1u8; 32]).public();
+    let peer_provider = SecretKey::from_bytes(&[2u8; 32]).public();
+    let kind = DownloadKind::Blob {
+        hash: Hash::new([0u8; 32]),
+    };
+    let handle = downloader
+        .queue(
+            kind.clone(),
+            vec![
+                (peer_candidate1, PeerRole::Candidate).into(),
+                (peer_provider, PeerRole::Provider).into(),
+                (peer_candidate2, PeerRole::Candidate).into(),
+            ],
+        )
+        .await;
+    let now = std::time::Instant::now();
+    assert!(handle.await.is_ok(), "download succeeded");
+    // this is, I think, currently the best way to test that no delay was performed. It should be
+    // safe enough to assume that test runtime is not longer than the delay of 500ms.
+    assert!(
+        now.elapsed() < INITIAL_REQUEST_DELAY,
+        "now initial delay was added to fetching from a provider"
+    );
+    getter.assert_history(&[(kind, peer_provider)]);
+    dialer.assert_history(&[peer_provider]);
 }

--- a/iroh/src/downloader/test.rs
+++ b/iroh/src/downloader/test.rs
@@ -218,6 +218,7 @@ async fn max_concurrent_requests_per_peer() {
 #[tokio::test]
 async fn peer_role_provider() {
     let dialer = dialer::TestingDialer::default();
+    dialer.set_dial_duration(Duration::from_millis(100));
     let getter = getter::TestingGetter::default();
     let concurrency_limits = ConcurrencyLimits::default();
 
@@ -246,7 +247,7 @@ async fn peer_role_provider() {
     // safe enough to assume that test runtime is not longer than the delay of 500ms.
     assert!(
         now.elapsed() < INITIAL_REQUEST_DELAY,
-        "now initial delay was added to fetching from a provider"
+        "no initial delay was added to fetching from a provider"
     );
     getter.assert_history(&[(kind, peer_provider)]);
     dialer.assert_history(&[peer_provider]);

--- a/iroh/src/downloader/test/dialer.rs
+++ b/iroh/src/downloader/test/dialer.rs
@@ -1,6 +1,7 @@
 //! Implementation of [`super::Dialer`] used for testing.
 
 use std::{
+    collections::HashSet,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,

--- a/iroh/src/downloader/test/dialer.rs
+++ b/iroh/src/downloader/test/dialer.rs
@@ -86,4 +86,9 @@ impl TestingDialer {
     pub(super) fn assert_history(&self, history: &[PublicKey]) {
         assert_eq!(self.0.read().dial_history, history)
     }
+
+    pub(super) fn set_dial_duration(&self, duration: Duration) {
+        let mut inner = self.0.write();
+        inner.dial_duration = duration;
+    }
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -44,12 +44,11 @@ use iroh_net::{
     tls, MagicEndpoint, NodeAddr,
 };
 use iroh_sync::store::Store as DocStore;
-use once_cell::sync::OnceCell;
 use quic_rpc::server::RpcChannel;
 use quic_rpc::transport::flume::FlumeConnection;
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use quic_rpc::{RpcClient, RpcServer, ServiceEndpoint};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{mpsc, oneshot, RwLock};
 use tokio::task::JoinError;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
@@ -333,10 +332,6 @@ where
             .max_concurrent_bidi_streams(MAX_STREAMS.try_into()?)
             .max_concurrent_uni_streams(0u32.into());
 
-        // init a cell that will hold our gossip handle to be used in endpoint callbacks
-        let gossip_cell: OnceCell<Gossip> = OnceCell::new();
-        let gossip_cell2 = gossip_cell.clone();
-
         let endpoint = MagicEndpoint::builder()
             .secret_key(self.secret_key.clone())
             .alpns(PROTOCOLS.iter().map(|p| p.to_vec()).collect())
@@ -344,15 +339,8 @@ where
             .transport_config(transport_config)
             .concurrent_connections(MAX_CONNECTIONS)
             .on_endpoints(Box::new(move |eps| {
-                if eps.is_empty() {
-                    return;
-                }
-                // send our updated endpoints to the gossip protocol to be sent as PeerData to peers
-                if let Some(gossip) = gossip_cell2.get() {
-                    gossip.update_endpoints(eps).ok();
-                }
-                if !endpoints_update_s.is_disconnected() {
-                    endpoints_update_s.send(()).ok();
+                if !eps.is_empty() {
+                    endpoints_update_s.send(eps.to_vec()).ok();
                 }
             }));
         let endpoint = match self.derp_map {
@@ -369,8 +357,6 @@ where
 
         // initialize the gossip protocol
         let gossip = Gossip::from_endpoint(endpoint.clone(), Default::default());
-        // insert into the gossip cell to be used in the endpoint callbacks above
-        gossip_cell.set(gossip.clone()).unwrap();
 
         // spawn the sync engine
         let downloader = Downloader::new(
@@ -401,10 +387,11 @@ where
             cancel_token,
             callbacks: callbacks.clone(),
             cb_sender,
-            rt,
+            rt: rt.clone(),
             sync,
         });
         let task = {
+            let gossip = gossip.clone();
             let handler = RpcHandler {
                 inner: inner.clone(),
                 collection_parser: self.collection_parser.clone(),
@@ -431,13 +418,25 @@ where
             task: task.map_err(Arc::new).boxed().shared(),
         };
 
+        // spawn a task that updates the gossip endpoints.
+        let (first_endpoint_update_tx, first_endpoint_update_rx) = oneshot::channel();
+        let mut first_endpoint_update_tx = Some(first_endpoint_update_tx);
+        rt.main().spawn(async move {
+            while let Ok(eps) = endpoints_update_r.recv_async().await {
+                if let Err(err) = gossip.update_endpoints(&eps) {
+                    warn!("Failed to update gossip endpoints: {err:?}");
+                }
+                if let Some(tx) = first_endpoint_update_tx.take() {
+                    tx.send(()).ok();
+                }
+            }
+        });
+
         // Wait for a single endpoint update, to make sure
         // we found some endpoints
-        tokio::time::timeout(ENDPOINT_WAIT, async move {
-            endpoints_update_r.recv_async().await
-        })
-        .await
-        .context("waiting for endpoint")??;
+        tokio::time::timeout(ENDPOINT_WAIT, first_endpoint_update_rx)
+            .await
+            .context("waiting for endpoint")??;
 
         Ok(node)
     }

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -792,9 +792,9 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                         debug!(peer = ?msg.delivered_from, topic = ?topic, "received entry via gossip");
                         // If the distance is 0, we received the message from its original author.
                         // In this case, assume that the peer can provide the content to us.
-                        let content_status = match msg.distance {
-                            0 => ContentStatus::Complete,
-                            _ => ContentStatus::Missing,
+                        let content_status = match msg.scope.is_direct() {
+                            true => ContentStatus::Complete,
+                            false => ContentStatus::Missing,
                         };
                         // At this point, we do not know if the peer has the content.
                         replica.insert_remote_entry(

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -800,7 +800,9 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                     Op::ContentReady(hash) => {
                         // Inform the downloader that we now know that this peer has the content
                         // for this hash.
-                        self.downloader.peers_have(hash, vec![(msg.delivered_from, PeerRole::Provider).into()]).await;
+                        self.downloader
+                            .peers_have(hash, vec![(msg.delivered_from, PeerRole::Provider).into()])
+                            .await;
                     }
                 }
             }

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -7,7 +7,7 @@ use std::{
     time::SystemTime,
 };
 
-use crate::downloader::{DownloadKind, Downloader};
+use crate::downloader::{DownloadKind, Downloader, PeerRole};
 use anyhow::{anyhow, bail, Result};
 use flume::r#async::RecvStream;
 use futures::{
@@ -841,7 +841,10 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                 if matches!(entry_status, EntryStatus::NotFound) {
                     let handle = self
                         .downloader
-                        .queue(DownloadKind::Blob { hash }, vec![from])
+                        .queue(
+                            DownloadKind::Blob { hash },
+                            vec![(from, PeerRole::Candidate).into()],
+                        )
                         .await;
                     let fut = async move {
                         // NOTE: this ignores the result for now, simply keeping the option

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -790,11 +790,17 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                 match op {
                     Op::Put(entry) => {
                         debug!(peer = ?msg.delivered_from, topic = ?topic, "received entry via gossip");
+                        // If the distance is 0, we received the message from its original author.
+                        // In this case, assume that the peer can provide the content to us.
+                        let content_status = match msg.distance {
+                            0 => ContentStatus::Complete,
+                            _ => ContentStatus::Missing,
+                        };
                         // At this point, we do not know if the peer has the content.
                         replica.insert_remote_entry(
                             entry,
                             *msg.delivered_from.as_bytes(),
-                            ContentStatus::Missing,
+                            content_status,
                         )?
                     }
                     Op::ContentReady(hash) => {

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -784,12 +784,12 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
         };
         match event {
             // We received a gossip message. Try to insert it into our replica.
-            Event::Received(data, prev_peer) => {
-                let op: Op = postcard::from_bytes(&data)?;
+            Event::Received(msg) => {
+                let op: Op = postcard::from_bytes(&msg.content)?;
                 match op {
                     Op::Put(entry) => {
-                        debug!(peer = ?prev_peer, topic = ?topic, "received entry via gossip");
-                        replica.insert_remote_entry(entry, *prev_peer.as_bytes())?
+                        debug!(peer = ?msg.delivered_from, topic = ?topic, "received entry via gossip");
+                        replica.insert_remote_entry(entry, *msg.delivered_from.as_bytes())?
                     }
                 }
             }


### PR DESCRIPTION
## Description

This improves content propagation for document sync by implementing the following features. 

* feat: allow to send gossip to neighbors only
* feat: provider and candidate roles for downloader
* feat: transfer content status during set reconciliation
* feat: inform neighbors about finished content downloads

## Notes & open questions

na

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
