### PR TITLE
feat: retry nodes in downloader

### DIFF
--- a/iroh-bytes/src/downloader.rs
+++ b/iroh-bytes/src/downloader.rs
@@ -255,15 +255,6 @@ impl DownloadKind {
     pub const fn hash_and_format(&self) -> HashAndFormat {
         self.0
     }
-
-    /// Switch from [`BlobFormat::Raw`] to [`BlobFormat::HashSeq`] and vice-versa.
-    fn with_format_switched(&self) -> Self {
-        let format = match self.format() {
-            BlobFormat::Raw => BlobFormat::HashSeq,
-            BlobFormat::HashSeq => BlobFormat::Raw,
-        };
-        Self(HashAndFormat::new(self.hash(), format))
-    }
 }
 
 impl fmt::Display for DownloadKind {
@@ -853,7 +844,7 @@ impl<DB: Store, G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D, 
                     self.retrying_nodes.remove(&node);
                 }
                 // cleanup provider map
-                if !self.queue.contains(&kind.with_format_switched()) {
+                if !self.queue.contains_hash(kind.hash()) {
                     self.providers.remove_hash_from_node(&kind.hash(), &node);
                 }
                 // update node busy/idle state

--- a/iroh-bytes/src/downloader.rs
+++ b/iroh-bytes/src/downloader.rs
@@ -1340,7 +1340,7 @@ impl Dialer for iroh_net::dialer::Dialer {
 #[derive(Debug, Default)]
 struct Queue {
     queue: LinkedHashSet<DownloadKind>,
-    parked: HashSet<DownloadKind>,
+    parked: LinkedHashSet<DownloadKind>,
 }
 
 impl Queue {
@@ -1348,16 +1348,14 @@ impl Queue {
         self.queue.front()
     }
 
-    pub fn iter_queue(&self) -> impl Iterator<Item = &DownloadKind> {
-        self.queue.iter()
-    }
-
+    #[cfg(any(test, debug_assertions))]
     pub fn iter_parked(&self) -> impl Iterator<Item = &DownloadKind> {
         self.parked.iter()
     }
 
-    pub fn iter_all(&self) -> impl Iterator<Item = &DownloadKind> {
-        self.iter_queue().chain(self.iter_parked())
+    #[cfg(any(test, debug_assertions))]
+    pub fn iter(&self) -> impl Iterator<Item = &DownloadKind> {
+        self.queue.iter().chain(self.parked.iter())
     }
 
     pub fn contains(&self, kind: &DownloadKind) -> bool {

--- a/iroh-bytes/src/downloader/invariants.rs
+++ b/iroh-bytes/src/downloader/invariants.rs
@@ -46,7 +46,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer, S: Store> Service<G, D, S
         );
 
         // check the active requests per peer don't exceed the limit
-        for (node, info) in self.nodes.iter() {
+        for (node, info) in self.connected_nodes.iter() {
             assert!(
                 info.active_requests() <= *max_concurrent_requests_per_node,
                 "max_concurrent_requests_per_node exceeded for {node}"
@@ -83,12 +83,13 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer, S: Store> Service<G, D, S
         );
         // check that the count of requests per peer matches the number of requests that have that
         // peer as active
-        let mut real_count: HashMap<NodeId, usize> = HashMap::with_capacity(self.nodes.len());
+        let mut real_count: HashMap<NodeId, usize> =
+            HashMap::with_capacity(self.connected_nodes.len());
         for req_info in self.active_requests.values() {
             // nothing like some classic word count
             *real_count.entry(req_info.node).or_default() += 1;
         }
-        for (peer, info) in self.nodes.iter() {
+        for (peer, info) in self.connected_nodes.iter() {
             assert_eq!(
                 info.active_requests(),
                 real_count.get(peer).copied().unwrap_or_default(),
@@ -100,7 +101,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer, S: Store> Service<G, D, S
     /// Checks that the queued requests all appear in the provider map and request map.
     #[track_caller]
     fn check_queued_requests_consistency(&self) {
-        for entry in &self.queue {
+        for entry in self.queue.iter_all() {
             assert!(
                 self.providers
                     .get_candidates(&entry.hash())
@@ -119,7 +120,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer, S: Store> Service<G, D, S
     #[track_caller]
     fn check_idle_peer_consistency(&self) {
         let idle_peers = self
-            .nodes
+            .connected_nodes
             .values()
             .filter(|info| info.active_requests() == 0)
             .count();
@@ -137,8 +138,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer, S: Store> Service<G, D, S
             let as_raw = DownloadKind(HashAndFormat::raw(*hash));
             let as_hash_seq = DownloadKind(HashAndFormat::hash_seq(*hash));
             assert!(
-                self.queue.contains(&as_raw)
-                    || self.queue.contains(&as_hash_seq)
+                self.queue.contains_hash(*hash)
                     || self.active_requests.contains_key(&as_raw)
                     || self.active_requests.contains_key(&as_hash_seq),
                 "all hashes in the provider map are in the queue or active"

--- a/iroh-bytes/src/downloader/invariants.rs
+++ b/iroh-bytes/src/downloader/invariants.rs
@@ -119,7 +119,7 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer, S: Store> Service<G, D, S
         // check that all parked hashes should be parked
         for entry in self.queue.iter_parked() {
             assert!(
-                matches!(self.next_step(entry), NextStep::WaitForNodeRetry),
+                matches!(self.next_step(entry), NextStep::Park),
                 "next step for parked node ist WaitForNodeRetry"
             );
             assert!(

--- a/iroh-bytes/src/downloader/test.rs
+++ b/iroh-bytes/src/downloader/test.rs
@@ -398,7 +398,7 @@ async fn retry_nodes() {
     };
 
     let downloader = Downloader::spawn_for_test(dialer.clone(), getter.clone(), concurrency_limits);
-    // send the downloads
+
     let good_nodes = [
         SecretKey::generate().public(),
         SecretKey::generate().public(),

--- a/iroh-bytes/src/downloader/test.rs
+++ b/iroh-bytes/src/downloader/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 use anyhow::anyhow;
 use futures::FutureExt;
-use std::time::Duration;
+use std::{sync::atomic::AtomicUsize, time::Duration};
 
 use iroh_net::key::SecretKey;
 
@@ -21,9 +21,22 @@ impl Downloader {
         getter: getter::TestingGetter,
         concurrency_limits: ConcurrencyLimits,
     ) -> Self {
+        Self::spawn_for_test_with_retry_config(
+            dialer,
+            getter,
+            concurrency_limits,
+            Default::default(),
+        )
+    }
+
+    fn spawn_for_test_with_retry_config(
+        dialer: dialer::TestingDialer,
+        getter: getter::TestingGetter,
+        concurrency_limits: ConcurrencyLimits,
+        retry_config: RetryConfig,
+    ) -> Self {
         let (msg_tx, msg_rx) = mpsc::channel(super::SERVICE_CHANNEL_CAPACITY);
         let db = crate::store::mem::Store::default();
-        let retry_config = RetryConfig::default();
 
         LocalPoolHandle::new(1).spawn_pinned(move || async move {
             // we want to see the logs of the service
@@ -355,7 +368,6 @@ async fn fail_while_running() {
     let dialer = dialer::TestingDialer::default();
     let getter = getter::TestingGetter::default();
     let downloader = Downloader::spawn_for_test(dialer.clone(), getter.clone(), Default::default());
-
     let blob_fail = HashAndFormat::raw(Hash::new([1u8; 32]));
     let blob_success = HashAndFormat::raw(Hash::new([2u8; 32]));
 
@@ -388,7 +400,66 @@ async fn fail_while_running() {
 }
 
 #[tokio::test]
-async fn retry_nodes() {
+async fn retry_nodes_simple() {
+    let _guard = iroh_test::logging::setup();
+    let dialer = dialer::TestingDialer::default();
+    let getter = getter::TestingGetter::default();
+    let downloader = Downloader::spawn_for_test(dialer.clone(), getter.clone(), Default::default());
+    let node = SecretKey::generate().public();
+    let dial_attempts = Arc::new(AtomicUsize::new(0));
+    let dial_attempts2 = dial_attempts.clone();
+    // fail on first dial, then succeed
+    dialer.set_dial_outcome(move |_node| {
+        if dial_attempts2.fetch_add(1, Ordering::SeqCst) == 0 {
+            false
+        } else {
+            true
+        }
+    });
+    let kind = HashAndFormat::raw(Hash::new([0u8; 32]));
+    let req = DownloadRequest::new(kind, vec![node]);
+    let handle = downloader.queue(req).await;
+
+    assert!(handle.await.is_ok());
+    assert_eq!(dial_attempts.load(Ordering::SeqCst), 2);
+    dialer.assert_history(&[node, node]);
+}
+
+#[tokio::test]
+async fn retry_nodes_fail() {
+    let _guard = iroh_test::logging::setup();
+    let dialer = dialer::TestingDialer::default();
+    let getter = getter::TestingGetter::default();
+    let config = RetryConfig {
+        initial_retry_delay: Duration::from_millis(10),
+        max_retries_per_node: 3,
+    };
+
+    let downloader = Downloader::spawn_for_test_with_retry_config(
+        dialer.clone(),
+        getter.clone(),
+        Default::default(),
+        config,
+    );
+    let node = SecretKey::generate().public();
+    let dial_attempts = Arc::new(AtomicUsize::new(0));
+    let dial_attempts2 = dial_attempts.clone();
+    // fail always
+    dialer.set_dial_outcome(move |_node| {
+        dial_attempts2.fetch_add(1, Ordering::SeqCst);
+        false
+    });
+    let kind = HashAndFormat::raw(Hash::new([0u8; 32]));
+    let req = DownloadRequest::new(kind, vec![node]);
+    let handle = downloader.queue(req).await;
+
+    assert!(handle.await.is_err());
+    assert_eq!(dial_attempts.load(Ordering::SeqCst), 4);
+    dialer.assert_history(&[node, node, node, node]);
+}
+
+#[tokio::test]
+async fn retry_nodes_jump_queue() {
     let _guard = iroh_test::logging::setup();
     let dialer = dialer::TestingDialer::default();
     let getter = getter::TestingGetter::default();
@@ -401,31 +472,29 @@ async fn retry_nodes() {
 
     let downloader = Downloader::spawn_for_test(dialer.clone(), getter.clone(), concurrency_limits);
 
-    let good_nodes = [
-        SecretKey::generate().public(),
-        SecretKey::generate().public(),
-    ];
-    let bad_nodes = [
-        SecretKey::generate().public(),
-        SecretKey::generate().public(),
-    ];
+    let good_node = SecretKey::generate().public();
+    let bad_node = SecretKey::generate().public();
 
-    dialer.set_dial_outcome(move |node| good_nodes.contains(&node));
+    dialer.set_dial_outcome(move |node| node == good_node);
     let kind1 = HashAndFormat::raw(Hash::new([0u8; 32]));
     let kind2 = HashAndFormat::raw(Hash::new([2u8; 32]));
 
-    let req1 = DownloadRequest::new(kind1, vec![bad_nodes[0], bad_nodes[1]]);
+    let req1 = DownloadRequest::new(kind1, vec![bad_node]);
     let h1 = downloader.queue(req1).await;
 
-    let req2 = DownloadRequest::new(kind2, vec![bad_nodes[1], good_nodes[0]]);
+    let req2 = DownloadRequest::new(kind2, vec![bad_node, good_node]);
     let h2 = downloader.queue(req2).await;
 
     // wait for req2 to complete - this tests that the "queue is jumped" and we are not
     // waiting for req1 to elapse all retries
     assert!(h2.await.is_ok());
 
-    // now we make download2 succeed!
-    dialer.set_dial_outcome(move |_node| true);
+    dialer.assert_history(&[bad_node, good_node]);
 
+    // now we make download1 succeed!
+    dialer.set_dial_outcome(move |_node| true);
     assert!(h1.await.is_ok());
+
+    // assert history
+    dialer.assert_history(&[bad_node, good_node, bad_node]);
 }

--- a/iroh-bytes/src/downloader/test.rs
+++ b/iroh-bytes/src/downloader/test.rs
@@ -23,12 +23,14 @@ impl Downloader {
     ) -> Self {
         let (msg_tx, msg_rx) = mpsc::channel(super::SERVICE_CHANNEL_CAPACITY);
         let db = crate::store::mem::Store::default();
+        let retry_config = RetryConfig::default();
 
         LocalPoolHandle::new(1).spawn_pinned(move || async move {
             // we want to see the logs of the service
             let _guard = iroh_test::logging::setup();
 
-            let service = Service::new(db, getter, dialer, concurrency_limits, msg_rx);
+            let service =
+                Service::new(db, getter, dialer, concurrency_limits, retry_config, msg_rx);
             service.run().await
         });
 


### PR DESCRIPTION
## Description

adds retries to #2085:

* after a node fails to dial, or fails during a transfer  with IO errors, we move the node into a delay queue, with an increasing timeout. once the delay expires, the node may be dialed again.
* if the head of the download queue can only proceed with nodes which are currently in the retry queue, we *park* the download in a separate set from the main queue, and proceed with the next download
* once a retrying node succeeds to reconnect, we unpark all parked hashes for which this node is a candidate

## Notes & open questions

Has a smoke test for retry behavior. Adding more tests would be great.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
