### PR TITLE
refactor(iroh-net): remove unused `expired` field from `Endpoint`

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1312,7 +1312,7 @@ impl Actor {
                 );
 
                 match ep.get_send_addrs().await {
-                    Ok((Some(udp_addr), Some(derp_region))) => {
+                    (Some(udp_addr), Some(derp_region)) => {
                         let res = self.send_raw(udp_addr, transmits.clone()).await;
                         self.send_derp(derp_region, public_key, Self::split_packets(transmits));
 
@@ -1320,22 +1320,16 @@ impl Actor {
                             warn!("failed to send UDP: {:?}", err);
                         }
                     }
-                    Ok((None, Some(derp_region))) => {
+                    (None, Some(derp_region)) => {
                         self.send_derp(derp_region, public_key, Self::split_packets(transmits));
                     }
-                    Ok((Some(udp_addr), None)) => {
+                    (Some(udp_addr), None) => {
                         if let Err(err) = self.send_raw(udp_addr, transmits).await {
                             warn!("failed to send UDP: {:?}", err);
                         }
                     }
-                    Ok((None, None)) => {
+                    (None, None) => {
                         warn!("no UDP or DERP addr")
-                    }
-                    Err(err) => {
-                        warn!(
-                            "failed to send messages to {}: {:?}",
-                            current_destination, err
-                        );
                     }
                 }
             }


### PR DESCRIPTION
## Description

This field is unused and models a concept from tailscale that we don't have. This doesn't mean the peer's info is stale, or that it was last seen long ago, it means that the peer's public key expired based on an explicit `KeyExpiry *time.Time`. 

From their docs

>```
>// Expired is whether this node's key has expired. Control may send
>// this; clients are only allowed to set this from false to true. On
>// the client, this is calculated client-side based on a timestamp sent
>// from control, to avoid clock skew issues.
>```

In tailscale the `Expired` is only set by a `ExpiryManager` based on that timestamp, from local computation; and only when the `NetworkMap` has not updated it based on a `MapResponse` requested to the server. We have none of this concepts. 

If we want to define that a peer/endpoint expired, we should do it on our terms later on if the need arises. 

## Notes & open questions

none

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
