### PR TITLE
deps(iroh-next): move from igd to igd-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,14 +231,13 @@ dependencies = [
 
 [[package]]
 name = "attohttpc"
-version = "0.16.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
+checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
 dependencies = [
  "http 0.2.12",
  "log",
  "url",
- "wildmatch",
 ]
 
 [[package]]
@@ -2181,11 +2180,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "igd"
-version = "0.12.1"
+name = "igd-next"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556b5a75cd4adb7c4ea21c64af1c48cefb2ce7d43dc4352c720a1fe47c21f355"
+checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
 dependencies = [
+ "async-trait",
  "attohttpc",
  "bytes",
  "futures",
@@ -2564,7 +2564,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.2.0",
  "hyper-util",
- "igd",
+ "igd-next",
  "iroh-base",
  "iroh-metrics",
  "iroh-test",
@@ -5804,12 +5804,6 @@ name = "widestring"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
-
-[[package]]
-name = "wildmatch"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f44b95f62d34113cf558c93511ac93027e03e9c29a60dd0fd70e6e025c7270a"
 
 [[package]]
 name = "winapi"

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -34,7 +34,7 @@ http = "1"
 http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
-igd = { version = "0.12.1", features = ["aio"] }
+igd-next = { version = "0.14.3", features = ["aio_tokio"] }
 iroh-base = { version = "0.13.0", path = "../iroh-base", features = ["key"] }
 libc = "0.2.139"
 num_enum = "0.7"

--- a/iroh-net/src/portmapper.rs
+++ b/iroh-net/src/portmapper.rs
@@ -210,7 +210,7 @@ impl Client {
 struct Probe {
     /// When was the probe last updated.
     last_probe: Instant,
-    /// The last [`igd::aio::Gateway`] and when was it last seen.
+    /// The last [`upnp::Gateway`] and when was it last seen.
     last_upnp_gateway_addr: Option<(upnp::Gateway, Instant)>,
     /// Last time PCP was seen.
     last_pcp: Option<Instant>,

--- a/iroh-net/src/portmapper/mapping.rs
+++ b/iroh-net/src/portmapper/mapping.rs
@@ -57,7 +57,7 @@ impl Mapping {
     pub(crate) async fn new_upnp(
         local_ip: Ipv4Addr,
         local_port: NonZeroU16,
-        gateway: Option<igd::aio::Gateway>,
+        gateway: Option<upnp::Gateway>,
         external_port: Option<NonZeroU16>,
     ) -> Result<Self> {
         upnp::Mapping::new(local_ip, local_port, gateway, external_port)


### PR DESCRIPTION
## Description

[`igd`](https://github.com/sbstp/rust-igd) has been archived, [`igd-next`](https://docs.rs/igd-next) it's a replacement. This still does not use hyper 1 but will (hopefully) be [upgraded](https://github.com/dariusc93/rust-igd/issues/4) soon™️

## Notes & open questions

n/a 

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
