### PR TITLE
feat(iroh): improve displaying content in the repl

### DIFF
--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -354,7 +354,7 @@ impl AuthorCommands {
 /// Format the content. If an error occurs it's returned in a formated, friendly way.
 async fn fmt_content(doc: &Doc, entry: &Entry, mode: DisplayContentMode) -> Result<String, String> {
     let read_failed = |err: anyhow::Error| format!("<failed to get content: {err}>");
-    let decode_failed = |_err: std::string::FromUtf8Error| format!("<invalid UTF-8>");
+    let decode_failed = |_err: std::string::FromUtf8Error| "<invalid UTF-8>".to_string();
 
     match mode {
         DisplayContentMode::Auto => {

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -110,6 +110,9 @@ pub enum DocCommands {
         author: Option<AuthorId>,
         /// Optional key prefix (parsed as UTF-8 string)
         prefix: Option<String>,
+        /// How to show the contents of the keys.
+        #[clap(short, long, default_value_t=DisplayContentMode::Auto)]
+        mode: DisplayContentMode,
     },
     /// Watch for changes and events on a document
     Watch {
@@ -227,16 +230,14 @@ impl DocCommands {
                 doc,
                 prefix,
                 author,
+                mode,
             } => {
                 let doc = get_doc(iroh, env, doc).await?;
                 let filter = GetFilter::author_prefix(author, prefix);
 
                 let mut stream = doc.get_many(filter).await?;
                 while let Some(entry) = stream.try_next().await? {
-                    println!(
-                        "{}",
-                        fmt_entry(&doc, &entry, DisplayContentMode::Auto).await
-                    );
+                    println!("{}", fmt_entry(&doc, &entry, mode).await);
                 }
             }
             Self::Watch { doc } => {


### PR DESCRIPTION
## Description

Allows formatting content in different ways in the repl.

There are now three content display modes:
- `hash`: what was previously
- `content`: the whole content. You add a txt novel you get a txt novel
- `auto`: displays the content fully if it's short or shortened if it's long

Display content mode is added to three commands:
- **`doc keys`** uses by default auto mode, but can be set to any mode with `--mode content|auto|hash`
- **`doc get <key>`**  uses by default auto mode, but can be set to any mode with `--mode content|auto|hash`
- **`doc watch`** behaviour is to use `auto` mode for available content and `hash` mode for missing and incomplete content

makes the keys bold because they are a bit hard to read otherwise

## Notes & open questions

Showcase:

```bash
> doc keys
# @bjh7nlhz…: appropriate time to sleep = between 1am and 3am (19 B)
# @othv7lf7…: second part = They would discuss matters of great importance, for example: How many loafs of b... (252 B)
```

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
