### PR TITLE
refactor(iroh-net): remove unneeded async interactions with the magicsock actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,6 +2429,7 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
+ "crypto_box",
  "curve25519-dalek",
  "data-encoding",
  "default-net",

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1310,7 +1310,7 @@ impl MagicSock {
     pub fn get_mapping_addr(&self, node_key: &PublicKey) -> Option<SocketAddr> {
         self.inner
             .node_map
-            .get_quic_mapped_addr_for_node_key(&node_key)
+            .get_quic_mapped_addr_for_node_key(node_key)
             .map(|a| a.0)
     }
 
@@ -2703,7 +2703,7 @@ pub(crate) mod tests {
             })
         }
 
-        async fn tracked_endpoints(&self) -> Vec<PublicKey> {
+        fn tracked_endpoints(&self) -> Vec<PublicKey> {
             self.endpoint
                 .magic_sock()
                 .tracked_endpoints()
@@ -2792,7 +2792,7 @@ pub(crate) mod tests {
             loop {
                 let mut ready = Vec::with_capacity(stacks.len());
                 for ms in stacks.iter() {
-                    let endpoints = ms.tracked_endpoints().await;
+                    let endpoints = ms.tracked_endpoints();
                     let my_node_id = ms.endpoint.node_id();
                     let all_nodes_meshed = all_node_ids
                         .iter()

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -339,14 +339,14 @@ impl Gui {
             x.map(|x| format!("{:.6}s", x.as_secs_f64()))
                 .unwrap_or_else(|| "unknown".to_string())
         };
-        let msg = match endpoint.connection_info(*node_id).await {
-            Ok(Some(EndpointInfo {
+        let msg = match endpoint.connection_info(*node_id) {
+            Some(EndpointInfo {
                 derp_url,
                 conn_type,
                 latency,
                 addrs,
                 ..
-            })) => {
+            }) => {
                 let derp_url = derp_url
                     .map(|x| x.to_string())
                     .unwrap_or_else(|| "unknown".to_string());
@@ -363,8 +363,7 @@ impl Gui {
                     derp_url, latency, conn_type, addrs
                 )
             }
-            Ok(None) => "connection info unavailable".to_string(),
-            Err(cause) => format!("error getting connection info: {}", cause),
+            None => "connection info unavailable".to_string(),
         };
         target.set_message(msg);
     }

--- a/iroh/src/commands/doctor.rs
+++ b/iroh/src/commands/doctor.rs
@@ -315,7 +315,7 @@ impl Gui {
         let counter_task = AbortingJoinHandle(tokio::spawn(async move {
             loop {
                 Self::update_counters(&counters2);
-                Self::update_connection_info(&conn_info, &endpoint, &node_id).await;
+                Self::update_connection_info(&conn_info, &endpoint, &node_id);
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
         }));
@@ -330,11 +330,7 @@ impl Gui {
         }
     }
 
-    async fn update_connection_info(
-        target: &ProgressBar,
-        endpoint: &MagicEndpoint,
-        node_id: &NodeId,
-    ) {
+    fn update_connection_info(target: &ProgressBar, endpoint: &MagicEndpoint, node_id: &NodeId) {
         let format_latency = |x: Option<Duration>| {
             x.map(|x| format!("{:.6}s", x.as_secs_f64()))
                 .unwrap_or_else(|| "unknown".to_string())

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1453,13 +1453,15 @@ impl<D: BaoStore> RpcHandler<D> {
         rx.into_stream()
     }
 
-    fn node_connection_info(
+    // This method is called as an RPC method, which have to be async
+    #[allow(clippy::unused_async)]
+    async fn node_connection_info(
         self,
         req: NodeConnectionInfoRequest,
-    ) -> std::future::Ready<RpcResult<NodeConnectionInfoResponse>> {
+    ) -> RpcResult<NodeConnectionInfoResponse> {
         let NodeConnectionInfoRequest { node_id } = req;
         let conn_info = self.inner.endpoint.connection_info(node_id);
-        std::future::ready(Ok(NodeConnectionInfoResponse { conn_info }))
+        Ok(NodeConnectionInfoResponse { conn_info })
     }
 
     async fn create_collection(

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1456,7 +1456,7 @@ impl<D: BaoStore> RpcHandler<D> {
     fn node_connection_info(
         self,
         req: NodeConnectionInfoRequest,
-    ) -> impl Future<Output = RpcResult<NodeConnectionInfoResponse>> {
+    ) -> std::future::Ready<RpcResult<NodeConnectionInfoResponse>> {
         let NodeConnectionInfoRequest { node_id } = req;
         let conn_info = self.inner.endpoint.connection_info(node_id);
         std::future::ready(Ok(NodeConnectionInfoResponse { conn_info }))


### PR DESCRIPTION
## Description

While working on #2056 I spotted that we use the actor inbox with return channels for information that is readily available already on the shared inner magicsock. This removes the unneeded complexity and thus simplifies `get_mapping_addr`, `endpoint_info` and `endpoint_infos` to return the information non-async and infallible. Yay!

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
