### PR TITLE
feat(iroh-cli): simplify config loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,12 +336,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -641,23 +635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "config"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
-dependencies = [
- "async-trait",
- "indexmap 1.9.3",
- "lazy_static",
- "nom",
- "pathdiff",
- "ron",
- "serde",
- "serde_json",
- "toml 0.5.11",
 ]
 
 [[package]]
@@ -2397,7 +2374,6 @@ dependencies = [
  "clap",
  "colored",
  "comfy-table",
- "config",
  "console",
  "derive_more",
  "dialoguer",
@@ -2428,6 +2404,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -2562,7 +2539,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-rustls-acme",
  "tokio-util",
- "toml 0.8.12",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3250,12 +3227,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pem"
@@ -4140,18 +4111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "indexmap 1.9.3",
- "serde",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4453,7 +4412,6 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
- "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -5209,20 +5167,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "indexmap 1.9.3",
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -23,19 +23,19 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.81"
-bao-tree = { version = "0.13" }
+bao-tree = "0.13"
 bytes = "1.5.0"
 clap = { version = "4", features = ["derive"] }
-colored = { version = "2.0.4" }
-comfy-table = { version = "7.0.1" }
-config = { version = "0.13.1", default-features = false, features = ["toml", "preserve_order"] }
-console = { version = "0.15.5" }
+colored = "2.0.4"
+comfy-table = "7.0.1"
+console = "0.15.5"
 derive_more = { version = "1.0.0-beta.1", features = ["display"] }
 dialoguer = { version = "0.11.0", default-features = false }
-dirs-next = { version = "2.0.0" }
+dirs-next = "2.0.0"
+flume = "0.11.0"
 futures = "0.3.30"
 hex = "0.4.3"
-human-time = { version = "0.1.6" }
+human-time = "0.1.6"
 indicatif = { version = "0.17", features = ["tokio"] }
 iroh = { version = "0.13.0", path = "../iroh", features = ["metrics"] }
 iroh-metrics = { version = "0.13.0", path = "../iroh-metrics" }
@@ -45,9 +45,9 @@ portable-atomic = "1"
 quic-rpc = { version = "0.7.0", features = ["flume-transport", "quinn-transport"] }
 quinn = "0.10.2"
 rand = "0.8.5"
-rustyline = { version = "12.0.0" }
-shell-words = { version = "1.1.0" }
-shellexpand = { version = "3.1.0" }
+rustyline = "12.0.0"
+shell-words = "1.1.0"
+shellexpand = "3.1.0"
 serde = { version = "1.0.197", features = ["derive"] }
 strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0.58"
@@ -56,7 +56,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.36.0", features = ["full"] }
 tempfile = "3.10.1"
-flume = "0.11.0"
+toml = { version = "0.8.12", features = ["preserve_order"] }
 
 [dev-dependencies]
 duct = "0.13.6"

--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -122,7 +122,7 @@ impl Cli {
             Commands::Console => {
                 let env = ConsoleEnv::for_console(data_dir)?;
                 if self.start {
-                    let config = NodeConfig::from_env(self.config.as_deref())?;
+                    let config = NodeConfig::load(self.config.as_deref()).await?;
                     start::run_with_command(
                         &config,
                         data_dir,
@@ -138,7 +138,7 @@ impl Cli {
             Commands::Rpc(command) => {
                 let env = ConsoleEnv::for_cli(data_dir)?;
                 if self.start {
-                    let config = NodeConfig::from_env(self.config.as_deref())?;
+                    let config = NodeConfig::load(self.config.as_deref()).await?;
                     start::run_with_command(
                         &config,
                         data_dir,
@@ -160,7 +160,7 @@ impl Cli {
                         path.display()
                     );
                 }
-                let mut config = NodeConfig::from_env(self.config.as_deref())?;
+                let mut config = NodeConfig::load(self.config.as_deref()).await?;
                 if let Some(metrics_port) = self.metrics_port {
                     config.metrics_addr = match metrics_port {
                         MetricsPort::Disabled => None,
@@ -187,7 +187,7 @@ impl Cli {
                 .await
             }
             Commands::Doctor { command } => {
-                let config = NodeConfig::from_env(self.config.as_deref())?;
+                let config = NodeConfig::load(self.config.as_deref()).await?;
                 self::doctor::run(command, &config).await
             }
         }

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -988,7 +988,7 @@ pub async fn run(command: Commands, config: &NodeConfig) -> anyhow::Result<()> {
             port_map_probe(config).await
         }
         Commands::RelayUrls { count } => {
-            let config = NodeConfig::from_env(None)?;
+            let config = NodeConfig::load(None).await?;
             relay_urls(count, config).await
         }
         Commands::TicketInspect { ticket } => inspect_ticket(&ticket),

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -1,7 +1,6 @@
 //! Configuration for the iroh CLI.
 
 use std::{
-    collections::HashMap,
     env, fmt,
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -9,8 +8,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{anyhow, bail, ensure, Context, Result};
-use config::{Environment, File, Value};
+use anyhow::{anyhow, bail, Context, Result};
 use iroh::net::{
     defaults::{default_eu_relay_node, default_na_relay_node},
     relay::{RelayMap, RelayNode},
@@ -19,22 +17,16 @@ use iroh::node::GcPolicy;
 use iroh::sync::{AuthorId, NamespaceId};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use tracing::debug;
-
-/// CONFIG_FILE_NAME is the name of the optional config file located in the iroh home directory
-pub(crate) const CONFIG_FILE_NAME: &str = "iroh.config.toml";
-
-/// ENV_PREFIX should be used along side the config field name to set a config field using
-/// environment variables
-/// For example, `IROH_PATH=/path/to/config` would set the value of the `Config.path` field
-pub(crate) const ENV_PREFIX: &str = "IROH";
 
 const ENV_AUTHOR: &str = "AUTHOR";
 const ENV_DOC: &str = "DOC";
 
+/// CONFIG_FILE_NAME is the name of the optional config file located in the iroh home directory
+pub(crate) const CONFIG_FILE_NAME: &str = "iroh.config.toml";
+
 /// Fetches the environment variable `IROH_<key>` from the current process.
 pub(crate) fn env_var(key: &str) -> std::result::Result<String, env::VarError> {
-    env::var(format!("{ENV_PREFIX}_{key}"))
+    env::var(format!("IROH_{key}"))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -105,77 +97,28 @@ impl Default for NodeConfig {
 }
 
 impl NodeConfig {
-    /// Make a config from the default environment variables.
-    ///
-    /// Optionally provide an additional configuration source.
-    pub(crate) fn from_env(additional_config_source: Option<&Path>) -> anyhow::Result<Self> {
-        let config_path = iroh_config_path(CONFIG_FILE_NAME).context("invalid config path")?;
-        if let Some(path) = additional_config_source {
-            ensure!(
-                path.is_file(),
-                "Config file does not exist: {}",
-                path.display()
-            );
-        }
-        let sources = [Some(config_path.as_path()), additional_config_source];
-        let config = Self::load(
-            // potential config files
-            &sources,
-            // env var prefix for this config
-            ENV_PREFIX,
-            // map of present command line arguments
-            // args.make_overrides_map(),
-            HashMap::<String, String>::new(),
-        )?;
-        Ok(config)
-    }
+    /// Create a config using defaults, and the passed in config file.
+    pub async fn load(file: Option<&Path>) -> Result<NodeConfig> {
+        let default_config = iroh_config_path(CONFIG_FILE_NAME)?;
 
-    /// Make a config using a default, files, environment variables, and commandline flags.
-    ///
-    /// Later items in the *file_paths* slice will have a higher priority than earlier ones.
-    ///
-    /// Environment variables are expected to start with the *env_prefix*. Nested fields can be
-    /// accessed using `.`, if your environment allows env vars with `.`
-    ///
-    /// Note: For the metrics configuration env vars, it is recommended to use the metrics
-    /// specific prefix `IROH_METRICS` to set a field in the metrics config. You can use the
-    /// above dot notation to set a metrics field, eg, `IROH_CONFIG_METRICS.SERVICE_NAME`, but
-    /// only if your environment allows it
-    pub(crate) fn load<S, V>(
-        file_paths: &[Option<&Path>],
-        env_prefix: &str,
-        flag_overrides: HashMap<S, V>,
-    ) -> Result<NodeConfig>
-    where
-        S: AsRef<str>,
-        V: Into<Value>,
-    {
-        let mut builder = config::Config::builder();
-
-        // layer on config options from files
-        for path in file_paths.iter().flatten() {
-            if path.exists() {
-                let p = path.to_str().ok_or_else(|| anyhow::anyhow!("empty path"))?;
-                builder = builder.add_source(File::with_name(p));
+        let config_file = match file {
+            Some(file) => Some(file),
+            None => {
+                if default_config.exists() {
+                    Some(default_config.as_ref())
+                } else {
+                    None
+                }
             }
-        }
+        };
+        let config = if let Some(file) = config_file {
+            let config = tokio::fs::read_to_string(file).await?;
+            toml::from_str(&config)?
+        } else {
+            Self::default()
+        };
 
-        // next, add any environment variables
-        builder = builder.add_source(
-            Environment::with_prefix(env_prefix)
-                .separator("__")
-                .try_parsing(true),
-        );
-
-        // finally, override any values
-        for (flag, val) in flag_overrides.into_iter() {
-            builder = builder.set_override(flag, val)?;
-        }
-
-        let cfg = builder.build()?;
-        debug!("make_config:\n{:#?}\n", cfg);
-        let cfg = cfg.try_deserialize()?;
-        Ok(cfg)
+        Ok(config)
     }
 
     /// Constructs a `RelayMap` based on the current configuration.
@@ -422,9 +365,9 @@ pub(crate) fn iroh_cache_path(file_name: &Path) -> Result<PathBuf> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_default_settings() {
-        let config = NodeConfig::load(&[][..], "__FOO", HashMap::<String, String>::new()).unwrap();
+    #[tokio::test]
+    async fn test_default_settings() {
+        let config = NodeConfig::load(None).await.unwrap();
 
         assert_eq!(config.relay_nodes.len(), 2);
     }


### PR DESCRIPTION
Loads the configuration from either the default path, or the passed in configuration path. Dropping the `config` dependency and simplifying the structure.

Removes unused overrides and detailed configuration via env variables.

