### PR TITLE
refactor(iroh-bytes): Simplify store traits

### DIFF
--- a/iroh-bytes/src/export.rs
+++ b/iroh-bytes/src/export.rs
@@ -10,7 +10,7 @@ use tracing::trace;
 
 use crate::{
     format::collection::Collection,
-    store::{ExportMode, MapEntry, Store as BaoStore},
+    store::{BaoBlobSize, ExportMode, MapEntry, Store as BaoStore},
     util::progress::{IdGenerator, ProgressSender},
     Hash,
 };
@@ -99,7 +99,7 @@ pub enum ExportProgress {
         /// The hash of the entry.
         hash: Hash,
         /// The size of the entry in bytes.
-        size: u64,
+        size: BaoBlobSize,
         /// The path to the file where the data is exported.
         outpath: PathBuf,
         /// Operation-specific metadata.

--- a/iroh-bytes/src/get/db.rs
+++ b/iroh-bytes/src/get/db.rs
@@ -22,7 +22,7 @@ use crate::{
         Stats,
     },
     protocol::{GetRequest, RangeSpecSeq},
-    store::{MapEntry, PartialMap, PartialMapEntry, Store as BaoStore},
+    store::{MapEntry, MapEntryMut, MapMut, Store as BaoStore},
     util::progress::{IdGenerator, ProgressSender},
     BlobFormat, HashAndFormat,
 };
@@ -143,7 +143,7 @@ async fn get_blob<
 }
 
 /// Given a partial entry, get the valid ranges.
-pub async fn valid_ranges<D: PartialMap>(entry: &D::PartialEntry) -> anyhow::Result<ChunkRanges> {
+pub async fn valid_ranges<D: MapMut>(entry: &D::EntryMut) -> anyhow::Result<ChunkRanges> {
     use tracing::trace as log;
     // compute the valid range from just looking at the data file
     let mut data_reader = entry.data_reader().await?;
@@ -217,7 +217,7 @@ async fn get_blob_inner<D: BaoStore>(
 async fn get_blob_inner_partial<D: BaoStore>(
     db: &D,
     at_header: AtBlobHeader,
-    entry: D::PartialEntry,
+    entry: D::EntryMut,
     sender: impl ProgressSender<Msg = DownloadProgress> + IdGenerator,
 ) -> Result<AtEndBlob, GetError> {
     // read the size. The size we get here is not verified, but since we use
@@ -469,7 +469,7 @@ pub enum BlobInfo<D: BaoStore> {
     /// we have the blob partially
     Partial {
         /// The partial entry.
-        entry: D::PartialEntry,
+        entry: D::EntryMut,
         /// The ranges that are available locally.
         valid_ranges: ChunkRanges,
     },

--- a/iroh-bytes/src/get/db.rs
+++ b/iroh-bytes/src/get/db.rs
@@ -203,6 +203,7 @@ async fn get_blob_inner<D: BaoStore>(
     let end = at_content.write_all_batch(&mut bw).await?;
     // sync the underlying storage, if needed
     bw.sync().await?;
+    drop(bw);
     db.insert_complete(entry).await?;
     // notify that we are done
     sender.send(DownloadProgress::Done { id }).await?;
@@ -253,6 +254,7 @@ async fn get_blob_inner_partial<D: BaoStore>(
     let at_end = at_content.write_all_batch(&mut bw).await?;
     // sync the underlying storage, if needed
     bw.sync().await?;
+    drop(bw);
     // we got to the end without error, so we can mark the entry as complete
     //
     // caution: this assumes that the request filled all the gaps in our local

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -9,7 +9,7 @@ use iroh_base::rpc::RpcError;
 use iroh_io::stats::{
     SliceReaderStats, StreamWriterStats, TrackingSliceReader, TrackingStreamWriter,
 };
-use iroh_io::{AsyncStreamWriter, TokioStreamWriter};
+use iroh_io::{AsyncSliceReader, AsyncStreamWriter, TokioStreamWriter};
 use serde::{Deserialize, Serialize};
 use tokio_util::task::LocalPoolHandle;
 use tracing::{debug, debug_span, info, trace, warn};
@@ -184,8 +184,8 @@ pub async fn transfer_collection<D: Map, E: EventSender>(
     // Response writer, containing the quinn stream.
     writer: &mut ResponseWriter<E>,
     // the collection to transfer
-    mut outboard: D::Outboard,
-    mut data: D::DataReader,
+    mut outboard: impl Outboard,
+    mut data: impl AsyncSliceReader,
     stats: &mut TransferStats,
 ) -> Result<SentStatus> {
     let hash = request.hash;

--- a/iroh-bytes/src/store/mem.rs
+++ b/iroh-bytes/src/store/mem.rs
@@ -15,6 +15,7 @@ use std::time::SystemTime;
 use super::flatten_to_io;
 use super::temp_name;
 use super::BaoBatchWriter;
+use super::BaoBlobSize;
 use super::CombinedBatchWriter;
 use super::DbIter;
 use super::PossiblyPartialEntry;
@@ -212,8 +213,8 @@ impl MapEntry for Entry {
         Ok(ChunkRanges::all())
     }
 
-    fn size(&self) -> u64 {
-        self.outboard.tree().size().0
+    fn size(&self) -> BaoBlobSize {
+        BaoBlobSize::Verified(self.outboard.tree().size().0)
     }
 
     async fn outboard(&self) -> io::Result<impl Outboard> {
@@ -246,8 +247,8 @@ impl MapEntry for EntryMut {
         Ok(ChunkRanges::all())
     }
 
-    fn size(&self) -> u64 {
-        self.outboard.tree().size().0
+    fn size(&self) -> BaoBlobSize {
+        BaoBlobSize::Unverified(self.outboard.tree().size().0)
     }
 
     async fn outboard(&self) -> io::Result<impl Outboard> {

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -10,8 +10,8 @@ use std::{
 
 use crate::{
     store::{
-        EntryStatus, ExportMode, ImportMode, ImportProgress, Map, MapEntry, PartialMap,
-        PartialMapEntry, ReadableStore, ValidateProgress,
+        EntryStatus, ExportMode, ImportMode, ImportProgress, Map, MapEntry, MapEntryMut,
+        MapMut, ReadableStore, ValidateProgress,
     },
     util::{
         progress::{IdGenerator, ProgressSender},
@@ -160,11 +160,11 @@ pub struct Entry {
     data: Bytes,
 }
 
-/// The [PartialMapEntry] implementation for [Store].
+/// The [MapEntryMut] implementation for [Store].
 ///
 /// This is an unoccupied type, since [Store] is does not allow creating partial entries.
 #[derive(Debug, Clone)]
-pub enum PartialEntry {}
+pub enum EntryMut {}
 
 impl MapEntry for Entry {
     fn hash(&self) -> Hash {
@@ -203,10 +203,10 @@ impl Map for Store {
     }
 }
 
-impl PartialMap for Store {
-    type PartialEntry = PartialEntry;
+impl MapMut for Store {
+    type EntryMut = EntryMut;
 
-    fn get_or_create_partial(&self, _hash: Hash, _size: u64) -> io::Result<PartialEntry> {
+    fn get_or_create_partial(&self, _hash: Hash, _size: u64) -> io::Result<EntryMut> {
         Err(io::Error::new(
             io::ErrorKind::Other,
             "cannot create temp entry in readonly database",
@@ -232,7 +232,7 @@ impl PartialMap for Store {
         })
     }
 
-    async fn insert_complete(&self, _entry: PartialEntry) -> io::Result<()> {
+    async fn insert_complete(&self, _entry: EntryMut) -> io::Result<()> {
         // this is unreachable, since we cannot create partial entries
         unreachable!()
     }
@@ -277,41 +277,41 @@ impl ReadableStore for Store {
     }
 }
 
-impl MapEntry for PartialEntry {
+impl MapEntry for EntryMut {
     fn hash(&self) -> Hash {
-        // this is unreachable, since PartialEntry can not be created
+        // this is unreachable, since EntryMut can not be created
         unreachable!()
     }
 
     async fn available_ranges(&self) -> io::Result<ChunkRanges> {
-        // this is unreachable, since PartialEntry can not be created
+        // this is unreachable, since EntryMut can not be created
         unreachable!()
     }
 
     fn size(&self) -> u64 {
-        // this is unreachable, since PartialEntry can not be created
+        // this is unreachable, since EntryMut can not be created
         unreachable!()
     }
 
     #[allow(refining_impl_trait)]
     async fn outboard(&self) -> io::Result<PreOrderMemOutboard> {
-        // this is unreachable, since PartialEntry can not be created
+        // this is unreachable, since EntryMut can not be created
         unreachable!()
     }
 
     #[allow(refining_impl_trait)]
     async fn data_reader(&self) -> io::Result<Bytes> {
-        // this is unreachable, since PartialEntry can not be created
+        // this is unreachable, since EntryMut can not be created
         unreachable!()
     }
 
     fn is_complete(&self) -> bool {
-        // this is unreachable, since PartialEntry can not be created
+        // this is unreachable, since EntryMut can not be created
         unreachable!()
     }
 }
 
-impl PartialMapEntry for PartialEntry {
+impl MapEntryMut for EntryMut {
     async fn batch_writer(&self) -> io::Result<impl BaoBatchWriter> {
         enum Bar {}
         impl BaoBatchWriter for Bar {

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -29,7 +29,7 @@ use futures::Stream;
 use iroh_io::AsyncSliceReader;
 use tokio::{io::AsyncWriteExt, sync::mpsc};
 
-use super::{BaoBatchWriter, DbIter, PossiblyPartialEntry};
+use super::{BaoBatchWriter, BaoBlobSize, DbIter, PossiblyPartialEntry};
 
 /// A readonly in memory database for iroh-bytes.
 ///
@@ -171,8 +171,8 @@ impl MapEntry for Entry {
         self.outboard.root().into()
     }
 
-    fn size(&self) -> u64 {
-        self.data.len() as u64
+    fn size(&self) -> BaoBlobSize {
+        BaoBlobSize::Verified(self.data.len() as u64)
     }
 
     async fn available_ranges(&self) -> io::Result<ChunkRanges> {
@@ -288,7 +288,7 @@ impl MapEntry for EntryMut {
         unreachable!()
     }
 
-    fn size(&self) -> u64 {
+    fn size(&self) -> BaoBlobSize {
         // this is unreachable, since EntryMut can not be created
         unreachable!()
     }

--- a/iroh-bytes/src/store/traits.rs
+++ b/iroh-bytes/src/store/traits.rs
@@ -52,6 +52,34 @@ pub enum PossiblyPartialEntry<D: MapMut> {
     NotFound,
 }
 
+/// The size of a bao file
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum BaoBlobSize {
+    /// A remote side told us the size, but we have insufficient data to verify it.
+    Unverified(u64),
+    /// We have verified the size.
+    Verified(u64),
+}
+
+impl BaoBlobSize {
+    /// Create a new `BaoFileSize` with the given size and verification status.
+    pub fn new(size: u64, verified: bool) -> Self {
+        if verified {
+            BaoBlobSize::Verified(size)
+        } else {
+            BaoBlobSize::Unverified(size)
+        }
+    }
+
+    /// Get just the value, no matter if it is verified or not.
+    pub fn value(&self) -> u64 {
+        match self {
+            BaoBlobSize::Unverified(size) => *size,
+            BaoBlobSize::Verified(size) => *size,
+        }
+    }
+}
+
 /// An entry for one hash in a bao map
 ///
 /// The entry has the ability to provide you with an (outboard, data)
@@ -62,7 +90,7 @@ pub trait MapEntry: Clone + Send + Sync + 'static {
     /// The hash of the entry.
     fn hash(&self) -> Hash;
     /// The size of the entry.
-    fn size(&self) -> u64;
+    fn size(&self) -> BaoBlobSize;
     /// Returns `true` if the entry is complete.
     ///
     /// Note that this does not actually verify if the bytes on disk are complete, it only checks

--- a/iroh-bytes/src/store/traits.rs
+++ b/iroh-bytes/src/store/traits.rs
@@ -43,11 +43,11 @@ pub enum EntryStatus {
 ///
 /// This correspnds to [`EntryStatus`], but also includes the entry itself.
 #[derive(Debug)]
-pub enum PossiblyPartialEntry<D: PartialMap> {
+pub enum PossiblyPartialEntry<D: MapMut> {
     /// A complete entry.
     Complete(D::Entry),
     /// A partial entry.
-    Partial(D::PartialEntry),
+    Partial(D::EntryMut),
     /// We got nothing.
     NotFound,
 }
@@ -100,7 +100,7 @@ pub trait Map: Clone + Send + Sync + 'static {
 }
 
 /// A partial entry
-pub trait PartialMapEntry: MapEntry {
+pub trait MapEntryMut: MapEntry {
     /// Get a batch writer
     fn batch_writer(&self) -> impl Future<Output = io::Result<impl BaoBatchWriter>> + Send;
 }
@@ -242,17 +242,15 @@ where
 }
 
 /// A mutable bao map
-pub trait PartialMap: Map {
-    /// A partial entry. This is an entry that is writeable and possibly incomplete.
-    ///
-    /// It must also be readable.
-    type PartialEntry: PartialMapEntry;
+pub trait MapMut: Map {
+    /// An entry that is possibly writable
+    type EntryMut: MapEntryMut;
 
     /// Get an existing partial entry, or create a new one.
     ///
     /// We need to know the size of the partial entry. This might produce an
     /// error e.g. if there is not enough space on disk.
-    fn get_or_create_partial(&self, hash: Hash, size: u64) -> io::Result<Self::PartialEntry>;
+    fn get_or_create_partial(&self, hash: Hash, size: u64) -> io::Result<Self::EntryMut>;
 
     /// Find out if the data behind a `hash` is complete, partial, or not present.
     ///
@@ -269,7 +267,7 @@ pub trait PartialMap: Map {
     fn get_possibly_partial(&self, hash: &Hash) -> io::Result<PossiblyPartialEntry<Self>>;
 
     /// Upgrade a partial entry to a complete entry.
-    fn insert_complete(&self, entry: Self::PartialEntry) -> impl Future<Output = io::Result<()>>;
+    fn insert_complete(&self, entry: Self::EntryMut) -> impl Future<Output = io::Result<()>>;
 }
 
 /// Extension of BaoMap to add misc methods used by the rpc calls.
@@ -308,7 +306,7 @@ pub trait ReadableStore: Map {
 }
 
 /// The mutable part of a BaoDb
-pub trait Store: ReadableStore + PartialMap {
+pub trait Store: ReadableStore + MapMut {
     /// This trait method imports a file from a local path.
     ///
     /// `data` is the path to the file.

--- a/iroh-bytes/src/store/traits.rs
+++ b/iroh-bytes/src/store/traits.rs
@@ -52,7 +52,7 @@ pub enum PossiblyPartialEntry<D: MapMut> {
     NotFound,
 }
 
-/// An entry for one hash in a bao collection
+/// An entry for one hash in a bao map
 ///
 /// The entry has the ability to provide you with an (outboard, data)
 /// reader pair. Creating the reader is async and may fail. The futures that
@@ -83,7 +83,14 @@ pub trait MapEntry: Clone + Send + Sync + 'static {
     fn data_reader(&self) -> impl Future<Output = io::Result<impl AsyncSliceReader>> + Send;
 }
 
-/// A generic collection of blobs with precomputed outboards
+/// A generic map from hashes to bao blobs (blobs with bao outboards).
+///
+/// This is the readonly view. To allow updates, a concrete implementation must
+/// also implement [`MapMut`].
+///
+/// Entries are *not* guaranteed to be complete for all implementations.
+/// They are also not guaranteed to be immutable, since this could be the
+/// readonly view of a mutable store.
 pub trait Map: Clone + Send + Sync + 'static {
     /// The entry type. An entry is a cheaply cloneable handle that can be used
     /// to open readers for both the data and the outboard
@@ -240,7 +247,9 @@ where
     }
 }
 
-/// A mutable bao map
+/// A mutable bao map.
+///
+/// This extends the readonly [`Map`] trait with methods to create and modify entries.
 pub trait MapMut: Map {
     /// An entry that is possibly writable
     type EntryMut: MapEntryMut;
@@ -269,7 +278,7 @@ pub trait MapMut: Map {
     fn insert_complete(&self, entry: Self::EntryMut) -> impl Future<Output = io::Result<()>>;
 }
 
-/// Extension of BaoMap to add misc methods used by the rpc calls.
+/// Extension of [`Map`] to add misc methods used by the rpc calls.
 pub trait ReadableStore: Map {
     /// list all blobs in the database. This includes both raw blobs that have
     /// been imported, and hash sequences that have been created internally.
@@ -304,7 +313,7 @@ pub trait ReadableStore: Map {
     ) -> impl Future<Output = io::Result<()>> + Send;
 }
 
-/// The mutable part of a BaoDb
+/// The mutable part of a Bao store.
 pub trait Store: ReadableStore + MapMut {
     /// This trait method imports a file from a local path.
     ///

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -821,13 +821,13 @@ async fn run_probe(
                     }
                     Ok(n) => {
                         let err = anyhow!("Failed to send full STUN request: {}", probe.proto());
-                        error!(%derp_addr, sent_len=n, req_len=req.len(), "{err:#}");
+                        warn!(%derp_addr, sent_len=n, req_len=req.len(), "{err:#}");
                         return Err(ProbeError::Error(err, probe.clone()));
                     }
                     Err(err) => {
                         let err = anyhow::Error::new(err)
                             .context(format!("Failed to send STUN request: {}", probe.proto()));
-                        error!(%derp_addr, "{err:#}");
+                        warn!(%derp_addr, "{err:#}");
                         return Err(ProbeError::Error(err, probe.clone()));
                     }
                 },

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -624,7 +624,7 @@ impl BlobDownloadProgress {
         while let Some(msg) = self.next().await {
             match msg? {
                 DownloadProgress::FoundLocal { size, .. } => {
-                    local_size += size;
+                    local_size += size.value();
                 }
                 DownloadProgress::Found { size, .. } => {
                     network_size += size;
@@ -714,8 +714,10 @@ impl BlobReader {
             Ok(_) => Err(io::Error::new(io::ErrorKind::Other, "Expected data frame")),
             Err(err) => Err(io::Error::new(io::ErrorKind::Other, format!("{err}"))),
         });
-        let len = len.map(|l| l as u64).unwrap_or_else(|| size - offset);
-        Ok(Self::new(size, len, is_complete, stream.boxed()))
+        let len = len
+            .map(|l| l as u64)
+            .unwrap_or_else(|| size.value() - offset);
+        Ok(Self::new(size.value(), len, is_complete, stream.boxed()))
     }
 
     /// Total size of this blob.
@@ -1286,7 +1288,7 @@ impl DocExportFileProgress {
         while let Some(msg) = self.next().await {
             match msg? {
                 ExportProgress::Found { size, outpath, .. } => {
-                    total_size = size;
+                    total_size = size.value();
                     path = Some(outpath);
                 }
                 ExportProgress::AllDone => {

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -812,7 +812,7 @@ impl<D: BaoStore> RpcHandler<D> {
                 continue;
             };
             let size = 0;
-            let expected_size = entry.size();
+            let expected_size = entry.size().value();
             co.yield_(Ok(BlobListIncompleteResponse {
                 hash,
                 size,
@@ -1395,7 +1395,7 @@ impl<D: BaoStore> RpcHandler<D> {
             .await?;
             let mut reader = entry.data_reader().await?;
 
-            let len = len.unwrap_or((size - offset) as usize);
+            let len = len.unwrap_or((size.value() - offset) as usize);
 
             let (num_chunks, chunk_size) = if len <= max_chunk_size {
                 (1, len)

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1379,10 +1379,10 @@ impl<D: BaoStore> RpcHandler<D> {
             }
         });
 
-        async fn read_loop<M: Map>(
+        async fn read_loop(
             offset: u64,
             len: Option<usize>,
-            entry: Option<impl MapEntry<M>>,
+            entry: Option<impl MapEntry>,
             tx: flume::Sender<RpcResult<BlobReadAtResponse>>,
             max_chunk_size: usize,
         ) -> anyhow::Result<()> {

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, net::SocketAddr, path::PathBuf};
 use bytes::Bytes;
 use derive_more::{From, TryInto};
 pub use iroh_bytes::{export::ExportProgress, get::db::DownloadProgress, BlobFormat, Hash};
-use iroh_bytes::{format::collection::Collection, util::Tag};
+use iroh_bytes::{format::collection::Collection, store::BaoBlobSize, util::Tag};
 use iroh_net::{
     key::PublicKey,
     magic_endpoint::{ConnectionInfo, NodeAddr},
@@ -955,7 +955,7 @@ pub enum BlobReadAtResponse {
     /// The entry header.
     Entry {
         /// The size of the blob
-        size: u64,
+        size: BaoBlobSize,
         /// Whether the blob is complete
         is_complete: bool,
     },

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -8,7 +8,7 @@ use rand::RngCore;
 
 use iroh_bytes::{
     hashseq::HashSeq,
-    store::{EntryStatus, PartialMap, Store},
+    store::{EntryStatus, MapMut, Store},
     util::Tag,
     BlobFormat, HashAndFormat,
 };
@@ -195,7 +195,7 @@ mod flat {
 
     use iroh_bytes::{
         hashseq::HashSeq,
-        store::{BaoBatchWriter, PartialMap, PartialMapEntry, Store},
+        store::{BaoBatchWriter, MapEntryMut, MapMut, Store},
         BlobFormat, HashAndFormat, Tag, TempTag, IROH_BLOCK_SIZE,
     };
 
@@ -366,7 +366,7 @@ mod flat {
     async fn simulate_download_partial<S: iroh_bytes::store::Store>(
         bao_store: &S,
         data: Bytes,
-    ) -> io::Result<(S::PartialEntry, TempTag)> {
+    ) -> io::Result<(S::EntryMut, TempTag)> {
         // simulate the remote side.
         let (hash, response) = simulate_remote(data.as_ref());
         // simulate the local side.

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -401,6 +401,7 @@ mod flat {
             reading = next;
         }
         bw.sync().await?;
+        drop(bw);
         Ok((entry, tt))
     }
 

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -27,7 +27,7 @@ use iroh_bytes::{
     },
     protocol::{GetRequest, RangeSpecSeq},
     provider,
-    store::{PartialMap, Store},
+    store::{MapMut, Store},
     BlobFormat, Hash,
 };
 use iroh_sync::store;


### PR DESCRIPTION
## Description

Simplify and rename some store traits, taking advantage of return position impl trait in trait.

The main change is that the map entries are no longer for one specific map impl, but just generic map entries, so the type parameter goes away. Other than that, the PartialXXX traits are renamed to XXXMut, which is more accurate. An immutable entry can be partial. Since MapEntry does not guarantee that it is complete (anymore), the main difference between MapEntry and MapEntryMut is not that the latter allows writing.

Edit: one additional change is to introduce BaoBlobSize, which is a size together with an information about whether the size is validated or not. Why not just (u64, bool)? Because later we might add more info to the unverified enum case.

## Notes & open questions

Note: this is not the end of it. Just trying to do this incrementally.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
