### PR TITLE
Remove custom get and custom collections

### DIFF
--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -2,11 +2,12 @@
 use std::{collections::BTreeSet, io, path::PathBuf, sync::Arc};
 
 use crate::{
+    collection::parse_link_seq,
     util::{
         progress::{IdGenerator, ProgressSender},
         BlobFormat, HashAndFormat, RpcError, Tag,
     },
-    Hash, collection::{parse_link_seq, LinkStream},
+    Hash,
 };
 use bao_tree::{blake3, ChunkNum};
 use bytes::Bytes;

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -2,12 +2,11 @@
 use std::{collections::BTreeSet, io, path::PathBuf, sync::Arc};
 
 use crate::{
-    collection::LinkSeqCollectionParser,
     util::{
         progress::{IdGenerator, ProgressSender},
         BlobFormat, HashAndFormat, RpcError, Tag,
     },
-    Hash,
+    Hash, collection::{parse_link_seq, LinkStream},
 };
 use bao_tree::{blake3, ChunkNum};
 use bytes::Bytes;
@@ -416,11 +415,11 @@ async fn gc_mark_task<'a>(
                     warn!("gc: {} creating data reader failed", hash);
                     continue;
                 };
-                let Ok((mut iter, stats)) = LinkSeqCollectionParser.parse(reader).await else {
+                let Ok((mut iter, count)) = parse_link_seq(reader).await else {
                     warn!("gc: {} parse failed", hash);
                     continue;
                 };
-                info!("parsed collection {} {:?}", hash, stats);
+                info!("parsed collection {} {:?}", hash, count);
                 loop {
                     let item = match iter.next().await {
                         Ok(Some(item)) => item,

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -2,7 +2,7 @@
 use std::{collections::BTreeSet, io, path::PathBuf, sync::Arc};
 
 use crate::{
-    collection::parse_link_seq,
+    hashseq::parse_hash_seq,
     util::{
         progress::{IdGenerator, ProgressSender},
         BlobFormat, HashAndFormat, RpcError, Tag,
@@ -416,7 +416,7 @@ async fn gc_mark_task<'a>(
                     warn!("gc: {} creating data reader failed", hash);
                     continue;
                 };
-                let Ok((mut iter, count)) = parse_link_seq(reader).await else {
+                let Ok((mut iter, count)) = parse_hash_seq(reader).await else {
                     warn!("gc: {} parse failed", hash);
                     continue;
                 };

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -51,7 +51,7 @@ impl Stats {
 pub mod fsm {
     use std::{io, result};
 
-    use crate::protocol::{NonEmptyRequestRangeSpecIter, Request, MAX_MESSAGE_SIZE};
+    use crate::protocol::{GetRequest, NonEmptyRequestRangeSpecIter, MAX_MESSAGE_SIZE, Request};
 
     use super::*;
 
@@ -79,7 +79,7 @@ pub mod fsm {
     }
 
     /// The entry point of the get response machine
-    pub fn start(connection: quinn::Connection, request: Request) -> AtInitial {
+    pub fn start(connection: quinn::Connection, request: GetRequest) -> AtInitial {
         AtInitial::new(connection, request)
     }
 
@@ -116,7 +116,7 @@ pub mod fsm {
     #[derive(Debug)]
     pub struct AtInitial {
         connection: quinn::Connection,
-        request: Request,
+        request: GetRequest,
     }
 
     impl AtInitial {
@@ -124,7 +124,7 @@ pub mod fsm {
         ///
         /// `connection` is an existing connection
         /// `request` is the request to be sent
-        pub fn new(connection: quinn::Connection, request: Request) -> Self {
+        pub fn new(connection: quinn::Connection, request: GetRequest) -> Self {
             Self {
                 connection,
                 request,
@@ -152,7 +152,7 @@ pub mod fsm {
         start: Instant,
         reader: TrackingReader<quinn::RecvStream>,
         writer: TrackingWriter<quinn::SendStream>,
-        request: Request,
+        request: GetRequest,
     }
 
     /// Possible next states after the handshake has been sent
@@ -178,18 +178,6 @@ pub mod fsm {
         /// Error when writing the request to the [`quinn::SendStream`]
         #[error("write: {0}")]
         Write(#[from] quinn::WriteError),
-        /// Error when reading a custom request from the [`quinn::RecvStream`]
-        #[error("read: {0}")]
-        Read(quinn::ReadError),
-        /// The remote side sent a custom request that is too big
-        #[error("custom request too big")]
-        CustomRequestTooBig,
-        /// Response terminated early when reading a custom request
-        #[error("eof")]
-        Eof,
-        /// Error when deserializing a received custom request
-        #[error("postcard: {0}")]
-        PostcardDe(postcard::Error),
         /// A generic io error
         #[error("io {0}")]
         Io(io::Error),
@@ -197,13 +185,9 @@ pub mod fsm {
 
     impl ConnectedNextError {
         fn from_io(cause: io::Error) -> Self {
-            if cause.kind() == io::ErrorKind::UnexpectedEof {
-                Self::Eof
-            } else if let Some(inner) = cause.get_ref() {
+            if let Some(inner) = cause.get_ref() {
                 if let Some(e) = inner.downcast_ref::<quinn::WriteError>() {
                     Self::Write(e.clone())
-                } else if let Some(e) = inner.downcast_ref::<quinn::ReadError>() {
-                    Self::Read(e.clone())
                 } else {
                     Self::Io(cause)
                 }
@@ -217,13 +201,8 @@ pub mod fsm {
         fn from(cause: ConnectedNextError) -> Self {
             match cause {
                 ConnectedNextError::Write(cause) => cause.into(),
-                ConnectedNextError::Read(cause) => cause.into(),
-                ConnectedNextError::Eof => io::ErrorKind::UnexpectedEof.into(),
                 ConnectedNextError::Io(cause) => cause,
                 ConnectedNextError::PostcardSer(cause) => {
-                    io::Error::new(io::ErrorKind::Other, cause)
-                }
-                ConnectedNextError::PostcardDe(cause) => {
                     io::Error::new(io::ErrorKind::Other, cause)
                 }
                 _ => io::Error::new(io::ErrorKind::Other, cause),
@@ -243,13 +222,16 @@ pub mod fsm {
                 start,
                 reader,
                 mut writer,
-                request,
+                mut request,
             } = self;
             // 1. Send Request
             {
                 debug!("sending request");
+                let wrapped = Request::Get(request);
                 let request_bytes =
-                    postcard::to_stdvec(&request).map_err(ConnectedNextError::PostcardSer)?;
+                    postcard::to_stdvec(&wrapped).map_err(ConnectedNextError::PostcardSer)?;
+                let Request::Get(x) = wrapped;
+                request = x;
 
                 if request_bytes.len() > MAX_MESSAGE_SIZE {
                     return Err(ConnectedNextError::RequestTooBig);
@@ -266,13 +248,6 @@ pub mod fsm {
             let (mut writer, bytes_written) = writer.into_parts();
             writer.finish().await?;
 
-            // 3. Turn a possible custom request into a get request
-            let request = match request {
-                Request::Get(get_request) => {
-                    // we already have a get request, just return it
-                    get_request
-                }
-            };
             let hash = request.hash;
             let ranges_iter = RangesIter::new(request.ranges);
             // this is in a box so we don't have to memcpy it on every state transition

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -51,7 +51,7 @@ impl Stats {
 pub mod fsm {
     use std::{io, result};
 
-    use crate::protocol::{GetRequest, NonEmptyRequestRangeSpecIter, MAX_MESSAGE_SIZE, Request};
+    use crate::protocol::{GetRequest, NonEmptyRequestRangeSpecIter, Request, MAX_MESSAGE_SIZE};
 
     use super::*;
 

--- a/iroh-bytes/src/lib.rs
+++ b/iroh-bytes/src/lib.rs
@@ -4,8 +4,8 @@
 #![recursion_limit = "256"]
 
 pub mod baomap;
-pub mod collection;
 pub mod get;
+pub mod hashseq;
 pub mod protocol;
 pub mod provider;
 pub mod util;

--- a/iroh-bytes/src/protocol/range_spec.rs
+++ b/iroh-bytes/src/protocol/range_spec.rs
@@ -1,4 +1,4 @@
-//! Specifications for ranges selection in blobs and collections.
+//! Specifications for ranges selection in blobs and sequences of blobs.
 //!
 //! The [`RangeSpec`] allows specifying which BAO chunks inside a single blob should be
 //! selected.

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -15,7 +15,7 @@ use tracing::{debug, debug_span, info, trace, warn};
 use tracing_futures::Instrument;
 
 use crate::baomap::*;
-use crate::collection::{parse_link_seq, LinkStream};
+use crate::collection::parse_link_seq;
 use crate::protocol::{GetRequest, RangeSpec, Request, RequestToken};
 use crate::util::{BlobFormat, RpcError, Tag};
 use crate::Hash;

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -15,7 +15,7 @@ use tracing::{debug, debug_span, info, trace, warn};
 use tracing_futures::Instrument;
 
 use crate::baomap::*;
-use crate::collection::parse_link_seq;
+use crate::hashseq::parse_hash_seq;
 use crate::protocol::{GetRequest, RangeSpec, Request, RequestToken};
 use crate::util::{BlobFormat, RpcError, Tag};
 use crate::Hash;
@@ -280,7 +280,7 @@ pub async fn transfer_collection<D: Map, E: EventSender>(
     let just_root = matches!(request.ranges.as_single(), Some((0, _)));
     let mut c = if !just_root {
         // use the collection parser to parse the collection
-        let (stream, count) = parse_link_seq(&mut data).await?;
+        let (stream, count) = parse_hash_seq(&mut data).await?;
         writer
             .events
             .send(Event::TransferCollectionStarted {

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -23,17 +23,17 @@ impl BlobFormat {
     /// Raw format
     pub const RAW: Self = Self(0);
 
-    /// Collection format
-    pub const COLLECTION: Self = Self(1);
+    /// Hash sequence format
+    pub const HASHSEQ: Self = Self(1);
 
     /// true if this is a raw blob
     pub const fn is_raw(&self) -> bool {
         self.0 == Self::RAW.0
     }
 
-    /// true if this is an iroh collection
-    pub const fn is_collection(&self) -> bool {
-        self.0 == Self::COLLECTION.0
+    /// true if this is sequence of hashes
+    pub const fn is_hash_seq(&self) -> bool {
+        self.0 == Self::HASHSEQ.0
     }
 }
 
@@ -47,8 +47,8 @@ impl fmt::Debug for BlobFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self == &Self::RAW {
             f.write_str("Raw")
-        } else if self == &Self::COLLECTION {
-            f.write_str("Collection")
+        } else if self == &Self::HASHSEQ {
+            f.write_str("HashSeq")
         } else {
             f.debug_tuple("Other").field(&self.0).finish()
         }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -70,11 +70,10 @@ ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"], optional
 
 [features]
 default = ["cli", "metrics"]
-cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "mem-db", "iroh-collection", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table"]
+cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "mem-db", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table"]
 metrics = ["iroh-metrics"]
 mem-db = []
 flat-db = []
-iroh-collection = []
 test = []
 example-sync = ["cli"]
 
@@ -97,11 +96,11 @@ required-features = ["cli"]
 
 [[example]]
 name = "collection"
-required-features = ["mem-db", "iroh-collection"]
+required-features = ["mem-db"]
 
 [[example]]
 name = "dump-blob-stream"
-required-features = ["mem-db", "iroh-collection"]
+required-features = ["mem-db"]
 
 [[example]]
 name = "hello-world"

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     // create a ticket
     // tickets wrap all details needed to get a collection
-    let ticket = node.ticket(hash, BlobFormat::COLLECTION).await?;
+    let ticket = node.ticket(hash, BlobFormat::HASHSEQ).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
     println!("node PeerID:     {}", ticket.node_addr().peer_id);

--- a/iroh/examples/dump-blob-fsm.rs
+++ b/iroh/examples/dump-blob-fsm.rs
@@ -44,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
     let connection = iroh::dial::dial(dial_options).await?;
 
     // create a request for a single blob
-    let request = GetRequest::single(ticket.hash()).into();
+    let request = GetRequest::single(ticket.hash());
 
     // create the initial state of the finite state machine
     let initial = iroh::bytes::get::fsm::start(connection, request);

--- a/iroh/examples/dump-blob-stream.rs
+++ b/iroh/examples/dump-blob-stream.rs
@@ -182,7 +182,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut stream = if ticket.recursive() {
         // create a request for a single blob
-        let request = GetRequest::all(ticket.hash()).into();
+        let request = GetRequest::all(ticket.hash());
 
         // create the initial state of the finite state machine
         let initial = iroh::bytes::get::fsm::start(connection, request);
@@ -191,7 +191,7 @@ async fn main() -> anyhow::Result<()> {
         stream_children(initial).boxed_local()
     } else {
         // create a request for a single blob
-        let request = GetRequest::single(ticket.hash()).into();
+        let request = GetRequest::single(ticket.hash());
 
         // create the initial state of the finite state machine
         let initial = iroh::bytes::get::fsm::start(connection, request);

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -25,12 +25,12 @@ use iroh::{
     downloader::Downloader,
     sync_engine::{LiveEvent, SyncEngine, SYNC_ALPN},
 };
+use iroh_bytes::util::runtime;
 use iroh_bytes::{
     baomap::{ImportMode, Map, MapEntry, Store as BaoStore},
     util::progress::IgnoreProgressSender,
     util::BlobFormat,
 };
-use iroh_bytes::util::runtime;
 use iroh_gossip::{
     net::{Gossip, GOSSIP_ALPN},
     proto::TopicId,

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -230,11 +230,8 @@ async fn run(args: Args) -> anyhow::Result<()> {
     std::fs::create_dir_all(&blob_path)?;
     let db = iroh::baomap::flat::Store::load(&blob_path, &blob_path, &blob_path, &rt).await?;
 
-    let collection_parser = LinkSeqCollectionParser;
-
     // create the live syncer
-    let downloader =
-        Downloader::new(db.clone(), collection_parser, endpoint.clone(), rt.clone()).await;
+    let downloader = Downloader::new(db.clone(), endpoint.clone(), rt.clone()).await;
     let live_sync = SyncEngine::spawn(
         rt.clone(),
         endpoint.clone(),
@@ -1027,7 +1024,6 @@ mod iroh_bytes_handlers {
                 conn,
                 self.db.clone(),
                 self.event_sender.clone(),
-                LinkSeqCollectionParser,
                 self.auth_handler.clone(),
                 self.rt.clone(),
             )

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -1003,7 +1003,7 @@ mod iroh_bytes_handlers {
     use iroh_bytes::{
         collection::LinkSeqCollectionParser,
         protocol::{GetRequest, RequestToken},
-        provider::{CustomGetHandler, EventSender, RequestAuthorizationHandler},
+        provider::{EventSender, RequestAuthorizationHandler},
     };
 
     #[derive(Debug, Clone)]
@@ -1011,7 +1011,6 @@ mod iroh_bytes_handlers {
         db: iroh::baomap::flat::Store,
         rt: iroh_bytes::util::runtime::Handle,
         event_sender: NoopEventSender,
-        get_handler: Arc<NoopCustomGetHandler>,
         auth_handler: Arc<NoopRequestAuthorizationHandler>,
     }
     impl IrohBytesHandlers {
@@ -1020,7 +1019,6 @@ mod iroh_bytes_handlers {
                 db,
                 rt,
                 event_sender: NoopEventSender,
-                get_handler: Arc::new(NoopCustomGetHandler),
                 auth_handler: Arc::new(NoopRequestAuthorizationHandler),
             }
         }
@@ -1030,7 +1028,6 @@ mod iroh_bytes_handlers {
                 self.db.clone(),
                 self.event_sender.clone(),
                 LinkSeqCollectionParser,
-                self.get_handler.clone(),
                 self.auth_handler.clone(),
                 self.rt.clone(),
             )
@@ -1044,17 +1041,6 @@ mod iroh_bytes_handlers {
     impl EventSender for NoopEventSender {
         fn send(&self, _event: iroh_bytes::provider::Event) -> BoxFuture<()> {
             async {}.boxed()
-        }
-    }
-    #[derive(Debug)]
-    struct NoopCustomGetHandler;
-    impl CustomGetHandler for NoopCustomGetHandler {
-        fn handle(
-            &self,
-            _token: Option<RequestToken>,
-            _request: Bytes,
-        ) -> BoxFuture<'static, anyhow::Result<GetRequest>> {
-            async move { Err(anyhow::anyhow!("no custom get handler defined")) }.boxed()
         }
     }
     #[derive(Debug)]

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -30,7 +30,7 @@ use iroh_bytes::{
     util::progress::IgnoreProgressSender,
     util::BlobFormat,
 };
-use iroh_bytes::{collection::LinkSeqCollectionParser, util::runtime};
+use iroh_bytes::util::runtime;
 use iroh_gossip::{
     net::{Gossip, GOSSIP_ALPN},
     proto::TopicId,
@@ -995,11 +995,9 @@ async fn copy(
 mod iroh_bytes_handlers {
     use std::sync::Arc;
 
-    use bytes::Bytes;
     use futures::{future::BoxFuture, FutureExt};
     use iroh_bytes::{
-        collection::LinkSeqCollectionParser,
-        protocol::{GetRequest, RequestToken},
+        protocol::RequestToken,
         provider::{EventSender, RequestAuthorizationHandler},
     };
 

--- a/iroh/src/collection.rs
+++ b/iroh/src/collection.rs
@@ -5,9 +5,9 @@ use anyhow::Context;
 use bao_tree::blake3;
 use bytes::Bytes;
 use iroh_bytes::baomap::{MapEntry, TempTag};
-use iroh_bytes::collection::LinkSeq;
 use iroh_bytes::get::fsm::EndBlobNext;
 use iroh_bytes::get::Stats;
+use iroh_bytes::hashseq::HashSeq;
 use iroh_bytes::util::BlobFormat;
 use iroh_bytes::{baomap, Hash};
 use iroh_io::AsyncSliceReaderExt;
@@ -46,7 +46,7 @@ impl Collection {
         let meta_bytes_hash = blake3::hash(&meta_bytes).into();
         let links = std::iter::once(meta_bytes_hash)
             .chain(self.links())
-            .collect::<LinkSeq>();
+            .collect::<HashSeq>();
         let links_bytes = links.into_inner();
         [meta_bytes.into(), links_bytes].into_iter()
     }
@@ -57,11 +57,11 @@ impl Collection {
     /// the links array, and the collection.
     pub async fn read_fsm(
         fsm_at_start_root: iroh_bytes::get::fsm::AtStartRoot,
-    ) -> anyhow::Result<(iroh_bytes::get::fsm::EndBlobNext, LinkSeq, Collection)> {
+    ) -> anyhow::Result<(iroh_bytes::get::fsm::EndBlobNext, HashSeq, Collection)> {
         let (next, links) = {
             let curr = fsm_at_start_root.next();
             let (curr, data) = curr.concatenate_into_vec().await?;
-            let links = LinkSeq::new(data.into()).context("links could not be parsed")?;
+            let links = HashSeq::new(data.into()).context("links could not be parsed")?;
             (curr.next(), links)
         };
         let EndBlobNext::MoreChildren(at_meta) = next else {
@@ -118,7 +118,7 @@ impl Collection {
         let links_entry = db.get(root).context("links not found")?;
         anyhow::ensure!(links_entry.is_complete(), "links not complete");
         let links_bytes = links_entry.data_reader().await?.read_to_end().await?;
-        let mut links = LinkSeq::try_from(links_bytes)?;
+        let mut links = HashSeq::try_from(links_bytes)?;
         let meta_hash = links.pop_front().context("meta hash not found")?;
         let meta_entry = db.get(&meta_hash).context("meta not found")?;
         anyhow::ensure!(links_entry.is_complete(), "links not complete");
@@ -142,9 +142,9 @@ impl Collection {
         let meta_tag = db.import_bytes(meta_bytes.into(), BlobFormat::RAW).await?;
         let links_bytes = std::iter::once(*meta_tag.hash())
             .chain(links)
-            .collect::<LinkSeq>();
+            .collect::<HashSeq>();
         let links_tag = db
-            .import_bytes(links_bytes.into_inner(), BlobFormat::COLLECTION)
+            .import_bytes(links_bytes.into(), BlobFormat::HASHSEQ)
             .await?;
         Ok(links_tag)
     }

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -251,7 +251,7 @@ impl FullCommands {
                     }
                 } else if let (Some(peer), Some(hash)) = (peer, hash) {
                     let format = match collection {
-                        true => BlobFormat::COLLECTION,
+                        true => BlobFormat::HASHSEQ,
                         false => BlobFormat::RAW,
                     };
                     self::get::GetInteractive {
@@ -559,7 +559,7 @@ impl BlobCommands {
                 } else {
                     let format = match recursive {
                         Some(false) | None => BlobFormat::RAW,
-                        Some(true) => BlobFormat::COLLECTION,
+                        Some(true) => BlobFormat::HASHSEQ,
                     };
                     (
                         PeerAddr::from_parts(peer.unwrap(), derp_region, addr),

--- a/iroh/src/commands/add.rs
+++ b/iroh/src/commands/add.rs
@@ -192,7 +192,7 @@ pub fn print_add_response(hash: Hash, format: BlobFormat, entries: Vec<ProvideRe
     println!();
     match format {
         BlobFormat::RAW => println!("Blob: {}", hash),
-        BlobFormat::COLLECTION => println!("Collection: {}", hash),
+        BlobFormat::HASHSEQ => println!("Collection: {}", hash),
         _ => println!("Hash (unsupported format): {}", hash),
     }
 }

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -20,7 +20,7 @@ use iroh_bytes::{
         self,
         fsm::{self, ConnectedNext, EndBlobNext},
     },
-    protocol::{GetRequest, RangeSpecSeq, Request, RequestToken},
+    protocol::{GetRequest, RangeSpecSeq, RequestToken},
     Hash,
 };
 use iroh_io::ConcatenateSliceWriter;
@@ -39,10 +39,8 @@ pub struct GetInteractive {
 }
 
 impl GetInteractive {
-    fn new_request(&self, query: RangeSpecSeq) -> Request {
-        GetRequest::new(self.hash, query)
-            .with_token(self.token.clone())
-            .into()
+    fn new_request(&self, query: RangeSpecSeq) -> GetRequest {
+        GetRequest::new(self.hash, query).with_token(self.token.clone())
     }
 
     /// Get into a file or directory

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -127,7 +127,7 @@ impl Ticket {
 
     /// True if the ticket is for a collection and should retrieve all blobs in it.
     pub fn recursive(&self) -> bool {
-        self.format.is_collection()
+        self.format.is_hash_seq()
     }
 
     /// Get the contents of the ticket, consuming it.
@@ -193,7 +193,7 @@ mod tests {
             hash,
             peer: PeerAddr::from_parts(peer, derp_region, vec![addr]),
             token: Some(token),
-            format: BlobFormat::COLLECTION,
+            format: BlobFormat::HASHSEQ,
         };
         let base32 = ticket.to_string();
         println!("Ticket: {base32}");

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -5,8 +5,6 @@
 //! - [`ProviderMap`]: Where the downloader obtains information about peers that could be
 //!   used to perform a download.
 //! - [`Store`]: Where data is stored.
-//! - [`CollectionParser`]: Used by the Get state machine logic to identify blobs encoding
-//!   collections.
 //!
 //! Once a download request is received, the logic is as follows:
 //! 1. The [`ProviderMap`] is queried for peers. From these peers some are selected

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -36,7 +36,6 @@ use std::{
 use futures::{future::LocalBoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use iroh_bytes::{
     baomap::{range_collections::RangeSet2, Store},
-    collection::CollectionParser,
     protocol::RangeSpecSeq,
     Hash,
 };
@@ -215,15 +214,13 @@ pub struct Downloader {
 
 impl Downloader {
     /// Create a new Downloader.
-    pub async fn new<S, C>(
+    pub async fn new<S>(
         store: S,
-        collection_parser: C,
         endpoint: MagicEndpoint,
         rt: iroh_bytes::util::runtime::Handle,
     ) -> Self
     where
         S: Store,
-        C: CollectionParser,
     {
         let me = endpoint.peer_id().fmt_short();
         let (msg_tx, msg_rx) = mpsc::channel(SERVICE_CHANNEL_CAPACITY);
@@ -231,10 +228,7 @@ impl Downloader {
 
         let create_future = move || {
             let concurrency_limits = ConcurrencyLimits::default();
-            let getter = get::IoGetter {
-                store,
-                collection_parser,
-            };
+            let getter = get::IoGetter { store };
 
             let service = Service::new(getter, dialer, concurrency_limits, msg_rx);
 

--- a/iroh/src/downloader/get.rs
+++ b/iroh/src/downloader/get.rs
@@ -415,7 +415,7 @@ pub async fn get_collection<D: Store>(
             .collect::<Vec<_>>();
         log!("requesting chunks {:?}", missing_iter);
         let request = GetRequest::new(*root_hash, RangeSpecSeq::from_ranges(missing_iter));
-        let request = get::fsm::start(conn, request.into());
+        let request = get::fsm::start(conn, request);
         // create a new bidi stream
         let connected = request.next().await?;
         log!("connected");

--- a/iroh/src/downloader/get.rs
+++ b/iroh/src/downloader/get.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use bao_tree::io::fsm::OutboardMut;
 use futures::FutureExt;
 use iroh_bytes::baomap::range_collections::RangeSet2;
-use iroh_bytes::collection::LinkSeqCollectionParser;
+use iroh_bytes::collection::parse_link_seq;
 use iroh_bytes::{
     baomap::{MapEntry, PartialMapEntry, Store},
     get::{
@@ -392,7 +392,7 @@ pub async fn get_collection<D: Store>(
         log!("already got collection - doing partial download");
         // got the collection
         let reader = entry.data_reader().await?;
-        let (mut collection, _) = LinkSeqCollectionParser.parse(reader).await.map_err(|e| {
+        let (mut collection, _) = parse_link_seq(reader).await.map_err(|e| {
             FailureAction::DropPeer(anyhow::anyhow!(
                 "peer sent data that can't be parsed as collection : {e}"
             ))
@@ -484,7 +484,7 @@ pub async fn get_collection<D: Store>(
             FailureAction::RetryLater(anyhow::anyhow!("data just downloaded was not found"))
         })?;
         let reader = entry.data_reader().await?;
-        let (mut collection, _) = LinkSeqCollectionParser.parse(reader).await.map_err(|_| {
+        let (mut collection, _) = parse_link_seq(reader).await.map_err(|_| {
             FailureAction::DropPeer(anyhow::anyhow!(
                 "peer sent data that can't be parsed as collection"
             ))

--- a/iroh/src/downloader/get.rs
+++ b/iroh/src/downloader/get.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use bao_tree::io::fsm::OutboardMut;
 use futures::FutureExt;
 use iroh_bytes::baomap::range_collections::RangeSet2;
-use iroh_bytes::collection::parse_link_seq;
+use iroh_bytes::hashseq::parse_hash_seq;
 use iroh_bytes::{
     baomap::{MapEntry, PartialMapEntry, Store},
     get::{
@@ -392,7 +392,7 @@ pub async fn get_collection<D: Store>(
         log!("already got collection - doing partial download");
         // got the collection
         let reader = entry.data_reader().await?;
-        let (mut collection, _) = parse_link_seq(reader).await.map_err(|e| {
+        let (mut collection, _) = parse_hash_seq(reader).await.map_err(|e| {
             FailureAction::DropPeer(anyhow::anyhow!(
                 "peer sent data that can't be parsed as collection : {e}"
             ))
@@ -484,7 +484,7 @@ pub async fn get_collection<D: Store>(
             FailureAction::RetryLater(anyhow::anyhow!("data just downloaded was not found"))
         })?;
         let reader = entry.data_reader().await?;
-        let (mut collection, _) = parse_link_seq(reader).await.map_err(|_| {
+        let (mut collection, _) = parse_hash_seq(reader).await.map_err(|_| {
             FailureAction::DropPeer(anyhow::anyhow!(
                 "peer sent data that can't be parsed as collection"
             ))

--- a/iroh/src/get.rs
+++ b/iroh/src/get.rs
@@ -310,7 +310,7 @@ pub async fn get_collection<D: BaoStore>(
             .collect::<Vec<_>>();
         log!("requesting chunks {:?}", missing_iter);
         let request = GetRequest::new(*root_hash, RangeSpecSeq::from_ranges(missing_iter));
-        let request = get::fsm::start(conn, request.into());
+        let request = get::fsm::start(conn, request);
         // create a new bidi stream
         let connected = request.next().await?;
         log!("connected");

--- a/iroh/src/get.rs
+++ b/iroh/src/get.rs
@@ -65,7 +65,7 @@ pub async fn get_blob<D: BaoStore>(
             .unwrap_or_else(RangeSet2::all);
         let request = GetRequest::new(*hash, RangeSpecSeq::from_ranges([required_ranges]));
         // full request
-        let request = get::fsm::start(conn, iroh_bytes::protocol::Request::Get(request));
+        let request = get::fsm::start(conn, request);
         // create a new bidi stream
         let connected = request.next().await?;
         // next step. we have requested a single hash, so this must be StartRoot
@@ -79,10 +79,7 @@ pub async fn get_blob<D: BaoStore>(
         get_blob_inner_partial(db, header, entry, progress).await?
     } else {
         // full request
-        let request = get::fsm::start(
-            conn,
-            iroh_bytes::protocol::Request::Get(GetRequest::single(*hash)),
-        );
+        let request = get::fsm::start(conn, GetRequest::single(*hash));
         // create a new bidi stream
         let connected = request.next().await?;
         // next step. we have requested a single hash, so this must be StartRoot
@@ -353,10 +350,7 @@ pub async fn get_collection<D: BaoStore>(
     } else {
         tracing::info!("don't have collection - doing full download");
         // don't have the collection, so probably got nothing
-        let request = get::fsm::start(
-            conn,
-            iroh_bytes::protocol::Request::Get(GetRequest::all(*root_hash)),
-        );
+        let request = get::fsm::start(conn, GetRequest::all(*root_hash));
         // create a new bidi stream
         let connected = request.next().await?;
         // next step. we have requested a single hash, so this must be StartRoot

--- a/iroh/src/get.rs
+++ b/iroh/src/get.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 use bao_tree::io::fsm::OutboardMut;
 use bao_tree::{ByteNum, ChunkNum};
 use iroh_bytes::baomap::range_collections::{range_set::RangeSetRange, RangeSet2};
-use iroh_bytes::collection::parse_link_seq;
+use iroh_bytes::hashseq::parse_hash_seq;
 use iroh_bytes::{
     baomap::{MapEntry, PartialMap, PartialMapEntry, Store as BaoStore},
     get::{
@@ -288,7 +288,7 @@ pub async fn get_collection<D: BaoStore>(
         log!("already got collection - doing partial download");
         // got the collection
         let reader = entry.data_reader().await?;
-        let (mut collection, count) = parse_link_seq(reader).await?;
+        let (mut collection, count) = parse_hash_seq(reader).await?;
         sender
             .send(GetProgress::FoundCollection {
                 hash: *root_hash,
@@ -364,7 +364,7 @@ pub async fn get_collection<D: BaoStore>(
         // read the collection fully for now
         let entry = db.get(root_hash).context("just downloaded")?;
         let reader = entry.data_reader().await?;
-        let (mut collection, count) = parse_link_seq(reader).await?;
+        let (mut collection, count) = parse_hash_seq(reader).await?;
         sender
             .send(GetProgress::FoundCollection {
                 hash: *root_hash,

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -7,7 +7,6 @@ pub use iroh_sync as sync;
 
 pub mod baomap;
 pub mod client;
-#[cfg(feature = "iroh-collection")]
 pub mod collection;
 pub mod dial;
 pub mod downloader;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -862,8 +862,7 @@ impl<D: BaoStore, S: DocStore> RpcHandler<D, S> {
                 let count = local
                     .spawn_pinned(|| async move {
                         let reader = entry.data_reader().await.ok()?;
-                        let (_collection, count) =
-                            parse_link_seq(reader).await.ok()?;
+                        let (_collection, count) = parse_link_seq(reader).await.ok()?;
                         Some(count)
                     })
                     .await

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -86,7 +86,7 @@ pub struct BlobAddPathResponse(pub AddProgress);
 pub struct BlobDownloadRequest {
     /// This mandatory field contains the hash of the data to download and share.
     pub hash: Hash,
-    /// If the format is [`BlobFormat::COLLECTION`], all children are downloaded and shared as
+    /// If the format is [`BlobFormat::HASHSEQ`], all children are downloaded and shared as
     /// well.
     pub format: BlobFormat,
     /// This mandatory field specifies the peer to download the data from.

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "mem-db", feature = "iroh-collection"))]
+#![cfg(feature = "mem-db")]
 use std::{
     collections::BTreeMap,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -290,7 +290,7 @@ where
         let mut events = Vec::new();
         while let Some(event) = events_recv.recv().await {
             match event {
-                Event::ByteProvide(provider::Event::TransferCollectionCompleted { .. })
+                Event::ByteProvide(provider::Event::TransferCompleted { .. })
                 | Event::ByteProvide(provider::Event::TransferAborted { .. }) => {
                     events.push(event);
                     break;
@@ -330,7 +330,7 @@ fn assert_events(events: Vec<Event>, num_blobs: usize) {
     ));
     assert!(matches!(
         events[2],
-        Event::ByteProvide(provider::Event::TransferCollectionStarted { .. })
+        Event::ByteProvide(provider::Event::TransferHashSeqStarted { .. })
     ));
     for (i, event) in events[3..num_total_events - 1].iter().enumerate() {
         match event {
@@ -342,7 +342,7 @@ fn assert_events(events: Vec<Event>, num_blobs: usize) {
     }
     assert!(matches!(
         events.last().unwrap(),
-        Event::ByteProvide(provider::Event::TransferCollectionCompleted { .. })
+        Event::ByteProvide(provider::Event::TransferCompleted { .. })
     ));
 }
 
@@ -391,7 +391,7 @@ async fn test_server_close() {
                 maybe_event = events_recv.recv() => {
                     match maybe_event {
                         Some(event) => match event {
-                            Event::ByteProvide(provider::Event::TransferCollectionCompleted { .. }) => node.shutdown(),
+                            Event::ByteProvide(provider::Event::TransferCompleted { .. }) => node.shutdown(),
                             Event::ByteProvide(provider::Event::TransferAborted { .. }) => {
                                 break Err(anyhow!("transfer aborted"));
                             }

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -32,7 +32,7 @@ use iroh_bytes::{
         fsm::{self, DecodeError},
         Stats,
     },
-    protocol::{GetRequest, RangeSpecSeq, Request, RequestToken},
+    protocol::{GetRequest, RangeSpecSeq, RequestToken},
     provider::{self, RequestAuthorizationHandler},
     util::{runtime, BlobFormat},
     Hash,
@@ -609,7 +609,7 @@ fn validate_children(collection: Collection, children: BTreeMap<u64, Bytes>) -> 
 
 async fn run_collection_get_request(
     opts: iroh::dial::Options,
-    request: Request,
+    request: GetRequest,
 ) -> anyhow::Result<(Collection, BTreeMap<u64, Bytes>, Stats)> {
     let connection = iroh::dial::dial(opts).await?;
     let initial = fsm::start(connection, request);

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -182,7 +182,7 @@ async fn multiple_clients() -> Result<()> {
                 let opts = get_options(peer_id, addrs);
                 let expected_data = &content;
                 let expected_name = &name;
-                let request = GetRequest::all(hash).into();
+                let request = GetRequest::all(hash);
                 let (collection, children, _stats) =
                     run_collection_get_request(opts, request).await?;
                 assert_eq!(expected_name, &collection.blobs()[0].name);
@@ -272,7 +272,7 @@ where
 
     let addrs = node.local_endpoint_addresses().await?;
     let opts = get_options(node.peer_id(), addrs);
-    let request = GetRequest::all(collection_hash).into();
+    let request = GetRequest::all(collection_hash);
     let (collection, children, _stats) = run_collection_get_request(opts, request).await?;
     assert_eq!(num_blobs, collection.blobs().len());
     for (i, (name, hash)) in lookup.into_iter().enumerate() {
@@ -379,7 +379,7 @@ async fn test_server_close() {
     .await
     .unwrap();
     let opts = get_options(peer_id, node_addr);
-    let request = GetRequest::all(hash).into();
+    let request = GetRequest::all(hash);
     let (_collection, _children, _stats) = run_collection_get_request(opts, request).await.unwrap();
 
     // Unwrap the JoinHandle, then the result of the Provider
@@ -449,7 +449,7 @@ async fn test_ipv6() {
     let peer_id = node.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = get_options(peer_id, addrs);
-        let request = GetRequest::all(hash).into();
+        let request = GetRequest::all(hash);
         run_collection_get_request(opts, request).await
     })
     .await
@@ -478,7 +478,7 @@ async fn test_not_found() {
     let peer_id = node.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = get_options(peer_id, addrs);
-        let request = GetRequest::single(hash).into();
+        let request = GetRequest::single(hash);
         let res = run_collection_get_request(opts, request).await;
         if let Err(cause) = res {
             if let Some(e) = cause.downcast_ref::<DecodeError>() {
@@ -522,7 +522,7 @@ async fn test_chunk_not_found_1() {
     let peer_id = node.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = get_options(peer_id, addrs);
-        let request = GetRequest::single(hash).into();
+        let request = GetRequest::single(hash);
         let res = run_collection_get_request(opts, request).await;
         if let Err(cause) = res {
             if let Some(e) = cause.downcast_ref::<DecodeError>() {
@@ -563,7 +563,7 @@ async fn test_run_ticket() {
             SecretKey::generate(),
             Some(iroh_net::defaults::default_derp_map()),
         );
-        let request = GetRequest::all(no_token_ticket.hash()).into();
+        let request = GetRequest::all(no_token_ticket.hash());
         let response = run_collection_get_request(opts, request).await;
         assert!(response.is_err());
         anyhow::Result::<_>::Ok(())
@@ -578,9 +578,7 @@ async fn test_run_ticket() {
         .unwrap()
         .with_token(token);
     tokio::time::timeout(Duration::from_secs(10), async move {
-        let request = GetRequest::all(hash)
-            .with_token(ticket.token().cloned())
-            .into();
+        let request = GetRequest::all(hash).with_token(ticket.token().cloned());
         run_collection_get_request(
             ticket.as_get_options(
                 SecretKey::generate(),
@@ -630,7 +628,7 @@ async fn test_run_fsm() {
     let peer_id = node.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = get_options(peer_id, addrs);
-        let request = GetRequest::all(hash).into();
+        let request = GetRequest::all(hash);
         let (collection, children, _) = run_collection_get_request(opts, request).await?;
         validate_children(collection, children)?;
         anyhow::Ok(())
@@ -679,7 +677,7 @@ async fn test_size_request_blob() {
     let addrs = node.local_endpoint_addresses().await.unwrap();
     let peer_id = node.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
-        let request = GetRequest::last_chunk(hash).into();
+        let request = GetRequest::last_chunk(hash);
         let connection = iroh::dial::dial(get_options(peer_id, addrs)).await?;
         let response = fsm::start(connection, request);
         let connected = response.next().await?;
@@ -720,8 +718,7 @@ async fn test_collection_stat() {
         let request = GetRequest::new(
             hash,
             RangeSpecSeq::from_ranges_infinite([RangeSet2::all(), ranges]),
-        )
-        .into();
+        );
         let opts = get_options(peer_id, addrs);
         let (_collection, items, _stats) = run_collection_get_request(opts, request).await?;
         // we should get the first <=1024 bytes and the last chunk of each child
@@ -811,7 +808,7 @@ async fn test_token_passthrough() -> Result<()> {
             .connect(peer_addr, &iroh_bytes::protocol::ALPN)
             .await
             .context("failed to connect to provider")?;
-        let request = GetRequest::all(hash).with_token(token).into();
+        let request = GetRequest::all(hash).with_token(token);
         let opts = get_options(peer_id, addrs);
         let (_collection, items, _stats) = run_collection_get_request(opts, request).await?;
         let actual = &items[&0];

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -557,7 +557,7 @@ async fn test_run_ticket() {
         .unwrap();
     let _drop_guard = node.cancel_token().drop_guard();
 
-    let no_token_ticket = node.ticket(hash, BlobFormat::COLLECTION).await.unwrap();
+    let no_token_ticket = node.ticket(hash, BlobFormat::HASHSEQ).await.unwrap();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = no_token_ticket.as_get_options(
             SecretKey::generate(),
@@ -573,7 +573,7 @@ async fn test_run_ticket() {
     .expect("getting without token failed in an unexpected way");
 
     let ticket = node
-        .ticket(hash, BlobFormat::COLLECTION)
+        .ticket(hash, BlobFormat::HASHSEQ)
         .await
         .unwrap()
         .with_token(token);


### PR DESCRIPTION
## Description

As discussed, this removes the custom get request. Fixes https://github.com/n0-computer/iroh/issues/1554

A custom get request is going to be replaced by the following:

- create a connection under another ALPN (not the iroh-bytes one)
- do whatever custom exchange needed to figure out what is to be done
- use the existing quinn stream for a bao sync

Also removes the custom collection parsing. Collections are now just sequences of blake3 hashes. Fixes https://github.com/n0-computer/iroh/issues/1553

Custom collections are going to be replaced by two things: For the purpose of the network protocol, they are going to be replaced with an exchange under a custom ALPN as described above. For the purpose of GC they are going to be replaced by a way to enumerate live nodes.

## Notes & open questions

How detailed will the examples have to be? It is hard to think of a small example that does not seem arbitrary, but a big example would be a lot of work.

Here is a possible big example: We define a protocol that allows exchanging arbitrary cids, with arbitrary hash fn. We could call it swapbits. We could even implement a more complex protocol to exchange dags, we could call it syncgraph.

Then we implement a node that supports this custom protocol and does the actual exchange using bao.

But as you can imagine this would be a rather large example.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
