### PR TITLE
refactor(iroh-bytes): Add the ability to box progress senders so we have a concrete type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3715,7 +3715,7 @@ dependencies = [
  "quote",
  "syn 2.0.52",
  "version_check",
- "yansi 1.0.0",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -6124,9 +6124,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yansi"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2861d76f58ec8fc95708b9b1e417f7b12fd72ad33c01fa6886707092dea0d3"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/iroh-bytes/src/util/progress.rs
+++ b/iroh-bytes/src/util/progress.rs
@@ -1,11 +1,11 @@
 //! Utilities for reporting progress.
 //!
 //! The main entry point is the [ProgressSender] trait.
+use std::{io, marker::PhantomData, ops::Deref, sync::Arc};
+
 use bytes::Bytes;
-use derive_more::Deref;
 use futures::{future::BoxFuture, Future, FutureExt};
 use iroh_io::AsyncSliceWriter;
-use std::{io, marker::PhantomData, sync::Arc};
 
 /// A general purpose progress sender. This should be usable for reporting progress
 /// from both blocking and non-blocking contexts.


### PR DESCRIPTION
## Description

refactor(iroh-bytes): Add the ability to box progress senders so we have a concrete type.

This is necessary to send progress senders via actor messages, but we also probably don't want to use a concrete progress sender type in the actor messges.

Quite a bit of plumbing, but the only public API changes are a new fn boxed() on ProgressSender that returns a concrete type `BoxedProgressSender<M>`.

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
