### PR TITLE
(wip) feat(iroh-sync): Inline small content

### DIFF
--- a/iroh-bytes/src/store/fs.rs
+++ b/iroh-bytes/src/store/fs.rs
@@ -1399,6 +1399,15 @@ impl super::Store for Store {
         Ok(tokio::task::spawn_blocking(move || this.import_bytes_sync(data, format)).await??)
     }
 
+    fn import_bytes_sync(
+        &self,
+        data: bytes::Bytes,
+        format: iroh_base::hash::BlobFormat,
+    ) -> io::Result<crate::TempTag> {
+        let tag = self.0.import_bytes_sync(data, format)?;
+        Ok(tag)
+    }
+
     async fn import_stream(
         &self,
         mut data: impl Stream<Item = io::Result<Bytes>> + Unpin + Send + 'static,

--- a/iroh-bytes/src/store/mem.rs
+++ b/iroh-bytes/src/store/mem.rs
@@ -199,6 +199,11 @@ impl super::Store for Store {
         .await?
     }
 
+    fn import_bytes_sync(&self, bytes: Bytes, format: BlobFormat) -> io::Result<TempTag> {
+        let tag = self.import_bytes_sync(0, bytes, format, IgnoreProgressSender::default())?;
+        Ok(tag)
+    }
+
     async fn set_tag(&self, name: Tag, value: Option<HashAndFormat>) -> io::Result<()> {
         let mut state = self.write_lock();
         if let Some(value) = value {

--- a/iroh-bytes/src/store/readonly_mem.rs
+++ b/iroh-bytes/src/store/readonly_mem.rs
@@ -323,6 +323,11 @@ impl super::Store for Store {
         Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
+    fn import_bytes_sync(&self, bytes: Bytes, format: BlobFormat) -> io::Result<TempTag> {
+        let _ = (bytes, format);
+        Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
+    }
+
     async fn import_stream(
         &self,
         data: impl Stream<Item = io::Result<Bytes>> + Unpin + Send,

--- a/iroh-bytes/src/store/traits.rs
+++ b/iroh-bytes/src/store/traits.rs
@@ -356,6 +356,13 @@ pub trait Store: ReadableStore + MapMut {
         format: BlobFormat,
     ) -> impl Future<Output = io::Result<TempTag>> + Send;
 
+    /// Import data from memory, synchronously.
+    fn import_bytes_sync(
+        &self,
+        bytes: Bytes,
+        format: BlobFormat,
+    ) -> io::Result<TempTag>;
+
     /// Import data from a stream of bytes.
     fn import_stream(
         &self,

--- a/iroh-cli/src/commands/doc.rs
+++ b/iroh-cli/src/commands/doc.rs
@@ -561,9 +561,9 @@ impl DocCommands {
                         LiveEvent::InsertRemote {
                             entry,
                             from,
-                            content_status,
+                            content,
                         } => {
-                            let content = match content_status {
+                            let content = match content.status() {
                                 iroh::sync::ContentStatus::Complete => {
                                     fmt_entry(&doc, &entry, DisplayContentMode::Auto).await
                                 }

--- a/iroh-sync/src/actor.rs
+++ b/iroh-sync/src/actor.rs
@@ -17,9 +17,8 @@ use tracing::{debug, error, error_span, trace, warn};
 use crate::{
     ranger::Message,
     store::{fs::StoreInstance, DownloadPolicy, ImportNamespaceOutcome, Query, Store},
-    Author, AuthorHeads, AuthorId, Capability, CapabilityKind, Content, ContentStatus,
-    ContentStatusCallback, Event, NamespaceId, NamespaceSecret, PeerIdBytes, Replica, SignedEntry,
-    SyncOutcome,
+    Author, AuthorHeads, AuthorId, Capability, CapabilityKind, Content, ContentCallback, Event,
+    NamespaceId, NamespaceSecret, PeerIdBytes, Replica, SignedEntry, SyncOutcome,
 };
 
 #[derive(derive_more::Debug, derive_more::Display)]
@@ -220,7 +219,7 @@ impl SyncHandle {
     /// Spawn a sync actor and return a handle.
     pub fn spawn(
         store: Store,
-        content_status_callback: Option<ContentStatusCallback>,
+        content_status_callback: Option<ContentCallback>,
         me: String,
     ) -> SyncHandle {
         const ACTION_CAP: usize = 1024;
@@ -528,7 +527,7 @@ struct Actor {
     store: Store,
     states: OpenReplicas,
     action_rx: flume::Receiver<Action>,
-    content_status_callback: Option<ContentStatusCallback>,
+    content_status_callback: Option<ContentCallback>,
 }
 
 impl Actor {

--- a/iroh-sync/src/ranger.rs
+++ b/iroh-sync/src/ranger.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ContentStatus;
+use crate::Content;
 
 /// Store entries that can be fingerprinted and put into ranges.
 pub trait RangeEntry: Debug + Clone {
@@ -165,7 +165,7 @@ pub struct RangeItems<E: RangeEntry> {
 pub struct RangeItem<E: RangeEntry> {
     #[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
     pub entry: E,
-    pub content: ContentStatus,
+    pub content: Content,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -349,7 +349,7 @@ where
     /// prefixes).
     ///
     /// `content_status_cb` is called for each outgoing entry about to be sent to the remote.
-    /// It must return a [`ContentStatus`], which will be sent to the remote with the entry.
+    /// It must return a [`Content`], which will be sent to the remote with the entry.
     pub fn process_message<F, F2, F3>(
         &mut self,
         message: Message<E>,
@@ -359,8 +359,8 @@ where
     ) -> Result<Option<Message<E>>, S::Error>
     where
         F: Fn(&S, &RangeItem<E>) -> bool,
-        F2: FnMut(&S, E, ContentStatus),
-        F3: Fn(&S, &E) -> ContentStatus,
+        F2: FnMut(&S, E, Content),
+        F3: Fn(&S, &E) -> Content,
     {
         let mut out = Vec::new();
 
@@ -1369,7 +1369,7 @@ mod tests {
                     msg,
                     &bob_validate_cb,
                     |_, _, _| (),
-                    |_, _| ContentStatus::Complete,
+                    |_, _| Content::complete(),
                 )
                 .unwrap()
             {
@@ -1379,7 +1379,7 @@ mod tests {
                         msg,
                         &alice_validate_cb,
                         |_, _, _| (),
-                        |_, _| ContentStatus::Complete,
+                        |_, _| Content::complete(),
                     )
                     .unwrap();
             }

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -9,7 +9,6 @@
 use std::{
     cmp::Ordering,
     fmt::Debug,
-    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -44,12 +43,6 @@ pub type PeerIdBytes = [u8; 32];
 /// Max time in the future from our wall clock time that we accept entries for.
 /// Value is 10 minutes.
 pub const MAX_TIMESTAMP_FUTURE_SHIFT: u64 = 10 * 60 * Duration::from_secs(1).as_millis() as u64;
-
-/// Callback that may be set on a replica to determine the availability status for a content hash.
-pub type ContentGetCallback = Arc<dyn Fn(Hash) -> Content + Send + Sync + 'static>;
-
-/// Callback to insert inlined content into a store.
-pub type ContentInsertCallback = Arc<dyn Fn(Bytes) -> std::io::Result<()> + Send + Sync + 'static>;
 
 /// Content handlers
 pub trait ContentStore: Clone + Send + Sync + 'static {
@@ -580,6 +573,7 @@ where
         from_peer: PeerIdBytes,
         state: &mut SyncOutcome,
     ) -> Result<Option<crate::ranger::Message<SignedEntry>>, anyhow::Error> {
+        tracing::warn!("process {message:#?}");
         self.ensure_open()?;
         let my_namespace = self.id();
         let now = system_time_now();

--- a/iroh/src/client/docs.rs
+++ b/iroh/src/client/docs.rs
@@ -14,7 +14,7 @@ use iroh_net::NodeAddr;
 use iroh_sync::{
     actor::OpenState,
     store::{DownloadPolicy, Query},
-    AuthorId, CapabilityKind, ContentStatus, NamespaceId, PeerIdBytes, RecordIdentifier,
+    AuthorId, CapabilityKind, Content, NamespaceId, PeerIdBytes, RecordIdentifier,
 };
 use portable_atomic::{AtomicBool, Ordering};
 use quic_rpc::{message::RpcMsg, RpcClient, ServiceConnection};
@@ -479,7 +479,7 @@ pub enum LiveEvent {
         /// The inserted entry.
         entry: Entry,
         /// If the content is available at the local node
-        content_status: ContentStatus,
+        content: Content,
     },
     /// The content of an entry was downloaded and is now available at the local node
     ContentReady {
@@ -503,10 +503,11 @@ impl From<crate::sync_engine::LiveEvent> for LiveEvent {
             crate::sync_engine::LiveEvent::InsertRemote {
                 from,
                 entry,
-                content_status,
+                content,
             } => Self::InsertRemote {
                 from,
-                content_status,
+                // TODO: maybe not drop the inlined content here but return
+                content,
                 entry: entry.into(),
             },
             crate::sync_engine::LiveEvent::ContentReady { hash } => Self::ContentReady { hash },


### PR DESCRIPTION
## Description

WIP

* Refactor interface between iroh-sync and a content store, use a trait instead of arc'ed callbacks
* Inline small content (< 1024 bytes) during set reconciliation and in gossip messages
* Store incoming inlined content in the content store

## Notes & open questions

* I updated the `sync_full_basic` test as a smoke test.  Most other integration tests are still broken because we don't emit  `ContentReady` events if the content is already available (marked as `Complete` ) in the `RemoteInsert` event. `ContentReady`  is only emitted if the content is not yet available at the time when the RemoteInsert is emitted.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
