### PR TITLE
tests(iroh-net): ignore save_load_peers test as flaky on windows

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -690,6 +690,7 @@ mod tests {
 
     /// Test that peers saved on shutdown are correctly loaded
     #[tokio::test]
+    #[cfg_attr(target_os = "windows", ignore = "flaky")]
     async fn save_load_peers() {
         let _guard = iroh_test::logging::setup();
 


### PR DESCRIPTION
## Description

tests(iroh-net): ignore save_load_peers test as flaky on windows

Issue is https://github.com/n0-computer/iroh/issues/2071

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
