### PR TITLE
feat: Update from `default-net` to rebranded `netdev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,23 +1042,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
-name = "default-net"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba429d84a27fa854c66fd2e29eb1cdf6d38bbfd4495bd9f522f12a7f21e05bf"
-dependencies = [
- "dlopen2",
- "libc",
- "memalloc",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-sys",
- "once_cell",
- "system-configuration",
- "windows 0.48.0",
-]
-
-[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,7 +2609,6 @@ dependencies = [
  "clap",
  "criterion",
  "crypto_box",
- "default-net",
  "der",
  "derive_more",
  "duct",
@@ -2649,6 +2631,7 @@ dependencies = [
  "iroh-metrics",
  "iroh-test",
  "libc",
+ "netdev",
  "netlink-packet-core",
  "netlink-packet-route",
  "netlink-sys",
@@ -2974,6 +2957,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "netdev"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb353f5a5a852d5cc779c1c80bec0bd14a696ef832f3a761cb10091802c37109"
+dependencies = [
+ "dlopen2",
+ "libc",
+ "memalloc",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
+ "once_cell",
+ "system-configuration 0.6.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -4221,7 +4221,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -5155,7 +5155,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5163,6 +5174,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5916,15 +5937,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
@@ -5942,6 +5954,16 @@ dependencies = [
  "windows-core 0.52.0",
  "windows-implement 0.52.0",
  "windows-interface 0.52.0",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
  "windows-targets 0.52.5",
 ]
 
@@ -5970,6 +5992,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.5",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,9 +3441,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -3452,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3462,9 +3462,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3475,9 +3475,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -21,7 +21,7 @@ aead = { version = "0.5.2", features = ["bytes"] }
 anyhow = { version = "1" }
 backoff = "0.4.0"
 bytes = "1"
-default-net = "0.20"
+netdev = "0.25"
 der = { version = "0.7", features = ["alloc", "derive"] }
 derive_more = { version = "1.0.0-beta.1", features = ["debug", "display", "from", "try_into", "deref"] }
 flume = "0.11"

--- a/iroh-net/src/net/interfaces.rs
+++ b/iroh-net/src/net/interfaces.rs
@@ -16,7 +16,7 @@ mod linux;
 #[cfg(target_os = "windows")]
 mod windows;
 
-pub use default_net::ip::{Ipv4Net, Ipv6Net};
+pub use netdev::ip::{Ipv4Net, Ipv6Net};
 
 use crate::net::ip::{is_loopback, is_private_v6, is_up};
 
@@ -36,7 +36,7 @@ use self::windows::default_route;
 /// Represents a network interface.
 #[derive(Debug)]
 pub struct Interface {
-    iface: default_net::interface::Interface,
+    iface: netdev::interface::Interface,
 }
 
 impl fmt::Display for Interface {
@@ -100,10 +100,10 @@ impl Interface {
     pub(crate) fn fake() -> Self {
         use std::net::Ipv4Addr;
 
-        use default_net::{interface::InterfaceType, mac::MacAddr, Gateway};
+        use netdev::{interface::InterfaceType, mac::MacAddr, NetworkDevice};
 
         Self {
-            iface: default_net::Interface {
+            iface: netdev::Interface {
                 index: 2,
                 name: String::from("wifi0"),
                 friendly_name: None,
@@ -119,10 +119,13 @@ impl Interface {
                 flags: 69699,
                 transmit_speed: None,
                 receive_speed: None,
-                gateway: Some(Gateway {
+                gateway: Some(NetworkDevice {
                     mac_addr: MacAddr::new(2, 3, 4, 5, 6, 8),
-                    ip_addr: IpAddr::V4(Ipv4Addr::from([192, 168, 0, 1])),
+                    ipv4: vec![Ipv4Addr::from([192, 168, 0, 1])],
+                    ipv6: vec![],
                 }),
+                dns_servers: vec![],
+                default: false,
             },
         }
     }
@@ -224,7 +227,7 @@ impl State {
         let mut have_v6 = false;
         let mut have_v4 = false;
 
-        let ifaces = default_net::interface::get_interfaces();
+        let ifaces = netdev::interface::get_interfaces();
         for iface in ifaces {
             let ni = Interface { iface };
             let if_up = ni.is_up();
@@ -398,7 +401,7 @@ impl HomeRouter {
     /// This is used as the destination for UPnP, NAT-PMP, PCP, etc queries.
     pub fn new() -> Option<Self> {
         let gateway = Self::get_default_gateway()?;
-        let my_ip = default_net::interface::get_local_ipaddr();
+        let my_ip = netdev::interface::get_local_ipaddr();
 
         Some(HomeRouter { gateway, my_ip })
     }
@@ -411,15 +414,21 @@ impl HomeRouter {
         target_os = "ios"
     ))]
     fn get_default_gateway() -> Option<IpAddr> {
-        // default_net doesn't work yet
+        // netdev doesn't work yet
         // See: https://github.com/shellrow/default-net/issues/34
         bsd::likely_home_router()
     }
 
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
     fn get_default_gateway() -> Option<IpAddr> {
-        let gateway = default_net::get_default_gateway().ok()?;
-        Some(gateway.ip_addr)
+        let gateway = netdev::get_default_gateway().ok()?;
+        gateway
+            .ipv4
+            .iter()
+            .cloned()
+            .map(IpAddr::V4)
+            .chain(gateway.ipv6.iter().cloned().map(IpAddr::V6))
+            .next()
     }
 }
 

--- a/iroh-net/src/net/interfaces/bsd.rs
+++ b/iroh-net/src/net/interfaces/bsd.rs
@@ -17,7 +17,7 @@ use macos::*;
 
 pub async fn default_route() -> Option<DefaultRouteDetails> {
     let idx = default_route_interface_index()?;
-    let interfaces = default_net::get_interfaces();
+    let interfaces = netdev::get_interfaces();
     let iface = interfaces.into_iter().find(|i| i.index == idx)?;
 
     Some(DefaultRouteDetails {

--- a/iroh-net/src/net/ip.rs
+++ b/iroh-net/src/net/ip.rs
@@ -25,7 +25,7 @@ impl LocalAddresses {
     /// If there are no regular addresses it will return any IPv4 linklocal or IPv6 unique local
     /// addresses because we know of environments where these are used with NAT to provide connectivity.
     pub fn new() -> Self {
-        let ifaces = default_net::interface::get_interfaces();
+        let ifaces = netdev::interface::get_interfaces();
 
         let mut loopback = Vec::new();
         let mut regular4 = Vec::new();
@@ -91,11 +91,11 @@ impl LocalAddresses {
     }
 }
 
-pub(crate) const fn is_up(interface: &default_net::Interface) -> bool {
+pub(crate) const fn is_up(interface: &netdev::Interface) -> bool {
     interface.flags & IFF_UP != 0
 }
 
-pub(crate) const fn is_loopback(interface: &default_net::Interface) -> bool {
+pub(crate) const fn is_loopback(interface: &netdev::Interface) -> bool {
     interface.flags & IFF_LOOPBACK != 0
 }
 


### PR DESCRIPTION
## Description

- Upgrades from `default-net` v0.20 to `netdev` v0.25, which is simply a rebrand of the original default-net
- Allows depending on `system-configuration` version 0.6 instead of 0.5.1 downstream. This fixes iOS compliation for us.

## Breaking Changes

~~Would need to check if/how much the `default-net` types were exposed in the API.~~
@divagant-martian says this is what changes in the API:
> ```diff
> Changed items in the public API
> ===============================
> -pub iroh_net::net::interfaces::IpNet::V4(netdev::ip::Ipv4Net)
> +pub iroh_net::net::interfaces::IpNet::V4(default_net::ip::Ipv4Net)
> -pub iroh_net::net::interfaces::IpNet::V6(netdev::ip::Ipv6Net)
> +pub iroh_net::net::interfaces::IpNet::V6(default_net::ip::Ipv6Net)
> ```

## Notes & open questions

~~Not sure yet if it fixes our iOS problems.~~ It's required to fix our iOS build.
This should also make this crates.io patch obsolete: https://github.com/n0-computer/iroh-ffi/blob/524e5c0bab219291ddca6fa03f4038302eb4f27f/Cargo.toml#L62

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant. (no mention of `default_net` in docs)
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
