### PR TITLE
docs(iroh-net): Update toplevel module documentation

### DIFF
--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -202,7 +202,7 @@ impl Builder {
     /// The DNS resolver is used to resolve relay hostnames, and node addresses if
     /// [`crate::discovery::dns::DnsDiscovery`] is configured.
     ///
-    /// By default, all magic endpoints share a DNS resolver, which is configured to use the
+    /// By default, all endpoints share a DNS resolver, which is configured to use the
     /// host system's DNS configuration. You can pass a custom instance of [`DnsResolver`]
     /// here to use a differently configured DNS resolver for this endpoint.
     pub fn dns_resolver(mut self, dns_resolver: DnsResolver) -> Self {

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -86,7 +86,7 @@
 //!   initiator of this stream has to send data before the peer will be aware of this
 //!   stream.
 //!
-//! Additionally to be extremely light-weight, streams can be interleaved and will not block
+//! Additionally to being extremely light-weight, streams can be interleaved and will not block
 //! each other.  Allowing many streams to co-exist, regardless of how long they last.
 //!
 //!

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -9,13 +9,13 @@
 //!
 //! An iroh-net connection between two iroh-net nodes is usually established with the help
 //! of a Relay server.  When creating the [`Endpoint`] it connects to the closest Relay
-//! server and designates this has the *home relay*.  When other nodes want to connect they
+//! server and designates this as the *home relay*.  When other nodes want to connect they
 //! first establish connection via this home relay.  As soon as connection between the two
 //! nodes is established they will attempt to create a direct connection, using [hole
 //! punching] if needed.  Once the direct connection is established the relay server is no
 //! longer involved in the connection.
 //!
-//! If one of the iroh-net nodes can be reached directly connectivity can also be
+//! If one of the iroh-net nodes can be reached directly, connectivity can also be
 //! established without involving a Relay server.  The [`NodeAddr`] can also contain a
 //! number of [socket addresses] on which a node is reachable and will be used to establish a
 //! connection.
@@ -26,7 +26,7 @@
 //! The connection is encrypted using TLS, like standard QUIC connections.  Unlike standard
 //! QUIC there is no client, server or server TLS key.  Instead each iroh-net node has a
 //! unique [`SecretKey`] used to authenticate and encrypt the connection.  When an iroh-net
-//! node connects it uses the corresponding [`PublicKey`] to ensure the connection is only
+//! node connects, it uses the corresponding [`PublicKey`] to ensure the connection is only
 //! established with the intended peer.
 //!
 //! Since the [`PublicKey`] is also used to identify the iroh-net node it is also known as
@@ -43,7 +43,7 @@
 //! **encrypted** traffic for iroh-net nodes which are connected to them, forwarding it to
 //! the correct destination based on the [`NodeId`] only.  Since nodes only send encrypted
 //! traffic, the Relay servers can not decode any traffic for other iroh-net nodes and only
-//! forwards it.
+//! forward it.
 //!
 //! The connections to the Relay server are initiated as normal HTTP 1.1 connections using
 //! TLS.  Once connected the transport is upgraded to a plain TCP connection using a custom
@@ -80,7 +80,7 @@
 //! - **Uni-directional** which only allows the peer which initiated the stream to send
 //!   data.
 //!
-//! - **Bi-directional** which allows both peers to send and receive data.  However the
+//! - **Bi-directional** which allows both peers to send and receive data.  However, the
 //!   initiator of this stream has to send data before the peer will be aware of this
 //!   stream.
 //!

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -25,7 +25,7 @@
 //! # Encryption
 //!
 //! The connection is encrypted using TLS, like standard QUIC connections.  Unlike standard
-//! QUIC there is no client, server or server TLS key.  Instead each iroh-net node has a
+//! QUIC there is no client, server or server TLS key and certificate chain.  Instead each iroh-net node has a
 //! unique [`SecretKey`] used to authenticate and encrypt the connection.  When an iroh-net
 //! node connects, it uses the corresponding [`PublicKey`] to ensure the connection is only
 //! established with the intended peer.

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -16,9 +16,10 @@
 //! longer involved in the connection.
 //!
 //! If one of the iroh-net nodes can be reached directly, connectivity can also be
-//! established without involving a Relay server.  The [`NodeAddr`] can also contain a
-//! number of [socket addresses] on which a node is reachable and will be used to establish a
-//! connection.
+//! established without involving a Relay server.  This is done by using the node's
+//! listening addresses in the connection establishement instead of the [`RelayUrl`] which
+//! is used to identify a Relay server.  Of course it is also possible to use both a
+//! [`RelayUrl`] and direct addresses at the same time to connect.
 //!
 //!
 //! # Encryption
@@ -60,8 +61,9 @@
 //!
 //! # Connections and Streams
 //!
-//! Connections are managed using the [`Endpoint`].  To establish a connection to an
-//! iroh-net node you need to know three pieces of information:
+//! An iroh-net node is managed using the [`Endpoint`] and this is used to create or accept
+//! connections to other nodes.  To establish a connection to an iroh-net node you need to
+//! know three pieces of information:
 //!
 //! - The [`NodeId`] of the peer to connect to.
 //! - Some addressing information:
@@ -88,6 +90,18 @@
 //! each other.  Allowing many streams to co-exist, regardless of how long they last.
 //!
 //!
+//! ## Node Discovery
+//!
+//! The need to know the [`RelayUrl`] *or* some direct addresses in addition to the
+//! [`NodeId`] to connect to an iroh-net node can be an obstacle.  To address this the
+//! [`endpoint::Builder`] allows to configure a [`discovery`] service.
+//!
+//! The [`DnsDiscovery`] service is a discovery service which will publish the [`RelayUrl`]
+//! and direct addresses to a service publishing those as DNS records.  To connect it looks
+//! up the [`NodeId`] in the DNS system to find the adressing details.  This enables
+//! connecting using only the [`NodeId`] which is often more convenient and resilient.
+//!
+//!
 //! [QUIC]: https://quickwg.org
 //! [hole punching]: https://en.wikipedia.org/wiki/Hole_punching_(networking)
 //! [socket addresses]: https://doc.rust-lang.org/stable/std/net/enum.SocketAddr.html
@@ -97,6 +111,8 @@
 //! [`SecretKey`]: crate::key::SecretKey
 //! [`PublicKey`]: crate::key::PublicKey
 //! [`RelayUrl`]: crate::relay::RelayUrl
+//! [`discovery`]: crate::endpoint::Builder::discovery
+//! [`DnsDiscovery`]: crate::discovery::dns::DnsDiscovery
 
 #![recursion_limit = "256"]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]


### PR DESCRIPTION
## Description

This updates the top-level docs for iroh-net to be a general
overview of what the crate provides, since this is effectively the
docs.rs landing page.

## Breaking Changes

None

## Notes & open questions

This should include an examples section as well.  However... the API
is a bit pants and does not lend itself to a nice echo example here.
Let's tackle this separately.

This does not change the README, that is already fairly decent and
seems compatible with this content.

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~