### PR TITLE
feat(iroh-net): watch relay changes

### DIFF
--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use derive_more::Debug;
-use futures_lite::StreamExt;
+use futures_lite::{Stream, StreamExt};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 use tracing::{debug, info_span, trace, warn};
 
@@ -399,6 +399,14 @@ impl Endpoint {
         let relay = self.my_relay();
         let addrs = eps.into_iter().map(|x| x.addr).collect();
         Ok(NodeAddr::from_parts(self.node_id(), relay, addrs))
+    }
+
+    /// Watch for changes to the home relay.
+    ///
+    /// Note that this can be used to wait for the initial home relay to be known. If the home
+    /// relay is known at this point, it will be the first item in the stream.
+    pub async fn watch_home_relay(&self) -> impl Stream<Item = RelayUrl> {
+        self.msock.watch_home_relay()
     }
 
     /// Get information on all the nodes we have connection information about.

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -405,7 +405,7 @@ impl Endpoint {
     ///
     /// Note that this can be used to wait for the initial home relay to be known. If the home
     /// relay is known at this point, it will be the first item in the stream.
-    pub async fn watch_home_relay(&self) -> impl Stream<Item = RelayUrl> {
+    pub fn watch_home_relay(&self) -> impl Stream<Item = RelayUrl> {
         self.msock.watch_home_relay()
     }
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -3334,9 +3334,11 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_watch_home_relay() {
-        let mut ops = Options::default();
         // use an empty relay map to get full control of the changes during the test
-        ops.relay_map = RelayMap::empty();
+        let ops = Options {
+            relay_map: RelayMap::empty(),
+            ..Default::default()
+        };
         let msock = MagicSock::spawn(ops).await.unwrap();
         let mut relay_stream = msock.watch_home_relay();
 


### PR DESCRIPTION
## Description

Closes #2162

Adds `watch_home_relay`, which reports the current home relay and any seen change.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [ ] ~All breaking changes documented.~
