### PR TITLE
refactor(iroh-bytes): Take advantage of impl T in trait, update bao-tree and iroh-io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155e7e0c896695a9049badd7bf2b915d29230e24dc82a7c7ef065eded072404f"
+checksum = "96c194b6b40b5abe645e9fc54a62b8247dbd86815443c0d0e10a89faa1218c10"
 dependencies = [
  "bytes",
  "futures",
@@ -2029,7 +2029,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.51.1",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -2346,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-io"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ace4f69567bfeb726672bab901d3e81be0c01119d860b2a10b7efb1553b880"
+checksum = "1fd67e386f948a6f09e71057b48fff51b6414f0080997495b5bdf2d1bdcdbe46"
 dependencies = [
  "bytes",
  "futures",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = { version = "0.9.1", features = ["tokio_fsm"], default-features = false, optional = true }
+bao-tree = { version = "0.10", features = ["tokio_fsm"], default-features = false, optional = true }
 data-encoding = { version = "2.3.3", optional = true }
 hex = "0.4.3"
 multibase = { version = "0.9.1", optional = true }

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = { version = "0.9.1", features = ["tokio_fsm"], default-features = false }
+bao-tree = { version = "0.10", features = ["tokio_fsm"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"
 data-encoding = "2.3.3"
@@ -27,7 +27,7 @@ futures = "0.3.25"
 genawaiter = { version = "0.99.1", features = ["futures03"] }
 hex = "0.4.3"
 iroh-base = { version = "0.12.0", path = "../iroh-base" }
-iroh-io = { version = "0.3.0", features = ["stats"] }
+iroh-io = { version = "0.4.0", features = ["stats"] }
 iroh-metrics = { version = "0.12.0", path = "../iroh-metrics", optional = true }
 iroh-net = { version = "0.12.0", path = "../iroh-net", optional = true }
 num_cpus = "1.15.0"

--- a/iroh-bytes/src/store/flat.rs
+++ b/iroh-bytes/src/store/flat.rs
@@ -517,27 +517,17 @@ pub enum MemOrFile {
 }
 
 impl AsyncSliceReader for MemOrFile {
-    type ReadAtFuture<'a> = futures::future::Either<
-        <Bytes as AsyncSliceReader>::ReadAtFuture<'a>,
-        <File as AsyncSliceReader>::ReadAtFuture<'a>,
-    >;
-
-    fn read_at(&mut self, offset: u64, len: usize) -> Self::ReadAtFuture<'_> {
+    async fn read_at(&mut self, offset: u64, len: usize) -> io::Result<Bytes> {
         match self {
-            MemOrFile::Mem(mem) => Either::Left(mem.read_at(offset, len)),
-            MemOrFile::File(file) => Either::Right(file.read_at(offset, len)),
+            MemOrFile::Mem(mem) => mem.read_at(offset, len).await,
+            MemOrFile::File(file) => file.read_at(offset, len).await,
         }
     }
 
-    type LenFuture<'a> = futures::future::Either<
-        <Bytes as AsyncSliceReader>::LenFuture<'a>,
-        <File as AsyncSliceReader>::LenFuture<'a>,
-    >;
-
-    fn len(&mut self) -> Self::LenFuture<'_> {
+    async fn len(&mut self) -> io::Result<u64> {
         match self {
-            MemOrFile::Mem(mem) => Either::Left(mem.len()),
-            MemOrFile::File(file) => Either::Right(file.len()),
+            MemOrFile::Mem(mem) => mem.len().await,
+            MemOrFile::File(file) => file.len().await,
         }
     }
 }

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -28,10 +28,7 @@ use bao_tree::{
     ChunkRanges,
 };
 use bytes::{Bytes, BytesMut};
-use futures::{
-    future::{self, BoxFuture},
-    FutureExt, Stream,
-};
+use futures::Stream;
 use tokio::{io::AsyncWriteExt, sync::mpsc};
 
 use super::{CombinedBatchWriter, DbIter, PossiblyPartialEntry};
@@ -180,16 +177,16 @@ impl MapEntry<Store> for Entry {
         self.data.len() as u64
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
-        futures::future::ok(ChunkRanges::all()).boxed()
+    async fn available_ranges(&self) -> io::Result<ChunkRanges> {
+        Ok(ChunkRanges::all())
     }
 
-    fn outboard(&self) -> BoxFuture<'_, io::Result<PreOrderMemOutboard<Bytes>>> {
-        futures::future::ok(self.outboard.clone()).boxed()
+    async fn outboard(&self) -> io::Result<PreOrderMemOutboard<Bytes>> {
+        Ok(self.outboard.clone())
     }
 
-    fn data_reader(&self) -> BoxFuture<'_, io::Result<Bytes>> {
-        futures::future::ok(self.data.clone()).boxed()
+    async fn data_reader(&self) -> io::Result<Bytes> {
+        Ok(self.data.clone())
     }
 
     fn is_complete(&self) -> bool {
@@ -241,7 +238,7 @@ impl PartialMap for Store {
         })
     }
 
-    fn insert_complete(&self, _entry: PartialEntry) -> BoxFuture<'_, io::Result<()>> {
+    async fn insert_complete(&self, _entry: PartialEntry) -> io::Result<()> {
         // this is unreachable, since we cannot create partial entries
         unreachable!()
     }
@@ -267,8 +264,8 @@ impl ReadableStore for Store {
         Box::new(std::iter::empty())
     }
 
-    fn validate(&self, _tx: mpsc::Sender<ValidateProgress>) -> BoxFuture<'static, io::Result<()>> {
-        future::ok(()).boxed()
+    async fn validate(&self, _tx: mpsc::Sender<ValidateProgress>) -> io::Result<()> {
+        Ok(())
     }
 
     async fn export(
@@ -292,7 +289,7 @@ impl MapEntry<Store> for PartialEntry {
         unreachable!()
     }
 
-    fn available_ranges(&self) -> BoxFuture<'_, io::Result<ChunkRanges>> {
+    async fn available_ranges(&self) -> io::Result<ChunkRanges> {
         // this is unreachable, since PartialEntry can not be created
         unreachable!()
     }
@@ -302,12 +299,12 @@ impl MapEntry<Store> for PartialEntry {
         unreachable!()
     }
 
-    fn outboard(&self) -> BoxFuture<'_, io::Result<PreOrderMemOutboard<Bytes>>> {
+    async fn outboard(&self) -> io::Result<PreOrderMemOutboard<Bytes>> {
         // this is unreachable, since PartialEntry can not be created
         unreachable!()
     }
 
-    fn data_reader(&self) -> BoxFuture<'_, io::Result<Bytes>> {
+    async fn data_reader(&self) -> io::Result<Bytes> {
         // this is unreachable, since PartialEntry can not be created
         unreachable!()
     }
@@ -319,10 +316,7 @@ impl MapEntry<Store> for PartialEntry {
 }
 
 impl PartialMapEntry<Store> for PartialEntry {
-    fn batch_writer(
-        &self,
-    ) -> futures::prelude::future::BoxFuture<'_, io::Result<<Store as PartialMap>::BatchWriter>>
-    {
+    async fn batch_writer(&self) -> io::Result<<Store as PartialMap>::BatchWriter> {
         // this is unreachable, since PartialEntry can not be created
         unreachable!()
     }

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -273,14 +273,14 @@ impl ReadableStore for Store {
         future::ok(()).boxed()
     }
 
-    fn export(
+    async fn export(
         &self,
         hash: Hash,
         target: PathBuf,
         mode: ExportMode,
         progress: impl Fn(u64) -> io::Result<()> + Send + Sync + 'static,
-    ) -> BoxFuture<'_, io::Result<()>> {
-        self.export_impl(hash, target, mode, progress).boxed()
+    ) -> io::Result<()> {
+        self.export_impl(hash, target, mode, progress).await
     }
 
     fn partial_blobs(&self) -> io::Result<DbIter<Hash>> {
@@ -333,41 +333,41 @@ impl PartialMapEntry<Store> for PartialEntry {
 }
 
 impl super::Store for Store {
-    fn import_file(
+    async fn import_file(
         &self,
         data: PathBuf,
         mode: ImportMode,
         format: BlobFormat,
         progress: impl ProgressSender<Msg = ImportProgress> + IdGenerator,
-    ) -> BoxFuture<'_, io::Result<(TempTag, u64)>> {
+    ) -> io::Result<(TempTag, u64)> {
         let _ = (data, mode, progress, format);
-        async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
+        Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
     /// import a byte slice
-    fn import_bytes(&self, bytes: Bytes, format: BlobFormat) -> BoxFuture<'_, io::Result<TempTag>> {
+    async fn import_bytes(&self, bytes: Bytes, format: BlobFormat) -> io::Result<TempTag> {
         let _ = (bytes, format);
-        async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
+        Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
-    fn import_stream(
+    async fn import_stream(
         &self,
         data: impl Stream<Item = io::Result<Bytes>> + Unpin + Send,
         format: BlobFormat,
         progress: impl ProgressSender<Msg = ImportProgress> + IdGenerator,
-    ) -> BoxFuture<'_, io::Result<(TempTag, u64)>> {
+    ) -> io::Result<(TempTag, u64)> {
         let _ = (data, format, progress);
-        async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
+        Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
     fn clear_live(&self) {}
 
-    fn set_tag(&self, _name: Tag, _hash: Option<HashAndFormat>) -> BoxFuture<'_, io::Result<()>> {
-        async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
+    async fn set_tag(&self, _name: Tag, _hash: Option<HashAndFormat>) -> io::Result<()> {
+        Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
-    fn create_tag(&self, _hash: HashAndFormat) -> BoxFuture<'_, io::Result<Tag>> {
-        async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
+    async fn create_tag(&self, _hash: HashAndFormat) -> io::Result<Tag> {
+        Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
     fn temp_tag(&self, inner: HashAndFormat) -> TempTag {
@@ -376,8 +376,8 @@ impl super::Store for Store {
 
     fn add_live(&self, _live: impl IntoIterator<Item = Hash>) {}
 
-    fn delete(&self, _hashes: Vec<Hash>) -> BoxFuture<'_, io::Result<()>> {
-        async move { Err(io::Error::new(io::ErrorKind::Other, "not implemented")) }.boxed()
+    async fn delete(&self, _hashes: Vec<Hash>) -> io::Result<()> {
+        Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
     fn is_live(&self, _hash: &Hash) -> bool {

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = { version = "0.9.1", features = ["tokio_fsm"], default-features = false }
+bao-tree = { version = "0.10", features = ["tokio_fsm"], default-features = false }
 bytes = "1"
 data-encoding = "2.4.0"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into", "from_str"] }
@@ -29,7 +29,7 @@ hashlink = "0.8.4"
 hex = { version = "0.4.3" }
 iroh-bytes = { version = "0.12.0", path = "../iroh-bytes", features = ["downloader"] }
 iroh-base = { version = "0.12.0", path = "../iroh-base" }
-iroh-io = { version = "0.3.0", features = ["stats"] }
+iroh-io = { version = "0.4.0", features = ["stats"] }
 iroh-metrics = { version = "0.12.0", path = "../iroh-metrics", optional = true }
 iroh-net = { version = "0.12.0", path = "../iroh-net" }
 num_cpus = { version = "1.15.0" }


### PR DESCRIPTION
## Description

bao-tree and iroh-io have been republished with new versions that require 1.75 and use impl trait in trait. This updates these two dependencies and also refactors the store traits to take advantage of 1.75 features, removing a ton of boxes along the way.

Instead of `BoxFuture<'a, T>` we use `impl Future<Output = T> + Send`
Instead of `LocalBoxFuture<'a, T>` we use `impl Future<Output = T>`

Explicit lifetimes are in some cases no longer necessary because the future returned by impl Future<...> will implicitly capture the lifetimes of all parameters.

See https://rust-lang.github.io/rfcs/3498-lifetime-capture-rules-2024.html

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
