### PR TITLE
fix(iroh-net): Try fix flaky udp_blocked test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,6 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "arrayref"

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.72"
 workspace = true
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { version = "1" }
 bao-tree = { version = "0.9.1", features = ["tokio_fsm"], default-features = false, optional = true }
 data-encoding = { version = "2.3.3", optional = true }
 hex = "0.4.3"

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.72"
 workspace = true
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { version = "1" }
 bao-tree = { version = "0.9.1", features = ["tokio_fsm"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 # proto dependencies (required)
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { version = "1" }
 blake3 = { package = "iroh-blake3", version = "1.4.3"}
 bytes = { version = "1.4.0", features = ["serde"] }
 data-encoding = "2.4.0"

--- a/iroh-metrics/Cargo.toml
+++ b/iroh-metrics/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.72"
 workspace = true
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { version = "1" }
 erased_set = "0.7"
 http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "http1"] }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 aead = { version = "0.5.2", features = ["bytes"] }
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { version = "1" }
 backoff = "0.4.0"
 bytes = "1"
 crypto_box = { version = "0.9.1", features = ["serde", "chacha20"] }

--- a/iroh-net/src/netcheck.rs
+++ b/iroh-net/src/netcheck.rs
@@ -949,6 +949,11 @@ mod tests {
         // create raw ICMP pings and we'll have to silenty accept this test is useless (if
         // we could, this would be a skip instead).
         let have_pinger = Pinger::new().is_ok();
+        if !have_pinger {
+            error!("pinger disabled, test effectively skipped");
+        } else {
+            info!("pinger enabled");
+        }
 
         // This is the test: we will fall back to sending ICMP pings.  These should
         // succeed when we have a working pinger.

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.72"
 workspace = true
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { version = "1" }
 bao-tree = { version = "0.9.1", features = ["tokio_fsm"], default-features = false }
 bytes = "1"
 data-encoding = "2.4.0"
@@ -82,7 +82,7 @@ flat-db = ["iroh-bytes/flat-db"]
 test = []
 
 [dev-dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { version = "1" }
 bytes = "1"
 console-subscriber = "0.2"
 duct = "0.13.6"


### PR DESCRIPTION
## Description

This test is flaky because somehow the executor is entirely blocked
for a solid 5 seconds after which the entire netcheck report is timing
out.  Thus the part of the netcheck report that is being tested never
executes.

What blocks the executor however is a mystery to me.  This fix assumes
that it is generating the backtrace in the log, because there simply
isn't anything else that it can be.  Thus the relevant change is no
longer producing the backtrace.  The error message is already pretty
obvious.

To  go further, this disables the anyhow backtrace feature entirely.
This will probably make our lifes a bit harder in some situations but
there are many places where they end up in the log otherwise and each
time this happens it blocks an executor thread for a long time.

This also tweaks the error reporting to not generate so much logging
noise when the captive portal fails in an expected way.

## Notes & open questions

An attempt at fixing #1901 

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.