### PR TITLE
deps(iroh): update quic-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,19 +1474,6 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin 0.9.8",
-]
-
-[[package]]
-name = "flume"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
@@ -2230,7 +2217,7 @@ dependencies = [
  "dirs-next",
  "duct",
  "ed25519-dalek",
- "flume 0.11.0",
+ "flume",
  "futures",
  "genawaiter",
  "hashlink",
@@ -2322,7 +2309,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "derive_more",
- "flume 0.11.0",
+ "flume",
  "futures",
  "genawaiter",
  "hex",
@@ -2439,7 +2426,7 @@ dependencies = [
  "derive_more",
  "duct",
  "ed25519-dalek",
- "flume 0.11.0",
+ "flume",
  "futures",
  "governor",
  "hex",
@@ -2535,7 +2522,7 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
- "flume 0.11.0",
+ "flume",
  "futures",
  "hex",
  "iroh-base",
@@ -3743,13 +3730,13 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d60c2fc2390baad4b9d41ae9957ae88c3095496f88e252ef50722df8b5b78d7"
+checksum = "1428fcf30c17a159ff10c1f3c69fca92fd7cfa11e9fef7d573f3c6f0da3b5920"
 dependencies = [
  "bincode",
  "educe",
- "flume 0.10.14",
+ "flume",
  "futures",
  "pin-project",
  "quinn",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -39,7 +39,7 @@ iroh-gossip = { version = "0.12.0", path = "../iroh-gossip" }
 once_cell = "1.18.0"
 parking_lot = "0.12.1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
-quic-rpc = { version = "0.6", default-features = false, features = ["flume-transport"] }
+quic-rpc = { version = "0.6.2", default-features = false, features = ["flume-transport"] }
 quinn = "0.10"
 range-collections = { version = "0.4.0" }
 rand = "0.8"


### PR DESCRIPTION
## Description

Fixes #1499

Current behavior:
run `iroh start` in terminal 1
run `iroh console` in terminal 2
kill and restart the node in terminal 1
run `doc list` (or any other command) in the console and it will fail

Post-update behaviour:
same setup but `doc list` will now function


## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
