### PR TITLE
feat(iroh): Add --log-fd flag on unix

### DIFF
--- a/iroh/src/commands.rs
+++ b/iroh/src/commands.rs
@@ -35,6 +35,11 @@ pub struct Cli {
     /// Start an iroh node in the background.
     #[clap(long, global = true)]
     start: bool,
+
+    /// Send log output to specified file descriptor.
+    #[cfg(unix)]
+    #[clap(long)]
+    pub log_fd: Option<i32>,
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/iroh/src/main.rs
+++ b/iroh/src/main.rs
@@ -25,11 +25,23 @@ fn main() -> Result<()> {
 
 async fn main_impl() -> Result<()> {
     let lp = tokio_util::task::LocalPoolHandle::new(num_cpus::get());
+    let cli = Cli::parse();
+
+    #[cfg(unix)]
+    if let Some(log_fd) = cli.log_fd {
+        use std::os::unix::io::FromRawFd;
+
+        let f = unsafe { std::fs::File::from_raw_fd(log_fd) };
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_writer(f))
+            .with(EnvFilter::from_default_env())
+            .init();
+        return cli.run(lp).await;
+    }
+
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
         .with(EnvFilter::from_default_env())
         .init();
-
-    let cli = Cli::parse();
     cli.run(lp).await
 }


### PR DESCRIPTION
## Description

This allows you to write log output to a specific filedescriptor in
the shell: iroh --log-fd 3 ... 3>some/file.log

Thus not interfering with normal stdout and stderr output and getting
the full functionality of this.

## Notes & open questions

This is splitting off some peripheral stuff from
https://github.com/n0-computer/iroh/pull/1984

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.