### PR TITLE
refactor(iroh-net)!: Rename Endpoint::my_addr to Endpoint::node_addr

### DIFF
--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -108,13 +108,13 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     println!("> our node id: {}", endpoint.node_id());
 
-    let my_addr = endpoint.my_addr().await?;
+    let my_addr = endpoint.node_addr().await?;
     // create the gossip protocol
     let gossip = Gossip::from_endpoint(endpoint.clone(), Default::default(), &my_addr.info);
 
     // print a ticket that includes our own node id and endpoint addresses
     let ticket = {
-        let me = endpoint.my_addr().await?;
+        let me = endpoint.node_addr().await?;
         let peers = peers.iter().cloned().chain([me]).collect();
         Ticket { topic, peers }
     };

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -416,7 +416,7 @@ mod tests {
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
         // wait for out address to be updated and thus published at least once
-        ep1.my_addr().await?;
+        ep1.node_addr().await?;
         let _conn = ep2.connect(ep1_addr, TEST_ALPN).await?;
         Ok(())
     }
@@ -442,7 +442,7 @@ mod tests {
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
         // wait for out address to be updated and thus published at least once
-        ep1.my_addr().await?;
+        ep1.node_addr().await?;
         let _conn = ep2.connect(ep1_addr, TEST_ALPN).await?;
         Ok(())
     }
@@ -472,7 +472,7 @@ mod tests {
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
         // wait for out address to be updated and thus published at least once
-        ep1.my_addr().await?;
+        ep1.node_addr().await?;
         let _conn = ep2.connect(ep1_addr, TEST_ALPN).await?;
         Ok(())
     }
@@ -495,7 +495,7 @@ mod tests {
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
         // wait for out address to be updated and thus published at least once
-        ep1.my_addr().await?;
+        ep1.node_addr().await?;
         let res = ep2.connect(ep1_addr, TEST_ALPN).await;
         assert!(res.is_err());
         Ok(())
@@ -518,7 +518,7 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         // wait for out address to be updated and thus published at least once
-        ep1.my_addr().await?;
+        ep1.node_addr().await?;
         let ep1_wrong_addr = NodeAddr {
             node_id: ep1.node_id(),
             info: AddrInfo {

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -568,7 +568,7 @@ impl Endpoint {
     /// The returned [`NodeAddr`] will have the current [`RelayUrl`] and local IP endpoints
     /// as they would be returned by [`Endpoint::my_relay`] and
     /// [`Endpoint::local_endpoints`].
-    pub async fn my_addr(&self) -> Result<NodeAddr> {
+    pub async fn node_addr(&self) -> Result<NodeAddr> {
         let addrs = self
             .local_endpoints()
             .next()
@@ -1067,7 +1067,7 @@ mod tests {
             .bind(0)
             .await
             .unwrap();
-        let my_addr = ep.my_addr().await.unwrap();
+        let my_addr = ep.node_addr().await.unwrap();
         let res = ep.connect(my_addr.clone(), TEST_ALPN).await;
         assert!(res.is_err());
         let err = res.err().unwrap();
@@ -1341,8 +1341,8 @@ mod tests {
             .bind(0)
             .await
             .unwrap();
-        let ep1_nodeaddr = ep1.my_addr().await.unwrap();
-        let ep2_nodeaddr = ep2.my_addr().await.unwrap();
+        let ep1_nodeaddr = ep1.node_addr().await.unwrap();
+        let ep2_nodeaddr = ep2.node_addr().await.unwrap();
         ep1.add_node_addr(ep2_nodeaddr.clone()).unwrap();
         ep2.add_node_addr(ep1_nodeaddr.clone()).unwrap();
         let ep1_nodeid = ep1.node_id();
@@ -1438,7 +1438,7 @@ mod tests {
         let ep1_nodeid = ep1.node_id();
         let ep2_nodeid = ep2.node_id();
 
-        let ep1_nodeaddr = ep1.my_addr().await.unwrap();
+        let ep1_nodeaddr = ep1.node_addr().await.unwrap();
         tracing::info!(
             "node id 1 {ep1_nodeid}, relay URL {:?}",
             ep1_nodeaddr.relay_url()

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -437,7 +437,7 @@ where
 
         debug!("rpc listening on: {:?}", self.rpc_endpoint.local_addr());
 
-        let addr = endpoint.my_addr().await?;
+        let addr = endpoint.node_addr().await?;
 
         // initialize the gossip protocol
         let gossip = Gossip::from_endpoint(endpoint.clone(), Default::default(), &addr.info);

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -741,7 +741,7 @@ impl<D: BaoStore> Handler<D> {
 
     async fn node_status(self, _: NodeStatusRequest) -> RpcResult<NodeStatus> {
         Ok(NodeStatus {
-            addr: self.inner.endpoint.my_addr().await?,
+            addr: self.inner.endpoint.node_addr().await?,
             listen_addrs: self
                 .inner
                 .local_endpoint_addresses()
@@ -757,7 +757,7 @@ impl<D: BaoStore> Handler<D> {
     }
 
     async fn node_addr(self, _: NodeAddrRequest) -> RpcResult<NodeAddr> {
-        let addr = self.inner.endpoint.my_addr().await?;
+        let addr = self.inner.endpoint.node_addr().await?;
         Ok(addr)
     }
 

--- a/iroh/src/node/rpc/docs.rs
+++ b/iroh/src/node/rpc/docs.rs
@@ -146,7 +146,7 @@ impl DocsEngine {
             mode,
             addr_options,
         } = req;
-        let mut me = self.endpoint.my_addr().await?;
+        let mut me = self.endpoint.node_addr().await?;
         me.apply_options(addr_options);
 
         let capability = match mode {


### PR DESCRIPTION
## Description

This is in line with e.g. Endpoint::node_id.

## Breaking Changes

- Endpoint::my_addr -> Endpoint::node_addr

## Notes & open questions

Other networking APIs tend to have something like "local_addr",
e.g. UdpSocket::local_addr in the standard library or
Endpoint::local_addr in Quinn.  Sometimes this is because they also
have a "peer_addr" version, e.g. UdpSocket::peer_addr.

In this light perhaps some of our APIs might benefit from using this
for consistency with other API conventions.  In this case this would
become Endpoint::local_node_addr.

We already have Endpoint::local_addr which returns the socket
addresses we are bound to.  Other candidates would be:

- Endpoint::home_relay -> Endpoint::local_home_relay
- Endpoint::node_id -> Endpoint::local_node_id
- Endpoint::secret_key -> Endpoint::local_secret_key

But, you can already see this fall apart.  Because our endpoint is not
the thing that is connected to a peer (that is the Connection) I don't
think it makes sense to use the term "local" in the APIs.

And perhaps Endpoint::local_addr should be changed anyway, while it is
compatible with other usages it is rather out of tone for us because
we have too many kind of addresses (socket address, node address,
direct address, ...?).  So perhaps that one is better off as
Endpoint::bound_sockets or so.


## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.