### PR TITLE
fix(net): correctly order binding of UDP socket 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72832d73be48bac96a5d7944568f305d829ed55b0ce3b483647089dfaf6cf704"
+checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1749,7 +1749,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
- "ahash 0.8.4",
+ "ahash 0.8.5",
  "allocator-api2",
 ]
 

--- a/iroh-net/examples/magic.rs
+++ b/iroh-net/examples/magic.rs
@@ -31,8 +31,11 @@ struct Cli {
 enum Command {
     Listen,
     Connect {
+        #[clap(long)]
         peer_id: String,
+        #[clap(long)]
         addrs: Option<Vec<SocketAddr>>,
+        #[clap(long)]
         derp_region: Option<u16>,
     },
 }

--- a/iroh-net/src/netcheck/reportgen/probes.rs
+++ b/iroh-net/src/netcheck/reportgen/probes.rs
@@ -160,6 +160,10 @@ impl ProbeSet {
     fn is_empty(&self) -> bool {
         self.probes.is_empty()
     }
+
+    pub(super) fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 impl<'a> IntoIterator for &'a ProbeSet {

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -266,7 +266,7 @@ async fn report(
     };
     println!("getting report using derp map {dm:#?}");
 
-    let r = client.get_report(dm, None, None).await?;
+    let r = client.get_report("doctor", dm, None, None).await?;
     println!("{r:#?}");
     Ok(())
 }


### PR DESCRIPTION
this fixes the case where a socket bound to `0` would only be available for usage later on.

This was seen when stun requests would time out, as the socket was not fully ready yet

TLDR: binding to `0` was probably taking longer, and we were setting `non_blocking` too early, so we weren't properly waiting for the binding to be setup (which is why it eventually recovered)


