### PR TITLE
fix(iroh): do not shut down node on internal rpc error

### DIFF
--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -458,8 +458,8 @@ where
                         Ok((msg, chan)) => {
                             handler.handle_rpc_request(msg, chan);
                         }
-                        Err(_) => {
-                            info!("last controller dropped, shutting down");
+                        Err(e) => {
+                            info!("internal rpc request error: {:?}", e);
                             break;
                         }
                     }


### PR DESCRIPTION
## Description

fix(iroh): do not shut down node on internal rpc error

Internal rpc errors can happen, e.g. when the client side gets dropped. No reason to shut down the entire node. We already have a cancellation token, so it's not like we rely on this for shutdown.

Fixes #2157, #2143

## Notes & open questions

Note: I also sneaked in a fix for #2143. Basically when we are unable to notify the db that a new gc epoch has started, we just shot down the gc loop, since clearly the store is not well (probably shut down).

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
