### PR TITLE
fix: actually allow to disable DERP

### DIFF
--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -613,7 +613,10 @@ mod test {
     use std::time::Duration;
 
     use iroh_net::PeerAddr;
-    use iroh_net::{derp::DerpMap, MagicEndpoint};
+    use iroh_net::{
+        derp::{DerpMap, DerpMode},
+        MagicEndpoint,
+    };
     use tokio::spawn;
     use tokio::time::timeout;
     use tokio_util::sync::CancellationToken;
@@ -624,7 +627,7 @@ mod test {
     async fn create_endpoint(derp_map: DerpMap) -> anyhow::Result<MagicEndpoint> {
         MagicEndpoint::builder()
             .alpns(vec![GOSSIP_ALPN.to_vec()])
-            .enable_derp(derp_map)
+            .derp_mode(DerpMode::Custom(derp_map))
             .bind(0)
             .await
     }

--- a/iroh-net/examples/magic.rs
+++ b/iroh-net/examples/magic.rs
@@ -2,8 +2,8 @@ use std::net::SocketAddr;
 
 use clap::Parser;
 use iroh_net::{
-    defaults::{default_derp_map, TEST_REGION_ID},
-    derp::DerpMap,
+    defaults::TEST_REGION_ID,
+    derp::{DerpMap, DerpMode},
     key::SecretKey,
     magic_endpoint::accept_conn,
     MagicEndpoint, PeerAddr,
@@ -50,16 +50,16 @@ async fn main() -> anyhow::Result<()> {
         Some(key) => parse_secret(&key)?,
     };
 
-    let derp_map = match args.derp_url {
-        None => default_derp_map(),
+    let derp_mode = match args.derp_url {
+        None => DerpMode::Default,
         // use `region_id` 65535, which is reserved for testing and experiments
-        Some(url) => DerpMap::from_url(url, TEST_REGION_ID),
+        Some(url) => DerpMode::Custom(DerpMap::from_url(url, TEST_REGION_ID)),
     };
 
     let endpoint = MagicEndpoint::builder()
         .secret_key(secret_key)
         .alpns(vec![args.alpn.to_string().into_bytes()])
-        .enable_derp(derp_map)
+        .derp_mode(derp_mode)
         .bind(args.bind_port)
         .await?;
 

--- a/iroh-net/src/derp.rs
+++ b/iroh-net/src/derp.rs
@@ -22,7 +22,7 @@ pub(crate) mod types;
 pub use self::client::{Client as DerpClient, ReceivedMessage};
 pub use self::codec::MAX_PACKET_SIZE;
 pub use self::http::Client as HttpClient;
-pub use self::map::{DerpMap, DerpNode, DerpRegion, UseIpv4, UseIpv6};
+pub use self::map::{DerpMap, DerpMode, DerpNode, DerpRegion, UseIpv4, UseIpv6};
 pub use self::metrics::Metrics;
 pub use self::server::{
     ClientConnHandler, MaybeTlsStream as MaybeTlsStreamServer, PacketForwarderHandler, Server,

--- a/iroh-net/src/derp/map.rs
+++ b/iroh-net/src/derp/map.rs
@@ -25,7 +25,7 @@ pub enum DerpMode {
 }
 
 /// Configuration of all the Derp servers that can be used.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DerpMap {
     /// A map of the different region IDs to the [`DerpRegion`] information
     regions: Arc<HashMap<u16, DerpRegion>>,
@@ -37,6 +37,13 @@ impl DerpMap {
         let mut ids: Vec<_> = self.regions.keys().copied().collect();
         ids.sort();
         ids
+    }
+
+    /// Create an empty Derp map.
+    pub fn empty() -> Self {
+        Self {
+            regions: Default::default()
+        }
     }
 
     /// Returns an `Iterator` over all known regions.

--- a/iroh-net/src/derp/map.rs
+++ b/iroh-net/src/derp/map.rs
@@ -13,6 +13,17 @@ use url::Url;
 
 use crate::defaults::DEFAULT_DERP_STUN_PORT;
 
+/// Configuration options for the Derp servers of the magic endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DerpMode {
+    /// Disable Derp servers completely.
+    Disabled,
+    /// Use the default Derp map, with Derp servers from n0.
+    Default,
+    /// Use a custom Derp map.
+    Custom(DerpMap),
+}
+
 /// Configuration of all the Derp servers that can be used.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DerpMap {

--- a/iroh-net/src/derp/map.rs
+++ b/iroh-net/src/derp/map.rs
@@ -42,7 +42,7 @@ impl DerpMap {
     /// Create an empty Derp map.
     pub fn empty() -> Self {
         Self {
-            regions: Default::default()
+            regions: Default::default(),
         }
     }
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -173,7 +173,7 @@ impl MagicEndpointBuilder {
     /// will result in an error.
     ///
     /// [`bind`]: MagicEndpointBuilder::bind
-    pub fn set_derp(mut self, derp_mode: DerpMode) -> Self {
+    pub fn derp_mode(mut self, derp_mode: DerpMode) -> Self {
         self.derp_mode = derp_mode;
         self
     }
@@ -600,7 +600,7 @@ mod tests {
             async move {
                 let ep = MagicEndpoint::builder()
                     .alpns(vec![TEST_ALPN.to_vec()])
-                    .enable_derp(derp_map)
+                    .derp_mode(DerpMode::Custom(derp_map))
                     .bind(0)
                     .await
                     .unwrap();

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -241,7 +241,7 @@ impl MagicEndpointBuilder {
     /// NOTE: This will be improved soon to add support for binding on specific addresses.
     pub async fn bind(self, bind_port: u16) -> Result<MagicEndpoint> {
         let derp_map = match self.derp_mode {
-            DerpMode::Disabled => DerpMap::default(),
+            DerpMode::Disabled => DerpMap::empty(),
             DerpMode::Default => default_derp_map(),
             DerpMode::Custom(derp_map) => {
                 ensure!(!derp_map.is_empty(), "Empty custom Derp server map",);

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -10,7 +10,7 @@ use tracing::{debug, trace};
 use crate::{
     config,
     defaults::default_derp_map,
-    derp::DerpMap,
+    derp::{DerpMap, DerpMode},
     key::{PublicKey, SecretKey},
     magicsock::{self, Callbacks, MagicSock},
     tls,
@@ -112,7 +112,7 @@ impl PeerAddr {
 #[derive(Debug)]
 pub struct MagicEndpointBuilder {
     secret_key: Option<SecretKey>,
-    derp_map: Option<DerpMap>,
+    derp_mode: DerpMode,
     alpn_protocols: Vec<Vec<u8>>,
     transport_config: Option<quinn::TransportConfig>,
     concurrent_connections: Option<u32>,
@@ -126,7 +126,7 @@ impl Default for MagicEndpointBuilder {
     fn default() -> Self {
         Self {
             secret_key: Default::default(),
-            derp_map: Some(default_derp_map()),
+            derp_mode: DerpMode::Default,
             alpn_protocols: Default::default(),
             transport_config: Default::default(),
             concurrent_connections: Default::default(),
@@ -162,32 +162,19 @@ impl MagicEndpointBuilder {
         self
     }
 
-    /// Enables using DERP servers to assist in establishing connectivity.
+    /// Sets the DERP servers to assist in establishing connectivity.
     ///
     /// DERP servers are used to discover other peers by [`PublicKey`] and also help
     /// establish connections between peers by being an initial relay for traffic while
     /// assisting in holepunching to establish a direct connection between peers.
     ///
-    /// The provided `derp_map` must contain at least one region with a configured derp
-    /// node.  If an invalid [`DerpMap`] is provided [`bind`] will result in an error.
-    ///
-    /// When calling neither this, nor [`disable_derp`] the builder uses the
-    /// [`default_derp_map`] containing number0's global derp servers.
+    /// When using [DerpMode::Custom], the provided `derp_map` must contain at least one
+    /// region with a configured derp node.  If an invalid [`DerpMap`] is provided [`bind`]
+    /// will result in an error.
     ///
     /// [`bind`]: MagicEndpointBuilder::bind
-    /// [`disable_derp`]: MagicEndpointBuilder::disable_derp
-    pub fn enable_derp(mut self, derp_map: DerpMap) -> Self {
-        self.derp_map = Some(derp_map);
-        self
-    }
-
-    /// Disables using DERP servers.
-    ///
-    /// See [`enable_derp`] for details.
-    ///
-    /// [`enable_derp`]: MagicEndpointBuilder::enable_derp
-    pub fn disable_derp(mut self) -> Self {
-        self.derp_map = None;
+    pub fn set_derp(mut self, derp_mode: DerpMode) -> Self {
+        self.derp_mode = derp_mode;
         self
     }
 
@@ -253,13 +240,14 @@ impl MagicEndpointBuilder {
     /// You can pass `0` to let the operating system choose a free port for you.
     /// NOTE: This will be improved soon to add support for binding on specific addresses.
     pub async fn bind(self, bind_port: u16) -> Result<MagicEndpoint> {
-        ensure!(
-            self.derp_map
-                .as_ref()
-                .map(|m| !m.is_empty())
-                .unwrap_or(true),
-            "Derp server enabled but DerpMap is empty",
-        );
+        let derp_map = match self.derp_mode {
+            DerpMode::Disabled => DerpMap::default(),
+            DerpMode::Default => default_derp_map(),
+            DerpMode::Custom(derp_map) => {
+                ensure!(!derp_map.is_empty(), "Empty custom Derp server map",);
+                derp_map
+            }
+        };
         let secret_key = self.secret_key.unwrap_or_else(SecretKey::generate);
         let mut server_config = make_server_config(
             &secret_key,
@@ -273,7 +261,7 @@ impl MagicEndpointBuilder {
         let msock_opts = magicsock::Options {
             port: bind_port,
             secret_key,
-            derp_map: self.derp_map.unwrap_or_default(),
+            derp_map,
             callbacks: self.callbacks,
             peers_path: self.peers_path,
         };
@@ -579,7 +567,7 @@ mod tests {
                     let ep = MagicEndpoint::builder()
                         .secret_key(server_secret_key)
                         .alpns(vec![TEST_ALPN.to_vec()])
-                        .enable_derp(derp_map)
+                        .derp_mode(DerpMode::Custom(derp_map))
                         .bind(0)
                         .await
                         .unwrap();

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -174,7 +174,7 @@ impl Default for Options {
         Options {
             port: 0,
             secret_key: SecretKey::generate(),
-            derp_map: Default::default(),
+            derp_map: DerpMap::empty(),
             callbacks: Default::default(),
             peers_path: None,
         }

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2648,7 +2648,7 @@ pub(crate) mod tests {
     use tracing_subscriber::{prelude::*, EnvFilter};
 
     use super::*;
-    use crate::{test_utils::run_derper, tls, MagicEndpoint};
+    use crate::{derp::DerpMode, test_utils::run_derper, tls, MagicEndpoint};
 
     fn make_transmit(destination: SocketAddr) -> quinn_udp::Transmit {
         quinn_udp::Transmit {
@@ -2797,7 +2797,7 @@ pub(crate) mod tests {
                     on_derp_s.try_send(()).ok();
                 }))
                 .transport_config(transport_config)
-                .enable_derp(derp_map)
+                .derp_mode(DerpMode::Custom(derp_map))
                 .alpns(vec![ALPN.to_vec()])
                 .bind(0)
                 .await?;

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -37,7 +37,6 @@ use iroh_gossip::{
 };
 use iroh_io::AsyncSliceReaderExt;
 use iroh_net::{
-    defaults::default_derp_map,
     derp::{DerpMap, DerpMode},
     key::SecretKey,
     magic_endpoint::get_alpn,

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -37,7 +37,10 @@ use iroh_gossip::{
 };
 use iroh_io::AsyncSliceReaderExt;
 use iroh_net::{
-    defaults::default_derp_map, derp::DerpMap, key::SecretKey, magic_endpoint::get_alpn,
+    defaults::default_derp_map,
+    derp::{DerpMap, DerpMode},
+    key::SecretKey,
+    magic_endpoint::get_alpn,
     MagicEndpoint, PeerAddr,
 };
 use iroh_sync::{
@@ -130,13 +133,14 @@ async fn run(args: Args) -> anyhow::Result<()> {
     println!("> our secret key: {}", secret_key);
 
     // configure our derp map
-    let derp_map = match (args.no_derp, args.derp) {
-        (false, None) => Some(default_derp_map()),
-        (false, Some(url)) => Some(DerpMap::from_url(url, 0)),
-        (true, None) => None,
+    // configure our derp map
+    let derp_mode = match (args.no_derp, args.derp) {
+        (false, None) => DerpMode::Default,
+        (false, Some(url)) => DerpMode::Custom(DerpMap::from_url(url, 0)),
+        (true, None) => DerpMode::Disabled,
         (true, Some(_)) => bail!("You cannot set --no-derp and --derp at the same time"),
     };
-    println!("> using DERP servers: {}", fmt_derp_map(&derp_map));
+    println!("> using DERP servers: {}", fmt_derp_mode(&derp_mode));
 
     // build our magic endpoint and the gossip protocol
     let (endpoint, gossip) = {
@@ -152,6 +156,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 SYNC_ALPN.to_vec(),
                 iroh_bytes::protocol::ALPN.to_vec(),
             ])
+            .derp_mode(derp_mode)
             .on_endpoints({
                 let gossip_cell = gossip_cell.clone();
                 Box::new(move |endpoints| {
@@ -162,12 +167,9 @@ async fn run(args: Args) -> anyhow::Result<()> {
                     // trigger oneshot on the first endpoint update
                     initial_endpoints_tx.try_send(endpoints.to_vec()).ok();
                 })
-            });
-        let endpoint = match derp_map {
-            Some(derp_map) => endpoint.enable_derp(derp_map),
-            None => endpoint,
-        };
-        let endpoint = endpoint.bind(args.bind_port).await?;
+            })
+            .bind(args.bind_port)
+            .await?;
 
         // initialize the gossip protocol
         let gossip = Gossip::from_endpoint(endpoint.clone(), Default::default());
@@ -956,10 +958,11 @@ fn fmt_hash(hash: impl AsRef<[u8]>) -> String {
     text.make_ascii_lowercase();
     format!("{}…{}", &text[..5], &text[(text.len() - 2)..])
 }
-fn fmt_derp_map(derp_map: &Option<DerpMap>) -> String {
-    match derp_map {
-        None => "None".to_string(),
-        Some(map) => map
+fn fmt_derp_mode(derp_mode: &DerpMode) -> String {
+    match derp_mode {
+        DerpMode::Disabled => "None".to_string(),
+        DerpMode::Default => "Default Derp servers".to_string(),
+        DerpMode::Custom(map) => map
             .regions()
             .flat_map(|region| region.nodes.iter().map(|node| node.url.to_string()))
             .collect::<Vec<_>>()

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -132,7 +132,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
     println!("> our secret key: {}", secret_key);
 
     // configure our derp map
-    // configure our derp map
     let derp_mode = match (args.no_derp, args.derp) {
         (false, None) => DerpMode::Default,
         (false, Some(url)) => DerpMode::Custom(DerpMap::from_url(url, 0)),

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -15,7 +15,7 @@ use iroh::util::progress::ProgressWriter;
 use iroh_net::{
     config,
     defaults::{DEFAULT_DERP_STUN_PORT, TEST_REGION_ID},
-    derp::{DerpMap, UseIpv4, UseIpv6},
+    derp::{DerpMap, DerpMode, UseIpv4, UseIpv6},
     key::{PublicKey, SecretKey},
     netcheck, portmapper, MagicEndpoint, PeerAddr,
 };
@@ -525,7 +525,7 @@ async fn make_endpoint(
         .on_endpoints(Box::new(on_endpoints))
         .on_derp_active(Box::new(on_derp_active));
     let endpoint = match derp_map {
-        Some(derp_map) => endpoint.enable_derp(derp_map),
+        Some(derp_map) => endpoint.derp_mode(DerpMode::Custom(derp_map)),
         None => endpoint,
     };
     let endpoint = endpoint.bind(0).await?;

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -246,7 +246,7 @@ async fn report(
             // creating a derp map from host name and stun port
             DerpMap::default_from_node(url, stun_port, UseIpv4::TryDns, UseIpv6::TryDns, 0)
         }
-        None => config.derp_map()?.unwrap_or_default(),
+        None => config.derp_map()?.unwrap_or_else(|| DerpMap::empty()),
     };
     println!("getting report using derp map {dm:#?}");
 

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -246,7 +246,7 @@ async fn report(
             // creating a derp map from host name and stun port
             DerpMap::default_from_node(url, stun_port, UseIpv4::TryDns, UseIpv6::TryDns, 0)
         }
-        None => config.derp_map()?.unwrap_or_else(|| DerpMap::empty()),
+        None => config.derp_map()?.unwrap_or_else(DerpMap::empty),
     };
     println!("getting report using derp map {dm:#?}");
 

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -21,6 +21,7 @@ use iroh_bytes::{
     Hash,
 };
 use iroh_io::ConcatenateSliceWriter;
+use iroh_net::derp::DerpMode;
 use tokio::sync::mpsc;
 
 use crate::commands::show_download_progress;
@@ -72,7 +73,7 @@ impl GetInteractive {
         // spin up temp node and ask it to download the data for us
         let mut provider = iroh::node::Node::builder(db, doc_store);
         if let Some(ref dm) = self.opts.derp_map {
-            provider = provider.enable_derp(dm.clone());
+            provider = provider.derp_mode(DerpMode::Custom(dm.clone()));
         }
         let provider = provider
             .runtime(&iroh_bytes::util::runtime::Handle::from_current(1)?)

--- a/iroh/src/commands/node.rs
+++ b/iroh/src/commands/node.rs
@@ -14,7 +14,10 @@ use iroh::{
     rpc_protocol::{ProviderRequest, ProviderResponse, ProviderService},
 };
 use iroh_bytes::{baomap::Store as BaoStore, protocol::RequestToken, util::runtime};
-use iroh_net::{derp::DerpMap, key::SecretKey};
+use iroh_net::{
+    derp::{DerpMap, DerpMode},
+    key::SecretKey,
+};
 use iroh_sync::store::{fs::Store as DocFsStore, Store as DocStore};
 use quic_rpc::{transport::quinn::QuinnServerEndpoint, ServiceEndpoint};
 use tokio::io::AsyncWriteExt;
@@ -115,7 +118,7 @@ async fn spawn_daemon_node<B: BaoStore, D: DocStore>(
         .peers_data_path(peers_data_path)
         .keylog(opts.keylog);
     if let Some(dm) = opts.derp_map {
-        builder = builder.enable_derp(dm);
+        builder = builder.derp_mode(DerpMode::Custom(dm));
     }
     let builder = builder.bind_addr(opts.addr).runtime(rt);
 

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -41,7 +41,7 @@ pub async fn dial(opts: Options) -> anyhow::Result<quinn::Connection> {
         Some(derp_map) => DerpMode::Custom(derp_map),
         None => DerpMode::Default,
     };
-    let endpoint = endpoint.set_derp(derp_mode);
+    let endpoint = endpoint.derp_mode(derp_mode);
     let endpoint = endpoint.bind(0).await?;
     endpoint
         .connect(opts.peer, &iroh_bytes::protocol::ALPN)

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, ensure, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
 use futures::future::{BoxFuture, Shared};
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt};
@@ -36,12 +36,11 @@ use iroh_bytes::{
 };
 use iroh_gossip::net::{Gossip, GOSSIP_ALPN};
 use iroh_io::AsyncSliceReader;
-use iroh_net::defaults::default_derp_map;
 use iroh_net::magic_endpoint::get_alpn;
 use iroh_net::util::AbortingJoinHandle;
 use iroh_net::{
     config::Endpoint,
-    derp::DerpMap,
+    derp::DerpMode,
     key::{PublicKey, SecretKey},
     tls, MagicEndpoint, PeerAddr,
 };
@@ -124,7 +123,7 @@ pub struct Builder<
     keylog: bool,
     custom_get_handler: Arc<dyn CustomGetHandler>,
     auth_handler: Arc<dyn RequestAuthorizationHandler>,
-    derp_map: Option<DerpMap>,
+    derp_mode: DerpMode,
     collection_parser: C,
     gc_policy: GcPolicy,
     rt: Option<runtime::Handle>,
@@ -182,7 +181,7 @@ impl<D: Map, S: DocStore> Builder<D, S> {
             secret_key: SecretKey::generate(),
             db,
             keylog: false,
-            derp_map: Some(default_derp_map()),
+            derp_mode: DerpMode::Default,
             rpc_endpoint: Default::default(),
             custom_get_handler: Arc::new(NoopCustomGetHandler),
             auth_handler: Arc::new(NoopRequestAuthorizationHandler),
@@ -216,7 +215,7 @@ where
             custom_get_handler: self.custom_get_handler,
             auth_handler: self.auth_handler,
             rpc_endpoint: value,
-            derp_map: self.derp_map,
+            derp_mode: self.derp_mode,
             collection_parser: self.collection_parser,
             gc_policy: self.gc_policy,
             rt: self.rt,
@@ -240,7 +239,7 @@ where
             custom_get_handler: self.custom_get_handler,
             auth_handler: self.auth_handler,
             rpc_endpoint: self.rpc_endpoint,
-            derp_map: self.derp_map,
+            derp_mode: self.derp_mode,
             gc_policy: self.gc_policy,
             rt: self.rt,
             docs: self.docs,
@@ -256,31 +255,17 @@ where
         self
     }
 
-    /// Enables using DERP servers to assist in establishing connectivity.
+    /// Sets the DERP servers to assist in establishing connectivity.
     ///
     /// DERP servers are used to discover other nodes by [`PublicKey`] and also help
     /// establish connections between peers by being an initial relay for traffic while
     /// assisting in holepunching to establish a direct connection between peers.
     ///
-    /// The provided `derp_map` must contain at least one region with a configured derp
-    /// node.
-    ///
-    /// When calling neither this, nor [`disable_derp`] the builder uses the
-    /// [`default_derp_map`] containing number0's global derp servers.
-    ///
-    /// [`disable_derp`]: Builder::disable_derp
-    pub fn enable_derp(mut self, dm: DerpMap) -> Self {
-        self.derp_map = Some(dm);
-        self
-    }
-
-    /// Disables using DERP servers.
-    ///
-    /// See [`enable_derp`] for details.
-    ///
-    /// [`enable_derp`]: Builder::enable_derp
-    pub fn disable_derp(mut self) -> Self {
-        self.derp_map = None;
+    /// When using [DerpMode::Custom], the provided `derp_map` must contain at least one
+    /// region with a configured derp node.  If an invalid [`DerpMap`] is provided [`bind`]
+    /// will result in an error.
+    pub fn derp_mode(mut self, dm: DerpMode) -> Self {
+        self.derp_mode = dm;
         self
     }
 
@@ -346,14 +331,6 @@ where
     pub async fn spawn(self) -> Result<Node<D, S>> {
         trace!("spawning node");
         let rt = self.rt.context("runtime not set")?;
-        ensure!(
-            self.derp_map
-                .as_ref()
-                .map(|m| !m.is_empty())
-                .unwrap_or(true),
-            "Derp server enabled but DerpMap is empty",
-        );
-
         // Initialize the metrics collection.
         //
         // The metrics are global per process. Subsequent calls do not change the metrics
@@ -375,6 +352,7 @@ where
             .keylog(self.keylog)
             .transport_config(transport_config)
             .concurrent_connections(MAX_CONNECTIONS)
+            .set_derp(self.derp_mode)
             .on_endpoints(Box::new(move |eps| {
                 if !eps.is_empty() {
                     endpoints_update_s.send(eps.to_vec()).ok();
@@ -382,10 +360,6 @@ where
             }));
         let endpoint = match self.peers_data_path {
             Some(path) => endpoint.peers_data_path(path),
-            None => endpoint,
-        };
-        let endpoint = match self.derp_map {
-            Some(derp_map) => endpoint.enable_derp(derp_map),
             None => endpoint,
         };
         let endpoint = endpoint.bind(self.bind_addr.port()).await?;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -262,8 +262,8 @@ where
     /// assisting in holepunching to establish a direct connection between peers.
     ///
     /// When using [DerpMode::Custom], the provided `derp_map` must contain at least one
-    /// region with a configured derp node.  If an invalid [`DerpMap`] is provided [`bind`]
-    /// will result in an error.
+    /// region with a configured derp node.  If an invalid [`iroh_net::derp::DerpMap`]
+    /// is provided [`Self::spawn`] will result in an error.
     pub fn derp_mode(mut self, dm: DerpMode) -> Self {
         self.derp_mode = dm;
         self
@@ -352,7 +352,7 @@ where
             .keylog(self.keylog)
             .transport_config(transport_config)
             .concurrent_connections(MAX_CONNECTIONS)
-            .set_derp(self.derp_mode)
+            .derp_mode(self.derp_mode)
             .on_endpoints(Box::new(move |eps| {
                 if !eps.is_empty() {
                     endpoints_update_s.send(eps.to_vec()).ok();

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -57,7 +57,6 @@ fn test_node<D: Store>(
     let store = iroh_sync::store::memory::Store::default();
     Node::builder(db, store)
         .collection_parser(LinkSeqCollectionParser)
-        .enable_derp(iroh_net::defaults::default_derp_map())
         .bind_addr(addr)
 }
 
@@ -732,7 +731,6 @@ async fn test_custom_collection_parser() {
     let doc_store = iroh_sync::store::memory::Store::default();
     let node = Node::builder(db, doc_store)
         .collection_parser(CollectionsAreJustLinks)
-        .enable_derp(iroh_net::defaults::default_derp_map())
         .bind_addr(addr)
         .runtime(&rt)
         .spawn()
@@ -1056,7 +1054,6 @@ async fn test_token_passthrough() -> Result<()> {
     tokio::time::timeout(Duration::from_secs(30), async move {
         let endpoint = MagicEndpoint::builder()
             .secret_key(SecretKey::generate())
-            .enable_derp(iroh_net::defaults::default_derp_map())
             .keylog(true)
             .bind(0)
             .await?;

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -35,10 +35,7 @@ fn test_node(
 ) -> Builder<iroh::baomap::mem::Store, store::memory::Store, DummyServerEndpoint> {
     let db = iroh::baomap::mem::Store::new(rt.clone());
     let store = iroh_sync::store::memory::Store::default();
-    Node::builder(db, store)
-        .enable_derp(iroh_net::defaults::default_derp_map())
-        .runtime(&rt)
-        .bind_addr(addr)
+    Node::builder(db, store).runtime(&rt).bind_addr(addr)
 }
 
 async fn spawn_node(


### PR DESCRIPTION
## Description

`node::Builder::disable_derp` is broken. We do not call `MagicEndpointBuilder::disable_derp` for that, and at some point we changed the magic endpoint to default to the default, n0-supplied derp servers.

This fixes this through a `DerpMode` enum that is much more explicit I think.

Fixes #1558 

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
