### PR TITLE
fix(docs): prevent deadlocks with streams returned from docs actor

### DIFF
--- a/iroh-docs/Cargo.toml
+++ b/iroh-docs/Cargo.toml
@@ -23,7 +23,7 @@ ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 flume = "0.11"
 futures-buffered = "0.2.4"
 futures-lite = "2.3.0"
-futures-util = { version = "0.3.25", optional = true }
+futures-util = { version = "0.3.25" }
 hex = "0.4"
 iroh-base = { version = "0.17.0", path = "../iroh-base" }
 iroh-blobs = { version = "0.17.0", path = "../iroh-blobs", optional = true, features = ["downloader"] }
@@ -42,7 +42,7 @@ serde = { version = "1.0.164", features = ["derive"] }
 strum = { version = "0.25", features = ["derive"] }
 tempfile = { version = "3.4" }
 thiserror = "1"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "rt", "time", "macros"] }
 tokio-stream = { version = "0.1", optional = true, features = ["sync"]}
 tokio-util = { version = "0.7", optional = true, features = ["codec", "io-util", "io"] }
 tracing = "0.1"
@@ -57,7 +57,7 @@ test-strategy = "0.3.1"
 
 [features]
 default = ["net", "metrics", "engine"]
-net = ["dep:iroh-net", "tokio/io-util", "dep:tokio-stream", "dep:tokio-util", "dep:futures-util"]
+net = ["dep:iroh-net", "tokio/io-util", "dep:tokio-stream", "dep:tokio-util"]
 metrics = ["dep:iroh-metrics"]
 engine = ["net", "dep:iroh-gossip", "dep:iroh-blobs"]
 

--- a/iroh-docs/src/actor.rs
+++ b/iroh-docs/src/actor.rs
@@ -277,12 +277,8 @@ impl SyncHandle {
     pub async fn open(&self, namespace: NamespaceId, opts: OpenOpts) -> Result<()> {
         let (reply, rx) = oneshot::channel();
         let action = ReplicaAction::Open { reply, opts };
-        tracing::debug!("SyncHandle::open IN");
         self.send_replica(namespace, action).await?;
-        tracing::debug!("SyncHandle::open MID");
-        let res = rx.await?;
-        tracing::debug!("SyncHandle::open OUT");
-        res
+        rx.await?
     }
 
     pub async fn close(&self, namespace: NamespaceId) -> Result<bool> {

--- a/iroh/src/node/rpc/docs.rs
+++ b/iroh/src/node/rpc/docs.rs
@@ -126,9 +126,7 @@ impl DocsEngine {
     }
 
     pub async fn doc_open(&self, req: DocOpenRequest) -> RpcResult<DocOpenResponse> {
-        tracing::debug!("doc_open IN");
         self.sync.open(req.doc_id, Default::default()).await?;
-        tracing::debug!("doc_open OUT");
         Ok(DocOpenResponse {})
     }
 

--- a/iroh/src/node/rpc/docs.rs
+++ b/iroh/src/node/rpc/docs.rs
@@ -126,7 +126,9 @@ impl DocsEngine {
     }
 
     pub async fn doc_open(&self, req: DocOpenRequest) -> RpcResult<DocOpenResponse> {
+        tracing::debug!("doc_open IN");
         self.sync.open(req.doc_id, Default::default()).await?;
+        tracing::debug!("doc_open OUT");
         Ok(DocOpenResponse {})
     }
 


### PR DESCRIPTION
## Description

Fixes #2345 

The iroh-docs actor loop can easily be deadlocked from the client side: If you call any RPC method that returns a stream, and the stream is longer than what the RPC layer buffers, and you call and await any other docs method *while consuming the stream*, the docs actor will deadlock. 
(It will only happen though if the stream is longer than the capacity of the intermediate channel that goes from the actor to the RPC layer, which is why this does not *always* happen)

This is the case for all methods that return iterators. The solution is twofold:

* Run single-threaded executor in iroh-docs actor loop
* For actions returning iterators/streams, spawn a task on that executor to forward the store iterator into the stream, yielding when the receiver is not consuming fast enough

To be able to spawn the iterators onto a task, they have to be `'static`. Which they can be - but only when operating on snapshots.

So this PR fixes the potential for deadlock. It has the downside, however, that whenever calling a docs client function that returns an iterator, the current write transaction will be committed first, which has a perfomance penalty. However this is preferable to deadlocks, IMO.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

This will need tests and likely documentation of the perfomance implications.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
