### PR TITLE
feat: mark iroh-cli's iroh binary as workspace default

### DIFF
--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -9,6 +9,10 @@ authors = ["dignifiedquire <me@dignifiedquire.com>", "n0 team"]
 repository = "https://github.com/n0-computer/iroh"
 keywords = ["networking", "p2p", "holepunching", "ipfs"]
 
+# Despite not being in the workspace root this is explicitly here to
+# make `cargo run` in the workspace root invoke `iroh`.
+default-run = "iroh"
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
# Description

This makes sure that when you call `cargo run` in the workspace root
the `iroh` binary from the iroh-cli crate will be chosen if no
additional --bin parameter is passed.

## Notes & open questions

If we are de-prioritising the iroh cli maybe this is the wrong default
to set?

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.