### PR TITLE
feat(cli): get node with rpc and stable node stats sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,6 +2091,7 @@ dependencies = [
  "iroh-net",
  "iroh-sync",
  "iroh-test",
+ "itertools 0.11.0",
  "multibase",
  "nix 0.27.1",
  "num_cpus",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -34,6 +34,7 @@ num_cpus = { version = "1.15.0" }
 portable-atomic = "1"
 iroh-sync = { version = "0.10.0", path = "../iroh-sync" }
 iroh-gossip = { version = "0.10.0", path = "../iroh-gossip" }
+itertools = "0.11.0"
 once_cell = "1.18.0"
 parking_lot = "0.12.1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }

--- a/iroh/examples/dump-blob-fsm.rs
+++ b/iroh/examples/dump-blob-fsm.rs
@@ -34,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
     //
     // in real applications, it would be very much preferable to use a persistent secret key
     let secret_key = SecretKey::generate();
-    let dial_options = ticket.as_get_options(secret_key, None);
+    let dial_options = ticket.as_get_options(secret_key, None, None);
 
     // connect to the peer
     //

--- a/iroh/examples/dump-blob-stream.rs
+++ b/iroh/examples/dump-blob-stream.rs
@@ -171,7 +171,7 @@ async fn main() -> anyhow::Result<()> {
     //
     // in real applications, it would be very much preferable to use a persistent secret key
     let secret_key = SecretKey::generate();
-    let dial_options = ticket.as_get_options(secret_key, None);
+    let dial_options = ticket.as_get_options(secret_key, None, None);
 
     // connect to the peer
     //

--- a/iroh/src/commands/node.rs
+++ b/iroh/src/commands/node.rs
@@ -178,7 +178,7 @@ async fn get_secret_key(key: Option<PathBuf>) -> Result<SecretKey> {
 }
 
 /// Makes a an RPC endpoint that uses a QUIC transport
-async fn make_rpc_endpoint(
+pub(crate) async fn make_rpc_endpoint(
     secret_key: &SecretKey,
     rpc_port: u16,
 ) -> Result<impl ServiceEndpoint<ProviderService>> {

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -16,6 +16,8 @@ pub struct Options {
     pub keylog: bool,
     /// The configuration of the derp services
     pub derp_map: Option<DerpMap>,
+    /// The rpc port to connect to via console
+    pub rpc_port: Option<u16>,
 }
 
 /// Create a new endpoint and dial a peer, returning the connection

--- a/iroh/src/ticket/blob.rs
+++ b/iroh/src/ticket/blob.rs
@@ -105,12 +105,18 @@ impl Ticket {
     }
 
     /// Convert this ticket into a [`Options`], adding the given secret key.
-    pub fn as_get_options(&self, secret_key: SecretKey, derp_map: Option<DerpMap>) -> Options {
+    pub fn as_get_options(
+        &self,
+        secret_key: SecretKey,
+        derp_map: Option<DerpMap>,
+        rpc_port: Option<u16>,
+    ) -> Options {
         Options {
             peer: self.node.clone(),
             secret_key,
             keylog: true,
             derp_map,
+            rpc_port,
         }
     }
 }

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -141,6 +141,7 @@ fn get_options(node_id: NodeId, addrs: Vec<SocketAddr>) -> iroh::dial::Options {
         peer,
         keylog: false,
         derp_map: Some(iroh_net::defaults::default_derp_map()),
+        rpc_port: None,
     }
 }
 
@@ -555,6 +556,7 @@ async fn test_run_ticket() {
         let opts = no_token_ticket.as_get_options(
             SecretKey::generate(),
             Some(iroh_net::defaults::default_derp_map()),
+            None,
         );
         let request = GetRequest::all(no_token_ticket.hash());
         let response = run_collection_get_request(opts, request).await;
@@ -576,6 +578,7 @@ async fn test_run_ticket() {
             ticket.as_get_options(
                 SecretKey::generate(),
                 Some(iroh_net::defaults::default_derp_map()),
+                None,
             ),
             request,
         )


### PR DESCRIPTION
## Description

Only remaining thing is how to catch an early abort to properly do `clear_rpc(...).await?;`

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
