### PR TITLE
fix: build successfully from `cargo vendor` tarball

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "config"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,9 +1417,14 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "218a870470cce1469024e9fb66b901aa983929d81304a1cdb299f28118e550d5"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -3126,6 +3140,12 @@ dependencies = [
  "primeorder",
  "sha2",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -5591,9 +5611,9 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "watchable"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff90d0baafb3c0abbeebec1a8a305b4211c356de1d953a0dd77aab006baa8a62"
+checksum = "45b42a2f611916b5965120a9cde2b60f2db4454826dd9ad5e6f47c24a5b3b259"
 dependencies = [
  "event-listener",
  "futures-util",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -71,7 +71,7 @@ tracing = "0.1"
 trust-dns-resolver = "0.23.0"
 ttl_cache = "0.5.1"
 url = { version = "2.4", features = ["serde"] }
-watchable = "1.1.1"
+watchable = "1.1.2"
 webpki = { package = "rustls-webpki", version = "0.101.4", features = ["std"] }
 webpki-roots = "0.25"
 x509-parser = "0.15"

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1263,7 +1263,7 @@ impl MagicSock {
 
     /// Waits for local endpoints to change and returns the new ones.
     pub async fn local_endpoints_change(&self) -> Result<Vec<config::Endpoint>> {
-        let mut watcher = self.inner.endpoints.watch();
+        let watcher = self.inner.endpoints.watch();
         let eps = watcher.next_value_async().await?;
         Ok(eps.into_iter().collect())
     }


### PR DESCRIPTION
## Description

closes #1931 

Fixes the broken build when building from the vendored tarball produced by `cargo vendor`. The problem was with a config in `watchable v1.1.1` and was fixed in `watchable v1.1.2` (https://github.com/khonsulabs/watchable/releases/tag/v1.1.2).

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
