### PR TITLE
refactor(iroh-bytes): Create helper structs for tables

### DIFF
--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -21,7 +21,7 @@ bao-tree = { version = "0.10", features = ["tokio_fsm"], default-features = fals
 bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"
 data-encoding = "2.3.3"
-derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "deref", "from", "try_into", "into"] }
+derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "deref", "deref_mut", "from", "try_into", "into"] }
 flume = "0.11"
 futures = "0.3.25"
 genawaiter = { version = "0.99.1", features = ["futures03"] }

--- a/iroh-bytes/src/store/redb.rs
+++ b/iroh-bytes/src/store/redb.rs
@@ -1469,7 +1469,11 @@ impl ActorState {
         Ok(EntryStateResponse { mem, db })
     }
 
-    fn get(&mut self, tables: &ReadOnlyTables, hash: Hash) -> ActorResult<Option<BaoFileHandle>> {
+    fn get(
+        &mut self,
+        tables: &impl ReadableTables,
+        hash: Hash,
+    ) -> ActorResult<Option<BaoFileHandle>> {
         if let Some(entry) = self.handles.get(&hash) {
             return Ok(Some(entry.clone()));
         }
@@ -1706,7 +1710,7 @@ impl ActorState {
     /// Read the entire blobs table. Callers can then sift through the results to find what they need
     fn blobs(
         &mut self,
-        tables: &ReadOnlyTables,
+        tables: &impl ReadableTables,
         filter: FilterPredicate<Hash, EntryState>,
     ) -> ActorResult<Vec<std::result::Result<(Hash, EntryState), StorageError>>> {
         let mut res = Vec::new();
@@ -1731,7 +1735,7 @@ impl ActorState {
     /// Read the entire tags table. Callers can then sift through the results to find what they need
     fn tags(
         &mut self,
-        tables: &ReadOnlyTables,
+        tables: &impl ReadableTables,
         filter: FilterPredicate<Tag, HashAndFormat>,
     ) -> ActorResult<Vec<std::result::Result<(Tag, HashAndFormat), StorageError>>> {
         let mut res = Vec::new();
@@ -2058,7 +2062,6 @@ impl ActorState {
         match msg {
             ActorMessage::GetOrCreate { hash, tx } => {
                 let txn = db.begin_write()?;
-                // TODO: what if this fails?
                 let res = self.get_or_create(&mut Tables::new(&txn)?, hash);
                 txn.commit()?;
                 tx.send(res).ok();

--- a/iroh-bytes/src/store/redb/tables.rs
+++ b/iroh-bytes/src/store/redb/tables.rs
@@ -1,0 +1,89 @@
+use redb::{ReadableTable, TableDefinition, TableError};
+
+use iroh_base::hash::{Hash, HashAndFormat};
+
+use super::EntryState;
+use crate::util::Tag;
+
+pub(super) const BLOBS_TABLE: TableDefinition<Hash, EntryState> = TableDefinition::new("blobs-0");
+
+pub(super) const TAGS_TABLE: TableDefinition<Tag, HashAndFormat> = TableDefinition::new("tags-0");
+
+pub(super) const INLINE_DATA_TABLE: TableDefinition<Hash, &[u8]> =
+    TableDefinition::new("inline-data-0");
+
+pub(super) const INLINE_OUTBOARD_TABLE: TableDefinition<Hash, &[u8]> =
+    TableDefinition::new("inline-outboard-0");
+
+pub(super) trait ReadableTables {
+    fn blobs(&self) -> &impl ReadableTable<Hash, EntryState>;
+    fn tags(&self) -> &impl ReadableTable<Tag, HashAndFormat>;
+    fn inline_data(&self) -> &impl ReadableTable<Hash, &'static [u8]>;
+    fn inline_outboard(&self) -> &impl ReadableTable<Hash, &'static [u8]>;
+}
+
+pub(super) struct Tables<'a, 'b> {
+    pub blobs: redb::Table<'a, 'b, Hash, EntryState>,
+    pub tags: redb::Table<'a, 'b, Tag, HashAndFormat>,
+    pub inline_data: redb::Table<'a, 'b, Hash, &'static [u8]>,
+    pub inline_outboard: redb::Table<'a, 'b, Hash, &'static [u8]>,
+}
+
+impl<'db, 'txn> Tables<'db, 'txn> {
+    pub fn new(tx: &'txn redb::WriteTransaction<'db>) -> std::result::Result<Self, TableError> {
+        Ok(Self {
+            blobs: tx.open_table(BLOBS_TABLE)?,
+            tags: tx.open_table(TAGS_TABLE)?,
+            inline_data: tx.open_table(INLINE_DATA_TABLE)?,
+            inline_outboard: tx.open_table(INLINE_OUTBOARD_TABLE)?,
+        })
+    }
+}
+
+impl ReadableTables for ReadOnlyTables<'_> {
+    fn blobs(&self) -> &impl ReadableTable<Hash, EntryState> {
+        &self.blobs
+    }
+    fn tags(&self) -> &impl ReadableTable<Tag, HashAndFormat> {
+        &self.tags
+    }
+    fn inline_data(&self) -> &impl ReadableTable<Hash, &'static [u8]> {
+        &self.inline_data
+    }
+    fn inline_outboard(&self) -> &impl ReadableTable<Hash, &'static [u8]> {
+        &self.inline_outboard
+    }
+}
+
+pub(super) struct ReadOnlyTables<'txn> {
+    pub blobs: redb::ReadOnlyTable<'txn, Hash, EntryState>,
+    pub tags: redb::ReadOnlyTable<'txn, Tag, HashAndFormat>,
+    pub inline_data: redb::ReadOnlyTable<'txn, Hash, &'static [u8]>,
+    pub inline_outboard: redb::ReadOnlyTable<'txn, Hash, &'static [u8]>,
+}
+
+impl<'txn> ReadOnlyTables<'txn> {
+    pub fn new(tx: &'txn redb::ReadTransaction<'txn>) -> std::result::Result<Self, TableError> {
+        Ok(Self {
+            blobs: tx.open_table(BLOBS_TABLE)?,
+            tags: tx.open_table(TAGS_TABLE)?,
+            inline_data: tx.open_table(INLINE_DATA_TABLE)?,
+            inline_outboard: tx.open_table(INLINE_OUTBOARD_TABLE)?,
+        })
+    }
+}
+
+impl ReadableTables for Tables<'_, '_> {
+    fn blobs(&self) -> &impl ReadableTable<Hash, EntryState> {
+        &self.blobs
+    }
+    fn tags(&self) -> &impl ReadableTable<Tag, HashAndFormat> {
+        &self.tags
+    }
+    fn inline_data(&self) -> &impl ReadableTable<Hash, &'static [u8]> {
+        &self.inline_data
+    }
+    fn inline_outboard(&self) -> &impl ReadableTable<Hash, &'static [u8]> {
+        &self.inline_outboard
+    }
+}

--- a/iroh-bytes/src/store/redb/tables.rs
+++ b/iroh-bytes/src/store/redb/tables.rs
@@ -1,3 +1,4 @@
+//! Table definitions and accessors for the redb database.
 use redb::{ReadableTable, TableDefinition, TableError};
 
 use iroh_base::hash::{Hash, HashAndFormat};
@@ -15,6 +16,9 @@ pub(super) const INLINE_DATA_TABLE: TableDefinition<Hash, &[u8]> =
 pub(super) const INLINE_OUTBOARD_TABLE: TableDefinition<Hash, &[u8]> =
     TableDefinition::new("inline-outboard-0");
 
+/// A trait similar to [`redb::ReadableTable`] but for all tables that make up
+/// the blob store. This can be used in places where either a readonly or
+/// mutable table is needed.
 pub(super) trait ReadableTables {
     fn blobs(&self) -> &impl ReadableTable<Hash, EntryState>;
     fn tags(&self) -> &impl ReadableTable<Tag, HashAndFormat>;
@@ -22,6 +26,8 @@ pub(super) trait ReadableTables {
     fn inline_outboard(&self) -> &impl ReadableTable<Hash, &'static [u8]>;
 }
 
+/// A struct similar to [`redb::Table`] but for all tables that make up the
+/// blob store.
 pub(super) struct Tables<'a, 'b> {
     pub blobs: redb::Table<'a, 'b, Hash, EntryState>,
     pub tags: redb::Table<'a, 'b, Tag, HashAndFormat>,
@@ -40,7 +46,7 @@ impl<'db, 'txn> Tables<'db, 'txn> {
     }
 }
 
-impl ReadableTables for ReadOnlyTables<'_> {
+impl ReadableTables for Tables<'_, '_> {
     fn blobs(&self) -> &impl ReadableTable<Hash, EntryState> {
         &self.blobs
     }
@@ -55,6 +61,8 @@ impl ReadableTables for ReadOnlyTables<'_> {
     }
 }
 
+/// A struct similar to [`redb::ReadOnlyTable`] but for all tables that make up
+/// the blob store.
 pub(super) struct ReadOnlyTables<'txn> {
     pub blobs: redb::ReadOnlyTable<'txn, Hash, EntryState>,
     pub tags: redb::ReadOnlyTable<'txn, Tag, HashAndFormat>,
@@ -73,7 +81,7 @@ impl<'txn> ReadOnlyTables<'txn> {
     }
 }
 
-impl ReadableTables for Tables<'_, '_> {
+impl ReadableTables for ReadOnlyTables<'_> {
     fn blobs(&self) -> &impl ReadableTable<Hash, EntryState> {
         &self.blobs
     }


### PR DESCRIPTION
Create helper structs for tables

Also separate transaction and table things more from other io. Generic io failures should not cause the actor to stop.

## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
