### PR TITLE
fix(iroh-net)!: ALPNs can be bytes, not just strings

### DIFF
--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -206,11 +206,11 @@ async fn handle_connection(
     let alpn = conn.alpn().await?;
     let conn = conn.await?;
     let peer_id = iroh_net::endpoint::get_remote_node_id(&conn)?;
-    match alpn.as_bytes() {
-        GOSSIP_ALPN => gossip
-            .handle_connection(conn)
-            .await
-            .context(format!("connection to {peer_id} with ALPN {alpn} failed"))?,
+    match alpn.as_ref() {
+        GOSSIP_ALPN => gossip.handle_connection(conn).await.context(format!(
+            "connection to {peer_id} with ALPN {} failed",
+            String::from_utf8_lossy(&alpn)
+        ))?,
         _ => println!("> ignoring connection from {peer_id}: unsupported ALPN protocol"),
     }
     Ok(())

--- a/iroh-net/examples/listen-unreliable.rs
+++ b/iroh-net/examples/listen-unreliable.rs
@@ -67,7 +67,8 @@ async fn main() -> anyhow::Result<()> {
         let conn = conn.await?;
         let node_id = iroh_net::endpoint::get_remote_node_id(&conn)?;
         info!(
-            "new (unreliable) connection from {node_id} with ALPN {alpn} (coming from {})",
+            "new (unreliable) connection from {node_id} with ALPN {} (coming from {})",
+            String::from_utf8_lossy(&alpn),
             conn.remote_address()
         );
         // spawn a task to handle reading and writing off of the connection

--- a/iroh-net/examples/listen.rs
+++ b/iroh-net/examples/listen.rs
@@ -66,7 +66,8 @@ async fn main() -> anyhow::Result<()> {
         let conn = conn.await?;
         let node_id = iroh_net::endpoint::get_remote_node_id(&conn)?;
         info!(
-            "new connection from {node_id} with ALPN {alpn} (coming from {})",
+            "new connection from {node_id} with ALPN {} (coming from {})",
+            String::from_utf8_lossy(&alpn),
             conn.remote_address()
         );
 

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -734,12 +734,12 @@ impl Default for GcPolicy {
 #[allow(clippy::too_many_arguments)]
 async fn handle_connection<D: BaoStore>(
     connecting: iroh_net::endpoint::Connecting,
-    alpn: String,
+    alpn: Vec<u8>,
     node: Arc<NodeInner<D>>,
     gossip: Gossip,
     sync: DocsEngine,
 ) -> Result<()> {
-    match alpn.as_bytes() {
+    match alpn.as_ref() {
         GOSSIP_ALPN => gossip.handle_connection(connecting.await?).await?,
         DOCS_ALPN => sync.handle_connection(connecting).await?,
         alpn if alpn == iroh_blobs::protocol::ALPN => {


### PR DESCRIPTION
## Breaking Changes

- `iroh_net::endpoint::Connecting::alpn` returns `Vec<u8>` instead of `String`
