### PR TITLE
refactor: Batch write trait

### DIFF
--- a/iroh-bytes/src/get.rs
+++ b/iroh-bytes/src/get.rs
@@ -60,7 +60,7 @@ pub mod fsm {
 
     use crate::{
         protocol::{GetRequest, NonEmptyRequestRangeSpecIter, Request, MAX_MESSAGE_SIZE},
-        store::BatchWriter,
+        store::BaoBatchWriter,
     };
 
     use super::*;
@@ -494,13 +494,10 @@ pub mod fsm {
             Ok(res)
         }
 
-        /// Write the entire blob to a slice writer and to an optional outboard.
-        ///
-        /// The outboard is only written to if the blob is larger than a single
-        /// chunk group.
+        /// Write the entire stream for this blob to a batch writer.
         pub async fn write_all_batch<B>(self, batch: B) -> result::Result<AtEndBlob, DecodeError>
         where
-            B: BatchWriter,
+            B: BaoBatchWriter,
         {
             let (content, _size) = self.next().await?;
             let res = content.write_all_batch(batch).await?;
@@ -703,10 +700,10 @@ pub mod fsm {
             Ok((done, res))
         }
 
-        /// Write the entire blob to a batch writer.
+        /// Write the entire stream for this blob to a batch writer.
         pub async fn write_all_batch<B>(self, writer: B) -> result::Result<AtEndBlob, DecodeError>
         where
-            B: BatchWriter,
+            B: BaoBatchWriter,
         {
             let mut writer = writer;
             let mut buf = Vec::new();

--- a/iroh-bytes/src/get/db.rs
+++ b/iroh-bytes/src/get/db.rs
@@ -8,6 +8,7 @@ use iroh_base::{hash::Hash, rpc::RpcError};
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::RangeSpec;
+use crate::store::FallibleProgressBatchWriter;
 use crate::util::progress::FallibleProgressSliceWriter;
 use std::io;
 
@@ -169,6 +170,7 @@ async fn get_blob_inner<D: BaoStore>(
     // create the temp file pair
     let entry = db.get_or_create_partial(hash, size)?;
     // open the data file in any case
+    // let bw = entry.batch_writer().await?;
     let df = entry.data_writer().await?;
     let mut of: Option<D::OutboardMut> = if needs_outboard(size) {
         Some(entry.outboard_mut().await?)
@@ -197,6 +199,7 @@ async fn get_blob_inner<D: BaoStore>(
             })?;
         Ok(())
     };
+    // let mut bw = FallibleProgressBatchWriter::new(bw, on_write);
     let mut pw = FallibleProgressSliceWriter::new(df, on_write);
     // use the convenience method to write all to the two vfs objects
     let end = at_content

--- a/iroh-bytes/src/get/db.rs
+++ b/iroh-bytes/src/get/db.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::protocol::RangeSpec;
 use crate::store::FallibleProgressBatchWriter;
-use crate::util::progress::FallibleProgressSliceWriter;
 use std::io;
 
 use crate::hashseq::parse_hash_seq;
@@ -26,12 +25,11 @@ use crate::{
     protocol::{GetRequest, RangeSpecSeq},
     store::{MapEntry, PartialMap, PartialMapEntry, Store as BaoStore},
     util::progress::{IdGenerator, ProgressSender},
-    BlobFormat, HashAndFormat, IROH_BLOCK_SIZE,
+    BlobFormat, HashAndFormat,
 };
 use anyhow::anyhow;
-use bao_tree::io::fsm::OutboardMut;
 use bao_tree::{ByteNum, ChunkRanges};
-use iroh_io::{AsyncSliceReader, AsyncSliceWriter};
+use iroh_io::AsyncSliceReader;
 use tracing::trace;
 
 /// Get a blob or collection into a store.
@@ -206,10 +204,6 @@ async fn get_blob_inner<D: BaoStore>(
     Ok(end)
 }
 
-fn needs_outboard(size: u64) -> bool {
-    size > (IROH_BLOCK_SIZE.bytes() as u64)
-}
-
 /// Get a blob that was requested partially.
 ///
 /// We get passed the data and outboard ids. Partial downloads are only done
@@ -225,13 +219,8 @@ async fn get_blob_inner_partial<D: BaoStore>(
 
     // read the size
     let (at_content, size) = at_header.next().await?;
-    // open the data file in any case
-    let df = entry.data_writer().await?;
-    let mut of = if needs_outboard(size) {
-        Some(entry.outboard_mut().await?)
-    } else {
-        None
-    };
+    // create a batch writer for the bao file
+    let bw = entry.batch_writer().await?;
     // allocate a new id for progress reports for this transfer
     let id = sender.new_id();
     let hash = at_content.hash();
@@ -256,17 +245,11 @@ async fn get_blob_inner_partial<D: BaoStore>(
             })?;
         Ok(())
     };
-    let mut pw = FallibleProgressSliceWriter::new(df, on_write);
+    let mut bw = FallibleProgressBatchWriter::new(bw, on_write);
     // use the convenience method to write all to the two vfs objects
-    let at_end = at_content
-        .write_all_with_outboard(of.as_mut(), &mut pw)
-        .await?;
+    let at_end = at_content.write_all_batch(&mut bw).await?;
     // sync the data file
-    pw.sync().await?;
-    // sync the outboard file
-    if let Some(mut of) = of {
-        of.sync().await?;
-    }
+    bw.sync().await?;
     // actually store the data. it is up to the db to decide if it wants to
     // rename the files or not.
     db.insert_complete(entry).await?;

--- a/iroh-bytes/src/store/flat.rs
+++ b/iroh-bytes/src/store/flat.rs
@@ -279,7 +279,7 @@ impl MapEntry<Store> for PartialEntry {
     }
 }
 
-impl PartialMapEntry<Store> for PartialEntry {
+impl PartialEntry {
     fn outboard_mut(&self) -> BoxIoFut<PreOrderOutboard<File>> {
         let hash = self.hash;
         let size = self.size;
@@ -313,7 +313,9 @@ impl PartialMapEntry<Store> for PartialEntry {
         })
         .boxed()
     }
+}
 
+impl PartialMapEntry<Store> for PartialEntry {
     fn batch_writer(
         &self,
     ) -> futures::prelude::future::BoxFuture<'_, io::Result<<Store as PartialMap>::BatchWriter>>

--- a/iroh-bytes/src/store/flat.rs
+++ b/iroh-bytes/src/store/flat.rs
@@ -330,13 +330,9 @@ impl PartialMapEntry<Store> for PartialEntry {
 }
 
 impl PartialMap for Store {
-    type OutboardMut = PreOrderOutboard<File>;
-
-    type DataWriter = iroh_io::File;
-
     type PartialEntry = PartialEntry;
 
-    type BatchWriter = CombinedBatchWriter<Self::DataWriter, Self::OutboardMut>;
+    type BatchWriter = CombinedBatchWriter<File, PreOrderOutboard<File>>;
 
     fn entry_status(&self, hash: &Hash) -> io::Result<EntryStatus> {
         let state = self.0.state.read().unwrap();

--- a/iroh-bytes/src/store/flat.rs
+++ b/iroh-bytes/src/store/flat.rs
@@ -142,7 +142,6 @@ use bao_tree::io::sync::ReadAt;
 use bao_tree::ChunkRanges;
 use bao_tree::{BaoTree, ByteNum};
 use bytes::Bytes;
-use futures::future::BoxFuture;
 use futures::future::Either;
 use futures::{Future, FutureExt, Stream, StreamExt};
 use iroh_io::{AsyncSliceReader, AsyncSliceWriter, File};
@@ -151,6 +150,8 @@ use tokio::sync::mpsc;
 use tracing::trace_span;
 
 use super::{flatten_to_io, new_uuid, temp_name, TempCounterMap};
+
+type BoxIoFut<'a, T> = futures::future::BoxFuture<'a, io::Result<T>>;
 
 #[derive(Debug, Default)]
 struct State {
@@ -249,11 +250,11 @@ impl MapEntry<Store> for PartialEntry {
         self.size
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
+    fn available_ranges(&self) -> BoxIoFut<ChunkRanges> {
         futures::future::ok(ChunkRanges::all()).boxed()
     }
 
-    fn outboard(&self) -> BoxFuture<'_, io::Result<<Store as Map>::Outboard>> {
+    fn outboard(&self) -> BoxIoFut<PreOrderOutboard<MemOrFile>> {
         async move {
             let file = File::open(self.outboard_path.clone()).await?;
             Ok(PreOrderOutboard {
@@ -265,7 +266,7 @@ impl MapEntry<Store> for PartialEntry {
         .boxed()
     }
 
-    fn data_reader(&self) -> BoxFuture<'_, io::Result<<Store as Map>::DataReader>> {
+    fn data_reader(&self) -> BoxIoFut<MemOrFile> {
         async move {
             let file = File::open(self.data_path.clone()).await?;
             Ok(MemOrFile::File(file))
@@ -279,7 +280,7 @@ impl MapEntry<Store> for PartialEntry {
 }
 
 impl PartialMapEntry<Store> for PartialEntry {
-    fn outboard_mut(&self) -> BoxFuture<'_, io::Result<<Store as PartialMap>::OutboardMut>> {
+    fn outboard_mut(&self) -> BoxIoFut<PreOrderOutboard<File>> {
         let hash = self.hash;
         let size = self.size;
         let tree = BaoTree::new(ByteNum(size), IROH_BLOCK_SIZE);
@@ -302,7 +303,7 @@ impl PartialMapEntry<Store> for PartialEntry {
         .boxed()
     }
 
-    fn data_writer(&self) -> BoxFuture<'_, io::Result<<Store as PartialMap>::DataWriter>> {
+    fn data_writer(&self) -> BoxIoFut<File> {
         let path = self.data_path.clone();
         iroh_io::File::create(move || {
             std::fs::OpenOptions::new()
@@ -380,7 +381,7 @@ impl PartialMap for Store {
         })
     }
 
-    fn insert_complete(&self, entry: Self::PartialEntry) -> BoxFuture<'_, io::Result<()>> {
+    fn insert_complete(&self, entry: Self::PartialEntry) -> BoxIoFut<()> {
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.insert_complete_sync(entry))
             .map(flatten_to_io)
@@ -465,11 +466,11 @@ impl MapEntry<Store> for Entry {
         }
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
+    fn available_ranges(&self) -> BoxIoFut<ChunkRanges> {
         futures::future::ok(ChunkRanges::all()).boxed()
     }
 
-    fn outboard(&self) -> BoxFuture<'_, io::Result<PreOrderOutboard<MemOrFile>>> {
+    fn outboard(&self) -> BoxIoFut<PreOrderOutboard<MemOrFile>> {
         async move {
             let size = self.entry.size();
             let data = self.entry.outboard_reader().await?;
@@ -482,7 +483,7 @@ impl MapEntry<Store> for Entry {
         .boxed()
     }
 
-    fn data_reader(&self) -> BoxFuture<'_, io::Result<MemOrFile>> {
+    fn data_reader(&self) -> BoxIoFut<MemOrFile> {
         self.entry.data_reader().boxed()
     }
 
@@ -653,7 +654,7 @@ impl ReadableStore for Store {
         Ok(Box::new(items.into_iter()))
     }
 
-    fn validate(&self, _tx: mpsc::Sender<ValidateProgress>) -> BoxFuture<'_, io::Result<()>> {
+    fn validate(&self, _tx: mpsc::Sender<ValidateProgress>) -> BoxIoFut<()> {
         unimplemented!()
     }
 
@@ -676,7 +677,7 @@ impl ReadableStore for Store {
         target: PathBuf,
         mode: ExportMode,
         progress: impl Fn(u64) -> io::Result<()> + Send + Sync + 'static,
-    ) -> BoxFuture<'_, io::Result<()>> {
+    ) -> BoxIoFut<()> {
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.export_sync(hash, target, mode, progress))
             .map(flatten_to_io)
@@ -691,14 +692,14 @@ impl super::Store for Store {
         mode: ImportMode,
         format: BlobFormat,
         progress: impl ProgressSender<Msg = ImportProgress> + IdGenerator,
-    ) -> BoxFuture<'_, io::Result<(TempTag, u64)>> {
+    ) -> BoxIoFut<(TempTag, u64)> {
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.import_file_sync(path, mode, format, progress))
             .map(flatten_to_io)
             .boxed()
     }
 
-    fn import_bytes(&self, data: Bytes, format: BlobFormat) -> BoxFuture<'_, io::Result<TempTag>> {
+    fn import_bytes(&self, data: Bytes, format: BlobFormat) -> BoxIoFut<TempTag> {
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.import_bytes_sync(data, format))
             .map(flatten_to_io)
@@ -710,7 +711,7 @@ impl super::Store for Store {
         mut data: impl Stream<Item = io::Result<Bytes>> + Unpin + Send + 'static,
         format: BlobFormat,
         progress: impl ProgressSender<Msg = ImportProgress> + IdGenerator,
-    ) -> BoxFuture<'_, io::Result<(TempTag, u64)>> {
+    ) -> BoxIoFut<(TempTag, u64)> {
         let this = self.clone();
         async move {
             let id = progress.new_id();
@@ -742,14 +743,14 @@ impl super::Store for Store {
         .boxed()
     }
 
-    fn create_tag(&self, value: HashAndFormat) -> BoxFuture<'_, io::Result<Tag>> {
+    fn create_tag(&self, value: HashAndFormat) -> BoxIoFut<Tag> {
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.create_tag_sync(value))
             .map(flatten_to_io)
             .boxed()
     }
 
-    fn set_tag(&self, name: Tag, value: Option<HashAndFormat>) -> BoxFuture<'_, io::Result<()>> {
+    fn set_tag(&self, name: Tag, value: Option<HashAndFormat>) -> BoxIoFut<()> {
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.set_tag_sync(name, value))
             .map(flatten_to_io)
@@ -776,7 +777,7 @@ impl super::Store for Store {
         state.live.contains(hash) || state.temp.contains(hash)
     }
 
-    fn delete(&self, hashes: Vec<Hash>) -> BoxFuture<'_, io::Result<()>> {
+    fn delete(&self, hashes: Vec<Hash>) -> BoxIoFut<()> {
         tracing::debug!("delete: {:?}", hashes);
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.delete_sync(hashes))

--- a/iroh-bytes/src/store/mem.rs
+++ b/iroh-bytes/src/store/mem.rs
@@ -14,6 +14,7 @@ use std::time::SystemTime;
 
 use super::flatten_to_io;
 use super::temp_name;
+use super::CombinedBatchWriter;
 use super::DbIter;
 use super::PossiblyPartialEntry;
 use super::TempCounterMap;
@@ -383,6 +384,8 @@ impl PartialMap for Store {
     type DataWriter = MutableMemFile;
 
     type PartialEntry = PartialEntry;
+
+    type BatchWriter = CombinedBatchWriter<Self::DataWriter, Self::OutboardMut>;
 
     fn entry_status(&self, hash: &Hash) -> io::Result<EntryStatus> {
         let state = self.0.state.read().unwrap();

--- a/iroh-bytes/src/store/mem.rs
+++ b/iroh-bytes/src/store/mem.rs
@@ -379,13 +379,9 @@ impl ReadableStore for Store {
 }
 
 impl PartialMap for Store {
-    type OutboardMut = PreOrderOutboard<MutableMemFile>;
-
-    type DataWriter = MutableMemFile;
-
     type PartialEntry = PartialEntry;
 
-    type BatchWriter = CombinedBatchWriter<Self::DataWriter, Self::OutboardMut>;
+    type BatchWriter = CombinedBatchWriter<MutableMemFile, PreOrderOutboard<MutableMemFile>>;
 
     fn entry_status(&self, hash: &Hash) -> io::Result<EntryStatus> {
         let state = self.0.state.read().unwrap();

--- a/iroh-bytes/src/store/mem.rs
+++ b/iroh-bytes/src/store/mem.rs
@@ -667,22 +667,24 @@ impl Store {
     }
 }
 
+impl PartialEntry {
+    fn outboard_mut(&self) -> PreOrderOutboard<MutableMemFile> {
+        self.outboard.clone()
+    }
+
+    fn data_writer(&self) -> MutableMemFile {
+        self.data.clone()
+    }
+}
+
 impl PartialMapEntry<Store> for PartialEntry {
-    fn outboard_mut(&self) -> BoxFuture<'_, io::Result<PreOrderOutboard<MutableMemFile>>> {
-        futures::future::ok(self.outboard.clone()).boxed()
-    }
-
-    fn data_writer(&self) -> BoxFuture<'_, io::Result<MutableMemFile>> {
-        futures::future::ok(self.data.clone()).boxed()
-    }
-
     fn batch_writer(
         &self,
     ) -> futures::prelude::future::BoxFuture<'_, io::Result<<Store as PartialMap>::BatchWriter>>
     {
         async move {
-            let data = self.data_writer().await?;
-            let outboard = self.outboard_mut().await?;
+            let data = self.data_writer();
+            let outboard = self.outboard_mut();
             Ok(CombinedBatchWriter { data, outboard })
         }
         .boxed()

--- a/iroh-bytes/src/store/mem.rs
+++ b/iroh-bytes/src/store/mem.rs
@@ -675,6 +675,18 @@ impl PartialMapEntry<Store> for PartialEntry {
     fn data_writer(&self) -> BoxFuture<'_, io::Result<MutableMemFile>> {
         futures::future::ok(self.data.clone()).boxed()
     }
+
+    fn batch_writer(
+        &self,
+    ) -> futures::prelude::future::BoxFuture<'_, io::Result<<Store as PartialMap>::BatchWriter>>
+    {
+        async move {
+            let data = self.data_writer().await?;
+            let outboard = self.outboard_mut().await?;
+            Ok(CombinedBatchWriter { data, outboard })
+        }
+        .boxed()
+    }
 }
 
 fn data_too_large(_: TryFromIntError) -> io::Error {

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -34,7 +34,7 @@ use futures::{
 };
 use tokio::{io::AsyncWriteExt, sync::mpsc};
 
-use super::{DbIter, PossiblyPartialEntry};
+use super::{CombinedBatchWriter, DbIter, PossiblyPartialEntry};
 
 /// A readonly in memory database for iroh-bytes.
 ///
@@ -216,6 +216,8 @@ impl PartialMap for Store {
     type DataWriter = BytesMut;
 
     type PartialEntry = PartialEntry;
+
+    type BatchWriter = CombinedBatchWriter<Self::DataWriter, Self::OutboardMut>;
 
     fn get_or_create_partial(&self, _hash: Hash, _size: u64) -> io::Result<PartialEntry> {
         Err(io::Error::new(

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -323,16 +323,6 @@ impl MapEntry<Store> for PartialEntry {
 }
 
 impl PartialMapEntry<Store> for PartialEntry {
-    fn outboard_mut(&self) -> BoxFuture<'_, io::Result<<Store as PartialMap>::OutboardMut>> {
-        // this is unreachable, since PartialEntry can not be created
-        unreachable!()
-    }
-
-    fn data_writer(&self) -> BoxFuture<'_, io::Result<<Store as PartialMap>::DataWriter>> {
-        // this is unreachable, since PartialEntry can not be created
-        unreachable!()
-    }
-
     fn batch_writer(
         &self,
     ) -> futures::prelude::future::BoxFuture<'_, io::Result<<Store as PartialMap>::BatchWriter>>

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -332,6 +332,14 @@ impl PartialMapEntry<Store> for PartialEntry {
         // this is unreachable, since PartialEntry can not be created
         unreachable!()
     }
+
+    fn batch_writer(
+        &self,
+    ) -> futures::prelude::future::BoxFuture<'_, io::Result<<Store as PartialMap>::BatchWriter>>
+    {
+        // this is unreachable, since PartialEntry can not be created
+        unreachable!()
+    }
 }
 
 impl super::Store for Store {

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -211,13 +211,9 @@ impl Map for Store {
 }
 
 impl PartialMap for Store {
-    type OutboardMut = PreOrderOutboard<BytesMut>;
-
-    type DataWriter = BytesMut;
-
     type PartialEntry = PartialEntry;
 
-    type BatchWriter = CombinedBatchWriter<Self::DataWriter, Self::OutboardMut>;
+    type BatchWriter = CombinedBatchWriter<BytesMut, PreOrderOutboard<BytesMut>>;
 
     fn get_or_create_partial(&self, _hash: Hash, _size: u64) -> io::Result<PartialEntry> {
         Err(io::Error::new(

--- a/iroh-bytes/src/store/traits.rs
+++ b/iroh-bytes/src/store/traits.rs
@@ -274,10 +274,6 @@ where
 
 /// A mutable bao map
 pub trait PartialMap: Map {
-    /// The outboard type to write data to the partial entry.
-    type OutboardMut: bao_tree::io::fsm::OutboardMut;
-    /// The writer type to write data to the partial entry.
-    type DataWriter: iroh_io::AsyncSliceWriter;
     /// A partial entry. This is an entry that is writeable and possibly incomplete.
     ///
     /// It must also be readable.

--- a/iroh-bytes/src/store/traits.rs
+++ b/iroh-bytes/src/store/traits.rs
@@ -7,7 +7,7 @@ use bao_tree::{
 };
 use bytes::Bytes;
 use futures::{
-    future::{BoxFuture, LocalBoxFuture},
+    future::{self, BoxFuture, LocalBoxFuture},
     stream::LocalBoxStream,
     FutureExt, Stream, StreamExt,
 };
@@ -269,8 +269,7 @@ where
 
     fn sync(&mut self) -> LocalBoxFuture<'_, io::Result<()>> {
         async move {
-            self.data.sync().await?;
-            self.outboard.sync().await?;
+            future::try_join(self.data.sync(), self.outboard.sync()).await?;
             Ok(())
         }
         .boxed_local()

--- a/iroh-bytes/src/store/traits.rs
+++ b/iroh-bytes/src/store/traits.rs
@@ -127,9 +127,12 @@ pub trait BaoBatchWriter {
     /// traversal offset. There is no guarantee that they will be consecutive
     /// though.
     ///
-    /// The size is the size the remote side told us. It is not guaranteed
-    /// to be correct, but it is guaranteed to be consistent with all data in the
-    /// batch.
+    /// The size is the total size of the blob that the remote side told us.
+    /// It is not guaranteed to be correct, but it is guaranteed to be
+    /// consistent with all data in the batch. The size therefore represents
+    /// an upper bound on the maximum offset of all leaf items.
+    /// So it is guaranteed that `leaf.offset + leaf.size <= size` for all
+    /// leaf items in the batch.
     ///
     /// Batches should not become too large. Typically, a batch is just a few
     /// parent nodes and a leaf.
@@ -144,7 +147,9 @@ pub trait BaoBatchWriter {
         batch: Vec<BaoContentItem>,
     ) -> LocalBoxFuture<'_, io::Result<()>>;
 
-    /// Sync the writer
+    /// Sync the written data to permanent storage, if applicable.
+    /// E.g. for a file based implementation, this would call sync_data
+    /// on all files.
     ///
     /// TODO: return impl Future<...> once we got 1.75
     fn sync(&mut self) -> LocalBoxFuture<'_, io::Result<()>>;

--- a/iroh-bytes/src/store/traits.rs
+++ b/iroh-bytes/src/store/traits.rs
@@ -110,10 +110,6 @@ pub trait Map: Clone + Send + Sync + 'static {
 
 /// A partial entry
 pub trait PartialMapEntry<D: PartialMap>: MapEntry<D> {
-    /// A future that resolves to an writeable outboard
-    fn outboard_mut(&self) -> BoxFuture<'_, io::Result<D::OutboardMut>>;
-    /// A future that resolves to a writer that can be used to write the data
-    fn data_writer(&self) -> BoxFuture<'_, io::Result<D::DataWriter>>;
     /// Get a batch writer
     fn batch_writer(&self) -> BoxFuture<'_, io::Result<D::BatchWriter>>;
 }

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -195,7 +195,7 @@ mod flat {
 
     use iroh_bytes::{
         hashseq::HashSeq,
-        store::{BatchWriter, PartialMap, PartialMapEntry, Store},
+        store::{BaoBatchWriter, PartialMap, PartialMapEntry, Store},
         BlobFormat, HashAndFormat, Tag, TempTag, IROH_BLOCK_SIZE,
     };
 

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -65,6 +65,7 @@ async fn gc_test_node() -> (
 }
 
 async fn step(evs: &flume::Receiver<iroh_bytes::store::Event>) {
+    while evs.try_recv().is_ok() {}
     for _ in 0..3 {
         while let Ok(ev) = evs.recv_async().await {
             if let iroh_bytes::store::Event::GcCompleted = ev {
@@ -190,7 +191,6 @@ mod flat {
         ChunkRanges,
     };
     use bytes::Bytes;
-    use iroh_io::AsyncSliceWriter;
     use testdir::testdir;
 
     use iroh_bytes::{
@@ -363,10 +363,10 @@ mod flat {
     /// the outboard file, then commit it to a complete entry.
     ///
     /// During this time, the partial entry is protected by a temp tag.
-    async fn simulate_download_protected<S: iroh_bytes::store::Store>(
+    async fn simulate_download_partial<S: iroh_bytes::store::Store>(
         bao_store: &S,
         data: Bytes,
-    ) -> io::Result<TempTag> {
+    ) -> io::Result<(S::PartialEntry, TempTag)> {
         // simulate the remote side.
         let (hash, response) = simulate_remote(data.as_ref());
         // simulate the local side.
@@ -401,6 +401,14 @@ mod flat {
             reading = next;
         }
         bw.sync().await?;
+        Ok((entry, tt))
+    }
+
+    async fn simulate_download_complete<S: iroh_bytes::store::Store>(
+        bao_store: &S,
+        data: Bytes,
+    ) -> io::Result<TempTag> {
+        let (entry, tt) = simulate_download_partial(bao_store, data).await?;
         // commit the entry
         bao_store.insert_complete(entry).await?;
         Ok(tt)
@@ -408,7 +416,7 @@ mod flat {
 
     /// Test that partial files are deleted.
     #[tokio::test]
-    #[ignore = "flaky"]
+    // #[ignore = "flaky"]
     async fn gc_flat_partial() -> Result<()> {
         let _ = tracing_subscriber::fmt::try_init();
         let dir = testdir!();
@@ -420,16 +428,9 @@ mod flat {
         let evs = attach_db_events(&node).await;
 
         let data1: Bytes = create_test_data(123456);
-        let (_o1, h1) = bao_tree::io::outboard(&data1, IROH_BLOCK_SIZE);
-        let h1 = h1.into();
-        let tt1 = bao_store.temp_tag(HashAndFormat::raw(h1));
-        {
-            let entry = bao_store.get_or_create_partial(h1, data1.len() as u64)?;
-            let mut dw = entry.data_writer().await?;
-            dw.write_bytes_at(0, data1.slice(..32 * 1024)).await?;
-            let _ow = entry.outboard_mut().await?;
-        }
-
+        let (_entry, tt1) = simulate_download_partial(&bao_store, data1.clone()).await?;
+        drop(_entry);
+        let h1 = *tt1.hash();
         // partial data and outboard files should be there
         step(&evs).await;
         assert!(count_partial_data(&h1)? == 1);
@@ -463,7 +464,7 @@ mod flat {
         // download
         for i in 0..100 {
             let data: Bytes = create_test_data(16 * 1024 * 3 + 1);
-            let tt = simulate_download_protected(&bao_store, data).await.unwrap();
+            let tt = simulate_download_complete(&bao_store, data).await.unwrap();
             if i % 100 == 0 {
                 let tag = Tag::from(format!("test{}", i));
                 bao_store


### PR DESCRIPTION
## Description

To take into account the fact that the size we get initially in the iroh-bytes protocol is not verified, I want to lazily move from mem storage to file storage only once some limit is *actually* exceeded.

This requires combining outboard and data file and treating them a bit more as one file to which you write batches.

For now, just add the trait and keep the impl the same.

## Notes & open questions

Should the BaoBatchWriter move to bao-tree io? I think in the long term yes, but for now let's keep it here to make things simple?

Note: this kind of code *really* wants 1.75 impl return types in traits.... I asked on the public discord if somebody has some major objections, otherwise I would just go with it.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
