### PR TITLE
refactor(iroh-bytes): Update bao-tree to 0.12 and adjust code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "futures-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,11 +320,9 @@ dependencies = [
 [[package]]
 name = "bao-tree"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdae307defb220bd2698a42495e226ff89e3173f024abfc2182129603e74b5c7"
 dependencies = [
  "bytes",
- "futures",
+ "futures-lite",
  "genawaiter",
  "iroh-blake3",
  "iroh-io",
@@ -1595,6 +1593,19 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,8 @@ dependencies = [
 [[package]]
 name = "bao-tree"
 version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb717f74416fc06c1f1972be717b4e53d30c95e4e7d2dc06abd6db64306d7f0"
 dependencies = [
  "bytes",
  "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ missing_debug_implementations = "warn"
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+bao-tree = { path = "../bao-tree" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,3 @@ missing_debug_implementations = "warn"
 
 [workspace.lints.clippy]
 unused-async = "warn"
-
-[patch.crates-io]
-bao-tree = { path = "../bao-tree" }

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = {  version = "0.11.1", features = ["tokio_fsm", "validate"], default-features = false, optional = true }
+bao-tree = {  version = "0.12", features = ["tokio_fsm", "validate"], default-features = false, optional = true }
 data-encoding = { version = "2.3.3", optional = true }
 hex = "0.4.3"
 multibase = { version = "0.9.1", optional = true }

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = {  version = "0.11.1", features = ["tokio_fsm"], default-features = false }
+bao-tree = {  version = "0.12", features = ["tokio_fsm"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"
 data-encoding = "2.3.3"

--- a/iroh-bytes/src/get/db.rs
+++ b/iroh-bytes/src/get/db.rs
@@ -1,6 +1,5 @@
 //! Functions that use the iroh-bytes protocol in conjunction with a bao store.
-
-use bao_tree::full_chunks;
+use bao_tree::ChunkNum;
 use futures::{Future, StreamExt};
 use iroh_base::hash::Hash;
 use iroh_base::rpc::RpcError;
@@ -147,7 +146,7 @@ pub async fn valid_ranges<D: MapMut>(entry: &D::EntryMut) -> anyhow::Result<Chun
     // compute the valid range from just looking at the data file
     let mut data_reader = entry.data_reader().await?;
     let data_size = data_reader.len().await?;
-    let valid_from_data = ChunkRanges::from(..full_chunks(data_size));
+    let valid_from_data = ChunkRanges::from(..ChunkNum::full_chunks(data_size));
     // compute the valid range from just looking at the outboard file
     let mut outboard = entry.outboard().await?;
     let all = ChunkRanges::all();

--- a/iroh-bytes/src/get/db.rs
+++ b/iroh-bytes/src/get/db.rs
@@ -1,5 +1,6 @@
 //! Functions that use the iroh-bytes protocol in conjunction with a bao store.
 
+use bao_tree::full_chunks;
 use futures::{Future, StreamExt};
 use iroh_base::hash::Hash;
 use iroh_base::rpc::RpcError;
@@ -26,7 +27,7 @@ use crate::{
     BlobFormat, HashAndFormat,
 };
 use anyhow::anyhow;
-use bao_tree::{ByteNum, ChunkRanges};
+use bao_tree::ChunkRanges;
 use iroh_io::AsyncSliceReader;
 use tracing::trace;
 
@@ -146,7 +147,7 @@ pub async fn valid_ranges<D: MapMut>(entry: &D::EntryMut) -> anyhow::Result<Chun
     // compute the valid range from just looking at the data file
     let mut data_reader = entry.data_reader().await?;
     let data_size = data_reader.len().await?;
-    let valid_from_data = ChunkRanges::from(..ByteNum(data_size).full_chunks());
+    let valid_from_data = ChunkRanges::from(..full_chunks(data_size));
     // compute the valid range from just looking at the outboard file
     let mut outboard = entry.outboard().await?;
     let all = ChunkRanges::all();

--- a/iroh-bytes/src/get/request.rs
+++ b/iroh-bytes/src/get/request.rs
@@ -6,7 +6,7 @@ use crate::{
     protocol::{GetRequest, RangeSpecSeq},
     Hash, HashAndFormat,
 };
-use bao_tree::{ByteNum, ChunkNum, ChunkRanges};
+use bao_tree::{full_chunks, ChunkNum, ChunkRanges};
 use bytes::Bytes;
 use rand::Rng;
 
@@ -177,16 +177,13 @@ pub async fn get_chunk_probe(
 /// The random chunk is chosen uniformly from the chunks of the children, so
 /// larger children are more likely to be selected.
 pub fn random_hash_seq_ranges(sizes: &[u64], mut rng: impl Rng) -> RangeSpecSeq {
-    let total_chunks = sizes
-        .iter()
-        .map(|size| ByteNum(*size).full_chunks().0)
-        .sum::<u64>();
+    let total_chunks = sizes.iter().map(|size| full_chunks(*size).0).sum::<u64>();
     let random_chunk = rng.gen_range(0..total_chunks);
     let mut remaining = random_chunk;
     let mut ranges = vec![];
     ranges.push(ChunkRanges::empty());
     for size in sizes.iter() {
-        let chunks = ByteNum(*size).full_chunks().0;
+        let chunks = full_chunks(*size).0;
         if remaining < chunks {
             ranges.push(ChunkRanges::from(
                 ChunkNum(remaining)..ChunkNum(remaining + 1),

--- a/iroh-bytes/src/get/request.rs
+++ b/iroh-bytes/src/get/request.rs
@@ -177,7 +177,10 @@ pub async fn get_chunk_probe(
 /// The random chunk is chosen uniformly from the chunks of the children, so
 /// larger children are more likely to be selected.
 pub fn random_hash_seq_ranges(sizes: &[u64], mut rng: impl Rng) -> RangeSpecSeq {
-    let total_chunks = sizes.iter().map(|size| ChunkNum::full_chunks(*size).0).sum::<u64>();
+    let total_chunks = sizes
+        .iter()
+        .map(|size| ChunkNum::full_chunks(*size).0)
+        .sum::<u64>();
     let random_chunk = rng.gen_range(0..total_chunks);
     let mut remaining = random_chunk;
     let mut ranges = vec![];

--- a/iroh-bytes/src/get/request.rs
+++ b/iroh-bytes/src/get/request.rs
@@ -6,7 +6,7 @@ use crate::{
     protocol::{GetRequest, RangeSpecSeq},
     Hash, HashAndFormat,
 };
-use bao_tree::{full_chunks, ChunkNum, ChunkRanges};
+use bao_tree::{ChunkNum, ChunkRanges};
 use bytes::Bytes;
 use rand::Rng;
 
@@ -177,13 +177,13 @@ pub async fn get_chunk_probe(
 /// The random chunk is chosen uniformly from the chunks of the children, so
 /// larger children are more likely to be selected.
 pub fn random_hash_seq_ranges(sizes: &[u64], mut rng: impl Rng) -> RangeSpecSeq {
-    let total_chunks = sizes.iter().map(|size| full_chunks(*size).0).sum::<u64>();
+    let total_chunks = sizes.iter().map(|size| ChunkNum::full_chunks(*size).0).sum::<u64>();
     let random_chunk = rng.gen_range(0..total_chunks);
     let mut remaining = random_chunk;
     let mut ranges = vec![];
     ranges.push(ChunkRanges::empty());
     for size in sizes.iter() {
-        let chunks = full_chunks(*size).0;
+        let chunks = ChunkNum::full_chunks(*size).0;
         if remaining < chunks {
             ranges.push(ChunkRanges::from(
                 ChunkNum(remaining)..ChunkNum(remaining + 1),

--- a/iroh-bytes/src/lib.rs
+++ b/iroh-bytes/src/lib.rs
@@ -22,4 +22,4 @@ pub use iroh_base::hash::{BlobFormat, Hash, HashAndFormat};
 use bao_tree::BlockSize;
 
 /// Block size used by iroh, 2^4*1024 = 16KiB
-pub const IROH_BLOCK_SIZE: BlockSize = BlockSize(4);
+pub const IROH_BLOCK_SIZE: BlockSize = BlockSize::from_chunk_log(4);

--- a/iroh-bytes/src/provider.rs
+++ b/iroh-bytes/src/provider.rs
@@ -495,7 +495,7 @@ pub async fn send_blob<D: Map, W: AsyncStreamWriter>(
     match db.get(&name).await? {
         Some(entry) => {
             let outboard = entry.outboard().await?;
-            let size = outboard.tree().size().0;
+            let size = outboard.tree().size();
             let mut file_reader = TrackingSliceReader::new(entry.data_reader().await?);
             let res = encode_ranges_validated(
                 &mut file_reader,

--- a/iroh-bytes/src/store/bao_file.rs
+++ b/iroh-bytes/src/store/bao_file.rs
@@ -872,7 +872,7 @@ pub mod test_support {
         let outboard = PostOrderMemOutboard::create(data, IROH_BLOCK_SIZE).flip();
         let mut encoded = Vec::new();
         encode_ranges_validated(data, &outboard, &chunk_ranges, &mut encoded).unwrap();
-        ((*outboard.hash()).into(), chunk_ranges, encoded)
+        (outboard.root.into(), chunk_ranges, encoded)
     }
 
     pub async fn validate(handle: &BaoFileHandle, original: &[u8], ranges: &[Range<u64>]) {

--- a/iroh-bytes/src/store/fs.rs
+++ b/iroh-bytes/src/store/fs.rs
@@ -74,7 +74,7 @@ use std::{
 
 use bao_tree::io::{
     fsm::Outboard,
-    outboard::PostOrderOutboard,
+    outboard::PreOrderOutboard,
     sync::{ReadAt, Size},
 };
 use bytes::Bytes;
@@ -2304,7 +2304,7 @@ fn compute_outboard(
     let buf_size = usize::try_from(size).unwrap_or(usize::MAX).min(1024 * 1024);
     let reader = BufReader::with_capacity(buf_size, reader);
 
-    let ob = PostOrderOutboard::<Vec<u8>>::create_sized(reader, size, IROH_BLOCK_SIZE)?;
+    let ob = PreOrderOutboard::<Vec<u8>>::create_sized(reader, size, IROH_BLOCK_SIZE)?;
     let root = ob.root.into();
     let data = ob.data;
     tracing::trace!(%root, "done");

--- a/iroh-bytes/src/store/mem.rs
+++ b/iroh-bytes/src/store/mem.rs
@@ -3,7 +3,7 @@
 //! Main entry point is [Store].
 use bao_tree::{
     io::{fsm::Outboard, outboard::PreOrderOutboard, sync::WriteAt},
-    BaoTree, ByteNum,
+    BaoTree,
 };
 use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
@@ -275,7 +275,7 @@ impl MapEntry for Entry {
         let size = self.inner.data.read().unwrap().current_size();
         Ok(PreOrderOutboard {
             root: self.hash().into(),
-            tree: BaoTree::new(ByteNum(size), IROH_BLOCK_SIZE),
+            tree: BaoTree::new(size, IROH_BLOCK_SIZE),
             data: OutboardReader(self.inner.clone()),
         })
     }

--- a/iroh-bytes/src/store/mutable_mem_storage.rs
+++ b/iroh-bytes/src/store/mutable_mem_storage.rs
@@ -1,6 +1,6 @@
 use bao_tree::{
     io::{fsm::BaoContentItem, sync::WriteAt},
-    BaoTree, ByteNum,
+    BaoTree,
 };
 use bytes::Bytes;
 
@@ -98,7 +98,7 @@ impl MutableMemStorage {
         size: u64,
         batch: &[BaoContentItem],
     ) -> std::io::Result<()> {
-        let tree = BaoTree::new(ByteNum(size), IROH_BLOCK_SIZE);
+        let tree = BaoTree::new(size, IROH_BLOCK_SIZE);
         for item in batch {
             match item {
                 BaoContentItem::Parent(parent) => {
@@ -113,8 +113,8 @@ impl MutableMemStorage {
                     }
                 }
                 BaoContentItem::Leaf(leaf) => {
-                    self.sizes.write(leaf.offset.0, size);
-                    self.data.write_all_at(leaf.offset.0, leaf.data.as_ref())?;
+                    self.sizes.write(leaf.offset, size);
+                    self.data.write_all_at(leaf.offset, leaf.data.as_ref())?;
                 }
             }
         }

--- a/iroh-bytes/src/store/mutable_mem_storage.rs
+++ b/iroh-bytes/src/store/mutable_mem_storage.rs
@@ -37,7 +37,7 @@ pub struct SizeInfo {
 impl SizeInfo {
     /// Create a new size info for a complete file of size `size`.
     pub(crate) fn complete(size: u64) -> Self {
-        let mask = (1 << IROH_BLOCK_SIZE.0) - 1;
+        let mask = (1 << IROH_BLOCK_SIZE.chunk_log()) - 1;
         // offset of the last bao chunk in a file of size `size`
         let last_chunk_offset = size & mask;
         Self {

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -64,9 +64,7 @@ impl Store {
             let name = name.into();
             let data: &[u8] = data.as_ref();
             // wrap into the right types
-            let outboard = PreOrderMemOutboard::create(data, IROH_BLOCK_SIZE)
-                .map_data(Bytes::from)
-                .unwrap();
+            let outboard = PreOrderMemOutboard::create(data, IROH_BLOCK_SIZE).map_data(Bytes::from);
             let hash = outboard.root();
             // add the name, this assumes that names are unique
             names.insert(name, hash);
@@ -84,9 +82,7 @@ impl Store {
         let inner = Arc::make_mut(&mut self.0);
         let data: &[u8] = data.as_ref();
         // wrap into the right types
-        let outboard = PreOrderMemOutboard::create(data, IROH_BLOCK_SIZE)
-            .map_data(Bytes::from)
-            .unwrap();
+        let outboard = PreOrderMemOutboard::create(data, IROH_BLOCK_SIZE).map_data(Bytes::from);
         let hash = outboard.root();
         let data = Bytes::from(data.to_vec());
         let hash = Hash::from(hash);

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -1,5 +1,5 @@
 //! Utility functions and types.
-use bao_tree::ChunkRanges;
+use bao_tree::{io::outboard::PostOrderMemOutboard, BaoTree, ByteNum, ChunkRanges};
 use bytes::Bytes;
 use derive_more::{Debug, Display, From, Into};
 use range_collections::range_set::RangeSetRange;
@@ -262,13 +262,13 @@ pub(crate) fn get_limited_slice(bytes: &Bytes, offset: u64, len: usize) -> Bytes
 /// Compute raw outboard size, without the size header.
 #[allow(dead_code)]
 pub(crate) fn raw_outboard_size(size: u64) -> u64 {
-    bao_tree::io::outboard_size(size, IROH_BLOCK_SIZE) - 8
+    BaoTree::new(ByteNum(size), IROH_BLOCK_SIZE)
+        .outboard_size()
+        .0
 }
 
 /// Compute raw outboard, without the size header.
 pub(crate) fn raw_outboard(data: &[u8]) -> (Vec<u8>, Hash) {
-    let (mut outboard, hash) = bao_tree::io::outboard(data, IROH_BLOCK_SIZE);
-    // remove the size header
-    outboard.splice(0..8, []);
-    (outboard, hash.into())
+    let res = PostOrderMemOutboard::create(data, IROH_BLOCK_SIZE);
+    (res.data, res.root.into())
 }

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -1,5 +1,5 @@
 //! Utility functions and types.
-use bao_tree::{io::outboard::PostOrderMemOutboard, BaoTree, ByteNum, ChunkRanges};
+use bao_tree::{io::outboard::PostOrderMemOutboard, BaoTree, ChunkRanges};
 use bytes::Bytes;
 use derive_more::{Debug, Display, From, Into};
 use range_collections::range_set::RangeSetRange;
@@ -210,9 +210,9 @@ pub fn total_bytes(ranges: ChunkRanges, size: u64) -> u64 {
         .map(|range| {
             let (start, end) = match range {
                 RangeSetRange::Range(r) => {
-                    (r.start.to_bytes().0.min(size), r.end.to_bytes().0.min(size))
+                    (r.start.to_bytes().min(size), r.end.to_bytes().min(size))
                 }
-                RangeSetRange::RangeFrom(range) => (range.start.to_bytes().0.min(size), size),
+                RangeSetRange::RangeFrom(range) => (range.start.to_bytes().min(size), size),
             };
             end.saturating_sub(start)
         })
@@ -262,9 +262,7 @@ pub(crate) fn get_limited_slice(bytes: &Bytes, offset: u64, len: usize) -> Bytes
 /// Compute raw outboard size, without the size header.
 #[allow(dead_code)]
 pub(crate) fn raw_outboard_size(size: u64) -> u64 {
-    BaoTree::new(ByteNum(size), IROH_BLOCK_SIZE)
-        .outboard_size()
-        .0
+    BaoTree::new(size, IROH_BLOCK_SIZE).outboard_size()
 }
 
 /// Compute raw outboard, without the size header.

--- a/iroh-bytes/src/util.rs
+++ b/iroh-bytes/src/util.rs
@@ -1,5 +1,5 @@
 //! Utility functions and types.
-use bao_tree::{io::outboard::PostOrderMemOutboard, BaoTree, ChunkRanges};
+use bao_tree::{io::outboard::PreOrderMemOutboard, BaoTree, ChunkRanges};
 use bytes::Bytes;
 use derive_more::{Debug, Display, From, Into};
 use range_collections::range_set::RangeSetRange;
@@ -267,6 +267,6 @@ pub(crate) fn raw_outboard_size(size: u64) -> u64 {
 
 /// Compute raw outboard, without the size header.
 pub(crate) fn raw_outboard(data: &[u8]) -> (Vec<u8>, Hash) {
-    let res = PostOrderMemOutboard::create(data, IROH_BLOCK_SIZE);
+    let res = PreOrderMemOutboard::create(data, IROH_BLOCK_SIZE);
     (res.data, res.root.into())
 }

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.81"
-bao-tree = { version = "0.11.1" }
+bao-tree = { version = "0.12" }
 bytes = "1.5.0"
 clap = { version = "4", features = ["derive"] }
 colored = { version = "2.0.4" }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-bao-tree = { version = "0.11.1", features = ["tokio_fsm"], default-features = false }
+bao-tree = { version = "0.12", features = ["tokio_fsm"], default-features = false }
 bytes = "1"
 data-encoding = "2.4.0"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into", "from_str"] }

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -290,7 +290,7 @@ impl<D: BaoStore> Handler<D> {
                 continue;
             };
             let hash = entry.hash();
-            let size = entry.outboard().await?.tree().size().0;
+            let size = entry.outboard().await?.tree().size();
             let path = "".to_owned();
             co.yield_(Ok(BlobListResponse { hash, size, path })).await;
         }

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -192,8 +192,8 @@ mod file {
 
     use anyhow::Result;
     use bao_tree::{
-        io::fsm::{BaoContentItem, ResponseDecoderReadingNext},
-        BaoTree, ByteNum, ChunkRanges,
+        io::fsm::{BaoContentItem, ResponseDecoderNext},
+        BaoTree, ChunkRanges,
     };
     use bytes::Bytes;
     use futures::StreamExt;
@@ -402,10 +402,10 @@ mod file {
         // get the size
         let size = response.read_u64_le().await?;
         // start reading the response
-        let mut reading = bao_tree::io::fsm::ResponseDecoderReading::new(
+        let mut reading = bao_tree::io::fsm::ResponseDecoder::new(
             hash,
             ChunkRanges::all(),
-            BaoTree::new(ByteNum(size), IROH_BLOCK_SIZE),
+            BaoTree::new(size, IROH_BLOCK_SIZE),
             response,
         );
         // create the partial entry
@@ -413,7 +413,7 @@ mod file {
         // create the
         let mut bw = entry.batch_writer().await?;
         let mut buf = Vec::new();
-        while let ResponseDecoderReadingNext::More((next, res)) = reading.next().await {
+        while let ResponseDecoderNext::More((next, res)) = reading.next().await {
             let item = res?;
             match &item {
                 BaoContentItem::Parent(_) => {


### PR DESCRIPTION
## Description

refactor(iroh-bytes): Update bao-tree to 0.12 and adjust code

bao-tree has some API changes that need to be adapted. Outboard creation is easier, and the ByteNum newtype is gone, replaced by just u64.

## Notes & open questions

~~There is still a test failure. Hopefully nothing major. But hence the draft status.~~

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
