### PR TITLE
feat(iroh-net): Implement `websocket` protocol upgrade in iroh-relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 [[package]]
 name = "fastwebsockets"
 version = "0.7.2"
+source = "git+https://github.com/denoland/fastwebsockets#efc0788ec512a2634253bf5d5d41005fa76413cd"
 dependencies = [
  "base64 0.21.7",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,12 +2902,13 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-rustls-acme",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite-wasm",
  "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
- "tungstenite",
+ "tungstenite 0.23.0",
  "url",
  "watchable",
  "webpki-roots 0.25.4",
@@ -5893,6 +5894,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
@@ -5900,7 +5913,25 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.23.0",
+]
+
+[[package]]
+name = "tokio-tungstenite-wasm"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e57a65894797a018b28345fa298a00c450a574aa9671e50b18218a6292a55ac"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "httparse",
+ "js-sys",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -6124,6 +6155,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,13 +2426,13 @@ dependencies = [
  "hex",
  "indicatif",
  "iroh",
- "iroh-base 0.18.0",
+ "iroh-base",
  "iroh-blobs",
  "iroh-docs",
  "iroh-gossip",
  "iroh-io",
- "iroh-metrics 0.18.0",
- "iroh-net 0.18.0",
+ "iroh-metrics",
+ "iroh-net",
  "iroh-quinn",
  "iroh-test",
  "num_cpus",
@@ -2491,34 +2491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-base"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13afc5b57e7204f74df49d1ce73c67d0e9d2a1b588a2985247af52c047ca964"
-dependencies = [
- "aead",
- "anyhow",
- "crypto_box",
- "data-encoding",
- "derive_more",
- "ed25519-dalek",
- "getrandom",
- "hex",
- "iroh-blake3",
- "once_cell",
- "postcard",
- "rand",
- "rand_core",
- "serde",
- "serde-error",
- "ssh-key",
- "thiserror",
- "ttl_cache",
- "url",
- "zeroize",
-]
-
-[[package]]
 name = "iroh-blake3"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,11 +2520,11 @@ dependencies = [
  "hashlink",
  "hex",
  "http-body 0.4.6",
- "iroh-base 0.18.0",
+ "iroh-base",
  "iroh-blobs",
  "iroh-io",
- "iroh-metrics 0.18.0",
- "iroh-net 0.18.0",
+ "iroh-metrics",
+ "iroh-net",
  "iroh-quinn",
  "iroh-test",
  "num_cpus",
@@ -2603,7 +2575,7 @@ dependencies = [
  "human-time",
  "indicatif",
  "iroh",
- "iroh-metrics 0.18.0",
+ "iroh-metrics",
  "nix 0.27.1",
  "parking_lot",
  "pkarr",
@@ -2651,8 +2623,8 @@ dependencies = [
  "hickory-resolver",
  "hickory-server",
  "http 1.1.0",
- "iroh-metrics 0.18.0",
- "iroh-net 0.18.0",
+ "iroh-metrics",
+ "iroh-net",
  "iroh-test",
  "lru",
  "mainline",
@@ -2694,12 +2666,12 @@ dependencies = [
  "futures-lite 2.3.0",
  "futures-util",
  "hex",
- "iroh-base 0.18.0",
+ "iroh-base",
  "iroh-blake3",
  "iroh-blobs",
  "iroh-gossip",
- "iroh-metrics 0.18.0",
- "iroh-net 0.18.0",
+ "iroh-metrics",
+ "iroh-net",
  "iroh-test",
  "lru",
  "num_enum",
@@ -2734,10 +2706,10 @@ dependencies = [
  "futures-lite 2.3.0",
  "genawaiter",
  "indexmap 2.2.6",
- "iroh-base 0.18.0",
+ "iroh-base",
  "iroh-blake3",
- "iroh-metrics 0.18.0",
- "iroh-net 0.18.0",
+ "iroh-metrics",
+ "iroh-net",
  "iroh-test",
  "postcard",
  "rand",
@@ -2767,27 +2739,6 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.18.0"
-dependencies = [
- "anyhow",
- "erased_set",
- "http-body-util",
- "hyper 1.3.1",
- "hyper-util",
- "once_cell",
- "prometheus-client",
- "reqwest 0.12.4",
- "serde",
- "struct_iterable",
- "time",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "iroh-metrics"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e767734a4d6b92e0ad0c74afd38240b82a37bdfeb0bb3141245c2a707efa4097"
 dependencies = [
  "anyhow",
  "erased_set",
@@ -2836,9 +2787,8 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "igd-next",
- "iroh-base 0.18.0",
- "iroh-metrics 0.18.0",
- "iroh-net 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-base",
+ "iroh-metrics",
  "iroh-quinn",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
@@ -2899,82 +2849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-net"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76677befbb2d205510c9c18f5509157cb8d84cb345420e595f6612c9a1a6f88c"
-dependencies = [
- "aead",
- "anyhow",
- "backoff",
- "base64 0.22.1",
- "bytes",
- "der",
- "derive_more",
- "duct",
- "flume",
- "futures-buffered",
- "futures-concurrency",
- "futures-lite 2.3.0",
- "futures-sink",
- "futures-util",
- "governor",
- "hex",
- "hickory-proto",
- "hickory-resolver",
- "hostname",
- "http 1.1.0",
- "http-body-util",
- "hyper 1.3.1",
- "hyper-util",
- "igd-next",
- "iroh-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iroh-metrics 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iroh-quinn",
- "iroh-quinn-proto",
- "iroh-quinn-udp",
- "libc",
- "netdev",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-sys",
- "num_enum",
- "once_cell",
- "parking_lot",
- "pin-project",
- "pkarr",
- "postcard",
- "rand",
- "rand_core",
- "rcgen 0.12.1",
- "reqwest 0.12.4",
- "ring 0.17.8",
- "rtnetlink",
- "rustls 0.21.12",
- "rustls-webpki 0.101.7",
- "serde",
- "smallvec",
- "socket2",
- "strum 0.26.2",
- "stun-rs",
- "surge-ping",
- "thiserror",
- "time",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-rustls-acme",
- "tokio-util",
- "tracing",
- "url",
- "watchable",
- "webpki-roots 0.25.4",
- "windows 0.51.1",
- "wmi",
- "x509-parser 0.15.1",
- "z32",
-]
-
-[[package]]
 name = "iroh-net-bench"
 version = "0.18.0"
 dependencies = [
@@ -2982,7 +2856,7 @@ dependencies = [
  "bytes",
  "clap",
  "hdrhistogram",
- "iroh-net 0.18.0",
+ "iroh-net",
  "quinn",
  "rcgen 0.11.3",
  "rustls 0.21.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,25 +1505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
-name = "fastwebsockets"
-version = "0.7.2"
-source = "git+https://github.com/denoland/fastwebsockets#efc0788ec512a2634253bf5d5d41005fa76413cd"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "http-body-util",
- "hyper 1.3.1",
- "hyper-util",
- "pin-project",
- "rand",
- "sha1",
- "simdutf8",
- "thiserror",
- "tokio",
- "utf-8",
-]
-
-[[package]]
 name = "fd-lock"
 version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,7 +2820,6 @@ dependencies = [
  "der",
  "derive_more",
  "duct",
- "fastwebsockets",
  "flume",
  "futures-buffered",
  "futures-concurrency",
@@ -5233,12 +5213,6 @@ dependencies = [
  "digest",
  "rand_core",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple-dns"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,6 +1505,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fastwebsockets"
+version = "0.7.2"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project",
+ "rand",
+ "sha1",
+ "simdutf8",
+ "thiserror",
+ "tokio",
+ "utf-8",
+]
+
+[[package]]
 name = "fd-lock"
 version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,13 +2444,13 @@ dependencies = [
  "hex",
  "indicatif",
  "iroh",
- "iroh-base",
+ "iroh-base 0.18.0",
  "iroh-blobs",
  "iroh-docs",
  "iroh-gossip",
  "iroh-io",
- "iroh-metrics",
- "iroh-net",
+ "iroh-metrics 0.18.0",
+ "iroh-net 0.18.0",
  "iroh-quinn",
  "iroh-test",
  "num_cpus",
@@ -2491,6 +2509,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-base"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13afc5b57e7204f74df49d1ce73c67d0e9d2a1b588a2985247af52c047ca964"
+dependencies = [
+ "aead",
+ "anyhow",
+ "crypto_box",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek",
+ "getrandom",
+ "hex",
+ "iroh-blake3",
+ "once_cell",
+ "postcard",
+ "rand",
+ "rand_core",
+ "serde",
+ "serde-error",
+ "ssh-key",
+ "thiserror",
+ "ttl_cache",
+ "url",
+ "zeroize",
+]
+
+[[package]]
 name = "iroh-blake3"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,11 +2566,11 @@ dependencies = [
  "hashlink",
  "hex",
  "http-body 0.4.6",
- "iroh-base",
+ "iroh-base 0.18.0",
  "iroh-blobs",
  "iroh-io",
- "iroh-metrics",
- "iroh-net",
+ "iroh-metrics 0.18.0",
+ "iroh-net 0.18.0",
  "iroh-quinn",
  "iroh-test",
  "num_cpus",
@@ -2575,7 +2621,7 @@ dependencies = [
  "human-time",
  "indicatif",
  "iroh",
- "iroh-metrics",
+ "iroh-metrics 0.18.0",
  "nix 0.27.1",
  "parking_lot",
  "pkarr",
@@ -2623,8 +2669,8 @@ dependencies = [
  "hickory-resolver",
  "hickory-server",
  "http 1.1.0",
- "iroh-metrics",
- "iroh-net",
+ "iroh-metrics 0.18.0",
+ "iroh-net 0.18.0",
  "iroh-test",
  "lru",
  "mainline",
@@ -2666,12 +2712,12 @@ dependencies = [
  "futures-lite 2.3.0",
  "futures-util",
  "hex",
- "iroh-base",
+ "iroh-base 0.18.0",
  "iroh-blake3",
  "iroh-blobs",
  "iroh-gossip",
- "iroh-metrics",
- "iroh-net",
+ "iroh-metrics 0.18.0",
+ "iroh-net 0.18.0",
  "iroh-test",
  "lru",
  "num_enum",
@@ -2706,10 +2752,10 @@ dependencies = [
  "futures-lite 2.3.0",
  "genawaiter",
  "indexmap 2.2.6",
- "iroh-base",
+ "iroh-base 0.18.0",
  "iroh-blake3",
- "iroh-metrics",
- "iroh-net",
+ "iroh-metrics 0.18.0",
+ "iroh-net 0.18.0",
  "iroh-test",
  "postcard",
  "rand",
@@ -2756,6 +2802,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-metrics"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e767734a4d6b92e0ad0c74afd38240b82a37bdfeb0bb3141245c2a707efa4097"
+dependencies = [
+ "anyhow",
+ "erased_set",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "once_cell",
+ "prometheus-client",
+ "reqwest 0.12.4",
+ "serde",
+ "struct_iterable",
+ "time",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iroh-net"
 version = "0.18.0"
 dependencies = [
@@ -2771,6 +2838,7 @@ dependencies = [
  "der",
  "derive_more",
  "duct",
+ "fastwebsockets",
  "flume",
  "futures-buffered",
  "futures-concurrency",
@@ -2787,8 +2855,9 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "igd-next",
- "iroh-base",
- "iroh-metrics",
+ "iroh-base 0.18.0",
+ "iroh-metrics 0.18.0",
+ "iroh-net 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-quinn",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
@@ -2832,10 +2901,88 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-rustls-acme",
+ "tokio-tungstenite",
  "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "tungstenite",
+ "url",
+ "watchable",
+ "webpki-roots 0.25.4",
+ "windows 0.51.1",
+ "wmi",
+ "x509-parser 0.15.1",
+ "z32",
+]
+
+[[package]]
+name = "iroh-net"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76677befbb2d205510c9c18f5509157cb8d84cb345420e595f6612c9a1a6f88c"
+dependencies = [
+ "aead",
+ "anyhow",
+ "backoff",
+ "base64 0.22.1",
+ "bytes",
+ "der",
+ "derive_more",
+ "duct",
+ "flume",
+ "futures-buffered",
+ "futures-concurrency",
+ "futures-lite 2.3.0",
+ "futures-sink",
+ "futures-util",
+ "governor",
+ "hex",
+ "hickory-proto",
+ "hickory-resolver",
+ "hostname",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "igd-next",
+ "iroh-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-metrics 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-quinn",
+ "iroh-quinn-proto",
+ "iroh-quinn-udp",
+ "libc",
+ "netdev",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
+ "num_enum",
+ "once_cell",
+ "parking_lot",
+ "pin-project",
+ "pkarr",
+ "postcard",
+ "rand",
+ "rand_core",
+ "rcgen 0.12.1",
+ "reqwest 0.12.4",
+ "ring 0.17.8",
+ "rtnetlink",
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
+ "serde",
+ "smallvec",
+ "socket2",
+ "strum 0.26.2",
+ "stun-rs",
+ "surge-ping",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-rustls-acme",
+ "tokio-util",
+ "tracing",
  "url",
  "watchable",
  "webpki-roots 0.25.4",
@@ -2853,7 +3000,7 @@ dependencies = [
  "bytes",
  "clap",
  "hdrhistogram",
- "iroh-net",
+ "iroh-net 0.18.0",
  "quinn",
  "rcgen 0.11.3",
  "rustls 0.21.12",
@@ -5086,6 +5233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "simple-dns"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5738,6 +5891,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5961,6 +6126,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,6 +6252,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,13 +2832,13 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-rustls-acme",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite",
  "tokio-tungstenite-wasm",
  "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
- "tungstenite 0.23.0",
+ "tungstenite",
  "url",
  "watchable",
  "webpki-roots 0.25.4",
@@ -5749,19 +5749,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.21.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.23.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5777,7 +5765,7 @@ dependencies = [
  "js-sys",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.21.0",
+ "tokio-tungstenite",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -6021,24 +6009,6 @@ dependencies = [
  "sha1",
  "thiserror",
  "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.1.0",
- "httparse",
- "log",
- "rand",
- "sha1",
- "thiserror",
  "utf-8",
 ]
 

--- a/iroh-blobs/src/downloader/test.rs
+++ b/iroh-blobs/src/downloader/test.rs
@@ -10,7 +10,7 @@ use iroh_net::key::SecretKey;
 
 use crate::{
     get::{db::BlobId, progress::TransferState},
-    util::progress::{FlumeProgressSender, IdGenerator, ProgressSender},
+    util::progress::{FlumeProgressSender, IdGenerator},
 };
 
 use super::*;

--- a/iroh-blobs/src/downloader/test/dialer.rs
+++ b/iroh-blobs/src/downloader/test/dialer.rs
@@ -1,9 +1,6 @@
 //! Implementation of [`super::Dialer`] used for testing.
 
-use std::{
-    collections::HashSet,
-    task::{Context, Poll},
-};
+use std::task::{Context, Poll};
 
 use parking_lot::RwLock;
 

--- a/iroh-blobs/src/downloader/test/getter.rs
+++ b/iroh-blobs/src/downloader/test/getter.rs
@@ -2,7 +2,6 @@
 
 use futures_lite::{future::Boxed as BoxFuture, FutureExt};
 use parking_lot::RwLock;
-use std::{sync::Arc, time::Duration};
 
 use super::*;
 

--- a/iroh-blobs/src/store/bao_file.rs
+++ b/iroh-blobs/src/store/bao_file.rs
@@ -732,7 +732,6 @@ pub mod test_support {
         BlockSize, ChunkRanges,
     };
     use futures_lite::{Stream, StreamExt};
-    use iroh_base::hash::Hash;
     use iroh_io::AsyncStreamReader;
     use rand::RngCore;
     use range_collections::RangeSet2;

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -44,7 +44,6 @@ use iroh::{
 };
 use portable_atomic::AtomicU64;
 use postcard::experimental::max_size::MaxSize;
-use ratatui::backend::Backend;
 use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncWriteExt, sync};
 

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -89,7 +89,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 iroh-metrics = { version = "0.18.0", path = "../iroh-metrics", default-features = false }
 strum = { version = "0.26.2", features = ["derive"] }
 tungstenite = "0.23.0"
-fastwebsockets = { git = "https://github.com/denoland/fastwebsockets", revision = "efc0788", features = ["upgrade", "unstable-split"] }
 tokio-tungstenite = "0.23.1"
 tokio-tungstenite-wasm = "0.3.1"
 

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -116,7 +116,6 @@ tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macr
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 iroh-test = { path = "../iroh-test" }
 serde_json = "1.0.107"
-iroh-net-old = { package = "iroh-net", version = "=0.18.0" }
 
 [[bench]]
 name = "key"

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -68,8 +68,11 @@ time = "0.3.20"
 tokio = { version = "1", features = ["io-util", "macros", "sync", "rt", "net", "fs", "io-std", "signal", "process"] }
 tokio-rustls = { version = "0.24" }
 tokio-rustls-acme = { version = "0.3" }
+tokio-tungstenite = "0.21"
+tokio-tungstenite-wasm = "0.3"
 tokio-util = { version = "0.7", features = ["io-util", "io", "codec"] }
 tracing = "0.1"
+tungstenite = "0.21"
 url = { version = "2.4", features = ["serde"] }
 watchable = "1.1.2"
 webpki = { package = "rustls-webpki", version = "0.101.4", features = ["std"] }
@@ -88,9 +91,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 # metrics
 iroh-metrics = { version = "0.18.0", path = "../iroh-metrics", default-features = false }
 strum = { version = "0.26.2", features = ["derive"] }
-tungstenite = "0.23.0"
-tokio-tungstenite = "0.23.1"
-tokio-tungstenite-wasm = "0.3.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 netlink-packet-core = "0.7.0"

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -89,7 +89,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 iroh-metrics = { version = "0.18.0", path = "../iroh-metrics", default-features = false }
 strum = { version = "0.26.2", features = ["derive"] }
 tungstenite = "0.23.0"
-fastwebsockets = { path = "../../fastwebsockets", version = "0.7.2", features = ["upgrade", "unstable-split"] }
+fastwebsockets = { git = "https://github.com/denoland/fastwebsockets", revision = "efc0788", features = ["upgrade", "unstable-split"] }
 tokio-tungstenite = "0.23.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -88,6 +88,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 # metrics
 iroh-metrics = { version = "0.18.0", path = "../iroh-metrics", default-features = false }
 strum = { version = "0.26.2", features = ["derive"] }
+tungstenite = "0.23.0"
+fastwebsockets = { path = "../../fastwebsockets", version = "0.7.2", features = ["upgrade", "unstable-split"] }
+tokio-tungstenite = "0.23.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 netlink-packet-core = "0.7.0"
@@ -113,6 +116,7 @@ tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macr
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 iroh-test = { path = "../iroh-test" }
 serde_json = "1.0.107"
+iroh-net-old = { package = "iroh-net", version = "=0.18.0" }
 
 [[bench]]
 name = "key"

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -91,6 +91,7 @@ strum = { version = "0.26.2", features = ["derive"] }
 tungstenite = "0.23.0"
 fastwebsockets = { git = "https://github.com/denoland/fastwebsockets", revision = "efc0788", features = ["upgrade", "unstable-split"] }
 tokio-tungstenite = "0.23.1"
+tokio-tungstenite-wasm = "0.3.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 netlink-packet-core = "0.7.0"

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2738,7 +2738,6 @@ impl NetInfo {
 #[cfg(test)]
 mod tests {
     use anyhow::Context;
-    use futures_lite::StreamExt;
     use iroh_test::CallOnDrop;
     use rand::RngCore;
 

--- a/iroh-net/src/relay.rs
+++ b/iroh-net/src/relay.rs
@@ -13,7 +13,7 @@
 pub(crate) mod client;
 pub(crate) mod client_conn;
 pub(crate) mod clients;
-mod codec;
+pub(crate) mod codec;
 pub mod http;
 pub mod iroh_relay;
 mod map;

--- a/iroh-net/src/relay/client.rs
+++ b/iroh-net/src/relay/client.rs
@@ -284,8 +284,8 @@ impl Stream for RelayConnReader {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match *self {
-            Self::Relay(ref mut ws) => ws.poll_next_unpin(cx),
-            Self::Ws(ref mut ws) => ws.poll_next_unpin(cx).map(Frame::from_wasm_ws_message),
+            Self::Relay(ref mut ws) => Pin::new(ws).poll_next(cx),
+            Self::Ws(ref mut ws) => Pin::new(ws).poll_next(cx).map(Frame::from_wasm_ws_message),
         }
     }
 }
@@ -295,31 +295,31 @@ impl Sink<Frame> for RelayConnWriter {
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
-            Self::Relay(ref mut ws) => ws.poll_ready_unpin(cx),
-            Self::Ws(ref mut ws) => ws.poll_ready_unpin(cx).map_err(tung_to_io_err),
+            Self::Relay(ref mut ws) => Pin::new(ws).poll_ready(cx),
+            Self::Ws(ref mut ws) => Pin::new(ws).poll_ready(cx).map_err(tung_to_io_err),
         }
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: Frame) -> Result<(), Self::Error> {
         match *self {
-            Self::Relay(ref mut ws) => ws.start_send_unpin(item),
-            Self::Ws(ref mut ws) => ws
-                .start_send_unpin(item.into_wasm_ws_message()?)
+            Self::Relay(ref mut ws) => Pin::new(ws).start_send(item),
+            Self::Ws(ref mut ws) => Pin::new(ws)
+                .start_send(item.into_wasm_ws_message()?)
                 .map_err(tung_to_io_err),
         }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
-            Self::Relay(ref mut ws) => ws.poll_flush_unpin(cx),
-            Self::Ws(ref mut ws) => ws.poll_flush_unpin(cx).map_err(tung_to_io_err),
+            Self::Relay(ref mut ws) => Pin::new(ws).poll_flush(cx),
+            Self::Ws(ref mut ws) => Pin::new(ws).poll_flush(cx).map_err(tung_to_io_err),
         }
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
-            Self::Relay(ref mut ws) => ws.poll_close_unpin(cx),
-            Self::Ws(ref mut ws) => ws.poll_close_unpin(cx).map_err(tung_to_io_err),
+            Self::Relay(ref mut ws) => Pin::new(ws).poll_close(cx),
+            Self::Ws(ref mut ws) => Pin::new(ws).poll_close(cx).map_err(tung_to_io_err),
         }
     }
 }

--- a/iroh-net/src/relay/client.rs
+++ b/iroh-net/src/relay/client.rs
@@ -275,7 +275,7 @@ pub(crate) enum RelayConnWriter {
     ),
 }
 
-fn tung_to_io_err(e: tokio_tungstenite_wasm::Error) -> std::io::Error {
+fn tung_wasm_to_io_err(e: tokio_tungstenite_wasm::Error) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
 }
 
@@ -296,7 +296,7 @@ impl Sink<Frame> for RelayConnWriter {
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
             Self::Relay(ref mut ws) => Pin::new(ws).poll_ready(cx),
-            Self::Ws(ref mut ws) => Pin::new(ws).poll_ready(cx).map_err(tung_to_io_err),
+            Self::Ws(ref mut ws) => Pin::new(ws).poll_ready(cx).map_err(tung_wasm_to_io_err),
         }
     }
 
@@ -305,21 +305,21 @@ impl Sink<Frame> for RelayConnWriter {
             Self::Relay(ref mut ws) => Pin::new(ws).start_send(item),
             Self::Ws(ref mut ws) => Pin::new(ws)
                 .start_send(item.into_wasm_ws_message()?)
-                .map_err(tung_to_io_err),
+                .map_err(tung_wasm_to_io_err),
         }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
             Self::Relay(ref mut ws) => Pin::new(ws).poll_flush(cx),
-            Self::Ws(ref mut ws) => Pin::new(ws).poll_flush(cx).map_err(tung_to_io_err),
+            Self::Ws(ref mut ws) => Pin::new(ws).poll_flush(cx).map_err(tung_wasm_to_io_err),
         }
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
             Self::Relay(ref mut ws) => Pin::new(ws).poll_close(cx),
-            Self::Ws(ref mut ws) => Pin::new(ws).poll_close(cx).map_err(tung_to_io_err),
+            Self::Ws(ref mut ws) => Pin::new(ws).poll_close(cx).map_err(tung_wasm_to_io_err),
         }
     }
 }

--- a/iroh-net/src/relay/client.rs
+++ b/iroh-net/src/relay/client.rs
@@ -71,7 +71,7 @@ impl ClientReceiver {
 pub struct InnerClient {
     /// Our local address, if known.
     ///
-    /// `None` if we don't control the connection establishment, e.g. in browsers.
+    /// Is `None` in tests or when using websockets (because we don't control connection establishment in browsers).
     local_addr: Option<SocketAddr>,
     /// Channel on which to communicate to the server. The associated [`mpsc::Receiver`] will close
     /// if there is ever an error writing to the server.
@@ -126,6 +126,8 @@ impl Client {
     }
 
     /// The local address that the [`Client`] is listening on.
+    ///
+    /// `None`, when run in a testing environment or when using websockets.
     pub fn local_addr(&self) -> Option<SocketAddr> {
         self.inner.local_addr
     }

--- a/iroh-net/src/relay/client.rs
+++ b/iroh-net/src/relay/client.rs
@@ -268,7 +268,10 @@ pub(crate) enum RelayConnWriter {
 }
 
 fn tung_wasm_to_io_err(e: tokio_tungstenite_wasm::Error) -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
+    match e {
+        tokio_tungstenite_wasm::Error::Io(io_err) => io_err,
+        _ => std::io::Error::new(std::io::ErrorKind::Other, e.to_string()),
+    }
 }
 
 impl Stream for RelayConnReader {

--- a/iroh-net/src/relay/client_conn.rs
+++ b/iroh-net/src/relay/client_conn.rs
@@ -5,10 +5,8 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use futures_lite::StreamExt;
-use futures_sink::Sink;
-use futures_util::{SinkExt, Stream};
+use futures_util::SinkExt;
 use tokio::sync::mpsc;
-use tokio_util::codec::Framed;
 use tokio_util::sync::CancellationToken;
 use tracing::{trace, Instrument};
 
@@ -17,8 +15,8 @@ use crate::{disco::looks_like_disco_wrapper, key::PublicKey};
 
 use iroh_metrics::{inc, inc_by};
 
-use super::codec::{DerpCodec, Frame};
-use super::server::{MaybeTlsStream, RelayIo};
+use super::codec::Frame;
+use super::server::RelayIo;
 use super::{
     codec::{write_frame, KEEP_ALIVE},
     metrics::Metrics,
@@ -454,11 +452,13 @@ impl ClientConnIo {
 #[cfg(test)]
 mod tests {
     use crate::key::SecretKey;
-    use crate::relay::codec::{recv_frame, FrameType};
+    use crate::relay::codec::{recv_frame, DerpCodec, FrameType};
+    use crate::relay::MaybeTlsStreamServer as MaybeTlsStream;
 
     use super::*;
 
     use anyhow::bail;
+    use tokio_util::codec::Framed;
 
     #[tokio::test]
     async fn test_client_conn_io_basic() -> Result<()> {

--- a/iroh-net/src/relay/clients.rs
+++ b/iroh-net/src/relay/clients.rs
@@ -260,7 +260,11 @@ mod tests {
 
     use crate::{
         key::SecretKey,
-        relay::codec::{recv_frame, DerpCodec, Frame, FrameType},
+        relay::{
+            codec::{recv_frame, DerpCodec, Frame, FrameType},
+            server::RelayIo,
+            MaybeTlsStreamServer as MaybeTlsStream,
+        },
     };
 
     use anyhow::Result;
@@ -278,7 +282,7 @@ mod tests {
             ClientConnBuilder {
                 key,
                 conn_num,
-                io: Framed::new(crate::relay::server::MaybeTlsStream::Test(io), DerpCodec),
+                io: RelayIo::Derp(Framed::new(MaybeTlsStream::Test(io), DerpCodec)),
                 write_timeout: None,
                 channel_capacity: 10,
                 server_channel,

--- a/iroh-net/src/relay/codec.rs
+++ b/iroh-net/src/relay/codec.rs
@@ -300,7 +300,7 @@ impl Frame {
         match msg {
             Ok(tungstenite::Message::Binary(vec)) => Some(Self::from_ws_vec(vec)),
             Ok(msg) => {
-                tracing::warn!(?msg, "Got msg of unsupported type, skipping.");
+                tracing::warn!(?msg, "Got websocket message of unsupported type, skipping.");
                 None
             }
             Err(e) => Some(Err(e.into())),
@@ -316,7 +316,7 @@ impl Frame {
         match msg {
             Ok(tokio_tungstenite_wasm::Message::Binary(vec)) => Some(Self::from_ws_vec(vec)),
             Ok(msg) => {
-                tracing::warn!(?msg, "Got msg of unsupported type, skipping.");
+                tracing::warn!(?msg, "Got websocket message of unsupported type, skipping.");
                 None
             }
             Err(e) => Some(Err(e.into())),

--- a/iroh-net/src/relay/codec.rs
+++ b/iroh-net/src/relay/codec.rs
@@ -275,10 +275,10 @@ impl Frame {
     }
 
     fn into_ws_vec(self) -> Vec<u8> {
-        let mut bytes = BytesMut::new();
+        let mut bytes = Vec::new();
         bytes.put_u8(self.typ().into());
         self.write_to(&mut bytes);
-        bytes.to_vec()
+        bytes
     }
 
     pub fn into_ws_message(self) -> std::io::Result<tungstenite::Message> {
@@ -316,7 +316,7 @@ impl Frame {
     }
 
     /// Writes it self to the given buffer.
-    fn write_to(&self, dst: &mut BytesMut) {
+    fn write_to(&self, mut dst: impl BufMut) {
         match self {
             Frame::ClientInfo {
                 client_public_key,

--- a/iroh-net/src/relay/codec.rs
+++ b/iroh-net/src/relay/codec.rs
@@ -2,10 +2,12 @@ use std::time::Duration;
 
 use anyhow::{bail, ensure, Context};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use fastwebsockets::WebSocketWrite;
 use futures_lite::{Stream, StreamExt};
 use futures_sink::Sink;
 use futures_util::SinkExt;
 use iroh_base::key::{Signature, PUBLIC_KEY_LENGTH};
+use tokio::io::AsyncWrite;
 use tokio_util::codec::{Decoder, Encoder};
 
 use super::types::ClientInfo;
@@ -112,6 +114,28 @@ impl std::fmt::Display for FrameType {
 }
 
 /// Writes complete frame, errors if it is unable to write within the given `timeout`.
+/// Ignores the timeout if it's `None`
+///
+/// Does not flush.
+pub(super) async fn write_frame_ws<S: AsyncWrite + Unpin>(
+    writer: &mut WebSocketWrite<S>,
+    frame: Frame,
+    timeout: Option<Duration>,
+) -> anyhow::Result<()> {
+    let mut bytes = BytesMut::new();
+    DerpCodec.encode(frame, &mut bytes)?;
+    let frame = fastwebsockets::Frame::binary(fastwebsockets::Payload::Bytes(bytes));
+
+    if let Some(duration) = timeout {
+        tokio::time::timeout(duration, writer.write_frame(frame)).await??;
+    } else {
+        writer.write_frame(frame).await?;
+    }
+
+    Ok(())
+}
+
+/// Writes complete frame, errors if it is unable to write within the given `timeout`.
 /// Ignores the timeout if `timeout.is_zero()`
 ///
 /// Does not flush.
@@ -149,6 +173,33 @@ pub(crate) async fn send_client_key<S: Sink<Frame, Error = std::io::Error> + Unp
         })
         .await?;
     writer.flush().await?;
+    Ok(())
+}
+
+/// Writes a `FrameType::ClientInfo`, including the client's [`PublicKey`],
+/// and the client's [`ClientInfo`], sealed using the server's [`PublicKey`].
+///
+/// Flushes after writing.
+pub(crate) async fn send_client_key_ws<S: AsyncWrite + Unpin>(
+    writer: &mut WebSocketWrite<S>,
+    client_secret_key: &SecretKey,
+    client_info: &ClientInfo,
+) -> anyhow::Result<()> {
+    let msg = postcard::to_stdvec(client_info)?;
+    let signature = client_secret_key.sign(&msg);
+    let frame = Frame::ClientInfo {
+        client_public_key: client_secret_key.public(),
+        message: msg.into(),
+        signature,
+    };
+    let mut bytes = BytesMut::new();
+    DerpCodec.encode(frame, &mut bytes)?;
+
+    writer
+        .write_frame(fastwebsockets::Frame::binary(
+            fastwebsockets::Payload::Bytes(bytes),
+        ))
+        .await?;
     Ok(())
 }
 

--- a/iroh-net/src/relay/codec.rs
+++ b/iroh-net/src/relay/codec.rs
@@ -324,7 +324,7 @@ impl Frame {
     }
 
     /// Writes it self to the given buffer.
-    fn write_to(&self, mut dst: impl BufMut) {
+    fn write_to(&self, dst: &mut impl BufMut) {
         match self {
             Frame::ClientInfo {
                 client_public_key,

--- a/iroh-net/src/relay/codec.rs
+++ b/iroh-net/src/relay/codec.rs
@@ -281,15 +281,20 @@ impl Frame {
         bytes
     }
 
-    pub fn into_ws_message(self) -> std::io::Result<tungstenite::Message> {
+    /// Serializes this to bytes and wraps it in a websocket binary message.
+    pub(crate) fn into_ws_message(self) -> std::io::Result<tungstenite::Message> {
         Ok(tungstenite::Message::binary(self.into_ws_vec()))
     }
 
-    pub fn into_wasm_ws_message(self) -> std::io::Result<tokio_tungstenite_wasm::Message> {
+    /// Serializes this to bytes and wraps it in a websocket binary message for use in wasm.
+    pub(crate) fn into_wasm_ws_message(self) -> std::io::Result<tokio_tungstenite_wasm::Message> {
         Ok(tokio_tungstenite_wasm::Message::binary(self.into_ws_vec()))
     }
 
-    pub fn from_ws_message(
+    /// Unwraps any binary messages received via websockets and parses them into `Frame`s.
+    ///
+    /// Ignores any non-binary websocket messages with a warning.
+    pub(crate) fn from_ws_message(
         msg: tungstenite::Result<tungstenite::Message>,
     ) -> Option<anyhow::Result<Self>> {
         match msg {
@@ -302,7 +307,10 @@ impl Frame {
         }
     }
 
-    pub fn from_wasm_ws_message(
+    /// Unwraps any binary messages received via websockets (in wasm) and parses them into `Frame`s.
+    ///
+    /// Ignores any non-binary websocket messages with a warning.
+    pub(crate) fn from_wasm_ws_message(
         msg: tokio_tungstenite_wasm::Result<tokio_tungstenite_wasm::Message>,
     ) -> Option<anyhow::Result<Self>> {
         match msg {

--- a/iroh-net/src/relay/codec.rs
+++ b/iroh-net/src/relay/codec.rs
@@ -290,30 +290,28 @@ impl Frame {
     }
 
     pub fn from_ws_message(
-        msg: Option<tungstenite::Result<tungstenite::Message>>,
+        msg: tungstenite::Result<tungstenite::Message>,
     ) -> Option<anyhow::Result<Self>> {
         match msg {
-            Some(Ok(tungstenite::Message::Binary(vec))) => Some(Self::from_ws_vec(vec)),
-            Some(Ok(msg)) => {
+            Ok(tungstenite::Message::Binary(vec)) => Some(Self::from_ws_vec(vec)),
+            Ok(msg) => {
                 tracing::warn!(?msg, "Got msg of unsupported type, skipping.");
                 None
             }
-            Some(Err(e)) => Some(Err(e.into())),
-            None => None,
+            Err(e) => Some(Err(e.into())),
         }
     }
 
     pub fn from_wasm_ws_message(
-        msg: Option<tokio_tungstenite_wasm::Result<tokio_tungstenite_wasm::Message>>,
+        msg: tokio_tungstenite_wasm::Result<tokio_tungstenite_wasm::Message>,
     ) -> Option<anyhow::Result<Self>> {
         match msg {
-            Some(Ok(tokio_tungstenite_wasm::Message::Binary(vec))) => Some(Self::from_ws_vec(vec)),
-            Some(Ok(msg)) => {
+            Ok(tokio_tungstenite_wasm::Message::Binary(vec)) => Some(Self::from_ws_vec(vec)),
+            Ok(msg) => {
                 tracing::warn!(?msg, "Got msg of unsupported type, skipping.");
                 None
             }
-            Some(Err(e)) => Some(Err(e.into())),
-            None => None,
+            Err(e) => Some(Err(e.into())),
         }
     }
 

--- a/iroh-net/src/relay/codec.rs
+++ b/iroh-net/src/relay/codec.rs
@@ -269,12 +269,12 @@ impl Frame {
             bail!("error parsing relay::codec::Frame: too few bytes (0)");
         }
         let bytes = Bytes::from(vec);
-        let typ = FrameType::try_from(bytes[0])?;
+        let typ = FrameType::from(bytes[0]);
         let frame = Self::from_bytes(typ, bytes.slice(1..))?;
         Ok(frame)
     }
 
-    fn to_ws_vec(self) -> Vec<u8> {
+    fn into_ws_vec(self) -> Vec<u8> {
         let mut bytes = BytesMut::new();
         bytes.put_u8(self.typ().into());
         self.write_to(&mut bytes);
@@ -282,11 +282,11 @@ impl Frame {
     }
 
     pub fn into_ws_message(self) -> std::io::Result<tungstenite::Message> {
-        Ok(tungstenite::Message::binary(self.to_ws_vec()))
+        Ok(tungstenite::Message::binary(self.into_ws_vec()))
     }
 
     pub fn into_wasm_ws_message(self) -> std::io::Result<tokio_tungstenite_wasm::Message> {
-        Ok(tokio_tungstenite_wasm::Message::binary(self.to_ws_vec()))
+        Ok(tokio_tungstenite_wasm::Message::binary(self.into_ws_vec()))
     }
 
     pub fn from_ws_message(

--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -2,11 +2,11 @@
 //! upgrades.
 //!
 mod client;
-pub(crate) mod server;
+mod server;
 pub(crate) mod streams;
 
 pub use self::client::{Client, ClientBuilder, ClientError, ClientReceiver};
-pub use self::server::{Server, ServerBuilder, ServerHandle, TlsAcceptor, TlsConfig};
+pub use self::server::{Protocol, Server, ServerBuilder, ServerHandle, TlsAcceptor, TlsConfig};
 
 pub(crate) const HTTP_UPGRADE_PROTOCOL: &str = "iroh derp http";
 pub(crate) const WEBSOCKET_UPGRADE_PROTOCOL: &str = "websocket";

--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -10,6 +10,7 @@ pub use self::server::{Protocol, Server, ServerBuilder, ServerHandle, TlsAccepto
 
 pub(crate) const HTTP_UPGRADE_PROTOCOL: &str = "iroh derp http";
 pub(crate) const WEBSOCKET_UPGRADE_PROTOCOL: &str = "websocket";
+pub(crate) const SUPPORTED_WEBSOCKET_VERSION: &str = "13";
 
 #[cfg(test)]
 mod tests {

--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -2,13 +2,14 @@
 //! upgrades.
 //!
 mod client;
-mod server;
+pub(crate) mod server;
 pub(crate) mod streams;
 
 pub use self::client::{Client, ClientBuilder, ClientError, ClientReceiver};
 pub use self::server::{Server, ServerBuilder, ServerHandle, TlsAcceptor, TlsConfig};
 
 pub(crate) const HTTP_UPGRADE_PROTOCOL: &str = "iroh derp http";
+pub(crate) const WEBSOCKET_UPGRADE_PROTOCOL: &str = "websocket";
 
 #[cfg(test)]
 mod tests {

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -588,9 +588,9 @@ impl Actor {
     }
 
     async fn connect_0(&self) -> Result<(RelayClient, RelayClientReceiver), ClientError> {
-        const PROTOCOL: Protocol = Protocol::Relay;
+        let protocol = Protocol::from_url_scheme(&self.url);
 
-        let (reader, writer, local_addr) = match &PROTOCOL {
+        let (reader, writer, local_addr) = match &protocol {
             Protocol::Websocket => {
                 let (writer, reader) = tokio_tungstenite_wasm::connect(self.url.as_str())
                     .await?
@@ -619,10 +619,10 @@ impl Actor {
                         .ok_or_else(|| ClientError::InvalidUrl("No tls servername".into()))?;
                     let tls_stream = self.tls_connector.connect(hostname, tcp_stream).await?;
                     debug!("tls_connector connect success");
-                    Self::start_upgrade(tls_stream, &PROTOCOL).await?
+                    Self::start_upgrade(tls_stream, &protocol).await?
                 } else {
                     debug!("Starting handshake");
-                    Self::start_upgrade(tcp_stream, &PROTOCOL).await?
+                    Self::start_upgrade(tcp_stream, &protocol).await?
                 };
 
                 if response.status() != hyper::StatusCode::SWITCHING_PROTOCOLS {

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -832,6 +832,7 @@ impl Actor {
 
     fn use_https(&self) -> bool {
         // only disable https if we are explicitly dialing a http url
+        #[allow(clippy::match_like_matches_macro)]
         match self.url.scheme() {
             "http" => false,
             "ws" => false,

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -641,7 +641,7 @@ impl Actor {
 
         debug!(server_addr = ?tcp_stream.peer_addr(), %local_addr, "TCP stream connected");
 
-        let response = if self.use_https() {
+        let response = if self.use_tls() {
             debug!("Starting TLS handshake");
             let hostname = self
                 .tls_servername()
@@ -824,8 +824,8 @@ impl Actor {
             .and_then(|s| rustls::ServerName::try_from(s).ok())
     }
 
-    fn use_https(&self) -> bool {
-        // only disable https if we are explicitly dialing a http url
+    fn use_tls(&self) -> bool {
+        // only disable tls if we are explicitly dialing a http url
         #[allow(clippy::match_like_matches_macro)]
         match self.url.scheme() {
             "http" => false,

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use bytes::Bytes;
-use fastwebsockets::WebSocket;
 use futures_lite::future::Boxed as BoxFuture;
 use futures_util::StreamExt;
 use http_body_util::Empty;
@@ -23,7 +22,6 @@ use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::Instant;
-use tokio_tungstenite_wasm::WebSocketStream;
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{debug, error, info_span, trace, warn, Instrument};
 use url::Url;
@@ -33,7 +31,6 @@ use crate::key::{PublicKey, SecretKey};
 use crate::relay::client::{RelayConnReader, RelayConnWriter};
 use crate::relay::codec::DerpCodec;
 use crate::relay::http::streams::{downcast_upgrade, MaybeTlsStream};
-use crate::relay::http::WEBSOCKET_UPGRADE_PROTOCOL;
 use crate::relay::RelayUrl;
 use crate::relay::{
     client::Client as RelayClient, client::ClientBuilder as RelayClientBuilder,
@@ -707,7 +704,7 @@ impl Actor {
                     .header(UPGRADE, protocol.upgrade_header())
                     .header(
                         "Sec-WebSocket-Key",
-                        fastwebsockets::handshake::generate_key(),
+                        tungstenite::handshake::client::generate_key(),
                     )
                     .header("Sec-WebSocket-Version", "13");
             }

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -14,6 +14,7 @@ use hyper::header::{HeaderValue, UPGRADE};
 use hyper::service::Service;
 use hyper::upgrade::Upgraded;
 use hyper::{HeaderMap, Method, Request, Response, StatusCode};
+use iroh_base::node_addr::RelayUrl;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 use tokio_rustls_acme::AcmeAcceptor;
@@ -68,6 +69,17 @@ impl Protocol {
         match self {
             Protocol::Relay => HTTP_UPGRADE_PROTOCOL,
             Protocol::Websocket => WEBSOCKET_UPGRADE_PROTOCOL,
+        }
+    }
+
+    pub fn from_url_scheme(url: &RelayUrl) -> Self {
+        match url.scheme() {
+            "ws" => Protocol::Websocket,
+            "wss" => Protocol::Websocket,
+            "http" => Protocol::Relay,
+            "https" => Protocol::Relay,
+            // We default to relay in case of weird URLs.
+            _ => Protocol::Relay,
         }
     }
 

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -95,7 +95,7 @@ impl Protocol {
 
     /// The server HTTP handler to do HTTP upgrades
     async fn relay_connection_handler(
-        &self,
+        self,
         conn_handler: &ClientConnHandler,
         upgraded: Upgraded,
     ) -> Result<()> {
@@ -107,7 +107,7 @@ impl Protocol {
             read_buf
         );
 
-        conn_handler.accept(*self, io).await
+        conn_handler.accept(self, io).await
     }
 }
 

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -62,9 +62,9 @@ fn downcast_upgrade(upgraded: Upgraded) -> Result<(MaybeTlsStream, Bytes)> {
 /// The HTTP upgrade protocol used for relaying.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Protocol {
-    /// Relays over the custom relaying protocol with a custom HTTP upgrade header
+    /// Relays over the custom relaying protocol with a custom HTTP upgrade header.
     Relay,
-    /// Relays over websockets
+    /// Relays over websockets.
     ///
     /// Originally introduced to support browser connections.
     Websocket,

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -57,13 +57,19 @@ fn downcast_upgrade(upgraded: Upgraded) -> Result<(MaybeTlsStream, Bytes)> {
     }
 }
 
+/// The HTTP upgrade protocol used for relaying.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Protocol {
+    /// Relays over the custom relaying protocol with a custom HTTP upgrade header
     Relay,
+    /// Relays over websockets
+    ///
+    /// Originally introduced to support browser connections.
     Websocket,
 }
 
 impl Protocol {
+    /// The HTTP upgrade header used or expected
     pub const fn upgrade_header(&self) -> &'static str {
         match self {
             Protocol::Relay => HTTP_UPGRADE_PROTOCOL,
@@ -71,6 +77,9 @@ impl Protocol {
         }
     }
 
+    /// Determines which protocol to use depending on a URL.
+    ///
+    /// `ws(s)` parses as websockets, `http(s)` parses to the custom relay protocol.
     pub fn from_url_scheme(url: &RelayUrl) -> Self {
         match url.scheme() {
             "ws" => Protocol::Websocket,
@@ -82,6 +91,7 @@ impl Protocol {
         }
     }
 
+    /// Tries to match the value of an HTTP upgrade header to figure out which protocol should be initiated.
     pub fn parse_header(header: &HeaderValue) -> Option<Self> {
         let header_bytes = header.as_bytes();
         if header_bytes == Protocol::Relay.upgrade_header().as_bytes() {

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -24,11 +24,9 @@ use tracing::{debug, debug_span, error, info, info_span, warn, Instrument};
 use tungstenite::handshake::derive_accept_key;
 
 use crate::key::SecretKey;
-use crate::relay::http::HTTP_UPGRADE_PROTOCOL;
+use crate::relay::http::{HTTP_UPGRADE_PROTOCOL, WEBSOCKET_UPGRADE_PROTOCOL};
 use crate::relay::server::{ClientConnHandler, MaybeTlsStream};
 use crate::relay::MaybeTlsStreamServer;
-
-use super::WEBSOCKET_UPGRADE_PROTOCOL;
 
 type BytesBody = http_body_util::Full<hyper::body::Bytes>;
 type HyperError = Box<dyn std::error::Error + Send + Sync>;

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -24,7 +24,9 @@ use tracing::{debug, debug_span, error, info, info_span, warn, Instrument};
 use tungstenite::handshake::derive_accept_key;
 
 use crate::key::SecretKey;
-use crate::relay::http::{HTTP_UPGRADE_PROTOCOL, WEBSOCKET_UPGRADE_PROTOCOL};
+use crate::relay::http::{
+    HTTP_UPGRADE_PROTOCOL, SUPPORTED_WEBSOCKET_VERSION, WEBSOCKET_UPGRADE_PROTOCOL,
+};
 use crate::relay::server::{ClientConnHandler, MaybeTlsStream};
 use crate::relay::MaybeTlsStreamServer;
 
@@ -487,12 +489,12 @@ impl Service<Request<Incoming>> for ClientConnHandler {
                             .expect("valid body"));
                     };
 
-                    if version.as_bytes() != b"13" {
+                    if version.as_bytes() != SUPPORTED_WEBSOCKET_VERSION.as_bytes() {
                         warn!("invalid header Sec-WebSocket-Version: {:?}", version);
                         return Ok(builder
                             .status(StatusCode::BAD_REQUEST)
                             // It's convention to send back the version(s) we *do* support
-                            .header("Sec-WebSocket-Version", "13")
+                            .header("Sec-WebSocket-Version", SUPPORTED_WEBSOCKET_VERSION)
                             .body(body_empty())
                             .expect("valid body"));
                     }

--- a/iroh-net/src/relay/metrics.rs
+++ b/iroh-net/src/relay/metrics.rs
@@ -60,6 +60,11 @@ pub struct Metrics {
     pub accepts: Counter,
     /// Number of connections we have removed because of an error
     pub disconnects: Counter,
+
+    /// Number of accepted websocket connections
+    pub websocket_accepts: Counter,
+    /// Number of accepted 'iroh derp http' connection upgrades
+    pub derp_accepts: Counter,
     // TODO: enable when we can have multiple connections for one node id
     // pub duplicate_client_keys: Counter,
     // pub duplicate_client_conns: Counter,
@@ -115,6 +120,9 @@ impl Default for Metrics {
 
             accepts: Counter::new("Number of times this server has accepted a connection."),
             disconnects: Counter::new("Number of clients that have then disconnected."),
+
+            websocket_accepts: Counter::new("Number of accepted websocket connections"),
+            derp_accepts: Counter::new("Number of accepted 'iroh derp http' connection upgrades"),
             // TODO: enable when we can have multiple connections for one node id
             // pub duplicate_client_keys: Counter::new("Number of duplicate client keys."),
             // pub duplicate_client_conns: Counter::new("Number of duplicate client connections."),

--- a/iroh-net/src/relay/server.rs
+++ b/iroh-net/src/relay/server.rs
@@ -6,11 +6,9 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use anyhow::{bail, Context as _, Result};
-use bytes::BytesMut;
-use futures_lite::stream::FilterMap;
 use futures_sink::Sink;
-use futures_util::sink::{SinkExt, SinkMapErr, With};
-use futures_util::{Stream, StreamExt, TryStreamExt};
+use futures_util::sink::SinkExt;
+use futures_util::{Stream, StreamExt};
 use hyper::HeaderMap;
 use iroh_metrics::core::UsageStatsReport;
 use iroh_metrics::{inc, report_usage_stats};
@@ -18,12 +16,10 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_tungstenite::WebSocketStream;
-use tokio_util::codec::{Decoder, Encoder, Framed};
-use tokio_util::either::Either;
+use tokio_util::codec::Framed;
 use tokio_util::sync::CancellationToken;
 use tracing::{info_span, trace, Instrument};
 use tungstenite::protocol::Role;
-use tungstenite::{Message, WebSocket};
 
 use crate::key::{PublicKey, SecretKey};
 
@@ -504,15 +500,11 @@ mod tests {
 
     use crate::relay::{
         client::{ClientBuilder, RelayConnReader, RelayConnWriter},
-        codec::{recv_frame, Frame, FrameType},
-        http::{
-            server::Protocol,
-            streams::{MaybeTlsStreamReader, MaybeTlsStreamWriter},
-        },
+        codec::{recv_frame, FrameType},
+        http::streams::{MaybeTlsStreamReader, MaybeTlsStreamWriter},
         types::ClientInfo,
         ReceivedMessage,
     };
-    use fastwebsockets::WebSocketRead;
     use tokio_util::codec::{FramedRead, FramedWrite};
     use tracing_subscriber::{prelude::*, EnvFilter};
 

--- a/iroh-net/src/relay/server.rs
+++ b/iroh-net/src/relay/server.rs
@@ -184,8 +184,12 @@ impl ClientConnHandler {
     pub async fn accept(&self, protocol: Protocol, io: MaybeTlsStream) -> Result<()> {
         trace!(?protocol, "accept: start");
         let mut io = match protocol {
-            Protocol::Relay => RelayIo::Derp(Framed::new(io, DerpCodec)),
+            Protocol::Relay => {
+                inc!(Metrics, derp_accepts);
+                RelayIo::Derp(Framed::new(io, DerpCodec))
+            }
             Protocol::Websocket => {
+                inc!(Metrics, websocket_accepts);
                 RelayIo::Ws(WebSocketStream::from_raw_socket(io, Role::Server, None).await)
             }
         };

--- a/iroh-net/src/relay/server.rs
+++ b/iroh-net/src/relay/server.rs
@@ -512,7 +512,7 @@ mod tests {
     use super::*;
 
     use crate::relay::{
-        client::{ClientBuilder, RelayConnReader, RelayConnWriter},
+        client::{ClientBuilder, ConnReader, ConnWriter},
         codec::{recv_frame, FrameType},
         http::streams::{MaybeTlsStreamReader, MaybeTlsStreamWriter},
         types::ClientInfo,
@@ -664,8 +664,8 @@ mod tests {
         let client_reader = MaybeTlsStreamReader::Mem(client_reader);
         let client_writer = MaybeTlsStreamWriter::Mem(client_writer);
 
-        let client_reader = RelayConnReader::Derp(FramedRead::new(client_reader, DerpCodec));
-        let client_writer = RelayConnWriter::Derp(FramedWrite::new(client_writer, DerpCodec));
+        let client_reader = ConnReader::Derp(FramedRead::new(client_reader, DerpCodec));
+        let client_writer = ConnWriter::Derp(FramedWrite::new(client_writer, DerpCodec));
 
         (
             server,

--- a/iroh-net/src/relay/server.rs
+++ b/iroh-net/src/relay/server.rs
@@ -370,7 +370,10 @@ pub(crate) enum RelayIo {
 }
 
 fn tung_to_io_err(e: tungstenite::Error) -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
+    match e {
+        tungstenite::Error::Io(io_err) => io_err,
+        _ => std::io::Error::new(std::io::ErrorKind::Other, e.to_string()),
+    }
 }
 
 impl Sink<Frame> for RelayIo {

--- a/iroh-test/src/logging.rs
+++ b/iroh-test/src/logging.rs
@@ -25,6 +25,7 @@ use tracing_subscriber::EnvFilter;
 ///     let _guard = iroh_test::logging::setup();
 ///     assert!(true);
 /// }
+/// ```
 #[must_use = "The tracing guard must only be dropped at the end of the test"]
 pub fn setup() -> tracing::subscriber::DefaultGuard {
     if let Ok(handle) = tokio::runtime::Handle::try_current() {

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -455,8 +455,6 @@ async fn handle_connection(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use anyhow::{bail, Context};
     use bytes::Bytes;
     use iroh_base::node_addr::AddrInfoOptions;


### PR DESCRIPTION
Implements the `websocket` protocol upgrade in iroh-relay and changes `iroh-net` clients to connect with `websocket` instead of `iroh derp http`.

State of this is:
- `cargo test -p iroh-net` runs green
- websocket on the relay is supported
- backwards compatibility is tested
- the client also supports connecting using websockets
  - (but we're forced to use tungstenites connection establishment, no custom `MaybeTlsStream`.)
  - It decides this via the URL scheme (`ws(s)://` vs. `http(s)://`) 

TODO:
- [x] Enumify the client so it's possible to keep using the old relay protocol
- [x] Cleanup!
- [x] Some perf TODOs in the server, less copying.
- [x] Update documentation (e.g. `local_addr` having another case being `None`)
- [x] Add metrics for websocket-accept & derp-accept counts
- [x] Snapshot tests (using `parse_hexdump`) for "new" wire format

## Description

- Supports clients connecting to iroh-relay with websockets & running the derp protocol over websocket `Binary` msgs.
- Adds support for the relay answering `Upgrade: websocket` headers instead of `Upgrade: iroh derp http` appropriately.
- Adds support for `ClientBuilder` to dial via websockets, if the relay URL is set with a `ws`/`wss` URL scheme.

## Breaking Changes

- Not in the protocol: The old HTTP upgrade & protocol should still be supported. There's tests to ensure this.
- `Client::local_addr` will now also return `None`, if one connected using websockets.
- `iroh_net::relay::http::ClientError`: Added a variant `WebsocketError` for errors when establishing a connection using websockets.

## Notes & open questions

Closes #2370 

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
