### PR TITLE
chore: move metrics init into CLI

### DIFF
--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -65,3 +65,7 @@ nix = { version = "0.27", features = ["signal", "process"] }
 regex = "1.10.3"
 testdir = "0.9.1"
 walkdir = "2"
+
+[features]
+default = ["metrics"]
+metrics = []

--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -89,7 +89,6 @@ pub(crate) enum Commands {
 
 impl Cli {
     pub(crate) async fn run(self, data_dir: &Path) -> Result<()> {
-
         // Initialize the metrics collection.
         //
         // The metrics are global per process. Subsequent calls do not change the metrics

--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -89,6 +89,16 @@ pub(crate) enum Commands {
 
 impl Cli {
     pub(crate) async fn run(self, data_dir: &Path) -> Result<()> {
+
+        // Initialize the metrics collection.
+        //
+        // The metrics are global per process. Subsequent calls do not change the metrics
+        // collection and will return an error. We ignore this error. This means that if you'd
+        // spawn multiple Iroh nodes in the same process, the metrics would be shared between the
+        // nodes.
+        #[cfg(feature = "metrics")]
+        iroh::metrics::try_init_metrics_collection().ok();
+
         match self.command {
             Commands::Console => {
                 let env = ConsoleEnv::for_console(data_dir)?;

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -280,15 +280,6 @@ where
         trace!("spawning node");
         let lp = LocalPoolHandle::new(num_cpus::get());
 
-        // Initialize the metrics collection.
-        //
-        // The metrics are global per process. Subsequent calls do not change the metrics
-        // collection and will return an error. We ignore this error. This means that if you'd
-        // spawn multiple Iroh nodes in the same process, the metrics would be shared between the
-        // nodes.
-        #[cfg(feature = "metrics")]
-        crate::metrics::try_init_metrics_collection().ok();
-
         let mut transport_config = quinn::TransportConfig::default();
         transport_config
             .max_concurrent_bidi_streams(MAX_STREAMS.try_into()?)


### PR DESCRIPTION
## Description

Moved the metrics init into CLI so the lib doesn't init the full metrics collection on its own and block other lib users to do their custom setup on top.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
