### PR TITLE
feat(iroh-net): small improvements to dns behaviour

### DIFF
--- a/iroh-net/src/dns.rs
+++ b/iroh-net/src/dns.rs
@@ -69,7 +69,7 @@ fn create_default_resolver() -> Result<TokioAsyncResolver> {
 
     // ensure multiple name servers are queried concurrently
     options.num_concurrent_reqs = 3;
-    options.timeout = std::time::Duration::from_millis(450);
+    options.timeout = std::time::Duration::from_millis(4500);
 
     // see [`lookup_ipv4_ipv6`] for info on why we avoid LookupIpStrategy::Ipv4AndIpv6
     options.ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv4thenIpv6;

--- a/iroh-net/src/dns.rs
+++ b/iroh-net/src/dns.rs
@@ -68,7 +68,7 @@ fn create_default_resolver() -> Result<TokioAsyncResolver> {
     }
 
     // lookup IPv4 and IPv6 in parallel
-    options.ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv4thenIpv6;
+    options.ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv4AndIpv6;
 
     let resolver = AsyncResolver::tokio(config, options);
     Ok(resolver)

--- a/iroh-net/src/dns.rs
+++ b/iroh-net/src/dns.rs
@@ -67,8 +67,12 @@ fn create_default_resolver() -> Result<TokioAsyncResolver> {
         }
     }
 
-    // lookup IPv4 and IPv6 in parallel
-    options.ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv4AndIpv6;
+    // ensure multiple name servers are queried concurrently
+    options.num_concurrent_reqs = 3;
+    options.timeout = std::time::Duration::from_millis(450);
+
+    // see [`lookup_ipv4_ipv6`] for info on why we avoid LookupIpStrategy::Ipv4AndIpv6
+    options.ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv4thenIpv6;
 
     let resolver = AsyncResolver::tokio(config, options);
     Ok(resolver)


### PR DESCRIPTION
## Description

Closes #2277

- According to the issue, we do sequencial queries with a relatively high
  timeout. However, from a quick check of hickory's docs, the default is a
  number of concurrent requests of 2. In summary, this was never actually an
  issue. To ensure we keep this behaviour even if the default changes, set the
  number of concurrent requests to 3.. just to gives us more room. 
- It also reduces the timeout for lookups to make it smaller than netcheck's.
- Change confusing comment that stated we configure Ipv4 AND Ipv6 when we
  actually avoid it.

## Breaking Changes

n/a

## Notes & open questions

From reading hickory's code and adding there some dirty log statements, this is
(and was) working as intended.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] ~Tests if relevant.~
- [ ] ~All breaking changes documented.~
