### PR TITLE
ci: add conventional-commit-checker

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,14 @@
+name: Commits
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-for-cc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-for-cc
+        id: check-for-cc
+        uses: agenthunt/conventional-commit-checker-action@v1.0.0


### PR DESCRIPTION
Adds a CI check for following the conventional commits in the PR title and body, as those will be used as the commit when merging through the merge queue.
