### PR TITLE
fix(console): prevent deadlock in `author new --switch`

### DIFF
--- a/iroh/src/config.rs
+++ b/iroh/src/config.rs
@@ -268,15 +268,13 @@ impl ConsoleEnv {
     /// Will error if not running in the Iroh console.
     /// Will persist to a file in the Iroh data dir otherwise.
     pub fn set_author(&self, author: AuthorId) -> anyhow::Result<()> {
+        let author_path = ConsolePaths::DefaultAuthor.with_root(self.iroh_data_dir());
         let mut inner = self.0.write();
         if !inner.is_console {
             bail!("Switching the author is only supported within the Iroh console, not on the command line");
         }
         inner.author = Some(author);
-        std::fs::write(
-            ConsolePaths::DefaultAuthor.with_root(self.iroh_data_dir()),
-            author.to_string().as_bytes(),
-        )?;
+        std::fs::write(author_path, author.to_string().as_bytes())?;
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Fixes #2024

This was caused by a read attempt over a lock nested inside a write lock. Thw write lock being `let mut inner = self.0.write()` and the read lock in `self.iroh_data_dir()`

## Notes & open questions

I checked the rest of the code in #2013 and I think `author new --switch` is the only command affected

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
