### PR TITLE
chore(ci): Do not test nightly rust on every PR

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -7,6 +7,8 @@ on:
     # 06:50 UTC every Monday
     - cron: '50 6 * * 1'
   workflow_dispatch:
+  # TODO: temporary to test in PR only
+  pull_request:
 
 concurrency:
   group: beta-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -20,21 +20,21 @@ jobs:
     with:
       rust-version: beta
   notify:
-    needs: [build_and_test_nix, build_and_test_windows]
-    if: ${{ always() }}
+    needs: tests
+    if: ${{ failure() }}
     runs-on: ubuntu-latest
     steps:
       - uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ failure() }}
+        # if: ${{ failure() }}
         with:
           severity: error
           details: rustc beta tests failed
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
       # TODO: temporarily to test the notification
-      - uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ success() }}
-        with:
-          severity: info
-          details: rustc beta tests succeeded
-          webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
+      # - uses: n0-computer/discord-webhook-notify@v1
+      #   if: ${{ success() }}
+      #   with:
+      #     severity: info
+      #     details: rustc beta tests succeeded
+      #     webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
 

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - run: |
           printf '${{ toJSON(needs) }}\n'
+          result=$(${{ toJSON(needs) }} | jq .tests.result | tr -d \")
+          echo $result
       - uses: n0-computer/discord-webhook-notify@v1
         if: ${{ failure() }}
         with:

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -24,6 +24,8 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      - run: |
+          printf '${{ toJSON(needs) }}\n'
       - uses: n0-computer/discord-webhook-notify@v1
         if: ${{ failure() }}
         with:

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -1,0 +1,19 @@
+# Run tests using the beta Rust compiler
+
+name: Beta Rust
+
+on:
+  schedule:
+    # 06:50 UTC every Monday
+    - cron: '50 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: beta-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    uses: './.github/workflows/tests.yaml'
+    with:
+      rust-version: beta

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -31,7 +31,7 @@ jobs:
           echo TESTS_RESULT=$result
           echo TESTS_RESULT=$result >>$GITHUB_ENV
       - uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ env.TEST_RESULTS == failure }}
+        if: ${{ env.TEST_RESULTS == 'failure' }}
         with:
           severity: error
           details: |
@@ -41,5 +41,7 @@ jobs:
       # TODO: temporarily to test the notification
       - run: |
           echo $TEST_RESULTS
-        if: ${{ env.TEST_RESULTS != failure }}
+          echo ${{ env.TEST_RESULTS == 'failure' }}
+          echo ${{ env.TEST_RESULTS != 'failure' }}
+        if: ${{ env.TEST_RESULTS != 'failure' }}
 

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -32,12 +32,12 @@ jobs:
           echo TESTS_RESULT=$result
           echo TESTS_RESULT=$result >>$GITHUB_ENV
       - run: |
-          echo $TEST_RESULTS
-          echo ${{ env.TEST_RESULTS == 'failure' }}
-          echo ${{ env.TEST_RESULTS != 'failure' }}
+          echo $TEST_RESULT
+          echo ${{ env.TEST_RESULT == 'failure' }}
+          echo ${{ env.TEST_RESULT != 'failure' }}
         if: ${{ always() }}
       - uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ always() && env.TEST_RESULTS == 'failure' }}
+        if: ${{ always() && env.TEST_RESULT == 'failure' }}
         with:
           severity: error
           details: |

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -31,11 +31,11 @@ jobs:
           echo TESTS_RESULT=$result
           echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
       - run: |
-          echo ${{ env.TEST_RESULT == 'failure' }}
-          echo ${{ env.TEST_RESULT != 'failure' }}
+          echo ${{ env.TESTS_RESULT == 'failure' }}
+          echo ${{ env.TESTS_RESULT != 'failure' }}
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ env.TEST_RESULT == 'failure' }}
+        if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
           severity: error
           details: |

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -21,20 +21,20 @@ jobs:
       rust-version: beta
   notify:
     needs: tests
-    if: ${{ failure() }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - uses: n0-computer/discord-webhook-notify@v1
-        # if: ${{ failure() }}
+        if: ${{ failure() }}
         with:
           severity: error
           details: rustc beta tests failed
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
       # TODO: temporarily to test the notification
-      # - uses: n0-computer/discord-webhook-notify@v1
-      #   if: ${{ success() }}
-      #   with:
-      #     severity: info
-      #     details: rustc beta tests succeeded
-      #     webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
+      - uses: n0-computer/discord-webhook-notify@v1
+        if: ${{ success() }}
+        with:
+          severity: info
+          details: rustc beta tests succeeded
+          webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
 

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -30,16 +30,13 @@ jobs:
           result=$(echo '${{ toJSON(needs) }}' | jq -r .tests.result)
           echo TESTS_RESULT=$result
           echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
-      - run: |
-          echo ${{ env.TESTS_RESULT == 'failure' }}
-          echo ${{ env.TESTS_RESULT != 'failure' }}
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
           severity: error
           details: |
-            rustc beta tests failed
-            see https://github.com/n0-computer/iroh/actions/workflows/beta.yaml
+            Rustc beta tests failed
+            See https://github.com/n0-computer/iroh/actions/workflows/beta.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
 

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -20,7 +20,7 @@ jobs:
     with:
       rust-version: beta
   notify:
-    needs: tests
+    needs: [build_and_test_nix, build_and_test_windows]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -17,3 +17,22 @@ jobs:
     uses: './.github/workflows/tests.yaml'
     with:
       rust-version: beta
+  notify:
+    needs: tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: n0-computer/discord-webhook-notify@v1
+        if: ${{ failure() }}
+        with:
+          severity: error
+          details: rustc beta tests failed
+          webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
+      # TODO: temporarily to test the notification
+      - uses: n0-computer/discord-webhook-notify@v1
+        if: ${{ success() }}
+        with:
+          severity: info
+          details: rustc beta tests succeeded
+          webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
+

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - run: |
           printf '${{ toJSON(needs) }}\n'
-          result=$(${{ toJSON(needs) }} | jq .tests.result | tr -d \")
+          result=$(${{ needs }} | jq .tests.result | tr -d \")
           echo $result
       - uses: n0-computer/discord-webhook-notify@v1
         if: ${{ failure() }}

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -32,7 +32,7 @@ jobs:
           echo TESTS_RESULT=$result >>$GITHUB_ENV
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ env.TEST_RESULT == 'failure' }}
+        if: ${{ always() && env.TEST_RESULT == 'failure' }}
         with:
           severity: error
           details: |

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -27,12 +27,15 @@ jobs:
       - name: Extract test results
         run: |
           printf '${{ toJSON(needs) }}\n'
-          result=$(echo '${{ toJSON(needs) }}' | jq .tests.result | tr -d \")
+          result=$(echo '${{ toJSON(needs) }}' | jq -r .tests.result)
           echo TESTS_RESULT=$result
-          echo TESTS_RESULT=$result >>$GITHUB_ENV
+          echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
+      - run: |
+          echo ${{ env.TEST_RESULT == 'failure' }}
+          echo ${{ env.TEST_RESULT != 'failure' }}
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ always() && env.TEST_RESULT == 'failure' }}
+        if: ${{ env.TEST_RESULT == 'failure' }}
         with:
           severity: error
           details: |

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -7,8 +7,6 @@ on:
     # 06:50 UTC every Monday
     - cron: '50 6 * * 1'
   workflow_dispatch:
-  # TODO: temporary to test in PR only
-  pull_request:
 
 concurrency:
   group: beta-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - run: |
           printf '${{ toJSON(needs) }}\n'
-          result=$(${{ needs }} | jq .tests.result | tr -d \")
+          result=$(echo "${{ toJSON(needs) }}" | jq .tests.result | tr -d \")
           echo $result
       - uses: n0-computer/discord-webhook-notify@v1
         if: ${{ failure() }}

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -24,12 +24,14 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Extract test results
+        run: |
           printf '${{ toJSON(needs) }}\n'
           result=$(echo '${{ toJSON(needs) }}' | jq .tests.result | tr -d \")
-          echo $result
+          echo TESTS_RESULT=$result
+          echo TESTS_RESULT=$result >>$GITHUB_ENV
       - uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ failure() }}
+        if: ${{ env.TEST_RESULTS == 'failure' }}
         with:
           severity: error
           details: |

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -31,7 +31,7 @@ jobs:
           echo TESTS_RESULT=$result
           echo TESTS_RESULT=$result >>$GITHUB_ENV
       - uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ env.TEST_RESULTS == 'failure' }}
+        if: ${{ env.TEST_RESULTS == failure }}
         with:
           severity: error
           details: |
@@ -41,5 +41,5 @@ jobs:
       # TODO: temporarily to test the notification
       - run: |
           echo $TEST_RESULTS
-        if: ${{ env.TEST_RESULTS != 'failure' }}
+        if: ${{ env.TEST_RESULTS != failure }}
 

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract test results
+        if: ${{ always() }}
         run: |
           printf '${{ toJSON(needs) }}\n'
           result=$(echo '${{ toJSON(needs) }}' | jq .tests.result | tr -d \")
@@ -34,8 +35,9 @@ jobs:
           echo $TEST_RESULTS
           echo ${{ env.TEST_RESULTS == 'failure' }}
           echo ${{ env.TEST_RESULTS != 'failure' }}
+        if: ${{ always() }}
       - uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ env.TEST_RESULTS == 'failure' }}
+        if: ${{ always() && env.TEST_RESULTS == 'failure' }}
         with:
           severity: error
           details: |

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -25,19 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract test results
-        if: ${{ always() }}
         run: |
           printf '${{ toJSON(needs) }}\n'
           result=$(echo '${{ toJSON(needs) }}' | jq .tests.result | tr -d \")
           echo TESTS_RESULT=$result
           echo TESTS_RESULT=$result >>$GITHUB_ENV
-      - run: |
-          echo $TEST_RESULT
-          echo ${{ env.TEST_RESULT == 'failure' }}
-          echo ${{ env.TEST_RESULT != 'failure' }}
-        if: ${{ always() }}
-      - uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ always() && env.TEST_RESULT == 'failure' }}
+      - name: Notify discord on failure
+        uses: n0-computer/discord-webhook-notify@v1
+        if: ${{ env.TEST_RESULT == 'failure' }}
         with:
           severity: error
           details: |

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -39,12 +39,7 @@ jobs:
             see https://github.com/n0-computer/iroh/actions/workflows/beta.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
       # TODO: temporarily to test the notification
-      - uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ success() }}
-        with:
-          severity: info
-          details: |
-            rustc beta tests succeeded
-            see https://github.com/n0-computer/iroh/actions/workflows/beta.yaml
-          webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
+      - run: |
+          echo $TEST_RESULTS
+        if: ${{ env.TEST_RESULTS != 'failure' }}
 

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -32,13 +32,17 @@ jobs:
         if: ${{ failure() }}
         with:
           severity: error
-          details: rustc beta tests failed
+          details: |
+            rustc beta tests failed
+            see https://github.com/n0-computer/iroh/actions/workflows/beta.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
       # TODO: temporarily to test the notification
       - uses: n0-computer/discord-webhook-notify@v1
         if: ${{ success() }}
         with:
           severity: info
-          details: rustc beta tests succeeded
+          details: |
+            rustc beta tests succeeded
+            see https://github.com/n0-computer/iroh/actions/workflows/beta.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
 

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -30,6 +30,10 @@ jobs:
           result=$(echo '${{ toJSON(needs) }}' | jq .tests.result | tr -d \")
           echo TESTS_RESULT=$result
           echo TESTS_RESULT=$result >>$GITHUB_ENV
+      - run: |
+          echo $TEST_RESULTS
+          echo ${{ env.TEST_RESULTS == 'failure' }}
+          echo ${{ env.TEST_RESULTS != 'failure' }}
       - uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TEST_RESULTS == 'failure' }}
         with:
@@ -38,10 +42,4 @@ jobs:
             rustc beta tests failed
             see https://github.com/n0-computer/iroh/actions/workflows/beta.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
-      # TODO: temporarily to test the notification
-      - run: |
-          echo $TEST_RESULTS
-          echo ${{ env.TEST_RESULTS == 'failure' }}
-          echo ${{ env.TEST_RESULTS != 'failure' }}
-        if: ${{ env.TEST_RESULTS != 'failure' }}
 

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - run: |
           printf '${{ toJSON(needs) }}\n'
-          result=$(echo "${{ toJSON(needs) }}" | jq .tests.result | tr -d \")
+          result=$(echo '${{ toJSON(needs) }}' | jq .tests.result | tr -d \")
           echo $result
       - uses: n0-computer/discord-webhook-notify@v1
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
-  # TODO: temp
-  # pull_request:
-  #   types: [ 'labeled', 'unlabeled', 'opened', 'synchronize', 'reopened' ]
+  pull_request:
+    types: [ 'labeled', 'unlabeled', 'opened', 'synchronize', 'reopened' ]
   merge_group:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  pull_request:
-    types: [ 'labeled', 'unlabeled', 'opened', 'synchronize', 'reopened' ]
+  # TODO: temp
+  # pull_request:
+  #   types: [ 'labeled', 'unlabeled', 'opened', 'synchronize', 'reopened' ]
   merge_group:
   push:
     branches:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -109,6 +109,8 @@ jobs:
             export RUST_LOG=DEBUG
         fi
         cargo test --workspace --all-features --doc
+        # TODO: just to test the workflow
+        false
 
   build_and_test_windows:
     timeout-minutes: 30

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -109,8 +109,6 @@ jobs:
             export RUST_LOG=DEBUG
         fi
         cargo test --workspace --all-features --doc
-        # TODO: just to test the workflow
-        false
 
   build_and_test_windows:
     timeout-minutes: 30

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,10 @@ name: Tests
 on:
   workflow_call:
     inputs:
+      rust-version:
+        description: 'The version of the rust compiler to run'
+        type: string
+        default: 'stable'
       flaky:
         description: 'Whether to also run flaky tests'
         type: boolean
@@ -29,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu-latest, macOS-arm-latest]
-        rust: [nightly, stable]
+        rust: [${{ inputs.rust-version }}]
         features: [all, none, default]
         include:
           - name: ubuntu-latest
@@ -114,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [windows-latest]
-        rust: [nightly, stable]
+        rust: [${{ inputs.rust-version}}]
         features: [all, none, default]
         target:
           - x86_64-pc-windows-msvc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,11 +41,11 @@ jobs:
             release-os: linux
             release-arch: amd64
             runner: [self-hosted, linux, X64]
-          # - name: macOS-arm-latest
-          #   os: macOS-latest
-          #   release-os: darwin
-          #   release-arch: aarch64
-          #   runner: [self-hosted, macOS, ARM64]
+          - name: macOS-arm-latest
+            os: macOS-latest
+            release-os: darwin
+            release-arch: aarch64
+            runner: [self-hosted, macOS, ARM64]
     env:
       # Using self-hosted runners so use local cache for sccache and
       # not SCCACHE_GHA_ENABLED.
@@ -112,72 +112,72 @@ jobs:
         # TODO: just to test the workflow
         false
 
-  # build_and_test_windows:
-  #   timeout-minutes: 30
-  #   name: "Tests"
-  #   runs-on: ${{ matrix.runner }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       name: [windows-latest]
-  #       rust: [ '${{ inputs.rust-version}}' ]
-  #       features: [all, none, default]
-  #       target:
-  #         - x86_64-pc-windows-msvc
-  #       include:
-  #         - name: windows-latest
-  #           os: windows
-  #           runner: [self-hosted, windows, x64]
-  #   env:
-  #     # Using self-hosted runners so use local cache for sccache and
-  #     # not SCCACHE_GHA_ENABLED.
-  #     RUSTC_WRAPPER: "sccache"
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-  #     with:
-  #       ref: ${{ inputs.git-ref }}
+  build_and_test_windows:
+    timeout-minutes: 30
+    name: "Tests"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [windows-latest]
+        rust: [ '${{ inputs.rust-version}}' ]
+        features: [all, none, default]
+        target:
+          - x86_64-pc-windows-msvc
+        include:
+          - name: windows-latest
+            os: windows
+            runner: [self-hosted, windows, x64]
+    env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.git-ref }}
 
-  #   - name: Install ${{ matrix.rust }}
-  #     run: |
-  #       rustup toolchain install ${{ matrix.rust }}
-  #       rustup toolchain default ${{ matrix.rust }}
-  #       rustup target add ${{ matrix.target }}
-  #       rustup set default-host ${{ matrix.target }}
+    - name: Install ${{ matrix.rust }}
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup toolchain default ${{ matrix.rust }}
+        rustup target add ${{ matrix.target }}
+        rustup set default-host ${{ matrix.target }}
 
-  #   - name: Install cargo-nextest
-  #     shell: powershell
-  #     run: |
-  #       $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-  #       Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-  #       $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
-  #       $tmp | Expand-Archive -DestinationPath $outputDir -Force
-  #       $tmp | Remove-Item
+    - name: Install cargo-nextest
+      shell: powershell
+      run: |
+        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+        $tmp | Expand-Archive -DestinationPath $outputDir -Force
+        $tmp | Remove-Item
 
-  #   - name: Select features
-  #     run: |
-  #       switch ("${{ matrix.features }}") {
-  #           "all" {
-  #               echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           "none" {
-  #               echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           "default" {
-  #               echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           default {
-  #               Exit 1
-  #           }
-  #       }
+    - name: Select features
+      run: |
+        switch ("${{ matrix.features }}") {
+            "all" {
+                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "none" {
+                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "default" {
+                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            default {
+                Exit 1
+            }
+        }
 
-  #   - name: Install sccache
-  #     uses: mozilla-actions/sccache-action@v0.0.3
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
-  #   - uses: msys2/setup-msys2@v2
+    - uses: msys2/setup-msys2@v2
 
-  #   - name: tests
-  #     run: |
-  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} ${{ inputs.flaky && '--run-ignored all' }}
-  #     env:
-  #       RUST_LOG: "TRACE"
+    - name: tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} ${{ inputs.flaky && '--run-ignored all' }}
+      env:
+        RUST_LOG: "TRACE"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,7 +56,7 @@ jobs:
       with:
         ref: ${{ inputs.git-ref }}
 
-    - name: Install ${{ matrix.rust }}
+    - name: Install ${{ matrix.rust }} rust
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [windows-latest]
-        rust: [${{ inputs.rust-version}}]
+        rust: ${{ inputs.rust-version}}
         features: [all, none, default]
         target:
           - x86_64-pc-windows-msvc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,11 +41,11 @@ jobs:
             release-os: linux
             release-arch: amd64
             runner: [self-hosted, linux, X64]
-          - name: macOS-arm-latest
-            os: macOS-latest
-            release-os: darwin
-            release-arch: aarch64
-            runner: [self-hosted, macOS, ARM64]
+          # - name: macOS-arm-latest
+          #   os: macOS-latest
+          #   release-os: darwin
+          #   release-arch: aarch64
+          #   runner: [self-hosted, macOS, ARM64]
     env:
       # Using self-hosted runners so use local cache for sccache and
       # not SCCACHE_GHA_ENABLED.
@@ -112,72 +112,72 @@ jobs:
         # TODO: just to test the workflow
         false
 
-  build_and_test_windows:
-    timeout-minutes: 30
-    name: "Tests"
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [windows-latest]
-        rust: [ '${{ inputs.rust-version}}' ]
-        features: [all, none, default]
-        target:
-          - x86_64-pc-windows-msvc
-        include:
-          - name: windows-latest
-            os: windows
-            runner: [self-hosted, windows, x64]
-    env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
-      RUSTC_WRAPPER: "sccache"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.git-ref }}
+  # build_and_test_windows:
+  #   timeout-minutes: 30
+  #   name: "Tests"
+  #   runs-on: ${{ matrix.runner }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       name: [windows-latest]
+  #       rust: [ '${{ inputs.rust-version}}' ]
+  #       features: [all, none, default]
+  #       target:
+  #         - x86_64-pc-windows-msvc
+  #       include:
+  #         - name: windows-latest
+  #           os: windows
+  #           runner: [self-hosted, windows, x64]
+  #   env:
+  #     # Using self-hosted runners so use local cache for sccache and
+  #     # not SCCACHE_GHA_ENABLED.
+  #     RUSTC_WRAPPER: "sccache"
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+  #     with:
+  #       ref: ${{ inputs.git-ref }}
 
-    - name: Install ${{ matrix.rust }}
-      run: |
-        rustup toolchain install ${{ matrix.rust }}
-        rustup toolchain default ${{ matrix.rust }}
-        rustup target add ${{ matrix.target }}
-        rustup set default-host ${{ matrix.target }}
+  #   - name: Install ${{ matrix.rust }}
+  #     run: |
+  #       rustup toolchain install ${{ matrix.rust }}
+  #       rustup toolchain default ${{ matrix.rust }}
+  #       rustup target add ${{ matrix.target }}
+  #       rustup set default-host ${{ matrix.target }}
 
-    - name: Install cargo-nextest
-      shell: powershell
-      run: |
-        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
-        $tmp | Expand-Archive -DestinationPath $outputDir -Force
-        $tmp | Remove-Item
+  #   - name: Install cargo-nextest
+  #     shell: powershell
+  #     run: |
+  #       $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+  #       Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+  #       $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+  #       $tmp | Expand-Archive -DestinationPath $outputDir -Force
+  #       $tmp | Remove-Item
 
-    - name: Select features
-      run: |
-        switch ("${{ matrix.features }}") {
-            "all" {
-                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "none" {
-                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "default" {
-                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            default {
-                Exit 1
-            }
-        }
+  #   - name: Select features
+  #     run: |
+  #       switch ("${{ matrix.features }}") {
+  #           "all" {
+  #               echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           "none" {
+  #               echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           "default" {
+  #               echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           default {
+  #               Exit 1
+  #           }
+  #       }
 
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+  #   - name: Install sccache
+  #     uses: mozilla-actions/sccache-action@v0.0.3
 
-    - uses: msys2/setup-msys2@v2
+  #   - uses: msys2/setup-msys2@v2
 
-    - name: tests
-      run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} ${{ inputs.flaky && '--run-ignored all' }}
-      env:
-        RUST_LOG: "TRACE"
+  #   - name: tests
+  #     run: |
+  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} ${{ inputs.flaky && '--run-ignored all' }}
+  #     env:
+  #       RUST_LOG: "TRACE"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu-latest, macOS-arm-latest]
-        rust: [${{ inputs.rust-version }}]
+        rust: [ ${{ inputs.rust-version }} ]
         features: [all, none, default]
         include:
           - name: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu-latest, macOS-arm-latest]
-        rust: ${{ inputs.rust-version }}
+        rust: [ '${{ inputs.rust-version }}' ]
         features: [all, none, default]
         include:
           - name: ubuntu-latest
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [windows-latest]
-        rust: ${{ inputs.rust-version}}
+        rust: [ '${{ inputs.rust-version}}' ]
         features: [all, none, default]
         target:
           - x86_64-pc-windows-msvc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu-latest, macOS-arm-latest]
-        rust: [ ${{ inputs.rust-version }} ]
+        rust: ${{ inputs.rust-version }}
         features: [all, none, default]
         include:
           - name: ubuntu-latest


### PR DESCRIPTION
## Description

Normal CI jobs for PRs now only run using the stable rust compiler,
this gives fewer surprises to users.

Instead the beta compiler is run in a new workflow which runs once a
week.  When the beta workflow fails we get a post in a discord channel.

## Notes & open questions

The required checks for branch protection have changed again.  We no
longer need the nightly checks in those.

## Change checklist

- [x] Self-review.