### PR TITLE
feat(iroh): allow to disable docs engine completely

### DIFF
--- a/iroh/src/client/authors.rs
+++ b/iroh/src/client/authors.rs
@@ -42,7 +42,7 @@ where
     ///
     /// The default author can be set with [`Self::set_default`].
     pub async fn default(&self) -> Result<AuthorId> {
-        let res = self.rpc.rpc(AuthorGetDefaultRequest).await?;
+        let res = self.rpc.rpc(AuthorGetDefaultRequest).await??;
         Ok(res.author_id)
     }
 

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -94,7 +94,7 @@ where
     gc_policy: GcPolicy,
     dns_resolver: Option<DnsResolver>,
     node_discovery: DiscoveryConfig,
-    docs_store: Option<DocsStorage>,
+    docs_storage: Option<DocsStorage>,
     #[cfg(any(test, feature = "test-utils"))]
     insecure_skip_relay_cert_verify: bool,
     /// Callback to register when a gc loop is done
@@ -155,7 +155,7 @@ impl Default for Builder<iroh_blobs::store::mem::Store> {
             dns_resolver: None,
             rpc_endpoint: Default::default(),
             gc_policy: GcPolicy::Disabled,
-            docs_store: Some(DocsStorage::Memory),
+            docs_storage: Some(DocsStorage::Memory),
             node_discovery: Default::default(),
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
@@ -168,7 +168,7 @@ impl<D: Map> Builder<D> {
     /// Creates a new builder for [`Node`] using the given databases.
     pub fn with_db_and_store(
         blobs_store: D,
-        docs_store: DocsStorage,
+        docs_storage: DocsStorage,
         storage: StorageConfig,
     ) -> Self {
         Self {
@@ -181,7 +181,7 @@ impl<D: Map> Builder<D> {
             dns_resolver: None,
             rpc_endpoint: Default::default(),
             gc_policy: GcPolicy::Disabled,
-            docs_store: Some(docs_store),
+            docs_storage: Some(docs_storage),
             node_discovery: Default::default(),
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
@@ -209,7 +209,7 @@ where
             .with_context(|| {
                 format!("Failed to load blobs database from {}", blob_dir.display())
             })?;
-        let docs_store = DocsStorage::Persistent(IrohPaths::DocsDatabase.with_root(root));
+        let docs_storage = DocsStorage::Persistent(IrohPaths::DocsDatabase.with_root(root));
 
         let v0 = blobs_store
             .import_flat_store(iroh_blobs::store::fs::FlatStorePaths {
@@ -245,7 +245,7 @@ where
             relay_mode: self.relay_mode,
             dns_resolver: self.dns_resolver,
             gc_policy: self.gc_policy,
-            docs_store: Some(docs_store),
+            docs_storage: Some(docs_storage),
             node_discovery: self.node_discovery,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
@@ -266,7 +266,7 @@ where
             relay_mode: self.relay_mode,
             dns_resolver: self.dns_resolver,
             gc_policy: self.gc_policy,
-            docs_store: self.docs_store,
+            docs_storage: self.docs_storage,
             node_discovery: self.node_discovery,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
@@ -292,7 +292,7 @@ where
             relay_mode: self.relay_mode,
             dns_resolver: self.dns_resolver,
             gc_policy: self.gc_policy,
-            docs_store: self.docs_store,
+            docs_storage: self.docs_storage,
             node_discovery: self.node_discovery,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
@@ -310,7 +310,7 @@ where
 
     /// Disables documents support on this node completely.
     pub fn disable_docs(mut self) -> Self {
-        self.docs_store = None;
+        self.docs_storage = None;
         self
     }
 
@@ -480,7 +480,7 @@ where
         let downloader = Downloader::new(self.blobs_store.clone(), endpoint.clone(), lp.clone());
 
         // Spawn the docs engine, if enabled.
-        let docs = if let Some(docs_storage) = &self.docs_store {
+        let docs = if let Some(docs_storage) = &self.docs_storage {
             let docs = DocsEngine::spawn(
                 docs_storage,
                 self.blobs_store.clone(),

--- a/iroh/src/node/docs.rs
+++ b/iroh/src/node/docs.rs
@@ -16,14 +16,15 @@ pub(crate) struct DocsEngine(Engine);
 
 impl DocsEngine {
     pub async fn spawn<S: iroh_blobs::store::Store>(
-        storage: &DocsStorage,
+        storage: DocsStorage,
         blobs_store: S,
         default_author_storage: DefaultAuthorStorage,
         endpoint: Endpoint,
         gossip: Gossip,
         downloader: Downloader,
-    ) -> anyhow::Result<Self> {
+    ) -> anyhow::Result<Option<Self>> {
         let docs_store = match storage {
+            DocsStorage::Disabled => return Ok(None),
             DocsStorage::Memory => iroh_docs::store::fs::Store::memory(),
             DocsStorage::Persistent(path) => iroh_docs::store::fs::Store::persistent(path)?,
         };
@@ -36,7 +37,7 @@ impl DocsEngine {
             default_author_storage,
         )
         .await?;
-        Ok(DocsEngine(engine))
+        Ok(Some(DocsEngine(engine)))
     }
 }
 

--- a/iroh/src/node/docs.rs
+++ b/iroh/src/node/docs.rs
@@ -1,0 +1,54 @@
+use std::{ops::Deref, sync::Arc};
+
+use anyhow::Result;
+use futures_lite::future::Boxed as BoxedFuture;
+use iroh_blobs::downloader::Downloader;
+use iroh_gossip::net::Gossip;
+
+use iroh_docs::engine::{DefaultAuthorStorage, Engine};
+use iroh_net::{endpoint::Connecting, Endpoint};
+
+use crate::node::{DocsStorage, ProtocolHandler};
+
+/// Wrapper around [`Engine`] so that we can implement our RPC methods directly.
+#[derive(Debug, Clone)]
+pub(crate) struct DocsEngine(Engine);
+
+impl DocsEngine {
+    pub async fn spawn<S: iroh_blobs::store::Store>(
+        storage: &DocsStorage,
+        blobs_store: S,
+        default_author_storage: DefaultAuthorStorage,
+        endpoint: Endpoint,
+        gossip: Gossip,
+        downloader: Downloader,
+    ) -> anyhow::Result<Self> {
+        let docs_store = match storage {
+            DocsStorage::Memory => iroh_docs::store::fs::Store::memory(),
+            DocsStorage::Persistent(path) => iroh_docs::store::fs::Store::persistent(path)?,
+        };
+        let engine = Engine::spawn(
+            endpoint,
+            gossip,
+            docs_store,
+            blobs_store,
+            downloader,
+            default_author_storage,
+        )
+        .await?;
+        Ok(DocsEngine(engine))
+    }
+}
+
+impl Deref for DocsEngine {
+    type Target = Engine;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ProtocolHandler for DocsEngine {
+    fn accept(self: Arc<Self>, conn: Connecting) -> BoxedFuture<Result<()>> {
+        Box::pin(async move { self.handle_connection(conn).await })
+    }
+}

--- a/iroh/src/node/protocol.rs
+++ b/iroh/src/node/protocol.rs
@@ -5,8 +5,6 @@ use futures_lite::future::Boxed as BoxedFuture;
 use futures_util::future::join_all;
 use iroh_net::endpoint::Connecting;
 
-use crate::node::DocsEngine;
-
 /// Handler for incoming connections.
 ///
 /// An iroh node can accept connections for arbitrary ALPN protocols. By default, the iroh node
@@ -117,11 +115,5 @@ impl iroh_blobs::provider::EventSender for MockEventSender {
 impl ProtocolHandler for iroh_gossip::net::Gossip {
     fn accept(self: Arc<Self>, conn: Connecting) -> BoxedFuture<Result<()>> {
         Box::pin(async move { self.handle_connection(conn.await?).await })
-    }
-}
-
-impl ProtocolHandler for DocsEngine {
-    fn accept(self: Arc<Self>, conn: Connecting) -> BoxedFuture<Result<()>> {
-        Box::pin(async move { self.handle_connection(conn).await })
     }
 }

--- a/iroh/src/node/rpc/docs.rs
+++ b/iroh/src/node/rpc/docs.rs
@@ -3,30 +3,29 @@
 use anyhow::anyhow;
 use futures_lite::Stream;
 use iroh_blobs::{store::Store as BaoStore, BlobFormat};
-use iroh_docs::{
-    Author, AuthorId, CapabilityKind, DocTicket, NamespaceId, NamespaceSecret, SignedEntry,
-};
+use iroh_docs::{Author, DocTicket, NamespaceSecret};
 use tokio_stream::StreamExt;
 
 use crate::client::docs::ShareMode;
-use crate::node::docs::DocsEngine;
+use crate::node::DocsEngine;
 use crate::rpc_protocol::{
     AuthorCreateRequest, AuthorCreateResponse, AuthorDeleteRequest, AuthorDeleteResponse,
     AuthorExportRequest, AuthorExportResponse, AuthorGetDefaultRequest, AuthorGetDefaultResponse,
-    AuthorImportRequest, AuthorImportResponse, AuthorListRequest, AuthorSetDefaultRequest,
-    AuthorSetDefaultResponse, DocCloseRequest, DocCloseResponse, DocCreateRequest,
-    DocCreateResponse, DocDelRequest, DocDelResponse, DocDropRequest, DocDropResponse,
-    DocGetDownloadPolicyRequest, DocGetDownloadPolicyResponse, DocGetExactRequest,
-    DocGetExactResponse, DocGetManyRequest, DocGetSyncPeersRequest, DocGetSyncPeersResponse,
-    DocImportRequest, DocImportResponse, DocLeaveRequest, DocLeaveResponse, DocListRequest,
-    DocOpenRequest, DocOpenResponse, DocSetDownloadPolicyRequest, DocSetDownloadPolicyResponse,
-    DocSetHashRequest, DocSetHashResponse, DocSetRequest, DocSetResponse, DocShareRequest,
-    DocShareResponse, DocStartSyncRequest, DocStartSyncResponse, DocStatusRequest,
-    DocStatusResponse, DocSubscribeRequest, DocSubscribeResponse, RpcResult,
+    AuthorImportRequest, AuthorImportResponse, AuthorListRequest, AuthorListResponse,
+    AuthorSetDefaultRequest, AuthorSetDefaultResponse, DocCloseRequest, DocCloseResponse,
+    DocCreateRequest, DocCreateResponse, DocDelRequest, DocDelResponse, DocDropRequest,
+    DocDropResponse, DocGetDownloadPolicyRequest, DocGetDownloadPolicyResponse, DocGetExactRequest,
+    DocGetExactResponse, DocGetManyRequest, DocGetManyResponse, DocGetSyncPeersRequest,
+    DocGetSyncPeersResponse, DocImportRequest, DocImportResponse, DocLeaveRequest,
+    DocLeaveResponse, DocListRequest, DocListResponse, DocOpenRequest, DocOpenResponse,
+    DocSetDownloadPolicyRequest, DocSetDownloadPolicyResponse, DocSetHashRequest,
+    DocSetHashResponse, DocSetRequest, DocSetResponse, DocShareRequest, DocShareResponse,
+    DocStartSyncRequest, DocStartSyncResponse, DocStatusRequest, DocStatusResponse,
+    DocSubscribeRequest, DocSubscribeResponse, RpcResult,
 };
 
 /// Capacity for the flume channels to forward sync store iterators to async RPC streams.
-pub(super) const ITER_CHANNEL_CAP: usize = 64;
+const ITER_CHANNEL_CAP: usize = 64;
 
 #[allow(missing_docs)]
 impl DocsEngine {
@@ -58,8 +57,8 @@ impl DocsEngine {
     pub fn author_list(
         &self,
         _req: AuthorListRequest,
-        tx: flume::Sender<anyhow::Result<AuthorId>>,
-    ) {
+    ) -> impl Stream<Item = RpcResult<AuthorListResponse>> {
+        let (tx, rx) = flume::bounded(ITER_CHANNEL_CAP);
         let sync = self.sync.clone();
         // we need to spawn a task to send our request to the sync handle, because the method
         // itself must be sync.
@@ -69,6 +68,10 @@ impl DocsEngine {
                 tx2.send_async(Err(err)).await.ok();
             }
         });
+        rx.into_stream().map(|r| {
+            r.map(|author_id| AuthorListResponse { author_id })
+                .map_err(Into::into)
+        })
     }
 
     pub async fn author_import(&self, req: AuthorImportRequest) -> RpcResult<AuthorImportResponse> {
@@ -105,12 +108,8 @@ impl DocsEngine {
         Ok(DocDropResponse {})
     }
 
-    pub fn doc_list(
-        &self,
-        _req: DocListRequest,
-        tx: flume::Sender<anyhow::Result<(NamespaceId, CapabilityKind)>>,
-    ) {
-        // let (tx, rx) = flume::bounded(ITER_CHANNEL_CAP);
+    pub fn doc_list(&self, _req: DocListRequest) -> impl Stream<Item = RpcResult<DocListResponse>> {
+        let (tx, rx) = flume::bounded(ITER_CHANNEL_CAP);
         let sync = self.sync.clone();
         // we need to spawn a task to send our request to the sync handle, because the method
         // itself must be sync.
@@ -120,6 +119,10 @@ impl DocsEngine {
                 tx2.send_async(Err(err)).await.ok();
             }
         });
+        rx.into_stream().map(|r| {
+            r.map(|(id, capability)| DocListResponse { id, capability })
+                .map_err(Into::into)
+        })
     }
 
     pub async fn doc_open(&self, req: DocOpenRequest) -> RpcResult<DocOpenResponse> {
@@ -246,9 +249,9 @@ impl DocsEngine {
     pub fn doc_get_many(
         &self,
         req: DocGetManyRequest,
-        tx: flume::Sender<anyhow::Result<SignedEntry>>,
-    ) {
+    ) -> impl Stream<Item = RpcResult<DocGetManyResponse>> {
         let DocGetManyRequest { doc_id, query } = req;
+        let (tx, rx) = flume::bounded(ITER_CHANNEL_CAP);
         let sync = self.sync.clone();
         // we need to spawn a task to send our request to the sync handle, because the method
         // itself must be sync.
@@ -258,6 +261,10 @@ impl DocsEngine {
                 tx2.send_async(Err(err)).await.ok();
             }
         });
+        rx.into_stream().map(|r| {
+            r.map(|entry| DocGetManyResponse { entry })
+                .map_err(Into::into)
+        })
     }
 
     pub async fn doc_get_exact(&self, req: DocGetExactRequest) -> RpcResult<DocGetExactResponse> {

--- a/iroh/src/node/rpc/docs.rs
+++ b/iroh/src/node/rpc/docs.rs
@@ -3,29 +3,30 @@
 use anyhow::anyhow;
 use futures_lite::Stream;
 use iroh_blobs::{store::Store as BaoStore, BlobFormat};
-use iroh_docs::{Author, DocTicket, NamespaceSecret};
+use iroh_docs::{
+    Author, AuthorId, CapabilityKind, DocTicket, NamespaceId, NamespaceSecret, SignedEntry,
+};
 use tokio_stream::StreamExt;
 
 use crate::client::docs::ShareMode;
-use crate::node::DocsEngine;
+use crate::node::docs::DocsEngine;
 use crate::rpc_protocol::{
     AuthorCreateRequest, AuthorCreateResponse, AuthorDeleteRequest, AuthorDeleteResponse,
     AuthorExportRequest, AuthorExportResponse, AuthorGetDefaultRequest, AuthorGetDefaultResponse,
-    AuthorImportRequest, AuthorImportResponse, AuthorListRequest, AuthorListResponse,
-    AuthorSetDefaultRequest, AuthorSetDefaultResponse, DocCloseRequest, DocCloseResponse,
-    DocCreateRequest, DocCreateResponse, DocDelRequest, DocDelResponse, DocDropRequest,
-    DocDropResponse, DocGetDownloadPolicyRequest, DocGetDownloadPolicyResponse, DocGetExactRequest,
-    DocGetExactResponse, DocGetManyRequest, DocGetManyResponse, DocGetSyncPeersRequest,
-    DocGetSyncPeersResponse, DocImportRequest, DocImportResponse, DocLeaveRequest,
-    DocLeaveResponse, DocListRequest, DocListResponse, DocOpenRequest, DocOpenResponse,
-    DocSetDownloadPolicyRequest, DocSetDownloadPolicyResponse, DocSetHashRequest,
-    DocSetHashResponse, DocSetRequest, DocSetResponse, DocShareRequest, DocShareResponse,
-    DocStartSyncRequest, DocStartSyncResponse, DocStatusRequest, DocStatusResponse,
-    DocSubscribeRequest, DocSubscribeResponse, RpcResult,
+    AuthorImportRequest, AuthorImportResponse, AuthorListRequest, AuthorSetDefaultRequest,
+    AuthorSetDefaultResponse, DocCloseRequest, DocCloseResponse, DocCreateRequest,
+    DocCreateResponse, DocDelRequest, DocDelResponse, DocDropRequest, DocDropResponse,
+    DocGetDownloadPolicyRequest, DocGetDownloadPolicyResponse, DocGetExactRequest,
+    DocGetExactResponse, DocGetManyRequest, DocGetSyncPeersRequest, DocGetSyncPeersResponse,
+    DocImportRequest, DocImportResponse, DocLeaveRequest, DocLeaveResponse, DocListRequest,
+    DocOpenRequest, DocOpenResponse, DocSetDownloadPolicyRequest, DocSetDownloadPolicyResponse,
+    DocSetHashRequest, DocSetHashResponse, DocSetRequest, DocSetResponse, DocShareRequest,
+    DocShareResponse, DocStartSyncRequest, DocStartSyncResponse, DocStatusRequest,
+    DocStatusResponse, DocSubscribeRequest, DocSubscribeResponse, RpcResult,
 };
 
 /// Capacity for the flume channels to forward sync store iterators to async RPC streams.
-const ITER_CHANNEL_CAP: usize = 64;
+pub(super) const ITER_CHANNEL_CAP: usize = 64;
 
 #[allow(missing_docs)]
 impl DocsEngine {
@@ -57,8 +58,8 @@ impl DocsEngine {
     pub fn author_list(
         &self,
         _req: AuthorListRequest,
-    ) -> impl Stream<Item = RpcResult<AuthorListResponse>> {
-        let (tx, rx) = flume::bounded(ITER_CHANNEL_CAP);
+        tx: flume::Sender<anyhow::Result<AuthorId>>,
+    ) {
         let sync = self.sync.clone();
         // we need to spawn a task to send our request to the sync handle, because the method
         // itself must be sync.
@@ -68,10 +69,6 @@ impl DocsEngine {
                 tx2.send_async(Err(err)).await.ok();
             }
         });
-        rx.into_stream().map(|r| {
-            r.map(|author_id| AuthorListResponse { author_id })
-                .map_err(Into::into)
-        })
     }
 
     pub async fn author_import(&self, req: AuthorImportRequest) -> RpcResult<AuthorImportResponse> {
@@ -108,8 +105,12 @@ impl DocsEngine {
         Ok(DocDropResponse {})
     }
 
-    pub fn doc_list(&self, _req: DocListRequest) -> impl Stream<Item = RpcResult<DocListResponse>> {
-        let (tx, rx) = flume::bounded(ITER_CHANNEL_CAP);
+    pub fn doc_list(
+        &self,
+        _req: DocListRequest,
+        tx: flume::Sender<anyhow::Result<(NamespaceId, CapabilityKind)>>,
+    ) {
+        // let (tx, rx) = flume::bounded(ITER_CHANNEL_CAP);
         let sync = self.sync.clone();
         // we need to spawn a task to send our request to the sync handle, because the method
         // itself must be sync.
@@ -119,10 +120,6 @@ impl DocsEngine {
                 tx2.send_async(Err(err)).await.ok();
             }
         });
-        rx.into_stream().map(|r| {
-            r.map(|(id, capability)| DocListResponse { id, capability })
-                .map_err(Into::into)
-        })
     }
 
     pub async fn doc_open(&self, req: DocOpenRequest) -> RpcResult<DocOpenResponse> {
@@ -249,9 +246,9 @@ impl DocsEngine {
     pub fn doc_get_many(
         &self,
         req: DocGetManyRequest,
-    ) -> impl Stream<Item = RpcResult<DocGetManyResponse>> {
+        tx: flume::Sender<anyhow::Result<SignedEntry>>,
+    ) {
         let DocGetManyRequest { doc_id, query } = req;
-        let (tx, rx) = flume::bounded(ITER_CHANNEL_CAP);
         let sync = self.sync.clone();
         // we need to spawn a task to send our request to the sync handle, because the method
         // itself must be sync.
@@ -261,10 +258,6 @@ impl DocsEngine {
                 tx2.send_async(Err(err)).await.ok();
             }
         });
-        rx.into_stream().map(|r| {
-            r.map(|entry| DocGetManyResponse { entry })
-                .map_err(Into::into)
-        })
     }
 
     pub async fn doc_get_exact(&self, req: DocGetExactRequest) -> RpcResult<DocGetExactResponse> {

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -439,7 +439,7 @@ pub struct AuthorCreateResponse {
 pub struct AuthorGetDefaultRequest;
 
 impl RpcMsg<RpcService> for AuthorGetDefaultRequest {
-    type Response = AuthorGetDefaultResponse;
+    type Response = RpcResult<AuthorGetDefaultResponse>;
 }
 
 /// Response for [`AuthorGetDefaultRequest`]
@@ -1153,7 +1153,7 @@ pub enum Response {
 
     AuthorList(RpcResult<AuthorListResponse>),
     AuthorCreate(RpcResult<AuthorCreateResponse>),
-    AuthorGetDefault(AuthorGetDefaultResponse),
+    AuthorGetDefault(RpcResult<AuthorGetDefaultResponse>),
     AuthorSetDefault(RpcResult<AuthorSetDefaultResponse>),
     AuthorImport(RpcResult<AuthorImportResponse>),
     AuthorExport(RpcResult<AuthorExportResponse>),

--- a/iroh/tests/gc.rs
+++ b/iroh/tests/gc.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::Result;
 use bao_tree::{blake3, io::sync::Outboard, ChunkRanges};
 use bytes::Bytes;
-use iroh::node::{self, Node};
+use iroh::node::{self, DocsStorage, Node};
 use rand::RngCore;
 
 use iroh_blobs::{
@@ -41,17 +41,19 @@ async fn wrap_in_node<S>(bao_store: S, gc_period: Duration) -> (Node<S>, flume::
 where
     S: iroh_blobs::store::Store,
 {
-    let doc_store = iroh_docs::store::Store::memory();
     let (gc_send, gc_recv) = flume::unbounded();
-    let node =
-        node::Builder::with_db_and_store(bao_store, doc_store, iroh::node::StorageConfig::Mem)
-            .gc_policy(iroh::node::GcPolicy::Interval(gc_period))
-            .register_gc_done_cb(Box::new(move || {
-                gc_send.send(()).ok();
-            }))
-            .spawn()
-            .await
-            .unwrap();
+    let node = node::Builder::with_db_and_store(
+        bao_store,
+        DocsStorage::Memory,
+        iroh::node::StorageConfig::Mem,
+    )
+    .gc_policy(iroh::node::GcPolicy::Interval(gc_period))
+    .register_gc_done_cb(Box::new(move || {
+        gc_send.send(()).ok();
+    }))
+    .spawn()
+    .await
+    .unwrap();
     (node, gc_recv)
 }
 

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use futures_lite::FutureExt;
-use iroh::node::Builder;
+use iroh::node::{Builder, DocsStorage};
 use iroh_base::node_addr::AddrInfoOptions;
 use iroh_net::{defaults::default_relay_map, key::SecretKey, NodeAddr, NodeId};
 use quic_rpc::transport::misc::DummyServerEndpoint;
@@ -40,8 +40,8 @@ async fn dial(secret_key: SecretKey, peer: NodeAddr) -> anyhow::Result<quinn::Co
 }
 
 fn test_node<D: Store>(db: D) -> Builder<D, DummyServerEndpoint> {
-    let store = iroh_docs::store::Store::memory();
-    iroh::node::Builder::with_db_and_store(db, store, iroh::node::StorageConfig::Mem).bind_port(0)
+    iroh::node::Builder::with_db_and_store(db, DocsStorage::Memory, iroh::node::StorageConfig::Mem)
+        .bind_port(0)
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description

Make the docs engine optional on the iroh node.

* Add `Builder::disable_docs()` to disable the docs engine completely
* If called, the docs engine will not be spawned and the docs protocol will not be registered. Incoming docs connnections will be dropped, and all docs-related RPC calls will return an error "docs are disabled".

## Breaking Changes

* `iroh::node::Builder::with_db_and_store` now takes a `DocsStorage` enum instead of a `iroh_docs::store::Store`.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
