### PR TITLE
feat: import and subscribe to a document in a single call

### DIFF
--- a/iroh/src/client/docs.rs
+++ b/iroh/src/client/docs.rs
@@ -66,8 +66,7 @@ where
 
     /// Import a document from a namespace capability.
     ///
-    /// This does not start sync automatically. Use [`Self::start_sync`] to open or accept sync
-    /// requests.
+    /// This does not start sync automatically. Use [`Doc::start_sync`] to start sync.
     pub async fn import_namespace(&self, capability: Capability) -> Result<Doc<C>> {
         let res = self.rpc.rpc(DocImportRequest { capability }).await??;
         let doc = Doc::new(self.rpc.clone(), res.doc_id);
@@ -77,8 +76,7 @@ where
     /// Import a document from a ticket and join all peers in the ticket.
     pub async fn import(&self, ticket: DocTicket) -> Result<Doc<C>> {
         let DocTicket { capability, nodes } = ticket;
-        let res = self.rpc.rpc(DocImportRequest { capability }).await??;
-        let doc = Doc::new(self.rpc.clone(), res.doc_id);
+        let doc = self.import_namespace(capability).await?;
         doc.start_sync(nodes).await?;
         Ok(doc)
     }

--- a/iroh/src/docs_engine/rpc.rs
+++ b/iroh/src/docs_engine/rpc.rs
@@ -164,13 +164,9 @@ impl Engine {
     }
 
     pub async fn doc_import(&self, req: DocImportRequest) -> RpcResult<DocImportResponse> {
-        let DocImportRequest(DocTicket {
-            capability,
-            nodes: peers,
-        }) = req;
+        let DocImportRequest { capability } = req;
         let doc_id = self.sync.import_namespace(capability).await?;
         self.sync.open(doc_id, Default::default()).await?;
-        self.start_sync(doc_id, peers).await?;
         Ok(DocImportResponse { doc_id })
     }
 

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -28,7 +28,8 @@ use iroh_net::{
 use iroh_docs::{
     actor::OpenState,
     store::{DownloadPolicy, Query},
-    Author, AuthorId, CapabilityKind, DocTicket, Entry, NamespaceId, PeerIdBytes, SignedEntry,
+    Author, AuthorId, Capability, CapabilityKind, DocTicket, Entry, NamespaceId, PeerIdBytes,
+    SignedEntry,
 };
 use quic_rpc::{
     message::{BidiStreaming, BidiStreamingMsg, Msg, RpcMsg, ServerStreaming, ServerStreamingMsg},
@@ -548,9 +549,12 @@ pub struct DocCreateResponse {
     pub id: NamespaceId,
 }
 
-/// Import a document from a ticket.
+/// Import a document from a capability.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DocImportRequest(pub DocTicket);
+pub struct DocImportRequest {
+    /// The namespace capability.
+    pub capability: Capability,
+}
 
 impl RpcMsg<RpcService> for DocImportRequest {
     type Response = RpcResult<DocImportResponse>;


### PR DESCRIPTION
## Description

This adds the much-needed `import_and_subscribe` call to make live sync events more reliable.

Did not test much yet but I think it should work as expected! 

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
