### PR TITLE
refactor(iroh-net): improve `PeerMap` and `Endpoint` abstractions

### DIFF
--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -18,7 +18,7 @@ use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::Instant;
-use tracing::{debug, info, info_span, instrument, trace, warn, Instrument};
+use tracing::{debug, info, info_span, trace, warn, Instrument};
 use url::Url;
 
 use crate::derp::{
@@ -674,7 +674,6 @@ impl Actor {
         if self.is_closed {
             return Err(ClientError::Closed);
         }
-        let key = self.secret_key.public();
         async move {
             if self.derp_client.is_none() {
                 trace!("no connection, trying to connect");

--- a/iroh-net/src/derp/http/server.rs
+++ b/iroh-net/src/derp/http/server.rs
@@ -471,7 +471,7 @@ where
                                         e
                                     );
                                 } else {
-                                    tracing::info!(
+                                    tracing::debug!(
                                         "upgrade to \"{HTTP_UPGRADE_PROTOCOL}\" success"
                                     );
                                 };

--- a/iroh-net/src/derp/http/server.rs
+++ b/iroh-net/src/derp/http/server.rs
@@ -388,7 +388,7 @@ impl ServerState {
                                 {
                                     error!("[{http_str}] derp: failed to handle connection: {e}");
                                 }
-                            }.instrument(info_span!("conn")));
+                            }.instrument(info_span!("conn", peer = %peer_addr)));
                         }
                         Err(err) => {
                             error!("[{http_str}] derp: failed to accept connection: {err}");

--- a/iroh-net/src/derp/server.rs
+++ b/iroh-net/src/derp/server.rs
@@ -123,7 +123,8 @@ where
         let cancel_token = CancellationToken::new();
         let done = cancel_token.clone();
         let server_task = tokio::spawn(
-            async move { server_actor.run(done).await }.instrument(info_span!("derp.server", me = %key.public().fmt_short())),
+            async move { server_actor.run(done).await }
+                .instrument(info_span!("derp.server", me = %key.public().fmt_short())),
         );
         let meta_cert = init_meta_cert(&key.public());
         Self {
@@ -687,7 +688,6 @@ mod tests {
         ReceivedMessage,
     };
     use tokio_util::codec::{FramedRead, FramedWrite};
-    use tracing::instrument;
     use tracing_subscriber::{prelude::*, EnvFilter};
 
     use anyhow::Result;

--- a/iroh-net/src/disco.rs
+++ b/iroh-net/src/disco.rs
@@ -224,7 +224,6 @@ impl Pong {
 impl CallMeMaybe {
     fn from_bytes(ver: u8, p: &[u8]) -> Result<Self> {
         ensure!(ver == V0, "invalid version");
-        // ensure!(p.len() % EP_LENGTH == 0, "invalid entries");
 
         let num_entries = p.len() / EP_LENGTH;
         let mut m = CallMeMaybe {
@@ -365,7 +364,12 @@ mod tests {
             Test {
                 name: "call_me_maybe",
                 m: Message::CallMeMaybe(CallMeMaybe { my_number: Vec::new(), clear_pongs: false }),
-                want: "03 00",
+                want: "03 00 00",
+            },
+            Test {
+                name: "call_me_maybe_clear_pongs",
+                m: Message::CallMeMaybe(CallMeMaybe { my_number: Vec::new(), clear_pongs: true }),
+                want: "03 00 01",
             },
             Test {
                 name: "call_me_maybe_endpoints",
@@ -376,7 +380,7 @@ mod tests {
                     ],
                     clear_pongs: false
                 }),
-                want: "03 00 00 00 00 00 00 00 00 00 00 00 ff ff 01 02 03 04 37 02 20 01 00 00 00 00 00 00 00 00 00 00 00 00 34 56 15 03",
+                want: "03 00 00 00 00 00 00 00 00 00 00 00 ff ff 01 02 03 04 37 02 20 01 00 00 00 00 00 00 00 00 00 00 00 00 34 56 15 03 00",
             },
         ];
         for test in tests {

--- a/iroh-net/src/disco.rs
+++ b/iroh-net/src/disco.rs
@@ -143,8 +143,6 @@ pub struct Pong {
 pub struct CallMeMaybe {
     /// What the peer believes its endpoints are.
     pub my_number: Vec<SocketAddr>,
-    /// If true invalidate all previous pongs. This is sent after a total state reset.
-    pub clear_pongs: bool,
 }
 
 impl Ping {
@@ -224,19 +222,16 @@ impl Pong {
 impl CallMeMaybe {
     fn from_bytes(ver: u8, p: &[u8]) -> Result<Self> {
         ensure!(ver == V0, "invalid version");
+        ensure!(p.len() % EP_LENGTH == 0, "invalid entries");
 
         let num_entries = p.len() / EP_LENGTH;
         let mut m = CallMeMaybe {
             my_number: Vec::with_capacity(num_entries),
-            clear_pongs: false,
         };
 
         for chunk in p.chunks_exact(EP_LENGTH) {
             let src = socket_addr_from_bytes(chunk);
             m.my_number.push(src);
-        }
-        if p.len() > EP_LENGTH * m.my_number.len() && p.last() == Some(&1u8) {
-            m.clear_pongs = true;
         }
 
         Ok(m)
@@ -244,7 +239,7 @@ impl CallMeMaybe {
 
     fn as_bytes(&self) -> Vec<u8> {
         let header = msg_header(MessageType::CallMeMaybe, V0);
-        let mut out = vec![0u8; HEADER_LEN + self.my_number.len() * EP_LENGTH + 1];
+        let mut out = vec![0u8; HEADER_LEN + self.my_number.len() * EP_LENGTH];
         out[..HEADER_LEN].copy_from_slice(&header);
 
         for (m, chunk) in self
@@ -255,12 +250,6 @@ impl CallMeMaybe {
             let raw = socket_addr_as_bytes(m);
             chunk.copy_from_slice(&raw);
         }
-        let clear_pongs = match self.clear_pongs {
-            true => 1u8,
-            false => 0u8,
-        };
-        let last = out.len() - 1;
-        out[last] = clear_pongs;
 
         out
     }
@@ -361,13 +350,8 @@ mod tests {
             },
             Test {
                 name: "call_me_maybe",
-                m: Message::CallMeMaybe(CallMeMaybe { my_number: Vec::new(), clear_pongs: false }),
-                want: "03 00 00",
-            },
-            Test {
-                name: "call_me_maybe_clear_pongs",
-                m: Message::CallMeMaybe(CallMeMaybe { my_number: Vec::new(), clear_pongs: true }),
-                want: "03 00 01",
+                m: Message::CallMeMaybe(CallMeMaybe { my_number: Vec::new() }),
+                want: "03 00",
             },
             Test {
                 name: "call_me_maybe_endpoints",
@@ -376,9 +360,8 @@ mod tests {
                         "1.2.3.4:567".parse().unwrap(),
                         "[2001::3456]:789".parse().unwrap(),
                     ],
-                    clear_pongs: false
                 }),
-                want: "03 00 00 00 00 00 00 00 00 00 00 00 ff ff 01 02 03 04 37 02 20 01 00 00 00 00 00 00 00 00 00 00 00 00 34 56 15 03 00",
+                want: "03 00 00 00 00 00 00 00 00 00 00 00 ff ff 01 02 03 04 37 02 20 01 00 00 00 00 00 00 00 00 00 00 00 00 34 56 15 03",
             },
         ];
         for test in tests {

--- a/iroh-net/src/disco.rs
+++ b/iroh-net/src/disco.rs
@@ -235,10 +235,8 @@ impl CallMeMaybe {
             let src = socket_addr_from_bytes(chunk);
             m.my_number.push(src);
         }
-        if p.len() > EP_LENGTH * m.my_number.len() {
-            if p.last() == Some(&1u8) {
-                m.clear_pongs = true;
-            }
+        if p.len() > EP_LENGTH * m.my_number.len() && p.last() == Some(&1u8) {
+            m.clear_pongs = true;
         }
 
         Ok(m)

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -759,6 +759,9 @@ mod tests {
                 let client_secret_key = client_secret_key.clone();
                 let fut = async move {
                     info!("client binding");
+                    info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1");
+                    info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1");
+                    info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1");
                     let start = Instant::now();
                     let ep = MagicEndpoint::builder()
                         .alpns(vec![TEST_ALPN.to_vec()])

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -710,6 +710,8 @@ mod tests {
         assert_eq!(conn_addr, direct_addr);
     }
 
+    // TODO: Enable in https://github.com/n0-computer/iroh/pull/1745
+    #[ignore]
     #[tokio::test]
     async fn magic_endpoint_derp_connect_loop() {
         let _guard = iroh_test::logging::setup();

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -713,8 +713,8 @@ mod tests {
     #[tokio::test]
     async fn magic_endpoint_derp_connect_loop() {
         let _guard = iroh_test::logging::setup();
-        let n_iters = 10;
-        let n_chunks_per_client = 5;
+        let n_iters = 5;
+        let n_chunks_per_client = 2;
         let chunk_size = 10;
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
         let (derp_map, region_id, _guard) = run_derper().await.unwrap();
@@ -759,9 +759,6 @@ mod tests {
                 let client_secret_key = client_secret_key.clone();
                 let fut = async move {
                     info!("client binding");
-                    info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1");
-                    info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1");
-                    info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1");
                     let start = Instant::now();
                     let ep = MagicEndpoint::builder()
                         .alpns(vec![TEST_ALPN.to_vec()])

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -712,7 +712,7 @@ mod tests {
 
     #[tokio::test]
     async fn magic_endpoint_derp_connect_loop() {
-        // let _guard = iroh_test::logging::setup();
+        let _guard = iroh_test::logging::setup();
         let n_iters = 5;
         let n_chunks_per_client = 2;
         let chunk_size = 10;

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -559,7 +559,10 @@ pub async fn get_peer_id(connection: &quinn::Connection) -> Result<PublicKey> {
 #[cfg(test)]
 mod tests {
 
-    use tracing::{info, info_span, Instrument};
+    use std::time::Instant;
+
+    use rand_core::SeedableRng;
+    use tracing::{error_span, info, info_span, Instrument};
 
     use crate::test_utils::run_derper;
 
@@ -705,6 +708,96 @@ mod tests {
             endpoint.connection_info(peer_id).await.unwrap().unwrap();
         let conn_addr = addrs.pop().unwrap().addr;
         assert_eq!(conn_addr, direct_addr);
+    }
+
+    #[tokio::test]
+    async fn magic_endpoint_derp_connect_loop() {
+        let _guard = iroh_test::logging::setup();
+        let n_iters = 10;
+        let n_chunks_per_client = 5;
+        let chunk_size = 10;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+        let (derp_map, region_id, _guard) = run_derper().await.unwrap();
+        let server_secret_key = SecretKey::generate_with_rng(&mut rng);
+        let server_node_id = server_secret_key.public();
+        let server = {
+            let derp_map = derp_map.clone();
+            tokio::spawn(
+                async move {
+                    let ep = MagicEndpoint::builder()
+                        .secret_key(server_secret_key)
+                        .alpns(vec![TEST_ALPN.to_vec()])
+                        .derp_mode(DerpMode::Custom(derp_map))
+                        .bind(12345)
+                        .await
+                        .unwrap();
+                    let eps = ep.local_addr().unwrap();
+                    info!(me = %ep.peer_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "server bound");
+                    for i in 0..n_iters {
+                        let conn = ep.accept().await.unwrap();
+                        let (peer_id, _alpn, conn) = accept_conn(conn).await.unwrap();
+                        info!(%i, peer = %peer_id.fmt_short(), "accepted connection");
+                        let (mut send, mut recv) = conn.accept_bi().await.unwrap();
+                        let mut buf = vec![0u8; chunk_size];
+                        for _i in 0..n_chunks_per_client {
+                            recv.read_exact(&mut buf).await.unwrap();
+                            send.write_all(&buf).await.unwrap();
+                        }
+                        send.finish().await.unwrap();
+                        recv.read_to_end(0).await.unwrap();
+                        info!(%i, peer = %peer_id.fmt_short(), "finished");
+                    }
+                }
+                .instrument(error_span!("server")),
+            )
+        };
+
+        let client_secret_key = SecretKey::generate_with_rng(&mut rng);
+        let client = tokio::spawn(async move {
+            for i in 0..n_iters {
+                let derp_map = derp_map.clone();
+                let client_secret_key = client_secret_key.clone();
+                let fut = async move {
+                    info!("client binding");
+                    let start = Instant::now();
+                    let ep = MagicEndpoint::builder()
+                        .alpns(vec![TEST_ALPN.to_vec()])
+                        .derp_mode(DerpMode::Custom(derp_map))
+                        .secret_key(client_secret_key)
+                        .bind(0)
+                        .await
+                        .unwrap();
+                    let eps = ep.local_addr().unwrap();
+                    info!(me = %ep.peer_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, t = ?start.elapsed(), "client bound");
+                    let peer_addr = PeerAddr::new(server_node_id).with_derp_region(region_id);
+                    info!(to = ?peer_addr, "client connecting");
+                    let t = Instant::now();
+                    let conn = ep.connect(peer_addr, TEST_ALPN).await.unwrap();
+                    info!(t = ?t.elapsed(), "client connected");
+                    let t = Instant::now();
+                    let (mut send, mut recv) = conn.open_bi().await.unwrap();
+
+                    for i in 0..n_chunks_per_client {
+                        let mut buf = vec![i; chunk_size];
+                        send.write_all(&buf).await.unwrap();
+                        recv.read_exact(&mut buf).await.unwrap();
+                        assert_eq!(buf, vec![i; chunk_size]);
+                    }
+                    send.finish().await.unwrap();
+                    recv.read_to_end(0).await.unwrap();
+                    info!(t = ?t.elapsed(), "client finished");
+                    ep.close(0u32.into(), &[]).await.unwrap();
+                    info!(total = ?start.elapsed(), "client closed");
+                }
+                .instrument(error_span!("client", %i));
+                tokio::task::spawn(fut).await.unwrap();
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        });
+
+        client.await.unwrap();
+        server.abort();
+        let _ = server.await;
     }
 
     // #[tokio::test]

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1002,7 +1002,7 @@ impl Inner {
                 actor_sender
                     .send(ActorMessage::ReStun("refresh-for-peering"))
                     .await
-                    .unwrap();
+                    .ok()
             });
 
             let actor_sender = self.actor_sender.clone();
@@ -1018,7 +1018,7 @@ impl Inner {
                                 dst_key,
                             })
                             .await
-                            .unwrap();
+                            .ok();
                     })
                 }),
             );
@@ -2455,9 +2455,7 @@ impl DiscoveredEndpoints {
     fn set(&mut self, endpoints: &[config::Endpoint]) -> bool {
         self.last_endpoints_time = Some(Instant::now());
         for (_de, f) in self.on_refresh.drain() {
-            tokio::task::spawn(async move {
-                f();
-            });
+            tokio::task::spawn(f());
         }
 
         if endpoint_sets_equal(endpoints, &self.last_endpoints) {

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -940,12 +940,12 @@ impl Inner {
             return Poll::Ready(Ok(()));
         }
         match *msg {
-            PingAction::SendCallMeMaybe{
+            PingAction::SendCallMeMaybe {
                 derp_region,
                 dst_key,
-                force_now
+                clear_pongs,
             } => {
-                self.send_call_me_maybe(derp_region, dst_key, force_now);
+                self.send_call_me_maybe(derp_region, dst_key, clear_pongs);
             }
             PingAction::SendPing(ref ping) => {
                 ready!(self.poll_send_ping(ping, cx))?;
@@ -994,7 +994,7 @@ impl Inner {
         futures::future::poll_fn(|cx| self.poll_send_udp(addr, &transmits, cx)).await
     }
 
-    fn send_call_me_maybe(&self, derp_region: u16, dst_key: PublicKey, force_now: bool) {
+    fn send_call_me_maybe(&self, derp_region: u16, dst_key: PublicKey, clear_pongs: bool) {
         let mut endpoints = self.endpoints.lock();
         let is_fresh = endpoints.fresh_enough();
         if !is_fresh {
@@ -1029,10 +1029,13 @@ impl Inner {
                     })
                 }),
             );
-        } 
-        if is_fresh || force_now {
+        }
+        if is_fresh || clear_pongs {
             let eps: Vec<_> = endpoints.iter().map(|ep| ep.addr).collect();
-            let msg = disco::CallMeMaybe { my_number: eps };
+            let msg = disco::CallMeMaybe {
+                my_number: eps,
+                clear_pongs,
+            };
             if !self.send_disco_message_derp(derp_region, dst_key, disco::Message::CallMeMaybe(msg))
             {
                 warn!(peer = %dst_key.fmt_short(), "Derp channel full, dropping CallMeMaybe");

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1231,7 +1231,7 @@ impl MagicSock {
             async move {
                 derp_actor.run(derp_actor_receiver).await;
             }
-            .instrument(info_span!("derp.actor")),
+            .instrument(info_span!("derp-actor")),
         );
 
         let inner2 = inner.clone();

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -344,7 +344,7 @@ impl DerpActor {
     }
 
     async fn send_derp(&mut self, region_id: u16, contents: DerpContents, peer: PublicKey) {
-        debug!(region_id, ?peer, "sending derp");
+        debug!(region_id, peer = %peer.fmt_short(),len = contents.iter().map(|c| c.len()).sum::<usize>(),  "sending derp");
         if !self.conn.derp_map.contains_region(region_id) {
             warn!("unknown region id {}", region_id);
             return;

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -376,7 +376,7 @@ impl DerpActor {
         }
 
         // Wake up the send waker if one is waiting for space in the channel
-        let mut wakers = self.conn.network_send_wakers.lock().unwrap();
+        let mut wakers = self.conn.network_send_wakers.lock();
         if let Some(waker) = wakers.take() {
             waker.wake();
         }

--- a/iroh-net/src/magicsock/peer_map.rs
+++ b/iroh-net/src/magicsock/peer_map.rs
@@ -336,7 +336,7 @@ impl PeerMapInner {
     fn receive_udp(&mut self, udp_addr: SocketAddr) -> Option<QuicMappedAddr> {
         let ip_port: IpPort = udp_addr.into();
         let Some(endpoint) = self.get_mut(EndpointId::IpPort(&ip_port)) else {
-            debug_assert!(false, "peer map inconsistency by_ip_port <-> by_id");
+            info!(src=%udp_addr, "receive_udp: no peer_map state found for addr, ignore");
             return None;
         };
         endpoint.receive_udp(ip_port, Instant::now());
@@ -345,7 +345,7 @@ impl PeerMapInner {
 
     fn receive_derp(&mut self, region_id: u16, src: &PublicKey) -> QuicMappedAddr {
         let endpoint = self.get_or_insert_with(EndpointId::NodeKey(src), || {
-            info!(peer=%src, "no peer_map state found for peer");
+            info!(peer=%src.fmt_short(), "receive_derp: packets from unknown peer, insert into peer map");
             Options {
                 public_key: *src,
                 derp_region: Some(region_id),

--- a/iroh-net/src/magicsock/peer_map.rs
+++ b/iroh-net/src/magicsock/peer_map.rs
@@ -28,7 +28,7 @@ mod best_addr;
 mod endpoint;
 
 pub use endpoint::{ConnectionType, DirectAddrInfo, EndpointInfo};
-pub(super) use endpoint::{DiscoPingPurpose, PingAction};
+pub(super) use endpoint::{DiscoPingPurpose, PingAction, PingRole};
 
 /// Number of peers that are inactive for which we keep info about. This limit is enforced
 /// periodically via [`PeerMap::prune_inactive`].
@@ -65,6 +65,13 @@ pub(super) struct PeerMapInner {
     next_id: usize,
 }
 
+enum EndpointId<'a> {
+    Id(&'a usize),
+    NodeKey(&'a PublicKey),
+    QuicMappedAddr(&'a QuicMappedAddr),
+    IpPort(&'a IpPort),
+}
+
 impl PeerMap {
     /// Create a new [`PeerMap`] from data stored in `path`.
     pub fn load_from_file(path: impl AsRef<Path>) -> anyhow::Result<Self> {
@@ -94,48 +101,16 @@ impl PeerMap {
         self.inner.lock().node_count()
     }
 
-    pub fn endpoint_id_to_public_key(&self, id: &usize) -> Option<PublicKey> {
-        self.inner.lock().by_id(id).map(|ep| ep.public_key)
+    pub fn node_key_for_endpoint_id(&self, id: &usize) -> Option<PublicKey> {
+        self.inner.lock().by_id.get(id).map(|ep| *ep.public_key())
     }
 
-    pub fn get_quic_mapped_addr_for_udp_recv(
-        &self,
-        udp_addr: SocketAddr,
-    ) -> Option<QuicMappedAddr> {
-        self.inner
-            .lock()
-            .receive_ip(udp_addr)
-            .map(|ep| ep.quic_mapped_addr)
+    pub fn receive_udp(&self, udp_addr: SocketAddr) -> Option<QuicMappedAddr> {
+        self.inner.lock().receive_udp(udp_addr)
     }
 
-    pub fn get_quic_mapped_addr_for_derp_recv(
-        &self,
-        region_id: u16,
-        src: PublicKey,
-    ) -> QuicMappedAddr {
-        let mut pm = self.inner.lock();
-        let ep_quic_mapped_addr = pm.endpoint_for_node_key_mut(&src).as_mut().map(|ep| {
-            // NOTE: we don't update the derp region if there is already one but the new one is
-            // different
-            if ep.derp_region().is_none() {
-                ep.set_derp_region(region_id);
-            }
-            ep.quic_mapped_addr
-        });
-
-        match ep_quic_mapped_addr {
-            Some(addr) => addr,
-            None => {
-                info!(peer=%src, "no peer_map state found for peer");
-                let id = pm.insert_endpoint(Options {
-                    public_key: src,
-                    derp_region: Some(region_id),
-                    active: true,
-                });
-                let ep = pm.by_id_mut(&id).expect("inserted");
-                ep.quic_mapped_addr
-            }
-        }
+    pub fn receive_derp(&self, region_id: u16, src: PublicKey) -> QuicMappedAddr {
+        self.inner.lock().receive_derp(region_id, &src)
     }
 
     pub fn notify_ping_sent(
@@ -146,25 +121,30 @@ impl PeerMap {
         purpose: DiscoPingPurpose,
         msg_sender: tokio::sync::mpsc::Sender<ActorMessage>,
     ) {
-        if let Some(ep) = self.inner.lock().by_id_mut(&id) {
+        if let Some(ep) = self.inner.lock().get_mut(EndpointId::Id(&id)) {
             ep.ping_sent(dst, tx_id, purpose, msg_sender);
         }
     }
 
     pub fn notify_ping_timeout(&self, id: usize, tx_id: stun::TransactionId) {
-        if let Some(ep) = self.inner.lock().by_id_mut(&id).as_mut() {
+        if let Some(ep) = self.inner.lock().get_mut(EndpointId::Id(&id)) {
             ep.ping_timeout(tx_id);
         }
     }
 
+    pub fn get_quic_mapped_addr_for_node_key(
+        &self,
+        node_key: &PublicKey,
+    ) -> Option<QuicMappedAddr> {
+        self.inner
+            .lock()
+            .get(EndpointId::NodeKey(node_key))
+            .map(|ep| *ep.quic_mapped_addr())
+    }
+
     /// Insert a received ping into the peer map, and return whether a ping with this tx_id was already
     /// received.
-    pub fn handle_ping(
-        &self,
-        sender: PublicKey,
-        src: &DiscoMessageSource,
-        tx_id: TransactionId,
-    ) -> bool {
+    pub fn handle_ping(&self, sender: PublicKey, src: SendAddr, tx_id: TransactionId) -> PingRole {
         self.inner.lock().handle_ping(sender, src, tx_id)
     }
 
@@ -176,20 +156,13 @@ impl PeerMap {
         self.inner.lock().handle_call_me_maybe(sender, cm)
     }
 
-    pub fn get_quic_mapped_addr_for_node_key(&self, nk: &PublicKey) -> Option<QuicMappedAddr> {
-        self.inner
-            .lock()
-            .endpoint_for_node_key(nk)
-            .map(|ep| ep.quic_mapped_addr)
-    }
-
     #[allow(clippy::type_complexity)]
     pub fn get_send_addrs_for_quic_mapped_addr(
         &self,
         addr: &QuicMappedAddr,
     ) -> Option<(PublicKey, Option<SocketAddr>, Option<u16>, Vec<PingAction>)> {
         let mut inner = self.inner.lock();
-        let ep = inner.endpoint_for_quic_mapped_addr_mut(addr)?;
+        let ep = inner.get_mut(EndpointId::QuicMappedAddr(addr))?;
         let public_key = *ep.public_key();
         let (udp_addr, derp_region, msgs) = ep.get_send_addrs();
         Some((public_key, udp_addr, derp_region, msgs))
@@ -316,21 +289,41 @@ impl PeerMapInner {
     fn add_peer_addr(&mut self, peer_addr: PeerAddr) {
         let PeerAddr { peer_id, info } = peer_addr;
 
-        if self.endpoint_for_node_key(&peer_id).is_none() {
-            info!(derp_region = ?info.derp_region, "inserting new peer endpoint in PeerMap");
-            self.insert_endpoint(Options {
-                public_key: peer_id,
-                derp_region: info.derp_region,
-                active: false,
-            });
-        }
+        let endpoint = self.get_or_insert_with(EndpointId::NodeKey(&peer_id), || Options {
+            public_key: peer_id,
+            derp_region: info.derp_region,
+            active: false,
+        });
 
-        if let Some(ep) = self.endpoint_for_node_key_mut(&peer_id) {
-            ep.update_from_node_addr(&info);
-            let id = ep.id;
-            for endpoint in &info.direct_addresses {
-                self.set_endpoint_for_ip_port(*endpoint, id);
-            }
+        endpoint.update_from_node_addr(&info);
+        let id = endpoint.id();
+        for endpoint in &info.direct_addresses {
+            self.set_endpoint_for_ip_port(*endpoint, id);
+        }
+    }
+
+    fn get_id(&self, id: EndpointId) -> Option<usize> {
+        match id {
+            EndpointId::Id(id) => Some(*id),
+            EndpointId::NodeKey(node_key) => self.by_node_key.get(node_key).copied(),
+            EndpointId::QuicMappedAddr(addr) => self.by_quic_mapped_addr.get(addr).copied(),
+            EndpointId::IpPort(ipp) => self.by_ip_port.get(ipp).copied(),
+        }
+    }
+
+    fn get_mut(&mut self, id: EndpointId) -> Option<&mut Endpoint> {
+        self.get_id(id).and_then(|id| self.by_id.get_mut(&id))
+    }
+
+    fn get(&self, id: EndpointId) -> Option<&Endpoint> {
+        self.get_id(id).and_then(|id| self.by_id.get(&id))
+    }
+
+    fn get_or_insert_with(&mut self, id: EndpointId, f: impl FnOnce() -> Options) -> &mut Endpoint {
+        let id = self.get_id(id);
+        match id {
+            None => self.insert_endpoint(f()),
+            Some(id) => self.by_id.get_mut(&id).expect("is not empty"),
         }
     }
 
@@ -339,55 +332,28 @@ impl PeerMapInner {
         self.by_id.len()
     }
 
-    fn by_id(&self, id: &usize) -> Option<&Endpoint> {
-        self.by_id.get(id)
-    }
-
-    fn by_id_mut(&mut self, id: &usize) -> Option<&mut Endpoint> {
-        self.by_id.get_mut(id)
-    }
-
-    /// Returns the endpoint for nk, or None if nk is not known to us.
-    fn endpoint_for_node_key(&self, nk: &PublicKey) -> Option<&Endpoint> {
-        self.by_node_key.get(nk).and_then(|id| self.by_id(id))
-    }
-
-    fn endpoint_for_node_key_mut(&mut self, nk: &PublicKey) -> Option<&mut Endpoint> {
-        self.by_node_key
-            .get(nk)
-            .and_then(|id| self.by_id.get_mut(id))
-    }
-
     /// Marks the peer we believe to be at `ipp` as recently used, returning the [`Endpoint`] if found.
-    fn receive_ip(&mut self, udp_addr: SocketAddr) -> Option<&Endpoint> {
+    fn receive_udp(&mut self, udp_addr: SocketAddr) -> Option<QuicMappedAddr> {
         let ip_port: IpPort = udp_addr.into();
-        // search by IpPort to get the Id
-        let id = *self.by_ip_port.get(&ip_port)?;
-        // search by Id to get the endpoint. This should never fail
-        let Some(endpoint) = self.by_id_mut(&id) else {
+        let Some(endpoint) = self.get_mut(EndpointId::IpPort(&ip_port)) else {
             debug_assert!(false, "peer map inconsistency by_ip_port <-> by_id");
             return None;
         };
-        // the endpoint we found must have the original address among its direct udp addresses if
-        // the peer map maintains consistency
-        let Some(state) = endpoint.direct_addr_state.get_mut(&ip_port) else {
-            debug_assert!(false, "peer map inconsistency by_ip_port <-> direct addr");
-            return None;
-        };
-        // record this peer and this address being in use
-        let now = Instant::now();
-        endpoint.last_used = Some(now);
-        state.last_payload_msg = Some(now);
-        Some(endpoint)
+        endpoint.receive_udp(ip_port, Instant::now());
+        Some(*endpoint.quic_mapped_addr())
     }
 
-    fn endpoint_for_quic_mapped_addr_mut(
-        &mut self,
-        addr: &QuicMappedAddr,
-    ) -> Option<&mut Endpoint> {
-        self.by_quic_mapped_addr
-            .get(addr)
-            .and_then(|id| self.by_id.get_mut(id))
+    fn receive_derp(&mut self, region_id: u16, src: &PublicKey) -> QuicMappedAddr {
+        let endpoint = self.get_or_insert_with(EndpointId::NodeKey(src), || {
+            info!(peer=%src, "no peer_map state found for peer");
+            Options {
+                public_key: *src,
+                derp_region: Some(region_id),
+                active: true,
+            }
+        });
+        endpoint.receive_derp(region_id, src, Instant::now());
+        *endpoint.quic_mapped_addr()
     }
 
     fn endpoints(&self) -> impl Iterator<Item = (&usize, &Endpoint)> {
@@ -405,13 +371,13 @@ impl PeerMapInner {
 
     /// Get the [`EndpointInfo`]s for each endpoint
     fn endpoint_info(&self, public_key: &PublicKey) -> Option<EndpointInfo> {
-        self.endpoint_for_node_key(public_key)
+        self.get(EndpointId::NodeKey(public_key))
             .map(|ep| ep.info(Instant::now()))
     }
 
     fn handle_pong(&mut self, sender: PublicKey, src: &DiscoMessageSource, pong: Pong) {
-        if let Some(ep) = self.endpoint_for_node_key_mut(&sender).as_mut() {
-            let insert = ep.handle_pong_conn(&pong, src.into());
+        if let Some(ep) = self.get_mut(EndpointId::NodeKey(&sender)).as_mut() {
+            let insert = ep.handle_pong(&pong, src.into());
             if let Some((src, key)) = insert {
                 self.set_node_key_for_ip_port(src, &key);
             }
@@ -422,7 +388,7 @@ impl PeerMapInner {
     }
 
     fn handle_call_me_maybe(&mut self, sender: PublicKey, cm: CallMeMaybe) {
-        match self.endpoint_for_node_key_mut(&sender) {
+        match self.get_mut(EndpointId::NodeKey(&sender)) {
             None => {
                 inc!(MagicsockMetrics, recv_disco_call_me_maybe_bad_disco);
                 debug!("received call-me-maybe: ignore, peer is unknown");
@@ -434,57 +400,38 @@ impl PeerMapInner {
         };
     }
 
-    fn handle_ping(
-        &mut self,
-        sender: PublicKey,
-        src: &DiscoMessageSource,
-        tx_id: TransactionId,
-    ) -> bool {
-        let unknown_sender = if self.endpoint_for_node_key(&sender).is_none() {
-            match src {
-                DiscoMessageSource::Udp(addr) => self.receive_ip(*addr).is_none(),
-                DiscoMessageSource::Derp { .. } => true,
-            }
-        } else {
-            false
-        };
-        // if we get here we got a valid ping from an unknown sender
-        // so insert an endpoint for them
-        if unknown_sender {
+    fn handle_ping(&mut self, sender: PublicKey, src: SendAddr, tx_id: TransactionId) -> PingRole {
+        let endpoint = self.get_or_insert_with(EndpointId::NodeKey(&sender), || {
             debug!("received ping: peer unknown, add to peer map");
-            self.insert_endpoint(Options {
+            Options {
                 public_key: sender,
                 derp_region: src.derp_region(),
                 active: true,
-            });
-        }
-        let is_duplicate = if let Some(ep) = self.endpoint_for_node_key_mut(&sender) {
-            if ep.endpoint_confirmed(src.into(), tx_id) {
-                true
-            } else {
-                if let DiscoMessageSource::Udp(addr) = src {
-                    self.set_node_key_for_ip_port(*addr, &sender);
-                }
-                false
             }
-        } else {
-            false
-        };
-        is_duplicate
+        });
+
+        let role = endpoint.handle_ping(src, tx_id);
+        if let SendAddr::Udp(addr) = src {
+            if matches!(role, PingRole::NewEndpoint) {
+                self.set_node_key_for_ip_port(addr, &sender);
+            }
+        }
+        role
     }
 
     /// Inserts a new endpoint into the [`PeerMap`].
-    fn insert_endpoint(&mut self, options: Options) -> usize {
+    fn insert_endpoint(&mut self, options: Options) -> &mut Endpoint {
+        info!(peer = %options.public_key.fmt_short(), derp_region = ?options.derp_region, "inserting new peer endpoint in PeerMap");
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);
         let ep = Endpoint::new(id, options);
 
         // update indices
-        self.by_quic_mapped_addr.insert(ep.quic_mapped_addr, id);
-        self.by_node_key.insert(ep.public_key, id);
+        self.by_quic_mapped_addr.insert(*ep.quic_mapped_addr(), id);
+        self.by_node_key.insert(*ep.public_key(), id);
 
         self.by_id.insert(id, ep);
-        id
+        self.by_id.get_mut(&id).expect("just inserted")
     }
 
     /// Makes future peer lookups by ipp return the same endpoint as a lookup by nk.
@@ -519,7 +466,7 @@ impl PeerMapInner {
             .by_id
             .values()
             .filter(|peer| !peer.is_active(&now))
-            .map(|peer| (*peer.public_key(), peer.last_used))
+            .map(|peer| (*peer.public_key(), peer.last_used()))
             .collect();
 
         let prune_count = prune_candidates.len().saturating_sub(MAX_INACTIVE_PEERS);
@@ -551,7 +498,7 @@ impl PeerMapInner {
                 self.by_ip_port.remove(&ip_port);
             }
 
-            self.by_quic_mapped_addr.remove(&ep.quic_mapped_addr);
+            self.by_quic_mapped_addr.remove(ep.quic_mapped_addr());
         }
     }
 }
@@ -595,229 +542,10 @@ impl IpPort {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
-    use std::time::Duration;
-
-    use super::best_addr::BestAddr;
-    use super::endpoint::{ControlMsg, EndpointState, PongReply, MAX_INACTIVE_DIRECT_ADDRESSES};
+    use super::endpoint::MAX_INACTIVE_DIRECT_ADDRESSES;
     use super::*;
     use crate::{key::SecretKey, magic_endpoint::AddrInfo};
-
-    #[test]
-    fn test_endpoint_infos() {
-        let new_relay_and_state = |region_id: Option<u16>| {
-            region_id.map(|region_id| (region_id, EndpointState::default()))
-        };
-
-        let now = Instant::now();
-        let elapsed = Duration::from_secs(3);
-        let later = now + elapsed;
-
-        // endpoint with a `best_addr` that has a latency
-        let pong_src = "0.0.0.0:1".parse().unwrap();
-        let latency = Duration::from_millis(50);
-        let (a_endpoint, a_socket_addr) = {
-            let ip_port = IpPort {
-                ip: Ipv4Addr::UNSPECIFIED.into(),
-                port: 10,
-            };
-            let endpoint_state = HashMap::from([(
-                ip_port,
-                EndpointState::with_pong_reply(PongReply {
-                    latency,
-                    pong_at: now,
-                    from: SendAddr::Udp(ip_port.into()),
-                    pong_src,
-                }),
-            )]);
-            let key = SecretKey::generate();
-            (
-                Endpoint {
-                    id: 0,
-                    quic_mapped_addr: QuicMappedAddr::generate(),
-                    public_key: key.public(),
-                    last_full_ping: None,
-                    derp_region: new_relay_and_state(Some(0)),
-                    best_addr: BestAddr::from_parts(
-                        ip_port.into(),
-                        latency,
-                        now,
-                        now + Duration::from_secs(100),
-                    ),
-                    direct_addr_state: endpoint_state,
-                    is_call_me_maybe_ep: HashMap::new(),
-                    pending_cli_pings: Vec::new(),
-                    sent_ping: HashMap::new(),
-                    last_used: Some(now),
-                },
-                ip_port.into(),
-            )
-        };
-        // endpoint w/ no best addr but a derp  w/ latency
-        let b_endpoint = {
-            // let socket_addr = "0.0.0.0:9".parse().unwrap();
-            let relay_state = EndpointState::with_pong_reply(PongReply {
-                latency,
-                pong_at: now,
-                from: SendAddr::Derp(0),
-                pong_src,
-            });
-            let key = SecretKey::generate();
-            Endpoint {
-                id: 1,
-                quic_mapped_addr: QuicMappedAddr::generate(),
-                public_key: key.public(),
-                last_full_ping: None,
-                derp_region: Some((0, relay_state)),
-                best_addr: BestAddr::default(),
-                direct_addr_state: HashMap::default(),
-                is_call_me_maybe_ep: HashMap::new(),
-                pending_cli_pings: Vec::new(),
-                sent_ping: HashMap::new(),
-                last_used: Some(now),
-            }
-        };
-
-        // endpoint w/ no best addr but a derp  w/ no latency
-        let c_endpoint = {
-            // let socket_addr = "0.0.0.0:8".parse().unwrap();
-            let endpoint_state = HashMap::new();
-            let key = SecretKey::generate();
-            Endpoint {
-                id: 2,
-                quic_mapped_addr: QuicMappedAddr::generate(),
-                public_key: key.public(),
-                last_full_ping: None,
-                derp_region: new_relay_and_state(Some(0)),
-                best_addr: BestAddr::default(),
-                direct_addr_state: endpoint_state,
-                is_call_me_maybe_ep: HashMap::new(),
-                pending_cli_pings: Vec::new(),
-                sent_ping: HashMap::new(),
-                last_used: Some(now),
-            }
-        };
-
-        // endpoint w/ expired best addr
-        let (d_endpoint, d_socket_addr) = {
-            let socket_addr: SocketAddr = "0.0.0.0:7".parse().unwrap();
-            let expired = now.checked_sub(Duration::from_secs(100)).unwrap();
-            let endpoint_state = HashMap::from([(
-                IpPort::from(socket_addr),
-                EndpointState::with_pong_reply(PongReply {
-                    latency,
-                    pong_at: now,
-                    from: SendAddr::Udp(socket_addr),
-                    pong_src,
-                }),
-            )]);
-            let relay_state = EndpointState::with_pong_reply(PongReply {
-                latency,
-                pong_at: now,
-                from: SendAddr::Derp(0),
-                pong_src,
-            });
-            let key = SecretKey::generate();
-            (
-                Endpoint {
-                    id: 3,
-                    quic_mapped_addr: QuicMappedAddr::generate(),
-                    public_key: key.public(),
-                    last_full_ping: None,
-                    derp_region: Some((0, relay_state)),
-                    best_addr: BestAddr::from_parts(
-                        socket_addr,
-                        Duration::from_millis(80),
-                        now,
-                        expired,
-                    ),
-                    direct_addr_state: endpoint_state,
-                    is_call_me_maybe_ep: HashMap::new(),
-                    pending_cli_pings: Vec::new(),
-                    sent_ping: HashMap::new(),
-                    last_used: Some(now),
-                },
-                socket_addr,
-            )
-        };
-        let expect = Vec::from([
-            EndpointInfo {
-                id: a_endpoint.id,
-                public_key: a_endpoint.public_key,
-                derp_region: a_endpoint.derp_region(),
-                addrs: Vec::from([DirectAddrInfo {
-                    addr: a_socket_addr,
-                    latency: Some(latency),
-                    last_control: Some((elapsed, ControlMsg::Pong)),
-                    last_payload: None,
-                }]),
-                conn_type: ConnectionType::Direct(a_socket_addr),
-                latency: Some(latency),
-                last_used: Some(elapsed),
-            },
-            EndpointInfo {
-                id: b_endpoint.id,
-                public_key: b_endpoint.public_key,
-                derp_region: b_endpoint.derp_region(),
-                addrs: Vec::new(),
-                conn_type: ConnectionType::Relay(0),
-                latency: Some(latency),
-                last_used: Some(elapsed),
-            },
-            EndpointInfo {
-                id: c_endpoint.id,
-                public_key: c_endpoint.public_key,
-                derp_region: c_endpoint.derp_region(),
-                addrs: Vec::new(),
-                conn_type: ConnectionType::Relay(0),
-                latency: None,
-                last_used: Some(elapsed),
-            },
-            EndpointInfo {
-                id: d_endpoint.id,
-                public_key: d_endpoint.public_key,
-                derp_region: d_endpoint.derp_region(),
-                addrs: Vec::from([DirectAddrInfo {
-                    addr: d_socket_addr,
-                    latency: Some(latency),
-                    last_control: Some((elapsed, ControlMsg::Pong)),
-                    last_payload: None,
-                }]),
-                conn_type: ConnectionType::Mixed(d_socket_addr, 0),
-                latency: Some(Duration::from_millis(50)),
-                last_used: Some(elapsed),
-            },
-        ]);
-
-        let peer_map = PeerMap::from_inner(PeerMapInner {
-            by_node_key: HashMap::from([
-                (a_endpoint.public_key, a_endpoint.id),
-                (b_endpoint.public_key, b_endpoint.id),
-                (c_endpoint.public_key, c_endpoint.id),
-                (d_endpoint.public_key, d_endpoint.id),
-            ]),
-            by_ip_port: HashMap::from([
-                (a_socket_addr.into(), a_endpoint.id),
-                (d_socket_addr.into(), d_endpoint.id),
-            ]),
-            by_quic_mapped_addr: HashMap::from([
-                (a_endpoint.quic_mapped_addr, a_endpoint.id),
-                (b_endpoint.quic_mapped_addr, b_endpoint.id),
-                (c_endpoint.quic_mapped_addr, c_endpoint.id),
-                (d_endpoint.quic_mapped_addr, d_endpoint.id),
-            ]),
-            by_id: HashMap::from([
-                (a_endpoint.id, a_endpoint),
-                (b_endpoint.id, b_endpoint),
-                (c_endpoint.id, c_endpoint),
-                (d_endpoint.id, d_endpoint),
-            ]),
-            next_id: 5,
-        });
-        let mut got = peer_map.endpoint_infos(later);
-        got.sort_by_key(|p| p.id);
-        assert_eq!(expect, got);
-    }
+    use std::net::Ipv4Addr;
 
     /// Test persisting and loading of known peers.
     #[tokio::test]
@@ -879,11 +607,15 @@ mod tests {
 
         let peer_map = PeerMap::default();
         let public_key = SecretKey::generate().public();
-        let id = peer_map.inner.lock().insert_endpoint(Options {
-            public_key,
-            derp_region: None,
-            active: false,
-        });
+        let id = peer_map
+            .inner
+            .lock()
+            .insert_endpoint(Options {
+                public_key,
+                derp_region: None,
+                active: false,
+            })
+            .id();
 
         const LOCALHOST: IpAddr = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
 
@@ -897,7 +629,7 @@ mod tests {
             // add address
             peer_map.add_peer_addr(peer_addr);
             // make it active
-            peer_map.inner.lock().receive_ip(addr);
+            peer_map.inner.lock().receive_udp(addr);
         }
 
         // offline adddresses
@@ -914,7 +646,7 @@ mod tests {
         for i in 0..MAX_INACTIVE_DIRECT_ADDRESSES {
             let addr = SendAddr::Udp(SocketAddr::new(LOCALHOST, 7000 + i as u16));
             let txid = stun::TransactionId::from([i as u8; 12]);
-            endpoint.endpoint_confirmed(addr, txid);
+            endpoint.handle_ping(addr, txid);
         }
 
         endpoint.prune_direct_addresses();
@@ -926,9 +658,8 @@ mod tests {
 
         assert_eq!(
             endpoint
-                .direct_addr_state
-                .values()
-                .filter(|state| !state.is_active())
+                .direct_address_states()
+                .filter(|(_addr, state)| !state.is_active())
                 .count(),
             MAX_INACTIVE_DIRECT_ADDRESSES
         )
@@ -941,7 +672,7 @@ mod tests {
         let active_peer = SecretKey::generate().public();
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 167);
         peer_map.add_peer_addr(PeerAddr::new(active_peer).with_direct_addresses([addr]));
-        peer_map.inner.lock().receive_ip(addr).expect("registered");
+        peer_map.inner.lock().receive_udp(addr).expect("registered");
 
         for _ in 0..MAX_INACTIVE_PEERS + 1 {
             let peer = SecretKey::generate().public();
@@ -954,7 +685,7 @@ mod tests {
         peer_map
             .inner
             .lock()
-            .endpoint_for_node_key(&active_peer)
+            .get(EndpointId::NodeKey(&active_peer))
             .expect("should not be pruned");
     }
 }

--- a/iroh-net/src/magicsock/peer_map.rs
+++ b/iroh-net/src/magicsock/peer_map.rs
@@ -393,7 +393,7 @@ impl PeerMapInner {
                 vec![]
             }
             Some(ep) => {
-                debug!(endpoints = ?cm.my_number, clear_pongs = %cm.clear_pongs, "received call-me-maybe");
+                debug!(endpoints = ?cm.my_number, "received call-me-maybe");
                 ep.handle_call_me_maybe(cm)
             }
         }

--- a/iroh-net/src/magicsock/peer_map.rs
+++ b/iroh-net/src/magicsock/peer_map.rs
@@ -101,10 +101,6 @@ impl PeerMap {
         self.inner.lock().node_count()
     }
 
-    pub fn node_key_for_endpoint_id(&self, id: &usize) -> Option<PublicKey> {
-        self.inner.lock().by_id.get(id).map(|ep| *ep.public_key())
-    }
-
     pub fn receive_udp(&self, udp_addr: SocketAddr) -> Option<QuicMappedAddr> {
         self.inner.lock().receive_udp(udp_addr)
     }

--- a/iroh-net/src/magicsock/peer_map.rs
+++ b/iroh-net/src/magicsock/peer_map.rs
@@ -393,7 +393,7 @@ impl PeerMapInner {
                 vec![]
             }
             Some(ep) => {
-                debug!("received call-me-maybe: {} endpoints", cm.my_number.len());
+                debug!(endpoints = ?cm.my_number, clear_pongs = %cm.clear_pongs, "received call-me-maybe");
                 ep.handle_call_me_maybe(cm)
             }
         }

--- a/iroh-net/src/magicsock/peer_map.rs
+++ b/iroh-net/src/magicsock/peer_map.rs
@@ -101,7 +101,7 @@ impl PeerMap {
         self.inner.lock().node_count()
     }
 
-    pub fn receive_udp(&self, udp_addr: SocketAddr) -> Option<QuicMappedAddr> {
+    pub fn receive_udp(&self, udp_addr: SocketAddr) -> Option<(PublicKey, QuicMappedAddr)> {
         self.inner.lock().receive_udp(udp_addr)
     }
 
@@ -330,14 +330,14 @@ impl PeerMapInner {
     }
 
     /// Marks the peer we believe to be at `ipp` as recently used, returning the [`Endpoint`] if found.
-    fn receive_udp(&mut self, udp_addr: SocketAddr) -> Option<QuicMappedAddr> {
+    fn receive_udp(&mut self, udp_addr: SocketAddr) -> Option<(PublicKey, QuicMappedAddr)> {
         let ip_port: IpPort = udp_addr.into();
         let Some(endpoint) = self.get_mut(EndpointId::IpPort(&ip_port)) else {
             info!(src=%udp_addr, "receive_udp: no peer_map state found for addr, ignore");
             return None;
         };
         endpoint.receive_udp(ip_port, Instant::now());
-        Some(*endpoint.quic_mapped_addr())
+        Some((*endpoint.public_key(), *endpoint.quic_mapped_addr()))
     }
 
     fn receive_derp(&mut self, region_id: u16, src: &PublicKey) -> QuicMappedAddr {

--- a/iroh-net/src/magicsock/peer_map/best_addr.rs
+++ b/iroh-net/src/magicsock/peer_map/best_addr.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use iroh_metrics::inc;
-use tracing::{debug, info};
+use tracing::info;
 
 use crate::magicsock::metrics::Metrics as MagicsockMetrics;
 
@@ -85,7 +85,7 @@ impl BestAddr {
     pub fn clear(&mut self, reason: ClearReason, has_derp: bool) -> bool {
         if let Some(addr) = self.addr() {
             self.0 = None;
-            debug!(?reason, ?has_derp, old_addr = %addr, "clearing best_addr");
+            info!(?reason, ?has_derp, old_addr = %addr, "clearing best_addr");
             // no longer relying on the direct connection
             inc!(MagicsockMetrics, num_direct_conns_removed);
             if has_derp {
@@ -154,7 +154,7 @@ impl BestAddr {
            %addr,
            latency = ?latency,
            trust_for = ?trust_until.duration_since(Instant::now()),
-           "new best_addr (candidate address with most recent pong)"
+           "new best_addr"
         );
         let was_empty = self.is_empty();
         let inner = BestAddrInner {

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -539,7 +539,7 @@ impl Endpoint {
                 // sent so our firewall ports are probably open and now
                 // would be a good time for them to connect.
                 let clear_pongs = self.last_full_ping.is_none();
-                info!(?derp_region, ?clear_pongs, "queue call-me-maybe");
+                debug!(?derp_region, ?clear_pongs, "queue call-me-maybe");
                 msgs.push(PingAction::SendCallMeMaybe {
                     derp_region: *derp_region,
                     dst_key: self.public_key,

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -875,6 +875,9 @@ impl Endpoint {
                 st.last_payload_msg = None;
             }
         }
+        if m.clear_pongs {
+            self.best_addr.clear(ClearReason::PruneCallMeMaybe, self.derp_region.is_some());
+        }
         self.send_pings(Instant::now(), false)
     }
 

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -51,9 +51,9 @@ const STAYIN_ALIVE_MIN_ELAPSED: Duration = Duration::from_secs(2);
 
 #[derive(Debug)]
 pub(in crate::magicsock) enum PingAction {
-    EnqueueCallMeMaybe {
+    SendCallMeMaybe {
         derp_region: u16,
-        endpoint_id: usize,
+        dst_key: PublicKey,
     },
     SendPing(SendPing),
 }
@@ -532,11 +532,10 @@ impl Endpoint {
                 // message to our peer via DERP informing them that we've
                 // sent so our firewall ports are probably open and now
                 // would be a good time for them to connect.
-                let id = self.id;
                 info!(?derp_region, "enqueue call-me-maybe");
-                msgs.push(PingAction::EnqueueCallMeMaybe {
+                msgs.push(PingAction::SendCallMeMaybe {
                     derp_region,
-                    endpoint_id: id,
+                    dst_key: self.public_key,
                 });
             }
         }


### PR DESCRIPTION
## Description

* refactor: Make the abstractions around `PeerMap` and `Endpoint` more solid:
  * Better getter API on `PeerMap`, making sure that no mismatch between the indexes and endpoints can emerge
  * No more public acccess to endpoint fields from the peermap (only methods)
* fix: Improvments to tracing spans, fields, levels
* fix: Actually send out pings after handling call-me-maybe messages (we did not do that)
* tests: add a test that recreates a node in a loop and connects to the same server node over derp

## Notes & open questions

The new test passes for me locally but still is super slow (~40 seconds for a loop of 5 times bind & connect & transfer 20 bytes). Something is still not correct. It should never take 10 seconds to connect and transfer 20 bytes.

I think I need some help here - my guess is now that something in the derper is not correct, but not sure.
<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
