### PR TITLE
fix(iroh-net): fix extra delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb353f5a5a852d5cc779c1c80bec0bd14a696ef832f3a761cb10091802c37109"
+checksum = "e12d9f49b8d4b9d7f97525ce65f6527079e549e8b2f010f15b921764e73d4baa"
 dependencies = [
  "dlopen2",
  "libc",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = { version = "1" }
 base64 = "0.22.1"
 backoff = "0.4.0"
 bytes = "1"
-netdev = "0.25"
+netdev = "0.27.0"
 der = { version = "0.7", features = ["alloc", "derive"] }
 derive_more = { version = "1.0.0-beta.6", features = ["debug", "display", "from", "try_into", "deref"] }
 flume = "0.11"

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2001,13 +2001,13 @@ impl Actor {
             .unwrap_or(false);
 
         let msock = self.msock.clone();
-        
-        tokio::spawn( async move {
+
+        tokio::spawn(async move {
             let LocalAddresses {
                 regular: mut ips,
                 loopback,
             } = LocalAddresses::new();
-    
+
             if is_unspecified_v4 || is_unspecified_v6 {
                 if ips.is_empty() && eps.is_empty() {
                     // Only include loopback addresses if we have no
@@ -2024,7 +2024,7 @@ impl Actor {
                         None
                     }
                 });
-    
+
                 let v6_port = local_addr_v6.and_then(|addr| {
                     if addr.ip().is_unspecified() {
                         Some(addr.port())
@@ -2032,7 +2032,7 @@ impl Actor {
                         None
                     }
                 });
-    
+
                 for ip in ips {
                     match ip {
                         IpAddr::V4(_) => {
@@ -2058,7 +2058,7 @@ impl Actor {
                     }
                 }
             }
-    
+
             if !is_unspecified_v4 {
                 if let Some(addr) = local_addr_v4 {
                     // Our local endpoint is bound to a particular address.
@@ -2066,7 +2066,7 @@ impl Actor {
                     add_addr!(already, eps, addr, config::EndpointType::Local);
                 }
             }
-    
+
             if !is_unspecified_v6 {
                 if let Some(addr) = local_addr_v6 {
                     // Our local endpoint is bound to a particular address.
@@ -2074,7 +2074,7 @@ impl Actor {
                     add_addr!(already, eps, addr, config::EndpointType::Local);
                 }
             }
-    
+
             // Note: the endpoints are intentionally returned in priority order,
             // from "farthest but most reliable" to "closest but least
             // reliable." Addresses returned from STUN should be globally
@@ -2084,7 +2084,7 @@ impl Actor {
             //
             // The STUN address(es) are always first.
             // Despite this sorting, clients are not relying on this sorting for decisions;
-    
+
             let updated = msock
                 .endpoints
                 .update(DiscoveredEndpoints::new(eps))
@@ -2094,7 +2094,7 @@ impl Actor {
                 eps.log_endpoint_change();
                 msock.publish_my_addr();
             }
-    
+
             // Regardless of whether our local endpoints changed, we now want to send any queued
             // call-me-maybe messages.
             msock.send_queued_call_me_maybes();

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2008,7 +2008,7 @@ impl Actor {
             let LocalAddresses {
                 regular: mut ips,
                 loopback,
-            } = tokio::task::spawn_blocking(|| LocalAddresses::new())
+            } = tokio::task::spawn_blocking(LocalAddresses::new)
                 .await
                 .unwrap();
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2003,8 +2003,8 @@ impl Actor {
         let msock = self.msock.clone();
 
         tokio::spawn(async move {
-            // Spawn the blocking call in a separate thread to prevent blocking the executor,
-            // and causing additional delay.
+            // Depending on the OS and network interfaces attached and their state enumerating
+            // the local interfaces can take a long time.  Especially Windows is very slow.
             let LocalAddresses {
                 regular: mut ips,
                 loopback,

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2003,10 +2003,14 @@ impl Actor {
         let msock = self.msock.clone();
 
         tokio::spawn(async move {
+            // Spawn the blocking call in a separate thread to prevent blocking the executor,
+            // and causing additional delay.
             let LocalAddresses {
                 regular: mut ips,
                 loopback,
-            } = LocalAddresses::new();
+            } = tokio::task::spawn_blocking(|| LocalAddresses::new())
+                .await
+                .unwrap();
 
             if is_unspecified_v4 || is_unspecified_v6 {
                 if ips.is_empty() && eps.is_empty() {

--- a/iroh-net/src/net/interfaces/windows.rs
+++ b/iroh-net/src/net/interfaces/windows.rs
@@ -15,7 +15,7 @@ struct Win32_IP4RouteTable {
 
 fn get_default_route() -> anyhow::Result<DefaultRouteDetails> {
     let com_con = COMLibrary::new()?;
-    let wmi_con = WMIConnection::new(com_con.into())?;
+    let wmi_con = WMIConnection::new(com_con)?;
 
     let query: HashMap<_, _> = [("Destination".into(), FilterValue::Str("0.0.0.0"))].into();
     let route: Win32_IP4RouteTable = wmi_con


### PR DESCRIPTION
## Description

Fix for https://github.com/n0-computer/iroh/issues/2328: Enumerating network devices is slow
on windows and causes delays in the magicsock actor.  This makes sure that this operation
does not block the remainder of the actor.

Also bumps netdev to v0.27.0 , to fix https://github.com/n0-computer/iroh/issues/2327.

