### PR TITLE
chore(iroh-bytes): update bao-tree dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ce734d9351fb4177b0cab2f954d32fea2a1090fcce4afe26c33a18d18bd1b0"
+checksum = "bdae307defb220bd2698a42495e226ff89e3173f024abfc2182129603e74b5c7"
 dependencies = [
  "bytes",
  "futures",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = {  version = "0.11", features = ["tokio_fsm", "validate"], default-features = false, optional = true }
+bao-tree = {  version = "0.11.1", features = ["tokio_fsm", "validate"], default-features = false, optional = true }
 data-encoding = { version = "2.3.3", optional = true }
 hex = "0.4.3"
 multibase = { version = "0.9.1", optional = true }

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = {  version = "0.11", features = ["tokio_fsm"], default-features = false }
+bao-tree = {  version = "0.11.1", features = ["tokio_fsm"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"
 data-encoding = "2.3.3"

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.81"
-bao-tree = { version = "0.11" }
+bao-tree = { version = "0.11.1" }
 bytes = "1.5.0"
 clap = { version = "4", features = ["derive"] }
 colored = { version = "2.0.4" }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = { version = "0.11", features = ["tokio_fsm"], default-features = false }
+bao-tree = { version = "0.11.1", features = ["tokio_fsm"], default-features = false }
 bytes = "1"
 data-encoding = "2.4.0"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into", "from_str"] }


### PR DESCRIPTION
## Description

chore(iroh-bytes): update bao-tree dependency

to fix a bug with validation when the last chunk group is a leaf for the tree. The bugfix was supposed to be in 0.11.0, but I screwed up publishing.

Some indication that this fixes the problem:

main:
```
❯ cargo run -p iroh-cli doctor blob-validate $APP_HOME/iroh/blobs | grep expected
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/iroh doctor blob-validate '/Users/rklaehn/Library/Application Support//iroh/blobs'`
EntryDone { id: 32, error: Some("expected chunk ranges RangeSet{0..1387}, got chunk ranges RangeSet{0..1376}") }
EntryDone { id: 9, error: Some("expected chunk ranges RangeSet{0..18856}, got chunk ranges RangeSet{0..18848}") }
```

this branch:
```
❯ cargo run -p iroh-cli doctor blob-validate $APP_HOME/iroh/blobs | grep expected
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/iroh doctor blob-validate '/Users/rklaehn/Library/Application Support//iroh/blobs'`
```

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
