### PR TITLE
fix: avoid double conns, better state tracking

### DIFF
--- a/iroh-net/src/key.rs
+++ b/iroh-net/src/key.rs
@@ -121,7 +121,7 @@ impl From<VerifyingKey> for PublicKey {
 
 impl Debug for PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut text = data_encoding::BASE32_NOPAD.encode(self.as_bytes());
+        let mut text = data_encoding::BASE32_NOPAD.encode(&self.as_bytes()[..10]);
         text.make_ascii_lowercase();
         write!(f, "PublicKey({text})")
     }

--- a/iroh-sync/src/net.rs
+++ b/iroh-sync/src/net.rs
@@ -1,9 +1,9 @@
 //! Network implementation of the iroh-sync protocol
 
-use std::{future::Future, net::SocketAddr};
+use std::{future::Future, net::SocketAddr, result::Result};
 
-use anyhow::{Context, Result};
 use iroh_net::{key::PublicKey, magic_endpoint::get_peer_id, MagicEndpoint};
+use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::{
@@ -30,18 +30,23 @@ pub async fn connect_and_sync<S: store::Store>(
     peer: PublicKey,
     derp_region: Option<u16>,
     addrs: &[SocketAddr],
-) -> Result<()> {
-    debug!(peer = ?peer, "sync (via connect): start");
+) -> Result<(), ConnectError> {
+    debug!(?peer, "sync[dial]: connect");
     let namespace = doc.namespace();
     let connection = endpoint
         .connect(peer, SYNC_ALPN, derp_region, addrs)
         .await
-        .context("failed to establish connection")?;
-    debug!(?peer, ?namespace, "sync (via connect): connected");
-    let (mut send_stream, mut recv_stream) = connection.open_bi().await?;
+        .map_err(ConnectError::connect)?;
+    debug!(?peer, ?namespace, "sync[dial]: connected");
+    let (mut send_stream, mut recv_stream) =
+        connection.open_bi().await.map_err(ConnectError::connect)?;
     let res = run_alice::<S, _, _>(&mut send_stream, &mut recv_stream, doc, peer).await;
-    send_stream.finish().await?;
-    recv_stream.read_to_end(0).await?;
+
+    send_stream.finish().await.map_err(ConnectError::close)?;
+    recv_stream
+        .read_to_end(0)
+        .await
+        .map_err(ConnectError::close)?;
 
     #[cfg(feature = "metrics")]
     if res.is_ok() {
@@ -50,47 +55,32 @@ pub async fn connect_and_sync<S: store::Store>(
         inc!(Metrics, sync_via_connect_failure);
     }
 
-    debug!(peer = ?peer, ?res, "sync (via connect): done");
+    debug!(?peer, ?namespace, ?res, "sync[dial]: done");
     res
 }
 
 /// What to do with incoming sync requests
-#[derive(Debug)]
-pub enum AcceptOutcome<S: store::Store> {
-    /// This namespace is not available for sync.
-    NotAvailable,
-    /// This namespace is already syncing, therefore abort.
-    AlreadySyncing,
-    /// Accept the sync request.
-    Accept(Replica<S::Instance>),
-}
-
-impl<S: store::Store> From<Option<Replica<S::Instance>>> for AcceptOutcome<S> {
-    fn from(replica: Option<Replica<S::Instance>>) -> Self {
-        match replica {
-            Some(replica) => AcceptOutcome::Accept(replica),
-            None => AcceptOutcome::NotAvailable,
-        }
-    }
-}
+pub type AcceptOutcome<S> = Result<Replica<<S as store::Store>::Instance>, AbortReason>;
 
 /// Handle an iroh-sync connection and sync all shared documents in the replica store.
 pub async fn handle_connection<S, F, Fut>(
     connecting: quinn::Connecting,
     accept_cb: F,
-) -> std::result::Result<(NamespaceId, PublicKey), SyncError>
+) -> Result<(NamespaceId, PublicKey), AcceptError>
 where
     S: store::Store,
     F: Fn(NamespaceId, PublicKey) -> Fut,
     Fut: Future<Output = anyhow::Result<AcceptOutcome<S>>>,
 {
-    let connection = connecting.await.map_err(SyncError::connect)?;
-    let peer = get_peer_id(&connection).await.map_err(SyncError::connect)?;
+    let connection = connecting.await.map_err(AcceptError::connect)?;
+    let peer = get_peer_id(&connection)
+        .await
+        .map_err(AcceptError::connect)?;
     let (mut send_stream, mut recv_stream) = connection
         .accept_bi()
         .await
-        .map_err(|error| SyncError::open(peer, error))?;
-    debug!(peer = ?peer, "sync (via accept): start");
+        .map_err(|e| AcceptError::open(peer, e))?;
+    debug!(?peer, "sync[accept]: handle");
 
     let res = run_bob::<S, _, _, _, _>(&mut send_stream, &mut recv_stream, accept_cb, peer).await;
 
@@ -101,24 +91,30 @@ where
         inc!(Metrics, sync_via_accept_failure);
     }
 
-    debug!(peer = ?peer, ?res, "sync (via accept): done");
+    let namespace = match &res {
+        Ok(namespace) => Some(*namespace),
+        Err(err) => err.namespace(),
+    };
 
-    let namespace = res?;
     send_stream
         .finish()
         .await
-        .map_err(|error| SyncError::close(peer, namespace, error))?;
+        .map_err(|error| AcceptError::close(peer, namespace, error))?;
     recv_stream
         .read_to_end(0)
         .await
-        .map_err(|error| SyncError::close(peer, namespace, error))?;
+        .map_err(|error| AcceptError::close(peer, namespace, error))?;
+    let namespace = res?;
+
+    debug!(?peer, ?namespace, "sync[accept]: done");
+
     Ok((namespace, peer))
 }
 
-/// Failure reasons for sync.
+/// Errors that may occur on handling incoming sync connections.
 #[derive(thiserror::Error, Debug)]
 #[allow(missing_docs)]
-pub enum SyncError {
+pub enum AcceptError {
     /// Failed to establish connection
     #[error("Failed to establish connection")]
     Connect {
@@ -132,6 +128,13 @@ pub enum SyncError {
         #[source]
         error: anyhow::Error,
     },
+    /// We aborted the sync request.
+    #[error("Aborted sync of {namespace:?} with {peer:?}: {reason:?}")]
+    Abort {
+        peer: PublicKey,
+        namespace: NamespaceId,
+        reason: AbortReason,
+    },
     /// Failed to run sync
     #[error("Failed to sync {namespace:?} with {peer:?}")]
     Sync {
@@ -144,13 +147,52 @@ pub enum SyncError {
     #[error("Failed to close {namespace:?} with {peer:?}")]
     Close {
         peer: PublicKey,
-        namespace: NamespaceId,
+        namespace: Option<NamespaceId>,
         #[source]
         error: anyhow::Error,
     },
 }
 
-impl SyncError {
+/// Errors that may occur on outgoing sync requests.
+#[derive(thiserror::Error, Debug)]
+#[allow(missing_docs)]
+pub enum ConnectError {
+    /// Failed to establish connection
+    #[error("Failed to establish connection")]
+    Connect {
+        #[source]
+        error: anyhow::Error,
+    },
+    /// The remote peer aborted the sync request.
+    #[error("Remote peer aborted sync: {reason:?}")]
+    RemoteAbort { reason: AbortReason },
+    /// We cancelled the operation
+    #[error("Cancelled")]
+    Cancelled,
+    /// Failed to run sync
+    #[error("Failed to sync")]
+    Sync {
+        #[source]
+        error: anyhow::Error,
+    },
+    /// Failed to close
+    #[error("Failed to close connection1")]
+    Close {
+        #[source]
+        error: anyhow::Error,
+    },
+}
+
+/// Reason why we aborted an incoming sync request.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AbortReason {
+    /// Namespace is not avaiable.
+    NotAvailable,
+    /// We are already syncing this namespace.
+    AlreadySyncing,
+}
+
+impl AcceptError {
     fn connect(error: impl Into<anyhow::Error>) -> Self {
         Self::Connect {
             error: error.into(),
@@ -173,7 +215,11 @@ impl SyncError {
             error: error.into(),
         }
     }
-    fn close(peer: PublicKey, namespace: NamespaceId, error: impl Into<anyhow::Error>) -> Self {
+    fn close(
+        peer: PublicKey,
+        namespace: Option<NamespaceId>,
+        error: impl Into<anyhow::Error>,
+    ) -> Self {
         Self::Close {
             peer,
             namespace,
@@ -183,20 +229,43 @@ impl SyncError {
     /// Get the peer's node ID (if available)
     pub fn peer(&self) -> Option<PublicKey> {
         match self {
-            SyncError::Connect { .. } => None,
-            SyncError::Open { peer, .. } => Some(*peer),
-            SyncError::Sync { peer, .. } => Some(*peer),
-            SyncError::Close { peer, .. } => Some(*peer),
+            AcceptError::Connect { .. } => None,
+            AcceptError::Open { peer, .. } => Some(*peer),
+            AcceptError::Sync { peer, .. } => Some(*peer),
+            AcceptError::Close { peer, .. } => Some(*peer),
+            AcceptError::Abort { peer, .. } => Some(*peer),
         }
     }
 
     /// Get the namespace (if available)
     pub fn namespace(&self) -> Option<NamespaceId> {
         match self {
-            SyncError::Connect { .. } => None,
-            SyncError::Open { .. } => None,
-            SyncError::Sync { namespace, .. } => namespace.to_owned(),
-            SyncError::Close { namespace, .. } => Some(*namespace),
+            AcceptError::Connect { .. } => None,
+            AcceptError::Open { .. } => None,
+            AcceptError::Sync { namespace, .. } => namespace.to_owned(),
+            AcceptError::Close { namespace, .. } => namespace.to_owned(),
+            AcceptError::Abort { namespace, .. } => Some(*namespace),
         }
+    }
+}
+
+impl ConnectError {
+    fn connect(error: impl Into<anyhow::Error>) -> Self {
+        Self::Connect {
+            error: error.into(),
+        }
+    }
+    fn close(error: impl Into<anyhow::Error>) -> Self {
+        Self::Close {
+            error: error.into(),
+        }
+    }
+    pub(crate) fn sync(error: impl Into<anyhow::Error>) -> Self {
+        Self::Sync {
+            error: error.into(),
+        }
+    }
+    pub(crate) fn remote_abort(reason: AbortReason) -> Self {
+        Self::RemoteAbort { reason }
     }
 }

--- a/iroh-sync/src/net.rs
+++ b/iroh-sync/src/net.rs
@@ -164,8 +164,8 @@ pub enum ConnectError {
         error: anyhow::Error,
     },
     /// The remote peer aborted the sync request.
-    #[error("Remote peer aborted sync: {reason:?}")]
-    RemoteAbort { reason: AbortReason },
+    #[error("Remote peer aborted sync: {0:?}")]
+    RemoteAbort(AbortReason),
     /// We cancelled the operation
     #[error("Cancelled")]
     Cancelled,
@@ -266,6 +266,6 @@ impl ConnectError {
         }
     }
     pub(crate) fn remote_abort(reason: AbortReason) -> Self {
-        Self::RemoteAbort { reason }
+        Self::RemoteAbort(reason)
     }
 }

--- a/iroh-sync/src/net.rs
+++ b/iroh-sync/src/net.rs
@@ -1,6 +1,6 @@
 //! Network implementation of the iroh-sync protocol
 
-use std::{future::Future, net::SocketAddr, result::Result};
+use std::{future::Future, net::SocketAddr};
 
 use iroh_net::{key::PublicKey, magic_endpoint::get_peer_id, MagicEndpoint};
 use serde::{Deserialize, Serialize};

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -1,6 +1,6 @@
-use std::future::Future;
+use std::{future::Future, result::Result};
 
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{anyhow, ensure};
 use bytes::{Buf, BufMut, BytesMut};
 use futures::SinkExt;
 use iroh_net::key::PublicKey;
@@ -11,7 +11,7 @@ use tokio_util::codec::{Decoder, Encoder, FramedRead, FramedWrite};
 use tracing::trace;
 
 use crate::{
-    net::{AcceptOutcome, SyncError},
+    net::{AbortReason, AcceptError, AcceptOutcome, ConnectError},
     store, NamespaceId, Replica,
 };
 
@@ -23,10 +23,7 @@ const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 1024; // This is likely too large,
 impl Decoder for SyncCodec {
     type Item = Message;
     type Error = anyhow::Error;
-    fn decode(
-        &mut self,
-        src: &mut BytesMut,
-    ) -> std::result::Result<Option<Self::Item>, Self::Error> {
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         if src.len() < 4 {
             return Ok(None);
         }
@@ -50,11 +47,7 @@ impl Decoder for SyncCodec {
 impl Encoder<Message> for SyncCodec {
     type Error = anyhow::Error;
 
-    fn encode(
-        &mut self,
-        item: Message,
-        dst: &mut BytesMut,
-    ) -> std::result::Result<(), Self::Error> {
+    fn encode(&mut self, item: Message, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let len =
             postcard::serialize_with_flavor(&item, postcard::ser_flavors::Size::default()).unwrap();
         ensure!(
@@ -81,13 +74,17 @@ impl Encoder<Message> for SyncCodec {
 /// On any error and on success the substream is closed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 enum Message {
+    /// Init message (sent by the dialing peer)
     Init {
         /// Namespace to sync
         namespace: NamespaceId,
         /// Initial message
         message: crate::sync::ProtocolMessage,
     },
+    /// Sync messages (sent by both peers)
     Sync(crate::sync::ProtocolMessage),
+    /// Abort message (sent by the accepting peer to decline a request)
+    Abort { reason: AbortReason },
 }
 
 /// Runs the initiator side of the sync protocol.
@@ -96,7 +93,7 @@ pub(super) async fn run_alice<S: store::Store, R: AsyncRead + Unpin, W: AsyncWri
     reader: &mut R,
     alice: &Replica<S::Instance>,
     other_peer_id: PublicKey,
-) -> Result<()> {
+) -> Result<(), ConnectError> {
     let other_peer_id = *other_peer_id.as_bytes();
     let mut reader = FramedRead::new(reader, SyncCodec);
     let mut writer = FramedWrite::new(writer, SyncCodec);
@@ -105,28 +102,37 @@ pub(super) async fn run_alice<S: store::Store, R: AsyncRead + Unpin, W: AsyncWri
 
     let init_message = Message::Init {
         namespace: alice.namespace(),
-        message: alice.sync_initial_message().map_err(Into::into)?,
+        message: alice.sync_initial_message().map_err(ConnectError::sync)?,
     };
     trace!("alice -> bob: {:#?}", init_message);
-    writer.send(init_message).await?;
+    writer
+        .send(init_message)
+        .await
+        .map_err(ConnectError::sync)?;
 
     // Sync message loop
-
     while let Some(msg) = reader.next().await {
-        match msg? {
+        let msg = msg.map_err(ConnectError::sync)?;
+        match msg {
             Message::Init { .. } => {
-                bail!("unexpected message: init");
+                return Err(ConnectError::sync(anyhow!("unexpected init message")));
             }
             Message::Sync(msg) => {
                 if let Some(msg) = alice
                     .sync_process_message(msg, other_peer_id)
-                    .map_err(Into::into)?
+                    .map_err(ConnectError::sync)?
                 {
                     trace!("alice -> bob: {:#?}", msg);
-                    writer.send(Message::Sync(msg)).await?;
+                    writer
+                        .send(Message::Sync(msg))
+                        .await
+                        .map_err(ConnectError::sync)?;
                 } else {
                     break;
                 }
+            }
+            Message::Abort { reason } => {
+                return Err(ConnectError::remote_abort(reason));
             }
         }
     }
@@ -140,7 +146,7 @@ pub(super) async fn run_bob<S, R, W, F, Fut>(
     reader: &mut R,
     accept_cb: F,
     other_peer_id: PublicKey,
-) -> std::result::Result<NamespaceId, SyncError>
+) -> Result<NamespaceId, AcceptError>
 where
     S: store::Store,
     R: AsyncRead + Unpin,
@@ -149,10 +155,7 @@ where
     Fut: Future<Output = anyhow::Result<AcceptOutcome<S>>>,
 {
     let mut state = BobState::<S>::new(other_peer_id);
-    state
-        .run(writer, reader, accept_cb)
-        .await
-        .map_err(|err| SyncError::sync(state.peer, state.namespace(), err))
+    state.run(writer, reader, accept_cb).await
 }
 
 struct BobState<S: store::Store> {
@@ -168,7 +171,16 @@ impl<S: store::Store> BobState<S> {
         }
     }
 
-    async fn run<R, W, F, Fut>(&mut self, writer: W, reader: R, accept_cb: F) -> Result<NamespaceId>
+    pub fn fail(&self, reason: impl Into<anyhow::Error>) -> AcceptError {
+        AcceptError::sync(self.peer, self.namespace(), reason.into())
+    }
+
+    async fn run<R, W, F, Fut>(
+        &mut self,
+        writer: W,
+        reader: R,
+        accept_cb: F,
+    ) -> Result<NamespaceId, AcceptError>
     where
         R: AsyncRead + Unpin,
         W: AsyncWrite + Unpin,
@@ -178,15 +190,23 @@ impl<S: store::Store> BobState<S> {
         let mut reader = FramedRead::new(reader, SyncCodec);
         let mut writer = FramedWrite::new(writer, SyncCodec);
         while let Some(msg) = reader.next().await {
-            let next = match (msg?, self.replica.as_ref()) {
+            let msg = msg.map_err(|e| self.fail(e))?;
+            let next = match (msg, self.replica.as_ref()) {
                 (Message::Init { namespace, message }, None) => {
-                    let replica = match accept_cb(namespace, self.peer).await? {
-                        AcceptOutcome::Accept(replica) => replica,
-                        AcceptOutcome::NotAvailable => {
-                            bail!("abort sync: {namespace:?} not available")
-                        }
-                        AcceptOutcome::AlreadySyncing => {
-                            bail!("abort sync: {namespace:?} already syncing")
+                    let accept = accept_cb(namespace, self.peer).await;
+                    let accept = accept.map_err(|e| self.fail(e))?;
+                    let replica = match accept {
+                        Ok(replica) => replica,
+                        Err(reason) => {
+                            writer
+                                .send(Message::Abort { reason })
+                                .await
+                                .map_err(|e| self.fail(e))?;
+                            return Err(AcceptError::Abort {
+                                namespace,
+                                peer: self.peer,
+                                reason,
+                            });
                         }
                     };
                     trace!(?namespace, peer = ?self.peer, "run_bob: recv initial message {message:#?}");
@@ -198,13 +218,24 @@ impl<S: store::Store> BobState<S> {
                     trace!(namespace = ?replica.namespace(), peer = ?self.peer, "run_bob: recv {msg:#?}");
                     replica.sync_process_message(msg, *self.peer.as_bytes())
                 }
-                (Message::Init { .. }, Some(_)) => bail!("double init message"),
-                (Message::Sync(_), None) => bail!("unexpected sync message before init"),
+                (Message::Init { .. }, Some(_)) => {
+                    return Err(self.fail(anyhow!("double init message")))
+                }
+                (Message::Sync(_), None) => {
+                    return Err(self.fail(anyhow!("unexpected sync message before init")))
+                }
+                (Message::Abort { reason }, _) => {
+                    return Err(self.fail(anyhow!("unexpected abort message ({reason:?})")))
+                }
             };
-            match next.map_err(Into::into)? {
+            let next = next.map_err(|e| self.fail(e))?;
+            match next {
                 Some(msg) => {
                     trace!(namespace = ?self.namespace(), peer = ?self.peer, "run_bob: send {msg:#?}");
-                    writer.send(Message::Sync(msg)).await?;
+                    writer
+                        .send(Message::Sync(msg))
+                        .await
+                        .map_err(|e| self.fail(e))?;
                 }
                 None => break,
             }
@@ -213,7 +244,7 @@ impl<S: store::Store> BobState<S> {
         trace!(namespace = ?self.namespace().unwrap(), peer = ?self.peer, "run_bob: finished");
 
         self.namespace()
-            .ok_or_else(|| anyhow!("Stream closed before init message"))
+            .ok_or_else(|| self.fail(anyhow!("Stream closed before init message")))
     }
 
     fn namespace(&self) -> Option<NamespaceId> {

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, result::Result};
+use std::future::Future;
 
 use anyhow::{anyhow, ensure};
 use bytes::{Buf, BufMut, BytesMut};

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -259,6 +259,7 @@ mod tests {
         sync::Namespace,
         AuthorId,
     };
+    use anyhow::Result;
     use iroh_bytes::Hash;
     use iroh_net::key::SecretKey;
     use rand_core::{CryptoRngCore, SeedableRng};
@@ -331,7 +332,7 @@ mod tests {
                     futures::future::ready(
                         bob_replica_store_task
                             .open_replica(&namespace)
-                            .map(Into::into),
+                            .map(|r| r.ok_or(AbortReason::NotAvailable)),
                     )
                 },
                 alice_peer_id,
@@ -533,7 +534,11 @@ mod tests {
                 &mut bob_writer,
                 &mut bob_reader,
                 |namespace, _| {
-                    futures::future::ready(bob_store.open_replica(&namespace).map(Into::into))
+                    futures::future::ready(
+                        bob_store
+                            .open_replica(&namespace)
+                            .map(|r| r.ok_or(AbortReason::NotAvailable)),
+                    )
                 },
                 alice_node_pubkey,
             )

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -570,8 +570,14 @@ const AUTHOR_BYTES: std::ops::Range<usize> = 32..64;
 const KEY_BYTES: std::ops::RangeFrom<usize> = 64..;
 
 /// The indentifier of a record.
-#[derive(Default, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RecordIdentifier(Bytes);
+
+impl Default for RecordIdentifier {
+    fn default() -> Self {
+        Self::new(NamespaceId::default(), AuthorId::default(), b"")
+    }
+}
 
 impl Debug for RecordIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -9,7 +9,7 @@ use iroh::{
     collection::IrohCollectionParser,
     node::{Builder, Node},
     rpc_protocol::ShareMode,
-    sync_engine::{LiveEvent, Origin, SyncEvent, SyncReason},
+    sync_engine::{LiveEvent, SyncEvent},
 };
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use tracing_subscriber::{prelude::*, EnvFilter};
@@ -227,8 +227,8 @@ async fn sync_full_basic() -> Result<()> {
     // now expect SyncFinished
     let event = events.try_next().await?.unwrap();
     let LiveEvent::SyncFinished(event) = event else {
-            panic!("expected SyncFinished but got {event:?}");
-        };
+        panic!("expected SyncFinished but got {event:?}");
+    };
     let expected = SyncEvent {
         peer: nodes[0].peer_id(),
         namespace: doc.id(),


### PR DESCRIPTION
## Description

On `main` the test `sync_full_basic` is flakey. This PR (hopefully) fixes it.

The reason was: We have the situation that two peers initiate connections to each other at (roughly) the same time. In #1491 this was sometimes prevented, but not reliably.

This PR fixes it by:
* When connecting, we set a `SyncState::Dialing` for the `(namespace, peer)`
* When accepting, if our own state is `Dialing` for the incoming request for `(namespace, peer)` we compare our peer id with that of the incoming request, and abort if ours is higher (doesn't matter which way, we care about a predictable outcome only
* Through this, only one of the two simoultanoues connections will survive
* Also added a `Abort` frame to the wire protocol to transfer to inform the dialer about the reason of the declined request, which is either "we do double sync, and will take the other conn" (`AlreadySyncing`) or "this replica is not here" (`NotAvailable`)

This PR also:
* Further improves logging
* Improves errors

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
