### PR TITLE
fix: do not wait_idle on endpoint close

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -495,8 +495,6 @@ impl MagicEndpoint {
     /// TODO: Document error cases.
     pub async fn close(&self, error_code: VarInt, reason: &[u8]) -> Result<()> {
         self.endpoint.close(error_code, reason);
-        self.endpoint.wait_idle().await;
-        // TODO: Now wait-idle on msock!
         self.msock.close().await?;
         Ok(())
     }
@@ -797,7 +795,6 @@ mod tests {
                 .instrument(error_span!("client", %i));
                 tokio::task::spawn(fut).await.unwrap();
                 println!("[client] round {} done in {:?}", i + 1, now.elapsed());
-                tokio::time::sleep(Duration::from_secs(1)).await;
             }
         });
 


### PR DESCRIPTION
## Description

In a longer debugging session with @dignifiedquire we found out that `wait_idle` will *always* wait on a close timer for a few 100 ms before actually completing. If application layer protocols always take care of finishing their work (which we do) this is not needed at all. Also the magicsock will very likely stay around long enough to still send out the close frame.

This together with #1752 brings the runtime of the `derp_connect_loop` test down from 15s to 4s on my machine! First round is 2-3s (due to bugs in netcheck making it too slow likely) and subsequent round are all >500ms!

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
