### PR TITLE
fix(metrics): labels need to be lowercase underscore format

### DIFF
--- a/iroh-gossip/src/metrics.rs
+++ b/iroh-gossip/src/metrics.rs
@@ -44,6 +44,6 @@ impl Default for Metrics {
 
 impl Metric for Metrics {
     fn name() -> &'static str {
-        "Iroh Gossip"
+        "gossip"
     }
 }

--- a/iroh-net/src/derp/metrics.rs
+++ b/iroh-net/src/derp/metrics.rs
@@ -126,6 +126,6 @@ impl Default for Metrics {
 
 impl Metric for Metrics {
     fn name() -> &'static str {
-        "Derpserver"
+        "derpserver"
     }
 }

--- a/iroh-net/src/magicsock/metrics.rs
+++ b/iroh-net/src/magicsock/metrics.rs
@@ -140,6 +140,6 @@ impl Default for Metrics {
 
 impl Metric for Metrics {
     fn name() -> &'static str {
-        "Magicsock"
+        "magicsock"
     }
 }

--- a/iroh-net/src/netcheck/metrics.rs
+++ b/iroh-net/src/netcheck/metrics.rs
@@ -36,6 +36,6 @@ impl Default for Metrics {
 
 impl Metric for Metrics {
     fn name() -> &'static str {
-        "Netcheck"
+        "netcheck"
     }
 }

--- a/iroh-net/src/portmapper/metrics.rs
+++ b/iroh-net/src/portmapper/metrics.rs
@@ -63,6 +63,6 @@ impl Default for Metrics {
 
 impl Metric for Metrics {
     fn name() -> &'static str {
-        "Portmap"
+        "portmap"
     }
 }

--- a/iroh-sync/src/metrics.rs
+++ b/iroh-sync/src/metrics.rs
@@ -36,6 +36,6 @@ impl Default for Metrics {
 
 impl Metric for Metrics {
     fn name() -> &'static str {
-        "iroh-sync"
+        "iroh_sync"
     }
 }

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -38,7 +38,7 @@ impl Default for Metrics {
 
 impl Metric for Metrics {
     fn name() -> &'static str {
-        "Iroh"
+        "iroh"
     }
 }
 


### PR DESCRIPTION
## Description

The current metrics names/labels are not compatible with the OpenMetrics format and prometheus declines to ingest them.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
