### PR TITLE
refactor(iroh-net): bump netcheck DNS timeout to 3s

### DIFF
--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -71,7 +71,7 @@ const CAPTIVE_PORTAL_TIMEOUT: Duration = Duration::from_secs(2);
 
 const ENOUGH_NODES: usize = 3;
 
-const DNS_TIMEOUT: Duration = Duration::from_secs(1);
+const DNS_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Holds the state for a single invocation of [`netcheck::Client::get_report`].
 ///

--- a/iroh-net/src/netcheck/reportgen/hairpin.rs
+++ b/iroh-net/src/netcheck/reportgen/hairpin.rs
@@ -93,7 +93,7 @@ struct Actor {
 impl Actor {
     async fn run(self) {
         match self.run_inner().await {
-            Ok(_) => debug!("hairpin actor finished successfully"),
+            Ok(_) => trace!("hairpin actor finished successfully"),
             Err(err) => error!("Hairpin actor failed: {err:#}"),
         }
     }
@@ -137,7 +137,7 @@ impl Actor {
             Ok(Err(_)) => bail!("netcheck actor dropped stun response channel"),
             Err(_) => false, // Elapsed
         };
-        tracing::debug!(
+        debug!(
             "hairpinning done in {:?}, res: {:?}",
             now.elapsed(),
             hairpinning_works


### PR DESCRIPTION
## Description

We've seen 1s not being long enough.  The probes time out after 3s, so
let's match that timeout and see how that goes.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.