### PR TITLE
fix(iroh-net): reconfirm best addr when receiving data on it

### DIFF
--- a/iroh-net/src/magicsock/node_map/best_addr.rs
+++ b/iroh-net/src/magicsock/node_map/best_addr.rs
@@ -145,16 +145,10 @@ impl BestAddr {
 
     /// Reset the expiry, if the passed in addr matches the currently used one.
     pub fn reconfirm_if_used(&mut self, addr: SocketAddr, source: Source, confirmed_at: Instant) {
-        match self.0.as_mut() {
-            None => {
-                // Nothing to do
-                // TODO: do we want to store this regardless?
-            }
-            Some(state) => {
-                if state.addr.addr == addr {
-                    state.confirmed_at = confirmed_at;
-                    state.trust_until = Some(source.trust_until(confirmed_at));
-                }
+        if let Some(state) = self.0.as_mut() {
+            if state.addr.addr == addr {
+                state.confirmed_at = confirmed_at;
+                state.trust_until = Some(source.trust_until(confirmed_at));
             }
         }
     }

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -26,7 +26,7 @@ use crate::{
 
 use crate::magicsock::{metrics::Metrics as MagicsockMetrics, ActorMessage, QuicMappedAddr};
 
-use super::best_addr::{self, BestAddr, ClearReason};
+use super::best_addr::{self, BestAddr, ClearReason, Source};
 use super::IpPort;
 
 /// Number of addresses that are not active that we keep around per node.
@@ -967,6 +967,8 @@ impl NodeState {
         };
         state.last_payload_msg = Some(now);
         self.last_used = Some(now);
+        self.best_addr
+            .reconfirm_if_used(addr.into(), Source::Udp, now);
     }
 
     pub(super) fn receive_relay(&mut self, url: &RelayUrl, _src: &PublicKey, now: Instant) {


### PR DESCRIPTION
When receiving data via UDP, we were not extending the validity of the current `best_addr`. This would trigger expiry of the `best_addr`, even though it was actively being used. 

This fix, extends the validity, everytime we successfully receive a UDP packet on the current `best_addr`.

Closes #2169

