### PR TITLE
test(iroh-net): disable test_icmp_probe_eu_derper as flaky on windows

### DIFF
--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -1309,6 +1309,7 @@ mod tests {
     //
     // TODO: Not sure what about IPv6 pings using sysctl.
     #[tokio::test]
+    #[cfg_attr(target_os = "windows", ignore = "flaky")]
     async fn test_icmp_probe_eu_derper() {
         let _logging_guard = iroh_test::logging::setup();
         let pinger = Pinger::new();


### PR DESCRIPTION
## Description

test(iroh-net): disable test_icmp_probe_eu_derper as flaky on windows

See for example https://github.com/n0-computer/iroh/actions/runs/8245723076/job/22550253677?pr=2051

Related issue: https://github.com/n0-computer/iroh/issues/2069

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
