### PR TITLE
feat: add `Doc::import_file` and `Doc::export_file`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,9 +476,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.84"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8e7c90afad890484a21653d08b6e209ae34770fb5ee298f9c699fcc1e5c856"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,9 +476,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "0f8e7c90afad890484a21653d08b6e209ae34770fb5ee298f9c699fcc1e5c856"
 dependencies = [
  "libc",
 ]
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.7"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
+checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.7"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
+checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
 dependencies = [
  "anstream",
  "anstyle",
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69037fe1b785e84986b4f2cbcf647381876a00671d25ceef715d7812dd7e1dd"
+checksum = "53a56f0780318174bad1c127063fd0c5fdfb35398e3cd79ffaab931a6c79df80"
 
 [[package]]
 name = "flate2"
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.2"
+version = "7.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+checksum = "a5b38e5c02b7c7be48c8dc5217c4f1634af2ea221caae2e024bffc7a7651c691"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -1813,9 +1813,9 @@ checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -3500,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -3512,7 +3512,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3877,12 +3877,6 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
-
-[[package]]
-name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
@@ -4059,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.21"
+version = "0.38.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+checksum = "ffb93593068e9babdad10e4fce47dc9b3ac25315a72a59766ffd9e9a71996a04"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -4096,9 +4090,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.5",
 ]
@@ -4242,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c309e515543e67811222dbc9e3dd7e1056279b782e1dacffe4242b718734fb6"
+checksum = "e388332cd64eb80cd595a00941baf513caffae8dce9cfd0467fc9c66397dade6"
 
 [[package]]
 name = "semver"
@@ -4455,9 +4449,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 dependencies = [
  "serde",
 ]
@@ -4903,9 +4897,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4933,9 +4927,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5192,9 +5186,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -5203,9 +5197,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -626,7 +626,7 @@ where
         Ok(())
     }
 
-    /// Add an entry from a file path
+    /// Add an entry from an absolute file path
     pub async fn import_file(
         &self,
         author: AuthorId,
@@ -649,7 +649,7 @@ where
         Ok(DocImportFileProgress::new(stream))
     }
 
-    /// Export an entry as a file to a given path.
+    /// Export an entry as a file to a given absolute path.
     pub async fn export_file(
         &self,
         entry: Entry,

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -36,13 +36,13 @@ use crate::rpc_protocol::{
     BlobListCollectionsResponse, BlobListIncompleteRequest, BlobListIncompleteResponse,
     BlobListRequest, BlobListResponse, BlobReadRequest, BlobReadResponse, BlobValidateRequest,
     CounterStats, DeleteTagRequest, DocCloseRequest, DocCreateRequest, DocDelRequest,
-    DocDelResponse, DocDropRequest, DocGetExactRequest, DocGetManyRequest, DocImportFileRequest,
-    DocImportProgress, DocImportRequest, DocLeaveRequest, DocListRequest, DocOpenRequest,
-    DocSetHashRequest, DocSetRequest, DocShareRequest, DocStartSyncRequest, DocStatusRequest,
-    DocSubscribeRequest, DocTicket, DownloadProgress, ListTagsRequest, ListTagsResponse,
-    NodeConnectionInfoRequest, NodeConnectionInfoResponse, NodeConnectionsRequest,
-    NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest, NodeStatusResponse, ProviderService,
-    SetTagOption, ShareMode, WrapOption,
+    DocDelResponse, DocDropRequest, DocExportFileRequest, DocExportProgress, DocGetExactRequest,
+    DocGetManyRequest, DocImportFileRequest, DocImportProgress, DocImportRequest, DocLeaveRequest,
+    DocListRequest, DocOpenRequest, DocSetHashRequest, DocSetRequest, DocShareRequest,
+    DocStartSyncRequest, DocStatusRequest, DocSubscribeRequest, DocTicket, DownloadProgress,
+    ListTagsRequest, ListTagsResponse, NodeConnectionInfoRequest, NodeConnectionInfoResponse,
+    NodeConnectionsRequest, NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest,
+    NodeStatusResponse, ProviderService, SetTagOption, ShareMode, WrapOption,
 };
 use crate::sync_engine::LiveEvent;
 
@@ -630,20 +630,20 @@ where
     pub async fn import_file(
         &self,
         author: AuthorId,
+        key: Bytes,
         path: impl AsRef<Path>,
-        path_to_key: impl Fn(PathBuf) -> Bytes + Send + Sync + 'static,
+        in_place: bool,
     ) -> Result<DocImportFileProgress> {
         self.ensure_open()?;
-        let path = path.as_ref().to_path_buf();
-        let key = path_to_key(path.clone());
         let stream = self
             .0
             .rpc
             .server_streaming(DocImportFileRequest {
                 doc_id: self.id(),
                 author_id: author,
-                path,
+                path: path.as_ref().into(),
                 key,
+                in_place,
             })
             .await?;
         Ok(DocImportFileProgress::new(stream))
@@ -652,19 +652,19 @@ where
     /// Export an entry as a file to a given path.
     pub async fn export_file(
         &self,
-        query: impl Into<Query>,
-        key_to_path: impl Fn(&[u8]) -> PathBuf + Send + Sync + 'static,
-    ) -> Result<()> {
+        entry: Entry,
+        path: impl AsRef<Path>,
+    ) -> Result<DocExportFileProgress> {
         self.ensure_open()?;
-        let entry = self.get_one(query).await?.context("Entry not found")?;
-        let path = key_to_path(entry.key());
-        if let Some(dir) = path.parent() {
-            tokio::fs::create_dir_all(dir).await?;
-        }
-        let mut file = tokio::fs::File::create(path).await?;
-        let mut reader = self.read(&entry).await?;
-        tokio::io::copy(&mut reader, &mut file).await?;
-        Ok(())
+        let stream = self
+            .0
+            .rpc
+            .server_streaming(DocExportFileRequest {
+                entry,
+                path: path.as_ref().into(),
+            })
+            .await?;
+        Ok(DocExportFileProgress::new(stream))
     }
 
     /// Read the content of an [`Entry`] as a streaming [`BlobReader`].
@@ -829,12 +829,11 @@ impl DocImportFileProgress {
                 DocImportProgress::Found { size, .. } => {
                     entry_size = size;
                 }
-                DocImportProgress::AllDone { key, tag } => {
+                DocImportProgress::AllDone { key } => {
                     let hash = entry_hash
                         .context("expected DocImportProgress::IngestDone event to occur")?;
                     let outcome = DocImportFileOutcome {
                         hash,
-                        tag,
                         key,
                         size: entry_size,
                     };
@@ -860,8 +859,6 @@ pub struct DocImportFileOutcome {
     size: u64,
     /// The key of the entry
     key: Bytes,
-    /// The tag of the entry
-    tag: Tag,
 }
 
 impl Stream for DocImportFileProgress {
@@ -871,48 +868,54 @@ impl Stream for DocImportFileProgress {
     }
 }
 
-// /// Progress stream for doc export operations.
-// #[derive(derive_more::Debug)]
-// pub struct DocExportFileProgress {
-//     #[debug(skip)]
-//     stream: Pin<Box<dyn Stream<Item = DocExportProgress> + Send + Unpin + 'static>>,
-// }
+/// Progress stream for doc export operations.
+#[derive(derive_more::Debug)]
+pub struct DocExportFileProgress {
+    #[debug(skip)]
+    stream: Pin<Box<dyn Stream<Item = Result<DocExportProgress>> + Send + Unpin + 'static>>,
+}
+impl DocExportFileProgress {
+    fn new(
+        stream: (impl Stream<Item = Result<impl Into<DocExportProgress>, impl Into<anyhow::Error>>>
+             + Send
+             + Unpin
+             + 'static),
+    ) -> Self {
+        let stream = stream.map(|item| match item {
+            Ok(item) => Ok(item.into()),
+            Err(err) => Err(err.into()),
+        });
+        Self {
+            stream: Box::pin(stream),
+        }
+    }
+    /// Iterate through the export progress stream, returning when the stream has completed.
 
-// impl DocExportFileProgress {
-//     fn new(stream: (impl Stream<Item = DocExportProgress> + Send + Unpin + 'static)) -> Self {
-//         Self {
-//             stream: Box::pin(stream),
-//         }
-//     }
-// }
-
-// /// Iterate through the export progress stream, returning when the stream has completed.
-//
-// /// Returns a [`DocExportFileOutcome`] which contains a file path the data was writen to and the size of the content.
-// pub async fn finish(mut self) -> Result<DocExportFileOutcome> {
-//     let mut total_size = 0;
-//     let mut path = None;
-//     while let Some(msg) = self.next().await {
-//         match msg? {
-//             DocExportProgress::Found { size, outpath, .. } => {
-//                 total_size = size;
-//                 path = Some(outpath);
-//             }
-//             DocExportProgress::AllDone => {
-//                 let path = path.context("expected DocExportProgress::Found event to occur")?;
-//                 let outcome = DocExportFileOutcome {
-//                     size: total_size,
-//                     path,
-//                 };
-//                 return Ok(outcome);
-//             }
-//             DocExportProgress::Abort(err) => return Err(err.into()),
-//             DocExportProgress::Progress { .. } => {}
-//         }
-//     }
-//     Err(anyhow!("Response stream ended prematurely"))
-// }
-// }
+    /// Returns a [`DocExportFileOutcome`] which contains a file path the data was writen to and the size of the content.
+    pub async fn finish(mut self) -> Result<DocExportFileOutcome> {
+        let mut total_size = 0;
+        let mut path = None;
+        while let Some(msg) = self.next().await {
+            match msg? {
+                DocExportProgress::Found { size, outpath, .. } => {
+                    total_size = size;
+                    path = Some(outpath);
+                }
+                DocExportProgress::AllDone => {
+                    let path = path.context("expected DocExportProgress::Found event to occur")?;
+                    let outcome = DocExportFileOutcome {
+                        size: total_size,
+                        path,
+                    };
+                    return Ok(outcome);
+                }
+                DocExportProgress::Abort(err) => return Err(err.into()),
+                DocExportProgress::Progress { .. } => {}
+            }
+        }
+        Err(anyhow!("Response stream ended prematurely"))
+    }
+}
 
 /// Outcome of a [`Doc::export_file`] operation
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -923,12 +926,12 @@ pub struct DocExportFileOutcome {
     path: PathBuf,
 }
 
-// impl Stream for DocExportFileProgress {
-//     type Item = Result<DocExportProgress>;
-//     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-//         self.stream.poll_next_unpin(cx)
-//     }
-// }
+impl Stream for DocExportFileProgress {
+    type Item = Result<DocExportProgress>;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.stream.poll_next_unpin(cx)
+    }
+}
 
 fn flatten<T, E1, E2>(
     s: impl Stream<Item = StdResult<StdResult<T, E1>, E2>>,
@@ -949,6 +952,8 @@ mod tests {
     use super::*;
 
     use iroh_bytes::util::runtime;
+    use rand::RngCore;
+    use tokio::io::AsyncWriteExt;
 
     #[tokio::test]
     async fn test_drop_doc_client_sync() -> Result<()> {
@@ -971,6 +976,81 @@ mod tests {
 
         tokio::task::spawn_blocking(move || res.join().map_err(|e| anyhow::anyhow!("{:?}", e)))
             .await??;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_doc_import_export() -> Result<()> {
+        let doc_store = iroh_sync::store::memory::Store::default();
+        let rt = runtime::Handle::from_current(1)?;
+        let db = iroh_bytes::store::mem::Store::new(rt.clone());
+        let node = crate::node::Node::builder(db, doc_store)
+            .runtime(&rt)
+            .spawn()
+            .await?;
+
+        // create temp file
+        let temp_dir = tempfile::tempdir().context("tempdir")?;
+
+        let in_root = temp_dir.path().join("in");
+        tokio::fs::create_dir_all(in_root.clone())
+            .await
+            .context("create dir all")?;
+        let out_root = temp_dir.path().join("out");
+
+        let path = in_root.join("test");
+
+        let size = 100;
+        let mut buf = vec![0u8; size];
+        rand::thread_rng().fill_bytes(&mut buf);
+        let mut file = tokio::fs::File::create(path.clone())
+            .await
+            .context("create file")?;
+        file.write_all(&buf.clone()).await.context("write_all")?;
+        file.flush().await.context("flush")?;
+
+        // create doc & author
+        let client = node.client();
+        let doc = client.docs.create().await.context("doc create")?;
+        let author = client.authors.create().await.context("author create")?;
+
+        // import file
+        let import_outcome = doc
+            .import_file(
+                author,
+                crate::util::fs::path_to_key(path.clone(), None, Some(in_root))?,
+                path,
+                true,
+            )
+            .await
+            .context("import file")?
+            .finish()
+            .await
+            .context("import finish")?;
+
+        // export file
+        let entry = doc
+            .get_one(Query::author(author).key_exact(import_outcome.key))
+            .await
+            .context("get one")?
+            .unwrap();
+        let key = entry.key().to_vec();
+        let export_outcome = doc
+            .export_file(
+                entry,
+                crate::util::fs::key_to_path(key, None, Some(out_root))?,
+            )
+            .await
+            .context("export file")?
+            .finish()
+            .await
+            .context("export finish")?;
+
+        let got_bytes = tokio::fs::read(export_outcome.path)
+            .await
+            .context("tokio read")?;
+        assert_eq!(buf, got_bytes);
 
         Ok(())
     }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1038,6 +1038,7 @@ impl<D: BaoStore> RpcHandler<D> {
 
         let hash_and_format = temp_tag.inner();
         let HashAndFormat { hash, .. } = *hash_and_format;
+        drop(temp_tag);
         self.inner
             .sync
             .doc_set_hash(DocSetHashRequest {

--- a/iroh/src/util/fs.rs
+++ b/iroh/src/util/fs.rs
@@ -1,9 +1,7 @@
 //! Utilities for filesystem operations.
 use std::{
     borrow::Cow,
-    ffi::OsStr,
     fs::read_dir,
-    os::unix::ffi::OsStrExt,
     path::{Component, Path, PathBuf},
 };
 
@@ -78,7 +76,7 @@ pub fn scan_path(path: PathBuf, wrap: WrapOption) -> anyhow::Result<Vec<DataSour
 }
 
 fn file_name(path: &Path) -> anyhow::Result<String> {
-    canonicalize_path(path.file_name().context("path is invalid")?)
+    relative_canonicalized_path_to_string(path.file_name().context("path is invalid")?)
 }
 
 /// Create data sources from a directory.
@@ -100,7 +98,7 @@ pub fn scan_dir(root: PathBuf, wrap: WrapOption) -> anyhow::Result<Vec<DataSourc
                 return Ok(None);
             }
             let path = entry.into_path();
-            let mut name = canonicalize_path(path.strip_prefix(&root)?)?;
+            let mut name = relative_canonicalized_path_to_string(path.strip_prefix(&root)?)?;
             if let Some(prefix) = &prefix {
                 name = format!("{prefix}/{name}");
             }
@@ -117,25 +115,8 @@ pub fn scan_dir(root: PathBuf, wrap: WrapOption) -> anyhow::Result<Vec<DataSourc
 /// This function will also fail if the path is non canonical, i.e. contains
 /// `..` or `.`, or if the path components contain any windows or unix path
 /// separators.
-pub fn canonicalize_path(path: impl AsRef<Path>) -> anyhow::Result<String> {
-    let parts = path
-        .as_ref()
-        .components()
-        .map(|c| {
-            let c = if let Component::Normal(x) = c {
-                x.to_str().context("invalid character in path")?
-            } else {
-                anyhow::bail!("invalid path component {:?}", c)
-            };
-            anyhow::ensure!(
-                !c.contains('/') && !c.contains('\\'),
-                "invalid path component {:?}",
-                c
-            );
-            Ok(c)
-        })
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    Ok(parts.join("/"))
+pub fn relative_canonicalized_path_to_string(path: impl AsRef<Path>) -> anyhow::Result<String> {
+    canonicalized_path_to_string(path, true)
 }
 
 /// Loads a [`SecretKey`] from the provided file.
@@ -228,8 +209,8 @@ fn path_content_info0(path: impl AsRef<Path>) -> anyhow::Result<PathContent> {
     Ok(PathContent { size, files })
 }
 
-/// Helper function that translates a key that was derived from a path on a filesystem back to that
-/// path.
+/// Helper function that translates a key that was derived from the [`path_to_key`] function back
+/// into a path.
 ///
 /// If `prefix` exists, it will be stripped before converting back to a path
 /// If `root` exists, will add the root as a parent to the created path
@@ -259,8 +240,7 @@ pub fn key_to_path(
         key
     };
 
-    // convert to a path
-    let path = PathBuf::from(OsStr::from_bytes(key));
+    let path = PathBuf::from(String::from_utf8(key.into()).context("key contains invalid data")?);
 
     // add root if it exists
     let path = if let Some(root) = root {
@@ -272,7 +252,7 @@ pub fn key_to_path(
     Ok(path)
 }
 
-/// Helper function that creates a document key from the path, removing the `root` and adding the `prefix`, if they exist
+/// Helper function that creates a document key from a canonicalized path, removing the `root` and adding the `prefix`, if they exist
 ///
 /// Appends the null byte to the end of the key.
 pub fn path_to_key(
@@ -280,16 +260,13 @@ pub fn path_to_key(
     prefix: Option<String>,
     root: Option<PathBuf>,
 ) -> anyhow::Result<Bytes> {
+    let path = path.as_ref();
     let path = if let Some(root) = root {
-        path.as_ref().strip_prefix(root)?
+        path.strip_prefix(root)?
     } else {
-        path.as_ref()
+        path
     };
-    let suffix = path
-        .to_str()
-        .map(|p| p.as_bytes())
-        .ok_or(anyhow::anyhow!("could not convert path to bytes"))?
-        .to_vec();
+    let suffix = canonicalized_path_to_string(path, false)?.into_bytes();
     let mut key = if let Some(prefix) = prefix {
         prefix.into_bytes().to_vec()
     } else {
@@ -298,6 +275,51 @@ pub fn path_to_key(
     key.extend(suffix);
     key.push(b'\0');
     Ok(key.into())
+}
+
+/// This function converts an already canonicalized path to a string.
+///
+/// If `must_be_relative` is true, the function will fail if any component of the path is
+/// `Component::RootDir`
+///
+/// This function will also fail if the path is non canonical, i.e. contains
+/// `..` or `.`, or if the path components contain any windows or unix path
+/// separators.
+pub fn canonicalized_path_to_string(
+    path: impl AsRef<Path>,
+    must_be_relative: bool,
+) -> anyhow::Result<String> {
+    let mut path_str = String::new();
+    let parts = path
+        .as_ref()
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(x) => {
+                let c = match x.to_str() {
+                    Some(c) => c,
+                    None => return Some(Err(anyhow::anyhow!("invalid character in path"))),
+                };
+
+                if !c.contains('/') && !c.contains('\\') {
+                    Some(Ok(c))
+                } else {
+                    Some(Err(anyhow::anyhow!("invalid path component {:?}", c)))
+                }
+            }
+            Component::RootDir => {
+                if must_be_relative {
+                    Some(Err(anyhow::anyhow!("invalid path component {:?}", c)))
+                } else {
+                    path_str.push('/');
+                    None
+                }
+            }
+            _ => Some(Err(anyhow::anyhow!("invalid path component {:?}", c))),
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let parts = parts.join("/");
+    path_str.push_str(&parts);
+    Ok(path_str)
 }
 
 #[cfg(test)]
@@ -338,8 +360,11 @@ mod tests {
     }
 
     #[test]
-    fn test_canonicalize_path() {
-        assert_eq!(super::canonicalize_path("foo/bar").unwrap(), "foo/bar");
+    fn test_relative_canonicalized_path_to_string() {
+        assert_eq!(
+            super::relative_canonicalized_path_to_string("foo/bar").unwrap(),
+            "foo/bar"
+        );
     }
 
     #[test]

--- a/iroh/src/util/fs.rs
+++ b/iroh/src/util/fs.rs
@@ -231,8 +231,9 @@ fn path_content_info0(path: impl AsRef<Path>) -> anyhow::Result<PathContent> {
 /// Helper function that translates a key that was derived from a path on a filesystem back to that
 /// path.
 ///
-/// If `strip_prefix` exists, it will be stripped before converting back to a path
-/// If `root` exists, it will add the root as a parent to the created path
+/// If `prefix` exists, it will be stripped before converting back to a path
+/// If `root` exists, will add the root as a parent to the created path
+/// Removes any null byte that has been appened to the key
 pub fn key_to_path(
     key: impl AsRef<[u8]>,
     prefix: Option<String>,
@@ -271,8 +272,7 @@ pub fn key_to_path(
     Ok(path)
 }
 
-/// Helper function that creates a document key from the path, removing the full canonicalized path, and adding
-/// whatever prefix the user requests.
+/// Helper function that creates a document key from the path, removing the `root` and adding the `prefix`, if they exist
 ///
 /// Appends the null byte to the end of the key.
 pub fn path_to_key(

--- a/iroh/src/util/fs.rs
+++ b/iroh/src/util/fs.rs
@@ -240,7 +240,17 @@ pub fn key_to_path(
         key
     };
 
-    let path = PathBuf::from(String::from_utf8(key.into()).context("key contains invalid data")?);
+    let mut path = PathBuf::new();
+    if key[0] == b'/' {
+        path = path.join("/");
+    }
+    for component in key
+        .split(|c| c == &b'/')
+        .map(|c| String::from_utf8(c.into()).context("key contains invalid data"))
+    {
+        let component = component?;
+        path = path.join(component);
+    }
 
     // add root if it exists
     let path = if let Some(root) = root {

--- a/iroh/src/util/fs.rs
+++ b/iroh/src/util/fs.rs
@@ -360,11 +360,34 @@ mod tests {
     }
 
     #[test]
-    fn test_relative_canonicalized_path_to_string() {
+    fn test_canonicalized_path_to_string() {
         assert_eq!(
-            super::relative_canonicalized_path_to_string("foo/bar").unwrap(),
+            canonicalized_path_to_string("foo/bar", true).unwrap(),
             "foo/bar"
         );
+        assert_eq!(canonicalized_path_to_string("", true).unwrap(), "");
+        assert_eq!(
+            canonicalized_path_to_string("foo bar/baz/bat", true).unwrap(),
+            "foo bar/baz/bat"
+        );
+        assert_eq!(
+            canonicalized_path_to_string("/foo/bar", true).map_err(|e| e.to_string()),
+            Err("invalid path component RootDir".to_string())
+        );
+
+        assert_eq!(
+            canonicalized_path_to_string("/foo/bar", false).unwrap(),
+            "/foo/bar"
+        );
+        let path = PathBuf::new()
+            .join("/")
+            .join("Ü")
+            .join("⁰€™■･�")
+            .join("東京");
+        assert_eq!(
+            canonicalized_path_to_string(path, false).unwrap(),
+            "/Ü/⁰€™■･�/東京"
+        )
     }
 
     #[test]


### PR DESCRIPTION
## Description

closes #1781 

### canonicalize_path:

There is now a `canonicalized_path_to_string` method that takes a path (that it expects to be canonicalized already) and turns it into a string.

What was previously `canonicalize_path` is now renamed to `relative_canonicalized_path_to_string`, and calls `canonicalized_path_to_string`, with the `must_be_relative` param set to `true`
