### PR TITLE
refactor(iroh-net): store a single pong

### DIFF
--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -1203,7 +1203,7 @@ struct EndpointState {
     /// If non-zero, is the time this endpoint was advertised last via a call-me-maybe disco message.
     call_me_maybe_time: Option<Instant>,
 
-    /// Ring buffer up to PongHistoryCount entries
+    /// Last [`PongReply`] received.
     recent_pong: Option<PongReply>,
 }
 


### PR DESCRIPTION
## Description

There seems to be no reason why we should store more than one `PongReply` since only the last is ever used

## Notes & open questions

If at some point we do need to check back on pong history this can be easily done with a `VecDeque`

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
