### PR TITLE
Collection = Vec<Hash>

### DIFF
--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -399,7 +399,7 @@ async fn gc_mark_task<'a>(
                     warn!("gc: {} creating data reader failed", hash);
                     continue;
                 };
-                let Ok((mut iter, stats)) = cp.parse(format.into(), reader).await else {
+                let Ok((mut iter, stats)) = cp.parse(reader).await else {
                     warn!("gc: {} parse failed", hash);
                     continue;
                 };

--- a/iroh-bytes/src/collection.rs
+++ b/iroh-bytes/src/collection.rs
@@ -1,5 +1,6 @@
 //! traits related to collections of blobs
 use crate::util::Hash;
+use bytes::Bytes;
 use futures::{
     future::{self, LocalBoxFuture},
     FutureExt,
@@ -40,6 +41,132 @@ pub trait LinkStream: Debug {
     fn skip(&mut self, n: u64) -> LocalBoxFuture<'_, anyhow::Result<()>>;
 }
 
+/// A sequence of links, backed by a [`Bytes`] object.
+#[derive(Debug, Clone)]
+pub struct LinkSeq(Bytes);
+
+impl FromIterator<Hash> for LinkSeq {
+    fn from_iter<T: IntoIterator<Item = Hash>>(iter: T) -> Self {
+        let iter = iter.into_iter();
+        let (lower, _upper) = iter.size_hint();
+        let mut bytes = Vec::with_capacity(lower * 32);
+        for hash in iter {
+            bytes.extend_from_slice(hash.as_ref());
+        }
+        Self(bytes.into())
+    }
+}
+
+impl TryFrom<Bytes> for LinkSeq {
+    type Error = anyhow::Error;
+
+    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
+        Self::new(bytes).ok_or_else(|| anyhow::anyhow!("invalid link sequence"))
+    }
+}
+
+impl IntoIterator for LinkSeq {
+    type Item = Hash;
+    type IntoIter = LinkSeqIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        LinkSeqIter(self)
+    }
+}
+
+impl LinkStream for LinkSeqIter {
+    fn next(&mut self) -> LocalBoxFuture<'_, anyhow::Result<Option<Hash>>> {
+        futures::future::ok(self.0.pop_front()).boxed_local()
+    }
+
+    fn skip(&mut self, n: u64) -> LocalBoxFuture<'_, anyhow::Result<()>> {
+        let ok = self.0.drop_front(n as usize);
+        if ok {
+            futures::future::ok(())
+        } else {
+            futures::future::err(anyhow::anyhow!("out of bounds"))
+        }
+        .boxed_local()
+    }
+}
+
+impl LinkSeq {
+    /// Create a new sequence of links.
+    pub fn new(bytes: Bytes) -> Option<Self> {
+        if bytes.len() % 32 == 0 {
+            Some(Self(bytes))
+        } else {
+            None
+        }
+    }
+
+    fn drop_front(&mut self, n: usize) -> bool {
+        let start = n * 32;
+        if start > self.0.len() {
+            false
+        } else {
+            self.0 = self.0.slice(start..);
+            true
+        }
+    }
+
+    /// Iterate over the hashes in this sequence.
+    pub fn iter(&self) -> impl Iterator<Item = Hash> + '_ {
+        self.0.chunks_exact(32).map(|chunk| {
+            let hash: [u8; 32] = chunk.try_into().unwrap();
+            hash.into()
+        })
+    }
+
+    /// Get the number of hashes in this sequence.
+    pub fn len(&self) -> usize {
+        self.0.len() / 32
+    }
+
+    /// Check if this sequence is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Get the hash at the given index.
+    pub fn get(&self, index: usize) -> Option<Hash> {
+        if index < self.len() {
+            let hash: [u8; 32] = self.0[index * 32..(index + 1) * 32].try_into().unwrap();
+            Some(hash.into())
+        } else {
+            None
+        }
+    }
+
+    /// Get and remove the first hash in this sequence.
+    pub fn pop_front(&mut self) -> Option<Hash> {
+        if self.is_empty() {
+            None
+        } else {
+            let hash = self.get(0).unwrap();
+            self.0 = self.0.slice(32..);
+            Some(hash)
+        }
+    }
+
+    /// Get the underlying bytes.
+    pub fn into_inner(self) -> Bytes {
+        self.0
+    }
+}
+
+/// Iterator over the hashes in a [`LinkSeq`].
+#[derive(Debug, Clone)]
+pub struct LinkSeqIter(LinkSeq);
+
+impl Iterator for LinkSeqIter {
+    type Item = Hash;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.pop_front()
+    }
+}
+
 /// Information about a collection.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct CollectionStats {
@@ -78,52 +205,10 @@ impl CollectionParser for LinkSeqCollectionParser {
     ) -> LocalBoxFuture<'a, anyhow::Result<(Box<dyn LinkStream>, CollectionStats)>> {
         async move {
             let bytes = reader.read_to_end().await?;
-            let links = postcard::from_bytes::<Box<[Hash]>>(&bytes)?;
-            let stream: Box<dyn LinkStream> = Box::new(ArrayLinkStream::new(links));
+            let links = LinkSeq::try_from(bytes)?;
+            let stream: Box<dyn LinkStream> = Box::new(links.into_iter());
             Ok((stream, Default::default()))
         }
         .boxed_local()
-    }
-}
-
-/// Stream of links that is used by the default collections
-///
-/// Just contains an array of hashes, so it requires at least all hashes to be loaded into memory.
-#[derive(Debug, Clone)]
-pub struct ArrayLinkStream {
-    hashes: Box<[Hash]>,
-    offset: usize,
-}
-
-impl ArrayLinkStream {
-    /// Create a new iterator over the given hashes.
-    pub fn new(hashes: Box<[Hash]>) -> Self {
-        Self { hashes, offset: 0 }
-    }
-}
-
-impl LinkStream for ArrayLinkStream {
-    fn next(&mut self) -> LocalBoxFuture<'_, anyhow::Result<Option<Hash>>> {
-        let res = if self.offset < self.hashes.len() {
-            let hash = self.hashes[self.offset];
-            self.offset += 1;
-            Some(hash)
-        } else {
-            None
-        };
-        future::ok(res).boxed_local()
-    }
-
-    fn skip(&mut self, n: u64) -> LocalBoxFuture<'_, anyhow::Result<()>> {
-        let res = if let Some(offset) = self
-            .offset
-            .checked_add(usize::try_from(n).unwrap_or(usize::MAX))
-        {
-            self.offset = offset;
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!("overflow"))
-        };
-        future::ready(res).boxed_local()
     }
 }

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -267,7 +267,7 @@ pub async fn transfer_collection<D: Map, E: EventSender, C: CollectionParser>(
     let just_root = matches!(request.ranges.as_single(), Some((0, _)));
     let mut c = if !just_root {
         // use the collection parser to parse the collection
-        let (c, stats) = collection_parser.parse(0, &mut data).await?;
+        let (c, stats) = collection_parser.parse(&mut data).await?;
         writer
             .events
             .send(Event::TransferCollectionStarted {

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -7,7 +7,7 @@
 //! run this example from the project root:
 //!     $ cargo run -p collection
 use iroh::bytes::util::runtime;
-use iroh::collection::{Blob, Collection, IrohCollectionParser};
+use iroh::collection::{Blob, Collection};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 // set the RUST_LOG env var to one of {debug,info,warn} to see logging info
@@ -47,7 +47,6 @@ async fn main() -> anyhow::Result<()> {
     // create a new node
     // we must configure the iroh collection parser so the node understands iroh collections
     let node = iroh::node::Node::builder(db, doc_store)
-        .collection_parser(IrohCollectionParser)
         .runtime(&rt)
         .spawn()
         .await?;

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
         .collect();
     // create a collection and add it to the db as well
     let collection = Collection::new(blobs, 0)?;
-    let hash = db.insert(collection.to_bytes()?);
+    let hash = db.insert_many(collection.to_blobs()).unwrap();
     // create a new iroh runtime with 1 worker thread, reusing the existing tokio runtime
     let rt = runtime::Handle::from_current(1)?;
 

--- a/iroh/examples/rpc.rs
+++ b/iroh/examples/rpc.rs
@@ -9,7 +9,6 @@
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use clap::Parser;
-use iroh::collection::IrohCollectionParser;
 use iroh::rpc_protocol::{ProviderRequest, ProviderResponse};
 use iroh::{bytes::util::runtime, rpc_protocol::ProviderService};
 use iroh_bytes::baomap::Store;
@@ -57,7 +56,6 @@ async fn run(db: impl Store) -> anyhow::Result<()> {
     let doc_store = iroh_sync::store::memory::Store::default();
     let node = iroh::node::Node::builder(db, doc_store)
         .secret_key(secret_key)
-        .collection_parser(IrohCollectionParser)
         .runtime(&rt)
         .rpc_endpoint(rpc_endpoint)
         .spawn()

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -25,12 +25,12 @@ use iroh::{
     downloader::Downloader,
     sync_engine::{LiveEvent, SyncEngine, SYNC_ALPN},
 };
-use iroh_bytes::util::runtime;
 use iroh_bytes::{
     baomap::{ImportMode, Map, MapEntry, Store as BaoStore},
     util::progress::IgnoreProgressSender,
     util::BlobFormat,
 };
+use iroh_bytes::{collection::LinkSeqCollectionParser, util::runtime};
 use iroh_gossip::{
     net::{Gossip, GOSSIP_ALPN},
     proto::TopicId,
@@ -230,7 +230,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
     std::fs::create_dir_all(&blob_path)?;
     let db = iroh::baomap::flat::Store::load(&blob_path, &blob_path, &blob_path, &rt).await?;
 
-    let collection_parser = iroh::collection::IrohCollectionParser;
+    let collection_parser = LinkSeqCollectionParser;
 
     // create the live syncer
     let downloader =
@@ -1000,11 +1000,10 @@ mod iroh_bytes_handlers {
     use bytes::Bytes;
     use futures::{future::BoxFuture, FutureExt};
     use iroh_bytes::{
+        collection::LinkSeqCollectionParser,
         protocol::{GetRequest, RequestToken},
         provider::{CustomGetHandler, EventSender, RequestAuthorizationHandler},
     };
-
-    use iroh::collection::IrohCollectionParser;
 
     #[derive(Debug, Clone)]
     pub struct IrohBytesHandlers {
@@ -1029,7 +1028,7 @@ mod iroh_bytes_handlers {
                 conn,
                 self.db.clone(),
                 self.event_sender.clone(),
-                IrohCollectionParser,
+                LinkSeqCollectionParser,
                 self.get_handler.clone(),
                 self.auth_handler.clone(),
                 self.rt.clone(),

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -98,6 +98,18 @@ impl Store {
         hash
     }
 
+    /// Insert multiple entries into the database, and return the hash of the last entry.
+    pub fn insert_many(
+        &mut self,
+        items: impl IntoIterator<Item = impl AsRef<[u8]>>,
+    ) -> Option<Hash> {
+        let mut hash = None;
+        for item in items.into_iter() {
+            hash = Some(self.insert(item));
+        }
+        hash
+    }
+
     /// Get the bytes associated with a hash, if they exist.
     pub fn get(&self, hash: &Hash) -> Option<Bytes> {
         let entry = self.0.get(hash)?;

--- a/iroh/src/collection.rs
+++ b/iroh/src/collection.rs
@@ -1,8 +1,16 @@
 //! The collection type used by iroh
-use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+
+use anyhow::Context;
+use bao_tree::blake3;
+use bytes::Bytes;
 use futures::{future::LocalBoxFuture, FutureExt};
-use iroh_bytes::collection::{ArrayLinkStream, CollectionParser, CollectionStats, LinkStream};
-use iroh_bytes::Hash;
+use iroh_bytes::baomap::{MapEntry, TempTag};
+use iroh_bytes::collection::{CollectionParser, CollectionStats, LinkSeq, LinkStream};
+use iroh_bytes::get::fsm::EndBlobNext;
+use iroh_bytes::get::Stats;
+use iroh_bytes::util::BlobFormat;
+use iroh_bytes::{baomap, Hash};
 use iroh_io::{AsyncSliceReader, AsyncSliceReaderExt};
 use serde::{Deserialize, Serialize};
 
@@ -17,18 +25,157 @@ pub struct Collection {
     pub(crate) total_blobs_size: u64,
 }
 
+/// Metadata for a collection
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+struct CollectionMeta {
+    names: Vec<String>,
+    total_blobs_size: u64,
+}
+
 impl Collection {
+    /// Convert the collection to an iterator of blobs, with the last being the
+    /// root blob.
     ///
-    pub fn from_parts(links: &[Hash], names: &[String]) -> anyhow::Result<Self> {
+    /// To persist the collection, write all the blobs to storage, and use the
+    /// hash of the last blob as the collection hash.
+    pub fn to_blobs(&self) -> impl Iterator<Item = Bytes> {
+        let meta = CollectionMeta {
+            names: self.names(),
+            total_blobs_size: self.total_blobs_size(),
+        };
+        let meta_bytes = postcard::to_stdvec(&meta).unwrap();
+        let meta_bytes_hash = blake3::hash(&meta_bytes).into();
+        let links = std::iter::once(meta_bytes_hash)
+            .chain(self.links())
+            .collect::<LinkSeq>();
+        let links_bytes = links.into_inner();
+        [meta_bytes.into(), links_bytes].into_iter()
+    }
+
+    /// Read the collection from a get fsm.
+    ///
+    /// Returns the fsm at the start of the first child blob (if any),
+    /// the links array, and the collection.
+    pub async fn read_fsm(
+        fsm_at_start_root: iroh_bytes::get::fsm::AtStartRoot,
+    ) -> anyhow::Result<(iroh_bytes::get::fsm::EndBlobNext, LinkSeq, Collection)> {
+        let (next, links) = {
+            let curr = fsm_at_start_root.next();
+            let (curr, data) = curr.concatenate_into_vec().await?;
+            let links = LinkSeq::new(data.into()).context("links could not be parsed")?;
+            (curr.next(), links)
+        };
+        let EndBlobNext::MoreChildren(at_meta) = next else {
+            anyhow::bail!("expected meta");
+        };
+        let (next, collection) = {
+            let mut children = links.clone();
+            let meta_link = children.pop_front().context("meta link not found")?;
+            let curr = at_meta.next(meta_link);
+            let (curr, names) = curr.concatenate_into_vec().await?;
+            let names = postcard::from_bytes::<CollectionMeta>(&names)?;
+            let collection = Collection::from_parts(children, names)?;
+            (curr.next(), collection)
+        };
+        Ok((next, links, collection))
+    }
+
+    /// Read the collection and all it's children from a get fsm.
+    ///
+    /// Returns the collection, a map from blob offsets to bytes, and the stats.
+    pub async fn read_fsm_all(
+        fsm_at_start_root: iroh_bytes::get::fsm::AtStartRoot,
+    ) -> anyhow::Result<(Collection, BTreeMap<u64, Bytes>, Stats)> {
+        let (next, links, collection) = Self::read_fsm(fsm_at_start_root).await?;
+        let mut res = BTreeMap::new();
+        let mut curr = next;
+        let end = loop {
+            match curr {
+                EndBlobNext::MoreChildren(more) => {
+                    let child_offset = more.child_offset();
+                    let Some(hash) = links.get(usize::try_from(child_offset)?) else {
+                        break more.finish();
+                    };
+                    let header = more.next(hash);
+                    let (next, blob) = header.concatenate_into_vec().await?;
+                    res.insert(child_offset - 1, blob.into());
+                    curr = next.next();
+                }
+                EndBlobNext::Closing(closing) => break closing,
+            }
+        };
+        let stats = end.next().await?;
+        Ok((collection, res, stats))
+    }
+
+    /// Load a collection from a store given a root hash
+    ///
+    /// This assumes that both the links and the metadata of the collection is stored in the store.
+    /// It does not require that all child blobs are stored in the store.
+    pub async fn load<D>(db: &D, root: &Hash) -> anyhow::Result<Self>
+    where
+        D: baomap::Map,
+    {
+        let links_entry = db.get(root).context("links not found")?;
+        anyhow::ensure!(links_entry.is_complete(), "links not complete");
+        let links_bytes = links_entry.data_reader().await?.read_to_end().await?;
+        let mut links = LinkSeq::try_from(links_bytes)?;
+        let meta_hash = links.pop_front().context("meta hash not found")?;
+        let meta_entry = db.get(&meta_hash).context("meta not found")?;
+        anyhow::ensure!(links_entry.is_complete(), "links not complete");
+        let meta_bytes = meta_entry.data_reader().await?.read_to_end().await?;
+        let meta: CollectionMeta = postcard::from_bytes(&meta_bytes)?;
+        anyhow::ensure!(
+            meta.names.len() == links.len(),
+            "names and links length mismatch"
+        );
+        Self::from_parts(links, meta)
+    }
+
+    /// Store a collection in a store. returns the root hash of the collection
+    /// as a TempTag.
+    pub async fn store<D>(self, db: &D) -> anyhow::Result<TempTag>
+    where
+        D: baomap::Store,
+    {
+        let (links, meta) = self.into_parts();
+        let meta_bytes = postcard::to_stdvec(&meta)?;
+        let meta_tag = db.import_bytes(meta_bytes.into(), BlobFormat::RAW).await?;
+        let links_bytes = std::iter::once(*meta_tag.hash())
+            .chain(links)
+            .collect::<LinkSeq>();
+        let links_tag = db
+            .import_bytes(links_bytes.into_inner(), BlobFormat::COLLECTION)
+            .await?;
+        Ok(links_tag)
+    }
+
+    /// Split a collection into a sequence of links and metadata
+    fn into_parts(self) -> (Vec<Hash>, CollectionMeta) {
+        let mut names = Vec::with_capacity(self.blobs().len());
+        let mut links = Vec::with_capacity(self.blobs().len());
+        for blob in self.blobs {
+            names.push(blob.name);
+            links.push(blob.hash);
+        }
+        let meta = CollectionMeta {
+            names,
+            total_blobs_size: self.total_blobs_size,
+        };
+        (links, meta)
+    }
+
+    /// Create a new collection from a list of hashes and metadata
+    fn from_parts(
+        links: impl IntoIterator<Item = Hash>,
+        meta: CollectionMeta,
+    ) -> anyhow::Result<Self> {
         let blobs = links
-            .iter()
-            .zip(names.iter())
-            .map(|(hash, name)| Blob {
-                name: name.clone(),
-                hash: *hash,
-            })
+            .into_iter()
+            .zip(meta.names)
+            .map(|(hash, name)| Blob { name, hash })
             .collect();
-        Self::new(blobs, 0)
+        Self::new(blobs, meta.total_blobs_size)
     }
 
     /// Create a new collection from a list of blobs and total size of the raw data
@@ -44,26 +191,14 @@ impl Collection {
         })
     }
 
-    /// Serialize this collection to a std `Vec<u8>`
-    pub fn to_bytes(&self) -> Result<Vec<u8>> {
-        Ok(postcard::to_stdvec(self)?)
-    }
-
     /// Get the links to the blobs in this collection
-    pub fn links(&self) -> Vec<Hash> {
-        self.blobs.iter().map(|x| x.hash).collect()
+    fn links(&self) -> impl Iterator<Item = Hash> + '_ {
+        self.blobs.iter().map(|x| x.hash)
     }
 
     /// Get the names of the blobs in this collection
-    pub fn names(&self) -> Vec<String> {
+    fn names(&self) -> Vec<String> {
         self.blobs.iter().map(|x| x.name.clone()).collect()
-    }
-
-    /// Deserialize a collection from a byte slice
-    pub fn from_bytes(data: &[u8]) -> Result<Self> {
-        let c: Collection =
-            postcard::from_bytes(data).context("failed to deserialize Collection data")?;
-        Ok(c)
     }
 
     /// Blobs in this collection
@@ -137,8 +272,8 @@ impl CollectionParser for IrohCollectionParser {
             // read to end
             let data = reader.read_to_end().await?;
             // parse the collection and just take the hashes
-            let hashes = postcard::from_bytes::<Box<[Hash]>>(&data)?;
-            let res: Box<dyn LinkStream> = Box::new(ArrayLinkStream::new(hashes));
+            let hashes = LinkSeq::try_from(data)?;
+            let res: Box<dyn LinkStream> = Box::new(hashes.into_iter());
             Ok((res, CollectionStats::default()))
         }
         .boxed_local()

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -8,7 +8,7 @@ use indicatif::{
     HumanBytes, HumanDuration, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle,
 };
 use iroh::{
-    collection::{Collection, IrohCollectionParser},
+    collection::Collection,
     rpc_protocol::{BlobDownloadRequest, DownloadLocation},
     util::{io::pathbuf_from_name, progress::ProgressSliceWriter},
 };
@@ -72,8 +72,7 @@ impl GetInteractive {
         // TODO: we don't need sync here, maybe disable completely?
         let doc_store = iroh_sync::store::memory::Store::default();
         // spin up temp node and ask it to download the data for us
-        let mut provider =
-            iroh::node::Node::builder(db, doc_store).collection_parser(IrohCollectionParser);
+        let mut provider = iroh::node::Node::builder(db, doc_store);
         if let Some(ref dm) = self.opts.derp_map {
             provider = provider.enable_derp(dm.clone());
         }

--- a/iroh/src/commands/provide.rs
+++ b/iroh/src/commands/provide.rs
@@ -10,7 +10,6 @@ use anyhow::{anyhow, ensure, Context, Result};
 use iroh::{
     baomap::flat,
     client::quic::RPC_ALPN,
-    collection::IrohCollectionParser,
     node::{Node, StaticTokenAuthHandler},
     rpc_protocol::{ProviderRequest, ProviderResponse, ProviderService},
 };
@@ -142,7 +141,6 @@ async fn provide<B: BaoStore, D: DocStore>(
     let secret_key = get_secret_key(key).await?;
 
     let mut builder = Node::builder(bao_store, doc_store)
-        .collection_parser(IrohCollectionParser)
         .custom_auth_handler(Arc::new(StaticTokenAuthHandler::new(opts.request_token)))
         .keylog(opts.keylog);
     if let Some(dm) = opts.derp_map {

--- a/iroh/src/downloader/get.rs
+++ b/iroh/src/downloader/get.rs
@@ -414,7 +414,7 @@ pub async fn get_collection<D: Store, C: CollectionParser>(
         log!("already got collection - doing partial download");
         // got the collection
         let reader = entry.data_reader().await?;
-        let (mut collection, _) = collection_parser.parse(0, reader).await.map_err(|e| {
+        let (mut collection, _) = collection_parser.parse(reader).await.map_err(|e| {
             FailureAction::DropPeer(anyhow::anyhow!(
                 "peer sent data that can't be parsed as collection : {e}"
             ))
@@ -509,7 +509,7 @@ pub async fn get_collection<D: Store, C: CollectionParser>(
             FailureAction::RetryLater(anyhow::anyhow!("data just downloaded was not found"))
         })?;
         let reader = entry.data_reader().await?;
-        let (mut collection, _) = collection_parser.parse(0, reader).await.map_err(|_| {
+        let (mut collection, _) = collection_parser.parse(reader).await.map_err(|_| {
             FailureAction::DropPeer(anyhow::anyhow!(
                 "peer sent data that can't be parsed as collection"
             ))

--- a/iroh/src/get.rs
+++ b/iroh/src/get.rs
@@ -293,7 +293,7 @@ pub async fn get_collection<D: BaoStore, C: CollectionParser>(
         log!("already got collection - doing partial download");
         // got the collection
         let reader = entry.data_reader().await?;
-        let (mut collection, stats) = collection_parser.parse(0, reader).await?;
+        let (mut collection, stats) = collection_parser.parse(reader).await?;
         sender
             .send(GetProgress::FoundCollection {
                 hash: *root_hash,
@@ -372,7 +372,7 @@ pub async fn get_collection<D: BaoStore, C: CollectionParser>(
         // read the collection fully for now
         let entry = db.get(root_hash).context("just downloaded")?;
         let reader = entry.data_reader().await?;
-        let (mut collection, stats) = collection_parser.parse(0, reader).await?;
+        let (mut collection, stats) = collection_parser.parse(reader).await?;
         sender
             .send(GetProgress::FoundCollection {
                 hash: *root_hash,

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -244,7 +244,7 @@ fn cli_provide_tree_resume() -> Result<()> {
         let get_output = get.unchecked().run()?;
         assert!(get_output.status.success());
         let matches = explicit_matches(match_get_stderr(get_output.stderr)?);
-        assert_eq!(matches, vec!["112.84 KiB"]);
+        assert_eq!(matches, vec!["112.88 KiB"]);
         compare_files(&src, &tgt)?;
         std::fs::remove_dir_all(&tgt)?;
     }
@@ -380,13 +380,13 @@ fn cli_provide_persistence() -> anyhow::Result<()> {
     let db_path = iroh_data_dir.join(BAO_DIR);
     let db = Store::load_blocking(&db_path, &db_path, &db_path, &rt)?;
     let blobs = db.blobs().collect::<Vec<_>>();
-    assert_eq!(blobs.len(), 2);
+    assert_eq!(blobs.len(), 3);
 
     provide(&bar_path)?;
     // should have more data now
     let db = Store::load_blocking(&db_path, &db_path, &db_path, &rt)?;
     let blobs = db.blobs().collect::<Vec<_>>();
-    assert_eq!(blobs.len(), 4);
+    assert_eq!(blobs.len(), 6);
 
     Ok(())
 }

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -642,7 +642,7 @@ async fn run_custom_get_request<C: CollectionParser>(
         };
         let (done, data) = sc.next().concatenate_into_vec().await?;
         let mut data = Bytes::from(data);
-        let (stream, _stats) = collection_parser.parse(0, &mut data).await?;
+        let (stream, _stats) = collection_parser.parse(&mut data).await?;
         (done.next(), data, stream)
     };
     // the previous *overall* offset, not child offset
@@ -699,7 +699,6 @@ pub struct CollectionsAreJustLinks;
 impl CollectionParser for CollectionsAreJustLinks {
     fn parse<'a, R: AsyncSliceReader + 'a>(
         &'a self,
-        _format: u64,
         mut reader: R,
     ) -> LocalBoxFuture<'_, anyhow::Result<(Box<dyn LinkStream>, CollectionStats)>> {
         async move {

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -6,7 +6,6 @@ use anyhow::{anyhow, bail, Result};
 use futures::{Stream, StreamExt, TryStreamExt};
 use iroh::{
     client::mem::Doc,
-    collection::IrohCollectionParser,
     node::{Builder, Node},
     rpc_protocol::ShareMode,
     sync_engine::{LiveEvent, SyncEvent},
@@ -33,16 +32,10 @@ fn test_runtime() -> runtime::Handle {
 fn test_node(
     rt: runtime::Handle,
     addr: SocketAddr,
-) -> Builder<
-    iroh::baomap::mem::Store,
-    store::memory::Store,
-    DummyServerEndpoint,
-    IrohCollectionParser,
-> {
+) -> Builder<iroh::baomap::mem::Store, store::memory::Store, DummyServerEndpoint> {
     let db = iroh::baomap::mem::Store::new(rt.clone());
     let store = iroh_sync::store::memory::Store::default();
     Node::builder(db, store)
-        .collection_parser(IrohCollectionParser)
         .enable_derp(iroh_net::defaults::default_derp_map())
         .runtime(&rt)
         .bind_addr(addr)


### PR DESCRIPTION
## Description

As discussed on Friday, this turns collections into just sequences of hashes

## Notes & open questions

~Just wanted to check how much effort this is. Not ready to merge. But the effort seems very manageable...~

How should the two concepts be named.

1. a collection as in a sequence of links
2. a thing that contains names and can therefore be used to map a directory tree

Todo:

- [x] add total size to metadata
- [x] remove IrohCollectionParser from iroh, add LinkSeqCollectionParser to iroh-bytes, and make it the default
- [x] add more convenient APIs to work with 2 initial blobs
- [x] skip size prefix for links

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
