### PR TITLE
fix(iroh-sync): fix panic in send

### DIFF
--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -754,7 +754,7 @@ impl Subscribers {
     async fn send(&mut self, event: Event) -> bool {
         let futs = self.0.iter().map(|sender| sender.send_async(event.clone()));
         let res = futures::future::join_all(futs).await;
-        for (i, res) in res.into_iter().enumerate() {
+        for (i, res) in res.into_iter().enumerate().rev() {
             if res.is_err() {
                 self.0.remove(i);
             }


### PR DESCRIPTION
## Description

this was referring to entries by index, which will fail if two items are removed in one iteration.

We are now iterating in reverse order, so removal won't shift the remaining elements.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
