### PR TITLE
fix(sync): handle migration 004 in the empty case

### DIFF
--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -903,4 +903,22 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_migration_004_populate_by_key_index() -> Result<()> {
+        let dbfile = tempfile::NamedTempFile::new()?;
+
+        let store = Store::new(dbfile.path())?;
+
+        // check that the new table is there, even if empty
+        {
+            let read_tx = store.db.begin_read()?;
+            let record_by_key_table = read_tx.open_table(RECORDS_BY_KEY_TABLE)?;
+            assert_eq!(record_by_key_table.len()?, 0);
+        }
+
+        // TODO: write test checking that the indexing is done correctly
+
+        Ok(())
+    }
 }

--- a/iroh-sync/src/store/fs/migrations.rs
+++ b/iroh-sync/src/store/fs/migrations.rs
@@ -118,11 +118,11 @@ fn migration_003_namespaces_delete_v1(tx: &WriteTransaction) -> Result<MigrateOu
     Ok(MigrateOutcome::Execute(1))
 }
 
-/// migration 003: populate the by_key index table(which did not exist before)
+/// migration 004: populate the by_key index table(which did not exist before)
 fn migration_004_populate_by_key_index(tx: &WriteTransaction) -> Result<MigrateOutcome> {
     let mut by_key_table = tx.open_table(RECORDS_BY_KEY_TABLE)?;
     let records_table = tx.open_table(RECORDS_TABLE)?;
-    if !by_key_table.is_empty()? || records_table.is_empty()? {
+    if !by_key_table.is_empty()? {
         return Ok(MigrateOutcome::Skip);
     }
 


### PR DESCRIPTION
The new test fails without the fix. 

Closes #1850

