### PR TITLE
refactor(iroh-net)!: Rename endpoint for nodes to node_state

### DIFF
--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -30,7 +30,7 @@ use iroh::{
         dns::default_resolver,
         key::{PublicKey, SecretKey},
         magic_endpoint,
-        magicsock::EndpointInfo,
+        magicsock::NodeInfo,
         netcheck, portmapper,
         relay::{RelayMap, RelayMode, RelayUrl},
         util::AbortingJoinHandle,
@@ -390,7 +390,7 @@ impl Gui {
                 .unwrap_or_else(|| "unknown".to_string())
         };
         let msg = match endpoint.connection_info(*node_id) {
-            Some(EndpointInfo {
+            Some(NodeInfo {
                 relay_url,
                 conn_type,
                 latency,

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -30,7 +30,7 @@ use iroh::{
         dns::default_resolver,
         key::{PublicKey, SecretKey},
         magic_endpoint,
-        magicsock::NodeInfo,
+        magicsock::ConnectionInfo,
         netcheck, portmapper,
         relay::{RelayMap, RelayMode, RelayUrl},
         util::AbortingJoinHandle,
@@ -390,7 +390,7 @@ impl Gui {
                 .unwrap_or_else(|| "unknown".to_string())
         };
         let msg = match endpoint.connection_info(*node_id) {
-            Some(NodeInfo {
+            Some(ConnectionInfo {
                 relay_url,
                 conn_type,
                 latency,

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -20,7 +20,7 @@ use crate::{
     tls, NodeId,
 };
 
-pub use super::magicsock::{LocalEndpointsStream, NodeInfo as ConnectionInfo};
+pub use super::magicsock::{ConnectionInfo, LocalEndpointsStream};
 
 pub use iroh_base::node_addr::{AddrInfo, NodeAddr};
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -376,7 +376,7 @@ impl MagicEndpoint {
     /// to the internal addressbook through [`MagicEndpoint::add_node_addr`]), so these connections
     /// are not necessarily active connections.
     pub fn connection_infos(&self) -> Vec<ConnectionInfo> {
-        self.msock.tracked_nodes()
+        self.msock.connection_infos()
     }
 
     /// Get connection information about a specific node.
@@ -385,7 +385,7 @@ impl MagicEndpoint {
     /// latency, and its [`crate::magicsock::ConnectionType`], which let's us know if we are
     /// currently communicating with that node over a `Direct` (UDP) or `Relay` (relay) connection.
     pub fn connection_info(&self, node_id: PublicKey) -> Option<ConnectionInfo> {
-        self.msock.tracked_node(node_id)
+        self.msock.connection_info(node_id)
     }
 
     pub(crate) fn cancelled(&self) -> WaitForCancellationFuture<'_> {

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -20,7 +20,7 @@ use crate::{
     tls, NodeId,
 };
 
-pub use super::magicsock::{EndpointInfo as ConnectionInfo, LocalEndpointsStream};
+pub use super::magicsock::{LocalEndpointsStream, NodeInfo as ConnectionInfo};
 
 pub use iroh_base::node_addr::{AddrInfo, NodeAddr};
 
@@ -376,7 +376,7 @@ impl MagicEndpoint {
     /// to the internal addressbook through [`MagicEndpoint::add_node_addr`]), so these connections
     /// are not necessarily active connections.
     pub fn connection_infos(&self) -> Vec<ConnectionInfo> {
-        self.msock.tracked_endpoints()
+        self.msock.tracked_nodes()
     }
 
     /// Get connection information about a specific node.
@@ -385,7 +385,7 @@ impl MagicEndpoint {
     /// latency, and its [`crate::magicsock::ConnectionType`], which let's us know if we are
     /// currently communicating with that node over a `Direct` (UDP) or `Relay` (relay) connection.
     pub fn connection_info(&self, node_id: PublicKey) -> Option<ConnectionInfo> {
-        self.msock.tracked_endpoint(node_id)
+        self.msock.tracked_node(node_id)
     }
 
     pub(crate) fn cancelled(&self) -> WaitForCancellationFuture<'_> {

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -81,7 +81,7 @@ pub use crate::net::UdpSocket;
 
 pub use self::metrics::Metrics;
 pub use self::node_map::{
-    ConnectionType, ConnectionTypeStream, ControlMsg, DirectAddrInfo, NodeInfo,
+    ConnectionType, ConnectionTypeStream, ControlMsg, DirectAddrInfo, NodeInfo as ConnectionInfo,
 };
 pub use self::timer::Timer;
 
@@ -1310,12 +1310,12 @@ impl MagicSock {
     }
 
     /// Retrieve connection information about nodes in the network.
-    pub fn tracked_nodes(&self) -> Vec<NodeInfo> {
+    pub fn connection_infos(&self) -> Vec<ConnectionInfo> {
         self.inner.node_map.node_infos(Instant::now())
     }
 
     /// Retrieve connection information about a node in the network.
-    pub fn tracked_node(&self, node_key: PublicKey) -> Option<NodeInfo> {
+    pub fn connection_info(&self, node_key: PublicKey) -> Option<ConnectionInfo> {
         self.inner.node_map.node_info(&node_key)
     }
 
@@ -2605,7 +2605,7 @@ pub(crate) mod tests {
         fn tracked_endpoints(&self) -> Vec<PublicKey> {
             self.endpoint
                 .magic_sock()
-                .tracked_nodes()
+                .connection_infos()
                 .into_iter()
                 .map(|ep| ep.node_id)
                 .collect()

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -211,7 +211,7 @@ impl NodeMap {
             .collect()
     }
 
-    /// Get the [`EndpointInfo`]s for each endpoint
+    /// Gets the [`NodeInfo`]s for each endpoint
     pub(super) fn node_infos(&self, now: Instant) -> Vec<NodeInfo> {
         self.inner.lock().node_infos(now)
     }
@@ -232,7 +232,7 @@ impl NodeMap {
         self.inner.lock().conn_type_stream(public_key)
     }
 
-    /// Get the [`EndpointInfo`]s for each endpoint
+    /// Get the [`NodeInfo`]s for each endpoint
     pub(super) fn node_info(&self, public_key: &PublicKey) -> Option<NodeInfo> {
         self.inner.lock().node_info(public_key)
     }
@@ -405,12 +405,12 @@ impl NodeMapInner {
         self.by_id.iter_mut()
     }
 
-    /// Get the [`EndpointInfo`]s for each endpoint
+    /// Get the [`NodeInfo`]s for each endpoint
     fn node_infos(&self, now: Instant) -> Vec<NodeInfo> {
         self.node_states().map(|(_, ep)| ep.info(now)).collect()
     }
 
-    /// Get the [`EndpointInfo`]s for each endpoint
+    /// Get the [`NodeInfo`]s for each endpoint
     fn node_info(&self, public_key: &PublicKey) -> Option<NodeInfo> {
         self.get(NodeStateKey::NodeId(public_key))
             .map(|ep| ep.info(Instant::now()))

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -10,13 +10,14 @@ use std::{
 
 use anyhow::{ensure, Context as _};
 use futures::Stream;
+use iroh_base::key::NodeId;
 use iroh_metrics::inc;
 use parking_lot::Mutex;
 use stun_rs::TransactionId;
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, info, instrument, trace, warn};
 
-use self::endpoint::{Endpoint, Options, PingHandled};
+use self::node_state::{NodeState, Options, PingHandled};
 use super::{
     metrics::Metrics as MagicsockMetrics, ActorMessage, DiscoMessageSource, QuicMappedAddr,
 };
@@ -28,20 +29,16 @@ use crate::{
 };
 
 mod best_addr;
-mod endpoint;
+mod node_state;
 
-pub use endpoint::{ConnectionType, ControlMsg, DirectAddrInfo, EndpointInfo};
-pub(super) use endpoint::{DiscoPingPurpose, PingAction, PingRole, SendPing};
+pub use node_state::{ConnectionType, ControlMsg, DirectAddrInfo, NodeInfo};
+pub(super) use node_state::{DiscoPingPurpose, PingAction, PingRole, SendPing};
 
 /// Number of nodes that are inactive for which we keep info about. This limit is enforced
 /// periodically via [`NodeMap::prune_inactive`].
 const MAX_INACTIVE_NODES: usize = 30;
 
-/// Map of the [`Endpoint`] information for all the known nodes.
-///
-/// Each endpoint is also known as a "Node" in the "(iroh) network", but this is a bit of a
-/// looser term.  It is where "NodeMap" comes from however.
-///
+/// Map of the [`NodeState`] information for all the known nodes.
 ///
 /// The nodes can be looked up by:
 ///
@@ -65,17 +62,21 @@ pub(super) struct NodeMap {
 
 #[derive(Default, Debug)]
 pub(super) struct NodeMapInner {
-    by_node_key: HashMap<PublicKey, usize>,
+    by_node_key: HashMap<NodeId, usize>,
     by_ip_port: HashMap<IpPort, usize>,
     by_quic_mapped_addr: HashMap<QuicMappedAddr, usize>,
-    by_id: HashMap<usize, Endpoint>,
+    by_id: HashMap<usize, NodeState>,
     next_id: usize,
 }
 
+/// Identifier to look up a [`NodeState`] in the [`NodeMap`].
+///
+/// You can look up entries in [`NodeMap`] with various keys, depending on the context you
+/// have for the node.  These are all the keys the [`NodeMap`] can use.
 #[derive(Clone)]
-enum EndpointId<'a> {
-    Id(&'a usize),
-    NodeKey(&'a PublicKey),
+enum NodeStateKey<'a> {
+    Idx(&'a usize),
+    NodeId(&'a NodeId),
     QuicMappedAddr(&'a QuicMappedAddr),
     IpPort(&'a IpPort),
 }
@@ -125,13 +126,13 @@ impl NodeMap {
         purpose: DiscoPingPurpose,
         msg_sender: tokio::sync::mpsc::Sender<ActorMessage>,
     ) {
-        if let Some(ep) = self.inner.lock().get_mut(EndpointId::Id(&id)) {
+        if let Some(ep) = self.inner.lock().get_mut(NodeStateKey::Idx(&id)) {
             ep.ping_sent(dst, tx_id, purpose, msg_sender);
         }
     }
 
     pub fn notify_ping_timeout(&self, id: usize, tx_id: stun::TransactionId) {
-        if let Some(ep) = self.inner.lock().get_mut(EndpointId::Id(&id)) {
+        if let Some(ep) = self.inner.lock().get_mut(NodeStateKey::Idx(&id)) {
             ep.ping_timeout(tx_id);
         }
     }
@@ -142,7 +143,7 @@ impl NodeMap {
     ) -> Option<QuicMappedAddr> {
         self.inner
             .lock()
-            .get(EndpointId::NodeKey(node_key))
+            .get(NodeStateKey::NodeId(node_key))
             .map(|ep| *ep.quic_mapped_addr())
     }
 
@@ -167,7 +168,7 @@ impl NodeMap {
     }
 
     #[allow(clippy::type_complexity)]
-    pub fn get_send_addrs_for_quic_mapped_addr(
+    pub fn get_send_addrs(
         &self,
         addr: &QuicMappedAddr,
         have_ipv6: bool,
@@ -178,7 +179,7 @@ impl NodeMap {
         Vec<PingAction>,
     )> {
         let mut inner = self.inner.lock();
-        let ep = inner.get_mut(EndpointId::QuicMappedAddr(addr))?;
+        let ep = inner.get_mut(NodeStateKey::QuicMappedAddr(addr))?;
         let public_key = *ep.public_key();
         let (udp_addr, relay_url, msgs) = ep.get_send_addrs(have_ipv6);
         Some((public_key, udp_addr, relay_url, msgs))
@@ -186,30 +187,29 @@ impl NodeMap {
 
     pub fn notify_shutdown(&self) {
         let mut inner = self.inner.lock();
-        for (_, ep) in inner.endpoints_mut() {
+        for (_, ep) in inner.node_states_mut() {
             ep.reset();
         }
     }
 
-    pub fn reset_endpoint_states(&self) {
+    pub fn reset_node_states(&self) {
         let mut inner = self.inner.lock();
-        for (_, ep) in inner.endpoints_mut() {
+        for (_, ep) in inner.node_states_mut() {
             ep.note_connectivity_change();
         }
     }
 
-    pub fn endpoints_stayin_alive(&self) -> Vec<PingAction> {
-        let mut msgs = Vec::new();
+    pub fn nodes_stayin_alive(&self) -> Vec<PingAction> {
         let mut inner = self.inner.lock();
-        for (_, ep) in inner.endpoints_mut() {
-            msgs.extend(ep.stayin_alive());
-        }
-        msgs
+        inner
+            .node_states_mut()
+            .flat_map(|(_idx, node_state)| node_state.stayin_alive())
+            .collect()
     }
 
     /// Get the [`EndpointInfo`]s for each endpoint
-    pub fn endpoint_infos(&self, now: Instant) -> Vec<EndpointInfo> {
-        self.inner.lock().endpoint_infos(now)
+    pub fn node_infos(&self, now: Instant) -> Vec<NodeInfo> {
+        self.inner.lock().node_infos(now)
     }
 
     /// Returns a stream of [`ConnectionType`].
@@ -226,8 +226,8 @@ impl NodeMap {
     }
 
     /// Get the [`EndpointInfo`]s for each endpoint
-    pub fn endpoint_info(&self, public_key: &PublicKey) -> Option<EndpointInfo> {
-        self.inner.lock().endpoint_info(public_key)
+    pub fn node_info(&self, public_key: &PublicKey) -> Option<NodeInfo> {
+        self.inner.lock().node_info(public_key)
     }
 
     /// Saves the known node info to the given path, returning the number of nodes persisted.
@@ -318,40 +318,44 @@ impl NodeMapInner {
     fn add_node_addr(&mut self, node_addr: NodeAddr) {
         let NodeAddr { node_id, info } = node_addr;
 
-        let endpoint = self.get_or_insert_with(EndpointId::NodeKey(&node_id), || Options {
-            public_key: node_id,
+        let node_state = self.get_or_insert_with(NodeStateKey::NodeId(&node_id), || Options {
+            node_id,
             relay_url: info.relay_url.clone(),
             active: false,
         });
 
-        endpoint.update_from_node_addr(&info);
-        let id = endpoint.id();
-        for endpoint in &info.direct_addresses {
-            self.set_endpoint_for_ip_port(*endpoint, id);
+        node_state.update_from_node_addr(&info);
+        let id = node_state.id();
+        for addr in &info.direct_addresses {
+            self.set_node_state_for_ip_port(*addr, id);
         }
     }
 
-    fn get_id(&self, id: EndpointId) -> Option<usize> {
+    fn get_id(&self, id: NodeStateKey) -> Option<usize> {
         match id {
-            EndpointId::Id(id) => Some(*id),
-            EndpointId::NodeKey(node_key) => self.by_node_key.get(node_key).copied(),
-            EndpointId::QuicMappedAddr(addr) => self.by_quic_mapped_addr.get(addr).copied(),
-            EndpointId::IpPort(ipp) => self.by_ip_port.get(ipp).copied(),
+            NodeStateKey::Idx(id) => Some(*id),
+            NodeStateKey::NodeId(node_key) => self.by_node_key.get(node_key).copied(),
+            NodeStateKey::QuicMappedAddr(addr) => self.by_quic_mapped_addr.get(addr).copied(),
+            NodeStateKey::IpPort(ipp) => self.by_ip_port.get(ipp).copied(),
         }
     }
 
-    fn get_mut(&mut self, id: EndpointId) -> Option<&mut Endpoint> {
+    fn get_mut(&mut self, id: NodeStateKey) -> Option<&mut NodeState> {
         self.get_id(id).and_then(|id| self.by_id.get_mut(&id))
     }
 
-    fn get(&self, id: EndpointId) -> Option<&Endpoint> {
+    fn get(&self, id: NodeStateKey) -> Option<&NodeState> {
         self.get_id(id).and_then(|id| self.by_id.get(&id))
     }
 
-    fn get_or_insert_with(&mut self, id: EndpointId, f: impl FnOnce() -> Options) -> &mut Endpoint {
+    fn get_or_insert_with(
+        &mut self,
+        id: NodeStateKey,
+        f: impl FnOnce() -> Options,
+    ) -> &mut NodeState {
         let id = self.get_id(id);
         match id {
-            None => self.insert_endpoint(f()),
+            None => self.insert_node(f()),
             Some(id) => self.by_id.get_mut(&id).expect("is not empty"),
         }
     }
@@ -361,47 +365,47 @@ impl NodeMapInner {
         self.by_id.len()
     }
 
-    /// Marks the node we believe to be at `ipp` as recently used, returning the [`Endpoint`] if found.
-    fn receive_udp(&mut self, udp_addr: SocketAddr) -> Option<(PublicKey, QuicMappedAddr)> {
+    /// Marks the node we believe to be at `ipp` as recently used.
+    fn receive_udp(&mut self, udp_addr: SocketAddr) -> Option<(NodeId, QuicMappedAddr)> {
         let ip_port: IpPort = udp_addr.into();
-        let Some(endpoint) = self.get_mut(EndpointId::IpPort(&ip_port)) else {
-            info!(src=%udp_addr, "receive_udp: no node_map state found for addr, ignore");
+        let Some(node_state) = self.get_mut(NodeStateKey::IpPort(&ip_port)) else {
+            info!(src=%udp_addr, "receive_udp: no node_state found for addr, ignore");
             return None;
         };
-        endpoint.receive_udp(ip_port, Instant::now());
-        Some((*endpoint.public_key(), *endpoint.quic_mapped_addr()))
+        node_state.receive_udp(ip_port, Instant::now());
+        Some((*node_state.public_key(), *node_state.quic_mapped_addr()))
     }
 
     #[instrument(skip_all, fields(src = %src.fmt_short()))]
     fn receive_relay(&mut self, relay_url: &RelayUrl, src: &PublicKey) -> QuicMappedAddr {
-        let endpoint = self.get_or_insert_with(EndpointId::NodeKey(src), || {
+        let node_state = self.get_or_insert_with(NodeStateKey::NodeId(src), || {
             trace!("packets from unknown node, insert into node map");
             Options {
-                public_key: *src,
+                node_id: *src,
                 relay_url: Some(relay_url.clone()),
                 active: true,
             }
         });
-        endpoint.receive_relay(relay_url, src, Instant::now());
-        *endpoint.quic_mapped_addr()
+        node_state.receive_relay(relay_url, src, Instant::now());
+        *node_state.quic_mapped_addr()
     }
 
-    fn endpoints(&self) -> impl Iterator<Item = (&usize, &Endpoint)> {
+    fn node_states(&self) -> impl Iterator<Item = (&usize, &NodeState)> {
         self.by_id.iter()
     }
 
-    fn endpoints_mut(&mut self) -> impl Iterator<Item = (&usize, &mut Endpoint)> {
+    fn node_states_mut(&mut self) -> impl Iterator<Item = (&usize, &mut NodeState)> {
         self.by_id.iter_mut()
     }
 
     /// Get the [`EndpointInfo`]s for each endpoint
-    fn endpoint_infos(&self, now: Instant) -> Vec<EndpointInfo> {
-        self.endpoints().map(|(_, ep)| ep.info(now)).collect()
+    fn node_infos(&self, now: Instant) -> Vec<NodeInfo> {
+        self.node_states().map(|(_, ep)| ep.info(now)).collect()
     }
 
     /// Get the [`EndpointInfo`]s for each endpoint
-    fn endpoint_info(&self, public_key: &PublicKey) -> Option<EndpointInfo> {
-        self.get(EndpointId::NodeKey(public_key))
+    fn node_info(&self, public_key: &PublicKey) -> Option<NodeInfo> {
+        self.get(NodeStateKey::NodeId(public_key))
             .map(|ep| ep.info(Instant::now()))
     }
 
@@ -415,18 +419,18 @@ impl NodeMapInner {
     /// Will return an error if there is not an entry in the [`NodeMap`] for
     /// the `public_key`
     fn conn_type_stream(&self, public_key: &PublicKey) -> anyhow::Result<ConnectionTypeStream> {
-        match self.get(EndpointId::NodeKey(public_key)) {
+        match self.get(NodeStateKey::NodeId(public_key)) {
             Some(ep) => Ok(ConnectionTypeStream {
-                initial: Some(ep.conn_type.get()),
-                inner: ep.conn_type.watch().into_stream(),
+                initial: Some(ep.conn_type()),
+                inner: ep.conn_type_stream(),
             }),
             None => anyhow::bail!("No endpoint for {public_key:?} found"),
         }
     }
 
     fn handle_pong(&mut self, sender: PublicKey, src: &DiscoMessageSource, pong: Pong) {
-        if let Some(ep) = self.get_mut(EndpointId::NodeKey(&sender)).as_mut() {
-            let insert = ep.handle_pong(&pong, src.into());
+        if let Some(ns) = self.get_mut(NodeStateKey::NodeId(&sender)).as_mut() {
+            let insert = ns.handle_pong(&pong, src.into());
             if let Some((src, key)) = insert {
                 self.set_node_key_for_ip_port(src, &key);
             }
@@ -438,23 +442,23 @@ impl NodeMapInner {
 
     #[must_use = "actions must be handled"]
     fn handle_call_me_maybe(&mut self, sender: PublicKey, cm: CallMeMaybe) -> Vec<PingAction> {
-        let ep_id = EndpointId::NodeKey(&sender);
-        if let Some(id) = self.get_id(ep_id.clone()) {
+        let ns_id = NodeStateKey::NodeId(&sender);
+        if let Some(id) = self.get_id(ns_id.clone()) {
             for number in &cm.my_numbers {
                 // ensure the new addrs are known
-                self.set_endpoint_for_ip_port(*number, id);
+                self.set_node_state_for_ip_port(*number, id);
             }
         }
-        match self.get_mut(ep_id) {
+        match self.get_mut(ns_id) {
             None => {
                 inc!(MagicsockMetrics, recv_disco_call_me_maybe_bad_disco);
                 debug!("received call-me-maybe: ignore, node is unknown");
                 vec![]
             }
-            Some(ep) => {
+            Some(ns) => {
                 debug!(endpoints = ?cm.my_numbers, "received call-me-maybe");
 
-                ep.handle_call_me_maybe(cm)
+                ns.handle_call_me_maybe(cm)
             }
         }
     }
@@ -465,40 +469,41 @@ impl NodeMapInner {
         src: SendAddr,
         tx_id: TransactionId,
     ) -> PingHandled {
-        let endpoint = self.get_or_insert_with(EndpointId::NodeKey(&sender), || {
+        let node_state = self.get_or_insert_with(NodeStateKey::NodeId(&sender), || {
             debug!("received ping: node unknown, add to node map");
             Options {
-                public_key: sender,
+                node_id: sender,
                 relay_url: src.relay_url(),
                 active: true,
             }
         });
 
-        let handled = endpoint.handle_ping(src.clone(), tx_id);
+        let handled = node_state.handle_ping(src.clone(), tx_id);
         if let SendAddr::Udp(ref addr) = src {
-            if matches!(handled.role, PingRole::NewEndpoint) {
+            if matches!(handled.role, PingRole::NewPath) {
                 self.set_node_key_for_ip_port(*addr, &sender);
             }
         }
         handled
     }
 
-    /// Inserts a new endpoint into the [`NodeMap`].
-    fn insert_endpoint(&mut self, options: Options) -> &mut Endpoint {
+    /// Inserts a new node into the [`NodeMap`].
+    fn insert_node(&mut self, options: Options) -> &mut NodeState {
         info!(
-            node = %options.public_key.fmt_short(),
+            node = %options.node_id.fmt_short(),
             relay_url = ?options.relay_url,
-            "inserting new node endpoint in NodeMap",
+            "inserting new node in NodeMap",
         );
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);
-        let ep = Endpoint::new(id, options);
+        let node_state = NodeState::new(id, options);
 
         // update indices
-        self.by_quic_mapped_addr.insert(*ep.quic_mapped_addr(), id);
-        self.by_node_key.insert(*ep.public_key(), id);
+        self.by_quic_mapped_addr
+            .insert(*node_state.quic_mapped_addr(), id);
+        self.by_node_key.insert(*node_state.public_key(), id);
 
-        self.by_id.insert(id, ep);
+        self.by_id.insert(id, node_state);
         self.by_id.get_mut(&id).expect("just inserted")
     }
 
@@ -521,7 +526,7 @@ impl NodeMapInner {
         }
     }
 
-    fn set_endpoint_for_ip_port(&mut self, ipp: impl Into<IpPort>, id: usize) {
+    fn set_node_state_for_ip_port(&mut self, ipp: impl Into<IpPort>, id: usize) {
         let ipp = ipp.into();
         trace!(?ipp, ?id, "set endpoint for ip:port");
         self.by_ip_port.insert(ipp, id);
@@ -629,7 +634,7 @@ impl IpPort {
 
 #[cfg(test)]
 mod tests {
-    use super::endpoint::MAX_INACTIVE_DIRECT_ADDRESSES;
+    use super::node_state::MAX_INACTIVE_DIRECT_ADDRESSES;
     use super::*;
     use crate::{key::SecretKey, magic_endpoint::AddrInfo};
     use std::net::Ipv4Addr;
@@ -697,8 +702,8 @@ mod tests {
         let id = node_map
             .inner
             .lock()
-            .insert_endpoint(Options {
-                public_key,
+            .insert_node(Options {
+                node_id: public_key,
                 relay_url: None,
                 active: false,
             })
@@ -778,7 +783,7 @@ mod tests {
         node_map
             .inner
             .lock()
-            .get(EndpointId::NodeKey(&active_node))
+            .get(NodeStateKey::NodeId(&active_node))
             .expect("should not be pruned");
     }
 }

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -31,7 +31,7 @@ use super::IpPort;
 
 /// Number of addresses that are not active that we keep around per node.
 ///
-/// See [`Endpoint::prune_direct_addresses`].
+/// See [`NodeState::prune_direct_addresses`].
 pub(super) const MAX_INACTIVE_DIRECT_ADDRESSES: usize = 20;
 
 /// How long since an endpoint path was last active before it might be pruned.
@@ -75,14 +75,14 @@ pub(in crate::magicsock) struct SendPing {
     pub purpose: DiscoPingPurpose,
 }
 
-/// Indicating an [`Endpoint`] has handled a ping.
+/// Indicating an [`NodeState`] has handled a ping.
 #[derive(Debug)]
 pub struct PingHandled {
-    /// What this ping did to the [`Endpoint`].
+    /// What this ping did to the [`NodeState`].
     pub role: PingRole,
     /// Whether the sender path should also be pinged.
     ///
-    /// This is the case if an [`Endpoint`] does not yet have a direct path, i.e. it has no
+    /// This is the case if an [`NodeState`] does not yet have a direct path, i.e. it has no
     /// best_addr.  In this case we want to ping right back to open the direct path in this
     /// direction as well.
     pub needs_ping_back: Option<SendPing>,
@@ -133,7 +133,7 @@ pub(super) struct NodeState {
     /// do a full ping + call-me-maybe.  Usually each side only needs to send one
     /// call-me-maybe to the other for holes to be punched in both directions however.  So
     /// we only try and send one per [`HEARTBEAT_INTERVAL`].  Each [`HEARTBEAT_INTERVAL`]
-    /// the [`Endpoint::stayin_alive`] function is called, which will trigger new
+    /// the [`NodeState::stayin_alive`] function is called, which will trigger new
     /// call-me-maybe messages as backup.
     last_call_me_maybe: Option<Instant>,
     /// The type of connection we have to the node, either direct, relay, mixed, or none.
@@ -369,7 +369,7 @@ impl NodeState {
     /// we only have a relay path, or our path is expired.
     ///
     /// When a call-me-maybe message is sent we also need to send pings to all known paths
-    /// of the endpoint.  The [`Endpoint::send_call_me_maybe`] function takes care of this.
+    /// of the endpoint.  The [`NodeState::send_call_me_maybe`] function takes care of this.
     #[instrument("want_call_me_maybe", skip_all)]
     fn want_call_me_maybe(&self, now: &Instant) -> bool {
         trace!("full ping: wanted?");
@@ -1091,7 +1091,7 @@ impl NodeState {
     }
 }
 
-/// State about a particular path to another [`Endpoint`].
+/// State about a particular path to another [`NodeState`].
 ///
 /// This state is used for both the relay path and any direct UDP paths.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]


### PR DESCRIPTION
## Description

We still have too many things named "endpoint", this targets cleaning
up the naming of the state for each node that is stored in the NodeMap.
This is now called `NodeState` instead of `Endpoint`.  All related APIs
now talk about nodes and node states instead of endpoints.

Another minor cleanup is in the `NodeState` we had private fields with
accessor functions, except for one field which was directly
accessible.  This is migrated to accessor functions for consistency as
well.

Finally it marks the visibility of some functions more explicitly, the
visibility of those was already as such.  This makes it easier to work
and realise the impact changes have however.

## Breaking Changes

* `MagicSock::tracked_endpoints` -> `MagicSock::connection_infos`
* `MagicSock::tracked_endpoint` -> `MagicSock::connection_info`
* `magicsock::EndpointInfo` -> `magicsock::ConnectionInfo`

## Notes & open questions

Finally had to courage to change this, it's much less worse than I
feared and to me it really helps calling this `NodeState`.  I find
it a noticeable improvement.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.