### PR TITLE
fix(net): do not dial regions in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,15 +428,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78a6932c88f1d2c29533a3b8a5f5a2f84cc19c3339b431677c3160c5c2e6ca85"
 
 [[package]]
-name = "bounded_join_set"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a551ab5b908bdda1554a7045f624c46cafed4032669dc588b75f2f44afd644"
-dependencies = [
- "tokio",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,7 +2252,6 @@ dependencies = [
  "aead",
  "anyhow",
  "backoff",
- "bounded_join_set",
  "bytes",
  "clap",
  "criterion",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.72"
 aead = { version = "0.5.2", features = ["bytes"] }
 anyhow = { version = "1", features = ["backtrace"] }
 backoff = "0.4.0"
-bounded_join_set = "0.1.0"
 bytes = "1"
 crypto_box = { version = "0.9.1", features = ["serde", "chacha20"] }
 curve25519-dalek = "4.0.0"


### PR DESCRIPTION
These are supposed to be dialed in order, not in parallel.

This should also fix the warnings in the logs about aborted dials.
