### PR TITLE
Add protocol level authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,6 +2221,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
  "walkdir",
 ]
 
@@ -5461,6 +5462,17 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+dependencies = [
+ "getrandom",
+ "rand",
+ "serde",
+]
 
 [[package]]
 name = "valuable"

--- a/iroh-base/src/auth.rs
+++ b/iroh-base/src/auth.rs
@@ -1,0 +1,85 @@
+//! Authentication related types and tooling.
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::hash::Hash;
+
+/// The error code sent using quinn when aborting due to authentication errors.
+pub const REJECTED_CODE: u32 = 10;
+
+#[derive(Debug, Clone)]
+pub struct Authenticator(Arc<dyn DynAuthenticator>);
+
+impl Deref for Authenticator {
+    type Target = dyn DynAuthenticator;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<A: DynAuthenticator> From<A> for Authenticator {
+    fn from(a: A) -> Self {
+        Authenticator(Arc::new(a))
+    }
+}
+
+pub trait DynAuthenticator: Sync + Send + std::fmt::Debug + 'static {
+    fn request(&self, request: Request) -> Result<Option<Token>>;
+    fn respond(&self, request: Request, token: &Option<Token>) -> Result<AcceptOutcome>;
+}
+
+/// A minimal authenticator that does nothing.
+#[derive(Debug, Clone)]
+pub struct NoAuthenticator;
+
+impl DynAuthenticator for NoAuthenticator {
+    fn request(&self, _request: Request) -> Result<Option<Token>> {
+        Ok(None)
+    }
+
+    fn respond(&self, _request: Request, _token: &Option<Token>) -> Result<AcceptOutcome> {
+        Ok(AcceptOutcome::Accept)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Request {
+    pub id: u64,
+    pub data: RequestData,
+}
+
+#[derive(Debug, Clone)]
+pub enum RequestData {
+    Gossip {
+        /// Topic ID (raw because of dependencies)
+        topic: [u8; 32],
+    },
+    Bytes(BytesRequestData),
+    Sync {
+        /// Namespace ID (raw, because of dependencies)
+        namespace: [u8; 32],
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum BytesRequestData {
+    Get { hash: Hash },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AcceptOutcome {
+    Accept,
+    Reject,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Token {
+    /// UUID
+    pub id: [u8; 16],
+    pub secret: [u8; 32], // set to a sentintel value (all zeros) if no secret present
+}

--- a/iroh-base/src/auth.rs
+++ b/iroh-base/src/auth.rs
@@ -85,7 +85,7 @@ pub enum AcceptOutcome {
     Reject,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Token {
     /// UUID
     pub id: [u8; 16],

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -7,3 +7,5 @@ pub mod hash;
 pub mod rpc;
 #[cfg(feature = "base32")]
 pub mod ticket;
+
+pub mod auth;

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -157,7 +157,7 @@ pub mod fsm {
 
             let token = self
                 .auth
-                .request(iroh_base::auth::Request {
+                .on_outgoing_request(iroh_base::auth::Request {
                     id: reader.id().index(),
                     data: iroh_base::auth::RequestData::Bytes(BytesRequestData::Get {
                         hash: self.request.hash,

--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -352,7 +352,7 @@ use crate::Hash;
 pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 100;
 
 /// The ALPN used with quic for the iroh bytes protocol.
-pub const ALPN: &[u8] = b"/iroh-bytes/3";
+pub const ALPN: &[u8] = b"/iroh-bytes/4";
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, From)]
 /// A request to the provider

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -327,7 +327,7 @@ async fn handle_stream<D: Map, E: EventSender>(
     match request {
         Request::Get(request) => {
             let outcome = auth
-                .respond(
+                .on_incoming_request(
                     iroh_base::auth::Request {
                         id: writer.request_id(),
                         data: iroh_base::auth::RequestData::Bytes(

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -47,15 +47,8 @@ pub enum Event {
         request_id: u64,
         /// The hash for which the client wants to receive data.
         hash: Hash,
-    },
-    /// A request was received from a client.
-    CustomGetRequestReceived {
-        /// An unique connection id.
-        connection_id: u64,
-        /// An identifier uniquely identifying this transfer request.
-        request_id: u64,
-        /// The size of the custom get request.
-        len: usize,
+        /// Optional token id passed in from the authentication.
+        token_id: Option<[u8; 16]>,
     },
     /// A sequence of hashes has been found and is being transferred.
     TransferHashSeqStarted {
@@ -376,6 +369,7 @@ pub async fn handle_get<D: Map, E: EventSender>(
             hash,
             connection_id: writer.connection_id(),
             request_id: writer.request_id(),
+            token_id: request.token.as_ref().map(|t| t.id),
         })
         .await;
 

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -277,19 +277,12 @@ pub trait EventSender: Clone + Sync + Send + 'static {
 
 /// Handle a single connection.
 pub async fn handle_connection<D: Map, E: EventSender>(
-    connecting: quinn::Connecting,
+    connection: quinn::Connection,
     db: D,
     events: E,
     rt: LocalPoolHandle,
 ) {
-    let remote_addr = connecting.remote_address();
-    let connection = match connecting.await {
-        Ok(conn) => conn,
-        Err(err) => {
-            warn!(%remote_addr, "Error connecting: {err:#}");
-            return;
-        }
-    };
+    let remote_addr = connection.remote_address();
     let connection_id = connection.stable_id() as u64;
     let span = debug_span!("connection", connection_id, %remote_addr);
     async move {

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context};
 use bytes::Bytes;
 use clap::Parser;
 use ed25519_dalek::Signature;
-use iroh_base::base32;
+use iroh_base::{auth::NoAuthenticator, base32};
 use iroh_gossip::{
     net::{Gossip, GOSSIP_ALPN},
     proto::{Event, TopicId},
@@ -112,7 +112,12 @@ async fn main() -> anyhow::Result<()> {
 
     let my_addr = endpoint.my_addr().await?;
     // create the gossip protocol
-    let gossip = Gossip::from_endpoint(endpoint.clone(), Default::default(), &my_addr.info);
+    let gossip = Gossip::from_endpoint(
+        endpoint.clone(),
+        Default::default(),
+        &my_addr.info,
+        NoAuthenticator.into(),
+    );
 
     // print a ticket that includes our own node id and endpoint addresses
     let ticket = {

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -635,7 +635,7 @@ async fn connection_loop(
                                 topic: *topic.as_bytes(),
                             }
                         };
-                        let token = auth.request(req)?;
+                        let token = auth.request(req).await?;
                         let msg = WireMessage {
                             topic,
                             message,
@@ -657,7 +657,7 @@ async fn connection_loop(
                                 topic: *topic.as_bytes(),
                             }
                         };
-                        match auth.respond(req, &token)? {
+                        match auth.respond(req, &token).await? {
                             iroh_base::auth::AcceptOutcome::Accept => {
                                 in_event_tx.send(InEvent::RecvMessage(from, Message { topic, message })).await?
                             }

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -635,7 +635,7 @@ async fn connection_loop(
                                 topic: *topic.as_bytes(),
                             }
                         };
-                        let token = auth.request(req).await?;
+                        let token = auth.on_outgoing_request(req).await?;
                         let msg = WireMessage {
                             topic,
                             message,
@@ -657,7 +657,7 @@ async fn connection_loop(
                                 topic: *topic.as_bytes(),
                             }
                         };
-                        match auth.respond(req, &token).await? {
+                        match auth.on_incoming_request(req, &token).await? {
                             iroh_base::auth::AcceptOutcome::Accept => {
                                 in_event_tx.send(InEvent::RecvMessage(from, Message { topic, message })).await?
                             }

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -23,7 +23,7 @@ use crate::proto::{self, Message, PeerData, Scope, TopicId, WireMessage};
 pub mod util;
 
 /// ALPN protocol name
-pub const GOSSIP_ALPN: &[u8] = b"/iroh-gossip/0";
+pub const GOSSIP_ALPN: &[u8] = b"/iroh-gossip/1";
 /// Maximum message size is limited currently. The limit is more-or-less arbitrary.
 // TODO: Make the limit configurable.
 pub const MAX_MESSAGE_SIZE: usize = 4096;

--- a/iroh-gossip/src/net/util.rs
+++ b/iroh-gossip/src/net/util.rs
@@ -14,15 +14,15 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
-use crate::proto::util::TimerMap;
+use crate::proto::{state::WireMessage, util::TimerMap};
 
-use super::{ProtoMessage, MAX_MESSAGE_SIZE};
+use super::MAX_MESSAGE_SIZE;
 
 /// Write a `ProtoMessage` as a length-prefixed, postcard-encoded message.
 pub async fn write_message<W: AsyncWrite + Unpin>(
     writer: &mut W,
     buffer: &mut BytesMut,
-    frame: &ProtoMessage,
+    frame: &WireMessage<PublicKey>,
 ) -> Result<()> {
     let len = postcard::experimental::serialized_size(&frame)?;
     ensure!(len < MAX_MESSAGE_SIZE);
@@ -38,7 +38,7 @@ pub async fn write_message<W: AsyncWrite + Unpin>(
 pub async fn read_message(
     reader: impl AsyncRead + Unpin,
     buffer: &mut BytesMut,
-) -> Result<Option<ProtoMessage>> {
+) -> Result<Option<WireMessage<PublicKey>>> {
     match read_lp(reader, buffer).await? {
         None => Ok(None),
         Some(data) => {

--- a/iroh-gossip/src/proto.rs
+++ b/iroh-gossip/src/proto.rs
@@ -60,7 +60,7 @@ pub mod util;
 mod tests;
 
 pub use plumtree::Scope;
-pub use state::{InEvent, Message, OutEvent, State, Timer, TopicId};
+pub use state::{InEvent, Message, OutEvent, State, Timer, TopicId, WireMessage};
 pub use topic::{Command, Config, Event, IO};
 
 /// The identifier for a peer.

--- a/iroh-sync/src/net.rs
+++ b/iroh-sync/src/net.rs
@@ -22,7 +22,7 @@ use crate::metrics::Metrics;
 use iroh_metrics::inc;
 
 /// The ALPN identifier for the iroh-sync protocol
-pub const SYNC_ALPN: &[u8] = b"/iroh-sync/1";
+pub const SYNC_ALPN: &[u8] = b"/iroh-sync/2";
 
 mod codec;
 

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -120,6 +120,7 @@ pub(super) async fn run_alice<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 namespace: *namespace.as_bytes(),
             },
         })
+        .await
         .map_err(ConnectError::sync)?;
     let init_message = Message::Init {
         namespace,
@@ -255,6 +256,7 @@ impl BobState {
                             },
                             &token,
                         )
+                        .await
                         .map_err(|e| self.fail(e))?;
 
                     match auth_outcome {

--- a/iroh-sync/src/net/codec.rs
+++ b/iroh-sync/src/net/codec.rs
@@ -114,7 +114,7 @@ pub(super) async fn run_alice<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         .await
         .map_err(ConnectError::sync)?;
     let token = auth
-        .request(iroh_base::auth::Request {
+        .on_outgoing_request(iroh_base::auth::Request {
             id: req_id,
             data: iroh_base::auth::RequestData::Sync {
                 namespace: *namespace.as_bytes(),
@@ -247,7 +247,7 @@ impl BobState {
 
                     let auth_outcome = self
                         .auth
-                        .respond(
+                        .on_incoming_request(
                             iroh_base::auth::Request {
                                 id: req_id,
                                 data: iroh_base::auth::RequestData::Sync {

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -58,6 +58,7 @@ clap = { version = "4", features = ["derive"], optional = true }
 comfy-table = { version = "7.0.1", optional = true }
 config = { version = "0.13.1", default-features = false, features = ["toml", "preserve_order"], optional = true }
 console = { version = "0.15.5", optional = true }
+colored = { version = "2.0.4", optional = true }
 dialoguer = { version = "0.11.0", default-features = false, optional = true }
 dirs-next = { version = "2.0.0", optional = true }
 indicatif = { version = "0.17", features = ["tokio"], optional = true }
@@ -70,14 +71,15 @@ time = { version = "0.3", optional = true, features = ["formatting"] }
 toml = { version = "0.8", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 url = { version = "2.4", features = ["serde"] }
-colored = { version = "2.0.4", optional = true }
+uuid = { version = "1.6.1", features = ["v4", "fast-rng", "serde"], optional = true }
 
 # Examples
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"], optional = true }
 
+
 [features]
 default = ["cli", "metrics"]
-cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table", "dialoguer", "time"]
+cli = ["clap", "config", "console", "dirs-next", "indicatif", "multibase", "quic-rpc/quinn-transport", "tokio/rt-multi-thread", "tracing-subscriber", "flat-db", "shell-words", "shellexpand", "rustyline", "colored", "toml", "human-time", "comfy-table", "dialoguer", "time", "uuid"]
 metrics = ["iroh-metrics"]
 flat-db = ["iroh-bytes/flat-db"]
 test = []

--- a/iroh/examples/dump-blob-fsm.rs
+++ b/iroh/examples/dump-blob-fsm.rs
@@ -10,6 +10,7 @@ use std::env::args;
 
 use iroh::dial::Options;
 use iroh::ticket::BlobTicket;
+use iroh_base::auth::NoAuthenticator;
 use iroh_bytes::get::fsm::{ConnectedNext, EndBlobNext};
 use iroh_bytes::protocol::GetRequest;
 use iroh_io::ConcatenateSliceWriter;
@@ -51,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
     let request = GetRequest::single(ticket.hash());
 
     // create the initial state of the finite state machine
-    let initial = iroh::bytes::get::fsm::start(connection, request);
+    let initial = iroh::bytes::get::fsm::start(connection, request, NoAuthenticator.into());
 
     // connect (create a stream pair)
     let connected = initial.next().await?;

--- a/iroh/examples/dump-blob-stream.rs
+++ b/iroh/examples/dump-blob-stream.rs
@@ -16,6 +16,7 @@ use genawaiter::sync::Co;
 use genawaiter::sync::Gen;
 use iroh::dial::Options;
 use iroh::ticket::BlobTicket;
+use iroh_base::auth::NoAuthenticator;
 use iroh_bytes::get::fsm::{AtInitial, BlobContentNext, ConnectedNext, EndBlobNext};
 use iroh_bytes::protocol::GetRequest;
 use iroh_net::key::SecretKey;
@@ -189,7 +190,7 @@ async fn main() -> anyhow::Result<()> {
         let request = GetRequest::all(ticket.hash());
 
         // create the initial state of the finite state machine
-        let initial = iroh::bytes::get::fsm::start(connection, request);
+        let initial = iroh::bytes::get::fsm::start(connection, request, NoAuthenticator.into());
 
         // create a stream that yields all the data of the blob
         stream_children(initial).boxed_local()
@@ -198,7 +199,7 @@ async fn main() -> anyhow::Result<()> {
         let request = GetRequest::single(ticket.hash());
 
         // create the initial state of the finite state machine
-        let initial = iroh::bytes::get::fsm::start(connection, request);
+        let initial = iroh::bytes::get::fsm::start(connection, request, NoAuthenticator.into());
 
         // create a stream that yields all the data of the blob
         stream_blob(initial).boxed_local()

--- a/iroh/src/auth.rs
+++ b/iroh/src/auth.rs
@@ -1,0 +1,51 @@
+//! Authenticator tooling.
+
+use std::future;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use iroh_base::auth::{AcceptOutcome, DynAuthenticator, Request, RequestData, Token};
+
+/// A minimal authenticator that only tracks IDs
+#[derive(Debug, Clone)]
+pub struct IdAuthenticator {
+    id: [u8; 16],
+}
+
+impl IdAuthenticator {
+    /// Constructs a new IdAuthenticator with the provided uuid.
+    pub fn new(id: [u8; 16]) -> Self {
+        IdAuthenticator { id }
+    }
+}
+
+impl DynAuthenticator for IdAuthenticator {
+    fn request(&self, _request: Request) -> BoxFuture<'static, Result<Option<Token>>> {
+        Box::pin(future::ready(Ok(Some(Token {
+            id: self.id,
+            secret: [0u8; 32],
+        }))))
+    }
+
+    fn respond(
+        &self,
+        request: Request,
+        token: &Option<Token>,
+    ) -> BoxFuture<'static, Result<AcceptOutcome>> {
+        if let Some(token) = token {
+            match request.data {
+                RequestData::Bytes(_) => {
+                    tracing::debug!("auth:bytes:{}", hex::encode(&token.id));
+                }
+                RequestData::Gossip { .. } => {
+                    tracing::debug!("auth:gossip:{}", hex::encode(&token.id));
+                }
+                RequestData::Sync { .. } => {
+                    tracing::debug!("auth:sync:{}", hex::encode(&token.id));
+                }
+            }
+        }
+
+        Box::pin(future::ready(Ok(AcceptOutcome::Accept)))
+    }
+}

--- a/iroh/src/auth.rs
+++ b/iroh/src/auth.rs
@@ -15,12 +15,14 @@ pub struct IdAuthenticator {
 impl IdAuthenticator {
     /// Constructs a new IdAuthenticator with the provided uuid.
     pub fn new(id: [u8; 16]) -> Self {
+        tracing::info!("auth:new {}", hex::encode(id));
         IdAuthenticator { id }
     }
 }
 
 impl DynAuthenticator for IdAuthenticator {
     fn request(&self, _request: Request) -> BoxFuture<'static, Result<Option<Token>>> {
+        tracing::info!("auth:request {}", hex::encode(self.id));
         Box::pin(future::ready(Ok(Some(Token {
             id: self.id,
             secret: [0u8; 32],
@@ -35,13 +37,13 @@ impl DynAuthenticator for IdAuthenticator {
         if let Some(token) = token {
             match request.data {
                 RequestData::Bytes(_) => {
-                    tracing::debug!("auth:bytes:{}", hex::encode(&token.id));
+                    tracing::info!("auth:bytes:{}", hex::encode(token.id));
                 }
                 RequestData::Gossip { .. } => {
-                    tracing::debug!("auth:gossip:{}", hex::encode(&token.id));
+                    tracing::info!("auth:gossip:{}", hex::encode(token.id));
                 }
                 RequestData::Sync { .. } => {
-                    tracing::debug!("auth:sync:{}", hex::encode(&token.id));
+                    tracing::info!("auth:sync:{}", hex::encode(token.id));
                 }
             }
         }

--- a/iroh/src/auth.rs
+++ b/iroh/src/auth.rs
@@ -21,7 +21,7 @@ impl IdAuthenticator {
 }
 
 impl DynAuthenticator for IdAuthenticator {
-    fn request(&self, _request: Request) -> BoxFuture<'static, Result<Option<Token>>> {
+    fn on_outgoing_request(&self, _request: Request) -> BoxFuture<'static, Result<Option<Token>>> {
         tracing::info!("auth:request {}", hex::encode(self.id));
         Box::pin(future::ready(Ok(Some(Token {
             id: self.id,
@@ -29,7 +29,7 @@ impl DynAuthenticator for IdAuthenticator {
         }))))
     }
 
-    fn respond(
+    fn on_incoming_request(
         &self,
         request: Request,
         token: &Option<Token>,

--- a/iroh/src/commands/doc.rs
+++ b/iroh/src/commands/doc.rs
@@ -950,7 +950,7 @@ mod tests {
         // run iroh node in the background, as if running `iroh start`
         std::env::set_var("IROH_DATA_DIR", data_dir.path().as_os_str());
         let lp = tokio_util::task::LocalPoolHandle::new(1);
-        let node = crate::commands::start::start_node(&lp, None).await?;
+        let node = crate::commands::start::start_node(&lp, None, uuid::Uuid::new_v4()).await?;
         let client = node.client();
         let doc = client.docs.create().await.context("doc create")?;
         let author = client.authors.create().await.context("author create")?;

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -20,6 +20,7 @@ use iroh_sync::{AuthorId, NamespaceId};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+use uuid::Uuid;
 
 /// CONFIG_FILE_NAME is the name of the optional config file located in the iroh home directory
 pub const CONFIG_FILE_NAME: &str = "iroh.config.toml";
@@ -118,6 +119,8 @@ pub struct NodeConfig {
     /// Bind address on which to serve Prometheus metrics
     #[cfg(feature = "metrics")]
     pub metrics_addr: Option<SocketAddr>,
+    /// UUID to attribute traffic.
+    pub uuid: Uuid,
 }
 
 impl Default for NodeConfig {
@@ -128,6 +131,7 @@ impl Default for NodeConfig {
             gc_policy: GcPolicy::Disabled,
             #[cfg(feature = "metrics")]
             metrics_addr: None,
+            uuid: Uuid::new_v4(),
         }
     }
 }

--- a/iroh/src/downloader.rs
+++ b/iroh/src/downloader.rs
@@ -37,6 +37,7 @@ use std::{
 
 use bao_tree::ChunkRanges;
 use futures::{future::LocalBoxFuture, FutureExt, StreamExt};
+use iroh_base::auth::Authenticator;
 use iroh_bytes::{protocol::RangeSpecSeq, store::Store, Hash, HashAndFormat, TempTag};
 use iroh_net::{MagicEndpoint, NodeId};
 use tokio::{
@@ -224,7 +225,12 @@ pub struct Downloader {
 
 impl Downloader {
     /// Create a new Downloader.
-    pub fn new<S>(store: S, endpoint: MagicEndpoint, rt: LocalPoolHandle) -> Self
+    pub fn new<S>(
+        store: S,
+        endpoint: MagicEndpoint,
+        rt: LocalPoolHandle,
+        auth: Authenticator,
+    ) -> Self
     where
         S: Store,
     {
@@ -234,7 +240,7 @@ impl Downloader {
 
         let create_future = move || {
             let concurrency_limits = ConcurrencyLimits::default();
-            let getter = get::IoGetter { store };
+            let getter = get::IoGetter { store, auth };
 
             let service = Service::new(getter, dialer, concurrency_limits, msg_rx);
 

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -12,6 +12,7 @@ pub use iroh_sync as sync;
 // iroh_base::rpc::* is exported from mod rpc_protocol
 pub use iroh_base::base32;
 
+pub mod auth;
 pub mod client;
 pub mod dial;
 pub mod downloader;

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -12,6 +12,7 @@ use iroh::{
     dial::Options,
     node::{Builder, Event, Node},
 };
+use iroh_base::auth::NoAuthenticator;
 use iroh_net::{key::SecretKey, NodeId};
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use rand::RngCore;
@@ -545,7 +546,7 @@ async fn run_collection_get_request(
     request: GetRequest,
 ) -> anyhow::Result<(Collection, BTreeMap<u64, Bytes>, Stats)> {
     let connection = iroh::dial::dial(opts).await?;
-    let initial = fsm::start(connection, request);
+    let initial = fsm::start(connection, request, NoAuthenticator.into());
     let connected = initial.next().await?;
     let ConnectedNext::StartRoot(fsm_at_start_root) = connected.next().await? else {
         anyhow::bail!("request did not include collection");
@@ -613,7 +614,7 @@ async fn test_size_request_blob() {
     tokio::time::timeout(Duration::from_secs(10), async move {
         let request = GetRequest::last_chunk(hash);
         let connection = iroh::dial::dial(get_options(peer_id, addrs)).await?;
-        let response = fsm::start(connection, request);
+        let response = fsm::start(connection, request, NoAuthenticator.into());
         let connected = response.next().await?;
         let ConnectedNext::StartRoot(start) = connected.next().await? else {
             panic!()


### PR DESCRIPTION
Brings back the general concept of authenticating requests. 

This is a protocol level breaking change, which is why all ALPN version numbers have been increased.

Currently there are two authenticators implemented 

- `NoAuthenticator`: does nothing
- `IdAuthenticator`: sends a single UUID for all requests, which allows attribution of incoming traffic to this id. By default this authenticator is use in the iroh cli, and the uuid can be set in the config or on the console using `IROH_UUID="my-uuid"`


## Open Questions

- Should gossip authenticate each message, or can we reduce this?



