### PR TITLE
feat(iroh): store rpc port in iroh data dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to iroh will be documented in this file.
 
+## [0.11.0](https://github.com/n0-computer/iroh/compare/v0.10.0..0.11.0) - 2023-11-08
+
+### ⛰️  Features
+
+- *(iroh)* Store rpc port in iroh data dir - ([ed85fb0](https://github.com/n0-computer/iroh/commit/ed85fb073106e18d165e40ace1aee1c26377f6d3))
+
+### 🚜 Refactor
+
+- Common base library ([#1780](https://github.com/n0-computer/iroh/issues/1780)) - ([de58d71](https://github.com/n0-computer/iroh/commit/de58d71998e49ed14c99b9765fc51d37965a95d9))
+
 ## [0.10.0](https://github.com/n0-computer/iroh/compare/v0.9.0..v0.10.0) - 2023-11-08
 
 ### ⛰️  Features
@@ -27,6 +37,7 @@ All notable changes to iroh will be documented in this file.
 
 - *(iroh-net)* Demote 'pong not received in timeout' message to debug ([#1769](https://github.com/n0-computer/iroh/issues/1769)) - ([56e92ca](https://github.com/n0-computer/iroh/commit/56e92caa1172ac416c2c2f5139a4aacd26cf27c7))
 - Switch to git-cliff for changelog generation - ([bcdccb3](https://github.com/n0-computer/iroh/commit/bcdccb39fa374ec8eac84eb347f1e38c2f4dbb09))
+- Release - ([c4514aa](https://github.com/n0-computer/iroh/commit/c4514aafa5e6452b881ae4917a63ab05cfe62e96))
 
 ## [0.9.0](https://github.com/n0-computer/iroh/compare/v0.8.0..v0.9.0) - 2023-10-31
 

--- a/iroh/release.toml
+++ b/iroh/release.toml
@@ -1,0 +1,1 @@
+pre-release-hook = ["git", "cliff", "--workdir", "../", "-o", "../CHANGELOG.md", "--tag", "{{version}}" ]

--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -471,13 +471,37 @@ impl RpcCommands {
     }
 }
 
+/// Where the data should be read from.
+#[derive(Debug, Clone, derive_more::Display, PartialEq, Eq)]
+pub enum BlobSource {
+    /// Reads from stdin
+    #[display("STDIN")]
+    Stdin,
+    /// Reads from the provided path
+    #[display("{}", _0.display())]
+    Path(PathBuf),
+}
+
+impl From<String> for BlobSource {
+    fn from(s: String) -> Self {
+        if s == "STDIN" {
+            return BlobSource::Stdin;
+        }
+
+        BlobSource::Path(s.into())
+    }
+}
+
 /// Options for the `blob add` command.
 #[derive(clap::Args, Debug, Clone)]
 pub struct BlobAddOptions {
-    /// The path to the file or folder to add.
+    /// The source of the file or folder to add.
     ///
-    /// If no path is specified, data will be read from STDIN.
-    path: Option<PathBuf>,
+    /// If `STDIN` is specified, the data will be read from stdin.
+    ///
+    /// When left empty no content is added.
+    #[clap(long, short)]
+    source: Option<BlobSource>,
 
     /// Add in place
     ///
@@ -1090,4 +1114,22 @@ pub async fn show_download_progress(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blob_source() {
+        assert_eq!(
+            BlobSource::from(BlobSource::Stdin.to_string()),
+            BlobSource::Stdin
+        );
+
+        assert_eq!(
+            BlobSource::from(BlobSource::Path("hello/world".into()).to_string()),
+            BlobSource::Path("hello/world".into()),
+        );
+    }
 }

--- a/iroh/src/commands/node.rs
+++ b/iroh/src/commands/node.rs
@@ -20,7 +20,7 @@ use quic_rpc::{transport::quinn::QuinnServerEndpoint, ServiceEndpoint};
 use tracing::{info_span, Instrument};
 
 use crate::{
-    commands::add,
+    commands::{add, rpc::clear_rpc},
     config::{get_iroh_data_root_with_env, path_with_env},
 };
 
@@ -84,6 +84,9 @@ pub async fn run(rt: &runtime::Handle, opts: StartOptions, add_opts: BlobAddOpti
     // makes this explicit.
     add_task.abort();
     drop(add_task);
+
+    clear_rpc(get_iroh_data_root_with_env()?).await?;
+
     Ok(())
 }
 

--- a/iroh/src/commands/rpc.rs
+++ b/iroh/src/commands/rpc.rs
@@ -60,6 +60,11 @@ pub async fn store_rpc(root: impl AsRef<Path>, rpc_port: u16) -> Result<()> {
     trace!("storing RPC lock: {}", p.display());
 
     ensure!(!p.exists(), "iroh is already running");
+    if let Some(parent) = p.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .context("creating parent dir")?;
+    }
     fs::write(&p, &rpc_port.to_le_bytes())
         .await
         .context("writing rpc lock file")?;

--- a/iroh/src/commands/rpc.rs
+++ b/iroh/src/commands/rpc.rs
@@ -66,6 +66,17 @@ pub async fn store_rpc(root: impl AsRef<Path>, rpc_port: u16) -> Result<()> {
     Ok(())
 }
 
+/// Cleans up an existing rpc lock
+pub async fn clear_rpc(root: impl AsRef<Path>) -> Result<()> {
+    let p = IrohPaths::RpcLock.with_root(root);
+    trace!("clearing RPC lock: {}", p.display());
+
+    // ignore errors
+    tokio::fs::remove_file(&p).await.ok();
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/iroh/src/commands/rpc.rs
+++ b/iroh/src/commands/rpc.rs
@@ -1,0 +1,85 @@
+use std::path::Path;
+
+use anyhow::{ensure, Context, Result};
+use iroh::util::path::IrohPaths;
+use tokio::{fs, io::AsyncReadExt};
+use tracing::trace;
+
+/// The current status of the RPC endpoint.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum RpcStatus {
+    /// Stopped.
+    Stopped,
+    /// Running on this port.
+    Running(u16),
+}
+
+impl RpcStatus {
+    pub async fn load(root: impl AsRef<Path>) -> Result<RpcStatus> {
+        let p = IrohPaths::RpcLock.with_root(root);
+        trace!("loading RPC lock: {}", p.display());
+
+        if p.exists() {
+            // Lock file exists, read the port and check if we can get a connection.
+            let mut file = fs::File::open(&p).await.context("open rpc lock file")?;
+            let file_len = file
+                .metadata()
+                .await
+                .context("reading rpc lock file metadata")?
+                .len();
+            if file_len == 2 {
+                let mut buffer = [0u8; 2];
+                file.read_exact(&mut buffer)
+                    .await
+                    .context("read rpc lock file")?;
+                let running_rpc_port = u16::from_le_bytes(buffer);
+                if iroh::client::quic::connect(running_rpc_port, None)
+                    .await
+                    .is_ok()
+                {
+                    return Ok(RpcStatus::Running(running_rpc_port));
+                }
+            }
+
+            // invalid or outdated rpc lock file, delete
+            drop(file);
+            fs::remove_file(&p)
+                .await
+                .context("deleting rpc lock file")?;
+            Ok(RpcStatus::Stopped)
+        } else {
+            // No lock file, stopped
+            Ok(RpcStatus::Stopped)
+        }
+    }
+}
+
+/// Store the current rpc status.
+pub async fn store_rpc(root: impl AsRef<Path>, rpc_port: u16) -> Result<()> {
+    let p = IrohPaths::RpcLock.with_root(root);
+    trace!("storing RPC lock: {}", p.display());
+
+    ensure!(!p.exists(), "iroh is already running");
+    fs::write(&p, &rpc_port.to_le_bytes())
+        .await
+        .context("writing rpc lock file")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_rpc_lock_file() {
+        let dir = testdir::testdir!();
+
+        let rpc_port = 7778;
+        store_rpc(&dir, rpc_port).await.unwrap();
+        let status = RpcStatus::load(&dir).await.unwrap();
+        assert_eq!(status, RpcStatus::Stopped);
+        let p = IrohPaths::RpcLock.with_root(&dir);
+        let exists = fs::try_exists(&p).await.unwrap();
+        assert!(!exists, "should be deleted as not running");
+    }
+}

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -38,11 +38,17 @@ pub fn env_var(key: &str) -> std::result::Result<String, env::VarError> {
 
 /// Get the path for this [`IrohPaths`] by joining the name to `IROH_DATA_DIR` environment variable.
 pub fn path_with_env(p: IrohPaths) -> Result<PathBuf> {
+    let root = get_iroh_data_root_with_env()?;
+    Ok(p.with_root(root))
+}
+
+/// Get the current root for [`IrohPaths`].
+pub fn get_iroh_data_root_with_env() -> Result<PathBuf> {
     let mut root = iroh_data_root()?;
     if !root.is_absolute() {
         root = std::env::current_dir()?.join(root);
     }
-    Ok(p.with_root(root))
+    Ok(root)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1130,7 +1130,11 @@ impl<D: BaoStore> RpcHandler<D> {
         } = msg;
         // Check that the path is absolute and exists.
         anyhow::ensure!(root.is_absolute(), "path must be absolute");
-        anyhow::ensure!(root.exists(), "path must exist");
+        anyhow::ensure!(
+            root.exists(),
+            "trying to add missing path: {}",
+            root.display()
+        );
 
         let import_mode = match in_place {
             true => ImportMode::TryReference,

--- a/iroh/src/util/path.rs
+++ b/iroh/src/util/path.rs
@@ -28,7 +28,7 @@ pub enum IrohPaths {
     /// Path to store known peer data.
     PeerData,
     #[strum(serialize = "rpc.lock")]
-    /// Path to RPC lock file, containint the RPC port if running.
+    /// Path to RPC lock file, containing the RPC port if running.
     RpcLock,
 }
 

--- a/iroh/src/util/path.rs
+++ b/iroh/src/util/path.rs
@@ -27,6 +27,9 @@ pub enum IrohPaths {
     #[strum(serialize = "peers.postcard")]
     /// Path to store known peer data.
     PeerData,
+    #[strum(serialize = "rpc.lock")]
+    /// Path to RPC lock file, containint the RPC port if running.
+    RpcLock,
 }
 
 impl AsRef<Path> for IrohPaths {

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -3,7 +3,6 @@
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Read};
 use std::net::SocketAddr;
-use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{env, io};
@@ -416,7 +415,7 @@ fn cli_provide_addresses() -> Result<()> {
     let get_output = cmd(iroh_bin(), ["node", "status"])
         .env_remove("RUST_LOG")
         .env("IROH_DATA_DIR", data_dir)
-        .stderr_file(std::io::stderr().as_raw_fd()) // for debug output
+        // .stderr_file(std::io::stderr().as_raw_fd()) // for debug output
         .stdout_capture()
         .run()?;
     let stdout = String::from_utf8(get_output.stdout).unwrap();

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -345,6 +345,7 @@ fn cli_provide_persistence() -> anyhow::Result<()> {
                 ADDR,
                 "--rpc-port",
                 "0",
+                "--source",
                 path.to_str().unwrap(),
                 "--wrap",
             ],
@@ -547,7 +548,6 @@ fn make_provider_in(
 ) -> Result<ReaderHandle> {
     let mut args = vec![
         "start",
-        path.to_str().unwrap(),
         "--addr",
         addr.unwrap_or(ADDR),
         "--rpc-port",
@@ -556,6 +556,16 @@ fn make_provider_in(
     if wrap {
         args.push("--wrap");
     }
+    args.push("--source");
+    match input {
+        Input::Stdin => {
+            args.push("STDIN");
+        }
+        Input::Path => {
+            args.push(path.to_str().unwrap());
+        }
+    }
+
     // spawn a provider & optionally provide from stdin
     let res = cmd(iroh_bin(), &args)
         // .stderr_null()

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -502,10 +502,8 @@ fn cli_rpc_lock_restart() -> Result<()> {
     .run()?;
 
     let output = std::str::from_utf8(&output.stderr).unwrap();
-    assert!(output.contains(&format!(
-        "Error: iroh is already running on port {}",
-        rpc_port
-    )));
+    println!("{}", output);
+    assert!(output.contains(&format!("iroh is already running on port {}", rpc_port)));
 
     Ok(())
 }


### PR DESCRIPTION
- prevents iroh from being started in the same iroh data dir
- retrieves the rpc port from the rpc.lock file
- removes  the `--rpc-port` argument from all commands other than `start`

This also changes the way in put handling is done on `start`, as I discovered some issues with the current state of things.

The way it works now is
```sh
# no adding of content
> iroh start
# adding from stdin
> iroh start --source STDIN
# adding from file
> iroh start --source ./path/to/file
```

Closes #1281
