### PR TITLE
feat(iroh): add more rpc methods

### DIFF
--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -37,16 +37,17 @@ use crate::rpc_protocol::{
     AuthorCreateRequest, AuthorListRequest, BlobAddPathRequest, BlobAddStreamRequest,
     BlobAddStreamUpdate, BlobDeleteBlobRequest, BlobDownloadRequest, BlobListCollectionsRequest,
     BlobListCollectionsResponse, BlobListIncompleteRequest, BlobListIncompleteResponse,
-    BlobListRequest, BlobListResponse, BlobReadRequest, BlobReadResponse, BlobValidateRequest,
-    CounterStats, CreateCollectionRequest, CreateCollectionResponse, DeleteTagRequest,
-    DocCloseRequest, DocCreateRequest, DocDelRequest, DocDelResponse, DocDropRequest,
-    DocExportFileRequest, DocExportProgress, DocGetDownloadPolicyRequest, DocGetExactRequest,
-    DocGetManyRequest, DocImportFileRequest, DocImportProgress, DocImportRequest, DocLeaveRequest,
-    DocListRequest, DocOpenRequest, DocSetDownloadPolicyRequest, DocSetHashRequest, DocSetRequest,
-    DocShareRequest, DocStartSyncRequest, DocStatusRequest, DocSubscribeRequest, DocTicket,
-    DownloadProgress, ListTagsRequest, ListTagsResponse, NodeConnectionInfoRequest,
-    NodeConnectionInfoResponse, NodeConnectionsRequest, NodeShutdownRequest, NodeStatsRequest,
-    NodeStatusRequest, NodeStatusResponse, ProviderService, SetTagOption, ShareMode, WrapOption,
+    BlobListRequest, BlobListResponse, BlobReadAtRequest, BlobReadAtResponse, BlobReadRequest,
+    BlobReadResponse, BlobValidateRequest, CounterStats, CreateCollectionRequest,
+    CreateCollectionResponse, DeleteTagRequest, DocCloseRequest, DocCreateRequest, DocDelRequest,
+    DocDelResponse, DocDropRequest, DocExportFileRequest, DocExportProgress,
+    DocGetDownloadPolicyRequest, DocGetExactRequest, DocGetManyRequest, DocImportFileRequest,
+    DocImportProgress, DocImportRequest, DocLeaveRequest, DocListRequest, DocOpenRequest,
+    DocSetDownloadPolicyRequest, DocSetHashRequest, DocSetRequest, DocShareRequest,
+    DocStartSyncRequest, DocStatusRequest, DocSubscribeRequest, DocTicket, DownloadProgress,
+    ListTagsRequest, ListTagsResponse, NodeConnectionInfoRequest, NodeConnectionInfoResponse,
+    NodeConnectionsRequest, NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest,
+    NodeStatusResponse, ProviderService, SetTagOption, ShareMode, WrapOption,
 };
 use crate::sync_engine::SyncEvent;
 
@@ -240,7 +241,12 @@ where
     ///
     /// Returns a [`BlobReader`], which can report the size of the blob before reading it.
     pub async fn read(&self, hash: Hash) -> Result<BlobReader> {
-        BlobReader::from_rpc(&self.rpc, hash).await
+        BlobReader::from_rpc_read(&self.rpc, hash).await
+    }
+
+    /// Read offset + len from a single blob.
+    pub async fn read_at(&self, hash: Hash, offset: u64, len: usize) -> Result<BlobReader> {
+        BlobReader::from_rpc_read_at(&self.rpc, hash, offset, len).await
     }
 
     /// Read all bytes of single blob.
@@ -249,7 +255,17 @@ where
     /// reading is small. If not sure, use [`Self::read`] and check the size with
     /// [`BlobReader::size`] before calling [`BlobReader::read_to_bytes`].
     pub async fn read_to_bytes(&self, hash: Hash) -> Result<Bytes> {
-        BlobReader::from_rpc(&self.rpc, hash)
+        BlobReader::from_rpc_read(&self.rpc, hash)
+            .await?
+            .read_to_bytes()
+            .await
+    }
+
+    /// Read all bytes of single blob at `offset` for length `len`.
+    ///
+    /// This allocates a buffer for the full length.
+    pub async fn read_at_to_bytes(&self, hash: Hash, offset: u64, len: usize) -> Result<Bytes> {
+        BlobReader::from_rpc_read_at(&self.rpc, hash, offset, len)
             .await?
             .read_to_bytes()
             .await
@@ -498,7 +514,7 @@ impl BlobReader {
         }
     }
 
-    async fn from_rpc<C: ServiceConnection<ProviderService>>(
+    async fn from_rpc_read<C: ServiceConnection<ProviderService>>(
         rpc: &RpcClient<ProviderService, C>,
         hash: Hash,
     ) -> anyhow::Result<Self> {
@@ -513,6 +529,31 @@ impl BlobReader {
 
         let stream = stream.map(|item| match item {
             Ok(BlobReadResponse::Data { chunk }) => Ok(chunk),
+            Ok(_) => Err(io::Error::new(io::ErrorKind::Other, "Expected data frame")),
+            Err(err) => Err(io::Error::new(io::ErrorKind::Other, format!("{err}"))),
+        });
+        Ok(Self::new(size, is_complete, stream.boxed()))
+    }
+
+    async fn from_rpc_read_at<C: ServiceConnection<ProviderService>>(
+        rpc: &RpcClient<ProviderService, C>,
+        hash: Hash,
+        offset: u64,
+        len: usize,
+    ) -> anyhow::Result<Self> {
+        let stream = rpc
+            .server_streaming(BlobReadAtRequest { hash, offset, len })
+            .await?;
+        let mut stream = flatten(stream);
+
+        let (size, is_complete) = match stream.next().await {
+            Some(Ok(BlobReadAtResponse::Entry { size, is_complete })) => (size, is_complete),
+            Some(Err(err)) => return Err(err),
+            None | Some(Ok(_)) => return Err(anyhow!("Expected header frame")),
+        };
+
+        let stream = stream.map(|item| match item {
+            Ok(BlobReadAtResponse::Data { chunk }) => Ok(chunk),
             Ok(_) => Err(io::Error::new(io::ErrorKind::Other, "Expected data frame")),
             Err(err) => Err(io::Error::new(io::ErrorKind::Other, format!("{err}"))),
         });
@@ -908,7 +949,7 @@ impl Entry {
     where
         C: ServiceConnection<ProviderService>,
     {
-        BlobReader::from_rpc(client.into(), self.content_hash()).await
+        BlobReader::from_rpc_read(client.into(), self.content_hash()).await
     }
 
     /// Read all content of an [`Entry`] into a buffer.
@@ -921,7 +962,7 @@ impl Entry {
     where
         C: ServiceConnection<ProviderService>,
     {
-        BlobReader::from_rpc(client.into(), self.content_hash())
+        BlobReader::from_rpc_read(client.into(), self.content_hash())
             .await?
             .read_to_bytes()
             .await
@@ -1318,6 +1359,89 @@ mod tests {
         assert_eq!(tags[0].hash, hash);
         assert_eq!(tags[0].name, tag);
         assert_eq!(tags[0].format, BlobFormat::HashSeq);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_blob_read_at() -> Result<()> {
+        // let _guard = iroh_test::logging::setup();
+
+        let doc_store = iroh_sync::store::memory::Store::default();
+        let db = iroh_bytes::store::mem::Store::new();
+        let node = crate::node::Node::builder(db, doc_store).spawn().await?;
+
+        // create temp file
+        let temp_dir = tempfile::tempdir().context("tempdir")?;
+
+        let in_root = temp_dir.path().join("in");
+        tokio::fs::create_dir_all(in_root.clone())
+            .await
+            .context("create dir all")?;
+
+        let path = in_root.join("test-blob");
+        let size = 1024 * 128;
+        let buf: Vec<u8> = (0..size).map(|i| i as u8).collect();
+        let mut file = tokio::fs::File::create(path.clone())
+            .await
+            .context("create file")?;
+        file.write_all(&buf.clone()).await.context("write_all")?;
+        file.flush().await.context("flush")?;
+
+        let client = node.client();
+
+        let import_outcome = client
+            .blobs
+            .add_from_path(
+                path.to_path_buf(),
+                false,
+                SetTagOption::Auto,
+                WrapOption::NoWrap,
+            )
+            .await
+            .context("import file")?
+            .finish()
+            .await
+            .context("import finish")?;
+
+        let hash = import_outcome.hash;
+
+        // Read everything
+        let res = client.blobs.read_to_bytes(hash).await?;
+        assert_eq!(&res, &buf[..]);
+
+        // Read at smaller than blob_get_chunk_size
+        let res = client.blobs.read_at_to_bytes(hash, 0, 100).await?;
+        assert_eq!(res.len(), 100);
+        assert_eq!(&res[..], &buf[0..100]);
+
+        let res = client.blobs.read_at_to_bytes(hash, 20, 120).await?;
+        assert_eq!(res.len(), 120);
+        assert_eq!(&res[..], &buf[20..140]);
+
+        // Read at equal to blob_get_chunk_size
+        let res = client.blobs.read_at_to_bytes(hash, 0, 1024 * 64).await?;
+        assert_eq!(res.len(), 1024 * 64);
+        assert_eq!(&res[..], &buf[0..1024 * 64]);
+
+        let res = client.blobs.read_at_to_bytes(hash, 20, 1024 * 64).await?;
+        assert_eq!(res.len(), 1024 * 64);
+        assert_eq!(&res[..], &buf[20..(20 + 1024 * 64)]);
+
+        // Read at larger than blob_get_chunk_size
+        let res = client
+            .blobs
+            .read_at_to_bytes(hash, 0, 10 + 1024 * 64)
+            .await?;
+        assert_eq!(res.len(), 10 + 1024 * 64);
+        assert_eq!(&res[..], &buf[0..(10 + 1024 * 64)]);
+
+        let res = client
+            .blobs
+            .read_at_to_bytes(hash, 20, 10 + 1024 * 64)
+            .await?;
+        assert_eq!(res.len(), 10 + 1024 * 64);
+        assert_eq!(&res[..], &buf[20..(20 + 10 + 1024 * 64)]);
 
         Ok(())
     }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1503,7 +1503,7 @@ impl<D: BaoStore> RpcHandler<D> {
 
         async fn read_loop<M: Map>(
             offset: u64,
-            len: usize,
+            len: Option<usize>,
             entry: Option<impl MapEntry<M>>,
             tx: flume::Sender<RpcResult<BlobReadAtResponse>>,
             max_chunk_size: usize,
@@ -1516,6 +1516,8 @@ impl<D: BaoStore> RpcHandler<D> {
             }))
             .await?;
             let mut reader = entry.data_reader().await?;
+
+            let len = len.unwrap_or_else(|| (size - offset) as usize);
 
             let (num_chunks, chunk_size) = if len <= max_chunk_size {
                 (1, len)

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1478,10 +1478,8 @@ impl<D: BaoStore> RpcHandler<D> {
             let (num_chunks, chunk_size) = if len <= max_chunk_size {
                 (1, len)
             } else {
-                (
-                    (len as f64 / max_chunk_size as f64).ceil() as usize,
-                    max_chunk_size,
-                )
+                let num_chunks = len / max_chunk_size + (len % max_chunk_size != 0) as usize;
+                (num_chunks, max_chunk_size)
             };
 
             let mut read = 0u64;

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -967,6 +967,42 @@ pub enum BlobReadResponse {
     },
 }
 
+/// Get the bytes for a hash
+#[derive(Serialize, Deserialize, Debug)]
+pub struct BlobReadAtRequest {
+    /// Hash to get bytes for
+    pub hash: Hash,
+    /// Offset to start reading at
+    pub offset: u64,
+    /// Lenghth of the data to get
+    pub len: usize,
+}
+
+impl Msg<ProviderService> for BlobReadAtRequest {
+    type Pattern = ServerStreaming;
+}
+
+impl ServerStreamingMsg<ProviderService> for BlobReadAtRequest {
+    type Response = RpcResult<BlobReadAtResponse>;
+}
+
+/// Response to [`BlobReadAtRequest`]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum BlobReadAtResponse {
+    /// The entry header.
+    Entry {
+        /// The size of the blob
+        size: u64,
+        /// Wether the blob is complete
+        is_complete: bool,
+    },
+    /// Chunks of entry data.
+    Data {
+        /// The data chunk
+        chunk: Bytes,
+    },
+}
+
 /// Write a blob from a byte stream
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BlobAddStreamRequest {
@@ -1036,6 +1072,7 @@ pub enum ProviderRequest {
     NodeWatch(NodeWatchRequest),
 
     BlobRead(BlobReadRequest),
+    BlobReadAt(BlobReadAtRequest),
     BlobAddStream(BlobAddStreamRequest),
     BlobAddStreamUpdate(BlobAddStreamUpdate),
     BlobAddPath(BlobAddPathRequest),
@@ -1088,6 +1125,7 @@ pub enum ProviderResponse {
     NodeWatch(NodeWatchResponse),
 
     BlobRead(RpcResult<BlobReadResponse>),
+    BlobReadAt(RpcResult<BlobReadAtResponse>),
     BlobAddStream(BlobAddStreamResponse),
     BlobAddPath(BlobAddPathResponse),
     BlobDownload(DownloadProgress),

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -975,7 +975,7 @@ pub struct BlobReadAtRequest {
     /// Offset to start reading at
     pub offset: u64,
     /// Lenghth of the data to get
-    pub len: usize,
+    pub len: Option<usize>,
 }
 
 impl Msg<ProviderService> for BlobReadAtRequest {

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -955,38 +955,6 @@ pub struct DocGetDownloadPolicyResponse {
 
 /// Get the bytes for a hash
 #[derive(Serialize, Deserialize, Debug)]
-pub struct BlobReadRequest {
-    /// Hash to get bytes for
-    pub hash: Hash,
-}
-
-impl Msg<ProviderService> for BlobReadRequest {
-    type Pattern = ServerStreaming;
-}
-
-impl ServerStreamingMsg<ProviderService> for BlobReadRequest {
-    type Response = RpcResult<BlobReadResponse>;
-}
-
-/// Response to [`BlobReadRequest`]
-#[derive(Serialize, Deserialize, Debug)]
-pub enum BlobReadResponse {
-    /// The entry header.
-    Entry {
-        /// The size of the blob
-        size: u64,
-        /// Wether the blob is complete
-        is_complete: bool,
-    },
-    /// Chunks of entry data.
-    Data {
-        /// The data chunk
-        chunk: Bytes,
-    },
-}
-
-/// Get the bytes for a hash
-#[derive(Serialize, Deserialize, Debug)]
 pub struct BlobReadAtRequest {
     /// Hash to get bytes for
     pub hash: Hash,
@@ -1089,7 +1057,6 @@ pub enum ProviderRequest {
     NodeConnectionInfo(NodeConnectionInfoRequest),
     NodeWatch(NodeWatchRequest),
 
-    BlobRead(BlobReadRequest),
     BlobReadAt(BlobReadAtRequest),
     BlobAddStream(BlobAddStreamRequest),
     BlobAddStreamUpdate(BlobAddStreamUpdate),
@@ -1143,7 +1110,6 @@ pub enum ProviderResponse {
     NodeShutdown(()),
     NodeWatch(NodeWatchResponse),
 
-    BlobRead(RpcResult<BlobReadResponse>),
     BlobReadAt(RpcResult<BlobReadAtResponse>),
     BlobAddStream(BlobAddStreamResponse),
     BlobAddPath(BlobAddPathResponse),

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -274,6 +274,24 @@ impl RpcMsg<ProviderService> for DeleteTagRequest {
     type Response = RpcResult<()>;
 }
 
+/// Get a collection
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BlobGetCollectionRequest {
+    /// Hash of the collection
+    pub hash: Hash,
+}
+
+impl RpcMsg<ProviderService> for BlobGetCollectionRequest {
+    type Response = RpcResult<BlobGetCollectionResponse>;
+}
+
+/// The response for a `BlobGetCollectionRequest`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BlobGetCollectionResponse {
+    /// The collection.
+    pub collection: Collection,
+}
+
 /// Create a collection.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateCollectionRequest {
@@ -1083,6 +1101,7 @@ pub enum ProviderRequest {
     BlobDeleteBlob(BlobDeleteBlobRequest),
     BlobValidate(BlobValidateRequest),
     CreateCollection(CreateCollectionRequest),
+    BlobGetCollection(BlobGetCollectionRequest),
 
     DeleteTag(DeleteTagRequest),
     ListTags(ListTagsRequest),
@@ -1134,6 +1153,7 @@ pub enum ProviderResponse {
     BlobListCollections(BlobListCollectionsResponse),
     BlobValidate(ValidateProgress),
     CreateCollection(RpcResult<CreateCollectionResponse>),
+    BlobGetCollection(RpcResult<BlobGetCollectionResponse>),
 
     ListTags(ListTagsResponse),
     DeleteTag(RpcResult<()>),


### PR DESCRIPTION
- add `blobs.read_at`: Allows to efficiently read parts of a blob via RPC
- add `blobs.get_collection`: read a collection

