### PR TITLE
fix(ci): avoid sccache on linux aarch64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
         rustup toolchain install ${{ matrix.rust }}
     
     - name: Run sccache-cache
+      if: matrix.release-os != 'linux' && matrix.release-arch != 'aarch64'
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: build release


### PR DESCRIPTION
## Description

No sccache release binaries for linux aarch64 available, and self building is worse for perf.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
