### PR TITLE
refactor(iroh-net): Log best addr on debug if not changed

### DIFF
--- a/iroh-net/src/magicsock/peer_map/best_addr.rs
+++ b/iroh-net/src/magicsock/peer_map/best_addr.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use iroh_metrics::inc;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::magicsock::metrics::Metrics as MagicsockMetrics;
 
@@ -149,12 +149,26 @@ impl BestAddr {
     ) {
         let trust_until = source.trust_until(confirmed_at);
 
-        info!(
-           %addr,
-           latency = ?latency,
-           trust_for = ?trust_until.duration_since(Instant::now()),
-           "new best_addr"
-        );
+        if self
+            .0
+            .as_ref()
+            .map(|prev| prev.addr.addr == addr)
+            .unwrap_or_default()
+        {
+            debug!(
+                %addr,
+                latency = ?latency,
+                trust_for = ?trust_until.duration_since(Instant::now()),
+                "new best_addr"
+            );
+        } else {
+            info!(
+               %addr,
+               latency = ?latency,
+               trust_for = ?trust_until.duration_since(Instant::now()),
+               "new best_addr"
+            );
+        }
         let was_empty = self.is_empty();
         let inner = BestAddrInner {
             addr: AddrLatency { addr, latency },


### PR DESCRIPTION
## Description

The best addr is renewed every few seconds, always logging this on
info level floods the info log.  Now we log it on debug if the address
has not changed.  Logging that is still useful since it shows how long
the validity is and the latency.

## Notes & open questions


## Change checklist

- [x] Self-review.