### PR TITLE
WIP: rustls 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,9 +2053,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2359,7 +2359,7 @@ dependencies = [
  "range-collections",
  "rcgen 0.12.1",
  "reflink-copy",
- "rustls",
+ "rustls 0.21.10",
  "self_cell",
  "serde",
  "serde-error",
@@ -2541,9 +2541,9 @@ dependencies = [
  "reqwest",
  "ring 0.17.8",
  "rtnetlink",
- "rustls",
+ "rustls 0.23.2",
  "rustls-pemfile",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -2558,7 +2558,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-rustls-acme",
  "tokio-util",
  "toml 0.8.10",
@@ -2583,7 +2583,7 @@ dependencies = [
  "iroh-net",
  "quinn",
  "rcgen 0.11.3",
- "rustls",
+ "rustls 0.23.2",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3841,7 +3841,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -3857,7 +3857,7 @@ dependencies = [
  "rand",
  "ring 0.16.20",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.10",
  "rustls-native-certs",
  "slab",
  "thiserror",
@@ -4144,7 +4144,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.10",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -4152,7 +4152,7 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4314,8 +4314,36 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbdb5ddfafe3040e01fe9dced711e27b5336ac97d4a9b2089f0066a04b5846"
+dependencies = [
+ "once_cell",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4340,12 +4368,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -5214,7 +5259,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.2",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -5233,12 +5289,12 @@ dependencies = [
  "rcgen 0.11.3",
  "reqwest",
  "ring 0.16.20",
- "rustls",
+ "rustls 0.21.10",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "url",
  "webpki-roots",
  "x509-parser",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -49,7 +49,8 @@ rand_core = "0.6.4"
 rcgen = "0.11"
 reqwest = { version = "0.11.19", default-features = false, features = ["rustls-tls"] }
 ring = "0.17"
-rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
+# std -> rustls::KeyLogfile req
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_bytes = "0.11.12"
 serdect = "0.2.0"
@@ -61,7 +62,7 @@ surge-ping = "0.8.0"
 thiserror = "1"
 time = "0.3.20"
 tokio = { version = "1", features = ["io-util", "macros", "sync", "rt", "net", "fs", "io-std", "signal", "process"] }
-tokio-rustls = { version = "0.24" }
+tokio-rustls = { version = "0.25" }
 tokio-rustls-acme = { version = "0.2" }
 tokio-util = { version = "0.7", features = ["io-util", "io", "codec"] }
 tracing = "0.1"

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -12,7 +12,7 @@ hdrhistogram = { version = "7.2", default-features = false }
 iroh-net = { path = ".." }
 quinn = "0.10"
 rcgen = "0.11.1"
-rustls = { version = "0.21.0", default-features = false, features = ["quic"] }
+rustls = { version = "0.23.0", default-features = false }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1"

--- a/iroh-net/src/derp/http/client.rs
+++ b/iroh-net/src/derp/http/client.rs
@@ -269,7 +269,7 @@ impl ClientBuilder {
         // TODO: review TLS config
         let mut roots = rustls::RootCertStore::empty();
         roots.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
-            rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
+            rustls::pki_types::TrustAnchor::from_subject_spki_name_constraints(
                 ta.subject,
                 ta.spki,
                 ta.name_constraints,
@@ -720,10 +720,10 @@ impl Actor {
         self.conn_gen
     }
 
-    fn tls_servername(&self) -> Option<rustls::ServerName> {
+    fn tls_servername(&self) -> Option<rustls::pki_types::ServerName> {
         self.url
             .host_str()
-            .and_then(|s| rustls::ServerName::try_from(s).ok())
+            .and_then(|s| rustls::pki_types::ServerName::try_from(s).ok())
     }
 
     fn url_port(&self) -> Option<u16> {
@@ -893,7 +893,7 @@ impl rustls::client::ServerCertVerifier for NoCertVerifier {
         &self,
         _end_entity: &rustls::Certificate,
         _intermediates: &[rustls::Certificate],
-        _server_name: &rustls::ServerName,
+        _server_name: &rustls::pki_types::ServerName,
         _scts: &mut dyn Iterator<Item = &[u8]>,
         _ocsp_response: &[u8],
         _now: std::time::SystemTime,

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -553,7 +553,7 @@ pub fn get_remote_node_id(connection: &quinn::Connection) -> Result<PublicKey> {
     let data = connection.peer_identity();
     match data {
         None => bail!("no peer certificate found"),
-        Some(data) => match data.downcast::<Vec<rustls::Certificate>>() {
+        Some(data) => match data.downcast::<Vec<rustls::pki_types::CertificateDer>>() {
             Ok(certs) => {
                 if certs.len() != 1 {
                     bail!(

--- a/iroh-net/src/tls/certificate.rs
+++ b/iroh-net/src/tls/certificate.rs
@@ -38,14 +38,14 @@ struct SignedKey<'a> {
 /// certificate extension containing the public key of the given secret key.
 pub fn generate(
     identity_secret_key: &SecretKey,
-) -> Result<(rustls::Certificate, rustls::PrivateKey), GenError> {
+) -> Result<(rustls::pki_types::CertificateDer, rustls::pki_types::PrivateKeyDer), GenError> {
     // SecretKey used to sign the certificate.
     // SHOULD NOT be related to the host's key.
     // Endpoints MAY generate a new key and certificate
     // for every connection attempt, or they MAY reuse the same key
     // and certificate for multiple connections.
     let certificate_keypair = rcgen::KeyPair::generate(P2P_SIGNATURE_ALGORITHM)?;
-    let rustls_key = rustls::PrivateKey(certificate_keypair.serialize_der());
+    let rustls_key = rustls::pki_types::PrivateKeyDer(certificate_keypair.serialize_der());
 
     let certificate = {
         let mut params = rcgen::CertificateParams::new(vec![]);
@@ -59,7 +59,7 @@ pub fn generate(
         rcgen::Certificate::from_params(params)?
     };
 
-    let rustls_certificate = rustls::Certificate(certificate.serialize_der()?);
+    let rustls_certificate = rustls::pki_types::CertificateDer(certificate.serialize_der()?);
 
     Ok((rustls_certificate, rustls_key))
 }
@@ -68,7 +68,7 @@ pub fn generate(
 ///
 /// For this to succeed, the certificate must contain the specified extension and the signature must
 /// match the embedded public key.
-pub fn parse(certificate: &rustls::Certificate) -> Result<P2pCertificate<'_>, ParseError> {
+pub fn parse(certificate: &rustls::pki_types::CertificateDer) -> Result<P2pCertificate<'_>, ParseError> {
     let certificate = parse_unverified(certificate.as_ref())?;
 
     certificate.verify()?;


### PR DESCRIPTION
## Description

WIP - Bump to rustls 0.23 - see how far it goes with just switching things over

## Notes & open questions

There are several rustls dependant thave have not bumped so this leads to complications e.g. quinn, tokio-rustls and hyper-rustls both still stuck at 0.21 / 0.22

$ cargo tree -i rustls
```
error: There are multiple `rustls` packages in your project, and the specification `rustls` is ambiguous.
Please re-run this command with one of the following specifications:
  rustls@0.21.10
  rustls@0.22.2
  rustls@0.23.2
[foobar@localhost iroh-net]$ cargo tree -i rustls@0.21.10
rustls v0.21.10
├── hyper-rustls v0.24.2
│   └── reqwest v0.11.24
│       ├── iroh-metrics v0.12.0 (/home/foobar/iroh/iroh-metrics)
│       │   └── iroh-net v0.12.0 (/home/foobar/iroh/iroh-net)
│       ├── iroh-net v0.12.0 (/home/foobar/iroh/iroh-net)
│       └── tokio-rustls-acme v0.2.0
│           └── iroh-net v0.12.0 (/home/foobar/iroh/iroh-net)
├── quinn v0.10.2
│   └── iroh-net v0.12.0 (/home/foobar/iroh/iroh-net)
├── quinn-proto v0.10.6
│   ├── iroh-net v0.12.0 (/home/foobar/iroh/iroh-net)
│   └── quinn v0.10.2 (*)
├── reqwest v0.11.24 (*)
├── tokio-rustls v0.24.1
│   ├── hyper-rustls v0.24.2 (*)
│   ├── reqwest v0.11.24 (*)
│   └── tokio-rustls-acme v0.2.0 (*)
└── tokio-rustls-acme v0.2.0 (*)
```

I wanted to see how much switcheroo needs to happen w/ types - just dumping this WIP here sorry :see_no_evil: 

0.23 brings custom CryptoProvider - e.g. [rustcrypto-rustls](https://github.com/RustCrypto/rustls-rustcrypto/) - and by default rustls has switched to aws-lc-rs over ring

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
