### PR TITLE
Integrate tagging with downloader

### DIFF
--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -315,10 +315,11 @@ impl TempTag {
     /// Create a new temp tag for the given hash and format
     ///
     /// This should only be used by store implementations.
+    ///
+    /// The caller is responsible for increasing the refcount on creation and to
+    /// make sure that temp tags that are created between a mark phase and a sweep
+    /// phase are protected.
     pub fn new(inner: HashAndFormat, liveness: Option<Arc<dyn LivenessTracker>>) -> Self {
-        if let Some(liveness) = liveness.as_ref() {
-            liveness.on_clone(&inner);
-        }
         Self { inner, liveness }
     }
 

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -9,12 +9,11 @@ use crate::{
     },
     Hash,
 };
-use bao_tree::{blake3, ChunkNum};
+use bao_tree::{blake3, ChunkRanges};
 use bytes::Bytes;
 use futures::{future::BoxFuture, stream::LocalBoxStream, Stream, StreamExt};
 use genawaiter::rc::{Co, Gen};
 use iroh_io::AsyncSliceReader;
-use range_collections::RangeSet2;
 use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncRead, sync::mpsc};
 
@@ -56,7 +55,7 @@ pub trait MapEntry<D: Map>: Clone + Send + Sync + 'static {
     /// It can also only ever be a best effort, since the underlying data may
     /// change at any time. E.g. somebody could flip a bit in the file, or download
     /// more chunks.
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<RangeSet2<ChunkNum>>>;
+    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>>;
     /// A future that resolves to a reader that can be used to read the outboard
     fn outboard(&self) -> BoxFuture<'_, io::Result<D::Outboard>>;
     /// A future that resolves to a reader that can be used to read the data

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -333,12 +333,12 @@ impl TempTag {
 
     /// The hash of the pinned item
     pub fn hash(&self) -> &Hash {
-        &self.inner.0
+        &self.inner.hash
     }
 
     /// The format of the pinned item
     pub fn format(&self) -> BlobFormat {
-        self.inner.1
+        self.inner.format
     }
 
     /// Keep the item alive until the end of the process
@@ -398,7 +398,7 @@ async fn gc_mark_task<'a>(
         roots.insert(haf);
     }
     let mut live: BTreeSet<Hash> = BTreeSet::new();
-    for HashAndFormat(hash, format) in roots {
+    for HashAndFormat { hash, format } in roots {
         // we need to do this for all formats except raw
         if live.insert(hash) && !format.is_raw() {
             let Some(entry) = store.get(&hash) else {

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -397,43 +397,38 @@ async fn gc_mark_task<'a>(
         info!("adding extra root {:?}", haf);
         roots.insert(haf);
     }
-    let mut current = roots.into_iter().collect::<Vec<_>>();
     let mut live: BTreeSet<Hash> = BTreeSet::new();
-    // process all current. Since we don't have nested collections, this will
-    // terminate after 1 iteration.
-    while !current.is_empty() {
-        for HashAndFormat(hash, format) in std::mem::take(&mut current) {
-            // we need to do this for all formats except raw
-            if live.insert(hash) && !format.is_raw() {
-                let Some(entry) = store.get(&hash) else {
-                    warn!("gc: {} not found", hash);
-                    continue;
+    for HashAndFormat(hash, format) in roots {
+        // we need to do this for all formats except raw
+        if live.insert(hash) && !format.is_raw() {
+            let Some(entry) = store.get(&hash) else {
+                warn!("gc: {} not found", hash);
+                continue;
+            };
+            if !entry.is_complete() {
+                warn!("gc: {} is partial", hash);
+                continue;
+            }
+            let Ok(reader) = entry.data_reader().await else {
+                warn!("gc: {} creating data reader failed", hash);
+                continue;
+            };
+            let Ok((mut iter, count)) = parse_hash_seq(reader).await else {
+                warn!("gc: {} parse failed", hash);
+                continue;
+            };
+            info!("parsed collection {} {:?}", hash, count);
+            loop {
+                let item = match iter.next().await {
+                    Ok(Some(item)) => item,
+                    Ok(None) => break,
+                    Err(_err) => {
+                        warn!("gc: {} parse failed", hash);
+                        break;
+                    }
                 };
-                if !entry.is_complete() {
-                    warn!("gc: {} is partial", hash);
-                    continue;
-                }
-                let Ok(reader) = entry.data_reader().await else {
-                    warn!("gc: {} creating data reader failed", hash);
-                    continue;
-                };
-                let Ok((mut iter, count)) = parse_hash_seq(reader).await else {
-                    warn!("gc: {} parse failed", hash);
-                    continue;
-                };
-                info!("parsed collection {} {:?}", hash, count);
-                loop {
-                    let item = match iter.next().await {
-                        Ok(Some(item)) => item,
-                        Ok(None) => break,
-                        Err(_err) => {
-                            warn!("gc: {} parse failed", hash);
-                            break;
-                        }
-                    };
-                    // if format != raw we would have to recurse here by adding this to current
-                    live.insert(item);
-                }
+                // if format != raw we would have to recurse here by adding this to current
+                live.insert(item);
             }
         }
     }

--- a/iroh-bytes/src/baomap.rs
+++ b/iroh-bytes/src/baomap.rs
@@ -320,6 +320,9 @@ impl TempTag {
     /// make sure that temp tags that are created between a mark phase and a sweep
     /// phase are protected.
     pub fn new(inner: HashAndFormat, liveness: Option<Arc<dyn LivenessTracker>>) -> Self {
+        if let Some(liveness) = liveness.as_ref() {
+            liveness.on_clone(&inner);
+        }
         Self { inner, liveness }
     }
 
@@ -349,9 +352,6 @@ impl TempTag {
 
 impl Clone for TempTag {
     fn clone(&self) -> Self {
-        if let Some(liveness) = self.liveness.as_ref() {
-            liveness.on_clone(&self.inner);
-        }
         Self::new(self.inner, self.liveness.clone())
     }
 }

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -19,7 +19,6 @@ use anyhow::Result;
 use bao_tree::io::fsm::BaoContentItem;
 use bao_tree::ChunkNum;
 use quinn::RecvStream;
-use range_collections::RangeSet2;
 use tracing::{debug, error};
 
 use crate::protocol::RangeSpecSeq;
@@ -64,7 +63,7 @@ pub mod fsm {
             },
             StartDecodeError,
         },
-        TreeNode,
+        ChunkRanges, TreeNode,
     };
     use derive_more::From;
     use iroh_io::AsyncSliceWriter;
@@ -102,7 +101,7 @@ pub mod fsm {
     }
 
     impl Iterator for RangesIter {
-        type Item = (u64, RangeSet2<ChunkNum>);
+        type Item = (u64, ChunkRanges);
 
         fn next(&mut self) -> Option<Self::Item> {
             self.0.with_dependent_mut(|_owner, iter| {
@@ -284,7 +283,7 @@ pub mod fsm {
     /// State of the get response when we start reading a collection
     #[derive(Debug)]
     pub struct AtStartRoot {
-        ranges: RangeSet2<ChunkNum>,
+        ranges: ChunkRanges,
         reader: TrackingReader<quinn::RecvStream>,
         misc: Box<Misc>,
         hash: Hash,
@@ -293,7 +292,7 @@ pub mod fsm {
     /// State of the get response when we start reading a child
     #[derive(Debug)]
     pub struct AtStartChild {
-        ranges: RangeSet2<ChunkNum>,
+        ranges: ChunkRanges,
         reader: TrackingReader<quinn::RecvStream>,
         misc: Box<Misc>,
         child_offset: u64,
@@ -310,7 +309,7 @@ pub mod fsm {
         }
 
         /// The ranges we have requested for the child
-        pub fn ranges(&self) -> &RangeSet2<ChunkNum> {
+        pub fn ranges(&self) -> &ChunkRanges {
             &self.ranges
         }
 
@@ -342,7 +341,7 @@ pub mod fsm {
 
     impl AtStartRoot {
         /// The ranges we have requested for the child
-        pub fn ranges(&self) -> &RangeSet2<ChunkNum> {
+        pub fn ranges(&self) -> &ChunkRanges {
             &self.ranges
         }
 
@@ -512,7 +511,7 @@ pub mod fsm {
         }
 
         /// The ranges we have requested for the current hash.
-        pub fn ranges(&self) -> &RangeSet2<ChunkNum> {
+        pub fn ranges(&self) -> &ChunkRanges {
             self.stream.ranges()
         }
     }

--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -132,11 +132,10 @@
 //! create a [`RangeSpecSeq`] like this:
 //!
 //! ```rust
-//! # use range_collections::range_set::RangeSet2;
-//! # use bao_tree::ChunkNum;
+//! # use bao_tree::{ChunkNum, ChunkRanges};
 //! # use iroh_bytes::protocol::{GetRequest, RangeSpecSeq};
 //! # let hash: iroh_bytes::Hash = [0; 32].into();
-//! let spec = RangeSpecSeq::from_ranges([RangeSet2::from(..ChunkNum(10))]);
+//! let spec = RangeSpecSeq::from_ranges([ChunkRanges::from(..ChunkNum(10))]);
 //! let request = GetRequest::new(hash, spec);
 //! ```
 //!
@@ -148,16 +147,16 @@
 //! of a large file, we would create a [`RangeSpecSeq`] like this:
 //!
 //! ```rust
-//! # use range_collections::range_set::RangeSet2;
-//! # use bao_tree::ChunkNum;
+//! # use bao_tree::{ChunkNum, ChunkRanges};
 //! # use iroh_bytes::protocol::{GetRequest, RangeSpecSeq};
 //! # let hash: iroh_bytes::Hash = [0; 32].into();
-//! let ranges = &RangeSet2::from(..ChunkNum(10)) | &RangeSet2::from(ChunkNum(100)..ChunkNum(110));
+//! let ranges = &ChunkRanges::from(..ChunkNum(10)) | &ChunkRanges::from(ChunkNum(100)..ChunkNum(110));
 //! let spec = RangeSpecSeq::from_ranges([ranges]);
 //! let request = GetRequest::new(hash, spec);
 //! ```
 //!
-//! To specify chunk ranges, we use the [`RangeSet`] type from the
+//! To specify chunk ranges, we use the [`ChunkRanges`] type alias.
+//! This is actually the [`RangeSet`] type from the
 //! [range_collections](https://crates.io/crates/range_collections) crate. This
 //! type supports efficient boolean operations on sets of non-overlapping ranges.
 //!
@@ -179,17 +178,16 @@
 //!
 //! One thing to note is that we might not yet know how many blobs are in the
 //! collection. Therefore, it is not possible to download an entire collection
-//! by just specifying [`RangeSet2::all()`] for all children.
+//! by just specifying [`ChunkRanges::all()`] for all children.
 //!
 //! Instead, [`RangeSpecSeq`] allows defining infinite sequences of range sets.
 //! The [`RangeSpecSeq::all()`] method returns a [`RangeSpecSeq`] that, when iterated
-//! over, will yield [`RangeSet2::all()`] forever.
+//! over, will yield [`ChunkRanges::all()`] forever.
 //!
 //! So specifying a collection would work like this:
 //!
 //! ```rust
-//! # use range_collections::range_set::RangeSet2;
-//! # use bao_tree::ChunkNum;
+//! # use bao_tree::{ChunkNum, ChunkRanges};
 //! # use iroh_bytes::protocol::{GetRequest, RangeSpecSeq};
 //! # let hash: iroh_bytes::Hash = [0; 32].into();
 //! let spec = RangeSpecSeq::all();
@@ -214,15 +212,14 @@
 //! We would create a [`GetRequest`] like this:
 //!
 //! ```rust
-//! # use range_collections::range_set::RangeSet2;
-//! # use bao_tree::ChunkNum;
+//! # use bao_tree::{ChunkNum, ChunkRanges};
 //! # use iroh_bytes::protocol::{GetRequest, RangeSpecSeq};
 //! # let hash: iroh_bytes::Hash = [0; 32].into();
 //! let spec = RangeSpecSeq::from_ranges([
-//!   RangeSet2::empty(), // we don't need the collection itself
-//!   RangeSet2::empty(), // we don't need the first child either
-//!   RangeSet2::from(ChunkNum(1000000)..), // we need the second child from chunk 1000000 onwards
-//!   RangeSet2::all(), // we need the third child completely
+//!   ChunkRanges::empty(), // we don't need the collection itself
+//!   ChunkRanges::empty(), // we don't need the first child either
+//!   ChunkRanges::from(ChunkNum(1000000)..), // we need the second child from chunk 1000000 onwards
+//!   ChunkRanges::all(), // we need the third child completely
 //! ]);
 //! let request = GetRequest::new(hash, spec);
 //! ```
@@ -237,13 +234,12 @@
 //! an infinite sequence.
 //!
 //! ```rust
-//! # use range_collections::range_set::RangeSet2;
-//! # use bao_tree::ChunkNum;
+//! # use bao_tree::{ChunkNum, ChunkRanges};
 //! # use iroh_bytes::protocol::{GetRequest, RangeSpecSeq};
 //! # let hash: iroh_bytes::Hash = [0; 32].into();
 //! let spec = RangeSpecSeq::from_ranges_infinite([
-//!   RangeSet2::all(), // the collection itself
-//!   RangeSet2::from(..ChunkNum(1)), // the first chunk of each child
+//!   ChunkRanges::all(), // the collection itself
+//!   ChunkRanges::from(..ChunkNum(1)), // the first chunk of each child
 //! ]);
 //! let request = GetRequest::new(hash, spec);
 //! ```
@@ -254,14 +250,13 @@
 //! the following would download the second child of a collection:
 //!
 //! ```rust
-//! # use range_collections::range_set::RangeSet2;
-//! # use bao_tree::ChunkNum;
+//! # use bao_tree::{ChunkNum, ChunkRanges};
 //! # use iroh_bytes::protocol::{GetRequest, RangeSpecSeq};
 //! # let hash: iroh_bytes::Hash = [0; 32].into();
 //! let spec = RangeSpecSeq::from_ranges([
-//!   RangeSet2::empty(), // we don't need the collection itself
-//!   RangeSet2::empty(), // we don't need the first child either
-//!   RangeSet2::all(), // we need the second child completely
+//!   ChunkRanges::empty(), // we don't need the collection itself
+//!   ChunkRanges::empty(), // we don't need the first child either
+//!   ChunkRanges::all(), // we need the second child completely
 //! ]);
 //! let request = GetRequest::new(hash, spec);
 //! ```
@@ -270,8 +265,7 @@
 //! look up the hash of the child and request it directly.
 //!
 //! ```rust
-//! # use range_collections::range_set::RangeSet2;
-//! # use bao_tree::ChunkNum;
+//! # use bao_tree::{ChunkNum, ChunkRanges};
 //! # use iroh_bytes::protocol::{GetRequest, RangeSpecSeq};
 //! # let child_hash: iroh_bytes::Hash = [0; 32].into();
 //! let request = GetRequest::single(child_hash);
@@ -280,7 +274,7 @@
 //! ### Why RangeSpec and RangeSpecSeq?
 //!
 //! You might wonder why we have [`RangeSpec`] and [`RangeSpecSeq`], when a simple
-//! sequence of [`RangeSet2`] might also do.
+//! sequence of [`ChunkRanges`] might also do.
 //!
 //! The [`RangeSpec`] and [`RangeSpecSeq`] types exist to provide an efficient
 //! representation of the request on the wire. In the [`RangeSpec`] type,
@@ -292,7 +286,7 @@
 //! Likewise, the [`RangeSpecSeq`] type is a sequence of [`RangeSpec`]s that
 //! does run length encoding to remove repeating elements. It also allows infinite
 //! sequences of [`RangeSpec`]s to be encoded, unlike a simple sequence of
-//! [`RangeSet2`]s.
+//! [`ChunkRanges`]s.
 //!
 //! [`RangeSpecSeq`] should be efficient even in case of very fragmented availability
 //! of chunks, like a download from multiple providers that was frequently interrupted.
@@ -354,11 +348,10 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 
 use anyhow::{ensure, Result};
-use bao_tree::ChunkNum;
+use bao_tree::{ChunkNum, ChunkRanges};
 use bytes::Bytes;
 use derive_more::From;
 use quinn::VarInt;
-use range_collections::RangeSet2;
 use serde::{Deserialize, Serialize};
 mod range_spec;
 pub use range_spec::{NonEmptyRequestRangeSpecIter, RangeSpec, RangeSpecSeq};
@@ -486,7 +479,7 @@ impl GetRequest {
         Self {
             hash,
             token: None,
-            ranges: RangeSpecSeq::from_ranges([RangeSet2::all()]),
+            ranges: RangeSpecSeq::from_ranges([ChunkRanges::all()]),
         }
     }
 
@@ -497,7 +490,7 @@ impl GetRequest {
         Self {
             hash,
             token: None,
-            ranges: RangeSpecSeq::from_ranges([RangeSet2::from(ChunkNum(u64::MAX)..)]),
+            ranges: RangeSpecSeq::from_ranges([ChunkRanges::from(ChunkNum(u64::MAX)..)]),
         }
     }
 
@@ -509,8 +502,8 @@ impl GetRequest {
             hash,
             token: None,
             ranges: RangeSpecSeq::from_ranges_infinite([
-                RangeSet2::all(),
-                RangeSet2::from(ChunkNum(u64::MAX)..),
+                ChunkRanges::all(),
+                ChunkRanges::from(ChunkNum(u64::MAX)..),
             ]),
         }
     }

--- a/iroh-bytes/src/protocol/range_spec.rs
+++ b/iroh-bytes/src/protocol/range_spec.rs
@@ -7,8 +7,7 @@
 //! collection.
 use std::fmt;
 
-use bao_tree::ChunkNum;
-use range_collections::{RangeSet2, RangeSetRef};
+use bao_tree::{ChunkNum, ChunkRanges, ChunkRangesRef};
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 
@@ -26,8 +25,8 @@ use smallvec::{smallvec, SmallVec};
 ///   - `[10, 10+1) = [10, 11)` is selected.
 ///   - `[11, inf)` is deselected.
 ///
-///   Such a [`RangeSpec`] can be converted to a [`RangeSet2`] using containing just the
-///   selected ranges: `RangeSet{2..7, 10..11}` using [`RangeSpec::to_chunk_ranges`].
+///   Such a [`RangeSpec`] can be converted to a [`ChunkRanges`] using containing just the
+///   selected ranges: `ChunkRanges{2..7, 10..11}` using [`RangeSpec::to_chunk_ranges`].
 ///
 /// - An empty range selects no spans, encoded as `[]`. This means nothing of the blob is
 ///   selected.
@@ -45,7 +44,7 @@ pub struct RangeSpec(SmallVec<[u64; 2]>);
 
 impl RangeSpec {
     /// Creates a new [`RangeSpec`] from a range set.
-    pub fn new(ranges: impl AsRef<RangeSetRef<ChunkNum>>) -> Self {
+    pub fn new(ranges: impl AsRef<ChunkRangesRef>) -> Self {
         let ranges = ranges.as_ref().boundaries();
         let mut res = SmallVec::new();
         if let Some((start, rest)) = ranges.split_first() {
@@ -79,28 +78,23 @@ impl RangeSpec {
         self.0.len() == 1 && self.0[0] == 0
     }
 
-    /// Creates a [`RangeSet2`] from this [`RangeSpec`].
-    ///
-    /// The [`RangeSet2`] is the same as a [`RangeSet`] but is used because it can store up
-    /// to two 2 span boundaries without allocating.
-    ///
-    /// [`RangeSet`]: range_collections::RangeSet
-    pub fn to_chunk_ranges(&self) -> RangeSet2<ChunkNum> {
+    /// Creates a [`ChunkRanges`] from this [`RangeSpec`].
+    pub fn to_chunk_ranges(&self) -> ChunkRanges {
         // this is zero allocation for single ranges
         // todo: optimize this in range collections
-        let mut ranges = RangeSet2::empty();
+        let mut ranges = ChunkRanges::empty();
         let mut current = ChunkNum(0);
         let mut on = false;
         for &width in self.0.iter() {
             let next = current + width;
             if on {
-                ranges |= RangeSet2::from(current..next);
+                ranges |= ChunkRanges::from(current..next);
             }
             current = next;
             on = !on;
         }
         if on {
-            ranges |= RangeSet2::from(current..);
+            ranges |= ChunkRanges::from(current..);
         }
         ranges
     }
@@ -191,9 +185,7 @@ impl RangeSpecSeq {
     }
 
     /// Convenience function to create a [`RangeSpecSeq`] from a finite sequence of range sets.
-    pub fn from_ranges(
-        ranges: impl IntoIterator<Item = impl AsRef<RangeSetRef<ChunkNum>>>,
-    ) -> Self {
+    pub fn from_ranges(ranges: impl IntoIterator<Item = impl AsRef<ChunkRangesRef>>) -> Self {
         Self::new(
             ranges
                 .into_iter()
@@ -207,7 +199,7 @@ impl RangeSpecSeq {
     /// Compared to [`RangeSpecSeq::from_ranges`], this will not add an empty range spec at the end, so the final
     /// range spec will repeat forever.
     pub fn from_ranges_infinite(
-        ranges: impl IntoIterator<Item = impl AsRef<RangeSetRef<ChunkNum>>>,
+        ranges: impl IntoIterator<Item = impl AsRef<ChunkRangesRef>>,
     ) -> Self {
         Self::new(ranges.into_iter().map(RangeSpec::new))
     }
@@ -362,21 +354,20 @@ mod tests {
     use bao_tree::ChunkNum;
     use iroh_test::{assert_eq_hex, hexdump::parse_hexdump};
     use proptest::prelude::*;
-    use range_collections::RangeSet2;
 
-    fn ranges(value_range: Range<u64>) -> impl Strategy<Value = RangeSet2<ChunkNum>> {
+    fn ranges(value_range: Range<u64>) -> impl Strategy<Value = ChunkRanges> {
         prop::collection::vec((value_range.clone(), value_range), 0..16).prop_map(|v| {
-            let mut res = RangeSet2::empty();
+            let mut res = ChunkRanges::empty();
             for (a, b) in v {
                 let start = a.min(b);
                 let end = a.max(b);
-                res |= RangeSet2::from(ChunkNum(start)..ChunkNum(end));
+                res |= ChunkRanges::from(ChunkNum(start)..ChunkNum(end));
             }
             res
         })
     }
 
-    fn range_spec_seq_roundtrip_impl(ranges: &[RangeSet2<ChunkNum>]) -> Vec<RangeSet2<ChunkNum>> {
+    fn range_spec_seq_roundtrip_impl(ranges: &[ChunkRanges]) -> Vec<ChunkRanges> {
         let spec = RangeSpecSeq::from_ranges(ranges.iter().cloned());
         spec.iter()
             .map(|x| x.to_chunk_ranges())
@@ -384,9 +375,7 @@ mod tests {
             .collect::<Vec<_>>()
     }
 
-    fn range_spec_seq_bytes_roundtrip_impl(
-        ranges: &[RangeSet2<ChunkNum>],
-    ) -> Vec<RangeSet2<ChunkNum>> {
+    fn range_spec_seq_bytes_roundtrip_impl(ranges: &[ChunkRanges]) -> Vec<ChunkRanges> {
         let spec = RangeSpecSeq::from_ranges(ranges.iter().cloned());
         let bytes = postcard::to_allocvec(&spec).unwrap();
         let spec2: RangeSpecSeq = postcard::from_bytes(&bytes).unwrap();
@@ -397,9 +386,9 @@ mod tests {
             .collect::<Vec<_>>()
     }
 
-    fn mk_case(case: Vec<Range<u64>>) -> Vec<RangeSet2<ChunkNum>> {
+    fn mk_case(case: Vec<Range<u64>>) -> Vec<ChunkRanges> {
         case.iter()
-            .map(|x| RangeSet2::from(ChunkNum(x.start)..ChunkNum(x.end)))
+            .map(|x| ChunkRanges::from(ChunkNum(x.start)..ChunkNum(x.end)))
             .collect::<Vec<_>>()
     }
 
@@ -416,21 +405,21 @@ mod tests {
                 ",
             ),
             (
-                RangeSpec::new(RangeSet2::from(ChunkNum(64)..)),
+                RangeSpec::new(ChunkRanges::from(ChunkNum(64)..)),
                 r"
                     01 # length prefix - 1 element
                     40 # span width - 64. everything starting from 64 is included
                 ",
             ),
             (
-                RangeSpec::new(RangeSet2::from(ChunkNum(10000)..)),
+                RangeSpec::new(ChunkRanges::from(ChunkNum(10000)..)),
                 r"
                     01 # length prefix - 1 element
                     904E # span width - 10000, 904E in postcard varint encoding. everything starting from 10000 is included
                 ",
             ),
             (
-                RangeSpec::new(RangeSet2::from(..ChunkNum(64))),
+                RangeSpec::new(ChunkRanges::from(..ChunkNum(64))),
                 r"
                     02 # length prefix - 2 elements
                     00 # span width - 0. everything stating from 0 is included
@@ -439,8 +428,8 @@ mod tests {
             ),
             (
                 RangeSpec::new(
-                    &RangeSet2::from(ChunkNum(1)..ChunkNum(3))
-                        | &RangeSet2::from(ChunkNum(9)..ChunkNum(13)),
+                    &ChunkRanges::from(ChunkNum(1)..ChunkNum(3))
+                        | &ChunkRanges::from(ChunkNum(9)..ChunkNum(13)),
                 ),
                 r"
                     04 # length prefix - 4 elements
@@ -472,8 +461,8 @@ mod tests {
             ),
             (
                 RangeSpecSeq::from_ranges([
-                    RangeSet2::from(ChunkNum(1)..ChunkNum(3)),
-                    RangeSet2::from(ChunkNum(7)..ChunkNum(13)),
+                    ChunkRanges::from(ChunkNum(1)..ChunkNum(3)),
+                    ChunkRanges::from(ChunkNum(7)..ChunkNum(13)),
                 ]),
                 r"
                     03 # 3 tuples in total
@@ -490,11 +479,11 @@ mod tests {
             ),
             (
                 RangeSpecSeq::from_ranges_infinite([
-                    RangeSet2::empty(),
-                    RangeSet2::empty(),
-                    RangeSet2::empty(),
-                    RangeSet2::from(ChunkNum(7)..),
-                    RangeSet2::all(),
+                    ChunkRanges::empty(),
+                    ChunkRanges::empty(),
+                    ChunkRanges::empty(),
+                    ChunkRanges::from(ChunkNum(7)..),
+                    ChunkRanges::all(),
                 ]),
                 r"
                     02 # 2 tuples in total
@@ -503,7 +492,7 @@ mod tests {
                     01 07 # range 7..
                     # second tuple
                     01 # span 1 until next (1 element is 7..)
-                    01 00 # RangeSet2::all() forever from now
+                    01 00 # ChunkRanges::all() forever from now
                 ",
             ),
         ];
@@ -513,7 +502,7 @@ mod tests {
         }
     }
 
-    /// Test that the roundtrip from [`Vec<RangeSet2>`] via [`RangeSpec`] to [`RangeSpecSeq`]  and back works.
+    /// Test that the roundtrip from [`Vec<ChunkRanges>`] via [`RangeSpec`] to [`RangeSpecSeq`]  and back works.
     #[test]
     fn range_spec_seq_roundtrip_cases() {
         for case in [
@@ -528,7 +517,7 @@ mod tests {
         }
     }
 
-    /// Test that the creation of a [`RangeSpecSeq`] from a sequence of [`RangeSet2`]s canonicalizes the result.
+    /// Test that the creation of a [`RangeSpecSeq`] from a sequence of [`ChunkRanges`]s canonicalizes the result.
     #[test]
     fn range_spec_seq_canonical() {
         for (case, expected_count) in [

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -16,48 +16,33 @@ pub mod progress;
 pub mod runtime;
 
 /// A format identifier
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct BlobFormat(u64);
-
-impl BlobFormat {
-    /// Raw format
-    pub const RAW: Self = Self(0);
-
-    /// Hash sequence format
-    pub const HASHSEQ: Self = Self(1);
-
-    /// true if this is a raw blob
-    pub const fn is_raw(&self) -> bool {
-        self.0 == Self::RAW.0
-    }
-
-    /// true if this is sequence of hashes
-    pub const fn is_hash_seq(&self) -> bool {
-        self.0 == Self::HASHSEQ.0
-    }
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default, Debug)]
+pub enum BlobFormat {
+    /// Raw blob
+    #[default]
+    Raw,
+    /// A sequence of BLAKE3 hashes
+    HashSeq,
 }
 
 impl From<BlobFormat> for u64 {
     fn from(value: BlobFormat) -> Self {
-        value.0
-    }
-}
-
-impl fmt::Debug for BlobFormat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self == &Self::RAW {
-            f.write_str("Raw")
-        } else if self == &Self::HASHSEQ {
-            f.write_str("HashSeq")
-        } else {
-            f.debug_tuple("Other").field(&self.0).finish()
+        match value {
+            BlobFormat::Raw => 0,
+            BlobFormat::HashSeq => 1,
         }
     }
 }
 
-impl Default for BlobFormat {
-    fn default() -> Self {
-        Self::RAW
+impl BlobFormat {
+    /// Is raw format
+    pub const fn is_raw(&self) -> bool {
+        matches!(self, BlobFormat::Raw)
+    }
+
+    /// Is hash seq format
+    pub const fn is_hash_seq(&self) -> bool {
+        matches!(self, BlobFormat::HashSeq)
     }
 }
 
@@ -133,12 +118,12 @@ pub struct HashAndFormat(pub Hash, pub BlobFormat);
 impl HashAndFormat {
     /// Create a new hash and format pair, using the default (raw) format.
     pub fn raw(hash: Hash) -> Self {
-        Self(hash, BlobFormat::RAW)
+        Self(hash, BlobFormat::Raw)
     }
 
     /// Create a new hash and format pair, using the collection format.
     pub fn hash_seq(hash: Hash) -> Self {
-        Self(hash, BlobFormat::HASHSEQ)
+        Self(hash, BlobFormat::HashSeq)
     }
 }
 

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -113,17 +113,28 @@ pub enum SetTagOption {
 
 /// A hash and format pair
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct HashAndFormat(pub Hash, pub BlobFormat);
+pub struct HashAndFormat {
+    /// The hash
+    pub hash: Hash,
+    /// The format
+    pub format: BlobFormat,
+}
 
 impl HashAndFormat {
     /// Create a new hash and format pair, using the default (raw) format.
     pub fn raw(hash: Hash) -> Self {
-        Self(hash, BlobFormat::Raw)
+        Self {
+            hash,
+            format: BlobFormat::Raw,
+        }
     }
 
     /// Create a new hash and format pair, using the collection format.
     pub fn hash_seq(hash: Hash) -> Self {
-        Self(hash, BlobFormat::HashSeq)
+        Self {
+            hash,
+            format: BlobFormat::HashSeq,
+        }
     }
 }
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -72,9 +72,8 @@ reflink-copy = { version = "0.1.8", optional = true }
 
 [features]
 default = ["cli", "metrics"]
-cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "mem-db", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table", "dialoguer"]
+cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table", "dialoguer"]
 metrics = ["iroh-metrics"]
-mem-db = []
 flat-db = ["reflink-copy"]
 test = []
 example-sync = ["cli"]
@@ -98,15 +97,15 @@ required-features = ["cli"]
 
 [[example]]
 name = "collection"
-required-features = ["mem-db"]
+required-features = []
 
 [[example]]
 name = "dump-blob-stream"
-required-features = ["mem-db"]
+required-features = []
 
 [[example]]
 name = "hello-world"
-required-features = ["mem-db"]
+required-features = []
 
 [[example]]
 name = "sync"

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     // create a ticket
     // tickets wrap all details needed to get a collection
-    let ticket = node.ticket(hash, BlobFormat::HASHSEQ).await?;
+    let ticket = node.ticket(hash, BlobFormat::HashSeq).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
     println!("node PeerID:     {}", ticket.node_addr().peer_id);

--- a/iroh/examples/hello-world.rs
+++ b/iroh/examples/hello-world.rs
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
         .spawn()
         .await?;
     // create a ticket
-    let ticket = node.ticket(hash, BlobFormat::RAW).await?;
+    let ticket = node.ticket(hash, BlobFormat::Raw).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
     println!("node PeerID:     {}", ticket.node_addr().peer_id);

--- a/iroh/src/baomap.rs
+++ b/iroh/src/baomap.rs
@@ -1,5 +1,12 @@
 //! Various database implementations for storing blob data
 
+use std::collections::BTreeMap;
+
+use iroh_bytes::{
+    util::{BlobFormat, HashAndFormat},
+    Hash,
+};
+
 #[cfg(feature = "flat-db")]
 pub mod flat;
 #[cfg(feature = "mem-db")]
@@ -28,4 +35,71 @@ fn new_uuid() -> [u8; 16] {
 #[cfg(any(feature = "mem-db", feature = "flat-db"))]
 fn temp_name() -> String {
     format!("{}.temp", hex::encode(new_uuid()))
+}
+
+#[derive(Debug, Default, Clone)]
+struct TempCounters {
+    /// number of raw temp tags for a hash
+    raw: u64,
+    /// number of hash seq temp tags for a hash
+    hash_seq: u64,
+}
+
+impl TempCounters {
+    fn counter(&mut self, format: BlobFormat) -> &mut u64 {
+        match format {
+            BlobFormat::Raw => &mut self.raw,
+            BlobFormat::HashSeq => &mut self.hash_seq,
+        }
+    }
+
+    fn inc(&mut self, format: BlobFormat) {
+        let counter = self.counter(format);
+        *counter = counter.checked_add(1).unwrap();
+    }
+
+    fn dec(&mut self, format: BlobFormat) {
+        let counter = self.counter(format);
+        *counter = counter.saturating_sub(1);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.raw == 0 && self.hash_seq == 0
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct TempCounterMap(BTreeMap<Hash, TempCounters>);
+
+impl TempCounterMap {
+    fn inc(&mut self, value: &HashAndFormat) {
+        let HashAndFormat(hash, format) = value;
+        self.0.entry(*hash).or_default().inc(*format)
+    }
+
+    fn dec(&mut self, value: &HashAndFormat) {
+        let HashAndFormat(hash, format) = value;
+        let counters = self.0.get_mut(&hash).unwrap();
+        counters.dec(*format);
+        if counters.is_empty() {
+            self.0.remove(&hash);
+        }
+    }
+
+    fn contains(&self, hash: &Hash) -> bool {
+        self.0.contains_key(hash)
+    }
+
+    fn keys(&self) -> impl Iterator<Item = HashAndFormat> {
+        let mut res = Vec::new();
+        for (k, v) in self.0.iter() {
+            if v.raw > 0 {
+                res.push(HashAndFormat(*k, BlobFormat::Raw));
+            }
+            if v.hash_seq > 0 {
+                res.push(HashAndFormat(*k, BlobFormat::HashSeq));
+            }
+        }
+        res.into_iter()
+    }
 }

--- a/iroh/src/baomap.rs
+++ b/iroh/src/baomap.rs
@@ -1,12 +1,10 @@
 //! Various database implementations for storing blob data
 #[cfg(feature = "flat-db")]
 pub mod flat;
-#[cfg(feature = "mem-db")]
 pub mod mem;
 
 pub mod readonly_mem;
 
-#[cfg(any(feature = "mem-db", feature = "flat-db"))]
 fn flatten_to_io<T>(
     e: std::result::Result<std::io::Result<T>, tokio::task::JoinError>,
 ) -> std::io::Result<T> {
@@ -17,19 +15,16 @@ fn flatten_to_io<T>(
 }
 
 /// Create a 16 byte unique ID.
-#[cfg(any(feature = "mem-db", feature = "flat-db"))]
 fn new_uuid() -> [u8; 16] {
     use rand::Rng;
     rand::thread_rng().gen::<[u8; 16]>()
 }
 
 /// Create temp file name based on a 16 byte UUID.
-#[cfg(any(feature = "mem-db", feature = "flat-db"))]
 fn temp_name() -> String {
     format!("{}.temp", hex::encode(new_uuid()))
 }
 
-#[cfg(any(feature = "mem-db", feature = "flat-db"))]
 #[derive(Debug, Default, Clone)]
 struct TempCounters {
     /// number of raw temp tags for a hash
@@ -38,7 +33,6 @@ struct TempCounters {
     hash_seq: u64,
 }
 
-#[cfg(any(feature = "mem-db", feature = "flat-db"))]
 impl TempCounters {
     fn counter(&mut self, format: iroh_bytes::util::BlobFormat) -> &mut u64 {
         match format {
@@ -62,11 +56,9 @@ impl TempCounters {
     }
 }
 
-#[cfg(any(feature = "mem-db", feature = "flat-db"))]
 #[derive(Debug, Clone, Default)]
 struct TempCounterMap(std::collections::BTreeMap<iroh_bytes::Hash, TempCounters>);
 
-#[cfg(any(feature = "mem-db", feature = "flat-db"))]
 impl TempCounterMap {
     fn inc(&mut self, value: &iroh_bytes::util::HashAndFormat) {
         let iroh_bytes::util::HashAndFormat { hash, format } = value;

--- a/iroh/src/baomap.rs
+++ b/iroh/src/baomap.rs
@@ -73,16 +73,16 @@ struct TempCounterMap(BTreeMap<Hash, TempCounters>);
 
 impl TempCounterMap {
     fn inc(&mut self, value: &HashAndFormat) {
-        let HashAndFormat(hash, format) = value;
+        let HashAndFormat { hash, format } = value;
         self.0.entry(*hash).or_default().inc(*format)
     }
 
     fn dec(&mut self, value: &HashAndFormat) {
-        let HashAndFormat(hash, format) = value;
-        let counters = self.0.get_mut(&hash).unwrap();
+        let HashAndFormat { hash, format } = value;
+        let counters = self.0.get_mut(hash).unwrap();
         counters.dec(*format);
         if counters.is_empty() {
-            self.0.remove(&hash);
+            self.0.remove(hash);
         }
     }
 
@@ -94,10 +94,10 @@ impl TempCounterMap {
         let mut res = Vec::new();
         for (k, v) in self.0.iter() {
             if v.raw > 0 {
-                res.push(HashAndFormat(*k, BlobFormat::Raw));
+                res.push(HashAndFormat::raw(*k));
             }
             if v.hash_seq > 0 {
-                res.push(HashAndFormat(*k, BlobFormat::HashSeq));
+                res.push(HashAndFormat::hash_seq(*k));
             }
         }
         res.into_iter()

--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -1030,7 +1030,7 @@ impl Store {
     fn delete_sync(&self, hash: Hash) -> io::Result<()> {
         let mut data = None;
         let mut outboard = None;
-        let mut external = None;
+        let mut paths = None;
         let mut partial_data = None;
         let mut partial_outboard = None;
         let complete_io_guard = self.0.complete_io_mutex.lock().unwrap();
@@ -1043,7 +1043,7 @@ impl Store {
                 outboard = Some(self.owned_outboard_path(&hash));
             }
             if !entry.external.is_empty() {
-                external = Some(self.0.options.paths_path(hash));
+                paths = Some(self.0.options.paths_path(hash));
             }
         }
         if let Some(partial) = state.partial.remove(&hash) {
@@ -1056,16 +1056,19 @@ impl Store {
         state.data.remove(&hash);
         drop(state);
         if let Some(data) = data {
+            tracing::debug!("deleting data {}", data.display());
             if let Err(cause) = std::fs::remove_file(data) {
                 tracing::warn!("failed to delete data file: {}", cause);
             }
         }
-        if let Some(external) = external {
+        if let Some(external) = paths {
+            tracing::debug!("deleting paths file {}", external.display());
             if let Err(cause) = std::fs::remove_file(external) {
-                tracing::warn!("failed to delete partial outboard file: {}", cause);
+                tracing::warn!("failed to delete paths file: {}", cause);
             }
         }
         if let Some(outboard) = outboard {
+            tracing::debug!("deleting outboard {}", outboard.display());
             if let Err(cause) = std::fs::remove_file(outboard) {
                 tracing::warn!("failed to delete outboard file: {}", cause);
             }

--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -132,13 +132,12 @@ use std::time::SystemTime;
 
 use bao_tree::io::outboard::{PostOrderMemOutboard, PreOrderOutboard};
 use bao_tree::io::sync::ReadAt;
-use bao_tree::{blake3, ChunkNum};
+use bao_tree::{blake3, ChunkRanges};
 use bao_tree::{BaoTree, ByteNum};
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::future::Either;
 use futures::{Future, FutureExt, Stream, StreamExt};
-use iroh_bytes::baomap::range_collections::RangeSet2;
 use iroh_bytes::baomap::{
     self, EntryStatus, ExportMode, ImportMode, ImportProgress, LivenessTracker, Map, MapEntry,
     PartialMap, PartialMapEntry, ReadableStore, TempTag, ValidateProgress,
@@ -250,8 +249,8 @@ impl MapEntry<Store> for PartialEntry {
         self.size
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<RangeSet2<ChunkNum>>> {
-        futures::future::ok(RangeSet2::all()).boxed()
+    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
+        futures::future::ok(ChunkRanges::all()).boxed()
     }
 
     fn outboard(&self) -> BoxFuture<'_, io::Result<<Store as Map>::Outboard>> {
@@ -450,8 +449,8 @@ impl MapEntry<Store> for Entry {
         }
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<RangeSet2<ChunkNum>>> {
-        futures::future::ok(RangeSet2::all()).boxed()
+    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
+        futures::future::ok(ChunkRanges::all()).boxed()
     }
 
     fn outboard(&self) -> BoxFuture<'_, io::Result<PreOrderOutboard<MemOrFile>>> {

--- a/iroh/src/baomap/flat.rs
+++ b/iroh/src/baomap/flat.rs
@@ -919,7 +919,7 @@ impl Store {
         progress.blocking_send(ImportProgress::OutboardDone { id, hash })?;
         use baomap::Store;
         // from here on, everything related to the hash is protected by the temp tag
-        let tag = self.temp_tag(HashAndFormat(hash, format));
+        let tag = self.temp_tag(HashAndFormat { hash, format });
         let hash = *tag.hash();
         let temp_outboard_path = if let Some(outboard) = outboard.as_ref() {
             let uuid = new_uuid();

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -621,7 +621,7 @@ impl Store {
         };
         let hash = hash.into();
         use baomap::Store;
-        let tag = self.temp_tag(HashAndFormat(hash, format));
+        let tag = self.temp_tag(HashAndFormat { hash, format });
         self.0
             .state
             .write()

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -21,7 +21,7 @@ use bao_tree::io::outboard::PreOrderOutboard;
 use bao_tree::io::outboard_size;
 use bao_tree::BaoTree;
 use bao_tree::ByteNum;
-use bao_tree::ChunkNum;
+use bao_tree::ChunkRanges;
 use bytes::Bytes;
 use bytes::BytesMut;
 use derive_more::From;
@@ -29,7 +29,6 @@ use futures::future::BoxFuture;
 use futures::FutureExt;
 use futures::{Stream, StreamExt};
 use iroh_bytes::baomap;
-use iroh_bytes::baomap::range_collections::RangeSet2;
 use iroh_bytes::baomap::EntryStatus;
 use iroh_bytes::baomap::ExportMode;
 use iroh_bytes::baomap::ImportMode;
@@ -225,8 +224,8 @@ impl MapEntry<Store> for Entry {
         self.hash
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<RangeSet2<ChunkNum>>> {
-        futures::future::ok(RangeSet2::all()).boxed()
+    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
+        futures::future::ok(ChunkRanges::all()).boxed()
     }
 
     fn size(&self) -> u64 {
@@ -259,8 +258,8 @@ impl MapEntry<Store> for PartialEntry {
         self.hash
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<RangeSet2<bao_tree::ChunkNum>>> {
-        futures::future::ok(RangeSet2::all()).boxed()
+    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
+        futures::future::ok(ChunkRanges::all()).boxed()
     }
 
     fn size(&self) -> u64 {

--- a/iroh/src/baomap/mem.rs
+++ b/iroh/src/baomap/mem.rs
@@ -556,14 +556,6 @@ impl baomap::Store for Store {
     }
 
     fn temp_tag(&self, tag: HashAndFormat) -> TempTag {
-        let mut state = self.0.state.write().unwrap();
-        // add to live set immediately. This prevents this blob from being deleted
-        // if this happens between a mark and a sweep phase.
-        state.live.insert(tag.0);
-        // increase the ref count
-        let entry = state.temp.entry(tag).or_default();
-        // panic if we overflow an u64
-        *entry = entry.checked_add(1).unwrap();
         TempTag::new(tag, Some(self.0.clone()))
     }
 
@@ -579,7 +571,10 @@ impl baomap::Store for Store {
 
     fn is_live(&self, hash: &Hash) -> bool {
         let state = self.0.state.read().unwrap();
+        // a blob is live if it is either in the live set, or it is temp tagged
         state.live.contains(hash)
+            || state.temp.contains_key(&HashAndFormat::raw(*hash))
+            || state.temp.contains_key(&HashAndFormat::hash_seq(*hash))
     }
 
     fn delete(&self, hash: &Hash) -> BoxFuture<'_, io::Result<()>> {

--- a/iroh/src/baomap/readonly_mem.rs
+++ b/iroh/src/baomap/readonly_mem.rs
@@ -14,7 +14,7 @@ use bao_tree::{
         outboard::{PreOrderMemOutboard, PreOrderOutboard},
         sync::Outboard,
     },
-    ChunkNum,
+    ChunkRanges,
 };
 use bytes::{Bytes, BytesMut};
 use futures::{
@@ -23,8 +23,8 @@ use futures::{
 };
 use iroh_bytes::{
     baomap::{
-        self, range_collections::RangeSet2, EntryStatus, ExportMode, ImportMode, ImportProgress,
-        Map, MapEntry, PartialMap, PartialMapEntry, ReadableStore, TempTag, ValidateProgress,
+        self, EntryStatus, ExportMode, ImportMode, ImportProgress, Map, MapEntry, PartialMap,
+        PartialMapEntry, ReadableStore, TempTag, ValidateProgress,
     },
     util::{
         progress::{IdGenerator, ProgressSender},
@@ -178,8 +178,8 @@ impl MapEntry<Store> for Entry {
         self.data.len() as u64
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<RangeSet2<ChunkNum>>> {
-        futures::future::ok(RangeSet2::all()).boxed()
+    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
+        futures::future::ok(ChunkRanges::all()).boxed()
     }
 
     fn outboard(&self) -> BoxFuture<'_, io::Result<PreOrderMemOutboard<Bytes>>> {
@@ -282,7 +282,7 @@ impl MapEntry<Store> for PartialEntry {
         unreachable!()
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<RangeSet2<bao_tree::ChunkNum>>> {
+    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
         // this is unreachable, since PartialEntry can not be created
         unreachable!()
     }

--- a/iroh/src/collection.rs
+++ b/iroh/src/collection.rs
@@ -139,12 +139,12 @@ impl Collection {
     {
         let (links, meta) = self.into_parts();
         let meta_bytes = postcard::to_stdvec(&meta)?;
-        let meta_tag = db.import_bytes(meta_bytes.into(), BlobFormat::RAW).await?;
+        let meta_tag = db.import_bytes(meta_bytes.into(), BlobFormat::Raw).await?;
         let links_bytes = std::iter::once(*meta_tag.hash())
             .chain(links)
             .collect::<HashSeq>();
         let links_tag = db
-            .import_bytes(links_bytes.into(), BlobFormat::HASHSEQ)
+            .import_bytes(links_bytes.into(), BlobFormat::HashSeq)
             .await?;
         Ok(links_tag)
     }

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -251,8 +251,8 @@ impl FullCommands {
                     }
                 } else if let (Some(peer), Some(hash)) = (peer, hash) {
                     let format = match collection {
-                        true => BlobFormat::HASHSEQ,
-                        false => BlobFormat::RAW,
+                        true => BlobFormat::HashSeq,
+                        false => BlobFormat::Raw,
                     };
                     self::get::GetInteractive {
                         rt: rt.clone(),
@@ -566,8 +566,8 @@ impl BlobCommands {
                     ticket.into_parts()
                 } else {
                     let format = match recursive {
-                        Some(false) | None => BlobFormat::RAW,
-                        Some(true) => BlobFormat::HASHSEQ,
+                        Some(false) | None => BlobFormat::Raw,
+                        Some(true) => BlobFormat::HashSeq,
                     };
                     (
                         PeerAddr::from_parts(peer.unwrap(), derp_region, addr),

--- a/iroh/src/commands/add.rs
+++ b/iroh/src/commands/add.rs
@@ -191,9 +191,8 @@ pub fn print_add_response(hash: Hash, format: BlobFormat, entries: Vec<ProvideRe
     println!("Total: {}", HumanBytes(total_size));
     println!();
     match format {
-        BlobFormat::RAW => println!("Blob: {}", hash),
-        BlobFormat::HASHSEQ => println!("Collection: {}", hash),
-        _ => println!("Hash (unsupported format): {}", hash),
+        BlobFormat::Raw => println!("Blob: {}", hash),
+        BlobFormat::HashSeq => println!("Collection: {}", hash),
     }
 }
 

--- a/iroh/src/commands/add.rs
+++ b/iroh/src/commands/add.rs
@@ -159,7 +159,7 @@ pub async fn aggregate_add_response(
                 if let Some(mp) = mp.take() {
                     mp.all_done();
                 }
-                hash_and_format = Some(HashAndFormat(hash, format));
+                hash_and_format = Some(HashAndFormat { hash, format });
                 break;
             }
             AddProgress::Abort(e) => {
@@ -170,7 +170,7 @@ pub async fn aggregate_add_response(
             }
         }
     }
-    let HashAndFormat(hash, format) =
+    let HashAndFormat { hash, format } =
         hash_and_format.context("Missing hash for collection or blob")?;
     let entries = collections
         .into_iter()

--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -1,19 +1,12 @@
 use std::path::PathBuf;
 
 use anyhow::{Context as _, Result};
+use bao_tree::ChunkRanges;
 use futures::StreamExt;
 use iroh::{
     collection::Collection,
     rpc_protocol::{BlobDownloadRequest, DownloadLocation},
     util::progress::ProgressSliceWriter,
-};
-use iroh_bytes::{
-    baomap::range_collections::RangeSet2,
-    provider::GetProgress,
-    util::{
-        progress::{FlumeProgressSender, IdGenerator, ProgressSender},
-        BlobFormat, SetTagOption,
-    },
 };
 use iroh_bytes::{
     get::{
@@ -22,6 +15,13 @@ use iroh_bytes::{
     },
     protocol::{GetRequest, RangeSpecSeq, RequestToken},
     Hash,
+};
+use iroh_bytes::{
+    provider::GetProgress,
+    util::{
+        progress::{FlumeProgressSender, IdGenerator, ProgressSender},
+        BlobFormat, SetTagOption,
+    },
 };
 use iroh_io::ConcatenateSliceWriter;
 use iroh_net::derp::DerpMode;
@@ -119,7 +119,7 @@ impl GetInteractive {
             tokio::task::spawn(show_download_progress(hash, receiver.into_stream().map(Ok)));
         let query = if self.format.is_raw() {
             // just get the entire first item
-            RangeSpecSeq::from_ranges([RangeSet2::all()])
+            RangeSpecSeq::from_ranges([ChunkRanges::all()])
         } else {
             // get everything (collection and children)
             RangeSpecSeq::all()

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -193,7 +193,7 @@ mod tests {
             hash,
             peer: PeerAddr::from_parts(peer, derp_region, vec![addr]),
             token: Some(token),
-            format: BlobFormat::HASHSEQ,
+            format: BlobFormat::HashSeq,
         };
         let base32 = ticket.to_string();
         println!("Ticket: {base32}");

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -157,6 +157,14 @@ impl DownloadKind {
         }
     }
 
+    // /// Get the requested hash and format.
+    // fn hash_and_format(&self) -> HashAndFormat {
+    //     match self {
+    //         DownloadKind::Blob { hash } => HashAndFormat::raw(*hash),
+    //         DownloadKind::Collection { hash } => HashAndFormat::hash_seq(*hash),
+    //     }
+    // }
+
     /// Get the ranges this download is requesting.
     // NOTE: necessary to extend downloads to support ranges of blobs ranges of collections.
     #[allow(dead_code)]

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -33,8 +33,9 @@ use std::{
 
 use futures::{future::LocalBoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use iroh_bytes::{
-    baomap::{range_collections::RangeSet2, Store},
+    baomap::{range_collections::RangeSet2, Store, TempTag},
     protocol::RangeSpecSeq,
+    util::HashAndFormat,
     Hash,
 };
 use iroh_net::{key::PublicKey, MagicEndpoint};
@@ -85,7 +86,7 @@ pub enum FailureAction {
 }
 
 /// Future of a get request.
-type GetFut = LocalBoxFuture<'static, Result<(), FailureAction>>;
+type GetFut = LocalBoxFuture<'static, Result<TempTag, FailureAction>>;
 
 /// Trait modelling performing a single request over a connection. This allows for IO-less testing.
 pub trait Getter {
@@ -142,9 +143,9 @@ pub enum DownloadKind {
         /// Blob to be downloaded.
         hash: Hash,
     },
-    /// Download a collection entirely.
-    Collection {
-        /// Blob to be downloaded.
+    /// Download a sequence of hashes entirely.
+    HashSeq {
+        /// Hash sequence to be downloaded.
         hash: Hash,
     },
 }
@@ -153,17 +154,17 @@ impl DownloadKind {
     /// Get the requested hash.
     const fn hash(&self) -> &Hash {
         match self {
-            DownloadKind::Blob { hash } | DownloadKind::Collection { hash } => hash,
+            DownloadKind::Blob { hash } | DownloadKind::HashSeq { hash } => hash,
         }
     }
 
-    // /// Get the requested hash and format.
-    // fn hash_and_format(&self) -> HashAndFormat {
-    //     match self {
-    //         DownloadKind::Blob { hash } => HashAndFormat::raw(*hash),
-    //         DownloadKind::Collection { hash } => HashAndFormat::hash_seq(*hash),
-    //     }
-    // }
+    /// Get the requested hash and format.
+    fn hash_and_format(&self) -> HashAndFormat {
+        match self {
+            DownloadKind::Blob { hash } => HashAndFormat::raw(*hash),
+            DownloadKind::HashSeq { hash } => HashAndFormat::hash_seq(*hash),
+        }
+    }
 
     /// Get the ranges this download is requesting.
     // NOTE: necessary to extend downloads to support ranges of blobs ranges of collections.
@@ -171,14 +172,14 @@ impl DownloadKind {
     fn ranges(&self) -> RangeSpecSeq {
         match self {
             DownloadKind::Blob { .. } => RangeSpecSeq::from_ranges([RangeSet2::all()]),
-            DownloadKind::Collection { .. } => RangeSpecSeq::all(),
+            DownloadKind::HashSeq { .. } => RangeSpecSeq::all(),
         }
     }
 }
 
 // For readability. In the future we might care about some data reporting on a successful download
 // or kind of failure in the error case.
-type DownloadResult = anyhow::Result<()>;
+type DownloadResult = anyhow::Result<TempTag>;
 
 /// Handle to interact with a download request.
 #[derive(Debug)]
@@ -438,7 +439,7 @@ enum PeerState {
 }
 
 /// Type of future that performs a download request.
-type DownloadFut = LocalBoxFuture<'static, (DownloadKind, Result<(), FailureAction>)>;
+type DownloadFut = LocalBoxFuture<'static, (DownloadKind, Result<TempTag, FailureAction>)>;
 
 #[derive(Debug)]
 struct Service<G: Getter, D: Dialer> {
@@ -739,7 +740,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     /// Checks if this hash is needed.
     fn is_needed(&self, hash: Hash) -> bool {
         let as_blob = DownloadKind::Blob { hash };
-        let as_collection = DownloadKind::Collection { hash };
+        let as_collection = DownloadKind::HashSeq { hash };
         self.current_requests.contains_key(&as_blob)
             || self.scheduled_requests.contains_key(&as_blob)
             || self.current_requests.contains_key(&as_collection)
@@ -749,7 +750,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     /// Check if this hash is currently being downloaded.
     fn is_current_request(&self, hash: Hash) -> bool {
         let as_blob = DownloadKind::Blob { hash };
-        let as_collection = DownloadKind::Collection { hash };
+        let as_collection = DownloadKind::HashSeq { hash };
         self.current_requests.contains_key(&as_blob)
             || self.current_requests.contains_key(&as_collection)
     }
@@ -757,7 +758,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     /// Remove a hash from the scheduled queue.
     fn unschedule(&mut self, hash: Hash) -> Option<(DownloadKind, PendingRequestInfo)> {
         let as_blob = DownloadKind::Blob { hash };
-        let as_collection = DownloadKind::Collection { hash };
+        let as_collection = DownloadKind::HashSeq { hash };
         let info = match self.scheduled_requests.remove(&as_blob) {
             Some(req) => Some(req),
             None => self.scheduled_requests.remove(&as_collection),
@@ -821,7 +822,11 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         self.start_download(kind, peer, conn, remaining_retries, intents);
     }
 
-    fn on_download_completed(&mut self, kind: DownloadKind, result: Result<(), FailureAction>) {
+    fn on_download_completed(
+        &mut self,
+        kind: DownloadKind,
+        result: Result<TempTag, FailureAction>,
+    ) {
         // first remove the request
         let info = self
             .current_requests
@@ -857,10 +862,10 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         let hash = *kind.hash();
 
         let peer_ready = match result {
-            Ok(()) => {
+            Ok(tt) => {
                 debug!(%peer, ?kind, "download completed");
                 for sender in intents.into_values() {
-                    let _ = sender.send(Ok(()));
+                    let _ = sender.send(Ok(tt.clone()));
                 }
                 true
             }

--- a/iroh/src/downloader/test/getter.rs
+++ b/iroh/src/downloader/test/getter.rs
@@ -24,11 +24,12 @@ impl Getter for TestingGetter {
 
     fn get(&mut self, kind: DownloadKind, peer: PublicKey) -> GetFut {
         let mut inner = self.0.write();
+        let tt = TempTag::new(kind.hash_and_format(), None);
         inner.request_history.push((kind, peer));
         let request_duration = inner.request_duration;
         async move {
             tokio::time::sleep(request_duration).await;
-            Ok(())
+            Ok(tt)
         }
         .boxed_local()
     }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1140,7 +1140,7 @@ impl<D: BaoStore, S: DocStore> RpcHandler<D, S> {
                             .import_file(
                                 source.path().to_owned(),
                                 import_mode,
-                                BlobFormat::RAW,
+                                BlobFormat::Raw,
                                 import_progress,
                             )
                             .await?;
@@ -1165,7 +1165,7 @@ impl<D: BaoStore, S: DocStore> RpcHandler<D, S> {
             let (tag, _size) = self
                 .inner
                 .db
-                .import_file(root, import_mode, BlobFormat::RAW, import_progress)
+                .import_file(root, import_mode, BlobFormat::Raw, import_progress)
                 .await?;
             tag
         };
@@ -1296,7 +1296,7 @@ impl<D: BaoStore, S: DocStore> RpcHandler<D, S> {
         let (temp_tag, _len) = self
             .inner
             .db
-            .import_stream(stream, BlobFormat::RAW, import_progress)
+            .import_stream(stream, BlobFormat::Raw, import_progress)
             .await?;
         let hash_and_format = *temp_tag.inner();
         let HashAndFormat(hash, format) = hash_and_format;
@@ -1660,7 +1660,7 @@ mod tests {
             .await
             .unwrap();
         let _drop_guard = node.cancel_token().drop_guard();
-        let ticket = node.ticket(hash, BlobFormat::RAW).await.unwrap();
+        let ticket = node.ticket(hash, BlobFormat::Raw).await.unwrap();
         println!("addrs: {:?}", ticket.node_addr().info);
         assert!(!ticket.node_addr().info.direct_addresses.is_empty());
     }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1673,7 +1673,6 @@ mod tests {
         assert!(!ticket.node_addr().info.direct_addresses.is_empty());
     }
 
-    #[cfg(feature = "mem-db")]
     #[tokio::test]
     async fn test_node_add_blob_stream() -> Result<()> {
         use iroh_bytes::util::SetTagOption;
@@ -1699,7 +1698,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "mem-db")]
     #[tokio::test]
     async fn test_node_add_tagged_blob_event() -> Result<()> {
         use iroh_bytes::util::SetTagOption;

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -86,7 +86,7 @@ pub struct BlobAddPathResponse(pub AddProgress);
 pub struct BlobDownloadRequest {
     /// This mandatory field contains the hash of the data to download and share.
     pub hash: Hash,
-    /// If the format is [`BlobFormat::HASHSEQ`], all children are downloaded and shared as
+    /// If the format is [`BlobFormat::HashSeq`], all children are downloaded and shared as
     /// well.
     pub format: BlobFormat,
     /// This mandatory field specifies the peer to download the data from.

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -188,7 +188,7 @@ impl<S: Store> SyncEngine<S> {
         let author = self.get_author(&author_id)?;
         let len = value.len();
         let tag = bao_store
-            .import_bytes(value.into(), BlobFormat::RAW)
+            .import_bytes(value.into(), BlobFormat::Raw)
             .await?;
         replica
             .insert(&key, &author, *tag.hash(), len as u64)

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -118,9 +118,9 @@ async fn gc_basics() -> Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
     let (node, bao_store, evs) = gc_test_node().await;
     let data1 = create_test_data(1234);
-    let tt1 = bao_store.import_bytes(data1, BlobFormat::RAW).await?;
+    let tt1 = bao_store.import_bytes(data1, BlobFormat::Raw).await?;
     let data2 = create_test_data(5678);
-    let tt2 = bao_store.import_bytes(data2, BlobFormat::RAW).await?;
+    let tt2 = bao_store.import_bytes(data2, BlobFormat::Raw).await?;
     let h1 = *tt1.hash();
     let h2 = *tt2.hash();
     // temp tags are still there, so the entries should be there
@@ -153,18 +153,20 @@ async fn gc_basics() -> Result<()> {
     Ok(())
 }
 
-async fn gc_hashseq_impl() -> Result<()> {
+/// Test gc for sequences of hashes that protect their children from deletion.
+#[tokio::test]
+async fn gc_hashseq() -> Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
     let (node, bao_store, evs) = gc_test_node().await;
     let data1 = create_test_data(1234);
-    let tt1 = bao_store.import_bytes(data1, BlobFormat::RAW).await?;
+    let tt1 = bao_store.import_bytes(data1, BlobFormat::Raw).await?;
     let data2 = create_test_data(5678);
-    let tt2 = bao_store.import_bytes(data2, BlobFormat::RAW).await?;
+    let tt2 = bao_store.import_bytes(data2, BlobFormat::Raw).await?;
     let seq = vec![*tt1.hash(), *tt2.hash()]
         .into_iter()
         .collect::<HashSeq>();
     let ttr = bao_store
-        .import_bytes(seq.into_inner(), BlobFormat::HASHSEQ)
+        .import_bytes(seq.into_inner(), BlobFormat::HashSeq)
         .await?;
     let h1 = *tt1.hash();
     let h2 = *tt2.hash();
@@ -207,15 +209,6 @@ async fn gc_hashseq_impl() -> Result<()> {
 
     node.shutdown();
     node.await?;
-    Ok(())
-}
-
-/// Test gc for sequences of hashes that protect their children from deletion.
-#[tokio::test]
-async fn gc_hashseq() -> Result<()> {
-    for _i in 0..10 {
-        gc_hashseq_impl().await?;
-    }
     Ok(())
 }
 
@@ -277,17 +270,17 @@ async fn gc_flat_basics() -> Result<()> {
     let evs = attach_db_events(&node).await;
     let data1 = create_test_data(123456);
     let tt1 = bao_store
-        .import_bytes(data1.clone(), BlobFormat::RAW)
+        .import_bytes(data1.clone(), BlobFormat::Raw)
         .await?;
     let data2 = create_test_data(567890);
     let tt2 = bao_store
-        .import_bytes(data2.clone(), BlobFormat::RAW)
+        .import_bytes(data2.clone(), BlobFormat::Raw)
         .await?;
     let seq = vec![*tt1.hash(), *tt2.hash()]
         .into_iter()
         .collect::<HashSeq>();
     let ttr = bao_store
-        .import_bytes(seq.into_inner(), BlobFormat::HASHSEQ)
+        .import_bytes(seq.into_inner(), BlobFormat::HashSeq)
         .await?;
 
     let h1 = *tt1.hash();

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -142,9 +142,7 @@ async fn gc_basics() -> Result<()> {
     Ok(())
 }
 
-/// Test gc for sequences of hashes that protect their children from deletion.
-#[tokio::test]
-async fn gc_hashseq() -> Result<()> {
+async fn gc_hashseq_impl() -> Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
     let (node, bao_store, evs) = gc_test_node().await;
     let data1 = create_test_data(1234);
@@ -198,6 +196,16 @@ async fn gc_hashseq() -> Result<()> {
 
     node.shutdown();
     node.await?;
+    Ok(())
+}
+
+
+/// Test gc for sequences of hashes that protect their children from deletion.
+#[tokio::test]
+async fn gc_hashseq() -> Result<()> {
+    for _i in 0..10 {
+        gc_hashseq_impl().await?;
+    }
     Ok(())
 }
 

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -103,8 +103,11 @@ async fn step(evs: &flume::Receiver<iroh_bytes::baomap::Event>) {
 }
 
 async fn sync_directory(dir: impl AsRef<Path>) -> io::Result<()> {
-    let dir = std::fs::File::open(dir)?;
-    dir.sync_all().ok();
+    // sync the directory to make sure the metadata is written
+    // does not work on windows
+    if let Ok(dir) = std::fs::File::open(dir) {
+        dir.sync_all().ok();
+    }
     tokio::time::sleep(Duration::from_millis(50)).await;
     Ok(())
 }

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -1,31 +1,15 @@
-#![cfg(feature = "mem-db")]
-use std::{
-    io::{self, Cursor},
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::time::Duration;
 
 use anyhow::Result;
-use bao_tree::{
-    blake3,
-    io::{
-        fsm::{BaoContentItem, Outboard, ResponseDecoderReadingNext},
-        Leaf, Parent,
-    },
-    ChunkRanges,
-};
 use bytes::Bytes;
 use futures::FutureExt;
 use iroh::{baomap, node::Node};
-use iroh_io::AsyncSliceWriter;
 use rand::RngCore;
-use testdir::testdir;
 
 use iroh_bytes::{
-    baomap::{EntryStatus, Map, PartialMap, PartialMapEntry, Store, TempTag},
+    baomap::{EntryStatus, Map, Store},
     hashseq::HashSeq,
     util::{runtime, BlobFormat, HashAndFormat, Tag},
-    IROH_BLOCK_SIZE,
 };
 
 /// Pick up the tokio runtime from the thread local and add a
@@ -100,16 +84,6 @@ async fn step(evs: &flume::Receiver<iroh_bytes::baomap::Event>) {
             break;
         }
     }
-}
-
-async fn sync_directory(dir: impl AsRef<Path>) -> io::Result<()> {
-    // sync the directory to make sure the metadata is written
-    // does not work on windows
-    if let Ok(dir) = std::fs::File::open(dir) {
-        dir.sync_all().ok();
-    }
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    Ok(())
 }
 
 /// Test the absolute basics of gc, temp tags and tags for blobs.
@@ -212,285 +186,336 @@ async fn gc_hashseq_impl() -> Result<()> {
     Ok(())
 }
 
-fn path(root: PathBuf, suffix: &'static str) -> impl Fn(&iroh_bytes::Hash) -> PathBuf {
-    move |hash| root.join(format!("{}.{}", hash.to_hex(), suffix))
-}
+#[cfg(feature = "flat-db")]
+mod flat {
+    use super::*;
+    use std::{
+        io::{self, Cursor},
+        path::{Path, PathBuf},
+        time::Duration,
+    };
 
-fn data_path(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> PathBuf {
-    path(root, "data")
-}
+    use anyhow::Result;
+    use bao_tree::{
+        blake3,
+        io::{
+            fsm::{BaoContentItem, Outboard, ResponseDecoderReadingNext},
+            Leaf, Parent,
+        },
+        ChunkRanges,
+    };
+    use bytes::Bytes;
+    use iroh::baomap;
+    use iroh_io::AsyncSliceWriter;
+    use testdir::testdir;
 
-fn outboard_path(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> PathBuf {
-    path(root, "obao4")
-}
-
-/// count the number of partial files for a hash. partial files are <hash>-<uuid>.<suffix>
-fn count_partial(
-    root: PathBuf,
-    suffix: &'static str,
-) -> impl Fn(&iroh_bytes::Hash) -> std::io::Result<usize> {
-    move |hash| {
-        let valid_names = std::fs::read_dir(&root)?
-            .filter_map(|e| e.ok())
-            .filter_map(|e| {
-                if e.metadata().ok()?.is_file() {
-                    e.file_name().into_string().ok()
-                } else {
-                    None
-                }
-            });
-        let prefix = format!("{}-", hash.to_hex());
-        Ok(valid_names
-            .filter(|x| x.starts_with(&prefix) && x.ends_with(suffix))
-            .count())
-    }
-}
-
-/// count the number of partial data files for a hash
-fn count_partial_data(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> std::io::Result<usize> {
-    count_partial(root, "data")
-}
-
-/// count the number of partial outboard files for a hash
-fn count_partial_outboard(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> std::io::Result<usize> {
-    count_partial(root, "obao4")
-}
-
-/// Test gc for sequences of hashes that protect their children from deletion.
-#[tokio::test]
-async fn gc_flat_basics() -> Result<()> {
-    let _ = tracing_subscriber::fmt::try_init();
-    let rt = test_runtime();
-    let dir = testdir!();
-    let path = data_path(dir.clone());
-    let outboard_path = outboard_path(dir.clone());
-
-    let bao_store = baomap::flat::Store::load(dir.clone(), dir.clone(), dir.clone(), &rt).await?;
-    let node = wrap_in_node(bao_store.clone(), rt, Duration::from_millis(0)).await;
-    let evs = attach_db_events(&node).await;
-    let data1 = create_test_data(123456);
-    let tt1 = bao_store
-        .import_bytes(data1.clone(), BlobFormat::Raw)
-        .await?;
-    let data2 = create_test_data(567890);
-    let tt2 = bao_store
-        .import_bytes(data2.clone(), BlobFormat::Raw)
-        .await?;
-    let seq = vec![*tt1.hash(), *tt2.hash()]
-        .into_iter()
-        .collect::<HashSeq>();
-    let ttr = bao_store
-        .import_bytes(seq.into_inner(), BlobFormat::HashSeq)
-        .await?;
-
-    let h1 = *tt1.hash();
-    let h2 = *tt2.hash();
-    let hr = *ttr.hash();
-
-    step(&evs).await;
-    assert!(path(&h1).exists());
-    assert!(outboard_path(&h1).exists());
-    assert!(path(&h2).exists());
-    assert!(outboard_path(&h2).exists());
-    assert!(path(&hr).exists());
-    // hr is too small to have an outboard file
-
-    drop(tt1);
-    drop(tt2);
-    let tag = Tag::from("test");
-    bao_store
-        .set_tag(tag.clone(), Some(HashAndFormat::hash_seq(*ttr.hash())))
-        .await?;
-    drop(ttr);
-
-    step(&evs).await;
-    assert!(path(&h1).exists());
-    assert!(outboard_path(&h1).exists());
-    assert!(path(&h2).exists());
-    assert!(outboard_path(&h2).exists());
-    assert!(path(&hr).exists());
-    assert!(!outboard_path(&hr).exists());
-
-    tracing::info!("changing tag from hashseq to raw, this should orphan the children");
-    bao_store
-        .set_tag(tag.clone(), Some(HashAndFormat::raw(hr)))
-        .await?;
-    step(&evs).await;
-    sync_directory(&dir).await?;
-    assert!(
-        !path(&h1).exists(),
-        "h1 data should be gone {}",
-        path(&h1).display()
-    );
-    assert!(
-        !outboard_path(&h1).exists(),
-        "h1 outboard should be gone {}",
-        outboard_path(&h1).display()
-    );
-    assert!(!path(&h2).exists());
-    assert!(!outboard_path(&h2).exists());
-    assert!(path(&hr).exists());
-
-    bao_store.set_tag(tag, None).await?;
-    step(&evs).await;
-    sync_directory(&dir).await?;
-    assert!(!path(&hr).exists());
-
-    node.shutdown();
-    node.await?;
-    Ok(())
-}
-
-/// Take some data and encode it
-#[allow(dead_code)]
-fn simulate_remote(data: &[u8]) -> (blake3::Hash, Cursor<Bytes>) {
-    let outboard = bao_tree::io::outboard::PostOrderMemOutboard::create(data, IROH_BLOCK_SIZE);
-    let mut encoded = Vec::new();
-    bao_tree::io::sync::encode_ranges_validated(data, &outboard, &ChunkRanges::all(), &mut encoded)
-        .unwrap();
-    let hash = outboard.root();
-    (hash, Cursor::new(encoded.into()))
-}
-
-/// Add a file to the store in the same way a download works.
-///
-/// we know the hash in advance, create a partial entry, write the data to it and
-/// the outboard file, then commit it to a complete entry.
-///
-/// During this time, the partial entry is protected by a temp tag.
-#[allow(dead_code)]
-async fn simulate_download_protected<S: iroh_bytes::baomap::Store>(
-    bao_store: &S,
-    data: Bytes,
-) -> io::Result<TempTag> {
-    use bao_tree::io::fsm::OutboardMut;
-    // simulate the remote side.
-    let (hash, response) = simulate_remote(data.as_ref());
-    // simulate the local side.
-    // we got a hash and a response from the remote side.
-    let tt = bao_store.temp_tag(HashAndFormat::raw(hash.into()));
-    // start reading the response
-    let at_start = bao_tree::io::fsm::ResponseDecoderStart::new(
-        hash,
-        ChunkRanges::all(),
+    use iroh_bytes::{
+        baomap::{PartialMap, PartialMapEntry, Store, TempTag},
+        hashseq::HashSeq,
+        util::{BlobFormat, HashAndFormat, Tag},
         IROH_BLOCK_SIZE,
-        response,
-    );
-    // get the size
-    let (mut reading, size) = at_start.next().await?;
-    // create the partial entry
-    let entry = bao_store.get_or_create_partial(hash.into(), size)?;
-    // create the
-    let mut ow = None;
-    let mut dw = entry.data_writer().await?;
-    while let ResponseDecoderReadingNext::More((next, res)) = reading.next().await {
-        match res? {
-            BaoContentItem::Parent(Parent { node, pair }) => {
-                // convoluted crap to create the outboard writer lazily, only if needed
-                let ow = if let Some(ow) = ow.as_mut() {
-                    ow
-                } else {
-                    let t = entry.outboard_mut().await?;
-                    ow = Some(t);
-                    ow.as_mut().unwrap()
-                };
-                ow.save(node, &pair).await?;
-            }
-            BaoContentItem::Leaf(Leaf { offset, data }) => {
-                dw.write_bytes_at(offset.0, data).await?;
-            }
-        }
-        reading = next;
+    };
+
+    fn path(root: PathBuf, suffix: &'static str) -> impl Fn(&iroh_bytes::Hash) -> PathBuf {
+        move |hash| root.join(format!("{}.{}", hash.to_hex(), suffix))
     }
-    // commit the entry
-    bao_store.insert_complete(entry).await?;
-    Ok(tt)
-}
 
-/// Test that partial files are deleted.
-#[tokio::test]
-async fn gc_flat_partial() -> Result<()> {
-    let _ = tracing_subscriber::fmt::try_init();
-    let rt = test_runtime();
-    let dir = testdir!();
-    let count_partial_data = count_partial_data(dir.clone());
-    let count_partial_outboard = count_partial_outboard(dir.clone());
+    fn data_path(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> PathBuf {
+        path(root, "data")
+    }
 
-    let bao_store = baomap::flat::Store::load(dir.clone(), dir.clone(), dir.clone(), &rt).await?;
-    let node = wrap_in_node(bao_store.clone(), rt, Duration::from_millis(0)).await;
-    let evs = attach_db_events(&node).await;
+    fn outboard_path(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> PathBuf {
+        path(root, "obao4")
+    }
 
-    let data1: Bytes = create_test_data(123456);
-    let (_o1, h1) = bao_tree::io::outboard(&data1, IROH_BLOCK_SIZE);
-    let h1 = h1.into();
-    let tt1 = bao_store.temp_tag(HashAndFormat::raw(h1));
-    {
-        let entry = bao_store.get_or_create_partial(h1, data1.len() as u64)?;
+    async fn sync_directory(dir: impl AsRef<Path>) -> io::Result<()> {
+        // sync the directory to make sure the metadata is written
+        // does not work on windows
+        if let Ok(dir) = std::fs::File::open(dir) {
+            dir.sync_all().ok();
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        Ok(())
+    }
+
+    /// count the number of partial files for a hash. partial files are <hash>-<uuid>.<suffix>
+    fn count_partial(
+        root: PathBuf,
+        suffix: &'static str,
+    ) -> impl Fn(&iroh_bytes::Hash) -> std::io::Result<usize> {
+        move |hash| {
+            let valid_names = std::fs::read_dir(&root)?
+                .filter_map(|e| e.ok())
+                .filter_map(|e| {
+                    if e.metadata().ok()?.is_file() {
+                        e.file_name().into_string().ok()
+                    } else {
+                        None
+                    }
+                });
+            let prefix = format!("{}-", hash.to_hex());
+            Ok(valid_names
+                .filter(|x| x.starts_with(&prefix) && x.ends_with(suffix))
+                .count())
+        }
+    }
+
+    /// count the number of partial data files for a hash
+    fn count_partial_data(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> std::io::Result<usize> {
+        count_partial(root, "data")
+    }
+
+    /// count the number of partial outboard files for a hash
+    fn count_partial_outboard(
+        root: PathBuf,
+    ) -> impl Fn(&iroh_bytes::Hash) -> std::io::Result<usize> {
+        count_partial(root, "obao4")
+    }
+
+    /// Test gc for sequences of hashes that protect their children from deletion.
+    #[tokio::test]
+    async fn gc_flat_basics() -> Result<()> {
+        let _ = tracing_subscriber::fmt::try_init();
+        let rt = test_runtime();
+        let dir = testdir!();
+        let path = data_path(dir.clone());
+        let outboard_path = outboard_path(dir.clone());
+
+        let bao_store =
+            baomap::flat::Store::load(dir.clone(), dir.clone(), dir.clone(), &rt).await?;
+        let node = wrap_in_node(bao_store.clone(), rt, Duration::from_millis(0)).await;
+        let evs = attach_db_events(&node).await;
+        let data1 = create_test_data(123456);
+        let tt1 = bao_store
+            .import_bytes(data1.clone(), BlobFormat::Raw)
+            .await?;
+        let data2 = create_test_data(567890);
+        let tt2 = bao_store
+            .import_bytes(data2.clone(), BlobFormat::Raw)
+            .await?;
+        let seq = vec![*tt1.hash(), *tt2.hash()]
+            .into_iter()
+            .collect::<HashSeq>();
+        let ttr = bao_store
+            .import_bytes(seq.into_inner(), BlobFormat::HashSeq)
+            .await?;
+
+        let h1 = *tt1.hash();
+        let h2 = *tt2.hash();
+        let hr = *ttr.hash();
+
+        step(&evs).await;
+        assert!(path(&h1).exists());
+        assert!(outboard_path(&h1).exists());
+        assert!(path(&h2).exists());
+        assert!(outboard_path(&h2).exists());
+        assert!(path(&hr).exists());
+        // hr is too small to have an outboard file
+
+        drop(tt1);
+        drop(tt2);
+        let tag = Tag::from("test");
+        bao_store
+            .set_tag(tag.clone(), Some(HashAndFormat::hash_seq(*ttr.hash())))
+            .await?;
+        drop(ttr);
+
+        step(&evs).await;
+        assert!(path(&h1).exists());
+        assert!(outboard_path(&h1).exists());
+        assert!(path(&h2).exists());
+        assert!(outboard_path(&h2).exists());
+        assert!(path(&hr).exists());
+        assert!(!outboard_path(&hr).exists());
+
+        tracing::info!("changing tag from hashseq to raw, this should orphan the children");
+        bao_store
+            .set_tag(tag.clone(), Some(HashAndFormat::raw(hr)))
+            .await?;
+        step(&evs).await;
+        sync_directory(&dir).await?;
+        assert!(
+            !path(&h1).exists(),
+            "h1 data should be gone {}",
+            path(&h1).display()
+        );
+        assert!(
+            !outboard_path(&h1).exists(),
+            "h1 outboard should be gone {}",
+            outboard_path(&h1).display()
+        );
+        assert!(!path(&h2).exists());
+        assert!(!outboard_path(&h2).exists());
+        assert!(path(&hr).exists());
+
+        bao_store.set_tag(tag, None).await?;
+        step(&evs).await;
+        sync_directory(&dir).await?;
+        assert!(!path(&hr).exists());
+
+        node.shutdown();
+        node.await?;
+        Ok(())
+    }
+
+    /// Take some data and encode it
+    #[allow(dead_code)]
+    fn simulate_remote(data: &[u8]) -> (blake3::Hash, Cursor<Bytes>) {
+        let outboard = bao_tree::io::outboard::PostOrderMemOutboard::create(data, IROH_BLOCK_SIZE);
+        let mut encoded = Vec::new();
+        bao_tree::io::sync::encode_ranges_validated(
+            data,
+            &outboard,
+            &ChunkRanges::all(),
+            &mut encoded,
+        )
+        .unwrap();
+        let hash = outboard.root();
+        (hash, Cursor::new(encoded.into()))
+    }
+
+    /// Add a file to the store in the same way a download works.
+    ///
+    /// we know the hash in advance, create a partial entry, write the data to it and
+    /// the outboard file, then commit it to a complete entry.
+    ///
+    /// During this time, the partial entry is protected by a temp tag.
+    #[allow(dead_code)]
+    async fn simulate_download_protected<S: iroh_bytes::baomap::Store>(
+        bao_store: &S,
+        data: Bytes,
+    ) -> io::Result<TempTag> {
+        use bao_tree::io::fsm::OutboardMut;
+        // simulate the remote side.
+        let (hash, response) = simulate_remote(data.as_ref());
+        // simulate the local side.
+        // we got a hash and a response from the remote side.
+        let tt = bao_store.temp_tag(HashAndFormat::raw(hash.into()));
+        // start reading the response
+        let at_start = bao_tree::io::fsm::ResponseDecoderStart::new(
+            hash,
+            ChunkRanges::all(),
+            IROH_BLOCK_SIZE,
+            response,
+        );
+        // get the size
+        let (mut reading, size) = at_start.next().await?;
+        // create the partial entry
+        let entry = bao_store.get_or_create_partial(hash.into(), size)?;
+        // create the
+        let mut ow = None;
         let mut dw = entry.data_writer().await?;
-        dw.write_bytes_at(0, data1.slice(..32 * 1024)).await?;
-        let _ow = entry.outboard_mut().await?;
-    }
-
-    // partial data and outboard files should be there
-    step(&evs).await;
-    assert!(count_partial_data(&h1)? == 1);
-    assert!(count_partial_outboard(&h1)? == 1);
-
-    drop(tt1);
-    // partial data and outboard files should be gone
-    step(&evs).await;
-    assert!(count_partial_data(&h1)? == 0);
-    assert!(count_partial_outboard(&h1)? == 0);
-
-    node.shutdown();
-    node.await?;
-    Ok(())
-}
-
-///
-#[tokio::test]
-#[cfg(not(debug_assertions))]
-async fn gc_flat_stress() -> Result<()> {
-    let _ = tracing_subscriber::fmt::try_init();
-    let rt = test_runtime();
-    let dir = testdir!();
-    let count_partial_data = count_partial_data(dir.clone());
-    let count_partial_outboard = count_partial_outboard(dir.clone());
-
-    let bao_store = baomap::flat::Store::load(dir.clone(), dir.clone(), dir.clone(), &rt).await?;
-    let node = wrap_in_node(bao_store.clone(), rt).await;
-
-    let mut deleted = Vec::new();
-    let mut live = Vec::new();
-    // download
-    for i in 0..10000 {
-        let data: Bytes = create_test_data(16 * 1024 * 3 + 1);
-        let tt = simulate_download_protected(&bao_store, data).await.unwrap();
-        if i % 100 == 0 {
-            let tag = Tag::from(format!("test{}", i));
-            bao_store
-                .set_tag(tag.clone(), Some(HashAndFormat::raw(*tt.hash())))
-                .await?;
-            live.push(*tt.hash());
-        } else {
-            deleted.push(*tt.hash());
+        while let ResponseDecoderReadingNext::More((next, res)) = reading.next().await {
+            match res? {
+                BaoContentItem::Parent(Parent { node, pair }) => {
+                    // convoluted crap to create the outboard writer lazily, only if needed
+                    let ow = if let Some(ow) = ow.as_mut() {
+                        ow
+                    } else {
+                        let t = entry.outboard_mut().await?;
+                        ow = Some(t);
+                        ow.as_mut().unwrap()
+                    };
+                    ow.save(node, &pair).await?;
+                }
+                BaoContentItem::Leaf(Leaf { offset, data }) => {
+                    dw.write_bytes_at(offset.0, data).await?;
+                }
+            }
+            reading = next;
         }
-    }
-    step().await;
-
-    for h in deleted.iter() {
-        assert!(count_partial_data(h)? == 0);
-        assert!(count_partial_outboard(h)? == 0);
-        assert_eq!(bao_store.contains(h), EntryStatus::NotFound);
+        // commit the entry
+        bao_store.insert_complete(entry).await?;
+        Ok(tt)
     }
 
-    for h in live.iter() {
-        assert!(count_partial_data(h)? == 0);
-        assert!(count_partial_outboard(h)? == 0);
-        assert_eq!(bao_store.contains(h), EntryStatus::Complete);
+    /// Test that partial files are deleted.
+    #[tokio::test]
+    async fn gc_flat_partial() -> Result<()> {
+        let _ = tracing_subscriber::fmt::try_init();
+        let rt = test_runtime();
+        let dir = testdir!();
+        let count_partial_data = count_partial_data(dir.clone());
+        let count_partial_outboard = count_partial_outboard(dir.clone());
+
+        let bao_store =
+            baomap::flat::Store::load(dir.clone(), dir.clone(), dir.clone(), &rt).await?;
+        let node = wrap_in_node(bao_store.clone(), rt, Duration::from_millis(0)).await;
+        let evs = attach_db_events(&node).await;
+
+        let data1: Bytes = create_test_data(123456);
+        let (_o1, h1) = bao_tree::io::outboard(&data1, IROH_BLOCK_SIZE);
+        let h1 = h1.into();
+        let tt1 = bao_store.temp_tag(HashAndFormat::raw(h1));
+        {
+            let entry = bao_store.get_or_create_partial(h1, data1.len() as u64)?;
+            let mut dw = entry.data_writer().await?;
+            dw.write_bytes_at(0, data1.slice(..32 * 1024)).await?;
+            let _ow = entry.outboard_mut().await?;
+        }
+
+        // partial data and outboard files should be there
+        step(&evs).await;
+        assert!(count_partial_data(&h1)? == 1);
+        assert!(count_partial_outboard(&h1)? == 1);
+
+        drop(tt1);
+        // partial data and outboard files should be gone
+        step(&evs).await;
+        assert!(count_partial_data(&h1)? == 0);
+        assert!(count_partial_outboard(&h1)? == 0);
+
+        node.shutdown();
+        node.await?;
+        Ok(())
     }
 
-    node.shutdown();
-    node.await?;
-    Ok(())
+    ///
+    #[tokio::test]
+    #[cfg(not(debug_assertions))]
+    async fn gc_flat_stress() -> Result<()> {
+        let _ = tracing_subscriber::fmt::try_init();
+        let rt = test_runtime();
+        let dir = testdir!();
+        let count_partial_data = count_partial_data(dir.clone());
+        let count_partial_outboard = count_partial_outboard(dir.clone());
+
+        let bao_store =
+            baomap::flat::Store::load(dir.clone(), dir.clone(), dir.clone(), &rt).await?;
+        let node = wrap_in_node(bao_store.clone(), rt).await;
+
+        let mut deleted = Vec::new();
+        let mut live = Vec::new();
+        // download
+        for i in 0..10000 {
+            let data: Bytes = create_test_data(16 * 1024 * 3 + 1);
+            let tt = simulate_download_protected(&bao_store, data).await.unwrap();
+            if i % 100 == 0 {
+                let tag = Tag::from(format!("test{}", i));
+                bao_store
+                    .set_tag(tag.clone(), Some(HashAndFormat::raw(*tt.hash())))
+                    .await?;
+                live.push(*tt.hash());
+            } else {
+                deleted.push(*tt.hash());
+            }
+        }
+        step().await;
+
+        for h in deleted.iter() {
+            assert!(count_partial_data(h)? == 0);
+            assert!(count_partial_outboard(h)? == 0);
+            assert_eq!(bao_store.contains(h), EntryStatus::NotFound);
+        }
+
+        for h in live.iter() {
+            assert!(count_partial_data(h)? == 0);
+            assert!(count_partial_outboard(h)? == 0);
+            assert_eq!(bao_store.contains(h), EntryStatus::Complete);
+        }
+
+        node.shutdown();
+        node.await?;
+        Ok(())
+    }
 }

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "mem-db")]
 use std::{
     collections::BTreeMap,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -148,7 +147,6 @@ fn get_options(peer_id: PublicKey, addrs: Vec<SocketAddr>) -> iroh::dial::Option
     }
 }
 
-#[cfg(feature = "mem-db")]
 #[tokio::test(flavor = "multi_thread")]
 async fn multiple_clients() -> Result<()> {
     let content = b"hello world!";
@@ -345,7 +343,6 @@ fn assert_events(events: Vec<Event>, num_blobs: usize) {
     ));
 }
 
-#[cfg(feature = "mem-db")]
 #[tokio::test]
 async fn test_server_close() {
     let rt = test_runtime();

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -557,7 +557,7 @@ async fn test_run_ticket() {
         .unwrap();
     let _drop_guard = node.cancel_token().drop_guard();
 
-    let no_token_ticket = node.ticket(hash, BlobFormat::HASHSEQ).await.unwrap();
+    let no_token_ticket = node.ticket(hash, BlobFormat::HashSeq).await.unwrap();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = no_token_ticket.as_get_options(
             SecretKey::generate(),
@@ -573,7 +573,7 @@ async fn test_run_ticket() {
     .expect("getting without token failed in an unexpected way");
 
     let ticket = node
-        .ticket(hash, BlobFormat::HASHSEQ)
+        .ticket(hash, BlobFormat::HashSeq)
         .await
         .unwrap()
         .with_token(token);

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -21,10 +21,9 @@ use iroh_net::{
 };
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use rand::RngCore;
-use range_collections::RangeSet2;
 use tokio::sync::mpsc;
 
-use bao_tree::{blake3, ChunkNum};
+use bao_tree::{blake3, ChunkNum, ChunkRanges};
 use iroh_bytes::{
     baomap::{PartialMap, Store},
     get::{
@@ -710,14 +709,14 @@ async fn test_collection_stat() {
     let peer_id = node.peer_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         // first 1024 bytes
-        let header = RangeSet2::from(..ChunkNum(1));
+        let header = ChunkRanges::from(..ChunkNum(1));
         // last chunk, whatever it is, to verify the size
-        let end = RangeSet2::from(ChunkNum(u64::MAX)..);
+        let end = ChunkRanges::from(ChunkNum(u64::MAX)..);
         // combine them
         let ranges = &header | &end;
         let request = GetRequest::new(
             hash,
-            RangeSpecSeq::from_ranges_infinite([RangeSet2::all(), ranges]),
+            RangeSpecSeq::from_ranges_infinite([ChunkRanges::all(), ranges]),
         );
         let opts = get_options(peer_id, addrs);
         let (_collection, items, _stats) = run_collection_get_request(opts, request).await?;

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "mem-db")]
-
 use std::{net::SocketAddr, time::Duration};
 
 use anyhow::{anyhow, bail, Result};


### PR DESCRIPTION
## Description

- Some code sharing between the mem and flat bao stores, and turning BlobFormat into an enum
- Create temp tags in the downloader and keep them alive while the download is ongoing

Fixes https://github.com/n0-computer/iroh/issues/1611

## Notes & open questions

Note: this looks worse than it is. I changed BlobFormat to an enum and changed HashAndFormat from a tuple struct to a normal struct. That is the majority of the changes.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
