### PR TITLE
fix: store console files in subdirectory of iroh data dir

### DIFF
--- a/iroh-cli/src/commands/console.rs
+++ b/iroh-cli/src/commands/console.rs
@@ -53,7 +53,7 @@ impl Repl {
     pub fn run(self) -> anyhow::Result<()> {
         let mut rl =
             DefaultEditor::with_config(Config::builder().check_cursor_position(true).build())?;
-        let history_path = ConsolePaths::History.with_root(self.env.iroh_data_dir());
+        let history_path = ConsolePaths::History.with_iroh_data_dir(self.env.iroh_data_dir());
         rl.load_history(&history_path).ok();
         loop {
             // prepare a channel to receive a signal from the main thread when a command completed


### PR DESCRIPTION
## Description

We used to store the console files (history and current author) in a subdirectory `console` under the iroh data dir. This got lost in some refacorings, and the console files currently are created in the iroh data directory directly.

This is bad because the iroh data directory is a single namespace, and we should use it cautiously.

This PR goes back to using a `console` subdirectory. Existing files are migrated on first start of the console.

Based on #2299 because this already made the environment init functions async.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
