### PR TITLE
refactor: download and export structure and progress events

### DIFF
--- a/iroh-base/src/rpc.rs
+++ b/iroh-base/src/rpc.rs
@@ -24,5 +24,11 @@ impl From<std::io::Error> for RpcError {
     }
 }
 
+impl std::clone::Clone for RpcError {
+    fn clone(&self) -> Self {
+        RpcError(serde_error::Error::new(self))
+    }
+}
+
 /// A serializable result type for use in RPC responses.
 pub type RpcResult<T> = std::result::Result<T, RpcError>;

--- a/iroh-bytes/src/export.rs
+++ b/iroh-bytes/src/export.rs
@@ -1,0 +1,129 @@
+//! Functions to export data from a store
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use bytes::Bytes;
+use iroh_base::rpc::RpcError;
+use serde::{Deserialize, Serialize};
+use tracing::trace;
+
+use crate::{
+    format::collection::Collection,
+    store::{ExportMode, MapEntry, Store as BaoStore},
+    util::progress::{IdGenerator, ProgressSender},
+    Hash,
+};
+
+/// Export a hash to the local file system.
+///
+/// This exports a single hash, or a collection `recursive` is true, from the `db` store to the
+/// local filesystem. Depending on `mode` the data is either copied or reflinked (if possible).
+///
+/// Progress is reported as [`ExportProgress`] through a [`ProgressSender`]. Note that the
+/// [`ExportProgress::AllDone`] event is not emitted from here, but left to an upper layer to send,
+/// if desired.
+pub async fn export<D: BaoStore>(
+    db: &D,
+    hash: Hash,
+    out: PathBuf,
+    recursive: bool,
+    mode: ExportMode,
+    progress: impl ProgressSender<Msg = ExportProgress> + IdGenerator,
+) -> anyhow::Result<()> {
+    let path = PathBuf::from(&out);
+    if recursive {
+        tokio::fs::create_dir_all(&path).await?;
+        let collection = Collection::load(db, &hash).await?;
+        for (name, hash) in collection.into_iter() {
+            #[allow(clippy::needless_borrow)]
+            let path = path.join(pathbuf_from_name(&name));
+            if let Some(parent) = path.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+            trace!("exporting blob {} to {}", hash, path.display());
+            let entry = db.get(&hash).context("entry not there")?;
+            let id = progress.new_id();
+            progress
+                .send(ExportProgress::Found {
+                    id,
+                    hash,
+                    outpath: path.clone(),
+                    size: entry.size(),
+                    meta: None,
+                })
+                .await?;
+            let progress1 = progress.clone();
+            db.export(hash, path, mode, move |offset| {
+                Ok(progress1.try_send(ExportProgress::Progress { id, offset })?)
+            })
+            .await?;
+            progress.send(ExportProgress::Done { id }).await?;
+        }
+    } else if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+        let id = progress.new_id();
+        let entry = db.get(&hash).context("entry not there")?;
+        progress
+            .send(ExportProgress::Found {
+                id,
+                hash,
+                outpath: out,
+                size: entry.size(),
+                meta: None,
+            })
+            .await?;
+        let progress1 = progress.clone();
+        db.export(hash, path, mode, move |offset| {
+            Ok(progress1.try_send(ExportProgress::Progress { id, offset })?)
+        })
+        .await?;
+        progress.send(ExportProgress::Done { id }).await?;
+    }
+    anyhow::Ok(())
+}
+
+/// Progress events for an export operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExportProgress {
+    /// The download part is done for this id, we are now exporting the data
+    /// to the specified out path.
+    Found {
+        /// Unique id of the entry.
+        id: u64,
+        /// The hash of the entry.
+        hash: Hash,
+        /// The size of the entry in bytes.
+        size: u64,
+        /// The path to the file where the data is exported.
+        outpath: PathBuf,
+        /// Operation-specific metadata.
+        meta: Option<Bytes>,
+    },
+    /// We have made progress exporting the data.
+    ///
+    /// This is only sent for large blobs.
+    Progress {
+        /// Unique id of the entry that is being exported.
+        id: u64,
+        /// The offset of the progress, in bytes.
+        offset: u64,
+    },
+    /// We finished exporting a blob
+    Done {
+        /// Unique id of the entry that is being exported.
+        id: u64,
+    },
+    /// We are done with the whole operation.
+    AllDone,
+    /// We got an error and need to abort.
+    Abort(RpcError),
+}
+
+fn pathbuf_from_name(name: &str) -> PathBuf {
+    let mut path = PathBuf::new();
+    for part in name.split('/') {
+        path.push(part);
+    }
+    path
+}

--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -21,6 +21,7 @@ use anyhow::Result;
 use bao_tree::io::fsm::BaoContentItem;
 use bao_tree::ChunkNum;
 use quinn::RecvStream;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, error};
 
 use crate::protocol::RangeSpecSeq;
@@ -32,7 +33,7 @@ pub mod error;
 pub mod request;
 
 /// Stats about the transfer.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Stats {
     /// The number of bytes written
     pub bytes_written: u64,

--- a/iroh-bytes/src/get/db.rs
+++ b/iroh-bytes/src/get/db.rs
@@ -1,10 +1,8 @@
 //! Functions that use the iroh-bytes protocol in conjunction with a bao store.
-use std::path::PathBuf;
 use std::time::Duration;
 
-use futures::Future;
-use futures::StreamExt;
-use iroh_base::{hash::Hash, rpc::RpcError};
+use futures::{Future, StreamExt};
+use iroh_base::hash::Hash;
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::RangeSpec;
@@ -531,7 +529,7 @@ impl<D: BaoStore> BlobInfo<D> {
 }
 
 /// Progress updates for the get operation.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DownloadProgress {
     /// Data was found locally.
     FoundLocal {
@@ -577,7 +575,7 @@ pub enum DownloadProgress {
         id: u64,
     },
     /// We are done with the network part - all data is local.
-    NetworkDone {
+    AllDone {
         /// The number of bytes written.
         bytes_written: u64,
         /// The number of bytes read.
@@ -585,29 +583,8 @@ pub enum DownloadProgress {
         /// The time it took to transfer the data.
         elapsed: Duration,
     },
-    /// The download part is done for this id, we are now exporting the data
-    /// to the specified out path.
-    Export {
-        /// Unique id of the entry.
-        id: u64,
-        /// The hash of the entry.
-        hash: Hash,
-        /// The size of the entry in bytes.
-        size: u64,
-        /// The path to the file where the data is exported.
-        target: PathBuf,
-    },
-    /// We have made progress exporting the data.
-    ///
-    /// This is only sent for large blobs.
-    ExportProgress {
-        /// Unique id of the entry that is being exported.
-        id: u64,
-        /// The offset of the progress, in bytes.
-        offset: u64,
-    },
     /// We got an error and need to abort.
-    Abort(RpcError),
-    /// We are done with the whole operation.
-    AllDone,
+    ///
+    /// This will be the last message in the stream.
+    Abort(String),
 }

--- a/iroh-bytes/src/lib.rs
+++ b/iroh-bytes/src/lib.rs
@@ -5,6 +5,7 @@
 
 #[cfg(feature = "downloader")]
 pub mod downloader;
+pub mod export;
 pub mod format;
 pub mod get;
 pub mod hashseq;

--- a/iroh-bytes/src/util/progress.rs
+++ b/iroh-bytes/src/util/progress.rs
@@ -272,6 +272,17 @@ impl<I: IdGenerator, U, F> IdGenerator for WithFilterMap<I, U, F> {
 }
 
 impl<
+        I: IdGenerator + ProgressSender,
+        U: Send + Sync + 'static,
+        F: Fn(U) -> I::Msg + Clone + Send + Sync + 'static,
+    > IdGenerator for WithMap<I, U, F>
+{
+    fn new_id(&self) -> u64 {
+        self.0.new_id()
+    }
+}
+
+impl<
         I: ProgressSender,
         U: Send + Sync + 'static,
         F: Fn(U) -> Option<I::Msg> + Clone + Send + Sync + 'static,

--- a/iroh/src/commands/blob.rs
+++ b/iroh/src/commands/blob.rs
@@ -16,7 +16,8 @@ use indicatif::{
 use iroh::{
     client::{BlobStatus, Iroh, ShareTicketOptions},
     rpc_protocol::{
-        BlobDownloadRequest, DownloadLocation, ProviderService, SetTagOption, WrapOption,
+        BlobDownloadExportProgress, BlobDownloadRequest, DownloadLocation, ProviderService,
+        SetTagOption, WrapOption,
     },
     ticket::BlobTicket,
 };
@@ -808,7 +809,7 @@ impl ProvideProgressState {
 
 pub async fn show_download_progress(
     hash: Hash,
-    mut stream: impl Stream<Item = Result<DownloadProgress>> + Unpin,
+    mut stream: impl Stream<Item = Result<BlobDownloadExportProgress>> + Unpin,
 ) -> Result<()> {
     eprintln!("Fetching: {}", hash);
     let mp = MultiProgress::new();
@@ -819,54 +820,66 @@ pub async fn show_download_progress(
     let mut seq = false;
     while let Some(x) = stream.next().await {
         match x? {
-            DownloadProgress::Connected => {
-                op.set_message(format!("{} Requesting ...\n", style("[2/3]").bold().dim()));
-            }
-            DownloadProgress::FoundHashSeq { children, .. } => {
-                op.set_message(format!(
-                    "{} Downloading {} blob(s)\n",
-                    style("[3/3]").bold().dim(),
-                    children + 1,
-                ));
-                op.set_length(children + 1);
-                op.reset();
-                seq = true;
-            }
-            DownloadProgress::Found { size, child, .. } => {
-                if seq {
-                    op.set_position(child);
-                } else {
-                    op.finish_and_clear();
+            BlobDownloadExportProgress::Download(p) => match p {
+                DownloadProgress::Connected => {
+                    op.set_message(format!("{} Requesting ...\n", style("[2/3]").bold().dim()));
                 }
-                ip.set_length(size);
-                ip.reset();
+                DownloadProgress::FoundHashSeq { children, .. } => {
+                    op.set_message(format!(
+                        "{} Downloading {} blob(s)\n",
+                        style("[3/3]").bold().dim(),
+                        children + 1,
+                    ));
+                    op.set_length(children + 1);
+                    op.reset();
+                    seq = true;
+                }
+                DownloadProgress::Found { size, child, .. } => {
+                    if seq {
+                        op.set_position(child);
+                    } else {
+                        op.finish_and_clear();
+                    }
+                    ip.set_length(size);
+                    ip.reset();
+                }
+                DownloadProgress::Progress { offset, .. } => {
+                    ip.set_position(offset);
+                }
+                DownloadProgress::Done { .. } => {
+                    ip.finish_and_clear();
+                }
+                DownloadProgress::AllDone {
+                    bytes_read,
+                    elapsed,
+                    ..
+                } => {
+                    op.finish_and_clear();
+                    eprintln!(
+                        "Transferred {} in {}, {}/s",
+                        HumanBytes(bytes_read),
+                        HumanDuration(elapsed),
+                        HumanBytes((bytes_read as f64 / elapsed.as_secs_f64()) as u64)
+                    );
+                }
+                DownloadProgress::Abort(e) => {
+                    bail!("download aborted: {:?}", e);
+                }
+                _ => {}
+            },
+            BlobDownloadExportProgress::Export(_p) => {
+                // todo: report export progress?
+                // match p {
+                //     ExportProgress::Start { id, hash, size, outpath, meta } => todo!(),
+                //     ExportProgress::Progress { id, offset } => todo!(),
+                //     ExportProgress::Done { id, offset } => todo!(),
+                //     ExportProgress::Abort(_) => todo!(),
+                //     ExportProgress::AllDone => todo!(),
+                // }
             }
-            DownloadProgress::Progress { offset, .. } => {
-                ip.set_position(offset);
-            }
-            DownloadProgress::Done { .. } => {
-                ip.finish_and_clear();
-            }
-            DownloadProgress::NetworkDone {
-                bytes_read,
-                elapsed,
-                ..
-            } => {
-                op.finish_and_clear();
-                eprintln!(
-                    "Transferred {} in {}, {}/s",
-                    HumanBytes(bytes_read),
-                    HumanDuration(elapsed),
-                    HumanBytes((bytes_read as f64 / elapsed.as_secs_f64()) as u64)
-                );
-            }
-            DownloadProgress::AllDone => {
+            BlobDownloadExportProgress::AllDone => {
                 break;
             }
-            DownloadProgress::Abort(e) => {
-                bail!("download aborted: {:?}", e);
-            }
-            _ => {}
         }
     }
     Ok(())

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -54,13 +54,13 @@ use tracing::{debug, error, error_span, info, trace, warn, Instrument};
 
 use crate::rpc_protocol::{
     BlobAddPathRequest, BlobAddPathResponse, BlobAddStreamRequest, BlobAddStreamResponse,
-    BlobAddStreamUpdate, BlobDeleteBlobRequest, BlobDownloadRequest, BlobGetCollectionRequest,
-    BlobGetCollectionResponse, BlobListCollectionsRequest, BlobListCollectionsResponse,
-    BlobListIncompleteRequest, BlobListIncompleteResponse, BlobListRequest, BlobListResponse,
-    BlobReadAtRequest, BlobReadAtResponse, BlobValidateRequest, CreateCollectionRequest,
-    CreateCollectionResponse, DeleteTagRequest, DocExportFileRequest, DocExportFileResponse,
-    DocExportProgress, DocImportFileRequest, DocImportFileResponse, DocImportProgress,
-    DocSetHashRequest, DownloadLocation, ListTagsRequest, ListTagsResponse,
+    BlobAddStreamUpdate, BlobDeleteBlobRequest, BlobDownloadExportProgress, BlobDownloadRequest,
+    BlobGetCollectionRequest, BlobGetCollectionResponse, BlobListCollectionsRequest,
+    BlobListCollectionsResponse, BlobListIncompleteRequest, BlobListIncompleteResponse,
+    BlobListRequest, BlobListResponse, BlobReadAtRequest, BlobReadAtResponse, BlobValidateRequest,
+    CreateCollectionRequest, CreateCollectionResponse, DeleteTagRequest, DocExportFileRequest,
+    DocExportFileResponse, DocImportFileRequest, DocImportFileResponse, DocImportProgress,
+    DocSetHashRequest, DownloadLocation, ExportProgress, ListTagsRequest, ListTagsResponse,
     NodeConnectionInfoRequest, NodeConnectionInfoResponse, NodeConnectionsRequest,
     NodeConnectionsResponse, NodeShutdownRequest, NodeStatsRequest, NodeStatsResponse,
     NodeStatusRequest, NodeStatusResponse, NodeWatchRequest, NodeWatchResponse, ProviderRequest,
@@ -1012,7 +1012,7 @@ impl<D: BaoStore> RpcHandler<D> {
         let tx2 = tx.clone();
         self.rt().spawn_pinned(|| async move {
             if let Err(e) = self.doc_export_file0(msg, tx).await {
-                tx2.send_async(DocExportProgress::Abort(e.into()))
+                tx2.send_async(ExportProgress::Abort(e.to_string()))
                     .await
                     .ok();
             }
@@ -1023,42 +1023,39 @@ impl<D: BaoStore> RpcHandler<D> {
     async fn doc_export_file0(
         self,
         msg: DocExportFileRequest,
-        progress: flume::Sender<DocExportProgress>,
+        progress: flume::Sender<ExportProgress>,
     ) -> anyhow::Result<()> {
         let progress = FlumeProgressSender::new(progress);
         let DocExportFileRequest { entry, path } = msg;
         let key = bytes::Bytes::from(entry.key().to_vec());
         let export_progress = progress.clone().with_filter_map(move |x| match x {
-            DownloadProgress::Export {
+            ExportProgress::Start {
                 id,
                 hash,
                 size,
-                target,
-            } => Some(DocExportProgress::Found {
+                outpath,
+                ..
+            } => Some(ExportProgress::Start {
                 id,
-                key: key.clone(),
-                size,
-                outpath: target,
                 hash,
+                size,
+                outpath,
+                meta: Some(key.clone()),
             }),
-            DownloadProgress::ExportProgress { id, offset } => {
-                Some(DocExportProgress::Progress { id, offset })
-            }
-            _ => None,
+            p => Some(p),
         });
-        self.blob_export(path, entry.content_hash(), false, false, export_progress)
+        self.blob_export0(path, entry.content_hash(), false, false, export_progress)
             .await?;
-        progress.send(DocExportProgress::AllDone).await?;
         Ok(())
     }
 
-    async fn blob_export(
+    async fn blob_export0(
         self,
         out: PathBuf,
         hash: Hash,
         recursive: bool,
         stable: bool,
-        progress: impl ProgressSender<Msg = DownloadProgress> + IdGenerator,
+        progress: impl ProgressSender<Msg = ExportProgress> + IdGenerator,
     ) -> anyhow::Result<()> {
         let db = &self.inner.db;
         let path = PathBuf::from(&out);
@@ -1081,7 +1078,7 @@ impl<D: BaoStore> RpcHandler<D> {
                 let id = progress.new_id();
                 let progress1 = progress.clone();
                 db.export(hash, path, mode, move |offset| {
-                    Ok(progress1.try_send(DownloadProgress::ExportProgress { id, offset })?)
+                    Ok(progress1.try_send(ExportProgress::Progress { id, offset })?)
                 })
                 .await?;
             }
@@ -1090,26 +1087,28 @@ impl<D: BaoStore> RpcHandler<D> {
             let id = progress.new_id();
             let entry = db.get(&hash).context("entry not there")?;
             progress
-                .send(DownloadProgress::Export {
+                .send(ExportProgress::Start {
                     id,
                     hash,
-                    target: out,
+                    outpath: out,
                     size: entry.size(),
+                    meta: None,
                 })
                 .await?;
             let progress1 = progress.clone();
             db.export(hash, path, mode, move |offset| {
-                Ok(progress1.try_send(DownloadProgress::ExportProgress { id, offset })?)
+                Ok(progress1.try_send(ExportProgress::Progress { id, offset })?)
             })
             .await?;
         }
+        progress.send(ExportProgress::AllDone).await?;
         anyhow::Ok(())
     }
 
     async fn blob_download0(
         self,
         msg: BlobDownloadRequest,
-        progress: impl ProgressSender<Msg = DownloadProgress> + IdGenerator,
+        progress: impl ProgressSender<Msg = BlobDownloadExportProgress> + IdGenerator,
     ) -> anyhow::Result<()> {
         let db = self.inner.db.clone();
         let peer = msg.peer.clone();
@@ -1121,14 +1120,20 @@ impl<D: BaoStore> RpcHandler<D> {
         let temp_pin = db.temp_tag(hash_and_format);
         let ep = self.inner.endpoint.clone();
         let get_conn = move || async move { ep.connect(peer, iroh_bytes::protocol::ALPN).await };
-        progress.send(DownloadProgress::Connected).await?;
+        progress
+            .send(BlobDownloadExportProgress::Download(
+                DownloadProgress::Connected,
+            ))
+            .await?;
 
         let db = self.inner.db.clone();
         let this = self.clone();
         self.inner.rt.spawn_pinned(move || async move {
             if let Err(err) = download_progress(db, get_conn, msg, progress.clone(), this).await {
                 progress
-                    .send(DownloadProgress::Abort(err.into()))
+                    .send(BlobDownloadExportProgress::Download(
+                        DownloadProgress::Abort(err.to_string()).into(),
+                    ))
                     .await
                     .ok();
                 drop(temp_pin);
@@ -1136,18 +1141,26 @@ impl<D: BaoStore> RpcHandler<D> {
             }
 
             drop(temp_pin);
-            progress.send(DownloadProgress::AllDone).await.ok();
+            progress
+                .send(BlobDownloadExportProgress::AllDone)
+                .await
+                .ok();
         });
         Ok(())
     }
 
-    fn blob_download(self, msg: BlobDownloadRequest) -> impl Stream<Item = DownloadProgress> {
+    fn blob_download(
+        self,
+        msg: BlobDownloadRequest,
+    ) -> impl Stream<Item = BlobDownloadExportProgress> {
         async move {
             let (sender, receiver) = flume::bounded(1024);
             let sender = FlumeProgressSender::new(sender);
             if let Err(cause) = self.blob_download0(msg, sender.clone()).await {
                 sender
-                    .send(DownloadProgress::Abort(cause.into()))
+                    .send(BlobDownloadExportProgress::Download(
+                        DownloadProgress::Abort(cause.to_string()),
+                    ))
                     .await
                     .unwrap();
             };
@@ -1555,7 +1568,7 @@ async fn download_progress<D, C, F>(
     db: D,
     get_conn: C,
     msg: BlobDownloadRequest,
-    progress: impl ProgressSender<Msg = DownloadProgress> + IdGenerator,
+    progress: impl ProgressSender<Msg = BlobDownloadExportProgress> + IdGenerator,
     rpc: RpcHandler<D>,
 ) -> Result<()>
 where
@@ -1568,26 +1581,34 @@ where
         format: msg.format,
     };
 
+    let download_progress = progress
+        .clone()
+        .with_map(|p| BlobDownloadExportProgress::Download(p));
     let stats =
-        iroh_bytes::get::db::get_to_db(&db, get_conn, &hash_and_format, progress.clone()).await?;
+        iroh_bytes::get::db::get_to_db(&db, get_conn, &hash_and_format, download_progress).await?;
 
     progress
-        .send(DownloadProgress::NetworkDone {
-            bytes_written: stats.bytes_written,
-            bytes_read: stats.bytes_read,
-            elapsed: stats.elapsed,
-        })
+        .send(BlobDownloadExportProgress::Download(
+            DownloadProgress::AllDone {
+                bytes_written: stats.bytes_written,
+                bytes_read: stats.bytes_read,
+                elapsed: stats.elapsed,
+            },
+        ))
         .await
         .ok();
 
     match msg.out {
         DownloadLocation::External { path, in_place } => {
-            rpc.blob_export(
+            let export_progress = progress
+                .clone()
+                .with_map(|p| BlobDownloadExportProgress::Export(p));
+            rpc.blob_export0(
                 path,
                 msg.hash,
                 msg.format.is_hash_seq(),
                 in_place,
-                progress.clone(),
+                export_progress,
             )
             .await?;
         }

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -131,7 +131,19 @@ impl Msg<ProviderService> for BlobDownloadRequest {
 }
 
 impl ServerStreamingMsg<ProviderService> for BlobDownloadRequest {
-    type Response = DownloadProgress;
+    type Response = BlobDownloadExportProgress;
+}
+
+/// Progress resposne for [`BlobDownloadRequest`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BlobDownloadExportProgress {
+    /// Download progress
+    Download(DownloadProgress),
+    /// Export progress (this will only be emitted if request.out is set to
+    /// [`DownloadLocation::External`])
+    Export(ExportProgress),
+    /// Both download and export finished.
+    AllDone,
 }
 
 /// A request to the node to validate the integrity of all provided data
@@ -764,9 +776,48 @@ pub enum DocImportProgress {
     Abort(RpcError),
 }
 
+/// Progress events for an export operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExportProgress {
+    /// The download part is done for this id, we are now exporting the data
+    /// to the specified out path.
+    Start {
+        /// Unique id of the entry.
+        id: u64,
+        /// The hash of the entry.
+        hash: Hash,
+        /// The size of the entry in bytes.
+        size: u64,
+        /// The path to the file where the data is exported.
+        outpath: PathBuf,
+        /// Operation-specific metadata.
+        meta: Option<Bytes>,
+    },
+    /// We have made progress exporting the data.
+    ///
+    /// This is only sent for large blobs.
+    Progress {
+        /// Unique id of the entry that is being exported.
+        id: u64,
+        /// The offset of the progress, in bytes.
+        offset: u64,
+    },
+    /// We finished exporting a blob
+    Done {
+        /// Unique id of the entry that is being exported.
+        id: u64,
+        /// The offset of the progress, in bytes.
+        offset: u64,
+    },
+    /// We got an error and need to abort.
+    Abort(String),
+    /// We are done with the whole operation.
+    AllDone,
+}
+
 /// A request to the node to save the data of the entry to the given filepath
 ///
-/// Will produce a stream of [`DocExportProgress`] messages.
+/// Will produce a stream of [`DocExportFileResponse`] messages.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DocExportFileRequest {
     /// The entry you want to export
@@ -787,43 +838,12 @@ impl ServerStreamingMsg<ProviderService> for DocExportFileRequest {
     type Response = DocExportFileResponse;
 }
 
-/// Wrapper around [`DocExportProgress`].
-#[derive(Debug, Serialize, Deserialize, derive_more::Into)]
-pub struct DocExportFileResponse(pub DocExportProgress);
-
 /// Progress messages for an doc export operation
 ///
 /// An export operation involves reading the entry from the database ans saving the entry to the
 /// given `outpath`
-#[derive(Debug, Serialize, Deserialize)]
-pub enum DocExportProgress {
-    /// An item was found with name `name`, from now on referred to via `id`
-    Found {
-        /// A new unique id for this entry.
-        id: u64,
-        /// The hash of the entry.
-        hash: Hash,
-        /// The key to the entry.
-        key: Bytes,
-        /// The size of the entry in bytes.
-        size: u64,
-        /// The path to where we are writing the entry
-        outpath: PathBuf,
-    },
-    /// We got progress exporting item `id`.
-    Progress {
-        /// The unique id of the entry.
-        id: u64,
-        /// The offset of the progress, in bytes.
-        offset: u64,
-    },
-    /// We are done writing the entry to the filesystem
-    AllDone,
-    /// We got an error and need to abort.
-    ///
-    /// This will be the last message in the stream.
-    Abort(RpcError),
-}
+#[derive(Debug, Serialize, Deserialize, derive_more::Into)]
+pub struct DocExportFileResponse(pub ExportProgress);
 
 /// Delete entries in a document
 #[derive(Serialize, Deserialize, Debug)]
@@ -1113,7 +1133,7 @@ pub enum ProviderResponse {
     BlobReadAt(RpcResult<BlobReadAtResponse>),
     BlobAddStream(BlobAddStreamResponse),
     BlobAddPath(BlobAddPathResponse),
-    BlobDownload(DownloadProgress),
+    BlobDownload(BlobDownloadExportProgress),
     BlobList(BlobListResponse),
     BlobListIncomplete(BlobListIncompleteResponse),
     BlobListCollections(BlobListCollectionsResponse),

--- a/iroh/src/util/io.rs
+++ b/iroh/src/util/io.rs
@@ -1,17 +1,8 @@
 //! Utilities for working with tokio io
 use bao_tree::io::EncodeError;
 use derive_more::Display;
-use std::{io::Write, path::PathBuf};
+use std::io::Write;
 use thiserror::Error;
-
-/// Create a pathbuf from a name.
-pub fn pathbuf_from_name(name: &str) -> PathBuf {
-    let mut path = PathBuf::new();
-    for part in name.split('/') {
-        path.push(part);
-    }
-    path
-}
 
 /// Todo: gather more information about validation errors. E.g. offset
 ///


### PR DESCRIPTION
## Description

This PR has a number of cleanups regarding download and export functionality:
* We currently have an enum `DownloadProgress` which contains events for both downloading a blob and for exporting a blob from the node's blob store to files on the local filesystem. This PR moves the export progress events into an `ExportProgress` enum.
* The code to export blobs to the local file system is moved from `iroh` to `iroh-bytes`
* Code duplication around export progress is reduced and a couple of RPC and client structs are cleaned up accordingly

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
