### PR TITLE
feat: clear pongs on initial connect via Derp

### DIFF
--- a/iroh-net/src/disco.rs
+++ b/iroh-net/src/disco.rs
@@ -143,6 +143,8 @@ pub struct Pong {
 pub struct CallMeMaybe {
     /// What the peer believes its endpoints are.
     pub my_number: Vec<SocketAddr>,
+    /// If true invalidate all previous pongs. This is sent after a total state reset.
+    pub clear_pongs: bool,
 }
 
 impl Ping {
@@ -222,16 +224,19 @@ impl Pong {
 impl CallMeMaybe {
     fn from_bytes(ver: u8, p: &[u8]) -> Result<Self> {
         ensure!(ver == V0, "invalid version");
-        ensure!(p.len() % EP_LENGTH == 0, "invalid entries");
 
         let num_entries = p.len() / EP_LENGTH;
         let mut m = CallMeMaybe {
             my_number: Vec::with_capacity(num_entries),
+            clear_pongs: false,
         };
 
         for chunk in p.chunks_exact(EP_LENGTH) {
             let src = socket_addr_from_bytes(chunk);
             m.my_number.push(src);
+        }
+        if p.len() > EP_LENGTH * m.my_number.len() && p.last() == Some(&1u8) {
+            m.clear_pongs = true;
         }
 
         Ok(m)
@@ -239,7 +244,7 @@ impl CallMeMaybe {
 
     fn as_bytes(&self) -> Vec<u8> {
         let header = msg_header(MessageType::CallMeMaybe, V0);
-        let mut out = vec![0u8; HEADER_LEN + self.my_number.len() * EP_LENGTH];
+        let mut out = vec![0u8; HEADER_LEN + self.my_number.len() * EP_LENGTH + 1];
         out[..HEADER_LEN].copy_from_slice(&header);
 
         for (m, chunk) in self
@@ -250,6 +255,12 @@ impl CallMeMaybe {
             let raw = socket_addr_as_bytes(m);
             chunk.copy_from_slice(&raw);
         }
+        let clear_pongs = match self.clear_pongs {
+            true => 1u8,
+            false => 0u8,
+        };
+        let last = out.len() - 1;
+        out[last] = clear_pongs;
 
         out
     }
@@ -350,8 +361,13 @@ mod tests {
             },
             Test {
                 name: "call_me_maybe",
-                m: Message::CallMeMaybe(CallMeMaybe { my_number: Vec::new() }),
-                want: "03 00",
+                m: Message::CallMeMaybe(CallMeMaybe { my_number: Vec::new(), clear_pongs: false }),
+                want: "03 00 00",
+            },
+            Test {
+                name: "call_me_maybe_clear_pongs",
+                m: Message::CallMeMaybe(CallMeMaybe { my_number: Vec::new(), clear_pongs: true }),
+                want: "03 00 01",
             },
             Test {
                 name: "call_me_maybe_endpoints",
@@ -360,8 +376,9 @@ mod tests {
                         "1.2.3.4:567".parse().unwrap(),
                         "[2001::3456]:789".parse().unwrap(),
                     ],
+                    clear_pongs: false
                 }),
-                want: "03 00 00 00 00 00 00 00 00 00 00 00 ff ff 01 02 03 04 37 02 20 01 00 00 00 00 00 00 00 00 00 00 00 00 34 56 15 03",
+                want: "03 00 00 00 00 00 00 00 00 00 00 00 ff ff 01 02 03 04 37 02 20 01 00 00 00 00 00 00 00 00 00 00 00 00 34 56 15 03 00",
             },
         ];
         for test in tests {

--- a/iroh-net/src/magicsock/peer_map.rs
+++ b/iroh-net/src/magicsock/peer_map.rs
@@ -393,7 +393,7 @@ impl PeerMapInner {
                 vec![]
             }
             Some(ep) => {
-                debug!(endpoints = ?cm.my_number, "received call-me-maybe");
+                debug!(endpoints = ?cm.my_number, clear_pongs = %cm.clear_pongs, "received call-me-maybe");
                 ep.handle_call_me_maybe(cm)
             }
         }

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -54,6 +54,7 @@ pub(in crate::magicsock) enum PingAction {
     SendCallMeMaybe {
         derp_region: u16,
         dst_key: PublicKey,
+        clear_pongs: bool,
     },
     SendPing(SendPing),
 }
@@ -537,10 +538,12 @@ impl Endpoint {
                 // message to our peer via DERP informing them that we've
                 // sent so our firewall ports are probably open and now
                 // would be a good time for them to connect.
-                debug!(?derp_region, "queue call-me-maybe");
+                let clear_pongs = self.last_full_ping.is_none();
+                debug!(?derp_region, ?clear_pongs, "queue call-me-maybe");
                 msgs.push(PingAction::SendCallMeMaybe {
                     derp_region: *derp_region,
                     dst_key: self.public_key,
+                    clear_pongs,
                 });
             }
         }
@@ -840,9 +843,10 @@ impl Endpoint {
                 new_eps.push(ep);
             }
         }
-        if !new_eps.is_empty() {
+        if !new_eps.is_empty() || m.clear_pongs {
             debug!(
                 ?new_eps,
+                clear_pongs = m.clear_pongs,
                 "received call-me-maybe, add new endpoints and reset state"
             );
         }
@@ -865,6 +869,15 @@ impl Endpoint {
         // even if it's been less than 5 seconds ago.
         for st in self.direct_addr_state.values_mut() {
             st.last_ping = None;
+            if m.clear_pongs {
+                st.recent_pong = None;
+                st.call_me_maybe_time = None;
+                st.last_payload_msg = None;
+            }
+        }
+        if m.clear_pongs {
+            self.best_addr
+                .clear(ClearReason::PruneCallMeMaybe, self.derp_region.is_some());
         }
         self.send_pings(Instant::now(), false)
     }


### PR DESCRIPTION
## Description

TLDR: If you connect to a node, abort, and then reconnect from a new magic socket over Derp, the other node will likely reply over UDP (because that's what its state indicates to do) but you won't be able to receive those messages. To solve, upon reconnecting send a message to the other node "please reset my address state".

Explanation of the problem:

* Node A binds
* Node B binds, connects to A by nodeid and derp region
* Node A and B communicate, do call-me-maybe, upgrade to UDP
* Node A now has a UDP `best_addr` set for node A. It is renewed on each ping-pong (every 1s) and has a valid time of 6s currently
* Node B shutdown
* Node B respawn, reconnect to Node A by nodeid and derp region
* Node A recvs packets by node B over Derp **but replies over UDP because it still has a best_addr set**
* Node B either doesn't receive the packets (because it bound to a new port) or discards them (because it does not know to which peer the addr belongs)
* Node A still has no reason to switch to Derp until its best_addr times out

To solve this situation, this PR does...

* Add a `clear_pongs` optional field to the `CallMeMaybe` disco message
* When connecting to a so-far unused node over Derp, first send a `CallMeMaybe` message with `clear_pongs: true`
* Even send this message right away, before we determined our own endpoints (currently all `CallMeMaybe` messages are held back and only sent out after we completed STUN, which takes a long time unforunately, but that's yet a different issue)
* When receiving `clear_pongs: true` , the node will reset the pong state of all addrs of the endpoint entry in the peer map for that node, and invalidate the `best_addr`, which means that it will send over Derp until a new ping-pong completes

The change in the wire protocol is backwards comaptible.

I'm very open to ideas how to solve this situation without a new message, but I couldn't come up with any alternative so far.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
