### PR TITLE
tests(iroh_net): mark test_icmpk_probe_eu_relayer as flaky on windows

### DIFF
--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -1316,6 +1316,7 @@ mod tests {
     //
     // TODO: Not sure what about IPv6 pings using sysctl.
     #[tokio::test]
+    #[cfg_attr(target_os = "windows", ignore = "flaky")]
     async fn test_icmpk_probe_eu_relayer() {
         let _logging_guard = iroh_test::logging::setup();
         let pinger = Pinger::new();


### PR DESCRIPTION
## Description

As described in #2239 

## Breaking Changes

n/a

## Notes & open questions

dns issue? why only the eu_relayer? - discussion for the issue

## Change checklist

- [x] Self-review.
- [ ] ~Documentation updates if relevant.~
- [ ] ~Tests if relevant.~
- [ ] ~All breaking changes documented.~
