### PR TITLE
Add better debug instance for AddrInfo

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -103,7 +103,6 @@ impl<T: std::fmt::Display> std::fmt::Debug for DD<T> {
     }
 }
 
-
 impl AddrInfo {
     /// Return whether this addressing information is empty.
     pub fn is_empty(&self) -> bool {
@@ -642,7 +641,10 @@ mod tests {
                 .into_iter()
                 .collect(),
         };
-        assert_eq!(format!("{:?}", info), r#"AddrInfo { derp_url: Some(https://derp.example.com/), direct_addresses: {1.2.3.4:1234} }"#);
+        assert_eq!(
+            format!("{:?}", info),
+            r#"AddrInfo { derp_url: Some(https://derp.example.com/), direct_addresses: {1.2.3.4:1234} }"#
+        );
     }
 
     #[ignore = "flaky"]

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -78,13 +78,31 @@ impl From<(PublicKey, Option<Url>, &[SocketAddr])> for NodeAddr {
 }
 
 /// Addressing information to connect to a peer.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AddrInfo {
     /// The peer's home DERP url.
     pub derp_url: Option<Url>,
     /// Socket addresses where the peer might be reached directly.
     pub direct_addresses: BTreeSet<SocketAddr>,
 }
+
+impl Debug for AddrInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AddrInfo")
+            .field("derp_url", &self.derp_url.as_ref().map(DD))
+            .field("direct_addresses", &self.direct_addresses)
+            .finish()
+    }
+}
+
+struct DD<T: std::fmt::Display>(T);
+
+impl<T: std::fmt::Display> std::fmt::Debug for DD<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
 
 impl AddrInfo {
     /// Return whether this addressing information is empty.
@@ -615,6 +633,17 @@ mod tests {
     use super::*;
 
     const TEST_ALPN: &[u8] = b"n0/iroh/test";
+
+    #[test]
+    fn test_addr_info_debug() {
+        let info = AddrInfo {
+            derp_url: Some(Url::parse("https://derp.example.com").unwrap()),
+            direct_addresses: vec![SocketAddr::from(([1, 2, 3, 4], 1234))]
+                .into_iter()
+                .collect(),
+        };
+        assert_eq!(format!("{:?}", info), r#"AddrInfo { derp_url: Some(https://derp.example.com/), direct_addresses: {1.2.3.4:1234} }"#);
+    }
 
     #[ignore = "flaky"]
     #[tokio::test]

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1473,7 +1473,7 @@ impl<D: BaoStore> RpcHandler<D> {
             .await?;
             let mut reader = entry.data_reader().await?;
 
-            let len = len.unwrap_or_else(|| (size - offset) as usize);
+            let len = len.unwrap_or((size - offset) as usize);
 
             let (num_chunks, chunk_size) = if len <= max_chunk_size {
                 (1, len)


### PR DESCRIPTION
## Description

Adds a better debug output for AddrInfo.

Before:
AddrInfo { derp_url: Some(Url { scheme: \"https\", cannot_be_a_base: false, username: \"\", password: None, host: Some(Domain(\"derp.example.com\")), port: None, path: \"/\", query: None, fragment: None }), direct_addresses: {1.2.3.4:1234} }

After:

AddrInfo { derp_url: Some(https://derp.example.com/), direct_addresses: {1.2.3.4:1234} }

## Notes & open questions

- Is there a way to make derive_more do this?
- should we make a newtype for DerpUrl that does this and also arc?

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [x] Tests if relevant.
