### PR TITLE
deps(iroh-net): use minimum safe version of quinn-proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3356,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13f81c9a9d574310b8351f8666f5a93ac3b0069c45c28ad52c10291389a7cf9"
+checksum = "2c78e758510582acc40acb90458401172d41f1016f8c9dde89e49677afb7eec1"
 dependencies = [
  "bytes",
  "rand",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -63,7 +63,7 @@ webpki = { package = "rustls-webpki", version = "0.101.4", features = ["std"] }
 webpki-roots = "0.25"
 wg = "0.3.1"
 quinn = "0.10"
-quinn-proto = ">=0.10.5"
+quinn-proto = "0.10.5"
 quinn-udp = "0.4"
 x509-parser = "0.15"
 zeroize = "1.5"

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -63,7 +63,7 @@ webpki = { package = "rustls-webpki", version = "0.101.4", features = ["std"] }
 webpki-roots = "0.25"
 wg = "0.3.1"
 quinn = "0.10"
-quinn-proto = "0.10"
+quinn-proto = ">=0.10.5"
 quinn-udp = "0.4"
 x509-parser = "0.15"
 zeroize = "1.5"


### PR DESCRIPTION
## Description

solves https://rustsec.org/advisories/RUSTSEC-2023-0063

## Notes & open questions

na

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
