### PR TITLE
refactor: improve content downloading in docs

### DIFF
--- a/iroh/src/sync_engine.rs
+++ b/iroh/src/sync_engine.rs
@@ -78,7 +78,7 @@ impl SyncEngine {
             endpoint.clone(),
             gossip.clone(),
             bao_store,
-            downloader.clone(),
+            downloader,
             to_live_actor_recv,
             live_actor_tx.clone(),
             to_gossip_actor,
@@ -87,7 +87,6 @@ impl SyncEngine {
             to_gossip_actor_recv,
             sync.clone(),
             gossip,
-            downloader,
             live_actor_tx.clone(),
         );
         let live_actor_task = tokio::task::spawn(

--- a/iroh/src/sync_engine/gossip.rs
+++ b/iroh/src/sync_engine/gossip.rs
@@ -15,7 +15,6 @@ use tokio::{
 use tracing::{debug, error, trace};
 
 use super::live::{Op, ToLiveActor};
-use iroh_bytes::downloader::Downloader;
 
 #[derive(strum::Display, Debug)]
 pub enum ToGossipActor {
@@ -35,7 +34,6 @@ pub struct GossipActor {
     inbox: mpsc::Receiver<ToGossipActor>,
     sync: SyncHandle,
     gossip: Gossip,
-    downloader: Downloader,
     to_sync_actor: mpsc::Sender<ToLiveActor>,
     joined: HashSet<NamespaceId>,
     want_join: HashSet<NamespaceId>,
@@ -47,14 +45,12 @@ impl GossipActor {
         inbox: mpsc::Receiver<ToGossipActor>,
         sync: SyncHandle,
         gossip: Gossip,
-        downloader: Downloader,
         to_sync_actor: mpsc::Sender<ToLiveActor>,
     ) -> Self {
         Self {
             inbox,
             sync,
             gossip,
-            downloader,
             to_sync_actor,
             joined: Default::default(),
             want_join: Default::default(),
@@ -176,11 +172,13 @@ impl GossipActor {
                             .await?;
                     }
                     Op::ContentReady(hash) => {
-                        // Inform the downloader that we now know that this peer has the content
-                        // for this hash.
-                        self.downloader
-                            .nodes_have(hash, vec![msg.delivered_from])
-                            .await;
+                        self.to_sync_actor
+                            .send(ToLiveActor::NeighborContentReady {
+                                namespace,
+                                node: msg.delivered_from,
+                                hash,
+                            })
+                            .await?;
                     }
                     Op::SyncReport(report) => {
                         self.to_sync_actor


### PR DESCRIPTION
## Description

based on #2085 

* do not start downloads without any known node
* track missing content hashes in the live sync session
* start downloads after content propagation properly
* reenable the sync_big test, let's see what CI says this time (was flakey before)

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
