### PR TITLE
chore(iroh-bytes): use latest bao tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,12 +320,13 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c194b6b40b5abe645e9fc54a62b8247dbd86815443c0d0e10a89faa1218c10"
+checksum = "a82f048f1b3b5ce0c7900e59aaeee3041dab048c80e5ee17ddf2823013b155c6"
 dependencies = [
  "bytes",
  "futures",
+ "genawaiter",
  "iroh-blake3",
  "iroh-io",
  "positioned-io",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = { version = "0.10", features = ["tokio_fsm"], default-features = false, optional = true }
+bao-tree = {  version = "0.10.2", features = ["tokio_fsm"], default-features = false, optional = true }
 data-encoding = { version = "2.3.3", optional = true }
 hex = "0.4.3"
 multibase = { version = "0.9.1", optional = true }

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = { version = "0.10", features = ["tokio_fsm"], default-features = false }
+bao-tree = {  version = "0.10.2", features = ["tokio_fsm"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"
 data-encoding = "2.3.3"

--- a/iroh-bytes/src/store/bao_file.rs
+++ b/iroh-bytes/src/store/bao_file.rs
@@ -183,12 +183,6 @@ impl SizeInfo {
 
     /// Persist into a file where each chunk has its own slot.
     fn persist(&self, mut target: impl WriteAt) -> io::Result<()> {
-        if self.offset & ((IROH_BLOCK_SIZE.bytes() as u64) - 1) != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "offset not aligned",
-            ));
-        }
         let size_offset = (self.offset >> IROH_BLOCK_SIZE.0) << 3;
         target.write_all_at(size_offset, self.size.to_le_bytes().as_slice())?;
         Ok(())

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.81"
-bao-tree = "0.10.1"
+bao-tree = { version = "0.10.2" }
 bytes = "1.5.0"
 clap = { version = "4", features = ["derive"] }
 colored = { version = "2.0.4" }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = { version = "0.10", features = ["tokio_fsm"], default-features = false }
+bao-tree = { version = "0.10.2", features = ["tokio_fsm"], default-features = false }
 bytes = "1"
 data-encoding = "2.4.0"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into", "from_str"] }


### PR DESCRIPTION
## Description

Use the latest version of bao-tree that has some bugfixes and a new validate fn.

## Notes & open questions

Due to the bugfix this means that it is no longer compatible with the previous version of iroh-bytes in some rare circumstances involving resume.

We would therefore have to increase the iroh-bytes APLN before the next release.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
