### PR TITLE
fix(iroh-net): do not prune addrs that are just added

### DIFF
--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -504,9 +504,6 @@ impl Endpoint {
             //TODOFRZ
             self.direct_addr_state.entry(addr.into()).or_default();
         }
-
-        // Delete outdated endpoints
-        self.prune_direct_addresses();
     }
 
     /// Clears all the endpoint's p2p state, reverting it to a DERP-only endpoint.


### PR DESCRIPTION
This pruning would delete all direct addrs that were just added, as they had no pings or so attached

