### PR TITLE
fix: fix abort on ctrl-c in console

### DIFF
--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -88,7 +88,7 @@ impl Cli {
                     start::run_with_command(
                         &rt,
                         &config,
-                        RunType::SingleCommand,
+                        RunType::SingleCommandNoAbort,
                         |iroh| async move { console::run(&iroh, &env).await },
                     )
                     .await
@@ -104,7 +104,7 @@ impl Cli {
                     start::run_with_command(
                         &rt,
                         &config,
-                        RunType::SingleCommand,
+                        RunType::SingleCommandAbortable,
                         |iroh| async move { command.run(&iroh, &env).await },
                     )
                     .await


### PR DESCRIPTION
## Description

This should fix `Ctrl-C` behavior in the console, especially for long running commands like `doc watch` or `blob import`.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
