### PR TITLE
refactor(iroh-net)!: Make the interfaces module private

### DIFF
--- a/iroh-net/src/net.rs
+++ b/iroh-net/src/net.rs
@@ -1,6 +1,6 @@
 //! Networking related utilities
 
-pub mod interfaces;
+pub(crate) mod interfaces;
 pub mod ip;
 mod ip_family;
 pub mod netmon;

--- a/iroh-net/src/net/interfaces.rs
+++ b/iroh-net/src/net/interfaces.rs
@@ -16,9 +16,9 @@ mod linux;
 #[cfg(target_os = "windows")]
 mod windows;
 
-pub use netdev::ip::{Ipv4Net, Ipv6Net};
+pub(crate) use netdev::ip::{Ipv4Net, Ipv6Net};
 
-use crate::net::ip::{is_loopback, is_private_v6, is_up};
+use crate::net::ip::{is_private_v6, is_up};
 
 #[cfg(any(
     target_os = "freebsd",
@@ -35,7 +35,7 @@ use self::windows::default_route;
 
 /// Represents a network interface.
 #[derive(Debug)]
-pub struct Interface {
+pub(crate) struct Interface {
     iface: netdev::interface::Interface,
 }
 
@@ -62,23 +62,18 @@ impl PartialEq for Interface {
 impl Eq for Interface {}
 
 impl Interface {
-    /// Does this represent the loopback interface?
-    pub fn is_loopback(&self) -> bool {
-        is_loopback(&self.iface)
-    }
-
     /// Is this interface up?
-    pub fn is_up(&self) -> bool {
+    pub(crate) fn is_up(&self) -> bool {
         is_up(&self.iface)
     }
 
     /// The name of the interface.
-    pub fn name(&self) -> &str {
+    pub(crate) fn name(&self) -> &str {
         &self.iface.name
     }
 
     /// A list of all ip addresses of this interface.
-    pub fn addrs(&self) -> impl Iterator<Item = IpNet> + '_ {
+    pub(crate) fn addrs(&self) -> impl Iterator<Item = IpNet> + '_ {
         self.iface
             .ipv4
             .iter()
@@ -133,7 +128,7 @@ impl Interface {
 
 /// Structure of an IP network, either IPv4 or IPv6.
 #[derive(Clone, Debug)]
-pub enum IpNet {
+pub(crate) enum IpNet {
     /// Structure of IPv4 Network.
     V4(Ipv4Net),
     /// Structure of IPv6 Network.
@@ -168,33 +163,33 @@ impl IpNet {
 /// Intended to store the state of the machine's network interfaces, routing table, and
 /// other network configuration. For now it's pretty basic.
 #[derive(Debug, PartialEq, Eq)]
-pub struct State {
+pub(crate) struct State {
     /// Maps from an interface name interface.
-    pub interfaces: HashMap<String, Interface>,
+    pub(crate) interfaces: HashMap<String, Interface>,
 
     /// Whether this machine has an IPv6 Global or Unique Local Address
     /// which might provide connectivity.
-    pub have_v6: bool,
+    pub(crate) have_v6: bool,
 
     /// Whether the machine has some non-localhost, non-link-local IPv4 address.
-    pub have_v4: bool,
+    pub(crate) have_v4: bool,
 
     //// Whether the current network interface is considered "expensive", which currently means LTE/etc
     /// instead of Wifi. This field is not populated by `get_state`.
-    pub is_expensive: bool,
+    pub(crate) is_expensive: bool,
 
     /// The interface name for the machine's default route.
     ///
     /// It is not yet populated on all OSes.
     ///
     /// When set, its value is the map key into `interface` and `interface_ips`.
-    pub default_route_interface: Option<String>,
+    pub(crate) default_route_interface: Option<String>,
 
     /// The HTTP proxy to use, if any.
-    pub http_proxy: Option<String>,
+    pub(crate) http_proxy: Option<String>,
 
     /// The URL to the Proxy Autoconfig URL, if applicable.
-    pub pac: Option<String>,
+    pub(crate) pac: Option<String>,
 }
 
 impl fmt::Display for State {
@@ -283,38 +278,6 @@ impl State {
             pac: None,
         }
     }
-
-    /// Is a PAC set?
-    pub fn has_pac(&self) -> bool {
-        self.pac.is_some()
-    }
-
-    /// Reports whether any interface has the provided IP address.
-    pub fn has_ip(&self, ip: &IpAddr) -> bool {
-        for pv in self.interfaces.values() {
-            for p in pv.addrs() {
-                match (p, ip) {
-                    (IpNet::V4(a), IpAddr::V4(b)) => {
-                        if &a.addr == b {
-                            return true;
-                        }
-                    }
-                    (IpNet::V6(a), IpAddr::V6(b)) => {
-                        if &a.addr == b {
-                            return true;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-        false
-    }
-
-    /// Reports whether any interface seems like it has internet access.
-    pub fn any_interface_up(&self) -> bool {
-        self.have_v4 || self.have_v6
-    }
 }
 
 /// Reports whether ip is a usable IPv4 address which should have Internet connectivity.
@@ -386,7 +349,7 @@ pub async fn default_route_interface() -> Option<String> {
 /// Likely IPs of the residentla router, and the ip address of the current
 /// machine using it.
 #[derive(Debug, Clone)]
-pub struct HomeRouter {
+pub(crate) struct HomeRouter {
     /// Ip of the router.
     pub gateway: IpAddr,
     /// Our local Ip if known.
@@ -399,7 +362,7 @@ impl HomeRouter {
     /// In addition, it returns the IP address of the current machine on
     /// the LAN using that gateway.
     /// This is used as the destination for UPnP, NAT-PMP, PCP, etc queries.
-    pub fn new() -> Option<Self> {
+    pub(crate) fn new() -> Option<Self> {
         let gateway = Self::get_default_gateway()?;
         let my_ip = netdev::interface::get_local_ipaddr();
 


### PR DESCRIPTION
## Description

This is leaking 3rd party types into our public interface, since this
really only exists for our own use it probably shouldn't be public to
start with.  So make it private.  As a result cleans up some dead
code.

## Breaking Changes

The `iroh_net::net::interfaces` module has been made private.


## Notes & open questions

There is probably more in `iroh_net::net` that needs to be private.
Maybe even the whole module.  I'm not sure if doing this stepwise or
in one large chunk is better.  This takes the stepwise approach.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.