### PR TITLE
refactor(iroh-net)!: Rename Endpoint::my_relay to home_relay

### DIFF
--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -742,7 +742,7 @@ async fn accept(
         secret_key.public(),
         remote_addrs,
     );
-    if let Some(relay_url) = endpoint.my_relay() {
+    if let Some(relay_url) = endpoint.home_relay() {
         println!(
             "\tUsing just the relay url:\niroh doctor connect {} --relay-url {}\n",
             secret_key.public(),

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -380,7 +380,7 @@ impl Actor {
                         Some(endpoints) => {
                             let addr = NodeAddr::from_parts(
                                 self.endpoint.node_id(),
-                                self.endpoint.my_relay(),
+                                self.endpoint.home_relay(),
                                 endpoints.into_iter().map(|x| x.addr).collect(),
                             );
                             let peer_data = encode_peer_data(&addr.info)?;

--- a/iroh-net/examples/connect-unreliable.rs
+++ b/iroh-net/examples/connect-unreliable.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let relay_url = endpoint
-        .my_relay()
+        .home_relay()
         .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
     println!("node relay server url: {relay_url}\n");
     // Build a `NodeAddr` from the node_id, relay url, and UDP addresses.

--- a/iroh-net/examples/connect.rs
+++ b/iroh-net/examples/connect.rs
@@ -66,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let relay_url = endpoint
-        .my_relay()
+        .home_relay()
         .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
     println!("node relay server url: {relay_url}\n");
     // Build a `NodeAddr` from the node_id, relay url, and UDP addresses.

--- a/iroh-net/examples/listen-unreliable.rs
+++ b/iroh-net/examples/listen-unreliable.rs
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
         .join(" ");
 
     let relay_url = endpoint
-        .my_relay()
+        .home_relay()
         .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
     println!("node relay server url: {relay_url}");
     println!("\nin a separate terminal run:");

--- a/iroh-net/examples/listen.rs
+++ b/iroh-net/examples/listen.rs
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
         .join(" ");
 
     let relay_url = endpoint
-        .my_relay()
+        .home_relay()
         .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
     println!("node relay server url: {relay_url}");
     println!("\nin a separate terminal run:");

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -566,7 +566,7 @@ impl Endpoint {
     /// Returns the current [`NodeAddr`] for this endpoint.
     ///
     /// The returned [`NodeAddr`] will have the current [`RelayUrl`] and local IP endpoints
-    /// as they would be returned by [`Endpoint::my_relay`] and
+    /// as they would be returned by [`Endpoint::home_relay`] and
     /// [`Endpoint::local_endpoints`].
     pub async fn my_addr(&self) -> Result<NodeAddr> {
         let addrs = self
@@ -574,7 +574,7 @@ impl Endpoint {
             .next()
             .await
             .ok_or(anyhow!("No IP endpoints found"))?;
-        let relay = self.my_relay();
+        let relay = self.home_relay();
         let addrs = addrs.into_iter().map(|x| x.addr).collect();
         Ok(NodeAddr::from_parts(self.node_id(), relay, addrs))
     }
@@ -591,7 +591,7 @@ impl Endpoint {
     /// Note that this will be `None` right after the [`Endpoint`] is created since it takes
     /// some time to connect to find and connect to the home relay server.  Use
     /// [`Endpoint::watch_home_relay`] to wait until the home relay server is available.
-    pub fn my_relay(&self) -> Option<RelayUrl> {
+    pub fn home_relay(&self) -> Option<RelayUrl> {
         self.msock.my_relay()
     }
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -147,7 +147,7 @@ impl<D: BaoStore> Node<D> {
 
     /// Get the relay server we are connected to.
     pub fn my_relay(&self) -> Option<iroh_net::relay::RelayUrl> {
-        self.inner.endpoint.my_relay()
+        self.inner.endpoint.home_relay()
     }
 
     /// Aborts the node.

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -763,7 +763,7 @@ impl<D: BaoStore> Handler<D> {
 
     #[allow(clippy::unused_async)]
     async fn node_relay(self, _: NodeRelayRequest) -> RpcResult<Option<RelayUrl>> {
-        Ok(self.inner.endpoint.my_relay())
+        Ok(self.inner.endpoint.home_relay())
     }
 
     #[allow(clippy::unused_async)]


### PR DESCRIPTION
## Description

This renames Endpoint::my_relay to Endpoint::home_relay.  This is more
descriptive, because home relay is how we describe this in other parts
of the documentation.  There is also no real consistency of the `my_`
prefix, there's only one other API currently which I'll independently
propose to remove.


## Breaking Changes

- Endpoint::my_relay -> Endpoint::home_relay

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.