### PR TITLE
refactor(dns): use one DNS record per attribute

### DIFF
--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -817,8 +817,9 @@ mod test_dns_pkarr {
                         continue;
                     };
                     let node_info = NodeInfo::from_pkarr_signed_packet(packet)?;
-                    let record = node_info.to_hickory_record(&this.origin, TTL)?;
-                    reply.add_answer(record);
+                    for record in node_info.to_hickory_records(&this.origin, TTL)? {
+                        reply.add_answer(record);
+                    }
                 }
                 Ok(())
             }

--- a/iroh-net/src/discovery/dns.rs
+++ b/iroh-net/src/discovery/dns.rs
@@ -17,8 +17,11 @@ pub const N0_TESTDNS_NODE_ORIGIN: &str = "testdns.iroh.link";
 /// When asked to resolve a [`NodeId`], this service performs a lookup in the Domain Name System (DNS).
 ///
 /// It uses the [`MagicEndpoint`]'s DNS resolver to query for `TXT` records under the domain
-/// `_iroh.<z32nodeid>.<origin>`. `<z32nodeid>` is the [`NodeId`] encoded in [`z-base-32`]
-/// format, and `<origin>` is the node origin domain as set in [`DnsDiscovery::new`].
+/// `_iroh.<z32-node-id>.<origin-domain>`:
+///
+/// * `_iroh`: is the record name
+/// * `<z32-node-id>` is the [`NodeId`] encoded in [`z-base-32`] format
+/// * `<origin-domain>` is the node origin domain as set in [`DnsDiscovery::new`].
 ///
 /// Each TXT record returned from the query is expected to contain a string in the format `<name>=<value>`.
 /// If a TXT record contains multiple character strings, they are concatenated first.
@@ -27,6 +30,7 @@ pub const N0_TESTDNS_NODE_ORIGIN: &str = "testdns.iroh.link";
 ///
 /// The DNS resolver defaults to using the nameservers configured on the host system, but can be changed
 /// with [`crate::magic_endpoint::MagicEndpointBuilder::dns_resolver`].
+///
 /// [z-base-32]: https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
 #[derive(Debug)]
 pub struct DnsDiscovery {

--- a/iroh-net/src/discovery/pkarr_publish.rs
+++ b/iroh-net/src/discovery/pkarr_publish.rs
@@ -66,8 +66,9 @@ impl Publisher {
     pub async fn publish_addr_info(&self, info: &AddrInfo) -> Result<()> {
         let info = NodeInfo::new(
             self.secret_key.public(),
-            info.relay_url.clone().map(Url::from),
+            info.relay_url.clone().map(Into::into),
         );
+        // only republish if the [`NodeInfo`] changed
         if self.last_published.read().as_ref() == Some(&info) {
             return Ok(());
         }

--- a/iroh-net/src/discovery/pkarr_publish.rs
+++ b/iroh-net/src/discovery/pkarr_publish.rs
@@ -2,13 +2,9 @@
 //!
 //! This service only implements the [`Discovery::publish`] method and does not provide discovery.
 //! It encodes the node information into a DNS packet in the format resolvable by the
-//! [`super::dns::DnsDiscovery`], which means a single _iroh_node TXT record, under the z32 encoded
-//! node id as origin domain.
+//! [`super::dns::DnsDiscovery`].
 //!
 //! [pkarr]: https://pkarr.org
-
-// TODO: Decide what to do with this module once publishing over relays land. Either remove, or
-// leave in the repo but do not enable it by default in the iroh node.
 
 use std::sync::Arc;
 
@@ -23,7 +19,7 @@ use crate::{discovery::Discovery, dns::node_info::NodeInfo, key::SecretKey, Addr
 /// The n0 testing pkarr relay
 pub const N0_TESTDNS_PKARR_RELAY: &str = "https://testdns.iroh.link/pkarr";
 
-/// Default TTL for the _iroh_node TXT record in the pkarr signed packet
+/// Default TTL for the _iroh TXT record in the pkarr signed packet
 const DEFAULT_PKARR_TTL: u32 = 30;
 
 /// Publish node info to a pkarr relay.

--- a/iroh-net/src/dns/node_info.rs
+++ b/iroh-net/src/dns/node_info.rs
@@ -44,12 +44,12 @@ pub async fn lookup_by_id(
 }
 
 async fn lookup_node_info(resolver: &TokioAsyncResolver, name: Name) -> Result<NodeInfo> {
-    let name = ensure_iroh_node_txt_label(name)?;
+    let name = ensure_iroh_txt_label(name)?;
     let lookup = resolver.txt_lookup(name).await?;
     NodeInfo::from_hickory_records(lookup.as_lookup().records())
 }
 
-fn ensure_iroh_node_txt_label(name: Name) -> Result<Name, ProtoError> {
+fn ensure_iroh_txt_label(name: Name) -> Result<Name, ProtoError> {
     if name.iter().next() == Some(IROH_TXT_NAME.as_bytes()) {
         Ok(name)
     } else {
@@ -74,7 +74,7 @@ pub fn from_z32(s: &str) -> Result<NodeId> {
     Ok(node_id)
 }
 
-/// Node info contained in a DNS _iroh_node TXT record.
+/// Node info contained in a DNS _iroh TXT record.
 #[derive(derive_more::Debug, Clone, Eq, PartialEq)]
 pub struct NodeInfo {
     /// The node id


### PR DESCRIPTION
Adapts #2045 to match #2149 

* change the DNS and pkarr encoding for the NodeInfo to use one DNS record for each attribue
* remove the node= attribute as the node id is contained in the DNS name

## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
