### PR TITLE
fix(iroh-gossip): do not enable "metrics" feature for iroh-net by default

### DIFF
--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -32,7 +32,7 @@ iroh-base = { version = "0.14.0", path = "../iroh-base" }
 
 # net dependencies (optional)
 futures = { version = "0.3.25", optional = true }
-iroh-net = { path = "../iroh-net", version = "0.14.0", optional = true }
+iroh-net = { path = "../iroh-net", version = "0.14.0", optional = true, default-features = false }
 quinn = { version = "0.10", optional = true }
 tokio = { version = "1", optional = true, features = ["io-util", "sync", "rt", "macros", "net", "fs"] }
 tokio-util = { version = "0.7.8", optional = true, features = ["codec"] }


### PR DESCRIPTION
Otherwise it is impossible to disable metrics support in iroh-net
if iroh-gossip is used.
