### PR TITLE
fix(iroh-net): Fix some flaky magicsock tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       if: matrix.target != 'i686-unknown-linux-gnu'
       run: cross build --all --target ${{ matrix.target }}
       env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
     - name: test
       # cross tests are currently broken vor armv7 and aarch64
@@ -70,7 +70,7 @@ jobs:
       if: matrix.target == 'i686-unknown-linux-gnu'
       run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
       env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
 
   check_fmt_and_docs:
     timeout-minutes: 30

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,7 +95,7 @@ jobs:
           cargo check -p $i $FEATURES --lib --bins
         done
       env:
-        RUST_LOG: ${{ runner.debug && 'DEBUG' || 'INFO'}}
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
     - name: build tests
       run: |
@@ -109,12 +109,14 @@ jobs:
       run: |
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
       env:
-        RUST_LOG: "TRACE"
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}
       run: |
         if [ -n "${{ runner.debug }}" ]; then
+            export RUST_LOG=TRACE
+        else
             export RUST_LOG=DEBUG
         fi
         cargo test --workspace --all-features --doc
@@ -195,4 +197,4 @@ jobs:
       run: |
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
       env:
-        RUST_LOG: "TRACE"
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}

--- a/iroh-net/src/key.rs
+++ b/iroh-net/src/key.rs
@@ -227,7 +227,11 @@ impl Debug for PublicKey {
 
 impl Display for PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", base32::fmt(self.as_bytes()))
+        if f.alternate() {
+            write!(f, "{}", base32::fmt_short(self.as_bytes()))
+        } else {
+            write!(f, "{}", base32::fmt(self.as_bytes()))
+        }
     }
 }
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -14,7 +14,7 @@ use crate::{
     derp::{DerpMap, DerpMode, DerpUrl},
     key::{PublicKey, SecretKey},
     magicsock::{self, Discovery, MagicSock},
-    tls,
+    tls, NodeId,
 };
 
 pub use super::magicsock::EndpointInfo as ConnectionInfo;
@@ -321,7 +321,7 @@ impl MagicEndpoint {
     }
 
     /// Get the node id of this endpoint.
-    pub fn node_id(&self) -> PublicKey {
+    pub fn node_id(&self) -> NodeId {
         self.secret_key.public()
     }
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2948,6 +2948,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "flaky"]
     async fn test_two_devices_roundtrip_network_change() -> Result<()> {
         time::timeout(
             Duration::from_secs(50),

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2560,7 +2560,6 @@ pub(crate) mod tests {
     use rand::RngCore;
     use tokio::{net, sync, task::JoinSet};
     use tracing::{debug_span, Instrument};
-    use tracing_subscriber::{prelude::*, EnvFilter};
 
     use super::*;
     use crate::{derp::DerpMode, test_utils::run_derper, tls, MagicEndpoint};
@@ -2756,25 +2755,6 @@ pub(crate) mod tests {
         }))
     }
 
-    /// The first call to this function will install a global logger.
-    ///
-    /// The logger uses the `RUST_LOG` environment variable to decide on what level to log
-    /// anything, which is set by our CI.  When running the tests with nextest the log
-    /// output will be captured for just the executing test.
-    ///
-    /// Logs to stdout since the assertion messages are logged on stderr by default.
-    pub fn setup_multithreaded_logging() {
-        tracing_subscriber::registry()
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .event_format(tracing_subscriber::fmt::format().with_line_number(true))
-                    .with_writer(std::io::stdout),
-            )
-            .with(EnvFilter::from_default_env())
-            .try_init()
-            .ok();
-    }
-
     #[instrument(skip_all, fields(me = %ep.endpoint.node_id().fmt_short()))]
     async fn echo_receiver(ep: MagicStack) -> Result<()> {
         info!("accepting conn");
@@ -2889,7 +2869,7 @@ pub(crate) mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_two_devices_roundtrip_quinn_magic() -> Result<()> {
-        setup_multithreaded_logging();
+        iroh_test::logging::setup_multithreaded();
         let (derp_map, derp_url, _cleanup_guard) = run_derper().await?;
 
         let m1 = MagicStack::new(derp_map.clone()).await?;
@@ -2972,7 +2952,7 @@ pub(crate) mod tests {
     #[ignore = "flaky"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_two_devices_roundtrip_network_change() -> Result<()> {
-        setup_multithreaded_logging();
+        iroh_test::logging::setup_multithreaded();
         let (derp_map, url, _cleanup) = run_derper().await?;
 
         let m1 = MagicStack::new(derp_map.clone()).await?;
@@ -3216,7 +3196,7 @@ pub(crate) mod tests {
     #[ignore = "flaky"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_two_devices_setup_teardown() -> Result<()> {
-        setup_multithreaded_logging();
+        iroh_test::logging::setup_multithreaded();
         for _ in 0..10 {
             let (derp_map, url, _cleanup) = run_derper().await?;
             println!("setting up magic stack");

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2947,10 +2947,18 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    /// Same structure as `test_two_devices_roundtrip_quinn_magic`, but interrupts regularly
-    /// with (simulated) network changes.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_two_devices_roundtrip_network_change() -> Result<()> {
+        time::timeout(
+            Duration::from_secs(50),
+            test_two_devices_roundtrip_network_change_impl(),
+        )
+        .await?
+    }
+
+    /// Same structure as `test_two_devices_roundtrip_quinn_magic`, but interrupts regularly
+    /// with (simulated) network changes.
+    async fn test_two_devices_roundtrip_network_change_impl() -> Result<()> {
         iroh_test::logging::setup_multithreaded();
         let (derp_map, derp_url, _cleanup) = run_derper().await?;
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2770,34 +2770,27 @@ pub(crate) mod tests {
         let conn = ep.endpoint.accept().await.expect("no conn");
 
         info!("connecting");
-        let conn = conn
-            .await
-            .with_context(|| format!("[receiver] connecting"))?;
+        let conn = conn.await.context("[receiver] connecting")?;
         info!("accepting bi");
-        let (mut send_bi, mut recv_bi) = conn
-            .accept_bi()
-            .await
-            .with_context(|| format!("[receiver] accepting bi"))?;
+        let (mut send_bi, mut recv_bi) =
+            conn.accept_bi().await.context("[receiver] accepting bi")?;
 
         info!("reading");
         let val = recv_bi
             .read_to_end(usize::MAX)
             .await
-            .with_context(|| format!("[receiver] reading to end"))?;
+            .context("[receiver] reading to end")?;
 
         info!("replying");
         for chunk in val.chunks(12) {
             send_bi
                 .write_all(chunk)
                 .await
-                .with_context(|| format!("[receiver] sending chunk"))?;
+                .context("[receiver] sending chunk")?;
         }
 
         info!("finishing");
-        send_bi
-            .finish()
-            .await
-            .with_context(|| format!("[receiver] finishing"))?;
+        send_bi.finish().await.context("[receiver] finishing")?;
 
         let stats = conn.stats();
         info!("stats: {:#?}", stats);
@@ -2827,33 +2820,21 @@ pub(crate) mod tests {
         let dest = NodeAddr::new(dest_id).with_derp_url(derp_url);
         let conn = ep
             .endpoint
-            .connect(dest, &ALPN)
+            .connect(dest, ALPN)
             .await
-            .with_context(|| format!("[sender] connect"))?;
+            .context("[sender] connect")?;
 
         info!("opening bi");
-        let (mut send_bi, mut recv_bi) = conn
-            .open_bi()
-            .await
-            .with_context(|| format!("[sender] open bi"))?;
+        let (mut send_bi, mut recv_bi) = conn.open_bi().await.context("[sender] open bi")?;
 
         info!("writing message");
-        send_bi
-            .write_all(msg)
-            .await
-            .with_context(|| format!("[sender] write all"))?;
+        send_bi.write_all(msg).await.context("[sender] write all")?;
 
         info!("finishing");
-        send_bi
-            .finish()
-            .await
-            .with_context(|| format!("[sender] finish"))?;
+        send_bi.finish().await.context("[sender] finish")?;
 
         info!("reading_to_end");
-        let val = recv_bi
-            .read_to_end(usize::MAX)
-            .await
-            .with_context(|| format!("[sender]"))?;
+        let val = recv_bi.read_to_end(usize::MAX).await.context("[sender]")?;
         assert_eq!(
             val,
             msg,

--- a/iroh-net/src/net/interfaces.rs
+++ b/iroh-net/src/net/interfaces.rs
@@ -206,7 +206,7 @@ impl fmt::Display for State {
                 }
             }
             if f.alternate() {
-                write!(f, "\n")?;
+                writeln!(f)?;
             } else {
                 write!(f, "; ")?;
             }

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -581,7 +581,7 @@ impl Actor {
     ///     aborted.  That is, the main actor loop stops polling them.
     async fn spawn_probes_task(&mut self) -> Result<JoinSet<Result<ProbeReport>>> {
         let if_state = interfaces::State::new().await;
-        debug!(?if_state, "Local interfaces");
+        debug!(%if_state, "Local interfaces");
         let plan = match self.last_report {
             Some(ref report) => ProbePlan::with_last_report(&self.derp_map, &if_state, report),
             None => ProbePlan::initial(&self.derp_map, &if_state),

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -52,7 +52,7 @@ impl CancelOnDrop {
 impl Drop for CancelOnDrop {
     fn drop(&mut self) {
         self.handle.abort();
-        tracing::debug!("{} completed", self.task_name);
+        tracing::trace!("{} completed (aborted)", self.task_name);
     }
 }
 

--- a/iroh-test/src/logging.rs
+++ b/iroh-test/src/logging.rs
@@ -39,6 +39,25 @@ pub fn setup() -> tracing::subscriber::DefaultGuard {
     testing_subscriber().set_default()
 }
 
+/// The first call to this function will install a global logger.
+///
+/// The logger uses the `RUST_LOG` environment variable to decide on what level to log
+/// anything, which is set by our CI.  When running the tests with nextest the log
+/// output will be captured for just the executing test.
+///
+/// Logs to stdout since the assertion messages are logged on stderr by default.
+pub fn setup_multithreaded() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .event_format(tracing_subscriber::fmt::format().with_line_number(true))
+                .with_writer(std::io::stdout),
+        )
+        .with(EnvFilter::from_default_env())
+        .try_init()
+        .ok();
+}
+
 // /// Invoke the future with test logging configured.
 // ///
 // /// This can be used to execute any future which uses tracing for logging, it sets up the

--- a/iroh-test/src/logging.rs
+++ b/iroh-test/src/logging.rs
@@ -74,12 +74,14 @@ pub fn testing_subscriber() -> impl tracing::Subscriber {
         Some(_) => None,
         None => Some(
             tracing_subscriber::fmt::layer()
+                .event_format(tracing_subscriber::fmt::format().with_line_number(true))
                 .with_writer(|| TestWriter)
                 .with_filter(LevelFilter::TRACE),
         ),
     };
     let env_log_layer = var.map(|_| {
         tracing_subscriber::fmt::layer()
+            .event_format(tracing_subscriber::fmt::format().with_line_number(true))
             .with_writer(|| TestWriter)
             .with_filter(EnvFilter::from_default_env())
     });


### PR DESCRIPTION
## Description

Fix flaky tests in iroh-net (hopefully).  The main issue was that the
testing code meshing together the sockets had a race-condition and
would sometimes fail.

Other improvements:

- Logging improvements of various parts.  These tests should now
  provide better info on failure.

- Add alternative formatting of NodeId to use the short format.

- Use NodeId in the public API, rather than PublicKey.

- Move multi-threaded logging setup to the testing utils crate now
  that it can work properly.  More code will have to switch.

## Notes & open questions

The local_endpoints_change API is really difficult to use correctly.
Even the way this testing code uses it now is wrong.  Instead of the
two current APIs there should be a single API which returns a stream.
I'll do this as a separate followup PR though.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
