### PR TITLE
refactor(*):  rework `NodeAddr`

### DIFF
--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt, net::SocketAddr, str::FromStr, sync::Arc};
+use std::{collections::HashMap, fmt, str::FromStr, sync::Arc};
 
 use anyhow::{bail, Context};
 use bytes::Bytes;
@@ -13,7 +13,7 @@ use iroh_net::{
     derp::DerpMap,
     key::{PublicKey, SecretKey},
     magic_endpoint::accept_conn,
-    MagicEndpoint,
+    MagicEndpoint, PeerData,
 };
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -144,8 +144,8 @@ async fn main() -> anyhow::Result<()> {
 
     // print a ticket that includes our own peer id and endpoint addresses
     let ticket = {
-        let me = PeerAddr::from_endpoint(&endpoint).await?;
-        let peers = peers.iter().chain([&me]).cloned().collect();
+        let me = endpoint.my_addr().await?;
+        let peers = peers.iter().cloned().chain([me]).collect();
         Ticket { topic, peers }
     };
     println!("> ticket to join us: {ticket}");
@@ -154,18 +154,16 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(endpoint_loop(endpoint.clone(), gossip.clone()));
 
     // join the gossip topic by connecting to known peers, if any
+    let peer_ids = peers.iter().map(|p| p.peer_id).collect();
     if peers.is_empty() {
         println!("> waiting for peers to join us...");
     } else {
         println!("> trying to connect to {} peers...", peers.len());
         // add the peer addrs from the ticket to our endpoint's addressbook so that they can be dialed
-        for peer in &peers {
-            endpoint
-                .add_known_addrs(peer.peer_id, peer.derp_region, &peer.addrs)
-                .await?;
+        for peer in peers.into_iter() {
+            endpoint.add_peer_data(peer).await?;
         }
     };
-    let peer_ids = peers.iter().map(|p| p.peer_id).collect();
     gossip.join(topic, peer_ids).await?.await?;
     println!("> connected!");
 
@@ -292,7 +290,7 @@ enum Message {
 #[derive(Debug, Serialize, Deserialize)]
 struct Ticket {
     topic: TopicId,
-    peers: Vec<PeerAddr>,
+    peers: Vec<PeerData>,
 }
 impl Ticket {
     /// Deserializes from bytes.
@@ -302,28 +300,6 @@ impl Ticket {
     /// Serializes to bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
         postcard::to_stdvec(self).expect("postcard::to_stdvec is infallible")
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-struct PeerAddr {
-    peer_id: PublicKey,
-    addrs: Vec<SocketAddr>,
-    derp_region: Option<u16>,
-}
-
-impl PeerAddr {
-    pub async fn from_endpoint(endpoint: &MagicEndpoint) -> anyhow::Result<Self> {
-        Ok(Self {
-            peer_id: endpoint.peer_id(),
-            derp_region: endpoint.my_derp().await,
-            addrs: endpoint
-                .local_endpoints()
-                .await?
-                .iter()
-                .map(|ep| ep.addr)
-                .collect(),
-        })
     }
 }
 

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -13,7 +13,7 @@ use iroh_net::{
     derp::DerpMap,
     key::{PublicKey, SecretKey},
     magic_endpoint::accept_conn,
-    MagicEndpoint, PeerData,
+    MagicEndpoint, PeerAddr,
 };
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -117,7 +117,7 @@ async fn main() -> anyhow::Result<()> {
             let gossip_cell = gossip_cell.clone();
             let notify = notify.clone();
             Box::new(move |endpoints| {
-                // send our updated endpoints to the gossip protocol to be sent as PeerData to peers
+                // send our updated endpoints to the gossip protocol to be sent as PeerAddr to peers
                 if let Some(gossip) = gossip_cell.get() {
                     gossip.update_endpoints(endpoints).ok();
                 }
@@ -290,7 +290,7 @@ enum Message {
 #[derive(Debug, Serialize, Deserialize)]
 struct Ticket {
     topic: TopicId,
-    peers: Vec<PeerData>,
+    peers: Vec<PeerAddr>,
 }
 impl Ticket {
     /// Deserializes from bytes.

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -161,7 +161,7 @@ async fn main() -> anyhow::Result<()> {
         println!("> trying to connect to {} peers...", peers.len());
         // add the peer addrs from the ticket to our endpoint's addressbook so that they can be dialed
         for peer in peers.into_iter() {
-            endpoint.add_peer_data(peer).await?;
+            endpoint.add_peer_addr(peer).await?;
         }
     };
     gossip.join(topic, peer_ids).await?.await?;

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -1,18 +1,14 @@
 //! Networking for the `iroh-gossip` protocol
 
-use std::{
-    collections::HashMap, fmt, future::Future, net::SocketAddr, sync::Arc, task::Poll,
-    time::Instant,
-};
-
 use anyhow::{anyhow, Context};
 use bytes::{Bytes, BytesMut};
 use futures::{stream::Stream, FutureExt};
 use genawaiter::sync::{Co, Gen};
+use iroh_net::magic_endpoint::AddrInfo;
 use iroh_net::{key::PublicKey, magic_endpoint::get_peer_id, MagicEndpoint};
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
-use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fmt, future::Future, sync::Arc, task::Poll, time::Instant};
 use tokio::{
     sync::{broadcast, mpsc, oneshot, watch},
     task::JoinHandle,
@@ -253,32 +249,6 @@ impl Future for JoinTopicFut {
     }
 }
 
-/// Addressing information for peers.
-///
-/// This struct is serialized and transmitted to peers in `Join` and `ForwardJoin` messages.
-/// It contains the information needed by `iroh-net` to connect to peers.
-///
-/// TODO: Replace with type from iroh-net
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct IrohInfo {
-    addrs: Vec<SocketAddr>,
-    derp_region: Option<u16>,
-}
-
-impl IrohInfo {
-    async fn from_endpoint(endpoint: &MagicEndpoint) -> anyhow::Result<Self> {
-        Ok(Self {
-            addrs: endpoint
-                .local_endpoints()
-                .await?
-                .iter()
-                .map(|ep| ep.addr)
-                .collect(),
-            derp_region: endpoint.my_derp().await,
-        })
-    }
-}
-
 /// Whether a connection is initiated by us (Dial) or by the remote peer (Accept)
 #[derive(Debug)]
 enum ConnOrigin {
@@ -370,7 +340,7 @@ impl Actor {
                     }
                 },
                 _ = self.on_endpoints_rx.changed() => {
-                    let info = IrohInfo::from_endpoint(&self.endpoint).await?;
+                    let info = self.endpoint.my_addr().await?;
                     let peer_data = postcard::to_stdvec(&info)?;
                     self.handle_in_event(InEvent::UpdatePeerData(peer_data.into()), Instant::now()).await?;
                 }
@@ -533,15 +503,15 @@ impl Actor {
                     self.pending_sends.remove(&peer);
                     self.dialer.abort_dial(&peer);
                 }
-                OutEvent::PeerData(peer, data) => match postcard::from_bytes::<IrohInfo>(&data) {
+                OutEvent::PeerData(peer, data) => match postcard::from_bytes::<AddrInfo>(&data) {
                     Err(err) => warn!("Failed to decode PeerData from {peer}: {err}"),
-                    Ok(info) => {
-                        debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known addrs: {info:?}");
-                        if let Err(err) = self
-                            .endpoint
-                            .add_known_addrs(peer, info.derp_region, &info.addrs)
-                            .await
-                        {
+                    Ok(addr_info) => {
+                        debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known addrs: {addr_info:?}");
+                        let peer_data = iroh_net::PeerData {
+                            peer_id: peer,
+                            addr_info,
+                        };
+                        if let Err(err) = self.endpoint.add_peer_data(peer_data).await {
                             debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known failed: {err:?}");
                         }
                     }
@@ -623,6 +593,7 @@ async fn connection_loop(
 mod test {
     use std::time::Duration;
 
+    use iroh_net::PeerData;
     use iroh_net::{derp::DerpMap, MagicEndpoint};
     use tokio::spawn;
     use tokio::time::timeout;
@@ -685,8 +656,12 @@ mod test {
 
         let topic: TopicId = blake3::hash(b"foobar").into();
         // share info that pi1 is on the same derp_region
-        ep2.add_known_addrs(pi1, derp_region, &[]).await.unwrap();
-        ep3.add_known_addrs(pi1, derp_region, &[]).await.unwrap();
+        ep2.add_peer_data(PeerData::new(pi1).with_derp_region(derp_region))
+            .await
+            .unwrap();
+        ep3.add_peer_data(PeerData::new(pi1).with_derp_region(derp_region))
+            .await
+            .unwrap();
         // join the topics and wait for the connection to succeed
         go1.join(topic, vec![]).await.unwrap();
         go2.join(topic, vec![pi1]).await.unwrap().await.unwrap();
@@ -799,7 +774,7 @@ mod test {
         /// [`MagicEndpoint::connect`]: crate::magic_endpoint::MagicEndpoint
         pub(crate) async fn run_derp_and_stun(
             stun_ip: IpAddr,
-        ) -> Result<(DerpMap, Option<u16>, CleanupDropGuard)> {
+        ) -> Result<(DerpMap, u16, CleanupDropGuard)> {
             // TODO: pass a mesh_key?
 
             let server_key = SecretKey::generate();
@@ -834,7 +809,7 @@ mod test {
                 server.shutdown().await;
             });
 
-            Ok((m, Some(region_id), CleanupDropGuard(tx)))
+            Ok((m, region_id, CleanupDropGuard(tx)))
         }
 
         /// Sets up a simple STUN server.

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -120,7 +120,7 @@ impl Gossip {
     ///
     ///
     /// This method only asks for [`PublicKey`]s. You must supply information on how to
-    /// connect to these peers manually before, by calling [`MagicEndpoint::add_known_addrs`] on
+    /// connect to these peers manually before, by calling [`MagicEndpoint::add_peer_data`] on
     /// the underlying [`MagicEndpoint`].
     ///
     /// This method returns a future that completes once the request reached the local actor.

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -505,13 +505,13 @@ impl Actor {
                 }
                 OutEvent::PeerData(peer, data) => match postcard::from_bytes::<AddrInfo>(&data) {
                     Err(err) => warn!("Failed to decode PeerData from {peer}: {err}"),
-                    Ok(addr_info) => {
-                        debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known addrs: {addr_info:?}");
-                        let peer_data = iroh_net::PeerAddr {
+                    Ok(info) => {
+                        debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known addrs: {info:?}");
+                        let peer_addr = iroh_net::PeerAddr {
                             peer_id: peer,
-                            addr_info,
+                            info,
                         };
-                        if let Err(err) = self.endpoint.add_peer_addr(peer_data).await {
+                        if let Err(err) = self.endpoint.add_peer_addr(peer_addr).await {
                             debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known failed: {err:?}");
                         }
                     }
@@ -593,7 +593,7 @@ async fn connection_loop(
 mod test {
     use std::time::Duration;
 
-    use iroh_net::PeerData;
+    use iroh_net::PeerAddr;
     use iroh_net::{derp::DerpMap, MagicEndpoint};
     use tokio::spawn;
     use tokio::time::timeout;
@@ -656,10 +656,10 @@ mod test {
 
         let topic: TopicId = blake3::hash(b"foobar").into();
         // share info that pi1 is on the same derp_region
-        ep2.add_peer_addr(PeerData::new(pi1).with_derp_region(derp_region))
+        ep2.add_peer_addr(PeerAddr::new(pi1).with_derp_region(derp_region))
             .await
             .unwrap();
-        ep3.add_peer_addr(PeerData::new(pi1).with_derp_region(derp_region))
+        ep3.add_peer_addr(PeerAddr::new(pi1).with_derp_region(derp_region))
             .await
             .unwrap();
         // join the topics and wait for the connection to succeed

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -120,7 +120,7 @@ impl Gossip {
     ///
     ///
     /// This method only asks for [`PublicKey`]s. You must supply information on how to
-    /// connect to these peers manually before, by calling [`MagicEndpoint::add_peer_data`] on
+    /// connect to these peers manually before, by calling [`MagicEndpoint::add_peer_addr`] on
     /// the underlying [`MagicEndpoint`].
     ///
     /// This method returns a future that completes once the request reached the local actor.
@@ -507,11 +507,11 @@ impl Actor {
                     Err(err) => warn!("Failed to decode PeerData from {peer}: {err}"),
                     Ok(addr_info) => {
                         debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known addrs: {addr_info:?}");
-                        let peer_data = iroh_net::PeerData {
+                        let peer_data = iroh_net::PeerAddr {
                             peer_id: peer,
                             addr_info,
                         };
-                        if let Err(err) = self.endpoint.add_peer_data(peer_data).await {
+                        if let Err(err) = self.endpoint.add_peer_addr(peer_data).await {
                             debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known failed: {err:?}");
                         }
                     }
@@ -656,10 +656,10 @@ mod test {
 
         let topic: TopicId = blake3::hash(b"foobar").into();
         // share info that pi1 is on the same derp_region
-        ep2.add_peer_data(PeerData::new(pi1).with_derp_region(derp_region))
+        ep2.add_peer_addr(PeerData::new(pi1).with_derp_region(derp_region))
             .await
             .unwrap();
-        ep3.add_peer_data(PeerData::new(pi1).with_derp_region(derp_region))
+        ep3.add_peer_addr(PeerData::new(pi1).with_derp_region(derp_region))
             .await
             .unwrap();
         // join the topics and wait for the connection to succeed

--- a/iroh-gossip/src/net/util.rs
+++ b/iroh-gossip/src/net/util.rs
@@ -105,7 +105,7 @@ impl Dialer {
     /// Start to dial a peer
     ///
     /// Note that the peer's addresses and/or derp region must be added to the endpoint's
-    /// addressbook for a dial to succeed, see [`MagicEndpoint::add_peer_data`].
+    /// addressbook for a dial to succeed, see [`MagicEndpoint::add_peer_addr`].
     pub fn queue_dial(&mut self, peer_id: PublicKey, alpn_protocol: &'static [u8]) {
         if self.is_pending(&peer_id) {
             return;
@@ -117,7 +117,7 @@ impl Dialer {
             let res = tokio::select! {
                 biased;
                 _ = cancel.cancelled() => Err(anyhow!("Cancelled")),
-                res = endpoint.connect(iroh_net::PeerData::new(peer_id), alpn_protocol) => res
+                res = endpoint.connect(iroh_net::PeerAddr::new(peer_id), alpn_protocol) => res
             };
             (peer_id, res)
         }

--- a/iroh-gossip/src/net/util.rs
+++ b/iroh-gossip/src/net/util.rs
@@ -105,7 +105,7 @@ impl Dialer {
     /// Start to dial a peer
     ///
     /// Note that the peer's addresses and/or derp region must be added to the endpoint's
-    /// addressbook for a dial to succeed, see [`MagicEndpoint::add_known_addrs`].
+    /// addressbook for a dial to succeed, see [`MagicEndpoint::add_peer_data`].
     pub fn queue_dial(&mut self, peer_id: PublicKey, alpn_protocol: &'static [u8]) {
         if self.is_pending(&peer_id) {
             return;

--- a/iroh-gossip/src/net/util.rs
+++ b/iroh-gossip/src/net/util.rs
@@ -117,7 +117,7 @@ impl Dialer {
             let res = tokio::select! {
                 biased;
                 _ = cancel.cancelled() => Err(anyhow!("Cancelled")),
-                res = endpoint.connect(peer_id, alpn_protocol, None, &[]) => res
+                res = endpoint.connect(iroh_net::PeerData::new(peer_id), alpn_protocol) => res
             };
             (peer_id, res)
         }

--- a/iroh-net/examples/magic.rs
+++ b/iroh-net/examples/magic.rs
@@ -6,7 +6,7 @@ use iroh_net::{
     derp::DerpMap,
     key::{PublicKey, SecretKey},
     magic_endpoint::accept_conn,
-    MagicEndpoint,
+    MagicEndpoint, PeerData,
 };
 use tracing::{debug, info};
 use url::Url;
@@ -98,9 +98,8 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let peer_id: PublicKey = peer_id.parse()?;
             let addrs = addrs.unwrap_or_default();
-            let conn = endpoint
-                .connect(peer_id, EXAMPLE_ALPN, derp_region, &addrs)
-                .await?;
+            let peer_data = PeerData::from_parts(peer_id, derp_region, addrs);
+            let conn = endpoint.connect(peer_data, EXAMPLE_ALPN).await?;
             info!("connected");
 
             let (mut send, mut recv) = conn.open_bi().await?;

--- a/iroh-net/examples/magic.rs
+++ b/iroh-net/examples/magic.rs
@@ -6,7 +6,7 @@ use iroh_net::{
     derp::DerpMap,
     key::{PublicKey, SecretKey},
     magic_endpoint::accept_conn,
-    MagicEndpoint, PeerData,
+    MagicEndpoint, PeerAddr,
 };
 use tracing::{debug, info};
 use url::Url;
@@ -98,8 +98,8 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let peer_id: PublicKey = peer_id.parse()?;
             let addrs = addrs.unwrap_or_default();
-            let peer_data = PeerData::from_parts(peer_id, derp_region, addrs);
-            let conn = endpoint.connect(peer_data, EXAMPLE_ALPN).await?;
+            let peer_addr = PeerAddr::from_parts(peer_id, derp_region, addrs);
+            let conn = endpoint.connect(peer_addr, EXAMPLE_ALPN).await?;
             info!("connected");
 
             let (mut send, mut recv) = conn.open_bi().await?;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -27,7 +27,7 @@ pub mod stun;
 pub mod tls;
 pub mod util;
 
-pub use magic_endpoint::{MagicEndpoint, NodeAddr};
+pub use magic_endpoint::{AddrInfo, MagicEndpoint, PeerData};
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -27,7 +27,7 @@ pub mod stun;
 pub mod tls;
 pub mod util;
 
-pub use magic_endpoint::{AddrInfo, MagicEndpoint, PeerData};
+pub use magic_endpoint::{AddrInfo, MagicEndpoint, PeerAddr};
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -69,7 +69,7 @@ impl From<(PublicKey, Option<u16>, &[SocketAddr])> for PeerData {
             peer_id,
             addr_info: AddrInfo {
                 derp_region,
-                direct_addresses: direct_addresses_iter.iter().copied().collect(),
+                direct_addresses: direct_addresses_iter.to_vec().iter().copied().collect(),
             },
         }
     }
@@ -92,7 +92,7 @@ impl AddrInfo {
 }
 
 impl PeerData {
-    /// Create a new [`NodeAddr`] from its parts.
+    /// Create a new [`PeerData`] from its parts.
     pub fn from_parts(
         peer_id: PublicKey,
         derp_region: Option<u16>,
@@ -373,7 +373,7 @@ impl MagicEndpoint {
         self.msock.my_derp().await
     }
 
-    /// Get the [`NodeAddr`] for this endpoint.
+    /// Get the [`PeerData`] for this endpoint.
     // TODO: We can save an async call by exposing this on the msock.
     pub async fn my_addr(&self) -> Result<PeerData> {
         let addrs = self.local_endpoints().await?;
@@ -389,7 +389,7 @@ impl MagicEndpoint {
     /// currently communicating with that node over a `Direct` (UDP) or `Relay` (DERP) connection.
     ///
     /// Connections are currently only pruned on user action (when we explicitly add a new address
-    /// to the internal addressbook through [`MagicEndpoint::add_known_addrs`]), so these connections
+    /// to the internal addressbook through [`MagicEndpoint::add_peer_data`]), so these connections
     /// are not necessarily active connections.
     pub async fn connection_infos(&self) -> anyhow::Result<Vec<ConnectionInfo>> {
         self.msock.tracked_endpoints().await

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -69,7 +69,7 @@ impl From<(PublicKey, Option<u16>, &[SocketAddr])> for PeerData {
             peer_id,
             addr_info: AddrInfo {
                 derp_region,
-                direct_addresses: direct_addresses_iter.to_vec().iter().copied().collect(),
+                direct_addresses: direct_addresses_iter.to_vec(),
             },
         }
     }

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2235,7 +2235,7 @@ impl Actor {
 
     #[instrument(skip_all)]
     fn add_known_addr(&mut self, n: PeerAddr) {
-        let PeerAddr { peer_id, addr_info } = n;
+        let PeerAddr { peer_id, info } = n;
         if self.peer_map.endpoint_for_node_key(&peer_id).is_none() {
             info!(
                 peer = ?n.peer_id,
@@ -2244,14 +2244,14 @@ impl Actor {
             self.peer_map.insert_endpoint(EndpointOptions {
                 msock_sender: self.inner.actor_sender.clone(),
                 public_key: peer_id,
-                derp_region: addr_info.derp_region,
+                derp_region: info.derp_region,
             });
         }
 
         if let Some(ep) = self.peer_map.endpoint_for_node_key_mut(&peer_id) {
-            ep.update_from_node_addr(&addr_info);
+            ep.update_from_node_addr(&info);
             let id = ep.id;
-            for endpoint in &addr_info.direct_addresses {
+            for endpoint in &info.direct_addresses {
                 self.peer_map
                     .set_endpoint_for_ip_port(&SendAddr::Udp(*endpoint), id);
             }
@@ -2765,7 +2765,7 @@ pub(crate) mod tests {
                 }
                 let addr = PeerAddr {
                     peer_id: me.public(),
-                    addr_info: crate::AddrInfo {
+                    info: crate::AddrInfo {
                         derp_region: Some(1),
                         direct_addresses: new_eps.iter().map(|ep| ep.addr).collect(),
                     },

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -49,7 +49,7 @@ use crate::{
     disco,
     dns::DNS_RESOLVER,
     key::{PublicKey, SecretKey, SharedSecret},
-    magic_endpoint::NodeAddr,
+    magic_endpoint::PeerData,
     net::{ip::LocalAddresses, netmon},
     netcheck, portmapper, stun,
     util::AbortingJoinHandle,
@@ -573,7 +573,7 @@ impl MagicSock {
 
     #[instrument(skip_all, fields(self.name = %self.inner.name))]
     /// Add addresses for a node to the magic socket's addresbook.
-    pub async fn add_known_addr(&self, addr: NodeAddr) -> Result<()> {
+    pub async fn add_peer_data(&self, addr: PeerData) -> Result<()> {
         let (s, r) = sync::oneshot::channel();
         self.inner
             .actor_sender
@@ -863,7 +863,7 @@ enum ActorMessage {
         dst_key: PublicKey,
         msg: disco::CallMeMaybe,
     },
-    AddKnownAddr(NodeAddr, sync::oneshot::Sender<()>),
+    AddKnownAddr(PeerData, sync::oneshot::Sender<()>),
     ReceiveDerp(DerpReadResult),
     EndpointPingExpired(usize, stun::TransactionId),
 }
@@ -2234,23 +2234,24 @@ impl Actor {
     }
 
     #[instrument(skip_all)]
-    fn add_known_addr(&mut self, n: NodeAddr) {
-        if self.peer_map.endpoint_for_node_key(&n.node_id).is_none() {
+    fn add_known_addr(&mut self, n: PeerData) {
+        let PeerData { peer_id, addr_info } = n;
+        if self.peer_map.endpoint_for_node_key(&peer_id).is_none() {
             info!(
-                peer = ?n.node_id,
+                peer = ?n.peer_id,
                 "inserting peer's endpoint in PeerMap"
             );
             self.peer_map.insert_endpoint(EndpointOptions {
                 msock_sender: self.inner.actor_sender.clone(),
-                public_key: n.node_id,
-                derp_region: n.derp_region,
+                public_key: peer_id,
+                derp_region: addr_info.derp_region,
             });
         }
 
-        if let Some(ep) = self.peer_map.endpoint_for_node_key_mut(&n.node_id) {
-            ep.update_from_node_addr(&n);
+        if let Some(ep) = self.peer_map.endpoint_for_node_key_mut(&peer_id) {
+            ep.update_from_node_addr(&addr_info);
             let id = ep.id;
-            for endpoint in &n.endpoints {
+            for endpoint in &addr_info.direct_addresses {
                 self.peer_map
                     .set_endpoint_for_ip_port(&SendAddr::Udp(*endpoint), id);
             }
@@ -2762,12 +2763,14 @@ pub(crate) mod tests {
                 if i == my_idx {
                     continue;
                 }
-                let addr = NodeAddr {
-                    endpoints: new_eps.iter().map(|ep| ep.addr).collect(),
-                    node_id: me.public(),
-                    derp_region: Some(1),
+                let addr = PeerData {
+                    peer_id: me.public(),
+                    addr_info: crate::AddrInfo {
+                        derp_region: Some(1),
+                        direct_addresses: new_eps.iter().map(|ep| ep.addr).collect(),
+                    },
                 };
-                let _ = m.endpoint.magic_sock().add_known_addr(addr).await;
+                let _ = m.endpoint.magic_sock().add_peer_data(addr).await;
             }
         }
 
@@ -2902,9 +2905,10 @@ pub(crate) mod tests {
                 let a_span = debug_span!("sender", a_name, %a_addr);
                 async move {
                     println!("[{}] connecting to {}", a_name, b_addr);
+                    let peer_b_data = PeerData::new(b_peer_id).with_derp_region(region).with_direct_addresses([b_addr]);
                     let conn = a
                         .endpoint
-                        .connect(b_peer_id, &ALPN, region, &[b_addr])
+                        .connect(peer_b_data, &ALPN)
                         .await
                         .with_context(|| format!("[{}] connect", a_name))?;
 

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -13,7 +13,7 @@ use tokio::{sync::mpsc, time::Instant};
 use tracing::{debug, info, trace, warn};
 
 use crate::{
-    config, disco, key::PublicKey, magic_endpoint::NodeAddr, magicsock::Timer,
+    config, disco, key::PublicKey, magic_endpoint::AddrInfo, magicsock::Timer,
     net::ip::is_unicast_link_local, stun, util::derp_only_mode,
 };
 
@@ -540,7 +540,7 @@ impl Endpoint {
         }
     }
 
-    pub fn update_from_node_addr(&mut self, n: &NodeAddr) {
+    pub fn update_from_node_addr(&mut self, n: &AddrInfo) {
         if self.best_addr.is_none() {
             // we do not have a direct connection, so changing the derp information may
             // have an effect on our connection status
@@ -564,7 +564,12 @@ impl Endpoint {
         for st in self.endpoint_state.values_mut() {
             st.index = Index::Deleted; // assume deleted until updated in next loop
         }
-        for (i, ep) in n.endpoints.iter().take(u16::MAX as usize).enumerate() {
+        for (i, ep) in n
+            .direct_addresses
+            .iter()
+            .take(u16::MAX as usize)
+            .enumerate()
+        {
             let index = Index::Some(i);
             let ep = SendAddr::Udp(*ep);
             if let Some(st) = self.endpoint_state.get_mut(&ep) {

--- a/iroh-net/src/test_utils.rs
+++ b/iroh-net/src/test_utils.rs
@@ -20,7 +20,7 @@ pub(crate) struct CleanupDropGuard(pub(crate) oneshot::Sender<()>);
 /// is always `Some` as that is how the [`MagicEndpoint::connect`] API expects it.
 ///
 /// [`MagicEndpoint::connect`]: crate::magic_endpoint::MagicEndpoint
-pub(crate) async fn run_derper() -> Result<(DerpMap, Option<u16>, CleanupDropGuard)> {
+pub(crate) async fn run_derper() -> Result<(DerpMap, u16, CleanupDropGuard)> {
     // TODO: pass a mesh_key?
 
     let server_key = SecretKey::generate();
@@ -69,5 +69,5 @@ pub(crate) async fn run_derper() -> Result<(DerpMap, Option<u16>, CleanupDropGua
         .instrument(info_span!("derp-stun-cleanup")),
     );
 
-    Ok((m, Some(region_id), CleanupDropGuard(tx)))
+    Ok((m, region_id, CleanupDropGuard(tx)))
 }

--- a/iroh-sync/src/net.rs
+++ b/iroh-sync/src/net.rs
@@ -34,7 +34,7 @@ pub async fn connect_and_sync<S: store::Store>(
     debug!(peer = ?peer, "sync (via connect): start");
     let namespace = doc.namespace();
     let connection = endpoint
-        .connect(peer, SYNC_ALPN, derp_region, addrs)
+        .connect((peer, derp_region, addrs).into(), SYNC_ALPN)
         .await
         .context("failed to establish connection")?;
     debug!(?peer, ?namespace, "sync (via connect): connected");

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -56,9 +56,9 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.node_addr().node_id);
+    println!("node PeerID:     {}", ticket.node_addr().peer_id);
     println!("node listening addresses:");
-    for addr in ticket.node_addr().endpoints.iter() {
+    for addr in ticket.node_addr().direct_addresses() {
         println!("\t{:?}", addr);
     }
     // print the ticket, containing all the above information

--- a/iroh/examples/hello-world.rs
+++ b/iroh/examples/hello-world.rs
@@ -37,9 +37,9 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash).await?.with_recursive(false);
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.node_addr().node_id);
+    println!("node PeerID:     {}", ticket.node_addr().peer_id);
     println!("node listening addresses:");
-    for addr in &ticket.node_addr().endpoints {
+    for addr in ticket.node_addr().direct_addresses() {
         println!("\t{:?}", addr);
     }
     // print the ticket, containing all the above information

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -11,7 +11,7 @@ use iroh::client::quic::Iroh;
 use iroh::dial::Ticket;
 use iroh::rpc_protocol::*;
 use iroh_bytes::{protocol::RequestToken, util::runtime, Hash};
-use iroh_net::NodeAddr;
+use iroh_net::PeerData;
 use iroh_net::{
     key::{PublicKey, SecretKey},
     magic_endpoint::ConnectionInfo,
@@ -253,7 +253,7 @@ impl FullCommands {
                         rt: rt.clone(),
                         hash,
                         opts: iroh::dial::Options {
-                            peer: NodeAddr::from_parts(peer, region, addrs),
+                            peer: PeerData::from_parts(peer, region, addrs),
                             keylog,
                             derp_map: config.derp_map()?,
                             secret_key: SecretKey::generate(),
@@ -466,7 +466,7 @@ impl BlobCommands {
                     ticket.into_parts()
                 } else {
                     (
-                        NodeAddr::from_parts(peer.unwrap(), derp_region, addr),
+                        PeerData::from_parts(peer.unwrap(), derp_region, addr),
                         hash.unwrap(),
                         token,
                         recursive.unwrap_or_default(),

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -11,7 +11,7 @@ use iroh::client::quic::Iroh;
 use iroh::dial::Ticket;
 use iroh::rpc_protocol::*;
 use iroh_bytes::{protocol::RequestToken, util::runtime, Hash};
-use iroh_net::PeerData;
+use iroh_net::PeerAddr;
 use iroh_net::{
     key::{PublicKey, SecretKey},
     magic_endpoint::ConnectionInfo,
@@ -253,7 +253,7 @@ impl FullCommands {
                         rt: rt.clone(),
                         hash,
                         opts: iroh::dial::Options {
-                            peer: PeerData::from_parts(peer, region, addrs),
+                            peer: PeerAddr::from_parts(peer, region, addrs),
                             keylog,
                             derp_map: config.derp_map()?,
                             secret_key: SecretKey::generate(),
@@ -466,7 +466,7 @@ impl BlobCommands {
                     ticket.into_parts()
                 } else {
                     (
-                        PeerData::from_parts(peer.unwrap(), derp_region, addr),
+                        PeerAddr::from_parts(peer.unwrap(), derp_region, addr),
                         hash.unwrap(),
                         token,
                         recursive.unwrap_or_default(),

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -17,7 +17,7 @@ use iroh_net::{
     defaults::{DEFAULT_DERP_STUN_PORT, TEST_REGION_ID},
     derp::{DerpMap, UseIpv4, UseIpv6},
     key::{PublicKey, SecretKey},
-    netcheck, portmapper, MagicEndpoint, PeerData,
+    netcheck, portmapper, MagicEndpoint, PeerAddr,
 };
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
@@ -550,8 +550,8 @@ async fn connect(
     let peer_id = PublicKey::try_from(&bytes[..]).context("failed to parse PublicKey")?;
 
     tracing::info!("dialing {:?}", peer_id);
-    let peer_data = PeerData::from_parts(peer_id, derp_region, direct_addresses);
-    let conn = endpoint.connect(peer_data, &DR_DERP_ALPN).await;
+    let peer_addr = PeerAddr::from_parts(peer_id, derp_region, direct_addresses);
+    let conn = endpoint.connect(peer_addr, &DR_DERP_ALPN).await;
     match conn {
         Ok(connection) => {
             if let Err(cause) = passive_side(connection).await {

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -17,7 +17,7 @@ use iroh_net::{
     defaults::{DEFAULT_DERP_STUN_PORT, TEST_REGION_ID},
     derp::{DerpMap, UseIpv4, UseIpv6},
     key::{PublicKey, SecretKey},
-    netcheck, portmapper, MagicEndpoint,
+    netcheck, portmapper, MagicEndpoint, PeerData,
 };
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
@@ -540,7 +540,7 @@ async fn make_endpoint(
 async fn connect(
     dial: String,
     secret_key: SecretKey,
-    remote_endpoints: Vec<SocketAddr>,
+    direct_addresses: Vec<SocketAddr>,
     derp_region: Option<u16>,
     derp_map: Option<DerpMap>,
 ) -> anyhow::Result<()> {
@@ -550,9 +550,8 @@ async fn connect(
     let peer_id = PublicKey::try_from(&bytes[..]).context("failed to parse PublicKey")?;
 
     tracing::info!("dialing {:?}", peer_id);
-    let conn = endpoint
-        .connect(peer_id, &DR_DERP_ALPN, derp_region, &remote_endpoints)
-        .await;
+    let peer_data = PeerData::from_parts(peer_id, derp_region, direct_addresses);
+    let conn = endpoint.connect(peer_data, &DR_DERP_ALPN).await;
     match conn {
         Ok(connection) => {
             if let Err(cause) = passive_side(connection).await {

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -72,7 +72,7 @@ impl Ticket {
         recursive: bool,
     ) -> Result<Self> {
         ensure!(
-            !peer.addr_info.direct_addresses.is_empty(),
+            !peer.info.direct_addresses.is_empty(),
             "addrs list can not be empty"
         );
         Ok(Self {
@@ -87,7 +87,7 @@ impl Ticket {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let slf: Ticket = postcard::from_bytes(bytes)?;
         ensure!(
-            !slf.peer.addr_info.direct_addresses.is_empty(),
+            !slf.peer.info.direct_addresses.is_empty(),
             "Invalid address list in ticket"
         );
         Ok(slf)

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -11,7 +11,7 @@ use iroh_bytes::protocol::RequestToken;
 use iroh_bytes::Hash;
 use iroh_net::derp::DerpMap;
 use iroh_net::key::SecretKey;
-use iroh_net::PeerData;
+use iroh_net::PeerAddr;
 use serde::{Deserialize, Serialize};
 
 /// Options for the client
@@ -20,7 +20,7 @@ pub struct Options {
     /// The secret key of the node
     pub secret_key: SecretKey,
     /// The peer to connect to.
-    pub peer: PeerData,
+    pub peer: PeerAddr,
     /// Whether to log the SSL keys when `SSLKEYLOGFILE` environment variable is set
     pub keylog: bool,
     /// The configuration of the derp services
@@ -54,7 +54,7 @@ pub async fn dial(opts: Options) -> anyhow::Result<quinn::Connection> {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ticket {
     /// The provider to get a file from.
-    peer: PeerData,
+    peer: PeerAddr,
     /// The hash to retrieve.
     hash: Hash,
     /// Optional Request token.
@@ -66,7 +66,7 @@ pub struct Ticket {
 impl Ticket {
     /// Creates a new ticket.
     pub fn new(
-        peer: PeerData,
+        peer: PeerAddr,
         hash: Hash,
         token: Option<RequestToken>,
         recursive: bool,
@@ -103,8 +103,8 @@ impl Ticket {
         self.hash
     }
 
-    /// The [`PeerData`] of the provider for this ticket.
-    pub fn node_addr(&self) -> &PeerData {
+    /// The [`PeerAddr`] of the provider for this ticket.
+    pub fn node_addr(&self) -> &PeerAddr {
         &self.peer
     }
 
@@ -129,7 +129,7 @@ impl Ticket {
     }
 
     /// Get the contents of the ticket, consuming it.
-    pub fn into_parts(self) -> (PeerData, Hash, Option<RequestToken>, bool) {
+    pub fn into_parts(self) -> (PeerAddr, Hash, Option<RequestToken>, bool) {
         let Ticket {
             peer,
             hash,
@@ -189,7 +189,7 @@ mod tests {
         let derp_region = Some(0);
         let ticket = Ticket {
             hash,
-            peer: PeerData::from_parts(peer, derp_region, vec![addr]),
+            peer: PeerAddr::from_parts(peer, derp_region, vec![addr]),
             token: Some(token),
             recursive: true,
         };

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -103,7 +103,7 @@ impl Ticket {
         self.hash
     }
 
-    /// The [`NodeAddr`] of the provider for this ticket.
+    /// The [`PeerData`] of the provider for this ticket.
     pub fn node_addr(&self) -> &PeerData {
         &self.peer
     }

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -11,7 +11,7 @@ use iroh_bytes::protocol::RequestToken;
 use iroh_bytes::Hash;
 use iroh_net::derp::DerpMap;
 use iroh_net::key::SecretKey;
-use iroh_net::NodeAddr;
+use iroh_net::PeerData;
 use serde::{Deserialize, Serialize};
 
 /// Options for the client
@@ -20,7 +20,7 @@ pub struct Options {
     /// The secret key of the node
     pub secret_key: SecretKey,
     /// The peer to connect to.
-    pub peer: NodeAddr,
+    pub peer: PeerData,
     /// Whether to log the SSL keys when `SSLKEYLOGFILE` environment variable is set
     pub keylog: bool,
     /// The configuration of the derp services
@@ -42,12 +42,7 @@ pub async fn dial(opts: Options) -> anyhow::Result<quinn::Connection> {
     };
     let endpoint = endpoint.bind(0).await?;
     endpoint
-        .connect(
-            opts.peer.node_id,
-            &iroh_bytes::protocol::ALPN,
-            opts.peer.derp_region,
-            &opts.peer.endpoints,
-        )
+        .connect(opts.peer, &iroh_bytes::protocol::ALPN)
         .await
         .context("failed to connect to provider")
 }
@@ -59,7 +54,7 @@ pub async fn dial(opts: Options) -> anyhow::Result<quinn::Connection> {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ticket {
     /// The provider to get a file from.
-    peer: NodeAddr,
+    peer: PeerData,
     /// The hash to retrieve.
     hash: Hash,
     /// Optional Request token.
@@ -71,12 +66,15 @@ pub struct Ticket {
 impl Ticket {
     /// Creates a new ticket.
     pub fn new(
-        peer: NodeAddr,
+        peer: PeerData,
         hash: Hash,
         token: Option<RequestToken>,
         recursive: bool,
     ) -> Result<Self> {
-        ensure!(!peer.endpoints.is_empty(), "addrs list can not be empty");
+        ensure!(
+            !peer.addr_info.direct_addresses.is_empty(),
+            "addrs list can not be empty"
+        );
         Ok(Self {
             hash,
             peer,
@@ -89,7 +87,7 @@ impl Ticket {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let slf: Ticket = postcard::from_bytes(bytes)?;
         ensure!(
-            !slf.peer.endpoints.is_empty(),
+            !slf.peer.addr_info.direct_addresses.is_empty(),
             "Invalid address list in ticket"
         );
         Ok(slf)
@@ -106,7 +104,7 @@ impl Ticket {
     }
 
     /// The [`NodeAddr`] of the provider for this ticket.
-    pub fn node_addr(&self) -> &NodeAddr {
+    pub fn node_addr(&self) -> &PeerData {
         &self.peer
     }
 
@@ -131,7 +129,7 @@ impl Ticket {
     }
 
     /// Get the contents of the ticket, consuming it.
-    pub fn into_parts(self) -> (NodeAddr, Hash, Option<RequestToken>, bool) {
+    pub fn into_parts(self) -> (PeerData, Hash, Option<RequestToken>, bool) {
         let Ticket {
             peer,
             hash,
@@ -191,7 +189,7 @@ mod tests {
         let derp_region = Some(0);
         let ticket = Ticket {
             hash,
-            peer: NodeAddr::from_parts(peer, derp_region, vec![addr]),
+            peer: PeerData::from_parts(peer, derp_region, vec![addr]),
             token: Some(token),
             recursive: true,
         };

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1468,8 +1468,8 @@ mod tests {
             .unwrap();
         let _drop_guard = node.cancel_token().drop_guard();
         let ticket = node.ticket(hash).await.unwrap();
-        println!("addrs: {:?}", ticket.node_addr().addr_info);
-        assert!(!ticket.node_addr().addr_info.direct_addresses.is_empty());
+        println!("addrs: {:?}", ticket.node_addr().info);
+        assert!(!ticket.node_addr().info.direct_addresses.is_empty());
     }
 
     #[cfg(feature = "mem-db")]

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -41,7 +41,7 @@ use iroh_net::{
     config::Endpoint,
     derp::DerpMap,
     key::{PublicKey, SecretKey},
-    tls, MagicEndpoint, NodeAddr,
+    tls, MagicEndpoint, PeerData,
 };
 use iroh_sync::store::Store as DocStore;
 use once_cell::sync::OnceCell;
@@ -712,7 +712,7 @@ impl<D: ReadableStore, S: DocStore> Node<D, S> {
     }
 
     /// Return the [`NodeAddr`] for this node.
-    pub async fn my_addr(&self) -> Result<NodeAddr> {
+    pub async fn my_addr(&self) -> Result<PeerData> {
         self.inner.endpoint.my_addr().await
     }
 
@@ -955,12 +955,7 @@ impl<D: BaoStore, S: DocStore, C: CollectionParser> RpcHandler<D, S, C> {
         let conn = self
             .inner
             .endpoint
-            .connect(
-                msg.peer.node_id,
-                &iroh_bytes::protocol::ALPN,
-                msg.peer.derp_region,
-                &msg.peer.endpoints,
-            )
+            .connect(msg.peer, &iroh_bytes::protocol::ALPN)
             .await?;
         progress.send(GetProgress::Connected).await?;
         let progress2 = progress.clone();
@@ -1473,8 +1468,8 @@ mod tests {
             .unwrap();
         let _drop_guard = node.cancel_token().drop_guard();
         let ticket = node.ticket(hash).await.unwrap();
-        println!("addrs: {:?}", ticket.node_addr().endpoints);
-        assert!(!ticket.node_addr().endpoints.is_empty());
+        println!("addrs: {:?}", ticket.node_addr().addr_info);
+        assert!(!ticket.node_addr().addr_info.direct_addresses.is_empty());
     }
 
     #[cfg(feature = "mem-db")]

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -711,7 +711,7 @@ impl<D: ReadableStore, S: DocStore> Node<D, S> {
         Ticket::new(me, hash, None, true)
     }
 
-    /// Return the [`NodeAddr`] for this node.
+    /// Return the [`PeerData`] for this node.
     pub async fn my_addr(&self) -> Result<PeerData> {
         self.inner.endpoint.my_addr().await
     }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -41,7 +41,7 @@ use iroh_net::{
     config::Endpoint,
     derp::DerpMap,
     key::{PublicKey, SecretKey},
-    tls, MagicEndpoint, PeerData,
+    tls, MagicEndpoint, PeerAddr,
 };
 use iroh_sync::store::Store as DocStore;
 use once_cell::sync::OnceCell;
@@ -711,8 +711,8 @@ impl<D: ReadableStore, S: DocStore> Node<D, S> {
         Ticket::new(me, hash, None, true)
     }
 
-    /// Return the [`PeerData`] for this node.
-    pub async fn my_addr(&self) -> Result<PeerData> {
+    /// Return the [`PeerAddr`] for this node.
+    pub async fn my_addr(&self) -> Result<PeerAddr> {
         self.inner.endpoint.my_addr().await
     }
 

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -15,7 +15,7 @@ pub use iroh_bytes::{protocol::RequestToken, provider::GetProgress, Hash};
 use iroh_gossip::proto::util::base32;
 use iroh_net::{
     key::PublicKey,
-    magic_endpoint::{ConnectionInfo, PeerData},
+    magic_endpoint::{ConnectionInfo, PeerAddr},
 };
 
 use iroh_sync::{
@@ -69,7 +69,7 @@ pub struct BlobDownloadRequest {
     /// children are downloaded and shared as well.
     pub recursive: bool,
     /// This mandatory field specifies the peer to download the data from.
-    pub peer: PeerData,
+    pub peer: PeerAddr,
     /// This optional field contains a request token that can be used to authorize
     /// the download request.
     pub token: Option<RequestToken>,

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -15,7 +15,7 @@ pub use iroh_bytes::{protocol::RequestToken, provider::GetProgress, Hash};
 use iroh_gossip::proto::util::base32;
 use iroh_net::{
     key::PublicKey,
-    magic_endpoint::{ConnectionInfo, NodeAddr},
+    magic_endpoint::{ConnectionInfo, PeerData},
 };
 
 use iroh_sync::{
@@ -69,7 +69,7 @@ pub struct BlobDownloadRequest {
     /// children are downloaded and shared as well.
     pub recursive: bool,
     /// This mandatory field specifies the peer to download the data from.
-    pub peer: NodeAddr,
+    pub peer: PeerData,
     /// This optional field contains a request token that can be used to authorize
     /// the download request.
     pub token: Option<RequestToken>,

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -695,7 +695,7 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                 .endpoint
                 .add_peer_addr(iroh_net::PeerAddr {
                     peer_id,
-                    addr_info: iroh_net::AddrInfo {
+                    info: iroh_net::AddrInfo {
                         derp_region,
                         direct_addresses: addrs,
                     },

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -685,13 +685,24 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
         let peer_ids: Vec<PublicKey> = peers.iter().map(|p| p.peer_id).collect();
 
         // add addresses of initial peers to our endpoint address book
-        for peer in &peers {
+        for PeerSource {
+            peer_id,
+            addrs,
+            derp_region,
+        } in peers.into_iter()
+        {
             if let Err(err) = self
                 .endpoint
-                .add_known_addrs(peer.peer_id, peer.derp_region, &peer.addrs)
+                .add_peer_data(iroh_net::PeerData {
+                    peer_id,
+                    addr_info: iroh_net::AddrInfo {
+                        derp_region,
+                        direct_addresses: addrs,
+                    },
+                })
                 .await
             {
-                warn!(peer = ?peer.peer_id, "failed to add known addrs: {err:?}");
+                warn!(peer = ?peer_id, "failed to add known addrs: {err:?}");
             }
         }
 

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -693,7 +693,7 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
         {
             if let Err(err) = self
                 .endpoint
-                .add_peer_data(iroh_net::PeerData {
+                .add_peer_addr(iroh_net::PeerAddr {
                     peer_id,
                     addr_info: iroh_net::AddrInfo {
                         derp_region,

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -613,14 +613,13 @@ fn test_provide_get_loop_single(
     let ticket = Ticket::from_str(&ticket).unwrap();
     let addrs = ticket
         .node_addr()
-        .endpoints
-        .iter()
+        .direct_addresses()
         .map(|x| x.to_string())
         .collect::<Vec<_>>();
-    let peer = ticket.node_addr().node_id.to_string();
+    let peer = ticket.node_addr().peer_id.to_string();
     let region = ticket
         .node_addr()
-        .derp_region
+        .derp_region()
         .context("should have derp region in ticket")?
         .to_string();
 

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -20,7 +20,7 @@ use iroh::{
 use iroh_io::{AsyncSliceReader, AsyncSliceReaderExt};
 use iroh_net::{
     key::{PublicKey, SecretKey},
-    MagicEndpoint,
+    MagicEndpoint, PeerData,
 };
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use rand::RngCore;
@@ -146,7 +146,7 @@ async fn empty_files() -> Result<()> {
 /// Create new get options with the given peer id and addresses, using a
 /// randomly generated secret key.
 fn get_options(peer_id: PublicKey, addrs: Vec<SocketAddr>) -> iroh::dial::Options {
-    let peer = iroh_net::NodeAddr::from_parts(peer_id, Some(1), addrs);
+    let peer = iroh_net::PeerData::from_parts(peer_id, Some(1), addrs);
     iroh::dial::Options {
         secret_key: SecretKey::generate(),
         peer,
@@ -923,8 +923,12 @@ async fn test_token_passthrough() -> Result<()> {
             .keylog(true)
             .bind(0)
             .await?;
+
+        let peer_data = PeerData::new(peer_id)
+            .with_derp_region(1)
+            .with_direct_addresses(addrs.clone());
         endpoint
-            .connect(peer_id, &iroh_bytes::protocol::ALPN, Some(1), &addrs)
+            .connect(peer_data, &iroh_bytes::protocol::ALPN)
             .await
             .context("failed to connect to provider")?;
         let request = GetRequest::all(hash).with_token(token).into();

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -20,7 +20,7 @@ use iroh::{
 use iroh_io::{AsyncSliceReader, AsyncSliceReaderExt};
 use iroh_net::{
     key::{PublicKey, SecretKey},
-    MagicEndpoint, PeerData,
+    MagicEndpoint, PeerAddr,
 };
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use rand::RngCore;
@@ -146,7 +146,7 @@ async fn empty_files() -> Result<()> {
 /// Create new get options with the given peer id and addresses, using a
 /// randomly generated secret key.
 fn get_options(peer_id: PublicKey, addrs: Vec<SocketAddr>) -> iroh::dial::Options {
-    let peer = iroh_net::PeerData::from_parts(peer_id, Some(1), addrs);
+    let peer = iroh_net::PeerAddr::from_parts(peer_id, Some(1), addrs);
     iroh::dial::Options {
         secret_key: SecretKey::generate(),
         peer,
@@ -924,11 +924,11 @@ async fn test_token_passthrough() -> Result<()> {
             .bind(0)
             .await?;
 
-        let peer_data = PeerData::new(peer_id)
+        let peer_addr = PeerAddr::new(peer_id)
             .with_derp_region(1)
             .with_direct_addresses(addrs.clone());
         endpoint
-            .connect(peer_data, &iroh_bytes::protocol::ALPN)
+            .connect(peer_addr, &iroh_bytes::protocol::ALPN)
             .await
             .context("failed to connect to provider")?;
         let request = GetRequest::all(hash).with_token(token).into();


### PR DESCRIPTION
## Description

- Adds a `AddrInfo` that contains the addressing information of peers. This is necessary as it's own type since it's serialized both in gossip and in #1488 
- Renames `NodeAddr` to `PeerData` (better name suggestions are well received) this helps consolidate the "peer" terminology already present throughout gossip, sync, downloader, and many other places
- Use this type in different parts of the code. Some other types that can be replaced by this are left to #1493 

## Notes & open questions

This applies the suggestion of doing `connect` using the full type. It's debatable if this is better than `connect(PublicKey, AddrInfo)` but both are imo an improvement over the current way since the idea if "what does iroh need to connect to a peer" is now fully described in a type

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
