### PR TITLE
refactor(iroh-net): allow to set a custom DNS resolver on the magic endpoint

### DIFF
--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -21,6 +21,7 @@ use iroh::{
     bytes::store::ReadableStore,
     net::{
         defaults::DEFAULT_RELAY_STUN_PORT,
+        dns::default_resolver,
         key::{PublicKey, SecretKey},
         magic_endpoint,
         magicsock::EndpointInfo,
@@ -275,7 +276,8 @@ async fn report(
     config: &NodeConfig,
 ) -> anyhow::Result<()> {
     let port_mapper = portmapper::Client::default();
-    let mut client = netcheck::Client::new(Some(port_mapper))?;
+    let dns_resolver = default_resolver().clone();
+    let mut client = netcheck::Client::new(Some(port_mapper), dns_resolver)?;
 
     let dm = match stun_host {
         Some(host_name) => {
@@ -761,10 +763,12 @@ async fn relay_urls(count: usize, config: NodeConfig) -> anyhow::Result<()> {
         println!("No relay nodes specified in the config file.");
     }
 
+    let dns_resolver = default_resolver();
     let mut clients = HashMap::new();
     for node in &config.relay_nodes {
         let secret_key = key.clone();
-        let client = iroh::net::relay::http::ClientBuilder::new(node.url.clone()).build(secret_key);
+        let client = iroh::net::relay::http::ClientBuilder::new(node.url.clone())
+            .build(secret_key, dns_resolver.clone());
 
         clients.insert(node.url.clone(), client);
     }

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -15,7 +15,7 @@ pub mod defaults;
 pub mod dialer;
 mod disco;
 pub mod discovery;
-mod dns;
+pub mod dns;
 pub mod magic_endpoint;
 pub mod magicsock;
 pub mod metrics;

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -55,7 +55,7 @@ use crate::{
     config,
     disco::{self, SendAddr},
     discovery::Discovery,
-    dns::DNS_RESOLVER,
+    dns::DnsResolver,
     key::{PublicKey, SecretKey, SharedSecret},
     magic_endpoint::NodeAddr,
     net::{interfaces, ip::LocalAddresses, netmon, IpFamily},
@@ -113,6 +113,12 @@ pub struct Options {
 
     /// Optional node discovery mechanism.
     pub discovery: Option<Box<dyn Discovery>>,
+
+    /// A DNS resolver to use for resolving relay URLs.
+    ///
+    /// You can use [`crate::dns::default_resolver`] for a resolver that uses the system's DNS
+    /// configuration.
+    pub dns_resolver: DnsResolver,
 }
 
 impl Default for Options {
@@ -123,6 +129,7 @@ impl Default for Options {
             relay_map: RelayMap::empty(),
             nodes_path: None,
             discovery: None,
+            dns_resolver: crate::dns::default_resolver().clone(),
         }
     }
 }
@@ -160,6 +167,9 @@ struct Inner {
     /// Stores wakers, to be called when relay_recv_ch receives new data.
     network_recv_wakers: parking_lot::Mutex<Option<Waker>>,
     network_send_wakers: parking_lot::Mutex<Option<Waker>>,
+
+    /// The DNS resolver to be used in this magicsock.
+    dns_resolver: DnsResolver,
 
     /// Key for this node.
     secret_key: SecretKey,
@@ -1135,6 +1145,7 @@ impl MagicSock {
             relay_map,
             discovery,
             nodes_path,
+            dns_resolver,
         } = opts;
 
         let nodes_path = match nodes_path {
@@ -1164,7 +1175,7 @@ impl MagicSock {
         let ipv4_addr = pconn4.local_addr()?;
         let ipv6_addr = pconn6.as_ref().and_then(|c| c.local_addr().ok());
 
-        let net_checker = netcheck::Client::new(Some(port_mapper.clone()))?;
+        let net_checker = netcheck::Client::new(Some(port_mapper.clone()), dns_resolver.clone())?;
 
         let (actor_sender, actor_receiver) = mpsc::channel(256);
         let (relay_actor_sender, relay_actor_receiver) = mpsc::channel(256);
@@ -1214,6 +1225,7 @@ impl MagicSock {
             endpoints: Watchable::new(Default::default()),
             pending_call_me_maybes: Default::default(),
             endpoints_update_state: EndpointUpdateState::new(),
+            dns_resolver,
         });
 
         let mut actor_tasks = JoinSet::default();
@@ -1696,7 +1708,7 @@ impl Actor {
         debug!("link change detected: major? {}", is_major);
 
         if is_major {
-            DNS_RESOLVER.clear_cache();
+            self.inner.dns_resolver.clear_cache();
             self.inner.re_stun("link-change-major");
             self.close_stale_relay_connections().await;
             self.reset_endpoint_states();

--- a/iroh-net/src/magicsock/relay_actor.rs
+++ b/iroh-net/src/magicsock/relay_actor.rs
@@ -487,7 +487,7 @@ impl RelayActor {
             })
             .can_ack_pings(true)
             .is_preferred(my_relay.as_ref() == Some(&url1))
-            .build(self.conn.secret_key.clone());
+            .build(self.conn.secret_key.clone(), self.conn.dns_resolver.clone());
 
         let (s, r) = mpsc::channel(64);
 

--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -129,7 +129,8 @@ mod tests {
         Client,
     ) {
         let client = ClientBuilder::new(server_url);
-        let (client, mut client_reader) = client.build(key.clone());
+        let dns_resolver = crate::dns::default_resolver();
+        let (client, mut client_reader) = client.build(key.clone(), dns_resolver.clone());
         let public_key = key.public();
         let (received_msg_s, received_msg_r) = tokio::sync::mpsc::channel(10);
         let client_reader_task = tokio::spawn(


### PR DESCRIPTION
## Description

This makes the DNS resolver to be used in the context of a MagicEndpoint configurable. Up to now, we used a single, global, unconfigurable DNS resolver, stored in a per-process global static. This PR changes this so that we can set a DNS resolver in the builder of the MagicEndpoint. This resolver is passed through to all places where we need a DNS resolver - which is all places where we need to resolve relay URLs.

The default is unchanged: A single, shared DNS resolver is used for all endpoints. However, this default can now be changed per-endpoint. The global resolver is only used as a default in the endpoint builder if no custom resolver is set, and in the doctor, and in tests.

This change will make testing things that use DNS - prominently: #2045 - much easier. And we now have the means in place for people to customize the DNS resolving, if needed.

## Notes & open questions

This makes the `hickory_resolver::TokioAsyncResolver` part of the public API surface of `iroh-net`.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
