### PR TITLE
chore(netsim): disable netsim prometheus reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,10 +399,6 @@ jobs:
         tar cvzf report.tar.gz report_prom.txt report_metro.txt report_metro_integration.txt logs/ report/ viz/
         aws s3 cp ./report.tar.gz s3://${{secrets.S3_REPORT_BUCKET}}/$aws_fname --no-progress
 
-        link_data='dump{fname="'$aws_fname'",commit="'${{ env.LAST_COMMIT_SHA }}'",branch="'${{ env.HEAD_REF }}'"} 1.0'
-        link_data=$(printf "%s\n " "$link_data")
-        curl -X POST -H  "Content-Type: text/plain" --data "$link_data" ${{secrets.PROM_ENDPOINT}}/metrics/job/netsim/instance/${instance}
-
     - name: Echo metrics
       run: |
         cd ../chuck/netsim

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -215,15 +215,6 @@ jobs:
         tar cvzf report.tar.gz report_prom.txt report.txt report_metro.txt report_metro_integration.txt logs/ report/ viz/
         aws s3 cp ./report.tar.gz s3://${{secrets.S3_REPORT_BUCKET}}/$aws_fname --no-progress
 
-        instance=$(echo "${{ env.HEAD_REF }}" | tr -c '[:alnum:]' '_')
-        d=$(cat report_prom.txt)
-        prom_data=$(printf "%s\n " "$d")
-        curl -X POST -H  "Content-Type: text/plain" --data "$prom_data" ${{secrets.PROM_ENDPOINT}}/metrics/job/netsim/instance/${instance}
-        
-        link_data='dump{fname="'$aws_fname'",commit="'${{ env.LAST_COMMIT_SHA }}'",branch="'${{ env.HEAD_REF }}'"} 1.0'
-        link_data=$(printf "%s\n " "$link_data")
-        curl -X POST -H  "Content-Type: text/plain" --data "$link_data" ${{secrets.PROM_ENDPOINT}}/metrics/job/netsim/instance/${instance}
-
     - name: Post metrics
       if: github.ref_name=='main' && github.event_name != 'issue_comment'
       run: |


### PR DESCRIPTION
## Description

Netsim runs are failing on PRs due to the old prometheus endpoint being unavailable (I moved some of the old infra around). It's a never used feature so I'm happy to just drop it.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
