### PR TITLE
feat(iroh-base): allow the addr info of tickets to be empty

### DIFF
--- a/iroh-base/src/ticket/blob.rs
+++ b/iroh-base/src/ticket/blob.rs
@@ -45,9 +45,6 @@ impl Ticket for BlobTicket {
     fn from_bytes(bytes: &[u8]) -> std::result::Result<Self, ticket::Error> {
         let res: TicketWireFormat = postcard::from_bytes(bytes).map_err(ticket::Error::Postcard)?;
         let TicketWireFormat::Variant0(res) = res;
-        if res.node.info.is_empty() {
-            return Err(ticket::Error::Verify("addressing info cannot be empty"));
-        }
         Ok(res)
     }
 }

--- a/iroh-base/src/ticket/node.rs
+++ b/iroh-base/src/ticket/node.rs
@@ -36,9 +36,6 @@ impl Ticket for NodeTicket {
     fn from_bytes(bytes: &[u8]) -> std::result::Result<Self, ticket::Error> {
         let res: TicketWireFormat = postcard::from_bytes(bytes).map_err(ticket::Error::Postcard)?;
         let TicketWireFormat::Variant0(res) = res;
-        if res.node.info.is_empty() {
-            return Err(ticket::Error::Verify("addressing info cannot be empty"));
-        }
         Ok(res)
     }
 }


### PR DESCRIPTION
## Description

feat(iroh-base): allow the addr info of tickets to be empty

Without this, a ticket that does not contain any addresses or relay URL can not be parsed. But we need to allow this if we want to use short tickets.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Note: I did not remove the error type Validation. That way we don't have breaking changes, and we might need it again in the future.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
