### PR TITLE
fix some dead-code warnings when using `--no-default-features`

### DIFF
--- a/iroh-metrics/src/core.rs
+++ b/iroh-metrics/src/core.rs
@@ -49,12 +49,14 @@ impl Counter {
     }
 
     /// Increase the [`Counter`] by `u64`, returning the previous value.
+    #[cfg(feature = "metrics")]
     pub fn inc_by(&self, v: u64) -> u64 {
-        #[cfg(feature = "metrics")]
-        {
-            self.counter.inc_by(v)
-        }
-        #[cfg(not(feature = "metrics"))]
+        self.counter.inc_by(v)
+    }
+
+    /// Increase the [`Counter`] by `u64`, returning the previous value.
+    #[cfg(not(feature = "metrics"))]
+    pub fn inc_by(&self, _v: u64) -> u64 {
         0
     }
 
@@ -105,7 +107,7 @@ pub trait Metric:
 
     /// Access to this metrics group to record a metric.
     #[cfg(not(feature = "metrics"))]
-    fn with_metric<T, F: FnOnce(&Self) -> T>(f: F) {
+    fn with_metric<T, F: FnOnce(&Self) -> T>(_f: F) {
         // nothing to do
     }
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -197,7 +197,9 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
     fn insert_entry(&self, entry: SignedEntry, origin: InsertOrigin) -> Result<(), InsertError<S>> {
         let expected_namespace = self.namespace();
 
+        #[cfg(feature = "metrics")]
         let len = entry.content_len();
+
         let mut inner = self.inner.write();
         let store = inner.peer.store();
         validate_entry(
@@ -401,6 +403,7 @@ impl Ord for SignedEntry {
 }
 
 impl SignedEntry {
+    #[cfg(feature = "fs-store")]
     pub(crate) fn new(signature: EntrySignature, entry: Entry) -> Self {
         SignedEntry { signature, entry }
     }
@@ -538,6 +541,7 @@ impl EntrySignature {
         Ok(())
     }
 
+    #[cfg(feature = "fs-store")]
     pub(crate) fn from_parts(namespace_sig: &[u8; 64], author_sig: &[u8; 64]) -> Self {
         let namespace_signature = Signature::from_bytes(namespace_sig);
         let author_signature = Signature::from_bytes(author_sig);
@@ -548,10 +552,12 @@ impl EntrySignature {
         }
     }
 
+    #[cfg(feature = "fs-store")]
     pub(crate) fn author_signature(&self) -> &Signature {
         &self.author_signature
     }
 
+    #[cfg(feature = "fs-store")]
     pub(crate) fn namespace_signature(&self) -> &Signature {
         &self.namespace_signature
     }
@@ -782,6 +788,8 @@ impl Record {
 
 #[cfg(test)]
 mod tests {
+
+    #[cfg(feature = "fs-store")]
     use std::collections::HashSet;
 
     use anyhow::Result;
@@ -966,6 +974,7 @@ mod tests {
         test_content_hashes_iterator(store)
     }
 
+    #[cfg(feature = "fs-store")]
     fn test_content_hashes_iterator<S: store::Store>(store: S) -> Result<()> {
         let mut rng = rand::thread_rng();
         let mut expected = HashSet::new();


### PR DESCRIPTION
## Description

Adds `cfg expressions` to remove dead-code warnings when testing using `--no-default-features` flag.

## Change checklist

- [x] Self-review.
