### PR TITLE
Add an additional event FoundLocal.

### DIFF
--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -155,6 +155,17 @@ pub enum AddProgress {
 /// Progress updates for the get operation.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum DownloadProgress {
+    /// Data was found locally.
+    FoundLocal {
+        /// child offset
+        child: u64,
+        /// The hash of the entry.
+        hash: Hash,
+        /// The size of the entry in bytes.
+        size: u64,
+        /// The ranges that are available locally.
+        valid_ranges: RangeSpec,
+    },
     /// A new connection was established.
     Connected,
     /// An item was found with hash `hash`, from now on referred to via `id`.
@@ -163,7 +174,7 @@ pub enum DownloadProgress {
         id: u64,
         /// child offset
         child: u64,
-        /// The name of the entry.
+        /// The hash of the entry.
         hash: Hash,
         /// The size of the entry in bytes.
         size: u64,

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -1,6 +1,8 @@
 //! Utility functions and types.
+use bao_tree::ChunkRanges;
 use bytes::Bytes;
 use derive_more::{Debug, Display, From, Into};
+use range_collections::range_set::RangeSetRange;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Borrow, fmt, sync::Arc, time::SystemTime};
 
@@ -151,6 +153,25 @@ impl Drop for TempTag {
             liveness.on_drop(&self.inner);
         }
     }
+}
+
+/// Get the number of bytes given a set of chunk ranges and the total size.
+///
+/// If some ranges are out of bounds, they will be clamped to the size.
+pub fn total_bytes(ranges: ChunkRanges, size: u64) -> u64 {
+    ranges
+        .iter()
+        .map(|range| {
+            let (start, end) = match range {
+                RangeSetRange::Range(r) => {
+                    (r.start.to_bytes().0.min(size), r.end.to_bytes().0.min(size))
+                }
+                RangeSetRange::RangeFrom(range) => (range.start.to_bytes().0.min(size), size),
+            };
+            end.saturating_sub(start)
+        })
+        .reduce(u64::saturating_add)
+        .unwrap_or_default()
 }
 
 /// A non-sendable marker type

--- a/iroh/src/downloader/get.rs
+++ b/iroh/src/downloader/get.rs
@@ -19,7 +19,7 @@ use iroh_bytes::{
 use iroh_metrics::{inc, inc_by};
 use tracing::trace;
 
-use crate::get::{get_missing_ranges_blob, get_missing_ranges_hash_seq, BlobInfo};
+use crate::get::{get_missing_ranges_hash_seq, get_valid_ranges, BlobInfo};
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
 use crate::util::progress::ProgressSliceWriter2;
@@ -243,10 +243,11 @@ pub async fn get_blob<D: Store>(
         PossiblyPartialEntry::Partial(entry) => {
             trace!("got partial data for {}", hash,);
 
-            let required_ranges = get_missing_ranges_blob::<D>(&entry)
+            let valid_ranges = get_valid_ranges::<D>(&entry)
                 .await
                 .ok()
                 .unwrap_or_else(ChunkRanges::all);
+            let required_ranges: ChunkRanges = ChunkRanges::all().difference(&valid_ranges);
             let request = GetRequest::new(*hash, RangeSpecSeq::from_ranges([required_ranges]));
             // full request
             let request = get::fsm::start(conn, request);
@@ -386,138 +387,142 @@ pub async fn get_hash_seq<D: Store>(
     root_hash: &Hash,
 ) -> Result<Stats, FailureAction> {
     use tracing::info as log;
-    let finishing = if let Some(entry) = db.get(root_hash) {
-        log!("already got collection - doing partial download");
-        // got the collection
-        let reader = entry.data_reader().await?;
-        let (mut collection, _) = parse_hash_seq(reader).await.map_err(|e| {
-            FailureAction::DropPeer(anyhow::anyhow!(
-                "peer sent data that can't be parsed as collection : {e}"
-            ))
-        })?;
-        let mut children: Vec<Hash> = vec![];
-        while let Some(hash) = collection.next().await.map_err(|e| {
-            FailureAction::DropPeer(anyhow::anyhow!(
-                "received collection data can't be iterated: {e}"
-            ))
-        })? {
-            children.push(hash);
-        }
-        let missing_info = get_missing_ranges_hash_seq(db, &children).await?;
-        if missing_info.iter().all(|x| matches!(x, BlobInfo::Complete)) {
-            log!("nothing to do");
-            return Ok(Stats::default());
-        }
-        let missing_iter = std::iter::once(ChunkRanges::empty())
-            .chain(missing_info.iter().map(|x| x.missing_chunks()))
-            .collect::<Vec<_>>();
-        log!("requesting chunks {:?}", missing_iter);
-        let request = GetRequest::new(*root_hash, RangeSpecSeq::from_ranges(missing_iter));
-        let request = get::fsm::start(conn, request);
-        // create a new bidi stream
-        let connected = request.next().await?;
-        log!("connected");
-        // we have not requested the root, so this must be StartChild
-        let ConnectedNext::StartChild(start) = connected.next().await? else {
-            return Err(FailureAction::DropPeer(anyhow::anyhow!(
-                "peer sent data that does not match requested info"
-            )));
-        };
-        let mut next = EndBlobNext::MoreChildren(start);
-        // read all the children
-        loop {
-            let start = match next {
-                EndBlobNext::MoreChildren(start) => start,
-                EndBlobNext::Closing(finish) => break finish,
+    let finishing =
+        if let PossiblyPartialEntry::Complete(entry) = db.get_possibly_partial(root_hash) {
+            log!("already got collection - doing partial download");
+            // got the collection
+            let reader = entry.data_reader().await?;
+            let (mut collection, _) = parse_hash_seq(reader).await.map_err(|e| {
+                FailureAction::DropPeer(anyhow::anyhow!(
+                    "peer sent data that can't be parsed as collection : {e}"
+                ))
+            })?;
+            let mut children: Vec<Hash> = vec![];
+            while let Some(hash) = collection.next().await.map_err(|e| {
+                FailureAction::DropPeer(anyhow::anyhow!(
+                    "received collection data can't be iterated: {e}"
+                ))
+            })? {
+                children.push(hash);
+            }
+            let missing_info = get_missing_ranges_hash_seq(db, &children).await?;
+            if missing_info
+                .iter()
+                .all(|x| matches!(x, BlobInfo::Complete { .. }))
+            {
+                log!("nothing to do");
+                return Ok(Stats::default());
+            }
+            let missing_iter = std::iter::once(ChunkRanges::empty())
+                .chain(missing_info.iter().map(|x| x.missing_ranges()))
+                .collect::<Vec<_>>();
+            log!("requesting chunks {:?}", missing_iter);
+            let request = GetRequest::new(*root_hash, RangeSpecSeq::from_ranges(missing_iter));
+            let request = get::fsm::start(conn, request);
+            // create a new bidi stream
+            let connected = request.next().await?;
+            log!("connected");
+            // we have not requested the root, so this must be StartChild
+            let ConnectedNext::StartChild(start) = connected.next().await? else {
+                return Err(FailureAction::DropPeer(anyhow::anyhow!(
+                    "peer sent data that does not match requested info"
+                )));
             };
-            let child_offset = usize::try_from(start.child_offset())
-                .context("child offset too large")
-                .map_err(|_| {
-                    FailureAction::AbortRequest(anyhow::anyhow!(
-                        "requested offsets surpasses platform's usize"
-                    ))
-                })?;
-            let (child_hash, info) =
-                match (children.get(child_offset), missing_info.get(child_offset)) {
-                    (Some(blob), Some(info)) => (*blob, info),
-                    _ => break start.finish(),
+            let mut next = EndBlobNext::MoreChildren(start);
+            // read all the children
+            loop {
+                let start = match next {
+                    EndBlobNext::MoreChildren(start) => start,
+                    EndBlobNext::Closing(finish) => break finish,
                 };
-            tracing::info!(
-                "requesting child {} {:?}",
-                child_hash,
-                info.missing_chunks()
-            );
-            let header = start.next(child_hash);
-            let end_blob = match info {
-                BlobInfo::Missing => get_blob_inner(db, header).await?,
-                BlobInfo::Partial { entry, .. } => {
-                    get_blob_inner_partial(db, header, entry.clone()).await?
-                }
-                BlobInfo::Complete => {
-                    return Err(FailureAction::DropPeer(anyhow::anyhow!(
-                        "peer sent data we did't request"
-                    )))
-                }
+                let child_offset = usize::try_from(start.child_offset())
+                    .context("child offset too large")
+                    .map_err(|_| {
+                        FailureAction::AbortRequest(anyhow::anyhow!(
+                            "requested offsets surpasses platform's usize"
+                        ))
+                    })?;
+                let (child_hash, info) =
+                    match (children.get(child_offset), missing_info.get(child_offset)) {
+                        (Some(blob), Some(info)) => (*blob, info),
+                        _ => break start.finish(),
+                    };
+                tracing::info!(
+                    "requesting child {} {:?}",
+                    child_hash,
+                    info.missing_ranges()
+                );
+                let header = start.next(child_hash);
+                let end_blob = match info {
+                    BlobInfo::Missing => get_blob_inner(db, header).await?,
+                    BlobInfo::Partial { entry, .. } => {
+                        get_blob_inner_partial(db, header, entry.clone()).await?
+                    }
+                    BlobInfo::Complete { .. } => {
+                        return Err(FailureAction::DropPeer(anyhow::anyhow!(
+                            "peer sent data we did't request"
+                        )))
+                    }
+                };
+                next = end_blob.next();
+            }
+        } else {
+            tracing::info!("don't have collection - doing full download");
+            // don't have the collection, so probably got nothing
+            let request = get::fsm::start(conn, GetRequest::all(*root_hash));
+            // create a new bidi stream
+            let connected = request.next().await?;
+            // next step. we have requested a single hash, so this must be StartRoot
+            let ConnectedNext::StartRoot(start) = connected.next().await? else {
+                return Err(FailureAction::DropPeer(anyhow::anyhow!(
+                    "expected StartRoot"
+                )));
             };
-            next = end_blob.next();
-        }
-    } else {
-        tracing::info!("don't have collection - doing full download");
-        // don't have the collection, so probably got nothing
-        let request = get::fsm::start(conn, GetRequest::all(*root_hash));
-        // create a new bidi stream
-        let connected = request.next().await?;
-        // next step. we have requested a single hash, so this must be StartRoot
-        let ConnectedNext::StartRoot(start) = connected.next().await? else {
-            return Err(FailureAction::DropPeer(anyhow::anyhow!(
-                "expected StartRoot"
-            )));
+            // move to the header
+            let header = start.next();
+            // read the blob and add it to the database
+            let end_root = get_blob_inner(db, header).await?;
+            // read the collection fully for now
+            let entry = db.get(root_hash).context("just downloaded").map_err(|_| {
+                FailureAction::RetryLater(anyhow::anyhow!("data just downloaded was not found"))
+            })?;
+            let reader = entry.data_reader().await?;
+            let (mut collection, _) = parse_hash_seq(reader).await.map_err(|_| {
+                FailureAction::DropPeer(anyhow::anyhow!(
+                    "peer sent data that can't be parsed as collection"
+                ))
+            })?;
+            let mut children = vec![];
+            while let Some(hash) = collection.next().await.map_err(|e| {
+                FailureAction::DropPeer(anyhow::anyhow!(
+                    "received collection data can't be iterated: {e}"
+                ))
+            })? {
+                children.push(hash);
+            }
+            let mut next = end_root.next();
+            // read all the children
+            loop {
+                let start = match next {
+                    EndBlobNext::MoreChildren(start) => start,
+                    EndBlobNext::Closing(finish) => break finish,
+                };
+                let child_offset = usize::try_from(start.child_offset())
+                    .context("child offset too large")
+                    .map_err(|_| {
+                        FailureAction::AbortRequest(anyhow::anyhow!(
+                            "requested offsets surpasses platform's usize"
+                        ))
+                    })?;
+                let child_hash = match children.get(child_offset) {
+                    Some(blob) => *blob,
+                    None => break start.finish(),
+                };
+                let header = start.next(child_hash);
+                let end_blob = get_blob_inner(db, header).await?;
+                next = end_blob.next();
+            }
         };
-        // move to the header
-        let header = start.next();
-        // read the blob and add it to the database
-        let end_root = get_blob_inner(db, header).await?;
-        // read the collection fully for now
-        let entry = db.get(root_hash).context("just downloaded").map_err(|_| {
-            FailureAction::RetryLater(anyhow::anyhow!("data just downloaded was not found"))
-        })?;
-        let reader = entry.data_reader().await?;
-        let (mut collection, _) = parse_hash_seq(reader).await.map_err(|_| {
-            FailureAction::DropPeer(anyhow::anyhow!(
-                "peer sent data that can't be parsed as collection"
-            ))
-        })?;
-        let mut children = vec![];
-        while let Some(hash) = collection.next().await.map_err(|e| {
-            FailureAction::DropPeer(anyhow::anyhow!(
-                "received collection data can't be iterated: {e}"
-            ))
-        })? {
-            children.push(hash);
-        }
-        let mut next = end_root.next();
-        // read all the children
-        loop {
-            let start = match next {
-                EndBlobNext::MoreChildren(start) => start,
-                EndBlobNext::Closing(finish) => break finish,
-            };
-            let child_offset = usize::try_from(start.child_offset())
-                .context("child offset too large")
-                .map_err(|_| {
-                    FailureAction::AbortRequest(anyhow::anyhow!(
-                        "requested offsets surpasses platform's usize"
-                    ))
-                })?;
-            let child_hash = match children.get(child_offset) {
-                Some(blob) => *blob,
-                None => break start.finish(),
-            };
-            let header = start.next(child_hash);
-            let end_blob = get_blob_inner(db, header).await?;
-            next = end_blob.next();
-        }
-    };
     // this closes the bidi stream. Do something with the stats?
     let stats = finishing.next().await?;
     Ok(stats)

--- a/iroh/src/get.rs
+++ b/iroh/src/get.rs
@@ -43,7 +43,7 @@ pub async fn get<D: BaoStore>(
 ///
 /// We need to create our own files and handle the case where an outboard
 /// is not needed.
-pub async fn get_blob<D: BaoStore>(
+async fn get_blob<D: BaoStore>(
     db: &D,
     conn: quinn::Connection,
     hash: &Hash,
@@ -299,7 +299,7 @@ pub(crate) async fn get_missing_ranges_hash_seq<D: BaoStore>(
 }
 
 /// Get a sequence of hashes
-pub async fn get_hash_seq<D: BaoStore>(
+async fn get_hash_seq<D: BaoStore>(
     db: &D,
     conn: quinn::Connection,
     root_hash: &Hash,


### PR DESCRIPTION
## Description

This event needs to be considered when computing how much data needs to be downloaded in case of resume.

Also change hashseq download to assume that at least the hashseq itself is complete. We currently do not support resume if the download of the hashseq itself was interrupted.

## Notes & open questions

1. I think this provides the required info to get good progress bars even in case of resume. But I don't know for sure until I have hacked it into sendme.
2. Sendme does 2 roundtrips and has accurate progress bars. Iroh does 1 request and has a 2 level progress bar because the total size is not known in advance. Should we change iroh to do what sendme does?

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
