### PR TITLE
feat(iroh-sync): store peers per doc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +64,12 @@ name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -1610,7 +1627,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1618,6 +1635,10 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -2198,6 +2219,7 @@ dependencies = [
  "iroh-metrics",
  "iroh-net",
  "iroh-test",
+ "lru",
  "once_cell",
  "ouroboros",
  "parking_lot",
@@ -2321,6 +2343,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
+dependencies = [
+ "hashbrown 0.14.0",
+]
 
 [[package]]
 name = "lru-cache"

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -44,6 +44,7 @@ tokio-util = { version = "0.7", optional = true, features = ["codec", "io-util",
 tokio-stream = { version = "0.1", optional = true, features = ["sync"]}
 quinn = { version = "0.10", optional = true }
 futures = { version = "0.3", optional = true }
+lru = "0.11.1"
 
 [dev-dependencies]
 iroh-test = { version = "0.6.0", path = "../iroh-test" }

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -43,7 +43,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
         Self: 'a;
 
     /// Iterator over authors in the store, returned from [`Self::get_sync_peers`]
-    type PeersIter<'a>: Iterator<Item = Result<PeerIdBytes>>
+    type PeersIter<'a>: Iterator<Item = PeerIdBytes>
     where
         Self: 'a;
 
@@ -103,7 +103,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     fn register_useful_peer(&self, namespace: NamespaceId, peer: PeerIdBytes);
 
     /// Get peers to use for syncing a document.
-    fn get_sync_peers(&self, namespace: &NamespaceId) -> Result<Self::PeersIter<'_>>;
+    fn get_sync_peers(&self, namespace: &NamespaceId) -> Result<Option<Self::PeersIter<'_>>>;
 }
 
 /// Filter a get query onto a namespace

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -50,7 +50,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     where
         Self: 'a;
 
-    /// Iterator over authors in the store, returned from [`Self::get_sync_peers`]
+    /// Iterator over peers in the store for a document, returned from [`Self::get_sync_peers`].
     type PeersIter<'a>: Iterator<Item = PeerIdBytes>
     where
         Self: 'a;

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -1,7 +1,5 @@
 //! Storage trait and implementation for iroh-sync documents
 
-use std::time::SystemTime;
-
 use anyhow::Result;
 use iroh_bytes::Hash;
 use rand_core::CryptoRngCore;
@@ -102,14 +100,10 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     fn content_hashes(&self) -> Result<Self::ContentHashesIter<'_>>;
 
     /// Register a peer that has been useful to sync a document.
-    fn register_useful_peer(
-        namespace: &NamespaceId,
-        peer: PeerIdBytes,
-        last_sync_timestamp: SystemTime,
-    );
+    fn register_useful_peer(&self, namespace: NamespaceId, peer: PeerIdBytes);
 
     /// Get peers to use for syncing a document.
-    fn get_sync_peers(namespace: &NamespaceId) -> Result<Self::PeersIter<'_>>;
+    fn get_sync_peers(&self, namespace: &NamespaceId) -> Result<Self::PeersIter<'_>>;
 }
 
 /// Filter a get query onto a namespace

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -20,7 +20,7 @@ mod pubkeys;
 pub use pubkeys::*;
 
 /// Number of [`PeerIdBytes`] objects to cache per document.
-const PEER_PER_DOC_CACHE_SIZE: NonZeroUsize = match NonZeroUsize::new(5) {
+const PEERS_PER_DOC_CACHE_SIZE: NonZeroUsize = match NonZeroUsize::new(5) {
     Some(val) => val,
     None => panic!("this is clearly non zero"),
 };

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -20,7 +20,7 @@ mod pubkeys;
 pub use pubkeys::*;
 
 /// Number of [`PeerIdBytes`] objects to cache per document.
-const PEERS_PER_DOC_CACHE_SIZE: NonZeroUsize = match NonZeroUsize::new(5) {
+pub(crate) const PEERS_PER_DOC_CACHE_SIZE: NonZeroUsize = match NonZeroUsize::new(5) {
     Some(val) => val,
     None => panic!("this is clearly non zero"),
 };

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -1,5 +1,7 @@
 //! Storage trait and implementation for iroh-sync documents
 
+use std::num::NonZeroUsize;
+
 use anyhow::Result;
 use iroh_bytes::Hash;
 use rand_core::CryptoRngCore;
@@ -16,6 +18,12 @@ pub mod fs;
 pub mod memory;
 mod pubkeys;
 pub use pubkeys::*;
+
+/// Number of [`PeerIdBytes`] objects to cache per document.
+const PEER_PER_DOC_CACHE_SIZE: NonZeroUsize = match NonZeroUsize::new(5) {
+    Some(val) => val,
+    None => panic!("this is clearly non zero"),
+};
 
 /// Abstraction over the different available storage solutions.
 pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
@@ -100,7 +108,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     fn content_hashes(&self) -> Result<Self::ContentHashesIter<'_>>;
 
     /// Register a peer that has been useful to sync a document.
-    fn register_useful_peer(&self, namespace: NamespaceId, peer: PeerIdBytes);
+    fn register_useful_peer(&self, namespace: NamespaceId, peer: PeerIdBytes) -> Result<()>;
 
     /// Get peers to use for syncing a document.
     fn get_sync_peers(&self, namespace: &NamespaceId) -> Result<Option<Self::PeersIter<'_>>>;

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -329,7 +329,7 @@ impl super::Store for Store {
         let read_tx = self.db.begin_read()?;
         let peers_table = read_tx.open_multimap_table(NAMESPACE_PEERS_TABLE)?;
         let mut peers = Vec::with_capacity(super::PEERS_PER_DOC_CACHE_SIZE.get());
-        for result in peers_table.get(namespace.as_bytes())? {
+        for result in peers_table.get(namespace.as_bytes())?.rev() {
             let (_nanos, &peer) = result?.value();
             peers.push(peer);
         }

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -19,7 +19,7 @@ use crate::{
     sync::{
         Author, Entry, EntrySignature, Namespace, Record, RecordIdentifier, Replica, SignedEntry,
     },
-    AuthorId, NamespaceId,
+    AuthorId, NamespaceId, PeerIdBytes,
 };
 
 use super::{pubkeys::MemPublicKeyStore, PublicKeyStore};
@@ -115,6 +115,7 @@ impl super::Store for Store {
     type ContentHashesIter<'a> = ContentHashesIterator<'a>;
     type AuthorsIter<'a> = std::vec::IntoIter<Result<Author>>;
     type NamespaceIter<'a> = std::vec::IntoIter<Result<NamespaceId>>;
+    type PeersIter<'a> = std::vec::IntoIter<Result<PeerIdBytes>>;
 
     fn open_replica(&self, namespace_id: &NamespaceId) -> Result<Option<Replica<Self::Instance>>> {
         if let Some(replica) = self.replicas.read().get(namespace_id) {
@@ -236,6 +237,12 @@ impl super::Store for Store {
 
     fn content_hashes(&self) -> Result<Self::ContentHashesIter<'_>> {
         ContentHashesIterator::create(&self.db)
+    }
+
+    fn register_useful_peer(&self, namespace: &NamespaceId, peer: crate::PeerIdBytes) {}
+
+    fn get_sync_peers(&self, namespace: &NamespaceId) -> Result<Self::PeersIter<'_>> {
+        Ok(vec![].into_iter())
     }
 }
 

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -115,7 +115,7 @@ impl super::Store for Store {
     type ContentHashesIter<'a> = ContentHashesIterator<'a>;
     type AuthorsIter<'a> = std::vec::IntoIter<Result<Author>>;
     type NamespaceIter<'a> = std::vec::IntoIter<Result<NamespaceId>>;
-    type PeersIter<'a> = std::vec::IntoIter<Result<PeerIdBytes>>;
+    type PeersIter<'a> = std::vec::IntoIter<PeerIdBytes>;
 
     fn open_replica(&self, namespace_id: &NamespaceId) -> Result<Option<Replica<Self::Instance>>> {
         if let Some(replica) = self.replicas.read().get(namespace_id) {
@@ -239,7 +239,7 @@ impl super::Store for Store {
         ContentHashesIterator::create(&self.db)
     }
 
-    fn register_useful_peer(&self, namespace: &NamespaceId, peer: crate::PeerIdBytes) {}
+    fn register_useful_peer(&self, namespace: NamespaceId, peer: crate::PeerIdBytes) {}
 
     fn get_sync_peers(&self, namespace: &NamespaceId) -> Result<Self::PeersIter<'_>> {
         Ok(vec![].into_iter())

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -252,6 +252,8 @@ impl super::Store for Store {
     }
 
     fn register_useful_peer(&self, namespace: NamespaceId, peer: crate::PeerIdBytes) -> Result<()> {
+        let peer = &peer;
+        let namespace = namespace.as_bytes();
         // calculate nanos since UNIX_EPOCH for a time measurement
         let nanos = std::time::UNIX_EPOCH
             .elapsed()
@@ -259,42 +261,63 @@ impl super::Store for Store {
         let write_tx = self.db.begin_write()?;
         {
             let mut peers_table = write_tx.open_multimap_table(NAMESPACE_PEERS_TABLE)?;
-            let namespace_peers = peers_table.get(namespace.as_bytes())?;
+            let mut namespace_peers = peers_table.get(namespace)?;
 
-            // find any previous entry for the same peer to remove it
-            let mut prev_peer_nanos = None;
-            // calculate the len in the same loop since calling `len` is another fallible operation
-            let mut len = 0;
-            // the oldest entry in the table, candidate for removal depending on len
-            let mut oldest_entry: Option<(Nanos, PeerIdBytes)> = None;
-            for result in namespace_peers {
-                len += 1;
-                let (peer_nanos, &peer_bytes) = result?.value();
-
-                if prev_peer_nanos.is_none() && peer_bytes == peer {
-                    prev_peer_nanos = Some(peer_nanos);
+            // get the oldest entry since it's candidate for removal
+            let maybe_oldest = namespace_peers.next().transpose()?.map(|guard| {
+                let (oldest_nanos, &oldest_peer) = guard.value();
+                (oldest_nanos, oldest_peer)
+            });
+            match maybe_oldest {
+                None => {
+                    // the table is empty so the peer can be inserted without further checks since
+                    // super::PEERS_PER_DOC_CACHE_SIZE is non zero
+                    drop(namespace_peers);
+                    peers_table.insert(namespace, (nanos, peer))?;
                 }
+                Some((oldest_nanos, oldest_peer)) => {
+                    let oldest_peer = &oldest_peer;
 
-                // adjust the oldest entry if this not an entry that will be removed
-                if peer_bytes != peer {
-                    let candidate = (peer_nanos, peer_bytes);
-                    oldest_entry = Some(
-                        oldest_entry
-                            .map(|current_oldest| current_oldest.min(candidate))
-                            .unwrap_or(candidate),
-                    );
+                    if oldest_peer == peer {
+                        // oldest peer is the current one, so replacing the entry for the peer will
+                        // maintain the size
+                        drop(namespace_peers);
+                        peers_table.remove(namespace, (oldest_nanos, oldest_peer))?;
+                        peers_table.insert(namespace, (nanos, peer))?;
+                    } else {
+                        // calculate the len in the same loop since calling `len` is another fallible operation
+                        let mut len = 1;
+                        // find any previous entry for the same peer to remove it
+                        let mut prev_peer_nanos = None;
+
+                        for result in namespace_peers {
+                            len += 1;
+                            let guard = result?;
+                            let (peer_nanos, peer_bytes) = guard.value();
+                            if prev_peer_nanos.is_none() && peer_bytes == peer {
+                                prev_peer_nanos = Some(peer_nanos)
+                            }
+                        }
+
+                        match prev_peer_nanos {
+                            Some(prev_nanos) => {
+                                // the peer was already present, so we can remove the old entry and
+                                // insert the new one without checking the size
+                                peers_table.remove(namespace, (prev_nanos, peer))?;
+                                peers_table.insert(namespace, (nanos, peer))?;
+                            }
+                            None => {
+                                // the peer is new and the table is non empty, add it and check the
+                                // size to decide if the oldest peer should be evicted
+                                peers_table.insert(namespace, (nanos, peer))?;
+                                len += 1;
+                                if len > super::PEERS_PER_DOC_CACHE_SIZE.get() {
+                                    peers_table.remove(namespace, (oldest_nanos, oldest_peer))?;
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-            if let Some(to_remove) = prev_peer_nanos {
-                peers_table.remove(namespace.as_bytes(), (to_remove, &peer))?;
-                len -= 1;
-            }
-            peers_table.insert(namespace.as_bytes(), (nanos, &peer))?;
-            len += 1;
-            if len > super::PEER_PER_DOC_CACHE_SIZE.get() {
-                let (nanos, evicted_peer) = oldest_entry
-                    .expect("there is at least one more entry than the one that was inserted");
-                peers_table.remove(namespace.as_bytes(), (nanos, &evicted_peer))?;
             }
         }
         write_tx.commit()?;
@@ -305,7 +328,7 @@ impl super::Store for Store {
     fn get_sync_peers(&self, namespace: &NamespaceId) -> Result<Option<Self::PeersIter<'_>>> {
         let read_tx = self.db.begin_read()?;
         let peers_table = read_tx.open_multimap_table(NAMESPACE_PEERS_TABLE)?;
-        let mut peers = Vec::with_capacity(super::PEER_PER_DOC_CACHE_SIZE.get());
+        let mut peers = Vec::with_capacity(super::PEERS_PER_DOC_CACHE_SIZE.get());
         for result in peers_table.get(namespace.as_bytes())? {
             let (_nanos, &peer) = result?.value();
             peers.push(peer);

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -145,7 +145,7 @@ impl super::Store for Store {
         let mut per_doc_cache = self.peers_per_doc.write();
         per_doc_cache
             .entry(namespace)
-            .or_insert_with(|| lru::LruCache::new(super::PEER_PER_DOC_CACHE_SIZE))
+            .or_insert_with(|| lru::LruCache::new(super::PEERS_PER_DOC_CACHE_SIZE))
             .put(peer, ());
         Ok(())
     }

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
     convert::Infallible,
-    num::NonZeroUsize,
     sync::Arc,
 };
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -961,7 +961,9 @@ mod tests {
         // behave like an lrucache
         let mut peer_a = [0; 32];
         rng.fill_bytes(&mut peer_a);
-        store.register_useful_peer(my_replica.namespace(), peer_a);
+        store
+            .register_useful_peer(my_replica.namespace(), peer_a)
+            .unwrap();
         let stored_peer = store
             .get_sync_peers(&my_replica.namespace())
             .unwrap()

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -793,7 +793,7 @@ mod tests {
     use std::collections::HashSet;
 
     use anyhow::Result;
-    use rand_core::SeedableRng;
+    use rand_core::{RngCore, SeedableRng};
 
     use crate::{
         ranger::{Range, Store as _},
@@ -956,6 +956,19 @@ mod tests {
 
         assert_eq!(entries_second.len(), 12);
         assert_eq!(entries, entries_second.into_iter().collect::<Vec<_>>());
+
+        // test basic peer persistence. In reality there is no contract for Store implementation to
+        // behave like an lrucache
+        let mut peer_a = [0; 32];
+        rng.fill_bytes(&mut peer_a);
+        store.register_useful_peer(my_replica.namespace(), peer_a);
+        let stored_peer = store
+            .get_sync_peers(&my_replica.namespace())
+            .unwrap()
+            .unwrap()
+            .next();
+
+        assert_eq!(stored_peer, Some(peer_a));
 
         Ok(())
     }

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -994,7 +994,7 @@ mod tests {
         }
         verify_peers(store, namespace, &expected_peers);
 
-        // one more peer should evit the last peer
+        // one more peer should evict the last peer
         expected_peers.pop();
         let newer_peer = [count as u8; 32];
         expected_peers.insert(0, newer_peer);

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -793,7 +793,7 @@ mod tests {
     use std::collections::HashSet;
 
     use anyhow::Result;
-    use rand_core::{RngCore, SeedableRng};
+    use rand_core::SeedableRng;
 
     use crate::{
         ranger::{Range, Store as _},
@@ -957,21 +957,55 @@ mod tests {
         assert_eq!(entries_second.len(), 12);
         assert_eq!(entries, entries_second.into_iter().collect::<Vec<_>>());
 
-        // test basic peer persistence. In reality there is no contract for Store implementation to
-        // behave like an lrucache
-        let mut peer_a = [0; 32];
-        rng.fill_bytes(&mut peer_a);
-        store
-            .register_useful_peer(my_replica.namespace(), peer_a)
-            .unwrap();
-        let stored_peer = store
-            .get_sync_peers(&my_replica.namespace())
-            .unwrap()
-            .unwrap()
-            .next();
+        test_lru_cache_like_behaviour(&store, my_replica.namespace())
+    }
 
-        assert_eq!(stored_peer, Some(peer_a));
+    /// Test that [`Store::register_useful_peer`] behaves like a LRUCache of size
+    /// [`super::store::PEERS_PER_DOC_CACHE_SIZE`].
+    fn test_lru_cache_like_behaviour<S: store::Store>(
+        store: &S,
+        namespace: NamespaceId,
+    ) -> Result<()> {
+        /// Helper to verify the store returns the expected peers for the namespace.
+        #[track_caller]
+        fn verify_peers<S: store::Store>(
+            store: &S,
+            namespace: NamespaceId,
+            expected_peers: &Vec<[u8; 32]>,
+        ) {
+            assert_eq!(
+                expected_peers,
+                &store
+                    .get_sync_peers(&namespace)
+                    .unwrap()
+                    .unwrap()
+                    .collect::<Vec<_>>(),
+                "sync peers differ"
+            );
+        }
 
+        let count = super::store::PEERS_PER_DOC_CACHE_SIZE.get();
+        // expected peers: newest peers are to the front, oldest to the back
+        let mut expected_peers = Vec::with_capacity(count);
+        for i in 0..count as u8 {
+            let peer = [i; 32];
+            expected_peers.insert(0, peer);
+            store.register_useful_peer(namespace, peer)?;
+        }
+        verify_peers(store, namespace, &expected_peers);
+
+        // one more peer should evit the last peer
+        expected_peers.pop();
+        let newer_peer = [count as u8; 32];
+        expected_peers.insert(0, newer_peer);
+        store.register_useful_peer(namespace, newer_peer)?;
+        verify_peers(store, namespace, &expected_peers);
+
+        // move one existing peer up
+        let refreshed_peer = expected_peers.remove(2);
+        expected_peers.insert(0, refreshed_peer);
+        store.register_useful_peer(namespace, refreshed_peer)?;
+        verify_peers(store, namespace, &expected_peers);
         Ok(())
     }
 

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -565,8 +565,30 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
     async fn start_sync(&mut self, namespace: NamespaceId, mut peers: Vec<PeerAddr>) -> Result<()> {
         self.ensure_open(namespace)?;
         self.syncing_replicas.insert(namespace);
-        let known_useful_peers = self.replica_store.get_sync_peers(&namespace);
-        peers.extend(known_useful_peers);
+        // add the peers stored for this document
+        match self.replica_store.get_sync_peers(&namespace) {
+            Ok(None) => {
+                // no peers for this document
+            }
+            Ok(Some(known_useful_peers)) => {
+                let as_peer_addr = known_useful_peers.filter_map(|peer_id_bytes| {
+                    // peers are stored as bytes, don't fail the operation if they can't be
+                    // decoded: simply ignore the peer
+                    match PublicKey::from_bytes(&peer_id_bytes) {
+                        Ok(public_key) => Some(PeerAddr::new(public_key)),
+                        Err(_signing_error) => {
+                            warn!("potential db corruption: peers per doc can't be decoded");
+                            None
+                        }
+                    }
+                });
+                peers.extend(as_peer_addr);
+            }
+            Err(e) => {
+                // try to continue if peers per doc can't be read since they are not vital for sync
+                warn!(%e, "db error reading peers per document")
+            }
+        }
         self.join_peers(namespace, peers).await?;
         Ok(())
     }
@@ -775,7 +797,8 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
         let state = match result {
             Ok(_) => {
                 // register the peer as useful for the document
-                self.replica_store.register_useful_peer(&namespace, &peer);
+                self.replica_store
+                    .register_useful_peer(namespace, *peer.as_bytes());
                 SyncState::Finished
             }
             Err(_) => SyncState::Failed,

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -799,8 +799,12 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
         let state = match result {
             Ok(_) => {
                 // register the peer as useful for the document
-                self.replica_store
-                    .register_useful_peer(namespace, *peer.as_bytes());
+                if let Err(e) = self
+                    .replica_store
+                    .register_useful_peer(namespace, *peer.as_bytes())
+                {
+                    debug!(%e, "failed to register peer for document")
+                }
                 SyncState::Finished
             }
             Err(_) => SyncState::Failed,


### PR DESCRIPTION
## Description

Store peers that have been useful for sync

## Notes & open questions

A live test consisted on:
- `node_a` creates and shares a ticket (with only `node_a` in it)
- `node_b` joins the ticket
- `node_c` joins the ticket. At this point all three peers are aware of the other two
- shutdown all nodes
- bring `node_c` back again
- join `node_c` using the ticket from `node_a` (which is gone)
- `node_c` has cached `node_b` as useful and dials it


## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
