### PR TITLE
chore(ci): Notify our discord channel for flaky failures

### DIFF
--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -44,3 +44,23 @@ jobs:
     with:
       flaky: true
       git-ref: ${{ inputs.branch }}
+  notify:
+    needs: tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract test results
+        run: |
+          printf '${{ toJSON(needs) }}\n'
+          result=$(echo '${{ toJSON(needs) }}' | jq -r .tests.result)
+          echo TESTS_RESULT=$result
+          echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
+      - name: Notify discord on failure
+        uses: n0-computer/discord-webhook-notify@v1
+        if: ${{ env.TESTS_RESULT == 'failure' }}
+        with:
+          severity: error
+          details: |
+            Flaky tests failed again, why don't you go fix them?
+            See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
+          webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

We always wanted some sort of notification to not completely forget
about these.  Since we now have a discord channel for github beta
tests re-use that here as well.

## Notes & open questions



## Change checklist

- [x] Self-review.