### PR TITLE
refactor(iroh-net): rename PeerAddr to NodeAddr, introduce NodeId alias

### DIFF
--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -12,7 +12,7 @@ use iroh_net::{
     derp::{DerpMap, DerpMode},
     key::{PublicKey, SecretKey},
     magic_endpoint::accept_conn,
-    MagicEndpoint, PeerAddr,
+    MagicEndpoint, NodeAddr,
 };
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -120,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
                 if endpoints.is_empty() {
                     return;
                 }
-                // send our updated endpoints to the gossip protocol to be sent as PeerAddr to peers
+                // send our updated endpoints to the gossip protocol to be sent as NodeAddr to peers
                 if let Some(gossip) = gossip_cell.get() {
                     gossip.update_endpoints(endpoints).ok();
                 }
@@ -153,7 +153,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(endpoint_loop(endpoint.clone(), gossip.clone()));
 
     // join the gossip topic by connecting to known peers, if any
-    let peer_ids = peers.iter().map(|p| p.peer_id).collect();
+    let peer_ids = peers.iter().map(|p| p.node_id).collect();
     if peers.is_empty() {
         println!("> waiting for peers to join us...");
     } else {
@@ -289,7 +289,7 @@ enum Message {
 #[derive(Debug, Serialize, Deserialize)]
 struct Ticket {
     topic: TopicId,
-    peers: Vec<PeerAddr>,
+    peers: Vec<NodeAddr>,
 }
 impl Ticket {
     /// Deserializes from bytes.

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context};
 use bytes::{Bytes, BytesMut};
 use futures::{stream::Stream, FutureExt};
 use genawaiter::sync::{Co, Gen};
-use iroh_net::{key::PublicKey, magic_endpoint::get_peer_id, AddrInfo, MagicEndpoint, PeerAddr};
+use iroh_net::{key::PublicKey, magic_endpoint::get_peer_id, AddrInfo, MagicEndpoint, NodeAddr};
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
 use std::{collections::HashMap, future::Future, sync::Arc, task::Poll, time::Instant};
@@ -548,16 +548,13 @@ impl Actor {
                     self.pending_sends.remove(&peer);
                     self.dialer.abort_dial(&peer);
                 }
-                OutEvent::PeerData(peer, data) => match decode_peer_data(&data) {
-                    Err(err) => warn!("Failed to decode {data:?} from {peer}: {err}"),
+                OutEvent::PeerData(node_id, data) => match decode_peer_data(&data) {
+                    Err(err) => warn!("Failed to decode {data:?} from {node_id}: {err}"),
                     Ok(info) => {
-                        debug!(peer = ?peer, "add known addrs: {info:?}");
-                        let peer_addr = PeerAddr {
-                            peer_id: peer,
-                            info,
-                        };
-                        if let Err(err) = self.endpoint.add_peer_addr(peer_addr) {
-                            debug!(peer = ?peer, "add known failed: {err:?}");
+                        debug!(peer = ?node_id, "add known addrs: {info:?}");
+                        let node_addr = NodeAddr { node_id, info };
+                        if let Err(err) = self.endpoint.add_peer_addr(node_addr) {
+                            debug!(peer = ?node_id, "add known failed: {err:?}");
                         }
                     }
                 },
@@ -653,7 +650,7 @@ fn decode_peer_data(peer_data: &PeerData) -> anyhow::Result<AddrInfo> {
 mod test {
     use std::time::Duration;
 
-    use iroh_net::PeerAddr;
+    use iroh_net::NodeAddr;
     use iroh_net::{
         derp::{DerpMap, DerpMode},
         MagicEndpoint,
@@ -732,7 +729,7 @@ mod test {
         debug!("----- adding peers  ----- ");
         let topic: TopicId = blake3::hash(b"foobar").into();
         // share info that pi1 is on the same derp_region
-        let addr1 = PeerAddr::new(pi1).with_derp_region(derp_region);
+        let addr1 = NodeAddr::new(pi1).with_derp_region(derp_region);
         ep2.add_peer_addr(addr1.clone()).unwrap();
         ep3.add_peer_addr(addr1).unwrap();
 

--- a/iroh-gossip/src/net/util.rs
+++ b/iroh-gossip/src/net/util.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, io, pin::Pin, time::Instant};
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use bytes::{Bytes, BytesMut};
 use futures::future::BoxFuture;
-use iroh_net::{key::PublicKey, MagicEndpoint, NodeAddr};
+use iroh_net::{key::PublicKey, MagicEndpoint, NodeAddr, NodeId};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     task::JoinSet,
@@ -81,9 +81,9 @@ pub async fn read_lp(
 /// Future for a pending dial operation
 pub type DialFuture = BoxFuture<'static, (PublicKey, anyhow::Result<quinn::Connection>)>;
 
-/// Dial peers and maintain a queue of pending dials
+/// Dial nodes and maintain a queue of pending dials
 ///
-/// This wraps a [`MagicEndpoint`], connects to peers through the endpoint, stores
+/// This wraps a [`MagicEndpoint`], connects to nodes through the endpoint, stores
 /// the pending connect futures and emits finished connect results.
 ///
 // TODO: Move to iroh-net
@@ -91,7 +91,7 @@ pub type DialFuture = BoxFuture<'static, (PublicKey, anyhow::Result<quinn::Conne
 pub struct Dialer {
     endpoint: MagicEndpoint,
     pending: JoinSet<(PublicKey, anyhow::Result<quinn::Connection>)>,
-    pending_peers: HashMap<PublicKey, CancellationToken>,
+    pending_dials: HashMap<PublicKey, CancellationToken>,
 }
 
 impl Dialer {
@@ -100,52 +100,52 @@ impl Dialer {
         Self {
             endpoint,
             pending: Default::default(),
-            pending_peers: Default::default(),
+            pending_dials: Default::default(),
         }
     }
 
-    /// Start to dial a peer
+    /// Start to dial a node.
     ///
-    /// Note that the peer's addresses and/or derp region must be added to the endpoint's
+    /// Note that the node's addresses and/or derp region must be added to the endpoint's
     /// addressbook for a dial to succeed, see [`MagicEndpoint::add_peer_addr`].
-    pub fn queue_dial(&mut self, peer_id: PublicKey, alpn_protocol: &'static [u8]) {
-        if self.is_pending(&peer_id) {
+    pub fn queue_dial(&mut self, node_id: NodeId, alpn_protocol: &'static [u8]) {
+        if self.is_pending(&node_id) {
             return;
         }
         let cancel = CancellationToken::new();
-        self.pending_peers.insert(peer_id, cancel.clone());
+        self.pending_dials.insert(node_id, cancel.clone());
         let endpoint = self.endpoint.clone();
         self.pending.spawn(async move {
             let res = tokio::select! {
                 biased;
                 _ = cancel.cancelled() => Err(anyhow!("Cancelled")),
-                res = endpoint.connect(NodeAddr::new(peer_id), alpn_protocol) => res
+                res = endpoint.connect(NodeAddr::new(node_id), alpn_protocol) => res
             };
-            (peer_id, res)
+            (node_id, res)
         });
     }
 
     /// Abort a pending dial
-    pub fn abort_dial(&mut self, peer_id: &PublicKey) {
-        if let Some(cancel) = self.pending_peers.remove(peer_id) {
+    pub fn abort_dial(&mut self, node_id: &NodeId) {
+        if let Some(cancel) = self.pending_dials.remove(node_id) {
             cancel.cancel();
         }
     }
 
-    /// Check if a peer is currently being dialed
-    pub fn is_pending(&self, peer: &PublicKey) -> bool {
-        self.pending_peers.contains_key(peer)
+    /// Check if a node is currently being dialed
+    pub fn is_pending(&self, node: &NodeId) -> bool {
+        self.pending_dials.contains_key(node)
     }
 
     /// Wait for the next dial operation to complete
     pub async fn next_conn(&mut self) -> (PublicKey, anyhow::Result<quinn::Connection>) {
-        match self.pending_peers.is_empty() {
+        match self.pending_dials.is_empty() {
             false => {
-                let (peer_id, res) = loop {
+                let (node_id, res) = loop {
                     match self.pending.join_next().await {
-                        Some(Ok((peer_id, res))) => {
-                            self.pending_peers.remove(&peer_id);
-                            break (peer_id, res);
+                        Some(Ok((node_id, res))) => {
+                            self.pending_dials.remove(&node_id);
+                            break (node_id, res);
                         }
                         Some(Err(e)) => {
                             error!("next conn error: {:?}", e);
@@ -157,7 +157,7 @@ impl Dialer {
                     }
                 };
 
-                (peer_id, res)
+                (node_id, res)
             }
             true => futures::future::pending().await,
         }
@@ -165,7 +165,7 @@ impl Dialer {
 
     /// Number of pending connections to be opened.
     pub fn pending_count(&self) -> usize {
-        self.pending_peers.len()
+        self.pending_dials.len()
     }
 }
 
@@ -177,9 +177,9 @@ impl futures::Stream for Dialer {
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         match self.pending.poll_join_next(cx) {
-            std::task::Poll::Ready(Some(Ok((peer_id, result)))) => {
-                self.pending_peers.remove(&peer_id);
-                std::task::Poll::Ready(Some((peer_id, result)))
+            std::task::Poll::Ready(Some(Ok((node_id, result)))) => {
+                self.pending_dials.remove(&node_id);
+                std::task::Poll::Ready(Some((node_id, result)))
             }
             std::task::Poll::Ready(Some(Err(e))) => {
                 error!("dialer error: {:?}", e);

--- a/iroh-gossip/src/net/util.rs
+++ b/iroh-gossip/src/net/util.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, io, pin::Pin, time::Instant};
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use bytes::{Bytes, BytesMut};
 use futures::future::BoxFuture;
-use iroh_net::{key::PublicKey, MagicEndpoint, PeerAddr};
+use iroh_net::{key::PublicKey, MagicEndpoint, NodeAddr};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     task::JoinSet,
@@ -119,7 +119,7 @@ impl Dialer {
             let res = tokio::select! {
                 biased;
                 _ = cancel.cancelled() => Err(anyhow!("Cancelled")),
-                res = endpoint.connect(PeerAddr::new(peer_id), alpn_protocol) => res
+                res = endpoint.connect(NodeAddr::new(peer_id), alpn_protocol) => res
             };
             (peer_id, res)
         });

--- a/iroh-net/bench/src/bin/bulk.rs
+++ b/iroh-net/bench/src/bin/bulk.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use iroh_net::{MagicEndpoint, PeerAddr};
+use iroh_net::{MagicEndpoint, NodeAddr};
 use tokio::sync::Semaphore;
 use tracing::{info, trace};
 
@@ -105,7 +105,7 @@ async fn server(endpoint: MagicEndpoint, opt: Opt) -> Result<()> {
     Ok(())
 }
 
-async fn client(server_addr: PeerAddr, opt: Opt) -> Result<ClientStats> {
+async fn client(server_addr: NodeAddr, opt: Opt) -> Result<ClientStats> {
     let (endpoint, connection) = connect_client(server_addr, opt).await?;
 
     let start = Instant::now();

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, net::SocketAddr, num::ParseIntError, str::FromStr};
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use clap::Parser;
-use iroh_net::{derp::DerpMode, MagicEndpoint, PeerAddr};
+use iroh_net::{derp::DerpMode, MagicEndpoint, NodeAddr};
 use tokio::runtime::{Builder, Runtime};
 use tracing::trace;
 
@@ -21,7 +21,7 @@ pub fn configure_tracing_subscriber() {
 }
 
 /// Creates a server endpoint which runs on the given runtime
-pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (PeerAddr, MagicEndpoint) {
+pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (NodeAddr, MagicEndpoint) {
     let _guard = rt.enter();
     rt.block_on(async move {
         let ep = MagicEndpoint::builder()
@@ -33,14 +33,14 @@ pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (PeerAddr, Ma
             .unwrap();
         let addr = ep.local_addr().unwrap();
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
-        let addr = PeerAddr::new(ep.peer_id()).with_direct_addresses([addr]);
+        let addr = NodeAddr::new(ep.peer_id()).with_direct_addresses([addr]);
         (addr, ep)
     })
 }
 
 /// Create a client endpoint and client connection
 pub async fn connect_client(
-    server_addr: PeerAddr,
+    server_addr: NodeAddr,
     opt: Opt,
 ) -> Result<(MagicEndpoint, quinn::Connection)> {
     let endpoint = MagicEndpoint::builder()

--- a/iroh-net/examples/magic.rs
+++ b/iroh-net/examples/magic.rs
@@ -6,7 +6,7 @@ use iroh_net::{
     derp::{DerpMap, DerpMode},
     key::SecretKey,
     magic_endpoint::accept_conn,
-    MagicEndpoint, PeerAddr,
+    MagicEndpoint, NodeAddr,
 };
 use tracing::{debug, info};
 use url::Url;
@@ -99,7 +99,7 @@ async fn main() -> anyhow::Result<()> {
             derp_region,
         } => {
             let addr =
-                PeerAddr::from_parts(peer_id.parse()?, derp_region, addrs.unwrap_or_default());
+                NodeAddr::from_parts(peer_id.parse()?, derp_region, addrs.unwrap_or_default());
             let conn = endpoint.connect(addr, EXAMPLE_ALPN).await?;
             info!("connected");
 

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -29,5 +29,7 @@ pub mod util;
 
 pub use magic_endpoint::{AddrInfo, MagicEndpoint, NodeAddr};
 
+pub use key::PublicKey as NodeId;
+
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -27,7 +27,7 @@ pub mod stun;
 pub mod tls;
 pub mod util;
 
-pub use magic_endpoint::{AddrInfo, MagicEndpoint, PeerAddr};
+pub use magic_endpoint::{AddrInfo, MagicEndpoint, NodeAddr};
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -20,18 +20,18 @@ pub use super::magicsock::EndpointInfo as ConnectionInfo;
 
 /// A peer and it's addressing information.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PeerAddr {
+pub struct NodeAddr {
     /// The node's public key.
-    pub peer_id: PublicKey,
-    /// Addressing information to connect to [`Self::peer_id`].
+    pub node_id: PublicKey,
+    /// Addressing information to connect to [`Self::node_id`].
     pub info: AddrInfo,
 }
 
-impl PeerAddr {
-    /// Create a new [`PeerAddr`] with empty [`AddrInfo`].
-    pub fn new(peer_id: PublicKey) -> Self {
-        PeerAddr {
-            peer_id,
+impl NodeAddr {
+    /// Create a new [`NodeAddr`] with empty [`AddrInfo`].
+    pub fn new(node_id: PublicKey) -> Self {
+        NodeAddr {
+            node_id,
             info: Default::default(),
         }
     }
@@ -62,11 +62,11 @@ impl PeerAddr {
     }
 }
 
-impl From<(PublicKey, Option<u16>, &[SocketAddr])> for PeerAddr {
+impl From<(PublicKey, Option<u16>, &[SocketAddr])> for NodeAddr {
     fn from(value: (PublicKey, Option<u16>, &[SocketAddr])) -> Self {
-        let (peer_id, derp_region, direct_addresses_iter) = value;
-        PeerAddr {
-            peer_id,
+        let (node_id, derp_region, direct_addresses_iter) = value;
+        NodeAddr {
+            node_id,
             info: AddrInfo {
                 derp_region,
                 direct_addresses: direct_addresses_iter.iter().copied().collect(),
@@ -91,15 +91,15 @@ impl AddrInfo {
     }
 }
 
-impl PeerAddr {
-    /// Create a new [`PeerAddr`] from its parts.
+impl NodeAddr {
+    /// Create a new [`NodeAddr`] from its parts.
     pub fn from_parts(
-        peer_id: PublicKey,
+        node_id: PublicKey,
         derp_region: Option<u16>,
         direct_addresses: Vec<SocketAddr>,
     ) -> Self {
         Self {
-            peer_id,
+            node_id,
             info: AddrInfo {
                 derp_region,
                 direct_addresses: direct_addresses.into_iter().collect(),
@@ -372,19 +372,19 @@ impl MagicEndpoint {
         self.msock.my_derp()
     }
 
-    /// Get the [`PeerAddr`] for this endpoint.
-    pub async fn my_addr(&self) -> Result<PeerAddr> {
+    /// Get the [`NodeAddr`] for this endpoint.
+    pub async fn my_addr(&self) -> Result<NodeAddr> {
         let addrs = self.local_endpoints().await?;
         let derp = self.my_derp();
         let addrs = addrs.into_iter().map(|x| x.addr).collect();
-        Ok(PeerAddr::from_parts(self.peer_id(), derp, addrs))
+        Ok(NodeAddr::from_parts(self.peer_id(), derp, addrs))
     }
 
-    /// Get the [`PeerAddr`] for this endpoint, while providing the endpoints.
-    pub fn my_addr_with_endpoints(&self, eps: Vec<config::Endpoint>) -> Result<PeerAddr> {
+    /// Get the [`NodeAddr`] for this endpoint, while providing the endpoints.
+    pub fn my_addr_with_endpoints(&self, eps: Vec<config::Endpoint>) -> Result<NodeAddr> {
         let derp = self.my_derp();
         let addrs = eps.into_iter().map(|x| x.addr).collect();
-        Ok(PeerAddr::from_parts(self.peer_id(), derp, addrs))
+        Ok(NodeAddr::from_parts(self.peer_id(), derp, addrs))
     }
 
     /// Get information on all the nodes we have connection information about.
@@ -422,20 +422,20 @@ impl MagicEndpoint {
     /// If the `derp_region` is not `None` and the configured DERP servers do not include a DERP node from the given `derp_region`, it will error.
     ///
     /// If no UDP addresses and no DERP region is provided, it will error.
-    pub async fn connect(&self, peer_addr: PeerAddr, alpn: &[u8]) -> Result<quinn::Connection> {
-        self.add_peer_addr(peer_addr.clone())?;
+    pub async fn connect(&self, node_addr: NodeAddr, alpn: &[u8]) -> Result<quinn::Connection> {
+        self.add_peer_addr(node_addr.clone())?;
 
-        let PeerAddr { peer_id, info } = peer_addr;
-        let addr = self.msock.get_mapping_addr(&peer_id).await;
+        let NodeAddr { node_id, info } = node_addr;
+        let addr = self.msock.get_mapping_addr(&node_id).await;
         let Some(addr) = addr else {
             return Err(match (info.direct_addresses.is_empty(), info.derp_region) {
                 (true, None) => {
-                    anyhow!("No UDP addresses or DERP region provided. Unable to dial peer {peer_id:?}")
+                    anyhow!("No UDP addresses or DERP region provided. Unable to dial node {node_id:?}")
                 }
                 (true, Some(region)) if !self.msock.has_derp_region(region) => {
-                    anyhow!("No UDP addresses provided and we do not have any DERP configuration for DERP region {region}. Unable to dial peer {peer_id:?}")
+                    anyhow!("No UDP addresses provided and we do not have any DERP configuration for DERP region {region}. Unable to dial node {node_id:?}")
                 }
-                _ => anyhow!("Failed to retrieve the mapped address from the magic socket. Unable to dial peer {peer_id:?}")
+                _ => anyhow!("Failed to retrieve the mapped address from the magic socket. Unable to dial node {node_id:?}")
             });
         };
 
@@ -443,7 +443,7 @@ impl MagicEndpoint {
             let alpn_protocols = vec![alpn.to_vec()];
             let tls_client_config = tls::make_client_config(
                 &self.secret_key,
-                Some(peer_id),
+                Some(node_id),
                 alpn_protocols,
                 self.keylog,
             )?;
@@ -456,7 +456,7 @@ impl MagicEndpoint {
 
         debug!(
             "connecting to {}: (via {} - {:?})",
-            peer_id, addr, info.direct_addresses
+            node_id, addr, info.direct_addresses
         );
 
         // TODO: We'd eventually want to replace "localhost" with something that makes more sense.
@@ -478,8 +478,8 @@ impl MagicEndpoint {
     /// If no UDP addresses are added, and `derp_region` is `None`, it will error.
     /// If no UDP addresses are added, and the given `derp_region` cannot be dialed, it will error.
     // TODO: Make sync
-    pub fn add_peer_addr(&self, peer_addr: PeerAddr) -> Result<()> {
-        self.msock.add_peer_addr(peer_addr);
+    pub fn add_peer_addr(&self, node_addr: NodeAddr) -> Result<()> {
+        self.msock.add_peer_addr(node_addr);
         Ok(())
     }
 
@@ -621,8 +621,8 @@ mod tests {
                     .await
                     .unwrap();
                 info!("client connecting");
-                let peer_addr = PeerAddr::new(server_peer_id).with_derp_region(region_id);
-                let conn = ep.connect(peer_addr, TEST_ALPN).await.unwrap();
+                let node_addr = NodeAddr::new(server_peer_id).with_derp_region(region_id);
+                let conn = ep.connect(node_addr, TEST_ALPN).await.unwrap();
                 let mut stream = conn.open_uni().await.unwrap();
 
                 // First write is accepted by server.  We need this bit of synchronisation
@@ -686,14 +686,14 @@ mod tests {
         let peer_id = SecretKey::generate().public();
         let direct_addr: SocketAddr =
             (std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 8758u16).into();
-        let peer_addr = PeerAddr::new(peer_id).with_direct_addresses([direct_addr]);
+        let node_addr = NodeAddr::new(peer_id).with_direct_addresses([direct_addr]);
 
         info!("setting up first endpoint");
         // first time, create a magic endpoint without peers but a peers file and add adressing
         // information for a peer
         let endpoint = new_endpoint(secret_key.clone(), path.clone()).await;
         assert!(endpoint.connection_infos().await.unwrap().is_empty());
-        endpoint.add_peer_addr(peer_addr).unwrap();
+        endpoint.add_peer_addr(node_addr).unwrap();
 
         info!("closing endpoint");
         // close the endpoint and restart it
@@ -772,10 +772,10 @@ mod tests {
                         .unwrap();
                     let eps = ep.local_addr().unwrap();
                     info!(me = %ep.peer_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, t = ?start.elapsed(), "client bound");
-                    let peer_addr = PeerAddr::new(server_node_id).with_derp_region(region_id);
-                    info!(to = ?peer_addr, "client connecting");
+                    let node_addr = NodeAddr::new(server_node_id).with_derp_region(region_id);
+                    info!(to = ?node_addr, "client connecting");
                     let t = Instant::now();
-                    let conn = ep.connect(peer_addr, TEST_ALPN).await.unwrap();
+                    let conn = ep.connect(node_addr, TEST_ALPN).await.unwrap();
                     info!(t = ?t.elapsed(), "client connected");
                     let t = Instant::now();
                     let (mut send, mut recv) = conn.open_bi().await.unwrap();

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -51,7 +51,7 @@ use crate::{
     disco,
     dns::DNS_RESOLVER,
     key::{PublicKey, SecretKey, SharedSecret},
-    magic_endpoint::PeerAddr,
+    magic_endpoint::NodeAddr,
     magicsock::peer_map::PingRole,
     net::{ip::LocalAddresses, netmon, IpFamily},
     netcheck, portmapper, stun,
@@ -1376,7 +1376,7 @@ impl MagicSock {
 
     #[instrument(skip_all, fields(me = %self.inner.me))]
     /// Add addresses for a node to the magic socket's addresbook.
-    pub fn add_peer_addr(&self, addr: PeerAddr) {
+    pub fn add_peer_addr(&self, addr: NodeAddr) {
         self.inner.peer_map.add_peer_addr(addr);
     }
 
@@ -2758,8 +2758,8 @@ pub(crate) mod tests {
                 if i == my_idx {
                     continue;
                 }
-                let addr = PeerAddr {
-                    peer_id: me.public(),
+                let addr = NodeAddr {
+                    node_id: me.public(),
                     info: crate::AddrInfo {
                         derp_region: Some(1),
                         direct_addresses: new_eps.iter().map(|ep| ep.addr).collect(),
@@ -2899,7 +2899,7 @@ pub(crate) mod tests {
                 let a_span = debug_span!("sender", a_name, %a_addr);
                 async move {
                     println!("[{}] connecting to {}", a_name, b_addr);
-                    let peer_b_data = PeerAddr::new(b_peer_id).with_derp_region(region).with_direct_addresses([b_addr]);
+                    let peer_b_data = NodeAddr::new(b_peer_id).with_derp_region(region).with_direct_addresses([b_addr]);
                     let conn = a
                         .endpoint
                         .connect(peer_b_data, &ALPN)

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -1167,11 +1167,12 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::time::Duration;
 
-    use super::*;
-    use crate::{
-        key::SecretKey,
-        magicsock::peer_map::{best_addr::BestAddr, IpPort, PeerMap, PeerMapInner},
+    use super::{
+        super::{PeerMap, PeerMapInner},
+        best_addr::BestAddr,
+        IpPort, *,
     };
+    use crate::key::SecretKey;
 
     #[test]
     fn test_endpoint_infos() {

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -14,7 +14,7 @@ use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
     config, disco, key::PublicKey, magic_endpoint::AddrInfo, magicsock::Timer,
-    net::ip::is_unicast_link_local, stun, util::derp_only_mode, PeerAddr,
+    net::ip::is_unicast_link_local, stun, util::derp_only_mode, NodeAddr,
 };
 
 use crate::magicsock::{
@@ -991,10 +991,10 @@ impl Endpoint {
     }
 
     /// Get the adressing information of this endpoint.
-    pub(super) fn peer_addr(&self) -> PeerAddr {
+    pub(super) fn node_addr(&self) -> NodeAddr {
         let direct_addresses = self.direct_addresses().map(SocketAddr::from).collect();
-        PeerAddr {
-            peer_id: self.public_key,
+        NodeAddr {
+            node_id: self.public_key,
             info: AddrInfo {
                 derp_region: self.derp_region(),
                 direct_addresses,

--- a/iroh-sync/src/net.rs
+++ b/iroh-sync/src/net.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use iroh_net::{key::PublicKey, magic_endpoint::get_peer_id, MagicEndpoint, PeerAddr};
+use iroh_net::{key::PublicKey, magic_endpoint::get_peer_id, MagicEndpoint, NodeAddr};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error_span, trace, Instrument};
 
@@ -30,10 +30,10 @@ pub async fn connect_and_sync(
     endpoint: &MagicEndpoint,
     sync: &SyncHandle,
     namespace: NamespaceId,
-    peer: PeerAddr,
+    peer: NodeAddr,
 ) -> Result<SyncFinished, ConnectError> {
     let t_start = Instant::now();
-    let peer_id = peer.peer_id;
+    let peer_id = peer.node_id;
     trace!("connect");
     let connection = endpoint
         .connect(peer, SYNC_ALPN)

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash, BlobFormat::HashSeq).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.node_addr().peer_id);
+    println!("node PeerID:     {}", ticket.node_addr().node_id);
     println!("node listening addresses:");
     for addr in ticket.node_addr().direct_addresses() {
         println!("\t{:?}", addr);

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash, BlobFormat::HashSeq).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.node_addr().node_id);
+    println!("node NodeId:     {}", ticket.node_addr().node_id);
     println!("node listening addresses:");
     for addr in ticket.node_addr().direct_addresses() {
         println!("\t{:?}", addr);

--- a/iroh/examples/hello-world.rs
+++ b/iroh/examples/hello-world.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash, BlobFormat::Raw).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.node_addr().peer_id);
+    println!("node PeerID:     {}", ticket.node_addr().node_id);
     println!("node listening addresses:");
     for addr in ticket.node_addr().direct_addresses() {
         println!("\t{:?}", addr);

--- a/iroh/examples/hello-world.rs
+++ b/iroh/examples/hello-world.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
     let ticket = node.ticket(hash, BlobFormat::Raw).await?;
     // print some info about the node
     println!("serving hash:    {}", ticket.hash());
-    println!("node PeerID:     {}", ticket.node_addr().node_id);
+    println!("node NodeId:     {}", ticket.node_addr().node_id);
     println!("node listening addresses:");
     for addr in ticket.node_addr().direct_addresses() {
         println!("\t{:?}", addr);

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -20,7 +20,7 @@ use iroh_bytes::store::ValidateProgress;
 use iroh_bytes::util::runtime;
 use iroh_bytes::Hash;
 use iroh_bytes::{BlobFormat, Tag};
-use iroh_net::{key::PublicKey, magic_endpoint::ConnectionInfo, PeerAddr};
+use iroh_net::{key::PublicKey, magic_endpoint::ConnectionInfo, NodeAddr};
 use iroh_sync::actor::OpenState;
 use iroh_sync::{store::GetFilter, AuthorId, Entry, NamespaceId};
 use quic_rpc::message::RpcMsg;
@@ -698,7 +698,7 @@ where
     }
 
     /// Start to sync this document with a list of peers.
-    pub async fn start_sync(&self, peers: Vec<PeerAddr>) -> Result<()> {
+    pub async fn start_sync(&self, peers: Vec<NodeAddr>) -> Result<()> {
         self.ensure_open()?;
         let _res = self
             .rpc(DocStartSyncRequest {

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -19,7 +19,7 @@ use iroh::rpc_protocol::*;
 use iroh::ticket::blob::Ticket;
 use iroh_bytes::{protocol::RequestToken, util::runtime, BlobFormat, Hash, Tag};
 use iroh_net::magicsock::DirectAddrInfo;
-use iroh_net::PeerAddr;
+use iroh_net::NodeAddr;
 use iroh_net::{
     key::{PublicKey, SecretKey},
     magic_endpoint::ConnectionInfo,
@@ -263,7 +263,7 @@ impl FullCommands {
                         rt: rt.clone(),
                         hash,
                         opts: iroh::dial::Options {
-                            peer: PeerAddr::from_parts(peer, region, addrs),
+                            peer: NodeAddr::from_parts(peer, region, addrs),
                             keylog,
                             derp_map: config.derp_map()?,
                             secret_key: SecretKey::generate(),
@@ -395,7 +395,7 @@ impl NodeCommands {
             Self::Status => {
                 let response = iroh.node.status().await?;
                 println!("Listening addresses: {:#?}", response.listen_addrs);
-                println!("Node public key: {}", response.addr.peer_id);
+                println!("Node public key: {}", response.addr.node_id);
                 println!("Version: {}", response.version);
             }
         }
@@ -612,7 +612,7 @@ impl BlobCommands {
                         Some(true) => BlobFormat::HashSeq,
                     };
                     (
-                        PeerAddr::from_parts(peer.unwrap(), derp_region, addr),
+                        NodeAddr::from_parts(peer.unwrap(), derp_region, addr),
                         hash.unwrap(),
                         format,
                         token,
@@ -662,11 +662,11 @@ impl BlobCommands {
             } => {
                 let NodeStatusResponse { addr, .. } = iroh.node.status().await?;
                 let node_addr = if no_derp {
-                    PeerAddr::new(addr.peer_id)
+                    NodeAddr::new(addr.node_id)
                         .with_direct_addresses(addr.direct_addresses().copied())
                 } else if derp_only {
                     if let Some(region) = addr.derp_region() {
-                        PeerAddr::new(addr.peer_id).with_derp_region(region)
+                        NodeAddr::new(addr.node_id).with_derp_region(region)
                     } else {
                         addr
                     }

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -648,10 +648,7 @@ impl BlobCommands {
 
                         // create the node address with the appropriate overrides
                         let node_addr = {
-                            let NodeAddr {
-                                node_id: peer_id,
-                                info,
-                            } = node_addr;
+                            let NodeAddr { node_id, info } = node_addr;
                             let addresses = if override_addresses {
                                 // use only the cli supplied ones
                                 address
@@ -665,7 +662,7 @@ impl BlobCommands {
                                 Some(Optional::Some(region)) => Some(region),
                                 None => info.derp_region,
                             };
-                            NodeAddr::from_parts(peer_id, region, addresses)
+                            NodeAddr::from_parts(node_id, region, addresses)
                         };
 
                         // check if the blob format has an override

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -24,7 +24,7 @@ use iroh_net::{
     magicsock::EndpointInfo,
     netcheck, portmapper,
     util::AbortingJoinHandle,
-    MagicEndpoint, PeerAddr,
+    MagicEndpoint, NodeAddr,
 };
 use portable_atomic::AtomicU64;
 use postcard::experimental::max_size::MaxSize;
@@ -620,8 +620,8 @@ async fn connect(
     let endpoint = make_endpoint(secret_key, derp_map).await?;
 
     tracing::info!("dialing {:?}", peer_id);
-    let peer_addr = PeerAddr::from_parts(peer_id, derp_region, direct_addresses);
-    let conn = endpoint.connect(peer_addr, &DR_DERP_ALPN).await;
+    let node_addr = NodeAddr::from_parts(peer_id, derp_region, direct_addresses);
+    let conn = endpoint.connect(node_addr, &DR_DERP_ALPN).await;
     match conn {
         Ok(connection) => {
             if let Err(cause) = passive_side(endpoint.clone(), connection).await {

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -24,7 +24,7 @@ use iroh_net::{
     magicsock::EndpointInfo,
     netcheck, portmapper,
     util::AbortingJoinHandle,
-    MagicEndpoint, NodeAddr,
+    MagicEndpoint, NodeAddr, NodeId,
 };
 use portable_atomic::AtomicU64;
 use postcard::experimental::max_size::MaxSize;
@@ -289,7 +289,7 @@ struct Gui {
 }
 
 impl Gui {
-    fn new(endpoint: MagicEndpoint, peer_id: PublicKey) -> Self {
+    fn new(endpoint: MagicEndpoint, node_id: NodeId) -> Self {
         let mp = MultiProgress::new();
         mp.set_draw_target(indicatif::ProgressDrawTarget::stderr());
         let counters = mp.add(ProgressBar::hidden());
@@ -314,7 +314,7 @@ impl Gui {
         let counter_task = AbortingJoinHandle(tokio::spawn(async move {
             loop {
                 Self::update_counters(&counters2);
-                Self::update_connection_info(&conn_info, &endpoint, &peer_id).await;
+                Self::update_connection_info(&conn_info, &endpoint, &node_id).await;
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
         }));
@@ -332,13 +332,13 @@ impl Gui {
     async fn update_connection_info(
         target: &ProgressBar,
         endpoint: &MagicEndpoint,
-        peer_id: &PublicKey,
+        node_id: &NodeId,
     ) {
         let format_latency = |x: Option<Duration>| {
             x.map(|x| format!("{:.6}s", x.as_secs_f64()))
                 .unwrap_or_else(|| "unknown".to_string())
         };
-        let msg = match endpoint.connection_info(*peer_id).await {
+        let msg = match endpoint.connection_info(*node_id).await {
             Ok(Some(EndpointInfo {
                 derp_region,
                 conn_type,
@@ -611,7 +611,7 @@ async fn make_endpoint(
 }
 
 async fn connect(
-    peer_id: PublicKey,
+    node_id: NodeId,
     secret_key: SecretKey,
     direct_addresses: Vec<SocketAddr>,
     derp_region: Option<u16>,
@@ -619,8 +619,8 @@ async fn connect(
 ) -> anyhow::Result<()> {
     let endpoint = make_endpoint(secret_key, derp_map).await?;
 
-    tracing::info!("dialing {:?}", peer_id);
-    let node_addr = NodeAddr::from_parts(peer_id, derp_region, direct_addresses);
+    tracing::info!("dialing {:?}", node_id);
+    let node_addr = NodeAddr::from_parts(node_id, derp_region, direct_addresses);
     let conn = endpoint.connect(node_addr, &DR_DERP_ALPN).await;
     match conn {
         Ok(connection) => {
@@ -629,7 +629,7 @@ async fn connect(
             }
         }
         Err(cause) => {
-            eprintln!("unable to connect to {peer_id}: {cause}");
+            eprintln!("unable to connect to {node_id}: {cause}");
         }
     }
 

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use iroh_net::derp::{DerpMap, DerpMode};
 use iroh_net::key::SecretKey;
-use iroh_net::PeerAddr;
+use iroh_net::NodeAddr;
 
 /// Options for the client
 #[derive(Clone, Debug)]
@@ -11,7 +11,7 @@ pub struct Options {
     /// The secret key of the node
     pub secret_key: SecretKey,
     /// The peer to connect to.
-    pub peer: PeerAddr,
+    pub peer: NodeAddr,
     /// Whether to log the SSL keys when `SSLKEYLOGFILE` environment variable is set
     pub keylog: bool,
     /// The configuration of the derp services

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -1,30 +1,30 @@
-//! Handle downloading blobs and collections concurrently and from peers.
+//! Handle downloading blobs and collections concurrently and from nodes.
 //!
 //! The [`Downloader`] interacts with four main components to this end.
-//! - [`Dialer`]: Used to queue opening connections to peers we need to perform downloads.
-//! - [`ProviderMap`]: Where the downloader obtains information about peers that could be
+//! - [`Dialer`]: Used to queue opening connections to nodes we need to perform downloads.
+//! - [`ProviderMap`]: Where the downloader obtains information about nodes that could be
 //!   used to perform a download.
 //! - [`Store`]: Where data is stored.
 //!
 //! Once a download request is received, the logic is as follows:
-//! 1. The [`ProviderMap`] is queried for peers. From these peers some are selected
-//!    prioritizing connected peers with lower number of active requests. If no useful peer is
-//!    connected, or useful connected peers have no capacity to perform the request, a connection
+//! 1. The [`ProviderMap`] is queried for nodes. From these nodes some are selected
+//!    prioritizing connected nodes with lower number of active requests. If no useful node is
+//!    connected, or useful connected nodes have no capacity to perform the request, a connection
 //!    attempt is started using the [`Dialer`].
 //! 2. The download is queued for processing at a later time. Downloads are not performed right
-//!    away. Instead, they are initially delayed to allow the peer to obtain the data itself, and
+//!    away. Instead, they are initially delayed to allow the node to obtain the data itself, and
 //!    to wait for the new connection to be established if necessary.
 //! 3. Once a request is ready to be sent after a delay (initial or for a retry), the preferred
-//!    peer is used if available. The request is now considered active.
+//!    node is used if available. The request is now considered active.
 //!
 //! Concurrency is limited in different ways:
 //! - *Total number of active request:* This is a way to prevent a self DoS by overwhelming our own
 //!   bandwidth capacity. This is a best effort heuristic since it doesn't take into account how
 //!   much data we are actually requesting or receiving.
-//! - *Total number of connected peers:* Peer connections are kept for a longer time than they are
+//! - *Total number of connected nodes:* Peer connections are kept for a longer time than they are
 //!   strictly needed since it's likely they will be useful soon again.
-//! - *Requests per peer*: to avoid overwhelming peers with requests, the number of concurrent
-//!   requests to a single peer is also limited.
+//! - *Requests per node*: to avoid overwhelming nodes with requests, the number of concurrent
+//!   requests to a single node is also limited.
 
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
@@ -38,7 +38,7 @@ use std::{
 use bao_tree::ChunkRanges;
 use futures::{future::LocalBoxFuture, FutureExt, StreamExt};
 use iroh_bytes::{protocol::RangeSpecSeq, store::Store, Hash, HashAndFormat, TempTag};
-use iroh_net::{key::PublicKey, MagicEndpoint};
+use iroh_net::{MagicEndpoint, NodeId};
 use tokio::{
     sync::{mpsc, oneshot},
     task::JoinSet,
@@ -54,7 +54,7 @@ mod test;
 const INITIAL_REQUEST_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 /// Number of retries initially assigned to a request.
 const INITIAL_RETRY_COUNT: u8 = 4;
-/// Duration for which we keep peers connected after they were last useful to us.
+/// Duration for which we keep nodes connected after they were last useful to us.
 const IDLE_PEER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// Capacity of the channel used to comunicate between the [`Downloader`] and the [`Service`].
 const SERVICE_CHANNEL_CAPACITY: usize = 128;
@@ -65,16 +65,16 @@ pub type Id = u64;
 
 /// Trait modeling a dialer. This allows for IO-less testing.
 pub trait Dialer:
-    futures::Stream<Item = (PublicKey, anyhow::Result<Self::Connection>)> + Unpin
+    futures::Stream<Item = (NodeId, anyhow::Result<Self::Connection>)> + Unpin
 {
     /// Type of connections returned by the Dialer.
     type Connection: Clone;
-    /// Dial a peer.
-    fn queue_dial(&mut self, peer_id: PublicKey);
-    /// Get the number of dialing peers.
+    /// Dial a node.
+    fn queue_dial(&mut self, node_id: NodeId);
+    /// Get the number of dialing nodes.
     fn pending_count(&self) -> usize;
-    /// Check if a peer is being dialed.
-    fn is_pending(&self, peer: &PublicKey) -> bool;
+    /// Check if a node is being dialed.
+    fn is_pending(&self, node: &NodeId) -> bool;
 }
 
 /// Signals what should be done with the request when it fails.
@@ -82,9 +82,9 @@ pub trait Dialer:
 pub enum FailureAction {
     /// An error ocurred that prevents the request from being retried at all.
     AbortRequest(anyhow::Error),
-    /// An error occurred that suggests the peer should not be used in general.
+    /// An error occurred that suggests the node should not be used in general.
     DropPeer(anyhow::Error),
-    /// An error occurred in which neither the peer nor the request are at fault.
+    /// An error occurred in which neither the node nor the request are at fault.
     RetryLater(anyhow::Error),
 }
 
@@ -104,8 +104,8 @@ pub trait Getter {
 pub struct ConcurrencyLimits {
     /// Maximum number of requests the service performs concurrently.
     pub max_concurrent_requests: usize,
-    /// Maximum number of requests performed by a single peer concurrently.
-    pub max_concurrent_requests_per_peer: usize,
+    /// Maximum number of requests performed by a single node concurrently.
+    pub max_concurrent_requests_per_node: usize,
     /// Maximum number of open connections the service maintains.
     pub max_open_connections: usize,
 }
@@ -115,7 +115,7 @@ impl Default for ConcurrencyLimits {
         // these numbers should be checked against a running node and might depend on platform
         ConcurrencyLimits {
             max_concurrent_requests: 50,
-            max_concurrent_requests_per_peer: 4,
+            max_concurrent_requests_per_node: 4,
             max_open_connections: 25,
         }
     }
@@ -127,9 +127,9 @@ impl ConcurrencyLimits {
         active_requests >= self.max_concurrent_requests
     }
 
-    /// Checks if the maximum number of concurrent requests per peer has been reached.
-    fn peer_at_request_capacity(&self, active_peer_requests: usize) -> bool {
-        active_peer_requests >= self.max_concurrent_requests_per_peer
+    /// Checks if the maximum number of concurrent requests per node has been reached.
+    fn node_at_request_capacity(&self, active_node_requests: usize) -> bool {
+        active_node_requests >= self.max_concurrent_requests_per_node
     }
 
     /// Checks if the maximum number of connections has been reached.
@@ -248,7 +248,7 @@ impl Downloader {
     }
 
     /// Queue a download.
-    pub async fn queue(&mut self, kind: DownloadKind, peers: Vec<PeerInfo>) -> DownloadHandle {
+    pub async fn queue(&mut self, kind: DownloadKind, nodes: Vec<NodeInfo>) -> DownloadHandle {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
 
         let (sender, receiver) = oneshot::channel();
@@ -261,7 +261,7 @@ impl Downloader {
             kind,
             id,
             sender,
-            peers,
+            nodes,
         };
         // if this fails polling the handle will fail as well since the sender side of the oneshot
         // will be dropped
@@ -287,57 +287,57 @@ impl Downloader {
         }
     }
 
-    /// Declare that certains peers can be used to download a hash.
-    pub async fn peers_have(&mut self, hash: Hash, peers: Vec<PeerInfo>) {
-        let msg = Message::PeersHave { hash, peers };
+    /// Declare that certains nodes can be used to download a hash.
+    pub async fn nodes_have(&mut self, hash: Hash, nodes: Vec<NodeInfo>) {
+        let msg = Message::PeersHave { hash, nodes };
         if let Err(send_err) = self.msg_tx.send(msg).await {
             let msg = send_err.0;
-            debug!(?msg, "peers have not sent")
+            debug!(?msg, "nodes have not been sent")
         }
     }
 }
 
-/// A peer and its role with regard to a hash.
+/// A node and its role with regard to a hash.
 #[derive(Debug, Clone, Copy)]
-pub struct PeerInfo {
-    peer_id: PublicKey,
-    role: PeerRole,
+pub struct NodeInfo {
+    node_id: NodeId,
+    role: Role,
 }
 
-impl PeerInfo {
+impl NodeInfo {
     /// Create a new [`PeerInfo`] from its parts.
-    pub fn new(peer_id: PublicKey, role: PeerRole) -> Self {
-        Self { peer_id, role }
+    pub fn new(node_id: NodeId, role: Role) -> Self {
+        Self { node_id, role }
     }
 }
 
-impl From<(PublicKey, PeerRole)> for PeerInfo {
-    fn from((peer_id, role): (PublicKey, PeerRole)) -> Self {
-        Self { peer_id, role }
+impl From<(NodeId, Role)> for NodeInfo {
+    fn from((node_id, role): (NodeId, Role)) -> Self {
+        Self { node_id, role }
     }
 }
 
-/// The role of a peer with regard to a download intent.
+/// The role of a node with regard to a download intent.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum PeerRole {
-    /// We have information that this peer has the requested blob.
+pub enum Role {
+    /// We have information that this node has the requested blob.
     Provider,
-    /// We do not have information if this peer has the requested blob.
+    /// We do not have information if this node has the requested blob.
     Candidate,
 }
 
-impl PartialOrd for PeerRole {
+impl PartialOrd for Role {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
-impl Ord for PeerRole {
+impl Ord for Role {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (self, other) {
-            (PeerRole::Provider, PeerRole::Provider) => std::cmp::Ordering::Equal,
-            (PeerRole::Candidate, PeerRole::Candidate) => std::cmp::Ordering::Equal,
-            (PeerRole::Provider, PeerRole::Candidate) => std::cmp::Ordering::Greater,
-            (PeerRole::Candidate, PeerRole::Provider) => std::cmp::Ordering::Less,
+            (Role::Provider, Role::Provider) => std::cmp::Ordering::Equal,
+            (Role::Candidate, Role::Candidate) => std::cmp::Ordering::Equal,
+            (Role::Provider, Role::Candidate) => std::cmp::Ordering::Greater,
+            (Role::Candidate, Role::Provider) => std::cmp::Ordering::Less,
         }
     }
 }
@@ -351,13 +351,13 @@ enum Message {
         id: Id,
         #[debug(skip)]
         sender: oneshot::Sender<DownloadResult>,
-        peers: Vec<PeerInfo>,
+        nodes: Vec<NodeInfo>,
     },
     /// Cancel an intent. The associated request will be cancelled when the last intent is
     /// cancelled.
     Cancel { id: Id, kind: DownloadKind },
-    /// Declare that peers have certains hash and can be used for downloading. This feeds the [`ProviderMap`].
-    PeersHave { hash: Hash, peers: Vec<PeerInfo> },
+    /// Declare that nodes have certains hash and can be used for downloading. This feeds the [`ProviderMap`].
+    PeersHave { hash: Hash, nodes: Vec<NodeInfo> },
 }
 
 /// Information about a request being processed.
@@ -372,7 +372,7 @@ struct ActiveRequestInfo {
     #[debug(skip)]
     cancellation: CancellationToken,
     /// Peer doing this request attempt.
-    peer: PublicKey,
+    node: NodeId,
 }
 
 /// Information about a request that has not started.
@@ -386,28 +386,28 @@ struct PendingRequestInfo {
     /// Key to manage the delay associated with this scheduled request.
     #[debug(skip)]
     delay_key: delay_queue::Key,
-    /// If this attempt was scheduled with a known potential peer, this is stored here to
+    /// If this attempt was scheduled with a known potential node, this is stored here to
     /// prevent another query to the [`ProviderMap`].
-    next_peer: Option<PublicKey>,
+    next_node: Option<NodeId>,
 }
 
-/// State of the connection to this peer.
+/// State of the connection to this node.
 #[derive(derive_more::Debug)]
 struct ConnectionInfo<Conn> {
-    /// Connection to this peer.
+    /// Connection to this node.
     ///
-    /// If this peer was deemed unusable by a request, this will be set to `None`. As a
-    /// consequence, when evaluating peers for a download, this peer will not be considered.
-    /// Since peers are kept for a longer time that they are strictly necessary, this acts as a
+    /// If this node was deemed unusable by a request, this will be set to `None`. As a
+    /// consequence, when evaluating nodes for a download, this node will not be considered.
+    /// Since nodes are kept for a longer time that they are strictly necessary, this acts as a
     /// temporary ban.
     #[debug(skip)]
     conn: Option<Conn>,
-    /// State of this peer.
+    /// State of this node.
     state: PeerState,
 }
 
 impl<Conn> ConnectionInfo<Conn> {
-    /// Create a new idle peer.
+    /// Create a new idle node.
     fn new_idle(connection: Conn, drop_key: delay_queue::Key) -> Self {
         ConnectionInfo {
             conn: Some(connection),
@@ -415,7 +415,7 @@ impl<Conn> ConnectionInfo<Conn> {
         }
     }
 
-    /// Count of active requests for the peer.
+    /// Count of active requests for the node.
     fn active_requests(&self) -> usize {
         match self.state {
             PeerState::Busy { active_requests } => active_requests.get(),
@@ -424,7 +424,7 @@ impl<Conn> ConnectionInfo<Conn> {
     }
 }
 
-/// State of a connected peer.
+/// State of a connected node.
 #[derive(derive_more::Debug)]
 enum PeerState {
     /// Peer is handling at least one request.
@@ -446,18 +446,18 @@ type DownloadRes = (DownloadKind, Result<TempTag, FailureAction>);
 struct Service<G: Getter, D: Dialer> {
     /// The getter performs individual requests.
     getter: G,
-    /// Map to query for peers that we believe have the data we are looking for.
+    /// Map to query for nodes that we believe have the data we are looking for.
     providers: ProviderMap,
-    /// Dialer to get connections for required peers.
+    /// Dialer to get connections for required nodes.
     dialer: D,
     /// Limits to concurrent tasks handled by the service.
     concurrency_limits: ConcurrencyLimits,
     /// Channel to receive messages from the service's handle.
     msg_rx: mpsc::Receiver<Message>,
     /// Peers available to use and their relevant information.
-    peers: HashMap<PublicKey, ConnectionInfo<D::Connection>>,
-    /// Queue to manage dropping peers.
-    goodbye_peer_queue: delay_queue::DelayQueue<PublicKey>,
+    nodes: HashMap<NodeId, ConnectionInfo<D::Connection>>,
+    /// Queue to manage dropping nodes.
+    goodbye_nodes_queue: delay_queue::DelayQueue<NodeId>,
     /// Requests performed for download intents. Two download requests can produce the same
     /// request. This map allows deduplication of efforts.
     current_requests: HashMap<DownloadKind, ActiveRequestInfo>,
@@ -482,8 +482,8 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             dialer,
             concurrency_limits,
             msg_rx,
-            peers: HashMap::default(),
-            goodbye_peer_queue: delay_queue::DelayQueue::default(),
+            nodes: HashMap::default(),
+            goodbye_nodes_queue: delay_queue::DelayQueue::default(),
             current_requests: HashMap::default(),
             in_progress_downloads: Default::default(),
             scheduled_requests: HashMap::default(),
@@ -500,9 +500,9 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
                 .at_requests_capacity(self.in_progress_downloads.len());
 
             tokio::select! {
-                Some((peer, conn_result)) = self.dialer.next() => {
+                Some((node, conn_result)) = self.dialer.next() => {
                     trace!("tick: connection ready");
-                    self.on_connection_ready(peer, conn_result);
+                    self.on_connection_ready(node, conn_result);
                 }
                 maybe_msg = self.msg_rx.recv() => {
                     trace!(msg=?maybe_msg, "tick: message received");
@@ -528,10 +528,10 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
                     let request_info = self.scheduled_requests.remove(&kind).expect("is registered");
                     self.on_scheduled_request_ready(kind, request_info);
                 }
-                Some(expired) = self.goodbye_peer_queue.next() => {
-                    let peer = expired.into_inner();
-                    self.peers.remove(&peer);
-                    trace!(%peer, "tick: goodbye peer");
+                Some(expired) = self.goodbye_nodes_queue.next() => {
+                    let node = expired.into_inner();
+                    self.nodes.remove(&node);
+                    trace!(%node, "tick: goodbye node");
                 }
             }
             #[cfg(any(test, debug_assertions))]
@@ -546,10 +546,10 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
                 kind,
                 id,
                 sender,
-                peers,
-            } => self.handle_queue_new_download(kind, id, sender, peers),
+                nodes,
+            } => self.handle_queue_new_download(kind, id, sender, nodes),
             Message::Cancel { id, kind } => self.handle_cancel_download(id, kind),
-            Message::PeersHave { hash, peers } => self.handle_peers_have(hash, peers),
+            Message::PeersHave { hash, nodes } => self.handle_nodes_have(hash, nodes),
         }
     }
 
@@ -562,9 +562,9 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         kind: DownloadKind,
         id: Id,
         sender: oneshot::Sender<DownloadResult>,
-        peers: Vec<PeerInfo>,
+        nodes: Vec<NodeInfo>,
     ) {
-        self.providers.add_peers(*kind.hash(), &peers);
+        self.providers.add_nodes(*kind.hash(), &nodes);
         if let Some(info) = self.current_requests.get_mut(&kind) {
             // this intent maps to a download that already exists, simply register it
             info.intents.insert(id, sender);
@@ -574,13 +574,13 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             return trace!(?kind, ?info, "intent registered with active request");
         }
 
-        let needs_peer = self
+        let needs_node = self
             .scheduled_requests
             .get(&kind)
-            .map(|info| info.next_peer.is_none())
+            .map(|info| info.next_node.is_none())
             .unwrap_or(true);
 
-        let next_peer = needs_peer
+        let next_node = needs_node
             .then(|| self.get_best_candidate(kind.hash()))
             .flatten();
 
@@ -588,14 +588,14 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         match self.scheduled_requests.get_mut(&kind) {
             Some(info) => {
                 info.intents.insert(id, sender);
-                // pre-emptively get a peer if we don't already have one
-                match (info.next_peer, next_peer) {
-                    // We did not yet have next peer, but have a peer now.
-                    (None, Some(next_peer)) => {
-                        info.next_peer = Some(next_peer);
+                // pre-emptively get a node if we don't already have one
+                match (info.next_node, next_node) {
+                    // We did not yet have next node, but have a node now.
+                    (None, Some(next_node)) => {
+                        info.next_node = Some(next_node);
                     }
-                    (Some(_old_next_peer), Some(_next_peer)) => {
-                        unreachable!("invariant: info.next_peer must be none because checked above with needs_peer")
+                    (Some(_old_next_node), Some(_next_node)) => {
+                        unreachable!("invariant: info.next_node must be none because checked above with needs_node")
                     }
                     _ => {}
                 }
@@ -607,7 +607,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             }
             None => {
                 let intents = HashMap::from([(id, sender)]);
-                self.schedule_request(kind, INITIAL_RETRY_COUNT, next_peer, intents)
+                self.schedule_request(kind, INITIAL_RETRY_COUNT, next_node, intents)
             }
         }
     }
@@ -615,13 +615,13 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     /// Gets the best candidate for a download.
     ///
     /// Peers are selected prioritizing those with an open connection and with capacity for another
-    /// request, followed by peers we are currently dialing with capacity for another request.
-    /// Lastly, peers not connected and not dialing are considered.
+    /// request, followed by nodes we are currently dialing with capacity for another request.
+    /// Lastly, nodes not connected and not dialing are considered.
     ///
     /// If the selected candidate is not connected and we have capacity for another connection, a
     /// dial is queued.
-    fn get_best_candidate(&mut self, hash: &Hash) -> Option<PublicKey> {
-        /// Model the state of peers found in the candidates
+    fn get_best_candidate(&mut self, hash: &Hash) -> Option<NodeId> {
+        /// Model the state of nodes found in the candidates
         #[derive(PartialEq, Eq, Clone, Copy)]
         enum ConnState {
             Dialing,
@@ -632,9 +632,9 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         impl Ord for ConnState {
             fn cmp(&self, other: &Self) -> std::cmp::Ordering {
                 // define the order of preference between candidates as follows:
-                // - prefer connected peers to dialing ones
-                // - prefer dialing peers to not connected ones
-                // - prefer peers with less active requests when connected
+                // - prefer connected nodes to dialing ones
+                // - prefer dialing nodes to not connected ones
+                // - prefer nodes with less active requests when connected
                 use std::cmp::Ordering::*;
                 match (self, other) {
                     (ConnState::Dialing, ConnState::Dialing) => Equal,
@@ -664,18 +664,18 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         let mut candidates = self
             .providers
             .get_candidates(hash)
-            .filter_map(|(peer_id, role)| {
-                let peer = PeerInfo::new(*peer_id, *role);
-                if let Some(info) = self.peers.get(peer_id) {
+            .filter_map(|(node_id, role)| {
+                let node = NodeInfo::new(*node_id, *role);
+                if let Some(info) = self.nodes.get(node_id) {
                     info.conn.as_ref()?;
                     let req_count = info.active_requests();
-                    // filter out peers at capacity
-                    let has_capacity = !self.concurrency_limits.peer_at_request_capacity(req_count);
-                    has_capacity.then_some((peer, ConnState::Connected(req_count)))
-                } else if self.dialer.is_pending(peer_id) {
-                    Some((peer, ConnState::Dialing))
+                    // filter out nodes at capacity
+                    let has_capacity = !self.concurrency_limits.node_at_request_capacity(req_count);
+                    has_capacity.then_some((node, ConnState::Connected(req_count)))
+                } else if self.dialer.is_pending(node_id) {
+                    Some((node, ConnState::Dialing))
                 } else {
-                    Some((peer, ConnState::NotConnected))
+                    Some((node, ConnState::NotConnected))
                 }
             })
             .collect::<Vec<_>>();
@@ -683,23 +683,23 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         // Sort candidates by:
         // * Role (Providers > Candidates)
         // * ConnState (Connected > Dialing > NotConnected)
-        candidates.sort_unstable_by_key(|(PeerInfo { role, .. }, state)| (*role, *state));
+        candidates.sort_unstable_by_key(|(NodeInfo { role, .. }, state)| (*role, *state));
 
-        // this is our best peer, check if we need to dial it
-        let (peer, state) = candidates.pop()?;
+        // this is our best node, check if we need to dial it
+        let (node, state) = candidates.pop()?;
 
         if let ConnState::NotConnected = state {
             if !self.at_connections_capacity() {
-                // peer is not connected, not dialing and concurrency limits allow another connection
-                debug!(peer = %peer.peer_id, "dialing peer");
-                self.dialer.queue_dial(peer.peer_id);
-                Some(peer.peer_id)
+                // node is not connected, not dialing and concurrency limits allow another connection
+                debug!(node = %node.node_id, "dialing node");
+                self.dialer.queue_dial(node.node_id);
+                Some(node.node_id)
             } else {
-                trace!(peer = %peer.peer_id, "required peer not dialed to maintain concurrency limits");
+                trace!(node = %node.node_id, "required node not dialed to maintain concurrency limits");
                 None
             }
         } else {
-            Some(peer.peer_id)
+            Some(node.node_id)
         }
     }
 
@@ -738,10 +738,10 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     }
 
     /// Handle a [`Message::PeersHave`].
-    fn handle_peers_have(&mut self, hash: Hash, peers: Vec<PeerInfo>) {
+    fn handle_nodes_have(&mut self, hash: Hash, nodes: Vec<NodeInfo>) {
         // check if this still needed
         if self.is_needed(hash) {
-            self.providers.add_peers(hash, &peers);
+            self.providers.add_nodes(hash, &nodes);
         }
     }
 
@@ -781,27 +781,27 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     }
 
     /// Handle receiving a new connection.
-    fn on_connection_ready(&mut self, peer: PublicKey, result: anyhow::Result<D::Connection>) {
+    fn on_connection_ready(&mut self, node: NodeId, result: anyhow::Result<D::Connection>) {
         match result {
             Ok(connection) => {
-                trace!(%peer, "connected to peer");
-                let drop_key = self.goodbye_peer_queue.insert(peer, IDLE_PEER_TIMEOUT);
-                self.peers
-                    .insert(peer, ConnectionInfo::new_idle(connection, drop_key));
-                self.on_peer_ready(peer);
+                trace!(%node, "connected to node");
+                let drop_key = self.goodbye_nodes_queue.insert(node, IDLE_PEER_TIMEOUT);
+                self.nodes
+                    .insert(node, ConnectionInfo::new_idle(connection, drop_key));
+                self.on_node_ready(node);
             }
             Err(err) => {
-                debug!(%peer, %err, "connection to peer failed")
+                debug!(%node, %err, "connection to node failed")
             }
         }
     }
 
-    /// Called after the connection to a peer is established, and after finishing a download.
+    /// Called after the connection to a node is established, and after finishing a download.
     ///
     /// Starts the next provider hash download, if there is one.
-    fn on_peer_ready(&mut self, peer: PublicKey) {
-        // Get the next provider hash for this peer.
-        let Some(hash) = self.providers.get_next_provider_hash_for_peer(&peer) else {
+    fn on_node_ready(&mut self, node: NodeId) {
+        // Get the next provider hash for this node.
+        let Some(hash) = self.providers.get_next_provider_hash_for_node(&node) else {
             return;
         };
 
@@ -809,7 +809,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             return;
         }
 
-        let Some(conn) = self.get_peer_connection_for_download(&peer) else {
+        let Some(conn) = self.get_node_connection_for_download(&node) else {
             return;
         };
 
@@ -827,7 +827,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             ..
         } = info;
 
-        self.start_download(kind, peer, conn, remaining_retries, intents);
+        self.start_download(kind, node, conn, remaining_retries, intents);
     }
 
     fn on_download_completed(
@@ -841,52 +841,52 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             .remove(&kind)
             .expect("request was active");
 
-        // update the active requests for this peer
+        // update the active requests for this node
         let ActiveRequestInfo {
             intents,
-            peer,
+            node,
             mut remaining_retries,
             ..
         } = info;
 
-        let peer_info = self
-            .peers
-            .get_mut(&peer)
-            .expect("peer exists in the mapping");
-        peer_info.state = match &peer_info.state {
+        let node_info = self
+            .nodes
+            .get_mut(&node)
+            .expect("node exists in the mapping");
+        node_info.state = match &node_info.state {
             PeerState::Busy { active_requests } => {
                 match NonZeroUsize::new(active_requests.get() - 1) {
                     Some(active_requests) => PeerState::Busy { active_requests },
                     None => {
-                        // last request of the peer was this one
-                        let drop_key = self.goodbye_peer_queue.insert(peer, IDLE_PEER_TIMEOUT);
+                        // last request of the node was this one
+                        let drop_key = self.goodbye_nodes_queue.insert(node, IDLE_PEER_TIMEOUT);
                         PeerState::Idle { drop_key }
                     }
                 }
             }
-            PeerState::Idle { .. } => unreachable!("peer was busy"),
+            PeerState::Idle { .. } => unreachable!("node was busy"),
         };
 
         let hash = *kind.hash();
 
-        let peer_ready = match result {
+        let node_ready = match result {
             Ok(tt) => {
-                debug!(%peer, ?kind, "download completed");
+                debug!(%node, ?kind, "download completed");
                 for sender in intents.into_values() {
                     let _ = sender.send(Ok(tt.clone()));
                 }
                 true
             }
             Err(FailureAction::AbortRequest(reason)) => {
-                debug!(%peer, ?kind, %reason, "aborting request");
+                debug!(%node, ?kind, %reason, "aborting request");
                 for sender in intents.into_values() {
                     let _ = sender.send(Err(anyhow::anyhow!("request aborted")));
                 }
                 true
             }
             Err(FailureAction::DropPeer(reason)) => {
-                debug!(%peer, ?kind, %reason, "peer will be dropped");
-                if let Some(_connection) = peer_info.conn.take() {
+                debug!(%node, ?kind, %reason, "node will be dropped");
+                if let Some(_connection) = node_info.conn.take() {
                     // TODO(@divma): this will fail open streams, do we want this?
                     // connection.close(..)
                 }
@@ -895,12 +895,12 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             Err(FailureAction::RetryLater(reason)) => {
                 // check if the download can be retried
                 if remaining_retries > 0 {
-                    debug!(%peer, ?kind, %reason, "download attempt failed");
+                    debug!(%node, ?kind, %reason, "download attempt failed");
                     remaining_retries -= 1;
-                    let next_peer = self.get_best_candidate(kind.hash());
-                    self.schedule_request(kind, remaining_retries, next_peer, intents);
+                    let next_node = self.get_best_candidate(kind.hash());
+                    self.schedule_request(kind, remaining_retries, next_node, intents);
                 } else {
-                    warn!(%peer, ?kind, %reason, "download failed");
+                    warn!(%node, ?kind, %reason, "download failed");
                     for sender in intents.into_values() {
                         let _ = sender.send(Err(anyhow::anyhow!("download ran out of attempts")));
                     }
@@ -912,51 +912,51 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         if !self.is_needed(hash) {
             self.providers.remove(hash)
         }
-        if peer_ready {
-            self.on_peer_ready(peer);
+        if node_ready {
+            self.on_node_ready(node);
         }
     }
 
     /// A scheduled request is ready to be processed.
     ///
-    /// The peer that was initially selected is used if possible. Otherwise we try to get a new
-    /// peer
+    /// The node that was initially selected is used if possible. Otherwise we try to get a new
+    /// node
     fn on_scheduled_request_ready(&mut self, kind: DownloadKind, info: PendingRequestInfo) {
         let PendingRequestInfo {
             intents,
             mut remaining_retries,
-            next_peer,
+            next_node,
             ..
         } = info;
 
-        // first try with the peer that was initially assigned
-        if let Some((peer_id, conn)) = next_peer.and_then(|peer_id| {
-            self.get_peer_connection_for_download(&peer_id)
-                .map(|conn| (peer_id, conn))
+        // first try with the node that was initially assigned
+        if let Some((node_id, conn)) = next_node.and_then(|node_id| {
+            self.get_node_connection_for_download(&node_id)
+                .map(|conn| (node_id, conn))
         }) {
-            return self.start_download(kind, peer_id, conn, remaining_retries, intents);
+            return self.start_download(kind, node_id, conn, remaining_retries, intents);
         }
 
-        // we either didn't have a peer or the peer is busy or dialing. In any case try to get
-        // another peer
-        let next_peer = match self.get_best_candidate(kind.hash()) {
+        // we either didn't have a node or the node is busy or dialing. In any case try to get
+        // another node
+        let next_node = match self.get_best_candidate(kind.hash()) {
             None => None,
-            Some(peer_id) => {
-                // optimistically check if the peer could do the request right away
-                match self.get_peer_connection_for_download(&peer_id) {
+            Some(node_id) => {
+                // optimistically check if the node could do the request right away
+                match self.get_node_connection_for_download(&node_id) {
                     Some(conn) => {
-                        return self.start_download(kind, peer_id, conn, remaining_retries, intents)
+                        return self.start_download(kind, node_id, conn, remaining_retries, intents)
                     }
-                    None => Some(peer_id),
+                    None => Some(node_id),
                 }
             }
         };
 
-        // we tried to get a peer to perform this request but didn't get one, so now this attempt
+        // we tried to get a node to perform this request but didn't get one, so now this attempt
         // is failed
         if remaining_retries > 0 {
             remaining_retries -= 1;
-            self.schedule_request(kind, remaining_retries, next_peer, intents);
+            self.schedule_request(kind, remaining_retries, next_node, intents);
         } else {
             // check if this hash is needed in some form, otherwise remove it from providers
             let hash = *kind.hash();
@@ -971,22 +971,22 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         }
     }
 
-    /// Start downloading from the given peer.
+    /// Start downloading from the given node.
     fn start_download(
         &mut self,
         kind: DownloadKind,
-        peer: PublicKey,
+        node: NodeId,
         conn: D::Connection,
         remaining_retries: u8,
         intents: HashMap<Id, oneshot::Sender<DownloadResult>>,
     ) {
-        debug!(%peer, ?kind, "starting download");
+        debug!(%node, ?kind, "starting download");
         let cancellation = CancellationToken::new();
         let info = ActiveRequestInfo {
             intents,
             remaining_retries,
             cancellation,
-            peer,
+            node,
         };
         let cancellation = info.cancellation.clone();
         self.current_requests.insert(kind.clone(), info);
@@ -996,8 +996,8 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             // NOTE: it's an open question if we should do timeouts at this point. Considerations from @Frando:
             // > at this stage we do not know the size of the download, so the timeout would have
             // > to be so large that it won't be useful for non-huge downloads. At the same time,
-            // > this means that a super slow peer would block a download from succeeding for a long
-            // > time, while faster peers could be readily available.
+            // > this means that a super slow node would block a download from succeeding for a long
+            // > time, while faster nodes could be readily available.
             // As a conclusion, timeouts should be added only after downloads are known to be bounded
             let res = tokio::select! {
                 _ = cancellation.cancelled() => Err(FailureAction::AbortRequest(anyhow::anyhow!("cancelled"))),
@@ -1015,7 +1015,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         &mut self,
         kind: DownloadKind,
         remaining_retries: u8,
-        next_peer: Option<PublicKey>,
+        next_node: Option<NodeId>,
         intents: HashMap<Id, oneshot::Sender<DownloadResult>>,
     ) {
         // this is simply INITIAL_REQUEST_DELAY * attempt_num where attempt_num (as an ordinal
@@ -1029,23 +1029,23 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             intents,
             remaining_retries,
             delay_key,
-            next_peer,
+            next_node,
         };
         debug!(?kind, ?info, "request scheduled");
         self.scheduled_requests.insert(kind, info);
     }
 
-    /// Gets the [`Dialer::Connection`] for a peer if it's connected and has capacity for another
-    /// request. In this case, the count of active requests for the peer is incremented.
-    fn get_peer_connection_for_download(&mut self, peer: &PublicKey) -> Option<D::Connection> {
-        let info = self.peers.get_mut(peer)?;
+    /// Gets the [`Dialer::Connection`] for a node if it's connected and has capacity for another
+    /// request. In this case, the count of active requests for the node is incremented.
+    fn get_node_connection_for_download(&mut self, node: &NodeId) -> Option<D::Connection> {
+        let info = self.nodes.get_mut(node)?;
         let connection = info.conn.as_ref()?;
-        // check if the peer can be sent another request
+        // check if the node can be sent another request
         match &mut info.state {
             PeerState::Busy { active_requests } => {
                 if !self
                     .concurrency_limits
-                    .peer_at_request_capacity(active_requests.get())
+                    .node_at_request_capacity(active_requests.get())
                 {
                     *active_requests = active_requests.saturating_add(1);
                     Some(connection.clone())
@@ -1054,8 +1054,8 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
                 }
             }
             PeerState::Idle { drop_key } => {
-                // peer is no longer idle
-                self.goodbye_peer_queue.remove(drop_key);
+                // node is no longer idle
+                self.goodbye_nodes_queue.remove(drop_key);
                 info.state = PeerState::Busy {
                     active_requests: NonZeroUsize::new(1).expect("clearly non zero"),
                 };
@@ -1070,15 +1070,15 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             .at_connections_capacity(self.connections_count())
     }
 
-    /// Get the total number of connected and dialing peers.
+    /// Get the total number of connected and dialing nodes.
     fn connections_count(&self) -> usize {
-        let connected_peers = self
-            .peers
+        let connected_nodes = self
+            .nodes
             .values()
             .filter(|info| info.conn.is_some())
             .count();
-        let dialing_peers = self.dialer.pending_count();
-        connected_peers + dialing_peers
+        let dialing_nodes = self.dialer.pending_count();
+        connected_nodes + dialing_nodes
     }
 
     #[allow(clippy::unused_async)]
@@ -1092,19 +1092,19 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
 #[derive(Default, Debug)]
 pub struct ProviderMap {
     /// Candidates to download a hash.
-    candidates: HashMap<Hash, HashMap<PublicKey, PeerRole>>,
-    /// Ordered list of provider hashes per peer.
+    candidates: HashMap<Hash, HashMap<NodeId, Role>>,
+    /// Ordered list of provider hashes per node.
     ///
-    /// I.e. blobs we assume the peer can provide.
-    provider_hashes_by_peer: HashMap<PublicKey, VecDeque<Hash>>,
+    /// I.e. blobs we assume the node can provide.
+    provider_hashes_by_node: HashMap<NodeId, VecDeque<Hash>>,
 }
 
 struct ProviderIter<'a> {
-    inner: Option<std::collections::hash_map::Iter<'a, PublicKey, PeerRole>>,
+    inner: Option<std::collections::hash_map::Iter<'a, NodeId, Role>>,
 }
 
 impl<'a> Iterator for ProviderIter<'a> {
-    type Item = (&'a PublicKey, &'a PeerRole);
+    type Item = (&'a NodeId, &'a Role);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.as_mut().and_then(|iter| iter.next())
@@ -1113,58 +1113,57 @@ impl<'a> Iterator for ProviderIter<'a> {
 
 impl ProviderMap {
     /// Get candidates to download this hash.
-    fn get_candidates(&self, hash: &Hash) -> impl Iterator<Item = (&PublicKey, &PeerRole)> {
-        let inner = self.candidates.get(hash).map(|peers| peers.iter());
+    fn get_candidates(&self, hash: &Hash) -> impl Iterator<Item = (&NodeId, &Role)> {
+        let inner = self.candidates.get(hash).map(|nodes| nodes.iter());
         ProviderIter { inner }
     }
 
-    /// Register peers for a hash. Should only be done for hashes we care to download.
-    fn add_peers(&mut self, hash: Hash, peers: &[PeerInfo]) {
+    /// Register nodes for a hash. Should only be done for hashes we care to download.
+    fn add_nodes(&mut self, hash: Hash, nodes: &[NodeInfo]) {
         let entry = self.candidates.entry(hash).or_default();
-        for peer in peers {
+        for node in nodes {
             entry
-                .entry(peer.peer_id)
-                .and_modify(|role| *role = (*role).max(peer.role))
-                .or_insert(peer.role);
-            if let PeerRole::Provider = peer.role {
-                self.provider_hashes_by_peer
-                    .entry(peer.peer_id)
+                .entry(node.node_id)
+                .and_modify(|role| *role = (*role).max(node.role))
+                .or_insert(node.role);
+            if let Role::Provider = node.role {
+                self.provider_hashes_by_node
+                    .entry(node.node_id)
                     .or_default()
                     .push_back(hash);
             }
         }
     }
 
-    /// Get the next provider hash for a peer.
+    /// Get the next provider hash for a node.
     ///
-    /// I.e. get the next hash that was added with [`PeerRole::Provider`] for this peer.
-    fn get_next_provider_hash_for_peer(&mut self, peer: &PublicKey) -> Option<Hash> {
+    /// I.e. get the next hash that was added with [`PeerRole::Provider`] for this node.
+    fn get_next_provider_hash_for_node(&mut self, node: &NodeId) -> Option<Hash> {
         let hash = self
-            .provider_hashes_by_peer
-            .get(peer)
+            .provider_hashes_by_node
+            .get(node)
             .and_then(|hashes| hashes.front())
             .copied();
         if let Some(hash) = hash {
-            self.move_hash_to_back(peer, hash);
+            self.move_hash_to_back(node, hash);
         }
         hash
     }
 
     /// Signal the registry that this hash is no longer of interest.
     fn remove(&mut self, hash: Hash) {
-        let peers = self.candidates.remove(&hash);
-        if let Some(peers) = peers {
-            for peer in peers.keys() {
-                if let Some(hashes) = self.provider_hashes_by_peer.get_mut(peer) {
+        if let Some(nodes) = self.candidates.remove(&hash) {
+            for node in nodes.keys() {
+                if let Some(hashes) = self.provider_hashes_by_node.get_mut(node) {
                     hashes.retain(|h| *h != hash);
                 }
             }
         }
     }
 
-    /// Move a hash to the back of the provider queue for a peer.
-    fn move_hash_to_back(&mut self, peer: &PublicKey, hash: Hash) {
-        let hashes = self.provider_hashes_by_peer.get_mut(peer);
+    /// Move a hash to the back of the provider queue for a node.
+    fn move_hash_to_back(&mut self, node: &NodeId, hash: Hash) {
+        let hashes = self.provider_hashes_by_node.get_mut(node);
         if let Some(hashes) = hashes {
             debug_assert_eq!(hashes.front(), Some(&hash));
             if !hashes.is_empty() {
@@ -1177,15 +1176,15 @@ impl ProviderMap {
 impl Dialer for iroh_gossip::net::util::Dialer {
     type Connection = quinn::Connection;
 
-    fn queue_dial(&mut self, peer_id: PublicKey) {
-        self.queue_dial(peer_id, &iroh_bytes::protocol::ALPN)
+    fn queue_dial(&mut self, node_id: NodeId) {
+        self.queue_dial(node_id, &iroh_bytes::protocol::ALPN)
     }
 
     fn pending_count(&self) -> usize {
         self.pending_count()
     }
 
-    fn is_pending(&self, peer: &PublicKey) -> bool {
-        self.is_pending(peer)
+    fn is_pending(&self, node: &NodeId) -> bool {
+        self.is_pending(node)
     }
 }

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -305,7 +305,7 @@ pub struct NodeInfo {
 }
 
 impl NodeInfo {
-    /// Create a new [`PeerInfo`] from its parts.
+    /// Create a new [`NodeInfo`] from its parts.
     pub fn new(node_id: NodeId, role: Role) -> Self {
         Self { node_id, role }
     }
@@ -1137,7 +1137,7 @@ impl ProviderMap {
 
     /// Get the next provider hash for a node.
     ///
-    /// I.e. get the next hash that was added with [`PeerRole::Provider`] for this node.
+    /// I.e. get the next hash that was added with [`Role::Provider`] for this node.
     fn get_next_provider_hash_for_node(&mut self, node: &NodeId) -> Option<Hash> {
         let hash = self
             .provider_hashes_by_node

--- a/iroh/src/downloader/test.rs
+++ b/iroh/src/downloader/test.rs
@@ -50,7 +50,7 @@ async fn smoke_test() {
         hash: Hash::new([0u8; 32]),
     };
     let handle = downloader
-        .queue(kind.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .queue(kind.clone(), vec![(peer, Role::Candidate).into()])
         .await;
     // wait for the download result to be reported
     handle.await.expect("should report success");
@@ -79,7 +79,7 @@ async fn deduplication() {
     let mut handles = Vec::with_capacity(10);
     for _ in 0..10 {
         let h = downloader
-            .queue(kind.clone(), vec![(peer, PeerRole::Candidate).into()])
+            .queue(kind.clone(), vec![(peer, Role::Candidate).into()])
             .await;
         handles.push(h);
     }
@@ -111,10 +111,10 @@ async fn cancellation() {
         hash: Hash::new([0u8; 32]),
     };
     let handle_a = downloader
-        .queue(kind_1.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .queue(kind_1.clone(), vec![(peer, Role::Candidate).into()])
         .await;
     let handle_b = downloader
-        .queue(kind_1.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .queue(kind_1.clone(), vec![(peer, Role::Candidate).into()])
         .await;
     downloader.cancel(handle_a).await;
 
@@ -123,10 +123,10 @@ async fn cancellation() {
         hash: Hash::new([1u8; 32]),
     };
     let handle_c = downloader
-        .queue(kind_2.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .queue(kind_2.clone(), vec![(peer, Role::Candidate).into()])
         .await;
     let handle_d = downloader
-        .queue(kind_2.clone(), vec![(peer, PeerRole::Candidate).into()])
+        .queue(kind_2.clone(), vec![(peer, Role::Candidate).into()])
         .await;
     downloader.cancel(handle_c).await;
     downloader.cancel(handle_d).await;
@@ -164,7 +164,7 @@ async fn max_concurrent_requests() {
             hash: Hash::new([i; 32]),
         };
         let h = downloader
-            .queue(kind.clone(), vec![(peer, PeerRole::Candidate).into()])
+            .queue(kind.clone(), vec![(peer, Role::Candidate).into()])
             .await;
         expected_history.push((kind, peer));
         handles.push(h);
@@ -193,7 +193,7 @@ async fn max_concurrent_requests_per_peer() {
     getter.set_request_duration(Duration::from_millis(500));
     // set the concurreny limit very low to ensure it's hit
     let concurrency_limits = ConcurrencyLimits {
-        max_concurrent_requests_per_peer: 1,
+        max_concurrent_requests_per_node: 1,
         max_concurrent_requests: 10000, // all requests can be performed at the same time
         ..Default::default()
     };
@@ -209,7 +209,7 @@ async fn max_concurrent_requests_per_peer() {
             hash: Hash::new([i; 32]),
         };
         let h = downloader
-            .queue(kind.clone(), vec![(peer, PeerRole::Candidate).into()])
+            .queue(kind.clone(), vec![(peer, Role::Candidate).into()])
             .await;
         handles.push(h);
     }
@@ -238,9 +238,9 @@ async fn peer_role_provider() {
         .queue(
             kind.clone(),
             vec![
-                (peer_candidate1, PeerRole::Candidate).into(),
-                (peer_provider, PeerRole::Provider).into(),
-                (peer_candidate2, PeerRole::Candidate).into(),
+                (peer_candidate1, Role::Candidate).into(),
+                (peer_provider, Role::Provider).into(),
+                (peer_candidate2, Role::Candidate).into(),
             ],
         )
         .await;

--- a/iroh/src/downloader/test/getter.rs
+++ b/iroh/src/downloader/test/getter.rs
@@ -14,15 +14,15 @@ struct TestingGetterInner {
     /// How long requests take.
     request_duration: Duration,
     /// History of requests performed by the [`Getter`] and if they were successful.
-    request_history: Vec<(DownloadKind, PublicKey)>,
+    request_history: Vec<(DownloadKind, NodeId)>,
 }
 
 impl Getter for TestingGetter {
     // since for testing we don't need a real connection, just keep track of what peer is the
     // request being sent to
-    type Connection = PublicKey;
+    type Connection = NodeId;
 
-    fn get(&mut self, kind: DownloadKind, peer: PublicKey) -> GetFut {
+    fn get(&mut self, kind: DownloadKind, peer: NodeId) -> GetFut {
         let mut inner = self.0.write();
         let tt = TempTag::new(kind.hash_and_format(), None);
         inner.request_history.push((kind, peer));
@@ -41,7 +41,7 @@ impl TestingGetter {
     }
     /// Verify that the request history is as expected
     #[track_caller]
-    pub(super) fn assert_history(&self, history: &[(DownloadKind, PublicKey)]) {
+    pub(super) fn assert_history(&self, history: &[(DownloadKind, NodeId)]) {
         assert_eq!(self.0.read().request_history, history);
     }
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -41,7 +41,7 @@ use iroh_net::{
     config::Endpoint,
     derp::DerpMode,
     key::{PublicKey, SecretKey},
-    tls, MagicEndpoint, PeerAddr,
+    tls, MagicEndpoint, NodeAddr,
 };
 use iroh_sync::store::Store as DocStore;
 use quic_rpc::server::{RpcChannel, RpcServerError};
@@ -755,8 +755,8 @@ impl<D: ReadableStore> Node<D> {
         Ticket::new(me, hash, format, None)
     }
 
-    /// Return the [`PeerAddr`] for this node.
-    pub async fn my_addr(&self) -> Result<PeerAddr> {
+    /// Return the [`NodeAddr`] for this node.
+    pub async fn my_addr(&self) -> Result<NodeAddr> {
         self.inner.endpoint.my_addr().await
     }
 

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -15,7 +15,7 @@ use iroh_bytes::util::{BlobFormat, Tag};
 pub use iroh_bytes::{protocol::RequestToken, provider::DownloadProgress, Hash};
 use iroh_net::{
     key::PublicKey,
-    magic_endpoint::{ConnectionInfo, PeerAddr},
+    magic_endpoint::{ConnectionInfo, NodeAddr},
 };
 
 use iroh_sync::{
@@ -100,7 +100,7 @@ pub struct BlobDownloadRequest {
     /// well.
     pub format: BlobFormat,
     /// This mandatory field specifies the peer to download the data from.
-    pub peer: PeerAddr,
+    pub peer: NodeAddr,
     /// This optional field contains a request token that can be used to authorize
     /// the download request.
     pub token: Option<RequestToken>,
@@ -342,7 +342,7 @@ impl RpcMsg<ProviderService> for NodeStatusRequest {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NodeStatusResponse {
     /// The peer id and socket addresses of this node.
-    pub addr: PeerAddr,
+    pub addr: NodeAddr,
     /// The bound listening addresses of the node
     pub listen_addrs: Vec<SocketAddr>,
     /// The version of the node
@@ -582,7 +582,7 @@ pub struct DocStartSyncRequest {
     /// The document id
     pub doc_id: NamespaceId,
     /// List of peers to join
-    pub peers: Vec<PeerAddr>,
+    pub peers: Vec<NodeAddr>,
 }
 
 impl RpcMsg<ProviderService> for DocStartSyncRequest {

--- a/iroh/src/sync_engine.rs
+++ b/iroh/src/sync_engine.rs
@@ -11,7 +11,7 @@ use futures::{
 };
 use iroh_bytes::{store::EntryStatus, util::runtime::Handle, Hash};
 use iroh_gossip::net::Gossip;
-use iroh_net::{key::PublicKey, MagicEndpoint, PeerAddr};
+use iroh_net::{key::PublicKey, MagicEndpoint, NodeAddr};
 use iroh_sync::{
     actor::SyncHandle, ContentStatus, ContentStatusCallback, Entry, InsertOrigin, NamespaceId,
 };
@@ -143,7 +143,7 @@ impl SyncEngine {
     ///
     /// If `peers` is non-empty, it will both do an initial set-reconciliation sync with each peer,
     /// and join an iroh-gossip swarm with these peers to receive and broadcast document updates.
-    pub async fn start_sync(&self, namespace: NamespaceId, peers: Vec<PeerAddr>) -> Result<()> {
+    pub async fn start_sync(&self, namespace: NamespaceId, peers: Vec<NodeAddr>) -> Result<()> {
         let (reply, reply_rx) = oneshot::channel();
         self.to_live_actor
             .send(ToLiveActor::StartSync {
@@ -157,7 +157,7 @@ impl SyncEngine {
     }
 
     /// Join and sync with a set of peers for a document that is already syncing.
-    pub async fn join_peers(&self, namespace: NamespaceId, peers: Vec<PeerAddr>) -> Result<()> {
+    pub async fn join_peers(&self, namespace: NamespaceId, peers: Vec<NodeAddr>) -> Result<()> {
         let (reply, reply_rx) = oneshot::channel();
         self.to_live_actor
             .send(ToLiveActor::JoinPeers {

--- a/iroh/src/sync_engine/gossip.rs
+++ b/iroh/src/sync_engine/gossip.rs
@@ -15,7 +15,7 @@ use tokio::{
 use tracing::{debug, error, trace};
 
 use super::live::{Op, ToLiveActor};
-use crate::downloader::{Downloader, PeerRole};
+use crate::downloader::{Downloader, Role};
 
 #[derive(strum::Display, Debug)]
 pub enum ToGossipActor {
@@ -179,7 +179,7 @@ impl GossipActor {
                         // Inform the downloader that we now know that this peer has the content
                         // for this hash.
                         self.downloader
-                            .peers_have(hash, vec![(msg.delivered_from, PeerRole::Provider).into()])
+                            .nodes_have(hash, vec![(msg.delivered_from, Role::Provider).into()])
                             .await;
                     }
                     Op::SyncReport(report) => {

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use futures::FutureExt;
 use iroh_bytes::{store::EntryStatus, Hash};
 use iroh_gossip::{net::Gossip, proto::TopicId};
-use iroh_net::{key::PublicKey, MagicEndpoint, PeerAddr};
+use iroh_net::{key::PublicKey, MagicEndpoint, NodeAddr};
 use iroh_sync::{
     actor::{OpenOpts, SyncHandle},
     net::{
@@ -52,13 +52,13 @@ pub struct SyncReport {
 pub enum ToLiveActor {
     StartSync {
         namespace: NamespaceId,
-        peers: Vec<PeerAddr>,
+        peers: Vec<NodeAddr>,
         #[debug("onsehot::Sender")]
         reply: sync::oneshot::Sender<anyhow::Result<()>>,
     },
     JoinPeers {
         namespace: NamespaceId,
-        peers: Vec<PeerAddr>,
+        peers: Vec<NodeAddr>,
         #[debug("onsehot::Sender")]
         reply: sync::oneshot::Sender<anyhow::Result<()>>,
     },
@@ -321,7 +321,7 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
         let endpoint = self.endpoint.clone();
         let sync = self.sync.clone();
         let fut = async move {
-            let res = connect_and_sync(&endpoint, &sync, namespace, PeerAddr::new(peer)).await;
+            let res = connect_and_sync(&endpoint, &sync, namespace, NodeAddr::new(peer)).await;
             (namespace, peer, reason, res)
         }
         .instrument(Span::current());
@@ -341,7 +341,7 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
         Ok(())
     }
 
-    async fn start_sync(&mut self, namespace: NamespaceId, mut peers: Vec<PeerAddr>) -> Result<()> {
+    async fn start_sync(&mut self, namespace: NamespaceId, mut peers: Vec<NodeAddr>) -> Result<()> {
         // update state to allow sync
         if !self.state.is_syncing(&namespace) {
             let opts = OpenOpts::default()
@@ -356,18 +356,18 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
                 // no peers for this document
             }
             Ok(Some(known_useful_peers)) => {
-                let as_peer_addr = known_useful_peers.into_iter().filter_map(|peer_id_bytes| {
+                let as_node_addr = known_useful_peers.into_iter().filter_map(|peer_id_bytes| {
                     // peers are stored as bytes, don't fail the operation if they can't be
                     // decoded: simply ignore the peer
                     match PublicKey::from_bytes(&peer_id_bytes) {
-                        Ok(public_key) => Some(PeerAddr::new(public_key)),
+                        Ok(public_key) => Some(NodeAddr::new(public_key)),
                         Err(_signing_error) => {
                             warn!("potential db corruption: peers per doc can't be decoded");
                             None
                         }
                     }
                 });
-                peers.extend(as_peer_addr);
+                peers.extend(as_node_addr);
             }
             Err(e) => {
                 // try to continue if peers per doc can't be read since they are not vital for sync
@@ -404,13 +404,13 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
     async fn join_peers(
         &mut self,
         namespace: NamespaceId,
-        peers: Vec<PeerAddr>,
+        peers: Vec<NodeAddr>,
     ) -> anyhow::Result<()> {
-        let peer_ids: Vec<PublicKey> = peers.iter().map(|p| p.peer_id).collect();
+        let peer_ids: Vec<PublicKey> = peers.iter().map(|p| p.node_id).collect();
 
         // add addresses of peers to our endpoint address book
         for peer in peers.into_iter() {
-            let peer_id = peer.peer_id;
+            let peer_id = peer.node_id;
             if let Err(err) = self.endpoint.add_peer_addr(peer) {
                 warn!(peer = %peer_id.fmt_short(), "failed to add known addrs: {err:?}");
             }

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, time::SystemTime};
 
-use crate::downloader::{DownloadKind, Downloader, PeerRole};
+use crate::downloader::{DownloadKind, Downloader, Role};
 use anyhow::{Context, Result};
 use futures::FutureExt;
 use iroh_bytes::{store::EntryStatus, Hash};
@@ -637,8 +637,8 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
                 if matches!(entry_status, EntryStatus::NotFound | EntryStatus::Partial) {
                     let from = PublicKey::from_bytes(&from)?;
                     let role = match content_status {
-                        ContentStatus::Complete => PeerRole::Provider,
-                        _ => PeerRole::Candidate,
+                        ContentStatus::Complete => Role::Provider,
+                        _ => Role::Candidate,
                     };
                     let handle = self
                         .downloader

--- a/iroh/src/ticket/blob.rs
+++ b/iroh/src/ticket/blob.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use anyhow::{ensure, Result};
 use iroh_bytes::{protocol::RequestToken, BlobFormat, Hash};
-use iroh_net::{derp::DerpMap, key::SecretKey, PeerAddr};
+use iroh_net::{derp::DerpMap, key::SecretKey, NodeAddr};
 use serde::{Deserialize, Serialize};
 
 use crate::dial::Options;
@@ -18,7 +18,7 @@ use super::*;
 #[display("{}", IrohTicket::serialize(self))]
 pub struct Ticket {
     /// The provider to get a file from.
-    node: PeerAddr,
+    node: NodeAddr,
     /// The format of the blob.
     format: BlobFormat,
     /// The hash to retrieve.
@@ -49,7 +49,7 @@ impl FromStr for Ticket {
 impl Ticket {
     /// Creates a new ticket.
     pub fn new(
-        peer: PeerAddr,
+        peer: NodeAddr,
         hash: Hash,
         format: BlobFormat,
         token: Option<RequestToken>,
@@ -68,8 +68,8 @@ impl Ticket {
         self.hash
     }
 
-    /// The [`PeerAddr`] of the provider for this ticket.
-    pub fn node_addr(&self) -> &PeerAddr {
+    /// The [`NodeAddr`] of the provider for this ticket.
+    pub fn node_addr(&self) -> &NodeAddr {
         &self.node
     }
 
@@ -94,7 +94,7 @@ impl Ticket {
     }
 
     /// Get the contents of the ticket, consuming it.
-    pub fn into_parts(self) -> (PeerAddr, Hash, BlobFormat, Option<RequestToken>) {
+    pub fn into_parts(self) -> (NodeAddr, Hash, BlobFormat, Option<RequestToken>) {
         let Ticket {
             node: peer,
             hash,
@@ -160,7 +160,7 @@ mod tests {
         let derp_region = Some(0);
         Ticket {
             hash,
-            node: PeerAddr::from_parts(peer, derp_region, vec![addr]),
+            node: NodeAddr::from_parts(peer, derp_region, vec![addr]),
             token: Some(token),
             format: BlobFormat::HashSeq,
         }

--- a/iroh/src/ticket/doc.rs
+++ b/iroh/src/ticket/doc.rs
@@ -1,6 +1,6 @@
 //! Tickets for [`iroh-sync`] documents.
 
-use iroh_net::PeerAddr;
+use iroh_net::NodeAddr;
 use serde::{Deserialize, Serialize};
 
 use crate::rpc_protocol::KeyBytes;
@@ -14,7 +14,7 @@ pub struct Ticket {
     /// either a public or private key
     pub key: KeyBytes,
     /// A list of nodes to contact.
-    pub nodes: Vec<PeerAddr>,
+    pub nodes: Vec<NodeAddr>,
 }
 
 impl IrohTicket for Ticket {
@@ -23,7 +23,7 @@ impl IrohTicket for Ticket {
 
 impl Ticket {
     /// Create a new doc ticket
-    pub fn new(key: KeyBytes, peers: Vec<PeerAddr>) -> Self {
+    pub fn new(key: KeyBytes, peers: Vec<NodeAddr>) -> Self {
         Self { key, nodes: peers }
     }
 }

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -635,7 +635,7 @@ fn test_provide_get_loop_single(
         .direct_addresses()
         .map(|x| x.to_string())
         .collect::<Vec<_>>();
-    let peer = ticket.node_addr().peer_id.to_string();
+    let peer = ticket.node_addr().node_id.to_string();
     let region = ticket
         .node_addr()
         .derp_region()

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -16,7 +16,7 @@ use iroh::{
 };
 use iroh_net::{
     key::{PublicKey, SecretKey},
-    MagicEndpoint, PeerAddr,
+    MagicEndpoint, NodeAddr,
 };
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use rand::RngCore;
@@ -138,7 +138,7 @@ async fn empty_files() -> Result<()> {
 /// Create new get options with the given peer id and addresses, using a
 /// randomly generated secret key.
 fn get_options(peer_id: PublicKey, addrs: Vec<SocketAddr>) -> iroh::dial::Options {
-    let peer = iroh_net::PeerAddr::from_parts(peer_id, Some(1), addrs);
+    let peer = iroh_net::NodeAddr::from_parts(peer_id, Some(1), addrs);
     iroh::dial::Options {
         secret_key: SecretKey::generate(),
         peer,
@@ -795,11 +795,11 @@ async fn test_token_passthrough() -> Result<()> {
             .bind(0)
             .await?;
 
-        let peer_addr = PeerAddr::new(peer_id)
+        let node_addr = NodeAddr::new(peer_id)
             .with_derp_region(1)
             .with_direct_addresses(addrs.clone());
         endpoint
-            .connect(peer_addr, &iroh_bytes::protocol::ALPN)
+            .connect(node_addr, &iroh_bytes::protocol::ALPN)
             .await
             .context("failed to connect to provider")?;
         let request = GetRequest::all(hash).with_token(token);

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -14,10 +14,7 @@ use iroh::{
     collection::{Blob, Collection},
     node::{Builder, Event, Node, StaticTokenAuthHandler},
 };
-use iroh_net::{
-    key::{PublicKey, SecretKey},
-    MagicEndpoint, NodeAddr,
-};
+use iroh_net::{key::SecretKey, MagicEndpoint, NodeAddr, NodeId};
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use rand::RngCore;
 use tokio::sync::mpsc;
@@ -137,8 +134,8 @@ async fn empty_files() -> Result<()> {
 
 /// Create new get options with the given peer id and addresses, using a
 /// randomly generated secret key.
-fn get_options(peer_id: PublicKey, addrs: Vec<SocketAddr>) -> iroh::dial::Options {
-    let peer = iroh_net::NodeAddr::from_parts(peer_id, Some(1), addrs);
+fn get_options(node_id: NodeId, addrs: Vec<SocketAddr>) -> iroh::dial::Options {
+    let peer = iroh_net::NodeAddr::from_parts(node_id, Some(1), addrs);
     iroh::dial::Options {
         secret_key: SecretKey::generate(),
         peer,


### PR DESCRIPTION
## Description
First step on dealing with the whole peer_id vs node_id. Changes include:
- renames `PeerAddr` to `NodeAddr` and it's inner fields from `peer_id` to `node_id`
- introduces the `NodeId` type alias as stated in #1388 
- moves every field and parameter defined as `peer_id: PublicKey` to `node_id: NodeId`. As far as I can tell everywhere touched is not doing any crypto stuff.

## Notes & open questions

The one place where this is not changed is the tls code as it does deal with crypto ops. Later refactors should update the code to use `key: PublicKey` instead of `peer_id: PublicKey` for example.

In the future it might be worth to actually rename `PublicKey` to `NodeId` or creating a newtype `NodeId` that can only be obtained from a `PublicKey` but has no crypto ops available. Not doing any of that since I know it's controversial.

Also note that this is intentionally kept partial. Reasons for this:
- the state already has a mixed peer_id/node_id state, so we are not passing from a consistent state into an inconsistent one, but from a less desirable and inconsistent one to a more desirable, still inconsistent one
- keeping the PR short to facilitate a meaningful review

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
