### PR TITLE
refactor(iroh-net)!: Do not use &NodeId in APIs as this is Copy

### DIFF
--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -692,7 +692,7 @@ async fn connect(
     let conn = endpoint.connect(node_addr, &DR_RELAY_ALPN).await;
     match conn {
         Ok(connection) => {
-            let maybe_stream = endpoint.conn_type_stream(&node_id);
+            let maybe_stream = endpoint.conn_type_stream(node_id);
             let gui = Gui::new(endpoint, node_id);
             if let Ok(stream) = maybe_stream {
                 log_connection_changes(gui.mp.clone(), node_id, stream);
@@ -770,7 +770,7 @@ async fn accept(
                         println!("Accepted connection from {}", remote_peer_id);
                         let t0 = Instant::now();
                         let gui = Gui::new(endpoint.clone(), remote_peer_id);
-                        if let Ok(stream) = endpoint.conn_type_stream(&remote_peer_id) {
+                        if let Ok(stream) = endpoint.conn_type_stream(remote_peer_id) {
                             log_connection_changes(gui.mp.clone(), remote_peer_id, stream);
                         }
                         let res = active_side(connection, &config, Some(&gui)).await;

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -33,6 +33,7 @@ use std::{
 use anyhow::{anyhow, Context as _, Result};
 use bytes::Bytes;
 use futures_lite::{FutureExt, Stream, StreamExt};
+use iroh_base::key::NodeId;
 use iroh_metrics::{inc, inc_by};
 use quinn::AsyncUdpSocket;
 use rand::{seq::SliceRandom, Rng, SeedableRng};
@@ -299,8 +300,8 @@ impl MagicSock {
     }
 
     /// Retrieve connection information about a node in the network.
-    pub fn connection_info(&self, node_key: PublicKey) -> Option<ConnectionInfo> {
-        self.node_map.node_info(&node_key)
+    pub fn connection_info(&self, node_id: NodeId) -> Option<ConnectionInfo> {
+        self.node_map.node_info(node_id)
     }
 
     /// Returns the local endpoints as a stream.
@@ -350,7 +351,7 @@ impl MagicSock {
     ///
     /// Will return an error if there is no address information known about the
     /// given `node_id`.
-    pub fn conn_type_stream(&self, node_id: &PublicKey) -> Result<ConnectionTypeStream> {
+    pub fn conn_type_stream(&self, node_id: NodeId) -> Result<ConnectionTypeStream> {
         self.node_map.conn_type_stream(node_id)
     }
 
@@ -358,9 +359,9 @@ impl MagicSock {
     ///
     /// Note this is a user-facing API and does not wrap the [`SocketAddr`] in a
     /// [`QuicMappedAddr`] as we do internally.
-    pub fn get_mapping_addr(&self, node_key: &PublicKey) -> Option<SocketAddr> {
+    pub fn get_mapping_addr(&self, node_id: NodeId) -> Option<SocketAddr> {
         self.node_map
-            .get_quic_mapped_addr_for_node_key(node_key)
+            .get_quic_mapped_addr_for_node_key(node_id)
             .map(|a| a.0)
     }
 
@@ -468,7 +469,7 @@ impl MagicSock {
         let mut transmits_sent = 0;
         match self
             .node_map
-            .get_send_addrs(&dest, self.ipv6_reported.load(Ordering::Relaxed))
+            .get_send_addrs(dest, self.ipv6_reported.load(Ordering::Relaxed))
         {
             Some((public_key, udp_addr, relay_url, mut msgs)) => {
                 let mut pings_sent = false;

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -962,7 +962,7 @@ impl NodeState {
             .reconfirm_if_used(addr.into(), Source::Udp, now);
     }
 
-    pub(super) fn receive_relay(&mut self, url: &RelayUrl, _src: &PublicKey, now: Instant) {
+    pub(super) fn receive_relay(&mut self, url: &RelayUrl, _src: NodeId, now: Instant) {
         match self.relay_url.as_mut() {
             Some((current_home, state)) if current_home == url => {
                 // We received on the expected url. update state.


### PR DESCRIPTION
## Description

Some of our APIs take NodeId by reference, some by value.  NodeId
itself however is Copy and takes 32 bytes.  I think it is more
consistent and rusty to pass this by value and use the Copy semantics.

Additionally this renames a few more types from PublicKey to NodeId to
keep in line with our convention of using NodeId when used as
identifier rather than cryptography.  I believe rust-analyser might be
inserting PublicKey by itself which is unfortunate.

QuicMappedAddr and IpPort are also a Copy types and get the same
treatment.

## Breaking Changes

- Endpoint::conn_type_stream takes NodeId by value instead of by reference.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.