### PR TITLE
feat(iroh)!: remove node events

### DIFF
--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -2,8 +2,6 @@
 //!
 //! A node is a server that serves various protocols.
 //!
-//! You can monitor what is happening in the node using [`Node::subscribe`].
-//!
 //! To shut down the node, call [`Node::shutdown`].
 use std::fmt::Debug;
 use std::net::SocketAddr;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -262,24 +262,7 @@ mod tests {
 
         let _drop_guard = node.cancel_token().drop_guard();
 
-        /* let (r, mut s) = mpsc::channel(1);
-        node.subscribe(move |event| {
-            let r = r.clone();
-            async move {
-                if let Event::ByteProvide(iroh_blobs::provider::Event::TaggedBlobAdded {
-                    hash,
-                    ..
-                }) = event
-                {
-                    r.send(hash).await.ok();
-                }
-            }
-            .boxed()
-        })
-            .await?;
-        */
-
-        let got_hash = tokio::time::timeout(Duration::from_secs(1), async move {
+        let _got_hash = tokio::time::timeout(Duration::from_secs(1), async move {
             let mut stream = node
                 .controller()
                 .server_streaming(BlobAddPathRequest {
@@ -307,9 +290,6 @@ mod tests {
         .await
         .context("timeout")?
         .context("get failed")?;
-
-        /*let event_hash = s.recv().await.expect("missing add tagged blob event");
-        assert_eq!(got_hash, event_hash);*/
 
         Ok(())
     }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use futures_lite::{future::Boxed as BoxFuture, FutureExt, StreamExt};
+use futures_lite::StreamExt;
 use iroh_base::key::PublicKey;
 use iroh_blobs::downloader::Downloader;
 use iroh_blobs::store::Store as BaoStore;
@@ -19,7 +19,6 @@ use iroh_net::util::AbortingJoinHandle;
 use iroh_net::{endpoint::LocalEndpointsStream, key::SecretKey, Endpoint};
 use quic_rpc::transport::flume::FlumeConnection;
 use quic_rpc::RpcClient;
-use tokio::sync::{mpsc, RwLock};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::LocalPoolHandle;
@@ -34,38 +33,6 @@ mod rpc_status;
 
 pub use self::builder::{Builder, DiscoveryConfig, GcPolicy, StorageConfig};
 pub use self::rpc_status::RpcStatus;
-
-type EventCallback = Box<dyn Fn(Event) -> BoxFuture<()> + 'static + Sync + Send>;
-
-#[derive(Default, derive_more::Debug, Clone)]
-struct Callbacks(#[debug("..")] Arc<RwLock<Vec<EventCallback>>>);
-
-impl Callbacks {
-    async fn push(&self, cb: EventCallback) {
-        self.0.write().await.push(cb);
-    }
-
-    #[allow(dead_code)]
-    async fn send(&self, event: Event) {
-        let cbs = self.0.read().await;
-        for cb in &*cbs {
-            cb(event.clone()).await;
-        }
-    }
-}
-
-impl iroh_blobs::provider::EventSender for Callbacks {
-    fn send(&self, event: iroh_blobs::provider::Event) -> BoxFuture<()> {
-        let this = self.clone();
-        async move {
-            let cbs = this.0.read().await;
-            for cb in &*cbs {
-                cb(Event::ByteProvide(event.clone())).await;
-            }
-        }
-        .boxed()
-    }
-}
 
 /// A server which implements the iroh node.
 ///
@@ -91,24 +58,12 @@ struct NodeInner<D> {
     secret_key: SecretKey,
     cancel_token: CancellationToken,
     controller: FlumeConnection<Response, Request>,
-    #[debug("callbacks: Sender<Box<dyn Fn(Event)>>")]
-    cb_sender: mpsc::Sender<Box<dyn Fn(Event) -> BoxFuture<()> + Send + Sync + 'static>>,
-    callbacks: Callbacks,
     #[allow(dead_code)]
     gc_task: Option<AbortingJoinHandle<()>>,
     #[debug("rt")]
     rt: LocalPoolHandle,
     pub(crate) sync: Engine,
     downloader: Downloader,
-}
-
-/// Events emitted by the [`Node`] informing about the current status.
-#[derive(Debug, Clone)]
-pub enum Event {
-    /// Events from the iroh-blobs transfer protocol.
-    ByteProvide(iroh_blobs::provider::Event),
-    /// Events from database
-    Db(iroh_blobs::store::Event),
 }
 
 /// In memory node.
@@ -175,18 +130,6 @@ impl<D: BaoStore> Node<D> {
     /// Returns the [`PublicKey`] of the node.
     pub fn node_id(&self) -> PublicKey {
         self.inner.secret_key.public()
-    }
-
-    /// Subscribe to [`Event`]s emitted from the node, informing about connections and
-    /// progress.
-    ///
-    /// Warning: The callback must complete quickly, as otherwise it will block ongoing work.
-    pub async fn subscribe<F: Fn(Event) -> BoxFuture<()> + Send + Sync + 'static>(
-        &self,
-        cb: F,
-    ) -> Result<()> {
-        self.inner.cb_sender.send(Box::new(cb)).await?;
-        Ok(())
     }
 
     /// Returns a handle that can be used to do RPC calls to the node internally.
@@ -319,7 +262,7 @@ mod tests {
 
         let _drop_guard = node.cancel_token().drop_guard();
 
-        let (r, mut s) = mpsc::channel(1);
+        /* let (r, mut s) = mpsc::channel(1);
         node.subscribe(move |event| {
             let r = r.clone();
             async move {
@@ -333,7 +276,8 @@ mod tests {
             }
             .boxed()
         })
-        .await?;
+            .await?;
+        */
 
         let got_hash = tokio::time::timeout(Duration::from_secs(1), async move {
             let mut stream = node
@@ -364,8 +308,8 @@ mod tests {
         .context("timeout")?
         .context("get failed")?;
 
-        let event_hash = s.recv().await.expect("missing add tagged blob event");
-        assert_eq!(got_hash, event_hash);
+        /*let event_hash = s.recv().await.expect("missing add tagged blob event");
+        assert_eq!(got_hash, event_hash);*/
 
         Ok(())
     }

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -88,7 +88,6 @@ where
     #[cfg(any(test, feature = "test-utils"))]
     insecure_skip_relay_cert_verify: bool,
     /// Callback to register when a gc loop is done
-    #[cfg(any(test, feature = "test-utils"))]
     #[debug("callback")]
     gc_done_callback: Option<Box<dyn Fn() + Send>>,
 }
@@ -138,7 +137,6 @@ impl Default for Builder<iroh_blobs::store::mem::Store> {
             node_discovery: Default::default(),
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
-            #[cfg(any(test, feature = "test-utils"))]
             gc_done_callback: None,
         }
     }
@@ -165,7 +163,6 @@ impl<D: Map> Builder<D> {
             node_discovery: Default::default(),
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
-            #[cfg(any(test, feature = "test-utils"))]
             gc_done_callback: None,
         }
     }
@@ -229,7 +226,6 @@ where
             node_discovery: self.node_discovery,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
-            #[cfg(any(test, feature = "test-utils"))]
             gc_done_callback: self.gc_done_callback,
         })
     }
@@ -251,7 +247,6 @@ where
             node_discovery: self.node_discovery,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
-            #[cfg(any(test, feature = "test-utils"))]
             gc_done_callback: self.gc_done_callback,
         }
     }
@@ -278,7 +273,6 @@ where
             node_discovery: self.node_discovery,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
-            #[cfg(any(test, feature = "test-utils"))]
             gc_done_callback: self.gc_done_callback,
         })
     }
@@ -449,10 +443,7 @@ where
         let gc_task = if let GcPolicy::Interval(gc_period) = self.gc_policy {
             tracing::info!("Starting GC task with interval {:?}", gc_period);
             let db = self.blobs_store.clone();
-            #[cfg(any(test, feature = "test-utils"))]
             let gc_done_callback = self.gc_done_callback.take();
-            #[cfg(not(any(test, feature = "test-utils")))]
-            let gc_done_callback = None;
 
             let task =
                 lp.spawn_pinned(move || Self::gc_loop(db, sync_db, gc_period, gc_done_callback));

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -631,7 +631,7 @@ where
             let doc_hashes = match ds.content_hashes().await {
                 Ok(hashes) => hashes,
                 Err(err) => {
-                    tracing::error!("Error getting doc hashes: {}", err);
+                    tracing::warn!("Error getting doc hashes: {}", err);
                     continue 'outer;
                 }
             };

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -52,7 +52,7 @@ use crate::rpc_protocol::{
     NodeWatchResponse, Request, RpcService, SetTagOption,
 };
 
-use super::{Event, NodeInner};
+use super::NodeInner;
 
 const HEALTH_POLL_WAIT: Duration = Duration::from_secs(1);
 /// Chunk size for getting blobs over RPC
@@ -761,13 +761,6 @@ impl<D: BaoStore> Handler<D> {
                 tag: tag.clone(),
             })
             .await?;
-        self.inner
-            .callbacks
-            .send(Event::ByteProvide(
-                iroh_blobs::provider::Event::TaggedBlobAdded { hash, format, tag },
-            ))
-            .await;
-
         Ok(())
     }
 

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -6,7 +6,6 @@ use std::{
 use anyhow::Result;
 use bao_tree::{blake3, io::sync::Outboard, ChunkRanges};
 use bytes::Bytes;
-use futures_lite::FutureExt;
 use iroh::node::{self, Node};
 use rand::RngCore;
 
@@ -38,54 +37,39 @@ pub fn simulate_remote(data: &[u8]) -> (blake3::Hash, Cursor<Bytes>) {
 }
 
 /// Wrap a bao store in a node that has gc enabled.
-async fn wrap_in_node<S>(bao_store: S, gc_period: Duration) -> Node<S>
+async fn wrap_in_node<S>(bao_store: S, gc_period: Duration) -> (Node<S>, flume::Receiver<()>)
 where
     S: iroh_blobs::store::Store,
 {
     let doc_store = iroh_docs::store::Store::memory();
-    node::Builder::with_db_and_store(bao_store, doc_store, iroh::node::StorageConfig::Mem)
-        .gc_policy(iroh::node::GcPolicy::Interval(gc_period))
-        .spawn()
-        .await
-        .unwrap()
-}
-
-async fn attach_db_events<D: iroh_blobs::store::Store>(
-    node: &Node<D>,
-) -> flume::Receiver<iroh_blobs::store::Event> {
-    let (db_send, db_recv) = flume::unbounded();
-    /*node.subscribe(move |ev| {
-        let db_send = db_send.clone();
-        async move {
-            if let iroh::node::Event::Db(ev) = ev {
-                db_send.into_send_async(ev).await.ok();
-            }
-        }
-        .boxed()
-    })
-    .await
-    .unwrap();*/
-    db_recv
+    let (gc_send, gc_recv) = flume::unbounded();
+    let node =
+        node::Builder::with_db_and_store(bao_store, doc_store, iroh::node::StorageConfig::Mem)
+            .gc_policy(iroh::node::GcPolicy::Interval(gc_period))
+            .register_gc_done_cb(Box::new(move || {
+                gc_send.send(()).ok();
+            }))
+            .spawn()
+            .await
+            .unwrap();
+    (node, gc_recv)
 }
 
 async fn gc_test_node() -> (
     Node<iroh_blobs::store::mem::Store>,
     iroh_blobs::store::mem::Store,
-    flume::Receiver<iroh_blobs::store::Event>,
+    flume::Receiver<()>,
 ) {
     let bao_store = iroh_blobs::store::mem::Store::new();
-    let node = wrap_in_node(bao_store.clone(), Duration::from_millis(500)).await;
-    let db_recv = attach_db_events(&node).await;
-    (node, bao_store, db_recv)
+    let (node, gc_recv) = wrap_in_node(bao_store.clone(), Duration::from_millis(500)).await;
+    (node, bao_store, gc_recv)
 }
 
-async fn step(evs: &flume::Receiver<iroh_blobs::store::Event>) {
+async fn step(evs: &flume::Receiver<()>) {
     while evs.try_recv().is_ok() {}
     for _ in 0..3 {
-        while let Ok(ev) = evs.recv_async().await {
-            /*if let iroh_blobs::store::Event::GcCompleted = ev {
-                break;
-            }*/
+        if let Ok(()) = evs.recv_async().await {
+            break;
         }
     }
 }
@@ -246,7 +230,7 @@ mod file {
         let _ = tracing_subscriber::fmt::try_init();
         let dir = testdir!();
         let bao_store = iroh_blobs::store::fs::Store::load(dir.join("store")).await?;
-        let node = wrap_in_node(bao_store.clone(), Duration::from_secs(10)).await;
+        let (node, _) = wrap_in_node(bao_store.clone(), Duration::from_secs(10)).await;
         let client = node.client();
         let doc = client.docs.create().await?;
         let author = client.authors.create().await?;
@@ -289,8 +273,7 @@ mod file {
         let outboard_path = outboard_path(dir.clone());
 
         let bao_store = iroh_blobs::store::fs::Store::load(dir.clone()).await?;
-        let node = wrap_in_node(bao_store.clone(), Duration::from_millis(100)).await;
-        let evs = attach_db_events(&node).await;
+        let (node, evs) = wrap_in_node(bao_store.clone(), Duration::from_millis(100)).await;
         let data1 = create_test_data(10000000);
         let tt1 = bao_store
             .import_bytes(data1.clone(), BlobFormat::Raw)
@@ -452,8 +435,7 @@ mod file {
         let outboard_path = outboard_path(dir.clone());
 
         let bao_store = iroh_blobs::store::fs::Store::load(dir.clone()).await?;
-        let node = wrap_in_node(bao_store.clone(), Duration::from_millis(10)).await;
-        let evs = attach_db_events(&node).await;
+        let (node, evs) = wrap_in_node(bao_store.clone(), Duration::from_millis(10)).await;
 
         let data1: Bytes = create_test_data(10000000);
         let (_entry, tt1) = simulate_download_partial(&bao_store, data1.clone()).await?;
@@ -484,8 +466,7 @@ mod file {
         let dir = testdir!();
 
         let bao_store = iroh_blobs::store::fs::Store::load(dir.clone()).await?;
-        let node = wrap_in_node(bao_store.clone(), Duration::from_secs(1)).await;
-        let evs = attach_db_events(&node).await;
+        let (node, evs) = wrap_in_node(bao_store.clone(), Duration::from_secs(1)).await;
 
         let mut deleted = Vec::new();
         let mut live = Vec::new();

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -66,7 +66,12 @@ async fn gc_test_node() -> (
 }
 
 async fn step(evs: &flume::Receiver<()>) {
-    evs.recv_async().await.unwrap();
+    // drain the event queue, we want a new GC
+    while evs.try_recv().is_ok() {}
+    // wait for several GC cycles
+    for _ in 0..3 {
+        evs.recv_async().await.unwrap();
+    }
 }
 
 /// Test the absolute basics of gc, temp tags and tags for blobs.

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -54,7 +54,7 @@ async fn attach_db_events<D: iroh_blobs::store::Store>(
     node: &Node<D>,
 ) -> flume::Receiver<iroh_blobs::store::Event> {
     let (db_send, db_recv) = flume::unbounded();
-    node.subscribe(move |ev| {
+    /*node.subscribe(move |ev| {
         let db_send = db_send.clone();
         async move {
             if let iroh::node::Event::Db(ev) = ev {
@@ -64,7 +64,7 @@ async fn attach_db_events<D: iroh_blobs::store::Store>(
         .boxed()
     })
     .await
-    .unwrap();
+    .unwrap();*/
     db_recv
 }
 
@@ -83,9 +83,9 @@ async fn step(evs: &flume::Receiver<iroh_blobs::store::Event>) {
     while evs.try_recv().is_ok() {}
     for _ in 0..3 {
         while let Ok(ev) = evs.recv_async().await {
-            if let iroh_blobs::store::Event::GcCompleted = ev {
+            /*if let iroh_blobs::store::Event::GcCompleted = ev {
                 break;
-            }
+            }*/
         }
     }
 }

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -66,12 +66,7 @@ async fn gc_test_node() -> (
 }
 
 async fn step(evs: &flume::Receiver<()>) {
-    while evs.try_recv().is_ok() {}
-    for _ in 0..3 {
-        if let Ok(()) = evs.recv_async().await {
-            break;
-        }
-    }
+    evs.recv_async().await.unwrap();
 }
 
 /// Test the absolute basics of gc, temp tags and tags for blobs.

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use futures_lite::FutureExt;
-use iroh::node::{Builder, Event};
+use iroh::node::Builder;
 use iroh_base::node_addr::AddrInfoOptions;
 use iroh_net::{defaults::default_relay_map, key::SecretKey, NodeAddr, NodeId};
 use quic_rpc::transport::misc::DummyServerEndpoint;
@@ -225,7 +225,7 @@ where
 
     let node = test_node(mdb.clone()).spawn().await?;
 
-    let (events_sender, mut events_recv) = mpsc::unbounded_channel();
+    /*let (events_sender, mut events_recv) = mpsc::unbounded_channel();
 
     node.subscribe(move |event| {
         let events_sender = events_sender.clone();
@@ -234,7 +234,7 @@ where
         }
         .boxed()
     })
-    .await?;
+    .await?;*/
 
     let addrs = node.local_endpoint_addresses().await?;
     let (secret_key, peer) = get_options(node.node_id(), addrs);
@@ -252,7 +252,7 @@ where
     }
 
     // We have to wait for the completed event before shutting down the node.
-    let events = tokio::time::timeout(Duration::from_secs(30), async move {
+    /*let events = tokio::time::timeout(Duration::from_secs(30), async move {
         let mut events = Vec::new();
         while let Some(event) = events_recv.recv().await {
             match event {
@@ -267,16 +267,16 @@ where
         events
     })
     .await
-    .expect("duration expired");
+    .expect("duration expired");*/
 
     node.shutdown().await?;
 
-    assert_events(events, num_blobs + 1);
+    // assert_events(events, num_blobs + 1);
 
     Ok(())
 }
 
-fn assert_events(events: Vec<Event>, num_blobs: usize) {
+/*fn assert_events(events: Vec<Event>, num_blobs: usize) {
     let num_basic_events = 4;
     let num_total_events = num_basic_events + num_blobs;
     assert_eq!(
@@ -309,7 +309,7 @@ fn assert_events(events: Vec<Event>, num_blobs: usize) {
         events.last().unwrap(),
         Event::ByteProvide(provider::Event::TransferCompleted { .. })
     ));
-}
+}*/
 
 #[tokio::test]
 async fn test_server_close() {
@@ -323,7 +323,7 @@ async fn test_server_close() {
     let node_addr = node.local_endpoint_addresses().await.unwrap();
     let peer_id = node.node_id();
 
-    let (events_sender, mut events_recv) = mpsc::unbounded_channel();
+    /*let (events_sender, mut events_recv) = mpsc::unbounded_channel();
     node.subscribe(move |event| {
         let events_sender = events_sender.clone();
         async move {
@@ -332,7 +332,8 @@ async fn test_server_close() {
         .boxed()
     })
     .await
-    .unwrap();
+        .unwrap();
+    */
     let (secret_key, peer) = get_options(peer_id, node_addr);
     let request = GetRequest::all(hash);
     let (_collection, _children, _stats) = run_collection_get_request(secret_key, peer, request)
@@ -340,7 +341,7 @@ async fn test_server_close() {
         .unwrap();
 
     // Unwrap the JoinHandle, then the result of the Provider
-    tokio::time::timeout(Duration::from_secs(10), async move {
+    /*tokio::time::timeout(Duration::from_secs(10), async move {
         loop {
             tokio::select! {
                 biased;
@@ -363,7 +364,7 @@ async fn test_server_close() {
     })
     .await
     .expect("supervisor timeout")
-    .expect("supervisor failed");
+    .expect("supervisor failed");*/
 }
 
 /// create an in memory test database containing the given entries and an iroh collection of all entries

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use bytes::Bytes;
 use futures_lite::FutureExt;
 use iroh::node::Builder;
@@ -13,7 +13,6 @@ use iroh_base::node_addr::AddrInfoOptions;
 use iroh_net::{defaults::default_relay_map, key::SecretKey, NodeAddr, NodeId};
 use quic_rpc::transport::misc::DummyServerEndpoint;
 use rand::RngCore;
-use tokio::sync::mpsc;
 
 use bao_tree::{blake3, ChunkNum, ChunkRanges};
 use iroh_blobs::{
@@ -24,7 +23,6 @@ use iroh_blobs::{
         Stats,
     },
     protocol::{GetRequest, RangeSpecSeq},
-    provider,
     store::{MapMut, Store},
     BlobFormat, Hash,
 };

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -225,17 +225,6 @@ where
 
     let node = test_node(mdb.clone()).spawn().await?;
 
-    /*let (events_sender, mut events_recv) = mpsc::unbounded_channel();
-
-    node.subscribe(move |event| {
-        let events_sender = events_sender.clone();
-        async move {
-            events_sender.send(event).ok();
-        }
-        .boxed()
-    })
-    .await?;*/
-
     let addrs = node.local_endpoint_addresses().await?;
     let (secret_key, peer) = get_options(node.node_id(), addrs);
     let request = GetRequest::all(collection_hash);
@@ -251,65 +240,10 @@ where
         assert_eq!(expected, got);
     }
 
-    // We have to wait for the completed event before shutting down the node.
-    /*let events = tokio::time::timeout(Duration::from_secs(30), async move {
-        let mut events = Vec::new();
-        while let Some(event) = events_recv.recv().await {
-            match event {
-                Event::ByteProvide(provider::Event::TransferCompleted { .. })
-                | Event::ByteProvide(provider::Event::TransferAborted { .. }) => {
-                    events.push(event);
-                    break;
-                }
-                _ => events.push(event),
-            }
-        }
-        events
-    })
-    .await
-    .expect("duration expired");*/
-
     node.shutdown().await?;
-
-    // assert_events(events, num_blobs + 1);
 
     Ok(())
 }
-
-/*fn assert_events(events: Vec<Event>, num_blobs: usize) {
-    let num_basic_events = 4;
-    let num_total_events = num_basic_events + num_blobs;
-    assert_eq!(
-        events.len(),
-        num_total_events,
-        "missing events, only got {:#?}",
-        events
-    );
-    assert!(matches!(
-        events[0],
-        Event::ByteProvide(provider::Event::ClientConnected { .. })
-    ));
-    assert!(matches!(
-        events[1],
-        Event::ByteProvide(provider::Event::GetRequestReceived { .. })
-    ));
-    assert!(matches!(
-        events[2],
-        Event::ByteProvide(provider::Event::TransferHashSeqStarted { .. })
-    ));
-    for (i, event) in events[3..num_total_events - 1].iter().enumerate() {
-        match event {
-            Event::ByteProvide(provider::Event::TransferBlobCompleted { index, .. }) => {
-                assert_eq!(*index, i as u64);
-            }
-            _ => panic!("unexpected event {:?}", event),
-        }
-    }
-    assert!(matches!(
-        events.last().unwrap(),
-        Event::ByteProvide(provider::Event::TransferCompleted { .. })
-    ));
-}*/
 
 #[tokio::test]
 async fn test_server_close() {
@@ -323,48 +257,11 @@ async fn test_server_close() {
     let node_addr = node.local_endpoint_addresses().await.unwrap();
     let peer_id = node.node_id();
 
-    /*let (events_sender, mut events_recv) = mpsc::unbounded_channel();
-    node.subscribe(move |event| {
-        let events_sender = events_sender.clone();
-        async move {
-            events_sender.send(event).ok();
-        }
-        .boxed()
-    })
-    .await
-        .unwrap();
-    */
     let (secret_key, peer) = get_options(peer_id, node_addr);
     let request = GetRequest::all(hash);
     let (_collection, _children, _stats) = run_collection_get_request(secret_key, peer, request)
         .await
         .unwrap();
-
-    // Unwrap the JoinHandle, then the result of the Provider
-    /*tokio::time::timeout(Duration::from_secs(10), async move {
-        loop {
-            tokio::select! {
-                biased;
-                maybe_event = events_recv.recv() => {
-                    match maybe_event {
-                        Some(event) => match event {
-                            Event::ByteProvide(provider::Event::TransferCompleted { .. }) => {
-                                return node.shutdown().await;
-                            },
-                            Event::ByteProvide(provider::Event::TransferAborted { .. }) => {
-                                break Err(anyhow!("transfer aborted"));
-                            }
-                            _ => (),
-                        }
-                        None => break Err(anyhow!("events ended")),
-                    }
-                }
-            }
-        }
-    })
-    .await
-    .expect("supervisor timeout")
-    .expect("supervisor failed");*/
 }
 
 /// create an in memory test database containing the given entries and an iroh collection of all entries


### PR DESCRIPTION
These seem to be mostly unused by consumers, and add complexity.

## Breaking Changes

- remove:
  -  `iroh::node::Event`
  - `iroh::node::Node::subscribe`

## Notes

- [x] Still need to figure out how to migrate the tests
