### PR TITLE
feat(iroh, iroh-gossip): introduce `log-self` feature

### DIFF
--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -46,6 +46,7 @@ url = "2.4.0"
 [features]
 default = ["net"]
 net = ["futures", "iroh-net", "quinn", "tokio", "tokio-util"]
+log-self = []
 
 [[example]]
 name = "chat"

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -13,6 +13,8 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::{debug, trace, warn};
+#[cfg(feature = "log-self")]
+use tracing::{debug_span, Instrument};
 
 use self::util::{read_message, write_message, Dialer, Timers};
 use crate::proto::{self, PeerData, Scope, TopicId};
@@ -85,6 +87,9 @@ impl Gossip {
         let (to_actor_tx, to_actor_rx) = mpsc::channel(TO_ACTOR_CAP);
         let (in_event_tx, in_event_rx) = mpsc::channel(IN_EVENT_CAP);
         let (on_endpoints_tx, on_endpoints_rx) = watch::channel(Default::default());
+
+        #[cfg(feature = "log-self")]
+        let me = endpoint.peer_id().fmt_short();
         let actor = Actor {
             endpoint,
             state,
@@ -101,7 +106,10 @@ impl Gossip {
             subscribers_topic: Default::default(),
         };
         let actor_handle = tokio::spawn(async move {
-            if let Err(err) = actor.run().await {
+            let fut = actor.run();
+            #[cfg(feature = "log-self")]
+            let fut = fut.instrument(debug_span!("gossip", %me));
+            if let Err(err) = fut.await {
                 warn!("gossip actor closed with error: {err:?}");
                 Err(err)
             } else {
@@ -333,7 +341,6 @@ struct Actor {
 
 impl Actor {
     pub async fn run(mut self) -> anyhow::Result<()> {
-        let me = *self.state.me();
         loop {
             tokio::select! {
                 biased;
@@ -341,7 +348,7 @@ impl Actor {
                     match msg {
                         Some(msg) => self.handle_to_actor_msg(msg, Instant::now()).await?,
                         None => {
-                            debug!(?me, "all gossip handles dropped, stop gossip actor");
+                            debug!("all gossip handles dropped, stop gossip actor");
                             break;
                         }
                     }
@@ -354,11 +361,11 @@ impl Actor {
                 (peer_id, res) = self.dialer.next_conn() => {
                     match res {
                         Ok(conn) => {
-                            debug!(?me, peer = ?peer_id, "dial successfull");
+                            debug!(peer = ?peer_id, "dial successfull");
                             self.handle_to_actor_msg(ToActor::ConnIncoming(peer_id, ConnOrigin::Dial, conn), Instant::now()).await.context("dialer.next -> conn -> handle_to_actor_msg")?;
                         }
                         Err(err) => {
-                            warn!(?me, peer = ?peer_id, "dial failed: {err}");
+                            warn!(peer = ?peer_id, "dial failed: {err}");
                         }
                     }
                 }
@@ -383,8 +390,7 @@ impl Actor {
     }
 
     async fn handle_to_actor_msg(&mut self, msg: ToActor, now: Instant) -> anyhow::Result<()> {
-        let me = *self.state.me();
-        trace!(?me, "handle to_actor  {msg:?}");
+        trace!("handle to_actor  {msg:?}");
         match msg {
             ToActor::ConnIncoming(peer_id, origin, conn) => {
                 self.conns.insert(peer_id, conn.clone());
@@ -395,13 +401,13 @@ impl Actor {
                 // Spawn a task for this connection
                 let in_event_tx = self.in_event_tx.clone();
                 tokio::spawn(async move {
-                    debug!(?me, peer = ?peer_id, "connection established");
+                    debug!(peer = ?peer_id, "connection established");
                     match connection_loop(peer_id, conn, origin, send_rx, &in_event_tx).await {
                         Ok(()) => {
-                            debug!(?me, peer = ?peer_id, "connection closed without error")
+                            debug!(peer = ?peer_id, "connection closed without error")
                         }
                         Err(err) => {
-                            debug!(?me, peer = ?peer_id, "connection closed with error {err:?}")
+                            debug!(peer = ?peer_id, "connection closed with error {err:?}")
                         }
                     }
                     in_event_tx
@@ -458,11 +464,10 @@ impl Actor {
     }
 
     async fn handle_in_event(&mut self, event: InEvent, now: Instant) -> anyhow::Result<()> {
-        let me = *self.state.me();
         if matches!(event, InEvent::TimerExpired(_)) {
-            trace!(?me, "handle in_event  {event:?}");
+            trace!("handle in_event  {event:?}");
         } else {
-            debug!(?me, "handle in_event  {event:?}");
+            debug!("handle in_event  {event:?}");
         };
         if let InEvent::PeerDisconnected(peer) = &event {
             self.conn_send_tx.remove(peer);
@@ -470,9 +475,9 @@ impl Actor {
         let out = self.state.handle(event, now);
         for event in out {
             if matches!(event, OutEvent::ScheduleTimer(_, _)) {
-                trace!(?me, "handle out_event {event:?}");
+                trace!("handle out_event {event:?}");
             } else {
-                debug!(?me, "handle out_event {event:?}");
+                debug!("handle out_event {event:?}");
             };
             match event {
                 OutEvent::SendMessage(peer_id, message) => {
@@ -482,7 +487,7 @@ impl Actor {
                             self.conn_send_tx.remove(&peer_id);
                         }
                     } else {
-                        debug!(?me, peer = ?peer_id, "dial");
+                        debug!(peer = ?peer_id, "dial");
                         self.dialer.queue_dial(peer_id, GOSSIP_ALPN);
                         // TODO: Enforce max length
                         self.pending_sends.entry(peer_id).or_default().push(message);
@@ -516,13 +521,13 @@ impl Actor {
                 OutEvent::PeerData(peer, data) => match decode_peer_data(&data) {
                     Err(err) => warn!("Failed to decode {data:?} from {peer}: {err}"),
                     Ok(info) => {
-                        debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known addrs: {info:?}");
+                        debug!(peer = ?peer, "add known addrs: {info:?}");
                         let peer_addr = PeerAddr {
                             peer_id: peer,
                             info,
                         };
                         if let Err(err) = self.endpoint.add_peer_addr(peer_addr).await {
-                            debug!(me = ?self.endpoint.peer_id(), peer = ?peer, "add known failed: {err:?}");
+                            debug!(peer = ?peer, "add known failed: {err:?}");
                         }
                     }
                 },

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -14,7 +14,7 @@ use tokio::{
 };
 use tracing::{debug, trace, warn};
 #[cfg(feature = "log-self")]
-use tracing::{debug_span, Instrument};
+use tracing::{trace_span, Instrument};
 
 use self::util::{read_message, write_message, Dialer, Timers};
 use crate::proto::{self, PeerData, Scope, TopicId};
@@ -108,7 +108,7 @@ impl Gossip {
         let actor_handle = tokio::spawn(async move {
             let fut = actor.run();
             #[cfg(feature = "log-self")]
-            let fut = fut.instrument(debug_span!("gossip", %me));
+            let fut = fut.instrument(trace_span!("gossip", %me));
             if let Err(err) = fut.await {
                 warn!("gossip actor closed with error: {err:?}");
                 Err(err)

--- a/iroh-gossip/src/proto/hyparview.rs
+++ b/iroh-gossip/src/proto/hyparview.rs
@@ -651,7 +651,7 @@ where
             io.push(OutEvent::EmitEvent(Event::NeighborDown(peer)));
             let data = self.peer_data.remove(&peer);
             self.add_passive(peer, data, io);
-            debug!(peer = ?self.me, other = ?peer, "removed from active view, reason: {reason:?}");
+            debug!(other = ?peer, "removed from active view, reason: {reason:?}");
             Some(peer)
         } else {
             None
@@ -701,7 +701,7 @@ where
     fn add_active_unchecked(&mut self, peer: PI, priority: Priority, io: &mut impl IO<PI>) {
         self.passive_view.remove(&peer);
         self.active_view.insert(peer);
-        debug!(peer = ?self.me, other = ?peer, "add to active view");
+        debug!(other = ?peer, "add to active view");
 
         let message = Message::Neighbor(Neighbor {
             priority,

--- a/iroh-net/src/key.rs
+++ b/iroh-net/src/key.rs
@@ -82,6 +82,14 @@ impl PublicKey {
     pub fn verify(&self, message: &[u8], signature: &Signature) -> Result<(), SignatureError> {
         self.public.verify_strict(message, signature)
     }
+
+    /// Convert to a base32 string limited to the first 10 bytes for a friendly string
+    /// representation of the key.
+    pub fn fmt_short(&self) -> String {
+        let mut text = data_encoding::BASE32_NOPAD.encode(self.as_bytes());
+        text.make_ascii_lowercase();
+        text
+    }
 }
 
 impl TryFrom<&[u8]> for PublicKey {

--- a/iroh-net/src/key.rs
+++ b/iroh-net/src/key.rs
@@ -86,7 +86,7 @@ impl PublicKey {
     /// Convert to a base32 string limited to the first 10 bytes for a friendly string
     /// representation of the key.
     pub fn fmt_short(&self) -> String {
-        let mut text = data_encoding::BASE32_NOPAD.encode(self.as_bytes());
+        let mut text = data_encoding::BASE32_NOPAD.encode(&self.as_bytes()[..10]);
         text.make_ascii_lowercase();
         text
     }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -69,7 +69,7 @@ colored = { version = "2.0.4", optional = true }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"], optional = true }
 
 [features]
-default = ["cli", "metrics"]
+default = ["cli", "metrics", "log_self"]
 cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tempfile", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "mem-db", "iroh-collection", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table"]
 metrics = ["iroh-metrics"]
 mem-db = []
@@ -77,6 +77,7 @@ flat-db = []
 iroh-collection = []
 test = []
 example-sync = ["cli"]
+log_self = []
 
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
@@ -110,7 +111,7 @@ required-features = ["mem-db"]
 
 [[example]]
 name = "sync"
-required-features = ["example-sync"]
+required-features = ["example-sync", "log_self"]
 
 [[example]]
 name = "rpc"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -69,7 +69,7 @@ colored = { version = "2.0.4", optional = true }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"], optional = true }
 
 [features]
-default = ["cli", "metrics", "log_self"]
+default = ["cli", "metrics", "log-self"]
 cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tempfile", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "mem-db", "iroh-collection", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table"]
 metrics = ["iroh-metrics"]
 mem-db = []
@@ -77,7 +77,7 @@ flat-db = []
 iroh-collection = []
 test = []
 example-sync = ["cli"]
-log_self = []
+log-self = ["iroh-gossip/log-self"]
 
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -111,7 +111,7 @@ required-features = ["mem-db"]
 
 [[example]]
 name = "sync"
-required-features = ["example-sync", "log_self"]
+required-features = ["example-sync"]
 
 [[example]]
 name = "rpc"

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -241,11 +241,13 @@ impl Downloader {
 
             let service = Service::new(getter, dialer, concurrency_limits, msg_rx);
 
-            let fut = service.run();
-
             #[cfg(feature = "log-self")]
-            let fut = fut.instrument(trace_span!("downloader", %me));
-            fut
+            {
+                service.run().instrument(trace_span!("downloader", %me))
+            }
+
+            #[cfg(not(feature = "log-self"))]
+            service.run()
         };
         rt.local_pool().spawn_pinned(create_future);
         Self { next_id: 0, msg_tx }

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -43,6 +43,8 @@ use iroh_bytes::{
 use iroh_net::{key::PublicKey, MagicEndpoint};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::{sync::CancellationToken, time::delay_queue};
+#[cfg(feature = "log_self")]
+use tracing::instrument;
 use tracing::{debug, trace};
 
 mod get;
@@ -225,6 +227,8 @@ impl Downloader {
         S: Store,
         C: CollectionParser,
     {
+        #[cfg(feature = "log_self")]
+        let me = endpoint.peer_id();
         let (msg_tx, msg_rx) = mpsc::channel(SERVICE_CHANNEL_CAPACITY);
         let dialer = iroh_gossip::net::util::Dialer::new(endpoint);
 
@@ -235,7 +239,14 @@ impl Downloader {
                 collection_parser,
             };
 
-            let service = Service::new(getter, dialer, concurrency_limits, msg_rx);
+            let service = Service::new(
+                #[cfg(feature = "log_self")]
+                me,
+                getter,
+                dialer,
+                concurrency_limits,
+                msg_rx,
+            );
 
             service.run()
         };
@@ -441,6 +452,8 @@ type DownloadFut = LocalBoxFuture<'static, (DownloadKind, Result<(), FailureActi
 
 #[derive(Debug)]
 struct Service<G: Getter, D: Dialer> {
+    #[cfg(feature = "log_self")]
+    me: PublicKey,
     /// The getter performs individual requests.
     getter: G,
     /// Map to query for peers that we believe have the data we are looking for.
@@ -468,12 +481,15 @@ struct Service<G: Getter, D: Dialer> {
 
 impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     fn new(
+        #[cfg(feature = "log_self")] me: PublicKey,
         getter: G,
         dialer: D,
         concurrency_limits: ConcurrencyLimits,
         msg_rx: mpsc::Receiver<Message>,
     ) -> Self {
         Service {
+            #[cfg(feature = "log_self")]
+            me,
             getter,
             providers: ProviderMap::default(),
             dialer,
@@ -489,6 +505,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     }
 
     /// Main loop for the service.
+    #[cfg_attr(feature = "log_self", instrument(skip_all, fields(me = %self.me)))]
     async fn run(mut self) {
         loop {
             // check if we have capacity to dequeue another scheduled request

--- a/iroh/src/downloader/test.rs
+++ b/iroh/src/downloader/test.rs
@@ -23,16 +23,7 @@ impl Downloader {
                 // we want to see the logs of the service
                 let _guard = iroh_test::logging::setup();
 
-                #[cfg(feature = "log_self")]
-                let me = SecretKey::generate().public();
-                let service = Service::new(
-                    #[cfg(feature = "log_self")]
-                    me,
-                    getter,
-                    dialer,
-                    concurrency_limits,
-                    msg_rx,
-                );
+                let service = Service::new(getter, dialer, concurrency_limits, msg_rx);
                 service.run().await
             });
 

--- a/iroh/src/downloader/test.rs
+++ b/iroh/src/downloader/test.rs
@@ -23,7 +23,16 @@ impl Downloader {
                 // we want to see the logs of the service
                 let _guard = iroh_test::logging::setup();
 
-                let service = Service::new(getter, dialer, concurrency_limits, msg_rx);
+                #[cfg(feature = "log_self")]
+                let me = SecretKey::generate().public();
+                let service = Service::new(
+                    #[cfg(feature = "log_self")]
+                    me,
+                    getter,
+                    dialer,
+                    concurrency_limits,
+                    msg_rx,
+                );
                 service.run().await
             });
 

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -185,7 +185,8 @@ impl<S: store::Store> LiveSync<S> {
         downloader: Downloader,
     ) -> Self {
         let (to_actor_tx, to_actor_rx) = mpsc::channel(CHANNEL_CAP);
-        let me = base32::fmt_short(endpoint.peer_id());
+        #[cfg(feature = "log-self")]
+        let me = endpoint.peer_id().fmt_short();
         let mut actor = Actor::new(
             endpoint,
             gossip,
@@ -1019,18 +1020,5 @@ async fn notify_all(subs: &mut HashMap<u64, OnLiveEventCallback>, event: LiveEve
         if matches!(res, KeepCallback::Drop) {
             subs.remove(&idx);
         }
-    }
-}
-
-/// Utilities for working with byte array identifiers
-// TODO: copy-pasted from iroh-gossip/src/proto/util.rs
-// Unify into iroh-common crate or similar
-pub(super) mod base32 {
-    /// Convert to a base32 string limited to the first 10 bytes
-    pub fn fmt_short(bytes: impl AsRef<[u8]>) -> String {
-        let len = bytes.as_ref().len().min(10);
-        let mut text = data_encoding::BASE32_NOPAD.encode(&bytes.as_ref()[..len]);
-        text.make_ascii_lowercase();
-        text
     }
 }

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -37,7 +37,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 #[cfg(feature = "log-self")]
-use tracing::{debug_span, Instrument};
+use tracing::{trace_span, Instrument};
 
 pub use iroh_sync::ContentStatus;
 
@@ -200,7 +200,7 @@ impl<S: store::Store> LiveSync<S> {
         let task = rt.main().spawn(async move {
             let fut = actor.run();
             #[cfg(feature = "log-self")]
-            let fut = fut.instrument(debug_span!("sync", %me));
+            let fut = fut.instrument(trace_span!("sync", %me));
             if let Err(err) = fut.await {
                 error!("live sync failed: {err:?}");
             }


### PR DESCRIPTION
## Description

Aff a feature flag to turn on logging our own `peer_id` in short form and plug this in in sync, gossip and the downloader. This is enabled by default (not sure if we want this for releases thought. Having it as a feature flag at least gives us the option to chose.

This is what I did to debug #1531 and it was really useful

## Notes & open questions

Log sample:
#### Sync
```log
2023-09-28T20:51:18.908126Z DEBUG sync{me=oywqb57ovmdry243}: iroh::sync_engine::live: sync[dial]: start namespace=NamespaceId(q47zmyim5r6isz22…) peer=PublicKey(2jnygwapdm26wwa2) reason=DirectJoin last_state=None
```
#### Gossip
```logs
2023-09-28T20:58:42.854730Z DEBUG gossip{me=zooj7iazcl7rsoal}: iroh_gossip::net: handle out_event EmitEvent(TopicId(wno5nwxtkhhtnqsm…), Received(GossipEvent { content: <33b>, delivered_from: PublicKey(7a7kkzndvbt6eulu), scope: Neighbors }))
```

#### Downloader
```
2023-09-28T21:00:11.107411Z DEBUG downloader{me=4vabufwku3wselbl}: iroh::downloader: download completed peer=2jnygwapdm26wwa26tvcprm3m5vqajmhwz7lx5xizwx637ad5sea kind=Blob { hash: Hash(224746ea89d286220e0770f89cda2ab138143b00e384dd795d5a13b77b094822) }
```

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
