### PR TITLE
Remove ipld prefix from to_string

### DIFF
--- a/iroh-base/src/hash.rs
+++ b/iroh-base/src/hash.rs
@@ -137,7 +137,7 @@ impl FromStr for Hash {
         anyhow::ensure!(sb.len() == 52, "invalid base32 length");
         // this is a base32 encoded hash, we can decode it directly
         let mut t = [0u8; 52];
-        t.copy_from_slice(&sb);
+        t.copy_from_slice(sb);
         // hack since data_encoding doesn't have BASE32LOWER_NOPAD as a const
         std::str::from_utf8_mut(t.as_mut())
             .unwrap()

--- a/iroh-base/src/hash.rs
+++ b/iroh-base/src/hash.rs
@@ -52,34 +52,6 @@ impl Hash {
         Self(blake3::Hash::from_bytes(bytes))
     }
 
-    /// Get the cid as bytes.
-    pub fn as_cid_bytes(&self) -> [u8; 36] {
-        let hash = self.0.as_bytes();
-        let mut res = [0u8; 36];
-        res[0..4].copy_from_slice(&CID_PREFIX);
-        res[4..36].copy_from_slice(hash);
-        res
-    }
-
-    /// Try to create a blake3 cid from cid bytes.
-    ///
-    /// This will only work if the prefix is the following:
-    /// - version 1
-    /// - raw codec
-    /// - blake3 hash function
-    /// - 32 byte hash size
-    pub fn from_cid_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
-        anyhow::ensure!(
-            bytes.len() == 36,
-            "invalid cid length, expected 36, got {}",
-            bytes.len()
-        );
-        anyhow::ensure!(bytes[0..4] == CID_PREFIX, "invalid cid prefix");
-        let mut hash = [0u8; 32];
-        hash.copy_from_slice(&bytes[4..36]);
-        Ok(Self::from(hash))
-    }
-
     /// Convert the hash to a hex string.
     pub fn to_hex(&self) -> String {
         self.0.to_hex().to_string()
@@ -136,10 +108,10 @@ impl Ord for Hash {
 
 impl fmt::Display for Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // result will be 58 bytes plus prefix
-        let mut res = [b'b'; 59];
+        // result will be 52 bytes
+        let mut res = [b'b'; 52];
         // write the encoded bytes
-        data_encoding::BASE32_NOPAD.encode_mut(&self.as_cid_bytes(), &mut res[1..]);
+        data_encoding::BASE32_NOPAD.encode_mut(self.as_bytes(), &mut res);
         // convert to string, this is guaranteed to succeed
         let t = std::str::from_utf8_mut(res.as_mut()).unwrap();
         // hack since data_encoding doesn't have BASE32LOWER_NOPAD as a const
@@ -155,34 +127,27 @@ impl FromStr for Hash {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let sb = s.as_bytes();
         if sb.len() == 64 {
-            // this is most likely a hex encoded cid
+            // this is most likely a hex encoded hash
             // try to decode it as hex
             let mut bytes = [0u8; 32];
             if hex::decode_to_slice(sb, &mut bytes).is_ok() {
                 return Ok(Self::from(bytes));
             }
         }
-        if sb.len() == 59 && sb[0] == b'b' {
-            // this is a base32 encoded cid, we can decode it directly
-            let mut t = [0u8; 58];
-            t.copy_from_slice(&sb[1..]);
-            // hack since data_encoding doesn't have BASE32LOWER_NOPAD as a const
-            std::str::from_utf8_mut(t.as_mut())
-                .unwrap()
-                .make_ascii_uppercase();
-            // decode the bytes
-            let mut res = [0u8; 36];
-            data_encoding::BASE32_NOPAD
-                .decode_mut(&t, &mut res)
-                .map_err(|_e| anyhow::anyhow!("invalid base32"))?;
-            // convert to cid, this will check the prefix
-            Self::from_cid_bytes(&res)
-        } else {
-            // if we want to support all the weird multibase prefixes, we have no choice
-            // but to use the multibase crate
-            let (_base, bytes) = multibase::decode(s)?;
-            Self::from_cid_bytes(bytes.as_ref())
-        }
+        anyhow::ensure!(sb.len() == 52, "invalid base32 length");
+        // this is a base32 encoded hash, we can decode it directly
+        let mut t = [0u8; 52];
+        t.copy_from_slice(&sb);
+        // hack since data_encoding doesn't have BASE32LOWER_NOPAD as a const
+        std::str::from_utf8_mut(t.as_mut())
+            .unwrap()
+            .make_ascii_uppercase();
+        // decode the bytes
+        let mut res = [0u8; 32];
+        data_encoding::BASE32_NOPAD
+            .decode_mut(&t, &mut res)
+            .map_err(|_e| anyhow::anyhow!("invalid base32"))?;
+        Ok(Self::from(res))
     }
 }
 
@@ -250,13 +215,6 @@ impl<'de> de::Visitor<'de> for HashVisitor {
 impl MaxSize for Hash {
     const POSTCARD_MAX_SIZE: usize = 32;
 }
-
-const CID_PREFIX: [u8; 4] = [
-    0x01, // version
-    0x55, // raw codec
-    0x1e, // hash function, blake3
-    0x20, // hash size, 32 bytes
-];
 
 /// A format identifier
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default, Debug)]
@@ -444,7 +402,7 @@ mod tests {
         assert_tokens(&hash.compact(), &tokens);
 
         let tokens = vec![Token::String(
-            "bafkr4ihkr4ld3m4gqkjf4reryxsy2s5tkbxprqkow6fin2iiyvreuzzab4",
+            "5khrmpntq2bjexseshc6ldklwnig56gbj23yvbxjbdcwestheahq",
         )];
         assert_tokens(&hash.readable(), &tokens);
     }
@@ -465,8 +423,8 @@ mod tests {
         let ser = serde_json::to_string(&hash).unwrap();
         let de = serde_json::from_str(&ser).unwrap();
         assert_eq!(hash, de);
-        // 59 bytes of base32 + 2 quotes
-        assert_eq!(ser.len(), 61);
+        // 52 bytes of base32 + 2 quotes
+        assert_eq!(ser.len(), 54);
     }
 
     #[test]

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -879,7 +879,7 @@ fn match_get_stderr(stderr: Vec<u8>) -> Result<Vec<(usize, Vec<String>)>> {
             (r"Iroh is running", 1),
             (r"Node ID: [_\w\d-]*", 1),
             (r"", 1),
-            (r"Fetching: [\da-z]{59}", 1),
+            (r"Fetching: [\da-z]{52}", 1),
             (
                 r"Transferred (\d*.?\d*? ?[BKMGT]i?B?) in \d* seconds?, \d*.?\d* ?(?:B|KiB|MiB|GiB|TiB)/s",
                 1,
@@ -909,8 +909,8 @@ fn match_provide_output<T: Read>(
     let reader = BufReader::new(reader);
 
     let blob_or_collection_matcher = match kind {
-        BlobOrCollection::Collection => (r"Collection: [\da-z]{59}", 1),
-        BlobOrCollection::Blob => (r"Blob: [\da-z]{59}", 1),
+        BlobOrCollection::Collection => (r"Collection: [\da-z]{52}", 1),
+        BlobOrCollection::Blob => (r"Blob: [\da-z]{52}", 1),
     };
 
     let mut caps = assert_matches_line(


### PR DESCRIPTION
## Description

This makes ToString for hash just produce the base32 encoded hash

## Notes & open questions

None

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
