### PR TITLE
refactor(iroh-bytes): add ability to operate without a temp dir

### DIFF
--- a/iroh-bytes/src/store/fs/test_support.rs
+++ b/iroh-bytes/src/store/fs/test_support.rs
@@ -368,7 +368,7 @@ pub fn make_partial(
         .build()?
         .block_on(async move {
             let blobs_path = path.join("blobs");
-            let store = Store::load(blobs_path).await?;
+            let store = Store::persistent(blobs_path).await?;
             store
                 .transform_entries(|hash, entry| match &entry {
                     EntryData::Complete { data, outboard } => match f(hash, data.len() as u64) {

--- a/iroh-bytes/src/store/fs/tests.rs
+++ b/iroh-bytes/src/store/fs/tests.rs
@@ -54,7 +54,7 @@ async fn create_test_db() -> (tempfile::TempDir, Store) {
         batch: Default::default(),
         inline: Default::default(),
     };
-    let db = Store::new(db_path, options).await.unwrap();
+    let db = Store::new(MemOrFile::File(db_path), options).await.unwrap();
     (testdir, db)
 }
 
@@ -807,7 +807,7 @@ async fn actor_store_smoke() {
         batch: Default::default(),
         inline: Default::default(),
     };
-    let db = Store::new(db_path, options).await.unwrap();
+    let db = Store::new(MemOrFile::File(db_path), options).await.unwrap();
     db.dump().await.unwrap();
     let data = random_test_data(1024 * 1024);
     #[allow(clippy::single_range_in_vec_init)]

--- a/iroh-bytes/src/store/fs/tests.rs
+++ b/iroh-bytes/src/store/fs/tests.rs
@@ -537,7 +537,7 @@ async fn import_file_tempdir_is_file() {
     let (tempdir, db) = create_test_db().await;
     // temp dir is readonly, this is a bit mean since we mess with the internals of the store
     {
-        let temp_dir = db.0.temp_file_name().parent().unwrap().to_owned();
+        let temp_dir = db.0.path_options.temp_path.as_ref().unwrap().to_owned();
         std::fs::remove_dir_all(&temp_dir).unwrap();
         std::fs::write(temp_dir, []).unwrap();
         // std::fs::set_permissions(temp_dir, std::os::unix::fs::PermissionsExt::from_mode(0o0))

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -974,7 +974,7 @@ pub async fn run(command: Commands, config: &NodeConfig) -> anyhow::Result<()> {
         }
         Commands::TicketInspect { ticket } => inspect_ticket(&ticket),
         Commands::ValidateBlobStore { path, repair } => {
-            let blob_store = iroh::bytes::store::fs::Store::load(path).await?;
+            let blob_store = iroh::bytes::store::fs::Store::persistent(path).await?;
             let (send, mut recv) = sync::mpsc::channel(1);
             let task = tokio::spawn(async move {
                 while let Some(msg) = recv.recv().await {

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -439,14 +439,14 @@ async fn cli_provide_persistence() -> anyhow::Result<()> {
     provide(&foo_path)?;
     // should have some data now
     let db_path = IrohPaths::BaoStoreDir.with_root(&iroh_data_dir);
-    let db = iroh::bytes::store::fs::Store::load(&db_path).await?;
+    let db = iroh::bytes::store::fs::Store::persistent(&db_path).await?;
     let blobs: Vec<std::io::Result<Hash>> = db.blobs().await.unwrap().collect::<Vec<_>>();
     drop(db);
     assert_eq!(blobs.len(), 3);
 
     provide(&bar_path)?;
     // should have more data now
-    let db = iroh::bytes::store::fs::Store::load(&db_path).await?;
+    let db = iroh::bytes::store::fs::Store::persistent(&db_path).await?;
     let blobs = db.blobs().await.unwrap().collect::<Vec<_>>();
     drop(db);
     assert_eq!(blobs.len(), 6);

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -141,7 +141,7 @@ where
         let blob_dir = IrohPaths::BaoStoreDir.with_root(root);
 
         tokio::fs::create_dir_all(&blob_dir).await?;
-        let blobs_store = iroh_bytes::store::fs::Store::load(&blob_dir)
+        let blobs_store = iroh_bytes::store::fs::Store::persistent(&blob_dir)
             .await
             .with_context(|| format!("Failed to load iroh database from {}", blob_dir.display()))?;
         let docs_store = iroh_sync::store::fs::Store::new(IrohPaths::DocsDatabase.with_root(root))?;


### PR DESCRIPTION
## Description

refactor(iroh-bytes): add ability to operate without a temp dir

This enables using the redb store in a mode where it does not use the file system at all except for imports and exports. The downside is that this is not very efficient for large blobs, and that there is an upper limit on the size of blobs in redb.

So sadly this can't be used as a replacement for the mem store. I think it is still useful to have the ability to have an in-mem store though.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
