### PR TITLE
Add optional redb support for foundational iroh-base types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,6 +2246,7 @@ dependencies = [
  "multibase",
  "postcard",
  "proptest",
+ "redb",
  "serde",
  "serde-error",
  "serde_json",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -36,4 +36,5 @@ serde_test = "1.0.176"
 default = ["hash", "base32"]
 hash = ["bao-tree", "multibase", "data-encoding", "postcard"]
 base32 = ["data-encoding"]
+redb = ["dep:redb"]
 

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -21,6 +21,7 @@ data-encoding = { version = "2.3.3", optional = true }
 hex = "0.4.3"
 multibase = { version = "0.9.1", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"], optional = true }
+redb = { version = "1.5.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde-error = "0.1.2"
 thiserror = "1"
@@ -35,3 +36,4 @@ serde_test = "1.0.176"
 default = ["hash", "base32"]
 hash = ["bao-tree", "multibase", "data-encoding", "postcard"]
 base32 = ["data-encoding"]
+

--- a/iroh-base/src/hash.rs
+++ b/iroh-base/src/hash.rs
@@ -261,7 +261,7 @@ mod redb_support {
         type AsBytes<'a> = [u8; Self::POSTCARD_MAX_SIZE];
 
         fn fixed_width() -> Option<usize> {
-            Some(33)
+            Some(Self::POSTCARD_MAX_SIZE)
         }
 
         fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>


### PR DESCRIPTION
## Description

Add optional redb support for foundational iroh-base types Hash, HashAndFormat, BlobFormat

## Notes & open questions

Should this be on by default? It is off now. I think this is mostly for us.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [x] Tests if relevant.
