### PR TITLE
fix(iroh-dns-server): fix bug in pkarr name parsing

### DIFF
--- a/iroh-dns-server/src/dns/node_authority.rs
+++ b/iroh-dns-server/src/dns/node_authority.rs
@@ -174,7 +174,8 @@ fn parse_name_as_pkarr_with_origin(
         let mut labels_without_origin = labels.skip(origin.num_labels() as usize);
         let pkey_label = labels_without_origin.next().expect("length checked above");
         let pkey_str = std::str::from_utf8(pkey_label)?;
-        let pkey = PublicKeyBytes::from_z32(pkey_str).context("not a valid pkarr name: invalid pubkey")?;
+        let pkey =
+            PublicKeyBytes::from_z32(pkey_str).context("not a valid pkarr name: invalid pubkey")?;
         let remaining_name = Name::from_labels(labels_without_origin.rev())?;
         return Ok((remaining_name, pkey, origin.clone()));
     }

--- a/iroh-dns-server/src/dns/node_authority.rs
+++ b/iroh-dns-server/src/dns/node_authority.rs
@@ -175,6 +175,7 @@ fn split_and_parse_pkarr(
         let pkey_str = std::str::from_utf8(pkey_label)?;
         let pkey = PublicKeyBytes::from_z32(pkey_str)?;
         let remaining_name = Name::from_labels(labels_without_origin)?;
+        let remaining_name = Name::from_labels(labels_without_origin.rev())?;
         return Ok((remaining_name, pkey, origin.clone()));
     }
     bail!("name does not match any origin");

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -13,7 +13,7 @@ mod util;
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
     use anyhow::Result;
     use hickory_resolver::{
@@ -28,9 +28,103 @@ mod tests {
         },
         key::SecretKey,
     };
+    use pkarr::SignedPacket;
     use url::Url;
 
     use crate::server::Server;
+
+    #[tokio::test]
+    async fn pkarr_publish_dns_resolve() -> Result<()> {
+        tracing_subscriber::fmt::init();
+        let (server, nameserver, http_url) = Server::spawn_for_tests().await?;
+        let pkarr_relay_url = {
+            let mut url = http_url.clone();
+            url.set_path("/pkarr");
+            url
+        };
+        let signed_packet = {
+            use pkarr::dns;
+            let keypair = pkarr::Keypair::random();
+            let mut packet = dns::Packet::new_reply(0);
+            // record at root
+            packet.answers.push(dns::ResourceRecord::new(
+                dns::Name::new("").unwrap(),
+                dns::CLASS::IN,
+                30,
+                dns::rdata::RData::TXT("hi0".try_into()?),
+            ));
+            // record at level one
+            packet.answers.push(dns::ResourceRecord::new(
+                dns::Name::new("_hello").unwrap(),
+                dns::CLASS::IN,
+                30,
+                dns::rdata::RData::TXT("hi1".try_into()?),
+            ));
+            // record at level two
+            packet.answers.push(dns::ResourceRecord::new(
+                dns::Name::new("_hello.world").unwrap(),
+                dns::CLASS::IN,
+                30,
+                dns::rdata::RData::TXT("hi2".try_into()?),
+            ));
+            // record of type A
+            packet.answers.push(dns::ResourceRecord::new(
+                dns::Name::new("").unwrap(),
+                dns::CLASS::IN,
+                30,
+                dns::rdata::RData::A(Ipv4Addr::LOCALHOST.into()),
+            ));
+            // record of type AAAA
+            packet.answers.push(dns::ResourceRecord::new(
+                dns::Name::new("foo.bar.baz").unwrap(),
+                dns::CLASS::IN,
+                30,
+                dns::rdata::RData::AAAA(Ipv6Addr::LOCALHOST.into()),
+            ));
+            SignedPacket::from_packet(&keypair, &packet)?
+        };
+        let pkarr_client = pkarr::PkarrClient::builder().build();
+        pkarr_client
+            .relay_put(&pkarr_relay_url, &signed_packet)
+            .await?;
+
+        use hickory_proto::rr::Name;
+        let pubkey = signed_packet.public_key().to_z32();
+        let resolver = test_resolver(nameserver);
+
+        // resolve root record
+        let name = Name::from_utf8(&format!("{pubkey}."))?;
+        let res = resolver.txt_lookup(name).await?;
+        let records = res.iter().map(|t| t.to_string()).collect::<Vec<_>>();
+        assert_eq!(records, vec!["hi0".to_string()]);
+
+        // resolve level one record
+        let name = Name::from_utf8(&format!("_hello.{pubkey}."))?;
+        let res = resolver.txt_lookup(name).await?;
+        let records = res.iter().map(|t| t.to_string()).collect::<Vec<_>>();
+        assert_eq!(records, vec!["hi1".to_string()]);
+
+        // resolve level two record
+        let name = Name::from_utf8(&format!("_hello.world.{pubkey}."))?;
+        let res = resolver.txt_lookup(name).await?;
+        let records = res.iter().map(|t| t.to_string()).collect::<Vec<_>>();
+        assert_eq!(records, vec!["hi2".to_string()]);
+
+        // resolve A record
+        let name = Name::from_utf8(&format!("{pubkey}."))?;
+        let res = resolver.ipv4_lookup(name).await?;
+        let records = res.iter().map(|t| t.0).collect::<Vec<_>>();
+        assert_eq!(records, vec![Ipv4Addr::LOCALHOST]);
+
+        // resolve AAAA record
+        let name = Name::from_utf8(&format!("foo.bar.baz.{pubkey}."))?;
+        let res = resolver.ipv6_lookup(name).await?;
+        let records = res.iter().map(|t| t.0).collect::<Vec<_>>();
+        assert_eq!(records, vec![Ipv6Addr::LOCALHOST]);
+
+        server.shutdown().await?;
+        Ok(())
+    }
 
     #[tokio::test]
     async fn integration_smoke() -> Result<()> {


### PR DESCRIPTION
## Description

The order of labels when parsing a DNS query as pkarr name was reversed. This means all queries for second-level subdomains under a pkarr pubkey failed.

* First commit is the actual fix. 
* Second commit adds a test for various record name and type variations
* Third and forth commit improve the debug and info logging

## Notes & open questions

Was discovered by @rklaehn in #2188 and fixes the wrong behavior observed there.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
