### PR TITLE
feat: iroh-perf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         # uses: obi1kenobi/cargo-semver-checks-action@v2
         uses: n0-computer/cargo-semver-checks-action@feat-baseline
         with:
-          package: iroh, iroh-base, iroh-blobs, iroh-cli, iroh-dns-server, iroh-gossip, iroh-metrics, iroh-net, iroh-docs
+          package: iroh, iroh-base, iroh-blobs, iroh-cli, iroh-dns-server, iroh-gossip, iroh-metrics, iroh-net, iroh-net-bench, iroh-docs
           baseline-rev: ${{ env.HEAD_COMMIT_SHA }}
           use-cache: false
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   SCCACHE_CACHE_SIZE: "50G"
-  CRATES_LIST: "iroh,iroh-blobs,iroh-gossip,iroh-metrics,iroh-net,iroh-docs,iroh-test,iroh-cli,iroh-dns-server"
+  CRATES_LIST: "iroh,iroh-blobs,iroh-gossip,iroh-metrics,iroh-net,iroh-net-bench,iroh-docs,iroh-test,iroh-cli,iroh-dns-server"
 
 jobs:
   build_and_test_nix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-net-bench"
-version = "0.13.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8487b59d62764df8231cb371c459314df895b41756df457a1fb1243d65c89195"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15eb61145320320eb919d9bab524617a7aa4216c78d342fae3a758bc33073e4"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,9 +395,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.14",
  "instant",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -450,6 +478,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.60",
+ "which",
 ]
 
 [[package]]
@@ -583,7 +634,7 @@ dependencies = [
 name = "cc"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -656,6 +707,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +766,15 @@ dependencies = [
  "error-code",
  "str-buf",
  "winapi",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -961,7 +1032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -973,7 +1044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1007,6 +1078,17 @@ dependencies = [
  "salsa20",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "cuckoofilter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -1284,6 +1366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,7 +1404,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -1354,7 +1442,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1522,7 +1610,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1568,6 +1656,12 @@ dependencies = [
  "nonempty",
  "thiserror",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1767,14 +1861,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1805,7 +1899,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "spinning_top",
 ]
@@ -1817,7 +1911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1877,6 +1971,12 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hash_hasher"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
@@ -1952,6 +2052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hickory-proto"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,7 +2073,7 @@ dependencies = [
  "idna 0.4.0",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "ring 0.16.20",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
@@ -1993,7 +2099,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "rustls 0.21.12",
  "serde",
@@ -2323,7 +2429,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rand",
+ "rand 0.8.5",
  "tokio",
  "url",
  "xmltree",
@@ -2393,6 +2499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b694dc9f70c3bda874626d2aed13b780f137aab435f4e9814121955cf706122e"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,8 +2557,8 @@ dependencies = [
  "postcard",
  "proptest",
  "quic-rpc",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",
@@ -2469,15 +2584,15 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
- "getrandom",
+ "getrandom 0.2.14",
  "hex",
  "iroh-blake3",
  "iroh-test",
  "once_cell",
  "postcard",
  "proptest",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "redb 2.1.0",
  "serde",
  "serde-error",
@@ -2531,7 +2646,7 @@ dependencies = [
  "parking_lot",
  "postcard",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "range-collections",
  "rcgen 0.12.1",
  "redb 1.5.1",
@@ -2582,7 +2697,7 @@ dependencies = [
  "portable-atomic",
  "postcard",
  "quic-rpc",
- "rand",
+ "rand 0.8.5",
  "ratatui",
  "regex",
  "reqwest 0.12.4",
@@ -2673,9 +2788,9 @@ dependencies = [
  "num_enum",
  "postcard",
  "proptest",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "redb 1.5.1",
  "redb 2.1.0",
  "self_cell",
@@ -2708,9 +2823,9 @@ dependencies = [
  "iroh-net",
  "iroh-test",
  "postcard",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
  "tokio",
  "tokio-util",
@@ -2803,9 +2918,9 @@ dependencies = [
  "postcard",
  "pretty_assertions",
  "proptest",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "rcgen 0.11.3",
  "regex",
  "reqwest 0.12.4",
@@ -2843,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-net-bench"
-version = "0.16.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2853,6 +2968,7 @@ dependencies = [
  "quinn",
  "rcgen 0.11.3",
  "rustls",
+ "s2n-quic",
  "socket2",
  "tokio",
  "tracing",
@@ -2883,7 +2999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f2656b322c7f6cf3eb95e632d1c0f2fa546841915b0270da581f918c70c4be"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring 0.16.20",
  "rustc-hash",
  "rustls 0.21.12",
@@ -2959,6 +3075,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,10 +3102,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "libm"
@@ -3055,7 +3196,7 @@ dependencies = [
  "ed25519-dalek",
  "flume",
  "lru",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bencode",
  "serde_bytes",
@@ -3104,6 +3245,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,9 +3282,15 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "nanorand"
@@ -3142,7 +3298,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -3366,7 +3522,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -3391,6 +3547,17 @@ name = "num-iter"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3560,7 +3727,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
 ]
 
@@ -3711,7 +3878,7 @@ dependencies = [
  "ed25519-dalek",
  "mainline",
  "rand",
- "reqwest 0.11.27",
+ "reqwest",
  "self_cell",
  "simple-dns",
  "thiserror",
@@ -3925,6 +4092,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4017,8 +4194,8 @@ dependencies = [
  "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.3",
  "rusty-fork",
@@ -4036,7 +4213,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -4092,7 +4269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring 0.16.20",
  "rustc-hash",
  "rustls",
@@ -4153,13 +4330,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4169,7 +4369,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -4178,7 +4387,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.14",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4187,7 +4405,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4317,7 +4535,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.14",
  "libredox",
  "thiserror",
 ]
@@ -4528,7 +4746,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.14",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -4548,7 +4766,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "signature",
  "spki",
@@ -4747,6 +4965,173 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "s2n-codec"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c1a1c2ffb3dc6f12c6185d7ad349608eb9aea4855c2009527e8784cd51bddb"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "zerocopy",
+]
+
+[[package]]
+name = "s2n-quic"
+version = "1.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d556469ff8f4e0e27cddf6ac1065cedafe2216460ce934d77e1ab6e8244f8e1e"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "cuckoofilter",
+ "futures",
+ "hash_hasher",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "s2n-codec",
+ "s2n-quic-core",
+ "s2n-quic-crypto",
+ "s2n-quic-platform",
+ "s2n-quic-tls-default",
+ "s2n-quic-transport",
+ "tokio",
+ "zerocopy",
+ "zeroize",
+]
+
+[[package]]
+name = "s2n-quic-core"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d874d608d0e9fa2ea207a6288e1d6926c847b37c777cadae9037c24175e798"
+dependencies = [
+ "atomic-waker",
+ "byteorder",
+ "bytes",
+ "cfg-if",
+ "crossbeam-utils",
+ "hex-literal",
+ "num-rational",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "s2n-codec",
+ "subtle",
+ "zerocopy",
+]
+
+[[package]]
+name = "s2n-quic-crypto"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1bab1f520dca4e26d81491c9177dc6f3aeb9289c0a8ccc64c24ea3ca178de7"
+dependencies = [
+ "aws-lc-rs",
+ "cfg-if",
+ "lazy_static",
+ "ring 0.16.20",
+ "s2n-codec",
+ "s2n-quic-core",
+ "zeroize",
+]
+
+[[package]]
+name = "s2n-quic-platform"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f554fdd14e0859b37ce321ec02ce65ad9be58dd13edc7ef1b48fd0e9b4a0d3"
+dependencies = [
+ "cfg-if",
+ "futures",
+ "lazy_static",
+ "libc",
+ "s2n-quic-core",
+ "socket2",
+ "tokio",
+]
+
+[[package]]
+name = "s2n-quic-rustls"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dcc2248b915dde6d4582940e2cddf1159daa38763d2a850ccd2d2864ab8e7a"
+dependencies = [
+ "bytes",
+ "rustls",
+ "rustls-pemfile 1.0.4",
+ "s2n-codec",
+ "s2n-quic-core",
+ "s2n-quic-crypto",
+]
+
+[[package]]
+name = "s2n-quic-tls"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619c244acd675c14bed8395a09c914b4e9ac47718b74e76fa3ae5f4de44c302f"
+dependencies = [
+ "bytes",
+ "errno",
+ "libc",
+ "s2n-codec",
+ "s2n-quic-core",
+ "s2n-quic-crypto",
+ "s2n-tls",
+]
+
+[[package]]
+name = "s2n-quic-tls-default"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c558abeb3aee9c92715dd9993ce25398c0ffd7a7f039b7c860bf3b7966d9e3"
+dependencies = [
+ "s2n-quic-rustls",
+ "s2n-quic-tls",
+]
+
+[[package]]
+name = "s2n-quic-transport"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f03d79bed78230473bced1db82b7778c0d7c605b1f90b23fa02dddc12f2dc3"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "hashbrown 0.14.3",
+ "intrusive-collections",
+ "once_cell",
+ "s2n-codec",
+ "s2n-quic-core",
+ "siphasher",
+ "smallvec",
+]
+
+[[package]]
+name = "s2n-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b989c13b04b7e23c0161e5f18f16c7efaa06f86d7647df4b469bbce43e1a63"
+dependencies = [
+ "errno",
+ "hex",
+ "libc",
+ "pin-project-lite",
+ "s2n-tls-sys",
+]
+
+[[package]]
+name = "s2n-tls-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58db90b89847b170999d01e95fe37f059af038d1c4f8609adc64a5241a2d99d"
+dependencies = [
+ "aws-lc-rs",
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "salsa20"
@@ -5045,6 +5430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5081,7 +5472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5092,6 +5483,12 @@ checksum = "01607fe2e61894468c6dc0b26103abb073fb08b79a3d9e4b6d76a1a341549958"
 dependencies = [
  "bitflags 2.5.0",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -5186,7 +5583,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand_core",
+ "rand_core 0.6.4",
  "rsa",
  "sec1",
  "sha2",
@@ -5348,7 +5745,7 @@ dependencies = [
  "precis-core",
  "precis-profiles",
  "quoted-string-parser",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5366,7 +5763,7 @@ dependencies = [
  "hex",
  "parking_lot",
  "pnet_packet",
- "rand",
+ "rand 0.8.5",
  "socket2",
  "thiserror",
  "tokio",
@@ -6123,6 +6520,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -6226,15 +6629,6 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
-dependencies = [
- "rustls-pki-types",
-]
 
 [[package]]
 name = "whoami"
@@ -6695,6 +7089,7 @@ version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -6714,3 +7109,17 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
  "synstructure 0.13.1",
 ]
 
@@ -224,18 +224,18 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -686,7 +686,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1034,7 +1034,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1057,8 +1057,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
- "syn 2.0.65",
+ "strsim 0.10.0",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1069,7 +1069,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1138,7 +1138,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1168,7 +1168,7 @@ checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
  "unicode-xid",
 ]
 
@@ -1251,7 +1251,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1409,7 +1409,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1429,7 +1429,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1684,7 +1684,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2850,6 +2850,10 @@ dependencies = [
  "clap",
  "hdrhistogram",
  "iroh-net",
+ "quinn",
+ "rcgen 0.11.3",
+ "rustls",
+ "socket2",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3431,7 +3435,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3597,11 +3601,11 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "3.0.4"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.22.0",
  "serde",
 ]
 
@@ -3651,7 +3655,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3682,7 +3686,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3788,7 +3792,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3999,7 +4003,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4024,9 +4028,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -4063,6 +4067,54 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring 0.16.20",
+ "rustc-hash",
+ "rustls",
+ "rustls-native-certs",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
+dependencies = [
+ "bytes",
+ "libc",
+ "socket2",
+ "tracing",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "quote"
@@ -4287,7 +4339,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4836,14 +4888,14 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -4917,7 +4969,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5152,7 +5204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
 dependencies = [
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5199,7 +5251,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5217,7 +5269,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5228,7 +5280,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5259,7 +5311,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5272,7 +5324,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5334,9 +5386,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5386,7 +5438,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5472,7 +5524,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5506,7 +5558,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5604,7 +5656,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5839,7 +5891,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6102,7 +6154,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -6136,7 +6188,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6322,7 +6374,7 @@ checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6333,7 +6385,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6344,7 +6396,7 @@ checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6355,7 +6407,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6654,7 +6706,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,12 +248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "attohttpc"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,34 +263,6 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8487b59d62764df8231cb371c459314df895b41756df457a1fb1243d65c89195"
-dependencies = [
- "aws-lc-sys",
- "mirai-annotations",
- "paste",
- "untrusted 0.7.1",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15eb61145320320eb919d9bab524617a7aa4216c78d342fae3a758bc33073e4"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "libc",
- "paste",
-]
 
 [[package]]
 name = "axum"
@@ -395,9 +361,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom",
  "instant",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -478,29 +444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.69.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
-dependencies = [
- "bitflags 2.5.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.60",
- "which",
 ]
 
 [[package]]
@@ -707,17 +650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,15 +698,6 @@ dependencies = [
  "error-code",
  "str-buf",
  "winapi",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1032,7 +955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1044,7 +967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -1078,17 +1001,6 @@ dependencies = [
  "salsa20",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "cuckoofilter"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
-dependencies = [
- "byteorder",
- "fnv",
- "rand 0.7.3",
 ]
 
 [[package]]
@@ -1366,12 +1278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,7 +1310,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2",
  "subtle",
@@ -1442,7 +1348,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1610,7 +1516,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1656,12 +1562,6 @@ dependencies = [
  "nonempty",
  "thiserror",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1868,7 +1768,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1899,7 +1799,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "spinning_top",
 ]
@@ -1911,7 +1811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1971,12 +1871,6 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hash_hasher"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
@@ -2052,12 +1946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
 name = "hickory-proto"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,7 +1961,7 @@ dependencies = [
  "idna 0.4.0",
  "ipnet",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
@@ -2099,7 +1987,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot",
- "rand 0.8.5",
+ "rand",
  "resolv-conf",
  "rustls 0.21.12",
  "serde",
@@ -2429,7 +2317,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rand 0.8.5",
+ "rand",
  "tokio",
  "url",
  "xmltree",
@@ -2499,15 +2387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "intrusive-collections"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b694dc9f70c3bda874626d2aed13b780f137aab435f4e9814121955cf706122e"
-dependencies = [
- "memoffset",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,8 +2436,8 @@ dependencies = [
  "postcard",
  "proptest",
  "quic-rpc",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "regex",
  "serde",
  "serde_json",
@@ -2584,15 +2463,15 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
- "getrandom 0.2.14",
+ "getrandom",
  "hex",
  "iroh-blake3",
  "iroh-test",
  "once_cell",
  "postcard",
  "proptest",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "redb 2.1.0",
  "serde",
  "serde-error",
@@ -2646,7 +2525,7 @@ dependencies = [
  "parking_lot",
  "postcard",
  "proptest",
- "rand 0.8.5",
+ "rand",
  "range-collections",
  "rcgen 0.12.1",
  "redb 1.5.1",
@@ -2697,7 +2576,7 @@ dependencies = [
  "portable-atomic",
  "postcard",
  "quic-rpc",
- "rand 0.8.5",
+ "rand",
  "ratatui",
  "regex",
  "reqwest 0.12.4",
@@ -2788,9 +2667,9 @@ dependencies = [
  "num_enum",
  "postcard",
  "proptest",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand",
+ "rand_chacha",
+ "rand_core",
  "redb 1.5.1",
  "redb 2.1.0",
  "self_cell",
@@ -2823,9 +2702,9 @@ dependencies = [
  "iroh-net",
  "iroh-test",
  "postcard",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand",
+ "rand_chacha",
+ "rand_core",
  "serde",
  "tokio",
  "tokio-util",
@@ -2918,9 +2797,9 @@ dependencies = [
  "postcard",
  "pretty_assertions",
  "proptest",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand",
+ "rand_chacha",
+ "rand_core",
  "rcgen 0.11.3",
  "regex",
  "reqwest 0.12.4",
@@ -2968,7 +2847,6 @@ dependencies = [
  "quinn",
  "rcgen 0.11.3",
  "rustls",
- "s2n-quic",
  "socket2",
  "tokio",
  "tracing",
@@ -2999,7 +2877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f2656b322c7f6cf3eb95e632d1c0f2fa546841915b0270da581f918c70c4be"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustc-hash",
  "rustls 0.21.12",
@@ -3075,15 +2953,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "jobserver"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,26 +2971,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "libloading"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.5",
-]
 
 [[package]]
 name = "libm"
@@ -3196,7 +3049,7 @@ dependencies = [
  "ed25519-dalek",
  "flume",
  "lru",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_bencode",
  "serde_bytes",
@@ -3245,15 +3098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,15 +3126,9 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "nanorand"
@@ -3298,7 +3136,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom",
 ]
 
 [[package]]
@@ -3522,7 +3360,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "zeroize",
 ]
@@ -3549,16 +3387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
  "num-integer",
  "num-traits",
 ]
@@ -3726,7 +3554,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "rand_core 0.6.4",
+ "rand_core",
  "sha2",
 ]
 
@@ -4091,16 +3919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
-dependencies = [
- "proc-macro2",
- "syn 2.0.60",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,8 +4011,8 @@ dependencies = [
  "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.3",
  "rusty-fork",
@@ -4212,7 +4030,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "web-sys",
  "winapi",
 ]
@@ -4268,7 +4086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustc-hash",
  "rustls",
@@ -4329,36 +4147,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -4368,16 +4163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -4386,16 +4172,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.14",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -4404,7 +4181,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -4534,7 +4311,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom",
  "libredox",
  "thiserror",
 ]
@@ -4745,7 +4522,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.14",
+ "getrandom",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -4765,7 +4542,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sha2",
  "signature",
  "spki",
@@ -4964,173 +4741,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "s2n-codec"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c1a1c2ffb3dc6f12c6185d7ad349608eb9aea4855c2009527e8784cd51bddb"
-dependencies = [
- "byteorder",
- "bytes",
- "zerocopy",
-]
-
-[[package]]
-name = "s2n-quic"
-version = "1.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556469ff8f4e0e27cddf6ac1065cedafe2216460ce934d77e1ab6e8244f8e1e"
-dependencies = [
- "bytes",
- "cfg-if",
- "cuckoofilter",
- "futures",
- "hash_hasher",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "s2n-codec",
- "s2n-quic-core",
- "s2n-quic-crypto",
- "s2n-quic-platform",
- "s2n-quic-tls-default",
- "s2n-quic-transport",
- "tokio",
- "zerocopy",
- "zeroize",
-]
-
-[[package]]
-name = "s2n-quic-core"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d874d608d0e9fa2ea207a6288e1d6926c847b37c777cadae9037c24175e798"
-dependencies = [
- "atomic-waker",
- "byteorder",
- "bytes",
- "cfg-if",
- "crossbeam-utils",
- "hex-literal",
- "num-rational",
- "num-traits",
- "once_cell",
- "pin-project-lite",
- "s2n-codec",
- "subtle",
- "zerocopy",
-]
-
-[[package]]
-name = "s2n-quic-crypto"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1bab1f520dca4e26d81491c9177dc6f3aeb9289c0a8ccc64c24ea3ca178de7"
-dependencies = [
- "aws-lc-rs",
- "cfg-if",
- "lazy_static",
- "ring 0.16.20",
- "s2n-codec",
- "s2n-quic-core",
- "zeroize",
-]
-
-[[package]]
-name = "s2n-quic-platform"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f554fdd14e0859b37ce321ec02ce65ad9be58dd13edc7ef1b48fd0e9b4a0d3"
-dependencies = [
- "cfg-if",
- "futures",
- "lazy_static",
- "libc",
- "s2n-quic-core",
- "socket2",
- "tokio",
-]
-
-[[package]]
-name = "s2n-quic-rustls"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dcc2248b915dde6d4582940e2cddf1159daa38763d2a850ccd2d2864ab8e7a"
-dependencies = [
- "bytes",
- "rustls",
- "rustls-pemfile 1.0.4",
- "s2n-codec",
- "s2n-quic-core",
- "s2n-quic-crypto",
-]
-
-[[package]]
-name = "s2n-quic-tls"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619c244acd675c14bed8395a09c914b4e9ac47718b74e76fa3ae5f4de44c302f"
-dependencies = [
- "bytes",
- "errno",
- "libc",
- "s2n-codec",
- "s2n-quic-core",
- "s2n-quic-crypto",
- "s2n-tls",
-]
-
-[[package]]
-name = "s2n-quic-tls-default"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c558abeb3aee9c92715dd9993ce25398c0ffd7a7f039b7c860bf3b7966d9e3"
-dependencies = [
- "s2n-quic-rustls",
- "s2n-quic-tls",
-]
-
-[[package]]
-name = "s2n-quic-transport"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f03d79bed78230473bced1db82b7778c0d7c605b1f90b23fa02dddc12f2dc3"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "hashbrown 0.14.3",
- "intrusive-collections",
- "once_cell",
- "s2n-codec",
- "s2n-quic-core",
- "siphasher",
- "smallvec",
-]
-
-[[package]]
-name = "s2n-tls"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a88b0b9021e361ad2f143318137e4efc9d5b7d24bcb8256c1b009b70107e65"
-dependencies = [
- "errno",
- "hex",
- "libc",
- "pin-project-lite",
- "s2n-tls-sys",
-]
-
-[[package]]
-name = "s2n-tls-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235821cfb07b213497b8211eb5d566bc681573cd502221726d4ff171198d7466"
-dependencies = [
- "aws-lc-rs",
- "cc",
- "libc",
-]
 
 [[package]]
 name = "salsa20"
@@ -5429,12 +5039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5471,7 +5075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -5482,12 +5086,6 @@ checksum = "01607fe2e61894468c6dc0b26103abb073fb08b79a3d9e4b6d76a1a341549958"
 dependencies = [
  "bitflags 2.5.0",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -5582,7 +5180,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand_core 0.6.4",
+ "rand_core",
  "rsa",
  "sec1",
  "sha2",
@@ -5744,7 +5342,7 @@ dependencies = [
  "precis-core",
  "precis-profiles",
  "quoted-string-parser",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -5762,7 +5360,7 @@ dependencies = [
  "hex",
  "parking_lot",
  "pnet_packet",
- "rand 0.8.5",
+ "rand",
  "socket2",
  "thiserror",
  "tokio",
@@ -6519,12 +6117,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -7088,7 +6680,6 @@ version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
@@ -7108,17 +6699,3 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -3555,11 +3555,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -4093,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn 2.0.60",
@@ -5111,9 +5110,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b989c13b04b7e23c0161e5f18f16c7efaa06f86d7647df4b469bbce43e1a63"
+checksum = "74a88b0b9021e361ad2f143318137e4efc9d5b7d24bcb8256c1b009b70107e65"
 dependencies = [
  "errno",
  "hex",
@@ -5124,9 +5123,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-sys"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58db90b89847b170999d01e95fe37f059af038d1c4f8609adc64a5241a2d99d"
+checksum = "235821cfb07b213497b8211eb5d566bc681573cd502221726d4ff171198d7466"
 dependencies = [
  "aws-lc-rs",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
  "synstructure 0.13.1",
 ]
 
@@ -224,18 +224,18 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -246,6 +246,12 @@ checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
@@ -329,7 +335,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -575,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
 name = "cfg-if"
@@ -598,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -680,7 +686,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1028,7 +1034,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1051,8 +1057,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.60",
+ "strsim",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1063,7 +1069,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1132,7 +1138,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1162,7 +1168,7 @@ checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
  "unicode-xid",
 ]
 
@@ -1245,7 +1251,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1390,7 +1396,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1403,7 +1409,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1423,7 +1429,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1678,7 +1684,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1761,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
@@ -2846,7 +2852,7 @@ dependencies = [
  "iroh-net",
  "quinn",
  "rcgen 0.11.3",
- "rustls",
+ "rustls 0.21.12",
  "socket2",
  "tokio",
  "tracing",
@@ -3429,7 +3435,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3595,11 +3601,11 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -3649,7 +3655,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3680,7 +3686,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3705,7 +3711,7 @@ dependencies = [
  "ed25519-dalek",
  "mainline",
  "rand",
- "reqwest",
+ "reqwest 0.11.27",
  "self_cell",
  "simple-dns",
  "thiserror",
@@ -3786,7 +3792,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3997,7 +4003,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4022,9 +4028,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -4073,7 +4079,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.12",
  "thiserror",
  "tokio",
  "tracing",
@@ -4089,7 +4095,7 @@ dependencies = [
  "rand",
  "ring 0.16.20",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.12",
  "rustls-native-certs",
  "slab",
  "thiserror",
@@ -4333,7 +4339,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4882,14 +4888,14 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -4963,7 +4969,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5198,7 +5204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
 dependencies = [
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5245,7 +5251,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5263,7 +5269,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5274,7 +5280,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5305,7 +5311,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5318,7 +5324,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5380,9 +5386,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5432,7 +5438,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5518,7 +5524,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5552,7 +5558,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5650,7 +5656,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5885,7 +5891,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -6148,7 +6154,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
  "wasm-bindgen-shared",
 ]
 
@@ -6182,7 +6188,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6220,6 +6226,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"
@@ -6359,7 +6374,7 @@ checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -6370,7 +6385,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -6381,7 +6396,7 @@ checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -6392,7 +6407,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -6691,7 +6706,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -17,5 +17,4 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
-s2n-quic = "1.37.0"
 socket2 = "0.5"

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-net-bench"
-version = "0.13.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -10,7 +10,11 @@ anyhow = "1.0.22"
 bytes = "1"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh-net = { path = ".." }
+quinn = "0.10"
+rcgen = "0.11.1"
+rustls = { version = "0.21.0", default-features = false, features = ["quic"] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
+socket2 = "0.5"

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-net-bench"
-version = "0.16.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -17,4 +17,5 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
+s2n-quic = "1.37.0"
 socket2 = "0.5"

--- a/iroh-net/bench/src/bin/bulk.rs
+++ b/iroh-net/bench/src/bin/bulk.rs
@@ -1,38 +1,42 @@
-use std::{
-    sync::{Arc, Mutex},
-    time::Instant,
-};
-
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
-use iroh_net::{
-    endpoint::{self, Connection},
-    Endpoint, NodeAddr,
-};
-use tokio::sync::Semaphore;
-use tracing::{info, trace};
 
-use iroh_net_bench::{
-    configure_tracing_subscriber, connect_client, drain_stream, rt, send_data_on_stream,
-    server_endpoint,
-    stats::{Stats, TransferResult},
-    Opt,
-};
+use iroh_net_bench::{configure_tracing_subscriber, iroh, quinn, rt, s2n, Commands, Opt};
 
 fn main() {
-    let opt = Opt::parse();
+    let cmd = Commands::parse();
     configure_tracing_subscriber();
 
+    match cmd {
+        Commands::Iroh(opt) => {
+            if let Err(e) = run_iroh(opt) {
+                eprintln!("failed: {e:#}");
+            }
+        }
+        Commands::Quinn(opt) => {
+            if let Err(e) = run_quinn(opt) {
+                eprintln!("failed: {e:#}");
+            }
+        }
+        Commands::S2n(opt) => {
+            if let Err(e) = run_s2n(opt) {
+                eprintln!("failed: {e:#}");
+            }
+        }
+    }
+}
+
+pub fn run_iroh(opt: Opt) -> Result<()> {
     let server_span = tracing::error_span!("server");
     let runtime = rt();
     let (server_addr, endpoint) = {
         let _guard = server_span.enter();
-        server_endpoint(&runtime, &opt)
+        iroh::server_endpoint(&runtime, &opt)
     };
 
     let server_thread = std::thread::spawn(move || {
         let _guard = server_span.entered();
-        if let Err(e) = runtime.block_on(server(endpoint, opt)) {
+        if let Err(e) = runtime.block_on(iroh::server(endpoint, opt)) {
             eprintln!("server failed: {e:#}");
         }
     });
@@ -43,7 +47,7 @@ fn main() {
         handles.push(std::thread::spawn(move || {
             let _guard = tracing::error_span!("client", id).entered();
             let runtime = rt();
-            match runtime.block_on(client(server_addr, opt)) {
+            match runtime.block_on(iroh::client(server_addr, opt)) {
                 Ok(stats) => Ok(stats),
                 Err(e) => {
                     eprintln!("client failed: {e:#}");
@@ -62,153 +66,53 @@ fn main() {
     }
 
     server_thread.join().expect("server thread");
-}
-
-async fn server(endpoint: Endpoint, opt: Opt) -> Result<()> {
-    let mut server_tasks = Vec::new();
-
-    // Handle only the expected amount of clients
-    for _ in 0..opt.clients {
-        let handshake = endpoint.accept().await.unwrap();
-        let connection = handshake.await.context("handshake failed")?;
-
-        server_tasks.push(tokio::spawn(async move {
-            loop {
-                let (mut send_stream, mut recv_stream) = match connection.accept_bi().await {
-                    Err(endpoint::ConnectionError::ApplicationClosed(_)) => break,
-                    Err(e) => {
-                        eprintln!("accepting stream failed: {e:?}");
-                        break;
-                    }
-                    Ok(stream) => stream,
-                };
-                trace!("stream established");
-
-                tokio::spawn(async move {
-                    drain_stream(&mut recv_stream, opt.read_unordered).await?;
-                    send_data_on_stream(&mut send_stream, opt.download_size).await?;
-                    Ok::<_, anyhow::Error>(())
-                });
-            }
-
-            if opt.stats {
-                println!("\nServer connection stats:\n{:#?}", connection.stats());
-            }
-        }));
-    }
-
-    // Await all the tasks. We have to do this to prevent the runtime getting dropped
-    // and all server tasks to be cancelled
-    for handle in server_tasks {
-        if let Err(e) = handle.await {
-            eprintln!("Server task error: {e:?}");
-        };
-    }
 
     Ok(())
 }
 
-async fn client(server_addr: NodeAddr, opt: Opt) -> Result<ClientStats> {
-    let (endpoint, connection) = connect_client(server_addr, opt).await?;
+pub fn run_quinn(opt: Opt) -> Result<()> {
+    let server_span = tracing::error_span!("server");
+    let runtime = rt();
+    let (server_addr, endpoint) = {
+        let _guard = server_span.enter();
+        quinn::server_endpoint(&runtime, &opt)
+    };
 
-    let start = Instant::now();
+    let server_thread = std::thread::spawn(move || {
+        let _guard = server_span.entered();
+        if let Err(e) = runtime.block_on(quinn::server(endpoint, opt)) {
+            eprintln!("server failed: {e:#}");
+        }
+    });
 
-    let connection = Arc::new(connection);
-
-    let mut stats = ClientStats::default();
-    let mut first_error = None;
-
-    let sem = Arc::new(Semaphore::new(opt.max_streams));
-    let results = Arc::new(Mutex::new(Vec::new()));
-    for _ in 0..opt.streams {
-        let permit = sem.clone().acquire_owned().await.unwrap();
-        let results = results.clone();
-        let connection = connection.clone();
-        tokio::spawn(async move {
-            let result =
-                handle_client_stream(connection, opt.upload_size, opt.read_unordered).await;
-            info!("stream finished: {:?}", result);
-            results.lock().unwrap().push(result);
-            drop(permit);
-        });
-    }
-
-    // Wait for remaining streams to finish
-    let _ = sem.acquire_many(opt.max_streams as u32).await.unwrap();
-
-    for result in results.lock().unwrap().drain(..) {
-        match result {
-            Ok((upload_result, download_result)) => {
-                stats.upload_stats.stream_finished(upload_result);
-                stats.download_stats.stream_finished(download_result);
-            }
-            Err(e) => {
-                if first_error.is_none() {
-                    first_error = Some(e);
+    let mut handles = Vec::new();
+    for id in 0..opt.clients {
+        handles.push(std::thread::spawn(move || {
+            let _guard = tracing::error_span!("client", id).entered();
+            let runtime = rt();
+            match runtime.block_on(quinn::client(server_addr, opt)) {
+                Ok(stats) => Ok(stats),
+                Err(e) => {
+                    eprintln!("client failed: {e:#}");
+                    Err(e)
                 }
             }
+        }));
+    }
+
+    for (id, handle) in handles.into_iter().enumerate() {
+        // We print all stats at the end of the test sequentially to avoid
+        // them being garbled due to being printed concurrently
+        if let Ok(stats) = handle.join().expect("client thread") {
+            stats.print(id);
         }
     }
 
-    stats.upload_stats.total_duration = start.elapsed();
-    stats.download_stats.total_duration = start.elapsed();
+    server_thread.join().expect("server thread");
 
-    // Explicit close of the connection, since handles can still be around due
-    // to `Arc`ing them
-    connection.close(0u32.into(), b"Benchmark done");
-
-    endpoint.close(0u32.into(), b"").await?;
-
-    if opt.stats {
-        println!("\nClient connection stats:\n{:#?}", connection.stats());
-    }
-
-    match first_error {
-        None => Ok(stats),
-        Some(e) => Err(e),
-    }
+    Ok(())
 }
 
-async fn handle_client_stream(
-    connection: Arc<Connection>,
-    upload_size: u64,
-    read_unordered: bool,
-) -> Result<(TransferResult, TransferResult)> {
-    let start = Instant::now();
-
-    let (mut send_stream, mut recv_stream) = connection
-        .open_bi()
-        .await
-        .context("failed to open stream")?;
-
-    send_data_on_stream(&mut send_stream, upload_size).await?;
-
-    let upload_result = TransferResult::new(start.elapsed(), upload_size);
-
-    let start = Instant::now();
-    let size = drain_stream(&mut recv_stream, read_unordered).await?;
-    let download_result = TransferResult::new(start.elapsed(), size as u64);
-
-    Ok((upload_result, download_result))
-}
-
-#[derive(Default)]
-struct ClientStats {
-    upload_stats: Stats,
-    download_stats: Stats,
-}
-
-impl ClientStats {
-    pub fn print(&self, client_id: usize) {
-        println!();
-        println!("Client {client_id} stats:");
-
-        if self.upload_stats.total_size != 0 {
-            self.upload_stats.print("upload");
-        }
-
-        if self.download_stats.total_size != 0 {
-            self.download_stats.print("download");
-        }
-    }
+pub fn run_s2n(_opt: s2n::Opt) -> Result<()> {
+    unimplemented!()
 }

--- a/iroh-net/bench/src/iroh.rs
+++ b/iroh-net/bench/src/iroh.rs
@@ -1,0 +1,232 @@
+use std::{
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use iroh_net::{
+    endpoint::{Connection, ConnectionError, RecvStream, SendStream, TransportConfig},
+    relay::RelayMode,
+    Endpoint, NodeAddr,
+};
+use tracing::trace;
+
+use crate::{
+    client_handler, stats::TransferResult, ClientStats, ConnectionSelector, EndpointSelector, Opt,
+};
+
+pub const ALPN: &[u8] = b"n0/iroh-net-bench/0";
+
+/// Creates a server endpoint which runs on the given runtime
+pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (NodeAddr, Endpoint) {
+    let _guard = rt.enter();
+    rt.block_on(async move {
+        let ep = Endpoint::builder()
+            .alpns(vec![ALPN.to_vec()])
+            .relay_mode(RelayMode::Disabled)
+            .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
+            .bind(0)
+            .await
+            .unwrap();
+        let addr = ep.local_addr();
+        let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
+        let addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
+        (addr, ep)
+    })
+}
+
+/// Create and run a client
+pub async fn client(server_addr: NodeAddr, opt: Opt) -> Result<ClientStats> {
+    let client_start = std::time::Instant::now();
+    let (endpoint, connection) = connect_client(server_addr, opt).await?;
+    let client_connect_time = client_start.elapsed();
+    let mut res = client_handler(
+        EndpointSelector::Iroh(endpoint),
+        ConnectionSelector::Iroh(connection),
+        opt,
+    )
+    .await?;
+    res.connect_time = client_connect_time;
+    Ok(res)
+}
+
+/// Create a client endpoint and client connection
+pub async fn connect_client(server_addr: NodeAddr, opt: Opt) -> Result<(Endpoint, Connection)> {
+    let endpoint = Endpoint::builder()
+        .alpns(vec![ALPN.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
+        .bind(0)
+        .await
+        .unwrap();
+
+    // TODO: We don't support passing client transport config currently
+    // let mut client_config = quinn::ClientConfig::new(Arc::new(crypto));
+    // client_config.transport_config(Arc::new(transport_config(&opt)));
+
+    let connection = endpoint
+        .connect(server_addr, ALPN)
+        .await
+        .context("unable to connect")?;
+    trace!("connected");
+
+    Ok((endpoint, connection))
+}
+
+pub fn transport_config(max_streams: usize, initial_mtu: u16) -> TransportConfig {
+    // High stream windows are chosen because the amount of concurrent streams
+    // is configurable as a parameter.
+    let mut config = TransportConfig::default();
+    config.max_concurrent_uni_streams(max_streams.try_into().unwrap());
+    config.initial_mtu(initial_mtu);
+
+    // TODO: reenable when we upgrade quinn version
+    // let mut acks = quinn::AckFrequencyConfig::default();
+    // acks.ack_eliciting_threshold(10u32.into());
+    // config.ack_frequency_config(Some(acks));
+
+    config
+}
+
+async fn drain_stream(
+    stream: &mut RecvStream,
+    read_unordered: bool,
+) -> Result<(usize, Duration, u64)> {
+    let mut read = 0;
+
+    let download_start = Instant::now();
+    let mut first_byte = true;
+    let mut ttfb = download_start.elapsed();
+
+    let mut num_chunks: u64 = 0;
+
+    if read_unordered {
+        while let Some(chunk) = stream.read_chunk(usize::MAX, false).await? {
+            if first_byte {
+                ttfb = download_start.elapsed();
+                first_byte = false;
+            }
+            read += chunk.bytes.len();
+            num_chunks += 1;
+        }
+    } else {
+        // These are 32 buffers, for reading approximately 32kB at once
+        #[rustfmt::skip]
+        let mut bufs = [
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        ];
+
+        while let Some(n) = stream.read_chunks(&mut bufs[..]).await? {
+            if first_byte {
+                ttfb = download_start.elapsed();
+                first_byte = false;
+            }
+            read += bufs.iter().take(n).map(|buf| buf.len()).sum::<usize>();
+            num_chunks += 1;
+        }
+    }
+
+    Ok((read, ttfb, num_chunks))
+}
+
+async fn send_data_on_stream(stream: &mut SendStream, stream_size: u64) -> Result<()> {
+    const DATA: &[u8] = &[0xAB; 1024 * 1024];
+    let bytes_data = Bytes::from_static(DATA);
+
+    let full_chunks = stream_size / (DATA.len() as u64);
+    let remaining = (stream_size % (DATA.len() as u64)) as usize;
+
+    for _ in 0..full_chunks {
+        stream
+            .write_chunk(bytes_data.clone())
+            .await
+            .context("failed sending data")?;
+    }
+
+    if remaining != 0 {
+        stream
+            .write_chunk(bytes_data.slice(0..remaining))
+            .await
+            .context("failed sending data")?;
+    }
+
+    stream.finish().await.context("failed finishing stream")?;
+
+    Ok(())
+}
+
+pub async fn handle_client_stream(
+    connection: &Connection,
+    upload_size: u64,
+    read_unordered: bool,
+) -> Result<(TransferResult, TransferResult)> {
+    let start = Instant::now();
+
+    let (mut send_stream, mut recv_stream) = connection
+        .open_bi()
+        .await
+        .context("failed to open stream")?;
+
+    send_data_on_stream(&mut send_stream, upload_size).await?;
+
+    let upload_result = TransferResult::new(start.elapsed(), upload_size, Duration::default(), 0);
+
+    let start = Instant::now();
+    let (size, ttfb, num_chunks) = drain_stream(&mut recv_stream, read_unordered).await?;
+    let download_result = TransferResult::new(start.elapsed(), size as u64, ttfb, num_chunks);
+
+    Ok((upload_result, download_result))
+}
+
+/// Take the provided endpoint and run the server
+pub async fn server(endpoint: Endpoint, opt: Opt) -> Result<()> {
+    let mut server_tasks = Vec::new();
+
+    // Handle only the expected amount of clients
+    for _ in 0..opt.clients {
+        let handshake = endpoint.accept().await.unwrap();
+        let connection = handshake.await.context("handshake failed")?;
+
+        server_tasks.push(tokio::spawn(async move {
+            loop {
+                let (mut send_stream, mut recv_stream) = match connection.accept_bi().await {
+                    Err(ConnectionError::ApplicationClosed(_)) => break,
+                    Err(e) => {
+                        eprintln!("accepting stream failed: {e:?}");
+                        break;
+                    }
+                    Ok(stream) => stream,
+                };
+                trace!("stream established");
+
+                tokio::spawn(async move {
+                    drain_stream(&mut recv_stream, opt.read_unordered).await?;
+                    send_data_on_stream(&mut send_stream, opt.download_size).await?;
+                    Ok::<_, anyhow::Error>(())
+                });
+            }
+
+            if opt.stats {
+                println!("\nServer connection stats:\n{:#?}", connection.stats());
+            }
+        }));
+    }
+
+    // Await all the tasks. We have to do this to prevent the runtime getting dropped
+    // and all server tasks to be cancelled
+    for handle in server_tasks {
+        if let Err(e) = handle.await {
+            eprintln!("Server task error: {e:?}");
+        };
+    }
+
+    Ok(())
+}

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -2,7 +2,7 @@ use std::{
     num::ParseIntError,
     str::FromStr,
     sync::{Arc, Mutex},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use anyhow::Result;

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -1,143 +1,32 @@
-use std::{net::SocketAddr, num::ParseIntError, str::FromStr};
+use std::{
+    num::ParseIntError,
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 
-use anyhow::{Context, Result};
-use bytes::Bytes;
+use anyhow::Result;
 use clap::Parser;
-use iroh_net::endpoint::{self, Connection, RecvStream, SendStream};
-use iroh_net::{relay::RelayMode, Endpoint, NodeAddr};
+use stats::Stats;
 use tokio::runtime::{Builder, Runtime};
-use tracing::trace;
+use tokio::sync::Semaphore;
+use tracing::info;
 
+pub mod iroh;
+pub mod quinn;
+pub mod s2n;
 pub mod stats;
-
-pub const ALPN: &[u8] = b"n0/iroh-net-bench/0";
-
-pub fn configure_tracing_subscriber() {
-    tracing::subscriber::set_global_default(
-        tracing_subscriber::FmtSubscriber::builder()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .finish(),
-    )
-    .unwrap();
-}
-
-/// Creates a server endpoint which runs on the given runtime
-pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (NodeAddr, Endpoint) {
-    let _guard = rt.enter();
-    rt.block_on(async move {
-        let ep = Endpoint::builder()
-            .alpns(vec![ALPN.to_vec()])
-            .relay_mode(RelayMode::Disabled)
-            .transport_config(transport_config(opt))
-            .bind(0)
-            .await
-            .unwrap();
-        let addr = ep.local_addr();
-        let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
-        let addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
-        (addr, ep)
-    })
-}
-
-/// Create a client endpoint and client connection
-pub async fn connect_client(server_addr: NodeAddr, opt: Opt) -> Result<(Endpoint, Connection)> {
-    let endpoint = Endpoint::builder()
-        .alpns(vec![ALPN.to_vec()])
-        .relay_mode(RelayMode::Disabled)
-        .transport_config(transport_config(&opt))
-        .bind(0)
-        .await
-        .unwrap();
-
-    // TODO: We don't support passing client transport config currently
-    // let mut client_config = quinn::ClientConfig::new(Arc::new(crypto));
-    // client_config.transport_config(Arc::new(transport_config(&opt)));
-
-    let connection = endpoint
-        .connect(server_addr, ALPN)
-        .await
-        .context("unable to connect")?;
-    trace!("connected");
-
-    Ok((endpoint, connection))
-}
-
-pub async fn drain_stream(stream: &mut RecvStream, read_unordered: bool) -> Result<usize> {
-    let mut read = 0;
-
-    if read_unordered {
-        while let Some(chunk) = stream.read_chunk(usize::MAX, false).await? {
-            read += chunk.bytes.len();
-        }
-    } else {
-        // These are 32 buffers, for reading approximately 32kB at once
-        #[rustfmt::skip]
-        let mut bufs = [
-            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
-            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
-            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
-            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
-            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
-            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
-            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
-            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
-        ];
-
-        while let Some(n) = stream.read_chunks(&mut bufs[..]).await? {
-            read += bufs.iter().take(n).map(|buf| buf.len()).sum::<usize>();
-        }
-    }
-
-    Ok(read)
-}
-
-pub async fn send_data_on_stream(stream: &mut SendStream, stream_size: u64) -> Result<()> {
-    const DATA: &[u8] = &[0xAB; 1024 * 1024];
-    let bytes_data = Bytes::from_static(DATA);
-
-    let full_chunks = stream_size / (DATA.len() as u64);
-    let remaining = (stream_size % (DATA.len() as u64)) as usize;
-
-    for _ in 0..full_chunks {
-        stream
-            .write_chunk(bytes_data.clone())
-            .await
-            .context("failed sending data")?;
-    }
-
-    if remaining != 0 {
-        stream
-            .write_chunk(bytes_data.slice(0..remaining))
-            .await
-            .context("failed sending data")?;
-    }
-
-    stream.finish().await.context("failed finishing stream")?;
-
-    Ok(())
-}
-
-pub fn rt() -> Runtime {
-    Builder::new_current_thread().enable_all().build().unwrap()
-}
-
-pub fn transport_config(opt: &Opt) -> endpoint::TransportConfig {
-    // High stream windows are chosen because the amount of concurrent streams
-    // is configurable as a parameter.
-    let mut config = endpoint::TransportConfig::default();
-    config.max_concurrent_uni_streams(opt.max_streams.try_into().unwrap());
-    config.initial_mtu(opt.initial_mtu);
-
-    // TODO: reenable when we upgrade quinn version
-    // let mut acks = quinn::AckFrequencyConfig::default();
-    // acks.ack_eliciting_threshold(10u32.into());
-    // config.ack_frequency_config(Some(acks));
-
-    config
-}
 
 #[derive(Parser, Debug, Clone, Copy)]
 #[clap(name = "bulk")]
+pub enum Commands {
+    Iroh(Opt),
+    Quinn(Opt),
+    S2n(s2n::Opt),
+}
+
+#[derive(Parser, Debug, Clone, Copy)]
+#[clap(name = "options")]
 pub struct Opt {
     /// The total number of clients which should be created
     #[clap(long = "clients", short = 'c', default_value = "1")]
@@ -171,6 +60,67 @@ pub struct Opt {
     pub initial_mtu: u16,
 }
 
+pub enum EndpointSelector {
+    Iroh(iroh_net::Endpoint),
+    Quinn(::quinn::Endpoint),
+}
+
+impl EndpointSelector {
+    pub async fn close(self) -> Result<()> {
+        match self {
+            EndpointSelector::Iroh(endpoint) => {
+                endpoint.close(0u32.into(), b"").await?;
+            }
+            EndpointSelector::Quinn(endpoint) => {
+                endpoint.close(0u32.into(), b"");
+            }
+        }
+        Ok(())
+    }
+}
+
+pub enum ConnectionSelector {
+    Iroh(iroh_net::endpoint::Connection),
+    Quinn(::quinn::Connection),
+}
+
+impl ConnectionSelector {
+    pub fn stats(&self) {
+        match self {
+            ConnectionSelector::Iroh(connection) => {
+                println!("{:#?}", connection.stats());
+            }
+            ConnectionSelector::Quinn(connection) => {
+                println!("{:#?}", connection.stats());
+            }
+        }
+    }
+
+    pub fn close(&self, error_code: u32, reason: &[u8]) {
+        match self {
+            ConnectionSelector::Iroh(connection) => {
+                connection.close(error_code.into(), reason);
+            }
+            ConnectionSelector::Quinn(connection) => {
+                connection.close(error_code.into(), reason);
+            }
+        }
+    }
+}
+
+pub fn configure_tracing_subscriber() {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .finish(),
+    )
+    .unwrap();
+}
+
+pub fn rt() -> Runtime {
+    Builder::new_current_thread().enable_all().build().unwrap()
+}
+
 fn parse_byte_size(s: &str) -> Result<u64, ParseIntError> {
     let s = s.trim();
 
@@ -191,4 +141,102 @@ fn parse_byte_size(s: &str) -> Result<u64, ParseIntError> {
     let base: u64 = u64::from_str(s)?;
 
     Ok(base * multiplier)
+}
+
+#[derive(Default)]
+pub struct ClientStats {
+    upload_stats: Stats,
+    download_stats: Stats,
+    connect_time: std::time::Duration,
+}
+
+impl ClientStats {
+    pub fn print(&self, client_id: usize) {
+        println!();
+        println!("Client {client_id} stats:");
+
+        let ct = self.connect_time.as_nanos() as f64 / 1_000_000.0;
+        println!("Connect time: {ct}ms");
+
+        if self.upload_stats.total_size != 0 {
+            self.upload_stats.print("upload");
+        }
+
+        if self.download_stats.total_size != 0 {
+            self.download_stats.print("download");
+        }
+    }
+}
+
+/// Take the provided endpoint and run the client benchmark
+pub async fn client_handler(
+    endpoint: EndpointSelector,
+    connection: ConnectionSelector,
+    opt: Opt,
+) -> Result<ClientStats> {
+    let start = Instant::now();
+
+    let connection = Arc::new(connection);
+
+    let mut stats = ClientStats::default();
+    let mut first_error = None;
+
+    let sem = Arc::new(Semaphore::new(opt.max_streams));
+    let results = Arc::new(Mutex::new(Vec::new()));
+    for _ in 0..opt.streams {
+        let permit = sem.clone().acquire_owned().await.unwrap();
+        let results = results.clone();
+        let connection = connection.clone();
+        tokio::spawn(async move {
+            let result = match &*connection {
+                ConnectionSelector::Iroh(connection) => {
+                    iroh::handle_client_stream(connection, opt.upload_size, opt.read_unordered)
+                        .await
+                }
+                ConnectionSelector::Quinn(connection) => {
+                    quinn::handle_client_stream(connection, opt.upload_size, opt.read_unordered)
+                        .await
+                }
+            };
+            // handle_client_stream(connection, opt.upload_size, opt.read_unordered).await;
+            info!("stream finished: {:?}", result);
+            results.lock().unwrap().push(result);
+            drop(permit);
+        });
+    }
+
+    // Wait for remaining streams to finish
+    let _ = sem.acquire_many(opt.max_streams as u32).await.unwrap();
+
+    for result in results.lock().unwrap().drain(..) {
+        match result {
+            Ok((upload_result, download_result)) => {
+                stats.upload_stats.stream_finished(upload_result);
+                stats.download_stats.stream_finished(download_result);
+            }
+            Err(e) => {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
+        }
+    }
+
+    stats.upload_stats.total_duration = start.elapsed();
+    stats.download_stats.total_duration = start.elapsed();
+
+    // Explicit close of the connection, since handles can still be around due
+    // to `Arc`ing them
+    connection.close(0u32, b"Benchmark done");
+
+    endpoint.close().await?;
+
+    if opt.stats {
+        println!("\nClient connection stats:\n{:#?}", connection.stats());
+    }
+
+    match first_error {
+        None => Ok(stats),
+        Some(e) => Err(e),
+    }
 }

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -2,7 +2,7 @@ use std::{
     num::ParseIntError,
     str::FromStr,
     sync::{Arc, Mutex},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::Result;

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -208,6 +208,9 @@ pub async fn client_handler(
     // Wait for remaining streams to finish
     let _ = sem.acquire_many(opt.max_streams as u32).await.unwrap();
 
+    stats.upload_stats.total_duration = start.elapsed();
+    stats.download_stats.total_duration = start.elapsed();
+
     for result in results.lock().unwrap().drain(..) {
         match result {
             Ok((upload_result, download_result)) => {
@@ -221,9 +224,6 @@ pub async fn client_handler(
             }
         }
     }
-
-    stats.upload_stats.total_duration = start.elapsed();
-    stats.download_stats.total_duration = start.elapsed();
 
     // Explicit close of the connection, since handles can still be around due
     // to `Arc`ing them

--- a/iroh-net/bench/src/quinn.rs
+++ b/iroh-net/bench/src/quinn.rs
@@ -1,0 +1,286 @@
+use std::{
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use quinn::{Connection, Endpoint, RecvStream, SendStream, TokioRuntime, TransportConfig};
+use socket2::{Domain, Protocol, Socket, Type};
+use tracing::{trace, warn};
+
+use crate::{
+    client_handler, stats::TransferResult, ClientStats, ConnectionSelector, EndpointSelector, Opt,
+};
+
+/// Derived from the iroh-net udp SOCKET_BUFFER_SIZE
+const SOCKET_BUFFER_SIZE: usize = 7 << 20;
+pub const ALPN: &[u8] = b"n0/quinn-bench/0";
+
+/// Creates a server endpoint which runs on the given runtime
+pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (SocketAddr, quinn::Endpoint) {
+    let secret_key = iroh_net::key::SecretKey::generate();
+    let crypto =
+        iroh_net::tls::make_server_config(&secret_key, vec![ALPN.to_vec()], false).unwrap();
+
+    let transport = transport_config(opt.max_streams, opt.initial_mtu);
+
+    let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(crypto));
+    server_config.transport_config(Arc::new(transport));
+
+    let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), 0);
+
+    let socket = bind_socket(addr).unwrap();
+
+    let _guard = rt.enter();
+    rt.block_on(async move {
+        let ep = quinn::Endpoint::new(
+            Default::default(),
+            Some(server_config),
+            socket,
+            Arc::new(TokioRuntime),
+        )
+        .unwrap();
+        let addr = ep.local_addr().unwrap();
+        (addr, ep)
+    })
+}
+
+/// Create and run a client
+pub async fn client(server_addr: SocketAddr, opt: Opt) -> Result<ClientStats> {
+    let client_start = std::time::Instant::now();
+    let (endpoint, connection) = connect_client(server_addr, opt).await?;
+    let client_connect_time = client_start.elapsed();
+    let mut res = client_handler(
+        EndpointSelector::Quinn(endpoint),
+        ConnectionSelector::Quinn(connection),
+        opt,
+    )
+    .await?;
+    res.connect_time = client_connect_time;
+    Ok(res)
+}
+
+/// Create a client endpoint and client connection
+pub async fn connect_client(
+    server_addr: SocketAddr,
+    opt: Opt,
+) -> Result<(::quinn::Endpoint, Connection)> {
+    let secret_key = iroh_net::key::SecretKey::generate();
+    let tls_client_config =
+        iroh_net::tls::make_client_config(&secret_key, None, vec![ALPN.to_vec()], false)?;
+    let mut config = quinn::ClientConfig::new(Arc::new(tls_client_config));
+
+    let transport = transport_config(opt.max_streams, opt.initial_mtu);
+
+    // let mut config = quinn::ClientConfig::new(Arc::new(crypto));
+    config.transport_config(Arc::new(transport));
+
+    let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), 0);
+
+    let socket = bind_socket(addr).unwrap();
+
+    let ep =
+        quinn::Endpoint::new(Default::default(), None, socket, Arc::new(TokioRuntime)).unwrap();
+    let connection = ep
+        .connect_with(config, server_addr, "local")?
+        .await
+        .context("connecting")
+        .unwrap();
+    Ok((ep, connection))
+}
+
+pub fn transport_config(max_streams: usize, initial_mtu: u16) -> TransportConfig {
+    // High stream windows are chosen because the amount of concurrent streams
+    // is configurable as a parameter.
+    let mut config = TransportConfig::default();
+    config.max_concurrent_uni_streams(max_streams.try_into().unwrap());
+    config.initial_mtu(initial_mtu);
+
+    // TODO: reenable when we upgrade quinn version
+    // let mut acks = quinn::AckFrequencyConfig::default();
+    // acks.ack_eliciting_threshold(10u32.into());
+    // config.ack_frequency_config(Some(acks));
+
+    config
+}
+
+fn bind_socket(addr: SocketAddr) -> Result<std::net::UdpSocket> {
+    let socket = Socket::new(Domain::for_address(addr), Type::DGRAM, Some(Protocol::UDP))
+        .context("create socket")?;
+
+    if addr.is_ipv6() {
+        socket.set_only_v6(false).context("set_only_v6")?;
+    }
+
+    socket
+        .bind(&socket2::SockAddr::from(addr))
+        .context("binding endpoint")?;
+    socket
+        .set_send_buffer_size(SOCKET_BUFFER_SIZE)
+        .context("send buffer size")?;
+    socket
+        .set_recv_buffer_size(SOCKET_BUFFER_SIZE)
+        .context("recv buffer size")?;
+
+    let buf_size = socket.send_buffer_size().context("send buffer size")?;
+    if buf_size < SOCKET_BUFFER_SIZE {
+        warn!(
+            "Unable to set desired send buffer size. Desired: {}, Actual: {}",
+            SOCKET_BUFFER_SIZE, buf_size
+        );
+    }
+
+    let buf_size = socket.recv_buffer_size().context("recv buffer size")?;
+    if buf_size < SOCKET_BUFFER_SIZE {
+        warn!(
+            "Unable to set desired recv buffer size. Desired: {}, Actual: {}",
+            SOCKET_BUFFER_SIZE, buf_size
+        );
+    }
+
+    Ok(socket.into())
+}
+
+async fn drain_stream(
+    stream: &mut RecvStream,
+    read_unordered: bool,
+) -> Result<(usize, Duration, u64)> {
+    let mut read = 0;
+
+    let download_start = Instant::now();
+    let mut first_byte = true;
+    let mut ttfb = download_start.elapsed();
+
+    let mut num_chunks: u64 = 0;
+
+    if read_unordered {
+        while let Some(chunk) = stream.read_chunk(usize::MAX, false).await? {
+            if first_byte {
+                ttfb = download_start.elapsed();
+                first_byte = false;
+            }
+            read += chunk.bytes.len();
+            num_chunks += 1;
+        }
+    } else {
+        // These are 32 buffers, for reading approximately 32kB at once
+        #[rustfmt::skip]
+        let mut bufs = [
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        ];
+
+        while let Some(n) = stream.read_chunks(&mut bufs[..]).await? {
+            if first_byte {
+                ttfb = download_start.elapsed();
+                first_byte = false;
+            }
+            read += bufs.iter().take(n).map(|buf| buf.len()).sum::<usize>();
+            num_chunks += 1;
+        }
+    }
+
+    Ok((read, ttfb, num_chunks))
+}
+
+async fn send_data_on_stream(stream: &mut SendStream, stream_size: u64) -> Result<()> {
+    const DATA: &[u8] = &[0xAB; 1024 * 1024];
+    let bytes_data = Bytes::from_static(DATA);
+
+    let full_chunks = stream_size / (DATA.len() as u64);
+    let remaining = (stream_size % (DATA.len() as u64)) as usize;
+
+    for _ in 0..full_chunks {
+        stream
+            .write_chunk(bytes_data.clone())
+            .await
+            .context("failed sending data")?;
+    }
+
+    if remaining != 0 {
+        stream
+            .write_chunk(bytes_data.slice(0..remaining))
+            .await
+            .context("failed sending data")?;
+    }
+
+    stream.finish().await.context("failed finishing stream")?;
+
+    Ok(())
+}
+
+pub async fn handle_client_stream(
+    connection: &Connection,
+    upload_size: u64,
+    read_unordered: bool,
+) -> Result<(TransferResult, TransferResult)> {
+    let start = Instant::now();
+
+    let (mut send_stream, mut recv_stream) = connection
+        .open_bi()
+        .await
+        .context("failed to open stream")?;
+
+    send_data_on_stream(&mut send_stream, upload_size).await?;
+
+    let upload_result = TransferResult::new(start.elapsed(), upload_size, Duration::default(), 0);
+
+    let start = Instant::now();
+    let (size, ttfb, num_chunks) = drain_stream(&mut recv_stream, read_unordered).await?;
+    let download_result = TransferResult::new(start.elapsed(), size as u64, ttfb, num_chunks);
+
+    Ok((upload_result, download_result))
+}
+
+/// Take the provided endpoint and run the server
+pub async fn server(endpoint: Endpoint, opt: Opt) -> Result<()> {
+    let mut server_tasks = Vec::new();
+
+    // Handle only the expected amount of clients
+    for _ in 0..opt.clients {
+        let handshake = endpoint.accept().await.unwrap();
+        let connection = handshake.await.context("handshake failed")?;
+
+        server_tasks.push(tokio::spawn(async move {
+            loop {
+                let (mut send_stream, mut recv_stream) = match connection.accept_bi().await {
+                    Err(::quinn::ConnectionError::ApplicationClosed(_)) => break,
+                    Err(e) => {
+                        eprintln!("accepting stream failed: {e:?}");
+                        break;
+                    }
+                    Ok(stream) => stream,
+                };
+                trace!("stream established");
+
+                tokio::spawn(async move {
+                    drain_stream(&mut recv_stream, opt.read_unordered).await?;
+                    send_data_on_stream(&mut send_stream, opt.download_size).await?;
+                    Ok::<_, anyhow::Error>(())
+                });
+            }
+
+            if opt.stats {
+                println!("\nServer connection stats:\n{:#?}", connection.stats());
+            }
+        }));
+    }
+
+    // Await all the tasks. We have to do this to prevent the runtime getting dropped
+    // and all server tasks to be cancelled
+    for handle in server_tasks {
+        if let Err(e) = handle.await {
+            eprintln!("Server task error: {e:?}");
+        };
+    }
+
+    Ok(())
+}

--- a/iroh-net/bench/src/quinn.rs
+++ b/iroh-net/bench/src/quinn.rs
@@ -86,8 +86,7 @@ pub async fn connect_client(
     let connection = ep
         .connect_with(config, server_addr, "local")?
         .await
-        .context("connecting")
-        .unwrap();
+        .context("connecting")?;
     Ok((ep, connection))
 }
 

--- a/iroh-net/bench/src/s2n.rs
+++ b/iroh-net/bench/src/s2n.rs
@@ -1,0 +1,5 @@
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone, Copy)]
+#[clap(name = "s2n")]
+pub struct Opt {}


### PR DESCRIPTION
## Description

In progress thing for what should later be `iroh-perf`. For now you can run with `cargo run --release -- iroh` and `cargo run --release -- quinn` to do a simple comparison benchmark.

More knobs are available for tuning with `--help`.
There's a much more stark difference on macOS compared to running on Linux.

Next steps bumping to test against `quinn 0.11`

Sample output:
```
iroh (macOS)

Client 0 stats:
Connect time: 13.788583ms
Overall download stats:

Transferred 1073741824 bytes on 1 streams in 5.47s (187.27 MiB/s)

Time to first byte (TTFB): 1ms

Total chunks: 130319

Average chunk time: 41.936ms

Average chunk size: 8.04KiB

Stream download metrics:

      │  Throughput   │ Duration 
──────┼───────────────┼──────────
 AVG  │  187.31 MiB/s │     5.47s
 P0   │  187.25 MiB/s │     5.46s
 P10  │  187.37 MiB/s │     5.47s
 P50  │  187.37 MiB/s │     5.47s
 P90  │  187.37 MiB/s │     5.47s
 P100 │  187.37 MiB/s │     5.47s
 ```
 
```
quinn (macOS)

Client 0 stats:
Connect time: 1.81875ms
Overall download stats:

Transferred 1073741824 bytes on 1 streams in 2.85s (358.92 MiB/s)

Time to first byte (TTFB): 61.168ms

Total chunks: 47412

Average chunk time: 60.176ms

Average chunk size: 22.12KiB

Stream download metrics:

      │  Throughput   │ Duration 
──────┼───────────────┼──────────
 AVG  │  358.88 MiB/s │     2.85s
 P0   │  358.75 MiB/s │     2.85s
 P10  │  359.00 MiB/s │     2.85s
 P50  │  359.00 MiB/s │     2.85s
 P90  │  359.00 MiB/s │     2.85s
 P100 │  359.00 MiB/s │     2.85s
 ```

```
iroh (linux)

Client 0 stats:
Connect time: 3.83554ms
Overall download stats:

Transferred 1073741824 bytes on 1 streams in 1.16s (884.52 MiB/s)

Time to first byte (TTFB): 2.014ms

Total chunks: 38046

Average chunk time: 30.408ms

Average chunk size: 27.55KiB

Stream download metrics:

      │  Throughput   │ Duration 
──────┼───────────────┼──────────
 AVG  │  884.75 MiB/s │     1.16s
 P0   │  884.50 MiB/s │     1.16s
 P10  │  885.00 MiB/s │     1.16s
 P50  │  885.00 MiB/s │     1.16s
 P90  │  885.00 MiB/s │     1.16s
 P100 │  885.00 MiB/s │     1.16s
 ```
 
```
quinn (linux)

Client 0 stats:
Connect time: 1.22085ms
Overall download stats:

Transferred 1073741824 bytes on 1 streams in 994.57ms (1029.59 MiB/s)

Time to first byte (TTFB): 1.483ms

Total chunks: 32809

Average chunk time: 30.296ms

Average chunk size: 31.96KiB

Stream download metrics:

      │  Throughput   │ Duration 
──────┼───────────────┼──────────
 AVG  │ 1030.50 MiB/s │  993.00ms
 P0   │ 1030.00 MiB/s │  993.00ms
 P10  │ 1031.00 MiB/s │  993.00ms
 P50  │ 1031.00 MiB/s │  993.00ms
 P90  │ 1031.00 MiB/s │  993.00ms
 P100 │ 1031.00 MiB/s │  993.00ms
 ```

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
