### PR TITLE
feat(iroh-cli): add file logging by default for start commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2466,6 +2466,7 @@ dependencies = [
  "regex",
  "rustyline",
  "serde",
+ "serde_with",
  "shell-words",
  "shellexpand",
  "strum 0.26.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,6 +2482,7 @@ dependencies = [
  "tokio-util",
  "toml 0.8.12",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "url",
  "walkdir",
@@ -5472,6 +5473,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -50,7 +50,7 @@ rand = "0.8.5"
 rustyline = { version = "12.0.0" }
 shell-words = { version = "1.1.0" }
 shellexpand = { version = "3.1.0" }
-serde = { version = "1.0.197", features = ["derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0.58"
 time = { version = "0.3", features = ["formatting"] }

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -33,6 +33,7 @@ console = { version = "0.15.5" }
 derive_more = { version = "1.0.0-beta.1", features = ["display"] }
 dialoguer = { version = "0.11.0", default-features = false }
 dirs-next = { version = "2.0.0" }
+flume = "0.11.0"
 futures = "0.3.30"
 hex = "0.4.3"
 human-time = { version = "0.1.6" }
@@ -40,25 +41,24 @@ indicatif = { version = "0.17", features = ["tokio"] }
 iroh = { version = "0.13.0", path = "../iroh", features = ["metrics"] }
 iroh-metrics = { version = "0.13.0", path = "../iroh-metrics" }
 parking_lot = "0.12.1"
-postcard = "1.0.8"
 portable-atomic = "1"
+postcard = "1.0.8"
 quic-rpc = { version = "0.7.0", features = ["flume-transport", "quinn-transport"] }
 quinn = "0.10.2"
 rand = "0.8.5"
 rustyline = { version = "12.0.0" }
+serde = { version = "1.0.197", features = ["derive"] }
+serde_with = "3.7.0"
 shell-words = { version = "1.1.0" }
 shellexpand = { version = "3.1.0" }
-serde = { version = "1.0.197", features = ["derive"] }
 strum = { version = "0.26.2", features = ["derive"] }
+tempfile = "3.10.1"
 thiserror = "1.0.58"
 time = { version = "0.3", features = ["formatting"] }
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.36.0", features = ["full"] }
-tempfile = "3.10.1"
-flume = "0.11.0"
+tracing = "0.1.40"
 tracing-appender = "0.2.3"
-serde_with = "3.7.0"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 duct = "0.13.6"

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -63,6 +63,7 @@ tempfile = "3.10.1"
 url = { version = "2.4", features = ["serde"] }
 flume = "0.11.0"
 tracing-appender = "0.2.3"
+serde_with = "3.7.0"
 
 [dev-dependencies]
 duct = "0.13.6"

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -62,6 +62,7 @@ tokio-util = { version = "0.7", features = ["codec", "io-util", "io", "time"] }
 tempfile = "3.10.1"
 url = { version = "2.4", features = ["serde"] }
 flume = "0.11.0"
+tracing-appender = "0.2.3"
 
 [dev-dependencies]
 duct = "0.13.6"

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -50,7 +50,7 @@ rand = "0.8.5"
 rustyline = { version = "12.0.0" }
 shell-words = { version = "1.1.0" }
 shellexpand = { version = "3.1.0" }
-serde = { version = "1.0.197", features = ["derive", "rc"] }
+serde = { version = "1.0.197", features = ["derive"] }
 strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0.58"
 time = { version = "0.3", features = ["formatting"] }

--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -131,6 +131,7 @@ impl Cli {
                     )
                     .await
                 } else {
+                    crate::logging::init_terminal_logging()?;
                     let iroh = IrohRpc::connect(data_dir).await.context("rpc connect")?;
                     console::run(&iroh, &env).await
                 }
@@ -147,6 +148,7 @@ impl Cli {
                     )
                     .await
                 } else {
+                    crate::logging::init_terminal_logging()?;
                     let iroh = IrohRpc::connect(data_dir).await.context("rpc connect")?;
                     command.run(&iroh, &env).await
                 }

--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -37,11 +37,6 @@ pub(crate) struct Cli {
     #[clap(long, global = true)]
     start: bool,
 
-    /// Send log output to specified file descriptor.
-    #[cfg(unix)]
-    #[clap(long)]
-    pub(crate) log_fd: Option<i32>,
-
     /// Port to serve metrics on. -1 to disable.
     #[clap(long)]
     pub(crate) metrics_port: Option<MetricsPort>,

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -933,6 +933,8 @@ fn inspect_ticket(ticket: &str) -> anyhow::Result<()> {
 }
 
 pub async fn run(command: Commands, config: &NodeConfig) -> anyhow::Result<()> {
+    let data_dir = iroh_data_root()?;
+    let _guard = crate::logging::init_terminal_and_file_logging(&config.file_logs, &data_dir)?;
     match command {
         Commands::Report {
             stun_host,

--- a/iroh-cli/src/commands/start.rs
+++ b/iroh-cli/src/commands/start.rs
@@ -37,6 +37,7 @@ where
     F: FnOnce(iroh::client::mem::Iroh) -> T + Send + 'static,
     T: Future<Output = Result<()>> + 'static,
 {
+    let _guard = crate::logging::init_terminal_and_file_logging(&config.file_logs, iroh_data_root)?;
     let metrics_fut = start_metrics_server(config.metrics_addr);
 
     let res = run_with_command_inner(config, iroh_data_root, run_type, command).await;

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -4,7 +4,6 @@ use std::{
     collections::HashMap,
     env,
     net::SocketAddr,
-    num::NonZeroUsize,
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
@@ -20,9 +19,7 @@ use iroh::node::GcPolicy;
 use iroh::sync::{AuthorId, NamespaceId};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use serde_with::{DeserializeFromStr, SerializeDisplay};
 use tracing::debug;
-use tracing_subscriber::Layer;
 
 /// CONFIG_FILE_NAME is the name of the optional config file located in the iroh home directory
 pub(crate) const CONFIG_FILE_NAME: &str = "iroh.config.toml";
@@ -323,9 +320,9 @@ fn env_doc() -> Result<Option<NamespaceId>> {
 
 /// Parse [`ENV_FILE_RUST_LOG`] as [`tracing_subscriber::EnvFilter`]. Returns `None` if not
 /// present.
-fn env_file_rust_log() -> Option<Result<EnvFilter>> {
+fn env_file_rust_log() -> Option<Result<crate::logging::EnvFilter>> {
     match env::var(ENV_FILE_RUST_LOG) {
-        Ok(s) => Some(EnvFilter::from_str(&s).map_err(Into::into)),
+        Ok(s) => Some(crate::logging::EnvFilter::from_str(&s).map_err(Into::into)),
         Err(e) => match e {
             env::VarError::NotPresent => None,
             e @ env::VarError::NotUnicode(_) => Some(Err(e.into())),

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -62,119 +62,6 @@ impl ConsolePaths {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(default)]
-pub(crate) struct FileLogging {
-    /// RUST_LOG directive to filter file logs.
-    rust_log: EnvFilter,
-    /// Maximum number of files to keep.
-    max_files: NonZeroUsize,
-    /// How often should a new log file be produced.
-    rotation: Rotation,
-}
-
-impl Default for FileLogging {
-    fn default() -> Self {
-        let filter = EnvFilter::default();
-        Self {
-            rust_log: filter,
-            max_files: NonZeroUsize::new(8).expect("clearly non zero"),
-            rotation: Rotation::default(),
-        }
-    }
-}
-
-impl FileLogging {
-    /// Obtain a layer for tracing compatible with the fmt subscriber.
-    ///
-    /// This layer will:
-    /// - use the defauilt [`tracing_subscriber::fmt::format::Format`].
-    /// - include line numbers.
-    /// - create log files in the `logs` dir inside the given `iroh_data_root`.
-    /// - rotate files every [`Self::rotation`].
-    /// - keep at most [`Self::max_files`] log files.
-    /// - use the filtering defined by [`Self::rust_log`].
-    /// - create log files with the name `iroh-<ROTATION_BASED_NAME>.log` (ex: iroh-2024-02-02.log)
-    pub(crate) fn layer(
-        &self,
-        iroh_data_root: &Path,
-    ) -> Result<(
-        impl Layer<tracing_subscriber::FmtSubscriber>,
-        tracing_appender::non_blocking::WorkerGuard,
-    )> {
-        use tracing_appender::rolling;
-        let FileLogging {
-            rust_log,
-            max_files,
-            rotation,
-        } = self;
-
-        let (file_logger, guard) = {
-            let rotation = match rotation {
-                Rotation::Hourly => rolling::Rotation::HOURLY,
-                Rotation::Daily => rolling::Rotation::DAILY,
-                Rotation::Never => rolling::Rotation::NEVER,
-            };
-            let logs_path = iroh_data_root.join("logs");
-
-            let file_appender = rolling::Builder::new()
-                .rotation(rotation)
-                .max_log_files(max_files.get())
-                .filename_prefix("iroh")
-                .filename_suffix("log")
-                .build(logs_path)?;
-            tracing_appender::non_blocking(file_appender)
-        };
-
-        Ok((
-            tracing_subscriber::fmt::Layer::new()
-                .with_line_number(true)
-                .with_writer(file_logger)
-                .with_filter(rust_log.layer()),
-            guard,
-        ))
-    }
-}
-
-/// Wrapper to obtain a [`tracing_subscriber::EnvFilter`] that satisfies required bounds.
-#[derive(
-    Debug, Clone, PartialEq, Eq, SerializeDisplay, DeserializeFromStr, derive_more::Display,
-)]
-#[display("{_0}")]
-pub(crate) struct EnvFilter(String);
-
-impl FromStr for EnvFilter {
-    type Err = <tracing_subscriber::EnvFilter as FromStr>::Err;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // validate the RUST_LOG statement
-        let _valid_env = tracing_subscriber::EnvFilter::from_str(s)?;
-        Ok(EnvFilter(s.into()))
-    }
-}
-
-impl Default for EnvFilter {
-    fn default() -> Self {
-        Self("debug".into())
-    }
-}
-
-impl EnvFilter {
-    pub(crate) fn layer(&self) -> tracing_subscriber::EnvFilter {
-        tracing_subscriber::EnvFilter::from_str(&self.0).expect("validated RUST_LOG statement")
-    }
-}
-
-/// Hoe often should a new file be created for file logs.
-/// Akin to [`tracing_appender::rolling::Rotation`].
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
-enum Rotation {
-    #[default]
-    Hourly,
-    Daily,
-    Never,
-}
-
 /// The configuration for an iroh node.
 #[derive(PartialEq, Eq, Debug, Deserialize, Serialize, Clone)]
 #[serde(default)]
@@ -185,7 +72,7 @@ pub(crate) struct NodeConfig {
     pub(crate) gc_policy: GcPolicy,
     /// Bind address on which to serve Prometheus metrics
     pub(crate) metrics_addr: Option<SocketAddr>,
-    pub(crate) file_logs: FileLogging,
+    pub(crate) file_logs: super::logging::FileLogging,
 }
 
 impl Default for NodeConfig {

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashMap,
-    env,
+    env, fmt,
     net::SocketAddr,
     path::{Path, PathBuf},
     str::FromStr,
@@ -38,14 +38,37 @@ pub(crate) fn env_var(key: &str) -> std::result::Result<String, env::VarError> {
     env::var(format!("{ENV_PREFIX}_{key}"))
 }
 
-#[derive(Debug, Clone, Copy, strum::IntoStaticStr, strum::Display, strum::EnumString)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum ConsolePaths {
-    #[strum(serialize = "default_author.pubkey")]
     DefaultAuthor,
-    #[strum(serialize = "history")]
     History,
 }
 
+impl From<&ConsolePaths> for &'static str {
+    fn from(value: &ConsolePaths) -> Self {
+        match value {
+            ConsolePaths::DefaultAuthor => "default_author.pubkey",
+            ConsolePaths::History => "history",
+        }
+    }
+}
+impl FromStr for ConsolePaths {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        Ok(match s {
+            "default_author.pubkey" => Self::DefaultAuthor,
+            "history" => Self::History,
+            _ => bail!("unknown file or directory"),
+        })
+    }
+}
+
+impl fmt::Display for ConsolePaths {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s: &str = self.into();
+        write!(f, "{s}")
+    }
+}
 impl AsRef<Path> for ConsolePaths {
     fn as_ref(&self) -> &Path {
         let s: &str = self.into();
@@ -143,7 +166,7 @@ impl NodeConfig {
         // next, add any environment variables
         builder = builder.add_source(
             Environment::with_prefix(env_prefix)
-                .separator("_")
+                .separator("__")
                 .try_parsing(true),
         );
 
@@ -425,16 +448,5 @@ mod tests {
         let config = NodeConfig::load(&[][..], "__FOO", HashMap::<String, String>::new()).unwrap();
 
         assert_eq!(config.relay_nodes.len(), 2);
-    }
-
-    #[test]
-    fn test_layering() {
-        let config = NodeConfig::load(
-            &[Some(Path::new("/home/divagant-martian/iroh_config.toml"))],
-            ENV_PREFIX,
-            HashMap::<String, String>::default(),
-        )
-        .unwrap();
-        println!("{config:?}")
     }
 }

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashMap,
-    env, fmt,
+    env,
     net::SocketAddr,
     path::{Path, PathBuf},
     str::FromStr,
@@ -37,37 +37,16 @@ pub(crate) fn env_var(key: &str) -> std::result::Result<String, env::VarError> {
     env::var(format!("{ENV_PREFIX}_{key}"))
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, strum::IntoStaticStr, strum::Display, strum::EnumString)]
 pub(crate) enum ConsolePaths {
+    #[strum(serialize = "default_author.pubkey")]
     DefaultAuthor,
+    #[strum(serialize = "history")]
     History,
+    #[strum(serialize = "logs")]
+    Logs,
 }
 
-impl From<&ConsolePaths> for &'static str {
-    fn from(value: &ConsolePaths) -> Self {
-        match value {
-            ConsolePaths::DefaultAuthor => "default_author.pubkey",
-            ConsolePaths::History => "history",
-        }
-    }
-}
-impl FromStr for ConsolePaths {
-    type Err = anyhow::Error;
-    fn from_str(s: &str) -> Result<Self> {
-        Ok(match s {
-            "default_author.pubkey" => Self::DefaultAuthor,
-            "history" => Self::History,
-            _ => bail!("unknown file or directory"),
-        })
-    }
-}
-
-impl fmt::Display for ConsolePaths {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s: &str = self.into();
-        write!(f, "{s}")
-    }
-}
 impl AsRef<Path> for ConsolePaths {
     fn as_ref(&self) -> &Path {
         let s: &str = self.into();

--- a/iroh-cli/src/logging.rs
+++ b/iroh-cli/src/logging.rs
@@ -13,8 +13,9 @@ use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, Lay
 /// - log to [`std::io::Stderr`]
 ///
 /// The file base logging layer will:
-/// - use the defauilt [`fmt::format::Format`].
-/// - include line numbers.
+/// - use the defauilt [`fmt::format::Format`] save for:
+///   - including line numbers.
+///   - not using ansi colors.
 /// - create log files in the `logs` dir inside the given `iroh_data_root`.
 /// - rotate files every [`Self::rotation`].
 /// - keep at most [`Self::max_files`] log files.
@@ -52,6 +53,7 @@ pub(crate) fn init_terminal_and_file_logging(
         };
 
         let layer = fmt::Layer::new()
+            .with_ansi(false)
             .with_line_number(true)
             .with_writer(file_logger)
             .with_filter(rust_log.layer());
@@ -120,7 +122,8 @@ impl FromStr for EnvFilter {
 
 impl Default for EnvFilter {
     fn default() -> Self {
-        Self("debug".into())
+        // rustyline is annoying
+        Self("rustyline=warn,debug".into())
     }
 }
 
@@ -133,7 +136,7 @@ impl EnvFilter {
 /// Hoe often should a new file be created for file logs.
 /// Akin to [`tracing_appender::rolling::Rotation`].
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
-enum Rotation {
+pub(crate) enum Rotation {
     #[default]
     Hourly,
     Daily,

--- a/iroh-cli/src/logging.rs
+++ b/iroh-cli/src/logging.rs
@@ -97,7 +97,7 @@ impl Default for FileLogging {
         let filter = EnvFilter::default();
         Self {
             rust_log: filter,
-            max_files: NonZeroUsize::new(8).expect("clearly non zero"),
+            max_files: NonZeroUsize::new(4).expect("clearly non zero"),
             rotation: Rotation::default(),
         }
     }

--- a/iroh-cli/src/logging.rs
+++ b/iroh-cli/src/logging.rs
@@ -136,6 +136,7 @@ impl EnvFilter {
 /// Hoe often should a new file be created for file logs.
 /// Akin to [`tracing_appender::rolling::Rotation`].
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
 pub(crate) enum Rotation {
     #[default]
     Hourly,

--- a/iroh-cli/src/logging.rs
+++ b/iroh-cli/src/logging.rs
@@ -1,0 +1,141 @@
+use std::{num::NonZeroUsize, path::Path};
+
+use derive_more::FromStr;
+use serde::{Deserialize, Serialize};
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+use tracing_appender::{non_blocking, rolling};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, Layer};
+
+/// Initialize logging both in the terminal and file based.
+///
+/// The terminal based logging layer will:
+/// - use the defauilt [`fmt::format::Format`].
+/// - log to [`std::io::Stderr`]
+///
+/// The file base logging layer will:
+/// - use the defauilt [`fmt::format::Format`].
+/// - include line numbers.
+/// - create log files in the `logs` dir inside the given `iroh_data_root`.
+/// - rotate files every [`Self::rotation`].
+/// - keep at most [`Self::max_files`] log files.
+/// - use the filtering defined by [`Self::rust_log`].
+/// - create log files with the name `iroh-<ROTATION_BASED_NAME>.log` (ex: iroh-2024-02-02.log)
+pub(crate) fn init_terminal_and_file_logging(
+    file_log_config: &FileLogging,
+    logs_dir: &Path,
+) -> anyhow::Result<non_blocking::WorkerGuard> {
+    let terminal_layer = fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_filter(tracing_subscriber::EnvFilter::from_default_env());
+    let (file_layer, guard) = {
+        let FileLogging {
+            rust_log,
+            max_files,
+            rotation,
+        } = file_log_config;
+
+        let (file_logger, guard) = {
+            let rotation = match rotation {
+                Rotation::Hourly => rolling::Rotation::HOURLY,
+                Rotation::Daily => rolling::Rotation::DAILY,
+                Rotation::Never => rolling::Rotation::NEVER,
+            };
+            let logs_path = logs_dir.join("logs");
+
+            let file_appender = rolling::Builder::new()
+                .rotation(rotation)
+                .max_log_files(max_files.get())
+                .filename_prefix("iroh")
+                .filename_suffix("log")
+                .build(logs_path)?;
+            non_blocking(file_appender)
+        };
+
+        let layer = fmt::Layer::new()
+            .with_line_number(true)
+            .with_writer(file_logger)
+            .with_filter(rust_log.layer());
+        (layer, guard)
+    };
+    tracing_subscriber::registry()
+        .with(file_layer)
+        .with(terminal_layer)
+        .try_init()?;
+    Ok(guard)
+}
+
+/// Initialize logging in the terminal.
+///
+/// This will:
+/// - use the defauilt [`fmt::format::Format`].
+/// - log to [`std::io::Stderr`]
+pub(crate) fn init_terminal_logging() -> anyhow::Result<()> {
+    let terminal_layer = fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_filter(tracing_subscriber::EnvFilter::from_default_env());
+    tracing_subscriber::registry()
+        .with(terminal_layer)
+        .try_init()?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub(crate) struct FileLogging {
+    /// RUST_LOG directive to filter file logs.
+    pub(crate) rust_log: EnvFilter,
+    /// Maximum number of files to keep.
+    pub(crate) max_files: NonZeroUsize,
+    /// How often should a new log file be produced.
+    pub(crate) rotation: Rotation,
+}
+
+impl Default for FileLogging {
+    fn default() -> Self {
+        let filter = EnvFilter::default();
+        Self {
+            rust_log: filter,
+            max_files: NonZeroUsize::new(8).expect("clearly non zero"),
+            rotation: Rotation::default(),
+        }
+    }
+}
+
+/// Wrapper to obtain a [`tracing_subscriber::EnvFilter`] that satisfies required bounds.
+#[derive(
+    Debug, Clone, PartialEq, Eq, SerializeDisplay, DeserializeFromStr, derive_more::Display,
+)]
+#[display("{_0}")]
+pub(crate) struct EnvFilter(String);
+
+impl FromStr for EnvFilter {
+    type Err = <tracing_subscriber::EnvFilter as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // validate the RUST_LOG statement
+        let _valid_env = tracing_subscriber::EnvFilter::from_str(s)?;
+        Ok(EnvFilter(s.into()))
+    }
+}
+
+impl Default for EnvFilter {
+    fn default() -> Self {
+        Self("debug".into())
+    }
+}
+
+impl EnvFilter {
+    pub(crate) fn layer(&self) -> tracing_subscriber::EnvFilter {
+        tracing_subscriber::EnvFilter::from_str(&self.0).expect("validated RUST_LOG statement")
+    }
+}
+
+/// Hoe often should a new file be created for file logs.
+/// Akin to [`tracing_appender::rolling::Rotation`].
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+enum Rotation {
+    #[default]
+    Hourly,
+    Daily,
+    Never,
+}

--- a/iroh-cli/src/logging.rs
+++ b/iroh-cli/src/logging.rs
@@ -140,6 +140,7 @@ impl EnvFilter {
 }
 
 /// How often should a new file be created for file logs.
+///
 /// Akin to [`tracing_appender::rolling::Rotation`].
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "lowercase")]

--- a/iroh-cli/src/logging.rs
+++ b/iroh-cli/src/logging.rs
@@ -139,7 +139,7 @@ impl EnvFilter {
     }
 }
 
-/// Hoe often should a new file be created for file logs.
+/// How often should a new file be created for file logs.
 /// Akin to [`tracing_appender::rolling::Rotation`].
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "lowercase")]

--- a/iroh-cli/src/logging.rs
+++ b/iroh-cli/src/logging.rs
@@ -9,11 +9,11 @@ use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, Lay
 /// Initialize logging both in the terminal and file based.
 ///
 /// The terminal based logging layer will:
-/// - use the defauilt [`fmt::format::Format`].
+/// - use the default [`fmt::format::Format`].
 /// - log to [`std::io::Stderr`]
 ///
 /// The file base logging layer will:
-/// - use the defauilt [`fmt::format::Format`] save for:
+/// - use the default [`fmt::format::Format`] save for:
 ///   - including line numbers.
 ///   - not using ansi colors.
 /// - create log files in the `logs` dir inside the given `iroh_data_root`.
@@ -69,7 +69,7 @@ pub(crate) fn init_terminal_and_file_logging(
 /// Initialize logging in the terminal.
 ///
 /// This will:
-/// - use the defauilt [`fmt::format::Format`].
+/// - use the default [`fmt::format::Format`].
 /// - log to [`std::io::Stderr`]
 pub(crate) fn init_terminal_logging() -> anyhow::Result<()> {
     let terminal_layer = fmt::layer()

--- a/iroh-cli/src/main.rs
+++ b/iroh-cli/src/main.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use anyhow::Result;
 use clap::Parser;
-use tracing_subscriber::{prelude::*, EnvFilter};
 
 mod commands;
 mod config;
@@ -27,44 +26,32 @@ async fn main_impl() -> Result<()> {
     let data_dir = config::iroh_data_root()?;
     let cli = Cli::parse();
 
-    #[cfg(unix)]
-    if let Some(log_fd) = cli.log_fd {
-        use std::fs::File;
-        use std::mem::ManuallyDrop;
-        use std::os::unix::io::FromRawFd;
-
-        // SAFETY: We take ownership but ensure it is never dropped, thus we never close the
-        // filedescriptor.  So even if the users chooses 0, 1 or 2 we do not close it,
-        // making sure those keep working as expected until process termination.
-        let inner = unsafe { ManuallyDrop::new(File::from_raw_fd(log_fd)) };
-        let writer = ManuallyDropFile(inner);
-        tracing_subscriber::registry()
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .event_format(tracing_subscriber::fmt::format().with_line_number(true))
-                    .with_writer(writer),
-            )
-            .with(EnvFilter::from_default_env())
-            .init();
-        return cli.run(&data_dir).await;
-    }
-
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-        .with(EnvFilter::from_default_env())
-        .init();
+    // TODO(@divma): remove
+    // #[cfg(unix)]
+    // if let Some(log_fd) = cli.log_fd {
+    //     use std::fs::File;
+    //     use std::mem::ManuallyDrop;
+    //     use std::os::unix::io::FromRawFd;
+    //
+    //     // SAFETY: We take ownership but ensure it is never dropped, thus we never close the
+    //     // filedescriptor.  So even if the users chooses 0, 1 or 2 we do not close it,
+    //     // making sure those keep working as expected until process termination.
+    //     let inner = unsafe { ManuallyDrop::new(File::from_raw_fd(log_fd)) };
+    //     let writer = ManuallyDropFile(inner);
+    //     tracing_subscriber::registry()
+    //         .with(
+    //             tracing_subscriber::fmt::layer()
+    //                 .event_format(tracing_subscriber::fmt::format().with_line_number(true))
+    //                 .with_writer(writer),
+    //         )
+    //         .with(EnvFilter::from_default_env())
+    //         .init();
+    //     return cli.run(&data_dir).await;
+    // }
+    //
+    // tracing_subscriber::registry()
+    //     .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+    //     .with(EnvFilter::from_default_env())
+    //     .init();
     cli.run(&data_dir).await
-}
-
-/// Newtype for `ManuallyDrop<File>` so we can impl a foreign trait.
-#[cfg(unix)]
-struct ManuallyDropFile(std::mem::ManuallyDrop<std::fs::File>);
-
-#[cfg(unix)]
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for ManuallyDropFile {
-    type Writer = &'a std::fs::File;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        &self.0
-    }
 }

--- a/iroh-cli/src/main.rs
+++ b/iroh-cli/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 
 mod commands;
 mod config;
+mod logging;
 
 use crate::commands::Cli;
 
@@ -25,33 +26,5 @@ fn main() -> Result<()> {
 async fn main_impl() -> Result<()> {
     let data_dir = config::iroh_data_root()?;
     let cli = Cli::parse();
-
-    // TODO(@divma): remove
-    // #[cfg(unix)]
-    // if let Some(log_fd) = cli.log_fd {
-    //     use std::fs::File;
-    //     use std::mem::ManuallyDrop;
-    //     use std::os::unix::io::FromRawFd;
-    //
-    //     // SAFETY: We take ownership but ensure it is never dropped, thus we never close the
-    //     // filedescriptor.  So even if the users chooses 0, 1 or 2 we do not close it,
-    //     // making sure those keep working as expected until process termination.
-    //     let inner = unsafe { ManuallyDrop::new(File::from_raw_fd(log_fd)) };
-    //     let writer = ManuallyDropFile(inner);
-    //     tracing_subscriber::registry()
-    //         .with(
-    //             tracing_subscriber::fmt::layer()
-    //                 .event_format(tracing_subscriber::fmt::format().with_line_number(true))
-    //                 .with_writer(writer),
-    //         )
-    //         .with(EnvFilter::from_default_env())
-    //         .init();
-    //     return cli.run(&data_dir).await;
-    // }
-    //
-    // tracing_subscriber::registry()
-    //     .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-    //     .with(EnvFilter::from_default_env())
-    //     .init();
     cli.run(&data_dir).await
 }


### PR DESCRIPTION
## Description

Adds file logging by default to commands that start a node.

Parameters are:
- the "RUST_LOG" directive, in the form of and env var `IROH_FILE_RUST_LOG` or in the configuration file.
- rotation: how often a new file is created. Either daily, hourly or never.
- max files: Maximum number of files to keep

File logging can be disabled by either setting the max_files to 0 in the configuration file or by setting the rust log statement to off, in either the env var or the config file.

(example config file)
```toml
[file_logs]
rust_log = "iroh=trace"
rotation = "daily"
max_files = 1
```

The files created live the `IROH_DATA_DIR/logs` dir and are named `iroh-2024-03-02.log` (for a daily rotation, or with the hour, for an hourly rotation)

By default, we log everything in debug, rotating hourly, keeping at most 4 files (so total 4 hours of logs). This is short default since debug logs, even in an idle node, are a lot

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
