### PR TITLE
chore: makes `SyncReason` public (as expected)

### DIFF
--- a/iroh/src/sync_engine.rs
+++ b/iroh/src/sync_engine.rs
@@ -31,7 +31,7 @@ use gossip::GossipActor;
 use live::{LiveActor, ToLiveActor};
 
 pub use self::live::SyncEvent;
-pub use self::state::Origin;
+pub use self::state::{Origin, SyncReason};
 pub use iroh_sync::net::SYNC_ALPN;
 
 /// Capacity of the channel for the [`ToLiveActor`] messages.


### PR DESCRIPTION
## Description

`SyncReason` is a public enum, but it is never exported from its private module.

We don't use `SyncReason` currently in the cli or console, but if other applications have use for it, we need to make it public. Also, allows us to using it in the ffi bindings.