### PR TITLE
Experiment: two stage builder approach for custom protocols

### DIFF
--- a/iroh-blobs/src/store/traits.rs
+++ b/iroh-blobs/src/store/traits.rs
@@ -6,6 +6,7 @@ use bao_tree::{
     BaoTree, ChunkRanges,
 };
 use bytes::Bytes;
+use derive_more::Debug;
 use futures_lite::{Stream, StreamExt};
 use genawaiter::rc::{Co, Gen};
 use iroh_base::rpc::RpcError;
@@ -295,7 +296,7 @@ pub trait ReadableStore: Map {
 }
 
 /// The mutable part of a Bao store.
-pub trait Store: ReadableStore + MapMut {
+pub trait Store: ReadableStore + MapMut + Debug {
     /// This trait method imports a file from a local path.
     ///
     /// `data` is the path to the file.

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -28,6 +28,7 @@ use tracing::debug;
 use crate::client::RpcService;
 
 mod builder;
+mod protocol;
 mod rpc;
 mod rpc_status;
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -9,11 +9,13 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use futures_lite::future::Boxed;
 use futures_lite::StreamExt;
 use iroh_base::key::PublicKey;
 use iroh_blobs::downloader::Downloader;
 use iroh_blobs::store::Store as BaoStore;
 use iroh_docs::engine::Engine;
+use iroh_net::endpoint::Connecting;
 use iroh_net::util::AbortingJoinHandle;
 use iroh_net::{endpoint::LocalEndpointsStream, key::SecretKey, Endpoint};
 use quic_rpc::transport::flume::FlumeConnection;
@@ -47,6 +49,17 @@ pub struct Node<D> {
     inner: Arc<NodeInner<D>>,
     task: Arc<JoinHandle<()>>,
     client: crate::client::MemIroh,
+}
+
+///
+pub trait Protocol: Send + Sync + Debug + 'static {
+    /// Accept a connection
+    fn accept(&self, conn: Connecting) -> Boxed<Result<()>>;
+
+    /// Shutdown
+    fn shutdown(&self) -> Boxed<()> {
+        Box::pin(async move {})
+    }
 }
 
 #[derive(derive_more::Debug)]

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -52,7 +52,7 @@ pub struct Node<D> {
     client: crate::client::MemIroh,
 }
 
-///
+/// A protocol
 pub trait Protocol: Send + Sync + Debug + 'static {
     /// Accept a connection
     fn accept(&self, conn: Connecting) -> Boxed<Result<()>>;

--- a/iroh/src/node/protocol.rs
+++ b/iroh/src/node/protocol.rs
@@ -57,7 +57,6 @@ impl Protocol for DocsEngine {
         let this = self.clone();
         Box::pin(async move { this.handle_connection(conn).await })
     }
-
     fn shutdown(&self) -> future::Boxed<()> {
         let this = self.clone();
         Box::pin(async move {

--- a/iroh/src/node/protocol.rs
+++ b/iroh/src/node/protocol.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+use futures_lite::future;
+use iroh_net::endpoint::Connecting;
+use std::ops::Deref;
+use tracing::warn;
+
+use super::{DocsEngine, Protocol};
+
+#[derive(Debug)]
+pub(crate) struct BlobsProtocol<S> {
+    rt: tokio_util::task::LocalPoolHandle,
+    store: S,
+}
+
+impl<S: iroh_blobs::store::Store> BlobsProtocol<S> {
+    pub fn new(store: S, rt: tokio_util::task::LocalPoolHandle) -> Self {
+        Self { rt, store }
+    }
+}
+
+impl<S: iroh_blobs::store::Store> Protocol for BlobsProtocol<S> {
+    fn accept(&self, conn: Connecting) -> future::Boxed<Result<()>> {
+        let store = self.store.clone();
+        let rt = self.rt.clone();
+        Box::pin(async move {
+            iroh_blobs::provider::handle_connection(conn.await?, store, MockEventSender, rt).await;
+            Ok(())
+        })
+    }
+
+    fn shutdown(&self) -> future::Boxed<()> {
+        let store = self.store.clone();
+        Box::pin(async move {
+            store.shutdown().await;
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MockEventSender;
+
+impl iroh_blobs::provider::EventSender for MockEventSender {
+    fn send(&self, _event: iroh_blobs::provider::Event) -> futures_lite::future::Boxed<()> {
+        Box::pin(std::future::ready(()))
+    }
+}
+
+impl Protocol for iroh_gossip::net::Gossip {
+    fn accept(&self, conn: Connecting) -> future::Boxed<Result<()>> {
+        let this = self.clone();
+        Box::pin(async move { this.handle_connection(conn.await?).await })
+    }
+}
+
+impl Protocol for DocsEngine {
+    fn accept(&self, conn: Connecting) -> future::Boxed<Result<()>> {
+        let this = self.clone();
+        Box::pin(async move { this.handle_connection(conn).await })
+    }
+
+    fn shutdown(&self) -> future::Boxed<()> {
+        let this = self.clone();
+        Box::pin(async move {
+            if let Err(err) = this.deref().shutdown().await {
+                warn!("Error while shutting down docs engine: {err:?}");
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Description

This is like https://github.com/n0-computer/iroh/pull/2358, but instead of having a factory function to create a protocol, it uses a two stage builder approach where you first build a non-accepting node, then add all the promised handlers, and then turn it into a full (accepting, rpc active) node.

Note that I have also changed the signature of the protocol handlers, but that is unrelated to the main difference and a matter of taste I guess. In one case you leave it up to the handlers to make a future long lived, in the other case you force the client to arc the handlers...

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
