### PR TITLE
chore(ci): Minimise stomping over build artefacts in target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,8 @@ jobs:
 
     # TODO: disabled while we do not have Powershell 7+ on the runner.
     # See https://github.com/actions/toolkit/issues/1179
-    # - name: Install sccache
-    #   uses: mozilla-actions/sccache-action@v0.0.3
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,6 @@ jobs:
     # TODO: disabled while we do not have Powershell 7+ on the runner.
     # See https://github.com/actions/toolkit/issues/1179
     - name: Install sccache
-      shell: powershell
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,11 @@ jobs:
           - name: windows-latest
             os: windows
             runner: [self-hosted, windows, x64]
-    env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
-      # TODO: disabled, see below.
-      # RUSTC_WRAPPER: "sccache"
+    # TODO: disabled, see below.
+    # env:
+    #   # Using self-hosted runners so use local cache for sccache and
+    #   # not SCCACHE_GHA_ENABLED.
+    #   RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,10 @@ jobs:
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
 
-    # TODO: disabled while we do not have Powershell 7+ on the runner.
-    # See https://github.com/actions/toolkit/issues/1179
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+    # TODO: disabled while we do not have Powershell 7+ on the runner
+    # as default shell. See https://github.com/actions/toolkit/issues/1179
+    # - name: Install sccache
+    #   uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
     # TODO: disabled while we do not have Powershell 7+ on the runner.
     # See https://github.com/actions/toolkit/issues/1179
     - name: Install sccache
+      shell: powershell
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
+    - name: tests (all features)
+      run: cargo test --workspace --all-features --lib --bins --tests
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+
     - name: check no default features
       run: |
         for i in ${CRATES_LIST//,/ }
@@ -75,6 +80,11 @@ jobs:
           echo "Checking $i"
           cargo check -p $i --no-default-features --lib --bins
         done
+      env:
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+      
+    - name: tests (no features)
+      run: cargo test --workspace --no-default-features --lib --bins --tests
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
@@ -88,16 +98,6 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-    - name: tests (all features)
-      run: cargo test --workspace --all-features --lib --bins --tests
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-      
-    - name: tests (no features)
-      run: cargo test --workspace --no-default-features --lib --bins --tests
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-
     - name: tests (default features)
       run: cargo test --workspace --lib --bins --tests
       env:
@@ -107,7 +107,7 @@ jobs:
       run: cargo test --workspace --all-features --doc
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
-      
+
   build_and_test_windows:
     timeout-minutes: 30
     name: Build and test (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.72"
   CRATES_LIST: "iroh,iroh-bytes,iroh-gossip,iroh-metrics,iroh-net,iroh-sync,iroh-test"
+  SCCACHE_CACHE_SIZE: "100G"
 
 jobs:
   build_and_test_nix:
@@ -40,7 +41,8 @@ jobs:
             release-arch: aarch64
             runner: [self-hosted, macOS, ARM64]
     env:
-      SCCACHE_GHA_ENABLED: "true"
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
@@ -53,7 +55,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     
-    - name: Run sccache-cache
+    - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: check all features
@@ -121,6 +123,10 @@ jobs:
           - name: windows-latest
             os: windows
             runner: [self-hosted, windows, x64]
+    env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -133,7 +139,10 @@ jobs:
         rustup toolchain default ${{ matrix.rust }}
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
-    
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
+
     - uses: msys2/setup-msys2@v2
 
     - name: tests (all features)
@@ -190,9 +199,11 @@ jobs:
           #   release-arch: amd64
           #   runner: [windows-latest]
     env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: "sccache"
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
-      SCCACHE_GHA_ENABLED: "true"
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -207,6 +218,9 @@ jobs:
     - name: Install ${{ matrix.rust }}
       run: |
         rustup toolchain install ${{ matrix.rust }}
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: build release
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,8 @@ jobs:
     env:
       # Using self-hosted runners so use local cache for sccache and
       # not SCCACHE_GHA_ENABLED.
-      RUSTC_WRAPPER: "sccache"
+      # TODO: disabled, see below.
+      # RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
       uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,12 +317,18 @@ jobs:
     timeout-minutes: 30
     name: Checking fmt and docs
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@master
 
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: fmt
       run: cargo fmt --all -- --check
@@ -333,6 +339,9 @@ jobs:
   clippy_check:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@master
     # Can be switched back once 1.75 lands
@@ -340,6 +349,8 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
           components: clippy
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     # TODO: We have a bunch of platform-dependent code so should
     #    probably run this job on the full platofrm matrix
@@ -356,11 +367,16 @@ jobs:
     timeout-minutes: 30
     name: Minimal Supported Rust Version
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@master
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.MSRV }}
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Check MSRV all features
       run: |
@@ -383,7 +399,8 @@ jobs:
     name: Run network simulations/benchmarks
     runs-on: [self-hosted, linux, X64]
     env:
-      SCCACHE_GHA_ENABLED: "true"
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
@@ -394,7 +411,7 @@ jobs:
     - name: Install rust stable
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Run sccache-cache
+    - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Build iroh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.72"
   CRATES_LIST: "iroh,iroh-bytes,iroh-gossip,iroh-metrics,iroh-net,iroh-sync,iroh-test"
-  SCCACHE_CACHE_SIZE: "100G"
+  SCCACHE_CACHE_SIZE: "50G"
 
 jobs:
   build_and_test_nix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,10 @@ jobs:
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
 
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+    # TODO: disabled while we do not have Powershell 7+ on the runner.
+    # See https://github.com/actions/toolkit/issues/1179
+    # - name: Install sccache
+    #   uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: msys2/setup-msys2@v2
 


### PR DESCRIPTION
## Description

This changes the sequence in the test step to minimise re-compiling crates because of different feature sets.

## Notes & open questions

An alternative to https://github.com/n0-computer/iroh/pull/1871

The downside of this approach is that adding more runners will not help
further speedup.

The upside is that as we currently don't have more runners we don't lose
in wall-clock time.  Plus the yaml is less complex due to less duplication.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
