### PR TITLE
refactor: more renaming of the term peer id to node id

### DIFF
--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -25,7 +25,7 @@ use url::Url;
 /// This broadcasts signed messages over iroh-gossip and verifies signatures
 /// on received messages.
 ///
-/// By default a new peer id is created when starting the example. To reuse your identity,
+/// By default a new node id is created when starting the example. To reuse your identity,
 /// set the `--secret-key` flag with the secret key printed on a previous invocation.
 ///
 /// By default, the DERP server run by n0 is used. To use a local DERP server, run
@@ -33,7 +33,7 @@ use url::Url;
 /// in another terminal and then set the `-d http://localhost:3340` flag on this example.
 #[derive(Parser, Debug)]
 struct Args {
-    /// secret key to derive our peer id from.
+    /// secret key to derive our node id from.
     #[clap(long)]
     secret_key: Option<String>,
     /// Set a custom DERP server. By default, the DERP server hosted by n0 will be used.
@@ -131,7 +131,7 @@ async fn main() -> anyhow::Result<()> {
         })
         .bind(args.bind_port)
         .await?;
-    println!("> our peer id: {}", endpoint.peer_id());
+    println!("> our node id: {}", endpoint.node_id());
 
     // wait for a first endpoint update so that we know about our endpoint addresses
     notify.notified().await;
@@ -142,7 +142,7 @@ async fn main() -> anyhow::Result<()> {
     // insert the gossip handle into the gossip cell to be used in the endpoint callbacks above
     gossip_cell.set(gossip.clone()).unwrap();
 
-    // print a ticket that includes our own peer id and endpoint addresses
+    // print a ticket that includes our own node id and endpoint addresses
     let ticket = {
         let me = endpoint.my_addr().await?;
         let peers = peers.iter().cloned().chain([me]).collect();
@@ -206,12 +206,12 @@ async fn subscribe_loop(gossip: Gossip, topic: TopicId) -> anyhow::Result<()> {
             match message {
                 Message::AboutMe { name } => {
                     names.insert(from, name.clone());
-                    println!("> {} is now known as {}", fmt_peer_id(&from), name);
+                    println!("> {} is now known as {}", fmt_node_id(&from), name);
                 }
                 Message::Message { text } => {
                     let name = names
                         .get(&from)
-                        .map_or_else(|| fmt_peer_id(&from), String::to_string);
+                        .map_or_else(|| fmt_node_id(&from), String::to_string);
                     println!("{}: {}", name, text);
                 }
             }
@@ -320,7 +320,7 @@ impl FromStr for Ticket {
 
 // helpers
 
-fn fmt_peer_id(input: &PublicKey) -> String {
+fn fmt_node_id(input: &PublicKey) -> String {
     base32::fmt_short(input.as_bytes())
 }
 fn parse_secret_key(secret: &str) -> anyhow::Result<SecretKey> {

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -33,7 +33,7 @@ pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (NodeAddr, Ma
             .unwrap();
         let addr = ep.local_addr().unwrap();
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
-        let addr = NodeAddr::new(ep.peer_id()).with_direct_addresses([addr]);
+        let addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
         (addr, ep)
     })
 }

--- a/iroh-net/examples/magic.rs
+++ b/iroh-net/examples/magic.rs
@@ -66,10 +66,10 @@ async fn main() -> anyhow::Result<()> {
         .bind(args.bind_port)
         .await?;
 
-    let me = endpoint.peer_id();
+    let me = endpoint.node_id();
     let local_addr = endpoint.local_addr()?;
     println!("magic socket listening on {local_addr:?}");
-    println!("our peer id: {me}");
+    println!("our node id: {me}");
 
     match args.command {
         Command::Listen => {

--- a/iroh-net/src/derp/client_conn.rs
+++ b/iroh-net/src/derp/client_conn.rs
@@ -228,7 +228,7 @@ impl ClientConnManager {
 ///     - receive a ping and write a pong back
 ///     - notify the server to send a packet to another peer on behalf of the client
 ///     - note whether the client is `preferred`, aka this client is the preferred way
-///     to speak to the peer ID associated with that client.
+///     to speak to the node ID associated with that client.
 ///
 /// If the `ClientConnIo` `can_mesh` that means that the associated [`super::client::Client`] is connected to
 /// a derp [`super::server::Server`] that is apart of the same mesh network as this [`super::server::Server`]. It can:

--- a/iroh-net/src/derp/metrics.rs
+++ b/iroh-net/src/derp/metrics.rs
@@ -60,7 +60,7 @@ pub struct Metrics {
     pub accepts: Counter,
     /// Number of connections we have removed because of an error
     pub disconnects: Counter,
-    // TODO: enable when we can have multiple connections for one peer id
+    // TODO: enable when we can have multiple connections for one node id
     // pub duplicate_client_keys: Counter,
     // pub duplicate_client_conns: Counter,
     // TODO: only important stat that we cannot track right now
@@ -115,7 +115,7 @@ impl Default for Metrics {
 
             accepts: Counter::new("Number of times this server has accepted a connection."),
             disconnects: Counter::new("Number of clients that have then disconnected."),
-            // TODO: enable when we can have multiple connections for one peer id
+            // TODO: enable when we can have multiple connections for one node id
             // pub duplicate_client_keys: Counter::new("Number of dupliate client keys."),
             // pub duplicate_client_conns: Counter::new("Number of duplicate client connections."),
             // TODO: only important stat that we cannot track right now

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2860,7 +2860,7 @@ pub(crate) mod tests {
 
                 let a_addr = b.endpoint.magic_sock().get_mapping_addr(&a.public()).await.unwrap();
                 let b_addr = a.endpoint.magic_sock().get_mapping_addr(&b.public()).await.unwrap();
-                let b_node_id = b.endpoint.peer_id();
+                let b_node_id = b.endpoint.node_id();
 
                 println!("{}: {}, {}: {}", a_name, a_addr, b_name, b_addr);
 

--- a/iroh-sync/src/net.rs
+++ b/iroh-sync/src/net.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use iroh_net::{key::PublicKey, magic_endpoint::get_peer_id, MagicEndpoint, NodeAddr};
+use iroh_net::{key::PublicKey, magic_endpoint::get_remote_node_id, MagicEndpoint, NodeAddr};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error_span, trace, Instrument};
 
@@ -115,7 +115,7 @@ where
 {
     let t_start = Instant::now();
     let connection = connecting.await.map_err(AcceptError::connect)?;
-    let peer = get_peer_id(&connection).map_err(AcceptError::connect)?;
+    let peer = get_remote_node_id(&connection).map_err(AcceptError::connect)?;
     let (mut send_stream, mut recv_stream) = connection
         .accept_bi()
         .await

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -62,7 +62,7 @@ pub enum Event {
 pub enum InsertOrigin {
     /// The entry was inserted locally.
     Local,
-    /// The entry was received from the remote peer identified by [`PeerIdBytes`].
+    /// The entry was received from the remote node identified by [`PeerIdBytes`].
     Sync {
         /// The peer from which we received this entry.
         from: PeerIdBytes,

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -1,7 +1,7 @@
 //! This example shows the shortest path to working with documents in iroh. This example creates a
 //! document and sets an entry with key: "hello", value: "world". The document is completely local.
 //!
-//! The iroh node that creates the document is backed by an in-memory database and a random peer ID
+//! The iroh node that creates the document is backed by an in-memory database and a random node ID
 //!
 //! run this example from the project root:
 //!     $ cargo run --example client

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -3,7 +3,7 @@
 //! Since this is using the default iroh collection format, it can be downloaded
 //! recursively using the iroh CLI.
 //!
-//! This is using an in memory database and a random peer id.
+//! This is using an in memory database and a random node id.
 //! run this example from the project root:
 //!     $ cargo run -p collection
 use iroh::bytes::util::runtime;

--- a/iroh/examples/hello-world.rs
+++ b/iroh/examples/hello-world.rs
@@ -2,7 +2,7 @@
 //!
 //! This can be downloaded using the iroh CLI.
 //!
-//! This is using an in memory database and a random peer id.
+//! This is using an in memory database and a random node id.
 //! run this example from the project root:
 //!     $ cargo run --example hello-world
 use iroh::bytes::util::runtime;

--- a/iroh/examples/rpc.rs
+++ b/iroh/examples/rpc.rs
@@ -61,7 +61,7 @@ async fn run(db: impl Store) -> anyhow::Result<()> {
         .spawn()
         .await?;
     // print some info about the node
-    let peer = node.peer_id();
+    let peer = node.node_id();
     let addrs = node.local_endpoint_addresses().await?;
     println!("node PeerID:     {peer}");
     println!("node listening addresses:");

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -91,7 +91,7 @@ pub enum Commands {
     },
     /// Connect to an iroh doctor accept node.
     Connect {
-        /// hex peer id of the node to connect to
+        /// hex node id of the node to connect to
         dial: PublicKey,
 
         /// One or more remote endpoints to use when dialing
@@ -535,7 +535,7 @@ async fn passive_side(
     endpoint: MagicEndpoint,
     connection: quinn::Connection,
 ) -> anyhow::Result<()> {
-    let remote_peer_id = magic_endpoint::get_peer_id(&connection)?;
+    let remote_peer_id = magic_endpoint::get_remote_node_id(&connection)?;
     let gui = Gui::new(endpoint, remote_peer_id);
     loop {
         match connection.accept_bi().await {
@@ -679,7 +679,8 @@ async fn accept(
             match connecting.await {
                 Ok(connection) => {
                     if n == 0 {
-                        let Ok(remote_peer_id) = magic_endpoint::get_peer_id(&connection) else {
+                        let Ok(remote_peer_id) = magic_endpoint::get_remote_node_id(&connection)
+                        else {
                             return;
                         };
                         println!("Accepted connection from {}", remote_peer_id);

--- a/iroh/src/commands/node.rs
+++ b/iroh/src/commands/node.rs
@@ -162,7 +162,7 @@ async fn spawn_daemon_node<B: iroh_bytes::store::Store, D: iroh_sync::store::Sto
         "DERP Region: {}",
         region.map_or("None".to_string(), |r| r.to_string())
     );
-    println!("PeerID: {}", provider.peer_id());
+    println!("PeerID: {}", provider.node_id());
     println!();
     Ok(provider)
 }

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -228,7 +228,7 @@ impl Downloader {
     where
         S: Store,
     {
-        let me = endpoint.peer_id().fmt_short();
+        let me = endpoint.node_id().fmt_short();
         let (msg_tx, msg_rx) = mpsc::channel(SERVICE_CHANNEL_CAPACITY);
         let dialer = iroh_gossip::net::util::Dialer::new(endpoint);
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -373,7 +373,7 @@ where
             let handler = RpcHandler {
                 inner: inner.clone(),
             };
-            let me = endpoint.peer_id().fmt_short();
+            let me = endpoint.node_id().fmt_short();
             rt2.main().spawn(
                 async move {
                     Self::run(
@@ -448,7 +448,7 @@ where
         // is only initialized once the endpoint is fully bound
         if let Ok(local_endpoints) = server.local_endpoints().await {
             if !local_endpoints.is_empty() {
-                debug!(me = ?server.peer_id(), "gossip initial update: {local_endpoints:?}");
+                debug!(me = ?server.node_id(), "gossip initial update: {local_endpoints:?}");
                 gossip.update_endpoints(&local_endpoints).ok();
             }
         }
@@ -719,7 +719,7 @@ impl<D: ReadableStore> Node<D> {
     }
 
     /// Returns the [`PublicKey`] of the node.
-    pub fn peer_id(&self) -> PublicKey {
+    pub fn node_id(&self) -> PublicKey {
         self.inner.secret_key.public()
     }
 

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -341,7 +341,7 @@ impl RpcMsg<ProviderService> for NodeStatusRequest {
 /// The response to a version request
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NodeStatusResponse {
-    /// The peer id and socket addresses of this node.
+    /// The node id and socket addresses of this node.
     pub addr: NodeAddr,
     /// The bound listening addresses of the node
     pub listen_addrs: Vec<SocketAddr>,

--- a/iroh/src/sync_engine.rs
+++ b/iroh/src/sync_engine.rs
@@ -70,7 +70,7 @@ impl SyncEngine {
     ) -> Self {
         let (live_actor_tx, to_live_actor_recv) = mpsc::channel(ACTOR_CHANNEL_CAP);
         let (to_gossip_actor, to_gossip_actor_recv) = mpsc::channel(ACTOR_CHANNEL_CAP);
-        let me = endpoint.peer_id().fmt_short();
+        let me = endpoint.node_id().fmt_short();
 
         let content_status_cb = {
             let bao_store = bao_store.clone();

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -696,7 +696,7 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
         peer: PublicKey,
     ) -> AcceptOutcome {
         self.state
-            .accept_request(&self.endpoint.peer_id(), &namespace, peer)
+            .accept_request(&self.endpoint.node_id(), &namespace, peer)
     }
 }
 

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -132,7 +132,7 @@ async fn empty_files() -> Result<()> {
     transfer_random_data(file_opts, &rt).await
 }
 
-/// Create new get options with the given peer id and addresses, using a
+/// Create new get options with the given node id and addresses, using a
 /// randomly generated secret key.
 fn get_options(node_id: NodeId, addrs: Vec<SocketAddr>) -> iroh::dial::Options {
     let peer = iroh_net::NodeAddr::from_parts(node_id, Some(1), addrs);
@@ -168,7 +168,7 @@ async fn multiple_clients() -> Result<()> {
         let file_hash: Hash = expect_hash;
         let name = expect_name.clone();
         let addrs = node.local_address().unwrap();
-        let peer_id = node.peer_id();
+        let peer_id = node.node_id();
         let content = content.to_vec();
 
         tasks.push(rt.local_pool().spawn_pinned(move || {
@@ -265,7 +265,7 @@ where
     .await?;
 
     let addrs = node.local_endpoint_addresses().await?;
-    let opts = get_options(node.peer_id(), addrs);
+    let opts = get_options(node.node_id(), addrs);
     let request = GetRequest::all(collection_hash);
     let (collection, children, _stats) = run_collection_get_request(opts, request).await?;
     assert_eq!(num_blobs, collection.blobs().len());
@@ -359,7 +359,7 @@ async fn test_server_close() {
     let addr = "127.0.0.1:0".parse().unwrap();
     let mut node = test_node(db, addr).runtime(&rt).spawn().await.unwrap();
     let node_addr = node.local_endpoint_addresses().await.unwrap();
-    let peer_id = node.peer_id();
+    let peer_id = node.node_id();
 
     let (events_sender, mut events_recv) = mpsc::unbounded_channel();
     node.subscribe(move |event| {
@@ -439,7 +439,7 @@ async fn test_ipv6() {
         }
     };
     let addrs = node.local_endpoint_addresses().await.unwrap();
-    let peer_id = node.peer_id();
+    let peer_id = node.node_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = get_options(peer_id, addrs);
         let request = GetRequest::all(hash);
@@ -468,7 +468,7 @@ async fn test_not_found() {
         }
     };
     let addrs = node.local_endpoint_addresses().await.unwrap();
-    let peer_id = node.peer_id();
+    let peer_id = node.node_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = get_options(peer_id, addrs);
         let request = GetRequest::single(hash);
@@ -512,7 +512,7 @@ async fn test_chunk_not_found_1() {
         }
     };
     let addrs = node.local_endpoint_addresses().await.unwrap();
-    let peer_id = node.peer_id();
+    let peer_id = node.node_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = get_options(peer_id, addrs);
         let request = GetRequest::single(hash);
@@ -618,7 +618,7 @@ async fn test_run_fsm() {
     let addr = (Ipv4Addr::UNSPECIFIED, 0).into();
     let node = test_node(db, addr).runtime(&rt).spawn().await.unwrap();
     let addrs = node.local_endpoint_addresses().await.unwrap();
-    let peer_id = node.peer_id();
+    let peer_id = node.node_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let opts = get_options(peer_id, addrs);
         let request = GetRequest::all(hash);
@@ -668,7 +668,7 @@ async fn test_size_request_blob() {
     let addr = "127.0.0.1:0".parse().unwrap();
     let node = test_node(db, addr).runtime(&rt).spawn().await.unwrap();
     let addrs = node.local_endpoint_addresses().await.unwrap();
-    let peer_id = node.peer_id();
+    let peer_id = node.node_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         let request = GetRequest::last_chunk(hash);
         let connection = iroh::dial::dial(get_options(peer_id, addrs)).await?;
@@ -700,7 +700,7 @@ async fn test_collection_stat() {
         .await
         .unwrap();
     let addrs = node.local_endpoint_addresses().await.unwrap();
-    let peer_id = node.peer_id();
+    let peer_id = node.node_id();
     tokio::time::timeout(Duration::from_secs(10), async move {
         // first 1024 bytes
         let header = ChunkRanges::from(..ChunkNum(1));
@@ -784,7 +784,7 @@ async fn test_token_passthrough() -> Result<()> {
     .await?;
 
     let addrs = node.local_endpoint_addresses().await?;
-    let peer_id = node.peer_id();
+    let peer_id = node.node_id();
     tokio::time::timeout(Duration::from_secs(30), async move {
         let endpoint = MagicEndpoint::builder()
             .secret_key(SecretKey::generate())

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -61,7 +61,7 @@ fn spawn_node(
     async move {
         let node = test_node(rt, "127.0.0.1:0".parse()?, secret_key);
         let node = node.spawn().await?;
-        info!(?i, me = %node.peer_id().fmt_short(), "node spawned");
+        info!(?i, me = %node.node_id().fmt_short(), "node spawned");
         Ok(node)
     }
 }
@@ -92,7 +92,7 @@ async fn sync_simple() -> Result<()> {
     let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
 
     // create doc on node0
-    let peer0 = nodes[0].peer_id();
+    let peer0 = nodes[0].node_id();
     let author0 = clients[0].authors.create().await?;
     let doc0 = clients[0].docs.create().await?;
     let hash0 = doc0
@@ -104,7 +104,7 @@ async fn sync_simple() -> Result<()> {
     let mut events0 = doc0.subscribe().await?;
 
     info!("node1: join");
-    let peer1 = nodes[1].peer_id();
+    let peer1 = nodes[1].node_id();
     let doc1 = clients[1].docs.import(ticket.clone()).await?;
     let mut events1 = doc1.subscribe().await?;
     info!("node1: assert 4 events");
@@ -171,7 +171,7 @@ async fn sync_gossip_bulk() -> Result<()> {
     let nodes = spawn_nodes(rt.clone(), 2, &mut rng).await?;
     let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
 
-    let _peer0 = nodes[0].peer_id();
+    let _peer0 = nodes[0].node_id();
     let author0 = clients[0].authors.create().await?;
     let doc0 = clients[0].docs.create().await?;
     let mut ticket = doc0.share(ShareMode::Write).await?;
@@ -257,7 +257,7 @@ async fn sync_full_basic() -> Result<()> {
     let mut clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
 
     // peer0: create doc and ticket
-    let peer0 = nodes[0].peer_id();
+    let peer0 = nodes[0].node_id();
     let author0 = clients[0].authors.create().await?;
     let doc0 = clients[0].docs.create().await?;
     let mut events0 = doc0.subscribe().await?;
@@ -277,7 +277,7 @@ async fn sync_full_basic() -> Result<()> {
     let ticket = doc0.share(ShareMode::Write).await?;
 
     info!("peer1: spawn");
-    let peer1 = nodes[1].peer_id();
+    let peer1 = nodes[1].node_id();
     let author1 = clients[1].authors.create().await?;
     info!("peer1: join doc");
     let doc1 = clients[1].docs.import(ticket.clone()).await?;
@@ -344,7 +344,7 @@ async fn sync_full_basic() -> Result<()> {
     nodes.push(spawn_node(rt.clone(), nodes.len(), &mut rng).await?);
     clients.push(nodes.last().unwrap().client());
     let doc2 = clients[2].docs.import(ticket).await?;
-    let peer2 = nodes[2].peer_id();
+    let peer2 = nodes[2].node_id();
     let mut events2 = doc2.subscribe().await?;
 
     info!("peer2: wait for 8 events (from sync with peers)");
@@ -498,7 +498,7 @@ async fn sync_subscribe_stop_close() -> Result<()> {
 //     });
 
 //     let nodes = spawn_nodes(rt, n_nodes, &mut rng).await?;
-//     let peer_ids = nodes.iter().map(|node| node.peer_id()).collect::<Vec<_>>();
+//     let peer_ids = nodes.iter().map(|node| node.node_id()).collect::<Vec<_>>();
 //     let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
 //     let authors = collect_futures(clients.iter().map(|c| c.authors.create())).await?;
 


### PR DESCRIPTION
## Description

some more purging of the term peer id to be consistent

## Notes & open questions

1. There are some structs like PeerIdBytes.
- Do we need them at all, now that PeerId is also 32 bytes?
- Should they also be renamed?

2. There are some places where I kept the term peer id, e.g. the p2p tls stuff. Also change? It is very internal, so maybe leave it?