### PR TITLE
feat: release artifacts & windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            name: [ubuntu-latest, ubuntu-arm-latest, macOS-latest, macOS-arm-latest]
+            name: [ubuntu-latest, ubuntu-arm-latest, macOS-latest, macOS-arm-latest, windows-latest]
             rust: [stable]
             experimental: [false]
             include:
@@ -50,10 +50,10 @@ jobs:
                 release-os: darwin
                 release-arch: aarch64
                 runner: [self-hosted, macOS, ARM64]
-              # - os: windows-latest
-              #   release-os: windows
-              #   release-arch: amd64
-              #   runner: [windows-latest]
+              - os: windows-latest
+                release-os: windows
+                release-arch: amd64
+                runner: [self-hosted, windows, X64]
         env:
           # Using self-hosted runners so use local cache for sccache and
           # not SCCACHE_GHA_ENABLED.
@@ -76,11 +76,19 @@ jobs:
             rustup toolchain install ${{ matrix.rust }}
     
         - name: Install sccache
+          if: matrix.name != 'windows-latest'
           uses: mozilla-actions/sccache-action@v0.0.3
     
         - name: build release
           run: |
             cargo build --profile optimized-release --all-features
+
+        - name: attach artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: iroh-${RELEASE_OS}-${RELEASE_ARCH}-${GITHUB_SHA::7}
+            path: target/optimized-release/iroh
+            compression-level: 0
     
         - name: Setup awscli on linux
           if: matrix.name == 'ubuntu-latest'


### PR DESCRIPTION
## Description

Enables windows builds again and uploads artifacts to GH runs, which we can then manually attach to releases.

## Notes & open questions

This is not really feasible to test without merging... (has no impact on general flows, needs to be manually or release triggered anyways)

Covers the first steps to https://github.com/n0-computer/iroh/issues/1986

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
