### PR TITLE
[WIP] feat: use zerocopy types for defining underlying docs fs types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -2668,6 +2668,7 @@ dependencies = [
  "rand_core",
  "redb",
  "serde",
+ "static_assertions",
  "strum 0.25.0",
  "tempfile",
  "test-strategy",
@@ -2677,6 +2678,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "zerocopy 0.8.0-alpha.7",
 ]
 
 [[package]]
@@ -6169,7 +6171,16 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.0-alpha.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24d6914f948ad0c1eaf3f2cb03a66e674714280d020ea8d955f765f8abb2e7a"
+dependencies = [
+ "zerocopy-derive 0.8.0-alpha.7",
 ]
 
 [[package]]
@@ -6177,6 +6188,17 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.0-alpha.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e862f7936bea2c96af2769d9d60ff534da9af29dd59943519403256f30bf5ac3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -49,6 +49,8 @@ tokio-stream = { version = "0.1", optional = true, features = ["sync"]}
 quinn = { version = "0.10", optional = true }
 futures = { version = "0.3", optional = true }
 lru = "0.12"
+zerocopy = { version = "0.8.0-alpha.7", features = ["derive"] }
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 iroh-test = { path = "../iroh-test" }

--- a/iroh-sync/src/store/fs/query.rs
+++ b/iroh-sync/src/store/fs/query.rs
@@ -15,7 +15,7 @@ use crate::{
 use super::{
     bounds::{ByKeyBounds, RecordsBounds},
     ranges::{RecordsByKeyRange, RecordsRange},
-    RecordsValue,
+    types,
 };
 
 /// A query iterator for entry queries.
@@ -100,8 +100,8 @@ impl<'a> Iterator for QueryIterator<'a> {
             let next = match &mut self.range {
                 QueryRange::AuthorKey { range, key_filter } => {
                     // get the next entry from the query range, filtered by the key and empty filters
-                    range.next_filtered(&self.query.sort_direction, |(_ns, _author, key), value| {
-                        key_filter.matches(key)
+                    range.next_filtered(&self.query.sort_direction, |key, value| {
+                        key_filter.matches(&key.key)
                             && (self.query.include_empty || !value_is_empty(&value))
                     })
                 }
@@ -155,7 +155,6 @@ impl<'a> Iterator for QueryIterator<'a> {
     }
 }
 
-fn value_is_empty(value: &RecordsValue) -> bool {
-    let (_timestamp, _namespace_sig, _author_sig, _len, hash) = value;
-    *hash == Hash::EMPTY.as_bytes()
+fn value_is_empty(value: &types::SignedRecord) -> bool {
+    &value.hash == Hash::EMPTY.as_bytes()
 }

--- a/iroh-sync/src/store/fs/types.rs
+++ b/iroh-sync/src/store/fs/types.rs
@@ -1,0 +1,171 @@
+use std::mem::align_of;
+use std::{fmt::Debug, mem::size_of};
+
+use redb::{RedbKey as Key, RedbValue as Value};
+use zerocopy::{native_endian::U64, FromBytes, IntoBytes, KnownLayout, NoCell, Unaligned};
+
+type Signature = [u8; 64];
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RecordIdentifierOwned(Box<[u8]>);
+
+impl RecordIdentifierOwned {
+    pub fn from_parts(namespace: &[u8; 32], value: &[u8; 32], key: &[u8]) -> Self {
+        let mut data = Vec::with_capacity(32 + 32 + key.len());
+        data.extend_from_slice(namespace);
+        data.extend_from_slice(value);
+        data.extend_from_slice(key);
+        Self(data.into_boxed_slice())
+    }
+}
+
+impl AsRef<RecordIdentifier> for RecordIdentifierOwned {
+    fn as_ref(&self) -> &RecordIdentifier {
+        RecordIdentifier::ref_from(&self.0).unwrap()
+    }
+}
+
+impl From<&RecordIdentifier> for RecordIdentifierOwned {
+    fn from(value: &RecordIdentifier) -> Self {
+        Self::from_parts(&value.namespace, &value.author, &value.key)
+    }
+}
+
+#[allow(missing_debug_implementations)]
+#[derive(KnownLayout, FromBytes, NoCell, Unaligned, IntoBytes)]
+#[repr(C, packed)]
+pub struct RecordIdentifier {
+    pub namespace: [u8; 32],
+    pub author: [u8; 32],
+    pub key: [u8],
+}
+
+impl Debug for &RecordIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecordIdentifier")
+            .field("namespace", &self.namespace)
+            .field("author", &self.author)
+            .field("key", &&self.key[..])
+            .finish()
+    }
+}
+
+impl PartialEq for &RecordIdentifier {
+    fn eq(&self, other: &Self) -> bool {
+        (self.namespace, self.author, &self.key).eq(&(other.namespace, other.author, &other.key))
+    }
+}
+
+impl PartialOrd for &RecordIdentifier {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        (self.namespace, self.author, &self.key).partial_cmp(&(
+            other.namespace,
+            other.author,
+            &other.key,
+        ))
+    }
+}
+
+impl Eq for &RecordIdentifier {}
+
+impl Ord for &RecordIdentifier {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+impl RecordIdentifier {
+    pub fn new(key: &[u8]) -> &Self {
+        RecordIdentifier::ref_from(key).expect("invalid key slice")
+    }
+}
+
+impl<'a> Key for &'a RecordIdentifier {
+    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+        let a = Self::from_bytes(data1);
+        let b = Self::from_bytes(data2);
+        a.cmp(&b)
+    }
+}
+
+impl AsRef<[u8]> for RecordIdentifier {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Value for &RecordIdentifier {
+    type SelfType<'a> = &'a RecordIdentifier where Self: 'a;
+    type AsBytes<'a> = &'a RecordIdentifier where Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        RecordIdentifier::ref_from(data).expect("length must match")
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'a,
+        Self: 'b,
+    {
+        value
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("RecordIdentifier")
+    }
+}
+
+#[derive(Debug, Clone, FromBytes, IntoBytes, PartialEq, Eq, KnownLayout, NoCell, Unaligned)]
+#[repr(C)]
+pub struct SignedRecord {
+    /// Record creation timestamp. Counted as micros since the Unix epoch.
+    pub timestamp: U64,
+    pub namespace_signature: Signature,
+    pub author_signature: Signature,
+    /// Length of the data referenced by `hash`.
+    pub len: U64,
+    /// Hash of the content data.
+    pub hash: [u8; 32],
+}
+
+impl AsRef<[u8]> for SignedRecord {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Value for &SignedRecord {
+    type SelfType<'a> = &'a SignedRecord where Self: 'a;
+    type AsBytes<'a> = &'a SignedRecord where Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        Some(size_of::<SignedRecord>())
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        SignedRecord::ref_from(data).unwrap()
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'a,
+        Self: 'b,
+    {
+        value
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("SignedRecord")
+    }
+}
+
+static_assertions::const_assert_eq!(align_of::<SignedRecord>(), 1);


### PR DESCRIPTION
First round of using zerocopy in the sync db. 

## Open tasks

- this is missing a migration currently
- in a next round, after redb@v2 is merged, it should be possible to reduce some of the current allocations further (hopefully)