### PR TITLE
fix(iroh-net): Do not unwrap sending on response channel

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1172,7 +1172,7 @@ impl Actor {
             }
             ActorMessage::AddKnownAddr(addr, s) => {
                 self.add_known_addr(addr);
-                s.send(()).unwrap();
+                s.send(()).ok();
             }
             ActorMessage::ReceiveDerp(read_result) => {
                 let passthroughs = self.process_derp_read_result(read_result).await;


### PR DESCRIPTION
## Description

This response is not critical.  If someone dropped the receiver it's
just fine, it meant they didn't care about the response anymore.

This has occurred during shutdown.

Part of #1528

## Notes & open questions

## Change checklist

- [x] Self-review.
- [x] ~~Documentation updates if relevant.~~
- [x] ~~Tests if relevant.~~