### PR TITLE
fix: Remove redundant imports

### DIFF
--- a/iroh-bytes/src/downloader/test/dialer.rs
+++ b/iroh-bytes/src/downloader/test/dialer.rs
@@ -2,9 +2,7 @@
 
 use std::{
     collections::HashSet,
-    sync::Arc,
     task::{Context, Poll},
-    time::Duration,
 };
 
 use parking_lot::RwLock;

--- a/iroh-bytes/src/downloader/test/getter.rs
+++ b/iroh-bytes/src/downloader/test/getter.rs
@@ -1,7 +1,5 @@
 //! Implementation of [`super::Getter`] used for testing.
 
-use std::{sync::Arc, time::Duration};
-
 use parking_lot::RwLock;
 
 use super::*;

--- a/iroh-bytes/src/format/collection.rs
+++ b/iroh-bytes/src/format/collection.rs
@@ -256,7 +256,6 @@ impl Collection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bao_tree::blake3;
 
     #[test]
     fn roundtrip_blob() {

--- a/iroh-bytes/src/protocol/range_spec.rs
+++ b/iroh-bytes/src/protocol/range_spec.rs
@@ -355,7 +355,6 @@ mod tests {
     use std::ops::Range;
 
     use super::*;
-    use bao_tree::ChunkNum;
     use iroh_test::{assert_eq_hex, hexdump::parse_hexdump};
     use proptest::prelude::*;
 

--- a/iroh-bytes/src/store/bao_file.rs
+++ b/iroh-bytes/src/store/bao_file.rs
@@ -732,7 +732,6 @@ pub mod test_support {
         BlockSize, ChunkRanges,
     };
     use futures::{Future, Stream, StreamExt};
-    use iroh_base::hash::Hash;
     use rand::RngCore;
     use range_collections::RangeSet2;
     use tokio::io::{AsyncRead, AsyncReadExt};
@@ -867,8 +866,6 @@ pub mod test_support {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use bao_tree::{blake3, ChunkNum, ChunkRanges};
     use futures::StreamExt;
     use tests::test_support::{

--- a/iroh-bytes/src/store/fs/tests.rs
+++ b/iroh-bytes/src/store/fs/tests.rs
@@ -1,7 +1,6 @@
 use bao_tree::ChunkRanges;
 use iroh_io::AsyncSliceReaderExt;
 use std::io::Cursor;
-use std::time::Duration;
 
 use crate::store::bao_file::test_support::{
     decode_response_into_batch, make_wire_data, random_test_data, simulate_remote, validate,

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -655,11 +655,7 @@ fn decode_peer_data(peer_data: &PeerData) -> anyhow::Result<AddrInfo> {
 mod test {
     use std::time::Duration;
 
-    use iroh_net::NodeAddr;
-    use iroh_net::{
-        relay::{RelayMap, RelayMode},
-        MagicEndpoint,
-    };
+    use iroh_net::relay::{RelayMap, RelayMode};
     use tokio::spawn;
     use tokio::time::timeout;
     use tokio_util::sync::CancellationToken;

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, net::SocketAddr, num::ParseIntError, str::FromStr};
+use std::{net::SocketAddr, num::ParseIntError, str::FromStr};
 
 use anyhow::{Context, Result};
 use bytes::Bytes;

--- a/iroh-net/src/bin/iroh-relay.rs
+++ b/iroh-net/src/bin/iroh-relay.rs
@@ -863,11 +863,9 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::time::Duration;
 
-    use anyhow::Result;
     use bytes::Bytes;
     use http_body_util::BodyExt;
     use iroh_base::node_addr::RelayUrl;
-    use iroh_net::key::SecretKey;
     use iroh_net::relay::http::ClientBuilder;
     use iroh_net::relay::ReceivedMessage;
     use tokio::task::JoinHandle;

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -265,14 +265,14 @@ mod tests {
         collections::{BTreeSet, HashMap},
         net::SocketAddr,
         sync::Arc,
-        time::{Duration, SystemTime},
+        time::SystemTime,
     };
 
-    use futures::{stream, StreamExt};
+    use futures::stream;
     use parking_lot::Mutex;
     use rand::Rng;
 
-    use crate::{key::SecretKey, relay::RelayMode, NodeAddr};
+    use crate::{key::SecretKey, relay::RelayMode};
 
     use super::*;
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2525,7 +2525,6 @@ pub(crate) mod tests {
     use futures::StreamExt;
     use iroh_test::CallOnDrop;
     use rand::RngCore;
-    use tokio::task::JoinSet;
 
     use crate::{relay::RelayMode, test_utils::run_relay_server, tls, MagicEndpoint};
 

--- a/iroh-net/src/magicsock/node_map/endpoint.rs
+++ b/iroh-net/src/magicsock/node_map/endpoint.rs
@@ -1387,12 +1387,10 @@ pub enum ConnectionType {
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
-    use std::time::Duration;
 
     use super::{
         super::{NodeMap, NodeMapInner},
-        best_addr::BestAddr,
-        IpPort, *,
+        *,
     };
     use crate::key::SecretKey;
 

--- a/iroh-net/src/netcheck.rs
+++ b/iroh-net/src/netcheck.rs
@@ -787,7 +787,6 @@ mod tests {
     use tracing::info;
 
     use crate::defaults::{DEFAULT_RELAY_STUN_PORT, EU_RELAY_HOSTNAME};
-    use crate::net::IpFamily;
     use crate::ping::Pinger;
     use crate::relay::RelayNode;
 

--- a/iroh-net/src/netcheck/reportgen/hairpin.rs
+++ b/iroh-net/src/netcheck/reportgen/hairpin.rs
@@ -178,8 +178,6 @@ impl Actor {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
-
     use bytes::BytesMut;
     use tokio::sync::mpsc;
     use tracing::info;

--- a/iroh-net/src/netcheck/reportgen/probes.rs
+++ b/iroh-net/src/netcheck/reportgen/probes.rs
@@ -467,7 +467,6 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use crate::defaults::default_relay_map;
-    use crate::net::interfaces;
     use crate::netcheck::RelayLatencies;
 
     use super::*;

--- a/iroh-net/src/relay/client_conn.rs
+++ b/iroh-net/src/relay/client_conn.rs
@@ -451,8 +451,6 @@ impl ClientConnIo {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use crate::key::SecretKey;
     use crate::relay::codec::{recv_frame, FrameType};
 

--- a/iroh-net/src/relay/clients.rs
+++ b/iroh-net/src/relay/clients.rs
@@ -258,10 +258,7 @@ mod tests {
 
     use crate::{
         key::SecretKey,
-        relay::{
-            client_conn::ClientConnBuilder,
-            codec::{recv_frame, DerpCodec, Frame, FrameType},
-        },
+        relay::codec::{recv_frame, DerpCodec, Frame, FrameType},
     };
 
     use anyhow::Result;

--- a/iroh-net/src/relay/codec.rs
+++ b/iroh-net/src/relay/codec.rs
@@ -542,8 +542,6 @@ pub(super) async fn recv_frame<S: Stream<Item = anyhow::Result<Frame>> + Unpin>(
 mod tests {
     use tokio_util::codec::{FramedRead, FramedWrite};
 
-    use crate::relay::codec::DerpCodec;
-
     use super::*;
 
     #[tokio::test]

--- a/iroh-net/src/relay/server.rs
+++ b/iroh-net/src/relay/server.rs
@@ -472,15 +472,13 @@ mod tests {
 
     use crate::relay::{
         client::ClientBuilder,
-        client_conn::ClientConnBuilder,
-        codec::{recv_frame, DerpCodec, FrameType},
+        codec::{recv_frame, FrameType},
         types::ClientInfo,
         ReceivedMessage,
     };
     use tokio_util::codec::{FramedRead, FramedWrite};
     use tracing_subscriber::{prelude::*, EnvFilter};
 
-    use anyhow::Result;
     use bytes::Bytes;
     use tokio::io::DuplexStream;
 

--- a/iroh-net/src/stun.rs
+++ b/iroh-net/src/stun.rs
@@ -152,7 +152,7 @@ pub fn parse_response(b: &[u8]) -> Result<(TransactionId, SocketAddr), Error> {
 #[cfg(test)]
 pub mod test {
     use std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::{IpAddr, Ipv4Addr},
         sync::Arc,
     };
 

--- a/iroh-sync/src/store/fs.rs
+++ b/iroh-sync/src/store/fs.rs
@@ -887,7 +887,6 @@ fn into_entry(key: RecordsId, value: RecordsValue) -> SignedEntry {
 #[cfg(test)]
 mod tests {
     use crate::ranger::Store as _;
-    use crate::NamespaceSecret;
 
     use super::*;
 

--- a/iroh-sync/src/sync.rs
+++ b/iroh-sync/src/sync.rs
@@ -1180,7 +1180,7 @@ mod tests {
     use crate::{
         actor::SyncHandle,
         ranger::{Range, Store as _},
-        store::{self, fs::StoreInstance, OpenError, Query, SortBy, SortDirection, Store},
+        store::{fs::StoreInstance, OpenError, Query, SortBy, SortDirection, Store},
     };
 
     use super::*;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -279,12 +279,10 @@ impl<D> NodeInner<D> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use std::time::Duration;
 
     use anyhow::{bail, Context};
     use bytes::Bytes;
-    use futures::StreamExt;
     use iroh_bytes::provider::AddProgress;
 
     use crate::rpc_protocol::{BlobAddPathRequest, BlobAddPathResponse, SetTagOption, WrapOption};

--- a/iroh/src/ticket/doc.rs
+++ b/iroh/src/ticket/doc.rs
@@ -67,7 +67,7 @@ mod tests {
     use super::*;
     use iroh_base::base32;
     use iroh_net::key::PublicKey;
-    use iroh_sync::{Capability, NamespaceId};
+    use iroh_sync::NamespaceId;
     use iroh_test::{assert_eq_hex, hexdump::parse_hexdump};
 
     #[test]

--- a/iroh/src/util/fs.rs
+++ b/iroh/src/util/fs.rs
@@ -337,7 +337,6 @@ pub fn canonicalized_path_to_string(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::fs::{path_content_info, PathContent};
 
     #[test]
     fn test_path_to_key_roundtrip() {

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -188,25 +188,20 @@ async fn gc_hashseq_impl() -> Result<()> {
 #[cfg(feature = "fs-store")]
 mod file {
     use super::*;
-    use std::{io, path::PathBuf, time::Duration};
+    use std::{io, path::PathBuf};
 
-    use anyhow::Result;
     use bao_tree::{
         io::fsm::{BaoContentItem, ResponseDecoderNext},
-        BaoTree, ChunkRanges,
+        BaoTree,
     };
-    use bytes::Bytes;
     use futures::StreamExt;
     use iroh_io::AsyncSliceReaderExt;
     use testdir::testdir;
 
     use iroh_bytes::{
-        hashseq::HashSeq,
-        store::{
-            BaoBatchWriter, ConsistencyCheckProgress, Map, MapEntryMut, MapMut, ReportLevel, Store,
-        },
+        store::{BaoBatchWriter, ConsistencyCheckProgress, Map, MapEntryMut, ReportLevel},
         util::progress::{FlumeProgressSender, ProgressSender as _},
-        BlobFormat, HashAndFormat, Tag, TempTag, IROH_BLOCK_SIZE,
+        TempTag,
     };
     use tokio::io::AsyncReadExt;
 


### PR DESCRIPTION
## Description

The rust beta compiler does not like redundant imports and fails on
them.  We have them mostly in tests, likely because of how the code
was grown.  This cleans up the redundant imports.

## Notes & open questions

Let's hope not too many new ones sneak in again, this will be a little
bit a catchup game until this makes it to stable.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.