### PR TITLE
tests: Remove flaky label from windows-DNS affected tests

### DIFF
--- a/iroh-net/src/dns.rs
+++ b/iroh-net/src/dns.rs
@@ -155,7 +155,6 @@ pub(crate) mod tests {
     use super::*;
 
     #[tokio::test]
-    #[cfg_attr(target_os = "windows", ignore = "flaky")]
     async fn test_dns_lookup_basic() {
         let _logging = iroh_test::logging::setup();
         let resolver = default_resolver();
@@ -166,7 +165,6 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(target_os = "windows", ignore = "flaky")]
     async fn test_dns_lookup_ipv4_ipv6() {
         let _logging = iroh_test::logging::setup();
         let resolver = default_resolver();

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -1315,7 +1315,6 @@ mod tests {
     // /etc/sysctl.conf or /etc/sysctl.d/* to persist this accross reboots.
     //
     // TODO: Not sure what about IPv6 pings using sysctl.
-    #[cfg_attr(target_os = "windows", ignore = "flaky")]
     #[tokio::test]
     async fn test_icmpk_probe_eu_relayer() {
         let _logging_guard = iroh_test::logging::setup();


### PR DESCRIPTION
## Description

They have been stable on CI for a while now.  Maybe the DNS config
tweak we did in #2075 made a difference.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Closes #2086 

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~