### PR TITLE
fix unused export found in nightly rust

### DIFF
--- a/iroh-bytes/src/protocol/range_spec.rs
+++ b/iroh-bytes/src/protocol/range_spec.rs
@@ -230,7 +230,7 @@ impl RangeSpecSeq {
     /// Thus the first call to `.next()` returns the range spec for the first blob, the next
     /// call returns the range spec of the second blob, etc.
     pub fn iter(&self) -> RequestRangeSpecIter<'_> {
-        let before_first = self.0.get(0).map(|(c, _)| *c).unwrap_or_default();
+        let before_first = self.0.first().map(|(c, _)| *c).unwrap_or_default();
         RequestRangeSpecIter {
             current: &EMPTY_RANGE_SPEC,
             count: before_first,
@@ -269,7 +269,7 @@ pub struct RequestRangeSpecIter<'a> {
 
 impl<'a> RequestRangeSpecIter<'a> {
     pub fn new(ranges: &'a [(u64, RangeSpec)]) -> Self {
-        let before_first = ranges.get(0).map(|(c, _)| *c).unwrap_or_default();
+        let before_first = ranges.first().map(|(c, _)| *c).unwrap_or_default();
         RequestRangeSpecIter {
             current: &EMPTY_RANGE_SPEC,
             count: before_first,
@@ -298,7 +298,7 @@ impl<'a> Iterator for RequestRangeSpecIter<'a> {
             } else if let Some(((_, new), rest)) = self.remaining.split_first() {
                 // get next current value, new count, and set remaining
                 self.current = new;
-                self.count = rest.get(0).map(|(c, _)| *c).unwrap_or_default();
+                self.count = rest.first().map(|(c, _)| *c).unwrap_or_default();
                 self.remaining = rest;
                 continue;
             } else {

--- a/iroh-sync/src/lib.rs
+++ b/iroh-sync/src/lib.rs
@@ -41,6 +41,5 @@ pub mod store;
 pub mod sync;
 
 pub use self::heads::*;
-#[allow(unused_imports)]
 pub use self::keys::*;
 pub use self::sync::*;

--- a/iroh-sync/src/lib.rs
+++ b/iroh-sync/src/lib.rs
@@ -40,6 +40,6 @@ mod ranger;
 pub mod store;
 pub mod sync;
 
-pub use heads::*;
-pub use keys::*;
-pub use sync::*;
+pub use self::heads::*;
+pub use self::keys::*;
+pub use self::sync::*;

--- a/iroh-sync/src/lib.rs
+++ b/iroh-sync/src/lib.rs
@@ -41,5 +41,6 @@ pub mod store;
 pub mod sync;
 
 pub use self::heads::*;
+#[allow(unused_imports)]
 pub use self::keys::*;
 pub use self::sync::*;

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -295,9 +295,8 @@ impl BobState {
 mod tests {
     use crate::{
         actor::OpenOpts,
+        keys::{AuthorId, Namespace},
         store::{self, GetFilter, Store},
-        sync::Namespace,
-        AuthorId,
     };
     use anyhow::Result;
     use iroh_bytes::Hash;

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -9,8 +9,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     heads::AuthorHeads,
+    keys::{Author, Namespace},
     ranger,
-    sync::{Author, Namespace, Replica, SignedEntry},
+    sync::{Replica, SignedEntry},
     AuthorId, NamespaceId, PeerIdBytes,
 };
 

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -19,11 +19,10 @@ use redb::{
 };
 
 use crate::{
+    keys::{Author, Namespace},
     ranger::{Fingerprint, Range, RangeEntry},
     store::Store as _,
-    sync::{
-        Author, Entry, EntrySignature, Namespace, Record, RecordIdentifier, Replica, SignedEntry,
-    },
+    sync::{Entry, EntrySignature, Record, RecordIdentifier, Replica, SignedEntry},
     AuthorId, NamespaceId, PeerIdBytes,
 };
 

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -12,8 +12,9 @@ use iroh_bytes::Hash;
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
 
 use crate::{
+    keys::{Author, Namespace},
     ranger::{Fingerprint, Range, RangeEntry},
-    sync::{Author, Namespace, RecordIdentifier, Replica, SignedEntry},
+    sync::{RecordIdentifier, Replica, SignedEntry},
     AuthorId, NamespaceId, PeerIdBytes, Record,
 };
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -13,8 +13,6 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-#[cfg(feature = "metrics")]
-use crate::metrics::Metrics;
 use bytes::{Bytes, BytesMut};
 use derive_more::Deref;
 #[cfg(feature = "metrics")]
@@ -25,8 +23,10 @@ use iroh_bytes::Hash;
 use serde::{Deserialize, Serialize};
 
 pub use crate::heads::AuthorHeads;
-pub use crate::keys::*;
+#[cfg(feature = "metrics")]
+use crate::metrics::Metrics;
 use crate::{
+    keys::{base32, Author, AuthorId, AuthorPublicKey, Namespace, NamespaceId, NamespacePublicKey},
     ranger::{self, Fingerprint, InsertOutcome, Peer, RangeEntry, RangeKey, RangeValue},
     store::{self, PublicKeyStore},
 };

--- a/iroh-test/src/hexdump.rs
+++ b/iroh-test/src/hexdump.rs
@@ -65,6 +65,33 @@ pub fn print_hexdump(bytes: impl AsRef<[u8]>, line_lengths: impl AsRef<[usize]>)
     output
 }
 
+/// This is a macro to assert that two byte slices are equal.
+///
+/// It is like assert_eq!, but it will print a nicely formatted hexdump of the
+/// two slices if they are not equal. This makes it much easier to track down
+/// a difference in a large byte slice.
+#[macro_export]
+macro_rules! assert_eq_hex {
+    ($a:expr, $b:expr) => {
+        assert_eq_hex!($a, $b, [])
+    };
+    ($a:expr, $b:expr, $hint:expr) => {
+        let a = $a;
+        let b = $b;
+        let hint = $hint;
+        let ar: &[u8] = a.as_ref();
+        let br: &[u8] = b.as_ref();
+        let hintr: &[usize] = hint.as_ref();
+        if ar != br {
+            panic!(
+                "assertion failed: `(left == right)`\nleft:\n{}\nright:\n{}\n",
+                ::iroh_test::hexdump::print_hexdump(ar, hintr),
+                ::iroh_test::hexdump::print_hexdump(br, hintr),
+            )
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::{parse_hexdump, print_hexdump};
@@ -150,31 +177,4 @@ mod tests {
         let output = print_hexdump(data, [1, 0, 0, 2]);
         assert_eq!(output, "01\n\n\n02 03\n04 05\n06 07\n08\n");
     }
-}
-
-/// This is a macro to assert that two byte slices are equal.
-///
-/// It is like assert_eq!, but it will print a nicely formatted hexdump of the
-/// two slices if they are not equal. This makes it much easier to track down
-/// a difference in a large byte slice.
-#[macro_export]
-macro_rules! assert_eq_hex {
-    ($a:expr, $b:expr) => {
-        assert_eq_hex!($a, $b, [])
-    };
-    ($a:expr, $b:expr, $hint:expr) => {
-        let a = $a;
-        let b = $b;
-        let hint = $hint;
-        let ar: &[u8] = a.as_ref();
-        let br: &[u8] = b.as_ref();
-        let hintr: &[usize] = hint.as_ref();
-        if ar != br {
-            panic!(
-                "assertion failed: `(left == right)`\nleft:\n{}\nright:\n{}\n",
-                ::iroh_test::hexdump::print_hexdump(ar, hintr),
-                ::iroh_test::hexdump::print_hexdump(br, hintr),
-            )
-        }
-    };
 }

--- a/iroh/examples/dump-blob-stream.rs
+++ b/iroh/examples/dump-blob-stream.rs
@@ -115,7 +115,7 @@ fn stream_children(initial: AtInitial) -> impl Stream<Item = io::Result<Bytes>> 
         let links: Box<[iroh_bytes::Hash]> = postcard::from_bytes(&links_bytes)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "failed to parse links"))?;
         let meta_link = *links
-            .get(0)
+            .first()
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "missing meta link"))?;
         let (meta_end, _meta_bytes) = at_meta.next(meta_link).concatenate_into_vec().await?;
         let mut curr = meta_end.next();

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -22,8 +22,8 @@ use iroh_net::{
 use iroh_sync::{
     actor::OpenState,
     store::GetFilter,
-    sync::{NamespaceId, SignedEntry},
-    AuthorId,
+    sync::SignedEntry,
+    {AuthorId, NamespaceId},
 };
 use quic_rpc::{
     message::{BidiStreaming, BidiStreamingMsg, Msg, RpcMsg, ServerStreaming, ServerStreamingMsg},

--- a/iroh/src/sync_engine.rs
+++ b/iroh/src/sync_engine.rs
@@ -13,7 +13,7 @@ use iroh_bytes::{store::EntryStatus, util::runtime::Handle, Hash};
 use iroh_gossip::net::Gossip;
 use iroh_net::{key::PublicKey, MagicEndpoint, PeerAddr};
 use iroh_sync::{
-    actor::SyncHandle, sync::NamespaceId, ContentStatus, ContentStatusCallback, Entry, InsertOrigin,
+    actor::SyncHandle, ContentStatus, ContentStatusCallback, Entry, InsertOrigin, NamespaceId,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -3,7 +3,7 @@
 use anyhow::anyhow;
 use futures::Stream;
 use iroh_bytes::{store::Store as BaoStore, util::BlobFormat};
-use iroh_sync::{sync::Namespace, Author};
+use iroh_sync::{Author, Namespace};
 use tokio_stream::StreamExt;
 
 use crate::{


### PR DESCRIPTION
Actual issue was a double reexport which went unnoticed in older rustc versions. 

Thanks to @bvanjoi in https://github.com/rust-lang/rust/issues/117120#issuecomment-1777113406 for pointing out the problem