### PR TITLE
fix(iroh-net)!: improve magicsock's shutdown story

### DIFF
--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -4,7 +4,7 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use derive_more::Debug;
-use futures::{future, StreamExt};
+use futures::StreamExt;
 use quinn_proto::VarInt;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 use tracing::{debug, trace};
@@ -568,30 +568,13 @@ impl MagicEndpoint {
             ..
         } = self;
         cancel_token.cancel();
+        tracing::debug!("Closing connections");
         endpoint.close(error_code, reason);
-
-        {
-            // waiting for connections to close can be slow: this timeout decide whethers we should
-            // inform the user of a slow operation
-            let logging_timeout = tokio::time::sleep(Duration::from_millis(500));
-            futures::pin_mut!(logging_timeout);
-
-            let wait_idle = endpoint.wait_idle();
-            futures::pin_mut!(wait_idle);
-
-            // race the timeout and closing. Nothing else needs to be done if closing finishes
-            // first. If the timeouts is done first, give the user some logs
-            if let future::Either::Right(((), wait_idle_fut)) =
-                future::select(wait_idle, logging_timeout).await
-            {
-                tracing::info!("Closing connections");
-                wait_idle_fut.await;
-                tracing::info!("Connections closed");
-            }
-        }
+        endpoint.wait_idle().await;
         // In case this is the last clone of `MagicEndpoint`, dropping the `quinn::Endpoint` will
         // make it more likely that the underlying socket is not polled by quinn anymore after this
         drop(endpoint);
+        tracing::debug!("Connections closed");
 
         msock.close().await?;
         Ok(())

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -289,6 +289,7 @@ impl Inner {
 
         let mut n = 0;
         if transmits.is_empty() {
+            tracing::trace!(is_closed=?self.is_closed(), "poll_send without any quinn_udp::Transmit");
             return Poll::Ready(Ok(n));
         }
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -485,7 +485,7 @@ impl Inner {
         Ok(sock)
     }
 
-    // NOTE: Receiving on a [`Self::closed`] socket will return [`Poll::Pending`] undefinitely.
+    /// NOTE: Receiving on a [`Self::closed`] socket will return [`Poll::Pending`] indefinitely.
     #[instrument(skip_all, fields(me = %self.me))]
     fn poll_recv(
         &self,
@@ -1410,6 +1410,8 @@ impl MagicSock {
     /// Closes the connection.
     ///
     /// Only the first close does anything. Any later closes return nil.
+    /// Polling the socket ([`AsyncUdpSocket::poll_recv`]) will return [`Poll::Pending`]
+    /// indefinitely after this call.
     #[instrument(skip_all, fields(me = %self.inner.me))]
     pub async fn close(&self) -> Result<()> {
         if self.inner.is_closed() {
@@ -1595,6 +1597,7 @@ impl AsyncUdpSocket for MagicSock {
         self.inner.poll_send(cx, transmits)
     }
 
+    /// NOTE: Receiving on a [`Self::close`]d socket will return [`Poll::Pending`] indefinitely.
     fn poll_recv(
         &self,
         cx: &mut Context,


### PR DESCRIPTION
## Description

- Waits for connections to actually be closed by calling `quinn::Endpoint::wait_idle` after close.
- Consumes the `MagicEndpoint` in an effort to express the fact that closing an endpoint is a terminal operation.
- Adds logging to closing the connections in case it's deemed necessary
- Changes `MagicSock::poll_recv` to return `Poll::Pending` on close instead of an error. More info on the logic behind this change below.
- Changes `MagicSock::poll_send` to not error if nothing is being sent.

## Breaking Changes

`MagicEndpoint::close` now consumes the endpoint.

## Notes & open questions

Shutdown `MagicSock` when quinn is done with it has proven something we can't do reliably.
- Drop based solutions (close when the `MagicSock` is dropped) are unreliable because the socket is held by multiple components on `quinn`, including spawned detached tasks. There is no really any way to trigger the dropping of these tasks/components from outside `quinn`, and would require quite en effort to change it to happen inside `quinn`.
- Close based solutions were rejected. The objective here was to stop polling the socket when the endpoint was both closed (close called) and all connections gracefully finalized. The reasoning here is that `quinn` both receives and sends frames after close to read new connection attempts and gracefully reject them. This is a fair argument on their side, despite it being clearly a limitation for a reliable freeing of resources from `quinn`.
- Taking into account the fact that the socket _will_ be polled after closed, both to send and receive, returning an error from these will always produce the logging error `quinn::endpoint: I/O error: connection closed` we have been chasing, _even_ after the `quinn::Endpoint` has been dropped. Therefore changing `poll_recv` to return `Poll::Pending` addresses this annoyance.
- Note that the part about _gracefully_ shutting down is actually done by calling `quinn::Endpoing::wait_idle` and that the (now averted) log error in `quinn` doesn't really tells us whether shutdown was or not gracefull.
- Note that the above point creates an API disparity between `poll_send` and `poll_recv`: one will error on close, the other will return `Pending`. I find this OK if `MagicSock` is simply a part of our implementation, but right now it's also part of our public API. I wonder if the `MagicSock` makes sense to users on its own or if we should remove it from the public API.
- NOTE that conversation with `quinn`'s maintainers to get a better api that allows to understand when all resources as freed has started. But this is playing the long game and we need to solve this on our end for now.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] ~Tests if relevant.~
- [x] All breaking changes documented.
