### PR TITLE
chore(iroh-bytes): Increase iroh-bytes ALPN

### DIFF
--- a/iroh-bytes/src/protocol.rs
+++ b/iroh-bytes/src/protocol.rs
@@ -351,7 +351,7 @@ use crate::Hash;
 pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 100;
 
 /// The ALPN used with quic for the iroh bytes protocol.
-pub const ALPN: &[u8] = b"/iroh-bytes/3";
+pub const ALPN: &[u8] = b"/iroh-bytes/4";
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, From)]
 /// A request to the provider


### PR DESCRIPTION
## Description

chore(iroh-bytes): Increase iroh-bytes ALPN

this is because there was a bao-tree bug with range requests that resulted in less than optimal encoding for small ranges.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
