### PR TITLE
fix(sync): fix `PeerData` encoding, neighbor events, better & predictable tests

### DIFF
--- a/iroh-gossip/src/proto.rs
+++ b/iroh-gossip/src/proto.rs
@@ -47,6 +47,7 @@
 
 use std::{fmt, hash::Hash};
 
+use bytes::Bytes;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 mod hyparview;
@@ -80,20 +81,26 @@ impl<T> PeerIdentity for T where T: Hash + Eq + Copy + fmt::Debug + Serialize + 
 ///
 /// Implementations may use these bytes to supply addresses or other information needed to connect
 /// to a peer that is not included in the peer's [`PeerIdentity`].
-#[derive(
-    derive_more::Debug,
-    Serialize,
-    Deserialize,
-    Clone,
-    PartialEq,
-    Eq,
-    derive_more::From,
-    derive_more::Into,
-    derive_more::Deref,
-    Default,
-)]
+#[derive(derive_more::Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
 #[debug("PeerData({}b)", self.0.len())]
-pub struct PeerData(bytes::Bytes);
+pub struct PeerData(Bytes);
+
+impl PeerData {
+    /// Create a new [`PeerData`] from a byte buffer.
+    pub fn new(data: impl Into<Bytes>) -> Self {
+        Self(data.into())
+    }
+
+    /// Get a reference to the contained [`bytes::Bytes`].
+    pub fn inner(&self) -> &bytes::Bytes {
+        &self.0
+    }
+
+    /// Get the peer data as a byte slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
 
 /// PeerInfo contains a peer's identifier and the opaque peer data as provided by the implementer.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -291,6 +291,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
                             println!("change: {}", fmt_entry(&entry));
                         }
                     }
+                    _ => {}
                 }
             }
         }

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -265,6 +265,12 @@ impl DocCommands {
                                 ),
                             }
                         }
+                        LiveEvent::NeighborUp(peer) => {
+                            println!("neighbor peer up: {peer:?}");
+                        }
+                        LiveEvent::NeighborDown(peer) => {
+                            println!("neighbor peer down: {peer:?}");
+                        }
                     }
                 }
             }

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -2,20 +2,27 @@
 
 use std::{net::SocketAddr, time::Duration};
 
-use anyhow::{anyhow, Result};
-use futures::{StreamExt, TryStreamExt};
+use anyhow::{anyhow, bail, Result};
+use futures::{Stream, StreamExt, TryStreamExt};
 use iroh::{
     client::mem::Doc,
     collection::IrohCollectionParser,
     node::{Builder, Node},
     rpc_protocol::ShareMode,
-    sync_engine::{LiveEvent, Origin, SyncEvent},
+    sync_engine::{LiveEvent, SyncEvent},
 };
+use iroh_net::key::PublicKey;
 use quic_rpc::transport::misc::DummyServerEndpoint;
+use tracing::{debug, info};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 use iroh_bytes::util::runtime;
-use iroh_sync::store::{self, GetFilter};
+use iroh_sync::{
+    store::{self, GetFilter},
+    ContentStatus, NamespaceId,
+};
+
+const LIMIT: Duration = Duration::from_secs(15);
 
 /// Pick up the tokio runtime from the thread local and add a
 /// thread per core runtime.
@@ -47,7 +54,7 @@ async fn spawn_node(
 ) -> anyhow::Result<Node<iroh::baomap::mem::Store, store::memory::Store>> {
     let node = test_node(rt, "127.0.0.1:0".parse()?);
     let node = node.spawn().await?;
-    tracing::info!("spawned node {i} {:?}", node.peer_id());
+    info!("spawned node {i} {:?}", node.peer_id());
     Ok(node)
 }
 
@@ -70,44 +77,42 @@ async fn sync_simple() -> Result<()> {
     let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
 
     // create doc on node0
-    let (ticket, doc0) = {
-        let iroh = &clients[0];
-        let author = iroh.authors.create().await?;
-        let doc = iroh.docs.create().await?;
-        doc.set_bytes(author, b"k1".to_vec(), b"v1".to_vec())
-            .await?;
-        assert_latest(&doc, b"k1", b"v1").await;
-        let ticket = doc.share(ShareMode::Write).await?;
-        (ticket, doc)
-    };
+    let peer0 = nodes[0].peer_id();
+    let author0 = clients[0].authors.create().await?;
+    let doc0 = clients[0].docs.create().await?;
+    let doc_id = doc0.id();
+    let hash0 = doc0
+        .set_bytes(author0, b"k1".to_vec(), b"v1".to_vec())
+        .await?;
+    assert_latest(&doc0, b"k1", b"v1").await;
+    let ticket = doc0.share(ShareMode::Write).await?;
 
     let mut events0 = doc0.subscribe().await?;
 
-    // node1: join in
-    let iroh = &clients[1];
-    let doc = iroh.docs.import(ticket.clone()).await?;
-    let mut events = doc.subscribe().await?;
-    let event = events.try_next().await?.unwrap();
-    assert!(matches!(event, LiveEvent::InsertRemote { .. }));
-    let event = events.try_next().await?.unwrap();
-    let LiveEvent::SyncFinished(event) = event else {
-        panic!("expected LiveEvent::SyncFinished, but got {event:?}");
-    };
-    assert_eq!(event.namespace, doc.id());
-    assert_eq!(event.peer, nodes[0].peer_id());
-    assert_eq!(event.result, Ok(()));
-    let event = events.try_next().await?.unwrap();
-    assert!(matches!(event, LiveEvent::ContentReady { .. }));
-    assert_latest(&doc, b"k1", b"v1").await;
+    info!("node1: join");
+    let peer1 = nodes[1].peer_id();
+    let doc1 = clients[1].docs.import(ticket.clone()).await?;
+    let mut events1 = doc1.subscribe().await?;
+    info!("node1: assert 4 events");
+    assert_each_unordered(
+        collect_some(&mut events1, 4, LIMIT).await?,
+        vec![
+            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer0)),
+            Box::new(move |e| matches!(e, LiveEvent::InsertRemote { from, .. } if *from == peer0 )),
+            Box::new(move |e| match_sync_finished(e, peer0, doc_id)),
+            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash0)),
+        ],
+    );
+    assert_latest(&doc1, b"k1", b"v1").await;
 
-    // check sync event on node0
-    let event = events0.try_next().await?.unwrap();
-    let LiveEvent::SyncFinished(event) = event else {
-        panic!("expected LiveEvent::SyncFinished, but got {event:?}");
-    };
-    assert_eq!(event.namespace, doc0.id());
-    assert_eq!(event.peer, nodes[1].peer_id());
-    assert_eq!(event.result, Ok(()));
+    info!("node0: assert 2 events");
+    assert_each_unordered(
+        collect_some(&mut events0, 2, LIMIT).await?,
+        vec![
+            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer1)),
+            Box::new(move |e| match_sync_finished(e, peer1, doc_id)),
+        ],
+    );
 
     for node in nodes {
         node.shutdown();
@@ -135,6 +140,7 @@ async fn sync_subscribe() -> Result<()> {
     Ok(())
 }
 
+/// This tests basic sync and gossip with 3 peers.
 #[tokio::test]
 async fn sync_full_basic() -> Result<()> {
     setup_logging();
@@ -142,126 +148,138 @@ async fn sync_full_basic() -> Result<()> {
     let mut nodes = spawn_nodes(rt.clone(), 2).await?;
     let mut clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
 
-    // node1: create doc and ticket
-    let (ticket, doc1) = {
-        let iroh = &clients[0];
-        let author = iroh.authors.create().await?;
-        let doc = iroh.docs.create().await?;
-        let key = b"k1";
-        let value = b"v1";
-        doc.set_bytes(author, key.to_vec(), value.to_vec()).await?;
-        assert_latest(&doc, key, value).await;
-        let ticket = doc.share(ShareMode::Write).await?;
-        (ticket, doc)
-    };
+    // peer0: create doc and ticket
+    let peer0 = nodes[0].peer_id();
+    let author0 = clients[0].authors.create().await?;
+    let doc0 = clients[0].docs.create().await?;
+    let mut events0 = doc0.subscribe().await?;
+    let doc_id = doc0.id();
+    let key0 = b"k1";
+    let value0 = b"v1";
+    let hash0 = doc0
+        .set_bytes(author0, key0.to_vec(), value0.to_vec())
+        .await?;
 
-    // node2: join in
-    let _doc2 = {
-        let iroh = &clients[1];
-        let author = iroh.authors.create().await?;
-        let doc = iroh.docs.import(ticket.clone()).await?;
+    info!("peer0: wait for 1 event (local insert)");
+    let e = next(&mut events0).await;
+    assert!(
+        matches!(&e, LiveEvent::InsertLocal { entry } if entry.content_hash() == hash0),
+        "expected LiveEvent::InsertLocal but got {e:?}",
+    );
+    assert_latest(&doc0, key0, value0).await;
+    let ticket = doc0.share(ShareMode::Write).await?;
 
-        // wait for remote insert on doc2
-        let mut events = doc.subscribe().await?;
-        let event = events.try_next().await?.unwrap();
-        assert!(
-            matches!(event, LiveEvent::InsertRemote { .. }),
-            "expected InsertRemote but got {event:?}"
-        );
-        let event = events.try_next().await?.unwrap();
-        assert!(
-            matches!(event, LiveEvent::SyncFinished(_)),
-            "expected SyncFinished but got {event:?}"
-        );
-        let event = events.try_next().await?.unwrap();
-        assert!(
-            matches!(event, LiveEvent::ContentReady { .. }),
-            "expected ContentReady but got {event:?}"
-        );
+    info!("peer1: spawn");
+    let peer1 = nodes[1].peer_id();
+    let author1 = clients[1].authors.create().await?;
+    info!("peer1: join doc");
+    let doc1 = clients[1].docs.import(ticket.clone()).await?;
 
-        assert_latest(&doc, b"k1", b"v1").await;
+    info!("peer1: wait for 4 events (for sync and join with peer0)");
+    let mut events1 = doc1.subscribe().await?;
+    assert_each_unordered(
+        collect_some(&mut events1, 4, LIMIT).await?,
+        vec![
+            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer0)),
+            Box::new(move |e| matches!(e, LiveEvent::InsertRemote { from, .. } if *from == peer0 )),
+            Box::new(move |e| match_sync_finished(e, peer0, doc_id)),
+            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash0)),
+        ],
+    );
 
-        // setup event channel on on doc1
-        let mut events = doc1.subscribe().await?;
+    info!("peer0: wait for 2 events (join & accept sync finished from peer1)");
+    assert_each_unordered(
+        collect_some(&mut events0, 2, LIMIT).await?,
+        vec![
+            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer1)),
+            Box::new(move |e| match_sync_finished(e, peer1, doc_id)),
+        ],
+    );
 
-        let key = b"k2";
-        let value = b"v2";
-        doc.set_bytes(author, key.to_vec(), value.to_vec()).await?;
-        assert_latest(&doc, key, value).await;
+    info!("peer1: insert entry");
+    let key1 = b"k2";
+    let value1 = b"v2";
+    let hash1 = doc1
+        .set_bytes(author1, key1.to_vec(), value1.to_vec())
+        .await?;
+    assert_latest(&doc1, key1, value1).await;
+    info!("peer1: wait for 1 event (local insert)");
+    let e = next(&mut events1).await;
+    assert!(
+        matches!(&e, LiveEvent::InsertLocal { entry } if entry.content_hash() == hash1),
+        "expected LiveEvent::InsertLocal but got {e:?}",
+    );
 
-        // wait for remote insert on doc1
-        let event = events.try_next().await?.unwrap();
-        assert!(
-            matches!(event, LiveEvent::InsertRemote { .. }),
-            "expected InsertRemote but got {event:?}"
-        );
-        let event = events.try_next().await?.unwrap();
-        assert!(
-            matches!(event, LiveEvent::ContentReady { .. }),
-            "expected ContentReady but got {event:?}"
-        );
+    // peer0: assert events for entry received via gossip
+    info!("peer0: wait for 2 events (gossip'ed entry from peer1)");
+    assert_each_unordered(
+        collect_some(&mut events0, 2, LIMIT).await?,
+        vec![
+            Box::new(
+                move |e| matches!(e, LiveEvent::InsertRemote { from, content_status: ContentStatus::Missing, .. } if *from == peer1),
+            ),
+            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash1)),
+        ],
+    );
+    assert_latest(&doc0, key1, value1).await;
 
-        assert_latest(&doc1, key, value).await;
-        doc
-    };
+    // Note: If we could check gossip messages directly here (we can't easily), we would notice
+    // that peer1 will receive a `Op::ContentReady` gossip message, broadcast
+    // by peer0 with neighbor scope. This message is superflous, and peer0 could know that, however
+    // our gossip implementation does not allow us to filter message receivers this way.
 
-    // node 3 joins & imports the doc from peer 1
+    info!("peer2: spawn");
     nodes.push(spawn_node(rt.clone(), nodes.len()).await?);
     clients.push(nodes.last().unwrap().client());
-    let iroh = &clients[2];
-    let doc = iroh.docs.import(ticket).await?;
+    let doc2 = clients[2].docs.import(ticket).await?;
+    let peer2 = nodes[2].peer_id();
+    let mut events2 = doc2.subscribe().await?;
 
-    // expect 2 times InsertRemote
-    let mut events = doc.subscribe().await?;
-    let event = events.try_next().await?.unwrap();
-    assert!(
-        matches!(event, LiveEvent::InsertRemote { .. }),
-        "expected InsertRemote but got {event:?}"
+    info!("peer2: wait for 8 events (from sync with peers)");
+    let actual = collect_some(&mut events2, 8, LIMIT).await?;
+    assert_each_unordered(
+        actual,
+        vec![
+            // 2 NeighborUp events
+            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer0)),
+            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer1)),
+            // 2 SyncFinished events
+            Box::new(move |e| match_sync_finished(e, peer0, doc_id)),
+            Box::new(move |e| match_sync_finished(e, peer1, doc_id)),
+            // 2 InsertRemote events
+            Box::new(
+                move |e| matches!(e, LiveEvent::InsertRemote { entry, content_status: ContentStatus::Missing, .. } if entry.content_hash() == hash0),
+            ),
+            Box::new(
+                move |e| matches!(e, LiveEvent::InsertRemote { entry, content_status: ContentStatus::Missing, .. } if entry.content_hash() == hash1),
+            ),
+            // 2 ContentReady events
+            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash0)),
+            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash1)),
+        ],
     );
-    let event = events.try_next().await?.unwrap();
-    assert!(
-        matches!(event, LiveEvent::InsertRemote { .. }),
-        "expected InsertRemote but got {event:?}"
+    assert_latest(&doc2, b"k1", b"v1").await;
+    assert_latest(&doc2, b"k2", b"v2").await;
+
+    info!("peer0: wait for 2 events (join & accept sync finished from peer2)");
+    assert_each_unordered(
+        collect_some(&mut events0, 2, LIMIT).await?,
+        vec![
+            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer2)),
+            Box::new(move |e| match_sync_finished(e, peer2, doc_id)),
+        ],
     );
 
-    // now expect SyncFinished
-    let event = events.try_next().await?.unwrap();
-    let LiveEvent::SyncFinished(event) = event else {
-        panic!("expected SyncFinished but got {event:?}");
-    };
-    let expected = SyncEvent {
-        peer: nodes[0].peer_id(),
-        namespace: doc.id(),
-        result: Ok(()),
-        origin: event.origin.clone(),
-        finished: event.finished,
-    };
-    assert_eq!(event, expected, "expected {expected:?} but got {event:?}");
+    info!("peer1: wait for 2 events (join & accept sync finished from peer2)");
+    assert_each_unordered(
+        collect_some(&mut events1, 2, LIMIT).await?,
+        vec![
+            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer2)),
+            Box::new(move |e| match_sync_finished(e, peer2, doc_id)),
+        ],
+    );
 
-    // expect 2 times ContentReady
-    // potentically a `SyncFinished` event with `Origin::Accept` is inbetween,
-    // as node1 or node2 could connect to us.
-    let mut i = 0;
-    while i < 2 {
-        let event = events.try_next().await?.unwrap();
-        if matches!(
-            event,
-            LiveEvent::SyncFinished(SyncEvent {
-                origin: Origin::Accept,
-                ..
-            })
-        ) {
-            continue;
-        }
-        assert!(
-            matches!(event, LiveEvent::ContentReady { .. }),
-            "expected ContentReady but got {event:?}"
-        );
-        i += 1;
-    }
-    assert_latest(&doc, b"k1", b"v1").await;
-    assert_latest(&doc, b"k2", b"v2").await;
-
+    info!("shutdown");
     for node in nodes {
         node.shutdown();
     }
@@ -321,4 +339,92 @@ fn setup_logging() {
         .with(EnvFilter::from_default_env())
         .try_init()
         .ok();
+}
+
+async fn next<T: std::fmt::Debug>(mut stream: impl Stream<Item = Result<T>> + Unpin) -> T {
+    let event = stream
+        .next()
+        .await
+        .expect("stream ended")
+        .expect("stream produced error");
+    debug!("Event: {event:?}");
+    event
+}
+
+/// Collect the next n elements of a [`TryStream`]
+///
+/// If `timeout` is exceeded before n elements are collected an error is returned.
+async fn collect_some<T: std::fmt::Debug>(
+    mut stream: impl Stream<Item = Result<T>> + Unpin,
+    n: usize,
+    timeout: Duration,
+) -> Result<Vec<T>> {
+    let mut res = Vec::with_capacity(n);
+    let sleep = tokio::time::sleep(timeout);
+    tokio::pin!(sleep);
+    while res.len() < n {
+        tokio::select! {
+            () = &mut sleep => {
+                bail!("Failed to collect {n} elements in {timeout:?} (collected only {})", res.len());
+            },
+            event = stream.try_next() => {
+                let event = event?;
+                match event {
+                    None => bail!("stream ended after {} items, but expected {n}", res.len()),
+                    Some(event) => res.push(event),
+                }
+            }
+        }
+    }
+    Ok(res)
+}
+
+/// Assert that each item in the iterator is matched by one of the functions in `fns`.
+///
+/// The iterator must yield exactly as many elements as are in the function list.
+/// Order is not imporant. Once a function matched an item, it is removed from the function list.
+#[allow(clippy::type_complexity)]
+fn assert_each_unordered<T: std::fmt::Debug>(
+    items: impl IntoIterator<Item = T>,
+    mut fns: Vec<Box<dyn Fn(&T) -> bool>>,
+) {
+    let len = fns.len();
+    let iter = items.into_iter();
+    for item in iter {
+        if fns.is_empty() {
+            panic!("iterator is longer than expected length of {len}");
+        }
+        let mut ok = false;
+        for i in 0..fns.len() {
+            if fns[i](&item) {
+                ok = true;
+                let _ = fns.remove(i);
+                break;
+            }
+        }
+        if !ok {
+            panic!("no rule matched item {item:?}");
+        }
+    }
+    if !fns.is_empty() {
+        panic!(
+            "expected {len} elements but stream stopped after {}",
+            len - fns.len()
+        );
+    }
+}
+
+/// Asserts that the event is a [`LiveEvent::SyncFinished`] and that the contained [`SyncEvent`]
+/// has no error and matches `peer` and `namespace`.
+fn match_sync_finished(event: &LiveEvent, peer: PublicKey, namespace: NamespaceId) -> bool {
+    let LiveEvent::SyncFinished(e) = event else {
+        return false;
+    };
+    e == &SyncEvent {
+        peer,
+        namespace,
+        result: Ok(()),
+        origin: e.origin.clone(),
+        finished: e.finished,
+    }
 }


### PR DESCRIPTION
## Description

* **fix(gossip): properly encode peer data.** #1506 introduced a bug: The `PeerData` was encoded from the `PeerAddr` (including the peer id) but decoded to `AddrInfo` (without the peer id). So it failed, and dialing peers failed. It only did not matter much because most tests use tickets separately, so do not rely on the `PeerData` gossip.
* **feat: expose neighbor events** through document subscriptions. for now used to write better and less flakey tests. also useful for stats like usecases, and potentially others.
* **tests: improve sync tests** and make `sync_full_basic` not flakey anymore (hopefully). the main change is that for some events, we don't care about the exact order in tests anymore, because the exact order is too unpredictable timing-wise for things that happen concurrently. instead they are matched in chunks.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
