### PR TITLE
deps: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,12 +329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,26 +1031,6 @@ name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
-
-[[package]]
-name = "data-encoding-macro"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c01c06f5f429efdf2bae21eb67c28b3df3cf85b7dd2d8ef09c0838dac5d33e"
-dependencies = [
- "data-encoding",
- "data-encoding-macro-internal",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0047d07f2c89b17dd631c80450d69841a6b5d7fb17278cbc43d7e4cfcf2576f3"
-dependencies = [
- "data-encoding",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "default-net"
@@ -1802,15 +1776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown 0.14.3",
-]
-
-[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,12 +2259,10 @@ dependencies = [
  "bytes",
  "clap",
  "console-subscriber",
- "data-encoding",
  "derive_more",
  "flume",
  "futures",
  "genawaiter",
- "hashlink",
  "hex",
  "indicatif",
  "iroh",
@@ -2312,7 +2275,6 @@ dependencies = [
  "iroh-sync",
  "iroh-test",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "portable-atomic",
  "postcard",
@@ -2321,7 +2283,6 @@ dependencies = [
  "quinn",
  "rand",
  "rand_chacha",
- "range-collections",
  "regex",
  "serde",
  "serde_json",
@@ -2350,7 +2311,6 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "iroh-test",
- "multibase",
  "once_cell",
  "postcard",
  "proptest",
@@ -2389,7 +2349,6 @@ dependencies = [
  "bao-tree",
  "bytes",
  "chrono",
- "data-encoding",
  "derive_more",
  "flume",
  "futures",
@@ -2403,7 +2362,6 @@ dependencies = [
  "iroh-net",
  "iroh-test",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "postcard",
  "proptest",
@@ -2417,7 +2375,6 @@ dependencies = [
  "rustls",
  "self_cell",
  "serde",
- "serde-error",
  "serde_json",
  "serde_test",
  "smallvec",
@@ -2453,9 +2410,7 @@ dependencies = [
  "indicatif",
  "iroh",
  "iroh-metrics",
- "multibase",
  "nix 0.27.1",
- "num_cpus",
  "parking_lot",
  "portable-atomic",
  "postcard",
@@ -2473,11 +2428,8 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-util",
- "toml 0.8.12",
  "tracing",
  "tracing-subscriber",
- "url",
  "walkdir",
 ]
 
@@ -2488,7 +2440,6 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
- "data-encoding",
  "derive_more",
  "ed25519-dalek",
  "futures",
@@ -2499,7 +2450,6 @@ dependencies = [
  "iroh-metrics",
  "iroh-net",
  "iroh-test",
- "once_cell",
  "postcard",
  "quinn",
  "rand",
@@ -2556,8 +2506,6 @@ dependencies = [
  "clap",
  "criterion",
  "crypto_box",
- "curve25519-dalek",
- "data-encoding",
  "default-net",
  "der",
  "derive_more",
@@ -2567,7 +2515,6 @@ dependencies = [
  "governor",
  "hex",
  "hickory-resolver",
- "hostname",
  "http 1.1.0",
  "http-body-util",
  "hyper 1.2.0",
@@ -2602,13 +2549,10 @@ dependencies = [
  "rustls-pemfile",
  "rustls-webpki",
  "serde",
- "serde_bytes",
  "serde_json",
  "serde_with",
- "serdect",
  "smallvec",
  "socket2",
- "strum 0.25.0",
  "stun-rs",
  "surge-ping",
  "testdir",
@@ -2639,8 +2583,6 @@ dependencies = [
  "hdrhistogram",
  "iroh-net",
  "quinn",
- "rcgen 0.11.3",
- "rustls",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2652,7 +2594,6 @@ version = "0.13.0"
 dependencies = [
  "anyhow",
  "bytes",
- "data-encoding",
  "derive_more",
  "ed25519-dalek",
  "flume",
@@ -2663,9 +2604,7 @@ dependencies = [
  "iroh-metrics",
  "iroh-net",
  "iroh-test",
- "lru",
  "num_enum",
- "once_cell",
  "parking_lot",
  "postcard",
  "proptest",
@@ -2684,7 +2623,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -2802,15 +2740,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "lru"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
-dependencies = [
- "hashbrown 0.14.3",
-]
-
-[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,17 +2817,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "multibase"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
-dependencies = [
- "base-x",
- "data-encoding",
- "data-encoding-macro",
 ]
 
 [[package]]
@@ -4514,15 +4432,6 @@ name = "serde-error"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e988182713aeed6a619a88bca186f6d6407483485ffe44c869ee264f8eabd13f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
  "serde",
 ]

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -19,7 +19,6 @@ anyhow = { version = "1" }
 bao-tree = {  version = "0.13", features = ["tokio_fsm", "validate"], default-features = false, optional = true }
 data-encoding = { version = "2.3.3", optional = true }
 hex = "0.4.3"
-multibase = { version = "0.9.1", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"], optional = true }
 redb = { version = "2.0.0", optional = true }
 serde = { version = "1", features = ["derive"] }
@@ -47,7 +46,7 @@ serde_test = "1.0.176"
 
 [features]
 default = ["hash", "base32"]
-hash = ["bao-tree", "multibase", "data-encoding", "postcard"]
+hash = ["bao-tree", "data-encoding", "postcard"]
 base32 = ["data-encoding"]
 redb = ["dep:redb"]
 key = ["dep:ed25519-dalek", "dep:once_cell", "dep:rand", "dep:rand_core", "dep:ssh-key", "dep:ttl_cache", "dep:aead", "dep:crypto_box", "dep:zeroize", "dep:url", "dep:derive_more"]

--- a/iroh-bytes/Cargo.toml
+++ b/iroh-bytes/Cargo.toml
@@ -20,7 +20,6 @@ anyhow = { version = "1" }
 bao-tree = {  version = "0.13", features = ["tokio_fsm"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"
-data-encoding = "2.3.3"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "deref", "deref_mut", "from", "try_into", "into"] }
 flume = "0.11"
 futures = "0.3.25"
@@ -32,7 +31,6 @@ iroh-io = { version = "0.6.0", features = ["stats"] }
 iroh-metrics = { version = "0.13.0", path = "../iroh-metrics", optional = true }
 iroh-net = { version = "0.13.0", path = "../iroh-net", optional = true }
 num_cpus = "1.15.0"
-once_cell = "1.17.0"
 parking_lot = { version = "0.12.1", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quinn = "0.10"
@@ -43,7 +41,6 @@ redb_v1  = { package = "redb", version = "1.5.1", optional = true }
 reflink-copy = { version = "0.1.8", optional = true }
 self_cell = "1.0.1"
 serde = { version = "1", features = ["derive"] }
-serde-error = "0.1.2"
 smallvec = { version = "1.10.0", features = ["serde", "const_new"] }
 tempfile = { version = "3.10.0", optional = true }
 thiserror = "1"

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -39,8 +39,6 @@ human-time = { version = "0.1.6" }
 indicatif = { version = "0.17", features = ["tokio"] }
 iroh = { version = "0.13.0", path = "../iroh", features = ["metrics"] }
 iroh-metrics = { version = "0.13.0", path = "../iroh-metrics" }
-multibase = { version = "0.9.1" }
-num_cpus = "1.16.0"
 parking_lot = "0.12.1"
 postcard = "1.0.8"
 portable-atomic = "1"
@@ -54,13 +52,10 @@ serde = { version = "1.0.197", features = ["derive"] }
 strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0.58"
 time = { version = "0.3", features = ["formatting"] }
-toml = { version = "0.8" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.36.0", features = ["full"] }
-tokio-util = { version = "0.7", features = ["codec", "io-util", "io", "time"] }
 tempfile = "3.10.1"
-url = { version = "2.4", features = ["serde"] }
 flume = "0.11.0"
 
 [dev-dependencies]

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 anyhow = { version = "1" }
 blake3 = { package = "iroh-blake3", version = "1.4.3"}
 bytes = { version = "1.4.0", features = ["serde"] }
-data-encoding = "2.4.0"
 derive_more = { version = "1.0.0-beta.1", features = ["add", "debug", "deref", "display", "from", "try_into", "into"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 indexmap = "2.0"
@@ -37,7 +36,6 @@ iroh-net = { path = "../iroh-net", version = "0.13.0", optional = true }
 quinn = { version = "0.10", optional = true }
 tokio = { version = "1", optional = true, features = ["io-util", "sync", "rt", "macros", "net", "fs"] }
 tokio-util = { version = "0.7.8", optional = true, features = ["codec"] }
-once_cell = "1.18.0"
 genawaiter = { version = "0.99.1", default-features = false, features = ["futures03"] }
 
 [dev-dependencies]

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -20,8 +20,6 @@ aead = { version = "0.5.2", features = ["bytes"] }
 anyhow = { version = "1" }
 backoff = "0.4.0"
 bytes = "1"
-curve25519-dalek = "4.0.0"
-data-encoding = "2.3.3"
 default-net = "0.20"
 der = { version = "0.7", features = ["alloc", "derive"] }
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into", "deref"] }
@@ -29,7 +27,6 @@ flume = "0.11"
 futures = "0.3.25"
 governor = "0.6.0"
 hex = "0.4.3"
-hostname = "0.3.1"
 http = "1"
 http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
@@ -51,11 +48,8 @@ reqwest = { version = "0.11.19", default-features = false, features = ["rustls-t
 ring = "0.17"
 rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
 serde = { version = "1", features = ["derive", "rc"] }
-serde_bytes = "0.11.12"
-serdect = "0.2.0"
 smallvec = "1.11.1"
 socket2 = "0.5.3"
-strum = { version = "0.25.0", features = ["derive"] }
 stun-rs = "0.1.5"
 surge-ping = "0.8.0"
 thiserror = "1"

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -11,8 +11,6 @@ bytes = "1"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh-net = { path = ".." }
 quinn = "0.10"
-rcgen = "0.11.1"
-rustls = { version = "0.21.0", default-features = false, features = ["quic"] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1"

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -17,20 +17,17 @@ workspace = true
 [dependencies]
 anyhow = "1"
 blake3 = { package = "iroh-blake3", version = "1.4.3"}
-data-encoding = "2.4.0"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "deref", "display", "from", "try_into", "into", "as_ref"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 flume = "0.11"
 iroh-base = { version = "0.13.0", path = "../iroh-base" }
 iroh-metrics = { version = "0.13.0", path = "../iroh-metrics", optional = true }
 num_enum = "0.7"
-once_cell = "1.18.0"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 rand = "0.8.5"
 rand_core = "0.6.4"
 serde = { version = "1.0.164", features = ["derive"] }
 strum = { version = "0.25", features = ["derive"] }
-url = "2.4"
 bytes = { version = "1.4", features = ["serde"] }
 parking_lot = "0.12.1"
 hex = "0.4"
@@ -49,7 +46,6 @@ tokio-util = { version = "0.7", optional = true, features = ["codec", "io-util",
 tokio-stream = { version = "0.1", optional = true, features = ["sync"]}
 quinn = { version = "0.10", optional = true }
 futures = { version = "0.3", optional = true }
-lru = "0.12"
 
 [dev-dependencies]
 iroh-test = { path = "../iroh-test" }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -19,12 +19,10 @@ workspace = true
 anyhow = { version = "1" }
 bao-tree = { version = "0.13", features = ["tokio_fsm"], default-features = false }
 bytes = "1"
-data-encoding = "2.4.0"
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into", "from_str"] }
 flume = "0.11"
 futures = "0.3.25"
 genawaiter = { version = "0.99", default-features = false, features = ["futures03"] }
-hashlink = "0.8.4"
 hex = { version = "0.4.3" }
 iroh-bytes = { version = "0.13.0", path = "../iroh-bytes", features = ["downloader"] }
 iroh-base = { version = "0.13.0", path = "../iroh-base", features = ["key"] }
@@ -35,12 +33,10 @@ num_cpus = { version = "1.15.0" }
 portable-atomic = "1"
 iroh-sync = { version = "0.13.0", path = "../iroh-sync" }
 iroh-gossip = { version = "0.13.0", path = "../iroh-gossip" }
-once_cell = "1.18.0"
 parking_lot = "0.12.1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quic-rpc = { version = "0.7.0", default-features = false, features = ["flume-transport", "quinn-transport"] }
 quinn = "0.10"
-range-collections = { version = "0.4.0" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.25", features = ["derive"] }


### PR DESCRIPTION
I just stumbled upon the very nice tool [`cargo machete`](https://blog.benj.me/2022/04/27/cargo-machete/) which finds unused dependencies. So let's remove them!

Ran only `cargo check` locally - let's see if CI also says that all is fine.