### PR TITLE
feat(net): add `Magicsock::network_change`

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -558,6 +558,15 @@ impl MagicEndpoint {
     }
 
     /// Call to notify the system of potential network changes.
+    ///
+    /// On many systems iroh is able to detect network changes by itself, however
+    /// some systems like android do not expose this functionality to native code. 
+    /// Android does however provide this functionality to Java code.  This
+    /// function allows for notifying iroh of any potential network changes like
+    /// this.
+    ///
+    /// Even when the network did not change, or iroh was already able to detect
+    /// the network change itself, there is no harm in calling this function.
     pub async fn network_change(&self) {
         self.msock.network_change().await;
     }

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -557,6 +557,13 @@ impl MagicEndpoint {
         Ok(())
     }
 
+    /// Call to notify the system of potential network changes.
+    ///
+    /// `is_major` indicates if the change was large enough to consider a full rebind.
+    pub async fn network_change(&self, is_major: bool) {
+        self.msock.network_change(is_major).await;
+    }
+
     #[cfg(test)]
     pub(crate) fn magic_sock(&self) -> &MagicSock {
         &self.msock

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -558,10 +558,8 @@ impl MagicEndpoint {
     }
 
     /// Call to notify the system of potential network changes.
-    ///
-    /// `is_major` indicates if the change was large enough to consider a full rebind.
-    pub async fn network_change(&self, is_major: bool) {
-        self.msock.network_change(is_major).await;
+    pub async fn network_change(&self) {
+        self.msock.network_change().await;
     }
 
     #[cfg(test)]

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -560,7 +560,7 @@ impl MagicEndpoint {
     /// Call to notify the system of potential network changes.
     ///
     /// On many systems iroh is able to detect network changes by itself, however
-    /// some systems like android do not expose this functionality to native code. 
+    /// some systems like android do not expose this functionality to native code.
     /// Android does however provide this functionality to Java code.  This
     /// function allows for notifying iroh of any potential network changes like
     /// this.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1424,6 +1424,17 @@ impl MagicSock {
     pub fn discovery(&self) -> Option<&dyn Discovery> {
         self.inner.discovery.as_ref().map(Box::as_ref)
     }
+
+    /// Call to notify the system of potential network changes.
+    ///
+    /// `is_major` indicates if the change was large enough to consider a full rebind.
+    pub async fn network_change(&self, is_major: bool) {
+        self.inner
+            .actor_sender
+            .send(ActorMessage::NetworkChange(is_major))
+            .await
+            .ok();
+    }
 }
 
 #[derive(Debug, Default)]
@@ -1551,6 +1562,7 @@ enum ActorMessage {
     ReceiveDerp(DerpReadResult),
     EndpointPingExpired(usize, stun::TransactionId),
     NetcheckReport(Result<Option<Arc<netcheck::Report>>>, &'static str),
+    NetworkChange(bool),
 }
 
 struct Actor {
@@ -1590,28 +1602,13 @@ impl Actor {
     async fn run(mut self) -> Result<()> {
         // Setup network monitoring
         let monitor = netmon::Monitor::new().await?;
-        let inner = self.inner.clone();
+
+        let (link_change_s, mut link_change_r) = mpsc::channel(8);
         let _token = monitor
             .subscribe(move |is_major| {
-                let inner = inner.clone();
+                let link_change_s = link_change_s.clone();
                 async move {
-                    info!("link change detected: major? {}", is_major);
-
-                    // Clear DNS cache
-                    DNS_RESOLVER.clear_cache();
-
-                    if is_major {
-                        let (s, r) = sync::oneshot::channel();
-                        inner.re_stun("link-change-major");
-                        inner
-                            .actor_sender
-                            .send(ActorMessage::RebindAll(s))
-                            .await
-                            .ok();
-                        r.await.ok();
-                    } else {
-                        inner.re_stun("link-change-minor");
-                    }
+                    link_change_s.send(is_major).await.ok();
                 }
                 .boxed()
             })
@@ -1675,10 +1672,33 @@ impl Actor {
                         Err(e) => debug!(%e, "failed to persist known nodes"),
                     }
                 }
+                Some(is_major) = link_change_r.recv() => {
+                    self.handle_network_change(is_major).await;
+                }
                 else => {
                     trace!("tick: other");
                 }
             }
+        }
+    }
+
+    async fn handle_network_change(&mut self, is_major: bool) {
+        info!("link change detected: major? {}", is_major);
+
+        if is_major {
+            // Clear DNS cache
+            DNS_RESOLVER.clear_cache();
+
+            let (s, r) = sync::oneshot::channel();
+            self.inner.re_stun("link-change-major");
+            self.inner
+                .actor_sender
+                .send(ActorMessage::RebindAll(s))
+                .await
+                .ok();
+            r.await.ok();
+        } else {
+            self.inner.re_stun("link-change-minor");
         }
     }
 
@@ -1779,6 +1799,9 @@ impl Actor {
                     }
                 }
                 self.finalize_endpoints_update(why);
+            }
+            ActorMessage::NetworkChange(is_major) => {
+                self.handle_network_change(is_major).await;
             }
         }
 

--- a/iroh-net/src/net/netmon.rs
+++ b/iroh-net/src/net/netmon.rs
@@ -75,6 +75,12 @@ impl Monitor {
         r.await?;
         Ok(())
     }
+
+    /// Potential change detected outside
+    pub async fn network_change(&self) -> Result<()> {
+        self.actor_tx.send(ActorMessage::NetworkChange).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/iroh-net/src/net/netmon/actor.rs
+++ b/iroh-net/src/net/netmon/actor.rs
@@ -75,6 +75,7 @@ pub(super) type Callback = Box<dyn Fn(bool) -> BoxFuture<'static, ()> + Sync + S
 pub(super) enum ActorMessage {
     Subscribe(Callback, oneshot::Sender<CallbackToken>),
     Unsubscribe(CallbackToken, oneshot::Sender<()>),
+    NetworkChange,
 }
 
 impl Actor {
@@ -142,6 +143,11 @@ impl Actor {
                     ActorMessage::Unsubscribe(token, s) => {
                         self.callbacks.remove(&token);
                         s.send(()).ok();
+                    }
+                    ActorMessage::NetworkChange => {
+                        trace!("external network activitiy detected");
+                        last_event.replace(false);
+                        debounce_interval.reset_immediately();
                     }
                 },
                 else => {


### PR DESCRIPTION
This allows notifying `iroh-net` when the network has likely changed.

Usually this is only needed on android, as on all other OSes this is automatically detected.
