### PR TITLE
fix(derp): restore `ClientInfo` `mesh_key` field

### DIFF
--- a/iroh-net/src/derp/client.rs
+++ b/iroh-net/src/derp/client.rs
@@ -312,6 +312,7 @@ impl ClientBuilder {
             version: PROTOCOL_VERSION,
             can_ack_pings: self.can_ack_pings,
             is_prober: self.is_prober,
+            mesh_key: None,
         };
         debug!("server_handshake: sending client_key: {:?}", &client_info);
         let shared_secret = self.secret_key.shared(&server_key);

--- a/iroh-net/src/derp/codec.rs
+++ b/iroh-net/src/derp/codec.rs
@@ -578,6 +578,7 @@ mod tests {
             version: PROTOCOL_VERSION,
             can_ack_pings: true,
             is_prober: true,
+            mesh_key: None,
         };
         println!("client_key pub {:?}", client_key.public());
         let shared_secret = client_key.shared(&server_key.public());

--- a/iroh-net/src/derp/server.rs
+++ b/iroh-net/src/derp/server.rs
@@ -602,6 +602,7 @@ mod tests {
                 version: PROTOCOL_VERSION,
                 can_ack_pings: true,
                 is_prober: true,
+                mesh_key: None,
             };
             let shared_secret = client_key.shared(&got_server_key);
             crate::derp::codec::send_client_key(

--- a/iroh-net/src/derp/types.rs
+++ b/iroh-net/src/derp/types.rs
@@ -56,6 +56,8 @@ pub(crate) struct ClientInfo {
     /// The DERP protocol version that the client was built with.
     /// See [`PROTOCOL_VERSION`].
     pub(crate) version: usize,
+    /// Unused field, ignored by the relay server.
+    pub(crate) mesh_key: Option<[u8; 32]>,
     /// Whether the client declares it's able to ack pings
     pub(crate) can_ack_pings: bool,
     /// Whether this client is a prober.


### PR DESCRIPTION
## Description

In order to preserve backwards compatibility, we should keep the `ClientInfo` unchanged. The `mesh_key` field is ignored by the server.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
