### PR TITLE
refactor: rustc beta is stricter again wrt imports and unused code

### DIFF
--- a/iroh-bytes/examples/fetch-fsm.rs
+++ b/iroh-bytes/examples/fetch-fsm.rs
@@ -161,14 +161,3 @@ async fn write_collection(initial: AtInitial) -> Result<()> {
     let _stats = closing.next().await?;
     Ok(())
 }
-
-#[derive(Clone)]
-struct MockEventSender;
-
-use futures::future::FutureExt;
-
-impl iroh_bytes::provider::EventSender for MockEventSender {
-    fn send(&self, _event: iroh_bytes::provider::Event) -> futures::future::BoxFuture<()> {
-        async move {}.boxed()
-    }
-}

--- a/iroh-bytes/examples/fetch-stream.rs
+++ b/iroh-bytes/examples/fetch-stream.rs
@@ -233,14 +233,3 @@ fn stream_children(initial: AtInitial) -> impl Stream<Item = io::Result<Bytes>> 
         }
     })
 }
-
-#[derive(Clone)]
-struct MockEventSender;
-
-use futures::future::FutureExt;
-
-impl iroh_bytes::provider::EventSender for MockEventSender {
-    fn send(&self, _event: iroh_bytes::provider::Event) -> futures::future::BoxFuture<()> {
-        async move {}.boxed()
-    }
-}

--- a/iroh-net/src/stun.rs
+++ b/iroh-net/src/stun.rs
@@ -151,10 +151,7 @@ pub fn parse_response(b: &[u8]) -> Result<(TransactionId, SocketAddr), Error> {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub(crate) mod test {
-    use std::{
-        net::{IpAddr, SocketAddr},
-        sync::Arc,
-    };
+    use std::{net::IpAddr, sync::Arc};
 
     use anyhow::Result;
     use tokio::{


### PR DESCRIPTION
## Description

Some more unused code and duplicate imports detected by the beta
compiler.

## Notes & open questions

Are the examples sufficiently tested by CI?

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.