### PR TITLE
fix(iroh-sync): dl policies exists only if doc exists

### DIFF
--- a/iroh-sync/src/store/memory.rs
+++ b/iroh-sync/src/store/memory.rs
@@ -164,6 +164,7 @@ impl super::Store for Store {
         }
         self.replica_records.write().remove(namespace);
         self.namespaces.write().remove(namespace);
+        self.download_policies.write().remove(namespace);
         Ok(())
     }
 
@@ -238,6 +239,11 @@ impl super::Store for Store {
     }
 
     fn set_download_policy(&self, namespace: &NamespaceId, policy: DownloadPolicy) -> Result<()> {
+        anyhow::ensure!(
+            self.namespaces.read().contains_key(&namespace),
+            "document not created"
+        );
+
         self.download_policies.write().insert(*namespace, policy);
         Ok(())
     }


### PR DESCRIPTION
## Description

Removes download policies when the replica is removed, and disallows adding download policies for documents not yet created

## Notes & open questions

na

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
