### PR TITLE
chore(ci): Use TRACE logging for tests run by nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,15 +91,18 @@ jobs:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
     - name: tests
-      run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests
       env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+        RUST_LOG: "TRACE"
 
     - name: doctests
       if: ${{ matrix.features == 'all' }}
-      run: cargo test --workspace --all-features --doc
-      env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+      run: |
+        if [ -n "${{ runner.debug }}" ];
+            export RUST_LOG=DEBUG
+        fi
+        cargo test --workspace --all-features --doc
 
   build_and_test_windows:
     timeout-minutes: 30
@@ -168,9 +171,10 @@ jobs:
     - uses: msys2/setup-msys2@v2
 
     - name: tests
-      run: cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }}
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }}
       env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+        RUST_LOG: "TRACE"
 
   cross:
     timeout-minutes: 30


### PR DESCRIPTION
## Description

The default log-level being set to INFO makes it really difficult
to debug flaky tests on CI.  This is a regression from earlier where
we had TRACE-level logging for tests using
iroh_test::logging::setup(), which was only possible for
single-threaded executor tests.

Now that we are running with cargo-nextest per-test output capturing
also works seamlessly for multi-threaded runners because of the
cargo-nextest execution model.  This means we can set a detailed log
level again by default, thus giving us detailed logs on any failure
without having to reproduce it.

## Notes & open questions

As can be seen in the doctests changes, where we can not use nextest,
we could also do this in some other ways.  Given we now depend on
cargo-nextest I guess we can as well go for always setting TRACE level
as the CI configuration stays much simpler.

## Change checklist

- [x] Self-review.
- ~~Documentation updates if relevant.~~
- ~~Tests if relevant.~~