### PR TITLE
fix(derper): update config to auto generate keys

### DIFF
--- a/iroh-net/src/bin/derper.rs
+++ b/iroh-net/src/bin/derper.rs
@@ -290,6 +290,7 @@ impl Config {
             .context("unable to read config")?;
         let config: Self = toml::from_str(&config_ser).context("unable to decode config")?;
         if !config_ser.contains("secret_key") {
+            info!("generating new secret key and updating config file");
             config.write_to_file(path).await?;
         }
 


### PR DESCRIPTION
## Description

Deploying a derper node is a bit cumbersome right now if you don't run with default config. You have to provide a `secret_key` but have no easy path to generate one so either you dance to create a fresh config and then modify it or need to use some external thing to generate keys for you. Either way it's cumbersome.

This just adds an extra handler to inject a secret key if not present already in the supplied config.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
