### PR TITLE
chore(ci): Warn in our discord channel on failure

### DIFF
--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
-          severity: error
+          severity: warn
           details: |
             Flaky tests failed again, why don't you go fix them?
             See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml


### PR DESCRIPTION
## Description

This is better than error, since flaky tests really are expected to be
flaky.  And we don't want to miss other errors in that channel which
are more important.

## Notes & open questions

Maybe warn is even a bit high, but all that matters is that we get
different colours in our channel.  If later we send more notifications
to that channel we can tweak the levels appropriately.

## Change checklist

- [x] Self-review.