### PR TITLE
Make the fields of `DocImportFileOutcome` public

### DIFF
--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -1014,11 +1014,11 @@ impl DocImportFileProgress {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DocImportFileOutcome {
     /// The hash of the entry's content
-    hash: Hash,
+    pub hash: Hash,
     /// The size of the entry
-    size: u64,
+    pub size: u64,
     /// The key of the entry
-    key: Bytes,
+    pub key: Bytes,
 }
 
 impl Stream for DocImportFileProgress {


### PR DESCRIPTION
## Description

This is returned by `DocExportFileProgress::finish` and it's fairly obvious that these fields were intended to be public but weren't. Useful for a variety of things.

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

None

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant. N/A
- [ ] Tests if relevant. N/A
