### PR TITLE
Move collection to iroh-bytes and add metadata header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5928,18 +5928,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.25"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.25"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/iroh-bytes/src/format.rs
+++ b/iroh-bytes/src/format.rs
@@ -1,0 +1,16 @@
+//! Defines data formats for HashSeq.
+//!
+//! The exact details how to use a HashSeq for specific purposes is up to the
+//! user. However, the following approach is used by iroh formats:
+//!
+//! The first child blob is a metadata blob. It starts with a header, followed
+//! by serialized metadata. We mostly use [postcard] for serialization. The
+//! metadata either implicitly or explicitly refers to the other blobs in the
+//! HashSeq by index.
+//!
+//! In a very simple case, the metadata just an array of items, where each item
+//! is the metadata for the corresponding blob. The metadata array will have
+//! n-1 items, where n is the number of blobs in the HashSeq.
+//!
+//! [postcard]: https://docs.rs/postcard/latest/postcard/
+pub mod collection;

--- a/iroh-bytes/src/lib.rs
+++ b/iroh-bytes/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![recursion_limit = "256"]
 
+pub mod format;
 pub mod get;
 pub mod hashseq;
 pub mod protocol;

--- a/iroh/examples/collection.rs
+++ b/iroh/examples/collection.rs
@@ -6,8 +6,7 @@
 //! This is using an in memory database and a random node id.
 //! run this example from the project root:
 //!     $ cargo run -p collection
-use iroh::collection::{Blob, Collection};
-use iroh_bytes::BlobFormat;
+use iroh_bytes::{format::collection::Collection, BlobFormat, Hash};
 use tokio_util::task::LocalPoolHandle;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
@@ -29,15 +28,11 @@ async fn main() -> anyhow::Result<()> {
         ("blob2", b"the second blob of bytes".to_vec()),
     ]);
     // create blobs from the data
-    let blobs = names
+    let collection: Collection = names
         .into_iter()
-        .map(|(name, hash)| Blob {
-            name,
-            hash: hash.into(),
-        })
+        .map(|(name, hash)| (name, Hash::from(hash)))
         .collect();
     // create a collection and add it to the db as well
-    let collection = Collection::new(blobs, 0)?;
     let hash = db.insert_many(collection.to_blobs()).unwrap();
     // create a new local pool handle with 1 worker thread
     let lp = LocalPoolHandle::new(1);

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -13,7 +13,6 @@ pub use iroh_sync as sync;
 pub use iroh_base::base32;
 
 pub mod client;
-pub mod collection;
 pub mod dial;
 pub mod downloader;
 pub mod get;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -19,6 +19,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use futures::future::{BoxFuture, Shared};
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt};
 use iroh_base::rpc::RpcResult;
+use iroh_bytes::format::collection::Collection;
 use iroh_bytes::hashseq::parse_hash_seq;
 use iroh_bytes::provider::DownloadProgress;
 use iroh_bytes::store::{
@@ -26,9 +27,7 @@ use iroh_bytes::store::{
     Store as BaoStore, ValidateProgress,
 };
 use iroh_bytes::util::progress::{FlumeProgressSender, IdGenerator, ProgressSender};
-use iroh_bytes::{
-    protocol::Closed, provider::AddProgress, BlobFormat, Hash, HashAndFormat, TempTag,
-};
+use iroh_bytes::{protocol::Closed, provider::AddProgress, BlobFormat, Hash, HashAndFormat};
 use iroh_gossip::net::{Gossip, GOSSIP_ALPN};
 use iroh_io::AsyncSliceReader;
 use iroh_net::magic_endpoint::get_alpn;
@@ -1068,11 +1067,10 @@ impl<D: BaoStore> RpcHandler<D> {
             ExportMode::Copy
         };
         if recursive {
-            use crate::collection::{Blob, Collection};
             use crate::util::io::pathbuf_from_name;
             tokio::fs::create_dir_all(&path).await?;
             let collection = Collection::load(db, &hash).await?;
-            for Blob { hash, name } in collection.blobs() {
+            for (name, hash) in collection.into_iter() {
                 #[allow(clippy::needless_borrow)]
                 let path = path.join(pathbuf_from_name(&name));
                 if let Some(parent) = path.parent() {
@@ -1081,7 +1079,7 @@ impl<D: BaoStore> RpcHandler<D> {
                 trace!("exporting blob {} to {}", hash, path.display());
                 let id = progress.new_id();
                 let progress1 = progress.clone();
-                db.export(*hash, path, mode, move |offset| {
+                db.export(hash, path, mode, move |offset| {
                     Ok(progress1.try_send(DownloadProgress::ExportProgress { id, offset })?)
                 })
                 .await?;
@@ -1199,10 +1197,7 @@ impl<D: BaoStore> RpcHandler<D> {
         msg: BlobAddPathRequest,
         progress: flume::Sender<AddProgress>,
     ) -> anyhow::Result<()> {
-        use crate::{
-            collection::{Blob, Collection},
-            rpc_protocol::WrapOption,
-        };
+        use crate::rpc_protocol::WrapOption;
         use futures::TryStreamExt;
         use iroh_bytes::store::ImportMode;
         use std::collections::BTreeMap;
@@ -1253,7 +1248,7 @@ impl<D: BaoStore> RpcHandler<D> {
             // import all files below root recursively
             let data_sources = crate::util::fs::scan_path(root, wrap)?;
             const IO_PARALLELISM: usize = 4;
-            let result: Vec<(Blob, u64, TempTag)> = futures::stream::iter(data_sources)
+            let result: Vec<_> = futures::stream::iter(data_sources)
                 .map(|source| {
                     let import_progress = import_progress.clone();
                     let db = self.inner.db.clone();
@@ -1268,19 +1263,18 @@ impl<D: BaoStore> RpcHandler<D> {
                             )
                             .await?;
                         let hash = *tag.hash();
-                        let blob = Blob { hash, name };
-                        io::Result::Ok((blob, size, tag))
+                        io::Result::Ok((name, hash, size, tag))
                     }
                 })
                 .buffered(IO_PARALLELISM)
                 .try_collect::<Vec<_>>()
                 .await?;
-            let total_blobs_size = result.iter().map(|(_, size, _)| *size).sum();
 
             // create a collection
-            let (blobs, _child_tags): (Vec<_>, Vec<_>) =
-                result.into_iter().map(|(blob, _, tag)| (blob, tag)).unzip();
-            let collection = Collection::new(blobs, total_blobs_size)?;
+            let (collection, _child_tags): (Collection, Vec<_>) = result
+                .into_iter()
+                .map(|(name, hash, _, tag)| ((name, hash), tag))
+                .unzip();
 
             collection.store(&self.inner.db).await?
         } else {

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -271,7 +271,7 @@ fn cli_provide_tree_resume() -> Result<()> {
         let get_output = get.unchecked().run()?;
         assert!(get_output.status.success());
         let matches = explicit_matches(match_get_stderr(get_output.stderr)?);
-        assert_eq!(matches, vec!["112.88 KiB"]);
+        assert_eq!(matches, vec!["112.89 KiB"]);
         compare_files(&src, &tgt)?;
         std::fs::remove_dir_all(&tgt)?;
     }

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -2,17 +2,13 @@ use std::{
     collections::BTreeMap,
     net::SocketAddr,
     ops::Range,
-    path::PathBuf,
     time::{Duration, Instant},
 };
 
 use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use futures::FutureExt;
-use iroh::{
-    collection::{Blob, Collection},
-    node::{Builder, Event, Node},
-};
+use iroh::node::{Builder, Event, Node};
 use iroh_net::{key::SecretKey, NodeId};
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use rand::RngCore;
@@ -20,6 +16,7 @@ use tokio::sync::mpsc;
 
 use bao_tree::{blake3, ChunkNum, ChunkRanges};
 use iroh_bytes::{
+    format::collection::Collection,
     get::{
         fsm::ConnectedNext,
         fsm::{self, DecodeError},
@@ -151,21 +148,15 @@ async fn multiple_clients() -> Result<()> {
 
     let mut db = iroh_bytes::store::readonly_mem::Store::default();
     let expect_hash = db.insert(content.as_slice());
-    let expect_name = "hello_world".to_string();
-    let collection = Collection::new(
-        vec![Blob {
-            name: expect_name.clone(),
-            hash: expect_hash,
-        }],
-        0,
-    )?;
+    let expect_name = "hello_world";
+    let collection = Collection::from_iter([(expect_name, expect_hash)]);
     let hash = db.insert_many(collection.to_blobs()).unwrap();
     let lp = test_local_pool();
     let node = test_node(db).local_pool(&lp).spawn().await?;
     let mut tasks = Vec::new();
     for _i in 0..3 {
         let file_hash: Hash = expect_hash;
-        let name = expect_name.clone();
+        let name = expect_name;
         let addrs = node.local_address().unwrap();
         let peer_id = node.node_id();
         let content = content.to_vec();
@@ -174,12 +165,12 @@ async fn multiple_clients() -> Result<()> {
             async move {
                 let opts = get_options(peer_id, addrs);
                 let expected_data = &content;
-                let expected_name = &name;
+                let expected_name = name;
                 let request = GetRequest::all(hash);
                 let (collection, children, _stats) =
                     run_collection_get_request(opts, request).await?;
-                assert_eq!(expected_name, &collection.blobs()[0].name);
-                assert_eq!(&file_hash, &collection.blobs()[0].hash);
+                assert_eq!(expected_name, &collection[0].0);
+                assert_eq!(&file_hash, &collection[0].1);
                 assert_eq!(expected_data, &children[&0]);
 
                 anyhow::Ok(())
@@ -217,34 +208,25 @@ where
     let mut expects = Vec::new();
     let num_blobs = file_opts.len();
 
-    let (mut mdb, lookup) = iroh_bytes::store::readonly_mem::Store::new(file_opts.clone());
+    let (mut mdb, _lookup) = iroh_bytes::store::readonly_mem::Store::new(file_opts.clone());
     let mut blobs = Vec::new();
-    let mut total_blobs_size = 0u64;
 
     for opt in file_opts.into_iter() {
         let (name, data) = opt;
-        let name = name.into();
+        let name: String = name.into();
         println!("Sending {}: {}b", name, data.len());
 
-        let path = PathBuf::from(&name);
         // get expected hash of file
         let hash = blake3::hash(&data);
         let hash = Hash::from(hash);
-        let blob = Blob {
-            name: name.clone(),
-            hash,
-        };
+        let blob = (name.clone(), hash);
         blobs.push(blob);
-        total_blobs_size += data.len() as u64;
 
         // keep track of expected values
-        expects.push((name, path, hash));
+        expects.push((name, hash));
     }
-    let collection = Collection::new(blobs, total_blobs_size)?;
-    let collection_hash = mdb.insert_many(collection.to_blobs()).unwrap();
-
-    // sort expects by name to match the canonical order of blobs
-    expects.sort_by(|a, b| a.0.cmp(&b.0));
+    let collection_orig = Collection::from_iter(blobs);
+    let collection_hash = mdb.insert_many(collection_orig.to_blobs()).unwrap();
 
     let node = test_node(mdb.clone()).local_pool(rt).spawn().await?;
 
@@ -263,15 +245,14 @@ where
     let opts = get_options(node.node_id(), addrs);
     let request = GetRequest::all(collection_hash);
     let (collection, children, _stats) = run_collection_get_request(opts, request).await?;
-    assert_eq!(num_blobs, collection.blobs().len());
-    for (i, (name, hash)) in lookup.into_iter().enumerate() {
-        let hash = Hash::from(hash);
-        let blob = &collection.blobs()[i];
-        let expect = mdb.get(&hash).unwrap();
+    assert_eq!(num_blobs, collection.len());
+    for (i, (expected_name, expected_hash)) in expects.iter().enumerate() {
+        let (name, hash) = &collection[i];
         let got = &children[&(i as u64)];
-        assert_eq!(name, blob.name);
-        assert_eq!(hash, blob.hash);
-        assert_eq!(&expect, got);
+        let expected = mdb.get(expected_hash).unwrap();
+        assert_eq!(expected_name, name);
+        assert_eq!(expected_hash, hash);
+        assert_eq!(expected, got);
     }
 
     // We have to wait for the completed event before shutting down the node.
@@ -342,14 +323,7 @@ async fn test_server_close() {
     let _guard = iroh_test::logging::setup();
     let mut db = iroh_bytes::store::readonly_mem::Store::default();
     let child_hash = db.insert(b"hello there");
-    let collection = Collection::new(
-        vec![Blob {
-            name: "hello".to_string(),
-            hash: child_hash,
-        }],
-        0,
-    )
-    .unwrap();
+    let collection = Collection::from_iter([("hello", child_hash)]);
     let hash = db.insert_many(collection.to_blobs()).unwrap();
     let mut node = test_node(db).local_pool(&lp).spawn().await.unwrap();
     let node_addr = node.local_endpoint_addresses().await.unwrap();
@@ -402,17 +376,7 @@ fn create_test_db(
     entries: impl IntoIterator<Item = (impl Into<String>, impl AsRef<[u8]>)>,
 ) -> (iroh_bytes::store::readonly_mem::Store, Hash) {
     let (mut db, hashes) = iroh_bytes::store::readonly_mem::Store::new(entries);
-    let collection = Collection::new(
-        hashes
-            .into_iter()
-            .map(|(name, hash)| Blob {
-                name,
-                hash: hash.into(),
-            })
-            .collect(),
-        0,
-    )
-    .unwrap();
+    let collection = Collection::from_iter(hashes);
     let hash = db.insert_many(collection.to_blobs()).unwrap();
     (db, hash)
 }
@@ -553,12 +517,12 @@ async fn test_run_ticket() {
 
 /// Utility to validate that the children of a collection are correct
 fn validate_children(collection: Collection, children: BTreeMap<u64, Bytes>) -> anyhow::Result<()> {
-    let blobs = collection.into_inner();
+    let blobs = collection.into_iter().collect::<Vec<_>>();
     anyhow::ensure!(blobs.len() == children.len());
-    for (child, blob) in blobs.into_iter().enumerate() {
+    for (child, (_name, hash)) in blobs.into_iter().enumerate() {
         let child = child as u64;
         let data = children.get(&child).unwrap();
-        anyhow::ensure!(blob.hash == blake3::hash(data).into());
+        anyhow::ensure!(hash == blake3::hash(data).into());
     }
     Ok(())
 }


### PR DESCRIPTION
## Description

This changes the collection type a bit to make it more idiomatic rust. E.g. it now implements traits to use it like a... collection, like FromIterator. It also moves collection (back) to iroh-bytes so it can be used from tools like sendme without having to depend on all of iroh.

This collection format is intended to be a minimum viable metadata format that we can support for a long time - just a sequence of strings with a string for each blob in the HashSeq. It is useful for tools like sendme and for gateways, so I think this is valuable enough to have as a separate format to e.g. document snapshots.

## Notes & open questions

Should this be sequences of blobs? Weirdly, in this case I am OK with a sequence of strings. If somebody wants names to be arbitrary blobs they can always define another metadata format.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
