### PR TITLE
feat(iroh-net): add `MagicEndpoint::conn_type_stream` returns a stream that reports connection type changes for a `node_id`

### DIFF
--- a/iroh-base/src/node_addr.rs
+++ b/iroh-base/src/node_addr.rs
@@ -204,7 +204,5 @@ mod tests {
 
         let url3 = RelayUrl::from(Url::parse("https://example.com/").unwrap());
         assert_eq!(url, url3);
-
-        assert_eq!(url1, url2);
     }
 }

--- a/iroh-base/src/node_addr.rs
+++ b/iroh-base/src/node_addr.rs
@@ -204,5 +204,7 @@ mod tests {
 
         let url3 = RelayUrl::from(Url::parse("https://example.com/").unwrap());
         assert_eq!(url, url3);
+
+        assert_eq!(url1, url2);
     }
 }

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -995,13 +995,18 @@ mod tests {
     async fn magic_endpoint_wait_for_direct_conn() {
         let _logging_guard = iroh_test::logging::setup();
         let (relay_map, relay_url, _relay_guard) = run_relay_server().await.unwrap();
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+        let ep1_secret_key = SecretKey::generate_with_rng(&mut rng);
+        let ep2_secret_key = SecretKey::generate_with_rng(&mut rng);
         let ep1 = MagicEndpoint::builder()
+            .secret_key(ep1_secret_key)
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .bind(0)
             .await
             .unwrap();
         let ep2 = MagicEndpoint::builder()
+            .secret_key(ep2_secret_key)
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map))
             .bind(0)

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -405,7 +405,7 @@ impl MagicEndpoint {
     /// Returns a stream that reports changes in the [`crate::magicsock::ConnectionType`]
     /// for the given `node_id`.
     ///
-    /// Errors:
+    /// # Errors
     ///
     /// Will error if we do not have any address information for the given `node_id`
     pub fn conn_type_stream(&self, node_id: &PublicKey) -> Result<ConnectionTypeStream> {

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -1000,6 +1000,7 @@ mod tests {
         let ep2_secret_key = SecretKey::generate_with_rng(&mut rng);
         let ep1 = MagicEndpoint::builder()
             .secret_key(ep1_secret_key)
+            .insecure_skip_relay_cert_verify(true)
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .bind(0)
@@ -1007,6 +1008,7 @@ mod tests {
             .unwrap();
         let ep2 = MagicEndpoint::builder()
             .secret_key(ep2_secret_key)
+            .insecure_skip_relay_cert_verify(true)
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map))
             .bind(0)

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1360,7 +1360,7 @@ impl MagicSock {
     ///
     /// The current [`ConnectionType`] will the the initial entry on the stream.
     ///
-    /// Errors:
+    /// # Errors
     ///
     /// Will return an error if there is no address information known about the
     /// given `node_id`.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1371,6 +1371,19 @@ impl MagicSock {
             .map(|a| a.0)
     }
 
+    /// Returns a [`tokio::sync::oneshot::Receiver`] that will be alerted once we have successfully
+    /// holepunched on a direct UDP address for this node_key.
+    ///
+    /// If we have already successfully holepunched, this will alert immediately.
+    ///
+    /// It is possible we will never successfully holepunch, in which case no alert
+    /// will ever be issued.
+    ///
+    /// If no endpoint exists for the given `node_key` in the `node_map`, one will be created.
+    pub fn notify_direct_conn(&self, node_key: &PublicKey) -> tokio::sync::oneshot::Receiver<()> {
+        self.inner.node_map.notify_direct_conn(node_key)
+    }
+
     /// Returns the relay node with the best latency.
     ///
     /// If `None`, then we currently have no verified connection to a relay node.

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -586,11 +586,7 @@ impl Stream for ConnectionTypeStream {
         if let Some(initial_conn_type) = this.initial.take() {
             return Poll::Ready(Some(initial_conn_type));
         }
-        match Pin::new(&mut this.inner).poll_next(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Some(conn_type)) => Poll::Ready(Some(conn_type)),
-            Poll::Ready(None) => Poll::Ready(None),
-        }
+        Pin::new(&mut this.inner).poll_next(cx)
     }
 }
 

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -217,7 +217,7 @@ impl NodeMap {
     /// Sends the current [`ConnectionType`] whenever any changes to the
     /// connection type for `public_key` has occured.
     ///
-    /// Errors:
+    /// # Errors
     ///
     /// Will return an error if there is not an entry in the [`NodeMap`] for
     /// the `public_key`
@@ -410,7 +410,7 @@ impl NodeMapInner {
     /// Sends the current [`ConnectionType`] whenever any changes to the
     /// connection type for `public_key` has occured.
     ///
-    /// Errors:
+    /// # Errors
     ///
     /// Will return an error if there is not an entry in the [`NodeMap`] for
     /// the `public_key`

--- a/iroh-net/src/magicsock/node_map/endpoint.rs
+++ b/iroh-net/src/magicsock/node_map/endpoint.rs
@@ -301,8 +301,6 @@ impl Endpoint {
     ///
     /// It is possible we will never have a viable `best_addr`, in which case
     /// no alert will ever be issued.
-    ///
-    /// This will only notify the *first* time we a valid `best_addr` for this endpoint.
     pub fn notify_has_best_addr(&mut self) -> oneshot::Receiver<()> {
         self.assign_best_addr_from_candidates_if_empty();
         let already_holepunched = matches!(


### PR DESCRIPTION
## Description
`MagicEndpoint::conn_type_stream` returns a `Stream` that reports changes for a `magicsock::Endpoint` with a given `node_id` in a `magicsock::NodeMap`.

It will error if no address information for that `node_id` exists in the `NodeMap`.

This PR also adjusts the `Endpoint::info()` method to use the same `ConnectionType` that gets reported to the stream.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
