### PR TITLE
refactor(iroh-net): remove rebinding

### DIFF
--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -93,6 +93,14 @@ rtnetlink = "0.13.0"
 wmi = "0.13"
 windows = { version = "0.51", features = ["Win32_NetworkManagement_IpHelper", "Win32_Foundation", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock"] }
 
+# [patch.crates-io]
+# quinn = { version = "0.11", path = "../../quinn/quinn" }
+# quinn-proto = { version = "0.11", path = "../../quinn/quinn-proto" }
+# quinn-udp = { version = "0.5", path = "../../quinn/quinn-udp" }
+# # quinn = "0.11"
+# # quinn-proto = "0.11"
+# # quinn-udp = "0.5"
+
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
 criterion = "0.5.1"

--- a/iroh-net/src/magicsock/rebinding_conn.rs
+++ b/iroh-net/src/magicsock/rebinding_conn.rs
@@ -15,8 +15,6 @@ use tracing::{debug, trace, warn};
 use crate::net::IpFamily;
 use crate::net::UdpSocket;
 
-use super::CurrentPortFate;
-
 /// A UDP socket that can be re-bound. Unix has no notion of re-binding a socket, so we swap it out for a new one.
 #[derive(Clone, Debug)]
 pub struct RebindingUdpConn {
@@ -29,33 +27,8 @@ impl RebindingUdpConn {
         self.io.clone()
     }
 
-    pub(super) fn rebind(
-        &mut self,
-        port: u16,
-        network: IpFamily,
-        cur_port_fate: CurrentPortFate,
-    ) -> anyhow::Result<()> {
-        trace!(
-            "rebinding from {} to {} ({:?})",
-            self.port(),
-            port,
-            cur_port_fate
-        );
-
-        // Do not bother rebinding if we are keeping the port.
-        if self.port() == port && cur_port_fate == CurrentPortFate::Keep {
-            return Ok(());
-        }
-
-        let sock = bind(Some(&self.io), port, network, cur_port_fate)?;
-        self.io = Arc::new(sock);
-        self.state = Default::default();
-
-        Ok(())
-    }
-
     pub(super) fn bind(port: u16, network: IpFamily) -> anyhow::Result<Self> {
-        let sock = bind(None, port, network, CurrentPortFate::Keep)?;
+        let sock = bind(port, network)?;
         Ok(Self {
             io: Arc::new(sock),
             state: Default::default(),
@@ -133,13 +106,8 @@ impl AsyncUdpSocket for RebindingUdpConn {
     }
 }
 
-fn bind(
-    inner: Option<&UdpSocket>,
-    port: u16,
-    network: IpFamily,
-    cur_port_fate: CurrentPortFate,
-) -> anyhow::Result<UdpSocket> {
-    debug!(?network, %port, ?cur_port_fate, "binding");
+fn bind(port: u16, network: IpFamily) -> anyhow::Result<UdpSocket> {
+    debug!(?network, %port, "binding");
 
     // Build a list of preferred ports.
     // - Best is the port that the user requested.
@@ -150,11 +118,6 @@ fn bind(
     if port != 0 {
         ports.push(port);
     }
-    if cur_port_fate == CurrentPortFate::Keep {
-        if let Some(cur_addr) = inner.as_ref().and_then(|i| i.local_addr().ok()) {
-            ports.push(cur_addr.port());
-        }
-    }
     // Backup port
     ports.push(0);
     // Remove duplicates. (All duplicates are consecutive.)
@@ -162,11 +125,6 @@ fn bind(
     debug!(?ports, "candidate ports");
 
     for port in &ports {
-        // Close the existing conn, in case it is sitting on the port we want.
-        if let Some(_inner) = inner {
-            // TODO: inner.close()
-        }
-        // Open a new one with the desired port.
         match UdpSocket::bind(network, *port) {
             Ok(pconn) => {
                 let local_addr = pconn.local_addr().context("UDP socket not bound")?;


### PR DESCRIPTION
We still handle major network changes, but we do not pretend to handle rebinding anymore.

There are a few reasons and implications that I'll write up properly tomorrow.

## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
