### PR TITLE
refactor(iroh-net): Delete some unused testing infrastructure

### DIFF
--- a/iroh-net/src/netcheck.rs
+++ b/iroh-net/src/netcheck.rs
@@ -383,10 +383,6 @@ struct Actor {
     reports: Reports,
 
     // Actor configuration.
-    /// Whether the client should try to reach things other than localhost.
-    ///
-    /// This is set to true in tests to avoid probing the local LAN's router, etc.
-    skip_external_network: bool,
     /// The port mapper client, if those are requested.
     ///
     /// The port mapper is responsible for talking to routers via UPnP and the like to try
@@ -414,7 +410,6 @@ impl Actor {
             receiver,
             sender,
             reports: Default::default(),
-            skip_external_network: false,
             port_mapper,
             in_flight_stun_requests: Default::default(),
             current_report_run: None,
@@ -516,7 +511,6 @@ impl Actor {
             self.addr(),
             self.reports.last.clone(),
             self.port_mapper.clone(),
-            self.skip_external_network,
             derp_map,
             stun_sock_v4,
             stun_sock_v6,


### PR DESCRIPTION
## Description

This came from the tailscale code but we never seem to have used it
and our routers haven't exploded yet.

## Notes & open questions

Admittedly it would be nice not to keep hitting so many external
things on the network.  But our entire testsuite would need a big
review for that.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.