### PR TITLE
tests(iroh-net): Make test more reliable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = []

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -535,6 +535,7 @@ mod tests {
 
     use std::time::Instant;
 
+    use iroh_test::CallOnDrop;
     use rand_core::SeedableRng;
     use tracing::{error_span, info, info_span, Instrument};
 
@@ -699,14 +700,17 @@ mod tests {
 
     #[tokio::test]
     async fn magic_endpoint_derp_connect_loop() {
-        let _guard = iroh_test::logging::setup();
-        let n_iters = 5;
+        let _logging_guard = iroh_test::logging::setup();
+        let start = Instant::now();
+        let n_clients = 5;
         let n_chunks_per_client = 2;
         let chunk_size = 10;
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
-        let (derp_map, derp_url, _guard) = run_derper().await.unwrap();
+        let (derp_map, derp_url, _derp_guard) = run_derper().await.unwrap();
         let server_secret_key = SecretKey::generate_with_rng(&mut rng);
         let server_node_id = server_secret_key.public();
+
+        // The server accepts the connections of the clients sequentially.
         let server = {
             let derp_map = derp_map.clone();
             tokio::spawn(
@@ -715,16 +719,16 @@ mod tests {
                         .secret_key(server_secret_key)
                         .alpns(vec![TEST_ALPN.to_vec()])
                         .derp_mode(DerpMode::Custom(derp_map))
-                        .bind(12345)
+                        .bind(0)
                         .await
                         .unwrap();
                     let eps = ep.local_addr().unwrap();
                     info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "server bound");
-                    for i in 0..n_iters {
+                    for i in 0..n_clients {
                         let now = Instant::now();
                         println!("[server] round {}", i + 1);
-                        let conn = ep.accept().await.unwrap();
-                        let (peer_id, _alpn, conn) = accept_conn(conn).await.unwrap();
+                        let incoming = ep.accept().await.unwrap();
+                        let (peer_id, _alpn, conn) = accept_conn(incoming).await.unwrap();
                         info!(%i, peer = %peer_id.fmt_short(), "accepted connection");
                         let (mut send, mut recv) = conn.accept_bi().await.unwrap();
                         let mut buf = vec![0u8; chunk_size];
@@ -741,56 +745,59 @@ mod tests {
                 .instrument(error_span!("server")),
             )
         };
-
-        let client_secret_key = SecretKey::generate_with_rng(&mut rng);
-        let client = tokio::spawn(async move {
-            for i in 0..n_iters {
-                let now = Instant::now();
-                println!("[client] round {}", i + 1);
-                let derp_map = derp_map.clone();
-                let client_secret_key = client_secret_key.clone();
-                let derp_url = derp_url.clone();
-                let fut = async move {
-                    info!("client binding");
-                    let start = Instant::now();
-                    let ep = MagicEndpoint::builder()
-                        .alpns(vec![TEST_ALPN.to_vec()])
-                        .derp_mode(DerpMode::Custom(derp_map))
-                        .secret_key(client_secret_key)
-                        .bind(0)
-                        .await
-                        .unwrap();
-                    let eps = ep.local_addr().unwrap();
-                    info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, t = ?start.elapsed(), "client bound");
-                    let node_addr = NodeAddr::new(server_node_id).with_derp_url(derp_url);
-                    info!(to = ?node_addr, "client connecting");
-                    let t = Instant::now();
-                    let conn = ep.connect(node_addr, TEST_ALPN).await.unwrap();
-                    info!(t = ?t.elapsed(), "client connected");
-                    let t = Instant::now();
-                    let (mut send, mut recv) = conn.open_bi().await.unwrap();
-
-                    for i in 0..n_chunks_per_client {
-                        let mut buf = vec![i; chunk_size];
-                        send.write_all(&buf).await.unwrap();
-                        recv.read_exact(&mut buf).await.unwrap();
-                        assert_eq!(buf, vec![i; chunk_size]);
-                    }
-                    send.finish().await.unwrap();
-                    recv.read_to_end(0).await.unwrap();
-                    info!(t = ?t.elapsed(), "client finished");
-                    ep.close(0u32.into(), &[]).await.unwrap();
-                    info!(total = ?start.elapsed(), "client closed");
-                }
-                .instrument(error_span!("client", %i));
-                tokio::task::spawn(fut).await.unwrap();
-                println!("[client] round {} done in {:?}", i + 1, now.elapsed());
-            }
+        let abort_handle = server.abort_handle();
+        let _server_guard = CallOnDrop::new(move || {
+            abort_handle.abort();
         });
 
-        client.await.unwrap();
-        server.abort();
-        let _ = server.await;
+        for i in 0..n_clients {
+            let now = Instant::now();
+            println!("[client] round {}", i + 1);
+            let derp_map = derp_map.clone();
+            let client_secret_key = SecretKey::generate_with_rng(&mut rng);
+            let derp_url = derp_url.clone();
+            async {
+                info!("client binding");
+                let ep = MagicEndpoint::builder()
+                    .alpns(vec![TEST_ALPN.to_vec()])
+                    .derp_mode(DerpMode::Custom(derp_map))
+                    .secret_key(client_secret_key)
+                    .bind(0)
+                    .await
+                    .unwrap();
+                let eps = ep.local_addr().unwrap();
+                info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "client bound");
+                let node_addr = NodeAddr::new(server_node_id).with_derp_url(derp_url);
+                info!(to = ?node_addr, "client connecting");
+                let conn = ep.connect(node_addr, TEST_ALPN).await.unwrap();
+                info!("client connected");
+                let (mut send, mut recv) = conn.open_bi().await.unwrap();
+
+                for i in 0..n_chunks_per_client {
+                    let mut buf = vec![i; chunk_size];
+                    send.write_all(&buf).await.unwrap();
+                    recv.read_exact(&mut buf).await.unwrap();
+                    assert_eq!(buf, vec![i; chunk_size]);
+                }
+                send.finish().await.unwrap();
+                recv.read_to_end(0).await.unwrap();
+                info!("client finished");
+                ep.close(0u32.into(), &[]).await.unwrap();
+                info!("client closed");
+            }
+            .instrument(error_span!("client", %i))
+            .await;
+            println!("[client] round {} done in {:?}", i + 1, now.elapsed());
+        }
+
+        server.await.unwrap();
+
+        // We appear to have seen this being very slow at times.  So ensure we fail if this
+        // test is too slow.  We're only making two connections transferring very little
+        // data, this really shouldn't take long.
+        if start.elapsed() > Duration::from_secs(15) {
+            panic!("Test too slow, something went wrong");
+        }
     }
 
     // #[tokio::test]

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2597,11 +2597,13 @@ fn disco_message_sent(msg: &disco::Message) {
 pub(crate) mod tests {
     use anyhow::Context;
     use futures::StreamExt;
+    use iroh_test::CallOnDrop;
     use rand::RngCore;
     use tokio::{net, sync, task::JoinSet};
 
-    use super::*;
     use crate::{derp::DerpMode, test_utils::run_derper, tls, MagicEndpoint};
+
+    use super::*;
 
     async fn pick_port() -> u16 {
         let conn = net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -2722,22 +2724,6 @@ pub(crate) mod tests {
 
         fn public(&self) -> PublicKey {
             self.secret_key.public()
-        }
-    }
-
-    struct CallOnDrop(Option<Box<dyn FnOnce()>>);
-
-    impl CallOnDrop {
-        fn new(f: impl FnOnce() + 'static) -> Self {
-            Self(Some(Box::new(f)))
-        }
-    }
-
-    impl Drop for CallOnDrop {
-        fn drop(&mut self) {
-            if let Some(f) = self.0.take() {
-                f();
-            }
         }
     }
 

--- a/iroh-test/src/lib.rs
+++ b/iroh-test/src/lib.rs
@@ -2,3 +2,21 @@
 
 pub mod hexdump;
 pub mod logging;
+
+// #[derive(derive_more::Debug)]
+#[allow(missing_debug_implementations)]
+pub struct CallOnDrop(Option<Box<dyn FnOnce()>>);
+
+impl CallOnDrop {
+    pub fn new(f: impl FnOnce() + 'static) -> Self {
+        Self(Some(Box::new(f)))
+    }
+}
+
+impl Drop for CallOnDrop {
+    fn drop(&mut self) {
+        if let Some(f) = self.0.take() {
+            f();
+        }
+    }
+}


### PR DESCRIPTION
## Description

This refactors this test which has had reports of being flaky a bit.
It tiedies up some logging but most significantly:

- The server task is now aborted properly regardless of how the test
  execution works out.

- The clients are no longer moved to a task.  The server is
  handling them sequentially anyway so there's not much to gain from
  having one of the clients sit around waiting to be accepted.

- Most importantly, and possibly the relevant bugfix, both clients
  were using the same NodeId.  This *may* just about work out if both
  are not connecting at the same time as it would maybe look like a
  migrating client to the server.  But combined with the clients
  before being spawned in tasks this would have confused the server's
  PathState quite a lot.  I don't believe these clients should have
  shared their NodeId.

- A (generous) timeout is added to the test.  The flake issue mentions
  that this is sometimes just very slow.  There really is no reason
  for this to be slow so consider these failures so that we get
  debugging info from them in the form of logs.


## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.