### PR TITLE
feat: emit PendingContentReady event

### DIFF
--- a/iroh-cli/src/commands/doc.rs
+++ b/iroh-cli/src/commands/doc.rs
@@ -609,6 +609,9 @@ impl DocCommands {
                         LiveEvent::NeighborDown(peer) => {
                             println!("neighbor peer down: {peer:?}");
                         }
+                        LiveEvent::PendingContentReady => {
+                            println!("all pending content is now ready")
+                        }
                     }
                 }
             }

--- a/iroh/src/client/docs.rs
+++ b/iroh/src/client/docs.rs
@@ -547,6 +547,14 @@ pub enum LiveEvent {
     NeighborDown(PublicKey),
     /// A set-reconciliation sync finished.
     SyncFinished(SyncEvent),
+    /// All pending content is now ready.
+    ///
+    /// This event is only emitted after a sync completed and `Self::SyncFinished` was emitted at
+    /// least once. It signals that all currently pending downloads have been completed.
+    ///
+    /// Receiving this event does not guarantee that all content in the document is available. If
+    /// blobs failed to download, this event will still be emitted after all operations completed.
+    PendingContentReady,
 }
 
 impl From<crate::docs_engine::LiveEvent> for LiveEvent {
@@ -568,6 +576,7 @@ impl From<crate::docs_engine::LiveEvent> for LiveEvent {
             crate::docs_engine::LiveEvent::NeighborUp(node) => Self::NeighborUp(node),
             crate::docs_engine::LiveEvent::NeighborDown(node) => Self::NeighborDown(node),
             crate::docs_engine::LiveEvent::SyncFinished(details) => Self::SyncFinished(details),
+            crate::docs_engine::LiveEvent::PendingContentReady => Self::PendingContentReady,
         }
     }
 }

--- a/iroh/src/client/docs.rs
+++ b/iroh/src/client/docs.rs
@@ -549,8 +549,10 @@ pub enum LiveEvent {
     SyncFinished(SyncEvent),
     /// All pending content is now ready.
     ///
-    /// This event is only emitted after a sync completed and `Self::SyncFinished` was emitted at
-    /// least once. It signals that all currently pending downloads have been completed.
+    /// This event signals that all queued content downloads from the last sync run have either
+    /// completed or failed.
+    ///
+    /// It will only be emitted after a [`Self::SyncFinished`] event, never before.
     ///
     /// Receiving this event does not guarantee that all content in the document is available. If
     /// blobs failed to download, this event will still be emitted after all operations completed.

--- a/iroh/src/docs_engine.rs
+++ b/iroh/src/docs_engine.rs
@@ -226,6 +226,14 @@ pub enum LiveEvent {
         /// The content hash of the newly available entry content
         hash: Hash,
     },
+    /// All pending content is now ready.
+    ///
+    /// This event is only emitted after a sync completed and `Self::SyncFinished` was emitted at
+    /// least once. It signals that all currently pending downloads have been completed.
+    ///
+    /// Receiving this event does not guarantee that all content in the document is available. If
+    /// blobs failed to download, this event will still be emitted after all operations completed.
+    PendingContentReady,
     /// We have a new neighbor in the swarm.
     NeighborUp(PublicKey),
     /// We lost a neighbor in the swarm.
@@ -241,6 +249,7 @@ impl From<live::Event> for LiveEvent {
             live::Event::NeighborUp(peer) => Self::NeighborUp(peer),
             live::Event::NeighborDown(peer) => Self::NeighborDown(peer),
             live::Event::SyncFinished(ev) => Self::SyncFinished(ev),
+            live::Event::PendingContentReady => Self::PendingContentReady,
         }
     }
 }

--- a/iroh/src/docs_engine.rs
+++ b/iroh/src/docs_engine.rs
@@ -228,8 +228,10 @@ pub enum LiveEvent {
     },
     /// All pending content is now ready.
     ///
-    /// This event is only emitted after a sync completed and `Self::SyncFinished` was emitted at
-    /// least once. It signals that all currently pending downloads have been completed.
+    /// This event signals that all queued content downloads from the last sync run have either
+    /// completed or failed.
+    ///
+    /// It will only be emitted after a [`Self::SyncFinished`] event, never before.
     ///
     /// Receiving this event does not guarantee that all content in the document is available. If
     /// blobs failed to download, this event will still be emitted after all operations completed.

--- a/iroh/src/docs_engine/live.rs
+++ b/iroh/src/docs_engine/live.rs
@@ -624,9 +624,9 @@ impl<B: iroh_blobs::store::Store> LiveActor<B> {
             self.missing_hashes.insert(hash);
         }
         for namespace in completed_namespaces.iter() {
-            if self.state.did_complete(&namespace) {
+            if self.state.did_complete(namespace) {
                 self.subscribers
-                    .send(&namespace, Event::PendingContentReady)
+                    .send(namespace, Event::PendingContentReady)
                     .await;
             }
         }

--- a/iroh/src/docs_engine/live.rs
+++ b/iroh/src/docs_engine/live.rs
@@ -575,7 +575,7 @@ impl<B: iroh_blobs::store::Store> LiveActor<B> {
             .send(&namespace, Event::SyncFinished(ev))
             .await;
 
-        if self.queued_hashes.is_empty(&namespace) {
+        if !self.queued_hashes.contains_namespace(&namespace) {
             self.subscribers
                 .send(&namespace, Event::PendingContentReady)
                 .await;
@@ -723,6 +723,7 @@ impl<B: iroh_blobs::store::Store> LiveActor<B> {
             return;
         }
         if self.queued_hashes.contains_hash(&hash) {
+            self.queued_hashes.insert(hash, namespace);
             self.downloader.nodes_have(hash, vec![node]).await;
         } else if !only_if_missing || self.missing_hashes.contains(&hash) {
             let req = DownloadRequest::untagged(HashAndFormat::raw(hash), vec![node]);
@@ -874,7 +875,7 @@ impl QueuedHashes {
         self.by_hash.contains_key(hash)
     }
 
-    fn is_empty(&self, namespace: &NamespaceId) -> bool {
+    fn contains_namespace(&self, namespace: &NamespaceId) -> bool {
         self.by_namespace.contains_key(namespace)
     }
 }

--- a/iroh/src/docs_engine/live.rs
+++ b/iroh/src/docs_engine/live.rs
@@ -117,6 +117,13 @@ pub enum Event {
     NeighborDown(PublicKey),
     /// A set-reconciliation sync finished.
     SyncFinished(SyncEvent),
+    /// All pending content is now ready.
+    ///
+    /// This event is only emitted after a sync completed and `Self::SyncFinished` was emitted at
+    /// least once. It signals that all currently pending downloads have been completed.
+    ///
+    /// Receiving this event does not guarantee that all content in the document is available. If
+    /// blobs failed to download, this event will still be emitted after all operations completed.
     PendingContentReady,
 }
 

--- a/iroh/src/docs_engine/state.rs
+++ b/iroh/src/docs_engine/state.rs
@@ -117,7 +117,7 @@ impl NamespaceStates {
         state.finish(origin, result)
     }
 
-    /// Set whether a [`super::Event::PendingContentReady`] may be emitted once the pending queue
+    /// Set whether a [`super::live::Event::PendingContentReady`] may be emitted once the pending queue
     /// becomes empty.
     ///
     /// This should be set to `true` if there are pending content hashes after a sync finished, and
@@ -127,7 +127,7 @@ impl NamespaceStates {
         state.may_emit_ready = value;
         Some(())
     }
-    /// Returns whether a [`super::Event::PendingContentReady`] event may be emitted once the
+    /// Returns whether a [`super::live::Event::PendingContentReady`] event may be emitted once the
     /// pending queue becomes empty.
     ///
     /// If this returns `false`, an event should not be emitted even if the queue becomes empty,

--- a/iroh/src/docs_engine/state.rs
+++ b/iroh/src/docs_engine/state.rs
@@ -52,6 +52,7 @@ pub struct NamespaceStates(BTreeMap<NamespaceId, NamespaceState>);
 #[derive(Default)]
 struct NamespaceState {
     nodes: BTreeMap<NodeId, PeerState>,
+    may_emit_ready: bool,
 }
 
 impl NamespaceStates {
@@ -63,18 +64,6 @@ impl NamespaceStates {
     /// Insert a namespace into the set of syncing namespaces.
     pub fn insert(&mut self, namespace: NamespaceId) {
         self.0.entry(namespace).or_default();
-    }
-
-    /// Returns `true` if at least one sync was completed for this namespace.
-    pub fn did_complete(&self, namespace: &NamespaceId) -> bool {
-        self.0
-            .get(namespace)
-            .map(|s| {
-                s.nodes
-                    .iter()
-                    .any(|(_peer, state)| state.last_sync.is_some())
-            })
-            .unwrap_or(false)
     }
 
     /// Start a sync request.
@@ -126,6 +115,32 @@ impl NamespaceStates {
     ) -> Option<(SystemTime, bool)> {
         let state = self.entry(namespace, node)?;
         state.finish(origin, result)
+    }
+
+    /// Set whether a [`super::Event::PendingContentReady`] may be emitted once the pending queue
+    /// becomes empty.
+    ///
+    /// This should be set to `true` if there are pending content hashes after a sync finished, and
+    /// to `false` whenever a `PendingContentReady` was emitted.
+    pub fn set_may_emit_ready(&mut self, namespace: &NamespaceId, value: bool) -> Option<()> {
+        let state = self.0.get_mut(namespace)?;
+        state.may_emit_ready = value;
+        Some(())
+    }
+    /// Returns whether a [`super::Event::PendingContentReady`] event may be emitted once the
+    /// pending queue becomes empty.
+    ///
+    /// If this returns `false`, an event should not be emitted even if the queue becomes empty,
+    /// because a currently running sync did not yet terminate. Once it terminates, the event will
+    /// be emitted from the handler for finished syncs.
+    pub fn may_emit_ready(&mut self, namespace: &NamespaceId) -> Option<bool> {
+        let state = self.0.get_mut(namespace)?;
+        if state.may_emit_ready {
+            state.may_emit_ready = false;
+            Some(true)
+        } else {
+            Some(false)
+        }
     }
 
     /// Remove a namespace from the set of syncing namespaces.

--- a/iroh/src/docs_engine/state.rs
+++ b/iroh/src/docs_engine/state.rs
@@ -65,6 +65,18 @@ impl NamespaceStates {
         self.0.entry(namespace).or_default();
     }
 
+    /// Returns `true` if at least one sync was completed for this namespace.
+    pub fn did_complete(&self, namespace: &NamespaceId) -> bool {
+        self.0
+            .get(namespace)
+            .map(|s| {
+                s.nodes
+                    .iter()
+                    .any(|(_peer, state)| state.last_sync.is_some())
+            })
+            .unwrap_or(false)
+    }
+
     /// Start a sync request.
     ///
     /// Returns true if the request should be performed, and false if it should be aborted.

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -634,6 +634,7 @@ async fn sync_restart_node() -> Result<()> {
         ],
         vec![
             match_event!(LiveEvent::SyncFinished(e) if e.peer == id2 && e.result.is_ok()),
+            match_event!(LiveEvent::PendingContentReady),
         ],
     )
     .await;

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -1234,8 +1234,7 @@ async fn assert_next<T: std::fmt::Debug + Clone>(
         items
     };
     let res = tokio::time::timeout(timeout, fut).await;
-    let events = res.expect("timeout reached");
-    events
+    res.expect("timeout reached")
 }
 
 /// Receive `matchers.len()` elements from a stream and assert that each element matches one of the

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -110,6 +110,7 @@ async fn sync_simple() -> Result<()> {
             Box::new(move |e| matches!(e, LiveEvent::InsertRemote { from, .. } if *from == peer0 )),
             Box::new(move |e| match_sync_finished(e, peer0)),
             Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash0)),
+            match_event!(LiveEvent::PendingContentReady),
         ],
     )
     .await;
@@ -286,10 +287,11 @@ async fn sync_full_basic() -> Result<()> {
         &mut events1,
         TIMEOUT,
         vec![
-            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer0)),
-            Box::new(move |e| matches!(e, LiveEvent::InsertRemote { from, .. } if *from == peer0 )),
+            match_event!(LiveEvent::NeighborUp(peer) if *peer == peer0),
+            match_event!(LiveEvent::InsertRemote { from, .. } if *from == peer0 ),
             Box::new(move |e| match_sync_finished(e, peer0)),
-            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash0)),
+            match_event!(LiveEvent::ContentReady { hash } if *hash == hash0),
+            match_event!(LiveEvent::PendingContentReady),
         ],
     )
     .await;
@@ -299,8 +301,9 @@ async fn sync_full_basic() -> Result<()> {
         &mut events0,
         TIMEOUT,
         vec![
-            Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer1)),
+            match_event!(LiveEvent::NeighborUp(peer) if *peer == peer1),
             Box::new(move |e| match_sync_finished(e, peer1)),
+            match_event!(LiveEvent::PendingContentReady),
         ],
     )
     .await;
@@ -329,6 +332,7 @@ async fn sync_full_basic() -> Result<()> {
                 move |e| matches!(e, LiveEvent::InsertRemote { from, content_status: ContentStatus::Missing, .. } if *from == peer1),
             ),
             Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash1)),
+            match_event!(LiveEvent::PendingContentReady),
         ],
     ).await;
     assert_latest(&doc0, key1, value1).await;
@@ -367,6 +371,7 @@ async fn sync_full_basic() -> Result<()> {
             // 2 ContentReady events
             Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash0)),
             Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash1)),
+            match_event!(LiveEvent::PendingContentReady),
         ],
         // optional events
         // it may happen that we run sync two times against our two peers:
@@ -522,6 +527,7 @@ async fn test_sync_via_relay() -> Result<()> {
             Box::new(
                 move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == inserted_hash),
             ),
+            match_event!(LiveEvent::PendingContentReady),
         ],
         vec![Box::new(move |e| match_sync_finished(e, node1_id))],
     ).await;
@@ -547,6 +553,7 @@ async fn test_sync_via_relay() -> Result<()> {
             Box::new(
                 move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == updated_hash),
             ),
+            Box::new(move |e| matches!(e, LiveEvent::PendingContentReady)),
         ],
         vec![Box::new(move |e| match_sync_finished(e, node1_id))],
     ).await;
@@ -616,6 +623,7 @@ async fn sync_restart_node() -> Result<()> {
             match_event!(LiveEvent::SyncFinished(e) if e.peer == id2 && e.result.is_ok()),
             match_event!(LiveEvent::InsertRemote { from, content_status: ContentStatus::Missing, .. } if *from == id2),
             match_event!(LiveEvent::ContentReady { hash } if *hash == hash_a),
+            match_event!(LiveEvent::PendingContentReady),
         ],
         vec![
             match_event!(LiveEvent::SyncFinished(e) if e.peer == id2 && e.result.is_ok()),
@@ -660,6 +668,7 @@ async fn sync_restart_node() -> Result<()> {
             match_event!(LiveEvent::SyncFinished(e) if e.peer == id2 && e.result.is_ok()),
             match_event!(LiveEvent::InsertRemote { from, content_status: ContentStatus::Missing, .. } if *from == id2),
             match_event!(LiveEvent::ContentReady { hash } if *hash == hash_b),
+            match_event!(LiveEvent::PendingContentReady),
         ],
         vec![
             match_event!(LiveEvent::SyncFinished(e) if e.peer == id2 && e.result.is_ok()),
@@ -676,6 +685,7 @@ async fn sync_restart_node() -> Result<()> {
         vec![
             match_event!(LiveEvent::InsertRemote { from, content_status: ContentStatus::Missing, .. } if *from == id2),
             match_event!(LiveEvent::ContentReady { hash } if *hash == hash_c),
+            match_event!(LiveEvent::PendingContentReady),
         ],
         vec![
             match_event!(LiveEvent::SyncFinished(e) if e.peer == id2 && e.result.is_ok()),

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -697,6 +697,8 @@ async fn sync_restart_node() -> Result<()> {
         vec![
             match_event!(LiveEvent::SyncFinished(e) if e.peer == id2 && e.result.is_ok()),
             match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::SyncFinished(e) if e.peer == id2 && e.result.is_ok()),
+            match_event!(LiveEvent::PendingContentReady),
         ]
     ).await;
 


### PR DESCRIPTION
## Description

This adds a new `LiveEvent` variant: `PendingContentReady`.

It is emitted once, after sync was started, the list of pending content blobs becomes empty. This is the case if either all blobs from this sesion have been downloaded, or failed.

I think this could help with simple examples like https://gist.github.com/dignifiedquire/efbd1a7a1da729494adb088d72f1ceaa#file-main-sync-rs-L84

It should not be used as a guarantee that all content is now available locally, and it should be used with a timeout usually, because it may very legally never be emitted (e.g. if the remote does not have all blobs themselves, or closes the connections, etc).

## Breaking Changes

* `LiveEvent` now has a new variant `PendingContentReady`. This event is emitted  after a sync completed and `Self::SyncFinished` was emitted. It signals that all currently pending downloads have been completed. Receiving this event does not guarantee that all content in the document is available. If blobs failed to download, this event will still be emitted after all operations completed.


## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
