### PR TITLE
chore(docs): update derp IP for EU region

### DIFF
--- a/iroh-net/docs/derp_regions.md
+++ b/iroh-net/docs/derp_regions.md
@@ -22,12 +22,12 @@ Region ID `65535` is reserved for testing and experiments.
                 DerpNode {
                     name: "default-1".into(),
                     region_id: 1,
-                    url: format!("https://derp.iroh.network")
+                    url: format!("https://use1-1.derp.iroh.network")
                         .parse()
                         .unwrap(),
                     stun_only: false,
                     stun_port: 3478,
-                    ipv4: UseIpv4::Some(std::net::Ipv4Addr::new(35, 175, 99, 113)),
+                    ipv4: UseIpv4::Some(std::net::Ipv4Addr::new(34, 207, 161, 128)),
                     ipv6: UseIpv6::TryDns,
                     stun_test_ip: None,
                 }
@@ -47,7 +47,7 @@ Region ID `65535` is reserved for testing and experiments.
                 DerpNode {
                     name: "default-1".into(),
                     region_id: 2,
-                    url: format!("https://eu1.derp.iroh.network")
+                    url: format!("https://euw1-1.derp.iroh.network.")
                         .parse()
                         .unwrap(),
                     stun_only: false,

--- a/iroh-net/docs/derp_regions.md
+++ b/iroh-net/docs/derp_regions.md
@@ -52,7 +52,7 @@ Region ID `65535` is reserved for testing and experiments.
                         .unwrap(),
                     stun_only: false,
                     stun_port: 3478,
-                    ipv4: UseIpv4::Some(std::net::Ipv4Addr::new(52, 30, 229, 248)),
+                    ipv4: UseIpv4::Some(std::net::Ipv4Addr::new(35, 253, 75, 5)),
                     ipv6: UseIpv6::TryDns,
                     stun_test_ip: None,
                 }


### PR DESCRIPTION
## Description

Probably due to mismanagement of nodes, but actually really unclear how, we had a derper with the wrong IP address for the eu node.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
