### PR TITLE
feat(iroh)!: expand ability to connect to RPC

### DIFF
--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -130,7 +130,7 @@ impl Cli {
                     .await
                 } else {
                     crate::logging::init_terminal_logging()?;
-                    let iroh = Iroh::connect(data_dir).await.context("rpc connect")?;
+                    let iroh = Iroh::connect_path(data_dir).await.context("rpc connect")?;
                     let env = ConsoleEnv::for_console(data_dir_owned, &iroh).await?;
                     console::run(&iroh, &env).await
                 }
@@ -151,7 +151,7 @@ impl Cli {
                     .await
                 } else {
                     crate::logging::init_terminal_logging()?;
-                    let iroh = Iroh::connect(data_dir).await.context("rpc connect")?;
+                    let iroh = Iroh::connect_path(data_dir).await.context("rpc connect")?;
                     let env = ConsoleEnv::for_cli(data_dir_owned, &iroh).await?;
                     command.run(&iroh, &env).await
                 }

--- a/iroh-cli/src/commands/doc.rs
+++ b/iroh-cli/src/commands/doc.rs
@@ -958,7 +958,7 @@ mod tests {
         let cli = ConsoleEnv::for_console(data_dir.path().to_owned(), &node)
             .await
             .context("ConsoleEnv")?;
-        let iroh = iroh::client::Iroh::connect(data_dir.path())
+        let iroh = iroh::client::Iroh::connect_path(data_dir.path())
             .await
             .context("rpc connect")?;
 

--- a/iroh-cli/src/commands/node.rs
+++ b/iroh-cli/src/commands/node.rs
@@ -75,6 +75,9 @@ impl NodeCommands {
                 println!("Listening addresses: {:#?}", response.listen_addrs);
                 println!("Node public key: {}", response.addr.node_id);
                 println!("Version: {}", response.version);
+                if let Some(port) = response.rpc_port {
+                    println!("RPC Port: {}", port);
+                }
             }
         }
         Ok(())

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -81,4 +81,6 @@ pub struct NodeStatus {
     pub listen_addrs: Vec<SocketAddr>,
     /// The version of the node
     pub version: String,
+    /// RPC port, if currently listening.
+    pub rpc_port: Option<u16>,
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -58,8 +58,6 @@ pub struct Node<D> {
 #[derive(derive_more::Debug)]
 struct NodeInner<D> {
     db: D,
-    #[allow(dead_code)]
-    storage: StorageConfig,
     rpc_port: Option<u16>,
     docs: Option<DocsEngine>,
     endpoint: Endpoint,

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -58,6 +58,9 @@ pub struct Node<D> {
 #[derive(derive_more::Debug)]
 struct NodeInner<D> {
     db: D,
+    #[allow(dead_code)]
+    storage: StorageConfig,
+    rpc_port: Option<u16>,
     docs: Option<DocsEngine>,
     endpoint: Endpoint,
     gossip: Gossip,
@@ -148,6 +151,11 @@ impl<D: BaoStore> Node<D> {
     /// Get the relay server we are connected to.
     pub fn my_relay(&self) -> Option<iroh_net::relay::RelayUrl> {
         self.inner.endpoint.home_relay()
+    }
+
+    /// Returns `Some(port)` if an RPC endpoint is running on this port.
+    pub fn my_rpc_port(&self) -> Option<u16> {
+        self.inner.rpc_port
     }
 
     /// Shutdown the node.

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -511,7 +511,6 @@ where
         let client = crate::client::Iroh::new(quic_rpc::RpcClient::new(controller.clone()));
 
         let inner = Arc::new(NodeInner {
-            storage: self.storage,
             rpc_port: self.rpc_port,
             db: self.blobs_store,
             docs,

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -790,6 +790,7 @@ impl<D: BaoStore> Handler<D> {
                 .await
                 .unwrap_or_default(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            rpc_port: self.inner.rpc_port,
         })
     }
 

--- a/iroh/src/node/rpc_status.rs
+++ b/iroh/src/node/rpc_status.rs
@@ -1,4 +1,7 @@
-use std::path::Path;
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    path::Path,
+};
 
 use anyhow::{ensure, Context, Result};
 use tokio::{fs, io::AsyncReadExt};
@@ -40,7 +43,8 @@ impl RpcStatus {
                     .await
                     .context("read rpc lock file")?;
                 let running_rpc_port = u16::from_le_bytes(buffer);
-                if let Ok(client) = crate::client::quic_connect_raw(running_rpc_port).await {
+                let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), running_rpc_port);
+                if let Ok(client) = crate::client::quic_connect_raw(addr).await {
                     return Ok(RpcStatus::Running {
                         port: running_rpc_port,
                         client,


### PR DESCRIPTION
Allows for easier connectivity of RPC, when not having access to the folder, e.g. in a docker setup

## Breaking Changes

- renamed `iroh::client::Iroh::connect` -> `iroh::client::Iroh::connect_path` 
- added `iroh::client::Iroh::connect_addr`
- added `rpc_port` field to `iroh::client::NodeStatus` 

## Notes & open questions

There might be nicer ways, but this works for now

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
