### PR TITLE
fix(iroh-cli): Fix printing of doctor connect/accept output

### DIFF
--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -400,7 +400,6 @@ impl Gui {
     fn update_counters(target: &ProgressBar) {
         if let Some(core) = Core::get() {
             let metrics = core.get_collector::<MagicsockMetrics>().unwrap();
-            tracing::error!("metrics enabled");
             let send_ipv4 = HumanBytes(metrics.send_ipv4.get());
             let send_ipv6 = HumanBytes(metrics.send_ipv6.get());
             let send_relay = HumanBytes(metrics.send_relay.get());


### PR DESCRIPTION
## Description

Apparently now metrics work and are attempted to be printed.
Unfortunately they also print a tracing error message to stderr, the
stderr which is also being used by the progress bar.  The result is
that the progress bar ends up with an extra newline and the first line
of it is not being repainted but flows up, resulting in lots of
garbage in the terminal history.

By removing the log message the output is perserved much better.

## Notes & open questions

It could be argued that this is not a good fix, if the loglevel is
changed to info or debug the same problems would occur.  However we
already have the ability to log to a random filedescriptor and will
soon be able to log to files.  So maybe that's just fine for now.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates if relevant.~~
- ~~[ ] Tests if relevant.~~