### PR TITLE
deps: update h2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
## Description

Update h2 to next patch release.
Fixes this cargo-deny warning:
> ID: RUSTSEC-2024-0332
>    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0332
>    = An attacker can send a flood of CONTINUATION frames, causing `h2` to process them indefinitely.
>      This results in an increase in CPU usage.
