### PR TITLE
refactor(iroh-net)!: remove the magicsock module from the public api

### DIFF
--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -29,9 +29,7 @@ use iroh::{
         },
         dns::default_resolver,
         key::{PublicKey, SecretKey},
-        magic_endpoint,
-        magicsock::ConnectionInfo,
-        netcheck, portmapper,
+        magic_endpoint, netcheck, portmapper,
         relay::{RelayMap, RelayMode, RelayUrl},
         util::AbortingJoinHandle,
         MagicEndpoint, NodeAddr, NodeId,
@@ -390,7 +388,7 @@ impl Gui {
                 .unwrap_or_else(|| "unknown".to_string())
         };
         let msg = match endpoint.connection_info(*node_id) {
-            Some(ConnectionInfo {
+            Some(magic_endpoint::ConnectionInfo {
                 relay_url,
                 conn_type,
                 latency,

--- a/iroh-cli/src/commands/node.rs
+++ b/iroh-cli/src/commands/node.rs
@@ -8,7 +8,10 @@ use comfy_table::{presets::NOTHING, Cell};
 use futures::{Stream, StreamExt};
 use human_time::ToHumanTimeString;
 use iroh::client::Iroh;
-use iroh::net::{key::PublicKey, magic_endpoint::ConnectionInfo, magicsock::DirectAddrInfo};
+use iroh::net::{
+    key::PublicKey,
+    magic_endpoint::{ConnectionInfo, DirectAddrInfo},
+};
 use iroh::rpc_protocol::ProviderService;
 use quic_rpc::ServiceConnection;
 

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -31,7 +31,7 @@ pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (NodeAddr, Ma
             .bind(0)
             .await
             .unwrap();
-        let addr = ep.local_addr().unwrap();
+        let addr = ep.local_addr();
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
         let addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
         (addr, ep)

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -17,7 +17,7 @@ mod disco;
 pub mod discovery;
 pub mod dns;
 pub mod magic_endpoint;
-pub mod magicsock;
+mod magicsock;
 pub mod metrics;
 pub mod net;
 pub mod netcheck;

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -15,7 +15,7 @@ use crate::{
     discovery::{Discovery, DiscoveryTask},
     dns::{default_resolver, DnsResolver},
     key::{PublicKey, SecretKey},
-    magicsock::{self, ConnectionTypeStream, MagicSockHandle},
+    magicsock::{self, ConnectionTypeStream, Handle},
     relay::{RelayMap, RelayMode, RelayUrl},
     tls, NodeId,
 };
@@ -230,7 +230,7 @@ pub fn make_server_config(
 #[derive(Clone, Debug)]
 pub struct MagicEndpoint {
     secret_key: Arc<SecretKey>,
-    msock: MagicSockHandle,
+    msock: Handle,
     endpoint: quinn::Endpoint,
     keylog: bool,
     cancel_token: CancellationToken,
@@ -252,7 +252,7 @@ impl MagicEndpoint {
         keylog: bool,
     ) -> Result<Self> {
         let secret_key = msock_opts.secret_key.clone();
-        let msock = magicsock::MagicSockHandle::new(msock_opts).await?;
+        let msock = magicsock::MagicSock::new(msock_opts).await?;
         trace!("created magicsock");
 
         let mut endpoint_config = quinn::EndpointConfig::default();
@@ -595,7 +595,7 @@ impl MagicEndpoint {
     }
 
     #[cfg(test)]
-    pub(crate) fn magic_sock(&self) -> MagicSockHandle {
+    pub(crate) fn magic_sock(&self) -> Handle {
         self.msock.clone()
     }
     #[cfg(test)]

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -15,7 +15,7 @@ use crate::{
     discovery::{Discovery, DiscoveryTask},
     dns::{default_resolver, DnsResolver},
     key::{PublicKey, SecretKey},
-    magicsock::{self, ConnectionTypeStream, MagicSock},
+    magicsock::{self, ConnectionTypeStream, MagicSockHandle},
     relay::{RelayMap, RelayMode, RelayUrl},
     tls, NodeId,
 };
@@ -230,7 +230,7 @@ pub fn make_server_config(
 #[derive(Clone, Debug)]
 pub struct MagicEndpoint {
     secret_key: Arc<SecretKey>,
-    msock: MagicSock,
+    msock: MagicSockHandle,
     endpoint: quinn::Endpoint,
     keylog: bool,
     cancel_token: CancellationToken,
@@ -252,7 +252,7 @@ impl MagicEndpoint {
         keylog: bool,
     ) -> Result<Self> {
         let secret_key = msock_opts.secret_key.clone();
-        let msock = magicsock::MagicSock::new(msock_opts).await?;
+        let msock = magicsock::MagicSockHandle::new(msock_opts).await?;
         trace!("created magicsock");
 
         let mut endpoint_config = quinn::EndpointConfig::default();
@@ -595,7 +595,7 @@ impl MagicEndpoint {
     }
 
     #[cfg(test)]
-    pub(crate) fn magic_sock(&self) -> MagicSock {
+    pub(crate) fn magic_sock(&self) -> MagicSockHandle {
         self.msock.clone()
     }
     #[cfg(test)]

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -22,7 +22,7 @@ use crate::{
     tls, NodeId,
 };
 
-pub use super::magicsock::*;
+// pub use super::magicsock::;
 
 pub use iroh_base::node_addr::{AddrInfo, NodeAddr};
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -303,7 +303,7 @@ impl MagicEndpoint {
     /// Get the local endpoint addresses on which the underlying magic socket is bound.
     ///
     /// Returns a tuple of the IPv4 and the optional IPv6 address.
-    pub fn local_addr(&self) -> Result<(SocketAddr, Option<SocketAddr>)> {
+    pub fn local_addr(&self) -> (SocketAddr, Option<SocketAddr>) {
         self.msock.local_addr()
     }
 
@@ -865,7 +865,7 @@ mod tests {
                         .bind(0)
                         .await
                         .unwrap();
-                    let eps = ep.local_addr().unwrap();
+                    let eps = ep.local_addr();
                     info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "server bound");
                     for i in 0..n_clients {
                         let now = Instant::now();
@@ -909,7 +909,7 @@ mod tests {
                     .bind(0)
                     .await
                     .unwrap();
-                let eps = ep.local_addr().unwrap();
+                let eps = ep.local_addr();
                 info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "client bound");
                 let node_addr = NodeAddr::new(server_node_id).with_relay_url(relay_url);
                 info!(to = ?node_addr, "client connecting");

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -15,12 +15,12 @@ use crate::{
     discovery::{Discovery, DiscoveryTask},
     dns::{default_resolver, DnsResolver},
     key::{PublicKey, SecretKey},
-    magicsock::{self, ConnectionTypeStream, Handle},
+    magicsock::{self, Handle},
     relay::{RelayMap, RelayMode, RelayUrl},
     tls, NodeId,
 };
 
-pub use super::magicsock::{ConnectionInfo, LocalEndpointsStream};
+pub use super::magicsock::*;
 
 pub use iroh_base::node_addr::{AddrInfo, NodeAddr};
 
@@ -226,7 +226,15 @@ pub fn make_server_config(
     Ok(server_config)
 }
 
-/// An endpoint that leverages a [quinn::Endpoint] backed by a [magicsock::MagicSock].
+/// Iroh connectivity layer.
+///
+/// This is responsible for routing packets to nodes based on node IDs, it will initially route
+/// packets via a relay and transparently try and establish a node-to-node connection and upgrade
+/// to it.  It will also keep looking for better connections as the network details of both nodes
+/// change.
+///
+/// It is usually only necessary to use a single [`MagicEndpoint`] instance in an application, it
+/// means any QUIC endpoints on top will be sharing as much information about nodes as possible.
 #[derive(Clone, Debug)]
 pub struct MagicEndpoint {
     secret_key: Arc<SecretKey>,

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -1,4 +1,6 @@
-//! An endpoint that leverages a [quinn::Endpoint] backed by a [magicsock::MagicSock].
+//! An endpoint that leverages a [`quinn::Endpoint`] and transparently routes packages via direct
+//! conenctions or a relay when necessary, optimizing the path to target nodes to ensure maximum
+//! connectivity.
 
 use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
@@ -321,11 +323,10 @@ impl MagicEndpoint {
     /// addresses it can listen on, for changes.  Whenever changes are detected this stream
     /// will yield a new list of endpoints.
     ///
-    /// Upon the first creation on the [`MagicSock`] it may not yet have completed a first
-    /// local endpoint discovery, in this case the first item of the stream will not be
-    /// immediately available.  Once this first set of local endpoints are discovered the
-    /// stream will always return the first set of endpoints immediately, which are the most
-    /// recently discovered endpoints.
+    /// Upon the first creation, the first local endpoint discovery might still be underway, in
+    /// this case the first item of the stream will not be immediately available.  Once this first
+    /// set of local endpoints are discovered the stream will always return the first set of
+    /// endpoints immediately, which are the most recently discovered endpoints.
     ///
     /// The list of endpoints yielded contains both the locally-bound addresses and the
     /// endpoint's publicly-reachable addresses, if they could be discovered through STUN or

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -22,7 +22,10 @@ use crate::{
     tls, NodeId,
 };
 
-// pub use super::magicsock::;
+pub use super::magicsock::{
+    ConnectionInfo, ConnectionType, ConnectionTypeStream, ControlMsg, DirectAddrInfo,
+    LocalEndpointsStream,
+};
 
 pub use iroh_base::node_addr::{AddrInfo, NodeAddr};
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -378,8 +378,8 @@ impl MagicEndpoint {
     /// Get information on all the nodes we have connection information about.
     ///
     /// Includes the node's [`PublicKey`], potential relay Url, its addresses with any known
-    /// latency, and its [`crate::magicsock::ConnectionType`], which let's us know if we are
-    /// currently communicating with that node over a `Direct` (UDP) or `Relay` (relay) connection.
+    /// latency, and its [`ConnectionType`], which let's us know if we are currently communicating
+    /// with that node over a `Direct` (UDP) or `Relay` (relay) connection.
     ///
     /// Connections are currently only pruned on user action (when we explicitly add a new address
     /// to the internal addressbook through [`MagicEndpoint::add_node_addr`]), so these connections
@@ -391,8 +391,8 @@ impl MagicEndpoint {
     /// Get connection information about a specific node.
     ///
     /// Includes the node's [`PublicKey`], potential relay Url, its addresses with any known
-    /// latency, and its [`crate::magicsock::ConnectionType`], which let's us know if we are
-    /// currently communicating with that node over a `Direct` (UDP) or `Relay` (relay) connection.
+    /// latency, and its [`ConnectionType`], which let's us know if we are currently communicating
+    /// with that node over a `Direct` (UDP) or `Relay` (relay) connection.
     pub fn connection_info(&self, node_id: PublicKey) -> Option<ConnectionInfo> {
         self.msock.connection_info(node_id)
     }
@@ -411,8 +411,7 @@ impl MagicEndpoint {
         self.connect(addr, alpn).await
     }
 
-    /// Returns a stream that reports changes in the [`crate::magicsock::ConnectionType`]
-    /// for the given `node_id`.
+    /// Returns a stream that reports changes in the [`ConnectionType`] for the given `node_id`.
     ///
     /// # Errors
     ///

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -700,7 +700,7 @@ mod tests {
     use rand_core::SeedableRng;
     use tracing::{error_span, info, info_span, Instrument};
 
-    use crate::{magicsock::ConnectionType, test_utils::run_relay_server};
+    use crate::test_utils::run_relay_server;
 
     use super::*;
 

--- a/iroh-net/src/magic_endpoint.rs
+++ b/iroh-net/src/magic_endpoint.rs
@@ -262,7 +262,7 @@ impl MagicEndpoint {
         keylog: bool,
     ) -> Result<Self> {
         let secret_key = msock_opts.secret_key.clone();
-        let msock = magicsock::MagicSock::new(msock_opts).await?;
+        let msock = magicsock::MagicSock::spawn(msock_opts).await?;
         trace!("created magicsock");
 
         let mut endpoint_config = quinn::EndpointConfig::default();

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -151,8 +151,9 @@ pub(crate) type RelayContents = SmallVec<[Bytes; 1]>;
 /// Handle for [`MagicSock`].
 ///
 /// Dereferences to [`MagicSock`], and handles closing.
-#[derive(Clone, Debug)]
-pub struct MagicSockHandle {
+#[derive(Clone, Debug, derive_more::Deref)]
+pub(super) struct MagicSockHandle {
+    #[deref(forward)]
     msock: Arc<MagicSock>,
     // Empty when closed
     actor_tasks: Arc<Mutex<JoinSet<()>>>,
@@ -169,7 +170,7 @@ pub struct MagicSockHandle {
 /// means any QUIC endpoints on top will be sharing as much information about nodes as
 /// possible.
 #[derive(derive_more::Debug)]
-struct MagicSock {
+pub(super) struct MagicSock {
     actor_sender: mpsc::Sender<ActorMessage>,
     relay_actor_sender: mpsc::Sender<RelayActorMessage>,
     /// String representation of the node_id of this node.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -160,7 +160,7 @@ pub(crate) type RelayContents = SmallVec<[Bytes; 1]>;
 /// possible.
 #[derive(Clone, Debug)]
 pub struct MagicSockHandle {
-    inner: Arc<MagicSock>,
+    msock: Arc<MagicSock>,
     // Empty when closed
     actor_tasks: Arc<Mutex<JoinSet<()>>>,
 }
@@ -1281,7 +1281,7 @@ impl MagicSockHandle {
                     msg_sender: actor_sender,
                     relay_actor_sender,
                     relay_actor_cancel_token,
-                    inner: inner2,
+                    msock: inner2,
                     relay_recv_sender,
                     periodic_re_stun_timer: new_re_stun_timer(false),
                     net_info_last: None,
@@ -1302,7 +1302,7 @@ impl MagicSockHandle {
         );
 
         let c = MagicSockHandle {
-            inner,
+            msock: inner,
             actor_tasks: Arc::new(Mutex::new(actor_tasks)),
         };
 
@@ -1311,12 +1311,12 @@ impl MagicSockHandle {
 
     /// Retrieve connection information about nodes in the network.
     pub fn connection_infos(&self) -> Vec<ConnectionInfo> {
-        self.inner.node_map.node_infos(Instant::now())
+        self.msock.node_map.node_infos(Instant::now())
     }
 
     /// Retrieve connection information about a node in the network.
     pub fn connection_info(&self, node_key: PublicKey) -> Option<ConnectionInfo> {
-        self.inner.node_map.node_info(&node_key)
+        self.msock.node_map.node_info(&node_key)
     }
 
     /// Returns the local endpoints as a stream.
@@ -1346,8 +1346,8 @@ impl MagicSockHandle {
     /// ```
     pub fn local_endpoints(&self) -> LocalEndpointsStream {
         LocalEndpointsStream {
-            initial: Some(self.inner.endpoints.get()),
-            inner: self.inner.endpoints.watch().into_stream(),
+            initial: Some(self.msock.endpoints.get()),
+            inner: self.msock.endpoints.watch().into_stream(),
         }
     }
 
@@ -1365,18 +1365,18 @@ impl MagicSockHandle {
     /// Will return an error if there is no address information known about the
     /// given `node_id`.
     pub fn conn_type_stream(&self, node_id: &PublicKey) -> Result<node_map::ConnectionTypeStream> {
-        self.inner.node_map.conn_type_stream(node_id)
+        self.msock.node_map.conn_type_stream(node_id)
     }
 
     /// Get the cached version of the Ipv4 and Ipv6 addrs of the current connection.
     pub fn local_addr(&self) -> Result<(SocketAddr, Option<SocketAddr>)> {
-        Ok(self.inner.local_addr())
+        Ok(self.msock.local_addr())
     }
 
     /// Triggers an address discovery. The provided why string is for debug logging only.
-    #[instrument(skip_all, fields(me = %self.inner.me))]
+    #[instrument(skip_all, fields(me = %self.msock.me))]
     pub fn re_stun(&self, why: &'static str) {
-        self.inner.re_stun(why);
+        self.msock.re_stun(why);
     }
 
     /// Returns the [`SocketAddr`] which can be used by the QUIC layer to dial this node.
@@ -1384,7 +1384,7 @@ impl MagicSockHandle {
     /// Note this is a user-facing API and does not wrap the [`SocketAddr`] in a
     /// `QuicMappedAddr` as we do internally.
     pub fn get_mapping_addr(&self, node_key: &PublicKey) -> Option<SocketAddr> {
-        self.inner
+        self.msock
             .node_map
             .get_quic_mapped_addr_for_node_key(node_key)
             .map(|a| a.0)
@@ -1394,18 +1394,18 @@ impl MagicSockHandle {
     ///
     /// If `None`, then we currently have no verified connection to a relay node.
     pub fn my_relay(&self) -> Option<RelayUrl> {
-        self.inner.my_relay()
+        self.msock.my_relay()
     }
 
-    #[instrument(skip_all, fields(me = %self.inner.me))]
+    #[instrument(skip_all, fields(me = %self.msock.me))]
     /// Add addresses for a node to the magic socket's addresbook.
     pub fn add_node_addr(&self, addr: NodeAddr) {
-        self.inner.node_map.add_node_addr(addr);
+        self.msock.node_map.add_node_addr(addr);
     }
 
     /// Get a reference to the DNS resolver used in this [`MagicSock`].
     pub fn dns_resolver(&self) -> &DnsResolver {
-        &self.inner.dns_resolver
+        &self.msock.dns_resolver
     }
 
     /// Closes the connection.
@@ -1413,15 +1413,15 @@ impl MagicSockHandle {
     /// Only the first close does anything. Any later closes return nil.
     /// Polling the socket ([`AsyncUdpSocket::poll_recv`]) will return [`Poll::Pending`]
     /// indefinitely after this call.
-    #[instrument(skip_all, fields(me = %self.inner.me))]
+    #[instrument(skip_all, fields(me = %self.msock.me))]
     pub async fn close(&self) -> Result<()> {
-        if self.inner.is_closed() {
+        if self.msock.is_closed() {
             return Ok(());
         }
-        self.inner.closing.store(true, Ordering::Relaxed);
-        self.inner.actor_sender.send(ActorMessage::Shutdown).await?;
-        self.inner.closed.store(true, Ordering::SeqCst);
-        self.inner.endpoints.shutdown();
+        self.msock.closing.store(true, Ordering::Relaxed);
+        self.msock.actor_sender.send(ActorMessage::Shutdown).await?;
+        self.msock.closed.store(true, Ordering::SeqCst);
+        self.msock.endpoints.shutdown();
 
         let mut tasks = self.actor_tasks.lock().await;
 
@@ -1448,12 +1448,12 @@ impl MagicSockHandle {
 
     /// Reference to optional discovery service
     pub fn discovery(&self) -> Option<&dyn Discovery> {
-        self.inner.discovery.as_ref().map(Box::as_ref)
+        self.msock.discovery.as_ref().map(Box::as_ref)
     }
 
     /// Call to notify the system of potential network changes.
     pub async fn network_change(&self) {
-        self.inner
+        self.msock
             .actor_sender
             .send(ActorMessage::NetworkChange)
             .await
@@ -1462,7 +1462,7 @@ impl MagicSockHandle {
 
     #[cfg(test)]
     async fn force_network_change(&self, is_major: bool) {
-        self.inner
+        self.msock
             .actor_sender
             .send(ActorMessage::ForceNetworkChange(is_major))
             .await
@@ -1595,7 +1595,7 @@ impl AsyncUdpSocket for MagicSockHandle {
         cx: &mut Context,
         transmits: &[quinn_udp::Transmit],
     ) -> Poll<io::Result<usize>> {
-        self.inner.poll_send(cx, transmits)
+        self.msock.poll_send(cx, transmits)
     }
 
     /// NOTE: Receiving on a [`Self::close`]d socket will return [`Poll::Pending`] indefinitely.
@@ -1605,11 +1605,11 @@ impl AsyncUdpSocket for MagicSockHandle {
         bufs: &mut [io::IoSliceMut<'_>],
         metas: &mut [quinn_udp::RecvMeta],
     ) -> Poll<io::Result<usize>> {
-        self.inner.poll_recv(cx, bufs, metas)
+        self.msock.poll_recv(cx, bufs, metas)
     }
 
     fn local_addr(&self) -> io::Result<SocketAddr> {
-        match &*self.inner.local_addrs.read().expect("not poisoned") {
+        match &*self.msock.local_addrs.read().expect("not poisoned") {
             (ipv4, None) => {
                 // Pretend to be IPv6, because our QuinnMappedAddrs
                 // need to be IPv6.
@@ -1636,7 +1636,7 @@ enum ActorMessage {
 }
 
 struct Actor {
-    inner: Arc<MagicSock>,
+    msock: Arc<MagicSock>,
     msg_receiver: mpsc::Receiver<ActorMessage>,
     msg_sender: mpsc::Sender<ActorMessage>,
     relay_actor_sender: mpsc::Sender<RelayActorMessage>,
@@ -1688,7 +1688,7 @@ impl Actor {
             time::Instant::now() + HEARTBEAT_INTERVAL,
             HEARTBEAT_INTERVAL,
         );
-        let mut endpoints_update_receiver = self.inner.endpoints_update_state.running.subscribe();
+        let mut endpoints_update_receiver = self.msock.endpoints_update_state.running.subscribe();
         let mut portmap_watcher = self.port_mapper.watch_external_address();
         let mut save_nodes_timer = if self.nodes_path.is_some() {
             tokio::time::interval_at(
@@ -1709,20 +1709,20 @@ impl Actor {
                 }
                 tick = self.periodic_re_stun_timer.tick() => {
                     trace!("tick: re_stun {:?}", tick);
-                    self.inner.re_stun("periodic");
+                    self.msock.re_stun("periodic");
                 }
                 Ok(()) = portmap_watcher.changed() => {
                     trace!("tick: portmap changed");
                     let new_external_address = *portmap_watcher.borrow();
                     debug!("external address updated: {new_external_address:?}");
-                    self.inner.re_stun("portmap_updated");
+                    self.msock.re_stun("portmap_updated");
                 },
                 _ = endpoint_heartbeat_timer.tick() => {
-                    trace!("tick: endpoint heartbeat {} endpoints", self.inner.node_map.node_count());
+                    trace!("tick: endpoint heartbeat {} endpoints", self.msock.node_map.node_count());
                     // TODO: this might trigger too many packets at once, pace this
 
-                    self.inner.node_map.prune_inactive();
-                    let msgs = self.inner.node_map.nodes_stayin_alive();
+                    self.msock.node_map.prune_inactive();
+                    let msgs = self.msock.node_map.nodes_stayin_alive();
                     self.handle_ping_actions(msgs).await;
                 }
                 _ = endpoints_update_receiver.changed() => {
@@ -1736,8 +1736,8 @@ impl Actor {
                     trace!("tick: nodes_timer");
                     let path = self.nodes_path.as_ref().expect("precondition: `is_some()`");
 
-                    self.inner.node_map.prune_inactive();
-                    match self.inner.node_map.save_to_file(path).await {
+                    self.msock.node_map.prune_inactive();
+                    match self.msock.node_map.save_to_file(path).await {
                         Ok(count) => debug!(count, "nodes persisted"),
                         Err(e) => debug!(%e, "failed to persist known nodes"),
                     }
@@ -1757,12 +1757,12 @@ impl Actor {
         debug!("link change detected: major? {}", is_major);
 
         if is_major {
-            self.inner.dns_resolver.clear_cache();
-            self.inner.re_stun("link-change-major");
+            self.msock.dns_resolver.clear_cache();
+            self.msock.re_stun("link-change-major");
             self.close_stale_relay_connections().await;
             self.reset_endpoint_states();
         } else {
-            self.inner.re_stun("link-change-minor");
+            self.msock.re_stun("link-change-minor");
         }
     }
 
@@ -1771,7 +1771,7 @@ impl Actor {
             return;
         }
         if let Err(err) =
-            futures::future::poll_fn(|cx| self.inner.poll_handle_ping_actions(cx, &mut msgs)).await
+            futures::future::poll_fn(|cx| self.msock.poll_handle_ping_actions(cx, &mut msgs)).await
         {
             debug!("failed to send pings: {err:?}");
         }
@@ -1785,9 +1785,9 @@ impl Actor {
             ActorMessage::Shutdown => {
                 debug!("shutting down");
 
-                self.inner.node_map.notify_shutdown();
+                self.msock.node_map.notify_shutdown();
                 if let Some(path) = self.nodes_path.as_ref() {
-                    match self.inner.node_map.save_to_file(path).await {
+                    match self.msock.node_map.save_to_file(path).await {
                         Ok(count) => {
                             debug!(count, "known nodes persisted")
                         }
@@ -1815,14 +1815,14 @@ impl Actor {
                         .send_async(passthrough)
                         .await
                         .expect("missing recv sender");
-                    let mut wakers = self.inner.network_recv_wakers.lock();
+                    let mut wakers = self.msock.network_recv_wakers.lock();
                     if let Some(waker) = wakers.take() {
                         waker.wake();
                     }
                 }
             }
             ActorMessage::EndpointPingExpired(id, txid) => {
-                self.inner.node_map.notify_ping_timeout(id, txid);
+                self.msock.node_map.notify_ping_timeout(id, txid);
             }
             ActorMessage::NetcheckReport(report, why) => {
                 match report {
@@ -1875,7 +1875,7 @@ impl Actor {
         }
         let url = &dm.url;
 
-        let quic_mapped_addr = self.inner.node_map.receive_relay(url, dm.src);
+        let quic_mapped_addr = self.msock.node_map.receive_relay(url, dm.src);
 
         // the relay packet is made up of multiple udp packets, prefixed by a u16 be length prefix
         //
@@ -1964,7 +1964,7 @@ impl Actor {
                 // port locally, assume they might've added a static
                 // port mapping on their router to the same explicit
                 // port that we are running with. Worst case it's an invalid candidate mapping.
-                let port = self.inner.port.load(Ordering::Relaxed);
+                let port = self.msock.port.load(Ordering::Relaxed);
                 if nr.mapping_varies_by_dest_ip.unwrap_or_default() && port != 0 {
                     let mut addr = global_v4;
                     addr.set_port(port);
@@ -2073,33 +2073,33 @@ impl Actor {
         // Despite this sorting, clients are not relying on this sorting for decisions;
 
         let updated = self
-            .inner
+            .msock
             .endpoints
             .update(DiscoveredEndpoints::new(eps))
             .is_ok();
         if updated {
-            let eps = self.inner.endpoints.read();
+            let eps = self.msock.endpoints.read();
             eps.log_endpoint_change();
-            self.inner.publish_my_addr();
+            self.msock.publish_my_addr();
         }
 
         // Regardless of whether our local endpoints changed, we now want to send any queued
         // call-me-maybe messages.
-        self.inner.send_queued_call_me_maybes();
+        self.msock.send_queued_call_me_maybes();
     }
 
     /// Called when an endpoints update is done, no matter if it was successful or not.
     fn finalize_endpoints_update(&mut self, why: &'static str) {
-        let new_why = self.inner.endpoints_update_state.next_update();
-        if !self.inner.is_closed() {
+        let new_why = self.msock.endpoints_update_state.next_update();
+        if !self.msock.is_closed() {
             if let Some(new_why) = new_why {
-                self.inner.endpoints_update_state.run(new_why);
+                self.msock.endpoints_update_state.run(new_why);
                 return;
             }
             self.periodic_re_stun_timer = new_re_stun_timer(true);
         }
 
-        self.inner.endpoints_update_state.finish_run();
+        self.msock.endpoints_update_state.finish_run();
         debug!("endpoint update done ({})", why);
     }
 
@@ -2134,7 +2134,7 @@ impl Actor {
     /// allow this easy mistake to be made.
     #[instrument(level = "debug", skip_all)]
     async fn update_net_info(&mut self, why: &'static str) {
-        if self.inner.relay_map.is_empty() {
+        if self.msock.relay_map.is_empty() {
             debug!("skipping netcheck, empty RelayMap");
             self.msg_sender
                 .send(ActorMessage::NetcheckReport(Ok(None), why))
@@ -2143,7 +2143,7 @@ impl Actor {
             return;
         }
 
-        let relay_map = self.inner.relay_map.clone();
+        let relay_map = self.msock.relay_map.clone();
         let pconn4 = Some(self.pconn4.as_socket());
         let pconn6 = self.pconn6.as_ref().map(|p| p.as_socket());
 
@@ -2180,7 +2180,7 @@ impl Actor {
 
     async fn handle_netcheck_report(&mut self, report: Option<Arc<netcheck::Report>>) {
         if let Some(ref report) = report {
-            self.inner
+            self.msock
                 .ipv6_reported
                 .store(report.ipv6, Ordering::Relaxed);
             let r = &report;
@@ -2231,12 +2231,12 @@ impl Actor {
     }
 
     fn set_nearest_relay(&mut self, relay_url: Option<RelayUrl>) -> bool {
-        let my_relay = self.inner.my_relay();
+        let my_relay = self.msock.my_relay();
         if relay_url == my_relay {
             // No change.
             return true;
         }
-        let old_relay = self.inner.set_my_relay(relay_url.clone());
+        let old_relay = self.msock.set_my_relay(relay_url.clone());
 
         if let Some(ref relay_url) = relay_url {
             inc!(MagicsockMetrics, relay_home_change);
@@ -2244,7 +2244,7 @@ impl Actor {
             // On change, notify all currently connected relay servers and
             // start connecting to our home relay if we are not already.
             info!("home is now relay {}, was {:?}", relay_url, old_relay);
-            self.inner.publish_my_addr();
+            self.msock.publish_my_addr();
 
             self.send_relay_actor(RelayActorMessage::SetHome {
                 url: relay_url.clone(),
@@ -2270,21 +2270,21 @@ impl Actor {
         //
         // We used to do the above for legacy clients, but never updated it for disco.
 
-        let my_relay = self.inner.my_relay();
+        let my_relay = self.msock.my_relay();
         if my_relay.is_some() {
             return my_relay;
         }
 
-        let ids = self.inner.relay_map.urls().collect::<Vec<_>>();
+        let ids = self.msock.relay_map.urls().collect::<Vec<_>>();
         let mut rng = rand::rngs::StdRng::seed_from_u64(0);
         ids.choose(&mut rng).map(|c| (*c).clone())
     }
 
     /// Resets the preferred address for all nodes.
     /// This is called when connectivity changes enough that we no longer trust the old routes.
-    #[instrument(skip_all, fields(me = %self.inner.me))]
+    #[instrument(skip_all, fields(me = %self.msock.me))]
     fn reset_endpoint_states(&mut self) {
-        self.inner.node_map.reset_node_states()
+        self.msock.node_map.reset_node_states()
     }
 
     /// Tells the relay actor to close stale relay connections.
@@ -2327,7 +2327,7 @@ impl Actor {
                     // TODO: return here?
                     warn!("Received relay disco message from connection for {}, but with message from {}", relay_node_src.fmt_short(), source.fmt_short());
                 }
-                self.inner.handle_disco_message(
+                self.msock.handle_disco_message(
                     source,
                     sealed_box,
                     DiscoMessageSource::Relay {
@@ -2990,8 +2990,8 @@ pub(crate) mod tests {
             m1.endpoint.close(0u32.into(), b"done").await?;
             m2.endpoint.close(0u32.into(), b"done").await?;
 
-            assert!(msock1.inner.is_closed());
-            assert!(msock2.inner.is_closed());
+            assert!(msock1.msock.is_closed());
+            assert!(msock2.msock.is_closed());
         }
         Ok(())
     }

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -148,6 +148,16 @@ impl Default for Options {
 /// common case of a single packet.
 pub(crate) type RelayContents = SmallVec<[Bytes; 1]>;
 
+/// Handle for [`MagicSock`].
+///
+/// Dereferences to [`MagicSock`], and handles closing.
+#[derive(Clone, Debug)]
+pub struct MagicSockHandle {
+    msock: Arc<MagicSock>,
+    // Empty when closed
+    actor_tasks: Arc<Mutex<JoinSet<()>>>,
+}
+
 /// Iroh connectivity layer.
 ///
 /// This is responsible for routing packets to nodes based on node IDs, it will initially
@@ -158,14 +168,6 @@ pub(crate) type RelayContents = SmallVec<[Bytes; 1]>;
 /// It is usually only necessary to use a single [`MagicSock`] instance in an application, it
 /// means any QUIC endpoints on top will be sharing as much information about nodes as
 /// possible.
-#[derive(Clone, Debug)]
-pub struct MagicSockHandle {
-    msock: Arc<MagicSock>,
-    // Empty when closed
-    actor_tasks: Arc<Mutex<JoinSet<()>>>,
-}
-
-/// The actual implementation of `MagicSock`.
 #[derive(derive_more::Debug)]
 struct MagicSock {
     actor_sender: mpsc::Sender<ActorMessage>,

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -74,7 +74,7 @@ mod relay_actor;
 mod timer;
 mod udp_conn;
 
-pub(crate) use self::metrics::Metrics;
+pub use self::metrics::Metrics;
 pub use self::node_map::{
     ConnectionType, ConnectionTypeStream, ControlMsg, DirectAddrInfo, NodeInfo as ConnectionInfo,
 };

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -305,19 +305,7 @@ impl MagicSock {
     /// stream will always return the first set of endpoints immediately, which are the most
     /// recently discovered endpoints.
     ///
-    /// # Examples
-    ///
-    /// To get the current endpoints, drop the stream after the first item was received:
-    /// ```
-    /// use futures::StreamExt;
-    /// use iroh_net::magicsock::MagicSock;
-    ///
-    /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    /// # rt.block_on(async move {
-    /// let ms = MagicSock::new(Default::default()).await.unwrap();
-    /// let _endpoints = ms.local_endpoints().next().await;
-    /// # });
-    /// ```
+    /// To get the current endpoints, drop the stream after the first item was received.
     pub fn local_endpoints(&self) -> LocalEndpointsStream {
         LocalEndpointsStream {
             initial: Some(self.endpoints.get()),

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -238,7 +238,7 @@ pub(super) struct MagicSock {
 
 impl MagicSock {
     /// Creates a magic [`MagicSock`] listening on [`Options::port`].
-    pub async fn new(opts: Options) -> Result<Handle> {
+    pub async fn spawn(opts: Options) -> Result<Handle> {
         Handle::new(opts).await
     }
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1631,7 +1631,7 @@ struct Actor {
     periodic_re_stun_timer: time::Interval,
     /// The `NetInfo` provided in the last call to `net_info_func`. It's used to deduplicate calls to netInfoFunc.
     net_info_last: Option<config::NetInfo>,
-    /// Path where connection info from [`Inner::node_map`] is persisted.
+    /// Path where connection info from [`MagicSock::node_map`] is persisted.
     nodes_path: Option<PathBuf>,
 
     // The underlying UDP sockets used to send/rcv packets.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1454,7 +1454,7 @@ impl Handle {
     }
 }
 
-/// Stream returning local endpoints of a [`MagicSock`] as they change.
+/// Stream returning local endpoints as they change.
 #[derive(Debug)]
 pub struct LocalEndpointsStream {
     initial: Option<DiscoveredEndpoints>,

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -74,9 +74,9 @@ mod relay_actor;
 mod timer;
 mod udp_conn;
 
-pub use self::metrics::Metrics;
+pub(crate) use self::metrics::Metrics;
 pub use self::node_map::{
-    ConnectionType, ConnectionTypeStream, DirectAddrInfo, NodeInfo as ConnectionInfo,
+    ConnectionType, ConnectionTypeStream, ControlMsg, DirectAddrInfo, NodeInfo as ConnectionInfo,
 };
 pub(super) use self::timer::Timer;
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2444,7 +2444,7 @@ fn split_packets(transmits: &[quinn_udp::Transmit]) -> RelayContents {
 
 /// Splits a packet into its component items.
 #[derive(Debug)]
-pub struct PacketSplitIter {
+pub(super) struct PacketSplitIter {
     bytes: Bytes,
 }
 

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -31,7 +31,7 @@ use crate::{
 mod best_addr;
 mod node_state;
 
-pub use node_state::{ConnectionType, DirectAddrInfo, NodeInfo};
+pub use node_state::{ConnectionType, ControlMsg, DirectAddrInfo, NodeInfo};
 pub(super) use node_state::{DiscoPingPurpose, PingAction, PingRole, SendPing};
 
 /// Number of nodes that are inactive for which we keep info about. This limit is enforced

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -31,7 +31,7 @@ use crate::{
 mod best_addr;
 mod node_state;
 
-pub use node_state::{ConnectionType, ControlMsg, DirectAddrInfo, NodeInfo};
+pub use node_state::{ConnectionType, DirectAddrInfo, NodeInfo};
 pub(super) use node_state::{DiscoPingPurpose, PingAction, PingRole, SendPing};
 
 /// Number of nodes that are inactive for which we keep info about. This limit is enforced

--- a/iroh-net/src/magicsock/timer.rs
+++ b/iroh-net/src/magicsock/timer.rs
@@ -1,14 +1,12 @@
 use std::time::Duration;
 
 use futures::Future;
-use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tokio::time::{self, Instant};
+use tokio::time;
 
 /// A timer that works similar to golangs `Timer`.
 #[derive(Debug)]
 pub struct Timer {
-    s: mpsc::Sender<Duration>,
     t: JoinHandle<()>,
 }
 
@@ -18,53 +16,17 @@ impl Timer {
     where
         F: Future<Output = ()> + Send + Sync + 'static,
     {
-        let (s, mut r) = mpsc::channel(1);
-
         let t = tokio::task::spawn(async move {
-            let sleep = time::sleep(d);
-            tokio::pin!(sleep);
-
-            loop {
-                tokio::select! {
-                    biased;
-
-                    msg = r.recv() => match msg {
-                        Some(new_duration) => {
-                            // Reset when a new duration was received.
-                            sleep.as_mut().reset(Instant::now() + new_duration);
-                        }
-                        None => {
-                            // dropped, end this
-                            break;
-                        }
-                    },
-                    _ = &mut sleep => {
-                        // expired
-                        f.await;
-                        break;
-                    }
-                }
-            }
+            time::sleep(d).await;
+            f.await
         });
 
-        Timer { s, t }
-    }
-
-    /// Reset the timer to stop after `d` has passed.
-    pub async fn reset(&self, d: Duration) {
-        self.s.send(d).await.ok();
+        Timer { t }
     }
 
     /// Abort the timer.
     pub fn abort(self) {
         self.t.abort();
-    }
-
-    /// Returns true if not yet expired.
-    pub async fn stop(self) -> bool {
-        self.t.abort();
-        // If the task was not completed yet, the abort triggers an error.
-        self.t.await.is_err()
     }
 }
 
@@ -117,7 +79,7 @@ mod tests {
         });
 
         assert!(!val.load(Ordering::Relaxed));
-        assert!(timer.stop().await);
+        timer.abort();
         assert!(!val.load(Ordering::Relaxed));
     }
 
@@ -135,35 +97,7 @@ mod tests {
         assert!(!val.load(Ordering::Relaxed));
         time::sleep(Duration::from_millis(75)).await;
 
-        assert!(!timer.stop().await);
-        assert!(val.load(Ordering::Relaxed));
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_timer_reset() {
-        let val = Arc::new(AtomicBool::new(false));
-
-        assert!(!val.load(Ordering::Relaxed));
-
-        let moved_val = val.clone();
-        let timer = Timer::after(Duration::from_millis(50), async move {
-            moved_val.store(true, Ordering::Relaxed);
-        });
-
-        assert!(!val.load(Ordering::Relaxed));
-        time::sleep(Duration::from_millis(25)).await;
-
-        // not yet expired
-        assert!(!val.load(Ordering::Relaxed));
-        // reset for another 100ms
-        timer.reset(Duration::from_millis(100)).await;
-
-        // would have expired if not reset
-        time::sleep(Duration::from_millis(25)).await;
-        assert!(!val.load(Ordering::Relaxed));
-
-        // definitely expired now
-        time::sleep(Duration::from_millis(125)).await;
+        timer.abort();
         assert!(val.load(Ordering::Relaxed));
     }
 }

--- a/iroh-net/src/netcheck.rs
+++ b/iroh-net/src/netcheck.rs
@@ -166,8 +166,7 @@ impl RelayLatencies {
 /// If all [`Client`]s are dropped the actor stops running.
 ///
 /// While running the netcheck actor expects to be passed all received stun packets using
-/// [`Client::receive_stun_packet`], the [`crate::magicsock::MagicSock`] using this
-/// client needs to be wired up to do so.
+/// [`Client::receive_stun_packet`].
 #[derive(Debug, Clone)]
 pub struct Client {
     /// Channel to send message to the [`Actor`].

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -163,13 +163,13 @@ impl<D: BaoStore> Node<D> {
     /// Note that this could be an unspecified address, if you need an address on which you
     /// can contact the node consider using [`Node::local_endpoint_addresses`].  However the
     /// port will always be the concrete port.
-    pub fn local_address(&self) -> Result<Vec<SocketAddr>> {
-        let (v4, v6) = self.inner.endpoint.local_addr()?;
+    pub fn local_address(&self) -> Vec<SocketAddr> {
+        let (v4, v6) = self.inner.endpoint.local_addr();
         let mut addrs = vec![v4];
         if let Some(v6) = v6 {
             addrs.push(v6);
         }
-        Ok(addrs)
+        addrs
     }
 
     /// Lists the local endpoint of this node.

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -20,11 +20,11 @@ use iroh_bytes::downloader::Downloader;
 use iroh_bytes::store::Store as BaoStore;
 use iroh_bytes::BlobFormat;
 use iroh_bytes::Hash;
-use iroh_net::magicsock::LocalEndpointsStream;
 use iroh_net::relay::RelayUrl;
 use iroh_net::util::AbortingJoinHandle;
 use iroh_net::{
     key::{PublicKey, SecretKey},
+    magic_endpoint::LocalEndpointsStream,
     MagicEndpoint, NodeAddr,
 };
 use quic_rpc::transport::flume::FlumeConnection;

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -491,13 +491,13 @@ where
     ) {
         let rpc = RpcServer::new(rpc);
         let internal_rpc = RpcServer::new(internal_rpc);
-        if let Ok((ipv4, ipv6)) = server.local_addr() {
-            debug!(
-                "listening at: {}{}",
-                ipv4,
-                ipv6.map(|addr| format!(" and {addr}")).unwrap_or_default()
-            );
-        }
+        let (ipv4, ipv6) = server.local_addr();
+        debug!(
+            "listening at: {}{}",
+            ipv4,
+            ipv6.map(|addr| format!(" and {addr}")).unwrap_or_default()
+        );
+
         let cancel_token = handler.inner.cancel_token.clone();
 
         // forward our initial endpoints to the gossip protocol

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -147,7 +147,7 @@ async fn multiple_clients() -> Result<()> {
     for _i in 0..3 {
         let file_hash: Hash = expect_hash;
         let name = expect_name;
-        let addrs = node.local_address().unwrap();
+        let addrs = node.local_address();
         let peer_id = node.node_id();
         let content = content.to_vec();
 


### PR DESCRIPTION
## Description

`magicsock` main's component, the `MagicSock` is not useful on it's own. Having it on our public API forces us to treat as breaking changes modifications that for a `MagicEndpoint` user are implementation details. To avoid this, this PR makes the following changes:
- expose all types that are part of the public functions of the `MagicSock` as `pub use`
- explicitly re-export every publicly exposed by `magicsock` from `magic_endpoint` (so that the types involved in the prev change can be used from `magic_endpoint` directly)
- changes the description of the `magic_endpoint` module to not include the `MagicSock` and make it more expressive at the same time.
- `MagicSock` had a bunch of methods that were simply methods of `Inner` re-exposed. Now that `MagicSock` is private, we can get rid of those all and simply use `Deref` to `Inner` without exposing `Inner` via trait associated types.
- That being said, renames `MagicSock` to `magicsock::Handle` which is what it really is, leaving only the new and close methods, which are the ones that handle creation and destruction of the associated tasks.
- Misc rename of fields of type `MagicSock` to `msock`, which I think aligns better to new naming as is more readable/clear.
- Simplifies the `Timer` code. The removed parts were considered used because they were publicly accessible. Becoming private showed parts that were dead code.
- `local_addr` no longer returns an error (it seems to be it never did), but it became more clear in the process of accessing the `MagicSock`(`Inner`) methods via `Deref`.
- `MagicEndpoint::local_addr` no longer returns an error

## Breaking Changes

- module `magicsock` is no longer public
- `iroh_net::magicsock::ConnectionType` -> `iroh_net::magic_endpoint::ConnectionType`
- `iroh_net::magicsock::ControlMsg` -> `iroh_net::magic_endpoint::ControlMsg`
- `iroh_net::magicsock::ConnectionInfo` -> `iroh_net::magic_endpoint::ConnectionInfo`
- `iroh_net::magicsock::ConnectionTypeStream` -> `iroh_net::magic_endpoint::ConnectionTypeStream`
- `iroh_net::magicsock::DirectAddrInfo` -> `iroh_net::magic_endpoint::DirectAddrInfo`
- `iroh_net::magicsock::LocalEndpointsStream` -> `iroh_net::magic_endpoint::LocalEndpointsStream`
- `iroh_net::magicsock::MagicSock` no longer accessible. Use `MagicEndpoint` instead.
- `iroh_net::magicsock::Options` no longer public. Used internally only.
- `iroh_net::magicsock::PacketSplitIter` no longer public. This is an implementation detail of internal use only.
- `iroh_net::magicsock::Timer` no longer public. This is an implementation detail of internal use only.
- `iroh_net::magicsock::UdpSocket` no longer public. This is an implementation detail of internal use only.

## Notes & open questions

ended up using `cargo public-api -p iroh-net diff` to get what was _added_ and make some of those not-for-public enums and structs private again. While really useful, checking this is very annoying. Hopefully we don't have to do it often.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] ~Tests if relevant.~
- [x] All breaking changes documented.
