### PR TITLE
Console download progress

### DIFF
--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -685,6 +685,7 @@ const PROGRESS_STYLE: &str =
 
 fn make_download_pb() -> ProgressBar {
     let pb = ProgressBar::hidden();
+    pb.set_draw_target(ProgressDrawTarget::stderr());
     pb.enable_steady_tick(std::time::Duration::from_millis(50));
     pb.set_style(
         ProgressStyle::with_template(PROGRESS_STYLE)
@@ -709,7 +710,6 @@ fn init_download_progress(pb: &ProgressBar, count: u64, missing_bytes: u64) -> R
     ));
     pb.set_length(missing_bytes);
     pb.reset();
-    pb.set_draw_target(ProgressDrawTarget::stderr());
 
     Ok(())
 }

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
@@ -6,8 +7,12 @@ use bytes::Bytes;
 use clap::{Args, Parser, Subcommand};
 use comfy_table::presets::NOTHING;
 use comfy_table::{Cell, Table};
+use console::style;
 use futures::{Stream, StreamExt};
 use human_time::ToHumanTimeString;
+use indicatif::{
+    HumanBytes, HumanDuration, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle,
+};
 use iroh::client::quic::Iroh;
 use iroh::dial::Ticket;
 use iroh::rpc_protocol::*;
@@ -558,10 +563,8 @@ impl BlobCommands {
                         tag,
                     })
                     .await?;
-                while let Some(item) = stream.next().await {
-                    let item = item?;
-                    println!("{:?}", item);
-                }
+
+                show_download_progress(hash, &mut stream).await?;
                 Ok(())
             }
             Self::List(cmd) => cmd.run(iroh).await,
@@ -675,4 +678,101 @@ fn fmt_latency(latency: Option<Duration>) -> String {
         Some(latency) => latency.to_human_time_string(),
         None => String::from("unknown"),
     }
+}
+
+const PROGRESS_STYLE: &str =
+    "{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})";
+
+fn make_download_pb() -> ProgressBar {
+    let pb = ProgressBar::hidden();
+    pb.enable_steady_tick(std::time::Duration::from_millis(50));
+    pb.set_style(
+        ProgressStyle::with_template(PROGRESS_STYLE)
+            .unwrap()
+            .with_key(
+                "eta",
+                |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                    write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
+                },
+            )
+            .progress_chars("#>-"),
+    );
+    pb
+}
+
+fn init_download_progress(pb: &ProgressBar, count: u64, missing_bytes: u64) -> Result<()> {
+    pb.set_message(format!(
+        "{} Downloading {} file(s) with total transfer size {}",
+        style("[3/3]").bold().dim(),
+        count,
+        HumanBytes(missing_bytes),
+    ));
+    pb.set_length(missing_bytes);
+    pb.reset();
+    pb.set_draw_target(ProgressDrawTarget::stderr());
+
+    Ok(())
+}
+
+pub async fn show_download_progress(
+    hash: Hash,
+    mut stream: impl Stream<Item = Result<GetProgress>> + Unpin,
+) -> Result<()> {
+    eprintln!("Fetching: {}", hash);
+    let pb = make_download_pb();
+    pb.set_message(format!("{} Connecting ...", style("[1/3]").bold().dim()));
+    let mut sizes = BTreeMap::new();
+    while let Some(x) = stream.next().await {
+        match x? {
+            GetProgress::Connected => {
+                pb.set_message(format!("{} Requesting ...", style("[2/3]").bold().dim()));
+            }
+            GetProgress::FoundCollection {
+                total_blobs_size,
+                num_blobs,
+                ..
+            } => {
+                init_download_progress(
+                    &pb,
+                    num_blobs.unwrap_or_default(),
+                    total_blobs_size.unwrap_or_default(),
+                )?;
+            }
+            GetProgress::Found { id, size, .. } => {
+                sizes.insert(id, (size, 0));
+            }
+            GetProgress::Progress { id, offset } => {
+                if let Some((_, current)) = sizes.get_mut(&id) {
+                    *current = offset;
+                    let total = sizes.values().map(|(_, current)| current).sum::<u64>();
+                    pb.set_position(total);
+                }
+            }
+            GetProgress::Done { id } => {
+                if let Some((size, current)) = sizes.get_mut(&id) {
+                    *current = *size;
+                    let total = sizes.values().map(|(_, current)| current).sum::<u64>();
+                    pb.set_position(total);
+                }
+            }
+            GetProgress::NetworkDone {
+                bytes_read,
+                elapsed,
+                ..
+            } => {
+                pb.finish_and_clear();
+                eprintln!(
+                    "Transferred {} in {}, {}/s",
+                    HumanBytes(bytes_read),
+                    HumanDuration(elapsed),
+                    HumanBytes((bytes_read as f64 / elapsed.as_secs_f64()) as u64)
+                );
+            }
+            GetProgress::AllDone => {
+                break;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context as _, Result};
 use console::style;
-use indicatif::{HumanBytes, HumanDuration, ProgressBar, ProgressDrawTarget};
+use indicatif::{HumanBytes, HumanDuration, ProgressBar};
 use iroh::{
     collection::{Collection, IrohCollectionParser},
     rpc_protocol::{BlobDownloadRequest, DownloadLocation},
@@ -172,7 +172,6 @@ async fn get_to_stdout_multi(curr: get::fsm::AtStartRoot, pb: ProgressBar) -> Re
         ));
         pb.set_length(missing_bytes);
         pb.reset();
-        pb.set_draw_target(ProgressDrawTarget::stderr());
         (curr.next(), collection.into_inner())
     };
     // read all the children

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -706,13 +706,6 @@ fn match_get_stderr(stderr: Vec<u8>) -> Result<Vec<(usize, Vec<String>)>> {
         std::io::Cursor::new(stderr),
         [
             (r"Fetching: [\da-z]{59}", 1),
-            (r"\[1/3\] Connecting ...", 1),
-            (r"\[2/3\] Requesting ...", 1),
-            (r"\[3/3\] Downloading ...", 1),
-            (
-                r"\d* file\(s\) with total transfer size [\d.]* ?(?:B|KiB|MiB|GiB|TiB)",
-                1,
-            ),
             (
                 r"Transferred (\d*.?\d*? ?[BKMGT]i?B?) in \d* seconds?, \d*.?\d* ?(?:B|KiB|MiB|GiB|TiB)/s",
                 1,


### PR DESCRIPTION
## Description

This brings the console download GUI in line with iroh get. You get a nice progress bar instead of just an event dump.

In addition I fixed(?) a few other things. The different download stages 1/3 connecting, 2/3 requesting 3/3 downloading are now only shown transiently as the progress bar message. The only thing that is permanent is "requesting <hash>" and the (successful or unsuccessful) outcome.

To make this possible I had to change the test regexes to only look for the permanent output, which I think is not bad. We really don't want to test the transient outputs in all the tests. Maybe there should be one test that does that that is specifically made to test the "console UI".

This is one thing I found that is related to https://github.com/n0-computer/iroh/issues/1498

## Notes & open questions

For debugging the event dump is not that bad. Maybe we need a mode where you always get the event dump?

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
