### PR TITLE
[wip] peermap cleanup take two

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -683,6 +683,7 @@ mod tests {
         let endpoint = new_endpoint(secret_key.clone(), path.clone()).await;
         assert!(endpoint.connection_infos().await.unwrap().is_empty());
         endpoint.add_peer_addr(peer_addr).await.unwrap();
+        endpoint.connect(PeerAddr::new(peer_id), TEST_ALPN).await;
 
         // close the endpoint and restart it
         endpoint.close(0u32.into(), b"done").await.unwrap();

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -683,7 +683,7 @@ mod tests {
         let endpoint = new_endpoint(secret_key.clone(), path.clone()).await;
         assert!(endpoint.connection_infos().await.unwrap().is_empty());
         endpoint.add_peer_addr(peer_addr).await.unwrap();
-        endpoint.connect(PeerAddr::new(peer_id), TEST_ALPN).await;
+        // TODO: connect to the peer
 
         // close the endpoint and restart it
         endpoint.close(0u32.into(), b"done").await.unwrap();


### PR DESCRIPTION
## Description

TBD

## Notes & open questions

I'm not convinced this is exactly what we want. If we think about the peer map as a connectionless connection manager then it makes sense to rapidly prune peers we have not heard from recently. If we think about this as an address book there is interest in keeping peers for a longer time, even if they are not used. 

For example, in the case of sync, peers are stored if they were recently used, but just their peer id. If the user shutdowns, does some work without joining the network and then comes back online, Iroh will have been running that time and will have pruned the contact info of the peers that where stored precisely for this case. 

Need to think more about this

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
