### PR TITLE
chore(ci): Update outdated actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           - aarch64-linux-android
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -80,14 +80,14 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.4
 
     - name: fmt
       run: cargo fmt --all -- --check
@@ -102,7 +102,7 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     # Can be switched back to stable once 1.75 lands
     # https://github.com/rust-lang/cargo/issues/12115#issuecomment-1768170381
     - uses: dtolnay/rust-toolchain@master
@@ -110,7 +110,7 @@ jobs:
           toolchain: nightly-2023-12-06
           components: clippy
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.4
 
     # TODO: We have a bunch of platform-dependent code so should
     #    probably run this job on the full platform matrix
@@ -132,12 +132,12 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.MSRV }}
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.4
 
     - name: Check MSRV all features
       run: |
@@ -148,7 +148,7 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           arguments: --workspace --all-features
@@ -166,7 +166,7 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     
@@ -174,7 +174,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.4
 
     - name: Build iroh
       run: |

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - name: Checkout
       if: github.event_name != 'issue_comment'
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -42,7 +42,7 @@ jobs:
     
     - name: Checkout
       if: github.event_name == 'issue_comment'
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.event.issue.repository.full_name }}
         submodules: recursive
@@ -52,7 +52,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
     
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.4
 
     - name: Build iroh
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           RUSTV: ${{ matrix.rust }}
         steps:
         - name: Checkout
-          uses: actions/checkout@master
+          uses: actions/checkout@v4
           with:
             submodules: recursive
     

--- a/.github/workflows/test_derper.yml
+++ b/.github/workflows/test_derper.yml
@@ -27,11 +27,11 @@ jobs:
             RUST_BACKTRACE: full
             RUSTV: stable
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
         - name: Install rust stable
           uses: dtolnay/rust-toolchain@stable
         - name: Install sccache
-          uses: mozilla-actions/sccache-action@v0.0.3
+          uses: mozilla-actions/sccache-action@v0.0.4
     
         - name: build release
           run: |
@@ -63,7 +63,7 @@ jobs:
         if: github.ref_name=='main'
         needs: build_derper
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
         - name: Run Staging Deploy Playbook
           uses: arqu/action-ansible-playbook@master
           with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,7 @@ jobs:
         tool: nextest
     
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.4
 
     - name: Select features
       run: |
@@ -179,7 +179,7 @@ jobs:
         }
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.4
 
     - uses: msys2/setup-msys2@v2
 


### PR DESCRIPTION
## Description

These actions use a deprecated nodejs version.  The newer versions do
not.

Also moves to released versions of actions/checkout as that's more
stable and the recommended way to use them.

## Notes & open questions


## Change checklist

- [x] Self-review.