### PR TITLE
refactor: improve code and args for CLI start

### DIFF
--- a/iroh/src/commands/start.rs
+++ b/iroh/src/commands/start.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args;
 use colored::Colorize;
 use futures::Future;
@@ -25,20 +25,26 @@ use quic_rpc::{transport::quinn::QuinnServerEndpoint, ServiceEndpoint};
 use tracing::{info_span, Instrument};
 
 use crate::{
-    commands::{
-        blob::{add_with_opts, BlobSource},
-        rpc::clear_rpc,
-    },
+    commands::rpc::clear_rpc,
     config::{get_iroh_data_root_with_env, path_with_env, NodeConfig},
 };
 
 use super::{
-    blob::BlobAddOptions,
     rpc::{store_rpc, RpcStatus},
-    RequestTokenOptions, MAX_RPC_CONNECTIONS, MAX_RPC_STREAMS,
+    RequestTokenOptions,
 };
 
 const DEFAULT_RPC_PORT: u16 = 0x1337;
+const MAX_RPC_CONNECTIONS: u32 = 16;
+const MAX_RPC_STREAMS: u64 = 1024;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum RunType {
+    /// Run a single command, and then shutdown the node.
+    SingleCommand,
+    /// Run until manually stopped (through Ctrl-C or shutdown RPC command)
+    UntilStopped,
+}
 
 #[derive(Args, Debug, Clone)]
 pub struct StartArgs {
@@ -75,106 +81,93 @@ impl StartArgs {
         self,
         rt: &runtime::Handle,
         config: &NodeConfig,
-        cmd: F,
+        run_type: RunType,
+        command: F,
     ) -> Result<()>
     where
-        F: FnOnce(iroh::client::mem::Iroh) -> T,
-        T: Future<Output = Result<()>>,
+        F: FnOnce(iroh::client::mem::Iroh) -> T + Send + 'static,
+        T: Future<Output = Result<()>> + 'static,
+    {
+        #[cfg(feature = "metrics")]
+        let metrics_fut = start_metrics_server(config.metrics_addr, &rt);
+
+        let res = self
+            .run_with_command_inner(rt, config, run_type, command)
+            .await;
+
+        #[cfg(feature = "metrics")]
+        if let Some(metrics_fut) = metrics_fut {
+            metrics_fut.abort();
+        }
+
+        clear_rpc(get_iroh_data_root_with_env()?).await?;
+
+        res
+    }
+
+    pub async fn run_with_command_inner<F, T>(
+        self,
+        rt: &runtime::Handle,
+        config: &NodeConfig,
+        run_type: RunType,
+        command: F,
+    ) -> Result<()>
+    where
+        F: FnOnce(iroh::client::mem::Iroh) -> T + Send + 'static,
+        T: Future<Output = Result<()>> + 'static,
     {
         let token = self.request_token();
         let derp_map = config.derp_map()?;
 
         let spinner = create_spinner("Iroh booting...");
-        let node = self.start_daemon_node(rt, token, derp_map).await?;
+        let node = self.start_node(rt, token, derp_map).await?;
         drop(spinner);
 
-        let msg = welcome_message(&node)?;
-        eprintln!("{}", msg);
+        eprintln!("{}", welcome_message(&node)?);
 
         let client = node.client();
 
-        let node2 = node.clone();
-        tokio::select! {
-            biased;
-            res = cmd(client) => {
-                res?;
-                node2.shutdown();
-            }
-            res = node => {
-                res?;
-            }
-        }
-
-        clear_rpc(get_iroh_data_root_with_env()?).await?;
-
-        Ok(())
-    }
-
-    pub async fn run(
-        self,
-        rt: &runtime::Handle,
-        config: &NodeConfig,
-        add_opts: BlobAddOptions,
-    ) -> Result<()> {
-        let token = self.request_token();
-        let derp_map = config.derp_map()?;
-
-        let spinner = create_spinner("Iroh is booting...");
-        let node = self.start_daemon_node(rt, token.clone(), derp_map).await?;
-        drop(spinner);
-
-        let msg = welcome_message(&node)?;
-        eprintln!("{}", msg);
-
-        let client = node.client();
-
-        let add_task = match add_opts.source {
-            Some(ref source) => {
-                if let BlobSource::Path(ref p) = source {
-                    ensure!(
-                        p.exists(),
-                        "Cannot provide nonexistent path: {}",
-                        p.display()
-                    );
-                }
-
-                Some(tokio::spawn(
-                    async move {
-                        if let Err(e) = add_with_opts(&client, add_opts, token).await {
-                            eprintln!("Failed to add data: {}", e);
-                            std::process::exit(1);
+        let mut command_task = rt.local_pool().spawn_pinned(move || {
+            async move {
+                match command(client).await {
+                    Err(err) => Err(err),
+                    Ok(()) => {
+                        // keep the task open forever if not running in single-command loop
+                        if run_type == RunType::UntilStopped {
+                            futures::future::pending().await
                         }
+                        Ok(())
                     }
-                    .instrument(info_span!("node-add")),
-                ))
+                }
             }
-            None => None,
-        };
+            .instrument(info_span!("command"))
+        });
 
         let node2 = node.clone();
         tokio::select! {
             biased;
+            // always abort on signal-c
             _ = tokio::signal::ctrl_c() => {
-                node2.shutdown();
+                command_task.abort();
+                node.shutdown();
+                node.await?;
             }
-            res = node => {
+            // abort if the command task finishes (will run forever if not in single-command mode)
+            res = &mut command_task => {
+                node.shutdown();
+                let _ = node.await;
+                res??;
+            }
+            // abort if the node future completes (shutdown called or error)
+            res = node2 => {
+                command_task.abort();
                 res?;
             }
         }
-
-        // the future holds a reference to the temp file, so we need to
-        // keep it for as long as the provider is running. The drop(fut)
-        // makes this explicit.
-        if let Some(add_task) = add_task {
-            add_task.abort();
-            drop(add_task);
-        }
-        clear_rpc(get_iroh_data_root_with_env()?).await?;
-
         Ok(())
     }
 
-    async fn start_daemon_node(
+    async fn start_node(
         &self,
         rt: &runtime::Handle,
         token: Option<RequestToken>,
@@ -197,7 +190,7 @@ impl StartArgs {
         let blob_dir = path_with_env(IrohPaths::BaoFlatStoreComplete)?;
         let partial_blob_dir = path_with_env(IrohPaths::BaoFlatStorePartial)?;
         let meta_dir = path_with_env(IrohPaths::BaoFlatStoreMeta)?;
-        let peer_data_path = path_with_env(IrohPaths::PeerData)?;
+        let peers_data_path = path_with_env(IrohPaths::PeerData)?;
         tokio::fs::create_dir_all(&blob_dir).await?;
         tokio::fs::create_dir_all(&partial_blob_dir).await?;
         let bao_store =
@@ -206,52 +199,26 @@ impl StartArgs {
                 .with_context(|| {
                     format!("Failed to load iroh database from {}", blob_dir.display())
                 })?;
-        let key = Some(path_with_env(IrohPaths::SecretKey)?);
+        let secret_key_path = Some(path_with_env(IrohPaths::SecretKey)?);
         let doc_store = iroh_sync::store::fs::Store::new(path_with_env(IrohPaths::DocsDatabase)?)?;
-        self.spawn_daemon_node(
-            rt,
-            bao_store,
-            doc_store,
-            key,
-            peer_data_path,
-            token,
-            derp_map,
-        )
-        .await
-    }
 
-    #[allow(clippy::too_many_arguments)]
-    async fn spawn_daemon_node<B: iroh_bytes::store::Store, D: iroh_sync::store::Store>(
-        &self,
-        rt: &runtime::Handle,
-        bao_store: B,
-        doc_store: D,
-        key: Option<PathBuf>,
-        peers_data_path: PathBuf,
-        token: Option<RequestToken>,
-        derp_map: Option<DerpMap>,
-    ) -> Result<Node<B>> {
-        let secret_key = get_secret_key(key).await?;
-
-        let mut builder = Node::builder(bao_store, doc_store)
-            .custom_auth_handler(Arc::new(StaticTokenAuthHandler::new(token)))
-            .peers_data_path(peers_data_path);
-        if let Some(dm) = derp_map {
-            builder = builder.derp_mode(DerpMode::Custom(dm));
-        }
-        let builder = builder.bind_addr(self.addr).runtime(rt);
-
-        let node = if let Some(rpc_port) = self.rpc_port.into() {
-            let rpc_endpoint = make_rpc_endpoint(&secret_key, rpc_port).await?;
-            builder
-                .rpc_endpoint(rpc_endpoint)
-                .secret_key(secret_key)
-                .spawn()
-                .await?
-        } else {
-            builder.secret_key(secret_key).spawn().await?
+        let secret_key = get_secret_key(secret_key_path).await?;
+        let rpc_endpoint = make_rpc_endpoint(&secret_key, self.rpc_port).await?;
+        let derp_mode = match derp_map {
+            None => DerpMode::Default,
+            Some(derp_map) => DerpMode::Custom(derp_map),
         };
-        Ok(node)
+
+        Node::builder(bao_store, doc_store)
+            .derp_mode(derp_mode)
+            .custom_auth_handler(Arc::new(StaticTokenAuthHandler::new(token)))
+            .peers_data_path(peers_data_path)
+            .bind_addr(self.addr)
+            .runtime(rt)
+            .rpc_endpoint(rpc_endpoint)
+            .secret_key(secret_key)
+            .spawn()
+            .await
     }
 }
 
@@ -330,4 +297,23 @@ fn create_spinner(msg: &'static str) -> ProgressBar {
     );
     pb.set_message(msg);
     pb.with_finish(indicatif::ProgressFinish::AndClear)
+}
+
+#[cfg(feature = "metrics")]
+pub fn start_metrics_server(
+    metrics_addr: Option<SocketAddr>,
+    rt: &iroh_bytes::util::runtime::Handle,
+) -> Option<tokio::task::JoinHandle<()>> {
+    // doesn't start the server if the address is None
+    if let Some(metrics_addr) = metrics_addr {
+        // metrics are initilaized in iroh::node::Node::spawn
+        // here we only start the server
+        return Some(rt.main().spawn(async move {
+            if let Err(e) = iroh_metrics::metrics::start_metrics_server(metrics_addr).await {
+                eprintln!("Failed to start metrics server: {e}");
+            }
+        }));
+    }
+    tracing::info!("Metrics server not started, no address provided");
+    None
 }

--- a/iroh/src/commands/start.rs
+++ b/iroh/src/commands/start.rs
@@ -89,7 +89,7 @@ impl StartArgs {
         T: Future<Output = Result<()>> + 'static,
     {
         #[cfg(feature = "metrics")]
-        let metrics_fut = start_metrics_server(config.metrics_addr, &rt);
+        let metrics_fut = start_metrics_server(config.metrics_addr, rt);
 
         let res = self
             .run_with_command_inner(rt, config, run_type, command)
@@ -105,7 +105,7 @@ impl StartArgs {
         res
     }
 
-    pub async fn run_with_command_inner<F, T>(
+    async fn run_with_command_inner<F, T>(
         self,
         rt: &runtime::Handle,
         config: &NodeConfig,

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -385,7 +385,7 @@ fn cli_provide_persistence() -> anyhow::Result<()> {
                 ADDR,
                 "--rpc-port",
                 "0",
-                "--source",
+                "--add",
                 path.to_str().unwrap(),
                 "--wrap",
             ],
@@ -623,7 +623,7 @@ fn make_provider_in(
     if wrap {
         args.push("--wrap");
     }
-    args.push("--source");
+    args.push("--add");
     let arg = input.as_arg();
     args.push(&arg);
 


### PR DESCRIPTION
## Description

Changes for #1802 

CLI command changes:

* `iroh start` takes `--add` not `--source`
* `iroh blob add` takes required  `SOURCE` arg and not optional `--source` opt

Internal changes:
* reduce code duplication around starting a node
* always start the metrics server (for both `iroh start` and `iroh CMD --start`)
* make sure to remove the rpc lock file if aborting with error
* cleanups

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- ~~[ ] Tests if relevant.~~
