### PR TITLE
tests(iroh-net): Remove a flaky test

### DIFF
--- a/iroh-net/src/dns.rs
+++ b/iroh-net/src/dns.rs
@@ -388,17 +388,6 @@ pub(crate) mod tests {
     const STAGGERING_DELAYS: &[u64] = &[200, 300];
 
     #[tokio::test]
-    #[cfg_attr(target_os = "windows", ignore = "flaky")]
-    async fn test_dns_lookup_basic() {
-        let _logging = iroh_test::logging::setup();
-        let resolver = default_resolver();
-        let res = resolver.lookup_ip(NA_RELAY_HOSTNAME).await.unwrap();
-        let res: Vec<_> = res.iter().collect();
-        assert!(!res.is_empty());
-        dbg!(res);
-    }
-
-    #[tokio::test]
     async fn test_dns_lookup_ipv4_ipv6() {
         let _logging = iroh_test::logging::setup();
         let resolver = default_resolver();


### PR DESCRIPTION
## Description

This flakyness seems to have been successfully addressed by the
staggered DNS lookup.  Converting this test to that basically results
in the same code as the next test: test_dns_lookup_ipv4_ipv6.  So just
remove this test as it no longer provides value.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates if relevant.~~
- [x] Tests if relevant.
- ~~[ ] All breaking changes documented.~~