### PR TITLE
perf: improve derp connection establishment

### DIFF
--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -557,7 +557,7 @@ impl Client {
             ));
         }
 
-        warn!("tls handshake done: {:?}", start.elapsed());
+        trace!("tls handshake done: {:?}", start.elapsed());
         let start = Instant::now();
 
         debug!("starting upgrade");
@@ -569,7 +569,7 @@ impl Client {
             }
         };
 
-        warn!("derp upgrade done: {:?}", start.elapsed());
+        trace!("derp upgrade done: {:?}", start.elapsed());
         let start = Instant::now();
 
         debug!("connection upgraded");
@@ -586,7 +586,7 @@ impl Client {
                 .await
                 .map_err(|e| ClientError::Build(e.to_string()))?;
 
-        warn!("derp handshake: {:?}", start.elapsed());
+        trace!("derp handshake: {:?}", start.elapsed());
         let start = Instant::now();
         if *self.inner.is_preferred.lock().await && derp_client.note_preferred(true).await.is_err()
         {
@@ -594,7 +594,7 @@ impl Client {
             return Err(ClientError::Send);
         }
 
-        warn!("connect_0 done: {:?}", start.elapsed());
+        trace!("connect_0 done: {:?}", start.elapsed());
         Ok(derp_client)
     }
 
@@ -676,7 +676,7 @@ impl Client {
             match res {
                 Ok((conn, node)) => {
                     // return on the first successfull one
-                    warn!("dialed region in {:?}", start.elapsed());
+                    trace!("dialed region in {:?}", start.elapsed());
                     return Ok((conn, node));
                 }
                 Err(e) => {

--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -935,8 +935,6 @@ impl Client {
     /// requires a connection, it will call `connect`.
     pub async fn close_for_reconnect(&self) {
         let mut client = self.inner.derp_client.lock().await;
-        // cleanup pings
-        self.inner.ping_tracker.lock().await.clear();
         if let Some(client) = client.take() {
             client.close().await
         }

--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -814,7 +814,7 @@ impl Client {
     /// There must be a task polling `recv_detail` to process the `pong` response.
     pub async fn ping(&self) -> Result<Duration, ClientError> {
         let ping = rand::thread_rng().gen::<[u8; 8]>();
-        debug!("ping: {}", hex::encode(&ping));
+        debug!("ping: {}", hex::encode(ping));
         let (client, _) = self.connect().await?;
 
         let start = Instant::now();
@@ -890,7 +890,7 @@ impl Client {
                     }
 
                     if let ReceivedMessage::Pong(ping) = msg {
-                        debug!("got pong: {}", hex::encode(&ping));
+                        trace!("got pong: {}", hex::encode(ping));
                         if let Some(chan) = self.unregister_ping(ping).await {
                             if chan.send(()).is_err() {
                                 warn!("pong recieved for ping {ping:?}, but the receiving channel was closed");

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -138,7 +138,11 @@ pub enum Commands {
     ///
     /// Tests the latencies of the default DERP regions and nodes. To test custom regions or nodes,
     /// adjust the [`Config`].
-    DerpRegions,
+    DerpRegions {
+        /// How often to execute.
+        #[clap(long, default_value_t = 5)]
+        count: usize,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, MaxSize)]
@@ -658,7 +662,7 @@ async fn port_map_probe(config: portmapper::Config) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn derp_regions(config: NodeConfig) -> anyhow::Result<()> {
+async fn derp_regions(count: usize, config: NodeConfig) -> anyhow::Result<()> {
     let key = SecretKey::generate();
     if config.derp_regions.is_empty() {
         println!("No DERP Regions specified in the config file.");
@@ -681,8 +685,8 @@ async fn derp_regions(config: NodeConfig) -> anyhow::Result<()> {
     let mut success = Vec::new();
     let mut fail = Vec::new();
 
-    for i in 0..5 {
-        println!("-- round {i}");
+    for i in 0..count {
+        println!("Round {}/{count}", i + 1);
         let derp_regions = config.derp_regions.clone();
         for region in derp_regions.into_iter() {
             let mut region_details = RegionDetails {
@@ -885,9 +889,9 @@ pub async fn run(command: Commands, config: &NodeConfig) -> anyhow::Result<()> {
 
             port_map_probe(config).await
         }
-        Commands::DerpRegions => {
+        Commands::DerpRegions { count } => {
             let config = NodeConfig::from_env(None)?;
-            derp_regions(config).await
+            derp_regions(count, config).await
         }
     }
 }


### PR DESCRIPTION
- make sure that TLS session resumption is possible, by caching the TLS config in the derper
- parallelise dials to derpers in the same region
- expand the `doctor derp-regions` command