### PR TITLE
refactor(iroh-net): Improve API to retrieve local endpoints

### DIFF
--- a/iroh-net/examples/connect-unreliable.rs
+++ b/iroh-net/examples/connect-unreliable.rs
@@ -7,7 +7,9 @@
 //! Run the `listen-unreliable` example first (`iroh-net/examples/listen-unreliable.rs`), which will give you instructions on how to run this example to watch two nodes connect and exchange bytes.
 use std::net::SocketAddr;
 
+use anyhow::Context;
 use clap::Parser;
+use futures::StreamExt;
 use iroh_base::base32;
 use iroh_net::{
     derp::{DerpMode, DerpUrl},
@@ -58,7 +60,12 @@ async fn main() -> anyhow::Result<()> {
     let me = endpoint.node_id();
     println!("node id: {me}");
     println!("node listening addresses:");
-    for local_endpoint in endpoint.local_endpoints().await? {
+    for local_endpoint in endpoint
+        .local_endpoints()
+        .next()
+        .await
+        .context("no endpoints")?
+    {
         println!("\t{}", local_endpoint.addr)
     }
 

--- a/iroh-net/examples/connect.rs
+++ b/iroh-net/examples/connect.rs
@@ -7,7 +7,9 @@
 //! Run the `listen` example first (`iroh-net/examples/listen.rs`), which will give you instructions on how to run this example to watch two nodes connect and exchange bytes.
 use std::net::SocketAddr;
 
+use anyhow::Context;
 use clap::Parser;
+use futures::StreamExt;
 use iroh_base::base32;
 use iroh_net::derp::DerpUrl;
 use iroh_net::{derp::DerpMode, key::SecretKey, MagicEndpoint, NodeAddr};
@@ -55,7 +57,12 @@ async fn main() -> anyhow::Result<()> {
     let me = endpoint.node_id();
     println!("node id: {me}");
     println!("node listening addresses:");
-    for local_endpoint in endpoint.local_endpoints().await? {
+    for local_endpoint in endpoint
+        .local_endpoints()
+        .next()
+        .await
+        .context("no endpoints")?
+    {
         println!("\t{}", local_endpoint.addr)
     }
 

--- a/iroh-net/examples/listen-unreliable.rs
+++ b/iroh-net/examples/listen-unreliable.rs
@@ -3,6 +3,8 @@
 //! This example uses the default DERP servers to attempt to holepunch, and will use that DERP server to relay packets if the two devices cannot establish a direct UDP connection.
 //! run this example from the project root:
 //!     $ cargo run --example listen-unreliable
+use anyhow::Context;
+use futures::StreamExt;
 use iroh_base::base32;
 use iroh_net::{derp::DerpMode, key::SecretKey, MagicEndpoint};
 use tracing::info;
@@ -38,7 +40,9 @@ async fn main() -> anyhow::Result<()> {
 
     let local_addrs = endpoint
         .local_endpoints()
-        .await?
+        .next()
+        .await
+        .context("no endpoints")?
         .into_iter()
         .map(|endpoint| {
             let addr = endpoint.addr.to_string();

--- a/iroh-net/examples/listen.rs
+++ b/iroh-net/examples/listen.rs
@@ -3,6 +3,8 @@
 //! This example uses the default DERP servers to attempt to holepunch, and will use that DERP server to relay packets if the two devices cannot establish a direct UDP connection.
 //! run this example from the project root:
 //!     $ cargo run --example listen
+use anyhow::Context;
+use futures::StreamExt;
 use iroh_base::base32;
 use iroh_net::{derp::DerpMode, key::SecretKey, MagicEndpoint};
 use tracing::{debug, info};
@@ -38,7 +40,9 @@ async fn main() -> anyhow::Result<()> {
 
     let local_addrs = endpoint
         .local_endpoints()
-        .await?
+        .next()
+        .await
+        .context("no endpoints")?
         .into_iter()
         .map(|endpoint| {
             let addr = endpoint.addr.to_string();

--- a/iroh-net/src/config.rs
+++ b/iroh-net/src/config.rs
@@ -10,7 +10,7 @@ use super::portmapper;
 // magicsock endpoint". this time it means "an IP address on which our local magicsock
 // endpoint is listening".  Name this better.
 /// An endpoint IPPort and an associated type.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Endpoint {
     /// The address of the endpoint.
     pub addr: SocketAddr,
@@ -19,7 +19,7 @@ pub struct Endpoint {
 }
 
 /// Type of endpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum EndpointType {
     /// Endpoint kind has not been determined yet.
     Unknown,

--- a/iroh-net/src/dns.rs
+++ b/iroh-net/src/dns.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dns_lookup_ipv4_ipv6() {
-        let res = lookup_ipv4_ipv6(NA_DERP_HOSTNAME, Duration::from_secs(1))
+        let res = lookup_ipv4_ipv6(NA_DERP_HOSTNAME, Duration::from_secs(5))
             .await
             .unwrap();
         assert!(!res.is_empty());


### PR DESCRIPTION
## Description

The API to retrieve local endpoints was split in two between the
current endpoints and updates to it.  This was very hard to use right
without any race conditions.

This replaces it with a single API which returns a stream.  This is a
little bit wordier to use if you just need the current local item, but
much harder to misuse.

## Notes & open questions

It would be possible to add a convenient `.current_local_endpoints()`
API if we wanted.  Not sure this is really worth it.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.