### PR TITLE
fix(iroh-net): Suppress HostUnreachable network error as well

### DIFF
--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -837,10 +837,10 @@ async fn run_stun_probe(
 
             // It is entirely normal that we are on a dual-stack machine with no
             // routed IPv6 network.  So silence that case.
-            // NetworkUnreachable is still experimental (io_error_more #86442)
-            // but it is already emitted.  So hack around this.
+            // NetworkUnreachable and HostUnreachable are still experimental (io_error_more
+            // #86442) but it is already emitted.  So hack around this.
             match format!("{kind:?}").as_str() {
-                "NetworkUnreachable" => {
+                "NetworkUnreachable" | "HostUnreachable" => {
                     debug!(%relay_addr, "{err:#}");
                     Err(ProbeError::AbortSet(err, probe.clone()))
                 }


### PR DESCRIPTION
## Description

Depending on the system and configuration the error retruned for an
unroutable IPv6 address might be slightly different.  But they need to
be treated the same way.

## Notes & open questions

This is hard to test, please verify this manually on the system where
it occurred.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates if relevant.~~
- ~~[ ] Tests if relevant.~~