### PR TITLE
feat(ci): CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     - name: tests (all features)
       run: |
         crates=iroh,iroh-net
-        for i in ${variable//,/ }
+        for i in ${crates//,/ }
         do
           cargo test -p $i --all-features --lib --bins --tests
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,12 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: tests (all features)
-      run: cargo test --workspace --all-features --lib --bins --tests
+      run: |
+        crates=iroh,iroh-net
+        for i in ${variable//,/ }
+        do
+          cargo test -p $i --all-features --lib --bins --tests
+        done
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,27 +28,18 @@ jobs:
         name: [ubuntu-latest, macOS-arm-latest]
         rust: [nightly, stable]
         include:
-          # - name: ubuntu-arm-latest
-          #   os: ubuntu-latest
-          #   release-os: linux
-          #   release-arch: aarch64
-          #   runner: [self-hosted, linux, ARM64]
           - name: ubuntu-latest
             os: ubuntu-latest
             release-os: linux
             release-arch: amd64
             runner: [self-hosted, linux, X64]
-          # - name: macOS-latest
-          #   os: macOS-latest
-          #   release-os: darwin
-          #   release-arch: x86_64
-          #   runner: [self-hosted, macOS, X64]
           - name: macOS-arm-latest
             os: macOS-latest
             release-os: darwin
             release-arch: aarch64
             runner: [self-hosted, macOS, ARM64]
-
+    env:
+      RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -153,6 +144,7 @@ jobs:
     env:
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
+      RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -222,7 +214,8 @@ jobs:
           - i686-unknown-linux-gnu
           - armv7-linux-androideabi
           - aarch64-linux-android
-
+    env:
+      RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -355,9 +348,8 @@ jobs:
         cd ../chuck/netsim
         sudo kill -9 $(pgrep ovs) || true
         sudo mn --clean || true
-        sudo python3 main.py --integration sims/iroh/iroh.json
-        sudo python3 main.py --integration sims/integration
-
+        sudo python3 main.py ${{ runner.debug && '--debug' || ''}} --integration sims/iroh/iroh.json
+        sudo python3 main.py ${{ runner.debug && '--debug' || ''}} --integration sims/integration
     - name: Cleanup
       run: |
         sudo kill -9 $(pgrep derper) || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,6 @@ jobs:
           - name: windows-latest
             os: windows
             runner: [self-hosted, windows, x64]
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -105,9 +102,6 @@ jobs:
         rustup toolchain default ${{ matrix.rust }}
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
-
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
     
     - uses: msys2/setup-msys2@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.72"
-  CRATES_LIST: "iroh,iroh-bytes,iroh-gossip,iroh-metrics,iroh-net,iroh-sync,iroh-test,iroh-net/bench"
+  CRATES_LIST: "iroh,iroh-bytes,iroh-gossip,iroh-metrics,iroh-net,iroh-sync,iroh-test"
 
 jobs:
   build_and_test_nix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.72"
+  CRATES_LIST: "iroh,iroh-bytes,iroh-gossip,iroh-metrics,iroh-net,iroh-sync,iroh-test,iroh-net/bench"
 
 jobs:
   build_and_test_nix:
@@ -57,8 +58,7 @@ jobs:
 
     - name: tests (all features)
       run: |
-        crates=iroh,iroh-net
-        for i in ${crates//,/ }
+        for i in ${CRATES_LIST//,/ }
         do
           cargo test -p $i --all-features --lib --bins --tests
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
             release-os: darwin
             release-arch: aarch64
             runner: [self-hosted, macOS, ARM64]
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -48,6 +51,9 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
+    
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: tests (all features)
       run: cargo test --workspace --all-features --lib --bins --tests
@@ -84,7 +90,9 @@ jobs:
           - name: windows-latest
             os: windows
             runner: [self-hosted, windows, x64]
-
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -97,6 +105,9 @@ jobs:
         rustup toolchain default ${{ matrix.rust }}
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
+
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
     
     - uses: msys2/setup-msys2@v2
 
@@ -156,6 +167,8 @@ jobs:
     env:
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -170,6 +183,9 @@ jobs:
     - name: Install ${{ matrix.rust }}
       run: |
         rustup toolchain install ${{ matrix.rust }}
+    
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: build release
       run: |
@@ -323,6 +339,9 @@ jobs:
     timeout-minutes: 30
     name: Run network simulations/benchmarks
     runs-on: [self-hosted, linux, X64]
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -331,6 +350,9 @@ jobs:
     
     - name: Install rust stable
       uses: dtolnay/rust-toolchain@stable
+
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Build iroh
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
             release-os: darwin
             release-arch: aarch64
             runner: [self-hosted, macOS, ARM64]
-    env:
-      RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -53,15 +51,23 @@ jobs:
 
     - name: tests (all features)
       run: cargo test --workspace --all-features --lib --bins --tests
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
       
     - name: tests (no features)
       run: cargo test --workspace --no-default-features --lib --bins --tests
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests (default features)
       run: cargo test --workspace --lib --bins --tests
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: doctests
       run: cargo test --workspace --all-features --doc
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
       
   build_and_test_windows:
     timeout-minutes: 30
@@ -96,12 +102,18 @@ jobs:
 
     - name: tests (all features)
       run: cargo test --workspace --all-features --lib --bins --tests --target ${{ matrix.target }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests (no features)
       run: cargo test --workspace --no-default-features --lib --bins --tests --target ${{ matrix.target }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
       
     - name: tests (default features)
       run: cargo test --workspace --lib --bins --tests --target ${{ matrix.target }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
   build_release:
     timeout-minutes: 60
@@ -144,7 +156,6 @@ jobs:
     env:
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
-      RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -214,8 +225,6 @@ jobs:
           - i686-unknown-linux-gnu
           - armv7-linux-androideabi
           - aarch64-linux-android
-    env:
-      RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -236,12 +245,16 @@ jobs:
 
     - name: check
       run: cross check --all --target ${{ matrix.target }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: test
       # cross tests are currently broken vor armv7 and aarch64
       # see https://github.com/cross-rs/cross/issues/1311
       if: matrix.target == 'i686-unknown-linux-gnu'
       run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
   check_fmt_and_docs:
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,17 +66,29 @@ jobs:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
       
     - name: tests (no features)
-      run: cargo test --workspace --no-default-features --lib --bins --tests
+      run: |
+        for i in ${CRATES_LIST//,/ }
+        do
+          cargo test -p $i --no-default-features --lib --bins --tests
+        done
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests (default features)
-      run: cargo test --workspace --lib --bins --tests
+      run: |
+        for i in ${CRATES_LIST//,/ }
+        do
+          cargo test -p $i --lib --bins --tests
+        done
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: doctests
-      run: cargo test --workspace --all-features --doc
+      run: |
+        for i in ${CRATES_LIST//,/ }
+        do
+          cargo test -p $i --all-features --doc
+        done
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
       

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -11,6 +11,8 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
   MSRV: "1.66"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   netsim:
@@ -47,6 +49,9 @@ jobs:
 
     - name: Install rust stable
       uses: dtolnay/rust-toolchain@stable
+    
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Build iroh
       run: |

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -348,6 +348,7 @@ fn cli_provide_persistence() -> anyhow::Result<()> {
             ],
         )
         .env("IROH_DATA_DIR", &iroh_data_dir)
+        .env_remove("RUST_LOG")
         .stdin_null()
         .stderr_capture()
         .reader()
@@ -410,6 +411,7 @@ fn cli_provide_addresses() -> Result<()> {
 
     // test output
     let get_output = cmd(iroh_bin(), ["--rpc-port", RPC_PORT, "node", "status"])
+        .env_remove("RUST_LOG")
         // .stderr_file(std::io::stderr().as_raw_fd()) for debug output
         .stdout_capture()
         .run()?;
@@ -486,6 +488,7 @@ fn make_provider_in(
         // .stderr_null()
         // .stderr_file(std::io::stderr().as_raw_fd()) // for debug output
         // .env("RUST_LOG", "iroh_bytes=debug,iroh_net=warn,iroh=debug,warn")
+        .env_remove("RUST_LOG")
         .env("IROH_DATA_DIR", iroh_data_dir);
 
     let provider = match input {
@@ -548,6 +551,7 @@ fn make_get_cmd(ticket: &str, out: Option<PathBuf>) -> duct::Expression {
     } else {
         cmd(iroh_bin(), ["get", "--ticket", ticket])
     }
+    .env_remove("RUST_LOG")
     .stdout_capture()
     .stderr_capture()
 }
@@ -653,6 +657,7 @@ fn test_provide_get_loop_single(
     let hash_str = hash.to_string();
     args.push(&hash_str);
     let cmd = cmd(iroh_bin(), args)
+        .env_remove("RUST_LOG")
         .stdout_capture()
         .stderr_capture()
         .unchecked();


### PR DESCRIPTION
## Description

😢 this does add ~3 min to the existing 7min of linux runs, but at least it properly checks all crates now.

Closes https://github.com/n0-computer/iroh/issues/1716
You can now click on re run job and in the bottom of the prompt you can check `enable debug logging` to run with `RUST_LOG=DEBUG` & `netsim --debug` for the appropriate tests to get full logging output.
<img width="640" alt="Screenshot 2023-10-26 at 12 57 52" src="https://github.com/n0-computer/iroh/assets/1760977/3920ee51-e26e-4557-b9f7-ef9f28bd8f25">
<img width="640" alt="Screenshot 2023-10-26 at 12 58 05" src="https://github.com/n0-computer/iroh/assets/1760977/743fc8d1-2cb1-4d9e-9a0e-6dbac4aa27f9">

Closes https://github.com/n0-computer/iroh/issues/1717
Linker changes are still up for debate

Closes https://github.com/n0-computer/iroh/issues/1423
We need to maintain the crates list, but shouldn't be too hard. Managed to pull it out into a single var.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
