### PR TITLE
test(iroh-sync): fix `test_content_hashes_iterator_memory`

### DIFF
--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -963,7 +963,7 @@ mod tests {
     #[test]
     fn test_content_hashes_iterator_memory() -> Result<()> {
         let store = store::memory::Store::default();
-        test_basics(store)
+        test_content_hashes_iterator(store)
     }
 
     #[cfg(feature = "fs-store")]


### PR DESCRIPTION
## Description

the content of this test is the same as `test_basics_memory` so it;s doing a duplicated test scenario. Name suggests this is what should be here instead

## Notes & open questions

na

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
