### PR TITLE
feat: basic MDNS discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "config"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,6 +2054,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "igd"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2397,7 @@ dependencies = [
  "iroh-metrics",
  "iroh-test",
  "libc",
+ "mdns-sd",
  "netlink-packet-core",
  "netlink-packet-route",
  "netlink-sys",
@@ -2659,6 +2679,19 @@ name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "mdns-sd"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a2299267f664ed19a64614562def624c91dfed4d682c1512645db2b050f12d"
+dependencies = [
+ "flume 0.11.0",
+ "if-addrs",
+ "log",
+ "polling",
+ "socket2 0.4.10",
+]
 
 [[package]]
 name = "memalloc"
@@ -3369,6 +3402,22 @@ dependencies = [
  "pnet_base",
  "pnet_macros",
  "pnet_macros_support",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -133,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
         println!("> trying to connect to {} peers...", peers.len());
         // add the peer addrs from the ticket to our endpoint's addressbook so that they can be dialed
         for peer in peers.into_iter() {
-            endpoint.add_node_addr(peer)?;
+            endpoint.add_node_addr(peer).await?;
         }
     };
     gossip.join(topic, peer_ids).await?.await?;

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -555,7 +555,7 @@ impl Actor {
                     Ok(info) => {
                         debug!(peer = ?node_id, "add known addrs: {info:?}");
                         let node_addr = NodeAddr { node_id, info };
-                        if let Err(err) = self.endpoint.add_node_addr(node_addr) {
+                        if let Err(err) = self.endpoint.add_node_addr(node_addr).await {
                             debug!(peer = ?node_id, "add known failed: {err:?}");
                         }
                     }
@@ -732,8 +732,8 @@ mod test {
         let topic: TopicId = blake3::hash(b"foobar").into();
         // share info that pi1 is on the same derp_node
         let addr1 = NodeAddr::new(pi1).with_derp_url(derp_url);
-        ep2.add_node_addr(addr1.clone()).unwrap();
-        ep3.add_node_addr(addr1).unwrap();
+        ep2.add_node_addr(addr1.clone()).await.unwrap();
+        ep3.add_node_addr(addr1).await.unwrap();
 
         debug!("----- joining  ----- ");
         // join the topics and wait for the connection to succeed

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -39,6 +39,7 @@ hyper-util = "0.1.1"
 igd = { version = "0.12.1", features = ["aio"] }
 iroh-base = { version = "0.12.0", path = "../iroh-base" }
 libc = "0.2.139"
+mdns-sd = "0.10.1"
 num_enum = "0.7"
 once_cell = "1.18.0"
 parking_lot = "0.12.1"

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -584,7 +584,9 @@ impl MagicEndpoint {
     ///
     /// If no UDP addresses and no DERP Url is provided, it will error.
     pub async fn connect(&self, node_addr: NodeAddr, alpn: &[u8]) -> Result<quinn::Connection> {
-        self.add_node_addr(node_addr.clone())?;
+        if !node_addr.info.direct_addresses.is_empty() || node_addr.info.derp_url.is_some() {
+            self.add_node_addr(node_addr.clone())?;
+        }
         let NodeAddr { node_id, info } = node_addr;
         let addr = self.msock.get_mapping_addr(&node_id).await;
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -351,7 +351,8 @@ impl MagicEndpoint {
                 &my_addrs[..],
                 port,
                 &properties[..],
-            )?;
+            )?
+            .enable_addr_auto(); // detect IP addr changes
 
             let service_fullname = service_info.get_fullname().to_string();
             debug!("mdns: registering {}", service_fullname);

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -506,7 +506,7 @@ impl MagicEndpoint {
                     trace!("mdns: service resolved: {:?}", info);
                     let fullname = info.get_fullname();
                     trace!("mdns: checking {} against {}", fullname, service_id);
-                    if &fullname[..64] == &service_id {
+                    if &fullname[..52] == &service_id {
                         // found the right service
                         let addrs = info.get_addresses();
                         let ipv4_port = info.get_port();

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -507,7 +507,7 @@ impl MagicEndpoint {
                         trace!("mdns: service resolved: {:?}", info);
                         let fullname = info.get_fullname();
                         trace!("mdns: checking {} against {}", fullname, service_id);
-                        if &fullname[..52] == &service_id {
+                        if fullname[..52] == service_id {
                             // found the right service
                             let addrs = info.get_addresses();
                             let ipv4_port = info.get_port();
@@ -515,18 +515,14 @@ impl MagicEndpoint {
                                 .get_property_val_str("ipv6_port")
                                 .and_then(|p| p.parse().ok());
                             let direct_addresses = addrs
-                                .into_iter()
+                                .iter()
                                 .filter_map(|ip| match ip {
                                     IpAddr::V4(ip) => {
                                         Some(SocketAddr::V4(SocketAddrV4::new(*ip, ipv4_port)))
                                     }
-                                    IpAddr::V6(ip) => {
-                                        if let Some(port) = ipv6_port {
-                                            Some(SocketAddr::V6(SocketAddrV6::new(*ip, port, 0, 0)))
-                                        } else {
-                                            None
-                                        }
-                                    }
+                                    IpAddr::V6(ip) => ipv6_port.map(|port| {
+                                        SocketAddr::V6(SocketAddrV6::new(*ip, port, 0, 0))
+                                    }),
                                 })
                                 .collect();
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -144,7 +144,7 @@ impl Default for MagicEndpointBuilder {
             keylog: Default::default(),
             discovery: Default::default(),
             peers_path: None,
-            use_mdns: true,
+            use_mdns: false,
         }
     }
 }
@@ -227,7 +227,7 @@ impl MagicEndpointBuilder {
     }
 
     /// Enable or disable discovery via MDNS.
-    pub fn mdns(mut self, use_mdns: bool) -> Self {
+    pub fn use_mdns(mut self, use_mdns: bool) -> Self {
         self.use_mdns = use_mdns;
         self
     }

--- a/iroh/src/commands/blob.rs
+++ b/iroh/src/commands/blob.rs
@@ -201,11 +201,6 @@ impl BlobCommands {
                     return Err(anyhow::anyhow!("The input arguments refer to a collection of blobs and output is set to STDOUT. Only single blobs may be passed in this case."));
                 }
 
-                if node_addr.info.is_empty() {
-                    return Err(anyhow::anyhow!(
-                        "no Derp url provided and no direct addresses provided"
-                    ));
-                }
                 let tag = match tag {
                     Some(tag) => SetTagOption::Named(Tag::from(tag)),
                     None => SetTagOption::Auto,

--- a/iroh/src/commands/doc.rs
+++ b/iroh/src/commands/doc.rs
@@ -928,6 +928,8 @@ impl ImportProgressBar {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::NodeConfig;
+
     use super::*;
 
     #[tokio::test]
@@ -950,7 +952,8 @@ mod tests {
         // run iroh node in the background, as if running `iroh start`
         std::env::set_var("IROH_DATA_DIR", data_dir.path().as_os_str());
         let lp = tokio_util::task::LocalPoolHandle::new(1);
-        let node = crate::commands::start::start_node(&lp, None).await?;
+        let config = NodeConfig::default();
+        let node = crate::commands::start::start_node(&lp, None, &config).await?;
         let client = node.client();
         let doc = client.docs.create().await.context("doc create")?;
         let author = client.authors.create().await.context("author create")?;

--- a/iroh/src/commands/start.rs
+++ b/iroh/src/commands/start.rs
@@ -79,7 +79,7 @@ where
     let derp_map = config.derp_map()?;
 
     let spinner = create_spinner("Iroh booting...");
-    let node = start_node(rt, derp_map).await?;
+    let node = start_node(rt, derp_map, config).await?;
     drop(spinner);
 
     eprintln!("{}", welcome_message(&node)?);
@@ -172,6 +172,7 @@ fn migrate_flat_store_v0_v1() -> anyhow::Result<()> {
 pub(crate) async fn start_node(
     rt: &LocalPoolHandle,
     derp_map: Option<DerpMap>,
+    config: &NodeConfig,
 ) -> Result<Node<iroh_bytes::store::flat::Store>> {
     let rpc_status = RpcStatus::load(iroh_data_root()?).await?;
     match rpc_status {
@@ -202,6 +203,7 @@ pub(crate) async fn start_node(
 
     Node::builder(bao_store, doc_store)
         .derp_mode(derp_mode)
+        .use_mdns(config.use_mdns)
         .peers_data_path(peers_data_path)
         .local_pool(rt)
         .rpc_endpoint(rpc_endpoint)

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -118,6 +118,8 @@ pub struct NodeConfig {
     /// Bind address on which to serve Prometheus metrics
     #[cfg(feature = "metrics")]
     pub metrics_addr: Option<SocketAddr>,
+    /// Enables MDNS discovery
+    pub use_mdns: bool,
 }
 
 impl Default for NodeConfig {
@@ -128,6 +130,7 @@ impl Default for NodeConfig {
             gc_policy: GcPolicy::Disabled,
             #[cfg(feature = "metrics")]
             metrics_addr: None,
+            use_mdns: false,
         }
     }
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -132,6 +132,7 @@ where
     docs: S,
     /// Path to store peer data. If `None`, peer data will not be persisted.
     peers_data_path: Option<PathBuf>,
+    use_mdns: bool,
 }
 
 const PROTOCOLS: [&[u8]; 3] = [&iroh_bytes::protocol::ALPN, GOSSIP_ALPN, SYNC_ALPN];
@@ -150,6 +151,7 @@ impl<D: Map, S: DocStore> Builder<D, S> {
             rt: None,
             docs,
             peers_data_path: None,
+            use_mdns: false,
         }
     }
 }
@@ -177,6 +179,7 @@ where
             rt: self.rt,
             docs: self.docs,
             peers_data_path: self.peers_data_path,
+            use_mdns: self.use_mdns,
         }
     }
 
@@ -199,6 +202,12 @@ where
     /// is provided [`Self::spawn`] will result in an error.
     pub fn derp_mode(mut self, dm: DerpMode) -> Self {
         self.derp_mode = dm;
+        self
+    }
+
+    /// Enable or disable `MDNS` discovery.
+    pub fn use_mdns(mut self, use_mdns: bool) -> Self {
+        self.use_mdns = use_mdns;
         self
     }
 
@@ -270,7 +279,8 @@ where
             .keylog(self.keylog)
             .transport_config(transport_config)
             .concurrent_connections(MAX_CONNECTIONS)
-            .derp_mode(self.derp_mode);
+            .derp_mode(self.derp_mode)
+            .use_mdns(self.use_mdns);
         let endpoint = match self.peers_data_path {
             Some(path) => endpoint.peers_data_path(path),
             None => endpoint,

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -411,7 +411,7 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
         // add addresses of peers to our endpoint address book
         for peer in peers.into_iter() {
             let peer_id = peer.node_id;
-            if let Err(err) = self.endpoint.add_node_addr(peer) {
+            if let Err(err) = self.endpoint.add_node_addr(peer).await {
                 warn!(peer = %peer_id.fmt_short(), "failed to add known addrs: {err:?}");
             }
         }


### PR DESCRIPTION
## Description

This uses a simple scheme to discover dialing information of local nodes via MDNS. 
The service is using a hashed version of the node id, to avoid broadcasting the node id directly.

## Notes & open questions

This is not a compile time feature, but just a runtime feature, seems okay to me, but others might have different opinions. 

