### PR TITLE
chore(baomap): drop all baomap logging to debug or lower

### DIFF
--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -345,7 +345,7 @@ impl PartialMap for Store {
         // this prevents this from happening until the live set is cleared at the
         // beginning of the next mark phase, at which point this hash is normally
         // reachable.
-        tracing::info!("protecting partial hash {}", hash);
+        tracing::debug!("protecting partial hash {}", hash);
         state.live.insert(hash);
         let entry = state
             .partial
@@ -894,7 +894,7 @@ impl Store {
     }
 
     fn set_tag_sync(&self, name: Tag, value: Option<HashAndFormat>) -> io::Result<()> {
-        tracing::info!("set_tag {} {:?}", name, value);
+        tracing::debug!("set_tag {} {:?}", name, value);
         let mut tags = self.0.tags.write().unwrap();
         let mut new_tags = tags.clone();
         let changed = if let Some(value) = value {
@@ -922,7 +922,7 @@ impl Store {
     }
 
     fn create_tag_sync(&self, value: HashAndFormat) -> io::Result<Tag> {
-        tracing::info!("create_tag {:?}", value);
+        tracing::debug!("create_tag {:?}", value);
         let mut tags = self.0.tags.write().unwrap();
         let mut new_tags = tags.clone();
         let tag = Tag::auto(SystemTime::now(), |x| new_tags.contains_key(x));
@@ -1094,7 +1094,7 @@ impl Store {
         // copy all the things
         let stable = mode == ExportMode::TryReference;
         let path_bytes = if size >= self.0.options.move_threshold && stable && owned {
-            tracing::info!("moving {} to {}", source.display(), target.display());
+            tracing::debug!("moving {} to {}", source.display(), target.display());
             if let Err(e) = std::fs::rename(source, &target) {
                 tracing::error!("rename failed: {}", e);
                 return Err(e)?;
@@ -1110,7 +1110,7 @@ impl Store {
             entry.external.insert(target);
             Some(entry.external_to_bytes())
         } else {
-            tracing::info!("copying {} to {}", source.display(), target.display());
+            tracing::debug!("copying {} to {}", source.display(), target.display());
             progress(0)?;
             // todo: progress
             std::fs::copy(&source, &target)?;
@@ -1143,7 +1143,7 @@ impl Store {
         meta_path: PathBuf,
         rt: iroh_bytes::util::runtime::Handle,
     ) -> anyhow::Result<Self> {
-        tracing::info!(
+        tracing::debug!(
             "loading database from {} {}",
             complete_path.display(),
             partial_path.display()
@@ -1357,11 +1357,11 @@ impl Store {
             for (uuid, (data_path, outboard_path)) in entries {
                 if Some(uuid) != keep {
                     if let Some(data_path) = data_path {
-                        tracing::info!("removing partial data file {}", data_path.display());
+                        tracing::debug!("removing partial data file {}", data_path.display());
                         std::fs::remove_file(data_path)?;
                     }
                     if let Some(outboard_path) = outboard_path {
-                        tracing::info!(
+                        tracing::debug!(
                             "removing partial outboard file {}",
                             outboard_path.display()
                         );
@@ -1371,18 +1371,18 @@ impl Store {
             }
         }
         for hash in complete.keys() {
-            tracing::info!("complete {}", hash);
+            tracing::debug!("complete {}", hash);
             partial.remove(hash);
         }
         for hash in partial.keys() {
-            tracing::info!("partial {}", hash);
+            tracing::debug!("partial {}", hash);
         }
         let tags_path = meta_path.join("tags.meta");
         let mut tags = BTreeMap::new();
         if tags_path.exists() {
             let data = std::fs::read(tags_path)?;
             tags = postcard::from_bytes(&data)?;
-            tracing::info!("loaded tags. {} entries", tags.len());
+            tracing::debug!("loaded tags. {} entries", tags.len());
         };
         Ok(Self(Arc::new(Inner {
             state: RwLock::new(State {

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -445,7 +445,7 @@ impl PartialMap for Store {
     }
 
     fn insert_complete(&self, entry: PartialEntry) -> BoxFuture<'_, io::Result<()>> {
-        tracing::info!("insert_complete_entry {:#}", entry.hash());
+        tracing::debug!("insert_complete_entry {:#}", entry.hash());
         async move {
             let hash = entry.hash.into();
             let data = entry.data.freeze();


### PR DESCRIPTION
## Description

We've decided that `INFO` logging level & above should be reserved for node operators that are at least familiar with iroh's different subsystems, but _not_ engineering internals.

This is less than ideal on node startup: 
<img width="1259" alt="Screenshot 2023-10-02 at 3 53 19 PM" src="https://github.com/n0-computer/iroh/assets/1154390/eaa53618-0bbe-4654-8067-6ff9ac798042">

So, drop to debug level.


## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] ~~Documentation updates if relevant.~~
- [ ] ~~Tests if relevant.~~
