### PR TITLE
fix: print enum variant name for RPC debug logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,8 +564,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "unicode-width",
 ]
 
@@ -1967,6 +1967,7 @@ dependencies = [
  "serde",
  "shell-words",
  "shellexpand",
+ "strum 0.25.0",
  "tempfile",
  "testdir",
  "thiserror",
@@ -4353,6 +4354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4363,6 +4373,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.31",
 ]
 
 [[package]]

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -98,7 +98,6 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
     /// the receiver to be received from.
     // TODO: Allow to clear a previous subscription?
     pub fn subscribe(&self) -> Option<flume::Receiver<(InsertOrigin, SignedEntry)>> {
-        println!("subscribing..");
         let mut on_insert_sender = self.on_insert_sender.write();
         match &*on_insert_sender {
             Some(_sender) => None,

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -39,6 +39,7 @@ quinn = "0.10"
 range-collections = { version = "0.4.0" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
+strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 tokio = { version = "1", features = ["io-util", "rt"] }
 tokio-stream = "0.1"

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1240,7 +1240,7 @@ fn handle_rpc_request<
     let handler = handler.clone();
     rt.main().spawn(async move {
         use ProviderRequest::*;
-        debug!("handling rpc request: {}", std::any::type_name::<E>());
+        debug!("handling rpc request: {msg}");
         match msg {
             NodeWatch(msg) => {
                 chan.server_streaming(msg, handler, RpcHandler::node_watch)

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -669,7 +669,7 @@ pub struct ProviderService;
 
 /// The request enum, listing all possible requests.
 #[allow(missing_docs)]
-#[derive(Debug, Serialize, Deserialize, From, TryInto)]
+#[derive(strum::Display, Debug, Serialize, Deserialize, From, TryInto)]
 pub enum ProviderRequest {
     NodeStatus(NodeStatusRequest),
     NodeStats(NodeStatsRequest),


### PR DESCRIPTION
## Description

Right now in the debug logs we print the following for each incoming RPC request:
```
handling rpc request: quic_rpc::transport::flume::FlumeServerEndpoint<iroh::rpc_protocol::ProviderRequest, iroh::rpc_protocol::ProviderResponse>
```
which is very long and not useful because it contains no info at all about incoming request.

Before that, we printed the full Debug impl, which contained too much (especially bytes).

This PR changes it to just print the enum variant name, so e.g.

```
handling rpc request: BlobRead
```

Also removes a debug leftover `println`.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
