### PR TITLE
Mem rpc add

### DIFF
--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -771,7 +771,7 @@ impl baomap::Store for Store {
 
 impl LivenessTracker for Inner {
     fn on_clone(&self, inner: &HashAndFormat) {
-        tracing::info!("temp tagging: {:?}", inner);
+        tracing::trace!("temp tagging: {:?}", inner);
         let mut state = self.state.write().unwrap();
         let entry = state.temp.entry(*inner).or_default();
         // panic if we overflow an u64
@@ -779,7 +779,7 @@ impl LivenessTracker for Inner {
     }
 
     fn on_drop(&self, inner: &HashAndFormat) {
-        tracing::info!("temp tag drop: {:?}", inner);
+        tracing::trace!("temp tag drop: {:?}", inner);
         let mut state = self.state.write().unwrap();
         let entry = state.temp.entry(*inner).or_default();
         *entry = entry.saturating_sub(1);

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -555,7 +555,7 @@ impl baomap::Store for Store {
 
 impl LivenessTracker for Inner {
     fn on_clone(&self, inner: &HashAndFormat) {
-        tracing::info!("temp tagging: {:?}", inner);
+        tracing::trace!("temp tagging: {:?}", inner);
         let mut state = self.state.write().unwrap();
         let entry = state.temp.entry(*inner).or_default();
         // panic if we overflow an u64
@@ -563,7 +563,7 @@ impl LivenessTracker for Inner {
     }
 
     fn on_drop(&self, inner: &HashAndFormat) {
-        tracing::info!("temp tag drop: {:?}", inner);
+        tracing::trace!("temp tag drop: {:?}", inner);
         let mut state = self.state.write().unwrap();
         let entry = state.temp.entry(*inner).or_default();
         *entry = entry.saturating_sub(1);


### PR DESCRIPTION
## Description

Tiny bugfix for the progress events when adding to a mem node. Before it would send extra ids, causing the progress display logic to panic. Now it is fixed.

To test, cargo run --example rpc and do somehting like add a directory.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
