### PR TITLE
chore(iroh): update quic-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,9 +3735,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4574b485c0ac86e1a087ad616d99daecd3742820b74172e3cd98b34707130c52"
+checksum = "30d960d0b328db80274cbcbaf4bf53728eff1f43df4fc36c34eb79a97753c7d9"
 dependencies = [
  "bincode",
  "educe",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -39,7 +39,7 @@ iroh-gossip = { version = "0.12.0", path = "../iroh-gossip" }
 once_cell = "1.18.0"
 parking_lot = "0.12.1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
-quic-rpc = { version = "0.6.2", default-features = false, features = ["flume-transport"] }
+quic-rpc = { version = "0.7.0", default-features = false, features = ["flume-transport"] }
 quinn = "0.10"
 range-collections = { version = "0.4.0" }
 rand = "0.8"


### PR DESCRIPTION
## Description

chore(iroh): update quic-rpc

Use latest version of quic-rpc so we can slowly modularize the rpc

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
