### PR TITLE
fix(console): remove ticket separator to improve usability

### DIFF
--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -11,7 +11,7 @@ use std::{
 
 use crate::config::{path_with_env, NodeConfig};
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use clap::Subcommand;
 use indicatif::{HumanBytes, MultiProgress, ProgressBar};
 use iroh::util::{path::IrohPaths, progress::ProgressWriter};
@@ -917,8 +917,7 @@ fn create_secret_key(secret_key: SecretKeyOption) -> anyhow::Result<SecretKey> {
 }
 
 fn inspect_ticket(ticket: &str) -> anyhow::Result<()> {
-    let (kind, _) = iroh::ticket::Kind::parse_prefix(ticket)
-        .ok_or_else(|| anyhow!("missing ticket prefix"))??;
+    let (kind, _) = iroh::ticket::Kind::parse_prefix(ticket)?;
     match kind {
         iroh::ticket::Kind::Blob => {
             let ticket = iroh::ticket::blob::Ticket::from_str(ticket)

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -748,7 +748,7 @@ fn match_provide_output<T: Read>(reader: T, num_blobs: usize) -> Result<String> 
             (r"Total: [_\w\d-]*", 1),
             (r"", 1),
             (r"Collection: [\da-z]{59}", 1),
-            (r"All-in-one ticket: ([_a-zA-Z:\d-]*)", 1),
+            (r"All-in-one ticket: ([_a-zA-Z\d-]*)", 1),
         ],
     );
 


### PR DESCRIPTION
## Description
removes the separator to keep the ticket alphanumeric entirely

## Notes & open questions
na

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
