### PR TITLE
perf: bring default scale of tokio runtime back

### DIFF
--- a/iroh/src/main.rs
+++ b/iroh/src/main.rs
@@ -12,7 +12,6 @@ use crate::commands::Cli;
 fn main() -> Result<()> {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .thread_name("main-runtime")
-        .worker_threads(2)
         .enable_all()
         .build()?;
     rt.block_on(main_impl())?;


### PR DESCRIPTION
I believe this should be removed and the default of num_cpus from tokio should be here