### PR TITLE
refactor(net): improve derp client handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
-  MSRV: "1.71"
+  MSRV: "1.72"
 
 jobs:
   build_and_test_nix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,18 +1156,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1335e0609db169713d97c340dd769773c6c63cd953c8fcf1063043fd3d6dd11"
+checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df541e0e2a8069352be228ce4b85a1da6f59bfd325e56f57e4b241babbc3f832"
+checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4092,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.19"
+version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
+checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -4845,9 +4845,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "tempfile"
@@ -4890,18 +4890,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,6 +2353,7 @@ dependencies = [
  "stun-rs",
  "surge-ping",
  "tempfile",
+ "testdir",
  "thiserror",
  "time",
  "tokio",

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["dignifiedquire <me@dignifiedquire.com>", "n0 team"]
 repository = "https://github.com/n0-computer/iroh"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["n0 team"]
 repository = "https://github.com/n0-computer/iroh-sync"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 # proto dependencies (required)

--- a/iroh-metrics/Cargo.toml
+++ b/iroh-metrics/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["arqu <asmir@n0.computer>", "n0 team"]
 repository = "https://github.com/n0-computer/iroh"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 prometheus-client = { version = "0.21.0", optional = true }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -100,6 +100,7 @@ ntest = "0.9"
 pretty_assertions = "1.4"
 proptest = "1.2.0"
 rand_chacha = "0.3.1"
+testdir = "0.8"
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 iroh-test = { path = "../iroh-test" }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["dignifiedquire <me@dignifiedquire.com>", "n0 team"]
 repository = "https://github.com/n0-computer/iroh"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 aead = { version = "0.5.2", features = ["bytes"] }

--- a/iroh-net/src/bin/derper.rs
+++ b/iroh-net/src/bin/derper.rs
@@ -964,7 +964,7 @@ mod tests {
         // set up clients
         let a_secret_key = SecretKey::generate();
         let a_key = a_secret_key.public();
-        let client_a = ClientBuilder::new()
+        let (client_a, mut client_a_receiver) = ClientBuilder::new()
             .server_url(derper_url.clone())
             .build(a_secret_key)?;
         let connect_client = client_a.clone();
@@ -988,7 +988,7 @@ mod tests {
 
         let b_secret_key = SecretKey::generate();
         let b_key = b_secret_key.public();
-        let client_b = ClientBuilder::new()
+        let (client_b, mut client_b_receiver) = ClientBuilder::new()
             .server_url(derper_url)
             .build(b_secret_key)?;
         client_b.connect().await?;
@@ -996,7 +996,7 @@ mod tests {
         let msg = Bytes::from("hello, b");
         client_a.send(b_key, msg.clone()).await?;
 
-        let (res, _) = client_b.recv_detail().await?;
+        let (res, _) = client_b_receiver.recv().await.unwrap()?;
         if let ReceivedMessage::ReceivedPacket { source, data } = res {
             assert_eq!(a_key, source);
             assert_eq!(msg, data);
@@ -1007,7 +1007,7 @@ mod tests {
         let msg = Bytes::from("howdy, a");
         client_b.send(a_key, msg.clone()).await?;
 
-        let (res, _) = client_a.recv_detail().await?;
+        let (res, _) = client_a_receiver.recv().await.unwrap()?;
         if let ReceivedMessage::ReceivedPacket { source, data } = res {
             assert_eq!(b_key, source);
             assert_eq!(msg, data);

--- a/iroh-net/src/derp/client.rs
+++ b/iroh-net/src/derp/client.rs
@@ -3,17 +3,16 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use bytes::Bytes;
 use futures::stream::Stream;
 use futures::{Sink, SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
-use tokio::sync::Mutex;
-use tokio::task::JoinHandle;
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{debug, info_span, Instrument};
 
+use super::codec::PER_CLIENT_READ_QUEUE_DEPTH;
 use super::{
     codec::{
         recv_frame, write_frame, DerpCodec, Frame, FrameType, MAX_PACKET_SIZE,
@@ -23,6 +22,7 @@ use super::{
 };
 
 use crate::key::{PublicKey, SecretKey};
+use crate::util::AbortingJoinHandle;
 
 const CLIENT_RECV_TIMEOUT: Duration = Duration::from_secs(120);
 
@@ -42,21 +42,38 @@ pub struct Client {
     inner: Arc<InnerClient>,
 }
 
+#[derive(Debug)]
+pub struct ClientReceiver {
+    /// The reader channel, receiving incoming messages.
+    reader_channel: mpsc::Receiver<Result<ReceivedMessage>>,
+}
+
+impl ClientReceiver {
+    /// Reads a messages from a DERP server.
+    ///
+    /// Once it returns an error, the [`Client`] is dead forever.
+    pub async fn recv(&mut self) -> Result<ReceivedMessage> {
+        let msg = self
+            .reader_channel
+            .recv()
+            .await
+            .ok_or(anyhow!("shut down"))??;
+        Ok(msg)
+    }
+}
+
 type DerpReader = FramedRead<Box<dyn AsyncRead + Unpin + Send + Sync + 'static>, DerpCodec>;
 
 #[derive(derive_more::Debug)]
 pub struct InnerClient {
     // our local addrs
     local_addr: SocketAddr,
-
     /// Channel on which to communicate to the server. The associated [`mpsc::Receiver`] will close
     /// if there is ever an error writing to the server.
     writer_channel: mpsc::Sender<ClientWriterMessage>,
     /// JoinHandle for the [`ClientWriter`] task
-    writer_task: Mutex<Option<JoinHandle<Result<()>>>>,
-    /// The reader connected to the server
-    #[debug("Mutex<DerpReader>")]
-    reader: Mutex<DerpReader>,
+    writer_task: AbortingJoinHandle<Result<()>>,
+    reader_task: AbortingJoinHandle<()>,
     /// [`PublicKey`] of the server we are connected to
     server_public_key: PublicKey,
 }
@@ -151,82 +168,8 @@ impl Client {
     /// Whether or not this [`Client`] is closed.
     ///
     /// The [`Client`] is considered closed if the write side of the client is no longer running.
-    pub async fn is_closed(&self) -> bool {
-        self.inner.writer_task.lock().await.is_none()
-    }
-
-    /// Reads a messages from a DERP server.
-    ///
-    /// The returned message may alias memory owned by the [`Client`]; it
-    /// should only be accessed until the next call to [`Client`].
-    ///
-    /// Once it returns an error, the [`Client`] is dead forever.
-    pub async fn recv(&self) -> Result<ReceivedMessage> {
-        if self.is_closed().await {
-            bail!("client is closed");
-        }
-        match tokio::time::timeout(CLIENT_RECV_TIMEOUT, self.recv_0()).await {
-            Err(e) => {
-                self.close().await;
-                Err(e.into())
-            }
-            Ok(Err(e)) => {
-                self.close().await;
-                Err(e)
-            }
-            Ok(Ok(msg)) => Ok(msg),
-        }
-    }
-
-    async fn recv_0(&self) -> Result<ReceivedMessage> {
-        let mut reader = self.inner.reader.lock().await;
-        let frame = match reader.next().await {
-            Some(Ok(frame)) => frame,
-            Some(Err(err)) => {
-                self.close().await;
-                bail!(err);
-            }
-            None => {
-                self.close().await;
-                bail!("EOF: reader stream ended");
-            }
-        };
-
-        match frame {
-            Frame::KeepAlive => {
-                // A one-way keep-alive message that doesn't require an ack.
-                // This predated FrameType::Ping/FrameType::Pong.
-                Ok(ReceivedMessage::KeepAlive)
-            }
-            Frame::PeerGone { peer } => Ok(ReceivedMessage::PeerGone(peer)),
-            Frame::PeerPresent { peer } => Ok(ReceivedMessage::PeerPresent(peer)),
-            Frame::RecvPacket { src_key, content } => {
-                let packet = ReceivedMessage::ReceivedPacket {
-                    source: src_key,
-                    data: content,
-                };
-                Ok(packet)
-            }
-            Frame::Ping { data } => Ok(ReceivedMessage::Ping(data)),
-            Frame::Pong { data } => Ok(ReceivedMessage::Pong(data)),
-            Frame::Health { problem } => {
-                let problem = std::str::from_utf8(&problem)?.to_owned();
-                let problem = Some(problem);
-                Ok(ReceivedMessage::Health { problem })
-            }
-            Frame::Restarting {
-                reconnect_in,
-                try_for,
-            } => {
-                let reconnect_in = Duration::from_millis(reconnect_in as u64);
-                let try_for = Duration::from_millis(try_for as u64);
-                Ok(ReceivedMessage::ServerRestarting {
-                    reconnect_in,
-                    try_for,
-                })
-            }
-            _ => bail!("unexpected packet: {:?}", frame.typ()),
-        }
+    pub fn is_closed(&self) -> bool {
+        self.inner.writer_task.is_finished()
     }
 
     /// Close the client
@@ -234,33 +177,59 @@ impl Client {
     /// Shuts down the write loop directly and marks the client as closed. The [`Client`] will
     /// check if the client is closed before attempting to read from it.
     pub async fn close(&self) {
-        let mut writer_task = self.inner.writer_task.lock().await;
-        let task = writer_task.take();
-        match task {
-            None => {}
-            Some(task) => {
-                // only error would be that the writer_channel receiver is closed
-                let _ = self
-                    .inner
-                    .writer_channel
-                    .send(ClientWriterMessage::Shutdown)
-                    .await;
-                match task.await {
-                    Ok(Err(e)) => {
-                        tracing::warn!("error closing down the client: {e:?}");
-                    }
-                    Err(e) => {
-                        tracing::warn!("error closing down the client: {e:?}");
-                    }
-                    _ => {}
-                }
-            }
+        if self.inner.writer_task.is_finished() && self.inner.reader_task.is_finished() {
+            return;
         }
+
+        self.inner
+            .writer_channel
+            .send(ClientWriterMessage::Shutdown)
+            .await
+            .ok();
+        self.inner.reader_task.abort();
     }
 
     /// The [`PublicKey`] of the [`super::server::Server`] this [`Client`] is connected with.
     pub fn server_public_key(self) -> PublicKey {
         self.inner.server_public_key
+    }
+}
+
+fn process_incoming_frame(frame: Frame) -> Result<ReceivedMessage> {
+    match frame {
+        Frame::KeepAlive => {
+            // A one-way keep-alive message that doesn't require an ack.
+            // This predated FrameType::Ping/FrameType::Pong.
+            Ok(ReceivedMessage::KeepAlive)
+        }
+        Frame::PeerGone { peer } => Ok(ReceivedMessage::PeerGone(peer)),
+        Frame::PeerPresent { peer } => Ok(ReceivedMessage::PeerPresent(peer)),
+        Frame::RecvPacket { src_key, content } => {
+            let packet = ReceivedMessage::ReceivedPacket {
+                source: src_key,
+                data: content,
+            };
+            Ok(packet)
+        }
+        Frame::Ping { data } => Ok(ReceivedMessage::Ping(data)),
+        Frame::Pong { data } => Ok(ReceivedMessage::Pong(data)),
+        Frame::Health { problem } => {
+            let problem = std::str::from_utf8(&problem)?.to_owned();
+            let problem = Some(problem);
+            Ok(ReceivedMessage::Health { problem })
+        }
+        Frame::Restarting {
+            reconnect_in,
+            try_for,
+        } => {
+            let reconnect_in = Duration::from_millis(reconnect_in as u64);
+            let try_for = Duration::from_millis(try_for as u64);
+            Ok(ReceivedMessage::ServerRestarting {
+                reconnect_in,
+                try_for,
+            })
+        }
+        _ => bail!("unexpected packet: {:?}", frame.typ()),
     }
 }
 
@@ -451,13 +420,13 @@ impl ClientBuilder {
         Ok((server_key, rate_limiter))
     }
 
-    pub async fn build(mut self) -> Result<Client> {
+    pub async fn build(mut self) -> Result<(Client, ClientReceiver)> {
         // exchange information with the server
         let (server_public_key, rate_limiter) = self.server_handshake().await?;
 
         // create task to handle writing to the server
         let (writer_sender, writer_recv) = mpsc::channel(PER_CLIENT_SEND_QUEUE_DEPTH);
-        let writer_task = tokio::spawn(
+        let writer_task = tokio::task::spawn(
             async move {
                 let client_writer = ClientWriter {
                     rate_limiter,
@@ -470,17 +439,60 @@ impl ClientBuilder {
             .instrument(info_span!("client.writer")),
         );
 
+        let (reader_sender, reader_recv) = mpsc::channel(PER_CLIENT_READ_QUEUE_DEPTH);
+        let writer_sender2 = writer_sender.clone();
+        let reader_task = tokio::task::spawn(async move {
+            loop {
+                let frame = tokio::time::timeout(CLIENT_RECV_TIMEOUT, self.reader.next()).await;
+                let res = match frame {
+                    Ok(Some(Ok(frame))) => process_incoming_frame(frame),
+                    Ok(Some(Err(err))) => {
+                        // Error processing incoming messages
+                        Err(err)
+                    }
+                    Ok(None) => {
+                        // EOF
+                        Err(anyhow::anyhow!("EOF: reader stream ended"))
+                    }
+                    Err(err) => {
+                        // Timeout
+                        Err(err.into())
+                    }
+                };
+                if res.is_err() {
+                    // shutdown
+                    writer_sender2
+                        .send(ClientWriterMessage::Shutdown)
+                        .await
+                        .ok();
+                    break;
+                }
+                if reader_sender.send(res).await.is_err() {
+                    // shutdown, as the reader is gone
+                    writer_sender2
+                        .send(ClientWriterMessage::Shutdown)
+                        .await
+                        .ok();
+                    break;
+                }
+            }
+        });
+
         let client = Client {
             inner: Arc::new(InnerClient {
                 local_addr: self.local_addr,
                 writer_channel: writer_sender,
-                writer_task: Mutex::new(Some(writer_task)),
-                reader: Mutex::new(self.reader),
+                writer_task: writer_task.into(),
+                reader_task: reader_task.into(),
                 server_public_key,
             }),
         };
 
-        Ok(client)
+        let client_receiver = ClientReceiver {
+            reader_channel: reader_recv,
+        };
+
+        Ok((client, client_receiver))
     }
 }
 

--- a/iroh-net/src/derp/client.rs
+++ b/iroh-net/src/derp/client.rs
@@ -144,7 +144,7 @@ impl Client {
     }
 
     /// The local address that the [`Client`] is listening on.
-    pub async fn local_addr(&self) -> Result<SocketAddr> {
+    pub fn local_addr(&self) -> Result<SocketAddr> {
         Ok(self.inner.local_addr)
     }
 

--- a/iroh-net/src/derp/client_conn.rs
+++ b/iroh-net/src/derp/client_conn.rs
@@ -7,11 +7,11 @@ use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 use tokio_util::codec::Framed;
 use tokio_util::sync::CancellationToken;
 use tracing::{trace, Instrument};
 
+use crate::util::AbortingJoinHandle;
 use crate::{disco::looks_like_disco_wrapper, key::PublicKey};
 
 use iroh_metrics::{inc, inc_by};
@@ -45,7 +45,7 @@ pub(crate) struct ClientConnManager {
     // TODO: replace with rate limiter, also, this should probably be on the ClientSets, not on
     // the client itself
     // replace_limiter: RateLimiter,
-    io_handle: JoinHandle<Result<()>>,
+    io_handle: AbortingJoinHandle<Result<()>>,
 
     /// Channels that allow the [`ClientConnManager`] (and the Server) to send
     /// the client messages. These `Senders` correspond to `Receivers` on the
@@ -182,7 +182,7 @@ impl ClientConnManager {
         ClientConnManager {
             conn_num,
             key,
-            io_handle,
+            io_handle: io_handle.into(),
             done,
             client_channels: ClientChannels {
                 send_queue: send_queue_s,

--- a/iroh-net/src/derp/codec.rs
+++ b/iroh-net/src/derp/codec.rs
@@ -27,6 +27,7 @@ pub(super) const KEEP_ALIVE: Duration = Duration::from_secs(60);
 pub(super) const SERVER_CHANNEL_SIZE: usize = 1024 * 100;
 /// The number of packets buffered for sending per client
 pub(super) const PER_CLIENT_SEND_QUEUE_DEPTH: usize = 512; //32;
+pub(super) const PER_CLIENT_READ_QUEUE_DEPTH: usize = 512;
 
 /// ProtocolVersion is bumped whenever there's a wire-incompatiable change.
 ///  - version 1 (zero on wire): consistent box headers, in use by employee dev nodes a bit

--- a/iroh-net/src/derp/http.rs
+++ b/iroh-net/src/derp/http.rs
@@ -46,7 +46,7 @@ mod tests {
     use reqwest::Url;
     use tokio::sync::mpsc;
     use tokio::task::JoinHandle;
-    use tracing::{info_span, Instrument};
+    use tracing::{info, info_span, Instrument};
     use tracing_subscriber::{prelude::*, EnvFilter};
 
     use crate::derp::{DerpNode, DerpRegion, ReceivedMessage, UseIpv4, UseIpv6};
@@ -81,7 +81,7 @@ mod tests {
                 anyhow::bail!("cannot get ipv4 addr from socket addr {addr:?}");
             }
         };
-        println!("addr: {addr}:{port}");
+        info!("addr: {addr}:{port}");
         let region = DerpRegion {
             region_id: 1,
             avoid: false,
@@ -102,26 +102,29 @@ mod tests {
         let derp_addr: Url = format!("http://{addr}:{port}").parse().unwrap();
         let (a_key, mut a_recv, client_a_task, client_a) =
             create_test_client(a_key, region.clone(), Some(derp_addr.clone()));
-        println!("created client {a_key:?}");
+        info!("created client {a_key:?}");
         let (b_key, mut b_recv, client_b_task, client_b) =
             create_test_client(b_key, region, Some(derp_addr));
-        println!("created client {b_key:?}");
+        info!("created client {b_key:?}");
 
+        info!("ping a");
         client_a.ping().await?;
+
+        info!("ping b");
         client_b.ping().await?;
 
-        println!("sending message from a to b");
+        info!("sending message from a to b");
         let msg = Bytes::from_static(b"hi there, client b!");
         client_a.send(b_key, msg.clone()).await?;
-        println!("waiting for message from a on b");
+        info!("waiting for message from a on b");
         let (got_key, got_msg) = b_recv.recv().await.expect("expected message from client_a");
         assert_eq!(a_key, got_key);
         assert_eq!(msg, got_msg);
 
-        println!("sending message from b to a");
+        info!("sending message from b to a");
         let msg = Bytes::from_static(b"right back at ya, client b!");
         client_b.send(a_key, msg.clone()).await?;
-        println!("waiting for message b on a");
+        info!("waiting for message b on a");
         let (got_key, got_msg) = a_recv.recv().await.expect("expected message from client_b");
         assert_eq!(b_key, got_key);
         assert_eq!(msg, got_msg);
@@ -160,18 +163,18 @@ mod tests {
         let client_reader_task = tokio::spawn(
             async move {
                 loop {
-                    println!("waiting for message on {:?}", key.public());
+                    info!("waiting for message on {:?}", key.public());
                     match client_reader.recv().await {
                         None => {
-                            println!("client received nothing");
+                            info!("client received nothing");
                             return;
                         }
                         Some(Err(e)) => {
-                            println!("client {:?} `recv_detail` error {e}", key.public());
+                            info!("client {:?} `recv` error {e}", key.public());
                             return;
                         }
                         Some(Ok((msg, _))) => {
-                            println!("got message on {:?}: {msg:?}", key.public());
+                            info!("got message on {:?}: {msg:?}", key.public());
                             if let ReceivedMessage::ReceivedPacket { source, data } = msg {
                                 received_msg_s
                                     .send((source, data))
@@ -226,7 +229,7 @@ mod tests {
                 anyhow::bail!("cannot get ipv4 addr from socket addr {addr:?}");
             }
         };
-        println!("DERP listening on: {addr}:{port}");
+        info!("DERP listening on: {addr}:{port}");
 
         let region = DerpRegion {
             region_id: 1,
@@ -247,25 +250,25 @@ mod tests {
         // create clients
         let (a_key, mut a_recv, client_a_task, client_a) =
             create_test_client(a_key, region.clone(), None);
-        println!("created client {a_key:?}");
+        info!("created client {a_key:?}");
         let (b_key, mut b_recv, client_b_task, client_b) = create_test_client(b_key, region, None);
-        println!("created client {b_key:?}");
+        info!("created client {b_key:?}");
 
         client_a.ping().await?;
         client_b.ping().await?;
 
-        println!("sending message from a to b");
+        info!("sending message from a to b");
         let msg = Bytes::from_static(b"hi there, client b!");
         client_a.send(b_key, msg.clone()).await?;
-        println!("waiting for message from a on b");
+        info!("waiting for message from a on b");
         let (got_key, got_msg) = b_recv.recv().await.expect("expected message from client_a");
         assert_eq!(a_key, got_key);
         assert_eq!(msg, got_msg);
 
-        println!("sending message from b to a");
+        info!("sending message from b to a");
         let msg = Bytes::from_static(b"right back at ya, client b!");
         client_b.send(a_key, msg.clone()).await?;
-        println!("waiting for message b on a");
+        info!("waiting for message b on a");
         let (got_key, got_msg) = a_recv.recv().await.expect("expected message from client_b");
         assert_eq!(b_key, got_key);
         assert_eq!(msg, got_msg);

--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -1046,7 +1046,7 @@ impl Actor {
     /// Creates the uri string from a [`DerpNode`]
     ///
     /// Return a TCP stream to the provided region, trying each node in order
-    /// (using [`Client::dial_node`]) until one connects
+    /// (using [`dial_node`]) until one connects
     async fn dial_region(
         &self,
         reg: DerpRegion,

--- a/iroh-net/src/derp/http/mesh_clients.rs
+++ b/iroh-net/src/derp/http/mesh_clients.rs
@@ -63,7 +63,7 @@ impl MeshClients {
         };
         let mut meshed_once_recvs = Vec::new();
         for addr in addrs {
-            let client = ClientBuilder::new()
+            let (client, client_receiver) = ClientBuilder::new()
                 .mesh_key(Some(self.mesh_key))
                 .server_url(addr)
                 .build(self.server_key.clone())
@@ -74,7 +74,7 @@ impl MeshClients {
             self.tasks.spawn(
                 async move {
                     if let Err(e) = client
-                        .run_mesh_client(packet_forwarder_handler, Some(sender))
+                        .run_mesh_client(packet_forwarder_handler, Some(sender), client_receiver)
                         .await
                     {
                         tracing::warn!("{e:?}");
@@ -173,14 +173,14 @@ mod tests {
 
         let alice_key = SecretKey::generate();
         println!("client alice: {:?}", alice_key.public());
-        let alice = ClientBuilder::new()
+        let (alice, mut alice_receiver) = ClientBuilder::new()
             .server_url(a_url)
             .build(alice_key.clone())?;
         let _ = alice.connect().await?;
 
         let bob_key = SecretKey::generate();
         println!("client bob: {:?}", bob_key.public());
-        let bob = ClientBuilder::new()
+        let (bob, mut bob_receiver) = ClientBuilder::new()
             .server_url(b_url)
             .build(bob_key.clone())?;
         let _ = bob.connect().await?;
@@ -220,11 +220,10 @@ mod tests {
 
         // ensure we get the message, but allow other chatter between the
         // client and the server
-        let b = bob.clone();
         let alice_pub_key = alice_key.public();
         tokio::time::timeout(Duration::from_secs(5), async move {
             loop {
-                let (recv, _) = b.recv_detail().await?;
+                let (recv, _) = bob_receiver.recv().await.unwrap()?;
                 if let ReceivedMessage::ReceivedPacket { source, data } = recv {
                     assert_eq!(alice_pub_key, source);
                     assert_eq!(msg, data);
@@ -246,7 +245,7 @@ mod tests {
         // client and the server
         tokio::time::timeout(Duration::from_secs(5), async move {
             loop {
-                let (recv, _) = alice.recv_detail().await?;
+                let (recv, _) = alice_receiver.recv().await.unwrap()?;
                 if let ReceivedMessage::ReceivedPacket { source, data } = recv {
                     assert_eq!(bob_key.public(), source);
                     assert_eq!(msg, data);

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -660,12 +660,7 @@ mod tests {
     /// Test that peers saved on shutdown are correctly loaded
     #[tokio::test]
     async fn save_load_peers() {
-        use tracing_subscriber::{prelude::*, EnvFilter};
-        tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-            .with(EnvFilter::from_default_env())
-            .try_init()
-            .ok();
+        let _guard = iroh_test::logging::setup();
 
         let secret_key = SecretKey::generate();
         let root = testdir::testdir!();

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -660,7 +660,13 @@ mod tests {
     /// Test that peers saved on shutdown are correctly loaded
     #[tokio::test]
     async fn save_load_peers() {
-        let _guard = iroh_test::logging::setup();
+        use tracing_subscriber::{prelude::*, EnvFilter};
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+            .with(EnvFilter::from_default_env())
+            .try_init()
+            .ok();
+
         let secret_key = SecretKey::generate();
         let tempdir = tempfile::tempdir().unwrap();
         let path: PathBuf = tempdir.path().into();

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -692,15 +692,18 @@ mod tests {
             (std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 8758u16).into();
         let peer_addr = PeerAddr::new(peer_id).with_direct_addresses([direct_addr]);
 
+        info!("setting up first endpoint");
         // first time, create a magic endpoint without peers but a peers file and add adressing
         // information for a peer
         let endpoint = new_endpoint(secret_key.clone(), path.clone()).await;
         assert!(endpoint.connection_infos().await.unwrap().is_empty());
         endpoint.add_peer_addr(peer_addr).await.unwrap();
 
+        info!("closing endpoint");
         // close the endpoint and restart it
         endpoint.close(0u32.into(), b"done").await.unwrap();
 
+        info!("restarting endpoint");
         // now restart it and check the addressing info of the peer
         let endpoint = new_endpoint(secret_key, path).await;
         let ConnectionInfo { mut addrs, .. } =

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -668,9 +668,8 @@ mod tests {
             .ok();
 
         let secret_key = SecretKey::generate();
-        let tempdir = tempfile::tempdir().unwrap();
-        let path: PathBuf = tempdir.path().into();
-        let path = path.join("peers");
+        let root = testdir::testdir!();
+        let path = root.join("peers");
 
         /// Create an endpoint for the test.
         async fn new_endpoint(secret_key: SecretKey, peers_path: PathBuf) -> MagicEndpoint {
@@ -708,7 +707,6 @@ mod tests {
             endpoint.connection_info(peer_id).await.unwrap().unwrap();
         let conn_addr = addrs.pop().unwrap().0;
         assert_eq!(conn_addr, direct_addr);
-        drop(tempdir);
     }
 
     // #[tokio::test]

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1514,7 +1514,6 @@ enum ActorMessage {
     SetPreferredPort(u16, sync::oneshot::Sender<()>),
     RebindAll(sync::oneshot::Sender<()>),
     Shutdown,
-    CloseOrReconnect(u16, &'static str),
     ReStun(&'static str),
     EnqueueCallMeMaybe {
         derp_region: u16,
@@ -1729,9 +1728,6 @@ impl Actor {
 
                 debug!("shutdown complete");
                 return true;
-            }
-            ActorMessage::CloseOrReconnect(region_id, reason) => {
-                self.send_derp_actor(DerpActorMessage::CloseOrReconnect { region_id, reason });
             }
             ActorMessage::ReStun(reason) => {
                 self.re_stun(reason).await;

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -51,7 +51,6 @@ struct ActiveDerp {
     /// The time of the last request for its write
     /// channel (currently even if there was no write).
     last_write: Instant,
-    create_time: Instant,
     reader: ReaderState,
     inbox: mpsc::Receiver<ActiveDerpMessage>,
     msg_sender: mpsc::Sender<ActorMessage>,
@@ -358,7 +357,6 @@ impl DerpActor {
             let ad = ActiveDerp {
                 c: c.clone(),
                 last_write: Instant::now(),
-                create_time: Instant::now(),
                 reader: ReaderState::new(region_id, c, dc_receiver),
                 inbox: r,
                 msg_sender,

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -511,7 +511,7 @@ impl DerpActor {
             debug!("closing connection to derp-{} ({:?})", region_id, why,);
 
             s.send(ActiveDerpMessage::Shutdown).await.ok();
-            t.await.ok(); // ensure the task is shutdown
+            t.abort(); // ensure the task is shutdown
 
             inc!(MagicsockMetrics, num_derp_conns_removed);
         }

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -63,6 +63,7 @@ struct ActiveDerp {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum ActiveDerpMessage {
     GetLastWrite(oneshot::Sender<Instant>),
     Ping(oneshot::Sender<Result<Duration, ClientError>>),
@@ -122,7 +123,7 @@ impl ActiveDerp {
                         },
                         ReadAction::RemovePeerRoutes { peers, } => {
                             self.derp_routes.retain(|peer| {
-                                !peers.contains(&peer)
+                                !peers.contains(peer)
                             });
                         }
                     }

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -1695,7 +1695,7 @@ impl AddrLatency {
 
 #[cfg(test)]
 mod tests {
-    use std::{env::temp_dir, net::Ipv4Addr};
+    use std::net::Ipv4Addr;
 
     use super::*;
     use crate::key::SecretKey;

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -1950,7 +1950,8 @@ mod tests {
         peer_map.add_peer_addr(peer_addr_c);
         peer_map.add_peer_addr(peer_addr_d);
 
-        let path = temp_dir().join("peers.postcard");
+        let root = testdir::testdir!();
+        let path = root.join("peers.postcard");
         peer_map.save_to_file(&path).await.unwrap();
 
         let loaded_peer_map = PeerMap::load_from_file(&path).unwrap();

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -1921,6 +1921,8 @@ mod tests {
     /// Test persisting and loading of known peers.
     #[tokio::test]
     async fn load_save_peer_data() {
+        let _guard = iroh_test::logging::setup();
+
         let peer_map = PeerMap::default();
 
         let peer_a = SecretKey::generate().public();

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use futures::future::BoxFuture;
 use iroh_metrics::inc;
 use parking_lot::Mutex;
@@ -1269,7 +1269,8 @@ impl PeerMap {
 
     /// Saves the known peer info to the given path, returning the number of peers persisted.
     pub(super) async fn save_to_file(&self, path: &Path) -> anyhow::Result<usize> {
-        // TODO: No allocation. But also cannot hold inner across await point.
+        ensure!(!path.is_dir(), "{} must be a file", path.display());
+
         // So, not sure what to do here.
         let mut known_peers = self
             .inner
@@ -1282,11 +1283,22 @@ impl PeerMap {
             // prevent file handling if unnecesary
             return Ok(0);
         }
-        let (tmp_file, tmp_path) = tempfile::NamedTempFile::new()
-            .context("cannot create temp file to save peer data")?
-            .into_parts();
 
-        let mut tmp = tokio::fs::File::from_std(tmp_file);
+        let mut ext = path.extension().map(|s| s.to_owned()).unwrap_or_default();
+        ext.push(".tmp");
+        let tmp_path = path.with_extension(ext);
+
+        if tokio::fs::try_exists(&tmp_path).await.unwrap_or(false) {
+            tokio::fs::remove_file(&tmp_path)
+                .await
+                .context("failed deleting existing tmp file")?;
+        }
+        if let Some(parent) = tmp_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let mut tmp = tokio::fs::File::create(&tmp_path)
+            .await
+            .context("failed creating tmp file")?;
 
         let mut count = 0;
         for peer_addr in known_peers {
@@ -1324,6 +1336,8 @@ impl PeerMapInner {
 
     /// Create a new [`PeerMap`] from data stored in `path`.
     pub fn load_from_file(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let path = path.as_ref();
+        ensure!(path.is_file(), "{} is not a file", path.display());
         let mut me = PeerMapInner::default();
         let contents = std::fs::read(path)?;
         let mut slice: &[u8] = &contents;

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["n0 team"]
 repository = "https://github.com/n0-computer/iroh"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 anyhow = "1"

--- a/iroh-test/Cargo.toml
+++ b/iroh-test/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/n0-computer/iroh"
 publish = true
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 anyhow = "1"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/n0-computer/iroh"
 default-run = "iroh"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -785,10 +785,13 @@ async fn derp_regions(count: usize, config: NodeConfig) -> anyhow::Result<()> {
                 hosts: region.nodes.iter().map(|n| n.url.clone()).collect(),
             };
 
-            let client = clients.get(&region.region_id).cloned().unwrap();
+            let client = clients
+                .get(&region.region_id)
+                .map(|(c, _)| c.clone())
+                .unwrap();
 
             let start = std::time::Instant::now();
-            assert!(!client.is_connected().await);
+            assert!(!client.is_connected().await?);
             match tokio::time::timeout(Duration::from_secs(2), client.connect()).await {
                 Err(e) => {
                     tracing::warn!("connect timeout");
@@ -799,22 +802,8 @@ async fn derp_regions(count: usize, config: NodeConfig) -> anyhow::Result<()> {
                     region_details.error = Some(e.to_string());
                 }
                 Ok(_) => {
-                    assert!(client.is_connected().await);
+                    assert!(client.is_connected().await?);
                     region_details.connect = Some(start.elapsed());
-
-                    let c = client.clone();
-                    let t = tokio::task::spawn(async move {
-                        loop {
-                            match c.recv_detail().await {
-                                Ok(msg) => {
-                                    tracing::debug!("derp: {:?}", msg);
-                                }
-                                Err(err) => {
-                                    tracing::warn!("derp: {:?}", err);
-                                }
-                            }
-                        }
-                    });
 
                     match client.ping().await {
                         Ok(latency) => {
@@ -825,12 +814,11 @@ async fn derp_regions(count: usize, config: NodeConfig) -> anyhow::Result<()> {
                             region_details.error = Some(e.to_string());
                         }
                     }
-                    t.abort();
                 }
             }
             // disconnect, to be able to measure reconnects
-            client.close_for_reconnect().await;
-            assert!(!client.is_connected().await);
+            client.close_for_reconnect().await?;
+            assert!(!client.is_connected().await?);
             if region_details.error.is_none() {
                 success.push(region_details);
             } else {


### PR DESCRIPTION
## Description

- Currently derp messages can be lost, due to using `tokio::select` and`futures::select_all` over non cancelation safe futures. This refactors the code to fix this.
- Additionally this refactors `derp::http::Client` to an actor like structure and removes the need for locks in it
- Bumps MSRV to `1.72` due to updated dependencies
- Refactor `derp::Client` to not use locks either

With this all of the `derp` code is stripped of locks :) 

