### PR TITLE
test: add test for iroh-dns-server with mainline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,6 +2521,7 @@ dependencies = [
  "iroh-net",
  "iroh-test",
  "lru",
+ "mainline",
  "parking_lot",
  "pkarr",
  "rcgen 0.12.1",

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -54,3 +54,4 @@ z32 = "1.1.1"
 hickory-resolver = "0.24.0"
 iroh-net = { version = "0.14.0", path = "../iroh-net" }
 iroh-test = { path = "../iroh-test" }
+mainline = "<1.5.0"

--- a/iroh-dns-server/src/config.rs
+++ b/iroh-dns-server/src/config.rs
@@ -71,8 +71,20 @@ pub struct MainlineConfig {
     pub enabled: bool,
     /// Set custom bootstrap nodes.
     ///
+    /// Addresses can either be `domain:port` or `ipv4:port`.
+    ///
     /// If empty this will use the default bittorrent mainline bootstrap nodes as defined by pkarr.
-    pub bootstrap: Vec<SocketAddr>,
+    pub bootstrap: Option<Vec<String>>,
+}
+
+/// Configure the bootstrap servers for mainline DHT resolution.
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub enum BootstrapOption {
+    /// Use the default bootstrap servers.
+    #[default]
+    Default,
+    /// Use custom bootstrap servers.
+    Custom(Vec<String>),
 }
 
 #[allow(clippy::derivable_impls)]
@@ -80,7 +92,7 @@ impl Default for MainlineConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            bootstrap: vec![],
+            bootstrap: None,
         }
     }
 }
@@ -128,11 +140,17 @@ impl Config {
         }
     }
 
-    pub(crate) fn mainline_enabled(&self) -> Option<&Vec<SocketAddr>> {
+    pub(crate) fn mainline_enabled(&self) -> Option<BootstrapOption> {
         match self.mainline.as_ref() {
             None => None,
-            Some(config) if !config.enabled => None,
-            Some(config) => Some(&config.bootstrap),
+            Some(MainlineConfig { enabled: false, .. }) => None,
+            Some(MainlineConfig {
+                bootstrap: Some(bootstrap),
+                ..
+            }) => Some(BootstrapOption::Custom(bootstrap.clone())),
+            Some(MainlineConfig {
+                bootstrap: None, ..
+            }) => Some(BootstrapOption::Default),
         }
     }
 }

--- a/iroh-dns-server/src/config.rs
+++ b/iroh-dns-server/src/config.rs
@@ -69,12 +69,16 @@ impl MetricsConfig {
 pub struct MainlineConfig {
     /// Set to true to enable the mainline lookup.
     pub enabled: bool,
+    /// Set custom bootstrap nodes.
+    ///
+    /// If empty this will use the default bittorrent mainline bootstrap nodes as defined by pkarr.
+    pub bootstrap: Vec<SocketAddr>,
 }
 
 #[allow(clippy::derivable_impls)]
 impl Default for MainlineConfig {
     fn default() -> Self {
-        Self { enabled: false }
+        Self { enabled: false, bootstrap: vec![]}
     }
 }
 
@@ -121,11 +125,12 @@ impl Config {
         }
     }
 
-    pub(crate) fn mainline_enabled(&self) -> bool {
-        self.mainline
-            .as_ref()
-            .map(|x| x.enabled)
-            .unwrap_or_default()
+    pub(crate) fn mainline_enabled(&self) -> Option<&Vec<SocketAddr>> {
+        match self.mainline.as_ref() {
+            None => None,
+            Some(config) if !config.enabled => None,
+            Some(config) => Some(&config.bootstrap),
+        }
     }
 }
 

--- a/iroh-dns-server/src/config.rs
+++ b/iroh-dns-server/src/config.rs
@@ -78,7 +78,10 @@ pub struct MainlineConfig {
 #[allow(clippy::derivable_impls)]
 impl Default for MainlineConfig {
     fn default() -> Self {
-        Self { enabled: false, bootstrap: vec![]}
+        Self {
+            enabled: false,
+            bootstrap: vec![],
+        }
     }
 }
 

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -34,7 +34,7 @@ mod tests {
     use pkarr::{PkarrClient, SignedPacket};
     use url::Url;
 
-    use crate::server::Server;
+    use crate::{config::BootstrapOption, server::Server};
 
     #[tokio::test]
     async fn pkarr_publish_dns_resolve() -> Result<()> {
@@ -186,15 +186,11 @@ mod tests {
 
         // run a mainline testnet
         let testnet = mainline::dht::Testnet::new(5);
-        let bootstrap = testnet
-            .bootstrap
-            .iter()
-            .map(|addr| SocketAddr::from_str(addr).unwrap())
-            .collect::<Vec<_>>();
+        let bootstrap = testnet.bootstrap.clone();
 
         // spawn our server with mainline support
         let (server, nameserver, _http_url) =
-            Server::spawn_for_tests_with_mainline(Some(bootstrap)).await?;
+            Server::spawn_for_tests_with_mainline(Some(BootstrapOption::Custom(bootstrap))).await?;
 
         let origin = "irohdns.example.";
 

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -13,7 +13,10 @@ mod util;
 
 #[cfg(test)]
 mod tests {
-    use std::{net::{Ipv4Addr, Ipv6Addr, SocketAddr}, str::FromStr};
+    use std::{
+        net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+        str::FromStr,
+    };
 
     use anyhow::Result;
     use hickory_resolver::{
@@ -190,7 +193,8 @@ mod tests {
             .collect::<Vec<_>>();
 
         // spawn our server with mainline support
-        let (server, nameserver, _http_url) = Server::spawn_for_tests_with_mainline(Some(bootstrap)).await?;
+        let (server, nameserver, _http_url) =
+            Server::spawn_for_tests_with_mainline(Some(bootstrap)).await?;
 
         let origin = "irohdns.example.";
 

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -202,7 +202,7 @@ mod tests {
         let secret_key = SecretKey::generate();
         let node_id = secret_key.public();
         let relay_url: Url = "https://relay.example.".parse()?;
-        let node_info = NodeInfo::new(node_id, Some(relay_url.clone()));
+        let node_info = NodeInfo::new(node_id, Some(relay_url.clone()), Default::default());
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
 
         // publish the signed packet to our DHT

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -13,10 +13,7 @@ mod util;
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-        str::FromStr,
-    };
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
     use anyhow::Result;
     use hickory_resolver::{

--- a/iroh-dns-server/src/server.rs
+++ b/iroh-dns-server/src/server.rs
@@ -17,7 +17,7 @@ pub async fn run_with_config_until_ctrl_c(config: Config) -> Result<()> {
     let mut store = ZoneStore::persistent(Config::signed_packet_store_path()?)?;
     if let Some(bootstrap) = config.mainline_enabled() {
         info!("mainline fallback enabled");
-        store = store.with_mainline_fallback(Some(bootstrap));
+        store = store.with_mainline_fallback(bootstrap);
     };
     let server = Server::spawn(config, store).await?;
     tokio::signal::ctrl_c().await?;
@@ -117,7 +117,7 @@ impl Server {
         let mut store = ZoneStore::in_memory()?;
         if let Some(bootstrap) = config.mainline_enabled() {
             info!("mainline fallback enabled");
-            store = store.with_mainline_fallback(Some(bootstrap));
+            store = store.with_mainline_fallback(bootstrap);
         };
         let server = Self::spawn(config, store).await?;
         let dns_addr = server.dns_server.local_addr();

--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -64,7 +64,7 @@ impl ZoneStore {
     ///
     /// Optionally set custom bootstrap nodes. If `bootstrap` is empty it will use the default
     /// mainline bootstrap nodes.
-    pub fn with_mainline_fallback(self, bootstrap: &Vec<SocketAddr>) -> Self {
+    pub fn with_mainline_fallback(self, bootstrap: &[SocketAddr]) -> Self {
         let pkarr_client = if bootstrap.is_empty() {
             PkarrClient::default()
         } else {

--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -64,18 +64,15 @@ impl ZoneStore {
     ///
     /// Optionally set custom bootstrap nodes. If `bootstrap` is empty it will use the default
     /// mainline bootstrap nodes.
-    pub fn with_mainline_fallback(self, bootstrap: Option<&Vec<SocketAddr>>) -> Self {
-        let pkarr_client = match bootstrap {
-            None => PkarrClient::default(),
-            Some(addrs) if addrs.is_empty() => PkarrClient::default(),
-            Some(addrs) => PkarrClient::builder()
-                .bootstrap(
-                    &addrs
-                        .iter()
-                        .map(|addr| addr.to_string())
-                        .collect::<Vec<_>>(),
-                )
-                .build(),
+    pub fn with_mainline_fallback(self, bootstrap: &Vec<SocketAddr>) -> Self {
+        let pkarr_client = if bootstrap.is_empty() {
+            PkarrClient::default()
+        } else {
+            let bootstrap = bootstrap
+                .iter()
+                .map(|addr| addr.to_string())
+                .collect::<Vec<_>>();
+            PkarrClient::builder().bootstrap(&bootstrap).build()
         };
         Self {
             pkarr: Some(Arc::new(pkarr_client)),


### PR DESCRIPTION
## Description

This adds a test for iroh-dns-server with mainline fallback resolution.
Needed to rework the config structure a little to not duplicate code too much.

## Breaking Changes

are documented in #2180 

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
