### PR TITLE
feat: leave and drop docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "thiserror",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +1958,7 @@ dependencies = [
  "console",
  "data-encoding",
  "derive_more",
+ "dialoguer",
  "dirs-next",
  "duct",
  "ed25519-dalek",

--- a/iroh-sync/src/keys.rs
+++ b/iroh-sync/src/keys.rs
@@ -221,13 +221,13 @@ impl fmt::Debug for Author {
 
 impl fmt::Debug for NamespacePublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "NamespaceId({})", self)
+        write!(f, "NamespacePublicKey({})", self)
     }
 }
 
 impl fmt::Debug for AuthorPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "AuthorId({})", self)
+        write!(f, "AuthorPublicKey({})", self)
     }
 }
 
@@ -410,7 +410,7 @@ impl AuthorId {
     /// Convert into [`AuthorPublicKey`].
     ///
     /// Fails if the bytes of this [`AuthorId`] are not a valid [`ed25519_dalek`] curve point.
-    pub fn into_public_key<S: PublicKeyStore>(&self) -> Result<AuthorPublicKey, SignatureError> {
+    pub fn into_public_key(&self) -> Result<AuthorPublicKey, SignatureError> {
         AuthorPublicKey::from_bytes(&self.0)
     }
 }
@@ -439,7 +439,7 @@ impl NamespaceId {
     /// Convert into [`NamespacePublicKey`].
     ///
     /// Fails if the bytes of this [`NamespaceId`] are not a valid [`ed25519_dalek`] curve point.
-    pub fn into_public_key<S: PublicKeyStore>(&self) -> Result<NamespacePublicKey, SignatureError> {
+    pub fn into_public_key(&self) -> Result<NamespacePublicKey, SignatureError> {
         NamespacePublicKey::from_bytes(&self.0)
     }
 }

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -62,6 +62,12 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     /// instance from the store's cache.
     fn close_replica(&self, namespace: &NamespaceId);
 
+    /// Remove a replica.
+    ///
+    /// Completely removes a replica and deletes both the namespace private key and all document
+    /// entries.
+    fn remove_replica(&self, namespace: &NamespaceId) -> Result<()>;
+
     /// Create a new author key and persist it in the store.
     fn new_author<R: CryptoRngCore + ?Sized>(&self, rng: &mut R) -> Result<Author> {
         let author = Author::new(rng);

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -134,7 +134,7 @@ impl super::Store for Store {
 
     fn close_replica(&self, namespace_id: &NamespaceId) {
         if let Some(replica) = self.replicas.write().remove(namespace_id) {
-            replica.unsubscribe();
+            replica.close();
         }
     }
 
@@ -191,6 +191,22 @@ impl super::Store for Store {
 
         self.replicas.write().insert(id, replica.clone());
         Ok(replica)
+    }
+
+    fn remove_replica(&self, namespace: &NamespaceId) -> Result<()> {
+        self.close_replica(namespace);
+        self.replicas.write().remove(namespace);
+        let start = range_start(namespace);
+        let end = range_end(namespace);
+        let write_tx = self.db.begin_write()?;
+        {
+            let mut record_table = write_tx.open_table(RECORDS_TABLE)?;
+            record_table.drain(start..=end)?;
+            let mut namespace_table = write_tx.open_table(NAMESPACES_TABLE)?;
+            namespace_table.remove(namespace.as_bytes())?;
+        }
+        write_tx.commit()?;
+        Ok(())
     }
 
     fn get_many(
@@ -445,7 +461,7 @@ impl crate::ranger::Store<SignedEntry> for StoreInstance {
                 // iterator for all entries in replica
                 let iter = RangeIterator::with_range(
                     &self.store.db,
-                    |table| table.range(start..end),
+                    |table| table.range(start..=end),
                     RangeFilter::None,
                 )?;
                 // empty iterator, returns nothing
@@ -481,7 +497,7 @@ impl crate::ranger::Store<SignedEntry> for StoreInstance {
                 // iterator for entries from range.x to end
                 let iter2 = RangeIterator::with_range(
                     &self.store.db,
-                    |table| table.range(start..end),
+                    |table| table.range(start..=end),
                     RangeFilter::None,
                 )?;
                 iter.chain(iter2)

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -48,7 +48,7 @@ impl super::Store for Store {
 
     fn close_replica(&self, namespace_id: &NamespaceId) {
         if let Some(replica) = self.replicas.read().get(namespace_id) {
-            replica.unsubscribe();
+            replica.close();
         }
     }
 
@@ -93,6 +93,13 @@ impl super::Store for Store {
             .write()
             .insert(replica.namespace(), replica.clone());
         Ok(replica)
+    }
+
+    fn remove_replica(&self, namespace: &NamespaceId) -> Result<()> {
+        self.close_replica(namespace);
+        self.replicas.write().remove(&namespace);
+        self.replica_records.write().remove(&namespace);
+        Ok(())
     }
 
     fn get_many(

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -97,8 +97,8 @@ impl super::Store for Store {
 
     fn remove_replica(&self, namespace: &NamespaceId) -> Result<()> {
         self.close_replica(namespace);
-        self.replicas.write().remove(&namespace);
-        self.replica_records.write().remove(&namespace);
+        self.replicas.write().remove(namespace);
+        self.replica_records.write().remove(namespace);
         Ok(())
     }
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -8,7 +8,10 @@
 
 use std::{
     fmt::Debug,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, SystemTime},
 };
 
@@ -74,20 +77,21 @@ pub enum ContentStatus {
 /// Local representation of a mutable, synchronizable key-value store.
 #[derive(derive_more::Debug, Clone)]
 pub struct Replica<S: ranger::Store<SignedEntry> + PublicKeyStore> {
-    inner: Arc<RwLock<InnerReplica<S>>>,
-    #[allow(clippy::type_complexity)]
-    on_insert_sender: Arc<RwLock<Option<flume::Sender<(InsertOrigin, SignedEntry)>>>>,
-
-    #[allow(clippy::type_complexity)]
-    #[debug("ContentStatusCallback")]
-    content_status_cb:
-        Arc<RwLock<Option<Box<dyn Fn(Hash) -> ContentStatus + Send + Sync + 'static>>>>,
+    inner: Arc<InnerReplica<S>>,
 }
 
 #[derive(derive_more::Debug)]
 struct InnerReplica<S: ranger::Store<SignedEntry> + PublicKeyStore> {
     namespace: Namespace,
-    peer: Peer<SignedEntry, S>,
+    peer: RwLock<Peer<SignedEntry, S>>,
+    #[allow(clippy::type_complexity)]
+    on_insert_sender: RwLock<Option<flume::Sender<(InsertOrigin, SignedEntry)>>>,
+
+    #[allow(clippy::type_complexity)]
+    #[debug("ContentStatusCallback")]
+    content_status_cb: RwLock<Option<Box<dyn Fn(Hash) -> ContentStatus + Send + Sync + 'static>>>,
+
+    closed: AtomicBool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -101,13 +105,20 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
     // TODO: make read only replicas possible
     pub fn new(namespace: Namespace, store: S) -> Self {
         Replica {
-            inner: Arc::new(RwLock::new(InnerReplica {
+            inner: Arc::new(InnerReplica {
                 namespace,
-                peer: Peer::from_store(store),
-            })),
-            on_insert_sender: Arc::new(RwLock::new(None)),
-            content_status_cb: Arc::new(RwLock::new(None)),
+                peer: RwLock::new(Peer::from_store(store)),
+                on_insert_sender: RwLock::new(None),
+                content_status_cb: RwLock::new(None),
+                closed: AtomicBool::new(false),
+            }),
         }
+    }
+
+    /// Mark the replica as closed, prohibiting any further operations.
+    pub(crate) fn close(&self) {
+        self.unsubscribe();
+        self.inner.closed.store(true, Ordering::Release);
     }
 
     /// Subscribe to insert events.
@@ -120,7 +131,7 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
     /// the receiver to be received from.
     // TODO: Allow to clear a previous subscription?
     pub fn subscribe(&self) -> Option<flume::Receiver<(InsertOrigin, SignedEntry)>> {
-        let mut on_insert_sender = self.on_insert_sender.write();
+        let mut on_insert_sender = self.inner.on_insert_sender.write();
         match &*on_insert_sender {
             Some(_sender) => None,
             None => {
@@ -133,7 +144,7 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
 
     /// Remove the subscription.
     pub fn unsubscribe(&self) -> bool {
-        self.on_insert_sender.write().take().is_some()
+        self.inner.on_insert_sender.write().take().is_some()
     }
 
     /// Set the content status callback.
@@ -144,7 +155,7 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
         &self,
         cb: Box<dyn Fn(Hash) -> ContentStatus + Send + Sync + 'static>,
     ) -> bool {
-        let mut content_status_cb = self.content_status_cb.write();
+        let mut content_status_cb = self.inner.content_status_cb.write();
         match &*content_status_cb {
             Some(_cb) => false,
             None => {
@@ -152,6 +163,23 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
                 true
             }
         }
+    }
+
+    fn ensure_open(&self) -> Result<(), InsertError<S>> {
+        if self.closed() {
+            Err(InsertError::Closed)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns true if the replica is closed.
+    ///
+    /// If a replica is closed, no further operations can be performed. A replica cannot be closed
+    /// manually, it must be closed via [`store::Store::close_replica`] or
+    /// [`store::Store::remove_replica`]
+    pub fn closed(&self) -> bool {
+        self.inner.closed.load(Ordering::Acquire)
     }
 
     /// Insert a new record at the given key.
@@ -167,10 +195,11 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
         hash: Hash,
         len: u64,
     ) -> Result<(), InsertError<S>> {
+        self.ensure_open()?;
         let id = RecordIdentifier::new(self.namespace(), author.id(), key);
         let record = Record::new_current(hash, len);
         let entry = Entry::new(id, record);
-        let signed_entry = entry.sign(&self.inner.read().namespace, author);
+        let signed_entry = entry.sign(&self.inner.namespace, author);
         self.insert_entry(signed_entry, InsertOrigin::Local)
     }
 
@@ -186,6 +215,7 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
         received_from: PeerIdBytes,
         content_status: ContentStatus,
     ) -> Result<(), InsertError<S>> {
+        self.ensure_open()?;
         let origin = InsertOrigin::Sync {
             from: received_from,
             content_status,
@@ -200,8 +230,8 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
         #[cfg(feature = "metrics")]
         let len = entry.content_len();
 
-        let mut inner = self.inner.write();
-        let store = inner.peer.store();
+        let mut peer = self.inner.peer.write();
+        let store = peer.store();
         validate_entry(
             system_time_now(),
             store,
@@ -209,10 +239,10 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
             &entry,
             &origin,
         )?;
-        inner.peer.put(entry.clone()).map_err(InsertError::Store)?;
-        drop(inner);
+        peer.put(entry.clone()).map_err(InsertError::Store)?;
+        drop(peer);
 
-        if let Some(sender) = self.on_insert_sender.read().as_ref() {
+        if let Some(sender) = self.inner.on_insert_sender.read().as_ref() {
             sender.send((origin.clone(), entry)).ok();
         }
 
@@ -243,6 +273,7 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
         author: &Author,
         data: impl AsRef<[u8]>,
     ) -> anyhow::Result<Hash> {
+        self.ensure_open()?;
         let len = data.as_ref().len() as u64;
         let hash = Hash::new(data);
         self.insert(key, author, hash, len)?;
@@ -251,13 +282,15 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
 
     /// Get the identifier for an entry in this replica.
     pub fn id(&self, key: impl AsRef<[u8]>, author: &Author) -> RecordIdentifier {
-        let inner = self.inner.read();
-        RecordIdentifier::new(inner.namespace.id(), author.id(), key)
+        RecordIdentifier::new(self.inner.namespace.id(), author.id(), key)
     }
 
     /// Create the initial message for the set reconciliation flow with a remote peer.
-    pub fn sync_initial_message(&self) -> Result<crate::ranger::Message<SignedEntry>, S::Error> {
-        self.inner.read().peer.initial_message()
+    pub fn sync_initial_message(
+        &self,
+    ) -> Result<crate::ranger::Message<SignedEntry>, anyhow::Error> {
+        self.ensure_open()?;
+        self.inner.peer.read().initial_message().map_err(Into::into)
     }
 
     /// Process a set reconciliation message from a remote peer.
@@ -267,46 +300,52 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
         &self,
         message: crate::ranger::Message<SignedEntry>,
         from_peer: PeerIdBytes,
-    ) -> Result<Option<crate::ranger::Message<SignedEntry>>, S::Error> {
+    ) -> Result<Option<crate::ranger::Message<SignedEntry>>, anyhow::Error> {
+        self.ensure_open()?;
         let expected_namespace = self.namespace();
         let now = system_time_now();
-        let reply = self.inner.write().peer.process_message(
-            message,
-            |store, entry, content_status| {
-                let origin = InsertOrigin::Sync {
-                    from: from_peer,
-                    content_status,
-                };
-                if validate_entry(now, store, expected_namespace, entry, &origin).is_ok() {
-                    if let Some(sender) = self.on_insert_sender.read().as_ref() {
-                        sender.send((origin, entry.clone())).ok();
+        let reply = self
+            .inner
+            .peer
+            .write()
+            .process_message(
+                message,
+                |store, entry, content_status| {
+                    let origin = InsertOrigin::Sync {
+                        from: from_peer,
+                        content_status,
+                    };
+                    if validate_entry(now, store, expected_namespace, entry, &origin).is_ok() {
+                        if let Some(sender) = self.inner.on_insert_sender.read().as_ref() {
+                            sender.send((origin, entry.clone())).ok();
+                        }
+                        true
+                    } else {
+                        false
                     }
-                    true
-                } else {
-                    false
-                }
-            },
-            |_store, entry| {
-                if let Some(cb) = self.content_status_cb.read().as_ref() {
-                    cb(entry.content_hash())
-                } else {
-                    ContentStatus::Missing
-                }
-            },
-        )?;
+                },
+                |_store, entry| {
+                    if let Some(cb) = self.inner.content_status_cb.read().as_ref() {
+                        cb(entry.content_hash())
+                    } else {
+                        ContentStatus::Missing
+                    }
+                },
+            )
+            .map_err(Into::into)?;
 
         Ok(reply)
     }
 
     /// Get the namespace identifier for this [`Replica`].
     pub fn namespace(&self) -> NamespaceId {
-        self.inner.read().namespace.id()
+        self.inner.namespace.id()
     }
 
     /// Get the byte represenation of the [`Namespace`] key for this replica.
     // TODO: Why return [u8; 32] and not `Namespace` here?
     pub fn secret_key(&self) -> [u8; 32] {
-        self.inner.read().namespace.to_bytes()
+        self.inner.namespace.to_bytes()
     }
 }
 
@@ -358,6 +397,9 @@ pub enum InsertError<S: ranger::Store<SignedEntry>> {
     /// Validation failure
     #[error("validation failure")]
     Validation(#[from] ValidationFailure),
+    /// The replica is closed, no operations may be performed.
+    #[error("replica is closed")]
+    Closed,
 }
 
 /// Reason why entry validation failed
@@ -943,8 +985,8 @@ mod tests {
         // Get Range of all should return all latest
         let entries_second: Vec<_> = replica
             .inner
-            .read()
             .peer
+            .read()
             .store()
             .get_range(Range::new(
                 RecordIdentifier::default(),
@@ -1297,6 +1339,65 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_replica_remove_memory() -> Result<()> {
+        let alice_store = store::memory::Store::default();
+        test_replica_remove(alice_store)?;
+        Ok(())
+    }
+
+    #[cfg(feature = "fs-store")]
+    #[test]
+    fn test_replica_remove_fs() -> Result<()> {
+        let alice_dbfile = tempfile::NamedTempFile::new()?;
+        let alice_store = store::fs::Store::new(alice_dbfile.path())?;
+        test_replica_remove(alice_store)?;
+
+        Ok(())
+    }
+
+    fn test_replica_remove<S: store::Store>(store: S) -> Result<()> {
+        let mut rng = rand::thread_rng();
+        let namespace = Namespace::new(&mut rng);
+        let author = Author::new(&mut rng);
+        let replica = store.new_replica(namespace.clone())?;
+
+        // insert entry
+        let hash = replica.hash_and_insert(b"foo", &author, b"bar")?;
+        let res = store
+            .get_many(namespace.id(), GetFilter::All)?
+            .collect::<Vec<_>>();
+        assert_eq!(res.len(), 1);
+
+        // remove replica
+        store.remove_replica(&namespace.id())?;
+        let res = store
+            .get_many(namespace.id(), GetFilter::All)?
+            .collect::<Vec<_>>();
+        assert_eq!(res.len(), 0);
+
+        // may not insert on removed replica
+        let res = replica.insert(b"foo", &author, hash, 3);
+        assert!(matches!(res, Err(InsertError::Closed)));
+        let res = store
+            .get_many(namespace.id(), GetFilter::All)?
+            .collect::<Vec<_>>();
+        assert_eq!(res.len(), 0);
+
+        // may not reopen removed replica
+        let res = store.open_replica(&namespace.id())?;
+        assert!(matches!(res, None));
+
+        // may recreate replica
+        let replica = store.new_replica(namespace.clone())?;
+        replica.insert(b"foo", &author, hash, 3)?;
+        let res = store
+            .get_many(namespace.id(), GetFilter::All)?
+            .collect::<Vec<_>>();
+        assert_eq!(res.len(), 1);
+        Ok(())
+    }
+
     fn get_entry<S: store::Store>(
         store: &S,
         namespace: NamespaceId,
@@ -1329,19 +1430,14 @@ mod tests {
         let alice_peer_id = [1u8; 32];
         let bob_peer_id = [2u8; 32];
         // Sync alice - bob
-        let mut next_to_bob = Some(alice.sync_initial_message().map_err(Into::into)?);
+        let mut next_to_bob = Some(alice.sync_initial_message()?);
         let mut rounds = 0;
         while let Some(msg) = next_to_bob.take() {
             assert!(rounds < 100, "too many rounds");
             rounds += 1;
             println!("round {}", rounds);
-            if let Some(msg) = bob
-                .sync_process_message(msg, alice_peer_id)
-                .map_err(Into::into)?
-            {
-                next_to_bob = alice
-                    .sync_process_message(msg, bob_peer_id)
-                    .map_err(Into::into)?;
+            if let Some(msg) = bob.sync_process_message(msg, alice_peer_id)? {
+                next_to_bob = alice.sync_process_message(msg, bob_peer_id)?
             }
         }
         Ok(())

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -116,6 +116,8 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
     }
 
     /// Mark the replica as closed, prohibiting any further operations.
+    ///
+    /// This method is not public. Use [store::Store::close_replica] instead.
     pub(crate) fn close(&self) {
         self.unsubscribe();
         self.inner.closed.store(true, Ordering::Release);

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -1386,7 +1386,7 @@ mod tests {
 
         // may not reopen removed replica
         let res = store.open_replica(&namespace.id())?;
-        assert!(matches!(res, None));
+        assert!(res.is_none());
 
         // may recreate replica
         let replica = store.new_replica(namespace.clone())?;

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -53,6 +53,7 @@ clap = { version = "4", features = ["derive"], optional = true }
 comfy-table = { version = "7.0.1", optional = true }
 config = { version = "0.13.1", default-features = false, features = ["toml", "preserve_order"], optional = true }
 console = { version = "0.15.5", optional = true }
+dialoguer = { version = "0.11.0", default-features = false, optional = true }
 dirs-next = { version = "2.0.0", optional = true }
 indicatif = { version = "0.17", features = ["tokio"], optional = true }
 human-time = { version = "0.1.6", optional = true }
@@ -68,11 +69,10 @@ colored = { version = "2.0.4", optional = true }
 # Examples
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"], optional = true }
 reflink-copy = { version = "0.1.8", optional = true }
-dialoguer = { version = "0.11.0", default-features = false }
 
 [features]
 default = ["cli", "metrics"]
-cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "mem-db", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table"]
+cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "mem-db", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table", "dialoguer"]
 metrics = ["iroh-metrics"]
 mem-db = []
 flat-db = ["reflink-copy"]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -68,6 +68,7 @@ colored = { version = "2.0.4", optional = true }
 # Examples
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"], optional = true }
 reflink-copy = { version = "0.1.8", optional = true }
+dialoguer = { version = "0.11.0", default-features = false }
 
 [features]
 default = ["cli", "metrics"]

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -30,11 +30,11 @@ use crate::rpc_protocol::{
     BlobListCollectionsResponse, BlobListIncompleteRequest, BlobListIncompleteResponse,
     BlobListRequest, BlobListResponse, BlobReadRequest, BlobReadResponse, BlobValidateRequest,
     CounterStats, DeleteTagRequest, DocCreateRequest, DocGetManyRequest, DocGetOneRequest,
-    DocImportRequest, DocInfoRequest, DocListRequest, DocSetRequest, DocShareRequest,
-    DocStartSyncRequest, DocStopSyncRequest, DocSubscribeRequest, DocTicket, GetProgress,
-    ListTagsRequest, ListTagsResponse, NodeConnectionInfoRequest, NodeConnectionInfoResponse,
-    NodeConnectionsRequest, NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest,
-    NodeStatusResponse, ProviderService, ShareMode, WrapOption,
+    DocImportRequest, DocInfoRequest, DocListRequest, DocRemoveRequest, DocSetRequest,
+    DocShareRequest, DocStartSyncRequest, DocStopSyncRequest, DocSubscribeRequest, DocTicket,
+    GetProgress, ListTagsRequest, ListTagsResponse, NodeConnectionInfoRequest,
+    NodeConnectionInfoResponse, NodeConnectionsRequest, NodeShutdownRequest, NodeStatsRequest,
+    NodeStatusRequest, NodeStatusResponse, ProviderService, ShareMode, WrapOption,
 };
 use crate::sync_engine::{LiveEvent, LiveStatus};
 
@@ -138,6 +138,12 @@ where
             rpc: self.rpc.clone(),
         };
         Ok(doc)
+    }
+
+    /// Remove a document.
+    pub async fn remove(&self, doc_id: NamespaceId) -> Result<()> {
+        self.rpc.rpc(DocRemoveRequest { id: doc_id }).await??;
+        Ok(())
     }
 
     /// Import a document from a ticket and join all peers in the ticket.

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -257,16 +257,15 @@ impl DocCommands {
             }
             Self::Leave { doc, remove } => {
                 let doc = get_doc(iroh, env, doc).await?;
+                doc.leave(remove).await?;
                 match remove {
                     false => {
-                        doc.stop_sync().await?;
                         println!(
                             "Doc {} is now inactive (not syncing with any peers).",
                             fmt_short(doc.id())
                         );
                     }
                     true => {
-                        iroh.docs.remove(doc.id()).await?;
                         println!("Doc {} has been removed.", fmt_short(doc.id()));
                     }
                 }
@@ -336,6 +335,7 @@ impl DocCommands {
                         LiveEvent::NeighborDown(peer) => {
                             println!("neighbor peer down: {peer:?}");
                         }
+                        LiveEvent::Closed => println!("document closed"),
                     }
                 }
             }

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -258,8 +258,17 @@ impl DocCommands {
             Self::Leave { doc, remove } => {
                 let doc = get_doc(iroh, env, doc).await?;
                 match remove {
-                    false => doc.stop_sync().await?,
-                    true => iroh.docs.remove(doc.id()).await?,
+                    false => {
+                        doc.stop_sync().await?;
+                        println!(
+                            "Doc {} is now inactive (not syncing with any peers).",
+                            fmt_short(doc.id())
+                        );
+                    }
+                    true => {
+                        iroh.docs.remove(doc.id()).await?;
+                        println!("Doc {} has been removed.", fmt_short(doc.id()));
+                    }
                 }
             }
             Self::Watch { doc } => {

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1477,6 +1477,12 @@ fn handle_rpc_request<D: BaoStore, S: DocStore, E: ServiceEndpoint<ProviderServi
                 })
                 .await
             }
+            DocDrop(msg) => {
+                chan.rpc(msg, handler, |handler, req| async move {
+                    handler.inner.sync.doc_drop(req).await
+                })
+                .await
+            }
             DocImport(msg) => {
                 chan.rpc(msg, handler, |handler, req| async move {
                     handler.inner.sync.doc_import(req).await

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1477,12 +1477,6 @@ fn handle_rpc_request<D: BaoStore, S: DocStore, E: ServiceEndpoint<ProviderServi
                 })
                 .await
             }
-            DocRemove(msg) => {
-                chan.rpc(msg, handler, |handler, req| async move {
-                    handler.inner.sync.doc_remove(req).await
-                })
-                .await
-            }
             DocImport(msg) => {
                 chan.rpc(msg, handler, |handler, req| async move {
                     handler.inner.sync.doc_import(req).await
@@ -1514,9 +1508,9 @@ fn handle_rpc_request<D: BaoStore, S: DocStore, E: ServiceEndpoint<ProviderServi
                 })
                 .await
             }
-            DocStopSync(msg) => {
+            DocLeave(msg) => {
                 chan.rpc(msg, handler, |handler, req| async move {
-                    handler.inner.sync.doc_stop_sync(req).await
+                    handler.inner.sync.doc_leave(req).await
                 })
                 .await
             }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1477,6 +1477,12 @@ fn handle_rpc_request<D: BaoStore, S: DocStore, E: ServiceEndpoint<ProviderServi
                 })
                 .await
             }
+            DocRemove(msg) => {
+                chan.rpc(msg, handler, |handler, req| async move {
+                    handler.inner.sync.doc_remove(req).await
+                })
+                .await
+            }
             DocImport(msg) => {
                 chan.rpc(msg, handler, |handler, req| async move {
                     handler.inner.sync.doc_import(req).await

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -485,21 +485,6 @@ pub struct DocCreateResponse {
     pub id: NamespaceId,
 }
 
-/// Remove a document
-#[derive(Serialize, Deserialize, Debug)]
-pub struct DocRemoveRequest {
-    /// The document id
-    pub id: NamespaceId,
-}
-
-impl RpcMsg<ProviderService> for DocRemoveRequest {
-    type Response = RpcResult<DocRemoveResponse>;
-}
-
-/// Response to [`DocRemoveRequest`]
-#[derive(Serialize, Deserialize, Debug)]
-pub struct DocRemoveResponse {}
-
 /// Contains both a key (either secret or public) to a document, and a list of peers to join.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct DocTicket {
@@ -608,20 +593,23 @@ impl RpcMsg<ProviderService> for DocStartSyncRequest {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DocStartSyncResponse {}
 
-/// Stop the live sync for a doc.
+/// Stop the live sync for a doc, and optionally delete the document.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocStopSyncRequest {
+pub struct DocLeaveRequest {
     /// The document id
     pub doc_id: NamespaceId,
+    /// Whether to fully remove the document from the node's store.
+    /// Note: This is a destructive operation!
+    pub remove: bool,
 }
 
-impl RpcMsg<ProviderService> for DocStopSyncRequest {
-    type Response = RpcResult<DocStopSyncResponse>;
+impl RpcMsg<ProviderService> for DocLeaveRequest {
+    type Response = RpcResult<DocLeaveResponse>;
 }
 
-/// Response to [`DocStopSyncRequest`]
+/// Response to [`DocLeaveRequest`]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocStopSyncResponse {}
+pub struct DocLeaveResponse {}
 
 /// Set an entry in a document
 #[derive(Serialize, Deserialize, Debug)]
@@ -812,13 +800,12 @@ pub enum ProviderRequest {
     DocInfo(DocInfoRequest),
     DocList(DocListRequest),
     DocCreate(DocCreateRequest),
-    DocRemove(DocRemoveRequest),
     DocImport(DocImportRequest),
     DocSet(DocSetRequest),
     DocGet(DocGetManyRequest),
     DocGetOne(DocGetOneRequest),
     DocStartSync(DocStartSyncRequest),
-    DocStopSync(DocStopSyncRequest),
+    DocLeave(DocLeaveRequest),
     DocShare(DocShareRequest),
     DocSubscribe(DocSubscribeRequest),
 
@@ -853,14 +840,13 @@ pub enum ProviderResponse {
     DocInfo(RpcResult<DocInfoResponse>),
     DocList(RpcResult<DocListResponse>),
     DocCreate(RpcResult<DocCreateResponse>),
-    DocRemove(RpcResult<DocRemoveResponse>),
     DocImport(RpcResult<DocImportResponse>),
     DocSet(RpcResult<DocSetResponse>),
     DocGet(RpcResult<DocGetManyResponse>),
     DocGetOne(RpcResult<DocGetOneResponse>),
     DocShare(RpcResult<DocShareResponse>),
     DocStartSync(RpcResult<DocStartSyncResponse>),
-    DocStopSync(RpcResult<DocStopSyncResponse>),
+    DocLeave(RpcResult<DocLeaveResponse>),
     DocSubscribe(RpcResult<DocSubscribeResponse>),
 
     AuthorList(RpcResult<AuthorListResponse>),

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -598,9 +598,6 @@ pub struct DocStartSyncResponse {}
 pub struct DocLeaveRequest {
     /// The document id
     pub doc_id: NamespaceId,
-    /// Whether to fully remove the document from the node's store.
-    /// Note: This is a destructive operation!
-    pub remove: bool,
 }
 
 impl RpcMsg<ProviderService> for DocLeaveRequest {
@@ -610,6 +607,21 @@ impl RpcMsg<ProviderService> for DocLeaveRequest {
 /// Response to [`DocLeaveRequest`]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DocLeaveResponse {}
+
+/// Stop the live sync for a doc, and optionally delete the document.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocDropRequest {
+    /// The document id
+    pub doc_id: NamespaceId,
+}
+
+impl RpcMsg<ProviderService> for DocDropRequest {
+    type Response = RpcResult<DocDropResponse>;
+}
+
+/// Response to [`DocDropRequest`]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocDropResponse {}
 
 /// Set an entry in a document
 #[derive(Serialize, Deserialize, Debug)]
@@ -800,6 +812,7 @@ pub enum ProviderRequest {
     DocInfo(DocInfoRequest),
     DocList(DocListRequest),
     DocCreate(DocCreateRequest),
+    DocDrop(DocDropRequest),
     DocImport(DocImportRequest),
     DocSet(DocSetRequest),
     DocGet(DocGetManyRequest),
@@ -840,6 +853,7 @@ pub enum ProviderResponse {
     DocInfo(RpcResult<DocInfoResponse>),
     DocList(RpcResult<DocListResponse>),
     DocCreate(RpcResult<DocCreateResponse>),
+    DocDrop(RpcResult<DocDropResponse>),
     DocImport(RpcResult<DocImportResponse>),
     DocSet(RpcResult<DocSetResponse>),
     DocGet(RpcResult<DocGetManyResponse>),

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -485,6 +485,21 @@ pub struct DocCreateResponse {
     pub id: NamespaceId,
 }
 
+/// Remove a document
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocRemoveRequest {
+    /// The document id
+    pub id: NamespaceId,
+}
+
+impl RpcMsg<ProviderService> for DocRemoveRequest {
+    type Response = RpcResult<DocRemoveResponse>;
+}
+
+/// Response to [`DocRemoveRequest`]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocRemoveResponse {}
+
 /// Contains both a key (either secret or public) to a document, and a list of peers to join.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct DocTicket {
@@ -797,6 +812,7 @@ pub enum ProviderRequest {
     DocInfo(DocInfoRequest),
     DocList(DocListRequest),
     DocCreate(DocCreateRequest),
+    DocRemove(DocRemoveRequest),
     DocImport(DocImportRequest),
     DocSet(DocSetRequest),
     DocGet(DocGetManyRequest),
@@ -837,6 +853,7 @@ pub enum ProviderResponse {
     DocInfo(RpcResult<DocInfoResponse>),
     DocList(RpcResult<DocListResponse>),
     DocCreate(RpcResult<DocCreateResponse>),
+    DocRemove(RpcResult<DocRemoveResponse>),
     DocImport(RpcResult<DocImportResponse>),
     DocSet(RpcResult<DocSetResponse>),
     DocGet(RpcResult<DocGetManyResponse>),

--- a/iroh/src/sync_engine.rs
+++ b/iroh/src/sync_engine.rs
@@ -73,20 +73,17 @@ impl<S: Store> SyncEngine<S> {
         namespace: NamespaceId,
         peers: Vec<PeerAddr>,
     ) -> anyhow::Result<()> {
-        self.live.start_sync(namespace, peers).await?;
-        Ok(())
+        self.live.start_sync(namespace, peers).await
     }
 
     /// Stop syncing a document.
-    pub async fn stop_sync(&self, namespace: NamespaceId) -> anyhow::Result<()> {
-        self.live.stop_sync(namespace).await?;
-        Ok(())
+    pub async fn leave(&self, namespace: NamespaceId, force_close: bool) -> anyhow::Result<()> {
+        self.live.leave(namespace, force_close).await
     }
 
     /// Shutdown the sync engine.
     pub async fn shutdown(&self) -> anyhow::Result<()> {
-        self.live.shutdown().await?;
-        Ok(())
+        self.live.shutdown().await
     }
 
     /// Get a [`Replica`] from the store, returning an error if the replica does not exist.

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -79,20 +79,24 @@ enum ToActor<S: store::Store> {
     StartSync {
         namespace: NamespaceId,
         peers: Vec<PeerAddr>,
+        #[debug("onsehot::Sender")]
         reply: sync::oneshot::Sender<anyhow::Result<()>>,
     },
     JoinPeers {
         namespace: NamespaceId,
         peers: Vec<PeerAddr>,
     },
-    StopSync {
+    Leave {
         namespace: NamespaceId,
+        /// If true removes all active client subscriptions.
+        force_remove: bool,
     },
     Shutdown,
     Subscribe {
         namespace: NamespaceId,
         #[debug("cb")]
         cb: OnLiveEventCallback,
+        #[debug("oneshot::Sender")]
         s: sync::oneshot::Sender<Result<RemovalToken>>,
     },
     Unsubscribe {
@@ -106,6 +110,7 @@ enum ToActor<S: store::Store> {
     AcceptSyncRequest {
         namespace: NamespaceId,
         peer: PublicKey,
+        #[debug("oneshot::Sender")]
         reply: sync::oneshot::Sender<AcceptOutcome<S>>,
     },
 }
@@ -152,6 +157,8 @@ pub enum LiveEvent {
     NeighborDown(PublicKey),
     /// A set-reconciliation sync finished.
     SyncFinished(SyncEvent),
+    /// The document was closed. No further events will be emitted.
+    Closed,
 }
 
 fn entry_to_content_status(entry: EntryStatus) -> ContentStatus {
@@ -241,9 +248,12 @@ impl<S: store::Store> LiveSync<S> {
     /// Stop the live sync for a document.
     ///
     /// This will leave the gossip swarm for this document.
-    pub async fn stop_sync(&self, namespace: NamespaceId) -> Result<()> {
+    pub async fn leave(&self, namespace: NamespaceId, force_remove: bool) -> Result<()> {
         self.to_actor_tx
-            .send(ToActor::<S>::StopSync { namespace })
+            .send(ToActor::<S>::Leave {
+                namespace,
+                force_remove,
+            })
             .await?;
         Ok(())
     }
@@ -400,8 +410,8 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
                             let res = self.start_sync(namespace, peers).await;
                             reply.send(res).ok();
                         },
-                        Some(ToActor::StopSync { namespace }) => {
-                            self.stop_sync(namespace).await?;
+                        Some(ToActor::Leave { namespace, force_remove }) => {
+                            self.leave(namespace, force_remove).await?;
                         }
                         Some(ToActor::JoinPeers { namespace, peers }) => {
                             self.join_peers(namespace, peers).await?;
@@ -532,11 +542,12 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
     }
 
     async fn shutdown(&mut self) -> anyhow::Result<()> {
-        for namespace in self.open_replicas.drain() {
-            self.syncing_replicas.remove(&namespace);
-            self.gossip.quit(namespace.into()).await?;
-            self.event_subscriptions.remove(&namespace);
-            self.replica_store.close_replica(&namespace);
+        // we have to clone the list of replicas here to reuse the Self::leave code.
+        let namespaces = self.open_replicas.iter().cloned().collect::<Vec<_>>();
+        for namespace in namespaces {
+            if let Err(err) = self.leave(namespace, true).await {
+                warn!(?namespace, "Error while closing: {err:?}");
+            }
         }
         Ok(())
     }
@@ -641,12 +652,18 @@ impl<S: store::Store, B: baomap::Store> Actor<S, B> {
         false
     }
 
-    async fn stop_sync(&mut self, namespace: NamespaceId) -> anyhow::Result<()> {
+    async fn leave(&mut self, namespace: NamespaceId, force_remove: bool) -> anyhow::Result<()> {
         if self.syncing_replicas.remove(&namespace) {
             self.gossip.quit(namespace.into()).await?;
             self.sync_state.retain(|(n, _peer), _value| *n != namespace);
-            self.maybe_close_replica(namespace);
         }
+        if force_remove {
+            let subs = self.event_subscriptions.remove(&namespace);
+            if let Some(mut subs) = subs {
+                notify_all(&mut subs, LiveEvent::Closed).await;
+            }
+        }
+        self.maybe_close_replica(namespace);
         Ok(())
     }
 

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -15,10 +15,10 @@ use crate::{
         AuthorCreateRequest, AuthorCreateResponse, AuthorListRequest, AuthorListResponse,
         DocCreateRequest, DocCreateResponse, DocGetManyRequest, DocGetManyResponse,
         DocGetOneRequest, DocGetOneResponse, DocImportRequest, DocImportResponse, DocInfoRequest,
-        DocInfoResponse, DocListRequest, DocListResponse, DocSetRequest, DocSetResponse,
-        DocShareRequest, DocShareResponse, DocStartSyncRequest, DocStartSyncResponse,
-        DocStopSyncRequest, DocStopSyncResponse, DocSubscribeRequest, DocSubscribeResponse,
-        DocTicket, RpcResult, ShareMode,
+        DocInfoResponse, DocListRequest, DocListResponse, DocRemoveRequest, DocRemoveResponse,
+        DocSetRequest, DocSetResponse, DocShareRequest, DocShareResponse, DocStartSyncRequest,
+        DocStartSyncResponse, DocStopSyncRequest, DocStopSyncResponse, DocSubscribeRequest,
+        DocSubscribeResponse, DocTicket, RpcResult, ShareMode,
     },
     sync_engine::{KeepCallback, LiveStatus, SyncEngine},
 };
@@ -61,6 +61,14 @@ impl<S: Store> SyncEngine<S> {
         Ok(DocCreateResponse {
             id: doc.namespace(),
         })
+    }
+
+    pub async fn doc_remove(&self, req: DocRemoveRequest) -> RpcResult<DocRemoveResponse> {
+        let DocRemoveRequest { id } = req;
+        let _replica = self.get_replica(&id)?;
+        self.stop_sync(id).await?;
+        self.store.remove_replica(&id)?;
+        Ok(DocRemoveResponse {})
     }
 
     pub fn doc_list(&self, _req: DocListRequest) -> impl Stream<Item = RpcResult<DocListResponse>> {

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -116,15 +116,15 @@ impl<S: Store> SyncEngine<S> {
             .live
             .subscribe(req.doc_id, {
                 move |event| {
-                        let s = s.clone();
-                        async move {
-                            // Send event over the channel, unsubscribe if the channel is closed.
-                            match s.send_async(Ok(DocSubscribeResponse { event })).await {
-                                Err(_err) => KeepCallback::Drop,
-                                Ok(()) => KeepCallback::Keep,
-                            }
+                    let s = s.clone();
+                    async move {
+                        // Send event over the channel, unsubscribe if the channel is closed.
+                        match s.send_async(Ok(DocSubscribeResponse { event })).await {
+                            Err(_err) => KeepCallback::Drop,
+                            Ok(()) => KeepCallback::Keep,
                         }
-                        .boxed()
+                    }
+                    .boxed()
                 }
             })
             .await;

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -116,7 +116,6 @@ impl<S: Store> SyncEngine<S> {
             .live
             .subscribe(req.doc_id, {
                 move |event| {
-                    {
                         let s = s.clone();
                         async move {
                             // Send event over the channel, unsubscribe if the channel is closed.
@@ -126,8 +125,6 @@ impl<S: Store> SyncEngine<S> {
                             }
                         }
                         .boxed()
-                    }
-                    .boxed()
                 }
             })
             .await;

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -117,7 +117,6 @@ impl<S: Store> SyncEngine<S> {
             .subscribe(req.doc_id, {
                 move |event| {
                     {
-                        println!("EV! {event:?}");
                         let s = s.clone();
                         async move {
                             // Send event over the channel, unsubscribe if the channel is closed.

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -334,7 +334,7 @@ async fn sync_remove_doc() -> Result<()> {
     let ev = sub.next().await;
     assert!(matches!(ev, Some(Ok(LiveEvent::Closed))));
     let ev = sub.next().await;
-    assert!(matches!(ev, None));
+    assert!(ev.is_none());
 
     Ok(())
 }

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -307,7 +307,7 @@ async fn sync_subscribe_stop() -> Result<()> {
 }
 
 #[tokio::test]
-async fn sync_remove_doc() -> Result<()> {
+async fn sync_drop_doc() -> Result<()> {
     setup_logging();
     let rt = test_runtime();
     let node = spawn_node(rt, 0).await?;
@@ -322,7 +322,7 @@ async fn sync_remove_doc() -> Result<()> {
     let ev = sub.next().await;
     assert!(matches!(ev, Some(Ok(LiveEvent::InsertLocal { .. }))));
 
-    doc.leave(true).await?;
+    client.docs.drop_doc(doc.id()).await?;
     let res = doc.get_one(author, b"foo".to_vec()).await;
     assert!(res.is_err());
     let res = doc


### PR DESCRIPTION
## Description

In `iroh-sync`:
* feat: Add `Store::remove_replica` to remove a replica (namespace secret key and all entries)
* feat: Adds `closed` atomic bool on `Replica` to ensure no operations can be performed on closed or removed replicas
* refactor: To not add yet another `Arc` for the `closed` marker, move all things into `InnerReplica`

In `iroh`:
* feat: Add `DocDrop` to RPC protocol
* rename `StopSync` to `Leave`
* feat: Add `doc leave` command to CLI / console. `doc leave` runs `DocStopSync` in the RPC layer (we already had that), 
* feat: Add `doc drop` command to delete a document

## Notes & open questions

Fixes #1497 

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
