### PR TITLE
refactor(iroh-bytes): Async bao store

### DIFF
--- a/iroh-bytes/src/export.rs
+++ b/iroh-bytes/src/export.rs
@@ -69,7 +69,7 @@ pub async fn export_blob<D: BaoStore>(
     }
     trace!("exporting blob {} to {}", hash, outpath.display());
     let id = progress.new_id();
-    let entry = db.get(&hash)?.context("entry not there")?;
+    let entry = db.get(&hash).await?.context("entry not there")?;
     progress
         .send(ExportProgress::Found {
             id,

--- a/iroh-bytes/src/format/collection.rs
+++ b/iroh-bytes/src/format/collection.rs
@@ -168,12 +168,12 @@ impl Collection {
     where
         D: crate::store::Map,
     {
-        let links_entry = db.get(root)?.context("links not found")?;
+        let links_entry = db.get(root).await?.context("links not found")?;
         anyhow::ensure!(links_entry.is_complete(), "links not complete");
         let links_bytes = links_entry.data_reader().await?.read_to_end().await?;
         let mut links = HashSeq::try_from(links_bytes)?;
         let meta_hash = links.pop_front().context("meta hash not found")?;
-        let meta_entry = db.get(&meta_hash)?.context("meta not found")?;
+        let meta_entry = db.get(&meta_hash).await?.context("meta not found")?;
         anyhow::ensure!(links_entry.is_complete(), "links not complete");
         let meta_bytes = meta_entry.data_reader().await?.read_to_end().await?;
         let meta: CollectionMeta = postcard::from_bytes(&meta_bytes)?;

--- a/iroh-bytes/src/get/db.rs
+++ b/iroh-bytes/src/get/db.rs
@@ -174,7 +174,7 @@ async fn get_blob_inner<D: BaoStore>(
     let hash = at_content.hash();
     let child_offset = at_content.offset();
     // get or create the partial entry
-    let entry = db.get_or_create_partial(hash, size)?;
+    let entry = db.get_or_create(hash, size)?;
     // open the data file in any case
     let bw = entry.batch_writer().await?;
     // allocate a new id for progress reports for this transfer
@@ -421,7 +421,8 @@ async fn get_hash_seq<
             let end_root = get_blob_inner(db, header, sender.clone()).await?;
             // read the collection fully for now
             let entry = db
-                .get(root_hash)?
+                .get(root_hash)
+                .await?
                 .ok_or_else(|| GetError::LocalFailure(anyhow!("just downloaded but not in db")))?;
             let reader = entry.data_reader().await?;
             let (mut collection, count) = parse_hash_seq(reader).await.map_err(|err| {

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -357,7 +357,7 @@ pub async fn handle_get<D: Map, E: EventSender>(
         .await;
 
     // 4. Attempt to find hash
-    match db.get(&hash)? {
+    match db.get(&hash).await? {
         // Collection or blob request
         Some(entry) => {
             let mut stats = Box::<TransferStats>::default();
@@ -492,7 +492,7 @@ pub async fn send_blob<D: Map, W: AsyncStreamWriter>(
     ranges: &RangeSpec,
     writer: W,
 ) -> Result<(SentStatus, u64, SliceReaderStats)> {
-    match db.get(&name)? {
+    match db.get(&name).await? {
         Some(entry) => {
             let outboard = entry.outboard().await?;
             let size = outboard.tree().size().0;

--- a/iroh-bytes/src/store/flat.rs
+++ b/iroh-bytes/src/store/flat.rs
@@ -347,7 +347,7 @@ impl MapMut for Store {
         })
     }
 
-    fn get_or_create_partial(&self, hash: Hash, size: u64) -> io::Result<Self::EntryMut> {
+    fn get_or_create(&self, hash: Hash, size: u64) -> io::Result<Self::EntryMut> {
         let mut state = self.0.state.write().unwrap();
         // this protects the entry from being deleted until the next mark phase
         //
@@ -573,7 +573,7 @@ pub struct EntryMut {
 
 impl Map for Store {
     type Entry = Entry;
-    fn get(&self, hash: &Hash) -> io::Result<Option<Self::Entry>> {
+    async fn get(&self, hash: &Hash) -> io::Result<Option<Self::Entry>> {
         let state = self.0.state.read().unwrap();
         Ok(if let Some(entry) = state.complete.get(hash) {
             state.get_entry(hash, entry, &self.0.options)

--- a/iroh-bytes/src/store/mem.rs
+++ b/iroh-bytes/src/store/mem.rs
@@ -271,7 +271,7 @@ impl MapEntry for EntryMut {
 impl Map for Store {
     type Entry = Entry;
 
-    fn get(&self, hash: &Hash) -> io::Result<Option<Self::Entry>> {
+    async fn get(&self, hash: &Hash) -> io::Result<Option<Self::Entry>> {
         let state = self.0.state.read().unwrap();
         // look up the ids
         Ok(if let Some((data, outboard)) = state.complete.get(hash) {
@@ -386,7 +386,7 @@ impl MapMut for Store {
         })
     }
 
-    fn get_or_create_partial(&self, hash: Hash, size: u64) -> io::Result<EntryMut> {
+    fn get_or_create(&self, hash: Hash, size: u64) -> io::Result<EntryMut> {
         let tree = BaoTree::new(ByteNum(size), IROH_BLOCK_SIZE);
         let outboard_size =
             usize::try_from(outboard_size(size, IROH_BLOCK_SIZE)).map_err(data_too_large)?;

--- a/iroh-bytes/src/store/mem.rs
+++ b/iroh-bytes/src/store/mem.rs
@@ -40,6 +40,7 @@ use bao_tree::ChunkRanges;
 use bytes::Bytes;
 use bytes::BytesMut;
 use derive_more::From;
+use futures::Future;
 use futures::FutureExt;
 use futures::{Stream, StreamExt};
 use iroh_io::{AsyncSliceReader, AsyncSliceWriter};
@@ -303,7 +304,7 @@ impl Map for Store {
 }
 
 impl ReadableStore for Store {
-    fn blobs(&self) -> io::Result<DbIter<Hash>> {
+    async fn blobs(&self) -> io::Result<DbIter<Hash>> {
         Ok(Box::new(
             self.0
                 .state
@@ -318,7 +319,7 @@ impl ReadableStore for Store {
         ))
     }
 
-    fn tags(&self) -> io::Result<DbIter<(Tag, HashAndFormat)>> {
+    async fn tags(&self) -> io::Result<DbIter<(Tag, HashAndFormat)>> {
         let tags = self
             .0
             .state
@@ -340,7 +341,7 @@ impl ReadableStore for Store {
         Ok(())
     }
 
-    fn partial_blobs(&self) -> io::Result<DbIter<Hash>> {
+    async fn partial_blobs(&self) -> io::Result<DbIter<Hash>> {
         let state = self.0.state.read().unwrap();
         let hashes = state.partial.keys().copied().map(Ok).collect::<Vec<_>>();
         Ok(Box::new(hashes.into_iter()))
@@ -363,7 +364,7 @@ impl ReadableStore for Store {
 impl MapMut for Store {
     type EntryMut = EntryMut;
 
-    fn entry_status(&self, hash: &Hash) -> io::Result<EntryStatus> {
+    fn entry_status_sync(&self, hash: &Hash) -> io::Result<EntryStatus> {
         let state = self.0.state.read().unwrap();
         Ok(if state.complete.contains_key(hash) {
             EntryStatus::Complete
@@ -374,7 +375,11 @@ impl MapMut for Store {
         })
     }
 
-    fn get_possibly_partial(&self, hash: &Hash) -> io::Result<PossiblyPartialEntry<Self>> {
+    async fn entry_status(&self, hash: &Hash) -> io::Result<EntryStatus> {
+        self.entry_status_sync(hash)
+    }
+
+    async fn get_possibly_partial(&self, hash: &Hash) -> io::Result<PossiblyPartialEntry<Self>> {
         let state = self.0.state.read().unwrap();
         Ok(match state.partial.get(hash) {
             Some((data, outboard)) => PossiblyPartialEntry::Partial(EntryMut {
@@ -386,7 +391,7 @@ impl MapMut for Store {
         })
     }
 
-    fn get_or_create(&self, hash: Hash, size: u64) -> io::Result<EntryMut> {
+    async fn get_or_create(&self, hash: Hash, size: u64) -> io::Result<EntryMut> {
         let tree = BaoTree::new(ByteNum(size), IROH_BLOCK_SIZE);
         let outboard_size =
             usize::try_from(outboard_size(size, IROH_BLOCK_SIZE)).map_err(data_too_large)?;
@@ -517,14 +522,15 @@ impl super::Store for Store {
         TempTag::new(tag, Some(self.0.clone()))
     }
 
-    fn clear_live(&self) {
+    async fn clear_live(&self) {
         let mut state = self.0.state.write().unwrap();
         state.live.clear();
     }
 
-    fn add_live(&self, live: impl IntoIterator<Item = Hash>) {
+    fn add_live(&self, live: impl IntoIterator<Item = Hash>) -> impl Future<Output = ()> {
         let mut state = self.0.state.write().unwrap();
         state.live.extend(live);
+        futures::future::ready(())
     }
 
     fn is_live(&self, hash: &Hash) -> bool {

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -25,7 +25,7 @@ use bao_tree::{
     ChunkRanges,
 };
 use bytes::Bytes;
-use futures::Stream;
+use futures::{Future, Stream};
 use iroh_io::AsyncSliceReader;
 use tokio::{io::AsyncWriteExt, sync::mpsc};
 
@@ -206,21 +206,25 @@ impl Map for Store {
 impl MapMut for Store {
     type EntryMut = EntryMut;
 
-    fn get_or_create(&self, _hash: Hash, _size: u64) -> io::Result<EntryMut> {
+    async fn get_or_create(&self, _hash: Hash, _size: u64) -> io::Result<EntryMut> {
         Err(io::Error::new(
             io::ErrorKind::Other,
             "cannot create temp entry in readonly database",
         ))
     }
 
-    fn entry_status(&self, hash: &Hash) -> io::Result<EntryStatus> {
+    fn entry_status_sync(&self, hash: &Hash) -> io::Result<EntryStatus> {
         Ok(match self.0.contains_key(hash) {
             true => EntryStatus::Complete,
             false => EntryStatus::NotFound,
         })
     }
 
-    fn get_possibly_partial(&self, hash: &Hash) -> io::Result<PossiblyPartialEntry<Self>> {
+    async fn entry_status(&self, hash: &Hash) -> io::Result<EntryStatus> {
+        self.entry_status_sync(hash)
+    }
+
+    async fn get_possibly_partial(&self, hash: &Hash) -> io::Result<PossiblyPartialEntry<Self>> {
         // return none because we do not have partial entries
         Ok(if let Some((o, d)) = self.0.get(hash) {
             PossiblyPartialEntry::Complete(Entry {
@@ -239,7 +243,7 @@ impl MapMut for Store {
 }
 
 impl ReadableStore for Store {
-    fn blobs(&self) -> io::Result<DbIter<Hash>> {
+    async fn blobs(&self) -> io::Result<DbIter<Hash>> {
         Ok(Box::new(
             self.0
                 .keys()
@@ -250,7 +254,7 @@ impl ReadableStore for Store {
         ))
     }
 
-    fn tags(&self) -> io::Result<DbIter<(Tag, HashAndFormat)>> {
+    async fn tags(&self) -> io::Result<DbIter<(Tag, HashAndFormat)>> {
         Ok(Box::new(std::iter::empty()))
     }
 
@@ -272,7 +276,7 @@ impl ReadableStore for Store {
         self.export_impl(hash, target, mode, progress).await
     }
 
-    fn partial_blobs(&self) -> io::Result<DbIter<Hash>> {
+    async fn partial_blobs(&self) -> io::Result<DbIter<Hash>> {
         Ok(Box::new(std::iter::empty()))
     }
 }
@@ -361,7 +365,7 @@ impl super::Store for Store {
         Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
-    fn clear_live(&self) {}
+    async fn clear_live(&self) {}
 
     async fn set_tag(&self, _name: Tag, _hash: Option<HashAndFormat>) -> io::Result<()> {
         Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
@@ -375,7 +379,9 @@ impl super::Store for Store {
         TempTag::new(inner, None)
     }
 
-    fn add_live(&self, _live: impl IntoIterator<Item = Hash>) {}
+    fn add_live(&self, _live: impl IntoIterator<Item = Hash>) -> impl Future<Output = ()> {
+        futures::future::ready(())
+    }
 
     async fn delete(&self, _hashes: Vec<Hash>) -> io::Result<()> {
         Err(io::Error::new(io::ErrorKind::Other, "not implemented"))

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -195,7 +195,7 @@ impl MapEntry for Entry {
 impl Map for Store {
     type Entry = Entry;
 
-    fn get(&self, hash: &Hash) -> io::Result<Option<Self::Entry>> {
+    async fn get(&self, hash: &Hash) -> io::Result<Option<Self::Entry>> {
         Ok(self.0.get(hash).map(|(o, d)| Entry {
             outboard: o.clone(),
             data: d.clone(),
@@ -206,7 +206,7 @@ impl Map for Store {
 impl MapMut for Store {
     type EntryMut = EntryMut;
 
-    fn get_or_create_partial(&self, _hash: Hash, _size: u64) -> io::Result<EntryMut> {
+    fn get_or_create(&self, _hash: Hash, _size: u64) -> io::Result<EntryMut> {
         Err(io::Error::new(
             io::ErrorKind::Other,
             "cannot create temp entry in readonly database",

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -478,7 +478,7 @@ where
             callbacks
                 .send(Event::Db(iroh_bytes::store::Event::GcStarted))
                 .await;
-            db.clear_live();
+            db.clear_live().await;
             let doc_hashes = match ds.content_hashes() {
                 Ok(hashes) => hashes,
                 Err(err) => {
@@ -495,7 +495,7 @@ where
                     None
                 }
             });
-            db.add_live(doc_hashes);
+            db.add_live(doc_hashes).await;
             if doc_db_error {
                 tracing::error!("Error getting doc hashes, skipping GC to be safe");
                 continue 'outer;
@@ -786,7 +786,7 @@ impl<D: BaoStore> RpcHandler<D> {
         use bao_tree::io::fsm::Outboard;
 
         let db = self.inner.db.clone();
-        for blob in db.blobs()? {
+        for blob in db.blobs().await? {
             let blob = blob?;
             let Some(entry) = db.get(&blob).await? else {
                 continue;
@@ -804,9 +804,10 @@ impl<D: BaoStore> RpcHandler<D> {
         co: &Co<RpcResult<BlobListIncompleteResponse>>,
     ) -> io::Result<()> {
         let db = self.inner.db.clone();
-        for hash in db.partial_blobs()? {
+        for hash in db.partial_blobs().await? {
             let hash = hash?;
-            let Ok(PossiblyPartialEntry::Partial(entry)) = db.get_possibly_partial(&hash) else {
+            let Ok(PossiblyPartialEntry::Partial(entry)) = db.get_possibly_partial(&hash).await
+            else {
                 continue;
             };
             let size = 0;
@@ -827,7 +828,7 @@ impl<D: BaoStore> RpcHandler<D> {
     ) -> anyhow::Result<()> {
         let db = self.inner.db.clone();
         let local = self.inner.rt.clone();
-        let tags = db.tags().unwrap();
+        let tags = db.tags().await.unwrap();
         for item in tags {
             let (name, HashAndFormat { hash, format }) = item?;
             if !format.is_hash_seq() {
@@ -902,11 +903,16 @@ impl<D: BaoStore> RpcHandler<D> {
         _msg: ListTagsRequest,
     ) -> impl Stream<Item = ListTagsResponse> + Send + 'static {
         tracing::info!("blob_list_tags");
-        futures::stream::iter(self.inner.db.tags().unwrap().filter_map(|item| {
-            let (name, HashAndFormat { hash, format }) = item.ok()?;
-            tracing::info!("{:?} {} {:?}", name, hash, format);
-            Some(ListTagsResponse { name, hash, format })
-        }))
+        Gen::new(|co| async move {
+            let tags = self.inner.db.tags().await.unwrap();
+            #[allow(clippy::manual_flatten)]
+            for item in tags {
+                if let Ok((name, HashAndFormat { hash, format })) = item {
+                    tracing::info!("{:?} {} {:?}", name, hash, format);
+                    co.yield_(ListTagsResponse { name, hash, format }).await;
+                }
+            }
+        })
     }
 
     /// Invoke validate on the database and stream out the result

--- a/iroh/src/sync_engine.rs
+++ b/iroh/src/sync_engine.rs
@@ -69,7 +69,7 @@ impl SyncEngine {
 
         let content_status_cb = {
             let bao_store = bao_store.clone();
-            Arc::new(move |hash| entry_to_content_status(bao_store.entry_status(&hash)))
+            Arc::new(move |hash| entry_to_content_status(bao_store.entry_status_sync(&hash)))
         };
         let sync = SyncHandle::spawn(
             replica_store.clone(),

--- a/iroh/src/sync_engine/live.rs
+++ b/iroh/src/sync_engine/live.rs
@@ -630,7 +630,7 @@ impl<B: iroh_bytes::store::Store> LiveActor<B> {
                 // A new entry was inserted from initial sync or gossip. Queue downloading the
                 // content.
                 let hash = entry.content_hash();
-                let entry_status = self.bao_store.entry_status(&hash)?;
+                let entry_status = self.bao_store.entry_status(&hash).await?;
                 // TODO: Make downloads configurable.
                 if matches!(entry_status, EntryStatus::NotFound | EntryStatus::Partial)
                     && should_download

--- a/iroh/tests/cli.rs
+++ b/iroh/tests/cli.rs
@@ -514,9 +514,9 @@ fn cli_bao_store_migration() -> anyhow::Result<()> {
 }
 
 #[cfg(all(unix, feature = "cli"))]
-#[test]
+#[tokio::test]
 #[ignore = "flaky"]
-fn cli_provide_persistence() -> anyhow::Result<()> {
+async fn cli_provide_persistence() -> anyhow::Result<()> {
     use iroh_bytes::store::flat::Store;
     use iroh_bytes::store::ReadableStore;
     use nix::{
@@ -568,13 +568,13 @@ fn cli_provide_persistence() -> anyhow::Result<()> {
     // should have some data now
     let db_path = IrohPaths::BaoFlatStoreDir.with_root(&iroh_data_dir);
     let db = Store::load_blocking(&db_path)?;
-    let blobs = db.blobs().unwrap().collect::<Vec<_>>();
+    let blobs = db.blobs().await.unwrap().collect::<Vec<_>>();
     assert_eq!(blobs.len(), 3);
 
     provide(&bar_path)?;
     // should have more data now
     let db = Store::load_blocking(&db_path)?;
-    let blobs = db.blobs().unwrap().collect::<Vec<_>>();
+    let blobs = db.blobs().await.unwrap().collect::<Vec<_>>();
     assert_eq!(blobs.len(), 6);
 
     Ok(())

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -382,7 +382,7 @@ mod flat {
         // get the size
         let (mut reading, size) = at_start.next().await?;
         // create the partial entry
-        let entry = bao_store.get_or_create_partial(hash.into(), size)?;
+        let entry = bao_store.get_or_create(hash.into(), size)?;
         // create the
         let mut bw = entry.batch_writer().await?;
         let mut buf = Vec::new();

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -468,7 +468,7 @@ async fn test_chunk_not_found_1() {
     let db = iroh_bytes::store::mem::Store::new();
     let data = (0..1024 * 64).map(|i| i as u8).collect::<Vec<_>>();
     let hash = blake3::hash(&data).into();
-    let _entry = db.get_or_create_partial(hash, data.len() as u64).unwrap();
+    let _entry = db.get_or_create(hash, data.len() as u64).unwrap();
     let node = match test_node(db).local_pool(&lp).spawn().await {
         Ok(provider) => provider,
         Err(_) => {

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -468,7 +468,7 @@ async fn test_chunk_not_found_1() {
     let db = iroh_bytes::store::mem::Store::new();
     let data = (0..1024 * 64).map(|i| i as u8).collect::<Vec<_>>();
     let hash = blake3::hash(&data).into();
-    let _entry = db.get_or_create(hash, data.len() as u64).unwrap();
+    let _entry = db.get_or_create(hash, data.len() as u64).await.unwrap();
     let node = match test_node(db).local_pool(&lp).spawn().await {
         Ok(provider) => provider,
         Err(_) => {


### PR DESCRIPTION
## Description

Asyncify bao store traits

Asyncify almost the complete surface area of the bao store traits, to make an actor based implementation that lives on its own std::thread::Thread at least theoretically possible.

## Notes & open questions

Note: There is a sync method `fn entry_status_sync` so we don't have to rewrite the document sync algorithm. It should be replaced asap since it will be not very efficient.

Note2: there is 1 unrelated change: get_or_create_partial is renamed to just get_or_create, since you have no control over whether the created entry is partial. If the entry is already complete, what do you do? You return a complete entry.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
