### PR TITLE
feat: doc import & export commands

### DIFF
--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -304,6 +304,17 @@ impl<'de> Deserialize<'de> for Hash {
     }
 }
 
+/// A convenience struct that contains metadata about a blob
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct BlobInfo {
+    /// name of the blob
+    pub name: String,
+    /// size of the blob
+    pub size: u64,
+    /// hash of the blob
+    pub hash: Hash,
+}
+
 struct HashVisitor;
 
 impl<'de> de::Visitor<'de> for HashVisitor {

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -29,11 +29,11 @@ use crate::rpc_protocol::{
     BlobListIncompleteRequest, BlobListIncompleteResponse, BlobListRequest, BlobListResponse,
     BlobReadResponse, BlobValidateRequest, BytesGetRequest, CounterStats, DeleteTagRequest,
     DocCreateRequest, DocGetManyRequest, DocGetOneRequest, DocImportRequest, DocInfoRequest,
-    DocListRequest, DocSetRequest, DocShareRequest, DocStartSyncRequest, DocStopSyncRequest,
-    DocSubscribeRequest, DocTicket, GetProgress, ListTagsRequest, ListTagsResponse,
-    NodeConnectionInfoRequest, NodeConnectionInfoResponse, NodeConnectionsRequest,
-    NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest, NodeStatusResponse, ProviderService,
-    ShareMode, WrapOption,
+    DocListRequest, DocSetHashRequest, DocSetRequest, DocShareRequest, DocStartSyncRequest,
+    DocStopSyncRequest, DocSubscribeRequest, DocTicket, GetProgress, ListTagsRequest,
+    ListTagsResponse, NodeConnectionInfoRequest, NodeConnectionInfoResponse,
+    NodeConnectionsRequest, NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest,
+    NodeStatusResponse, ProviderService, ShareMode, WrapOption,
 };
 use crate::sync_engine::{LiveEvent, LiveStatus};
 
@@ -407,6 +407,20 @@ where
     /// Get the document id of this doc.
     pub fn id(&self) -> NamespaceId {
         self.id
+    }
+
+    /// Set the content of a key to a hash value
+    pub async fn set_hash(&self, author_id: AuthorId, key: Vec<u8>, hash: Hash) -> Result<Hash> {
+        let res = self
+            .rpc
+            .rpc(DocSetHashRequest {
+                doc_id: self.id,
+                author_id,
+                key,
+                hash,
+            })
+            .await??;
+        Ok(res.entry.content_hash())
     }
 
     /// Set the content of a key to a byte array.

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -410,7 +410,13 @@ where
     }
 
     /// Set the content of a key to a hash value
-    pub async fn set_hash(&self, author_id: AuthorId, key: Vec<u8>, hash: Hash) -> Result<Hash> {
+    pub async fn set_hash(
+        &self,
+        author_id: AuthorId,
+        key: Vec<u8>,
+        hash: Hash,
+        size: u64,
+    ) -> Result<Hash> {
         let res = self
             .rpc
             .rpc(DocSetHashRequest {
@@ -418,6 +424,7 @@ where
                 author_id,
                 key,
                 hash,
+                size,
             })
             .await??;
         Ok(res.entry.content_hash())

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -15,7 +15,7 @@ use futures::stream::BoxStream;
 use futures::{Stream, StreamExt, TryStreamExt};
 use iroh_bytes::baomap::ValidateProgress;
 use iroh_bytes::provider::AddProgress;
-use iroh_bytes::util::{SetTagOption, Tag};
+use iroh_bytes::util::{BlobInfo, SetTagOption, Tag};
 use iroh_bytes::Hash;
 use iroh_net::{key::PublicKey, magic_endpoint::ConnectionInfo, PeerAddr};
 use iroh_sync::{store::GetFilter, AuthorId, Entry, NamespaceId};
@@ -414,8 +414,7 @@ where
         &self,
         author_id: AuthorId,
         key: Vec<u8>,
-        hash: Hash,
-        size: u64,
+        entry: BlobInfo,
     ) -> Result<Hash> {
         let res = self
             .rpc
@@ -423,8 +422,7 @@ where
                 doc_id: self.id,
                 author_id,
                 key,
-                hash,
-                size,
+                entry,
             })
             .await??;
         Ok(res.entry.content_hash())

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -115,13 +115,13 @@ pub enum DocCommands {
         #[clap(short, long)]
         author: Option<AuthorId>,
         /// Prefex to add to imported entries (parsed as UTF-8 string). Defaults to no prefix
-        #[clap(short, long)]
+        #[clap(long)]
         prefix: String,
         /// Path to a local file or directory to import
         ///
         /// Pathnames will be used as the document key
-        #[clap(short, long)]
-        file: String,
+        #[clap(long)]
+        path: String,
         /// If true, don't copy the file into iroh, reference the existing file instead
         ///
         /// Moving a file imported with in-place will result in data corruption
@@ -272,7 +272,7 @@ impl DocCommands {
                 doc,
                 author,
                 mut prefix,
-                file,
+                path,
                 in_place,
             } => {
                 let doc = get_doc(iroh, env, doc).await?;
@@ -281,7 +281,7 @@ impl DocCommands {
                 if prefix.ends_with('/') {
                     prefix.pop();
                 }
-                let root = canonicalize_path(&file)?.canonicalize()?;
+                let root = canonicalize_path(&path)?.canonicalize()?;
                 let files = walkdir::WalkDir::new(&root).into_iter();
                 // TODO: parallelize
                 for file in files {

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -9,6 +9,7 @@ use iroh::{
     rpc_protocol::{DocTicket, ShareMode},
     sync_engine::{LiveEvent, Origin},
 };
+use iroh_bytes::util::SetTagOption;
 use iroh_sync::{store::GetFilter, AuthorId, Entry, NamespaceId};
 
 use crate::{commands::add::aggregate_add_response, config::ConsoleEnv};
@@ -302,7 +303,8 @@ impl DocCommands {
 
                         let stream = iroh
                             .blobs
-                            .add_from_path(file.path().into(), in_place)
+                            // TODO: what should the name be
+                            .add_from_path(file.path().into(), in_place, SetTagOption::Auto)
                             .await?;
                         // TODO(b5): horrible hack b/c add_from_path creates a collection
                         // and we really just want the raw blob

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -305,13 +305,13 @@ impl DocCommands {
                     counts.1 += entry.size;
                     // adjust the key so that it does not leak the entire directory structure of
                     // the importer's machine
-                    let key: Vec<u8> = PathBuf::from(entry.name)
+                    let key: Vec<u8> = PathBuf::from(entry.name.clone())
                         .strip_prefix(root_prefix.clone())?
                         .to_str()
                         .map(|p| p.as_bytes())
                         .ok_or(anyhow!("could not convert path to bytes"))?
                         .into();
-                    doc.set_hash(author, key, entry.hash, entry.size).await?;
+                    doc.set_hash(author, key, entry).await?;
                 }
                 println!(
                     "Imported {} entries totaling {}",

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1544,9 +1544,8 @@ fn handle_rpc_request<
                 .await
             }
             DocSetHash(msg) => {
-                let bao_store = handler.inner.db.clone();
                 chan.rpc(msg, handler, |handler, req| async move {
-                    handler.inner.sync.doc_set_hash(&bao_store, req).await
+                    handler.inner.sync.doc_set_hash(req).await
                 })
                 .await
             }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1543,6 +1543,13 @@ fn handle_rpc_request<
                 })
                 .await
             }
+            DocSetHash(msg) => {
+                let bao_store = handler.inner.db.clone();
+                chan.rpc(msg, handler, |handler, req| async move {
+                    handler.inner.sync.doc_set_hash(&bao_store, req).await
+                })
+                .await
+            }
             DocGet(msg) => {
                 chan.server_streaming(msg, handler, |handler, req| {
                     handler.inner.sync.doc_get_many(req)

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, fmt, net::SocketAddr, path::PathBuf, str::FromSt
 
 use bytes::Bytes;
 use derive_more::{From, TryInto};
-use iroh_bytes::util::{BlobFormat, SetTagOption, Tag};
+use iroh_bytes::util::{BlobFormat, BlobInfo, SetTagOption, Tag};
 pub use iroh_bytes::{protocol::RequestToken, provider::GetProgress, Hash};
 use iroh_gossip::proto::util::base32;
 use iroh_net::{
@@ -631,10 +631,8 @@ pub struct DocSetHashRequest {
     pub author_id: AuthorId,
     /// Key of this entry.
     pub key: Vec<u8>,
-    /// Value of this entry.
-    pub hash: Hash,
-    /// Size of the entry.
-    pub size: u64,
+    /// Info on the entry to add to the doc
+    pub entry: BlobInfo,
 }
 
 impl RpcMsg<ProviderService> for DocSetHashRequest {

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -614,7 +614,6 @@ pub struct DocSetRequest {
     /// Key of this entry.
     pub key: Vec<u8>,
     /// Value of this entry.
-    // TODO: Allow to provide the hash directly
     // TODO: Add a way to provide content as stream
     pub value: Vec<u8>,
 }
@@ -623,9 +622,33 @@ impl RpcMsg<ProviderService> for DocSetRequest {
     type Response = RpcResult<DocSetResponse>;
 }
 
+/// Set an entry in a document to a given hash
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocSetHashRequest {
+    /// The document id
+    pub doc_id: NamespaceId,
+    /// Author of this entry.
+    pub author_id: AuthorId,
+    /// Key of this entry.
+    pub key: Vec<u8>,
+    /// Value of this entry.
+    pub hash: Hash,
+}
+
+impl RpcMsg<ProviderService> for DocSetHashRequest {
+    type Response = RpcResult<DocSetHashResponse>;
+}
+
 /// Response to [`DocSetRequest`]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DocSetResponse {
+    /// The newly-created entry.
+    pub entry: SignedEntry,
+}
+
+/// Response to [`DocSetHashRequest`]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocSetHashResponse {
     /// The newly-created entry.
     pub entry: SignedEntry,
 }
@@ -764,6 +787,7 @@ pub enum ProviderRequest {
     DocCreate(DocCreateRequest),
     DocImport(DocImportRequest),
     DocSet(DocSetRequest),
+    DocSetHash(DocSetHashRequest),
     DocGet(DocGetManyRequest),
     DocGetOne(DocGetOneRequest),
     DocStartSync(DocStartSyncRequest),
@@ -803,6 +827,7 @@ pub enum ProviderResponse {
     DocCreate(RpcResult<DocCreateResponse>),
     DocImport(RpcResult<DocImportResponse>),
     DocSet(RpcResult<DocSetResponse>),
+    DocSetHash(RpcResult<DocSetHashResponse>),
     DocGet(RpcResult<DocGetManyResponse>),
     DocGetOne(RpcResult<DocGetOneResponse>),
     DocShare(RpcResult<DocShareResponse>),

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -633,6 +633,8 @@ pub struct DocSetHashRequest {
     pub key: Vec<u8>,
     /// Value of this entry.
     pub hash: Hash,
+    /// Size of the entry.
+    pub size: u64,
 }
 
 impl RpcMsg<ProviderService> for DocSetHashRequest {

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -7,7 +7,7 @@ use rand::rngs::OsRng;
 
 use iroh_bytes::{
     baomap::Store as BaoStore,
-    util::{BlobFormat, RpcError},
+    util::{BlobFormat, BlobInfo, RpcError},
 };
 use iroh_sync::{store::Store, sync::Namespace};
 
@@ -195,9 +195,9 @@ impl<S: Store> SyncEngine<S> {
             doc_id,
             author_id,
             key,
-            hash,
-            size,
+            entry,
         } = req;
+        let BlobInfo { hash, size, .. } = entry;
         let replica = self.get_replica(&doc_id)?;
         let author = self.get_author(&author_id)?;
 

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -6,7 +6,6 @@ use itertools::Itertools;
 use rand::rngs::OsRng;
 
 use iroh_bytes::{
-    baomap::MapEntry,
     baomap::Store as BaoStore,
     util::{BlobFormat, RpcError},
 };
@@ -191,26 +190,19 @@ impl<S: Store> SyncEngine<S> {
             .ok_or_else(|| anyhow!("failed to get entry after insertion"))?;
         Ok(DocSetResponse { entry })
     }
-    pub async fn doc_set_hash<B: BaoStore>(
-        &self,
-        bao_store: &B,
-        req: DocSetHashRequest,
-    ) -> RpcResult<DocSetHashResponse> {
+    pub async fn doc_set_hash(&self, req: DocSetHashRequest) -> RpcResult<DocSetHashResponse> {
         let DocSetHashRequest {
             doc_id,
             author_id,
             key,
             hash,
+            size,
         } = req;
         let replica = self.get_replica(&doc_id)?;
         let author = self.get_author(&author_id)?;
-        let entry = bao_store
-            .get(&hash)
-            .ok_or_else(|| anyhow!("hash is not present in store"))?;
-        let len = entry.size();
 
         replica
-            .insert(&key, &author, hash, len)
+            .insert(&key, &author, hash, size)
             .map_err(anyhow::Error::from)?;
         let entry = self
             .store


### PR DESCRIPTION
## Description

* Rough outline porting over the "fs" commands from the repl example into the main CLI & console.
* This ends up requiring a set_hash command on the core side, which I think is great.
* I'm also trying to keep all the import / export logic in the iroh crate. don't think any of this belongs in core

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
