### PR TITLE
fix: allow some dead code for the nightly compiler

### DIFF
--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -838,7 +838,10 @@ mod test {
         ///
         /// After dropping the test infrastructure will asynchronously shutdown and release its
         /// resources.
+        // Nightly sees the sender as dead code currently, but we only rely on Drop of the
+        // sender.
         #[derive(Debug)]
+        #[allow(dead_code)]
         pub(crate) struct CleanupDropGuard(pub(crate) oneshot::Sender<()>);
 
         /// Runs a  DERP server with STUN enabled suitable for tests.

--- a/iroh-net/src/test_utils.rs
+++ b/iroh-net/src/test_utils.rs
@@ -12,7 +12,10 @@ use crate::key::SecretKey;
 ///
 /// After dropping the test infrastructure will asynchronously shutdown and release its
 /// resources.
+// Nightly sees the sender as dead code currently, but we only rely on Drop of the
+// sender.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) struct CleanupDropGuard(pub(crate) oneshot::Sender<()>);
 
 /// Runs a  DERP server with STUN enabled suitable for tests.

--- a/iroh/src/util/progress.rs
+++ b/iroh/src/util/progress.rs
@@ -378,6 +378,7 @@ impl<R, F: Fn(ProgressReaderUpdate)> Drop for ProgressReader<R, F> {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ProgressReaderUpdate {
     /// A progress event containing the current offset.
+    #[allow(dead_code)]
     Progress(u64),
     /// The reader has been dropped.
     Done,


### PR DESCRIPTION
## Description

The nightly compiler (rightly I think) identifies the u64 as unread
and suggests changing it with unit instead.

However the nightly compiler wrongly identifies some oneshot senders
as dead code.  Just get main working on CI again for now.

## Notes & open questions

This is the easy way out, not very nice.  We also have a
ProgressReader2 in iroh-bytes that's very similar.  Maybe we should
extract these and put them somewhere common.

## Change checklist

- [x] Self-review.