### PR TITLE
fix(iroh-cli): avoid using debug formatting for rpc errors

### DIFF
--- a/iroh-base/src/rpc.rs
+++ b/iroh-base/src/rpc.rs
@@ -8,7 +8,7 @@ pub struct RpcError(serde_error::Error);
 
 impl fmt::Display for RpcError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        fmt::Display::fmt(&self.0, f)
     }
 }
 

--- a/iroh-cli/src/commands/blob.rs
+++ b/iroh-cli/src/commands/blob.rs
@@ -1053,7 +1053,7 @@ pub async fn show_download_progress(
                 break;
             }
             DownloadProgress::Abort(e) => {
-                bail!("download aborted: {:?}", e);
+                bail!("download aborted: {}", e);
             }
         }
     }


### PR DESCRIPTION
## Description

fix(iroh-cli): avoid using debug formatting for rpc errors

For a human readable error message, RpcError(...) does not add anything and makes things more confusing.

See https://github.com/n0-computer/iroh/issues/2183

## Notes & open questions

This fixes this in one place. Probably more...

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
