### PR TITLE
refactor(iroh_net)!: Remove Endpoint::my_addr_with_endpoints

### DIFF
--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -378,7 +378,11 @@ impl Actor {
                 new_endpoints = self.on_endpoints_rx.recv() => {
                     match new_endpoints {
                         Some(endpoints) => {
-                            let addr = self.endpoint.my_addr_with_endpoints(endpoints)?;
+                            let addr = NodeAddr::from_parts(
+                                self.endpoint.node_id(),
+                                self.endpoint.my_relay(),
+                                endpoints.into_iter().map(|x| x.addr).collect(),
+                            );
                             let peer_data = encode_peer_data(&addr.info)?;
                             self.handle_in_event(InEvent::UpdatePeerData(peer_data), Instant::now()).await?;
                         }

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -28,7 +28,6 @@ use tracing::{debug, info_span, trace, warn};
 use url::Url;
 
 use crate::{
-    config,
     defaults::default_relay_map,
     discovery::{Discovery, DiscoveryTask},
     dns::{default_resolver, DnsResolver},
@@ -577,16 +576,6 @@ impl Endpoint {
             .ok_or(anyhow!("No IP endpoints found"))?;
         let relay = self.my_relay();
         let addrs = addrs.into_iter().map(|x| x.addr).collect();
-        Ok(NodeAddr::from_parts(self.node_id(), relay, addrs))
-    }
-
-    /// Returns the [`NodeAddr`] for this endpoint with the provided endpoints.
-    ///
-    /// Like [`Endpoint::my_addr`] but uses the provided IP endpoints rather than those from
-    /// [`Endpoint::local_endpoints`].
-    pub fn my_addr_with_endpoints(&self, eps: Vec<config::Endpoint>) -> Result<NodeAddr> {
-        let relay = self.my_relay();
-        let addrs = eps.into_iter().map(|x| x.addr).collect();
         Ok(NodeAddr::from_parts(self.node_id(), relay, addrs))
     }
 


### PR DESCRIPTION
## Description

This removes the Endpoint::my_addr_with_endpoints API.  It is rather
esoteric, very easy to do by hand and uses the dreaded endpoint noun
in the wrong context.

## Breaking Changes

- Endpoing::my_addr_with_endpoints has been removed.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- ~~Tests if relevant.~~
- [x] All breaking changes documented.