### PR TITLE
fix(iroh): handle rpc args in any position

### DIFF
--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -100,7 +100,6 @@ impl Cli {
                 #[cfg(feature = "metrics")]
                 let metrics_fut = start_metrics_server(metrics_addr, &rt);
 
-
                 let res = command.run(&rt, &config, keylog, self.rpc_port).await;
 
                 #[cfg(feature = "metrics")]

--- a/iroh/src/commands/node.rs
+++ b/iroh/src/commands/node.rs
@@ -1,8 +1,6 @@
 use std::{
-    fmt,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     path::PathBuf,
-    str::FromStr,
     sync::Arc,
 };
 
@@ -174,40 +172,4 @@ fn make_rpc_endpoint(
     let rpc_endpoint =
         QuinnServerEndpoint::<ProviderRequest, ProviderResponse>::new(rpc_quinn_endpoint)?;
     Ok(rpc_endpoint)
-}
-
-#[derive(Debug, Clone)]
-pub enum RpcPort {
-    Enabled(u16),
-    Disabled,
-}
-
-impl From<RpcPort> for Option<u16> {
-    fn from(value: RpcPort) -> Self {
-        match value {
-            RpcPort::Enabled(port) => Some(port),
-            RpcPort::Disabled => None,
-        }
-    }
-}
-
-impl fmt::Display for RpcPort {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RpcPort::Enabled(port) => write!(f, "{port}"),
-            RpcPort::Disabled => write!(f, "disabled"),
-        }
-    }
-}
-
-impl FromStr for RpcPort {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "disabled" {
-            Ok(RpcPort::Disabled)
-        } else {
-            Ok(RpcPort::Enabled(s.parse()?))
-        }
-    }
 }

--- a/iroh/src/commands/node.rs
+++ b/iroh/src/commands/node.rs
@@ -28,7 +28,7 @@ use super::{BlobAddOptions, MAX_RPC_CONNECTIONS, MAX_RPC_STREAMS};
 #[derive(Debug)]
 pub struct StartOptions {
     pub addr: SocketAddr,
-    pub rpc_port: RpcPort,
+    pub rpc_port: u16,
     pub keylog: bool,
     pub request_token: Option<RequestToken>,
     pub derp_map: Option<DerpMap>,

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -342,7 +342,7 @@ fn cli_provide_persistence() -> anyhow::Result<()> {
                 "--addr",
                 ADDR,
                 "--rpc-port",
-                "disabled",
+                "0",
                 path.to_str().unwrap(),
                 "--wrap",
             ],
@@ -476,7 +476,7 @@ fn make_provider_in(
         "--addr",
         addr.unwrap_or(ADDR),
         "--rpc-port",
-        rpc_port.unwrap_or("disabled"),
+        rpc_port.unwrap_or("0"),
     ];
     if wrap {
         args.push("--wrap");


### PR DESCRIPTION
It is now possible to do any of these 

```
> iroh start --rpc-port 1234
> iroh --rpc-port 1234 start
> iroh console --rpc-port 1234
> iroh --rpc-port 1234 console
```

Closes #1639

