### PR TITLE
chore(ci): run non-flaky tests again

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -94,7 +94,7 @@ jobs:
 
     - name: tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests ${{ inputs.flaky && '--run-ignored all' }}
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests ${{ inputs.flaky && '--run-ignored all' || '' }}
       env:
         RUST_LOG: "TRACE"
 
@@ -172,6 +172,6 @@ jobs:
 
     - name: tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} ${{ inputs.flaky && '--run-ignored all' }}
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} ${{ inputs.flaky && '--run-ignored all' || '' }}
       env:
         RUST_LOG: "TRACE"

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -617,6 +617,7 @@ fn cli_provide_addresses() -> Result<()> {
 }
 
 #[test]
+#[ignore = "flaky"]
 fn cli_rpc_lock_restart() -> Result<()> {
     let dir = testdir!();
     let iroh_data_dir = dir.join("data-dir");


### PR DESCRIPTION
## Description

We had a bug in the github actions job that resulted in not running
any tests.  Oops.

## Notes & open questions

Running 248 tests again!

Newly marked flaky test already covered by #1935 

## Change checklist

- [x] Self-review.