### PR TITLE
chore(ci): split jobs so they do not stomp over target directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ env:
   SCCACHE_CACHE_SIZE: "50G"
 
 jobs:
-  build_and_test_nix:
+  build_and_test_nix_all_features:
     timeout-minutes: 30
-    name: Build and test (Nix)
+    name: "Build and test (Nix) - all features + doctests"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -68,6 +68,54 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
+    - name: tests (all features)
+      run: cargo test --workspace --all-features --lib --bins --tests
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+
+    - name: doctests
+      run: cargo test --workspace --all-features --doc
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+
+  build_and_test_nix_no_features:
+    timeout-minutes: 30
+    name: "Build and test (Nix) - no default features"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [ubuntu-latest, macOS-arm-latest]
+        rust: [nightly, stable]
+        include:
+          - name: ubuntu-latest
+            os: ubuntu-latest
+            release-os: linux
+            release-arch: amd64
+            runner: [self-hosted, linux, X64]
+          - name: macOS-arm-latest
+            os: macOS-latest
+            release-os: darwin
+            release-arch: aarch64
+            runner: [self-hosted, macOS, ARM64]
+    env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+      with:
+        submodules: recursive
+
+    - name: Install ${{ matrix.rust }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+    
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
+
     - name: check no default features
       run: |
         for i in ${CRATES_LIST//,/ }
@@ -77,6 +125,49 @@ jobs:
         done
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+
+    - name: tests (no features)
+      run: cargo test --workspace --no-default-features --lib --bins --tests
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+
+  build_and_test_nix_default_features:
+    timeout-minutes: 30
+    name: "Build and test (Nix) - default features"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [ubuntu-latest, macOS-arm-latest]
+        rust: [nightly, stable]
+        include:
+          - name: ubuntu-latest
+            os: ubuntu-latest
+            release-os: linux
+            release-arch: amd64
+            runner: [self-hosted, linux, X64]
+          - name: macOS-arm-latest
+            os: macOS-latest
+            release-os: darwin
+            release-arch: aarch64
+            runner: [self-hosted, macOS, ARM64]
+    env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+      with:
+        submodules: recursive
+
+    - name: Install ${{ matrix.rust }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+    
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: check default features
       run: |
@@ -88,26 +179,11 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-    - name: tests (all features)
-      run: cargo test --workspace --all-features --lib --bins --tests
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-      
-    - name: tests (no features)
-      run: cargo test --workspace --no-default-features --lib --bins --tests
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
     - name: tests (default features)
       run: cargo test --workspace --lib --bins --tests
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-    - name: doctests
-      run: cargo test --workspace --all-features --doc
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-      
   build_and_test_windows:
     timeout-minutes: 30
     name: Build and test (Windows)
@@ -158,6 +234,141 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
       
+    - name: tests (default features)
+      run: cargo test --workspace --lib --bins --tests --target ${{ matrix.target }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+
+  build_and_test_windows_all_featres:
+    timeout-minutes: 30
+    name: "Build and test (Windows) - all features"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [windows-latest]
+        rust: [nightly, stable]
+        target:
+          - x86_64-pc-windows-msvc
+        include:
+          - name: windows-latest
+            os: windows
+            runner: [self-hosted, windows, x64]
+    # TODO: disabled, see below.
+    # env:
+    #   # Using self-hosted runners so use local cache for sccache and
+    #   # not SCCACHE_GHA_ENABLED.
+    #   RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+      with:
+        submodules: recursive
+
+    - name: Install ${{ matrix.rust }}
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup toolchain default ${{ matrix.rust }}
+        rustup target add ${{ matrix.target }}
+        rustup set default-host ${{ matrix.target }}
+
+    # TODO: disabled while we do not have Powershell 7+ on the runner
+    # as default shell. See https://github.com/actions/toolkit/issues/1179
+    # - name: Install sccache
+    #   uses: mozilla-actions/sccache-action@v0.0.3
+
+    - uses: msys2/setup-msys2@v2
+
+    - name: tests (all features)
+      run: cargo test --workspace --all-features --lib --bins --tests --target ${{ matrix.target }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+
+  build_and_test_windows_no_features:
+    timeout-minutes: 30
+    name: "Build and test (Windows) - no default features"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [windows-latest]
+        rust: [nightly, stable]
+        target:
+          - x86_64-pc-windows-msvc
+        include:
+          - name: windows-latest
+            os: windows
+            runner: [self-hosted, windows, x64]
+    # TODO: disabled, see below.
+    # env:
+    #   # Using self-hosted runners so use local cache for sccache and
+    #   # not SCCACHE_GHA_ENABLED.
+    #   RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+      with:
+        submodules: recursive
+
+    - name: Install ${{ matrix.rust }}
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup toolchain default ${{ matrix.rust }}
+        rustup target add ${{ matrix.target }}
+        rustup set default-host ${{ matrix.target }}
+
+    # TODO: disabled while we do not have Powershell 7+ on the runner
+    # as default shell. See https://github.com/actions/toolkit/issues/1179
+    # - name: Install sccache
+    #   uses: mozilla-actions/sccache-action@v0.0.3
+
+    - uses: msys2/setup-msys2@v2
+
+    - name: tests (no features)
+      run: cargo test --workspace --no-default-features --lib --bins --tests --target ${{ matrix.target }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+
+  build_and_test_windows_default_features:
+    timeout-minutes: 30
+    name: "Build and test (Windows) - default features"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [windows-latest]
+        rust: [nightly, stable]
+        target:
+          - x86_64-pc-windows-msvc
+        include:
+          - name: windows-latest
+            os: windows
+            runner: [self-hosted, windows, x64]
+    # TODO: disabled, see below.
+    # env:
+    #   # Using self-hosted runners so use local cache for sccache and
+    #   # not SCCACHE_GHA_ENABLED.
+    #   RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+      with:
+        submodules: recursive
+
+    - name: Install ${{ matrix.rust }}
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup toolchain default ${{ matrix.rust }}
+        rustup target add ${{ matrix.target }}
+        rustup set default-host ${{ matrix.target }}
+
+    # TODO: disabled while we do not have Powershell 7+ on the runner
+    # as default shell. See https://github.com/actions/toolkit/issues/1179
+    # - name: Install sccache
+    #   uses: mozilla-actions/sccache-action@v0.0.3
+
+    - uses: msys2/setup-msys2@v2
+
     - name: tests (default features)
       run: cargo test --workspace --lib --bins --tests --target ${{ matrix.target }}
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build_and_test_nix_all_features:
     timeout-minutes: 30
-    name: "Build and test (Nix) - all features + doctests"
+    name: "Tests all feats"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -80,7 +80,7 @@ jobs:
 
   build_and_test_nix_no_features:
     timeout-minutes: 30
-    name: "Build and test (Nix) - no default features"
+    name: "Tests no feats"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -133,7 +133,7 @@ jobs:
 
   build_and_test_nix_default_features:
     timeout-minutes: 30
-    name: "Build and test (Nix) - default features"
+    name: "Tests default feats"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -184,64 +184,9 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-  build_and_test_windows:
-    timeout-minutes: 30
-    name: Build and test (Windows)
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [windows-latest]
-        rust: [nightly, stable]
-        target:
-          - x86_64-pc-windows-msvc
-        include:
-          - name: windows-latest
-            os: windows
-            runner: [self-hosted, windows, x64]
-    # TODO: disabled, see below.
-    # env:
-    #   # Using self-hosted runners so use local cache for sccache and
-    #   # not SCCACHE_GHA_ENABLED.
-    #   RUSTC_WRAPPER: "sccache"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-      with:
-        submodules: recursive
-
-    - name: Install ${{ matrix.rust }}
-      run: |
-        rustup toolchain install ${{ matrix.rust }}
-        rustup toolchain default ${{ matrix.rust }}
-        rustup target add ${{ matrix.target }}
-        rustup set default-host ${{ matrix.target }}
-
-    # TODO: disabled while we do not have Powershell 7+ on the runner
-    # as default shell. See https://github.com/actions/toolkit/issues/1179
-    # - name: Install sccache
-    #   uses: mozilla-actions/sccache-action@v0.0.3
-
-    - uses: msys2/setup-msys2@v2
-
-    - name: tests (all features)
-      run: cargo test --workspace --all-features --lib --bins --tests --target ${{ matrix.target }}
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
-    - name: tests (no features)
-      run: cargo test --workspace --no-default-features --lib --bins --tests --target ${{ matrix.target }}
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-      
-    - name: tests (default features)
-      run: cargo test --workspace --lib --bins --tests --target ${{ matrix.target }}
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
   build_and_test_windows_all_featres:
     timeout-minutes: 30
-    name: "Build and test (Windows) - all features"
+    name: "Tests all feats"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -286,7 +231,7 @@ jobs:
 
   build_and_test_windows_no_features:
     timeout-minutes: 30
-    name: "Build and test (Windows) - no default features"
+    name: "Tests no feats"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -331,7 +276,7 @@ jobs:
 
   build_and_test_windows_default_features:
     timeout-minutes: 30
-    name: "Build and test (Windows) - default features"
+    name: "Tests default feats"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,8 @@ jobs:
 
     # TODO: disabled while we do not have Powershell 7+ on the runner.
     # See https://github.com/actions/toolkit/issues/1179
-    # - name: Install sccache
-    #   uses: mozilla-actions/sccache-action@v0.0.3
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
+      badbadbad:
       with:
         submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,6 @@ jobs:
     # TODO: disabled while we do not have Powershell 7+ on the runner.
     # See https://github.com/actions/toolkit/issues/1179
     - name: Install sccache
-      shell: powershell
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
 
     - name: Select features
       run: |
-        switch (${{ matrix.features }} {
+        switch (${{ matrix.features }}) {
             "all" {
                 echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,11 @@ jobs:
           - name: windows-latest
             os: windows
             runner: [self-hosted, windows, x64]
-    env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
-      # TODO: disabled, see below.
-      # RUSTC_WRAPPER: "sccache"
+    # TODO: disabled, see below.
+    # env:
+    #   # Using self-hosted runners so use local cache for sccache and
+    #   # not SCCACHE_GHA_ENABLED.
+    #   RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,10 @@ jobs:
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
 
-    # TODO: disabled while we do not have Powershell 7+ on the runner.
-    # See https://github.com/actions/toolkit/issues/1179
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+    # TODO: disabled while we do not have Powershell 7+ on the runner
+    # as default shell. See https://github.com/actions/toolkit/issues/1179
+    # - name: Install sccache
+    #   uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
     # TODO: disabled while we do not have Powershell 7+ on the runner.
     # See https://github.com/actions/toolkit/issues/1179
     - name: Install sccache
+      shell: powershell
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
     name: Build release binaries
     runs-on: ${{ matrix.runner }}
     continue-on-error: false
-    needs: build_and_test_nix
+    needs: build_and_test_nix_all_features
     if: ${{ always() && github.ref_name=='main' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
     name: Build release binaries
     runs-on: ${{ matrix.runner }}
     continue-on-error: false
-    needs: build_and_test_nix_all_features
+    needs: build_and_test_nix
     if: ${{ always() && github.ref_name=='main' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,68 +96,68 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-  build_and_test_windows:
-    timeout-minutes: 30
-    name: "Testsss"
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [windows-latest]
-        rust: [nightly, stable]
-        features: [all, none, default]
-        target:
-          - x86_64-pc-windows-msvc
-        include:
-          - name: windows-latest
-            os: windows
-            runner: [self-hosted, windows, x64]
-    # TODO: disabled, see below.
-    # env:
-    #   # Using self-hosted runners so use local cache for sccache and
-    #   # not SCCACHE_GHA_ENABLED.
-    #   RUSTC_WRAPPER: "sccache"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-      with:
-        submodules: recursive
+  # build_and_test_windows:
+  #   timeout-minutes: 30
+  #   name: "Tests"
+  #   runs-on: ${{ matrix.runner }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       name: [windows-latest]
+  #       rust: [nightly, stable]
+  #       features: [all, none, default]
+  #       target:
+  #         - x86_64-pc-windows-msvc
+  #       include:
+  #         - name: windows-latest
+  #           os: windows
+  #           runner: [self-hosted, windows, x64]
+  #   # TODO: disabled, see below.
+  #   # env:
+  #   #   # Using self-hosted runners so use local cache for sccache and
+  #   #   # not SCCACHE_GHA_ENABLED.
+  #   #   RUSTC_WRAPPER: "sccache"
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@master
+  #     with:
+  #       submodules: recursive
 
-    - name: Install ${{ matrix.rust }}
-      run: |
-        rustup toolchain install ${{ matrix.rust }}
-        rustup toolchain default ${{ matrix.rust }}
-        rustup target add ${{ matrix.target }}
-        rustup set default-host ${{ matrix.target }}
+  #   - name: Install ${{ matrix.rust }}
+  #     run: |
+  #       rustup toolchain install ${{ matrix.rust }}
+  #       rustup toolchain default ${{ matrix.rust }}
+  #       rustup target add ${{ matrix.target }}
+  #       rustup set default-host ${{ matrix.target }}
 
-    - name: Select features
-      run: |
-        switch (${{ matrix.features }} {
-            "all" {
-                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "none" {
-                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "default" {
-                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            default {
-                Exit 1
-            }
-        }
+  #   - name: Select features
+  #     run: |
+  #       switch (${{ matrix.features }} {
+  #           "all" {
+  #               echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           "none" {
+  #               echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           "default" {
+  #               echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           default {
+  #               Exit 1
+  #           }
+  #       }
 
-    # TODO: disabled while we do not have Powershell 7+ on the runner
-    # as default shell. See https://github.com/actions/toolkit/issues/1179
-    # - name: Install sccache
-    #   uses: mozilla-actions/sccache-action@v0.0.3
+  #   # TODO: disabled while we do not have Powershell 7+ on the runner
+  #   # as default shell. See https://github.com/actions/toolkit/issues/1179
+  #   # - name: Install sccache
+  #   #   uses: mozilla-actions/sccache-action@v0.0.3
 
-    - uses: msys2/setup-msys2@v2
+  #   - uses: msys2/setup-msys2@v2
 
-    - name: tests
-      run: cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }}
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+  #   - name: tests
+  #     run: cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }}
+  #     env:
+  #       RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
   build_release:
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,16 @@ jobs:
 
     - name: Select features
       run: |
-        case "${{ matrix.features }}"
+        case "${{ matrix.features }}" in
             all)
                 echo "FEATURES=--all-features" >> "$GITHUB_ENV"
+                ;;
             none)
                 echo "FEATURES=--no-default-features" >> "$GITHUB_ENV"
+                ;;
             default)
                 echo "FEATURES=''" >> "$GITHUB_ENV"
+                ;;
             *)
                 exit 1
         esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
 
   build_and_test_windows:
     timeout-minutes: 30
-    name: "Tests"
+    name: "Testsss"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -120,7 +120,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-      badbadbad:
       with:
         submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.72"
   CRATES_LIST: "iroh,iroh-bytes,iroh-gossip,iroh-metrics,iroh-net,iroh-sync,iroh-test"
+  SCCACHE_CACHE_SIZE: "100G"
 
 jobs:
   build_and_test_nix:
@@ -40,7 +41,8 @@ jobs:
             release-arch: aarch64
             runner: [self-hosted, macOS, ARM64]
     env:
-      SCCACHE_GHA_ENABLED: "true"
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
@@ -53,7 +55,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     
-    - name: Run sccache-cache
+    - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: check all features
@@ -121,6 +123,10 @@ jobs:
           - name: windows-latest
             os: windows
             runner: [self-hosted, windows, x64]
+    env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -133,7 +139,10 @@ jobs:
         rustup toolchain default ${{ matrix.rust }}
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
-    
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
+
     - uses: msys2/setup-msys2@v2
 
     - name: tests (all features)
@@ -190,9 +199,11 @@ jobs:
           #   release-arch: amd64
           #   runner: [windows-latest]
     env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: "sccache"
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
-      SCCACHE_GHA_ENABLED: "true"
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -207,6 +218,9 @@ jobs:
     - name: Install ${{ matrix.rust }}
       run: |
         rustup toolchain install ${{ matrix.rust }}
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: build release
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
                 echo "FEATURES=--no-default-features" >> "$GITHUB_ENV"
                 ;;
             default)
-                echo "FEATURES=''" >> "$GITHUB_ENV"
+                echo "FEATURES=\"\"" >> "$GITHUB_ENV"
                 ;;
             *)
                 exit 1
@@ -79,14 +79,14 @@ jobs:
       run: |
         for i in ${CRATES_LIST//,/ }
         do
-          echo "Checking $i"
+          echo "Checking $i $FEATURES"
           cargo check -p $i $FEATURES --lib --bins
         done
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests (all features)
-      run: cargo test --workspace $FEATURES --lib --bins --tests
+      run: cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
                 echo "FEATURES=--no-default-features" >> "$GITHUB_ENV"
                 ;;
             default)
-                echo "FEATURES=\"\"" >> "$GITHUB_ENV"
+                echo "FEATURES=" >> "$GITHUB_ENV"
                 ;;
             *)
                 exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,68 +96,68 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-  # build_and_test_windows:
-  #   timeout-minutes: 30
-  #   name: "Tests"
-  #   runs-on: ${{ matrix.runner }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       name: [windows-latest]
-  #       rust: [nightly, stable]
-  #       features: [all, none, default]
-  #       target:
-  #         - x86_64-pc-windows-msvc
-  #       include:
-  #         - name: windows-latest
-  #           os: windows
-  #           runner: [self-hosted, windows, x64]
-  #   # TODO: disabled, see below.
-  #   # env:
-  #   #   # Using self-hosted runners so use local cache for sccache and
-  #   #   # not SCCACHE_GHA_ENABLED.
-  #   #   RUSTC_WRAPPER: "sccache"
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@master
-  #     with:
-  #       submodules: recursive
+  build_and_test_windows:
+    timeout-minutes: 30
+    name: "Tests"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [windows-latest]
+        rust: [nightly, stable]
+        features: [all, none, default]
+        target:
+          - x86_64-pc-windows-msvc
+        include:
+          - name: windows-latest
+            os: windows
+            runner: [self-hosted, windows, x64]
+    # TODO: disabled, see below.
+    # env:
+    #   # Using self-hosted runners so use local cache for sccache and
+    #   # not SCCACHE_GHA_ENABLED.
+    #   RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+      with:
+        submodules: recursive
 
-  #   - name: Install ${{ matrix.rust }}
-  #     run: |
-  #       rustup toolchain install ${{ matrix.rust }}
-  #       rustup toolchain default ${{ matrix.rust }}
-  #       rustup target add ${{ matrix.target }}
-  #       rustup set default-host ${{ matrix.target }}
+    - name: Install ${{ matrix.rust }}
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup toolchain default ${{ matrix.rust }}
+        rustup target add ${{ matrix.target }}
+        rustup set default-host ${{ matrix.target }}
 
-  #   - name: Select features
-  #     run: |
-  #       switch (${{ matrix.features }} {
-  #           "all" {
-  #               echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           "none" {
-  #               echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           "default" {
-  #               echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           default {
-  #               Exit 1
-  #           }
-  #       }
+    - name: Select features
+      run: |
+        switch (${{ matrix.features }} {
+            "all" {
+                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "none" {
+                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "default" {
+                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            default {
+                Exit 1
+            }
+        }
 
-  #   # TODO: disabled while we do not have Powershell 7+ on the runner
-  #   # as default shell. See https://github.com/actions/toolkit/issues/1179
-  #   # - name: Install sccache
-  #   #   uses: mozilla-actions/sccache-action@v0.0.3
+    # TODO: disabled while we do not have Powershell 7+ on the runner
+    # as default shell. See https://github.com/actions/toolkit/issues/1179
+    # - name: Install sccache
+    #   uses: mozilla-actions/sccache-action@v0.0.3
 
-  #   - uses: msys2/setup-msys2@v2
+    - uses: msys2/setup-msys2@v2
 
-  #   - name: tests
-  #     run: cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }}
-  #     env:
-  #       RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+    - name: tests
+      run: cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
   build_release:
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,8 @@ jobs:
     env:
       # Using self-hosted runners so use local cache for sccache and
       # not SCCACHE_GHA_ENABLED.
-      RUSTC_WRAPPER: "sccache"
+      # TODO: disabled, see below.
+      # RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,12 +317,18 @@ jobs:
     timeout-minutes: 30
     name: Checking fmt and docs
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@master
 
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: fmt
       run: cargo fmt --all -- --check
@@ -333,6 +339,9 @@ jobs:
   clippy_check:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@master
     # Can be switched back once 1.75 lands
@@ -340,6 +349,8 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
           components: clippy
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     # TODO: We have a bunch of platform-dependent code so should
     #    probably run this job on the full platofrm matrix
@@ -356,11 +367,16 @@ jobs:
     timeout-minutes: 30
     name: Minimal Supported Rust Version
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@master
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.MSRV }}
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Check MSRV all features
       run: |
@@ -383,7 +399,8 @@ jobs:
     name: Run network simulations/benchmarks
     runs-on: [self-hosted, linux, X64]
     env:
-      SCCACHE_GHA_ENABLED: "true"
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
@@ -394,7 +411,7 @@ jobs:
     - name: Install rust stable
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Run sccache-cache
+    - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Build iroh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,16 @@ env:
   SCCACHE_CACHE_SIZE: "50G"
 
 jobs:
-  build_and_test_nix_all_features:
+  build_and_test_nix:
     timeout-minutes: 30
-    name: "Tests all feats"
+    name: "Tests"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         name: [ubuntu-latest, macOS-arm-latest]
         rust: [nightly, stable]
+        features: [all, none, default]
         include:
           - name: ubuntu-latest
             os: ubuntu-latest
@@ -58,129 +59,37 @@ jobs:
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.3
 
-    - name: check all features
+    - name: Select features
+      run: |
+        case "${{ matrix.features }}"
+            all)
+                echo "FEATURES=--all-features" >> "$GITHUB_ENV"
+            none)
+                echo "FEATURES=--no-default-features" >> "$GITHUB_ENV"
+            default)
+                echo "FEATURES=''" >> "$GITHUB_ENV"
+            *)
+                exit 1
+        esac
+
+    - name: check features
       run: |
         for i in ${CRATES_LIST//,/ }
         do
           echo "Checking $i"
-          cargo check -p $i --all-features --lib --bins
+          cargo check -p $i $FEATURES --lib --bins
         done
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests (all features)
-      run: cargo test --workspace --all-features --lib --bins --tests
+      run: cargo test --workspace $FEATURES --lib --bins --tests
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: doctests
+      if: ${{ matrix.features == 'all' }}
       run: cargo test --workspace --all-features --doc
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
-  build_and_test_nix_no_features:
-    timeout-minutes: 30
-    name: "Tests no feats"
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [ubuntu-latest, macOS-arm-latest]
-        rust: [nightly, stable]
-        include:
-          - name: ubuntu-latest
-            os: ubuntu-latest
-            release-os: linux
-            release-arch: amd64
-            runner: [self-hosted, linux, X64]
-          - name: macOS-arm-latest
-            os: macOS-latest
-            release-os: darwin
-            release-arch: aarch64
-            runner: [self-hosted, macOS, ARM64]
-    env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
-      RUSTC_WRAPPER: "sccache"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-      with:
-        submodules: recursive
-
-    - name: Install ${{ matrix.rust }}
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.rust }}
-    
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
-
-    - name: check no default features
-      run: |
-        for i in ${CRATES_LIST//,/ }
-        do
-          echo "Checking $i"
-          cargo check -p $i --no-default-features --lib --bins
-        done
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
-    - name: tests (no features)
-      run: cargo test --workspace --no-default-features --lib --bins --tests
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
-  build_and_test_nix_default_features:
-    timeout-minutes: 30
-    name: "Tests default feats"
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [ubuntu-latest, macOS-arm-latest]
-        rust: [nightly, stable]
-        include:
-          - name: ubuntu-latest
-            os: ubuntu-latest
-            release-os: linux
-            release-arch: amd64
-            runner: [self-hosted, linux, X64]
-          - name: macOS-arm-latest
-            os: macOS-latest
-            release-os: darwin
-            release-arch: aarch64
-            runner: [self-hosted, macOS, ARM64]
-    env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
-      RUSTC_WRAPPER: "sccache"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-      with:
-        submodules: recursive
-
-    - name: Install ${{ matrix.rust }}
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.rust }}
-    
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
-
-    - name: check default features
-      run: |
-        for i in ${CRATES_LIST//,/ }
-        do
-          echo "Checking $i"
-          cargo check -p $i --lib --bins
-        done
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
-    - name: tests (default features)
-      run: cargo test --workspace --lib --bins --tests
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.72"
   CRATES_LIST: "iroh,iroh-bytes,iroh-gossip,iroh-metrics,iroh-net,iroh-sync,iroh-test"
-  SCCACHE_CACHE_SIZE: "100G"
+  SCCACHE_CACHE_SIZE: "50G"
 
 jobs:
   build_and_test_nix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-    - name: tests (all features)
+    - name: tests
       run: cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
@@ -96,15 +96,16 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-  build_and_test_windows_all_featres:
+  build_and_test_windows:
     timeout-minutes: 30
-    name: "Tests all feats"
+    name: "Tests"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         name: [windows-latest]
         rust: [nightly, stable]
+        features: [all, none, default]
         target:
           - x86_64-pc-windows-msvc
         include:
@@ -129,50 +130,22 @@ jobs:
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
 
-    # TODO: disabled while we do not have Powershell 7+ on the runner
-    # as default shell. See https://github.com/actions/toolkit/issues/1179
-    # - name: Install sccache
-    #   uses: mozilla-actions/sccache-action@v0.0.3
-
-    - uses: msys2/setup-msys2@v2
-
-    - name: tests (all features)
-      run: cargo test --workspace --all-features --lib --bins --tests --target ${{ matrix.target }}
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
-  build_and_test_windows_no_features:
-    timeout-minutes: 30
-    name: "Tests no feats"
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [windows-latest]
-        rust: [nightly, stable]
-        target:
-          - x86_64-pc-windows-msvc
-        include:
-          - name: windows-latest
-            os: windows
-            runner: [self-hosted, windows, x64]
-    # TODO: disabled, see below.
-    # env:
-    #   # Using self-hosted runners so use local cache for sccache and
-    #   # not SCCACHE_GHA_ENABLED.
-    #   RUSTC_WRAPPER: "sccache"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-      with:
-        submodules: recursive
-
-    - name: Install ${{ matrix.rust }}
+    - name: Select features
       run: |
-        rustup toolchain install ${{ matrix.rust }}
-        rustup toolchain default ${{ matrix.rust }}
-        rustup target add ${{ matrix.target }}
-        rustup set default-host ${{ matrix.target }}
+        switch (${{ matrix.features }} {
+            "all" {
+                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "none" {
+                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "default" {
+                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            default {
+                Exit 1
+            }
+        }
 
     # TODO: disabled while we do not have Powershell 7+ on the runner
     # as default shell. See https://github.com/actions/toolkit/issues/1179
@@ -181,53 +154,8 @@ jobs:
 
     - uses: msys2/setup-msys2@v2
 
-    - name: tests (no features)
-      run: cargo test --workspace --no-default-features --lib --bins --tests --target ${{ matrix.target }}
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
-  build_and_test_windows_default_features:
-    timeout-minutes: 30
-    name: "Tests default feats"
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [windows-latest]
-        rust: [nightly, stable]
-        target:
-          - x86_64-pc-windows-msvc
-        include:
-          - name: windows-latest
-            os: windows
-            runner: [self-hosted, windows, x64]
-    # TODO: disabled, see below.
-    # env:
-    #   # Using self-hosted runners so use local cache for sccache and
-    #   # not SCCACHE_GHA_ENABLED.
-    #   RUSTC_WRAPPER: "sccache"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-      with:
-        submodules: recursive
-
-    - name: Install ${{ matrix.rust }}
-      run: |
-        rustup toolchain install ${{ matrix.rust }}
-        rustup toolchain default ${{ matrix.rust }}
-        rustup target add ${{ matrix.target }}
-        rustup set default-host ${{ matrix.target }}
-
-    # TODO: disabled while we do not have Powershell 7+ on the runner
-    # as default shell. See https://github.com/actions/toolkit/issues/1179
-    # - name: Install sccache
-    #   uses: mozilla-actions/sccache-action@v0.0.3
-
-    - uses: msys2/setup-msys2@v2
-
-    - name: tests (default features)
-      run: cargo test --workspace --lib --bins --tests --target ${{ matrix.target }}
+    - name: tests
+      run: cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }}
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
 
     - name: Select features
       run: |
-        switch (${{ matrix.features }}) {
+        switch ("${{ matrix.features }}") {
             "all" {
                 echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,10 @@ jobs:
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
 
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+    # TODO: disabled while we do not have Powershell 7+ on the runner.
+    # See https://github.com/actions/toolkit/issues/1179
+    # - name: Install sccache
+    #   uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2
 


### PR DESCRIPTION
## Description

Building multiple combinations of features in the same jobs means they will stomp over the target directory.  This is an approach at avoiding this.

Furthermore by splitting this up into more jobs we can get more parallelism
by adding more workers.  However even without this we already get some
improvements due to no longer stomping over the target directory and thanks
to sccache helping the various runs.

## Notes & open questions

There's an alternative version of this where we change the sequence but don't increase
the runners.

Without sccache working this would be a step backwards, you can observe this
with windows currently.

See https://github.com/n0-computer/iroh/issues/1864 for bigger picture.

## Change checklist

- [x] Self-review.
- ~~Documentation updates if relevant.~~
- ~~Tests if relevant.~~
