### PR TITLE
chore(ci): run cargo build for android platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,8 +280,12 @@ jobs:
       # See https://github.com/cross-rs/cross/issues/1222
       run: cargo install cross --git https://github.com/cross-rs/cross
 
-    - name: check
-      run: cross check --all --target ${{ matrix.target }}
+    - name: build
+      # cross tests are currently broken vor armv7 and aarch64
+      # see https://github.com/cross-rs/cross/issues/1311.  So on
+      # those platforms we only build but do not run tests.
+      if: matrix.target != 'i686-unknown-linux-gnu'
+      run: cross build --all --target ${{ matrix.target }} -- --test-threads=12
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
       # see https://github.com/cross-rs/cross/issues/1311.  So on
       # those platforms we only build but do not run tests.
       if: matrix.target != 'i686-unknown-linux-gnu'
-      run: cross build --all --target ${{ matrix.target }} -- --test-threads=12
+      run: cross build --all --target ${{ matrix.target }}
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 


### PR DESCRIPTION
## Description

Due to a bug in redb we are currently not running tets on android.
This is a bit problematic as we break android builds this way.

This makes sure we can at least build, so the linker will also run.

## Notes & open questions

The next step would be to run the tests for android which do not
depend on redb.
 
Running `cargo check` in a separate step does not provide any benefit,
it is an extra compiler step which does take time and does not result
in catching errors which otherwise aren't caught.  Maybe we should also
remove this step from the non-cross checks, but that belongs better in
a different PR probably.

## Change checklist

- [x] Self-review.
- ~~Documentation updates if relevant.~~
- ~~Tests if relevant.~~