### PR TITLE
feat(iroh-sync): Rename get_one to get_exact, add flag to get empty entries, query single entry on client

### DIFF
--- a/iroh-sync/src/actor.rs
+++ b/iroh-sync/src/actor.rs
@@ -377,7 +377,7 @@ impl SyncHandle {
         Ok(())
     }
 
-    pub async fn get_one(
+    pub async fn get_exact(
         &self,
         namespace: NamespaceId,
         author: AuthorId,
@@ -589,7 +589,7 @@ impl<S: store::Store> Actor<S> {
             ReplicaAction::GetOne { author, key, include_empty, reply } => {
                 send_reply_with(reply, self, move |this| {
                     this.states.ensure_open(&namespace)?;
-                    this.store.get_one(namespace, author, key, include_empty)
+                    this.store.get_exact(namespace, author, key, include_empty)
                 })
             }
             ReplicaAction::GetMany { query, reply } => {

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -140,7 +140,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
         namespace: NamespaceId,
         author: AuthorId,
         key: impl AsRef<[u8]>,
-        include_empty: bool
+        include_empty: bool,
     ) -> Result<Option<SignedEntry>>;
 
     /// Get all content hashes of all replicas in the store.

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -140,6 +140,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
         namespace: NamespaceId,
         author: AuthorId,
         key: impl AsRef<[u8]>,
+        include_empty: bool
     ) -> Result<Option<SignedEntry>>;
 
     /// Get all content hashes of all replicas in the store.

--- a/iroh-sync/src/store.rs
+++ b/iroh-sync/src/store.rs
@@ -135,7 +135,7 @@ pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
     ) -> Result<Self::GetIter<'_>>;
 
     /// Get an entry by key and author.
-    fn get_one(
+    fn get_exact(
         &self,
         namespace: NamespaceId,
         author: AuthorId,

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -281,7 +281,7 @@ impl super::Store for Store {
         namespace: NamespaceId,
         author: AuthorId,
         key: impl AsRef<[u8]>,
-        include_empty: bool
+        include_empty: bool,
     ) -> Result<Option<SignedEntry>> {
         let read_tx = self.db.begin_read()?;
         let record_table = read_tx.open_table(RECORDS_TABLE)?;
@@ -444,7 +444,8 @@ impl crate::ranger::Store<SignedEntry> for StoreInstance {
     }
 
     fn get(&self, id: &RecordIdentifier) -> Result<Option<SignedEntry>> {
-        self.store.get_exact(id.namespace(), id.author(), id.key(), true)
+        self.store
+            .get_exact(id.namespace(), id.author(), id.key(), true)
     }
 
     fn len(&self) -> Result<usize> {

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -276,7 +276,7 @@ impl super::Store for Store {
         QueryIterator::new(&self.db, namespace, query.into())
     }
 
-    fn get_one(
+    fn get_exact(
         &self,
         namespace: NamespaceId,
         author: AuthorId,
@@ -285,7 +285,7 @@ impl super::Store for Store {
     ) -> Result<Option<SignedEntry>> {
         let read_tx = self.db.begin_read()?;
         let record_table = read_tx.open_table(RECORDS_TABLE)?;
-        get_one(&record_table, namespace, author, key, include_empty)
+        get_exact(&record_table, namespace, author, key, include_empty)
     }
 
     fn content_hashes(&self) -> Result<Self::ContentHashesIter<'_>> {
@@ -386,7 +386,7 @@ impl super::Store for Store {
     }
 }
 
-fn get_one(
+fn get_exact(
     record_table: &RecordsTable,
     namespace: NamespaceId,
     author: AuthorId,
@@ -444,7 +444,7 @@ impl crate::ranger::Store<SignedEntry> for StoreInstance {
     }
 
     fn get(&self, id: &RecordIdentifier) -> Result<Option<SignedEntry>> {
-        self.store.get_one(id.namespace(), id.author(), id.key(), true)
+        self.store.get_exact(id.namespace(), id.author(), id.key(), true)
     }
 
     fn len(&self) -> Result<usize> {
@@ -652,7 +652,7 @@ impl Iterator for ParentIterator<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         let records_table = self.reader.table();
         while !self.key.is_empty() {
-            let entry = get_one(records_table, self.namespace, self.author, &self.key, false);
+            let entry = get_exact(records_table, self.namespace, self.author, &self.key, false);
             self.key.pop();
             match entry {
                 Err(err) => return Some(Err(err)),

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -281,10 +281,11 @@ impl super::Store for Store {
         namespace: NamespaceId,
         author: AuthorId,
         key: impl AsRef<[u8]>,
+        include_empty: bool
     ) -> Result<Option<SignedEntry>> {
         let read_tx = self.db.begin_read()?;
         let record_table = read_tx.open_table(RECORDS_TABLE)?;
-        get_one(&record_table, namespace, author, key, false)
+        get_one(&record_table, namespace, author, key, include_empty)
     }
 
     fn content_hashes(&self) -> Result<Self::ContentHashesIter<'_>> {
@@ -443,7 +444,7 @@ impl crate::ranger::Store<SignedEntry> for StoreInstance {
     }
 
     fn get(&self, id: &RecordIdentifier) -> Result<Option<SignedEntry>> {
-        self.store.get_one(id.namespace(), id.author(), id.key())
+        self.store.get_one(id.namespace(), id.author(), id.key(), true)
     }
 
     fn len(&self) -> Result<usize> {

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -167,7 +167,7 @@ impl super::Store for Store {
         Ok(QueryIterator::new(records, namespace, query))
     }
 
-    fn get_one(
+    fn get_exact(
         &self,
         namespace: NamespaceId,
         author: AuthorId,

--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -172,6 +172,7 @@ impl super::Store for Store {
         namespace: NamespaceId,
         author: AuthorId,
         key: impl AsRef<[u8]>,
+        include_empty: bool,
     ) -> Result<Option<SignedEntry>> {
         let inner = self.replica_records.read();
         let Some(records) = inner.get(&namespace) else {
@@ -180,10 +181,11 @@ impl super::Store for Store {
         let entry = records
             .by_author
             .get(&(author, key.as_ref().to_vec().into()));
-        Ok(entry.and_then(|entry| match entry.is_empty() {
-            true => None,
-            false => Some(entry.clone()),
-        }))
+        Ok(match entry {
+            Some(entry) if !include_empty && entry.is_empty() => None,
+            Some(entry) => Some(entry.clone()),
+            None => None,
+        })
     }
 
     /// Get all content hashes of all replicas in the store.

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -1374,7 +1374,9 @@ mod tests {
         replica
             .insert_entry(entry.clone(), InsertOrigin::Local)
             .unwrap();
-        let res = store.get_exact(namespace.id(), author.id(), key, false)?.unwrap();
+        let res = store
+            .get_exact(namespace.id(), author.id(), key, false)?
+            .unwrap();
         assert_eq!(res, entry);
 
         let entry2 = {
@@ -1386,7 +1388,9 @@ mod tests {
 
         let res = replica.insert_entry(entry2, InsertOrigin::Local);
         assert!(matches!(res, Err(InsertError::NewerEntryExists)));
-        let res = store.get_exact(namespace.id(), author.id(), key, false)?.unwrap();
+        let res = store
+            .get_exact(namespace.id(), author.id(), key, false)?
+            .unwrap();
         assert_eq!(res, entry);
 
         Ok(())
@@ -1599,9 +1603,18 @@ mod tests {
         // delete
         let deleted = replica.delete_prefix(b"foo", &alice)?;
         assert_eq!(deleted, 2);
-        assert_eq!(store.get_exact(myspace.id(), alice.id(), b"foobar", false)?, None);
-        assert_eq!(store.get_exact(myspace.id(), alice.id(), b"fooboo", false)?, None);
-        assert_eq!(store.get_exact(myspace.id(), alice.id(), b"foo", false)?, None);
+        assert_eq!(
+            store.get_exact(myspace.id(), alice.id(), b"foobar", false)?,
+            None
+        );
+        assert_eq!(
+            store.get_exact(myspace.id(), alice.id(), b"fooboo", false)?,
+            None
+        );
+        assert_eq!(
+            store.get_exact(myspace.id(), alice.id(), b"foo", false)?,
+            None
+        );
 
         Ok(())
     }

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -1055,7 +1055,7 @@ mod tests {
 
         for i in 0..10 {
             let res = store
-                .get_one(my_replica.namespace(), alice.id(), format!("/{i}"))?
+                .get_one(my_replica.namespace(), alice.id(), format!("/{i}"), false)?
                 .unwrap();
             let len = format!("{i}: hello from alice").as_bytes().len() as u64;
             assert_eq!(res.entry().record().content_len(), len);
@@ -1065,12 +1065,12 @@ mod tests {
         // Test multiple records for the same key
         my_replica.hash_and_insert("/cool/path", &alice, "round 1")?;
         let _entry = store
-            .get_one(my_replica.namespace(), alice.id(), "/cool/path")?
+            .get_one(my_replica.namespace(), alice.id(), "/cool/path", false)?
             .unwrap();
         // Second
         my_replica.hash_and_insert("/cool/path", &alice, "round 2")?;
         let _entry = store
-            .get_one(my_replica.namespace(), alice.id(), "/cool/path")?
+            .get_one(my_replica.namespace(), alice.id(), "/cool/path", false)?
             .unwrap();
 
         // Get All by author
@@ -1374,7 +1374,7 @@ mod tests {
         replica
             .insert_entry(entry.clone(), InsertOrigin::Local)
             .unwrap();
-        let res = store.get_one(namespace.id(), author.id(), key)?.unwrap();
+        let res = store.get_one(namespace.id(), author.id(), key, false)?.unwrap();
         assert_eq!(res, entry);
 
         let entry2 = {
@@ -1386,7 +1386,7 @@ mod tests {
 
         let res = replica.insert_entry(entry2, InsertOrigin::Local);
         assert!(matches!(res, Err(InsertError::NewerEntryExists)));
-        let res = store.get_one(namespace.id(), author.id(), key)?.unwrap();
+        let res = store.get_one(namespace.id(), author.id(), key, false)?.unwrap();
         assert_eq!(res, entry);
 
         Ok(())
@@ -1599,9 +1599,9 @@ mod tests {
         // delete
         let deleted = replica.delete_prefix(b"foo", &alice)?;
         assert_eq!(deleted, 2);
-        assert_eq!(store.get_one(myspace.id(), alice.id(), b"foobar")?, None);
-        assert_eq!(store.get_one(myspace.id(), alice.id(), b"fooboo")?, None);
-        assert_eq!(store.get_one(myspace.id(), alice.id(), b"foo")?, None);
+        assert_eq!(store.get_one(myspace.id(), alice.id(), b"foobar", false)?, None);
+        assert_eq!(store.get_one(myspace.id(), alice.id(), b"fooboo", false)?, None);
+        assert_eq!(store.get_one(myspace.id(), alice.id(), b"foo", false)?, None);
 
         Ok(())
     }
@@ -2126,7 +2126,7 @@ mod tests {
         key: &[u8],
     ) -> anyhow::Result<SignedEntry> {
         let entry = store
-            .get_one(namespace, author, key)?
+            .get_one(namespace, author, key, true)?
             .ok_or_else(|| anyhow::anyhow!("not found"))?;
         Ok(entry)
     }
@@ -2138,7 +2138,7 @@ mod tests {
         key: &[u8],
     ) -> anyhow::Result<Option<Hash>> {
         let hash = store
-            .get_one(namespace, author, key)?
+            .get_one(namespace, author, key, false)?
             .map(|e| e.content_hash());
         Ok(hash)
     }
@@ -2174,7 +2174,7 @@ mod tests {
         set: &[&str],
     ) -> Result<()> {
         for el in set {
-            store.get_one(*namespace, author.id(), el)?;
+            store.get_one(*namespace, author.id(), el, false)?;
         }
         Ok(())
     }

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -1055,7 +1055,7 @@ mod tests {
 
         for i in 0..10 {
             let res = store
-                .get_one(my_replica.namespace(), alice.id(), format!("/{i}"), false)?
+                .get_exact(my_replica.namespace(), alice.id(), format!("/{i}"), false)?
                 .unwrap();
             let len = format!("{i}: hello from alice").as_bytes().len() as u64;
             assert_eq!(res.entry().record().content_len(), len);
@@ -1065,12 +1065,12 @@ mod tests {
         // Test multiple records for the same key
         my_replica.hash_and_insert("/cool/path", &alice, "round 1")?;
         let _entry = store
-            .get_one(my_replica.namespace(), alice.id(), "/cool/path", false)?
+            .get_exact(my_replica.namespace(), alice.id(), "/cool/path", false)?
             .unwrap();
         // Second
         my_replica.hash_and_insert("/cool/path", &alice, "round 2")?;
         let _entry = store
-            .get_one(my_replica.namespace(), alice.id(), "/cool/path", false)?
+            .get_exact(my_replica.namespace(), alice.id(), "/cool/path", false)?
             .unwrap();
 
         // Get All by author
@@ -1374,7 +1374,7 @@ mod tests {
         replica
             .insert_entry(entry.clone(), InsertOrigin::Local)
             .unwrap();
-        let res = store.get_one(namespace.id(), author.id(), key, false)?.unwrap();
+        let res = store.get_exact(namespace.id(), author.id(), key, false)?.unwrap();
         assert_eq!(res, entry);
 
         let entry2 = {
@@ -1386,7 +1386,7 @@ mod tests {
 
         let res = replica.insert_entry(entry2, InsertOrigin::Local);
         assert!(matches!(res, Err(InsertError::NewerEntryExists)));
-        let res = store.get_one(namespace.id(), author.id(), key, false)?.unwrap();
+        let res = store.get_exact(namespace.id(), author.id(), key, false)?.unwrap();
         assert_eq!(res, entry);
 
         Ok(())
@@ -1599,9 +1599,9 @@ mod tests {
         // delete
         let deleted = replica.delete_prefix(b"foo", &alice)?;
         assert_eq!(deleted, 2);
-        assert_eq!(store.get_one(myspace.id(), alice.id(), b"foobar", false)?, None);
-        assert_eq!(store.get_one(myspace.id(), alice.id(), b"fooboo", false)?, None);
-        assert_eq!(store.get_one(myspace.id(), alice.id(), b"foo", false)?, None);
+        assert_eq!(store.get_exact(myspace.id(), alice.id(), b"foobar", false)?, None);
+        assert_eq!(store.get_exact(myspace.id(), alice.id(), b"fooboo", false)?, None);
+        assert_eq!(store.get_exact(myspace.id(), alice.id(), b"foo", false)?, None);
 
         Ok(())
     }
@@ -2126,7 +2126,7 @@ mod tests {
         key: &[u8],
     ) -> anyhow::Result<SignedEntry> {
         let entry = store
-            .get_one(namespace, author, key, true)?
+            .get_exact(namespace, author, key, true)?
             .ok_or_else(|| anyhow::anyhow!("not found"))?;
         Ok(entry)
     }
@@ -2138,7 +2138,7 @@ mod tests {
         key: &[u8],
     ) -> anyhow::Result<Option<Hash>> {
         let hash = store
-            .get_one(namespace, author, key, false)?
+            .get_exact(namespace, author, key, false)?
             .map(|e| e.content_hash());
         Ok(hash)
     }
@@ -2174,7 +2174,7 @@ mod tests {
         set: &[&str],
     ) -> Result<()> {
         for el in set {
-            store.get_one(*namespace, author.id(), el, false)?;
+            store.get_exact(*namespace, author.id(), el, false)?;
         }
         Ok(())
     }

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -659,13 +659,14 @@ where
     }
 
     /// Get the latest entry for a key and author.
-    pub async fn get_one(&self, author: AuthorId, key: impl AsRef<[u8]>) -> Result<Option<Entry>> {
+    pub async fn get_one(&self, author: AuthorId, key: impl AsRef<[u8]>, include_empty: bool) -> Result<Option<Entry>> {
         self.ensure_open()?;
         let res = self
             .rpc(DocGetOneRequest {
                 author,
                 key: key.as_ref().to_vec().into(),
                 doc_id: self.id(),
+                include_empty
             })
             .await??;
         Ok(res.entry.map(|entry| entry.into()))

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -35,7 +35,7 @@ use crate::rpc_protocol::{
     BlobListCollectionsResponse, BlobListIncompleteRequest, BlobListIncompleteResponse,
     BlobListRequest, BlobListResponse, BlobReadRequest, BlobReadResponse, BlobValidateRequest,
     CounterStats, DeleteTagRequest, DocCloseRequest, DocCreateRequest, DocDelRequest,
-    DocDelResponse, DocDropRequest, DocGetManyRequest, DocGetOneRequest, DocImportRequest,
+    DocDelResponse, DocDropRequest, DocGetExactRequest, DocGetManyRequest, DocImportRequest,
     DocLeaveRequest, DocListRequest, DocOpenRequest, DocSetHashRequest, DocSetRequest,
     DocShareRequest, DocStartSyncRequest, DocStatusRequest, DocSubscribeRequest, DocTicket,
     DownloadProgress, ListTagsRequest, ListTagsResponse, NodeConnectionInfoRequest,
@@ -669,7 +669,7 @@ where
     ) -> Result<Option<Entry>> {
         self.ensure_open()?;
         let res = self
-            .rpc(DocGetOneRequest {
+            .rpc(DocGetExactRequest {
                 author,
                 key: key.as_ref().to_vec().into(),
                 doc_id: self.id(),

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -659,7 +659,7 @@ where
     }
 
     /// Get the latest entry for a key and author.
-    pub async fn get_one(&self, author: AuthorId, key: impl AsRef<[u8]>, include_empty: bool) -> Result<Option<Entry>> {
+    pub async fn get_exact(&self, author: AuthorId, key: impl AsRef<[u8]>, include_empty: bool) -> Result<Option<Entry>> {
         self.ensure_open()?;
         let res = self
             .rpc(DocGetOneRequest {

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1563,7 +1563,7 @@ fn handle_rpc_request<D: BaoStore, E: ServiceEndpoint<ProviderService>>(
             }
             DocGetOne(msg) => {
                 chan.rpc(msg, handler, |handler, req| async move {
-                    handler.inner.sync.doc_get_one(req).await
+                    handler.inner.sync.doc_get_exact(req).await
                 })
                 .await
             }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1561,7 +1561,7 @@ fn handle_rpc_request<D: BaoStore, E: ServiceEndpoint<ProviderService>>(
                 })
                 .await
             }
-            DocGetOne(msg) => {
+            DocGetExact(msg) => {
                 chan.rpc(msg, handler, |handler, req| async move {
                     handler.inner.sync.doc_get_exact(req).await
                 })

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -719,7 +719,7 @@ pub struct DocGetManyResponse {
 
 /// Get entries from a document
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocGetOneRequest {
+pub struct DocGetExactRequest {
     /// The document id
     pub doc_id: NamespaceId,
     /// Key matcher
@@ -727,16 +727,16 @@ pub struct DocGetOneRequest {
     /// Author matcher
     pub author: AuthorId,
     /// Whether to include empty entries (prefix deletion markers)
-    pub include_empty: bool
+    pub include_empty: bool,
 }
 
-impl RpcMsg<ProviderService> for DocGetOneRequest {
-    type Response = RpcResult<DocGetOneResponse>;
+impl RpcMsg<ProviderService> for DocGetExactRequest {
+    type Response = RpcResult<DocGetExactResponse>;
 }
 
-/// Response to [`DocGetOneRequest`]
+/// Response to [`DocGetExactRequest`]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocGetOneResponse {
+pub struct DocGetExactResponse {
     /// The document entry
     pub entry: Option<SignedEntry>,
 }
@@ -865,7 +865,7 @@ pub enum ProviderRequest {
     DocSet(DocSetRequest),
     DocSetHash(DocSetHashRequest),
     DocGet(DocGetManyRequest),
-    DocGetOne(DocGetOneRequest),
+    DocGetExact(DocGetExactRequest),
     DocDel(DocDelRequest),
     DocStartSync(DocStartSyncRequest),
     DocLeave(DocLeaveRequest),
@@ -910,7 +910,7 @@ pub enum ProviderResponse {
     DocSet(RpcResult<DocSetResponse>),
     DocSetHash(RpcResult<DocSetHashResponse>),
     DocGet(RpcResult<DocGetManyResponse>),
-    DocGetOne(RpcResult<DocGetOneResponse>),
+    DocGetExact(RpcResult<DocGetExactResponse>),
     DocDel(RpcResult<DocDelResponse>),
     DocShare(RpcResult<DocShareResponse>),
     DocStartSync(RpcResult<DocStartSyncResponse>),

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -726,6 +726,8 @@ pub struct DocGetOneRequest {
     pub key: Bytes,
     /// Author matcher
     pub author: AuthorId,
+    /// Whether to include empty entries (prefix deletion markers)
+    pub include_empty: bool
 }
 
 impl RpcMsg<ProviderService> for DocGetOneRequest {

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -172,7 +172,7 @@ impl SyncEngine {
             .await?;
         let entry = self
             .sync
-            .get_one(doc_id, author_id, key, false)
+            .get_exact(doc_id, author_id, key, false)
             .await?
             .ok_or_else(|| anyhow!("failed to get entry after insertion"))?;
         Ok(DocSetResponse { entry })
@@ -223,7 +223,7 @@ impl SyncEngine {
         })
     }
 
-    pub async fn doc_get_one(&self, req: DocGetOneRequest) -> RpcResult<DocGetOneResponse> {
+    pub async fn doc_get_exact(&self, req: DocGetOneRequest) -> RpcResult<DocGetOneResponse> {
         let DocGetOneRequest {
             doc_id,
             author,
@@ -232,7 +232,7 @@ impl SyncEngine {
         } = req;
         let entry = self
             .sync
-            .get_one(doc_id, author, key, include_empty)
+            .get_exact(doc_id, author, key, include_empty)
             .await?;
         Ok(DocGetOneResponse { entry })
     }

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -10,13 +10,13 @@ use crate::{
     rpc_protocol::{
         AuthorCreateRequest, AuthorCreateResponse, AuthorListRequest, AuthorListResponse,
         DocCloseRequest, DocCloseResponse, DocCreateRequest, DocCreateResponse, DocDelRequest,
-        DocDelResponse, DocDropRequest, DocDropResponse, DocGetManyRequest, DocGetManyResponse,
-        DocGetOneRequest, DocGetOneResponse, DocImportRequest, DocImportResponse, DocLeaveRequest,
-        DocLeaveResponse, DocListRequest, DocListResponse, DocOpenRequest, DocOpenResponse,
-        DocSetHashRequest, DocSetHashResponse, DocSetRequest, DocSetResponse, DocShareRequest,
-        DocShareResponse, DocStartSyncRequest, DocStartSyncResponse, DocStatusRequest,
-        DocStatusResponse, DocSubscribeRequest, DocSubscribeResponse, DocTicket, RpcResult,
-        ShareMode,
+        DocDelResponse, DocDropRequest, DocDropResponse, DocGetExactRequest, DocGetExactResponse,
+        DocGetManyRequest, DocGetManyResponse, DocImportRequest, DocImportResponse,
+        DocLeaveRequest, DocLeaveResponse, DocListRequest, DocListResponse, DocOpenRequest,
+        DocOpenResponse, DocSetHashRequest, DocSetHashResponse, DocSetRequest, DocSetResponse,
+        DocShareRequest, DocShareResponse, DocStartSyncRequest, DocStartSyncResponse,
+        DocStatusRequest, DocStatusResponse, DocSubscribeRequest, DocSubscribeResponse, DocTicket,
+        RpcResult, ShareMode,
     },
     sync_engine::SyncEngine,
 };
@@ -223,8 +223,8 @@ impl SyncEngine {
         })
     }
 
-    pub async fn doc_get_exact(&self, req: DocGetOneRequest) -> RpcResult<DocGetOneResponse> {
-        let DocGetOneRequest {
+    pub async fn doc_get_exact(&self, req: DocGetExactRequest) -> RpcResult<DocGetExactResponse> {
+        let DocGetExactRequest {
             doc_id,
             author,
             key,
@@ -234,6 +234,6 @@ impl SyncEngine {
             .sync
             .get_exact(doc_id, author, key, include_empty)
             .await?;
-        Ok(DocGetOneResponse { entry })
+        Ok(DocGetExactResponse { entry })
     }
 }

--- a/iroh/src/sync_engine/rpc.rs
+++ b/iroh/src/sync_engine/rpc.rs
@@ -172,7 +172,7 @@ impl SyncEngine {
             .await?;
         let entry = self
             .sync
-            .get_one(doc_id, author_id, key)
+            .get_one(doc_id, author_id, key, false)
             .await?
             .ok_or_else(|| anyhow!("failed to get entry after insertion"))?;
         Ok(DocSetResponse { entry })
@@ -228,8 +228,12 @@ impl SyncEngine {
             doc_id,
             author,
             key,
+            include_empty,
         } = req;
-        let entry = self.sync.get_one(doc_id, author, key).await?;
+        let entry = self
+            .sync
+            .get_one(doc_id, author, key, include_empty)
+            .await?;
         Ok(DocGetOneResponse { entry })
     }
 }

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -755,7 +755,7 @@ async fn doc_delete() -> Result<()> {
     let deleted = doc.del(author, b"foo".to_vec()).await?;
     assert_eq!(deleted, 1);
 
-    let entry = doc.get_one(author, b"foo".to_vec()).await?;
+    let entry = doc.get_one(author, b"foo".to_vec(), false).await?;
     assert!(entry.is_none());
 
     // wait for gc
@@ -785,7 +785,7 @@ async fn sync_drop_doc() -> Result<()> {
     assert!(matches!(ev, Some(Ok(LiveEvent::InsertLocal { .. }))));
 
     client.docs.drop_doc(doc.id()).await?;
-    let res = doc.get_one(author, b"foo".to_vec()).await;
+    let res = doc.get_one(author, b"foo".to_vec(), true).await;
     assert!(res.is_err());
     let res = doc
         .set_bytes(author, b"foo".to_vec(), b"bar".to_vec())

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -755,7 +755,7 @@ async fn doc_delete() -> Result<()> {
     let deleted = doc.del(author, b"foo".to_vec()).await?;
     assert_eq!(deleted, 1);
 
-    let entry = doc.get_one(author, b"foo".to_vec(), false).await?;
+    let entry = doc.get_exact(author, b"foo".to_vec(), false).await?;
     assert!(entry.is_none());
 
     // wait for gc
@@ -785,7 +785,7 @@ async fn sync_drop_doc() -> Result<()> {
     assert!(matches!(ev, Some(Ok(LiveEvent::InsertLocal { .. }))));
 
     client.docs.drop_doc(doc.id()).await?;
-    let res = doc.get_one(author, b"foo".to_vec(), true).await;
+    let res = doc.get_exact(author, b"foo".to_vec(), true).await;
     assert!(res.is_err());
     let res = doc
         .set_bytes(author, b"foo".to_vec(), b"bar".to_vec())


### PR DESCRIPTION
## Description

* Renames `get_one` to `get_exact`
* Add flag to `get_exact` whether to include empty entries or not
* Add `get_one` to `iroh::client::Doc` to get a single entry with the same query mechanisms as `get_many`

Based on #1766

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- ~~[ ] Tests if relevant.~~
