### PR TITLE
refactor(iroh-net): call-me-maybe improvements (no more tasks for queue, better logic on recv)

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1006,12 +1006,10 @@ impl Inner {
             self.pending_call_me_maybes
                 .lock()
                 .insert(dst_key, derp_region);
-
             info!(
                 "want call-me-maybe but endpoints stale; restunning ({:?})",
                 endpoints.last_endpoints_time
             );
-
             self.re_stun("refresh-for-peering");
         }
     }

--- a/iroh-net/src/magicsock/peer_map/best_addr.rs
+++ b/iroh-net/src/magicsock/peer_map/best_addr.rs
@@ -58,7 +58,6 @@ pub(super) enum State<'a> {
 pub enum ClearReason {
     Reset,
     Inactive,
-    PruneCallMeMaybe,
     PongTimeout,
 }
 


### PR DESCRIPTION
## Description

Removes the task spawning for queued call-me-maybes. Instead just keep them in a hashmap. This is possible now because sending call-me-maybes is sync anyway. We will lose them if the derp channel is full, which might be a problem, but that is already a problem on main.

Additionally removes `ActorMessage::ReStun` and instead moves the `EndpointUpdateState` onto `Inner`. One less thing to go over the main channel - not needed, because the `EndpointUpdateState` already is a concurrent data structure (with a mutex added for the `next_update`).

Also improves (hopefully) the logic when receiving a call-me-maybe: It now clears the `recent_pong` for all addresses not included in the call-me-maybe, and clears the `best_addr` trust if not included in the call-me-maybe.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
