### PR TITLE
feat(iroh-net): add DerpMode::StunOnly

### DIFF
--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -14,28 +14,34 @@ pub const DEFAULT_DERP_STUN_PORT: u16 = 3478;
 
 /// Get the default [`DerpMap`].
 pub fn default_derp_map() -> DerpMap {
-    DerpMap::from_nodes([default_na_derp_node(), default_eu_derp_node()])
+    DerpMap::from_nodes([default_na_derp_node(false), default_eu_derp_node(false)])
+        .expect("default nodes invalid")
+}
+
+/// Get the default [`DerpMap`] but only enable stun.
+pub fn default_derp_map_stun() -> DerpMap {
+    DerpMap::from_nodes([default_na_derp_node(true), default_eu_derp_node(true)])
         .expect("default nodes invalid")
 }
 
 /// Get the default [`DerpNode`] for NA.
-pub fn default_na_derp_node() -> DerpNode {
+pub fn default_na_derp_node(stun_only: bool) -> DerpNode {
     // The default NA derper run by number0.
     let url: Url = format!("https://{NA_DERP_HOSTNAME}").parse().unwrap();
     DerpNode {
-        url: url.clone(),
-        stun_only: false,
+        url,
+        stun_only,
         stun_port: DEFAULT_DERP_STUN_PORT,
     }
 }
 
 /// Get the default [`DerpNode`] for EU.
-pub fn default_eu_derp_node() -> DerpNode {
+pub fn default_eu_derp_node(stun_only: bool) -> DerpNode {
     // The default EU derper run by number0.
     let url: Url = format!("https://{EU_DERP_HOSTNAME}").parse().unwrap();
     DerpNode {
-        url: url.clone(),
-        stun_only: false,
+        url,
+        stun_only,
         stun_port: DEFAULT_DERP_STUN_PORT,
     }
 }

--- a/iroh-net/src/derp/map.rs
+++ b/iroh-net/src/derp/map.rs
@@ -17,6 +17,8 @@ pub enum DerpMode {
     Default,
     /// Use a custom Derp map.
     Custom(DerpMap),
+    /// Use the default Derp map, but only for stun.
+    StunOnly,
 }
 
 /// Configuration of all the Derp servers that can be used.

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use crate::{
     config,
-    defaults::default_derp_map,
+    defaults::{default_derp_map, default_derp_map_stun},
     derp::{DerpMap, DerpMode},
     key::{PublicKey, SecretKey},
     magicsock::{self, Discovery, MagicSock},
@@ -243,6 +243,7 @@ impl MagicEndpointBuilder {
         let derp_map = match self.derp_mode {
             DerpMode::Disabled => DerpMap::empty(),
             DerpMode::Default => default_derp_map(),
+            DerpMode::StunOnly => default_derp_map_stun(),
             DerpMode::Custom(derp_map) => {
                 ensure!(!derp_map.is_empty(), "Empty custom Derp server map",);
                 derp_map

--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -124,7 +124,7 @@ impl Default for NodeConfig {
     fn default() -> Self {
         Self {
             // TODO(ramfox): this should probably just be a derp map
-            derp_nodes: [default_na_derp_node(), default_eu_derp_node()].into(),
+            derp_nodes: [default_na_derp_node(false), default_eu_derp_node(false)].into(),
             gc_policy: GcPolicy::Disabled,
             #[cfg(feature = "metrics")]
             metrics_addr: None,


### PR DESCRIPTION
This allows to use the default derp map, but only using them for stun, not relay.

