### PR TITLE
fix(iroh): use tokio transport for quic rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,8 +4042,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e56dc58272a3f9c151b1c3a6df0e3caca083fd843b337e60f706fae2d974b6b"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=feat-async-channel#e004ac4fbbcb9fb4a7cf8da47733a968b7a3eaf6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4059,6 +4058,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-serde",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ missing_debug_implementations = "warn"
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "feat-async-channel" }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -37,7 +37,7 @@ iroh-docs = { version = "0.18.0", path = "../iroh-docs" }
 iroh-gossip = { version = "0.18.0", path = "../iroh-gossip" }
 parking_lot = "0.12.1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
-quic-rpc = { version = "0.10.2", default-features = false, features = ["flume-transport", "quinn-transport"] }
+quic-rpc = { version = "0.10.2", default-features = false, features = ["flume-transport", "tokio-mpsc-transport", "quinn-transport"] }
 quinn = { package = "iroh-quinn", version = "0.10" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -23,7 +23,7 @@ use iroh_net::{
 };
 use quic_rpc::{
     transport::{
-        flume::FlumeServerEndpoint, misc::DummyServerEndpoint, quinn::QuinnServerEndpoint,
+        misc::DummyServerEndpoint, quinn::QuinnServerEndpoint, tokio_mpsc::ServerEndpoint,
     },
     ServiceEndpoint,
 };
@@ -494,7 +494,7 @@ where
         .await?;
 
         // Initialize the internal RPC connection.
-        let (internal_rpc, controller) = quic_rpc::transport::flume::connection(1);
+        let (internal_rpc, controller) = quic_rpc::transport::tokio_mpsc::connection(1);
         // box the controller. Boxing has a special case for the flume channel that avoids allocations,
         // so this has zero overhead.
         let controller = quic_rpc::transport::boxed::Connection::new(controller);
@@ -538,7 +538,7 @@ where
 #[derive(derive_more::Debug)]
 pub struct ProtocolBuilder<D, E> {
     inner: Arc<NodeInner<D>>,
-    internal_rpc: FlumeServerEndpoint<RpcService>,
+    internal_rpc: ServerEndpoint<RpcService>,
     external_rpc: E,
     protocols: ProtocolMap,
     #[debug("callback")]


### PR DESCRIPTION
Depends on https://github.com/n0-computer/quic-rpc/pull/86