### PR TITLE
refactor: streamline local endpoint discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2418,7 @@ dependencies = [
  "trust-dns-resolver",
  "ttl_cache",
  "url",
+ "watchable",
  "webpki-roots",
  "windows 0.51.1",
  "wmi",
@@ -5573,6 +5580,18 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "watchable"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff90d0baafb3c0abbeebec1a8a305b4211c356de1d953a0dd77aab006baa8a62"
+dependencies = [
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "thiserror",
+]
 
 [[package]]
 name = "web-sys"

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -110,9 +110,6 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     println!("> our node id: {}", endpoint.node_id());
 
-    // wait for a first endpoint update so that we know about our endpoint addresses
-    let _endpoints = endpoint.local_endpoints().await?;
-
     let my_addr = endpoint.my_addr().await?;
     // create the gossip protocol
     let gossip = Gossip::from_endpoint(endpoint.clone(), Default::default(), &my_addr.info);

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -70,6 +70,7 @@ tracing = "0.1"
 trust-dns-resolver = "0.23.0"
 ttl_cache = "0.5.1"
 url = { version = "2.4", features = ["serde"] }
+watchable = "1.1.1"
 webpki = { package = "rustls-webpki", version = "0.101.4", features = ["std"] }
 webpki-roots = "0.25"
 x509-parser = "0.15"

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -348,13 +348,10 @@ impl MagicEndpoint {
     /// This list contains both the locally-bound addresses and the endpoint's
     /// publicly-reachable addresses, if they could be discovered through
     /// STUN or port mapping.
+    ///
+    /// If called before there are any endpoints, waits for the first time there are some.
     pub async fn local_endpoints(&self) -> Result<Vec<config::Endpoint>> {
         self.msock.local_endpoints().await
-    }
-
-    /// Returns the next non empty version of `local_endpoints`.
-    pub async fn ensure_local_endpoints(&self) -> Result<Vec<config::Endpoint>> {
-        self.msock.ensure_local_endpoints().await
     }
 
     /// Get the DERP region we are connected to with the lowest latency.

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -354,6 +354,11 @@ impl MagicEndpoint {
         self.msock.local_endpoints().await
     }
 
+    /// Waits for local endpoints to change and returns the new ones.
+    pub async fn local_endpoints_change(&self) -> Result<Vec<config::Endpoint>> {
+        self.msock.local_endpoints_change().await
+    }
+
     /// Get the DERP region we are connected to with the lowest latency.
     ///
     /// Returns `None` if we are not connected to any DERP region.

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -352,10 +352,9 @@ impl MagicEndpoint {
         self.msock.local_endpoints().await
     }
 
-    /// The same as `local_endpoints`, except it waits for the first endpoint update.
+    /// Returns the next non empty version of `local_endpoints`.
     pub async fn ensure_local_endpoints(&self) -> Result<Vec<config::Endpoint>> {
-        self.msock.next_endpoint_update().await;
-        self.msock.local_endpoints().await
+        self.msock.ensure_local_endpoints().await
     }
 
     /// Get the DERP region we are connected to with the lowest latency.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2766,7 +2766,7 @@ pub(crate) mod tests {
             let m = m.clone();
             let stacks = stacks.clone();
             tasks.spawn(async move {
-                while let Ok(new_eps) = m.endpoint.magic_sock().local_endpoints().await {
+                while let Ok(new_eps) = m.endpoint.magic_sock().local_endpoints_change().await {
                     debug!("conn{} endpoints update: {:?}", my_idx + 1, new_eps);
                     update_eps(&stacks, my_idx, new_eps);
                 }

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1282,6 +1282,12 @@ impl MagicSock {
                 return Ok(current_value.clone().into_iter().collect());
             }
         }
+
+        self.local_endpoints_change().await
+    }
+
+    /// Waits for local endpoints to change and returns the new ones.
+    pub async fn local_endpoints_change(&self) -> Result<Vec<config::Endpoint>> {
         let mut watcher = self.inner.endpoints.watch();
         let eps = watcher.next_value_async().await?;
         Ok(eps.into_iter().collect())

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1275,14 +1275,14 @@ impl MagicSock {
     ///
     /// Will wait until some endpoints are discovered.
     pub async fn local_endpoints(&self) -> Result<Vec<config::Endpoint>> {
-        let mut watcher = self.inner.endpoints.watch();
         {
             // check if we have some value already
-            let current_value = watcher.read();
+            let current_value = self.inner.endpoints.read();
             if !current_value.is_empty() {
                 return Ok(current_value.clone().into_iter().collect());
             }
         }
+        let mut watcher = self.inner.endpoints.watch();
         let eps = watcher.next_value_async().await?;
         Ok(eps.into_iter().collect())
     }

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2774,7 +2774,6 @@ pub(crate) mod tests {
 
         Ok(move || {
             tasks.abort_all();
-            println!("tasks aborted");
         })
     }
 

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -498,11 +498,6 @@ impl DerpActor {
 
         self.log_active_derp();
 
-        if let Some(ref f) = self.conn.on_derp_active {
-            // TODO: spawn
-            f();
-        }
-
         dc
     }
 

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -959,6 +959,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_drop_doc_client_sync() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
+
         let db = iroh_bytes::store::readonly_mem::Store::default();
         let doc_store = iroh_sync::store::memory::Store::default();
         let lp = LocalPoolHandle::new(1);
@@ -984,6 +986,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_doc_import_export() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
+
         let doc_store = iroh_sync::store::memory::Store::default();
         let db = iroh_bytes::store::mem::Store::new();
         let node = crate::node::Node::builder(db, doc_store).spawn().await?;

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -586,7 +586,7 @@ async fn make_endpoint(
     };
     let endpoint = endpoint.bind(0).await?;
 
-    tokio::time::timeout(Duration::from_secs(10), endpoint.ensure_local_endpoints())
+    tokio::time::timeout(Duration::from_secs(10), endpoint.local_endpoints())
         .await
         .context("wait for derp connection")??;
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -355,7 +355,7 @@ where
         let ep = endpoint.clone();
         tokio::task::spawn(async move {
             loop {
-                match ep.local_endpoints().await {
+                match ep.local_endpoints_change().await {
                     Ok(eps) => {
                         if let Err(err) = gossip.update_endpoints(&eps) {
                             warn!("Failed to update gossip endpoints: {err:?}");

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -355,7 +355,7 @@ where
         let ep = endpoint.clone();
         tokio::task::spawn(async move {
             loop {
-                match ep.ensure_local_endpoints().await {
+                match ep.local_endpoints().await {
                     Ok(eps) => {
                         if let Err(err) = gossip.update_endpoints(&eps) {
                             warn!("Failed to update gossip endpoints: {err:?}");
@@ -371,7 +371,7 @@ where
 
         // Wait for a single endpoint update, to make sure
         // we found some endpoints
-        tokio::time::timeout(ENDPOINT_WAIT, endpoint.ensure_local_endpoints())
+        tokio::time::timeout(ENDPOINT_WAIT, endpoint.local_endpoints())
             .await
             .context("waiting for endpoint")??;
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -403,10 +403,8 @@ where
         // it may happen the the first endpoint update callback is missed because the gossip cell
         // is only initialized once the endpoint is fully bound
         if let Ok(local_endpoints) = server.local_endpoints().await {
-            if !local_endpoints.is_empty() {
-                debug!(me = ?server.node_id(), "gossip initial update: {local_endpoints:?}");
-                gossip.update_endpoints(&local_endpoints).ok();
-            }
+            debug!(me = ?server.node_id(), "gossip initial update: {local_endpoints:?}");
+            gossip.update_endpoints(&local_endpoints).ok();
         }
 
         loop {


### PR DESCRIPTION
To avoid the issues seen when setting up an `iroh-net` node, this allows to dynamically subscribe to endpoint changes. It also removes the other callbacks on the magicsock, which where unused.

