### PR TITLE
examples: minimize use of raw base32 in examples

### DIFF
--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -86,9 +86,9 @@ async fn main() -> anyhow::Result<()> {
     // parse or generate our secret key
     let secret_key = match args.secret_key {
         None => SecretKey::generate(),
-        Some(key) => parse_secret_key(&key)?,
+        Some(key) => key.parse()?,
     };
-    println!("> our secret key: {}", base32::fmt(secret_key.to_bytes()));
+    println!("> our secret key: {secret_key}");
 
     // confgure our relay map
     let relay_mode = match (args.no_relay, args.relay) {
@@ -176,12 +176,12 @@ async fn subscribe_loop(gossip: Gossip, topic: TopicId) -> anyhow::Result<()> {
             match message {
                 Message::AboutMe { name } => {
                     names.insert(from, name.clone());
-                    println!("> {} is now known as {}", fmt_node_id(&from), name);
+                    println!("> {} is now known as {}", from.fmt_short(), name);
                 }
                 Message::Message { text } => {
                     let name = names
                         .get(&from)
-                        .map_or_else(|| fmt_node_id(&from), String::to_string);
+                        .map_or_else(|| from.fmt_short(), String::to_string);
                     println!("{}: {}", name, text);
                 }
             }
@@ -294,14 +294,6 @@ impl FromStr for Ticket {
 }
 
 // helpers
-
-fn fmt_node_id(input: &PublicKey) -> String {
-    base32::fmt_short(input.as_bytes())
-}
-fn parse_secret_key(secret: &str) -> anyhow::Result<SecretKey> {
-    let bytes: [u8; 32] = base32::parse_array(secret)?;
-    Ok(SecretKey::from(bytes))
-}
 
 fn fmt_relay_mode(relay_mode: &RelayMode) -> String {
     match relay_mode {

--- a/iroh-net/examples/connect-unreliable.rs
+++ b/iroh-net/examples/connect-unreliable.rs
@@ -10,7 +10,6 @@ use std::net::SocketAddr;
 use anyhow::Context;
 use clap::Parser;
 use futures_lite::StreamExt;
-use iroh_base::base32;
 use iroh_net::{
     key::SecretKey,
     relay::{RelayMode, RelayUrl},
@@ -40,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     println!("\nconnect (unreliable) example!\n");
     let args = Cli::parse();
     let secret_key = SecretKey::generate();
-    println!("secret key: {}", base32::fmt(secret_key.to_bytes()));
+    println!("secret key: {secret_key}");
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay protocol and relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.
     let endpoint = Endpoint::builder()

--- a/iroh-net/examples/connect.rs
+++ b/iroh-net/examples/connect.rs
@@ -10,7 +10,6 @@ use std::net::SocketAddr;
 use anyhow::Context;
 use clap::Parser;
 use futures_lite::StreamExt;
-use iroh_base::base32;
 use iroh_net::relay::RelayUrl;
 use iroh_net::{key::SecretKey, relay::RelayMode, Endpoint, NodeAddr};
 use tracing::info;
@@ -37,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
     println!("\nconnect example!\n");
     let args = Cli::parse();
     let secret_key = SecretKey::generate();
-    println!("secret key: {}", base32::fmt(secret_key.to_bytes()));
+    println!("secret key: {secret_key}");
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay protocol and relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.
     let endpoint = Endpoint::builder()

--- a/iroh-net/examples/listen-unreliable.rs
+++ b/iroh-net/examples/listen-unreliable.rs
@@ -5,7 +5,6 @@
 //!     $ cargo run --example listen-unreliable
 use anyhow::Context;
 use futures_lite::StreamExt;
-use iroh_base::base32;
 use iroh_net::{key::SecretKey, relay::RelayMode, Endpoint};
 use tracing::info;
 
@@ -17,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     println!("\nlisten (unreliable) example!\n");
     let secret_key = SecretKey::generate();
-    println!("secret key: {}", base32::fmt(secret_key.to_bytes()));
+    println!("secret key: {secret_key}");
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.
     let endpoint = Endpoint::builder()

--- a/iroh-net/examples/listen.rs
+++ b/iroh-net/examples/listen.rs
@@ -5,7 +5,6 @@
 //!     $ cargo run --example listen
 use anyhow::Context;
 use futures_lite::StreamExt;
-use iroh_base::base32;
 use iroh_net::{key::SecretKey, relay::RelayMode, Endpoint};
 use tracing::{debug, info};
 
@@ -17,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     println!("\nlisten example!\n");
     let secret_key = SecretKey::generate();
-    println!("secret key: {}", base32::fmt(secret_key.to_bytes()));
+    println!("secret key: {secret_key}");
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay protocol and relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.
     let endpoint = Endpoint::builder()

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -34,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
 fn fmt_entry(entry: &Entry) -> String {
     let id = entry.id();
     let key = std::str::from_utf8(id.key()).unwrap_or("<bad key>");
-    let author = base32::fmt_short(id.author());
+    let author = id.author().fmt_short();
     let hash = entry.content_hash();
     let hash = base32::fmt_short(hash.as_bytes());
     let len = HumanBytes(entry.content_len());


### PR DESCRIPTION
## Description

I noticed that in the example code (particularly `iroh-net`'s code), there are a few explicit uses of `base32` encoding and decoding that are unnecessary. In particular, `SecretKey` is manually `base32`-encoded in the networking examples, although the `Display` implementation uses that same encoding. I figure that the examples were just written before the utility encoding/decoding code in the main libraries were and weren't updated when that utility code was added. I hope that catching this is helpful!

## Breaking Changes

None.

## Notes & open questions

None.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
