### PR TITLE
chore(ci): add name to tests step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   tests:
+    name: CI Test Suite
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
     uses: './.github/workflows/tests.yaml'
 


### PR DESCRIPTION
## Description

Seems like the lack of job name makes it invisible on the branch protections, hence can't make the step required for the nested runs. Raw `Tests` job is available.  This is just theory for now.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
