### PR TITLE
Use smallvec to avoid allocation when sending a single message to derp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,6 +2346,7 @@ dependencies = [
  "serde",
  "serde_with",
  "serdect",
+ "smallvec",
  "socket2 0.5.4",
  "ssh-key",
  "stun-rs",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -46,6 +46,7 @@ rustls = { version = "0.21", default-features = false, features = ["dangerous_co
 serde = { version = "1", features = ["derive", "rc"] }
 ssh-key = { version = "0.6.0", features = ["ed25519", "std", "rand_core"] }
 serdect = "0.2.0"
+smallvec = "1.11.1"
 socket2 = "0.5.3"
 stun-rs = "0.1.4"
 surge-ping = "0.8.0"

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -17,8 +17,8 @@ use crate::{
     key::{PublicKey, PUBLIC_KEY_LENGTH},
 };
 
-use super::Metrics as MagicsockMetrics;
 use super::{ActorMessage, Inner};
+use super::{DerpContents, Metrics as MagicsockMetrics};
 
 /// How long a non-home DERP connection needs to be idle (last written to) before we close it.
 const DERP_INACTIVE_CLEANUP_TIME: Duration = Duration::from_secs(60);
@@ -29,7 +29,7 @@ const DERP_CLEAN_STALE_INTERVAL: Duration = Duration::from_secs(15);
 pub(super) enum DerpActorMessage {
     Send {
         region_id: u16,
-        contents: Vec<Bytes>,
+        contents: DerpContents,
         peer: PublicKey,
     },
     Connect {
@@ -180,7 +180,7 @@ impl DerpActor {
         .await;
     }
 
-    async fn send_derp(&mut self, region_id: u16, contents: Vec<Bytes>, peer: PublicKey) {
+    async fn send_derp(&mut self, region_id: u16, contents: DerpContents, peer: PublicKey) {
         debug!(region_id, ?peer, "sending derp");
         if !self.conn.derp_map.contains_region(region_id) {
             warn!("unknown region id {}", region_id);


### PR DESCRIPTION
## Description

I did a local test and noticed that there are a lot of times where there is only a single packet going to the derper. This would prevent allocations in that case.

## Notes & open questions

- I guess 1 is by far the most common case. Should we make it larger?
- This will rarely help on linux, but then again mac needs all the help it can get...

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
