### PR TITLE
fix(cli,console): default to 'hash' mode for the keys command

### DIFF
--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -130,7 +130,7 @@ pub enum DocCommands {
         /// Optional key prefix (parsed as UTF-8 string)
         prefix: Option<String>,
         /// How to show the contents of the keys.
-        #[clap(short, long, default_value_t=DisplayContentMode::Auto)]
+        #[clap(short, long, default_value_t=DisplayContentMode::Hash)]
         mode: DisplayContentMode,
     },
     /// Watch for changes and events on a document


### PR DESCRIPTION
## Description
The purpose of the `doc keys` command is to list keys. Having a default of `auto` that shows content, which makes the output unreadable from a "fast review of the keys in this doc" use case:
<img width="1291" alt="Screenshot 2023-10-11 at 1 20 19 PM" src="https://github.com/n0-computer/iroh/assets/1154390/baf700a9-4994-4875-b7ba-ad2acabbcc33">

one default change keeps both the option, and makes the output useful again:

<img width="1291" alt="Screenshot 2023-10-11 at 1 22 26 PM" src="https://github.com/n0-computer/iroh/assets/1154390/8e487bae-4b78-438d-a39b-12d8692386ae">

This leaves `doc get` untouched, which should absolutely keep the `auto` default.

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
