### PR TITLE
refactor(iroh-net)!: Rename Endpoint::local_addr to bound_sockets

### DIFF
--- a/iroh-net/bench/src/iroh.rs
+++ b/iroh-net/bench/src/iroh.rs
@@ -29,7 +29,7 @@ pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (NodeAddr, En
             .bind(0)
             .await
             .unwrap();
-        let addr = ep.local_addr();
+        let addr = ep.bound_sockets();
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
         let addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
         (addr, ep)

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -650,7 +650,7 @@ impl Endpoint {
     ///
     /// The [`Endpoint`] always binds on an IPv4 address and also tries to bind on an IPv6
     /// address if available.
-    pub fn local_addr(&self) -> (SocketAddr, Option<SocketAddr>) {
+    pub fn bound_sockets(&self) -> (SocketAddr, Option<SocketAddr>) {
         self.msock.local_addr()
     }
 
@@ -1246,7 +1246,7 @@ mod tests {
                         .bind(0)
                         .await
                         .unwrap();
-                    let eps = ep.local_addr();
+                    let eps = ep.bound_sockets();
                     info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "server bound");
                     for i in 0..n_clients {
                         let now = Instant::now();
@@ -1291,7 +1291,7 @@ mod tests {
                     .bind(0)
                     .await
                     .unwrap();
-                let eps = ep.local_addr();
+                let eps = ep.bound_sockets();
                 info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "client bound");
                 let node_addr = NodeAddr::new(server_node_id).with_relay_url(relay_url);
                 info!(to = ?node_addr, "client connecting");

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -107,7 +107,7 @@ impl<D: BaoStore> Node<D> {
     /// can contact the node consider using [`Node::local_endpoint_addresses`].  However the
     /// port will always be the concrete port.
     pub fn local_address(&self) -> Vec<SocketAddr> {
-        let (v4, v6) = self.inner.endpoint.local_addr();
+        let (v4, v6) = self.inner.endpoint.bound_sockets();
         let mut addrs = vec![v4];
         if let Some(v6) = v6 {
             addrs.push(v6);

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -552,7 +552,7 @@ where
     ) {
         let rpc = RpcServer::new(rpc);
         let internal_rpc = RpcServer::new(internal_rpc);
-        let (ipv4, ipv6) = server.local_addr();
+        let (ipv4, ipv6) = server.bound_sockets();
         debug!(
             "listening at: {}{}",
             ipv4,


### PR DESCRIPTION
## Description

This renames Endpoint::local_addr to Endpoint::bound_sockets.  We have
a lot of different meanings for "addr" and also don't really have a
notion of "local_" prefix, since the endpoint is not 1:1 connected
with a peer.  The "local_" naming comes from connected sockets which
have local_addr and peer_addr, which is not applicable for the
Endpoint.

## Breaking Changes

- Endpoint::local_addr -> Endpoint::bound_sockets

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.