### PR TITLE
feat(iroh-net): extend discovery NodeInfo to allow direct addrs

### DIFF
--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
     println!("publish to {pkarr_relay} ...");
 
     let pkarr = PkarrRelayClient::new(pkarr_relay);
-    let node_info = NodeInfo::new(node_id, Some(args.relay_url));
+    let node_info = NodeInfo::new(node_id, Some(args.relay_url), Default::default());
     let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
     pkarr.publish(&signed_packet).await?;
 

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -162,7 +162,7 @@ mod tests {
         let node_id = secret_key.public();
         let relay_url: Url = "https://relay.example.".parse()?;
         let pkarr = PkarrRelayClient::new(pkarr_relay);
-        let node_info = NodeInfo::new(node_id, Some(relay_url.clone()));
+        let node_info = NodeInfo::new(node_id, Some(relay_url.clone()), Default::default());
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
 
         pkarr.publish(&signed_packet).await?;

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -581,6 +581,7 @@ mod test_dns_pkarr {
         let node_info = NodeInfo::new(
             secret_key.public(),
             Some("https://relay.example".parse().unwrap()),
+            Default::default(),
         );
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
         state.upsert(signed_packet)?;

--- a/iroh-net/src/discovery/pkarr_publish.rs
+++ b/iroh-net/src/discovery/pkarr_publish.rs
@@ -87,7 +87,11 @@ impl PkarrPublisher {
     ///
     /// This is a nonblocking function, the actual update is performed in the background.
     pub fn update_addr_info(&self, info: &AddrInfo) {
-        let info = NodeInfo::new(self.node_id, info.relay_url.clone().map(Into::into));
+        let info = NodeInfo::new(
+            self.node_id,
+            info.relay_url.clone().map(Into::into),
+            Default::default(),
+        );
         self.watchable.update(Some(info)).ok();
     }
 }

--- a/iroh-net/src/dns/node_info.rs
+++ b/iroh-net/src/dns/node_info.rs
@@ -90,7 +90,7 @@ impl From<TxtAttrs<IrohAttr>> for NodeInfo {
 impl From<&TxtAttrs<IrohAttr>> for NodeInfo {
     fn from(attrs: &TxtAttrs<IrohAttr>) -> Self {
         let node_id = attrs.node_id();
-        let attrs: &BTreeMap<IrohAttr, Vec<String>> = attrs.attrs();
+        let attrs = attrs.attrs();
         let relay_url = attrs
             .get(&IrohAttr::Relay)
             .into_iter()


### PR DESCRIPTION
## Description

feat(iroh-net): extend discovery NodeInfo to allow direct addrs

This should be compatible with what is sketched in https://github.com/n0-computer/iroh/issues/2149

For now we leave the direct addresses empty, but having this would allow tools like https://github.com/n0-computer/iroh-examples/tree/main/iroh-pkarr-node-discovery to publish everything (optionally) without having to reimplement the conversion from/to signed packets.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
