### PR TITLE
refactor(iroh-net): Introduce a minimal DerpUrl

### DIFF
--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -10,13 +10,12 @@ use iroh_gossip::{
     proto::{Event, TopicId},
 };
 use iroh_net::{
-    derp::{DerpMap, DerpMode},
+    derp::{DerpMap, DerpMode, DerpUrl},
     key::{PublicKey, SecretKey},
     magic_endpoint::accept_conn,
     MagicEndpoint, NodeAddr,
 };
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 /// Chat over iroh-gossip
 ///
@@ -36,7 +35,7 @@ struct Args {
     secret_key: Option<String>,
     /// Set a custom DERP server. By default, the DERP server hosted by n0 will be used.
     #[clap(short, long)]
-    derp: Option<Url>,
+    derp: Option<DerpUrl>,
     /// Disable DERP completely.
     #[clap(long)]
     no_derp: bool,

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -826,13 +826,12 @@ mod test {
 
         use anyhow::Result;
         use iroh_net::{
-            derp::DerpMap,
+            derp::{DerpMap, DerpUrl},
             key::SecretKey,
             stun::{is, parse_binding_request, response},
         };
         use tokio::sync::oneshot;
         use tracing::{debug, info, trace};
-        use url::Url;
 
         /// A drop guard to clean up test infrastructure.
         ///
@@ -852,7 +851,7 @@ mod test {
         /// [`MagicEndpoint::connect`]: crate::magic_endpoint::MagicEndpoint
         pub(crate) async fn run_derp_and_stun(
             stun_ip: IpAddr,
-        ) -> Result<(DerpMap, Url, CleanupDropGuard)> {
+        ) -> Result<(DerpMap, DerpUrl, CleanupDropGuard)> {
             // TODO: pass a mesh_key?
 
             let server_key = SecretKey::generate();
@@ -866,7 +865,7 @@ mod test {
             info!("DERP listening on {:?}", http_addr);
 
             let (stun_addr, stun_drop_guard) = serve(stun_ip).await?;
-            let derp_url: Url = format!("http://localhost:{}", http_addr.port())
+            let derp_url: DerpUrl = format!("http://localhost:{}", http_addr.port())
                 .parse()
                 .unwrap();
             let m = DerpMap::default_from_node(derp_url.clone(), stun_addr.port());

--- a/iroh-net/examples/connect-unreliable.rs
+++ b/iroh-net/examples/connect-unreliable.rs
@@ -9,9 +9,12 @@ use std::net::SocketAddr;
 
 use clap::Parser;
 use iroh_base::base32;
-use iroh_net::{derp::DerpMode, key::SecretKey, MagicEndpoint, NodeAddr};
+use iroh_net::{
+    derp::{DerpMode, DerpUrl},
+    key::SecretKey,
+    MagicEndpoint, NodeAddr,
+};
 use tracing::info;
-use url::Url;
 
 // An example ALPN that we are using to communicate over the `MagicEndpoint`
 const EXAMPLE_ALPN: &[u8] = b"n0/iroh/examples/magic/0";
@@ -26,7 +29,7 @@ struct Cli {
     addrs: Vec<SocketAddr>,
     /// The url of the DERP server the remote node can also be reached at.
     #[clap(long)]
-    derp_url: Url,
+    derp_url: DerpUrl,
 }
 
 #[tokio::main]

--- a/iroh-net/examples/connect.rs
+++ b/iroh-net/examples/connect.rs
@@ -9,9 +9,9 @@ use std::net::SocketAddr;
 
 use clap::Parser;
 use iroh_base::base32;
+use iroh_net::derp::DerpUrl;
 use iroh_net::{derp::DerpMode, key::SecretKey, MagicEndpoint, NodeAddr};
 use tracing::info;
-use url::Url;
 
 // An example ALPN that we are using to communicate over the `MagicEndpoint`
 const EXAMPLE_ALPN: &[u8] = b"n0/iroh/examples/magic/0";
@@ -26,7 +26,7 @@ struct Cli {
     addrs: Vec<SocketAddr>,
     /// The url of the DERP server the remote node can also be reached at.
     #[clap(long)]
-    derp_url: Url,
+    derp_url: DerpUrl,
 }
 
 #[tokio::main]

--- a/iroh-net/src/bin/derper.rs
+++ b/iroh-net/src/bin/derper.rs
@@ -18,13 +18,12 @@ use hyper::body::Incoming;
 use hyper::{Method, Request, Response, StatusCode};
 use iroh_metrics::inc;
 use iroh_net::defaults::{DEFAULT_DERP_STUN_PORT, NA_DERP_HOSTNAME};
-use iroh_net::derp;
 use iroh_net::derp::http::{
     MeshAddrs, ServerBuilder as DerpServerBuilder, TlsAcceptor, TlsConfig as DerpTlsConfig,
 };
+use iroh_net::derp::{self, DerpUrl};
 use iroh_net::key::SecretKey;
 use iroh_net::stun;
-use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use tokio::net::{TcpListener, UdpSocket};
@@ -208,7 +207,7 @@ struct MeshConfig {
     mesh_psk_file: PathBuf,
     /// Comma-separated list of urls to mesh with. Must also include the scheme ('http' or
     /// 'https').
-    mesh_with: Vec<Url>,
+    mesh_with: Vec<DerpUrl>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -967,7 +966,7 @@ mod tests {
 
         let derper_addr = addr_recv.await?;
         let derper_str_url = format!("http://{}", derper_addr);
-        let derper_url: Url = derper_str_url.parse().unwrap();
+        let derper_url: DerpUrl = derper_str_url.parse().unwrap();
 
         // set up clients
         let a_secret_key = SecretKey::generate();

--- a/iroh-net/src/config.rs
+++ b/iroh-net/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, fmt::Display, net::SocketAddr};
 
-use url::Url;
+use crate::derp::DerpUrl;
 
 use super::portmapper;
 
@@ -73,7 +73,7 @@ pub struct NetInfo {
     /// connected to multiple DERP servers (to send to other nodes)
     /// but PreferredDERP is the instance number that the node
     /// subscribes to traffic at. Zero means disconnected or unknown.
-    pub preferred_derp: Option<Url>,
+    pub preferred_derp: Option<DerpUrl>,
 
     /// LinkType is the current link type, if known.
     pub link_type: Option<LinkType>,

--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -23,7 +23,7 @@ pub fn default_na_derp_node() -> DerpNode {
     // The default NA derper run by number0.
     let url: Url = format!("https://{NA_DERP_HOSTNAME}").parse().unwrap();
     DerpNode {
-        url: url.clone(),
+        url: url.into(),
         stun_only: false,
         stun_port: DEFAULT_DERP_STUN_PORT,
     }
@@ -34,7 +34,7 @@ pub fn default_eu_derp_node() -> DerpNode {
     // The default EU derper run by number0.
     let url: Url = format!("https://{EU_DERP_HOSTNAME}").parse().unwrap();
     DerpNode {
-        url: url.clone(),
+        url: url.into(),
         stun_only: false,
         stun_port: DEFAULT_DERP_STUN_PORT,
     }

--- a/iroh-net/src/derp.rs
+++ b/iroh-net/src/derp.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -70,12 +71,15 @@ impl From<Url> for DerpUrl {
     }
 }
 
+/// This is a convenience only to directly parse strings.
+///
+/// If you need more control over the error first create a [`Url`] and use [`DerpUrl::from`]
+/// instead.
 impl FromStr for DerpUrl {
-    // Be aware, we are re-exporting another crate's public type in our API.
-    type Err = url::ParseError;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let inner = Url::from_str(s)?;
+        let inner = Url::from_str(s).context("invalid URL")?;
         Ok(DerpUrl::from(inner))
     }
 }
@@ -120,10 +124,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_derp_url_debug() {
+    fn test_derp_url_debug_display() {
         let url = DerpUrl::from(Url::parse("https://example.com").unwrap());
 
         assert_eq!(format!("{url:?}"), r#"DerpUrl("https://example.com./")"#);
+
+        assert_eq!(format!("{url}"), "https://example.com./");
     }
 
     #[test]

--- a/iroh-net/src/derp.rs
+++ b/iroh-net/src/derp.rs
@@ -11,7 +11,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 use std::fmt;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -80,17 +80,17 @@ impl FromStr for DerpUrl {
     }
 }
 
+/// Dereference to the wrapped [`Url`].
+///
+/// Note that [`DerefMut`] is not implemented on purpose, so this type has more flexibility
+/// to change the inner later.
+///
+/// [`DerefMut`]: std::ops::DerefMut
 impl Deref for DerpUrl {
     type Target = Url;
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl DerefMut for DerpUrl {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/iroh-net/src/derp.rs
+++ b/iroh-net/src/derp.rs
@@ -76,7 +76,7 @@ impl FromStr for DerpUrl {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let inner = Url::from_str(s)?;
-        Ok(DerpUrl(inner))
+        Ok(DerpUrl::from(inner))
     }
 }
 

--- a/iroh-net/src/derp.rs
+++ b/iroh-net/src/derp.rs
@@ -9,6 +9,14 @@
 //! Based on tailscale/derp/derp.go
 
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
 pub(crate) mod client;
 pub(crate) mod client_conn;
 pub(crate) mod clients;
@@ -28,3 +36,109 @@ pub use self::server::{
     ClientConnHandler, MaybeTlsStream as MaybeTlsStreamServer, PacketForwarderHandler, Server,
 };
 pub use self::types::{MeshKey, PacketForwarder};
+
+/// A URL identifying a DERP server.
+///
+/// This is but a wrapper around [`Url`], with a few custom tweaks:
+///
+/// - A DERP URL is never a relative URL, so an implicit `.` is added at the end of the
+///   domain name if missing.
+///
+/// - [`fmt::Debug`] is implemented so it prints the URL rather than the URL struct fields.
+///   Useful when logging e.g. `Option<DerpUrl>`.
+///
+/// To create a [`DerpUrl`] use the `From<Url>` implementation.
+#[derive(
+    Clone, derive_more::Display, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub struct DerpUrl(Url);
+
+impl From<Url> for DerpUrl {
+    fn from(mut url: Url) -> Self {
+        if let Some(domain) = url.domain() {
+            if !domain.ends_with('.') {
+                let domain = String::from(domain) + ".";
+
+                // This can fail, though it is unlikely the resulting URL is usable as a
+                // DERP URL, probably it has the wrong scheme or is not a base URL or the
+                // like.  We don't do full URL validation however, so just silently leave
+                // this bad URL in place.  Something will fail later.
+                url.set_host(Some(&domain)).ok();
+            }
+        }
+        Self(url)
+    }
+}
+
+impl FromStr for DerpUrl {
+    // Be aware, we are re-exporting another crate's public type in our API.
+    type Err = url::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let inner = Url::from_str(s)?;
+        Ok(DerpUrl(inner))
+    }
+}
+
+impl Deref for DerpUrl {
+    type Target = Url;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for DerpUrl {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl fmt::Debug for DerpUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DerpUrl")
+            .field(&DbgStr(self.0.as_str()))
+            .finish()
+    }
+}
+
+/// Helper struct to format a &str without allocating a String.
+///
+/// Maybe this is entirely unneeded and the compiler would be smart enough to never allocate
+/// the String anyway.  Who knows.  Writing this was faster than checking the assembler
+/// output.
+struct DbgStr<'a>(&'a str);
+
+impl<'a> fmt::Debug for DbgStr<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_derp_url_debug() {
+        let url = DerpUrl::from(Url::parse("https://example.com").unwrap());
+
+        assert_eq!(format!("{url:?}"), r#"DerpUrl("https://example.com./")"#);
+    }
+
+    #[test]
+    fn test_derp_url_absolute() {
+        let url = DerpUrl::from(Url::parse("https://example.com").unwrap());
+
+        assert_eq!(url.domain(), Some("example.com."));
+
+        let url1 = DerpUrl::from(Url::parse("https://example.com.").unwrap());
+        assert_eq!(url, url1);
+
+        let url2 = DerpUrl::from(Url::parse("https://example.com./").unwrap());
+        assert_eq!(url, url2);
+
+        let url3 = DerpUrl::from(Url::parse("https://example.com/").unwrap());
+        assert_eq!(url, url3);
+    }
+}

--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -23,6 +23,7 @@ use tokio::time::Instant;
 use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 use url::Url;
 
+use crate::derp::DerpUrl;
 use crate::derp::{
     client::Client as DerpClient, client::ClientBuilder as DerpClientBuilder,
     client::ClientReceiver as DerpClientReceiver, metrics::Metrics, server::PacketForwarderHandler,
@@ -158,7 +159,7 @@ struct Actor {
     mesh_key: Option<MeshKey>,
     is_prober: bool,
     server_public_key: Option<PublicKey>,
-    url: Url,
+    url: DerpUrl,
     #[debug("TlsConnector")]
     tls_connector: tokio_rustls::TlsConnector,
     pings: PingTracker,
@@ -203,7 +204,7 @@ pub struct ClientBuilder {
     /// Expected PublicKey of the server
     server_public_key: Option<PublicKey>,
     /// Server url.
-    url: Url,
+    url: DerpUrl,
 }
 
 impl std::fmt::Debug for ClientBuilder {
@@ -218,7 +219,7 @@ impl std::fmt::Debug for ClientBuilder {
 
 impl ClientBuilder {
     /// Create a new [`ClientBuilder`]
-    pub fn new(url: impl Into<Url>) -> Self {
+    pub fn new(url: impl Into<DerpUrl>) -> Self {
         ClientBuilder {
             can_ack_pings: false,
             is_preferred: false,
@@ -231,7 +232,7 @@ impl ClientBuilder {
     }
 
     /// Sets the server url
-    pub fn server_url(mut self, url: impl Into<Url>) -> Self {
+    pub fn server_url(mut self, url: impl Into<DerpUrl>) -> Self {
         self.url = url.into();
         self
     }

--- a/iroh-net/src/derp/http/mesh_clients.rs
+++ b/iroh-net/src/derp/http/mesh_clients.rs
@@ -1,10 +1,9 @@
-use reqwest::Url;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info_span, Instrument};
 
 use crate::{
-    derp::{http::ClientBuilder, DerpMap, MeshKey, PacketForwarderHandler},
+    derp::{http::ClientBuilder, DerpMap, DerpUrl, MeshKey, PacketForwarderHandler},
     key::SecretKey,
 };
 
@@ -94,8 +93,8 @@ impl MeshClients {
 pub enum MeshAddrs {
     /// Supply a [`DerpMap`] of all the derp servers you want to mesh with.
     DerpMap(DerpMap),
-    /// Supply a list of [`Url`]s of all the derp server you want to mesh with.
-    Addrs(Vec<Url>),
+    /// Supply a list of [`Url`]s of all the derp servers you want to mesh with.
+    Addrs(Vec<DerpUrl>),
 }
 
 #[cfg(test)]
@@ -136,10 +135,10 @@ mod tests {
             .spawn()
             .await?;
 
-        let a_url: Url = format!("http://{}/derp", derp_server_a.addr())
+        let a_url: DerpUrl = format!("http://{}/derp", derp_server_a.addr())
             .parse()
             .unwrap();
-        let b_url: Url = format!("http://{}/derp", derp_server_b.addr())
+        let b_url: DerpUrl = format!("http://{}/derp", derp_server_b.addr())
             .parse()
             .unwrap();
 

--- a/iroh-net/src/derp/http/mesh_clients.rs
+++ b/iroh-net/src/derp/http/mesh_clients.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info_span, Instrument};
@@ -51,9 +53,9 @@ impl MeshClients {
                 let mut urls = Vec::new();
                 for url in derp_map.urls() {
                     // note: `node.host_name` is expected to include the scheme
-                    let mut url = url.clone();
+                    let mut url = url.deref().clone();
                     url.set_path("/derp");
-                    urls.push(url);
+                    urls.push(DerpUrl::from(url));
                 }
                 urls
             }

--- a/iroh-net/src/derp/http/mesh_clients.rs
+++ b/iroh-net/src/derp/http/mesh_clients.rs
@@ -93,7 +93,7 @@ impl MeshClients {
 pub enum MeshAddrs {
     /// Supply a [`DerpMap`] of all the derp servers you want to mesh with.
     DerpMap(DerpMap),
-    /// Supply a list of [`Url`]s of all the derp servers you want to mesh with.
+    /// Supply a list of [`DerpUrl`]s of all the derp servers you want to mesh with.
     Addrs(Vec<DerpUrl>),
 }
 

--- a/iroh-net/src/derp/map.rs
+++ b/iroh-net/src/derp/map.rs
@@ -4,9 +4,10 @@ use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use anyhow::{ensure, Result};
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 use crate::defaults::DEFAULT_DERP_STUN_PORT;
+
+use super::DerpUrl;
 
 /// Configuration options for the Derp servers of the magic endpoint.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,15 +21,15 @@ pub enum DerpMode {
 }
 
 /// Configuration of all the Derp servers that can be used.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DerpMap {
     /// A map of the different derp IDs to the [`DerpNode`] information
-    nodes: Arc<BTreeMap<Url, Arc<DerpNode>>>,
+    nodes: Arc<BTreeMap<DerpUrl, Arc<DerpNode>>>,
 }
 
 impl DerpMap {
     /// Returns the sorted DERP URLs.
-    pub fn urls(&self) -> impl Iterator<Item = &Url> {
+    pub fn urls(&self) -> impl Iterator<Item = &DerpUrl> {
         self.nodes.keys()
     }
 
@@ -40,17 +41,17 @@ impl DerpMap {
     }
 
     /// Returns an `Iterator` over all known nodes.
-    pub fn nodes(&self) -> impl Iterator<Item = (&Url, &Arc<DerpNode>)> {
+    pub fn nodes(&self) -> impl Iterator<Item = (&DerpUrl, &Arc<DerpNode>)> {
         self.nodes.iter()
     }
 
     /// Is this a known node?
-    pub fn contains_node(&self, url: &Url) -> bool {
+    pub fn contains_node(&self, url: &DerpUrl) -> bool {
         self.nodes.contains_key(url)
     }
 
     /// Get the given node.
-    pub fn get_node(&self, url: &Url) -> Option<&Arc<DerpNode>> {
+    pub fn get_node(&self, url: &DerpUrl) -> Option<&Arc<DerpNode>> {
         self.nodes.get(url)
     }
 
@@ -68,7 +69,7 @@ impl DerpMap {
     ///
     /// Allows to set a custom STUN port and different IP addresses for IPv4 and IPv6.
     /// If IP addresses are provided, no DNS lookup will be performed.
-    pub fn default_from_node(url: Url, stun_port: u16) -> Self {
+    pub fn default_from_node(url: DerpUrl, stun_port: u16) -> Self {
         let mut nodes = BTreeMap::new();
         nodes.insert(
             url.clone(),
@@ -89,7 +90,7 @@ impl DerpMap {
     ///
     /// This will use the default STUN port and IP addresses resolved from the URL's host name via DNS.
     /// Derp nodes are specified at <../../../docs/derp_nodes.md>
-    pub fn from_url(url: Url) -> Self {
+    pub fn from_url(url: DerpUrl) -> Self {
         Self::default_from_node(url, DEFAULT_DERP_STUN_PORT)
     }
 
@@ -104,16 +105,6 @@ impl DerpMap {
     }
 }
 
-impl fmt::Debug for DerpMap {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut m = f.debug_map();
-        for (url, node) in self.nodes.iter() {
-            m.entry(&url.as_str(), node);
-        }
-        m.finish()
-    }
-}
-
 impl fmt::Display for DerpMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self, f)
@@ -123,11 +114,10 @@ impl fmt::Display for DerpMap {
 /// Information on a specific derp server.
 ///
 /// Includes the Url where it can be dialed.
-#[derive(derive_more::Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct DerpNode {
     /// The [`Url`] where this derp server can be dialed.
-    #[debug("{}", url)]
-    pub url: Url,
+    pub url: DerpUrl,
     /// Whether this derp server should only be used for STUN requests.
     ///
     /// This essentially allows you to use a normal STUN server as a DERP node, no DERP

--- a/iroh-net/src/derp/map.rs
+++ b/iroh-net/src/derp/map.rs
@@ -86,7 +86,7 @@ impl DerpMap {
         }
     }
 
-    /// Returns a [`DerpMap`] from a [`Url`].
+    /// Returns a [`DerpMap`] from a [`DerpUrl`].
     ///
     /// This will use the default STUN port and IP addresses resolved from the URL's host name via DNS.
     /// Derp nodes are specified at <../../../docs/derp_nodes.md>
@@ -116,7 +116,7 @@ impl fmt::Display for DerpMap {
 /// Includes the Url where it can be dialed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct DerpNode {
-    /// The [`Url`] where this derp server can be dialed.
+    /// The [`DerpUrl`] where this derp server can be dialed.
     pub url: DerpUrl,
     /// Whether this derp server should only be used for STUN requests.
     ///

--- a/iroh-net/src/disco.rs
+++ b/iroh-net/src/disco.rs
@@ -26,7 +26,7 @@ use std::{
 use anyhow::{anyhow, bail, ensure, Result};
 use url::Url;
 
-use crate::{key, net::ip::to_canonical};
+use crate::{derp::DerpUrl, key, net::ip::to_canonical};
 
 use super::{key::PublicKey, stun};
 
@@ -138,7 +138,7 @@ pub enum SendAddr {
     /// UDP, the ip addr.
     Udp(SocketAddr),
     /// Derp Url.
-    Derp(Url),
+    Derp(DerpUrl),
 }
 
 impl SendAddr {
@@ -148,7 +148,7 @@ impl SendAddr {
     }
 
     /// Returns the `Some(Url)` if it is a derp addr.
-    pub fn derp_url(&self) -> Option<Url> {
+    pub fn derp_url(&self) -> Option<DerpUrl> {
         match self {
             Self::Derp(url) => Some(url.clone()),
             Self::Udp(_) => None,
@@ -224,7 +224,7 @@ fn send_addr_from_bytes(p: &[u8]) -> Result<SendAddr> {
         1u8 => {
             let s = std::str::from_utf8(&p[1..])?;
             let u: Url = s.parse()?;
-            Ok(SendAddr::Derp(u))
+            Ok(SendAddr::Derp(u.into()))
         }
         _ => {
             bail!("invalid addr type {}", p[0]);

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -625,7 +625,7 @@ mod tests {
         };
         assert_eq!(
             format!("{:?}", info),
-            r#"AddrInfo { derp_url: Some(DerpUrl("https://derp.example.com/")), direct_addresses: {1.2.3.4:1234} }"#
+            r#"AddrInfo { derp_url: Some(DerpUrl("https://derp.example.com./")), direct_addresses: {1.2.3.4:1234} }"#
         );
     }
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -625,7 +625,7 @@ mod tests {
         };
         assert_eq!(
             format!("{:?}", info),
-            r#"AddrInfo { derp_url: Some(https://derp.example.com/), direct_addresses: {1.2.3.4:1234} }"#
+            r#"AddrInfo { derp_url: Some(DerpUrl("https://derp.example.com/")), direct_addresses: {1.2.3.4:1234} }"#
         );
     }
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -77,29 +77,12 @@ impl From<(PublicKey, Option<DerpUrl>, &[SocketAddr])> for NodeAddr {
 }
 
 /// Addressing information to connect to a peer.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AddrInfo {
     /// The peer's home DERP url.
     pub derp_url: Option<DerpUrl>,
     /// Socket addresses where the peer might be reached directly.
     pub direct_addresses: BTreeSet<SocketAddr>,
-}
-
-impl Debug for AddrInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AddrInfo")
-            .field("derp_url", &self.derp_url.as_ref().map(DD))
-            .field("direct_addresses", &self.direct_addresses)
-            .finish()
-    }
-}
-
-struct DD<T: std::fmt::Display>(T);
-
-impl<T: std::fmt::Display> std::fmt::Debug for DD<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.0, f)
-    }
 }
 
 impl AddrInfo {

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -7,12 +7,11 @@ use derive_more::Debug;
 use quinn_proto::VarInt;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
-use url::Url;
 
 use crate::{
     config,
     defaults::default_derp_map,
-    derp::{DerpMap, DerpMode},
+    derp::{DerpMap, DerpMode, DerpUrl},
     key::{PublicKey, SecretKey},
     magicsock::{self, Discovery, MagicSock},
     tls,
@@ -39,7 +38,7 @@ impl NodeAddr {
     }
 
     /// Add a derp url to the peer's [`AddrInfo`].
-    pub fn with_derp_url(mut self, derp_url: Url) -> Self {
+    pub fn with_derp_url(mut self, derp_url: DerpUrl) -> Self {
         self.info.derp_url = Some(derp_url);
         self
     }
@@ -59,13 +58,13 @@ impl NodeAddr {
     }
 
     /// Get the derp url of this peer.
-    pub fn derp_url(&self) -> Option<&Url> {
+    pub fn derp_url(&self) -> Option<&DerpUrl> {
         self.info.derp_url.as_ref()
     }
 }
 
-impl From<(PublicKey, Option<Url>, &[SocketAddr])> for NodeAddr {
-    fn from(value: (PublicKey, Option<Url>, &[SocketAddr])) -> Self {
+impl From<(PublicKey, Option<DerpUrl>, &[SocketAddr])> for NodeAddr {
+    fn from(value: (PublicKey, Option<DerpUrl>, &[SocketAddr])) -> Self {
         let (node_id, derp_url, direct_addresses_iter) = value;
         NodeAddr {
             node_id,
@@ -81,7 +80,7 @@ impl From<(PublicKey, Option<Url>, &[SocketAddr])> for NodeAddr {
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AddrInfo {
     /// The peer's home DERP url.
-    pub derp_url: Option<Url>,
+    pub derp_url: Option<DerpUrl>,
     /// Socket addresses where the peer might be reached directly.
     pub direct_addresses: BTreeSet<SocketAddr>,
 }
@@ -114,7 +113,7 @@ impl NodeAddr {
     /// Create a new [`NodeAddr`] from its parts.
     pub fn from_parts(
         node_id: PublicKey,
-        derp_url: Option<Url>,
+        derp_url: Option<DerpUrl>,
         direct_addresses: Vec<SocketAddr>,
     ) -> Self {
         Self {
@@ -380,7 +379,7 @@ impl MagicEndpoint {
     /// Get the DERP url we are connected to with the lowest latency.
     ///
     /// Returns `None` if we are not connected to any DERPer.
-    pub fn my_derp(&self) -> Option<Url> {
+    pub fn my_derp(&self) -> Option<DerpUrl> {
         self.msock.my_derp()
     }
 
@@ -636,7 +635,7 @@ mod tests {
     #[test]
     fn test_addr_info_debug() {
         let info = AddrInfo {
-            derp_url: Some(Url::parse("https://derp.example.com").unwrap()),
+            derp_url: Some("https://derp.example.com".parse().unwrap()),
             direct_addresses: vec![SocketAddr::from(([1, 2, 3, 4], 1234))]
                 .into_iter()
                 .collect(),

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -17,10 +17,9 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, info_span, trace, warn, Instrument};
-use url::Url;
 
 use crate::{
-    derp::{self, http::ClientError, ReceivedMessage, MAX_PACKET_SIZE},
+    derp::{self, http::ClientError, DerpUrl, ReceivedMessage, MAX_PACKET_SIZE},
     key::{PublicKey, PUBLIC_KEY_LENGTH},
 };
 
@@ -35,15 +34,15 @@ const DERP_CLEAN_STALE_INTERVAL: Duration = Duration::from_secs(15);
 
 pub(super) enum DerpActorMessage {
     Send {
-        url: Url,
+        url: DerpUrl,
         contents: DerpContents,
         peer: PublicKey,
     },
     Connect {
-        url: Url,
+        url: DerpUrl,
         peer: Option<PublicKey>,
     },
-    NotePreferred(Url),
+    NotePreferred(DerpUrl),
     MaybeCloseDerpsOnRebind(Vec<IpAddr>),
 }
 
@@ -60,7 +59,7 @@ struct ActiveDerp {
     /// home connection, or what was once our home), then we remember that route here to optimistically
     /// use instead of creating a new DERP connection back to their home.
     derp_routes: Vec<PublicKey>,
-    url: Url,
+    url: DerpUrl,
     derp_client: derp::http::Client,
     derp_client_receiver: derp::http::ClientReceiver,
     /// The set of senders we know are present on this connection, based on
@@ -85,7 +84,7 @@ enum ActiveDerpMessage {
 
 impl ActiveDerp {
     fn new(
-        url: Url,
+        url: DerpUrl,
         derp_client: derp::http::Client,
         derp_client_receiver: derp::http::ClientReceiver,
         msg_sender: mpsc::Sender<ActorMessage>,
@@ -272,9 +271,9 @@ impl ActiveDerp {
 pub(super) struct DerpActor {
     conn: Arc<Inner>,
     /// DERP Url -> connection to the node
-    active_derp: BTreeMap<Url, (mpsc::Sender<ActiveDerpMessage>, JoinHandle<()>)>,
+    active_derp: BTreeMap<DerpUrl, (mpsc::Sender<ActiveDerpMessage>, JoinHandle<()>)>,
     msg_sender: mpsc::Sender<ActorMessage>,
-    ping_tasks: JoinSet<(Url, bool)>,
+    ping_tasks: JoinSet<(DerpUrl, bool)>,
     cancel_token: CancellationToken,
 }
 
@@ -355,7 +354,7 @@ impl DerpActor {
         }
     }
 
-    async fn note_preferred(&self, my_url: &Url) {
+    async fn note_preferred(&self, my_url: &DerpUrl) {
         futures::future::join_all(self.active_derp.iter().map(|(url, (s, _))| async move {
             let is_preferred = url == my_url;
             s.send(ActiveDerpMessage::NotePreferred(is_preferred))
@@ -365,7 +364,7 @@ impl DerpActor {
         .await;
     }
 
-    async fn send_derp(&mut self, url: &Url, contents: DerpContents, peer: PublicKey) {
+    async fn send_derp(&mut self, url: &DerpUrl, contents: DerpContents, peer: PublicKey) {
         trace!(%url, peer = %peer.fmt_short(),len = contents.iter().map(|c| c.len()).sum::<usize>(),  "sending derp");
         // Derp Send
         let derp_client = self.connect_derp(url, Some(&peer)).await;
@@ -400,7 +399,7 @@ impl DerpActor {
     }
 
     /// Returns `true`if the message was sent successfully.
-    async fn send_to_active(&mut self, url: &Url, msg: ActiveDerpMessage) -> bool {
+    async fn send_to_active(&mut self, url: &DerpUrl, msg: ActiveDerpMessage) -> bool {
         match self.active_derp.get(url) {
             Some((s, _)) => match s.send(msg).await {
                 Ok(_) => true,
@@ -414,7 +413,11 @@ impl DerpActor {
     }
 
     /// Connect to the given derp node.
-    async fn connect_derp(&mut self, url: &Url, peer: Option<&PublicKey>) -> derp::http::Client {
+    async fn connect_derp(
+        &mut self,
+        url: &DerpUrl,
+        peer: Option<&PublicKey>,
+    ) -> derp::http::Client {
         // See if we have a connection open to that DERP node ID first. If so, might as
         // well use it. (It's a little arbitrary whether we use this one vs. the reverse route
         // below when we have both.)
@@ -565,7 +568,7 @@ impl DerpActor {
 
     /// Closes the DERP connection to the provided `url` and starts reconnecting it if it's
     /// our current home DERP.
-    async fn close_or_reconnect_derp(&mut self, url: &Url, why: &'static str) {
+    async fn close_or_reconnect_derp(&mut self, url: &DerpUrl, why: &'static str) {
         self.close_derp(url, why).await;
         if self.conn.my_derp().as_ref() == Some(url) {
             self.connect_derp(url, None).await;
@@ -625,7 +628,7 @@ impl DerpActor {
         self.log_active_derp();
     }
 
-    async fn close_derp(&mut self, url: &Url, why: &'static str) {
+    async fn close_derp(&mut self, url: &DerpUrl, why: &'static str) {
         if let Some((s, t)) = self.active_derp.remove(url) {
             debug!(%url, "closing connection: {}", why);
 
@@ -649,7 +652,7 @@ impl DerpActor {
         });
     }
 
-    fn active_derp_sorted(&self) -> impl Iterator<Item = Url> {
+    fn active_derp_sorted(&self) -> impl Iterator<Item = DerpUrl> {
         let mut ids: Vec<_> = self.active_derp.keys().cloned().collect();
         ids.sort();
 
@@ -659,7 +662,7 @@ impl DerpActor {
 
 #[derive(derive_more::Debug)]
 pub(super) struct DerpReadResult {
-    pub(super) url: Url,
+    pub(super) url: DerpUrl,
     pub(super) src: PublicKey,
     /// packet data
     #[debug(skip)]

--- a/iroh-net/src/magicsock/peer_map/endpoint.rs
+++ b/iroh-net/src/magicsock/peer_map/endpoint.rs
@@ -10,9 +10,9 @@ use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::{debug, info, instrument, trace, warn};
-use url::Url;
 
 use crate::{
+    derp::DerpUrl,
     disco::{self, SendAddr},
     key::PublicKey,
     magic_endpoint::AddrInfo,
@@ -55,7 +55,10 @@ const STAYIN_ALIVE_MIN_ELAPSED: Duration = Duration::from_secs(2);
 
 #[derive(Debug)]
 pub(in crate::magicsock) enum PingAction {
-    SendCallMeMaybe { derp_url: Url, dst_key: PublicKey },
+    SendCallMeMaybe {
+        derp_url: DerpUrl,
+        dst_key: PublicKey,
+    },
     SendPing(SendPing),
 }
 
@@ -89,7 +92,7 @@ pub(super) struct Endpoint {
     last_full_ping: Option<Instant>,
     /// The url of DERP node that we can relay over to communicate.
     /// The fallback/bootstrap path, if non-zero (non-zero for well-behaved clients).
-    derp_url: Option<(Url, EndpointState)>,
+    derp_url: Option<(DerpUrl, EndpointState)>,
     /// Best non-DERP path.
     best_addr: BestAddr,
     /// [`EndpointState`] for this node's direct addresses.
@@ -105,7 +108,7 @@ pub(super) struct Endpoint {
 #[derive(Debug)]
 pub(super) struct Options {
     pub(super) public_key: PublicKey,
-    pub(super) derp_url: Option<Url>,
+    pub(super) derp_url: Option<DerpUrl>,
     /// Is this endpoint currently active (sending data)?
     pub(super) active: bool,
 }
@@ -191,13 +194,13 @@ impl Endpoint {
     }
 
     /// Returns the derp url of this endpoint
-    pub(super) fn derp_url(&self) -> Option<Url> {
+    pub(super) fn derp_url(&self) -> Option<DerpUrl> {
         self.derp_url.as_ref().map(|(url, _state)| url.clone())
     }
 
     /// Returns the address(es) that should be used for sending the next packet.
     /// Zero, one, or both of UDP address and DERP addr may be non-zero.
-    fn addr_for_send(&mut self, now: &Instant) -> (Option<SocketAddr>, Option<Url>, bool) {
+    fn addr_for_send(&mut self, now: &Instant) -> (Option<SocketAddr>, Option<DerpUrl>, bool) {
         if derp_only_mode() {
             debug!("in `DEV_DERP_ONLY` mode, giving the DERP address as the only viable address for this endpoint");
             return (None, self.derp_url(), false);
@@ -779,7 +782,7 @@ impl Endpoint {
         self.last_used = Some(now);
     }
 
-    pub(super) fn receive_derp(&mut self, url: &Url, _src: &PublicKey, now: Instant) {
+    pub(super) fn receive_derp(&mut self, url: &DerpUrl, _src: &PublicKey, now: Instant) {
         match self.derp_url.as_mut() {
             Some((current_home, state)) if current_home == url => {
                 // We received on the expected url. update state.
@@ -862,7 +865,9 @@ impl Endpoint {
     }
 
     #[instrument("get_send_addrs", skip_all, fields(node = %self.public_key.fmt_short()))]
-    pub(crate) fn get_send_addrs(&mut self) -> (Option<SocketAddr>, Option<Url>, Vec<PingAction>) {
+    pub(crate) fn get_send_addrs(
+        &mut self,
+    ) -> (Option<SocketAddr>, Option<DerpUrl>, Vec<PingAction>) {
         let now = Instant::now();
         self.last_used.replace(now);
         let (udp_addr, derp_url, should_ping) = self.addr_for_send(&now);
@@ -1146,7 +1151,7 @@ pub struct EndpointInfo {
     /// The public key of the endpoint.
     pub public_key: PublicKey,
     /// Derper, if available.
-    pub derp_url: Option<Url>,
+    pub derp_url: Option<DerpUrl>,
     /// List of addresses at which this node might be reachable, plus any latency information we
     /// have about that address and the last time the address was used.
     pub addrs: Vec<DirectAddrInfo>,
@@ -1166,13 +1171,13 @@ pub enum ConnectionType {
     Direct(SocketAddr),
     /// Relay connection over DERP
     #[display("relay")]
-    Relay(Url),
+    Relay(DerpUrl),
     /// Both a UDP and a DERP connection are used.
     ///
     /// This is the case if we do have a UDP address, but are missing a recent confirmation that
     /// the address works.
     #[display("mixed")]
-    Mixed(SocketAddr, Url),
+    Mixed(SocketAddr, DerpUrl),
     /// We have no verified connection to this PublicKey
     #[display("none")]
     None,
@@ -1192,12 +1197,13 @@ mod tests {
 
     #[test]
     fn test_endpoint_infos() {
-        let new_relay_and_state = |url: Option<Url>| url.map(|url| (url, EndpointState::default()));
+        let new_relay_and_state =
+            |url: Option<DerpUrl>| url.map(|url| (url, EndpointState::default()));
 
         let now = Instant::now();
         let elapsed = Duration::from_secs(3);
         let later = now + elapsed;
-        let send_addr: Url = "https://my-derp.com".parse().unwrap();
+        let send_addr: DerpUrl = "https://my-derp.com".parse().unwrap();
         // endpoint with a `best_addr` that has a latency
         let pong_src = SendAddr::Udp("0.0.0.0:1".parse().unwrap());
         let latency = Duration::from_millis(50);

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -29,11 +29,10 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::{self, Instant};
 use tracing::{debug, debug_span, error, info_span, instrument, trace, warn, Instrument, Span};
-use url::Url;
 
 use super::NetcheckMetrics;
 use crate::defaults::DEFAULT_DERP_STUN_PORT;
-use crate::derp::{DerpMap, DerpNode};
+use crate::derp::{DerpMap, DerpNode, DerpUrl};
 use crate::dns::DNS_RESOLVER;
 use crate::net::interfaces;
 use crate::net::ip;
@@ -890,7 +889,7 @@ async fn run_probe(
 /// return a "204 No Content" response and checking if that's what we get.
 ///
 /// The boolean return is whether we think we have a captive portal.
-async fn check_captive_portal(dm: &DerpMap, preferred_derp: Option<Url>) -> Result<bool> {
+async fn check_captive_portal(dm: &DerpMap, preferred_derp: Option<DerpUrl>) -> Result<bool> {
     // If we have a preferred DERP node, try that; otherwise, pick a random one not marked as "Avoid".
     let url = match preferred_derp {
         Some(url) => url,

--- a/iroh-net/src/netcheck/reportgen/probes.rs
+++ b/iroh-net/src/netcheck/reportgen/probes.rs
@@ -10,9 +10,8 @@ use std::sync::Arc;
 
 use anyhow::{ensure, Result};
 use tokio::time::Duration;
-use url::Url;
 
-use crate::derp::{DerpMap, DerpNode};
+use crate::derp::{DerpMap, DerpNode, DerpUrl};
 use crate::net::interfaces;
 use crate::netcheck::Report;
 
@@ -412,7 +411,7 @@ impl FromIterator<ProbeSet> for ProbePlan {
 fn sort_derps<'a>(
     derp_map: &'a DerpMap,
     last_report: &Report,
-) -> Vec<(&'a Url, &'a Arc<DerpNode>)> {
+) -> Vec<(&'a DerpUrl, &'a Arc<DerpNode>)> {
     let mut prev: Vec<_> = derp_map.nodes().collect();
     prev.sort_by(|(a_url, _a), (b_url, _b)| {
         let latencies_a = last_report.derp_latency.get(a_url);
@@ -727,9 +726,9 @@ mod tests {
     }
 
     fn create_last_report(
-        url_1: &Url,
+        url_1: &DerpUrl,
         latency_1: Option<Duration>,
-        url_2: &Url,
+        url_2: &DerpUrl,
         latency_2: Option<Duration>,
     ) -> Report {
         let mut latencies = DerpLatencies::new();

--- a/iroh-net/src/stun.rs
+++ b/iroh-net/src/stun.rs
@@ -153,7 +153,7 @@ pub mod test {
     };
 
     use crate::{
-        derp::{DerpMap, DerpNode},
+        derp::{DerpMap, DerpNode, DerpUrl},
         test_utils::CleanupDropGuard,
     };
 
@@ -164,7 +164,6 @@ pub mod test {
         sync::{oneshot, Mutex},
     };
     use tracing::{debug, trace};
-    use url::Url;
 
     // (read_ipv4, read_ipv5)
     #[derive(Debug, Default, Clone)]
@@ -186,9 +185,9 @@ pub mod test {
             let host = addr.ip();
             let port = addr.port();
 
-            let url: Url = format!("http://{host}:{port}").parse().unwrap();
+            let url: DerpUrl = format!("http://{host}:{port}").parse().unwrap();
             DerpNode {
-                url: url.clone(),
+                url,
                 stun_port: port,
                 stun_only,
             }

--- a/iroh-net/src/test_utils.rs
+++ b/iroh-net/src/test_utils.rs
@@ -3,9 +3,8 @@
 use anyhow::Result;
 use tokio::sync::oneshot;
 use tracing::{error_span, info_span, Instrument};
-use url::Url;
 
-use crate::derp::{DerpMap, DerpNode};
+use crate::derp::{DerpMap, DerpNode, DerpUrl};
 use crate::key::SecretKey;
 
 /// A drop guard to clean up test infrastructure.
@@ -24,7 +23,7 @@ pub(crate) struct CleanupDropGuard(pub(crate) oneshot::Sender<()>);
 /// is always `Some` as that is how the [`MagicEndpoint::connect`] API expects it.
 ///
 /// [`MagicEndpoint::connect`]: crate::magic_endpoint::MagicEndpoint
-pub(crate) async fn run_derper() -> Result<(DerpMap, Url, CleanupDropGuard)> {
+pub(crate) async fn run_derper() -> Result<(DerpMap, DerpUrl, CleanupDropGuard)> {
     // TODO: pass a mesh_key?
 
     let server_key = SecretKey::generate();
@@ -41,7 +40,7 @@ pub(crate) async fn run_derper() -> Result<(DerpMap, Url, CleanupDropGuard)> {
     println!("DERP listening on {:?}", https_addr);
 
     let (stun_addr, _, stun_drop_guard) = crate::stun::test::serve(server.addr().ip()).await?;
-    let url: Url = format!("https://localhost:{}", https_addr.port())
+    let url: DerpUrl = format!("https://localhost:{}", https_addr.port())
         .parse()
         .unwrap();
     let m = DerpMap::from_nodes([DerpNode {

--- a/iroh-net/src/ticket/node.rs
+++ b/iroh-net/src/ticket/node.rs
@@ -129,7 +129,7 @@ mod tests {
         let ticket = NodeTicket {
             node: NodeAddr::from_parts(
                 node_id,
-                Some("http://derp.me".parse().unwrap()),
+                Some("http://derp.me./".parse().unwrap()),
                 vec!["127.0.0.1:1024".parse().unwrap()],
             ),
         };
@@ -138,7 +138,7 @@ mod tests {
             00 # variant
             ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6 # node id, 32 bytes, see above
             01 # derp url present
-            0f 687474703a2f2f646572702e6d652f # derp url, 15 bytes, see above
+            10 687474703a2f2f646572702e6d652e2f # derp url, 16 bytes, see above
             01 # one direct address
             00 # ipv4
             7f000001 8008 # address, see above

--- a/iroh/src/commands/blob.rs
+++ b/iroh/src/commands/blob.rs
@@ -24,10 +24,9 @@ use iroh_bytes::{
     get::db::DownloadProgress, provider::AddProgress, store::ValidateProgress, BlobFormat, Hash,
     HashAndFormat, Tag,
 };
-use iroh_net::{key::PublicKey, NodeAddr};
+use iroh_net::{derp::DerpUrl, key::PublicKey, NodeAddr};
 use quic_rpc::ServiceConnection;
 use tokio::io::AsyncWriteExt;
-use url::Url;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug, Clone)]
@@ -55,7 +54,7 @@ pub enum BlobCommands {
         address: Vec<SocketAddr>,
         /// Override the Derp URL to use to contact the node.
         #[clap(long)]
-        derp_url: Option<Url>,
+        derp_url: Option<DerpUrl>,
         /// Override to treat the blob as a raw blob or a hash sequence.
         #[clap(long)]
         recursive: Option<bool>,

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -18,7 +18,7 @@ use iroh::util::{path::IrohPaths, progress::ProgressWriter};
 use iroh_base::ticket::Ticket;
 use iroh_net::{
     defaults::DEFAULT_DERP_STUN_PORT,
-    derp::{DerpMap, DerpMode},
+    derp::{DerpMap, DerpMode, DerpUrl},
     key::{PublicKey, SecretKey},
     magic_endpoint,
     magicsock::EndpointInfo,
@@ -33,7 +33,6 @@ use tokio::{io::AsyncWriteExt, sync};
 
 use iroh_metrics::core::Core;
 use iroh_net::metrics::MagicsockMetrics;
-use url::Url;
 
 #[derive(Debug, Clone, derive_more::Display)]
 pub enum SecretKeyOption {
@@ -117,7 +116,7 @@ pub enum Commands {
         ///
         /// Default is `None`.
         #[clap(long)]
-        derp_url: Option<Url>,
+        derp_url: Option<DerpUrl>,
     },
     /// Probe the port mapping protocols.
     PortMapProbe {
@@ -597,7 +596,7 @@ async fn connect(
     node_id: NodeId,
     secret_key: SecretKey,
     direct_addresses: Vec<SocketAddr>,
-    derp_url: Option<Url>,
+    derp_url: Option<DerpUrl>,
     derp_map: Option<DerpMap>,
 ) -> anyhow::Result<()> {
     let endpoint = make_endpoint(secret_key, derp_map).await?;
@@ -829,7 +828,7 @@ async fn derp_urls(count: usize, config: NodeConfig) -> anyhow::Result<()> {
 struct NodeDetails {
     connect: Option<Duration>,
     latency: Option<Duration>,
-    host: Url,
+    host: DerpUrl,
     error: Option<String>,
 }
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -30,6 +30,7 @@ use iroh_bytes::util::progress::{FlumeProgressSender, IdGenerator, ProgressSende
 use iroh_bytes::{protocol::Closed, provider::AddProgress, BlobFormat, Hash, HashAndFormat};
 use iroh_gossip::net::{Gossip, GOSSIP_ALPN};
 use iroh_io::AsyncSliceReader;
+use iroh_net::derp::DerpUrl;
 use iroh_net::magic_endpoint::get_alpn;
 use iroh_net::util::AbortingJoinHandle;
 use iroh_net::{
@@ -49,7 +50,6 @@ use tokio::task::JoinError;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::LocalPoolHandle;
 use tracing::{debug, error, error_span, info, trace, warn, Instrument};
-use url::Url;
 
 use crate::downloader::Downloader;
 use crate::rpc_protocol::{
@@ -722,7 +722,7 @@ impl<D: ReadableStore> Node<D> {
     }
 
     /// Get the DERPer we are connected to.
-    pub fn my_derp(&self) -> Option<Url> {
+    pub fn my_derp(&self) -> Option<DerpUrl> {
         self.inner.endpoint.my_derp()
     }
 


### PR DESCRIPTION
## Description

This addresses two issues for now: some very minimal normalisation and
nicer Debug printing.

The type is purely a wrapper and does extremely minimal extra things
to the underlying Url.  There is no validation happening and no added
contraints to the URLs.  It is still possible to construct a DerpUrl
that will fail, e.g. by using the mailto: scheme.  The users of the
DerpUrl are expected to fail in such cases.

## Notes & open questions

I was initially trying to keep this crate-local to iroh-net.  However
iroh-net has a surprisingly large public API and that would be painful
and largely defeat the point to leave all those public APIs as Url.
Thus it is a public API.

As a consequence there are a few uses of this outside of the iroh-net
crate as well.  I think they are reasonable.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.