### PR TITLE
refactor(*): rename Peer to Node in peer_map related code

### DIFF
--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -160,7 +160,7 @@ async fn main() -> anyhow::Result<()> {
         println!("> trying to connect to {} peers...", peers.len());
         // add the peer addrs from the ticket to our endpoint's addressbook so that they can be dialed
         for peer in peers.into_iter() {
-            endpoint.add_peer_addr(peer)?;
+            endpoint.add_node_addr(peer)?;
         }
     };
     gossip.join(topic, peer_ids).await?.await?;

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -131,7 +131,7 @@ impl Gossip {
     ///
     ///
     /// This method only asks for [`PublicKey`]s. You must supply information on how to
-    /// connect to these peers manually before, by calling [`MagicEndpoint::add_peer_addr`] on
+    /// connect to these peers manually before, by calling [`MagicEndpoint::add_node_addr`] on
     /// the underlying [`MagicEndpoint`].
     ///
     /// This method returns a future that completes once the request reached the local actor.
@@ -553,7 +553,7 @@ impl Actor {
                     Ok(info) => {
                         debug!(peer = ?node_id, "add known addrs: {info:?}");
                         let node_addr = NodeAddr { node_id, info };
-                        if let Err(err) = self.endpoint.add_peer_addr(node_addr) {
+                        if let Err(err) = self.endpoint.add_node_addr(node_addr) {
                             debug!(peer = ?node_id, "add known failed: {err:?}");
                         }
                     }
@@ -730,8 +730,8 @@ mod test {
         let topic: TopicId = blake3::hash(b"foobar").into();
         // share info that pi1 is on the same derp_region
         let addr1 = NodeAddr::new(pi1).with_derp_region(derp_region);
-        ep2.add_peer_addr(addr1.clone()).unwrap();
-        ep3.add_peer_addr(addr1).unwrap();
+        ep2.add_node_addr(addr1.clone()).unwrap();
+        ep3.add_node_addr(addr1).unwrap();
 
         debug!("----- joining  ----- ");
         // join the topics and wait for the connection to succeed

--- a/iroh-gossip/src/net/util.rs
+++ b/iroh-gossip/src/net/util.rs
@@ -107,7 +107,7 @@ impl Dialer {
     /// Start to dial a node.
     ///
     /// Note that the node's addresses and/or derp region must be added to the endpoint's
-    /// addressbook for a dial to succeed, see [`MagicEndpoint::add_peer_addr`].
+    /// addressbook for a dial to succeed, see [`MagicEndpoint::add_node_addr`].
     pub fn queue_dial(&mut self, node_id: NodeId, alpn_protocol: &'static [u8]) {
         if self.is_pending(&node_id) {
             return;

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -263,7 +263,7 @@ impl MagicEndpointBuilder {
             secret_key,
             derp_map,
             callbacks: self.callbacks,
-            peers_path: self.peers_path,
+            nodes_path: self.peers_path,
         };
         MagicEndpoint::bind(Some(server_config), msock_opts, self.keylog).await
     }
@@ -394,7 +394,7 @@ impl MagicEndpoint {
     /// currently communicating with that node over a `Direct` (UDP) or `Relay` (DERP) connection.
     ///
     /// Connections are currently only pruned on user action (when we explicitly add a new address
-    /// to the internal addressbook through [`MagicEndpoint::add_peer_addr`]), so these connections
+    /// to the internal addressbook through [`MagicEndpoint::add_node_addr`]), so these connections
     /// are not necessarily active connections.
     pub async fn connection_infos(&self) -> anyhow::Result<Vec<ConnectionInfo>> {
         self.msock.tracked_endpoints().await
@@ -423,7 +423,7 @@ impl MagicEndpoint {
     ///
     /// If no UDP addresses and no DERP region is provided, it will error.
     pub async fn connect(&self, node_addr: NodeAddr, alpn: &[u8]) -> Result<quinn::Connection> {
-        self.add_peer_addr(node_addr.clone())?;
+        self.add_node_addr(node_addr.clone())?;
 
         let NodeAddr { node_id, info } = node_addr;
         let addr = self.msock.get_mapping_addr(&node_id).await;
@@ -478,8 +478,8 @@ impl MagicEndpoint {
     /// If no UDP addresses are added, and `derp_region` is `None`, it will error.
     /// If no UDP addresses are added, and the given `derp_region` cannot be dialed, it will error.
     // TODO: Make sync
-    pub fn add_peer_addr(&self, node_addr: NodeAddr) -> Result<()> {
-        self.msock.add_peer_addr(node_addr);
+    pub fn add_node_addr(&self, node_addr: NodeAddr) -> Result<()> {
+        self.msock.add_node_addr(node_addr);
         Ok(())
     }
 
@@ -693,7 +693,7 @@ mod tests {
         // information for a peer
         let endpoint = new_endpoint(secret_key.clone(), path.clone()).await;
         assert!(endpoint.connection_infos().await.unwrap().is_empty());
-        endpoint.add_peer_addr(node_addr).unwrap();
+        endpoint.add_node_addr(node_addr).unwrap();
 
         info!("closing endpoint");
         // close the endpoint and restart it

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -411,7 +411,7 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
         // add addresses of peers to our endpoint address book
         for peer in peers.into_iter() {
             let peer_id = peer.node_id;
-            if let Err(err) = self.endpoint.add_peer_addr(peer) {
+            if let Err(err) = self.endpoint.add_node_addr(peer) {
                 warn!(peer = %peer_id.fmt_short(), "failed to add known addrs: {err:?}");
             }
         }


### PR DESCRIPTION
## Description

incremental followup for #1765 
rename Peer to Node in peer_map related code.
The module renaming should be done at the very end and in another PR to prevent overwriting the file's history

## Notes & open questions

mostly dumb renaming that should be fine. Please push your feedback directly to the PR

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
