### PR TITLE
fix: comment about grease_quic_bit

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -538,7 +538,8 @@ impl Inner {
                 } else {
                     // overwrite the first byte of the packets with zero.
                     // this makes quinn reliably and quickly ignore the packet as long as
-                    // [`quinn::EndpointConfig::grease_quic_bit`] is set to `true`.
+                    // [`quinn::EndpointConfig::grease_quic_bit`] is set to `false`
+                    // (which we always do in MagicEndpoint::bind).
                     buf[start] = 0u8;
                 }
                 start = end;


### PR DESCRIPTION
## Description

The comment about `grease_quic_bit` was the wrong way round, this fixes it.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
