### PR TITLE
fix(iroh-bytes): do not log redundant file delete error

### DIFF
--- a/iroh-bytes/src/store/fs/tables.rs
+++ b/iroh-bytes/src/store/fs/tables.rs
@@ -149,12 +149,15 @@ impl DeleteSet {
                 BaoFilePart::Sizes => options.owned_sizes_path(hash),
             };
             if let Err(cause) = std::fs::remove_file(&path) {
-                tracing::warn!(
-                    "failed to delete {:?} {}: {}",
-                    to_delete,
-                    path.display(),
-                    cause
-                );
+                // Ignore NotFound errors, if the file is already gone that's fine.
+                if cause.kind() != std::io::ErrorKind::NotFound {
+                    tracing::warn!(
+                        "failed to delete {:?} {}: {}",
+                        to_delete,
+                        path.display(),
+                        cause
+                    );
+                }
             }
         }
         self.0.clear();


### PR DESCRIPTION
## Description

fix(iroh-bytes): do not log when a file can not be deleted...

because it is not there. this makes the delete op idempotent, and also helps in case the file was not there in the first place.

Fixes https://github.com/n0-computer/iroh/issues/2142

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
