### PR TITLE
refactor(iroh-sync): move replica event channels to iroh_sync, track open/close state of replicas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,7 +2127,7 @@ dependencies = [
  "dirs-next",
  "duct",
  "ed25519-dalek",
- "flume",
+ "flume 0.11.0",
  "futures",
  "genawaiter",
  "hex",
@@ -2184,7 +2196,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "derive_more",
- "flume",
+ "flume 0.11.0",
  "futures",
  "genawaiter",
  "hex",
@@ -2289,7 +2301,7 @@ dependencies = [
  "derive_more",
  "duct",
  "ed25519-dalek",
- "flume",
+ "flume 0.11.0",
  "futures",
  "governor",
  "hex",
@@ -2363,7 +2375,7 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
- "flume",
+ "flume 0.11.0",
  "futures",
  "hex",
  "iroh-blake3",
@@ -3564,7 +3576,7 @@ checksum = "6d60c2fc2390baad4b9d41ae9957ae88c3095496f88e252ef50722df8b5b78d7"
 dependencies = [
  "bincode",
  "educe",
- "flume",
+ "flume 0.10.14",
  "futures",
  "pin-project",
  "quinn",

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -18,7 +18,7 @@ bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"
 data-encoding = "2.3.3"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into", "into"] }
-flume = "0.10.14"
+flume = "0.11"
 futures = "0.3.25"
 genawaiter = { version = "0.99.1", features = ["futures03"] }
 hex = "0.4.3"

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -589,7 +589,7 @@ async fn wait_for_neighbor_up(mut sub: broadcast::Receiver<Event>) -> anyhow::Re
             Ok(Event::NeighborUp(_neighbor)) => break Ok(()),
             Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
             Err(broadcast::error::RecvError::Closed) => {
-                break Err(anyhow!("Failed to join swarm: Gossip actor dropped"))
+                break Err(anyhow!("Failed to join swarm: channel closed"))
             }
         }
     }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -23,7 +23,7 @@ data-encoding = "2.3.3"
 der = { version = "0.7", features = ["alloc", "derive"] }
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into", "deref"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
-flume = "0.10.14"
+flume = "0.11"
 futures = "0.3.25"
 governor = "0.6.0"
 hex = "0.4.3"

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -18,7 +18,7 @@ crossbeam = "0.8.2"
 data-encoding = "2.4.0"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "deref", "display", "from", "try_into", "into", "as_ref"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
-flume = "0.10"
+flume = "0.11"
 iroh-bytes = { version = "0.7.0", path = "../iroh-bytes" }
 iroh-metrics = { version = "0.7.0", path = "../iroh-metrics", optional = true }
 once_cell = "1.18.0"

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -294,7 +294,7 @@ impl BobState {
 #[cfg(test)]
 mod tests {
     use crate::{
-        actor::StateUpdate,
+        actor::OpenOpts,
         store::{self, GetFilter, Store},
         sync::Namespace,
         AuthorId,
@@ -351,10 +351,9 @@ mod tests {
         let (alice, bob) = tokio::io::duplex(64);
 
         let (mut alice_reader, mut alice_writer) = tokio::io::split(alice);
-        let (alice_handle, _events) =
-            SyncHandle::spawn(alice_store.clone(), None, "alice".to_string());
+        let alice_handle = SyncHandle::spawn(alice_store.clone(), None, "alice".to_string());
         alice_handle
-            .update_state(namespace.id(), StateUpdate::with_sync(true))
+            .open(namespace.id(), OpenOpts::default().sync())
             .await?;
         let namespace_id = namespace.id();
         let alice_handle2 = alice_handle.clone();
@@ -370,9 +369,9 @@ mod tests {
         });
 
         let (mut bob_reader, mut bob_writer) = tokio::io::split(bob);
-        let (bob_handle, _events) = SyncHandle::spawn(bob_store.clone(), None, "bob".to_string());
+        let bob_handle = SyncHandle::spawn(bob_store.clone(), None, "bob".to_string());
         bob_handle
-            .update_state(namespace.id(), StateUpdate::with_sync(true))
+            .open(namespace.id(), OpenOpts::default().sync())
             .await?;
         let bob_handle2 = bob_handle.clone();
         let bob_task = tokio::task::spawn(async move {
@@ -481,9 +480,8 @@ mod tests {
 
         let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(99);
 
-        let (alice_handle, _events) =
-            SyncHandle::spawn(alice_store.clone(), None, "alice".to_string());
-        let (bob_handle, _events) = SyncHandle::spawn(bob_store.clone(), None, "bob".to_string());
+        let alice_handle = SyncHandle::spawn(alice_store.clone(), None, "alice".to_string());
+        let bob_handle = SyncHandle::spawn(bob_store.clone(), None, "bob".to_string());
 
         for num_messages in num_messages {
             for num_authors in num_authors {
@@ -569,10 +567,10 @@ mod tests {
         namespace: NamespaceId,
     ) -> Result<()> {
         alice_handle
-            .update_state(namespace, StateUpdate::with_sync(true))
+            .open(namespace, OpenOpts::default().sync())
             .await?;
         bob_handle
-            .update_state(namespace, StateUpdate::with_sync(true))
+            .open(namespace, OpenOpts::default().sync())
             .await?;
         let (alice, bob) = tokio::io::duplex(1024);
 
@@ -655,9 +653,8 @@ mod tests {
             vec![(author.id(), key.clone(), hash_bob)]
         );
 
-        let (alice_handle, _events) =
-            SyncHandle::spawn(alice_store.clone(), None, "alice".to_string());
-        let (bob_handle, _events) = SyncHandle::spawn(bob_store.clone(), None, "bob".to_string());
+        let alice_handle = SyncHandle::spawn(alice_store.clone(), None, "alice".to_string());
+        let bob_handle = SyncHandle::spawn(bob_store.clone(), None, "bob".to_string());
 
         run_sync(
             alice_handle.clone(),

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -112,6 +112,9 @@ impl Subscribers {
     pub fn send(&mut self, event: Event) {
         self.0.retain(|sender| sender.send(event.clone()).is_ok())
     }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
     pub fn send_with(&mut self, f: impl FnOnce() -> Event) {
         if !self.0.is_empty() {
             self.send(f())
@@ -182,7 +185,7 @@ impl<S: ranger::Store<SignedEntry> + PublicKeyStore + 'static> Replica<S> {
 
     /// Get the number of current event subscribers.
     pub fn subscribers_count(&self) -> usize {
-        self.inner.subscribers.lock().0.len()
+        self.inner.subscribers.lock().len()
     }
 
     /// Set the content status callback.

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -121,7 +121,7 @@ impl Subscribers {
         }
     }
     pub fn clear(&mut self) {
-        self.0 = vec![];
+        self.0.clear()
     }
 }
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -18,7 +18,7 @@ bao-tree = { version = "0.9.1", features = ["tokio_fsm"], default-features = fal
 bytes = "1"
 data-encoding = "2.4.0"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into"] }
-flume = "0.10.14"
+flume = "0.11"
 futures = "0.3.25"
 genawaiter = { version = "0.99", default-features = false, features = ["futures03"] }
 hex = { version = "0.4.3" }

--- a/iroh/examples/sync.rs
+++ b/iroh/examples/sync.rs
@@ -271,16 +271,12 @@ async fn run(args: Args) -> anyhow::Result<()> {
         Arc::new(tokio::sync::Mutex::new(None));
 
     let watch = current_watch.clone();
-    let mut doc_events = live_sync
-        .doc_subscribe(iroh::rpc_protocol::DocSubscribeRequest {
-            doc_id: doc.namespace(),
-        })
-        .await;
+    let mut doc_events = live_sync.subscribe(doc.namespace());
     rt.main().spawn(async move {
         while let Some(Ok(event)) = doc_events.next().await {
             let matcher = watch.lock().await;
             if let Some(matcher) = &*matcher {
-                match event.event {
+                match event {
                     LiveEvent::ContentReady { .. } | LiveEvent::SyncFinished { .. } => {}
                     LiveEvent::InsertLocal { entry } | LiveEvent::InsertRemote { entry, .. } => {
                         let key = entry.id().key();

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -7,6 +7,8 @@ use std::io::{self, Cursor};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::result::Result as StdResult;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use anyhow::{anyhow, Result};
@@ -18,7 +20,9 @@ use iroh_bytes::store::ValidateProgress;
 use iroh_bytes::Hash;
 use iroh_bytes::{BlobFormat, Tag};
 use iroh_net::{key::PublicKey, magic_endpoint::ConnectionInfo, PeerAddr};
+use iroh_sync::actor::OpenState;
 use iroh_sync::{store::GetFilter, AuthorId, Entry, NamespaceId};
+use quic_rpc::message::RpcMsg;
 use quic_rpc::{RpcClient, ServiceConnection};
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use tokio_util::io::{ReaderStream, StreamReader};
@@ -29,15 +33,15 @@ use crate::rpc_protocol::{
     BlobAddStreamUpdate, BlobDeleteBlobRequest, BlobDownloadRequest, BlobListCollectionsRequest,
     BlobListCollectionsResponse, BlobListIncompleteRequest, BlobListIncompleteResponse,
     BlobListRequest, BlobListResponse, BlobReadRequest, BlobReadResponse, BlobValidateRequest,
-    CounterStats, DeleteTagRequest, DocCreateRequest, DocDelRequest, DocDelResponse,
-    DocDropRequest, DocGetManyRequest, DocGetOneRequest, DocImportRequest, DocInfoRequest,
-    DocLeaveRequest, DocListRequest, DocSetHashRequest, DocSetRequest, DocShareRequest,
-    DocStartSyncRequest, DocSubscribeRequest, DocTicket, GetProgress, ListTagsRequest,
-    ListTagsResponse, NodeConnectionInfoRequest, NodeConnectionInfoResponse,
-    NodeConnectionsRequest, NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest,
-    NodeStatusResponse, ProviderService, SetTagOption, ShareMode, WrapOption,
+    CounterStats, DeleteTagRequest, DocCloseRequest, DocCreateRequest, DocDelRequest,
+    DocDelResponse, DocDropRequest, DocGetManyRequest, DocGetOneRequest, DocImportRequest,
+    DocLeaveRequest, DocListRequest, DocOpenRequest, DocSetHashRequest, DocSetRequest,
+    DocShareRequest, DocStartSyncRequest, DocStatusRequest, DocSubscribeRequest, DocTicket,
+    GetProgress, ListTagsRequest, ListTagsResponse, NodeConnectionInfoRequest,
+    NodeConnectionInfoResponse, NodeConnectionsRequest, NodeShutdownRequest, NodeStatsRequest,
+    NodeStatusRequest, NodeStatusResponse, ProviderService, SetTagOption, ShareMode, WrapOption,
 };
-use crate::sync_engine::{LiveEvent, LiveStatus};
+use crate::sync_engine::LiveEvent;
 
 pub mod mem;
 #[cfg(feature = "cli")]
@@ -134,10 +138,7 @@ where
     /// Create a new document.
     pub async fn create(&self) -> Result<Doc<C>> {
         let res = self.rpc.rpc(DocCreateRequest {}).await??;
-        let doc = Doc {
-            id: res.id,
-            rpc: self.rpc.clone(),
-        };
+        let doc = Doc::new(self.rpc.clone(), res.id);
         Ok(doc)
     }
 
@@ -154,10 +155,7 @@ where
     /// Import a document from a ticket and join all peers in the ticket.
     pub async fn import(&self, ticket: DocTicket) -> Result<Doc<C>> {
         let res = self.rpc.rpc(DocImportRequest(ticket)).await??;
-        let doc = Doc {
-            id: res.doc_id,
-            rpc: self.rpc.clone(),
-        };
+        let doc = Doc::new(self.rpc.clone(), res.doc_id);
         Ok(doc)
     }
 
@@ -169,13 +167,8 @@ where
 
     /// Get a [`Doc`] client for a single document. Return None if the document cannot be found.
     pub async fn open(&self, id: NamespaceId) -> Result<Option<Doc<C>>> {
-        if let Err(_err) = self.rpc.rpc(DocInfoRequest { doc_id: id }).await? {
-            return Ok(None);
-        }
-        let doc = Doc {
-            id,
-            rpc: self.rpc.clone(),
-        };
+        self.rpc.rpc(DocOpenRequest { doc_id: id }).await??;
+        let doc = Doc::new(self.rpc.clone(), id);
         Ok(Some(doc))
     }
 }
@@ -523,18 +516,66 @@ impl AsyncRead for BlobReader {
 
 /// Document handle
 #[derive(Debug, Clone)]
-pub struct Doc<C> {
+pub struct Doc<C: ServiceConnection<ProviderService>>(Arc<DocInner<C>>);
+
+#[derive(Debug)]
+struct DocInner<C: ServiceConnection<ProviderService>> {
     id: NamespaceId,
     rpc: RpcClient<ProviderService, C>,
+    closed: AtomicBool,
+}
+
+impl<C> Drop for DocInner<C>
+where
+    C: ServiceConnection<ProviderService>,
+{
+    fn drop(&mut self) {
+        let doc_id = self.id;
+        let rpc = self.rpc.clone();
+        tokio::task::spawn(async move {
+            rpc.rpc(DocCloseRequest { doc_id }).await.ok();
+        });
+    }
 }
 
 impl<C> Doc<C>
 where
     C: ServiceConnection<ProviderService>,
 {
+    fn new(rpc: RpcClient<ProviderService, C>, id: NamespaceId) -> Self {
+        Self(Arc::new(DocInner {
+            rpc,
+            id,
+            closed: AtomicBool::new(false),
+        }))
+    }
+
+    async fn rpc<M>(&self, msg: M) -> Result<M::Response>
+    where
+        M: RpcMsg<ProviderService>,
+    {
+        let res = self.0.rpc.rpc(msg).await?;
+        Ok(res)
+    }
+
     /// Get the document id of this doc.
     pub fn id(&self) -> NamespaceId {
-        self.id
+        self.0.id
+    }
+
+    /// Close the document.
+    pub async fn close(&self) -> Result<()> {
+        self.0.closed.store(true, Ordering::Release);
+        self.rpc(DocCloseRequest { doc_id: self.id() }).await??;
+        Ok(())
+    }
+
+    fn ensure_open(&self) -> Result<()> {
+        if self.0.closed.load(Ordering::Acquire) {
+            Err(anyhow!("document is closed"))
+        } else {
+            Ok(())
+        }
     }
 
     /// Set the content of a key to a byte array.
@@ -544,10 +585,10 @@ where
         key: impl Into<Bytes>,
         value: impl Into<Bytes>,
     ) -> Result<Hash> {
+        self.ensure_open()?;
         let res = self
-            .rpc
             .rpc(DocSetRequest {
-                doc_id: self.id,
+                doc_id: self.id(),
                 author_id,
                 key: key.into(),
                 value: value.into(),
@@ -564,26 +605,28 @@ where
         hash: Hash,
         size: u64,
     ) -> Result<()> {
-        self.rpc
-            .rpc(DocSetHashRequest {
-                doc_id: self.id,
-                author_id,
-                key: key.into(),
-                hash,
-                size,
-            })
-            .await??;
+        self.ensure_open()?;
+        self.rpc(DocSetHashRequest {
+            doc_id: self.id(),
+            author_id,
+            key: key.into(),
+            hash,
+            size,
+        })
+        .await??;
         Ok(())
     }
 
     /// Read the content of an [`Entry`] as a streaming [`BlobReader`].
     pub async fn read(&self, entry: &Entry) -> Result<BlobReader> {
-        BlobReader::from_rpc(&self.rpc, entry.content_hash()).await
+        self.ensure_open()?;
+        BlobReader::from_rpc(&self.0.rpc, entry.content_hash()).await
     }
 
     /// Read all content of an [`Entry`] into a buffer.
     pub async fn read_to_bytes(&self, entry: &Entry) -> Result<Bytes> {
-        BlobReader::from_rpc(&self.rpc, entry.content_hash())
+        self.ensure_open()?;
+        BlobReader::from_rpc(&self.0.rpc, entry.content_hash())
             .await?
             .read_to_bytes()
             .await
@@ -596,10 +639,10 @@ where
     ///
     /// Returns the number of entries deleted.
     pub async fn del(&self, author_id: AuthorId, prefix: impl Into<Bytes>) -> Result<usize> {
+        self.ensure_open()?;
         let res = self
-            .rpc
             .rpc(DocDelRequest {
-                doc_id: self.id,
+                doc_id: self.id(),
                 author_id,
                 prefix: prefix.into(),
             })
@@ -610,12 +653,12 @@ where
 
     /// Get the latest entry for a key and author.
     pub async fn get_one(&self, author: AuthorId, key: impl Into<Bytes>) -> Result<Option<Entry>> {
+        self.ensure_open()?;
         let res = self
-            .rpc
             .rpc(DocGetOneRequest {
                 author,
                 key: key.into(),
-                doc_id: self.id,
+                doc_id: self.id(),
             })
             .await??;
         Ok(res.entry.map(|entry| entry.into()))
@@ -623,10 +666,12 @@ where
 
     /// Get entries.
     pub async fn get_many(&self, filter: GetFilter) -> Result<impl Stream<Item = Result<Entry>>> {
+        self.ensure_open()?;
         let stream = self
+            .0
             .rpc
             .server_streaming(DocGetManyRequest {
-                doc_id: self.id,
+                doc_id: self.id(),
                 filter,
             })
             .await?;
@@ -635,10 +680,10 @@ where
 
     /// Share this document with peers over a ticket.
     pub async fn share(&self, mode: ShareMode) -> anyhow::Result<DocTicket> {
+        self.ensure_open()?;
         let res = self
-            .rpc
             .rpc(DocShareRequest {
-                doc_id: self.id,
+                doc_id: self.id(),
                 mode,
             })
             .await??;
@@ -647,10 +692,10 @@ where
 
     /// Start to sync this document with a list of peers.
     pub async fn start_sync(&self, peers: Vec<PeerAddr>) -> Result<()> {
+        self.ensure_open()?;
         let _res = self
-            .rpc
             .rpc(DocStartSyncRequest {
-                doc_id: self.id,
+                doc_id: self.id(),
                 peers,
             })
             .await??;
@@ -659,22 +704,26 @@ where
 
     /// Stop the live sync for this document.
     pub async fn leave(&self) -> Result<()> {
-        let _res = self.rpc.rpc(DocLeaveRequest { doc_id: self.id }).await??;
+        self.ensure_open()?;
+        let _res = self.rpc(DocLeaveRequest { doc_id: self.id() }).await??;
         Ok(())
     }
 
     /// Subscribe to events for this document.
     pub async fn subscribe(&self) -> anyhow::Result<impl Stream<Item = anyhow::Result<LiveEvent>>> {
+        self.ensure_open()?;
         let stream = self
+            .0
             .rpc
-            .server_streaming(DocSubscribeRequest { doc_id: self.id })
+            .server_streaming(DocSubscribeRequest { doc_id: self.id() })
             .await?;
         Ok(flatten(stream).map_ok(|res| res.event).map_err(Into::into))
     }
 
     /// Get status info for this document
-    pub async fn status(&self) -> anyhow::Result<LiveStatus> {
-        let res = self.rpc.rpc(DocInfoRequest { doc_id: self.id }).await??;
+    pub async fn status(&self) -> anyhow::Result<OpenState> {
+        self.ensure_open()?;
+        let res = self.rpc(DocStatusRequest { doc_id: self.id() }).await??;
         Ok(res.status)
     }
 }

--- a/iroh/src/commands/sync.rs
+++ b/iroh/src/commands/sync.rs
@@ -521,7 +521,6 @@ impl DocCommands {
                         LiveEvent::NeighborDown(peer) => {
                             println!("neighbor peer down: {peer:?}");
                         }
-                        LiveEvent::Closed => println!("document closed"),
                     }
                 }
             }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1487,9 +1487,21 @@ fn handle_rpc_request<D: BaoStore, S: DocStore, E: ServiceEndpoint<ProviderServi
             AuthorImport(_msg) => {
                 todo!()
             }
-            DocInfo(msg) => {
+            DocOpen(msg) => {
                 chan.rpc(msg, handler, |handler, req| async move {
-                    handler.inner.sync.doc_info(req).await
+                    handler.inner.sync.doc_open(req).await
+                })
+                .await
+            }
+            DocClose(msg) => {
+                chan.rpc(msg, handler, |handler, req| async move {
+                    handler.inner.sync.doc_close(req).await
+                })
+                .await
+            }
+            DocStatus(msg) => {
+                chan.rpc(msg, handler, |handler, req| async move {
+                    handler.inner.sync.doc_status(req).await
                 })
                 .await
             }

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -20,6 +20,7 @@ use iroh_net::{
 };
 
 use iroh_sync::{
+    actor::OpenState,
     store::GetFilter,
     sync::{NamespaceId, SignedEntry},
     AuthorId,
@@ -32,7 +33,7 @@ use serde::{Deserialize, Serialize};
 
 pub use iroh_bytes::{provider::AddProgress, store::ValidateProgress, util::RpcResult};
 
-use crate::sync_engine::{LiveEvent, LiveStatus};
+use crate::sync_engine::LiveEvent;
 
 /// A 32-byte key or token
 pub type KeyBytes = [u8; 32];
@@ -568,22 +569,52 @@ pub struct DocShareResponse(pub DocTicket);
 
 /// Get info on a document
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocInfoRequest {
+pub struct DocStatusRequest {
     /// The document id
     pub doc_id: NamespaceId,
 }
 
-impl RpcMsg<ProviderService> for DocInfoRequest {
-    type Response = RpcResult<DocInfoResponse>;
+impl RpcMsg<ProviderService> for DocStatusRequest {
+    type Response = RpcResult<DocStatusResponse>;
 }
 
-/// Response to [`DocInfoRequest`]
+/// Response to [`DocStatusRequest`]
 // TODO: actually provide info
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocInfoResponse {
+pub struct DocStatusResponse {
     /// Live sync status
-    pub status: LiveStatus,
+    pub status: OpenState,
 }
+
+/// Open a document
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocOpenRequest {
+    /// The document id
+    pub doc_id: NamespaceId,
+}
+
+impl RpcMsg<ProviderService> for DocOpenRequest {
+    type Response = RpcResult<DocOpenResponse>;
+}
+
+/// Response to [`DocOpenRequest`]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocOpenResponse {}
+
+/// Open a document
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocCloseRequest {
+    /// The document id
+    pub doc_id: NamespaceId,
+}
+
+impl RpcMsg<ProviderService> for DocCloseRequest {
+    type Response = RpcResult<DocCloseResponse>;
+}
+
+/// Response to [`DocCloseRequest`]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocCloseResponse {}
 
 /// Start to sync a doc with peers.
 #[derive(Serialize, Deserialize, Debug)]
@@ -863,7 +894,9 @@ pub enum ProviderRequest {
     DeleteTag(DeleteTagRequest),
     ListTags(ListTagsRequest),
 
-    DocInfo(DocInfoRequest),
+    DocOpen(DocOpenRequest),
+    DocClose(DocCloseRequest),
+    DocStatus(DocStatusRequest),
     DocList(DocListRequest),
     DocCreate(DocCreateRequest),
     DocDrop(DocDropRequest),
@@ -906,7 +939,9 @@ pub enum ProviderResponse {
     ListTags(ListTagsResponse),
     DeleteTag(RpcResult<()>),
 
-    DocInfo(RpcResult<DocInfoResponse>),
+    DocOpen(RpcResult<DocOpenResponse>),
+    DocClose(RpcResult<DocCloseResponse>),
+    DocStatus(RpcResult<DocStatusResponse>),
     DocList(RpcResult<DocListResponse>),
     DocCreate(RpcResult<DocCreateResponse>),
     DocDrop(RpcResult<DocDropResponse>),

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -365,7 +365,7 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
 
     async fn shutdown(&mut self) -> anyhow::Result<()> {
         // cancel all subscriptions
-        self.subscribers = Default::default();
+        self.subscribers.clear();
         // shutdown gossip actor
         self.gossip_actor_tx
             .send(ToGossipActor::Shutdown)
@@ -767,6 +767,10 @@ impl SubscribersMap {
 
     fn remove(&mut self, namespace: &NamespaceId) {
         self.0.remove(namespace);
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
     }
 }
 


### PR DESCRIPTION
## Description

This PR contains changes on top of #1612. Made a separate PR to ease reviewing. I'd merge this into #1612 after a review here, and then hopefully merge #1612 into main right after.

Has the following changes:

* Change the subscription model on `Replica`s to be a `Vec<flume::Sender<Event>>`. This now allows to directly subscribe to replica events from multiple places. This allows us to have subscription to replica events from the client not go through any actor. The replica events are merged together with the events from the `sync_engine::live` actor, and that's it. Should improve latency and ease work on the actors. Because we merge the channels for replica events and live actor events for client subscriptions, this means, that closing a replica from the client does not end the subscription stream, because the subscription on the live actor will remain active. To end the subscription, the client would need to drop the receiver. I think this is fine for now. What we might want to do instead is to split the subscription from the client to two methods and channels, `subscribe_insert_events` and `subscribe_sync_events` or so, then we could close them separately. However the one for sync events would still stay open indefinitely, because you wouldn't want to drop and recreate, I think, in case you do `join` / `leave` / `join`. Or do we?

* Track the open state of Replicas in the `iroh_sync::actor`. I opted for a simple implementation to start: The actor counts calls to `open` and decrements on calls to `close` and closes the replica once the count reaches zero. This works fine, however for replicas opened from the RPC client, because there's no async drop, I spawn a tokio task in drop to send the close call to the node. This means that if a client is force-killed, the replica would remain open indefinitely. It would be better to solve this cleaner - the only idea I had so far was to give out something like `ReplicaDescriptor`s on `open` and then send require regular keep-alive calls from the RPC client. I think it's fine to defer this change to a followup (which will be straightforward with the architecture in place now) because the impl in this PR is already quite an improvement over the state in `main` or #1612, where we don't ever close replicas.
* event subscriptions for replica insert events are now handled directly in the `iroh_sync::actor`, which is much nicer IMO. For the RPC subscription this event stream is merged with a subscription for sync events from the `iroh::sync_engine::live` actor. 

## Notes & open questions

included in description..

One more thought: Now that the `Replica`s are usually only used in the `iroh_sync::actor::Actor`, which is a single loop with `&mut` access, we could think about removing the `Clone` impl and allo locks from the `Replica`. If you wanted to use `Replica`s outside of the actor, you'd have to lock them yourself. Didn't think it through fully, but possibly worthwhile to investigate.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
