### PR TITLE
refactor(iroh-net): make `ControlMsg` public

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -76,7 +76,7 @@ mod timer;
 pub use crate::net::UdpSocket;
 
 pub use self::metrics::Metrics;
-pub use self::peer_map::{ConnectionType, DirectAddrInfo, EndpointInfo};
+pub use self::peer_map::{ConnectionType, ControlMsg, DirectAddrInfo, EndpointInfo};
 pub use self::timer::Timer;
 
 /// How long we consider a STUN-derived endpoint valid for. UDP NAT mappings typically

--- a/iroh-net/src/magicsock/peer_map.rs
+++ b/iroh-net/src/magicsock/peer_map.rs
@@ -27,7 +27,7 @@ use crate::{
 mod best_addr;
 mod endpoint;
 
-pub use endpoint::{ConnectionType, DirectAddrInfo, EndpointInfo};
+pub use endpoint::{ConnectionType, ControlMsg, DirectAddrInfo, EndpointInfo};
 pub(super) use endpoint::{DiscoPingPurpose, PingAction, PingRole, SendPing};
 
 /// Number of nodes that are inactive for which we keep info about. This limit is enforced

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -1106,6 +1106,7 @@ pub enum DiscoPingPurpose {
     StayinAlive,
 }
 
+/// The type of control message we have received.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, derive_more::Display)]
 pub enum ControlMsg {
     /// We received a Ping from the node.


### PR DESCRIPTION
## Description

`ControlMsg` is used in a field of the public struct `DirectAddrInfo`, but was previously a private struct.

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.

