### PR TITLE
feat(iroh-sync): Sync propagation

### DIFF
--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -21,8 +21,9 @@ pub mod util;
 
 /// ALPN protocol name
 pub const GOSSIP_ALPN: &[u8] = b"/iroh-gossip/0";
-/// Maximum message size is limited to 1024 bytes.
-pub const MAX_MESSAGE_SIZE: usize = 1024;
+/// Maximum message size is limited currently. The limit is more-or-less arbitrary.
+// TODO: Make the limit configurable.
+pub const MAX_MESSAGE_SIZE: usize = 4096;
 
 /// Channel capacity for all subscription broadcast channels (single)
 const SUBSCRIBE_ALL_CAP: usize = 2048;

--- a/iroh-net/src/key.rs
+++ b/iroh-net/src/key.rs
@@ -88,7 +88,7 @@ fn get_or_create_crypto_keys<T>(
 ///
 /// Serialisation or creation from a byte array is cheap if the key is already
 /// in the cache, but expensive if it is not.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 pub struct PublicKey([u8; 32]);
 
 impl Hash for PublicKey {

--- a/iroh-sync/src/actor.rs
+++ b/iroh-sync/src/actor.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{hash_map, HashMap},
+    num::NonZeroU64,
     sync::Arc,
 };
 
@@ -138,7 +139,7 @@ enum ReplicaAction {
     HasNewsForUs {
         heads: AuthorHeads,
         #[debug("reply")]
-        reply: oneshot::Sender<Result<bool>>,
+        reply: oneshot::Sender<Result<Option<NonZeroU64>>>,
     },
 }
 
@@ -357,7 +358,7 @@ impl SyncHandle {
         &self,
         namespace: NamespaceId,
         heads: AuthorHeads,
-    ) -> Result<bool> {
+    ) -> Result<Option<NonZeroU64>> {
         let (reply, rx) = oneshot::channel();
         let action = ReplicaAction::HasNewsForUs { reply, heads };
         self.send_replica(namespace, action).await?;

--- a/iroh-sync/src/heads.rs
+++ b/iroh-sync/src/heads.rs
@@ -1,0 +1,53 @@
+//! Author heads
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::AuthorId;
+
+/// Timestamps of the latest entry for each author.
+// TODO: If we want to encode this in gossip messages we have to enforce a max length.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default)]
+pub struct AuthorHeads {
+    heads: BTreeMap<AuthorId, u64>,
+}
+
+impl AuthorHeads {
+    /// Insert a new timestamp.
+    pub fn insert(&mut self, author: AuthorId, timestamp: u64) {
+        self.heads
+            .entry(author)
+            .and_modify(|t| *t = (*t).max(timestamp))
+            .or_insert(timestamp);
+    }
+}
+
+impl AuthorHeads {
+    /// Can this state offer newer stuff to `other`?
+    pub fn has_news_for(&self, other: &Self) -> bool {
+        for (a, t) in self.heads.iter() {
+            match other.heads.get(a) {
+                None => return true,
+                Some(ot) => {
+                    if t > ot {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Merge another author head state into this one.
+    pub fn merge(&mut self, other: &Self) {
+        for (a, t) in other.iter() {
+            self.insert(*a, *t);
+        }
+    }
+
+    /// Create an iterator over the entries in this state.
+    pub fn iter(&self) -> std::collections::btree_map::Iter<AuthorId, u64> {
+        self.heads.iter()
+    }
+}

--- a/iroh-sync/src/heads.rs
+++ b/iroh-sync/src/heads.rs
@@ -2,35 +2,39 @@
 
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
+use anyhow::Result;
 
 use crate::AuthorId;
 
+type Timestamp = u64;
+
 /// Timestamps of the latest entry for each author.
-// TODO: If we want to encode this in gossip messages we have to enforce a max length.
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct AuthorHeads {
-    heads: BTreeMap<AuthorId, u64>,
+    heads: BTreeMap<AuthorId, Timestamp>,
 }
 
 impl AuthorHeads {
     /// Insert a new timestamp.
-    pub fn insert(&mut self, author: AuthorId, timestamp: u64) {
+    pub fn insert(&mut self, author: AuthorId, timestamp: Timestamp) {
         self.heads
             .entry(author)
             .and_modify(|t| *t = (*t).max(timestamp))
             .or_insert(timestamp);
     }
-}
 
-impl AuthorHeads {
+    /// Number of author-timestamp pairs.
+    pub fn len(&self) -> usize {
+        self.heads.len()
+    }
+
     /// Can this state offer newer stuff to `other`?
     pub fn has_news_for(&self, other: &Self) -> bool {
-        for (a, t) in self.heads.iter() {
-            match other.heads.get(a) {
+        for (author, ts_theirs) in other.iter() {
+            match self.heads.get(&author) {
                 None => return true,
-                Some(ot) => {
-                    if t > ot {
+                Some(ts_ours) => {
+                    if ts_theirs > ts_ours {
                         return true;
                     }
                 }
@@ -47,7 +51,80 @@ impl AuthorHeads {
     }
 
     /// Create an iterator over the entries in this state.
-    pub fn iter(&self) -> std::collections::btree_map::Iter<AuthorId, u64> {
+    pub fn iter(&self) -> std::collections::btree_map::Iter<AuthorId, Timestamp> {
         self.heads.iter()
+    }
+
+    /// Encode into a byte array with a limited size.
+    ///
+    /// Will skip oldest entries if the size limit is reached.
+    /// Returns a byte array with a maximum length of `size_limit`.
+    pub fn encode(&self, size_limit: Option<usize>) -> Result<Vec<u8>> {
+        let mut by_timestamp = BTreeMap::new();
+        for (author, ts) in self.iter() {
+            by_timestamp.insert(*ts, *author);
+        }
+        let mut items = Vec::new();
+        for (ts, author) in by_timestamp.into_iter().rev() {
+            items.push((ts, author));
+            if let Some(size_limit) = size_limit {
+                if postcard::experimental::serialized_size(&items)? > size_limit {
+                    items.pop();
+                    break;
+                }
+            }
+        }
+        let encoded = postcard::to_stdvec(&items)?;
+        debug_assert!(size_limit.map(|s| encoded.len() <= s).unwrap_or(true));
+        Ok(encoded)
+    }
+
+    /// Decode from byte slice created with [`Self::encode`].
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        let items: Vec<(Timestamp, AuthorId)> = postcard::from_bytes(bytes)?;
+        let mut heads = AuthorHeads::default();
+        for (ts, author) in items {
+            heads.insert(author, ts);
+        }
+        Ok(heads)
+    }
+}
+
+impl FromIterator<(AuthorId, Timestamp)> for AuthorHeads {
+    fn from_iter<T: IntoIterator<Item = (AuthorId, Timestamp)>>(iter: T) -> Self {
+        Self {
+            heads: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl FromIterator<(Timestamp, AuthorId)> for AuthorHeads {
+    fn from_iter<T: IntoIterator<Item = (Timestamp, AuthorId)>>(iter: T) -> Self {
+        Self {
+            heads: iter.into_iter().map(|(ts, author)| (author, ts)).collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Record;
+
+    use super::*;
+    #[test]
+    fn author_heads_encode_decode() -> Result<()> {
+        let mut heads = AuthorHeads::default();
+        let start = Record::empty_current().timestamp();
+        for i in 0..10u64 {
+            heads.insert(AuthorId::from(&[i as u8; 32]), start + i);
+        }
+        let encoded = heads.encode(Some(256))?;
+        let decoded = AuthorHeads::decode(&encoded)?;
+        assert_eq!(decoded.len(), 6);
+        let expected: AuthorHeads = (0u64..6)
+            .map(|n| (AuthorId::from(&[9 - n as u8; 32]), start + (9 - n as u64)))
+            .collect();
+        assert_eq!(expected, decoded);
+        Ok(())
     }
 }

--- a/iroh-sync/src/lib.rs
+++ b/iroh-sync/src/lib.rs
@@ -30,6 +30,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 pub mod actor;
+mod heads;
 mod keys;
 #[cfg(feature = "metrics")]
 pub mod metrics;
@@ -39,5 +40,6 @@ mod ranger;
 pub mod store;
 pub mod sync;
 
+pub use heads::*;
 pub use keys::*;
 pub use sync::*;

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -1,6 +1,6 @@
 //! Storage trait and implementation for iroh-sync documents
 
-use std::num::{NonZeroUsize, NonZeroU64};
+use std::num::{NonZeroU64, NonZeroUsize};
 
 use anyhow::Result;
 use iroh_bytes::Hash;
@@ -146,7 +146,11 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     /// Check if a [`AuthorHeads`] contains entry timestamps that we do not have locally.
     ///
     /// Returns the number of authors that the other peer has updates for.
-    fn has_news_for_us(&self, namespace: NamespaceId, heads: &AuthorHeads) -> Result<Option<NonZeroU64>> {
+    fn has_news_for_us(
+        &self,
+        namespace: NamespaceId,
+        heads: &AuthorHeads,
+    ) -> Result<Option<NonZeroU64>> {
         let our_heads = {
             let latest = self.get_latest_for_each_author(namespace)?;
             let mut heads = AuthorHeads::default();

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -8,6 +8,7 @@ use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    heads::AuthorHeads,
     ranger,
     sync::{Author, Namespace, Replica, SignedEntry},
     AuthorId, NamespaceId, PeerIdBytes,
@@ -61,6 +62,13 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
 
     /// Iterator over authors in the store, returned from [`Self::list_authors`]
     type AuthorsIter<'a>: Iterator<Item = Result<Author>>
+    where
+        Self: 'a;
+
+    /// Iterator over the latest entry for each author.
+    ///
+    /// The iterator returns a tuple of (AuthorId, Timestamp, Key).
+    type LatestIter<'a>: Iterator<Item = Result<(AuthorId, u64, Vec<u8>)>>
     where
         Self: 'a;
 
@@ -131,6 +139,24 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
 
     /// Get all content hashes of all replicas in the store.
     fn content_hashes(&self) -> Result<Self::ContentHashesIter<'_>>;
+
+    /// Get the latest timestamp and key for each author in a namespace
+    fn get_latest(&self, namespace: NamespaceId) -> Result<Self::LatestIter<'_>>;
+
+    /// Check if a state vector contains pointers that we do not have locally.
+    fn has_news_for_us(&self, namespace: NamespaceId, heads: &AuthorHeads) -> Result<bool> {
+        let our_heads = {
+            let latest = self.get_latest(namespace)?;
+            let mut heads = AuthorHeads::default();
+            for e in latest {
+                let (author, timestamp, _key) = e?;
+                heads.insert(author, timestamp);
+            }
+            heads
+        };
+        let has_news_for_us = heads.has_news_for(&our_heads);
+        Ok(has_news_for_us)
+    }
 
     /// Register a peer that has been useful to sync a document.
     fn register_useful_peer(&self, namespace: NamespaceId, peer: PeerIdBytes) -> Result<()>;

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -309,7 +309,7 @@ impl super::Store for Store {
         ContentHashesIterator::create(&self.db)
     }
 
-    fn get_latest(&self, namespace: NamespaceId) -> Result<Self::LatestIter<'_>> {
+    fn get_latest_for_each_author(&self, namespace: NamespaceId) -> Result<Self::LatestIter<'_>> {
         LatestIterator::create(&self.db, namespace)
     }
 
@@ -1149,7 +1149,7 @@ mod tests {
             replica.hash_and_insert(b"k3", &author1, b"v1")?;
 
             let expected = store
-                .get_latest(namespace.id())?
+                .get_latest_for_each_author(namespace.id())?
                 .collect::<Result<Vec<_>>>()?;
             // drop everything to clear file locks.
             store.close_replica(replica);
@@ -1167,7 +1167,7 @@ mod tests {
         // open the copied db file, which will run the migration.
         let store = Store::new(dbfile_before_migration.path())?;
         let actual = store
-            .get_latest(namespace.id())?
+            .get_latest_for_each_author(namespace.id())?
             .collect::<Result<Vec<_>>>()?;
 
         assert_eq!(expected, actual);

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -1,6 +1,6 @@
 //! On disk storage for replicas.
 
-use std::{cmp::Ordering, collections::HashSet, path::Path, sync::Arc};
+use std::{cmp::Ordering, collections::{HashSet, HashMap}, path::Path, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use derive_more::From;
@@ -10,7 +10,7 @@ use ouroboros::self_referencing;
 use parking_lot::RwLock;
 use redb::{
     Database, MultimapTableDefinition, Range as TableRange, ReadOnlyTable, ReadTransaction,
-    ReadableMultimapTable, ReadableTable, StorageError, TableDefinition,
+    ReadableMultimapTable, ReadableTable, StorageError, Table, TableDefinition,
 };
 
 use crate::{
@@ -55,6 +55,17 @@ const NAMESPACES_TABLE: TableDefinition<&[u8; 32], &[u8; 32]> =
 //  # (timestamp, signature_namespace, signature_author, len, hash)
 const RECORDS_TABLE: TableDefinition<RecordsId, RecordsValue> = TableDefinition::new("records-1");
 
+// Latest by author
+// Table
+// Key: ([u8; 32], [u8; 32]) # (NamespaceId, AuthorId)
+// Value: (u64, Vec<u8>) # (Timestamp, Key)
+const LATEST_TABLE: TableDefinition<LatestKey, LatestValue> =
+    TableDefinition::new("latest-by-author-1");
+type LatestKey<'a> = (&'a [u8; 32], &'a [u8; 32]);
+type LatestValue<'a> = (u64, &'a [u8]);
+type LatestTable<'a> = ReadOnlyTable<'a, LatestKey<'static>, LatestValue<'static>>;
+type LatestRange<'a> = TableRange<'a, LatestKey<'static>, LatestValue<'static>>;
+
 type RecordsId<'a> = (&'a [u8; 32], &'a [u8; 32], &'a [u8]);
 type RecordsValue<'a> = (u64, &'a [u8; 64], &'a [u8; 64], u64, &'a [u8; 32]);
 type RecordsRange<'a> = TableRange<'a, RecordsId<'static>, RecordsValue<'static>>;
@@ -72,6 +83,37 @@ type Nanos = u64;
 const NAMESPACE_PEERS_TABLE: MultimapTableDefinition<&[u8; 32], (Nanos, &PeerIdBytes)> =
     MultimapTableDefinition::new("sync-peers-1");
 
+/// migration 001: populate the latest table (which did not exist before)
+fn migration_001_populate_latest_table(
+    records_table: &Table<RecordsId<'static>, RecordsValue<'static>>,
+    latest_table: &mut Table<LatestKey<'static>, LatestValue<'static>>,
+) -> Result<()> {
+    tracing::info!("Starting migration: 001_populate_latest_table");
+    #[allow(clippy::type_complexity)]
+    let mut heads: HashMap<([u8; 32], [u8; 32]), (u64, Vec<u8>)> = HashMap::new();
+    let iter = records_table.iter()?;
+
+    for next in iter {
+        let next = next?;
+        let (namespace, author, key) = next.0.value();
+        let (timestamp, _namespace_sig, _author_sig, _len, _hash) = next.1.value();
+        heads
+            .entry((*namespace, *author))
+            .and_modify(|e| {
+                if timestamp >= e.0 {
+                    *e = (timestamp, key.to_vec());
+                }
+            })
+            .or_insert_with(|| (timestamp, key.to_vec()));
+    }
+    let len = heads.len();
+    for ((namespace, author), (timestamp, key)) in heads {
+        latest_table.insert((&namespace, &author), (timestamp, key.as_slice()))?;
+    }
+    tracing::info!("Migration finished (inserted {} entries)", len);
+    Ok(())
+}
+
 impl Store {
     /// Create or open a store from a `path` to a database file.
     ///
@@ -82,10 +124,16 @@ impl Store {
         // Setup all tables
         let write_tx = db.begin_write()?;
         {
-            let _table = write_tx.open_table(RECORDS_TABLE)?;
+            let records_table = write_tx.open_table(RECORDS_TABLE)?;
             let _table = write_tx.open_table(NAMESPACES_TABLE)?;
             let _table = write_tx.open_table(AUTHORS_TABLE)?;
+            let mut latest_table = write_tx.open_table(LATEST_TABLE)?;
             let _table = write_tx.open_multimap_table(NAMESPACE_PEERS_TABLE)?;
+
+            // migration 001: populate latest table if it was empty before
+            if latest_table.is_empty()? && !records_table.is_empty()? {
+                migration_001_populate_latest_table(&records_table, &mut latest_table)?;
+            }
         }
         write_tx.commit()?;
 
@@ -124,6 +172,7 @@ impl super::Store for Store {
     type Instance = StoreInstance;
     type GetIter<'a> = RangeIterator<'a>;
     type ContentHashesIter<'a> = ContentHashesIterator<'a>;
+    type LatestIter<'a> = LatestIterator<'a>;
     type AuthorsIter<'a> = std::vec::IntoIter<Result<Author>>;
     type NamespaceIter<'a> = std::vec::IntoIter<Result<NamespaceId>>;
     type PeersIter<'a> = std::vec::IntoIter<PeerIdBytes>;
@@ -253,6 +302,10 @@ impl super::Store for Store {
 
     fn content_hashes(&self) -> Result<Self::ContentHashesIter<'_>> {
         ContentHashesIterator::create(&self.db)
+    }
+
+    fn get_latest(&self, namespace: NamespaceId) -> Result<Self::LatestIter<'_>> {
+        LatestIterator::create(&self.db, namespace)
     }
 
     fn register_useful_peer(&self, namespace: NamespaceId, peer: crate::PeerIdBytes) -> Result<()> {
@@ -567,6 +620,12 @@ impl crate::ranger::Store<SignedEntry> for StoreInstance {
                 hash.as_bytes(),
             );
             record_table.insert(key, value)?;
+
+            // insert into latest table
+            let mut latest_table = write_tx.open_table(LATEST_TABLE)?;
+            let key = (&e.id().namespace().to_bytes(), &e.id().author().to_bytes());
+            let value = (e.timestamp(), e.id().key());
+            latest_table.insert(key, value)?;
         }
         write_tx.commit()?;
         Ok(())
@@ -803,6 +862,52 @@ impl Iterator for ContentHashesIterator<'_> {
     }
 }
 
+/// Iterator over the latest entry per author.
+#[self_referencing]
+pub struct LatestIterator<'a> {
+    read_tx: ReadTransaction<'a>,
+    #[borrows(read_tx)]
+    #[covariant]
+    record_table: LatestTable<'this>,
+    #[covariant]
+    #[borrows(record_table)]
+    records: LatestRange<'this>,
+}
+impl<'a> LatestIterator<'a> {
+    fn create(db: &'a Arc<Database>, namespace: NamespaceId) -> anyhow::Result<Self> {
+        let iter = Self::try_new(
+            db.begin_read()?,
+            |read_tx| {
+                read_tx
+                    .open_table(LATEST_TABLE)
+                    .map_err(anyhow::Error::from)
+            },
+            |table| {
+                let start = (namespace.as_bytes(), &[u8::MIN; 32]);
+                let end = (namespace.as_bytes(), &[u8::MAX; 32]);
+                table.range(start..=end).map_err(anyhow::Error::from)
+            },
+        )?;
+        Ok(iter)
+    }
+}
+
+impl Iterator for LatestIterator<'_> {
+    type Item = Result<(AuthorId, u64, Vec<u8>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.with_mut(|fields| match fields.records.next() {
+            None => None,
+            Some(Err(err)) => Some(Err(err.into())),
+            Some(Ok((key, value))) => {
+                let (_namespace, author) = key.value();
+                let (timestamp, key) = value.value();
+                Some(Ok((author.into(), timestamp, key.to_vec())))
+            }
+        })
+    }
+}
+
 #[self_referencing]
 pub struct RangeIterator<'a> {
     read_tx: ReadTransaction<'a>,
@@ -1005,6 +1110,63 @@ mod tests {
         // get latest
         let entries = store.get_all(namespace.id())?.collect::<Result<Vec<_>>>()?;
         assert_eq!(entries.len(), 0);
+
+        Ok(())
+    }
+
+    fn copy_and_modify(
+        source: &Path,
+        modify: impl Fn(&redb::WriteTransaction) -> Result<()>,
+    ) -> Result<tempfile::NamedTempFile> {
+        let dbfile = tempfile::NamedTempFile::new()?;
+        std::fs::copy(source, dbfile.path())?;
+        // drop the latest table to test the migration.
+        let db = Database::create(dbfile.path())?;
+        let write_tx = db.begin_write()?;
+        modify(&write_tx)?;
+        write_tx.commit()?;
+        Ok(dbfile)
+    }
+
+    #[test]
+    fn test_migration_001_populate_latest_table() -> Result<()> {
+        let dbfile = tempfile::NamedTempFile::new()?;
+        let namespace = Namespace::new(&mut rand::thread_rng());
+
+        // create a store and add some data
+        let expected = {
+            let store = Store::new(dbfile.path())?;
+            let author1 = store.new_author(&mut rand::thread_rng())?;
+            let author2 = store.new_author(&mut rand::thread_rng())?;
+            let replica = store.new_replica(namespace.clone())?;
+            replica.hash_and_insert(b"k1", &author1, b"v1")?;
+            replica.hash_and_insert(b"k2", &author2, b"v1")?;
+            replica.hash_and_insert(b"k3", &author1, b"v1")?;
+
+            let expected = store
+                .get_latest(namespace.id())?
+                .collect::<Result<Vec<_>>>()?;
+            // drop everything to clear file locks.
+            drop(replica);
+            store.close_replica(&namespace.id());
+            drop(store);
+            expected
+        };
+        assert_eq!(expected.len(), 2);
+
+        // create a copy of our db file with the latest table deleted.
+        let dbfile_before_migration = copy_and_modify(dbfile.path(), |tx| {
+            tx.delete_table(LATEST_TABLE)?;
+            Ok(())
+        })?;
+
+        // open the copied db file, which will run the migration.
+        let store = Store::new(dbfile_before_migration.path())?;
+        let actual = store
+            .get_latest(namespace.id())?
+            .collect::<Result<Vec<_>>>()?;
+
+        assert_eq!(expected, actual);
 
         Ok(())
     }

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -165,7 +165,7 @@ impl super::Store for Store {
         })
     }
 
-    fn get_latest(&self, namespace: NamespaceId) -> Result<LatestIterator<'_>> {
+    fn get_latest_for_each_author(&self, namespace: NamespaceId) -> Result<LatestIterator<'_>> {
         let records =
             RwLockReadGuard::try_map(self.latest.read(), move |map| map.get(&namespace)).ok();
         Ok(LatestIterator {

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -1774,7 +1774,7 @@ mod tests {
 
         replica.hash_and_insert(b"a0.1", &author0, b"hi")?;
         let latest = store
-            .get_latest(namespace.id())?
+            .get_latest_for_each_author(namespace.id())?
             .collect::<Result<Vec<_>>>()?;
         assert_eq!(latest.len(), 1);
         assert_eq!(latest[0].2, b"a0.1".to_vec());
@@ -1782,7 +1782,7 @@ mod tests {
         replica.hash_and_insert(b"a1.1", &author1, b"hi")?;
         replica.hash_and_insert(b"a0.2", &author0, b"hi")?;
         let latest = store
-            .get_latest(namespace.id())?
+            .get_latest_for_each_author(namespace.id())?
             .collect::<Result<Vec<_>>>()?;
         let mut latest_keys: Vec<Vec<u8>> = latest.iter().map(|r| r.2.to_vec()).collect();
         latest_keys.sort();

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -1770,7 +1770,7 @@ mod tests {
         let author0 = Author::new(&mut rng);
         let author1 = Author::new(&mut rng);
         let namespace = Namespace::new(&mut rng);
-        let replica = store.new_replica(namespace.clone())?;
+        let mut replica = store.new_replica(namespace.clone())?;
 
         replica.hash_and_insert(b"a0.1", &author0, b"hi")?;
         let latest = store

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -24,16 +24,12 @@ use ed25519_dalek::{Signature, SignatureError};
 use iroh_bytes::Hash;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    ranger::{self, Fingerprint, Peer, RangeEntry, RangeKey},
-    store::PublicKeyStore,
-};
-use crate::{
-    ranger::{InsertOutcome, RangeValue},
-    store,
-};
-
+pub use crate::heads::AuthorHeads;
 pub use crate::keys::*;
+use crate::{
+    ranger::{self, Fingerprint, InsertOutcome, Peer, RangeEntry, RangeKey, RangeValue},
+    store::{self, PublicKeyStore},
+};
 
 /// Protocol message for the set reconciliation protocol.
 ///
@@ -89,6 +85,8 @@ pub enum ContentStatus {
 /// Outcome of a sync operation.
 #[derive(Debug, Clone, Default)]
 pub struct SyncOutcome {
+    /// Timestamp of the latest entry for each author in the set we received.
+    pub heads_received: AuthorHeads,
     /// Number of entries we received.
     pub num_recv: usize,
     /// Number of entries we sent.
@@ -360,6 +358,11 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
 
         // update state with incoming data.
         state.num_recv += message.value_count();
+        for (entry, _content_status) in message.values() {
+            state
+                .heads_received
+                .insert(entry.author(), entry.timestamp());
+        }
 
         // let subscribers = std::rc::Rc::new(&mut self.subscribers);
         // l
@@ -1745,6 +1748,45 @@ mod tests {
         let prefix = vec![0u8];
         replica.delete_prefix(prefix, &author)?;
         assert_keys(&store, namespace.id(), vec![vec![1u8, 0u8], vec![1u8, 2u8]]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_latest_iter_memory() -> Result<()> {
+        let store = store::memory::Store::default();
+        test_latest_iter(store)
+    }
+
+    #[cfg(feature = "fs-store")]
+    #[test]
+    fn test_latest_iter_fs() -> Result<()> {
+        let dbfile = tempfile::NamedTempFile::new()?;
+        let store = store::fs::Store::new(dbfile.path())?;
+        test_latest_iter(store)
+    }
+
+    fn test_latest_iter<S: store::Store>(store: S) -> Result<()> {
+        let mut rng = rand::thread_rng();
+        let author0 = Author::new(&mut rng);
+        let author1 = Author::new(&mut rng);
+        let namespace = Namespace::new(&mut rng);
+        let replica = store.new_replica(namespace.clone())?;
+
+        replica.hash_and_insert(b"a0.1", &author0, b"hi")?;
+        let latest = store
+            .get_latest(namespace.id())?
+            .collect::<Result<Vec<_>>>()?;
+        assert_eq!(latest.len(), 1);
+        assert_eq!(latest[0].2, b"a0.1".to_vec());
+
+        replica.hash_and_insert(b"a1.1", &author1, b"hi")?;
+        replica.hash_and_insert(b"a0.2", &author0, b"hi")?;
+        let latest = store
+            .get_latest(namespace.id())?
+            .collect::<Result<Vec<_>>>()?;
+        let mut latest_keys: Vec<Vec<u8>> = latest.iter().map(|r| r.2.to_vec()).collect();
+        latest_keys.sort();
+        assert_eq!(latest_keys, vec![b"a0.2".to_vec(), b"a1.1".to_vec()]);
 
         Ok(())
     }

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -503,14 +503,11 @@ impl DocCommands {
                                 Origin::Connect(_) => "we initiated",
                             };
                             match event.result {
-                                Ok(_) => println!(
-                                    "synced doc {} with peer {} ({origin})",
-                                    fmt_short(event.namespace),
-                                    fmt_short(event.peer)
-                                ),
+                                Ok(()) => {
+                                    println!("synced peer {} ({origin})", fmt_short(event.peer))
+                                }
                                 Err(err) => println!(
-                                    "failed to sync doc {} with peer {} ({origin}): {err}",
-                                    fmt_short(event.namespace),
+                                    "failed to sync with peer {} ({origin}): {err}",
                                     fmt_short(event.peer)
                                 ),
                             }

--- a/iroh/src/sync_engine.rs
+++ b/iroh/src/sync_engine.rs
@@ -25,11 +25,13 @@ use crate::downloader::Downloader;
 mod gossip;
 mod live;
 pub mod rpc;
+mod state;
 
 use gossip::GossipActor;
 use live::{LiveActor, ToLiveActor};
 
-pub use self::live::{Origin, SyncEvent};
+pub use self::live::SyncEvent;
+pub use self::state::Origin;
 pub use iroh_sync::net::SYNC_ALPN;
 
 /// Capacity of the channel for the [`ToLiveActor`] messages.

--- a/iroh/src/sync_engine/gossip.rs
+++ b/iroh/src/sync_engine/gossip.rs
@@ -182,6 +182,14 @@ impl GossipActor {
                             .peers_have(hash, vec![(msg.delivered_from, PeerRole::Provider).into()])
                             .await;
                     }
+                    Op::SyncReport(report) => {
+                        self.to_sync_actor
+                            .send(ToLiveActor::IncomingSyncReport {
+                                from: msg.delivered_from,
+                                report,
+                            })
+                            .await?;
+                    }
                 }
             }
             // A new neighbor appeared in the gossip swarm. Try to sync with it directly.

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -1,9 +1,6 @@
 #![allow(missing_docs)]
 
-use std::{
-    collections::HashMap,
-    time::{SystemTime},
-};
+use std::{collections::HashMap, time::SystemTime};
 
 use crate::downloader::{DownloadKind, Downloader, PeerRole};
 use anyhow::{Context, Result};

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashMap,
-    time::{Duration, SystemTime},
+    time::{SystemTime},
 };
 
 use crate::downloader::{DownloadKind, Downloader, PeerRole};
@@ -28,9 +28,6 @@ use tracing::{debug, error, info, instrument, trace, warn, Instrument, Span};
 
 use super::gossip::ToGossipActor;
 use super::state::{NamespaceStates, Origin, SyncReason};
-
-/// Minimium time to pass to do a new sync on a `NeighborUp` event.
-pub const RESYNC_INTERVAL: Duration = Duration::from_secs(60);
 
 /// An iroh-sync operation
 ///

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -17,7 +17,7 @@ use iroh_sync::{
         connect_and_sync, handle_connection, AbortReason, AcceptError, AcceptOutcome, ConnectError,
         SyncFinished,
     },
-    ContentStatus, InsertOrigin, NamespaceId, SignedEntry,AuthorHeads
+    AuthorHeads, ContentStatus, InsertOrigin, NamespaceId, SignedEntry,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -605,9 +605,8 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
             }
             Err(err) => {
                 warn!("sync actor error: {err:?}");
-                return;
             }
-        };
+        }
     }
 
     async fn on_replica_event(&mut self, event: iroh_sync::Event) -> Result<()> {

--- a/iroh/src/sync_engine/state.rs
+++ b/iroh/src/sync_engine/state.rs
@@ -18,9 +18,9 @@ pub enum SyncReason {
     DirectJoin,
     /// Peer showed up as new neighbor in the gossip swarm
     NewNeighbor,
-    /// We synced after receiving a [`SyncReport`] that indicated news for us
+    /// We synced after receiving a sync report that indicated news for us
     SyncReport,
-    /// We received a [`SyncReport`] while a sync was running, so run again afterwars
+    /// We received a sync report while a sync was running, so run again afterwars
     Resync,
 }
 
@@ -157,7 +157,7 @@ impl PeerState {
                 // Incoming sync request while we are dialing ourselves.
                 // In this case, compare the binary representations of our and the other node's peer id
                 // to deterministically decide which of the two concurrent connections will succeed.
-                Origin::Connect(_reason) => match expected_sync_direction(&me, &peer) {
+                Origin::Connect(_reason) => match expected_sync_direction(me, peer) {
                     SyncDirection::Accept => AcceptOutcome::Allow,
                     SyncDirection::Connect => AcceptOutcome::Reject(AbortReason::AlreadySyncing),
                 },

--- a/iroh/src/sync_engine/state.rs
+++ b/iroh/src/sync_engine/state.rs
@@ -5,7 +5,7 @@ use iroh_sync::{
     NamespaceId,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::time::{Instant, SystemTime};
 use tracing::{debug, warn};
 
@@ -47,11 +47,11 @@ impl Default for SyncState {
 /// Contains an entry for each active (syncing) namespace, and in there an entry for each peer we
 /// synced with.
 #[derive(Default)]
-pub struct NamespaceStates(HashMap<NamespaceId, NamespaceState>);
+pub struct NamespaceStates(BTreeMap<NamespaceId, NamespaceState>);
 
 #[derive(Default)]
 struct NamespaceState {
-    peers: HashMap<PublicKey, PeerState>,
+    peers: BTreeMap<PublicKey, PeerState>,
 }
 
 impl NamespaceStates {

--- a/iroh/src/sync_engine/state.rs
+++ b/iroh/src/sync_engine/state.rs
@@ -1,0 +1,193 @@
+use anyhow::Result;
+use iroh_net::key::PublicKey;
+use iroh_sync::{
+    net::{AbortReason, AcceptOutcome, SyncFinished},
+    NamespaceId,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::{Instant, SystemTime};
+use tracing::{debug, warn};
+
+use super::live::RESYNC_INTERVAL;
+
+/// Why we started a sync request
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Copy)]
+pub enum SyncReason {
+    /// Direct join request via API
+    DirectJoin,
+    /// Peer showed up as new neighbor in the gossip swarm
+    NewNeighbor,
+    /// We synced after receiving a [`SyncReport`] that indicated news for us
+    SyncReport,
+    /// We received a [`SyncReport`] while a sync was running, so run again afterwars
+    Resync,
+}
+
+/// Why we performed a sync exchange
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub enum Origin {
+    /// We initiated the exchange
+    Connect(SyncReason),
+    /// A peer connected to us and we accepted the exchange
+    Accept,
+}
+
+/// The state we're in for a peer and a namespace
+#[derive(Debug, Clone)]
+pub enum SyncState {
+    Idle,
+    Running { start: SystemTime, origin: Origin },
+}
+
+impl Default for SyncState {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+/// Contains an entry for each active (syncing) namespace, and in there an entry for each peer we
+/// synced with.
+#[derive(Default)]
+pub struct NamespaceStates(HashMap<NamespaceId, NamespaceState>);
+
+#[derive(Default)]
+struct NamespaceState {
+    peers: HashMap<PublicKey, PeerState>,
+}
+
+impl NamespaceStates {
+    /// Are we syncing this namespace?
+    pub fn is_syncing(&self, namespace: &NamespaceId) -> bool {
+        self.0.contains_key(namespace)
+    }
+
+    /// Insert a namespace into the set of syncing namespaces.
+    pub fn insert(&mut self, namespace: NamespaceId) {
+        self.0.entry(namespace).or_default();
+    }
+
+    /// Get the [`PeerState`] for a namespace and peer.
+    /// If the namespace is syncing and the peer so far unknown, initialize and return a default [`PeerState`].
+    /// If the namespace is not syncing return None.
+    pub fn entry(&mut self, namespace: &NamespaceId, peer: PublicKey) -> Option<&mut PeerState> {
+        self.0
+            .get_mut(namespace)
+            .map(|n| n.peers.entry(peer).or_default())
+    }
+
+    /// Remove a namespace from the set of syncing namespaces.
+    pub fn remove(&mut self, namespace: &NamespaceId) -> bool {
+        self.0.remove(namespace).is_some()
+    }
+}
+
+/// State of a peer with regard to a namespace.
+#[derive(Default)]
+pub struct PeerState {
+    state: SyncState,
+    resync_requested: bool,
+    last_sync: Option<(Instant, Result<SyncFinished>)>,
+}
+
+impl PeerState {
+    pub fn finish(
+        &mut self,
+        origin: &Origin,
+        result: Result<SyncFinished>,
+    ) -> Option<(SystemTime, bool)> {
+        let start = match &self.state {
+            SyncState::Running {
+                start,
+                origin: origin2,
+            } => {
+                if origin2 != origin {
+                    warn!(actual = ?origin, expected = ?origin2, "finished sync origin does not match state")
+                }
+                Some(*start)
+            }
+            SyncState::Idle => {
+                warn!("sync state finish called but not in running state");
+                None
+            }
+        };
+
+        self.last_sync = Some((Instant::now(), result));
+        self.state = SyncState::Idle;
+        start.map(|s| (s, self.resync_requested))
+    }
+
+    pub fn start_connect(&mut self, now: Instant, reason: SyncReason) -> bool {
+        let start_sync = match self.state {
+            // never run two syncs at the same time
+            SyncState::Running { .. } => {
+                debug!("abort connect: sync already running");
+                if matches!(reason, SyncReason::SyncReport) {
+                    debug!("resync queued");
+                    self.resync_requested = true;
+                }
+                false
+            }
+            SyncState::Idle => match (reason, &self.last_sync) {
+                (_, None) => true,
+                (_, Some((_, Err(_)))) => true,
+                (SyncReason::NewNeighbor, Some((time, Ok(_)))) => {
+                    let do_sync = now
+                        .checked_duration_since(*time)
+                        .map(|duration| duration > RESYNC_INTERVAL)
+                        .unwrap_or(true);
+                    if !do_sync {
+                        debug!("abort connect: last sync too recent for new neighbor syn");
+                    }
+                    do_sync
+                }
+                (_, _) => true,
+            },
+        };
+        if start_sync {
+            self.set_sync_running(Origin::Connect(reason));
+        }
+        start_sync
+    }
+    pub fn accept_request(&mut self, me: &PublicKey, peer: &PublicKey) -> AcceptOutcome {
+        let outcome = match &self.state {
+            SyncState::Idle => AcceptOutcome::Allow,
+            SyncState::Running { origin, .. } => match origin {
+                Origin::Accept => AcceptOutcome::Reject(AbortReason::AlreadySyncing),
+                // Incoming sync request while we are dialing ourselves.
+                // In this case, compare the binary representations of our and the other node's peer id
+                // to deterministically decide which of the two concurrent connections will succeed.
+                Origin::Connect(_reason) => match expected_sync_direction(&me, &peer) {
+                    SyncDirection::Accept => AcceptOutcome::Allow,
+                    SyncDirection::Connect => AcceptOutcome::Reject(AbortReason::AlreadySyncing),
+                },
+            },
+        };
+        if let AcceptOutcome::Allow = outcome {
+            self.set_sync_running(Origin::Accept);
+        }
+        outcome
+    }
+
+    fn set_sync_running(&mut self, origin: Origin) {
+        self.state = SyncState::Running {
+            origin,
+            start: SystemTime::now(),
+        };
+        self.resync_requested = false;
+    }
+}
+
+#[derive(Debug)]
+enum SyncDirection {
+    Accept,
+    Connect,
+}
+
+fn expected_sync_direction(self_peer_id: &PublicKey, other_peer_id: &PublicKey) -> SyncDirection {
+    if self_peer_id.as_bytes() > other_peer_id.as_bytes() {
+        SyncDirection::Accept
+    } else {
+        SyncDirection::Connect
+    }
+}

--- a/iroh/src/sync_engine/state.rs
+++ b/iroh/src/sync_engine/state.rs
@@ -67,31 +67,84 @@ impl NamespaceStates {
         self.0.entry(namespace).or_default();
     }
 
-    /// Get the [`PeerState`] for a namespace and peer.
-    /// If the namespace is syncing and the peer so far unknown, initialize and return a default [`PeerState`].
-    /// If the namespace is not syncing return None.
-    pub fn entry(&mut self, namespace: &NamespaceId, peer: PublicKey) -> Option<&mut PeerState> {
-        self.0
-            .get_mut(namespace)
-            .map(|n| n.peers.entry(peer).or_default())
+    /// Start a sync request.
+    ///
+    /// Returns true if the request should be performed, and false if it should be aborted.
+    pub fn start_connect(
+        &mut self,
+        namespace: &NamespaceId,
+        peer: PublicKey,
+        reason: SyncReason,
+    ) -> bool {
+        let Some(state) = self.entry(namespace, peer) else {
+            debug!("abort connect: namespace is not in sync set");
+            return false;
+        };
+        if !state.start_connect(Instant::now(), reason) {
+            debug!("abort connect: may not connect to peer at this time");
+            return false;
+        }
+        true
+    }
+
+    /// Accept a sync request.
+    ///
+    /// Returns the [`AcceptOutcome`] to be perfomed.
+    pub fn accept_request(
+        &mut self,
+        me: &PublicKey,
+        namespace: &NamespaceId,
+        peer: PublicKey,
+    ) -> AcceptOutcome {
+        let Some(state) = self.entry(namespace, peer) else {
+            return AcceptOutcome::Reject(AbortReason::NotFound);
+        };
+        state.accept_request(me, &peer)
+    }
+
+    /// Insert a finished sync operation into the state.
+    ///
+    /// Returns the time when the operation was started, and a `bool` that is true if another sync
+    /// request should be triggered right afterwards.
+    ///
+    /// Returns `None` if the namespace is not syncing or the sync state doesn't expect a finish
+    /// event.
+    pub fn finish(
+        &mut self,
+        namespace: &NamespaceId,
+        peer: PublicKey,
+        origin: &Origin,
+        result: Result<SyncFinished>,
+    ) -> Option<(SystemTime, bool)> {
+        let state = self.entry(namespace, peer)?;
+        state.finish(origin, result)
     }
 
     /// Remove a namespace from the set of syncing namespaces.
     pub fn remove(&mut self, namespace: &NamespaceId) -> bool {
         self.0.remove(namespace).is_some()
     }
+
+    /// Get the [`PeerState`] for a namespace and peer.
+    /// If the namespace is syncing and the peer so far unknown, initialize and return a default [`PeerState`].
+    /// If the namespace is not syncing return None.
+    fn entry(&mut self, namespace: &NamespaceId, peer: PublicKey) -> Option<&mut PeerState> {
+        self.0
+            .get_mut(namespace)
+            .map(|n| n.peers.entry(peer).or_default())
+    }
 }
 
 /// State of a peer with regard to a namespace.
 #[derive(Default)]
-pub struct PeerState {
+struct PeerState {
     state: SyncState,
     resync_requested: bool,
     last_sync: Option<(Instant, Result<SyncFinished>)>,
 }
 
 impl PeerState {
-    pub fn finish(
+    fn finish(
         &mut self,
         origin: &Origin,
         result: Result<SyncFinished>,
@@ -117,7 +170,7 @@ impl PeerState {
         start.map(|s| (s, self.resync_requested))
     }
 
-    pub fn start_connect(&mut self, now: Instant, reason: SyncReason) -> bool {
+    fn start_connect(&mut self, now: Instant, reason: SyncReason) -> bool {
         let start_sync = match self.state {
             // never run two syncs at the same time
             SyncState::Running { .. } => {
@@ -149,7 +202,8 @@ impl PeerState {
         }
         start_sync
     }
-    pub fn accept_request(&mut self, me: &PublicKey, peer: &PublicKey) -> AcceptOutcome {
+
+    fn accept_request(&mut self, me: &PublicKey, peer: &PublicKey) -> AcceptOutcome {
         let outcome = match &self.state {
             SyncState::Idle => AcceptOutcome::Allow,
             SyncState::Running { origin, .. } => match origin {

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
-use futures::{Stream, StreamExt};
+use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use iroh::{
     client::mem::Doc,
     node::{Builder, Node},
@@ -478,6 +478,263 @@ async fn sync_subscribe_stop_close() -> Result<()> {
     assert!(!status.sync);
 
     Ok(())
+}
+
+/// Test sync between many nodes with propagation through sync reports.
+#[tokio::test]
+async fn sync_big() -> Result<()> {
+    #[cfg(tokio_unstable)]
+    console_subscriber::init();
+    let mut rng = test_rng(b"sync_big");
+    setup_logging();
+    let rt = test_runtime();
+    let n_nodes = std::env::var("NODES")
+        .map(|v| v.parse().expect("NODES must be a number"))
+        .unwrap_or(10);
+    let n_entries_init = 1;
+    // let n_entries_live = 2;
+    // let n_entries_phase2 = 5;
+
+    tokio::task::spawn(async move {
+        for i in 0.. {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            info!("tick {i}");
+        }
+    });
+
+    let nodes = spawn_nodes(rt, n_nodes, &mut rng).await?;
+    let peer_ids = nodes.iter().map(|node| node.peer_id()).collect::<Vec<_>>();
+    let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
+    let authors = collect_futures(clients.iter().map(|c| c.authors.create())).await?;
+
+    let doc0 = clients[0].docs.create().await?;
+    let mut ticket = doc0.share(ShareMode::Write).await?;
+    // do not join for now, just import without any peer info
+    let peer0 = ticket.peers[0].clone();
+    ticket.peers = vec![];
+
+    let mut docs = vec![];
+    docs.push(doc0);
+    docs.extend_from_slice(
+        &collect_futures(
+            clients
+                .iter()
+                .skip(1)
+                .map(|c| c.docs.import(ticket.clone())),
+        )
+        .await?,
+    );
+
+    let mut expected = vec![];
+
+    // create initial data on each node
+    publish(&docs, &mut expected, n_entries_init, |i, j| {
+        (
+            authors[i],
+            format!("init/{}/{j}", peer_ids[i].fmt_short()),
+            format!("init:{i}:{j}"),
+        )
+    })
+    .await?;
+
+    // assert initial data
+    for (i, doc) in docs.iter().enumerate() {
+        let entries = get_all_with_content(doc).await?;
+        let mut expected = expected
+            .iter()
+            .filter(|e| e.author == authors[i])
+            .cloned()
+            .collect::<Vec<_>>();
+        expected.sort();
+        assert_eq!(entries, expected, "phase1 pre-sync correct");
+    }
+
+    // setup event streams
+    let events = collect_futures(docs.iter().map(|d| d.subscribe())).await?;
+
+    // join nodes together
+    for (i, doc) in docs.iter().enumerate().skip(1) {
+        info!(me = %peer_ids[i].fmt_short(), peer = %peer0.peer_id.fmt_short(), "join");
+        doc.start_sync(vec![peer0.clone()]).await?;
+    }
+
+    // wait for InsertRemote events stuff to happen
+    info!("wait for all peers to receive insert events");
+    let expected_inserts = (n_nodes - 1) * n_entries_init;
+    let mut futs = vec![];
+    for (i, events) in events.into_iter().enumerate() {
+        let doc = docs[i].clone();
+        let expected = expected.clone();
+        let me = peer_ids[i].fmt_short();
+        let fut = async move {
+            wait_for_events(events, expected_inserts, TIMEOUT, me.clone(), |e| {
+                matches!(e, LiveEvent::InsertRemote { .. })
+            })
+            .await?;
+            let entries = get_all(&doc).await?;
+            if entries != expected {
+                Err(anyhow!(
+                    "node {i} failed (have {} but expected {})",
+                    entries.len(),
+                    expected.len()
+                ))
+            } else {
+                info!(%me, "received and checked all {} expected entries", expected.len());
+                Ok(())
+            }
+        };
+        let fut = fut.map(move |r| r.with_context(move || format!("node {i}")));
+        futs.push(fut);
+    }
+    futures::future::try_join_all(futs).await?;
+
+    assert_all_docs(&docs, &peer_ids, &expected, "after initial sync").await;
+
+    // the latter part of the test is working already.
+    // disabled for now - will move into another test.
+    //
+    // add entries while everyone is live.
+    // create initial data on each node
+    // info!("publish {n_entries_live} entries on each node");
+    // publish(&docs, &mut expected, n_entries_live, |i, j| {
+    //     (authors[i], format!("live/{j}"), format!("live:{i}:{j}"))
+    // })
+    // .await?;
+    //
+    // // wait for stuff to happen!
+    // info!("sleep 3s");
+    // tokio::time::sleep(Duration::from_secs(3)).await;
+    //
+    // // assert that everyone has everything...
+    // assert_all_docs(&docs, &peer_ids, &expected, "after gossip").await;
+    //
+    // info!(
+    //     "peer1 {:?} goes offline and adds a new entry",
+    //     nodes[1].peer_id()
+    // );
+    // docs[1].stop_sync().await?;
+    // publish(&[docs[1].clone()], &mut expected, 1, |i, j| {
+    //     (authors[1], format!("change/{j}"), format!("change:{i}:{j}"))
+    // })
+    // .await?;
+    // info!(
+    //     "peer1 {:?} goes online again and joins peer0 {:?}",
+    //     nodes[1].peer_id(),
+    //     nodes[0].peer_id(),
+    // );
+    // docs[1].start_sync(vec![peer0.clone()]).await?;
+    //
+    // info!("sleep 3s");
+    // tokio::time::sleep(Duration::from_secs(3)).await;
+    // assert_all_docs(&docs, &peer_ids, &expected, "after peer1 published").await;
+
+    info!("shutdown");
+    for node in nodes {
+        node.shutdown();
+    }
+
+    Ok(())
+}
+
+/// Get all entries of a document.
+async fn get_all(doc: &Doc) -> anyhow::Result<Vec<Entry>> {
+    let entries = doc.get_many(GetFilter::All).await?;
+    let entries = entries.collect::<Vec<_>>().await;
+    entries.into_iter().collect()
+}
+
+/// Get all entries of a document with the blob content.
+async fn get_all_with_content(doc: &Doc) -> anyhow::Result<Vec<(Entry, Bytes)>> {
+    let entries = doc.get_many(GetFilter::All).await?;
+    let entries = entries.and_then(|entry| async {
+        let content = doc.read_to_bytes(&entry).await;
+        content.map(|c| (entry, c))
+    });
+    let entries = entries.collect::<Vec<_>>().await;
+    let entries = entries.into_iter().collect::<Result<Vec<_>>>()?;
+    Ok(entries)
+}
+
+async fn publish(
+    docs: &[Doc],
+    expected: &mut Vec<ExpectedEntry>,
+    n: usize,
+    cb: impl Fn(usize, usize) -> (AuthorId, String, String),
+) -> anyhow::Result<()> {
+    for (i, doc) in docs.iter().enumerate() {
+        for j in 0..n {
+            let (author, key, value) = cb(i, j);
+            doc.set_bytes(author, key.as_bytes().to_vec(), value.as_bytes().to_vec())
+                .await?;
+            expected.push(ExpectedEntry { author, key, value });
+        }
+    }
+    expected.sort();
+    Ok(())
+}
+
+/// Collect an iterator into futures by joining them all and failing if any future failed.
+async fn collect_futures<T>(
+    futs: impl IntoIterator<Item = impl Future<Output = anyhow::Result<T>>>,
+) -> anyhow::Result<Vec<T>> {
+    futures::future::join_all(futs)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()
+}
+
+/// Collect `count` events from the `events` stream, only collecting events for which `matcher`
+/// returns true.
+async fn wait_for_events(
+    mut events: impl Stream<Item = Result<LiveEvent>> + Send + Unpin + 'static,
+    count: usize,
+    timeout: Duration,
+    me: String,
+    matcher: impl Fn(&LiveEvent) -> bool,
+) -> anyhow::Result<Vec<LiveEvent>> {
+    let mut res = Vec::with_capacity(count);
+    let sleep = tokio::time::sleep(timeout);
+    tokio::pin!(sleep);
+    while res.len() < count {
+        tokio::select! {
+            () = &mut sleep => {
+                bail!("Failed to collect {count} elements in {timeout:?} (collected only {})", res.len());
+            },
+            event = events.try_next() => {
+                let event = event?;
+                match event {
+                    None => bail!("stream ended after {} items, but expected {count}", res.len()),
+                    Some(event) => if matcher(&event) {
+                        res.push(event);
+                        debug!(%me, "recv event {} of {count}", res.len());
+                    }
+                }
+            }
+        }
+    }
+    Ok(res)
+}
+
+async fn assert_all_docs(
+    docs: &[Doc],
+    peer_ids: &[PublicKey],
+    expected: &Vec<ExpectedEntry>,
+    label: &str,
+) {
+    info!("validate all peers: {label}");
+    for (i, doc) in docs.iter().enumerate() {
+        let entries = get_all(doc).await.unwrap_or_else(|err| {
+            panic!("failed to get entries for peer {:?}: {err:?}", peer_ids[i])
+        });
+        assert_eq!(
+            &entries,
+            expected,
+            "{label}: peer {i} {:?} failed (have {} but expected {})",
+            peer_ids[i],
+            entries.len(),
+            expected.len()
+        );
+    }
 }
 
 #[derive(Debug, Ord, Eq, PartialEq, PartialOrd, Clone)]

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -12,7 +12,7 @@ use iroh::{
     client::mem::Doc,
     node::{Builder, Node},
     rpc_protocol::ShareMode,
-    sync_engine::{LiveEvent, SyncEvent},
+    sync_engine::LiveEvent,
 };
 use iroh_net::key::{PublicKey, SecretKey};
 use quic_rpc::transport::misc::DummyServerEndpoint;
@@ -968,11 +968,5 @@ fn match_sync_finished(event: &LiveEvent, peer: PublicKey, namespace: NamespaceI
     let LiveEvent::SyncFinished(e) = event else {
         return false;
     };
-    e == &SyncEvent {
-        peer,
-        namespace,
-        result: Ok(()),
-        origin: e.origin.clone(),
-        finished: e.finished,
-    }
+    e.peer == peer && e.namespace == namespace && e.result == Ok(())
 }


### PR DESCRIPTION
## Description

This PR implements sync propagation. 

* When a set-reconcilation sync completes, `iroh-sync` now returns a struct `AuthorHeads` which contains a map with an entry for each author for which we *received* entries in the sync operation, and the *latest timestamp* of all entries we received. So it is a kind of "cheapo vector clock", indicating "what's the latest entry we received in this sync op for each author"
* This `AuthorHeads` struct is then sent as a gossip message * to neighbors only*  as a `SyncReport`
* When receiving a sync report, a node checks if the `AuthorHeads` have any news to offer (i.e. if it contains a timestamp for an author newer than the latest existing entry for this author in the local store). If so, the node starts a sync request *to the node we received the report from*

Through this, the sync operations should propagate, and through checking the `AuthorHeads` if there are actually news for us loops should be avoided.

The PR also contains a much-needed refactoring for better state handling in the `live` actor.

## Notes & open questions

My biggest question is if that propagation model of sending the`AuthorHeads` to neighbors will scale in practice.

There is a test included that passes mostly, but sometimes not on CI (timeout of 60s reached before receiving all events). It really should not take 60s to sync 10 nodes together on localhost.

Some notes:
* For big sync operations with many messages we might want to limit the `AuthorHeads` to some number of authors
* We will want to debounce and merge sending sync reports over some interval
* We might want to delay sending sync reports, or not send sync reports for very recent entries,to not "race" with gossip


<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
