### PR TITLE
port `quinn` benchmark to iroh-net and compare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bench"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "clap",
+ "hdrhistogram",
+ "iroh-net",
+ "quinn",
+ "rcgen",
+ "rustls",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "binary-merge"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1637,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2732,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4615,6 +4651,8 @@ checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -4888,6 +4926,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "iroh-net",
   "iroh-sync",
   "iroh-test",
+  "iroh-net/bench"
 ]
 resolver = "2"
 

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bench"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+anyhow = "1.0.22"
+bytes = "1"
+hdrhistogram = { version = "7.2", default-features = false }
+iroh-net = { path = ".." }
+quinn = "0.10"
+rcgen = "0.11.1"
+rustls = { version = "0.21.0", default-features = false, features = ["quic"] }
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1.0.1", features = ["rt", "sync"] }
+tracing = "0.1.10"
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }

--- a/iroh-net/bench/src/bin/bulk.rs
+++ b/iroh-net/bench/src/bin/bulk.rs
@@ -1,0 +1,211 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use iroh_net::{MagicEndpoint, PeerAddr};
+use tokio::sync::Semaphore;
+use tracing::{info, trace};
+
+use bench::{
+    configure_tracing_subscriber, connect_client, drain_stream, rt, send_data_on_stream,
+    server_endpoint,
+    stats::{Stats, TransferResult},
+    Opt,
+};
+
+fn main() {
+    let opt = Opt::parse();
+    configure_tracing_subscriber();
+
+    let server_span = tracing::error_span!("server");
+    let runtime = rt();
+    let (server_addr, endpoint) = {
+        let _guard = server_span.enter();
+        server_endpoint(&runtime, &opt)
+    };
+
+    let server_thread = std::thread::spawn(move || {
+        let _guard = server_span.entered();
+        if let Err(e) = runtime.block_on(server(endpoint, opt)) {
+            eprintln!("server failed: {e:#}");
+        }
+    });
+
+    let mut handles = Vec::new();
+    for id in 0..opt.clients {
+        let server_addr = server_addr.clone();
+        handles.push(std::thread::spawn(move || {
+            let _guard = tracing::error_span!("client", id).entered();
+            let runtime = rt();
+            match runtime.block_on(client(server_addr, opt)) {
+                Ok(stats) => Ok(stats),
+                Err(e) => {
+                    eprintln!("client failed: {e:#}");
+                    Err(e)
+                }
+            }
+        }));
+    }
+
+    for (id, handle) in handles.into_iter().enumerate() {
+        // We print all stats at the end of the test sequentially to avoid
+        // them being garbled due to being printed concurrently
+        if let Ok(stats) = handle.join().expect("client thread") {
+            stats.print(id);
+        }
+    }
+
+    server_thread.join().expect("server thread");
+}
+
+async fn server(endpoint: MagicEndpoint, opt: Opt) -> Result<()> {
+    let mut server_tasks = Vec::new();
+
+    // Handle only the expected amount of clients
+    for _ in 0..opt.clients {
+        let handshake = endpoint.accept().await.unwrap();
+        let connection = handshake.await.context("handshake failed")?;
+
+        server_tasks.push(tokio::spawn(async move {
+            loop {
+                let (mut send_stream, mut recv_stream) = match connection.accept_bi().await {
+                    Err(quinn::ConnectionError::ApplicationClosed(_)) => break,
+                    Err(e) => {
+                        eprintln!("accepting stream failed: {e:?}");
+                        break;
+                    }
+                    Ok(stream) => stream,
+                };
+                trace!("stream established");
+
+                tokio::spawn(async move {
+                    drain_stream(&mut recv_stream, opt.read_unordered).await?;
+                    send_data_on_stream(&mut send_stream, opt.download_size).await?;
+                    Ok::<_, anyhow::Error>(())
+                });
+            }
+
+            if opt.stats {
+                println!("\nServer connection stats:\n{:#?}", connection.stats());
+            }
+        }));
+    }
+
+    // Await all the tasks. We have to do this to prevent the runtime getting dropped
+    // and all server tasks to be cancelled
+    for handle in server_tasks {
+        if let Err(e) = handle.await {
+            eprintln!("Server task error: {e:?}");
+        };
+    }
+
+    Ok(())
+}
+
+async fn client(server_addr: PeerAddr, opt: Opt) -> Result<ClientStats> {
+    let (endpoint, connection) = connect_client(server_addr, opt).await?;
+
+    let start = Instant::now();
+
+    let connection = Arc::new(connection);
+
+    let mut stats = ClientStats::default();
+    let mut first_error = None;
+
+    let sem = Arc::new(Semaphore::new(opt.max_streams));
+    let results = Arc::new(Mutex::new(Vec::new()));
+    for _ in 0..opt.streams {
+        let permit = sem.clone().acquire_owned().await.unwrap();
+        let results = results.clone();
+        let connection = connection.clone();
+        tokio::spawn(async move {
+            let result =
+                handle_client_stream(connection, opt.upload_size, opt.read_unordered).await;
+            info!("stream finished: {:?}", result);
+            results.lock().unwrap().push(result);
+            drop(permit);
+        });
+    }
+
+    // Wait for remaining streams to finish
+    let _ = sem.acquire_many(opt.max_streams as u32).await.unwrap();
+
+    for result in results.lock().unwrap().drain(..) {
+        match result {
+            Ok((upload_result, download_result)) => {
+                stats.upload_stats.stream_finished(upload_result);
+                stats.download_stats.stream_finished(download_result);
+            }
+            Err(e) => {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
+        }
+    }
+
+    stats.upload_stats.total_duration = start.elapsed();
+    stats.download_stats.total_duration = start.elapsed();
+
+    // Explicit close of the connection, since handles can still be around due
+    // to `Arc`ing them
+    connection.close(0u32.into(), b"Benchmark done");
+
+    endpoint.close(0u32.into(), b"").await?;
+
+    if opt.stats {
+        println!("\nClient connection stats:\n{:#?}", connection.stats());
+    }
+
+    match first_error {
+        None => Ok(stats),
+        Some(e) => Err(e),
+    }
+}
+
+async fn handle_client_stream(
+    connection: Arc<quinn::Connection>,
+    upload_size: u64,
+    read_unordered: bool,
+) -> Result<(TransferResult, TransferResult)> {
+    let start = Instant::now();
+
+    let (mut send_stream, mut recv_stream) = connection
+        .open_bi()
+        .await
+        .context("failed to open stream")?;
+
+    send_data_on_stream(&mut send_stream, upload_size).await?;
+
+    let upload_result = TransferResult::new(start.elapsed(), upload_size);
+
+    let start = Instant::now();
+    let size = drain_stream(&mut recv_stream, read_unordered).await?;
+    let download_result = TransferResult::new(start.elapsed(), size as u64);
+
+    Ok((upload_result, download_result))
+}
+
+#[derive(Default)]
+struct ClientStats {
+    upload_stats: Stats,
+    download_stats: Stats,
+}
+
+impl ClientStats {
+    pub fn print(&self, client_id: usize) {
+        println!();
+        println!("Client {client_id} stats:");
+
+        if self.upload_stats.total_size != 0 {
+            self.upload_stats.print("upload");
+        }
+
+        if self.download_stats.total_size != 0 {
+            self.download_stats.print("download");
+        }
+    }
+}

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -1,0 +1,195 @@
+use std::{convert::TryInto, num::ParseIntError, str::FromStr};
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use clap::Parser;
+use iroh_net::{derp::DerpMode, MagicEndpoint, PeerAddr};
+use tokio::runtime::{Builder, Runtime};
+use tracing::trace;
+
+pub mod stats;
+
+pub const ALPN: &[u8] = b"n0/iroh-net-bench/0";
+
+pub fn configure_tracing_subscriber() {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .finish(),
+    )
+    .unwrap();
+}
+
+/// Creates a server endpoint which runs on the given runtime
+pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (PeerAddr, MagicEndpoint) {
+    let _guard = rt.enter();
+    rt.block_on(async move {
+        let ep = MagicEndpoint::builder()
+            .alpns(vec![ALPN.to_vec()])
+            .derp_mode(DerpMode::Disabled)
+            .transport_config(transport_config(opt))
+            .bind(0)
+            .await
+            .unwrap();
+        let addr = ep.local_addr().unwrap();
+        let addr = PeerAddr::new(ep.peer_id()).with_direct_addresses([addr.0]);
+        (addr, ep)
+    })
+}
+
+/// Create a client endpoint and client connection
+pub async fn connect_client(
+    server_addr: PeerAddr,
+    opt: Opt,
+) -> Result<(MagicEndpoint, quinn::Connection)> {
+    let endpoint = MagicEndpoint::builder()
+        .alpns(vec![ALPN.to_vec()])
+        .transport_config(transport_config(&opt))
+        .bind(0)
+        .await
+        .unwrap();
+
+    // TODO: We don't support passing client transport config currently
+    // let mut client_config = quinn::ClientConfig::new(Arc::new(crypto));
+    // client_config.transport_config(Arc::new(transport_config(&opt)));
+
+    let connection = endpoint
+        .connect(server_addr, ALPN)
+        .await
+        .context("unable to connect")?;
+    trace!("connected");
+
+    Ok((endpoint, connection))
+}
+
+pub async fn drain_stream(stream: &mut quinn::RecvStream, read_unordered: bool) -> Result<usize> {
+    let mut read = 0;
+
+    if read_unordered {
+        while let Some(chunk) = stream.read_chunk(usize::MAX, false).await? {
+            read += chunk.bytes.len();
+        }
+    } else {
+        // These are 32 buffers, for reading approximately 32kB at once
+        #[rustfmt::skip]
+        let mut bufs = [
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        ];
+
+        while let Some(n) = stream.read_chunks(&mut bufs[..]).await? {
+            read += bufs.iter().take(n).map(|buf| buf.len()).sum::<usize>();
+        }
+    }
+
+    Ok(read)
+}
+
+pub async fn send_data_on_stream(stream: &mut quinn::SendStream, stream_size: u64) -> Result<()> {
+    const DATA: &[u8] = &[0xAB; 1024 * 1024];
+    let bytes_data = Bytes::from_static(DATA);
+
+    let full_chunks = stream_size / (DATA.len() as u64);
+    let remaining = (stream_size % (DATA.len() as u64)) as usize;
+
+    for _ in 0..full_chunks {
+        stream
+            .write_chunk(bytes_data.clone())
+            .await
+            .context("failed sending data")?;
+    }
+
+    if remaining != 0 {
+        stream
+            .write_chunk(bytes_data.slice(0..remaining))
+            .await
+            .context("failed sending data")?;
+    }
+
+    stream.finish().await.context("failed finishing stream")?;
+
+    Ok(())
+}
+
+pub fn rt() -> Runtime {
+    Builder::new_current_thread().enable_all().build().unwrap()
+}
+
+pub fn transport_config(opt: &Opt) -> quinn::TransportConfig {
+    // High stream windows are chosen because the amount of concurrent streams
+    // is configurable as a parameter.
+    let mut config = quinn::TransportConfig::default();
+    config.max_concurrent_uni_streams(opt.max_streams.try_into().unwrap());
+    config.initial_mtu(opt.initial_mtu);
+
+    // TODO: reenable when we upgrade quinn version
+    // let mut acks = quinn::AckFrequencyConfig::default();
+    // acks.ack_eliciting_threshold(10u32.into());
+    // config.ack_frequency_config(Some(acks));
+
+    config
+}
+
+#[derive(Parser, Debug, Clone, Copy)]
+#[clap(name = "bulk")]
+pub struct Opt {
+    /// The total number of clients which should be created
+    #[clap(long = "clients", short = 'c', default_value = "1")]
+    pub clients: usize,
+    /// The total number of streams which should be created
+    #[clap(long = "streams", short = 'n', default_value = "1")]
+    pub streams: usize,
+    /// The amount of concurrent streams which should be used
+    #[clap(long = "max_streams", short = 'm', default_value = "1")]
+    pub max_streams: usize,
+    /// Number of bytes to transmit from server to client
+    ///
+    /// This can use SI prefixes for sizes. E.g. 1M will transfer 1MiB, 10G
+    /// will transfer 10GiB.
+    #[clap(long, default_value = "1G", value_parser = parse_byte_size)]
+    pub download_size: u64,
+    /// Number of bytes to transmit from client to server
+    ///
+    /// This can use SI prefixes for sizes. E.g. 1M will transfer 1MiB, 10G
+    /// will transfer 10GiB.
+    #[clap(long, default_value = "0", value_parser = parse_byte_size)]
+    pub upload_size: u64,
+    /// Show connection stats the at the end of the benchmark
+    #[clap(long = "stats")]
+    pub stats: bool,
+    /// Whether to use the unordered read API
+    #[clap(long = "unordered")]
+    pub read_unordered: bool,
+    /// Starting guess for maximum UDP payload size
+    #[clap(long, default_value = "1200")]
+    pub initial_mtu: u16,
+}
+
+fn parse_byte_size(s: &str) -> Result<u64, ParseIntError> {
+    let s = s.trim();
+
+    let multiplier = match s.chars().last() {
+        Some('T') => 1024 * 1024 * 1024 * 1024,
+        Some('G') => 1024 * 1024 * 1024,
+        Some('M') => 1024 * 1024,
+        Some('k') => 1024,
+        _ => 1,
+    };
+
+    let s = if multiplier != 1 {
+        &s[..s.len() - 1]
+    } else {
+        s
+    };
+
+    let base: u64 = u64::from_str(s)?;
+
+    Ok(base * multiplier)
+}
+

--- a/iroh-net/bench/src/stats.rs
+++ b/iroh-net/bench/src/stats.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+
+use hdrhistogram::Histogram;
+
+#[derive(Default)]
+pub struct Stats {
+    pub total_size: u64,
+    pub total_duration: Duration,
+    pub streams: usize,
+    pub stream_stats: StreamStats,
+}
+
+impl Stats {
+    pub fn stream_finished(&mut self, stream_result: TransferResult) {
+        self.total_size += stream_result.size;
+        self.streams += 1;
+
+        self.stream_stats
+            .duration_hist
+            .record(stream_result.duration.as_millis() as u64)
+            .unwrap();
+        self.stream_stats
+            .throughput_hist
+            .record(stream_result.throughput as u64)
+            .unwrap();
+    }
+
+    pub fn print(&self, stat_name: &str) {
+        println!("Overall {stat_name} stats:\n");
+        println!(
+            "Transferred {} bytes on {} streams in {:4.2?} ({:.2} MiB/s)\n",
+            self.total_size,
+            self.streams,
+            self.total_duration,
+            throughput_bps(self.total_duration, self.total_size) / 1024.0 / 1024.0
+        );
+
+        println!("Stream {stat_name} metrics:\n");
+
+        println!("      │  Throughput   │ Duration ");
+        println!("──────┼───────────────┼──────────");
+
+        let print_metric = |label: &'static str, get_metric: fn(&Histogram<u64>) -> u64| {
+            println!(
+                " {} │ {:7.2} MiB/s │ {:>9.2?}",
+                label,
+                get_metric(&self.stream_stats.throughput_hist) as f64 / 1024.0 / 1024.0,
+                Duration::from_millis(get_metric(&self.stream_stats.duration_hist))
+            );
+        };
+
+        print_metric("AVG ", |hist| hist.mean() as u64);
+        print_metric("P0  ", |hist| hist.value_at_quantile(0.00));
+        print_metric("P10 ", |hist| hist.value_at_quantile(0.10));
+        print_metric("P50 ", |hist| hist.value_at_quantile(0.50));
+        print_metric("P90 ", |hist| hist.value_at_quantile(0.90));
+        print_metric("P100", |hist| hist.value_at_quantile(1.00));
+    }
+}
+
+pub struct StreamStats {
+    pub duration_hist: Histogram<u64>,
+    pub throughput_hist: Histogram<u64>,
+}
+
+impl Default for StreamStats {
+    fn default() -> Self {
+        Self {
+            duration_hist: Histogram::<u64>::new(3).unwrap(),
+            throughput_hist: Histogram::<u64>::new(3).unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TransferResult {
+    pub duration: Duration,
+    pub size: u64,
+    pub throughput: f64,
+}
+
+impl TransferResult {
+    pub fn new(duration: Duration, size: u64) -> Self {
+        let throughput = throughput_bps(duration, size);
+        TransferResult {
+            duration,
+            size,
+            throughput,
+        }
+    }
+}
+
+pub fn throughput_bps(duration: Duration, size: u64) -> f64 {
+    (size as f64) / (duration.as_secs_f64())
+}


### PR DESCRIPTION
Did a quick-and-dirty port of the [`quinn` benchmark](https://github.com/quinn-rs/quinn/blob/main/bench/) to `iroh-net`.

Results on my machine (Linux, Thinkpad T480, Intel 8250u), running with `cargo run --release` in the respective `bench` project
(-c is the number of clients, -n is the number of streams per client)

**quinn**
```
-c 1 -n 1:    AVG  Throughput  ~614 MiB/s 
-c 1 -n 10:   AVG Througput per client ~576 MiB/s
-c 10 -n 1:   AVG  Throughput  per client ~50 MiB/s 
-c 10 -n 10:  AVG  Throughput  per client ~46 MiB/s 
 
**iroh-net**
```
-c 1 -n 1:   AVG  Throughput  ~210 MiB/s 
-c 1 -n 10:   AVG Througput per client ~180 MiB/s
-c 10 -n 1:   AVG  Throughput  per client ~26 MiB/s 
-c 10 -n 10:  AVG  Throughput  per client ~25 MiB/s 

```