### PR TITLE
deps(iroh-blake3): Upgrade to version fixing more symbol collions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-blake3"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb52cd11b3de4407f29579ebcd10fd746b0bd8ab758a2afac69baf88e96bede"
+checksum = "efbba31f40a650f58fa28dd585a8ca76d8ae3ba63aacab4c8269004a0c803930"
 dependencies = [
  "arrayref",
  "arrayvec",

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 # proto dependencies (required)
 anyhow = { version = "1" }
-blake3 = { package = "iroh-blake3", version = "1.4.3"}
+blake3 = { package = "iroh-blake3", version = "1.4.5"}
 bytes = { version = "1.4.0", features = ["serde"] }
 derive_more = { version = "1.0.0-beta.1", features = ["add", "debug", "deref", "display", "from", "try_into", "into"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }

--- a/iroh-sync/Cargo.toml
+++ b/iroh-sync/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1"
-blake3 = { package = "iroh-blake3", version = "1.4.3"}
+blake3 = { package = "iroh-blake3", version = "1.4.5"}
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "deref", "display", "from", "try_into", "into", "as_ref"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 flume = "0.11"


### PR DESCRIPTION
## Description

We did get reports of the iroh-blake3 still having symbol collisions
with blake3.  Depend on the new version now.  Hopefully these were the
last of the symbol collisions.

Closes #2217

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~