### PR TITLE
chore(ci): Run tests from the PR branch, not main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.72"
-  CRATES_LIST: "iroh,iroh-bytes,iroh-gossip,iroh-metrics,iroh-net,iroh-sync,iroh-test"
   SCCACHE_CACHE_SIZE: "50G"
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ on:
       git-ref:
         description: 'Which git ref to checkout'
         type: string
-        default: 'main'
+        default: ${{ github.ref }}
 
 env:
   RUST_BACKTRACE: 1
@@ -96,9 +96,17 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
 
-    - name: tests
+    - name: build tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests ${{ inputs.flaky && '--run-ignored all' || '' }}
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+
+    - name: list ignored tests
+      run: |
+        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
+
+    - name: run tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
       env:
         RUST_LOG: "TRACE"
 
@@ -174,8 +182,16 @@ jobs:
 
     - uses: msys2/setup-msys2@v2
 
+    - name: build tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+
+    - name: list ignored tests
+      run: |
+        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+
     - name: tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} ${{ inputs.flaky && '--run-ignored all' || '' }}
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
       env:
         RUST_LOG: "TRACE"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   SCCACHE_CACHE_SIZE: "50G"
+  CRATES_LIST: "iroh,iroh-bytes,iroh-gossip,iroh-metrics,iroh-net,iroh-sync,iroh-test"
 
 jobs:
   build_and_test_nix:

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -616,7 +616,7 @@ mod tests {
 
     const TEST_ALPN: &[u8] = b"n0/iroh/test";
 
-    #[ignore]
+    #[ignore = "flaky"]
     #[tokio::test]
     async fn magic_endpoint_connect_close() {
         let _guard = iroh_test::logging::setup();

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2713,6 +2713,7 @@ pub(crate) mod tests {
             .ok();
     }
 
+    #[ignore = "flaky"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_two_devices_roundtrip_quinn_magic() -> Result<()> {
         setup_multithreaded_logging();
@@ -2885,6 +2886,7 @@ pub(crate) mod tests {
 
     /// Same structure as `test_two_devices_roundtrip_quinn_magic`, but interrupts regularly
     /// with (simulated) network changes.
+    #[ignore = "flaky"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_two_devices_roundtrip_network_change() -> Result<()> {
         setup_multithreaded_logging();
@@ -3131,6 +3133,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
+    #[ignore = "flaky"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_two_devices_setup_teardown() -> Result<()> {
         setup_multithreaded_logging();


### PR DESCRIPTION
## Description

This fixes the tests to run from the PR branch and not from main.

Additionally it splits the tests running into three steps:

- Building the tests.
- Listing ignored tests.
- Running tests.

This makes the output easier to consume and does not add any slowdown.
Listing ignored tests is useful since nextest only says how many tests
are ignored rather than listing them all.

Finally it fixes the features testing by moving the CRATES_LIST environment
variable to the right workflow.

## Notes & open questions

Flaky tests tracked in #1966 

## Change checklist

- [x] Self-review.