### PR TITLE
Call wait_idle on close to give the graceful close msg some time...

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -553,6 +553,7 @@ impl MagicEndpoint {
     /// TODO: Document error cases.
     pub async fn close(&self, error_code: VarInt, reason: &[u8]) -> Result<()> {
         self.endpoint.close(error_code, reason);
+        self.endpoint.wait_idle().await;
         self.msock.close().await?;
         Ok(())
     }


### PR DESCRIPTION
## Description

From the quinn docs it seems that after calling close you should call wait_idle to give the endpoints some time to actually
send the close message.

See https://docs.rs/quinn/latest/quinn/struct.Endpoint.html#method.wait_idle

## Notes & open questions

Do we need a test for this?

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
