### PR TITLE
Small fixes

### DIFF
--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -351,7 +351,7 @@ use crate::Hash;
 pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 100;
 
 /// The ALPN used with quic for the iroh bytes protocol.
-pub const ALPN: [u8; 13] = *b"/iroh-bytes/3";
+pub const ALPN: &[u8] = b"/iroh-bytes/3";
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, From)]
 /// A request to the provider

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2621,7 +2621,7 @@ pub(crate) mod tests {
         endpoint: MagicEndpoint,
     }
 
-    const ALPN: [u8; 9] = *b"n0/test/1";
+    const ALPN: &[u8] = b"n0/test/1";
 
     impl MagicStack {
         async fn new(derp_map: DerpMap) -> Result<Self> {

--- a/iroh-net/src/magicsock/rebinding_conn.rs
+++ b/iroh-net/src/magicsock/rebinding_conn.rs
@@ -195,7 +195,7 @@ mod tests {
     use super::*;
     use anyhow::Result;
 
-    const ALPN: [u8; 9] = *b"n0/test/1";
+    const ALPN: &[u8] = b"n0/test/1";
 
     fn wrap_socket(conn: impl AsyncUdpSocket) -> Result<(quinn::Endpoint, key::SecretKey)> {
         let key = key::SecretKey::generate();

--- a/iroh-net/src/ticket/blob.rs
+++ b/iroh-net/src/ticket/blob.rs
@@ -160,14 +160,9 @@ mod tests {
         let hash =
             Hash::from_str("0b84d358e4c8be6c38626b2182ff575818ba6bd3f4b90464994be14cb354a072")
                 .unwrap();
-        let node_id = PublicKey::from_bytes(
-            &<[u8; 32]>::try_from(
-                hex::decode("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
-                    .unwrap(),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        let node_id =
+            PublicKey::from_str("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
+                .unwrap();
 
         let ticket = BlobTicket {
             node: NodeAddr::from_parts(node_id, None, vec![]),

--- a/iroh-net/src/ticket/node.rs
+++ b/iroh-net/src/ticket/node.rs
@@ -122,14 +122,9 @@ mod tests {
 
     #[test]
     fn test_ticket_base32() {
-        let node_id = PublicKey::from_bytes(
-            &<[u8; 32]>::try_from(
-                hex::decode("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
-                    .unwrap(),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        let node_id =
+            PublicKey::from_str("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
+                .unwrap();
 
         let ticket = NodeTicket {
             node: NodeAddr::from_parts(

--- a/iroh/src/dial.rs
+++ b/iroh/src/dial.rs
@@ -34,7 +34,7 @@ pub async fn dial(opts: Options) -> anyhow::Result<quinn::Connection> {
     let endpoint = endpoint.derp_mode(derp_mode);
     let endpoint = endpoint.bind(0).await?;
     endpoint
-        .connect(opts.peer, &iroh_bytes::protocol::ALPN)
+        .connect(opts.peer, iroh_bytes::protocol::ALPN)
         .await
         .context("failed to connect to provider")
 }

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -1177,7 +1177,7 @@ impl Dialer for iroh_gossip::net::util::Dialer {
     type Connection = quinn::Connection;
 
     fn queue_dial(&mut self, node_id: NodeId) {
-        self.queue_dial(node_id, &iroh_bytes::protocol::ALPN)
+        self.queue_dial(node_id, iroh_bytes::protocol::ALPN)
     }
 
     fn pending_count(&self) -> usize {

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1119,7 +1119,7 @@ impl<D: BaoStore> RpcHandler<D> {
         let conn = self
             .inner
             .endpoint
-            .connect(msg.peer, &iroh_bytes::protocol::ALPN)
+            .connect(msg.peer, iroh_bytes::protocol::ALPN)
             .await?;
         progress.send(DownloadProgress::Connected).await?;
         let progress2 = progress.clone();

--- a/iroh/src/ticket/doc.rs
+++ b/iroh/src/ticket/doc.rs
@@ -62,6 +62,8 @@ impl std::str::FromStr for DocTicket {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use iroh_base::base32;
     use iroh_net::key::PublicKey;
@@ -70,14 +72,9 @@ mod tests {
 
     #[test]
     fn test_ticket_base32() {
-        let node_id = PublicKey::from_bytes(
-            &<[u8; 32]>::try_from(
-                hex::decode("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
-                    .unwrap(),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        let node_id =
+            PublicKey::from_str("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
+                .unwrap();
         let namespace_id = NamespaceId::from(
             &<[u8; 32]>::try_from(
                 hex::decode("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")


### PR DESCRIPTION
## Description

- use a &'static str instead of a sized array for the iroh-bytes ALPN
- make use of the new PublicKey::from_str to make tests a bit nicer

Extracted from https://github.com/n0-computer/iroh/pull/1894 since these two should be uncontroversial.