### PR TITLE
GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,6 +2004,7 @@ dependencies = [
  "derive_more",
  "flume",
  "futures",
+ "genawaiter",
  "hex",
  "http-body",
  "iroh-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,14 +434,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.28"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
 
@@ -2001,6 +2003,7 @@ dependencies = [
  "anyhow",
  "bao-tree",
  "bytes",
+ "chrono",
  "data-encoding",
  "derive_more",
  "flume",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13f81c9a9d574310b8351f8666f5a93ac3b0069c45c28ad52c10291389a7cf9"
+checksum = "2c78e758510582acc40acb90458401172d41f1016f8c9dde89e49677afb7eec1"
 dependencies = [
  "bytes",
  "rand",

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -19,6 +19,7 @@ data-encoding = "2.3.3"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into"] }
 flume = "0.10.14"
 futures = "0.3.25"
+genawaiter = "0.99.1"
 hex = "0.4.3"
 iroh-io = { version = "0.2.2" }
 multibase = "0.9.1"

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.70"
 anyhow = { version = "1", features = ["backtrace"] }
 bao-tree = { version = "0.7.0", features = ["tokio_fsm"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
+chrono = "0.4.31"
 data-encoding = "2.3.3"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into"] }
 flume = "0.10.14"

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -138,10 +138,10 @@ pub trait ReadableStore: Map {
     /// This function should not block to perform io. The knowledge about
     /// existing blobs must be present in memory.
     fn blobs(&self) -> Box<dyn Iterator<Item = Hash> + Send + Sync + 'static>;
-    /// list all roots (collections or other explicitly added things) in the database
+    /// list all tags (collections or other explicitly added things) in the database
     ///
     /// This function should not block to perform io. The knowledge about
-    /// existing roots must be present in memory.
+    /// existing tags must be present in memory.
     fn tags(&self) -> Box<dyn Iterator<Item = (Bytes, Cid)> + Send + Sync + 'static>;
 
     /// Temp pins

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -371,7 +371,6 @@ async fn gc_mark_task<'a>(
             co.yield_(GcMarkEvent::CustomWarning(format!($($arg)*), None)).await;
         };
     }
-    store.clear_live();
     let mut roots = BTreeSet::new();
     info!("traversing tags");
     for (name, cid) in store.tags() {

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -194,6 +194,21 @@ pub trait Store: ReadableStore + PartialMap {
     /// It is a special case of `import` that does not use the file system.
     fn import_bytes(&self, bytes: Bytes, format: Format) -> BoxFuture<'_, io::Result<PinnedCid>>;
 
+    /// Set a named pin
+    fn set_tag(&self, name: &[u8], hash: Option<Cid>) -> BoxFuture<io::Result<()>> {
+        let _ = name;
+        let _ = hash;
+        async move { Ok(()) }.boxed()
+    }
+
+    /// Create a temporary pin for this store
+    fn temp_pin(&self, cid: Cid) -> PinnedCid {
+        PinnedCid {
+            cid,
+            liveness: None,
+        }
+    }
+
     /// Traverse all roots recursively and mark them as live.
     ///
     /// Poll this stream to completion to perform a full gc mark phase.
@@ -254,13 +269,6 @@ pub trait Store: ReadableStore + PartialMap {
         let _ = live;
     }
 
-    /// Set a named pin
-    fn set_root(&self, name: &[u8], hash: Option<Cid>) -> BoxFuture<io::Result<()>> {
-        let _ = name;
-        let _ = hash;
-        async move { Ok(()) }.boxed()
-    }
-
     /// True if the given hash is live.
     fn is_live(&self, hash: &Hash) -> bool {
         let _ = hash;
@@ -271,14 +279,6 @@ pub trait Store: ReadableStore + PartialMap {
     fn delete(&self, hash: &Hash) -> BoxFuture<'_, io::Result<()>> {
         let _ = hash;
         async move { Ok(()) }.boxed()
-    }
-
-    /// Create a temporary pin for this store
-    fn temp_pin(&self, cid: Cid) -> PinnedCid {
-        PinnedCid {
-            cid,
-            liveness: None,
-        }
     }
 }
 

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -5,7 +5,7 @@ use crate::{
     collection::CollectionParser,
     util::{
         progress::{IdGenerator, ProgressSender},
-        BlobFormat, Cid, RpcError,
+        BlobFormat, Cid, RpcError, Tag,
     },
     Hash,
 };
@@ -142,7 +142,7 @@ pub trait ReadableStore: Map {
     ///
     /// This function should not block to perform io. The knowledge about
     /// existing tags must be present in memory.
-    fn tags(&self) -> Box<dyn Iterator<Item = (Bytes, Cid)> + Send + Sync + 'static>;
+    fn tags(&self) -> Box<dyn Iterator<Item = (Tag, Cid)> + Send + Sync + 'static>;
 
     /// Temp tags
     fn temp_tags(&self) -> Box<dyn Iterator<Item = Cid> + Send + Sync + 'static>;
@@ -194,8 +194,11 @@ pub trait Store: ReadableStore + PartialMap {
     /// It is a special case of `import` that does not use the file system.
     fn import_bytes(&self, bytes: Bytes, format: BlobFormat) -> BoxFuture<'_, io::Result<TempTag>>;
 
-    /// Set a named pin
-    fn set_tag(&self, name: Bytes, hash: Option<Cid>) -> BoxFuture<'_, io::Result<()>>;
+    /// Set a tag
+    fn set_tag(&self, name: Tag, hash: Option<Cid>) -> BoxFuture<'_, io::Result<()>>;
+
+    /// Create a new tag
+    fn create_tag(&self, hash: Cid) -> BoxFuture<'_, io::Result<Tag>>;
 
     /// Create a temporary pin for this store
     fn temp_tag(&self, cid: Cid) -> TempTag;

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -285,7 +285,7 @@ pub trait Store: ReadableStore + PartialMap {
 /// A trait for things that can track liveness of cids.
 ///
 /// A cid in iroh is just a hash and a format. This trait works together with
-/// [PinnedCid] to keep track of the liveness of a cid.
+/// [TempTag] to keep track of the liveness of a cid.
 ///
 /// It is important to include the format in the liveness tracking, since
 /// pinning a blob and pinning a collection are different things.

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -195,7 +195,7 @@ pub trait Store: ReadableStore + PartialMap {
     fn import_bytes(&self, bytes: Bytes, format: Format) -> BoxFuture<'_, io::Result<PinnedCid>>;
 
     /// Set a named pin
-    fn set_tag(&self, name: &[u8], hash: Option<Cid>) -> BoxFuture<io::Result<()>> {
+    fn set_tag(&self, name: Bytes, hash: Option<Cid>) -> BoxFuture<'_, io::Result<()>> {
         let _ = name;
         let _ = hash;
         async move { Ok(()) }.boxed()

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -382,7 +382,7 @@ async fn gc_mark_task<'a>(
     // process all current. Since we don't have nested collections, this will
     // terminate after 1 iteration.
     while !current.is_empty() {
-        for (hash, format) in std::mem::take(&mut current) {
+        for Cid(hash, format) in std::mem::take(&mut current) {
             // we need to do this for all formats except raw
             if live.insert(hash) && !format.is_raw() {
                 let Some(entry) = store.get(&hash) else {

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -383,7 +383,8 @@ async fn gc_mark_task<'a>(
     // terminate after 1 iteration.
     while !current.is_empty() {
         for (hash, format) in std::mem::take(&mut current) {
-            if live.insert(hash) && format == BlobFormat::Collection {
+            // we need to do this for all formats except raw
+            if live.insert(hash) && !format.is_raw() {
                 let Some(entry) = store.get(&hash) else {
                     warn!("gc: {} not found", hash);
                     continue;
@@ -396,7 +397,7 @@ async fn gc_mark_task<'a>(
                     warn!("gc: {} creating data reader failed", hash);
                     continue;
                 };
-                let Ok((mut iter, stats)) = cp.parse(0, reader).await else {
+                let Ok((mut iter, stats)) = cp.parse(format.into(), reader).await else {
                     warn!("gc: {} parse failed", hash);
                     continue;
                 };

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -99,7 +99,7 @@ impl Tag {
         let now = chrono::DateTime::<chrono::Utc>::from(time);
         let mut i = 0;
         loop {
-            let mut text = format!("auto-{}", now);
+            let mut text = format!("auto-{}", now.format("%Y-%m-%dT%H:%M:%S%.3fZ"));
             if i != 0 {
                 text.push_str(&format!("-{}", i));
             }

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -15,7 +15,7 @@ pub mod runtime;
 
 /// A format identifier
 ///
-/// Should we make this an u64 and use https://github.com/multiformats/multicodec/blob/master/table.csv?
+/// Should we make this an u64 and use <https://github.com/multiformats/multicodec/blob/master/table.csv>?
 ///
 /// That table is so weird. There is so much unrelated stuff in there, so the smallest value we would be
 /// able to use for iroh collections would be 2 bytes varint encoded or something...

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -13,6 +13,23 @@ pub mod io;
 pub mod progress;
 pub mod runtime;
 
+/// A format identifier
+///
+/// Should we make this an u64 and use https://github.com/multiformats/multicodec/blob/master/table.csv?
+///
+/// That table is so weird. There is so much unrelated stuff in there, so the smallest value we would be
+/// able to use for iroh collections would be 2 bytes varint encoded or something...
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Format {
+    /// Hash refers to a blob
+    Blob,
+    /// Hash refers to an iroh collection (format here?)
+    Collection,
+}
+
+/// A hash and format pair
+pub type Cid = (Hash, Format);
+
 /// Hash type used throught.
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub struct Hash(blake3::Hash);

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -16,26 +16,15 @@ pub mod progress;
 pub mod runtime;
 
 /// A format identifier
-///
-/// Should we make this an u64 and use ?
-///
-/// That table is so weird. There is so much unrelated stuff in there, so the smallest value we would be
-/// able to use for iroh collections would be 2 bytes varint encoded or something...
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct BlobFormat(u64);
 
 impl BlobFormat {
     /// Raw format
-    ///
-    /// raw binary in the multiformat table
-    pub const RAW: Self = Self(0x55);
+    pub const RAW: Self = Self(0);
 
     /// Collection format
-    ///
-    /// seems to be one of the smallest values that are free
-    /// if we were to change a collection to be just a sequence of hashes,
-    /// we could just use the blake3 value (0x1e) here
-    pub const COLLECTION: Self = Self(0x73);
+    pub const COLLECTION: Self = Self(1);
 
     /// true if this is a raw blob
     pub const fn is_raw(&self) -> bool {
@@ -133,7 +122,7 @@ pub enum SetTagOption {
 
 /// A hash and format pair
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Cid(pub Hash, pub BlobFormat);
+pub struct HashAndFormat(pub Hash, pub BlobFormat);
 
 /// Hash type used throught.
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -19,7 +19,7 @@ pub mod runtime;
 ///
 /// That table is so weird. There is so much unrelated stuff in there, so the smallest value we would be
 /// able to use for iroh collections would be 2 bytes varint encoded or something...
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Format {
     /// Hash refers to a blob
     Blob,

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -66,6 +66,12 @@ impl fmt::Debug for BlobFormat {
     }
 }
 
+impl Default for BlobFormat {
+    fn default() -> Self {
+        Self::RAW
+    }
+}
+
 /// A tag
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, From, Into)]
 pub struct Tag(pub Bytes);

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -15,16 +15,53 @@ pub mod runtime;
 
 /// A format identifier
 ///
-/// Should we make this an u64 and use <https://github.com/multiformats/multicodec/blob/master/table.csv>?
+/// Should we make this an u64 and use ?
 ///
 /// That table is so weird. There is so much unrelated stuff in there, so the smallest value we would be
 /// able to use for iroh collections would be 2 bytes varint encoded or something...
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum BlobFormat {
-    /// Hash refers to a blob
-    Raw,
-    /// Hash refers to an iroh collection (format here?)
-    Collection,
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct BlobFormat(u64);
+
+impl BlobFormat {
+    /// Raw format
+    ///
+    /// raw binary in the multiformat table
+    pub const RAW: Self = Self(0x55);
+
+    /// Collection format
+    ///
+    /// seems to be one of the smallest values that are free
+    /// if we were to change a collection to be just a sequence of hashes,
+    /// we could just use the blake3 value (0x1e) here
+    pub const COLLECTION: Self = Self(0x73);
+
+    /// true if this is a raw blob
+    pub const fn is_raw(&self) -> bool {
+        self.0 == Self::RAW.0
+    }
+
+    /// true if this is an iroh collection
+    pub const fn is_collection(&self) -> bool {
+        self.0 == Self::COLLECTION.0
+    }
+}
+
+impl From<BlobFormat> for u64 {
+    fn from(value: BlobFormat) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Debug for BlobFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self == &Self::RAW {
+            f.write_str("Raw")
+        } else if self == &Self::COLLECTION {
+            f.write_str("Collection")
+        } else {
+            f.debug_tuple("Other").field(&self.0).finish()
+        }
+    }
 }
 
 /// A hash and format pair

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -31,8 +31,22 @@ pub enum BlobFormat {
 pub type Cid = (Hash, BlobFormat);
 
 /// Hash type used throught.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
 pub struct Hash(blake3::Hash);
+
+impl fmt::Debug for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Hash").field(&DD(self.to_hex())).finish()
+    }
+}
+
+struct DD<T: fmt::Display>(T);
+
+impl<T: fmt::Display> fmt::Debug for DD<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
 
 impl Hash {
     /// Calculate the hash of the provide bytes.

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -65,7 +65,8 @@ impl fmt::Debug for BlobFormat {
 }
 
 /// A hash and format pair
-pub type Cid = (Hash, BlobFormat);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Cid(pub Hash, pub BlobFormat);
 
 /// Hash type used throught.
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -10,7 +10,7 @@ use futures::FutureExt;
 
 /// A join handle that owns the task it is running, and aborts it when dropped.
 #[derive(Debug, derive_more::Deref)]
-pub(crate) struct AbortingJoinHandle<T>(tokio::task::JoinHandle<T>);
+pub struct AbortingJoinHandle<T>(pub tokio::task::JoinHandle<T>);
 
 impl<T> From<tokio::task::JoinHandle<T>> for AbortingJoinHandle<T> {
     fn from(handle: tokio::task::JoinHandle<T>) -> Self {

--- a/iroh/examples/rpc.rs
+++ b/iroh/examples/rpc.rs
@@ -87,7 +87,7 @@ async fn main() -> anyhow::Result<()> {
     match args.path {
         Some(path) => {
             tokio::fs::create_dir_all(&path).await?;
-            let db = iroh::baomap::flat::Store::load(path.clone(), path, &rt).await?;
+            let db = iroh::baomap::flat::Store::load(&path, &path, &path, &rt).await?;
             run(db).await
         }
         None => {

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -228,7 +228,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
     // create a bao store for the iroh-bytes blobs
     let blob_path = storage_path.join("blobs");
     std::fs::create_dir_all(&blob_path)?;
-    let db = iroh::baomap::flat::Store::load(&blob_path, &blob_path, &rt).await?;
+    let db = iroh::baomap::flat::Store::load(&blob_path, &blob_path, &blob_path, &rt).await?;
 
     let collection_parser = iroh::collection::IrohCollectionParser;
 

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -363,7 +363,7 @@ impl ReplState {
             Cmd::Set { key, value } => {
                 let value = value.into_bytes();
                 let len = value.len();
-                let cid = self.db.import_bytes(value.into(), BlobFormat::Raw).await?;
+                let cid = self.db.import_bytes(value.into(), BlobFormat::RAW).await?;
                 self.doc
                     .insert(key, &self.author, *cid.hash(), len as u64)?;
             }
@@ -460,7 +460,7 @@ impl ReplState {
                                     let len = value.len();
                                     let key = format!("{}/{}/{}", prefix, t, i);
                                     let cid =
-                                        db.import_bytes(value.into(), BlobFormat::Raw).await?;
+                                        db.import_bytes(value.into(), BlobFormat::RAW).await?;
                                     doc.insert(key, &author, *cid.hash(), len as u64)?;
                                 }
                                 Ok(count)
@@ -520,7 +520,7 @@ impl ReplState {
                     .import(
                         file_path.clone(),
                         ImportMode::Copy,
-                        BlobFormat::Raw,
+                        BlobFormat::RAW,
                         IgnoreProgressSender::default(),
                     )
                     .await?;
@@ -556,7 +556,7 @@ impl ReplState {
                             .import(
                                 file.path().into(),
                                 ImportMode::Copy,
-                                BlobFormat::Raw,
+                                BlobFormat::RAW,
                                 IgnoreProgressSender::default(),
                             )
                             .await?;

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -363,9 +363,9 @@ impl ReplState {
             Cmd::Set { key, value } => {
                 let value = value.into_bytes();
                 let len = value.len();
-                let cid = self.db.import_bytes(value.into(), BlobFormat::RAW).await?;
+                let tag = self.db.import_bytes(value.into(), BlobFormat::RAW).await?;
                 self.doc
-                    .insert(key, &self.author, *cid.hash(), len as u64)?;
+                    .insert(key, &self.author, *tag.hash(), len as u64)?;
             }
             Cmd::Get {
                 key,
@@ -459,9 +459,9 @@ impl ReplState {
                                         String::from_utf8(bytes.clone()).unwrap().into_bytes();
                                     let len = value.len();
                                     let key = format!("{}/{}/{}", prefix, t, i);
-                                    let cid =
+                                    let tag =
                                         db.import_bytes(value.into(), BlobFormat::RAW).await?;
-                                    doc.insert(key, &author, *cid.hash(), len as u64)?;
+                                    doc.insert(key, &author, *tag.hash(), len as u64)?;
                                 }
                                 Ok(count)
                             });
@@ -515,7 +515,7 @@ impl ReplState {
         match cmd {
             FsCmd::ImportFile { file_path, key } => {
                 let file_path = canonicalize_path(&file_path)?.canonicalize()?;
-                let (cid, len) = self
+                let (tag, len) = self
                     .db
                     .import(
                         file_path.clone(),
@@ -524,7 +524,7 @@ impl ReplState {
                         IgnoreProgressSender::default(),
                     )
                     .await?;
-                let hash = *cid.hash();
+                let hash = *tag.hash();
                 self.doc.insert(key, &self.author, hash, len)?;
                 println!(
                     "> imported {file_path:?}: {} ({})",
@@ -551,7 +551,7 @@ impl ReplState {
                             continue;
                         }
                         let key = format!("{key_prefix}/{relative}");
-                        let (cid, len) = self
+                        let (tag, len) = self
                             .db
                             .import(
                                 file.path().into(),
@@ -560,7 +560,7 @@ impl ReplState {
                                 IgnoreProgressSender::default(),
                             )
                             .await?;
-                        let hash = *cid.hash();
+                        let hash = *tag.hash();
                         self.doc.insert(key, &self.author, hash, len)?;
                         println!(
                             "> imported {relative}: {} ({})",

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -362,7 +362,7 @@ impl ReplState {
             Cmd::Set { key, value } => {
                 let value = value.into_bytes();
                 let len = value.len();
-                let hash = self.db.import_bytes(value.into()).await?;
+                let hash = self.db.import_bytes(value.into(), Format::Blob).await?;
                 self.doc.insert(key, &self.author, hash, len as u64)?;
             }
             Cmd::Get {
@@ -457,7 +457,7 @@ impl ReplState {
                                         String::from_utf8(bytes.clone()).unwrap().into_bytes();
                                     let len = value.len();
                                     let key = format!("{}/{}/{}", prefix, t, i);
-                                    let hash = db.import_bytes(value.into()).await?;
+                                    let hash = db.import_bytes(value.into(), Format::Blob).await?;
                                     doc.insert(key, &author, hash, len as u64)?;
                                 }
                                 Ok(count)
@@ -517,6 +517,7 @@ impl ReplState {
                     .import(
                         file_path.clone(),
                         ImportMode::Copy,
+                        Format::Blob,
                         IgnoreProgressSender::default(),
                     )
                     .await?;
@@ -551,6 +552,7 @@ impl ReplState {
                             .import(
                                 file.path().into(),
                                 ImportMode::Copy,
+                                Format::Blob,
                                 IgnoreProgressSender::default(),
                             )
                             .await?;

--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -121,6 +121,7 @@
 //!
 //! Once the download is complete, the partial data and partial outboard files are renamed
 //! to the final partial data and partial outboard files.
+#![allow(clippy::mutable_key_type)]
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::{self, BufReader, Write};

--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -650,7 +650,7 @@ impl ReadableStore for Store {
         let items = inner
             .tags
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
+            .map(|(k, v)| (k.clone(), *v))
             .collect::<Vec<_>>();
         Box::new(items.into_iter())
     }
@@ -710,10 +710,10 @@ impl baomap::Store for Store {
     }
 
     fn set_tag(&self, name: &[u8], value: Option<Cid>) -> BoxFuture<io::Result<()>> {
-        let name_debug = if let Ok(text) = std::str::from_utf8(&name) {
+        let name_debug = if let Ok(text) = std::str::from_utf8(name) {
             format!("\"{}\"", text)
         } else {
-            hex::encode(&name)
+            hex::encode(name)
         };
         tracing::info!("set_root {} {:?}", name_debug, value);
         let mut state = self.0.state.write().unwrap();
@@ -974,7 +974,7 @@ impl Store {
         let complete_io_guard = self.0.complete_io_mutex.lock().unwrap();
         // for a short time we will have neither partial nor complete
         self.0.state.write().unwrap().partial.remove(&hash);
-        std::fs::rename(temp_data_path, &data_path)?;
+        std::fs::rename(temp_data_path, data_path)?;
         let outboard = if temp_outboard_path.exists() {
             let outboard_path = self.0.options.owned_outboard_path(&hash);
             std::fs::rename(temp_outboard_path, &outboard_path)?;

--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -828,7 +828,7 @@ impl Store {
                 })?;
                 progress.blocking_send(ImportProgress::OutboardDone { id, hash })?;
                 use baomap::Store;
-                let cid = self.temp_tag((hash, format));
+                let cid = self.temp_tag(Cid(hash, format));
                 (cid, CompleteEntry::new_external(size, path), outboard)
             }
             ImportMode::Copy => {
@@ -853,7 +853,7 @@ impl Store {
                 use baomap::Store;
                 // the cid must be pinned before we move the file, otherwise there is a race condition
                 // where it might be deleted here.
-                let cid = self.temp_tag((hash, BlobFormat::RAW));
+                let cid = self.temp_tag(Cid(hash, BlobFormat::RAW));
                 std::fs::rename(temp_data_path, data_path)?;
                 (cid, CompleteEntry::new_default(size), outboard)
             }
@@ -919,7 +919,7 @@ impl Store {
         let (outboard, hash) = bao_tree::io::outboard(&data, IROH_BLOCK_SIZE);
         let hash = hash.into();
         use baomap::Store;
-        let cid = self.temp_tag((hash, format));
+        let cid = self.temp_tag(Cid(hash, format));
         let data_path = self.owned_data_path(&hash);
         std::fs::write(data_path, &data)?;
         if outboard.len() > 8 {

--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -853,7 +853,7 @@ impl Store {
                 use baomap::Store;
                 // the cid must be pinned before we move the file, otherwise there is a race condition
                 // where it might be deleted here.
-                let cid = self.temp_tag((hash, BlobFormat::Raw));
+                let cid = self.temp_tag((hash, BlobFormat::RAW));
                 std::fs::rename(temp_data_path, data_path)?;
                 (cid, CompleteEntry::new_default(size), outboard)
             }

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -337,7 +337,7 @@ impl ReadableStore for Store {
         )
     }
 
-    fn roots(&self) -> Box<dyn Iterator<Item = (Bytes, Cid)> + Send + Sync + 'static> {
+    fn tags(&self) -> Box<dyn Iterator<Item = (Bytes, Cid)> + Send + Sync + 'static> {
         Box::new(std::iter::empty())
     }
 

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -595,7 +595,7 @@ impl Store {
         };
         let hash = hash.into();
         use baomap::Store;
-        let cid = self.temp_tag((hash, format));
+        let cid = self.temp_tag(Cid(hash, format));
         self.0
             .state
             .write()

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -26,6 +26,7 @@ use iroh_bytes::baomap;
 use iroh_bytes::baomap::range_collections::RangeSet2;
 use iroh_bytes::baomap::EntryStatus;
 use iroh_bytes::baomap::ExportMode;
+use iroh_bytes::baomap::Format;
 use iroh_bytes::baomap::ImportMode;
 use iroh_bytes::baomap::ImportProgress;
 use iroh_bytes::baomap::PartialMap;
@@ -335,7 +336,7 @@ impl ReadableStore for Store {
         )
     }
 
-    fn roots(&self) -> Box<dyn Iterator<Item = Hash> + Send + Sync + 'static> {
+    fn roots(&self) -> Box<dyn Iterator<Item = (Hash, Format)> + Send + Sync + 'static> {
         Box::new(std::iter::empty())
     }
 

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -24,7 +24,7 @@ use futures::{
 use iroh_bytes::{
     baomap::{
         self, range_collections::RangeSet2, EntryStatus, ExportMode, ImportMode, ImportProgress,
-        Map, MapEntry, PartialMap, PartialMapEntry, PinnedCid, ReadableStore, ValidateProgress,
+        Map, MapEntry, PartialMap, PartialMapEntry, ReadableStore, TempTag, ValidateProgress,
     },
     util::{
         progress::{IdGenerator, ProgressSender},
@@ -237,7 +237,7 @@ impl ReadableStore for Store {
         Box::new(std::iter::empty())
     }
 
-    fn temp_pins(&self) -> Box<dyn Iterator<Item = Cid> + Send + Sync + 'static> {
+    fn temp_tags(&self) -> Box<dyn Iterator<Item = Cid> + Send + Sync + 'static> {
         Box::new(std::iter::empty())
     }
 
@@ -314,17 +314,13 @@ impl baomap::Store for Store {
         mode: ImportMode,
         format: BlobFormat,
         progress: impl ProgressSender<Msg = ImportProgress> + IdGenerator,
-    ) -> BoxFuture<'_, io::Result<(PinnedCid, u64)>> {
+    ) -> BoxFuture<'_, io::Result<(TempTag, u64)>> {
         let _ = (data, mode, progress, format);
         async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
     }
 
     /// import a byte slice
-    fn import_bytes(
-        &self,
-        bytes: Bytes,
-        format: BlobFormat,
-    ) -> BoxFuture<'_, io::Result<PinnedCid>> {
+    fn import_bytes(&self, bytes: Bytes, format: BlobFormat) -> BoxFuture<'_, io::Result<TempTag>> {
         let _ = (bytes, format);
         async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
     }

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -233,7 +233,7 @@ impl ReadableStore for Store {
         Box::new(self.0.keys().cloned().collect::<Vec<_>>().into_iter())
     }
 
-    fn roots(&self) -> Box<dyn Iterator<Item = (Bytes, Cid)> + Send + Sync + 'static> {
+    fn tags(&self) -> Box<dyn Iterator<Item = (Bytes, Cid)> + Send + Sync + 'static> {
         Box::new(std::iter::empty())
     }
 

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -23,8 +23,9 @@ use futures::{
 };
 use iroh_bytes::{
     baomap::{
-        self, range_collections::RangeSet2, EntryStatus, ExportMode, ImportMode, ImportProgress,
-        Map, MapEntry, PartialMap, PartialMapEntry, ReadableStore, ValidateProgress,
+        self, range_collections::RangeSet2, EntryStatus, ExportMode, Format, ImportMode,
+        ImportProgress, Map, MapEntry, PartialMap, PartialMapEntry, ReadableStore,
+        ValidateProgress,
     },
     util::progress::{IdGenerator, ProgressSender},
     Hash, IROH_BLOCK_SIZE,
@@ -230,7 +231,7 @@ impl ReadableStore for Store {
         Box::new(self.0.keys().cloned().collect::<Vec<_>>().into_iter())
     }
 
-    fn roots(&self) -> Box<dyn Iterator<Item = Hash> + Send + Sync + 'static> {
+    fn roots(&self) -> Box<dyn Iterator<Item = (Hash, Format)> + Send + Sync + 'static> {
         Box::new(std::iter::empty())
     }
 

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -324,4 +324,25 @@ impl baomap::Store for Store {
         let _ = (bytes, format);
         async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
     }
+
+    fn clear_live(&self) {}
+
+    fn set_tag(&self, name: Bytes, hash: Option<Cid>) -> BoxFuture<'_, io::Result<()>> {
+        let _ = (name, hash);
+        async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
+    }
+
+    fn temp_tag(&self, cid: Cid) -> TempTag {
+        TempTag::new(cid, None)
+    }
+
+    fn add_live(&self, _live: impl IntoIterator<Item = Hash>) {}
+
+    fn delete(&self, _hash: &Hash) -> BoxFuture<'_, io::Result<()>> {
+        async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
+    }
+
+    fn is_live(&self, _hash: &Hash) -> bool {
+        true
+    }
 }

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -28,7 +28,7 @@ use iroh_bytes::{
     },
     util::{
         progress::{IdGenerator, ProgressSender},
-        BlobFormat, Cid,
+        BlobFormat, Cid, Tag,
     },
     Hash, IROH_BLOCK_SIZE,
 };
@@ -233,7 +233,7 @@ impl ReadableStore for Store {
         Box::new(self.0.keys().cloned().collect::<Vec<_>>().into_iter())
     }
 
-    fn tags(&self) -> Box<dyn Iterator<Item = (Bytes, Cid)> + Send + Sync + 'static> {
+    fn tags(&self) -> Box<dyn Iterator<Item = (Tag, Cid)> + Send + Sync + 'static> {
         Box::new(std::iter::empty())
     }
 
@@ -327,8 +327,11 @@ impl baomap::Store for Store {
 
     fn clear_live(&self) {}
 
-    fn set_tag(&self, name: Bytes, hash: Option<Cid>) -> BoxFuture<'_, io::Result<()>> {
-        let _ = (name, hash);
+    fn set_tag(&self, _name: Tag, _hash: Option<Cid>) -> BoxFuture<'_, io::Result<()>> {
+        async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
+    }
+
+    fn create_tag(&self, _hash: Cid) -> BoxFuture<'_, io::Result<Tag>> {
         async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
     }
 

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -28,7 +28,7 @@ use iroh_bytes::{
     },
     util::{
         progress::{IdGenerator, ProgressSender},
-        BlobFormat, Cid, Tag,
+        BlobFormat, HashAndFormat, Tag,
     },
     Hash, IROH_BLOCK_SIZE,
 };
@@ -233,11 +233,11 @@ impl ReadableStore for Store {
         Box::new(self.0.keys().cloned().collect::<Vec<_>>().into_iter())
     }
 
-    fn tags(&self) -> Box<dyn Iterator<Item = (Tag, Cid)> + Send + Sync + 'static> {
+    fn tags(&self) -> Box<dyn Iterator<Item = (Tag, HashAndFormat)> + Send + Sync + 'static> {
         Box::new(std::iter::empty())
     }
 
-    fn temp_tags(&self) -> Box<dyn Iterator<Item = Cid> + Send + Sync + 'static> {
+    fn temp_tags(&self) -> Box<dyn Iterator<Item = HashAndFormat> + Send + Sync + 'static> {
         Box::new(std::iter::empty())
     }
 
@@ -327,16 +327,16 @@ impl baomap::Store for Store {
 
     fn clear_live(&self) {}
 
-    fn set_tag(&self, _name: Tag, _hash: Option<Cid>) -> BoxFuture<'_, io::Result<()>> {
+    fn set_tag(&self, _name: Tag, _hash: Option<HashAndFormat>) -> BoxFuture<'_, io::Result<()>> {
         async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
     }
 
-    fn create_tag(&self, _hash: Cid) -> BoxFuture<'_, io::Result<Tag>> {
+    fn create_tag(&self, _hash: HashAndFormat) -> BoxFuture<'_, io::Result<Tag>> {
         async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
     }
 
-    fn temp_tag(&self, cid: Cid) -> TempTag {
-        TempTag::new(cid, None)
+    fn temp_tag(&self, inner: HashAndFormat) -> TempTag {
+        TempTag::new(inner, None)
     }
 
     fn add_live(&self, _live: impl IntoIterator<Item = Hash>) {}

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -15,6 +15,7 @@ use futures::stream::BoxStream;
 use futures::{Stream, StreamExt, TryStreamExt};
 use iroh_bytes::baomap::ValidateProgress;
 use iroh_bytes::provider::AddProgress;
+use iroh_bytes::util::{SetTagOption, Tag};
 use iroh_bytes::Hash;
 use iroh_net::{key::PublicKey, magic_endpoint::ConnectionInfo};
 use iroh_sync::{store::GetFilter, AuthorId, Entry, NamespaceId};
@@ -226,7 +227,7 @@ where
         &self,
         path: PathBuf,
         in_place: bool,
-        tag: Option<Bytes>,
+        tag: SetTagOption,
     ) -> Result<impl Stream<Item = Result<AddProgress>>> {
         let stream = self
             .rpc
@@ -294,7 +295,7 @@ where
     }
 
     /// Delete a tag.
-    pub async fn delete_tag(&self, name: Bytes) -> Result<()> {
+    pub async fn delete_tag(&self, name: Tag) -> Result<()> {
         self.rpc.rpc(BlobDeleteTagRequest { name }).await??;
         Ok(())
     }

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -225,10 +225,15 @@ where
         &self,
         path: PathBuf,
         in_place: bool,
+        tag: Option<Bytes>,
     ) -> Result<impl Stream<Item = Result<AddProgress>>> {
         let stream = self
             .rpc
-            .server_streaming(BlobAddPathRequest { path, in_place })
+            .server_streaming(BlobAddPathRequest {
+                path,
+                in_place,
+                tag,
+            })
             .await?;
         Ok(stream.map_err(anyhow::Error::from))
     }

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -23,9 +23,10 @@ use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use tokio_util::io::StreamReader;
 
 use crate::rpc_protocol::{
-    AuthorCreateRequest, AuthorListRequest, BlobAddPathRequest, BlobDownloadRequest,
-    BlobListCollectionsRequest, BlobListCollectionsResponse, BlobListIncompleteRequest,
-    BlobListIncompleteResponse, BlobListRequest, BlobListResponse, BlobReadResponse,
+    AuthorCreateRequest, AuthorListRequest, BlobAddPathRequest, BlobDeleteBlobRequest,
+    BlobDeleteTagRequest, BlobDownloadRequest, BlobListCollectionsRequest,
+    BlobListCollectionsResponse, BlobListIncompleteRequest, BlobListIncompleteResponse,
+    BlobListRequest, BlobListResponse, BlobListTagsRequest, BlobListTagsResponse, BlobReadResponse,
     BlobValidateRequest, BytesGetRequest, CounterStats, DocCreateRequest, DocGetManyRequest,
     DocGetOneRequest, DocImportRequest, DocInfoRequest, DocListRequest, DocSetRequest,
     DocShareRequest, DocStartSyncRequest, DocStopSyncRequest, DocSubscribeRequest, DocTicket,
@@ -284,6 +285,24 @@ where
             .server_streaming(BlobListCollectionsRequest)
             .await?;
         Ok(stream.map_err(anyhow::Error::from))
+    }
+
+    /// List all tags.
+    pub async fn list_tags(&self) -> Result<impl Stream<Item = Result<BlobListTagsResponse>>> {
+        let stream = self.rpc.server_streaming(BlobListTagsRequest).await?;
+        Ok(stream.map_err(anyhow::Error::from))
+    }
+
+    /// Delete a tag.
+    pub async fn delete_tag(&self, name: Bytes) -> Result<()> {
+        self.rpc.rpc(BlobDeleteTagRequest { name }).await??;
+        Ok(())
+    }
+
+    /// Delete a blob.
+    pub async fn delete_blob(&self, hash: Hash) -> Result<()> {
+        self.rpc.rpc(BlobDeleteBlobRequest { hash }).await??;
+        Ok(())
     }
 }
 

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -25,13 +25,13 @@ use tokio_util::io::StreamReader;
 
 use crate::rpc_protocol::{
     AuthorCreateRequest, AuthorListRequest, BlobAddPathRequest, BlobDeleteBlobRequest,
-    BlobDeleteTagRequest, BlobDownloadRequest, BlobListCollectionsRequest,
-    BlobListCollectionsResponse, BlobListIncompleteRequest, BlobListIncompleteResponse,
-    BlobListRequest, BlobListResponse, BlobListTagsRequest, BlobListTagsResponse, BlobReadResponse,
-    BlobValidateRequest, BytesGetRequest, CounterStats, DocCreateRequest, DocGetManyRequest,
-    DocGetOneRequest, DocImportRequest, DocInfoRequest, DocListRequest, DocSetRequest,
-    DocShareRequest, DocStartSyncRequest, DocStopSyncRequest, DocSubscribeRequest, DocTicket,
-    GetProgress, NodeConnectionInfoRequest, NodeConnectionInfoResponse, NodeConnectionsRequest,
+    BlobDownloadRequest, BlobListCollectionsRequest, BlobListCollectionsResponse,
+    BlobListIncompleteRequest, BlobListIncompleteResponse, BlobListRequest, BlobListResponse,
+    BlobReadResponse, BlobValidateRequest, BytesGetRequest, CounterStats, DeleteTagRequest,
+    DocCreateRequest, DocGetManyRequest, DocGetOneRequest, DocImportRequest, DocInfoRequest,
+    DocListRequest, DocSetRequest, DocShareRequest, DocStartSyncRequest, DocStopSyncRequest,
+    DocSubscribeRequest, DocTicket, GetProgress, ListTagsRequest, ListTagsResponse,
+    NodeConnectionInfoRequest, NodeConnectionInfoResponse, NodeConnectionsRequest,
     NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest, NodeStatusResponse, ProviderService,
     ShareMode,
 };
@@ -52,6 +52,8 @@ pub struct Iroh<C> {
     pub docs: DocsClient<C>,
     /// Client for author operations.
     pub authors: AuthorsClient<C>,
+    /// Client for tags operations.
+    pub tags: TagsClient<C>,
 }
 
 impl<C> Iroh<C>
@@ -64,7 +66,8 @@ where
             node: NodeClient { rpc: rpc.clone() },
             blobs: BlobsClient { rpc: rpc.clone() },
             docs: DocsClient { rpc: rpc.clone() },
-            authors: AuthorsClient { rpc },
+            authors: AuthorsClient { rpc: rpc.clone() },
+            tags: TagsClient { rpc },
         }
     }
 }
@@ -188,6 +191,29 @@ where
     }
 }
 
+/// Iroh tags client.
+#[derive(Debug, Clone)]
+pub struct TagsClient<C> {
+    rpc: RpcClient<ProviderService, C>,
+}
+
+impl<C> TagsClient<C>
+where
+    C: ServiceConnection<ProviderService>,
+{
+    /// List all tags.
+    pub async fn list(&self) -> Result<impl Stream<Item = Result<ListTagsResponse>>> {
+        let stream = self.rpc.server_streaming(ListTagsRequest).await?;
+        Ok(stream.map_err(anyhow::Error::from))
+    }
+
+    /// Delete a tag.
+    pub async fn delete(&self, name: Tag) -> Result<()> {
+        self.rpc.rpc(DeleteTagRequest { name }).await??;
+        Ok(())
+    }
+}
+
 /// Iroh blobs client.
 #[derive(Debug, Clone)]
 pub struct BlobsClient<C> {
@@ -286,18 +312,6 @@ where
             .server_streaming(BlobListCollectionsRequest)
             .await?;
         Ok(stream.map_err(anyhow::Error::from))
-    }
-
-    /// List all tags.
-    pub async fn list_tags(&self) -> Result<impl Stream<Item = Result<BlobListTagsResponse>>> {
-        let stream = self.rpc.server_streaming(BlobListTagsRequest).await?;
-        Ok(stream.map_err(anyhow::Error::from))
-    }
-
-    /// Delete a tag.
-    pub async fn delete_tag(&self, name: Tag) -> Result<()> {
-        self.rpc.rpc(BlobDeleteTagRequest { name }).await??;
-        Ok(())
     }
 
     /// Delete a blob.

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -235,7 +235,7 @@ impl FullCommands {
                         keylog,
                         request_token,
                         derp_map: config.derp_map()?,
-                        gc_period: config.gc_period,
+                        gc_policy: config.gc_policy,
                     },
                 )
                 .await

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -10,6 +10,7 @@ use human_time::ToHumanTimeString;
 use iroh::client::quic::Iroh;
 use iroh::dial::Ticket;
 use iroh::rpc_protocol::*;
+use iroh_bytes::util::{SetTagOption, Tag};
 use iroh_bytes::{protocol::RequestToken, util::runtime, Hash};
 use iroh_net::NodeAddr;
 use iroh_net::{
@@ -221,7 +222,10 @@ impl FullCommands {
                     Some(RequestTokenOptions::Token(token)) => Some(token),
                     None => None,
                 };
-                let tag = tag.map(|t| t.into_bytes().into());
+                let tag = match tag {
+                    Some(tag) => SetTagOption::Named(Tag::from(tag)),
+                    None => SetTagOption::Auto,
+                };
                 self::provide::run(
                     rt,
                     path,
@@ -496,7 +500,10 @@ impl BlobCommands {
                         in_place,
                     },
                 };
-                let tag = tag.map(|x| x.into_bytes().into());
+                let tag = match tag {
+                    Some(tag) => SetTagOption::Named(Tag::from(tag)),
+                    None => SetTagOption::Auto,
+                };
                 let mut stream = iroh
                     .blobs
                     .download(BlobDownloadRequest {
@@ -521,7 +528,13 @@ impl BlobCommands {
                 path,
                 in_place,
                 tag,
-            } => self::add::run(iroh, path, in_place, tag.map(|x| x.into_bytes().into())).await,
+            } => {
+                let tag = match tag {
+                    Some(tag) => SetTagOption::Named(Tag::from(tag)),
+                    None => SetTagOption::Auto,
+                };
+                self::add::run(iroh, path, in_place, tag).await
+            }
         }
     }
 }

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -228,7 +228,7 @@ impl FullCommands {
                     rt,
                     path,
                     in_place,
-                    tag.map(String::into_bytes),
+                    tag.map(|x| x.into_bytes().into()),
                     ProvideOptions {
                         addr,
                         rpc_port,
@@ -518,7 +518,7 @@ impl BlobCommands {
                         token: token.cloned(),
                         out: out.map(|x| x.display().to_string()),
                         in_place,
-                        tag: tag.map(|x| x.into_bytes()),
+                        tag: tag.map(|x| x.into_bytes().into()),
                     })
                     .await?;
                 while let Some(item) = stream.next().await {
@@ -534,7 +534,7 @@ impl BlobCommands {
                 path,
                 in_place,
                 tag,
-            } => self::add::run(client, path, in_place, tag.map(String::into_bytes)).await,
+            } => self::add::run(client, path, in_place, tag.map(|x| x.into_bytes().into())).await,
         }
     }
 }

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -28,6 +28,7 @@ const MAX_RPC_CONNECTIONS: u32 = 16;
 const MAX_RPC_STREAMS: u64 = 1024;
 
 pub mod add;
+pub mod delete;
 pub mod doctor;
 pub mod get;
 pub mod list;
@@ -452,6 +453,9 @@ pub enum BlobCommands {
         #[clap(long, default_value_t = false)]
         repair: bool,
     },
+    /// Delete content on the node.
+    #[clap(subcommand)]
+    Delete(self::delete::Commands),
 }
 
 impl BlobCommands {
@@ -511,6 +515,7 @@ impl BlobCommands {
                 Ok(())
             }
             Self::List(cmd) => cmd.run(iroh).await,
+            Self::Delete(cmd) => cmd.run(iroh).await,
             Self::Validate { repair } => self::validate::run(iroh, repair).await,
             Self::Add {
                 path,

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -31,6 +31,7 @@ const MAX_RPC_CONNECTIONS: u32 = 16;
 const MAX_RPC_STREAMS: u64 = 1024;
 
 pub mod add;
+pub mod delete;
 pub mod doctor;
 pub mod get;
 pub mod list;
@@ -442,6 +443,9 @@ pub enum BlobCommands {
     },
     /// List availble content on the node.
     #[clap(subcommand)]
+    Delete(self::delete::Commands),
+    /// List availble content on the node.
+    #[clap(subcommand)]
     List(self::list::Commands),
     /// Validate hashes on the running node.
     Validate {
@@ -510,6 +514,7 @@ impl BlobCommands {
                 Ok(())
             }
             Self::List(cmd) => cmd.run(client).await,
+            Self::Delete(cmd) => cmd.run(client).await,
             Self::Validate { repair } => self::validate::run(client, repair).await,
             Self::Add { path, in_place } => self::add::run(client, path, in_place).await,
         }

--- a/iroh/src/commands/add.rs
+++ b/iroh/src/commands/add.rs
@@ -5,15 +5,16 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
 use iroh::client::quic::Iroh;
 use iroh_bytes::{provider::AddProgress, Hash};
 
-pub async fn run(iroh: &Iroh, path: PathBuf, in_place: bool) -> Result<()> {
+pub async fn run(iroh: &Iroh, path: PathBuf, in_place: bool, tag: Option<Bytes>) -> Result<()> {
     let absolute = path.canonicalize()?;
     println!("Adding {} as {}...", path.display(), absolute.display());
-    let stream = iroh.blobs.add_from_path(absolute, in_place).await?;
+    let stream = iroh.blobs.add_from_path(absolute, in_place, tag).await?;
     let (hash, entries) = aggregate_add_response(stream).await?;
     print_add_response(hash, entries);
     Ok(())

--- a/iroh/src/commands/add.rs
+++ b/iroh/src/commands/add.rs
@@ -5,13 +5,12 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
 use iroh::client::quic::Iroh;
-use iroh_bytes::{provider::AddProgress, Hash};
+use iroh_bytes::{provider::AddProgress, util::SetTagOption, Hash};
 
-pub async fn run(iroh: &Iroh, path: PathBuf, in_place: bool, tag: Option<Bytes>) -> Result<()> {
+pub async fn run(iroh: &Iroh, path: PathBuf, in_place: bool, tag: SetTagOption) -> Result<()> {
     let absolute = path.canonicalize()?;
     println!("Adding {} as {}...", path.display(), absolute.display());
     let stream = iroh.blobs.add_from_path(absolute, in_place, tag).await?;

--- a/iroh/src/commands/add.rs
+++ b/iroh/src/commands/add.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
 use iroh::{client::quic::RpcClient, rpc_protocol::ProvideRequest};
@@ -14,7 +15,7 @@ pub async fn run(
     client: RpcClient,
     path: PathBuf,
     in_place: bool,
-    tag: Option<Vec<u8>>,
+    tag: Option<Bytes>,
 ) -> Result<()> {
     let absolute = path.canonicalize()?;
     println!("Adding {} as {}...", path.display(), absolute.display());

--- a/iroh/src/commands/add.rs
+++ b/iroh/src/commands/add.rs
@@ -10,13 +10,19 @@ use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
 use iroh::{client::quic::RpcClient, rpc_protocol::ProvideRequest};
 use iroh_bytes::{provider::ProvideProgress, Hash};
 
-pub async fn run(client: RpcClient, path: PathBuf, in_place: bool) -> Result<()> {
+pub async fn run(
+    client: RpcClient,
+    path: PathBuf,
+    in_place: bool,
+    tag: Option<Vec<u8>>,
+) -> Result<()> {
     let absolute = path.canonicalize()?;
     println!("Adding {} as {}...", path.display(), absolute.display());
     let stream = client
         .server_streaming(ProvideRequest {
             path: absolute,
             in_place,
+            tag,
         })
         .await?;
     let (hash, entries) = aggregate_add_response(stream).await?;

--- a/iroh/src/commands/delete.rs
+++ b/iroh/src/commands/delete.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use clap::Subcommand;
+use iroh::{client::quic::RpcClient, rpc_protocol::SetRootRequest};
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum Commands {
+    /// Delete the given roots
+    Roots { name: String },
+}
+
+impl Commands {
+    pub async fn run(self, client: RpcClient) -> Result<()> {
+        match self {
+            Commands::Roots { name } => {
+                let name = if name.starts_with("\"") && name.ends_with("\"") && name.len() > 1 {
+                    name[1..name.len() - 1].as_bytes().to_vec()
+                } else {
+                    hex::decode(name)?
+                }
+                .into();
+                let response = client.rpc(SetRootRequest { name, value: None }).await?;
+                if let Err(e) = response {
+                    println!("Error: {}", e);
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/iroh/src/commands/delete.rs
+++ b/iroh/src/commands/delete.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
+use bytes::Bytes;
 use clap::Subcommand;
 use iroh::client::quic::Iroh;
-use iroh_bytes::Hash;
+use iroh_bytes::{util::Tag, Hash};
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
@@ -31,11 +32,10 @@ impl Commands {
         match self {
             Commands::Tag { name, hex } => {
                 let name = if hex {
-                    hex::decode(name)?
+                    Tag::from(Bytes::from(hex::decode(name)?))
                 } else {
-                    name.into_bytes()
-                }
-                .into();
+                    name.into()
+                };
                 let response = iroh.blobs.delete_tag(name).await;
                 if let Err(e) = response {
                     println!("Error: {}", e);

--- a/iroh/src/commands/delete.rs
+++ b/iroh/src/commands/delete.rs
@@ -1,26 +1,38 @@
 use anyhow::Result;
 use clap::Subcommand;
-use iroh::{client::quic::RpcClient, rpc_protocol::SetRootRequest};
+use iroh::{client::quic::RpcClient, rpc_protocol::SetTagRequest};
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
-    /// Delete the given roots
-    Roots { name: String },
+    /// Delete the given tags
+    Tags {
+        /// Tag names to delete
+        #[arg(required = true)]
+        names: Vec<String>,
+
+        /// Tag names are hex encoded
+        ///
+        /// This is useful for tags that are not valid utf8.
+        #[arg(long, default_value_t = false)]
+        hex: bool,
+    },
 }
 
 impl Commands {
     pub async fn run(self, client: RpcClient) -> Result<()> {
         match self {
-            Commands::Roots { name } => {
-                let name = if name.starts_with("\"") && name.ends_with("\"") && name.len() > 1 {
-                    name[1..name.len() - 1].as_bytes().to_vec()
-                } else {
-                    hex::decode(name)?
-                }
-                .into();
-                let response = client.rpc(SetRootRequest { name, value: None }).await?;
-                if let Err(e) = response {
-                    println!("Error: {}", e);
+            Commands::Tags { names, hex } => {
+                for name in names {
+                    let name = if hex {
+                        hex::decode(name)?
+                    } else {
+                        name.into_bytes()
+                    }
+                    .into();
+                    let response = client.rpc(SetTagRequest { name, value: None }).await?;
+                    if let Err(e) = response {
+                        println!("Error: {}", e);
+                    }
                 }
             }
         }

--- a/iroh/src/commands/delete.rs
+++ b/iroh/src/commands/delete.rs
@@ -1,24 +1,10 @@
 use anyhow::Result;
-use bytes::Bytes;
 use clap::Subcommand;
 use iroh::client::quic::Iroh;
-use iroh_bytes::{util::Tag, Hash};
+use iroh_bytes::Hash;
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
-    /// Delete the given tag
-    Tag {
-        /// Tag names to delete
-        #[arg(required = true)]
-        name: String,
-
-        /// Tag names are hex encoded
-        ///
-        /// This is useful for tags that are not valid utf8.
-        #[arg(long, default_value_t = false)]
-        hex: bool,
-    },
-
     /// Delete the given blobs
     Blob {
         /// Blobs to delete
@@ -30,17 +16,6 @@ pub enum Commands {
 impl Commands {
     pub async fn run(self, iroh: &Iroh) -> Result<()> {
         match self {
-            Commands::Tag { name, hex } => {
-                let name = if hex {
-                    Tag::from(Bytes::from(hex::decode(name)?))
-                } else {
-                    name.into()
-                };
-                let response = iroh.blobs.delete_tag(name).await;
-                if let Err(e) = response {
-                    println!("Error: {}", e);
-                }
-            }
             Commands::Blob { hash } => {
                 let response = iroh.blobs.delete_blob(hash).await;
                 if let Err(e) = response {

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -68,7 +68,7 @@ impl GetInteractive {
         }
         tokio::fs::create_dir_all(&temp_dir).await?;
         let db: iroh::baomap::flat::Store =
-            iroh::baomap::flat::Store::load(temp_dir.clone(), temp_dir.clone(), &self.rt).await?;
+            iroh::baomap::flat::Store::load(&temp_dir, &temp_dir, &temp_dir, &self.rt).await?;
         // TODO: we don't need sync here, maybe disable completely?
         let doc_store = iroh_sync::store::memory::Store::default();
         // spin up temp node and ask it to download the data for us

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -12,7 +12,7 @@ use iroh::{
     rpc_protocol::{BlobDownloadRequest, DownloadLocation},
     util::{io::pathbuf_from_name, progress::ProgressSliceWriter},
 };
-use iroh_bytes::{baomap::range_collections::RangeSet2, provider::GetProgress};
+use iroh_bytes::{baomap::range_collections::RangeSet2, provider::GetProgress, util::SetTagOption};
 use iroh_bytes::{
     get::{
         self,
@@ -100,7 +100,7 @@ impl GetInteractive {
                     path: out,
                     in_place: true,
                 },
-                tag: None,
+                tag: SetTagOption::Auto,
             })
             .await?;
         let pb = make_download_pb();

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -100,6 +100,7 @@ impl GetInteractive {
                     path: out,
                     in_place: true,
                 },
+                tag: None,
             })
             .await?;
         let pb = make_download_pb();

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -99,6 +99,7 @@ impl GetInteractive {
                 token: self.token,
                 in_place: true,
                 out: Some(out),
+                tag: None,
             })
             .await?;
         let pb = make_download_pb();

--- a/iroh/src/commands/list.rs
+++ b/iroh/src/commands/list.rs
@@ -12,6 +12,8 @@ pub enum Commands {
     IncompleteBlobs,
     /// List the available collections on the running provider.
     Collections,
+    /// List the available tags on the running provider.
+    Tags,
 }
 
 impl Commands {
@@ -35,10 +37,15 @@ impl Commands {
                 let mut response = iroh.blobs.list_collections().await?;
                 while let Some(collection) = response.next().await {
                     let collection = collection?;
+                    let name = match std::str::from_utf8(&collection.tag) {
+                        Ok(name) => format!("\"{}\"", name),
+                        Err(_) => hex::encode(collection.tag),
+                    };
                     let total_blobs_count = collection.total_blobs_count.unwrap_or_default();
                     let total_blobs_size = collection.total_blobs_size.unwrap_or_default();
                     println!(
-                        "{}: {} {} ({})",
+                        "{}: {} {} {} ({})",
+                        name,
                         collection.hash,
                         total_blobs_count,
                         if total_blobs_count > 1 {
@@ -48,6 +55,17 @@ impl Commands {
                         },
                         HumanBytes(total_blobs_size),
                     );
+                }
+            }
+            Commands::Tags => {
+                let mut response = iroh.blobs.list_tags().await?;
+                while let Some(tag) = response.next().await {
+                    let tag = tag?;
+                    let name = match std::str::from_utf8(&tag.name) {
+                        Ok(name) => format!("\"{}\"", name),
+                        Err(_) => hex::encode(tag.name),
+                    };
+                    println!("{}: {} ({:?})", name, tag.hash, tag.format,);
                 }
             }
         }

--- a/iroh/src/commands/list.rs
+++ b/iroh/src/commands/list.rs
@@ -12,8 +12,6 @@ pub enum Commands {
     IncompleteBlobs,
     /// List the available collections on the running provider.
     Collections,
-    /// List the available tags on the running provider.
-    Tags,
 }
 
 impl Commands {
@@ -51,13 +49,6 @@ impl Commands {
                         },
                         HumanBytes(total_blobs_size),
                     );
-                }
-            }
-            Commands::Tags => {
-                let mut response = iroh.blobs.list_tags().await?;
-                while let Some(res) = response.next().await {
-                    let res = res?;
-                    println!("{}: {} ({:?})", res.name, res.hash, res.format,);
                 }
             }
         }

--- a/iroh/src/commands/list.rs
+++ b/iroh/src/commands/list.rs
@@ -5,7 +5,7 @@ use indicatif::HumanBytes;
 use iroh::{
     client::quic::RpcClient,
     rpc_protocol::{
-        ListBlobsRequest, ListIncompleteBlobsRequest, ListRootsRequest, ListRootsResponse,
+        ListBlobsRequest, ListIncompleteBlobsRequest, ListTagsRequest, ListTagsResponse,
     },
 };
 
@@ -16,7 +16,7 @@ pub enum Commands {
     /// List the available blobs on the running provider.
     IncompleteBlobs,
     /// List the available roots on the running provider.
-    Roots,
+    Tags,
 }
 
 impl Commands {
@@ -36,10 +36,11 @@ impl Commands {
                     println!("{} {}", item.hash, item.size);
                 }
             }
-            Commands::Roots => {
-                let mut response = client.server_streaming(ListRootsRequest).await?;
+            Commands::Tags => {
+                let mut response = client.server_streaming(ListTagsRequest).await?;
                 while let Some(item) = response.next().await {
-                    let ListRootsResponse { name, hash, format } = item?;
+                    let ListTagsResponse { name, cid } = item?;
+                    let (hash, format) = cid;
                     let name = if let Ok(text) = std::str::from_utf8(&name) {
                         format!("\"{}\"", text)
                     } else {

--- a/iroh/src/commands/list.rs
+++ b/iroh/src/commands/list.rs
@@ -44,7 +44,7 @@ impl Commands {
                     let name = if let Ok(text) = std::str::from_utf8(&name) {
                         format!("\"{}\"", text)
                     } else {
-                        hex::encode(&name)
+                        hex::encode(name)
                     };
                     println!("{}: {} {:?}", name, hash, format,);
                 }

--- a/iroh/src/commands/list.rs
+++ b/iroh/src/commands/list.rs
@@ -35,18 +35,14 @@ impl Commands {
             }
             Commands::Collections => {
                 let mut response = iroh.blobs.list_collections().await?;
-                while let Some(collection) = response.next().await {
-                    let collection = collection?;
-                    let name = match std::str::from_utf8(&collection.tag) {
-                        Ok(name) => format!("\"{}\"", name),
-                        Err(_) => hex::encode(collection.tag),
-                    };
-                    let total_blobs_count = collection.total_blobs_count.unwrap_or_default();
-                    let total_blobs_size = collection.total_blobs_size.unwrap_or_default();
+                while let Some(res) = response.next().await {
+                    let res = res?;
+                    let total_blobs_count = res.total_blobs_count.unwrap_or_default();
+                    let total_blobs_size = res.total_blobs_size.unwrap_or_default();
                     println!(
                         "{}: {} {} {} ({})",
-                        name,
-                        collection.hash,
+                        res.tag,
+                        res.hash,
                         total_blobs_count,
                         if total_blobs_count > 1 {
                             "blobs"
@@ -59,13 +55,9 @@ impl Commands {
             }
             Commands::Tags => {
                 let mut response = iroh.blobs.list_tags().await?;
-                while let Some(tag) = response.next().await {
-                    let tag = tag?;
-                    let name = match std::str::from_utf8(&tag.name) {
-                        Ok(name) => format!("\"{}\"", name),
-                        Err(_) => hex::encode(tag.name),
-                    };
-                    println!("{}: {} ({:?})", name, tag.hash, tag.format,);
+                while let Some(res) = response.next().await {
+                    let res = res?;
+                    println!("{}: {} ({:?})", res.name, res.hash, res.format,);
                 }
             }
         }

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use anyhow::{anyhow, ensure, Context, Result};
-use bytes::Bytes;
 use iroh::{
     baomap::flat,
     client::quic::RPC_ALPN,
@@ -15,7 +14,11 @@ use iroh::{
     node::{Node, StaticTokenAuthHandler},
     rpc_protocol::{ProviderRequest, ProviderResponse, ProviderService},
 };
-use iroh_bytes::{baomap::Store as BaoStore, protocol::RequestToken, util::runtime};
+use iroh_bytes::{
+    baomap::Store as BaoStore,
+    protocol::RequestToken,
+    util::{runtime, SetTagOption},
+};
 use iroh_net::{derp::DerpMap, key::SecretKey};
 use iroh_sync::store::Store as DocStore;
 use quic_rpc::{transport::quinn::QuinnServerEndpoint, ServiceEndpoint};
@@ -42,7 +45,7 @@ pub async fn run(
     rt: &runtime::Handle,
     path: Option<PathBuf>,
     in_place: bool,
-    tag: Option<Bytes>,
+    tag: SetTagOption,
     opts: ProvideOptions,
 ) -> Result<()> {
     if let Some(ref path) = path {

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use anyhow::{anyhow, ensure, Context, Result};
+use bytes::Bytes;
 use futures::StreamExt;
 use iroh::{
     baomap::flat,
@@ -48,7 +49,7 @@ pub async fn run(
     rt: &runtime::Handle,
     path: Option<PathBuf>,
     in_place: bool,
-    tag: Option<Vec<u8>>,
+    tag: Option<Bytes>,
     opts: ProvideOptions,
 ) -> Result<()> {
     if let Some(ref path) = path {
@@ -62,9 +63,10 @@ pub async fn run(
     let gc_period = opts.gc_period;
     let blob_dir = IrohPaths::BaoFlatStoreComplete.with_env()?;
     let partial_blob_dir = IrohPaths::BaoFlatStorePartial.with_env()?;
+    let meta_dir = IrohPaths::BaoFlatStorePartial.with_env()?;
     tokio::fs::create_dir_all(&blob_dir).await?;
     tokio::fs::create_dir_all(&partial_blob_dir).await?;
-    let db = flat::Store::load(&blob_dir, &partial_blob_dir, rt)
+    let db = flat::Store::load(&blob_dir, &partial_blob_dir, &meta_dir, rt)
         .await
         .with_context(|| format!("Failed to load iroh database from {}", blob_dir.display()))?;
     let key = Some(IrohPaths::SecretKey.with_env()?);

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::{anyhow, ensure, Context, Result};
+use bytes::Bytes;
 use iroh::{
     baomap::flat,
     client::quic::RPC_ALPN,
@@ -41,6 +42,7 @@ pub async fn run(
     rt: &runtime::Handle,
     path: Option<PathBuf>,
     in_place: bool,
+    tag: Option<Bytes>,
     opts: ProvideOptions,
 ) -> Result<()> {
     if let Some(ref path) = path {
@@ -89,7 +91,7 @@ pub async fn run(
                     (path_buf, Some(path))
                 };
                 // tell the provider to add the data
-                let stream = client.blobs.add_from_path(path, in_place).await?;
+                let stream = client.blobs.add_from_path(path, in_place, tag).await?;
                 match aggregate_add_response(stream).await {
                     Ok((hash, entries)) => {
                         print_add_response(hash, entries);

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -6,11 +6,11 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
-    time::Duration,
 };
 
 use anyhow::{anyhow, bail, Context, Result};
 use config::{Environment, File, Value};
+use iroh::node::GcPolicy;
 use iroh_net::{
     defaults::{default_eu_derp_region, default_na_derp_region},
     derp::{DerpMap, DerpRegion},
@@ -178,7 +178,7 @@ pub struct NodeConfig {
     /// The regions for DERP to use.
     pub derp_regions: Vec<DerpRegion>,
     /// How often to run garbage collection.
-    pub gc_period: Duration,
+    pub gc_policy: GcPolicy,
 }
 
 impl Default for NodeConfig {
@@ -186,8 +186,7 @@ impl Default for NodeConfig {
         Self {
             // TODO(ramfox): this should probably just be a derp map
             derp_regions: [default_na_derp_region(), default_eu_derp_region()].into(),
-            // TODO: increase this to a few minutes
-            gc_period: Duration::from_secs(10),
+            gc_policy: GcPolicy::Disabled,
         }
     }
 }

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -6,6 +6,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -173,6 +174,8 @@ impl ConsolePaths {
 pub struct NodeConfig {
     /// The regions for DERP to use.
     pub derp_regions: Vec<DerpRegion>,
+    /// How often to run garbage collection.
+    pub gc_period: Duration,
 }
 
 impl Default for NodeConfig {
@@ -180,6 +183,8 @@ impl Default for NodeConfig {
         Self {
             // TODO(ramfox): this should probably just be a derp map
             derp_regions: [default_na_derp_region(), default_eu_derp_region()].into(),
+            // TODO: increase this to a few minutes
+            gc_period: Duration::from_secs(10),
         }
     }
 }

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -45,6 +45,8 @@ pub enum IrohPaths {
     BaoFlatStoreComplete,
     /// Path to the node's [flat-file store](iroh::baomap::flat) for partial blobs.
     BaoFlatStorePartial,
+    /// Path to the node's [flat-file store](iroh::baomap::flat) for metadata such as the tags table.
+    BaoFlatStoreMeta,
     /// Path to the [iroh-sync document database](iroh_sync::store::fs::Store)
     DocsDatabase,
     /// Path to the console state
@@ -57,6 +59,7 @@ impl From<&IrohPaths> for &'static str {
             IrohPaths::SecretKey => "keypair",
             IrohPaths::BaoFlatStoreComplete => "blobs.v0",
             IrohPaths::BaoFlatStorePartial => "blobs-partial.v0",
+            IrohPaths::BaoFlatStoreMeta => "blobs-meta.v0",
             IrohPaths::DocsDatabase => "docs.redb",
             IrohPaths::Console => "console",
         }

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -6,6 +6,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -186,7 +187,7 @@ impl Default for NodeConfig {
         Self {
             // TODO(ramfox): this should probably just be a derp map
             derp_regions: [default_na_derp_region(), default_eu_derp_region()].into(),
-            gc_policy: GcPolicy::Disabled,
+            gc_policy: GcPolicy::Interval(Duration::from_secs(10)),
         }
     }
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1139,8 +1139,10 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             }
             if let Some(tag) = msg.tag {
                 db.set_tag(tag, Some(cid)).await?;
-            };
-            drop(temp_pin);
+                drop(temp_pin);
+            } else {
+                temp_pin.leak();
+            }
             progress.send(GetProgress::AllDone).await?;
             anyhow::Ok(())
         });
@@ -1243,7 +1245,10 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         progress.send(AddProgress::AllDone { hash }).await?;
         if let Some(tag) = msg.tag {
             self.inner.db.set_tag(tag, Some(*pinned_cid.cid())).await?;
-        };
+            drop(pinned_cid);
+        } else {
+            pinned_cid.leak();
+        }
         drop(pinned_cids);
         self.inner
             .callbacks

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -27,7 +27,7 @@ use iroh_bytes::collection::{CollectionParser, NoCollectionParser};
 use iroh_bytes::protocol::GetRequest;
 use iroh_bytes::provider::GetProgress;
 use iroh_bytes::util::progress::{FlumeProgressSender, IdGenerator, ProgressSender};
-use iroh_bytes::util::{BlobFormat, RpcResult};
+use iroh_bytes::util::{BlobFormat, Cid, RpcResult};
 use iroh_bytes::{
     protocol::{Closed, Request, RequestToken},
     provider::{AddProgress, CustomGetHandler, RequestAuthorizationHandler},
@@ -935,7 +935,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         let db = self.inner.db.clone();
         let local = self.inner.rt.local_pool().clone();
         let tags = db.tags();
-        futures::stream::iter(tags).filter_map(move |(name, (hash, format))| {
+        futures::stream::iter(tags).filter_map(move |(name, Cid(hash, format))| {
             let db = db.clone();
             let local = local.clone();
             let cp = self.collection_parser.clone();
@@ -977,7 +977,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         _msg: BlobListTagsRequest,
     ) -> impl Stream<Item = BlobListTagsResponse> + Send + 'static {
         tracing::info!("blob_list_tags");
-        futures::stream::iter(self.inner.db.tags().map(|(name, (hash, format))| {
+        futures::stream::iter(self.inner.db.tags().map(|(name, Cid(hash, format))| {
             tracing::info!("{:?} {} {:?}", name, hash, format);
             BlobListTagsResponse { name, hash, format }
         }))
@@ -1089,7 +1089,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             BlobFormat::RAW
         };
         let db = self.inner.db.clone();
-        let cid = (hash, format);
+        let cid = Cid(hash, format);
         let temp_pin = db.temp_tag(cid);
         let conn = self
             .inner

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -186,7 +186,7 @@ impl<D: Map, S: DocStore> Builder<D, S> {
             custom_get_handler: Arc::new(NoopCustomGetHandler),
             auth_handler: Arc::new(NoopRequestAuthorizationHandler),
             collection_parser: NoCollectionParser,
-            gc_policy: GcPolicy::Interval(std::time::Duration::from_secs(10)),
+            gc_policy: GcPolicy::Disabled,
             rt: None,
             docs,
         }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -940,7 +940,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             let local = local.clone();
             let cp = self.collection_parser.clone();
             async move {
-                if format != BlobFormat::Collection {
+                if !format.is_collection() {
                     return None;
                 }
                 let entry = db.get(&hash)?;
@@ -1084,9 +1084,9 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         let hash = msg.hash;
         debug!("share: {:?}", msg);
         let format = if msg.recursive {
-            BlobFormat::Collection
+            BlobFormat::COLLECTION
         } else {
-            BlobFormat::Raw
+            BlobFormat::RAW
         };
         let db = self.inner.db.clone();
         let cid = (hash, format);
@@ -1217,7 +1217,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
                         .import(
                             source.path().to_owned(),
                             mode,
-                            BlobFormat::Raw,
+                            BlobFormat::RAW,
                             import_progress,
                         )
                         .await?;
@@ -1239,7 +1239,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         let pinned_cid = self
             .inner
             .db
-            .import_bytes(data.into(), BlobFormat::Collection)
+            .import_bytes(data.into(), BlobFormat::COLLECTION)
             .await?;
         let hash = *pinned_cid.hash();
         progress.send(AddProgress::AllDone { hash }).await?;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -823,11 +823,9 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             .filter_map(move |(name, cid)| async move { Some(ListTagsResponse { name, cid }) })
     }
 
-    fn set_tag(self, msg: SetTagRequest) -> impl Future<Output = RpcResult<()>> {
-        async move {
-            self.inner.db.set_tag(&msg.name, msg.value).await?;
-            Ok(())
-        }
+    async fn set_tag(self, msg: SetTagRequest) -> RpcResult<()> {
+        self.inner.db.set_tag(&msg.name, msg.value).await?;
+        Ok(())
     }
 
     /// Invoke validate on the database and stream out the result

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -821,7 +821,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         let db = self.inner.db.clone();
         let local = self.inner.rt.local_pool().clone();
         let roots = db.roots();
-        futures::stream::iter(roots).filter_map(move |hash| {
+        futures::stream::iter(roots).filter_map(move |(hash, _format)| {
             let db = db.clone();
             let local = local.clone();
             let cp = self.collection_parser.clone();

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1063,7 +1063,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         };
         let db = self.inner.db.clone();
         let cid = (hash, format);
-        let temp_pin = db.temp_pin(cid);
+        let temp_pin = db.temp_tag(cid);
         let conn = self
             .inner
             .endpoint
@@ -1140,7 +1140,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
     ) -> anyhow::Result<()> {
         use crate::collection::{Blob, Collection};
         use futures::TryStreamExt;
-        use iroh_bytes::baomap::{ImportMode, ImportProgress, PinnedCid};
+        use iroh_bytes::baomap::{ImportMode, ImportProgress, TempTag};
         use std::{collections::BTreeMap, sync::Mutex};
 
         let progress = FlumeProgressSender::new(progress);
@@ -1178,7 +1178,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             ImportMode::Copy
         };
         const IO_PARALLELISM: usize = 4;
-        let result: Vec<(Blob, u64, PinnedCid)> = futures::stream::iter(data_sources)
+        let result: Vec<(Blob, u64, TempTag)> = futures::stream::iter(data_sources)
             .map(|source| {
                 let import_progress = import_progress.clone();
                 let db = self.inner.db.clone();

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -824,7 +824,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
     }
 
     async fn set_tag(self, msg: SetTagRequest) -> RpcResult<()> {
-        self.inner.db.set_tag(&msg.name, msg.value).await?;
+        self.inner.db.set_tag(msg.name, msg.value).await?;
         Ok(())
     }
 
@@ -987,7 +987,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
                 }
             }
             if let Some(tag) = msg.tag {
-                db.set_tag(&tag, Some((hash, format))).await?;
+                db.set_tag(tag, Some((hash, format))).await?;
             };
             drop(temp_pin);
             progress.send(ShareProgress::AllDone).await?;
@@ -1094,8 +1094,8 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
             .db
             .import_bytes(data.into(), Format::Collection)
             .await?;
-        let root_name = rand::thread_rng().gen::<[u8; 16]>();
-        self.inner.db.set_tag(&root_name, Some(*cid.cid()));
+        let root_name = rand::thread_rng().gen::<[u8; 16]>().to_vec().into();
+        self.inner.db.set_tag(root_name, Some(*cid.cid()));
         // now that we have set the collection cid as a root, we can drop the temp pins
         drop(cids);
         progress

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, fmt, net::SocketAddr, path::PathBuf, str::FromSt
 
 use bytes::Bytes;
 use derive_more::{From, TryInto};
-use iroh_bytes::util::{BlobFormat, Cid};
+use iroh_bytes::util::BlobFormat;
 pub use iroh_bytes::{protocol::RequestToken, provider::GetProgress, Hash};
 use iroh_gossip::proto::util::base32;
 use iroh_net::{
@@ -179,6 +179,9 @@ pub struct BlobListCollectionsRequest;
 /// A response to a list collections request
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlobListCollectionsResponse {
+    /// Tag of the collection
+    pub tag: Bytes,
+
     /// Hash of the collection
     pub hash: Hash,
     /// Number of children in the collection
@@ -224,16 +227,25 @@ impl ServerStreamingMsg<ProviderService> for BlobListTagsRequest {
     type Response = BlobListTagsResponse;
 }
 
-/// Set one tag to a new value or clear it
+/// Delete a tag
 #[derive(Debug, Serialize, Deserialize)]
-pub struct BlobSetTagRequest {
+pub struct BlobDeleteTagRequest {
     /// Name of the tag
     pub name: Bytes,
-    /// Hash and format for the tag
-    pub value: Option<Cid>,
 }
 
-impl RpcMsg<ProviderService> for BlobSetTagRequest {
+impl RpcMsg<ProviderService> for BlobDeleteTagRequest {
+    type Response = RpcResult<()>;
+}
+
+/// Delete a blob
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BlobDeleteBlobRequest {
+    /// Name of the tag
+    pub hash: Hash,
+}
+
+impl RpcMsg<ProviderService> for BlobDeleteBlobRequest {
     type Response = RpcResult<()>;
 }
 
@@ -728,7 +740,8 @@ pub enum ProviderRequest {
     BlobListIncomplete(BlobListIncompleteRequest),
     BlobListCollections(BlobListCollectionsRequest),
     BlobListTags(BlobListTagsRequest),
-    BlobSetTag(BlobSetTagRequest),
+    BlobDeleteTag(BlobDeleteTagRequest),
+    BlobDeleteBlob(BlobDeleteBlobRequest),
     BlobValidate(BlobValidateRequest),
 
     DocInfo(DocInfoRequest),
@@ -766,7 +779,7 @@ pub enum ProviderResponse {
     BlobListIncomplete(BlobListIncompleteResponse),
     BlobListCollections(BlobListCollectionsResponse),
     BlobListTags(BlobListTagsResponse),
-    BlobSetTag(RpcResult<()>),
+    BlobDeleteTag(RpcResult<()>),
     BlobValidate(ValidateProgress),
 
     DocInfo(RpcResult<DocInfoResponse>),

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -48,7 +48,7 @@ pub struct ProvideRequest {
     /// can be shared in place.
     pub in_place: bool,
     /// Optional tag for the data.
-    pub tag: Option<Vec<u8>>,
+    pub tag: Option<Bytes>,
 }
 
 impl Msg<ProviderService> for ProvideRequest {
@@ -78,7 +78,7 @@ pub struct ShareRequest {
     /// over the DERP protocol.
     pub derp_region: Option<u16>,
     /// Tag under which to store the data
-    pub tag: Option<Vec<u8>>,
+    pub tag: Option<Bytes>,
     /// This optional field contains the path to store the data to. If it is not
     /// set, the data is dumped to stdout.
     pub out: Option<String>,

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, fmt, net::SocketAddr, path::PathBuf, str::FromSt
 
 use bytes::Bytes;
 use derive_more::{From, TryInto};
-use iroh_bytes::util::BlobFormat;
+use iroh_bytes::util::{BlobFormat, SetTagOption, Tag};
 pub use iroh_bytes::{protocol::RequestToken, provider::GetProgress, Hash};
 use iroh_gossip::proto::util::base32;
 use iroh_net::{
@@ -51,8 +51,8 @@ pub struct BlobAddPathRequest {
     /// True if the provider can assume that the data will not change, so it
     /// can be shared in place.
     pub in_place: bool,
-    /// Optional tag to tag the data with.
-    pub tag: Option<Bytes>,
+    /// Tag to tag the data with.
+    pub tag: SetTagOption,
 }
 
 impl Msg<ProviderService> for BlobAddPathRequest {
@@ -77,7 +77,7 @@ pub struct BlobDownloadRequest {
     /// the download request.
     pub token: Option<RequestToken>,
     /// Optional tag to tag the data with.
-    pub tag: Option<Bytes>,
+    pub tag: SetTagOption,
     /// This field contains the location to store the data at.
     pub out: DownloadLocation,
 }
@@ -180,7 +180,7 @@ pub struct BlobListCollectionsRequest;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlobListCollectionsResponse {
     /// Tag of the collection
-    pub tag: Bytes,
+    pub tag: Tag,
 
     /// Hash of the collection
     pub hash: Hash,
@@ -212,7 +212,7 @@ pub struct BlobListTagsRequest;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlobListTagsResponse {
     /// Name of the tag
-    pub name: Bytes,
+    pub name: Tag,
     /// Format of the data
     pub format: BlobFormat,
     /// Hash of the data
@@ -231,7 +231,7 @@ impl ServerStreamingMsg<ProviderService> for BlobListTagsRequest {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlobDeleteTagRequest {
     /// Name of the tag
-    pub name: Bytes,
+    pub name: Tag,
 }
 
 impl RpcMsg<ProviderService> for BlobDeleteTagRequest {

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -206,11 +206,11 @@ impl ServerStreamingMsg<ProviderService> for BlobListCollectionsRequest {
 ///
 /// Lists all collections that have been explicitly added to the database.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct BlobListTagsRequest;
+pub struct ListTagsRequest;
 
 /// A response to a list collections request
 #[derive(Debug, Serialize, Deserialize)]
-pub struct BlobListTagsResponse {
+pub struct ListTagsResponse {
     /// Name of the tag
     pub name: Tag,
     /// Format of the data
@@ -219,23 +219,12 @@ pub struct BlobListTagsResponse {
     pub hash: Hash,
 }
 
-impl Msg<ProviderService> for BlobListTagsRequest {
+impl Msg<ProviderService> for ListTagsRequest {
     type Pattern = ServerStreaming;
 }
 
-impl ServerStreamingMsg<ProviderService> for BlobListTagsRequest {
-    type Response = BlobListTagsResponse;
-}
-
-/// Delete a tag
-#[derive(Debug, Serialize, Deserialize)]
-pub struct BlobDeleteTagRequest {
-    /// Name of the tag
-    pub name: Tag,
-}
-
-impl RpcMsg<ProviderService> for BlobDeleteTagRequest {
-    type Response = RpcResult<()>;
+impl ServerStreamingMsg<ProviderService> for ListTagsRequest {
+    type Response = ListTagsResponse;
 }
 
 /// Delete a blob
@@ -246,6 +235,17 @@ pub struct BlobDeleteBlobRequest {
 }
 
 impl RpcMsg<ProviderService> for BlobDeleteBlobRequest {
+    type Response = RpcResult<()>;
+}
+
+/// Delete a tag
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteTagRequest {
+    /// Name of the tag
+    pub name: Tag,
+}
+
+impl RpcMsg<ProviderService> for DeleteTagRequest {
     type Response = RpcResult<()>;
 }
 
@@ -739,10 +739,11 @@ pub enum ProviderRequest {
     BlobList(BlobListRequest),
     BlobListIncomplete(BlobListIncompleteRequest),
     BlobListCollections(BlobListCollectionsRequest),
-    BlobListTags(BlobListTagsRequest),
-    BlobDeleteTag(BlobDeleteTagRequest),
     BlobDeleteBlob(BlobDeleteBlobRequest),
     BlobValidate(BlobValidateRequest),
+
+    DeleteTag(DeleteTagRequest),
+    ListTags(ListTagsRequest),
 
     DocInfo(DocInfoRequest),
     DocList(DocListRequest),
@@ -778,9 +779,10 @@ pub enum ProviderResponse {
     BlobList(BlobListResponse),
     BlobListIncomplete(BlobListIncompleteResponse),
     BlobListCollections(BlobListCollectionsResponse),
-    BlobListTags(BlobListTagsResponse),
-    BlobDeleteTag(RpcResult<()>),
     BlobValidate(ValidateProgress),
+
+    ListTags(ListTagsResponse),
+    DeleteTag(RpcResult<()>),
 
     DocInfo(RpcResult<DocInfoResponse>),
     DocList(RpcResult<DocListResponse>),

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -2,7 +2,10 @@
 
 use anyhow::anyhow;
 use futures::{FutureExt, Stream};
-use iroh_bytes::{baomap::Store as BaoStore, util::RpcError};
+use iroh_bytes::{
+    baomap::Store as BaoStore,
+    util::{Format, RpcError},
+};
 use iroh_sync::{store::Store, sync::Namespace};
 use itertools::Itertools;
 use rand::rngs::OsRng;
@@ -176,9 +179,9 @@ impl<S: Store> SyncEngine<S> {
         let replica = self.get_replica(&doc_id)?;
         let author = self.get_author(&author_id)?;
         let len = value.len();
-        let hash = bao_store.import_bytes(value.into()).await?;
+        let cid = bao_store.import_bytes(value.into(), Format::Blob).await?;
         replica
-            .insert(&key, &author, hash, len as u64)
+            .insert(&key, &author, *cid.hash(), len as u64)
             .map_err(anyhow::Error::from)?;
         let entry = self
             .store

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -177,11 +177,11 @@ impl<S: Store> SyncEngine<S> {
         let replica = self.get_replica(&doc_id)?;
         let author = self.get_author(&author_id)?;
         let len = value.len();
-        let cid = bao_store
+        let tag = bao_store
             .import_bytes(value.into(), BlobFormat::RAW)
             .await?;
         replica
-            .insert(&key, &author, *cid.hash(), len as u64)
+            .insert(&key, &author, *tag.hash(), len as u64)
             .map_err(anyhow::Error::from)?;
         let entry = self
             .store

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -178,7 +178,7 @@ impl<S: Store> SyncEngine<S> {
         let author = self.get_author(&author_id)?;
         let len = value.len();
         let cid = bao_store
-            .import_bytes(value.into(), BlobFormat::Raw)
+            .import_bytes(value.into(), BlobFormat::RAW)
             .await?;
         replica
             .insert(&key, &author, *cid.hash(), len as u64)

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -374,13 +374,13 @@ fn cli_provide_persistence() -> anyhow::Result<()> {
     );
     // should have some data now
     let db_path = iroh_data_dir.join(BAO_DIR);
-    let db = Store::load_blocking(&db_path, &db_path, &rt)?;
+    let db = Store::load_blocking(&db_path, &db_path, &db_path, &rt)?;
     let blobs = db.blobs().collect::<Vec<_>>();
     assert_eq!(blobs.len(), 2);
 
     provide(&bar_path)?;
     // should have more data now
-    let db = Store::load_blocking(&db_path, &db_path, &rt)?;
+    let db = Store::load_blocking(&db_path, &db_path, &db_path, &rt)?;
     let blobs = db.blobs().collect::<Vec<_>>();
     assert_eq!(blobs.len(), 4);
 


### PR DESCRIPTION
## Description

Adds the concept of GC.

There is an additional persisted table roots, which is name -> (hash, format) where `name` is any blob. Currently `format` is either blob or collection, but in the future this might become a multiformat or something.

The GC computes the set of all live hashes from these roots and user-provided extra roots. This is the mark phase, which mostly involves IO for opening collections and the like.

Then it does a second phase which is the sweep phase. In this phase it just looks at all blobs and deletes the ones which are not in the life set. This involves the actual deletion, which may or may not be expensive depending on the file system.

Anything hash that is added between the mark phase and the sweep phase is protected against being deleted, and will only be considered during the next mark phase.

To protect stuff against deletion there are two mechanisms:

- named roots, see above, which are persisted to disk
- temp pins, which are also (hash, format) pairs but are purely in memory

While adding files or during sync, temp pins can be used to protect temporary data from gc.

Todo:

- [x] actually persist the roots table
- [x] change RPC api to list named roots and to manipulate named roots
- [ ] think more about all the possible race conditions
- [x] format blob/collection vs multiformats format
- [x] document integration
- [x] add GC to the mem version

## Notes & open questions

All that I need from iroh-docs is an iterator of all hashes as (hash, Format::Blob) pairs. ~The exact timing needs some thought for this to be safe. I think it needs to happen after the life set is cleared, which makes the current impl buggy.~

I added the ability to delete blobs even if they are pinned. Not sure if everybody agrees, but I think you should be able to do this. Imagine you got something that you really don't want to have due to legal reasons.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
