### PR TITLE
fix(iroh-net): enforce storing a single derp region per peer

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1283,8 +1283,10 @@ impl Actor {
 
         let ep_quic_mapped_addr = match self.peer_map.endpoint_for_node_key_mut(&dm.src) {
             Some(ep) => {
+                // NOTE: we don't update the derp region if there is already one but the new one is
+                // different
                 if ep.derp_region().is_none() {
-                    ep.add_derp_region(region_id);
+                    ep.set_derp_region(region_id);
                 }
                 ep.quic_mapped_addr
             }
@@ -2286,7 +2288,7 @@ impl Actor {
         };
 
         if let Some(ep) = self.peer_map.endpoint_for_node_key_mut(&dst_key) {
-            if ep.add_candidate_endpoint(src, dm.tx_id) {
+            if ep.endpoint_confirmed(src, dm.tx_id) {
                 debug!("disco: ping got duplicate endpoint {} - {}", src, dm.tx_id);
                 return;
             }

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2454,13 +2454,6 @@ impl SendAddr {
         matches!(self, Self::Derp(_))
     }
 
-    fn as_udp(&self) -> Option<&SocketAddr> {
-        match self {
-            Self::Derp(_) => None,
-            Self::Udp(addr) => Some(addr),
-        }
-    }
-
     fn derp_region(&self) -> Option<u16> {
         match self {
             Self::Derp(region) => Some(*region),

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1295,7 +1295,6 @@ impl Actor {
                     derp_region: Some(region_id),
                     active: true,
                 });
-                // TODO(@divma): removed here
                 let ep = self.peer_map.by_id_mut(&id).expect("inserted");
                 ep.quic_mapped_addr
             }

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1229,10 +1229,7 @@ impl Actor {
     /// Returns `true` if the message should be processed.
     fn receive_ip(&mut self, bytes: &Bytes, meta: &mut quinn_udp::RecvMeta) -> bool {
         debug!("received data {} from {}", meta.len, meta.addr);
-        match self
-            .peer_map
-            .endpoint_for_ip_port(&SendAddr::Udp(meta.addr))
-        {
+        match self.peer_map.endpoint_for_ip_port(meta.addr) {
             None => {
                 warn!(peer=?meta.addr, "no peer_map state found for peer, skipping");
                 return false;

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -640,7 +640,7 @@ impl Endpoint {
 
     /// Handles a Pong message (a reply to an earlier ping).
     ///
-    /// It report the address and key that should be inserted for the endpoint if any.
+    /// It reports the address and key that should be inserted for the endpoint if any.
     pub(super) async fn handle_pong_conn(
         &mut self,
         conn_disco_public: &PublicKey,
@@ -963,6 +963,10 @@ pub struct AddrLatency {
     pub latency: Option<Duration>,
 }
 
+/// An (Ip, Port) pair.
+///
+/// NOTE: storing an [`IpPort`] is safer than storing a [`SocketAddr`] because for IPv6 socket
+/// addresses include fields that can't be assumed consistent even within a single connection.
 #[derive(Debug, derive_more::Display, Clone, Copy, Hash, PartialEq, Eq)]
 #[display("{}", SocketAddr::from(*self))]
 pub struct IpPort {
@@ -970,8 +974,6 @@ pub struct IpPort {
     port: u16,
 }
 
-/// NOTE: storing an [`IpPort`] is safer than storing a [`SocketAddr`] because for IPv6 socket
-/// addresses include fields that can't be assumed consitent even within a single connection.
 impl From<SocketAddr> for IpPort {
     fn from(socket_addr: SocketAddr) -> Self {
         Self {

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -155,10 +155,9 @@ impl Endpoint {
             .endpoint_state
             .iter()
             .filter_map(|(addr, endpoint_state)| match addr {
-                SendAddr::Udp(addr) => Some((
-                    SocketAddr::from(*addr),
-                    endpoint_state.recent_pong().map(|pong| pong.latency),
-                )),
+                SendAddr::Udp(addr) => {
+                    Some((*addr, endpoint_state.recent_pong().map(|pong| pong.latency)))
+                }
                 _ => None,
             })
             .collect();

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -324,7 +324,7 @@ impl Endpoint {
         let mut msgs = Vec::new();
         let (udp_addr, derp_region, _should_ping) = self.addr_for_send(&now);
         if let Some(derp_region) = derp_region {
-            // TODO(@divma):: this is cli_ping, never used
+            // TODO(@divma):: this is cli_ping, never used. Intentionally commented out
             // if let Some(msg) = self.start_ping(SendAddr::Derp(derp_region), DiscoPingPurpose::Cli) {
             //     msgs.push(msg);
             // }
@@ -599,7 +599,7 @@ impl Endpoint {
         ep: SendAddr,
         for_rx_ping_tx_id: stun::TransactionId,
     ) -> bool {
-        // cretes a new endpoint for adding
+        // creates a new endpoint for adding
         let new_endpoint = || EndpointState {
             last_got_ping: Some(Instant::now()),
             last_got_ping_tx_id: Some(for_rx_ping_tx_id),

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -617,13 +617,13 @@ impl Endpoint {
                 return duplicate_ping;
             }
             st.last_got_ping.replace(Instant::now());
-            return duplicate_ping;
+            duplicate_ping
         };
 
         match ep {
             SendAddr::Udp(addr) => match self.direct_addr_state.entry(addr.into()) {
                 Entry::Occupied(mut occupied) => return update_endpoint(occupied.get_mut()),
-                Entry::Vacant(mut vacant) => {
+                Entry::Vacant(vacant) => {
                     let addr = vacant.key();
                     let peer = self.public_key.fmt_short();
                     info!(%peer, %addr, "disco: new direct addr for peer");


### PR DESCRIPTION
## Description

The Endpoint contained `SendAddr` instead of `ip`, `port` pairs. This is problematic for a couple of reasons:
- it makes it harder to reason about direct addresses and relay addresses
- makes it harder to properly update the derp-related information
- in principle, we shouldn't be storing multiple derp regions per peer

So this PR enforces storing a single derp region per peer. Some relevant note with these changes:


## Notes & open questions

- this proves we never ping a peer via their relay address. I left some TODOs that I intend to address in a later PR when it's clear how we should be doing this
- I also noticed updating a peer's region is different between "updating from node" to receiving a ping. Maybe this is the right thing to do but it's also peculiar. If a peer pinged us via relay we update their derp region, if we add a ticket or receive info from a gossip peer exchange we only update the region if we don't have any. To me this makes sense, but again, it draws my attention. I left a comment about it in the code
Basically TLDR, next step is adding ping via relays with some appropriate tests. This should at a minimum solve the second part of #1576 

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
