### PR TITLE
fix: avoid blockage in endpoint handling

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -365,11 +365,17 @@ impl MagicEndpoint {
     }
 
     /// Get the [`PeerAddr`] for this endpoint.
-    // TODO: We can save an async call by exposing this on the msock.
     pub async fn my_addr(&self) -> Result<PeerAddr> {
         let addrs = self.local_endpoints().await?;
         let derp = self.my_derp().await;
         let addrs = addrs.into_iter().map(|x| x.addr).collect();
+        Ok(PeerAddr::from_parts(self.peer_id(), derp, addrs))
+    }
+
+    /// Get the [`PeerAddr`] for this endpoint, while providing the endpoints.
+    pub async fn my_addr_with_endpoints(&self, eps: Vec<config::Endpoint>) -> Result<PeerAddr> {
+        let derp = self.my_derp().await;
+        let addrs = eps.into_iter().map(|x| x.addr).collect();
         Ok(PeerAddr::from_parts(self.peer_id(), derp, addrs))
     }
 

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -112,7 +112,7 @@ async fn sync_simple() -> Result<()> {
 
 /// Test subscribing to replica events (without sync)
 #[tokio::test]
-async fn sync_subscribe() -> Result<()> {
+async fn sync_subscribe_no_sync() -> Result<()> {
     setup_logging();
     let rt = test_runtime();
     let node = spawn_node(rt, 0).await?;


### PR DESCRIPTION
- avoid using `tokio::sync::watch` has it has a history of causing random blockages
- do not recursively call into the magicsocket to retrieve endpoints


Closes #1568 