### PR TITLE
Key hex parse

### DIFF
--- a/iroh-net/src/key.rs
+++ b/iroh-net/src/key.rs
@@ -106,7 +106,7 @@ impl Serialize for PublicKey {
         if serializer.is_human_readable() {
             serializer.serialize_str(&self.to_string())
         } else {
-            serializer.serialize_bytes(&self.0)
+            self.0.serialize(serializer)
         }
     }
 }
@@ -120,8 +120,8 @@ impl<'de> Deserialize<'de> for PublicKey {
             let s = String::deserialize(deserializer)?;
             Self::from_str(&s).map_err(serde::de::Error::custom)
         } else {
-            let bytes: &serde_bytes::Bytes = serde::Deserialize::deserialize(deserializer)?;
-            Self::try_from(bytes.as_ref()).map_err(serde::de::Error::custom)
+            let data: [u8; 32] = serde::Deserialize::deserialize(deserializer)?;
+            Self::try_from(data.as_ref()).map_err(serde::de::Error::custom)
         }
     }
 }
@@ -396,7 +396,24 @@ impl TryFrom<&[u8]> for SecretKey {
 
 #[cfg(test)]
 mod tests {
+    use iroh_test::{assert_eq_hex, hexdump::parse_hexdump};
+
     use super::*;
+
+    #[test]
+    fn test_public_key_postcard() {
+        let public_key = PublicKey::try_from(
+            hex::decode("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        let bytes = postcard::to_stdvec(&public_key).unwrap();
+        let expected =
+            parse_hexdump("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
+                .unwrap();
+        assert_eq_hex!(bytes, expected);
+    }
 
     #[test]
     fn test_secret_key_openssh_roundtrip() {
@@ -463,7 +480,8 @@ mod tests {
 
         let k5 = random_verifying_key();
         let bytes = postcard::to_stdvec(&k5).unwrap();
-        let _key: PublicKey = postcard::from_bytes(&bytes).unwrap();
+        // VerifyingKey serialises with a length prefix, PublicKey does not.
+        let _key: PublicKey = postcard::from_bytes(&bytes[1..]).unwrap();
         assert!(lock_key_cache().contains_key(k5.as_bytes()));
     }
 }


### PR DESCRIPTION
## Description

Especially for tests I find hex keys nicer. So this does to PublicKey and PrivateKey what we are already doing with Hash: allow parsing as either base32 or hex. There is no potential for mixing these up, since the length will be different except for the case of 1 or 2 bytes, and we got 32 bytes here.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
