### PR TITLE
Enable GC

### DIFF
--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -83,15 +83,22 @@ const ENDPOINT_WAIT: Duration = Duration::from_secs(5);
 const RPC_BLOB_GET_CHUNK_SIZE: usize = 1024 * 64;
 /// Channel cap for getting blobs over RPC
 const RPC_BLOB_GET_CHANNEL_CAP: usize = 2;
+/// Default interval between GC runs.
+const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60 * 5);
 
 /// Policy for garbage collection.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GcPolicy {
     /// Garbage collection is disabled.
-    #[default]
     Disabled,
     /// Garbage collection is run at the given interval.
     Interval(Duration),
+}
+
+impl Default for GcPolicy {
+    fn default() -> Self {
+        Self::Interval(DEFAULT_GC_INTERVAL)
+    }
 }
 
 /// Builder for the [`Node`].


### PR DESCRIPTION
## Description

Enable at an interval of 5 minutes plus the actual GC time.

## Notes & open questions

If somebody has data in their iroh data dir from 2 versions ago, this will delete all the data since it is not tagged. Is that acceptable?

Data added 1 version ago would have tags, so it would be fine. Also, of course data that has been added by reference will not be touched.

So I think it is OK.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
