### PR TITLE
refactor(metrics): metrics on by default

### DIFF
--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -40,6 +40,10 @@ pub(crate) struct Cli {
     #[cfg(unix)]
     #[clap(long)]
     pub(crate) log_fd: Option<i32>,
+
+    /// Port to serve metrics on. -1 to disable.
+    #[clap(long)]
+    pub(crate) metrics_port: Option<i16>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -127,7 +131,14 @@ impl Cli {
                         path.display()
                     );
                 }
-                let config = NodeConfig::from_env(self.config.as_deref())?;
+                let mut config = NodeConfig::from_env(self.config.as_deref())?;
+                if let Some(metrics_port) = self.metrics_port {
+                    if metrics_port < 0 {
+                        config.metrics_addr = None;
+                    } else {
+                        config.metrics_addr = Some(([127, 0, 0, 1], metrics_port as u16).into())
+                    }
+                }
 
                 let add_command = add.map(|source| blob::BlobCommands::Add {
                     source,

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -99,7 +99,7 @@ impl Default for NodeConfig {
             // TODO(ramfox): this should probably just be a relay map
             relay_nodes: [default_na_relay_node(), default_eu_relay_node()].into(),
             gc_policy: GcPolicy::Disabled,
-            metrics_addr: None,
+            metrics_addr: Some(([127, 0, 0, 1], 9090).into()),
         }
     }
 }


### PR DESCRIPTION
## Description

Now metrics default to serving on `localhost:9090` but you can override with a custom port or turn off if you like with `--metrics-port`. If you want to actually expose the metrics endpoint to the world, it's assumed you will set up a config file with a custom `metrics_addr`.

I guess the config override could have been done in a bit more elegant way but didn't want to commit refactoring the `NodeConfig` nor did I want fancy extra task specific fn's.

The configuration is limited to the iroh node start path, the rest are ignored as they are expected to be short lived processes.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
