### PR TITLE
refactor(iroh-net): Don't send pings over the actor channel

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -884,12 +884,12 @@ impl Inner {
             Ok(_n) => {
                 debug!(%msg, "sent disco message");
                 inc!(MagicsockMetrics, sent_disco_udp);
-                disco_message_sent(&msg);
+                disco_message_sent(msg);
                 Ok(true)
             }
             Err(err) => {
                 warn!(?msg, ?err, "failed to send disco message");
-                Err(err.into())
+                Err(err)
             }
         })
     }

--- a/iroh-net/src/magicsock/endpoint.rs
+++ b/iroh-net/src/magicsock/endpoint.rs
@@ -493,6 +493,7 @@ impl Endpoint {
     fn send_pings(&mut self, now: Instant, send_call_me_maybe: bool) -> Vec<PingAction> {
         let mut msgs = Vec::new();
 
+        // queue a ping to our derper, if needed.
         if let Some((region, state)) = self.derp_region.as_ref() {
             if state.needs_ping(&now) {
                 debug!(?region, "peer's derp region needs ping");
@@ -512,6 +513,7 @@ impl Endpoint {
             );
             return msgs;
         }
+
         self.last_full_ping.replace(now);
         self.prune_direct_addresses();
 


### PR DESCRIPTION
## Description

Small refactor in iroh-net: Do not send disco messages (pings and pongs) over the main actor channel. Instead, either send them right away if the request comes from a poll function, or use a new, small, dedicated task that just sends out the disco messages over UDP. For Derp we drop messages anyway if the channel is full, so no need to pass over the main actor. 


## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
