### PR TITLE
feat(iroh): make `out` argument required for `iroh get`

### DIFF
--- a/iroh/src/commands/get.rs
+++ b/iroh/src/commands/get.rs
@@ -26,6 +26,8 @@ use iroh_net::derp::DerpMode;
 
 use crate::commands::show_download_progress;
 
+use super::OutputTarget;
+
 #[derive(Debug)]
 pub struct GetInteractive {
     pub rt: iroh_bytes::util::runtime::Handle,
@@ -99,11 +101,10 @@ impl GetInteractive {
         Ok(())
     }
 
-    pub async fn get_interactive(self, out_dir: Option<PathBuf>) -> Result<()> {
-        if let Some(out_dir) = out_dir {
-            self.get_to_dir(out_dir).await
-        } else {
-            self.get_to_stdout().await
+    pub async fn get_interactive(self, out_dir: OutputTarget) -> Result<()> {
+        match out_dir {
+            OutputTarget::Path(dir) => self.get_to_dir(dir).await,
+            OutputTarget::Stdout => self.get_to_stdout().await,
         }
     }
 


### PR DESCRIPTION
When using `iroh get` always require `--out` to specify the place to store the output.

```sh
# stdout
> iroh get --ticket <TICKET> --out STDOUT
# directory
> iroh get --ticket <TICKET> --out ./my-dir
```

Closes #843

