### PR TITLE
feat!: new quic-rpc, simlified generics, bump MSRV to 1.76

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
-  MSRV: "1.75"
+  MSRV: "1.76"
   SCCACHE_CACHE_SIZE: "50G"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
-  MSRV: "1.75"
+  MSRV: "1.76"
   SCCACHE_CACHE_SIZE: "50G"
   BIN_NAMES: "iroh,iroh-relay,iroh-dns-server"
   RELEASE_VERSION: ${{ github.event.inputs.release_version }}

--- a/.github/workflows/test_relay_server.yml
+++ b/.github/workflows/test_relay_server.yml
@@ -13,7 +13,7 @@ env:
     RUST_BACKTRACE: 1
     RUSTFLAGS: -Dwarnings
     RUSTDOCFLAGS: -Dwarnings
-    MSRV: "1.75"
+    MSRV: "1.76"
     SCCACHE_CACHE_SIZE: "50G"
     
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +812,12 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -1142,6 +1161,19 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2396,7 +2428,7 @@ dependencies = [
  "bao-tree",
  "bytes",
  "clap",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "flume",
  "futures-buffered",
  "futures-lite 2.3.0",
@@ -2445,7 +2477,7 @@ dependencies = [
  "anyhow",
  "crypto_box",
  "data-encoding",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "ed25519-dalek",
  "getrandom",
  "hex",
@@ -2489,7 +2521,7 @@ dependencies = [
  "bao-tree",
  "bytes",
  "chrono",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "flume",
  "futures-buffered",
  "futures-lite 2.3.0",
@@ -2542,7 +2574,7 @@ dependencies = [
  "comfy-table",
  "console",
  "crossterm",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "dialoguer",
  "dirs-next",
  "duct",
@@ -2593,7 +2625,7 @@ dependencies = [
  "base64-url",
  "bytes",
  "clap",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "dirs-next",
  "futures-lite 2.3.0",
  "governor",
@@ -2637,7 +2669,7 @@ version = "0.16.0"
 dependencies = [
  "anyhow",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "ed25519-dalek",
  "flume",
  "futures-util",
@@ -2675,7 +2707,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "ed25519-dalek",
  "futures-lite 2.3.0",
  "genawaiter",
@@ -2742,7 +2774,7 @@ dependencies = [
  "criterion",
  "crypto_box",
  "der",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "duct",
  "flume",
  "futures-buffered",
@@ -4012,15 +4044,17 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f365b77f07281f6dfc300eb5a9913185fa686e9119c787200ace337a53bdbf"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=main#105937087d2abf7dfa77b8b684f5f07932d05f9a"
 dependencies = [
  "bincode",
+ "blake3",
+ "derive_more 0.99.17",
  "educe",
  "flume",
  "futures-lite 2.3.0",
  "futures-sink",
  "futures-util",
+ "hex",
  "iroh-quinn",
  "pin-project",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "synstructure 0.13.1",
 ]
 
@@ -224,7 +224,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -235,7 +235,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -489,19 +489,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake3"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -699,7 +686,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -819,12 +806,6 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -1053,7 +1034,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1077,7 +1058,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1088,7 +1069,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1157,7 +1138,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1168,19 +1149,6 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1200,7 +1168,7 @@ checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "unicode-xid",
 ]
 
@@ -1283,7 +1251,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1428,7 +1396,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1441,7 +1409,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1461,7 +1429,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1716,7 +1684,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2450,7 +2418,7 @@ dependencies = [
  "bao-tree",
  "bytes",
  "clap",
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "flume",
  "futures-buffered",
  "futures-lite 2.3.0",
@@ -2499,7 +2467,7 @@ dependencies = [
  "anyhow",
  "crypto_box",
  "data-encoding",
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "ed25519-dalek",
  "getrandom",
  "hex",
@@ -2543,7 +2511,7 @@ dependencies = [
  "bao-tree",
  "bytes",
  "chrono",
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "flume",
  "futures-buffered",
  "futures-lite 2.3.0",
@@ -2596,7 +2564,7 @@ dependencies = [
  "comfy-table",
  "console",
  "crossterm",
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "dialoguer",
  "dirs-next",
  "duct",
@@ -2647,7 +2615,7 @@ dependencies = [
  "base64-url",
  "bytes",
  "clap",
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "dirs-next",
  "futures-lite 2.3.0",
  "governor",
@@ -2691,7 +2659,7 @@ version = "0.16.0"
 dependencies = [
  "anyhow",
  "bytes",
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "ed25519-dalek",
  "flume",
  "futures-util",
@@ -2729,7 +2697,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "ed25519-dalek",
  "futures-lite 2.3.0",
  "genawaiter",
@@ -2797,7 +2765,7 @@ dependencies = [
  "criterion",
  "crypto_box",
  "der",
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "duct",
  "flume",
  "futures-buffered",
@@ -2893,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b934380145fd5d53a583d01ae9500f4807efe6b0f0fe115c7be4afa2b35db99f"
+checksum = "906875956feb75d3d41d708ddaffeb11fdb10cd05f23efbcb17600037e411779"
 dependencies = [
  "bytes",
  "iroh-quinn-proto",
@@ -2910,13 +2878,13 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn-proto"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f2656b322c7f6cf3eb95e632d1c0f2fa546841915b0270da581f918c70c4be"
+checksum = "c6bf92478805e67f2320459285496e1137edf5171411001a0d4d85f9bbafb792"
 dependencies = [
  "bytes",
  "rand",
- "ring 0.16.20",
+ "ring 0.17.8",
  "rustc-hash",
  "rustls 0.21.12",
  "rustls-native-certs",
@@ -2928,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn-udp"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6679979a7271c24f9dae9622c0b4a543881508aa3a7396f55dfbaaa56f01c063"
+checksum = "edc7915b3a31f08ee0bc02f73f4d61a5d5be146a1081ef7f70622a11627fd314"
 dependencies = [
  "bytes",
  "libc",
@@ -3467,7 +3435,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3687,7 +3655,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3718,7 +3686,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3824,7 +3792,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4035,7 +4003,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4075,13 +4043,12 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3131faef53f1eae5d2f394b2ce6f130326245863f3f29b639dcc3f5616c88316"
+checksum = "f0d69b05325e19956f123fce85ebc4d99226552a0bb24bba4c886106297e708b"
 dependencies = [
  "bincode",
- "blake3",
- "derive_more 0.99.17",
+ "derive_more",
  "educe",
  "flume",
  "futures-lite 2.3.0",
@@ -4374,7 +4341,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4923,7 +4890,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5004,7 +4971,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5239,7 +5206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
 dependencies = [
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5286,7 +5253,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5304,7 +5271,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5315,7 +5282,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5346,7 +5313,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5359,7 +5326,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5421,9 +5388,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5473,7 +5440,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5559,7 +5526,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5593,7 +5560,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5691,7 +5658,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5926,7 +5893,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6189,7 +6156,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -6223,7 +6190,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6409,7 +6376,7 @@ checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6420,7 +6387,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6431,7 +6398,7 @@ checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6442,7 +6409,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6741,7 +6708,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,8 +4075,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.9.0"
-source = "git+https://github.com/n0-computer/quic-rpc.git?branch=main#105937087d2abf7dfa77b8b684f5f07932d05f9a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3131faef53f1eae5d2f394b2ce6f130326245863f3f29b639dcc3f5616c88316"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ missing_debug_implementations = "warn"
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,3 @@ missing_debug_implementations = "warn"
 
 [workspace.lints.clippy]
 unused-async = "warn"
-
-[patch.crates-io]
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "main" }

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["n0 team"]
 repository = "https://github.com/n0-computer/iroh"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.75"
+rust-version = "1.76"
 
 [lints]
 workspace = true

--- a/iroh-blobs/Cargo.toml
+++ b/iroh-blobs/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/n0-computer/iroh"
 keywords = ["hashing", "quic", "blake3"]
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.75"
+rust-version = "1.76"
 
 [lints]
 workspace = true

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -45,7 +45,7 @@ parking_lot = "0.12.1"
 pkarr = { version = "1.1.5", default-features = false }
 portable-atomic = "1"
 postcard = "1.0.8"
-quic-rpc = { version = "0.9.0", features = ["flume-transport", "quinn-transport"] }
+quic-rpc = { version = "0.10.0", features = ["flume-transport", "quinn-transport"] }
 rand = "0.8.5"
 ratatui = "0.26.2"
 reqwest = { version = "0.12.4", default-features = false, features = ["json", "rustls-tls"] }

--- a/iroh-docs/Cargo.toml
+++ b/iroh-docs/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["n0 team"]
 repository = "https://github.com/n0-computer/iroh"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.75"
+rust-version = "1.76"
 
 [lints]
 workspace = true

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["n0 team"]
 repository = "https://github.com/n0-computer/iroh"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.75"
+rust-version = "1.76"
 
 [lints]
 workspace = true

--- a/iroh-metrics/Cargo.toml
+++ b/iroh-metrics/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["arqu <asmir@n0.computer>", "n0 team"]
 repository = "https://github.com/n0-computer/iroh"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.75"
+rust-version = "1.76"
 
 [lints]
 workspace = true

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/n0-computer/iroh"
 keywords = ["quic", "networking", "holepunching", "p2p"]
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.75"
+rust-version = "1.76"
 
 [lints]
 workspace = true

--- a/iroh-test/Cargo.toml
+++ b/iroh-test/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/n0-computer/iroh"
 publish = true
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.75"
+rust-version = "1.76"
 
 [lints]
 workspace = true

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/n0-computer/iroh"
 keywords = ["networking", "p2p", "holepunching", "ipfs"]
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.75"
+rust-version = "1.76"
 
 [lints]
 workspace = true

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -37,7 +37,7 @@ iroh-docs = { version = "0.16.0", path = "../iroh-docs" }
 iroh-gossip = { version = "0.16.0", path = "../iroh-gossip" }
 parking_lot = "0.12.1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
-quic-rpc = { version = "0.9.0", default-features = false, features = ["flume-transport", "quinn-transport"] }
+quic-rpc = { version = "0.10.0", default-features = false, features = ["flume-transport", "quinn-transport"] }
 quinn = { package = "iroh-quinn", version = "0.10" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/iroh/src/client/mem.rs
+++ b/iroh/src/client/mem.rs
@@ -5,15 +5,15 @@
 
 use quic_rpc::transport::flume::FlumeConnection;
 
-use crate::rpc_protocol::{Request, Response, RpcService};
+use crate::rpc_protocol::RpcService;
 
 /// RPC client to an iroh node running in the same process.
-pub type RpcClient = quic_rpc::RpcClient<RpcService, FlumeConnection<Response, Request>>;
+pub type RpcClient = quic_rpc::RpcClient<RpcService, FlumeConnection<RpcService>>;
 
 /// In-memory client to an iroh node running in the same process.
 ///
 /// This is obtained from [`crate::node::Node::client`].
-pub type Iroh = super::Iroh<FlumeConnection<Response, Request>>;
+pub type Iroh = super::Iroh<FlumeConnection<RpcService>>;
 
 /// In-memory document client to an iroh node running in the same process.
-pub type Doc = super::docs::Doc<FlumeConnection<Response, Request>>;
+pub type Doc = super::docs::Doc<FlumeConnection<RpcService>>;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -25,8 +25,8 @@ use tokio_util::sync::CancellationToken;
 use tokio_util::task::LocalPoolHandle;
 use tracing::debug;
 
+use crate::client::RpcService;
 use crate::docs_engine::Engine;
-use crate::rpc_protocol::{Request, Response};
 
 mod builder;
 mod rpc;
@@ -90,7 +90,7 @@ struct NodeInner<D> {
     endpoint: Endpoint,
     secret_key: SecretKey,
     cancel_token: CancellationToken,
-    controller: FlumeConnection<Response, Request>,
+    controller: FlumeConnection<RpcService>,
     #[debug("callbacks: Sender<Box<dyn Fn(Event)>>")]
     cb_sender: mpsc::Sender<Box<dyn Fn(Event) -> BoxFuture<()> + Send + Sync + 'static>>,
     callbacks: Callbacks,

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -35,7 +35,7 @@ use crate::{
     client::RPC_ALPN,
     docs_engine::Engine,
     node::{Event, NodeInner},
-    rpc_protocol::{Request, Response, RpcService},
+    rpc_protocol::RpcService,
     util::{fs::load_secret_key, path::IrohPaths},
 };
 
@@ -246,7 +246,7 @@ where
     }
 
     /// Configure the default iroh rpc endpoint.
-    pub async fn enable_rpc(self) -> Result<Builder<D, QuinnServerEndpoint<Request, Response>>> {
+    pub async fn enable_rpc(self) -> Result<Builder<D, QuinnServerEndpoint<RpcService>>> {
         let (ep, actual_rpc_port) = make_rpc_endpoint(&self.secret_key, DEFAULT_RPC_PORT)?;
         if let StorageConfig::Persistent(ref root) = self.storage {
             // store rpc endpoint
@@ -737,7 +737,7 @@ const MAX_RPC_STREAMS: u32 = 1024;
 fn make_rpc_endpoint(
     secret_key: &SecretKey,
     rpc_port: u16,
-) -> Result<(QuinnServerEndpoint<Request, Response>, u16)> {
+) -> Result<(QuinnServerEndpoint<RpcService>, u16)> {
     let rpc_addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, rpc_port);
     let mut transport_config = quinn::TransportConfig::default();
     transport_config
@@ -772,7 +772,7 @@ fn make_rpc_endpoint(
     };
 
     let actual_rpc_port = rpc_quinn_endpoint.local_addr()?.port();
-    let rpc_endpoint = QuinnServerEndpoint::<Request, Response>::new(rpc_quinn_endpoint)?;
+    let rpc_endpoint = QuinnServerEndpoint::<RpcService>::new(rpc_quinn_endpoint)?;
 
     Ok((rpc_endpoint, actual_rpc_port))
 }


### PR DESCRIPTION
## Description

Adapts iroh for n0-computer/quic-rpc#76

Wit this change, a quic client is
`pub type QuicIroh = Iroh<QuinnConnection<RpcService>>`
instead of
`pub type QuicIroh = Iroh<QuinnConnection<ProviderRequest, ProviderResponse>>`

## Breaking Changes
* Increased mimimal supported rust version (MSRV) from 1.75 to 1.76
* The generics of the iroh clients changed: Instead of taking `ProviderRequest, ProviderResponse` as generics, they now take `RpcService`

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
