### PR TITLE
iroh-net: Use BTreeSet for AddrInfo

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -1,6 +1,6 @@
 //! An endpoint that leverages a [quinn::Endpoint] backed by a [magicsock::MagicSock].
 
-use std::{collections::HashSet, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::BTreeSet, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, ensure, Context, Result};
 use quinn_proto::VarInt;
@@ -81,7 +81,7 @@ pub struct AddrInfo {
     /// The peer's home DERP region.
     pub derp_region: Option<u16>,
     /// Socket addresses where the peer might be reached directly.
-    pub direct_addresses: HashSet<SocketAddr>,
+    pub direct_addresses: BTreeSet<SocketAddr>,
 }
 
 impl AddrInfo {


### PR DESCRIPTION
## Description

rationale: this way the serialized representation of AddrInfo and all the things that contain AddrInfo is unique instead of constantly toggling when there are 2 or more addrs.)

## Notes & open questions

Is there any place that will only work if the addrs are randomized? I don't think so, and I also don't think we should have it. But you never know...

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
