### PR TITLE
feat: set more than one node on download requests

### DIFF
--- a/iroh-cli/src/commands/blob.rs
+++ b/iroh-cli/src/commands/blob.rs
@@ -263,7 +263,7 @@ impl BlobCommands {
                     .download(BlobDownloadRequest {
                         hash,
                         format,
-                        peer: node_addr,
+                        nodes: vec![node_addr],
                         tag,
                         mode,
                     })

--- a/iroh/examples/collection-fetch.rs
+++ b/iroh/examples/collection-fetch.rs
@@ -60,12 +60,12 @@ async fn main() -> Result<()> {
         // When interacting with the iroh API, you will most likely be using blobs and collections.
         format: ticket.format(),
 
-        // The `peer` field is a `NodeAddr`, which combines all of the known address information we have for the remote node.
+        // The `nodes` field is a list of `NodeAddr`, where each combines all of the known address information we have for the remote node.
         // This includes the `node_id` (or `PublicKey` of the node), any direct UDP addresses we know about for that node, as well as the relay url of that node. The relay url is the url of the relay server that that node is connected to.
         // If the direct UDP addresses to that node do not work, than we can use the relay node to attempt to holepunch between your current node and the remote node.
         // If holepunching fails, iroh will use the relay node to proxy a connection to the remote node over HTTPS.
         // Thankfully, the ticket contains all of this information
-        peer: ticket.node_addr().clone(),
+        nodes: vec![ticket.node_addr().clone()],
 
         // You can create a special tag name (`SetTagOption::Named`), or create an automatic tag that is derived from the timestamp.
         tag: iroh::rpc_protocol::SetTagOption::Auto,

--- a/iroh/examples/hello-world-fetch.rs
+++ b/iroh/examples/hello-world-fetch.rs
@@ -60,12 +60,12 @@ async fn main() -> Result<()> {
         // When interacting with the iroh API, you will most likely be using blobs and collections.
         format: ticket.format(),
 
-        // The `peer` field is a `NodeAddr`, which combines all of the known address information we have for the remote node.
+        // The `nodes` field is a list of `NodeAddr`, where each combines all of the known address information we have for the remote node.
         // This includes the `node_id` (or `PublicKey` of the node), any direct UDP addresses we know about for that node, as well as the relay url of that node. The relay url is the url of the relay server that that node is connected to.
         // If the direct UDP addresses to that node do not work, than we can use the relay node to attempt to holepunch between your current node and the remote node.
         // If holepunching fails, iroh will use the relay node to proxy a connection to the remote node over HTTPS.
         // Thankfully, the ticket contains all of this information
-        peer: ticket.node_addr().clone(),
+        nodes: vec![ticket.node_addr().clone()],
 
         // You can create a special tag name (`SetTagOption::Named`), or create an automatic tag that is derived from the timestamp.
         tag: iroh::rpc_protocol::SetTagOption::Auto,

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -96,8 +96,13 @@ pub struct BlobDownloadRequest {
     /// If the format is [`BlobFormat::HashSeq`], all children are downloaded and shared as
     /// well.
     pub format: BlobFormat,
-    /// This mandatory field specifies the peer to download the data from.
-    pub peer: NodeAddr,
+    /// This mandatory field specifies the nodes to download the data from.
+    ///
+    /// If set to more than a single node, they will all be tried. If `mode` is set to
+    /// [`DownloadMode::Direct`], they will be tried sequentially until a download succeeds.
+    /// If `mode` is set to [`DownloadMode::Queued`], the nodes may be dialed in parallel,
+    /// if the concurrency limits permit.
+    pub nodes: Vec<NodeAddr>,
     /// Optional tag to tag the data with.
     pub tag: SetTagOption,
     /// Whether to directly start the download or add it to the downlod queue.
@@ -107,10 +112,14 @@ pub struct BlobDownloadRequest {
 /// Set the mode for whether to directly start the download or add it to the download queue.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DownloadMode {
-    /// Start the download right away. This also bypasses the downloader concurrency limits.
+    /// Start the download right away.
+    ///
+    /// No concurrency limits or queuing will be applied. It is up to the user to manage download
+    /// concurrency.
     Direct,
-    /// Queue the download. The download queue will be processed in-order, respecting the
-    /// downloader concurrency limit.
+    /// Queue the download.
+    ///
+    /// The download queue will be processed in-order, while respecting the downloader concurrency limits.
     Queued,
 }
 


### PR DESCRIPTION
## Description

Based on #2085 

The downloader already has the feature to try multiple nodes for a single hash or hashseq. With #2085 we expose the downloader over the RPC protocol, by adding a `DownloadMode { Queued, Direct }` enum to the `BlobDownloadRequest`. 
This PR modifies the `BlobDownloadRequest` to include a list of provider nodes for a hash instead of just a single node. For queued requests that go to the downloader, the nodes are just passed to the downloader. For direct requests, the nodes are tried in-order, until one succeeds.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
