### PR TITLE
refactor(iroh-net): Remove manual struct logging

### DIFF
--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -692,6 +692,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[ignore = "flaky"]
     async fn gossip_net_smoke() {
         let _guard = iroh_test::logging::setup();
         let (derp_map, derp_url, cleanup) = util::run_derp_and_stun([127, 0, 0, 1].into())

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -316,7 +316,6 @@ impl Actor {
         self.netcheck
             .send(netcheck::Message::ReportReady {
                 report: Box::new(self.report.clone()),
-                derp_map: self.derp_map.clone(),
             })
             .await?;
 

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -579,6 +579,7 @@ fn cli_provide_persistence() -> anyhow::Result<()> {
 }
 
 #[test]
+#[ignore = "flaky"]
 fn cli_provide_addresses() -> Result<()> {
     let dir = testdir!();
     let path = dir.join("foo");


### PR DESCRIPTION
## Description

This was essentially re-implementing the Rust Debug trait.  Now that
DerpUrl has a nice Debug log there really is no need to manually
implement this, instead we rely on Debug.


## Notes & open questions

This is splitting off some peripheral stuff from
https://github.com/n0-computer/iroh/pull/1984

New flaky test marked: https://github.com/n0-computer/iroh/issues/2010 and #1935 

## Change checklist

- [x] Self-review.