### PR TITLE
feat(bytes): switch to a single directory for the flat store

### DIFF
--- a/iroh/examples/rpc.rs
+++ b/iroh/examples/rpc.rs
@@ -92,7 +92,7 @@ async fn main() -> anyhow::Result<()> {
     match args.path {
         Some(path) => {
             tokio::fs::create_dir_all(&path).await?;
-            let db = iroh_bytes::store::flat::Store::load(&path, &path, &path).await?;
+            let db = iroh_bytes::store::flat::Store::load(&path).await?;
             run(db).await
         }
         None => {

--- a/iroh/src/commands/start.rs
+++ b/iroh/src/commands/start.rs
@@ -124,6 +124,49 @@ where
     Ok(())
 }
 
+/// Migrate the flat store from v0 to v1. This can not be done in the store itself, since the
+/// constructor of the store now only takes a single directory.
+fn migrate_flat_store_v0_v1() -> anyhow::Result<()> {
+    let iroh_data_root = iroh_data_root()?;
+    let complete_v0 = iroh_data_root.join("blobs.v0");
+    let partial_v0 = iroh_data_root.join("blobs-partial.v0");
+    let meta_v0 = iroh_data_root.join("blobs-meta.v0");
+    let complete_v1 = path_with_env(IrohPaths::BaoFlatStoreDir)
+        .unwrap()
+        .join("complete");
+    let partial_v1 = path_with_env(IrohPaths::BaoFlatStoreDir)
+        .unwrap()
+        .join("partial");
+    let meta_v1 = path_with_env(IrohPaths::BaoFlatStoreDir)
+        .unwrap()
+        .join("meta");
+    if complete_v0.exists() && !complete_v1.exists() {
+        tracing::info!(
+            "moving complete files from {} to {}",
+            complete_v0.display(),
+            complete_v1.display()
+        );
+        std::fs::rename(complete_v0, complete_v1).context("migrating complete store failed")?;
+    }
+    if partial_v0.exists() && !partial_v1.exists() {
+        tracing::info!(
+            "moving partial files from {} to {}",
+            partial_v0.display(),
+            partial_v1.display()
+        );
+        std::fs::rename(partial_v0, partial_v1).context("migrating partial store failed")?;
+    }
+    if meta_v0.exists() && !meta_v1.exists() {
+        tracing::info!(
+            "moving meta files from {} to {}",
+            meta_v0.display(),
+            meta_v1.display()
+        );
+        std::fs::rename(meta_v0, meta_v1).context("migrating meta store failed")?;
+    }
+    Ok(())
+}
+
 async fn start_node(
     rt: &LocalPoolHandle,
     derp_map: Option<DerpMap>,
@@ -141,6 +184,7 @@ async fn start_node(
     let blob_dir = path_with_env(IrohPaths::BaoFlatStoreDir)?;
     let peers_data_path = path_with_env(IrohPaths::PeerData)?;
     tokio::fs::create_dir_all(&blob_dir).await?;
+    tokio::task::spawn_blocking(migrate_flat_store_v0_v1).await??;
     let bao_store = iroh_bytes::store::flat::Store::load(&blob_dir)
         .await
         .with_context(|| format!("Failed to load iroh database from {}", blob_dir.display()))?;

--- a/iroh/src/commands/start.rs
+++ b/iroh/src/commands/start.rs
@@ -138,13 +138,10 @@ async fn start_node(
         }
     }
 
-    let blob_dir = path_with_env(IrohPaths::BaoFlatStoreComplete)?;
-    let partial_blob_dir = path_with_env(IrohPaths::BaoFlatStorePartial)?;
-    let meta_dir = path_with_env(IrohPaths::BaoFlatStoreMeta)?;
+    let blob_dir = path_with_env(IrohPaths::BaoFlatStoreDir)?;
     let peers_data_path = path_with_env(IrohPaths::PeerData)?;
     tokio::fs::create_dir_all(&blob_dir).await?;
-    tokio::fs::create_dir_all(&partial_blob_dir).await?;
-    let bao_store = iroh_bytes::store::flat::Store::load(&blob_dir, &partial_blob_dir, &meta_dir)
+    let bao_store = iroh_bytes::store::flat::Store::load(&blob_dir)
         .await
         .with_context(|| format!("Failed to load iroh database from {}", blob_dir.display()))?;
     let secret_key_path = Some(path_with_env(IrohPaths::SecretKey)?);

--- a/iroh/src/util/path.rs
+++ b/iroh/src/util/path.rs
@@ -3,21 +3,15 @@
 use std::path::{Path, PathBuf};
 
 /// Paths to files or directories used by Iroh.
-#[derive(Debug, Clone, Eq, PartialEq, strum::AsRefStr, strum::EnumString, strum::Display)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, strum::AsRefStr, strum::EnumString, strum::Display)]
 #[cfg_attr(test, derive(strum::EnumIter))]
 pub enum IrohPaths {
     /// Path to the node's secret key for the [`iroh_net::key::PublicKey`].
     #[strum(serialize = "keypair")]
     SecretKey,
-    /// Path to the node's [flat-file store](iroh_bytes::store::flat) for complete blobs.
-    #[strum(serialize = "blobs.v0")]
-    BaoFlatStoreComplete,
-    /// Path to the node's [flat-file store](iroh_bytes::store::flat) for partial blobs.
-    #[strum(serialize = "blobs-partial.v0")]
-    BaoFlatStorePartial,
-    /// Path to the node's [flat-file store](iroh_bytes::store::flat) for metadata such as the tags table.
-    #[strum(serialize = "blobs-meta.v0")]
-    BaoFlatStoreMeta,
+    /// Path to the node's [flat-file store](iroh_bytes::store::flat).
+    #[strum(serialize = "blobs.v1")]
+    BaoFlatStoreDir,
     /// Path to the [iroh-sync document database](iroh_sync::store::fs::Store)
     #[strum(serialize = "docs.redb")]
     DocsDatabase,
@@ -60,7 +54,7 @@ mod tests {
         for iroh_path in IrohPaths::iter() {
             println!("{iroh_path}");
             let root = PathBuf::from("/tmp");
-            let path = root.join(&iroh_path);
+            let path = root.join(iroh_path);
             let fname = path.file_name().unwrap().to_str().unwrap();
             let parsed = IrohPaths::from_str(fname).unwrap();
             assert_eq!(iroh_path, parsed);

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -2,6 +2,7 @@
 #![cfg(feature = "cli")]
 use std::collections::BTreeMap;
 use std::env;
+use std::ffi::OsString;
 use std::io::{BufRead, BufReader, Read};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -13,6 +14,7 @@ use duct::{cmd, ReaderHandle};
 use iroh::bytes::Hash;
 use iroh::ticket::blob::Ticket;
 use iroh::util::path::IrohPaths;
+use iroh_bytes::HashAndFormat;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::{Rng, SeedableRng};
 use regex::Regex;
@@ -340,6 +342,97 @@ fn cli_provide_from_stdin_to_stdout() -> Result<()> {
     make_rand_file(1000, &path)?;
     // provide a file, pipe content to the provider's stdin, pipe content to the getter's stdout
     test_provide_get_loop(Input::Stdin(path), Output::Stdout)
+}
+
+/// Creates a v0 flat store in the given directory.
+fn init_v0_blob_store(iroh_data_dir: &Path) -> anyhow::Result<()> {
+    let complete_v0 = iroh_data_dir.join("blobs.v0");
+    let partial_v0 = iroh_data_dir.join("blobs-partial.v0");
+    let meta_v0 = iroh_data_dir.join("blobs-meta.v0");
+    std::fs::create_dir_all(&complete_v0)?;
+    std::fs::create_dir_all(&partial_v0)?;
+    std::fs::create_dir_all(&meta_v0)?;
+    let complete = b"complete";
+    let partial = vec![0u8; 1024 * 17];
+    let complete_hash = blake3::hash(complete).into();
+    let partial_hash = blake3::hash(&partial).into();
+    let mut tags = BTreeMap::<String, HashAndFormat>::new();
+    tags.insert("complete".to_string(), HashAndFormat::raw(complete_hash));
+    tags.insert("partial".to_string(), HashAndFormat::raw(partial_hash));
+    let tags = postcard::to_stdvec(&tags)?;
+    let uuid = [0u8; 16];
+    std::fs::write(
+        complete_v0.join(format!("{}.data", complete_hash.to_hex())),
+        complete,
+    )?;
+    std::fs::write(
+        partial_v0.join(format!(
+            "{}-{}.data",
+            partial_hash.to_hex(),
+            hex::encode(uuid)
+        )),
+        partial,
+    )?;
+    std::fs::write(
+        partial_v0.join(format!(
+            "{}-{}.obao4",
+            partial_hash.to_hex(),
+            hex::encode(uuid)
+        )),
+        vec![],
+    )?;
+    std::fs::write(meta_v0.join("tags.meta"), tags)?;
+    Ok(())
+}
+
+fn run_cli(
+    iroh_data_dir: impl Into<OsString>,
+    args: impl IntoIterator<Item = impl Into<OsString>>,
+) -> anyhow::Result<String> {
+    let output = cmd(iroh_bin(), args)
+        .env_remove("RUST_LOG")
+        .env("IROH_DATA_DIR", iroh_data_dir)
+        // .stderr_file(std::io::stderr().as_raw_fd()) // for debug output
+        .stdout_capture()
+        .run()?;
+    let text = String::from_utf8(output.stdout)?;
+    Ok(text)
+}
+
+#[cfg(feature = "cli")]
+#[test]
+fn cli_bao_store_migration() -> anyhow::Result<()> {
+    let dir = testdir!();
+    let iroh_data_dir = dir.join("iroh_data_dir");
+    init_v0_blob_store(&iroh_data_dir)?;
+    let mut reader_handle = cmd(iroh_bin(), ["start"])
+        .env_remove("RUST_LOG")
+        .env("IROH_DATA_DIR", &iroh_data_dir)
+        .stderr_to_stdout()
+        .reader()?;
+
+    assert_matches_line(
+        BufReader::new(&mut reader_handle),
+        [(r"Iroh is running", 1), (r"Node ID: [_\w\d-]*", 1)],
+    );
+
+    println!("iroh started up.");
+    let tags_output = run_cli(&iroh_data_dir, ["tag", "list"])?;
+    let expected = r#""complete": 2vfkw5gcrtbybfsczoxq4mae47svtgcgsniwcvoz7xf36nz45yfa (Raw)
+"partial": 4yny3v7anmzzsajv2amm3nxpqd2owfw4dqnjwq6anv7nj2djmt2q (Raw)
+"#;
+    assert_eq!(tags_output, expected);
+
+    let blob_output = run_cli(&iroh_data_dir, ["blob", "list", "blobs"])?;
+    let expected = r#" 2vfkw5gcrtbybfsczoxq4mae47svtgcgsniwcvoz7xf36nz45yfa (8 B)
+"#;
+    assert_eq!(blob_output, expected);
+
+    let incomplete_blob_output = run_cli(iroh_data_dir, ["blob", "list", "incomplete-blobs"])?;
+    let expected = r#"4yny3v7anmzzsajv2amm3nxpqd2owfw4dqnjwq6anv7nj2djmt2q 0
+"#;
+    assert_eq!(incomplete_blob_output, expected);
+    Ok(())
 }
 
 #[cfg(all(unix, feature = "cli"))]

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -210,11 +210,13 @@ mod flat {
     }
 
     fn data_path(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> PathBuf {
-        path(root, "data")
+        // this assumes knowledge of the internal directory structure of the flat store
+        path(root.join("complete"), "data")
     }
 
     fn outboard_path(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> PathBuf {
-        path(root, "obao4")
+        // this assumes knowledge of the internal directory structure of the flat store
+        path(root.join("complete"), "obao4")
     }
 
     async fn sync_directory(dir: impl AsRef<Path>) -> io::Result<()> {
@@ -251,14 +253,14 @@ mod flat {
 
     /// count the number of partial data files for a hash
     fn count_partial_data(root: PathBuf) -> impl Fn(&iroh_bytes::Hash) -> std::io::Result<usize> {
-        count_partial(root, "data")
+        count_partial(root.join("partial"), "data")
     }
 
     /// count the number of partial outboard files for a hash
     fn count_partial_outboard(
         root: PathBuf,
     ) -> impl Fn(&iroh_bytes::Hash) -> std::io::Result<usize> {
-        count_partial(root, "obao4")
+        count_partial(root.join("partial"), "obao4")
     }
 
     /// Test gc for sequences of hashes that protect their children from deletion.
@@ -269,8 +271,7 @@ mod flat {
         let path = data_path(dir.clone());
         let outboard_path = outboard_path(dir.clone());
 
-        let bao_store =
-            iroh_bytes::store::flat::Store::load(dir.clone(), dir.clone(), dir.clone()).await?;
+        let bao_store = iroh_bytes::store::flat::Store::load(dir.clone()).await?;
         let node = wrap_in_node(bao_store.clone(), Duration::from_millis(0)).await;
         let evs = attach_db_events(&node).await;
         let data1 = create_test_data(123456);
@@ -425,8 +426,7 @@ mod flat {
         let count_partial_data = count_partial_data(dir.clone());
         let count_partial_outboard = count_partial_outboard(dir.clone());
 
-        let bao_store =
-            iroh_bytes::store::flat::Store::load(dir.clone(), dir.clone(), dir.clone()).await?;
+        let bao_store = iroh_bytes::store::flat::Store::load(dir.clone()).await?;
         let node = wrap_in_node(bao_store.clone(), Duration::from_millis(0)).await;
         let evs = attach_db_events(&node).await;
 
@@ -465,8 +465,7 @@ mod flat {
         let count_partial_data = count_partial_data(dir.clone());
         let count_partial_outboard = count_partial_outboard(dir.clone());
 
-        let bao_store =
-            iroh_bytes::store::flat::Store::load(dir.clone(), dir.clone(), dir.clone()).await?;
+        let bao_store = iroh_bytes::store::flat::Store::load(dir.clone()).await?;
         let node = wrap_in_node(bao_store.clone(), Duration::from_secs(1)).await;
         let evs = attach_db_events(&node).await;
 


### PR DESCRIPTION
## Description

Have the constructor for the bao db take a single directory. Internally it will still have 3 directories, although this is not strictly speaking necessary because the files can be distinguished by their extension.

Implements https://github.com/n0-computer/iroh/issues/1662

## Notes & open questions

~This does not yet include a migration. Do we need one, or do we declare that the number of changes is just too big for this release? It's not super hard to write, but we would then have to drag it around for a while.~

Added a migration

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
