### PR TITLE
Fix flakiness of gc_hashseq test

### DIFF
--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -315,10 +315,11 @@ impl TempTag {
     /// Create a new temp tag for the given hash and format
     ///
     /// This should only be used by store implementations.
+    ///
+    /// The caller is responsible for increasing the refcount on creation and to
+    /// make sure that temp tags that are created between a mark phase and a sweep
+    /// phase are protected.
     pub fn new(inner: HashAndFormat, liveness: Option<Arc<dyn LivenessTracker>>) -> Self {
-        if let Some(liveness) = liveness.as_ref() {
-            liveness.on_clone(&inner);
-        }
         Self { inner, liveness }
     }
 

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -320,6 +320,9 @@ impl TempTag {
     /// make sure that temp tags that are created between a mark phase and a sweep
     /// phase are protected.
     pub fn new(inner: HashAndFormat, liveness: Option<Arc<dyn LivenessTracker>>) -> Self {
+        if let Some(liveness) = liveness.as_ref() {
+            liveness.on_clone(&inner);
+        }
         Self { inner, liveness }
     }
 
@@ -349,9 +352,6 @@ impl TempTag {
 
 impl Clone for TempTag {
     fn clone(&self) -> Self {
-        if let Some(liveness) = self.liveness.as_ref() {
-            liveness.on_clone(&self.inner);
-        }
         Self::new(self.inner, self.liveness.clone())
     }
 }

--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -1030,7 +1030,7 @@ impl Store {
     fn delete_sync(&self, hash: Hash) -> io::Result<()> {
         let mut data = None;
         let mut outboard = None;
-        let mut external = None;
+        let mut paths = None;
         let mut partial_data = None;
         let mut partial_outboard = None;
         let complete_io_guard = self.0.complete_io_mutex.lock().unwrap();
@@ -1043,7 +1043,7 @@ impl Store {
                 outboard = Some(self.owned_outboard_path(&hash));
             }
             if !entry.external.is_empty() {
-                external = Some(self.0.options.paths_path(hash));
+                paths = Some(self.0.options.paths_path(hash));
             }
         }
         if let Some(partial) = state.partial.remove(&hash) {
@@ -1056,16 +1056,19 @@ impl Store {
         state.data.remove(&hash);
         drop(state);
         if let Some(data) = data {
+            tracing::debug!("deleting data {}", data.display());
             if let Err(cause) = std::fs::remove_file(data) {
                 tracing::warn!("failed to delete data file: {}", cause);
             }
         }
-        if let Some(external) = external {
+        if let Some(external) = paths {
+            tracing::debug!("deleting paths file {}", external.display());
             if let Err(cause) = std::fs::remove_file(external) {
-                tracing::warn!("failed to delete partial outboard file: {}", cause);
+                tracing::warn!("failed to delete paths file: {}", cause);
             }
         }
         if let Some(outboard) = outboard {
+            tracing::debug!("deleting outboard {}", outboard.display());
             if let Err(cause) = std::fs::remove_file(outboard) {
                 tracing::warn!("failed to delete outboard file: {}", cause);
             }

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -556,14 +556,6 @@ impl baomap::Store for Store {
     }
 
     fn temp_tag(&self, tag: HashAndFormat) -> TempTag {
-        let mut state = self.0.state.write().unwrap();
-        // add to live set immediately. This prevents this blob from being deleted
-        // if this happens between a mark and a sweep phase.
-        state.live.insert(tag.0);
-        // increase the ref count
-        let entry = state.temp.entry(tag).or_default();
-        // panic if we overflow an u64
-        *entry = entry.checked_add(1).unwrap();
         TempTag::new(tag, Some(self.0.clone()))
     }
 
@@ -579,7 +571,10 @@ impl baomap::Store for Store {
 
     fn is_live(&self, hash: &Hash) -> bool {
         let state = self.0.state.read().unwrap();
+        // a blob is live if it is either in the live set, or it is temp tagged
         state.live.contains(hash)
+            || state.temp.contains_key(&HashAndFormat::raw(*hash))
+            || state.temp.contains_key(&HashAndFormat::hash_seq(*hash))
     }
 
     fn delete(&self, hash: &Hash) -> BoxFuture<'_, io::Result<()>> {

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -142,9 +142,7 @@ async fn gc_basics() -> Result<()> {
     Ok(())
 }
 
-/// Test gc for sequences of hashes that protect their children from deletion.
-#[tokio::test]
-async fn gc_hashseq() -> Result<()> {
+async fn gc_hashseq_impl() -> Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
     let (node, bao_store, evs) = gc_test_node().await;
     let data1 = create_test_data(1234);
@@ -198,6 +196,16 @@ async fn gc_hashseq() -> Result<()> {
 
     node.shutdown();
     node.await?;
+    Ok(())
+}
+
+
+/// Test gc for sequences of hashes that protect their children from deletion.
+#[tokio::test]
+async fn gc_hashseq() -> Result<()> {
+    for _i in 0..10 {
+        gc_hashseq_impl().await?;
+    }
     Ok(())
 }
 

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -103,8 +103,11 @@ async fn step(evs: &flume::Receiver<iroh_bytes::baomap::Event>) {
 }
 
 async fn sync_directory(dir: impl AsRef<Path>) -> io::Result<()> {
-    let dir = std::fs::File::open(dir)?;
-    dir.sync_all().ok();
+    // sync the directory to make sure the metadata is written
+    // does not work on windows
+    if let Ok(dir) = std::fs::File::open(dir) {
+        dir.sync_all().ok();
+    }
     tokio::time::sleep(Duration::from_millis(50)).await;
     Ok(())
 }


### PR DESCRIPTION
## Description

The issue was that a temp tag was not inserted into the live set. This is not a problem if it happens outside a gc. But if it happens right between a gc mark phase and a gc sweep phase, the temp pin will not be considered, and the data associated with the temp pin might be deleted.

I knew that this had to be done, and I think I even did it at some point, but it must have been lost in some refactoring.

## Notes & open questions

There are a number of places where temp pins are not used. See https://github.com/n0-computer/iroh/issues/1611 . But I think this should be done in a separate PR since this definitely fixes something.

This increases the gc frequency so much that gc is running continuously with no pause whatsoever for some tests. That was the only way to get the failure mentioned above at least semi-reliably.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
