### PR TITLE
fix(iroh-net): avoid double connections to relays

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -233,8 +233,11 @@ impl Inner {
     /// Sets the relay node with the best latency.
     ///
     /// If we are not connected to any relay nodes, set this to `None`.
-    fn set_my_relay(&self, my_relay: Option<RelayUrl>) {
-        *self.my_relay.write().expect("not poisoned") = my_relay;
+    fn set_my_relay(&self, my_relay: Option<RelayUrl>) -> Option<RelayUrl> {
+        let mut lock = self.my_relay.write().expect("not poisoned");
+        let old = lock.take();
+        *lock = my_relay;
+        old
     }
 
     fn is_closing(&self) -> bool {
@@ -2188,20 +2191,18 @@ impl Actor {
             // No change.
             return true;
         }
-        self.inner.set_my_relay(relay_url.clone());
+        let old_relay = self.inner.set_my_relay(relay_url.clone());
 
         if let Some(ref relay_url) = relay_url {
             inc!(MagicsockMetrics, relay_home_change);
 
             // On change, notify all currently connected relay servers and
             // start connecting to our home relay if we are not already.
-            info!("home is now relay {}", relay_url);
+            info!("home is now relay {}, was {:?}", relay_url, old_relay);
             self.inner.publish_my_addr();
 
-            self.send_relay_actor(RelayActorMessage::NotePreferred(relay_url.clone()));
-            self.send_relay_actor(RelayActorMessage::Connect {
+            self.send_relay_actor(RelayActorMessage::SetHome {
                 url: relay_url.clone(),
-                peer: None,
             });
         }
 

--- a/iroh-net/src/magicsock/relay_actor.rs
+++ b/iroh-net/src/magicsock/relay_actor.rs
@@ -478,7 +478,7 @@ impl RelayActor {
         let url = url.clone();
         let url1 = url.clone();
 
-        // building a client does not dial
+        // building a client dials the relay
         let (dc, dc_receiver) = relay::http::ClientBuilder::new(url1.clone())
             .address_family_selector(move || {
                 let ipv6_reported = ipv6_reported.clone();


### PR DESCRIPTION
The `self.connect` call in `Actor::recv_detail` was racing to create a connection with an incoming actor message to do so.

This simplifies `recv_detail` and only attempts to do so if there is already a connection, which is the correct logic in the first place.

Closes #2144 

