### PR TITLE
fix(iroh-net): reverse ip-port mapping stores only direct addresses in the peermap

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1295,7 +1295,6 @@ impl Actor {
                     derp_region: Some(region_id),
                     active: true,
                 });
-                // TODO(@divma): removed here
                 let ep = self.peer_map.by_id_mut(&id).expect("inserted");
                 ep.quic_mapped_addr
             }

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1229,10 +1229,7 @@ impl Actor {
     /// Returns `true` if the message should be processed.
     fn receive_ip(&mut self, bytes: &Bytes, meta: &mut quinn_udp::RecvMeta) -> bool {
         debug!("received data {} from {}", meta.len, meta.addr);
-        match self
-            .peer_map
-            .endpoint_for_ip_port(&SendAddr::Udp(meta.addr))
-        {
+        match self.peer_map.endpoint_for_ip_port(meta.addr) {
             None => {
                 warn!(peer=?meta.addr, "no peer_map state found for peer, skipping");
                 return false;

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2276,11 +2276,17 @@ impl Actor {
 
         let dst_key = match derp_node_src {
             Some(dst_key) => {
-                assert!(src.is_derp());
+                if !src.is_derp() {
+                    error!(%src, from=%sender.fmt_short(), "ignoring ping reported both as direct and relayed");
+                    return debug_assert!(false, "`derp_node_src` is some but `src` is not derp");
+                }
                 dst_key
             }
             None => {
-                assert!(!src.is_derp());
+                if src.is_derp() {
+                    error!(%src, from=%sender.fmt_short(), "ignoring ping reported both as direct and relayed");
+                    return debug_assert!(false, "`derp_node_src` is none but `src` is derp");
+                }
                 di.node_key
             }
         };

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -640,7 +640,7 @@ impl Endpoint {
 
     /// Handles a Pong message (a reply to an earlier ping).
     ///
-    /// It report the address and key that should be inserted for the endpoint if any.
+    /// It reports the address and key that should be inserted for the endpoint if any.
     pub(super) async fn handle_pong_conn(
         &mut self,
         conn_disco_public: &PublicKey,
@@ -963,6 +963,10 @@ pub struct AddrLatency {
     pub latency: Option<Duration>,
 }
 
+/// An (Ip, Port) pair.
+///
+/// NOTE: storing an [`IpPort`] is safer than storing a [`SocketAddr`] because for IPv6 socket
+/// addresses include fields that can't be assumed consistent even within a single connection.
 #[derive(Debug, derive_more::Display, Clone, Copy, Hash, PartialEq, Eq)]
 #[display("{}", SocketAddr::from(*self))]
 pub struct IpPort {
@@ -970,8 +974,6 @@ pub struct IpPort {
     port: u16,
 }
 
-/// NOTE: storing an [`IpPort`] is safer than storing a [`SocketAddr`] because for IPv6 socket
-/// addresses include fields that can't be assumed consitent even within a single connection.
 impl From<SocketAddr> for IpPort {
     fn from(socket_addr: SocketAddr) -> Self {
         Self {

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -155,10 +155,9 @@ impl Endpoint {
             .endpoint_state
             .iter()
             .filter_map(|(addr, endpoint_state)| match addr {
-                SendAddr::Udp(addr) => Some((
-                    SocketAddr::from(*addr),
-                    endpoint_state.recent_pong().map(|pong| pong.latency),
-                )),
+                SendAddr::Udp(addr) => {
+                    Some((*addr, endpoint_state.recent_pong().map(|pong| pong.latency)))
+                }
                 _ => None,
             })
             .collect();


### PR DESCRIPTION
## Description

We were storing reverse mappings for `SendAddr::Derp` in the `PeerMap`. This means basically treating the DERP as a peer itself. We concluded this is something we shouldn't do. To fix the issue, the better solution is to enforce it via the type system. As such, we now only do reverse mapping from socket addresses.

As a note, I added a new type `IpPort`. Using `SocketAddr`s as key to hashmaps often goes wrong with ipv6 because of the flow control & class fields it contains. These fields can't be assumed stable even within the same connection: sending a the socket address made from an (ipv6, port) and receiving a response can make it look like the socket address is different (same ip, same port, different flow labels) Ignoring these fields has some limitations in extremely exceptional cases (link local addresses with a single interface) As a note, ignoring these fields is what tailscale does (all they store is an ip and a port). This makes communications over ipv6 work better in the common case so I think it's worth doing

## Notes & open questions

Some references
- flow label [RFC 2460 section 6](https://datatracker.ietf.org/doc/html/rfc2460#section-6)
- traffic class [RFC 2460 section 7](https://datatracker.ietf.org/doc/html/rfc2460#section-7)
- scope id [RFC 4007](https://www.rfc-editor.org/rfc/rfc4007)


## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
