### PR TITLE
fix(iroh-gossip): do not drop existing peer connection when we get incoming one

### DIFF
--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -619,11 +619,13 @@ async fn connection_loop(
     loop {
         tokio::select! {
             biased;
-            msg = send_rx.recv() => {
-                match msg {
-                    None => break,
-                    Some(msg) =>  write_message(&mut send, &mut send_buf, &msg).await?,
-                }
+            // If `send_rx` is closed,
+            // stop selecting it but don't quit.
+            // We are not going to use connection for sending anymore,
+            // but the other side may still want to use it to
+            // send data to us.
+            Some(msg) = send_rx.recv(), if !send_rx.is_closed() => {
+                write_message(&mut send, &mut send_buf, &msg).await?
             }
 
             msg = read_message(&mut recv, &mut recv_buf) => {


### PR DESCRIPTION
Otherwise if two peers try to connect to each other at the same time, they may end up creating two connection and then closing both of them. Better keep two one-directional connections.

deltachat-core-rust will have a downstream test that reliably triggers the problem at https://github.com/deltachat/deltachat-core-rust/pull/5595
I did not manage to reproduce the problem in Rust, it seems to depend on timing and is triggered in the test which sends tickets around using SMTP.

Fixes https://github.com/n0-computer/iroh/issues/2307

Replaces https://github.com/n0-computer/iroh/pull/2308