### PR TITLE
refactor(iroh-net): Avoid using .unwrap() calls

### DIFF
--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -21,7 +21,9 @@ pub fn default_derp_map() -> DerpMap {
 /// Get the default [`DerpNode`] for NA.
 pub fn default_na_derp_node() -> DerpNode {
     // The default NA derper run by number0.
-    let url: Url = format!("https://{NA_DERP_HOSTNAME}").parse().unwrap();
+    let url: Url = format!("https://{NA_DERP_HOSTNAME}")
+        .parse()
+        .expect("default url");
     DerpNode {
         url: url.into(),
         stun_only: false,
@@ -32,7 +34,9 @@ pub fn default_na_derp_node() -> DerpNode {
 /// Get the default [`DerpNode`] for EU.
 pub fn default_eu_derp_node() -> DerpNode {
     // The default EU derper run by number0.
-    let url: Url = format!("https://{EU_DERP_HOSTNAME}").parse().unwrap();
+    let url: Url = format!("https://{EU_DERP_HOSTNAME}")
+        .parse()
+        .expect("default_url");
     DerpNode {
         url: url.into(),
         stun_only: false,

--- a/iroh-net/src/derp/client_conn.rs
+++ b/iroh-net/src/derp/client_conn.rs
@@ -428,7 +428,10 @@ where
     async fn send_packet(&mut self, packet: Packet) -> Result<()> {
         let src_key = packet.src;
         let content = packet.bytes;
-        inc_by!(Metrics, bytes_sent, content.len().try_into().unwrap());
+
+        if let Ok(len) = content.len().try_into() {
+            inc_by!(Metrics, bytes_sent, len);
+        }
         write_frame(
             &mut self.io,
             Frame::RecvPacket { src_key, content },

--- a/iroh-net/src/derp/server.rs
+++ b/iroh-net/src/derp/server.rs
@@ -596,12 +596,8 @@ fn init_meta_cert(server_key: &PublicKey) -> Vec<u8> {
         rcgen::CertificateParams::new([format!("derpkey{}", hex::encode(server_key.as_bytes()))]);
     params.serial_number = Some((PROTOCOL_VERSION as u64).into());
     // Windows requires not_after and not_before set:
-    params.not_after = time::OffsetDateTime::now_utc()
-        .checked_add(30 * time::Duration::DAY)
-        .unwrap();
-    params.not_before = time::OffsetDateTime::now_utc()
-        .checked_sub(30 * time::Duration::DAY)
-        .unwrap();
+    params.not_after = time::OffsetDateTime::now_utc().saturating_add(30 * time::Duration::DAY);
+    params.not_before = time::OffsetDateTime::now_utc().saturating_sub(30 * time::Duration::DAY);
 
     rcgen::Certificate::from_params(params)
         .expect("fixed inputs")

--- a/iroh-net/src/derp/types.rs
+++ b/iroh-net/src/derp/types.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{bail, Context, Result};
 use bytes::Bytes;
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
@@ -25,8 +25,10 @@ impl RateLimiter {
         if bytes_per_second == 0 || bytes_burst == 0 {
             return Ok(None);
         }
-        let bytes_per_second = NonZeroU32::new(u32::try_from(bytes_per_second)?).unwrap();
-        let bytes_burst = NonZeroU32::new(u32::try_from(bytes_burst)?).unwrap();
+        let bytes_per_second = NonZeroU32::new(u32::try_from(bytes_per_second)?)
+            .context("bytes_per_second not non-zero")?;
+        let bytes_burst =
+            NonZeroU32::new(u32::try_from(bytes_burst)?).context("bytes_burst not non-zero")?;
         Ok(Some(Self {
             inner: governor::RateLimiter::direct(
                 governor::Quota::per_second(bytes_per_second).allow_burst(bytes_burst),
@@ -35,8 +37,7 @@ impl RateLimiter {
     }
 
     pub(crate) fn check_n(&self, n: usize) -> Result<()> {
-        ensure!(n != 0);
-        let n = NonZeroU32::new(u32::try_from(n)?).unwrap();
+        let n = NonZeroU32::new(u32::try_from(n)?).context("n not non-zero")?;
         match self.inner.check_n(n) {
             Ok(_) => Ok(()),
             Err(_) => bail!("batch cannot go through"),

--- a/iroh-net/src/key.rs
+++ b/iroh-net/src/key.rs
@@ -53,7 +53,7 @@ static KEY_CACHE: OnceCell<Mutex<TtlCache<[u8; 32], CryptoKeys>>> = OnceCell::ne
 
 fn lock_key_cache() -> std::sync::MutexGuard<'static, TtlCache<[u8; 32], CryptoKeys>> {
     let mutex = KEY_CACHE.get_or_init(|| Mutex::new(TtlCache::new(KEY_CACHE_CAPACITY)));
-    mutex.lock().unwrap()
+    mutex.lock().expect("not poisoned")
 }
 
 /// Get or create the crypto keys, and project something out of them.

--- a/iroh-net/src/key/encryption.rs
+++ b/iroh-net/src/key/encryption.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 
 use aead::Buffer;
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 
 pub(crate) const NONCE_LEN: usize = 24;
 
@@ -47,7 +47,9 @@ impl SharedSecret {
         ensure!(buffer.len() > NONCE_LEN, "too short");
 
         let offset = buffer.len() - NONCE_LEN;
-        let nonce: [u8; NONCE_LEN] = buffer.as_ref()[offset..].try_into().unwrap();
+        let nonce: [u8; NONCE_LEN] = buffer.as_ref()[offset..]
+            .try_into()
+            .context("nonce wrong length")?;
 
         buffer.truncate(offset);
         self.0

--- a/iroh-net/src/magicsock/derp_actor.rs
+++ b/iroh-net/src/magicsock/derp_actor.rs
@@ -205,8 +205,11 @@ impl ActiveDerp {
                 // reset
                 self.backoff.reset();
                 let now = Instant::now();
-                if self.last_packet_time.is_none()
-                    || self.last_packet_time.as_ref().unwrap().elapsed() > Duration::from_secs(5)
+                if self
+                    .last_packet_time
+                    .as_ref()
+                    .map(|t| t.elapsed() > Duration::from_secs(5))
+                    .unwrap_or(true)
                 {
                     self.last_packet_time = Some(now);
                 }
@@ -220,8 +223,11 @@ impl ActiveDerp {
                         trace!(len=%data.len(), "received msg");
                         // If this is a new sender we hadn't seen before, remember it and
                         // register a route for this peer.
-                        if self.last_packet_src.is_none()
-                            || &source != self.last_packet_src.as_ref().unwrap()
+                        if self
+                            .last_packet_src
+                            .as_ref()
+                            .map(|p| *p != source)
+                            .unwrap_or(true)
                         {
                             // avoid map lookup w/ high throughput single peer
                             self.last_packet_src = Some(source);

--- a/iroh-net/src/net/netmon/linux.rs
+++ b/iroh-net/src/net/netmon/linux.rs
@@ -108,12 +108,12 @@ impl RouteMonitor {
                                 .unwrap_or_default();
                             if let Some(dst) = get_nla!(msg, route::Nla::Destination) {
                                 let dst_addr = match dst.len() {
-                                    4 => Some(IpAddr::from(
-                                        TryInto::<[u8; 4]>::try_into(&dst[..]).unwrap(),
-                                    )),
-                                    16 => Some(IpAddr::from(
-                                        TryInto::<[u8; 16]>::try_into(&dst[..]).unwrap(),
-                                    )),
+                                    4 => TryInto::<[u8; 4]>::try_into(&dst[..])
+                                        .ok()
+                                        .map(IpAddr::from),
+                                    16 => TryInto::<[u8; 16]>::try_into(&dst[..])
+                                        .ok()
+                                        .map(IpAddr::from),
                                     _ => None,
                                 };
                                 if let Some(dst_addr) = dst_addr {

--- a/iroh-net/src/netcheck.rs
+++ b/iroh-net/src/netcheck.rs
@@ -647,14 +647,15 @@ impl Actor {
         let mut best_any = Duration::default();
         let mut old_derp_cur_latency = Duration::default();
         {
-            for (url, d) in r.derp_latency.iter() {
+            for (url, duration) in r.derp_latency.iter() {
                 if Some(url) == prev_derp.as_ref() {
-                    old_derp_cur_latency = d;
+                    old_derp_cur_latency = duration;
                 }
-                let best = best_recent.get(url).unwrap();
-                if r.preferred_derp.is_none() || best < best_any {
-                    best_any = best;
-                    r.preferred_derp.replace(url.clone());
+                if let Some(best) = best_recent.get(url) {
+                    if r.preferred_derp.is_none() || best < best_any {
+                        best_any = best;
+                        r.preferred_derp.replace(url.clone());
+                    }
                 }
             }
 

--- a/iroh-net/src/netcheck/reportgen/hairpin.rs
+++ b/iroh-net/src/netcheck/reportgen/hairpin.rs
@@ -12,7 +12,7 @@
 //! Note it will only perform a single hairpin check before shutting down.  Any further
 //! requests to it will fail which is intentional.
 
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
@@ -164,7 +164,7 @@ impl Actor {
         // documentation-only IPv4 range is enough to set up the mapping.
         // So do that for now. In the future we might want to classify networks
         // that do and don't require this separately. But for now help it.
-        let documentation_ip: SocketAddr = "203.0.113.1:12345".parse().unwrap();
+        let documentation_ip = SocketAddr::from((Ipv4Addr::new(203, 0, 113, 1), 12345));
 
         socket
             .send_to(

--- a/iroh-net/src/stun.rs
+++ b/iroh-net/src/stun.rs
@@ -91,8 +91,12 @@ pub fn parse_binding_request(b: &[u8]) -> Result<TransactionId, Error> {
 
     // TODO: Tailscale sets the software to tailscale, we should check if we want to do this too.
 
-    let attrs = msg.attributes();
-    if attrs.is_empty() || !attrs.last().unwrap().is_fingerprint() {
+    if msg
+        .attributes()
+        .last()
+        .map(|attr| attr.is_fingerprint())
+        .unwrap_or_default()
+    {
         return Err(Error::NoFingerprint);
     }
 

--- a/iroh-net/src/ticket/node.rs
+++ b/iroh-net/src/ticket/node.rs
@@ -91,13 +91,13 @@ mod tests {
     use iroh_test::{assert_eq_hex, hexdump::parse_hexdump};
 
     use crate::key::{PublicKey, SecretKey};
-    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, SocketAddr};
 
     use super::*;
 
     fn make_ticket() -> NodeTicket {
         let peer = SecretKey::generate().public();
-        let addr = SocketAddr::from_str("127.0.0.1:1234").unwrap();
+        let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
         let derp_url = None;
         NodeTicket {
             node: NodeAddr::from_parts(peer, derp_url, vec![addr]),

--- a/iroh-net/src/tls/certificate.rs
+++ b/iroh-net/src/tls/certificate.rs
@@ -186,10 +186,14 @@ fn make_libp2p_extension(
     };
 
     let public_key = identity_secret_key.public();
+    let public_key_ref = OctetStringRef::new(&public_key.as_bytes()[..])
+        .map_err(|_| rcgen::RcgenError::CouldNotParseKeyPair)?;
     let signature = signature.to_bytes();
+    let signature_ref =
+        OctetStringRef::new(&signature).map_err(|_| rcgen::RcgenError::CouldNotParseCertificate)?;
     let key = SignedKey {
-        public_key: OctetStringRef::new(&public_key.as_bytes()[..]).unwrap(),
-        signature: OctetStringRef::new(&signature).unwrap(),
+        public_key: public_key_ref,
+        signature: signature_ref,
     };
 
     let mut extension_content = Vec::new();


### PR DESCRIPTION
## Description

This is an attempt at an audit of all the .unwrap() calls in iroh-net.
A few are replaced by .expect() with clear reasons why they're
reasonable.  Some are replaces by non-panicking versions which will
never take the failure branch because of the invariants that are
supposed to be upheld.

Closes #1528

## Notes & open questions

This was surprisingly horrible and long to do.  Oh well.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.