### PR TITLE
fix(iroh-net)!: only call quinn_connect if a send addr is available

### DIFF
--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -398,7 +398,7 @@ impl Gui {
                 ..
             }) => {
                 let relay_url = relay_url
-                    .map(|x| x.to_string())
+                    .map(|x| x.relay_url.to_string())
                     .unwrap_or_else(|| "unknown".to_string());
                 let latency = format_latency(latency);
                 let addrs = addrs

--- a/iroh-cli/src/commands/node.rs
+++ b/iroh-cli/src/commands/node.rs
@@ -96,7 +96,7 @@ async fn fmt_connections(
         let node_id: Cell = conn_info.node_id.to_string().into();
         let relay_url = conn_info
             .relay_url
-            .map_or(String::new(), |url| url.to_string())
+            .map_or(String::new(), |url_info| url_info.relay_url.to_string())
             .into();
         let conn_type = conn_info.conn_type.to_string().into();
         let latency = match conn_info.latency {
@@ -132,7 +132,7 @@ fn fmt_connection(info: ConnectionInfo) -> String {
     table.add_row([bold_cell("current time"), timestamp.into()]);
     table.add_row([bold_cell("node id"), node_id.to_string().into()]);
     let relay_url = relay_url
-        .map(|r| r.to_string())
+        .map(|r| r.relay_url.to_string())
         .unwrap_or_else(|| String::from("unknown"));
     table.add_row([bold_cell("relay url"), relay_url.into()]);
     table.add_row([bold_cell("connection type"), conn_type.to_string().into()]);

--- a/iroh-net/src/disco.rs
+++ b/iroh-net/src/disco.rs
@@ -24,6 +24,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, ensure, Context, Result};
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{key, net::ip::to_canonical, relay::RelayUrl};
@@ -133,7 +134,7 @@ pub struct Pong {
 }
 
 /// Addresses to which we can send. This is either a UDP or a relay address.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SendAddr {
     /// UDP, the ip addr.
     Udp(SocketAddr),

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -530,9 +530,8 @@ impl MagicEndpoint {
     /// Note: updating the magic socket's *netmap* will also prune any connections that are *not*
     /// present in the netmap.
     ///
-    /// If no UDP addresses are added, and `relay_url` is `None`, it will error.
-    /// If no UDP addresses are added, and the given `relay_url` cannot be dialed, it will error.
-    // TODO: This is infallible, stop returning a result.
+    /// # Errors
+    /// Will return an error if we attempt to add our own [`PublicKey`] to the node map.
     pub fn add_node_addr(&self, node_addr: NodeAddr) -> Result<()> {
         // Connecting to ourselves is not supported.
         if node_addr.node_id == self.node_id() {
@@ -1094,5 +1093,39 @@ mod tests {
 
         res_ep1.await.unwrap().unwrap();
         res_ep2.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_dial_via_node_id_only() -> Result<()> {
+        // set up pkarr dns server
+        // start two magic endpoints w/ discovery
+        // dial one
+
+        // let _logging_guard = iroh_test::logging::setup();
+        // let (relay_map, relay_url, _relay_guard) = run_relay_server().await.unwrap();
+
+        // pkarr dns server
+        // let (nameserver, pkarr_url, state, pkarr_task) = iroh::net::discovery::test::run_dns_and_pkarr_servers();
+
+        // let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+        // let ep1_secret_key = SecretKey::generate_with_rng(&mut rng);
+        // let ep2_secret_key = SecretKey::generate_with_rng(&mut rng);
+        // let ep1 = MagicEndpoint::builder()
+        //     .secret_key(ep1_secret_key)
+        //     .insecure_skip_relay_cert_verify(true)
+        //     .alpns(vec![TEST_ALPN.to_vec()])
+        //     .relay_mode(RelayMode::Custom(relay_map.clone()))
+        //     .bind(0)
+        //     .await
+        //     .unwrap();
+        // let ep2 = MagicEndpoint::builder()
+        //     .secret_key(ep2_secret_key)
+        //     .insecure_skip_relay_cert_verify(true)
+        //     .alpns(vec![TEST_ALPN.to_vec()])
+        //     .relay_mode(RelayMode::Custom(relay_map))
+        //     .bind(0)
+        //     .await
+        //     .unwrap();
+        todo!();
     }
 }

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -445,7 +445,7 @@ impl MagicEndpoint {
         let NodeAddr { node_id, info } = node_addr;
 
         // Get the mapped IPv6 address from the magic socket. Quinn will connect to this address.
-        let (addr, discovery) = match self.msock.get_mapping_addr(&node_id) {
+        let (addr, discovery) = match self.msock.get_mapping_addr_if_send_addr_available(&node_id) {
             Some(addr) => {
                 // We got a mapped address, which means we either spoke to this endpoint before, or
                 // the user provided addressing info with the [`NodeAddr`].
@@ -469,7 +469,7 @@ impl MagicEndpoint {
                 // path to the remote endpoint.
                 let mut discovery = DiscoveryTask::start(self.clone(), node_id)?;
                 discovery.first_arrived().await?;
-                let addr = self.msock.get_mapping_addr(&node_id).ok_or_else(|| {
+                let addr = self.msock.get_mapping_addr_if_send_addr_available(&node_id).ok_or_else(|| {
                     anyhow!("Failed to retrieve the mapped address from the magic socket. Unable to dial node {node_id:?}")
                 })?;
                 (addr, Some(discovery))

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -1094,38 +1094,4 @@ mod tests {
         res_ep1.await.unwrap().unwrap();
         res_ep2.await.unwrap().unwrap();
     }
-
-    #[tokio::test]
-    async fn test_dial_via_node_id_only() -> Result<()> {
-        // set up pkarr dns server
-        // start two magic endpoints w/ discovery
-        // dial one
-
-        // let _logging_guard = iroh_test::logging::setup();
-        // let (relay_map, relay_url, _relay_guard) = run_relay_server().await.unwrap();
-
-        // pkarr dns server
-        // let (nameserver, pkarr_url, state, pkarr_task) = iroh::net::discovery::test::run_dns_and_pkarr_servers();
-
-        // let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
-        // let ep1_secret_key = SecretKey::generate_with_rng(&mut rng);
-        // let ep2_secret_key = SecretKey::generate_with_rng(&mut rng);
-        // let ep1 = MagicEndpoint::builder()
-        //     .secret_key(ep1_secret_key)
-        //     .insecure_skip_relay_cert_verify(true)
-        //     .alpns(vec![TEST_ALPN.to_vec()])
-        //     .relay_mode(RelayMode::Custom(relay_map.clone()))
-        //     .bind(0)
-        //     .await
-        //     .unwrap();
-        // let ep2 = MagicEndpoint::builder()
-        //     .secret_key(ep2_secret_key)
-        //     .insecure_skip_relay_cert_verify(true)
-        //     .alpns(vec![TEST_ALPN.to_vec()])
-        //     .relay_mode(RelayMode::Custom(relay_map))
-        //     .bind(0)
-        //     .await
-        //     .unwrap();
-        todo!();
-    }
 }

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -442,39 +442,14 @@ impl MagicEndpoint {
             self.add_node_addr(node_addr.clone())?;
         }
 
-        let NodeAddr { node_id, info } = node_addr;
+        let NodeAddr { node_id, info } = node_addr.clone();
 
         // Get the mapped IPv6 address from the magic socket. Quinn will connect to this address.
-        let (addr, discovery) = match self.msock.get_mapping_addr_if_send_addr_available(&node_id) {
-            Some(addr) => {
-                // We got a mapped address, which means we either spoke to this endpoint before, or
-                // the user provided addressing info with the [`NodeAddr`].
-                // This does not mean that we can actually connect to any of these addresses.
-                // Therefore, we will invoke the discovery service if we haven't received from the
-                // endpoint on any of the existing paths recently.
-                // If the user provided addresses in this connect call, we will add a delay
-                // followed by a recheck before starting the discovery, to give the magicsocket a
-                // chance to test the newly provided addresses.
-                let delay = (!info.is_empty()).then_some(DISCOVERY_WAIT_PERIOD);
-                let discovery = DiscoveryTask::maybe_start_after_delay(self, node_id, delay)
-                    .ok()
-                    .flatten();
-                (addr, discovery)
-            }
-
-            None => {
-                // We have not spoken to this endpoint before, and the user provided no direct
-                // addresses or relay URLs. Thus, we start a discovery task and wait for the first
-                // result to arrive, and only then continue, because otherwise we wouldn't have any
-                // path to the remote endpoint.
-                let mut discovery = DiscoveryTask::start(self.clone(), node_id)?;
-                discovery.first_arrived().await?;
-                let addr = self.msock.get_mapping_addr_if_send_addr_available(&node_id).ok_or_else(|| {
-                    anyhow!("Failed to retrieve the mapped address from the magic socket. Unable to dial node {node_id:?}")
-                })?;
-                (addr, Some(discovery))
-            }
-        };
+        // Start discovery for this node if it's enabled and we have no valid or verified
+        // address information for this node.
+        let (addr, discovery) = self
+            .get_mapping_addr_and_maybe_start_discovery(node_addr)
+            .await?;
 
         debug!(
             "connecting to {}: (via {} - {:?})",
@@ -520,6 +495,63 @@ impl MagicEndpoint {
             .connect_with(client_config, addr, "localhost")?;
 
         connect.await.context("failed connecting to provider")
+    }
+
+    /// Return the quic mapped address for this `node_id` and possibly start discovery
+    /// services if discovery is enabled on this magic endpoint.
+    ///
+    /// This will launch discovery in all cases except if:
+    /// 1) we do not have discovery enabled
+    /// 2) we have discovery enabled, but already have at least one verified, unexpired
+    /// addresses for this `node_id`
+    ///
+    /// # Errors
+    ///
+    /// This method may fail if we have no way of dialing the node. This can occur if
+    /// because we were given no dialing information in the [`NodeAddr`] and no discovery
+    /// services configured or discovery failed to fetch any dialing information.
+    async fn get_mapping_addr_and_maybe_start_discovery(
+        &self,
+        node_addr: NodeAddr,
+    ) -> Result<(SocketAddr, Option<DiscoveryTask>)> {
+        let node_id = node_addr.node_id;
+        let addr = if self.msock.has_send_address(node_id) {
+            self.msock.get_mapping_addr(&node_id)
+        } else {
+            None
+        };
+        match addr {
+            Some(addr) => {
+                // We got a mapped address, which means we either spoke to this endpoint before, or
+                // the user provided addressing info with the [`NodeAddr`].
+                // This does not mean that we can actually connect to any of these addresses.
+                // Therefore, we will invoke the discovery service if we haven't received from the
+                // endpoint on any of the existing paths recently.
+                // If the user provided addresses in this connect call, we will add a delay
+                // followed by a recheck before starting the discovery, to give the magicsocket a
+                // chance to test the newly provided addresses.
+                let delay = (!node_addr.info.is_empty()).then_some(DISCOVERY_WAIT_PERIOD);
+                let discovery = DiscoveryTask::maybe_start_after_delay(self, node_id, delay)
+                    .ok()
+                    .flatten();
+                Ok((addr, discovery))
+            }
+
+            None => {
+                // We have not spoken to this endpoint before, and the user provided no direct
+                // addresses or relay URLs. Thus, we start a discovery task and wait for the first
+                // result to arrive, and only then continue, because otherwise we wouldn't have any
+                // path to the remote endpoint.
+                let mut discovery = DiscoveryTask::start(self.clone(), node_id)?;
+                discovery.first_arrived().await?;
+                if self.msock.has_send_address(node_id) {
+                    let addr = self.msock.get_mapping_addr(&node_id).expect("checked");
+                    Ok((addr, Some(discovery)))
+                } else {
+                    bail!("Failed to retrieve the mapped address from the magic socket. Unable to dial node {node_id:?}");
+                }
+            }
+        }
     }
 
     /// Inform the magic socket about addresses of the peer.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1324,6 +1324,13 @@ impl MagicSock {
         self.inner.node_map.node_info(&node_key)
     }
 
+    /// Returns `true` if we have at least one candidate address where we can send packets to.
+    pub fn has_send_address(&self, node_key: PublicKey) -> bool {
+        self.connection_info(node_key)
+            .map(|info| info.has_send_address())
+            .unwrap_or(false)
+    }
+
     /// Returns the local endpoints as a stream.
     ///
     /// The [`MagicSock`] continuously monitors the local endpoints, the network addresses
@@ -1393,6 +1400,23 @@ impl MagicSock {
             .node_map
             .get_quic_mapped_addr_for_node_key(node_key)
             .map(|a| a.0)
+    }
+
+    /// Returns the [`SocketAddr`] which can be used by the QUIC layer to dial this node.
+    ///
+    /// Returns `None` if no send address is available.
+    pub fn get_mapping_addr_if_send_addr_available(
+        &self,
+        node_key: &PublicKey,
+    ) -> Option<SocketAddr> {
+        if self.has_send_address(*node_key) {
+            self.inner
+                .node_map
+                .get_quic_mapped_addr_for_node_key(node_key)
+                .map(|a| a.0)
+        } else {
+            None
+        }
     }
 
     /// Returns the relay node with the best latency.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1402,23 +1402,6 @@ impl MagicSock {
             .map(|a| a.0)
     }
 
-    /// Returns the [`SocketAddr`] which can be used by the QUIC layer to dial this node.
-    ///
-    /// Returns `None` if no send address is available.
-    pub fn get_mapping_addr_if_send_addr_available(
-        &self,
-        node_key: &PublicKey,
-    ) -> Option<SocketAddr> {
-        if self.has_send_address(*node_key) {
-            self.inner
-                .node_map
-                .get_quic_mapped_addr_for_node_key(node_key)
-                .map(|a| a.0)
-        } else {
-            None
-        }
-    }
-
     /// Returns the relay node with the best latency.
     ///
     /// If `None`, then we currently have no verified connection to a relay node.

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1393,6 +1393,11 @@ impl NodeInfo {
             .filter_map(|addr| addr.last_control.map(|x| x.0).min(addr.last_payload))
             .min()
     }
+
+    /// Returns `true` if we this info contains either a relay URL or at least one direct address.
+    pub fn has_send_address(&self) -> bool {
+        self.relay_url.is_some() || !self.addrs.is_empty()
+    }
 }
 
 /// The type of connection we have to the endpoint.

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1394,7 +1394,7 @@ impl NodeInfo {
             .min()
     }
 
-    /// Returns `true` if we this info contains either a relay URL or at least one direct address.
+    /// Returns `true` if this info contains either a relay URL or at least one direct address.
     pub fn has_send_address(&self) -> bool {
         self.relay_url.is_some() || !self.addrs.is_empty()
     }

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1614,7 +1614,7 @@ mod tests {
                 node_id: b_endpoint.node_id,
                 relay_url: Some(RelayUrlInfo {
                     relay_url: b_endpoint.relay_url.as_ref().unwrap().0.clone(),
-                    last_alive: Some(elapsed),
+                    last_alive: None,
                     latency: Some(latency),
                 }),
                 addrs: Vec::new(),
@@ -1640,7 +1640,7 @@ mod tests {
                 node_id: d_endpoint.node_id,
                 relay_url: Some(RelayUrlInfo {
                     relay_url: d_endpoint.relay_url.as_ref().unwrap().0.clone(),
-                    last_alive: Some(elapsed),
+                    last_alive: None,
                     latency: Some(latency),
                 }),
                 addrs: Vec::from([DirectAddrInfo {
@@ -1682,30 +1682,15 @@ mod tests {
         });
         let mut got = node_map.node_infos(later);
         got.sort_by_key(|p| p.id);
-        assert_node_infos_eq(expect, got);
+        remove_non_deterministic_fields(&mut got);
+        assert_eq!(expect, got);
     }
 
-    fn assert_node_infos_eq(expect: Vec<NodeInfo>, got: Vec<NodeInfo>) {
-        for (expect, got) in expect.iter().zip(got.iter()) {
-            assert_node_info_eq(expect, got);
-        }
-    }
-
-    fn assert_node_info_eq(expect: &NodeInfo, got: &NodeInfo) {
-        assert_eq!(expect.id, got.id);
-        assert_eq!(expect.node_id, got.node_id);
-        assert_eq!(expect.addrs, got.addrs);
-        assert_eq!(expect.conn_type, got.conn_type);
-        assert_eq!(expect.latency, got.latency);
-        assert_eq!(expect.last_used, got.last_used);
-
-        if expect.relay_url.is_some() && got.relay_url.is_some() {
-            let expect_relay_url = expect.relay_url.clone().unwrap();
-            let got_relay_url = expect.relay_url.clone().unwrap();
-            assert_eq!(expect_relay_url.relay_url, got_relay_url.relay_url);
-            assert_eq!(expect_relay_url.latency, got_relay_url.latency);
-        } else {
-            assert_eq!(expect.relay_url, got.relay_url);
+    fn remove_non_deterministic_fields(infos: &mut [NodeInfo]) {
+        for info in infos.iter_mut() {
+            if info.relay_url.is_some() {
+                info.relay_url.as_mut().unwrap().last_alive = None;
+            }
         }
     }
 


### PR DESCRIPTION
## Description

A bug in the discovery flow assumed that if we had a mapped quic address for a `node_id`, then we had at least a relay URL or one direct address available for that node.

This meant there were instances in which discovery should have been launched before attempting to dial the node, but was never launched, leading to `no UDP or relay address available for node` errors.

Now we check if addresses are available for a `node_id` and launch discovery if we do not have any before we attempt to dial.

We also now take into account the "alive" status of any relay URL information we have on a `node_id` when determining if we need to run discovery for that `node_id`

### tests
This also refactors the test DNS server and the test Pkarr relay server to use `CleanupDropGuard` for resource cleanup. It also moves the functions that launch those servers into the `iroh-net::test_utils` crate. This ended up being an unnecessary refactor (I ended up writing the test in the `discovery` crate anyway), but I left it in case we need to do other tests that rely on discovery outside of the `discovery` crate.

## Notes & open questions

The above issue uncovered a more serious bug: the endpoint currently dies when it attempts to dial a node without any available address information because we return the `no UDP or relay address available for node` error. We should not do this. In that situation, we should let that connection timeout or launch discovery services inside the magicsocket. That bug (#2226)  is not fixed in this PR.

## Breaking changes
- Created new public struct `RelayUrlInfo` that combines the relay_url and additional information about the state of our connection to the remote node at this relay URL:
```
struct RelayUrlInfo {
    relay_url: RelayUrl,
    /// How long since there has been activity on this relay url
    last_alive: Option<Duration>,
    /// Latest latency information for this relay url
    latency: Option<Duration>,
}
```
- `NodeInfo.relay_url` (called `ConnectionInfo` outside of `iroh-net`) is now `Option<RelayUrlInfo>`, changed from `Option<RelayUrl>`

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.