### PR TITLE
fix(iroh): do not establish connection if content already exists locally

### DIFF
--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -20,11 +20,11 @@ use futures::future::{BoxFuture, Shared};
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt};
 use iroh_base::rpc::RpcResult;
 use iroh_bytes::format::collection::Collection;
-use iroh_bytes::get::{db::DownloadProgress, Stats};
+use iroh_bytes::get::db::DownloadProgress;
 use iroh_bytes::hashseq::parse_hash_seq;
 use iroh_bytes::store::{
-    EntryStatus, ExportMode, GcMarkEvent, GcSweepEvent, ImportProgress, Map, MapEntry,
-    PossiblyPartialEntry, ReadableStore, Store as BaoStore, ValidateProgress,
+    ExportMode, GcMarkEvent, GcSweepEvent, ImportProgress, Map, MapEntry, PossiblyPartialEntry,
+    ReadableStore, Store as BaoStore, ValidateProgress,
 };
 use iroh_bytes::util::progress::{FlumeProgressSender, IdGenerator, ProgressSender};
 use iroh_bytes::{protocol::Closed, provider::AddProgress, BlobFormat, Hash, HashAndFormat};
@@ -1118,37 +1118,30 @@ impl<D: BaoStore> RpcHandler<D> {
         let haf = HashAndFormat { hash, format };
 
         let progress3 = progress.clone();
-        let (stats, temp_pin) = if EntryStatus::Complete != self.inner.db.entry_status(&hash) {
-            // only download if this entry doesn't already exists
-            let temp_pin = db.temp_tag(haf);
-            let conn = self
-                .inner
-                .endpoint
-                .connect(msg.peer, iroh_bytes::protocol::ALPN)
-                .await?;
-            progress.send(DownloadProgress::Connected).await?;
-            let progress2 = progress.clone();
 
-            let db = self.inner.db.clone();
-            let db2 = db.clone();
-            let stats = local
-                .spawn_pinned(move || async move {
-                    iroh_bytes::get::db::get_to_db(
-                        &db2,
-                        conn,
-                        &HashAndFormat {
-                            hash: msg.hash,
-                            format: msg.format,
-                        },
-                        progress2,
-                    )
-                    .await
-                })
-                .await??;
-            (stats, Some(temp_pin))
-        } else {
-            (Stats::default(), None)
-        };
+        let temp_pin = db.temp_tag(haf);
+        let ep = self.inner.endpoint.clone();
+        let get_conn =
+            move || async move { ep.connect(msg.peer, iroh_bytes::protocol::ALPN).await };
+        progress.send(DownloadProgress::Connected).await?;
+        let progress2 = progress.clone();
+
+        let db = self.inner.db.clone();
+        let db2 = db.clone();
+        let stats = local
+            .spawn_pinned(move || async move {
+                iroh_bytes::get::db::get_to_db(
+                    &db2,
+                    get_conn,
+                    &HashAndFormat {
+                        hash: msg.hash,
+                        format: msg.format,
+                    },
+                    progress2,
+                )
+                .await
+            })
+            .await??;
 
         let this = self.clone();
         let _export = local.spawn_pinned(move || async move {


### PR DESCRIPTION
Avoid establishing a connection in `blobs.download` if content is already locally available.

Closes #1947 
