### PR TITLE
fix: iroh-bytes log levels

### DIFF
--- a/iroh-bytes/src/store/fs.rs
+++ b/iroh-bytes/src/store/fs.rs
@@ -1119,7 +1119,7 @@ impl StoreInner {
         progress: impl ProgressSender<Msg = ImportProgress> + IdGenerator,
     ) -> OuterResult<(TempTag, u64)> {
         let data_size = file.len()?;
-        tracing::info!("finalize_import_sync {:?} {}", file, data_size);
+        tracing::debug!("finalize_import_sync {:?} {}", file, data_size);
         progress.blocking_send(ImportProgress::Size {
             id,
             size: data_size,


### PR DESCRIPTION
## Description

Demotes a log line from `info` to `debug`.

When importing stuff into the store the remaining info level logs are:

```
2024-04-15T22:10:08.889505Z  INFO iroh_bytes::store::fs: stored external reference /path/to/file
2024-04-15T22:10:08.889565Z  INFO iroh_bytes::store::fs: reading external data to inline it: /path/to/file
```
I think we should reduce it to a single line, and use the tracing fields.