### PR TITLE
feat: node-wide default author for documents

### DIFF
--- a/iroh/src/client/authors.rs
+++ b/iroh/src/client/authors.rs
@@ -6,8 +6,8 @@ use iroh_docs::{Author, AuthorId};
 use quic_rpc::{RpcClient, ServiceConnection};
 
 use crate::rpc_protocol::{
-    AuthorCreateRequest, AuthorDeleteRequest, AuthorExportRequest, AuthorImportRequest,
-    AuthorListRequest, RpcService,
+    AuthorCreateRequest, AuthorDefaultRequest, AuthorDeleteRequest, AuthorExportRequest,
+    AuthorImportRequest, AuthorListRequest, RpcService,
 };
 
 use super::flatten;
@@ -25,6 +25,12 @@ where
     /// Create a new document author.
     pub async fn create(&self) -> Result<AuthorId> {
         let res = self.rpc.rpc(AuthorCreateRequest).await??;
+        Ok(res.author_id)
+    }
+
+    /// Get the default document author of this node.
+    pub async fn default(&self) -> Result<AuthorId> {
+        let res = self.rpc.rpc(AuthorDefaultRequest).await?;
         Ok(res.author_id)
     }
 
@@ -53,6 +59,8 @@ where
     /// Deletes the given author by id.
     ///
     /// Warning: This permanently removes this author.
+    ///
+    /// Deleting the default author is not supported.
     pub async fn delete(&self, author: AuthorId) -> Result<()> {
         self.rpc.rpc(AuthorDeleteRequest { author }).await??;
         Ok(())

--- a/iroh/src/docs_engine.rs
+++ b/iroh/src/docs_engine.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
 use iroh_blobs::downloader::Downloader;
 use iroh_blobs::{store::EntryStatus, Hash};
+use iroh_docs::AuthorId;
 use iroh_docs::{actor::SyncHandle, ContentStatus, ContentStatusCallback, Entry, NamespaceId};
 use iroh_gossip::net::Gossip;
 use iroh_net::util::SharedAbortingJoinHandle;
@@ -46,6 +47,7 @@ pub struct Engine {
     actor_handle: SharedAbortingJoinHandle<()>,
     #[debug("ContentStatusCallback")]
     content_status_cb: ContentStatusCallback,
+    default_author: AuthorId,
 }
 
 impl Engine {
@@ -59,6 +61,7 @@ impl Engine {
         replica_store: iroh_docs::store::Store,
         bao_store: B,
         downloader: Downloader,
+        default_author: AuthorId,
     ) -> Self {
         let (live_actor_tx, to_live_actor_recv) = mpsc::channel(ACTOR_CHANNEL_CAP);
         let (to_gossip_actor, to_gossip_actor_recv) = mpsc::channel(ACTOR_CHANNEL_CAP);
@@ -101,6 +104,7 @@ impl Engine {
             to_live_actor: live_actor_tx,
             actor_handle: actor_handle.into(),
             content_status_cb,
+            default_author,
         }
     }
 

--- a/iroh/src/docs_engine/rpc.rs
+++ b/iroh/src/docs_engine/rpc.rs
@@ -8,8 +8,9 @@ use tokio_stream::StreamExt;
 
 use crate::client::docs::ShareMode;
 use crate::rpc_protocol::{
-    AuthorDeleteRequest, AuthorDeleteResponse, AuthorExportRequest, AuthorExportResponse,
-    AuthorImportRequest, AuthorImportResponse, DocGetSyncPeersRequest, DocGetSyncPeersResponse,
+    AuthorDefaultRequest, AuthorDefaultResponse, AuthorDeleteRequest, AuthorDeleteResponse,
+    AuthorExportRequest, AuthorExportResponse, AuthorImportRequest, AuthorImportResponse,
+    DocGetSyncPeersRequest, DocGetSyncPeersResponse,
 };
 use crate::{
     docs_engine::Engine,
@@ -44,6 +45,12 @@ impl Engine {
         })
     }
 
+    pub fn author_default(&self, _req: AuthorDefaultRequest) -> AuthorDefaultResponse {
+        AuthorDefaultResponse {
+            author_id: self.default_author,
+        }
+    }
+
     pub fn author_list(
         &self,
         _req: AuthorListRequest,
@@ -76,6 +83,9 @@ impl Engine {
     }
 
     pub async fn author_delete(&self, req: AuthorDeleteRequest) -> RpcResult<AuthorDeleteResponse> {
+        if req.author == self.default_author {
+            return Err(anyhow!("Deleting the default author is not supported").into());
+        }
         self.sync.delete_author(req.author).await?;
         Ok(AuthorDeleteResponse)
     }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -465,4 +465,74 @@ mod tests {
         );
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_default_author_memory() -> Result<()> {
+        let iroh = Node::memory().spawn().await?;
+        let author = iroh.authors.default().await?;
+        assert!(iroh.authors.export(author).await?.is_some());
+        assert!(iroh.authors.delete(author).await.is_err());
+        Ok(())
+    }
+
+    #[cfg(feature = "fs-store")]
+    #[tokio::test]
+    async fn test_default_author_persist() -> Result<()> {
+        use crate::util::path::IrohPaths;
+
+        let _guard = iroh_test::logging::setup();
+
+        let iroh_root_dir = tempfile::TempDir::new()?;
+        let iroh_root = iroh_root_dir.path();
+
+        // check that the default author exists and cannot be deleted.
+        let default_author = {
+            let iroh = Node::persistent(iroh_root).await?.spawn().await?;
+            let author = iroh.authors.default().await?;
+            assert!(iroh.authors.export(author).await?.is_some());
+            assert!(iroh.authors.delete(author).await.is_err());
+            iroh.shutdown().await?;
+            author
+        };
+
+        // check that the default author is persisted across restarts.
+        {
+            let iroh = Node::persistent(iroh_root).await?.spawn().await?;
+            let author = iroh.authors.default().await?;
+            assert_eq!(author, default_author);
+            assert!(iroh.authors.export(author).await?.is_some());
+            assert!(iroh.authors.delete(author).await.is_err());
+            iroh.shutdown().await?;
+        };
+
+        // check that a new default author is created if the default author file is deleted
+        // manually.
+        let default_author = {
+            tokio::fs::remove_file(IrohPaths::DefaultAuthor.with_root(&iroh_root)).await?;
+            let iroh = Node::persistent(iroh_root).await?.spawn().await?;
+            let author = iroh.authors.default().await?;
+            assert!(author != default_author);
+            assert!(iroh.authors.export(author).await?.is_some());
+            assert!(iroh.authors.delete(author).await.is_err());
+            iroh.shutdown().await?;
+            author
+        };
+
+        // check that the node fails to start if the default author is missing from the docs store.
+        {
+            let mut docs_store = iroh_docs::store::fs::Store::persistent(
+                IrohPaths::DocsDatabase.with_root(&iroh_root),
+            )?;
+            docs_store.delete_author(default_author)?;
+            docs_store.flush()?;
+            drop(docs_store);
+            let iroh = Node::persistent(iroh_root).await?.spawn().await;
+            assert!(iroh.is_err());
+            tokio::fs::remove_file(IrohPaths::DefaultAuthor.with_root(&iroh_root)).await?;
+            let iroh = Node::persistent(iroh_root).await?.spawn().await;
+            assert!(iroh.is_ok());
+        }
+
+        Ok(())
+    }
 }

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -161,6 +161,12 @@ impl<D: BaoStore> Handler<D> {
                     })
                     .await
                 }
+                AuthorDefault(msg) => {
+                    chan.rpc(msg, handler, |handler, req| async move {
+                        handler.inner.sync.author_default(req)
+                    })
+                    .await
+                }
                 DocOpen(msg) => {
                     chan.rpc(msg, handler, |handler, req| async move {
                         handler.inner.sync.doc_open(req).await

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -437,6 +437,21 @@ pub struct AuthorCreateResponse {
     pub author_id: AuthorId,
 }
 
+/// Get the default author.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AuthorDefaultRequest;
+
+impl RpcMsg<RpcService> for AuthorDefaultRequest {
+    type Response = AuthorDefaultResponse;
+}
+
+/// Response for [`AuthorDefaultRequest`]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AuthorDefaultResponse {
+    /// The id of the author
+    pub author_id: AuthorId,
+}
+
 /// Delete an author
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AuthorDeleteRequest {
@@ -1066,6 +1081,7 @@ pub enum Request {
 
     AuthorList(AuthorListRequest),
     AuthorCreate(AuthorCreateRequest),
+    AuthorDefault(AuthorDefaultRequest),
     AuthorImport(AuthorImportRequest),
     AuthorExport(AuthorExportRequest),
     AuthorDelete(AuthorDeleteRequest),
@@ -1126,6 +1142,7 @@ pub enum Response {
 
     AuthorList(RpcResult<AuthorListResponse>),
     AuthorCreate(RpcResult<AuthorCreateResponse>),
+    AuthorDefault(AuthorDefaultResponse),
     AuthorImport(RpcResult<AuthorImportResponse>),
     AuthorExport(RpcResult<AuthorExportResponse>),
     AuthorDelete(RpcResult<AuthorDeleteResponse>),

--- a/iroh/src/util/fs.rs
+++ b/iroh/src/util/fs.rs
@@ -3,10 +3,12 @@ use std::{
     borrow::Cow,
     fs::read_dir,
     path::{Component, Path, PathBuf},
+    str::FromStr,
 };
 
 use anyhow::{bail, Context};
 use bytes::Bytes;
+use iroh_docs::AuthorId;
 use iroh_net::key::SecretKey;
 use tokio::io::AsyncWriteExt;
 use walkdir::WalkDir;
@@ -117,6 +119,35 @@ pub fn scan_dir(root: PathBuf, wrap: WrapOption) -> anyhow::Result<Vec<DataSourc
 /// separators.
 pub fn relative_canonicalized_path_to_string(path: impl AsRef<Path>) -> anyhow::Result<String> {
     canonicalized_path_to_string(path, true)
+}
+
+/// Load the default author public key from a path, and check that it is present in the `docs_store`.
+///
+/// If `path` does not exist, a new author keypair is created and persisted in the docs store, and
+/// the public key is written to `path`, in base32 encoding.
+///
+/// If `path` does exist, but does not contain an ed25519 public key in base32 encoding, an error
+/// is returned.
+///
+/// If `path` exists and is a valid author public key, but its secret key does not exist in the
+/// docs store, an error is returned.
+pub async fn load_default_author(
+    path: PathBuf,
+    docs_store: &mut iroh_docs::store::fs::Store,
+) -> anyhow::Result<AuthorId> {
+    if path.exists() {
+        let data = tokio::fs::read_to_string(&path).await?;
+        let author_id = AuthorId::from_str(&data)?;
+        if !docs_store.get_author(&author_id)?.is_some() {
+            bail!("The default author is missing from the docs store. To recover, delete the file `{}`. Then iroh will create a new default author.", path.to_string_lossy())
+        }
+        Ok(author_id)
+    } else {
+        let author_id = docs_store.new_author(&mut rand::thread_rng())?.id();
+        docs_store.flush()?;
+        tokio::fs::write(path, author_id.to_string()).await?;
+        Ok(author_id)
+    }
 }
 
 /// Loads a [`SecretKey`] from the provided file, or stores a newly generated one

--- a/iroh/src/util/path.rs
+++ b/iroh/src/util/path.rs
@@ -24,6 +24,9 @@ pub enum IrohPaths {
     #[strum(serialize = "rpc.lock")]
     /// Path to RPC lock file, containing the RPC port if running.
     RpcLock,
+    /// Path to the [`AuthorId`] of the node's default author
+    #[strum(serialize = "default-author")]
+    DefaultAuthor,
 }
 
 impl AsRef<Path> for IrohPaths {


### PR DESCRIPTION
## Description

This adds the notion of a node-wide default author for documents.

The default author can be retrieved via `iroh.authors.default()`. On persistent nodes, on first start a new author is created and its public key is saved to `IROH_DATA_DIR/default-author` (as a base32 string). For in-memory nodes, a new author is created.

When trying to delete the default author via `iroh.authors.delete`, an error is returned, stating that the default author may not be deleted.

The default author can not be changed. 

If the `default-author` file is deleted manually, a new default author will be created on the next start.

## Breaking Changes

* Added `AuthorClient::default()`, which returns author id of a single default author per node 

## Notes & open questions

There are certainly other ways to go around the interactions between the iroh-local notion of a default author and the author database in the iroh-docs store. Quoting from discord (this PR implements option B.1):

> if you delete the default author with the author api, what should happen?
>* A: default author remains in place, further operations with it fail
>  * A.1: on next start new default author is created automatically
>  * A.2: next start fails, says "delete default_author file by hand"
>* B: deletion of default author fails. 
>  * B1: that's the way it is, only way to delete it is to delete `default-author` file by hand and restart the node
>  * B2: add `set_default_author` rpc call
>* C: a new default author is created and set always & automatically

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
