### PR TITLE
feat(sync): Add `close_replica` and enable subscriptions without active sync

### DIFF
--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -50,6 +50,12 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     // TODO: Add close_replica
     fn open_replica(&self, namespace: &NamespaceId) -> Result<Option<Replica<Self::Instance>>>;
 
+    /// Close a replica.
+    ///
+    /// This removes the event subscription from the replica, if active, and removes the replica
+    /// instance from the store's cache.
+    fn close_replica(&self, namespace: &NamespaceId);
+
     /// Create a new author key and persist it in the store.
     fn new_author<R: CryptoRngCore + ?Sized>(&self, rng: &mut R) -> Result<Author> {
         let author = Author::new(rng);

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -130,6 +130,12 @@ impl super::Store for Store {
         Ok(Some(replica))
     }
 
+    fn close_replica(&self, namespace_id: &NamespaceId) {
+        if let Some(replica) = self.replicas.write().remove(namespace_id) {
+            replica.unsubscribe();
+        }
+    }
+
     fn list_namespaces(&self) -> Result<Self::NamespaceIter<'_>> {
         // TODO: avoid collect
         let read_tx = self.db.begin_read()?;

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -44,6 +44,12 @@ impl super::Store for Store {
         Ok(replicas.get(namespace).cloned())
     }
 
+    fn close_replica(&self, namespace_id: &NamespaceId) {
+        if let Some(replica) = self.replicas.read().get(namespace_id) {
+            replica.unsubscribe();
+        }
+    }
+
     fn list_namespaces(&self) -> Result<Self::NamespaceIter<'_>> {
         // TODO: avoid collect?
         Ok(self

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -110,6 +110,11 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
         }
     }
 
+    /// Remove the subscription.
+    pub fn unsubscribe(&self) -> bool {
+        self.on_insert_sender.write().take().is_some()
+    }
+
     /// Insert a new record at the given key.
     ///
     /// The entry will by signed by the provided `author`.

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -238,8 +238,8 @@ async fn run(args: Args) -> anyhow::Result<()> {
     let live_sync = SyncEngine::spawn(
         rt.clone(),
         endpoint.clone(),
-        docs.clone(),
         gossip.clone(),
+        docs.clone(),
         db.clone(),
         downloader,
     );

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -238,8 +238,8 @@ async fn run(args: Args) -> anyhow::Result<()> {
     let live_sync = SyncEngine::spawn(
         rt.clone(),
         endpoint.clone(),
-        gossip.clone(),
         docs.clone(),
+        gossip.clone(),
         db.clone(),
         downloader,
     );

--- a/iroh/src/sync_engine.rs
+++ b/iroh/src/sync_engine.rs
@@ -2,8 +2,6 @@
 //!
 //! [`iroh_sync::Replica`] is also called documents here.
 
-use std::{collections::HashSet, sync::Arc};
-
 use anyhow::anyhow;
 use iroh_bytes::{baomap::Store as BaoStore, util::runtime::Handle};
 use iroh_gossip::net::Gossip;
@@ -12,7 +10,6 @@ use iroh_sync::{
     store::Store,
     sync::{Author, AuthorId, NamespaceId, Replica},
 };
-use parking_lot::RwLock;
 
 use crate::downloader::Downloader;
 
@@ -32,7 +29,6 @@ pub struct SyncEngine<S: Store> {
     pub(crate) store: S,
     pub(crate) endpoint: MagicEndpoint,
     pub(crate) live: LiveSync<S>,
-    active: Arc<RwLock<HashSet<NamespaceId>>>,
 }
 
 impl<S: Store> SyncEngine<S> {
@@ -52,13 +48,19 @@ impl<S: Store> SyncEngine<S> {
         bao_store: B,
         downloader: Downloader,
     ) -> Self {
-        let live = LiveSync::spawn(rt.clone(), endpoint.clone(), gossip, bao_store, downloader);
+        let live = LiveSync::spawn(
+            rt.clone(),
+            endpoint.clone(),
+            store.clone(),
+            gossip,
+            bao_store,
+            downloader,
+        );
         Self {
             live,
             store,
             rt,
             endpoint,
-            active: Default::default(),
         }
     }
 
@@ -71,20 +73,12 @@ impl<S: Store> SyncEngine<S> {
         namespace: NamespaceId,
         peers: Vec<PeerSource>,
     ) -> anyhow::Result<()> {
-        if !self.active.read().contains(&namespace) {
-            let replica = self.get_replica(&namespace)?;
-            self.live.start_sync(replica, peers).await?;
-            self.active.write().insert(namespace);
-        } else if !peers.is_empty() {
-            self.live.join_peers(namespace, peers).await?;
-        }
+        self.live.start_sync(namespace, peers).await?;
         Ok(())
     }
 
     /// Stop syncing a document.
     pub async fn stop_sync(&self, namespace: NamespaceId) -> anyhow::Result<()> {
-        let replica = self.get_replica(&namespace)?;
-        self.active.write().remove(&replica.namespace());
         self.live.stop_sync(namespace).await?;
         Ok(())
     }

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -86,6 +86,8 @@ impl<S: Store> SyncEngine<S> {
     }
 
     pub async fn doc_share(&self, req: DocShareRequest) -> RpcResult<DocShareResponse> {
+        self.start_sync(req.doc_id, vec![]).await?;
+        let me = PeerSource::from_endpoint(&self.endpoint).await?;
         let replica = self.get_replica(&req.doc_id)?;
         let key = match req.mode {
             ShareMode::Read => {
@@ -95,8 +97,6 @@ impl<S: Store> SyncEngine<S> {
             }
             ShareMode::Write => replica.secret_key(),
         };
-        let me = PeerSource::from_endpoint(&self.endpoint).await?;
-        self.start_sync(replica.namespace(), vec![]).await?;
         Ok(DocShareResponse(DocTicket {
             key,
             peers: vec![me],
@@ -150,15 +150,13 @@ impl<S: Store> SyncEngine<S> {
         req: DocStartSyncRequest,
     ) -> RpcResult<DocStartSyncResponse> {
         let DocStartSyncRequest { doc_id, peers } = req;
-        let replica = self.get_replica(&doc_id)?;
-        self.start_sync(replica.namespace(), peers).await?;
+        self.start_sync(doc_id, peers).await?;
         Ok(DocStartSyncResponse {})
     }
 
     pub async fn doc_stop_sync(&self, req: DocStopSyncRequest) -> RpcResult<DocStopSyncResponse> {
         let DocStopSyncRequest { doc_id } = req;
-        let replica = self.get_replica(&doc_id)?;
-        self.stop_sync(replica.namespace()).await?;
+        self.stop_sync(doc_id).await?;
         Ok(DocStopSyncResponse {})
     }
 

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "mem-db")]
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use anyhow::{anyhow, Result};
 use futures::{StreamExt, TryStreamExt};
@@ -114,6 +114,23 @@ async fn sync_simple() -> Result<()> {
     for node in nodes {
         node.shutdown();
     }
+    Ok(())
+}
+
+/// Test subscribing to replica events (without sync)
+#[tokio::test]
+async fn sync_subscribe() -> Result<()> {
+    setup_logging();
+    let rt = test_runtime();
+    let node = spawn_node(rt).await?;
+    let client = node.client();
+    let doc = client.create_doc().await?;
+    let mut sub = doc.subscribe().await?;
+    let author = client.create_author().await?;
+    doc.set_bytes(author, b"k".to_vec(), b"v".to_vec()).await?;
+    let event = tokio::time::timeout(Duration::from_millis(100), sub.next()).await?;
+    assert!(matches!(event, Some(Ok(LiveEvent::InsertLocal { .. } ))), "expected InsertLocal but got {event:?}") ;
+    node.shutdown();
     Ok(())
 }
 

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -129,7 +129,10 @@ async fn sync_subscribe() -> Result<()> {
     let author = client.create_author().await?;
     doc.set_bytes(author, b"k".to_vec(), b"v".to_vec()).await?;
     let event = tokio::time::timeout(Duration::from_millis(100), sub.next()).await?;
-    assert!(matches!(event, Some(Ok(LiveEvent::InsertLocal { .. } ))), "expected InsertLocal but got {event:?}") ;
+    assert!(
+        matches!(event, Some(Ok(LiveEvent::InsertLocal { .. }))),
+        "expected InsertLocal but got {event:?}"
+    );
     node.shutdown();
     Ok(())
 }


### PR DESCRIPTION
## Description

Based on #1491 

This adds two related features that were missing so far:

* Add `iroh_sync::store::close_replica` to remove a replica instance from the store-internal cache of open replicas. This is needed because otherwise it grows unbounded (for anchor nodes especially).
* Properly handle open replicas in the `LiveSync`, and through this allow to subscribe to replica events for replicas that are not in the set of actively syncing replicas. This was not possible before (you could only subscribe to replicas that are active for sync)
* Add test for subscribing without sync

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
