### PR TITLE
fix: do not block on network change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,9 @@ jobs:
         RUST_LOG: 'TRACE' #${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests
-      run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests
+      run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests -- --nocapture --test-threads=1
       env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+        RUST_LOG: 'TRACE' #${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: doctests
       if: ${{ matrix.features == 'all' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests_hangs
-      run: cargo test --workspace ${{ env.FEATURES }} test_two_devices_roundtrip_quinn_magic
+      run: cargo test --workspace ${{ env.FEATURES }} test_two_devices_roundtrip_quinn_magic -- --nocapture
       env:
         RUST_LOG: 'TRACE' #${{ runner.debug && 'DEBUG' || 'INFO'}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         RUST_LOG: 'TRACE' #${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests
-      run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests -- --nocapture --test-threads=1
+      run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests -- --nocapture
       env:
         RUST_LOG: 'TRACE' #${{ runner.debug && 'DEBUG' || 'INFO'}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests
-      run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests -- --nocapture
+      run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,15 +90,10 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-    - name: tests_hangs
-      run: cargo test --workspace ${{ env.FEATURES }} test_two_devices_roundtrip_quinn_magic -- --nocapture
-      env:
-        RUST_LOG: 'TRACE' #${{ runner.debug && 'DEBUG' || 'INFO'}}
-
     - name: tests
       run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests -- --nocapture
       env:
-        RUST_LOG: 'TRACE' #${{ runner.debug && 'DEBUG' || 'INFO'}}
+        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: doctests
       if: ${{ matrix.features == 'all' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,11 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
+    - name: tests_hangs
+      run: cargo test --workspace ${{ env.FEATURES }} test_two_devices_roundtrip_quinn_magic
+      env:
+        RUST_LOG: 'TRACE' #${{ runner.debug && 'DEBUG' || 'INFO'}}
+
     - name: tests
       run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests
       env:

--- a/iroh-net/src/derp/client_conn.rs
+++ b/iroh-net/src/derp/client_conn.rs
@@ -294,14 +294,14 @@ where
                 _ = done.cancelled() => {
                     trace!("cancelled");
                     // final flush
-                    self.io.flush().await?;
+                    self.io.flush().await.context("flush")?;
                     return Ok(());
                 }
                 read_res = self.io.next() => {
                     trace!("handle read");
                     match read_res {
                         Some(Ok(frame)) => {
-                            self.handle_read(frame).await?;
+                            self.handle_read(frame).await.context("handle_read")?;
                         }
                         Some(Err(err)) => {
                             return Err(err);
@@ -325,26 +325,26 @@ where
                 packet = self.send_queue.recv() => {
                     let packet = packet.context("Server.send_queue dropped")?;
                     trace!("send packet");
-                    self.send_packet(packet).await?;
+                    self.send_packet(packet).await.context("send packet")?;
                     // TODO: stats
                     // record `packet.enqueuedAt`
                 }
                 packet = self.disco_send_queue.recv() => {
                     let packet = packet.context("Server.disco_send_queue dropped")?;
                     trace!("send disco packet");
-                    self.send_packet(packet).await?;
+                    self.send_packet(packet).await.context("send packet")?;
                     // TODO: stats
                     // record `packet.enqueuedAt`
                 }
                 _ = keep_alive.tick() => {
                     trace!("keep alive");
-                    self.send_keep_alive().await?;
+                    self.send_keep_alive().await.context("send keep alive")?;
                 }
             }
             // TODO: golang batches as many writes as are in all the channels
             // & then flushes when there is no more work to be done at the moment.
             // refactor to get something similar
-            self.io.flush().await?;
+            self.io.flush().await.context("final flush")?;
         }
     }
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1664,7 +1664,7 @@ impl Actor {
     }
 
     async fn handle_network_change(&mut self, is_major: bool) {
-        warn!("link change detected: major? {}", is_major);
+        debug!("link change detected: major? {}", is_major);
 
         if is_major {
             // Clear DNS cache
@@ -3117,7 +3117,7 @@ pub(crate) mod tests {
             let delay = rand::thread_rng().gen_range(10..=500);
             Duration::from_millis(delay)
         };
-        let rounds = 20;
+        let rounds = 10;
 
         let m1_t = m1.clone();
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2945,7 +2945,7 @@ pub(crate) mod tests {
             };
         }
 
-        for i in 0..1000 {
+        for i in 0..20 {
             println!("-- round {}", i + 1);
             roundtrip!(m1, m2, b"hello m1");
             roundtrip!(m2, m1, b"hello m2");

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1143,7 +1143,7 @@ impl MagicSock {
 
         let net_checker = netcheck::Client::new(Some(port_mapper.clone()))?;
 
-        let (actor_sender, actor_receiver) = mpsc::channel(128);
+        let (actor_sender, actor_receiver) = mpsc::channel(256);
         let (derp_actor_sender, derp_actor_receiver) = mpsc::channel(256);
         let (udp_disco_sender, mut udp_disco_receiver) = mpsc::channel(256);
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2930,7 +2930,7 @@ pub(crate) mod tests {
             };
         }
 
-        for i in 0..100 {
+        for i in 0..10 {
             println!("-- round {}", i + 1);
             roundtrip!(m1, m2, b"hello m1");
             roundtrip!(m2, m1, b"hello m2");

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2934,7 +2934,7 @@ pub(crate) mod tests {
             };
         }
 
-        for i in 0..10 {
+        for i in 0..1000 {
             println!("-- round {}", i + 1);
             roundtrip!(m1, m2, b"hello m1");
             roundtrip!(m2, m1, b"hello m2");

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2945,7 +2945,7 @@ pub(crate) mod tests {
             };
         }
 
-        for i in 0..20 {
+        for i in 0..5 {
             println!("-- round {}", i + 1);
             roundtrip!(m1, m2, b"hello m1");
             roundtrip!(m2, m1, b"hello m2");
@@ -3117,7 +3117,7 @@ pub(crate) mod tests {
             let delay = rand::thread_rng().gen_range(10..=500);
             Duration::from_millis(delay)
         };
-        let rounds = 10;
+        let rounds = 5;
 
         let m1_t = m1.clone();
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2351,7 +2351,7 @@ fn new_re_stun_timer(initial_delay: bool) -> time::Interval {
 fn bind(port: u16) -> Result<(RebindingUdpConn, Option<RebindingUdpConn>)> {
     let pconn4 = RebindingUdpConn::bind(port, IpFamily::V4).context("bind IPv4 failed")?;
     let ip4_port = pconn4.local_addr()?.port();
-    let ip6_port = ip4_port.checked_add(1).unwrap_or_else(|| ip4_port - 1);
+    let ip6_port = ip4_port.checked_add(1).unwrap_or(ip4_port - 1);
 
     let pconn6 = match RebindingUdpConn::bind(ip6_port, IpFamily::V6) {
         Ok(conn) => Some(conn),

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2351,7 +2351,7 @@ fn new_re_stun_timer(initial_delay: bool) -> time::Interval {
 fn bind(port: u16) -> Result<(RebindingUdpConn, Option<RebindingUdpConn>)> {
     let pconn4 = RebindingUdpConn::bind(port, IpFamily::V4).context("bind IPv4 failed")?;
     let ip4_port = pconn4.local_addr()?.port();
-    let ip6_port = ip4_port + 1;
+    let ip6_port = ip4_port.checked_add(1).unwrap_or_else(|| ip4_port - 1);
 
     let pconn6 = match RebindingUdpConn::bind(ip6_port, IpFamily::V6) {
         Ok(conn) => Some(conn),

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2930,7 +2930,7 @@ pub(crate) mod tests {
             };
         }
 
-        for i in 0..1000 {
+        for i in 0..100 {
             println!("-- round {}", i + 1);
             roundtrip!(m1, m2, b"hello m1");
             roundtrip!(m2, m1, b"hello m2");

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -868,7 +868,8 @@ impl Endpoint {
         let mut msgs = Vec::new();
 
         // Trigger a round of pings if we haven't had any full pings yet.
-        if should_ping && self.want_full_ping(&now) {
+        if should_ping {
+            // && self.want_full_ping(&now) {
             msgs = self.send_pings(now, true);
         }
 

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -610,6 +610,9 @@ impl Endpoint {
     pub(super) fn note_connectivity_change(&mut self) {
         trace!("connectivity changed");
         self.best_addr.clear_trust();
+        for es in self.direct_addr_state.values_mut() {
+            es.clear();
+        }
     }
 
     /// Handles a Pong message (a reply to an earlier ping).
@@ -868,8 +871,7 @@ impl Endpoint {
         let mut msgs = Vec::new();
 
         // Trigger a round of pings if we haven't had any full pings yet.
-        if should_ping {
-            // && self.want_full_ping(&now) {
+        if should_ping && self.want_full_ping(&now) {
             msgs = self.send_pings(now, true);
         }
 
@@ -1064,6 +1066,14 @@ impl EndpointState {
                 }
             }
         }
+    }
+
+    fn clear(&mut self) {
+        self.last_ping = None;
+        self.last_got_ping = None;
+        self.last_got_ping_tx_id = None;
+        self.call_me_maybe_time = None;
+        self.recent_pong = None;
     }
 }
 


### PR DESCRIPTION
There was a deadlock due to the usage of the inner actor message loop in handling network changes, which would trigger a deadlock. 

Additionally the following two fixes are included
- clearing endpoint state when connectivity is changed
- drop incoming messages when the magicsock is overloaded

