### PR TITLE
fix(iroh): use two stage accept from quic-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4041,8 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.10.2"
-source = "git+https://github.com/n0-computer/quic-rpc?branch=two-stage-accept#90137e6899076ad92feec94c7d68c8227e5ae54a"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110f0fbbf7c4a694902e11d890157245801d89a18d8e9b8d9d2afd91358a6a7c"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,8 +4042,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e56dc58272a3f9c151b1c3a6df0e3caca083fd843b337e60f706fae2d974b6b"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=two-stage-accept#90137e6899076ad92feec94c7d68c8227e5ae54a"
 dependencies = [
  "anyhow",
  "bincode",

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -45,7 +45,7 @@ parking_lot = "0.12.1"
 pkarr = { version = "1.1.5", default-features = false }
 portable-atomic = "1"
 postcard = "1.0.8"
-quic-rpc = { version = "0.10.2", features = ["flume-transport", "quinn-transport"] }
+quic-rpc = { version = "0.10.2", features = ["flume-transport", "quinn-transport"], git = "https://github.com/n0-computer/quic-rpc", branch = "two-stage-accept" }
 rand = "0.8.5"
 ratatui = "0.26.2"
 reqwest = { version = "0.12.4", default-features = false, features = ["json", "rustls-tls"] }

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -45,7 +45,7 @@ parking_lot = "0.12.1"
 pkarr = { version = "1.1.5", default-features = false }
 portable-atomic = "1"
 postcard = "1.0.8"
-quic-rpc = { version = "0.10.2", features = ["flume-transport", "quinn-transport"], git = "https://github.com/n0-computer/quic-rpc", branch = "two-stage-accept" }
+quic-rpc = { version = "0.11", features = ["flume-transport", "quinn-transport"] }
 rand = "0.8.5"
 ratatui = "0.26.2"
 reqwest = { version = "0.12.4", default-features = false, features = ["json", "rustls-tls"] }

--- a/iroh-cli/src/commands/blob.rs
+++ b/iroh-cli/src/commands/blob.rs
@@ -277,11 +277,8 @@ impl BlobCommands {
                     Some(OutputTarget::Stdout) => {
                         // we asserted above that `OutputTarget::Stdout` is only permitted if getting a
                         // single hash and not a hashseq.
-                        tracing::info!("calling read on blob");
                         let mut blob_read = iroh.blobs().read(hash).await?;
-                        tracing::info!("copying blob to stdout");
                         tokio::io::copy(&mut blob_read, &mut tokio::io::stdout()).await?;
-                        tracing::info!("copying done");
                     }
                     Some(OutputTarget::Path(path)) => {
                         let absolute = std::env::current_dir()?.join(&path);

--- a/iroh-cli/src/commands/blob.rs
+++ b/iroh-cli/src/commands/blob.rs
@@ -277,8 +277,11 @@ impl BlobCommands {
                     Some(OutputTarget::Stdout) => {
                         // we asserted above that `OutputTarget::Stdout` is only permitted if getting a
                         // single hash and not a hashseq.
+                        tracing::info!("calling read on blob");
                         let mut blob_read = iroh.blobs().read(hash).await?;
+                        tracing::info!("copying blob to stdout");
                         tokio::io::copy(&mut blob_read, &mut tokio::io::stdout()).await?;
+                        tracing::info!("copying done");
                     }
                     Some(OutputTarget::Path(path)) => {
                         let absolute = std::env::current_dir()?.join(&path);

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -37,7 +37,7 @@ iroh-docs = { version = "0.18.0", path = "../iroh-docs" }
 iroh-gossip = { version = "0.18.0", path = "../iroh-gossip" }
 parking_lot = "0.12.1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
-quic-rpc = { version = "0.10.2", default-features = false, features = ["flume-transport", "quinn-transport"] }
+quic-rpc = { version = "0.10.2", default-features = false, features = ["flume-transport", "quinn-transport"], git = "https://github.com/n0-computer/quic-rpc", branch = "two-stage-accept" }
 quinn = { package = "iroh-quinn", version = "0.10" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -37,7 +37,7 @@ iroh-docs = { version = "0.18.0", path = "../iroh-docs" }
 iroh-gossip = { version = "0.18.0", path = "../iroh-gossip" }
 parking_lot = "0.12.1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
-quic-rpc = { version = "0.10.2", default-features = false, features = ["flume-transport", "quinn-transport"], git = "https://github.com/n0-computer/quic-rpc", branch = "two-stage-accept" }
+quic-rpc = { version = "0.11", default-features = false, features = ["flume-transport", "quinn-transport"] }
 quinn = { package = "iroh-quinn", version = "0.10" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -273,15 +273,8 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
                 // accept is just a pending future.
                 request = external_rpc.accept() => {
                     match request {
-                        Ok(request) => {
-                            match  request.read_first().await {
-                                Ok((msg, chan)) => {
-                                    rpc::Handler::spawn_rpc_request(self.clone(), &mut join_set, msg, chan);
-                                }
-                                Err(e) => {
-                                    info!("rpc request error: {:?}", e);
-                                }
-                            }
+                        Ok(accepting) => {
+                            rpc::Handler::spawn_rpc_request(self.clone(), &mut join_set, accepting);
                         }
                         Err(e) => {
                             info!("rpc request error: {:?}", e);
@@ -291,15 +284,8 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
                 // handle internal rpc requests.
                 request = internal_rpc.accept() => {
                     match request {
-                        Ok(request) => {
-                            match  request.read_first().await {
-                                Ok((msg, chan)) => {
-                                    rpc::Handler::spawn_rpc_request(self.clone(), &mut join_set, msg, chan);
-                                }
-                                Err(e) => {
-                                    info!("internal rpc request error: {:?}", e);
-                                }
-                            }
+                        Ok(accepting) => {
+                            rpc::Handler::spawn_rpc_request(self.clone(), &mut join_set, accepting);
                         }
                         Err(e) => {
                             info!("internal rpc request error: {:?}", e);

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -273,8 +273,15 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
                 // accept is just a pending future.
                 request = external_rpc.accept() => {
                     match request {
-                        Ok((msg, chan)) => {
-                            rpc::Handler::spawn_rpc_request(self.clone(), &mut join_set, msg, chan);
+                        Ok(request) => {
+                            match  request.read_first().await {
+                                Ok((msg, chan)) => {
+                                    rpc::Handler::spawn_rpc_request(self.clone(), &mut join_set, msg, chan);
+                                }
+                                Err(e) => {
+                                    info!("rpc request error: {:?}", e);
+                                }
+                            }
                         }
                         Err(e) => {
                             info!("rpc request error: {:?}", e);
@@ -284,8 +291,15 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
                 // handle internal rpc requests.
                 request = internal_rpc.accept() => {
                     match request {
-                        Ok((msg, chan)) => {
-                            rpc::Handler::spawn_rpc_request(self.clone(), &mut join_set, msg, chan);
+                        Ok(request) => {
+                            match  request.read_first().await {
+                                Ok((msg, chan)) => {
+                                    rpc::Handler::spawn_rpc_request(self.clone(), &mut join_set, msg, chan);
+                                }
+                                Err(e) => {
+                                    info!("internal rpc request error: {:?}", e);
+                                }
+                            }
                         }
                         Err(e) => {
                             info!("internal rpc request error: {:?}", e);

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -494,7 +494,7 @@ where
         .await?;
 
         // Initialize the internal RPC connection.
-        let (internal_rpc, controller) = quic_rpc::transport::flume::connection(1);
+        let (internal_rpc, controller) = quic_rpc::transport::flume::connection(32);
         // box the controller. Boxing has a special case for the flume channel that avoids allocations,
         // so this has zero overhead.
         let controller = quic_rpc::transport::boxed::Connection::new(controller);

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -109,11 +109,11 @@ impl<D: BaoStore> Handler<D> {
     pub(crate) fn spawn_rpc_request<E: ServiceEndpoint<RpcService>>(
         inner: Arc<NodeInner<D>>,
         join_set: &mut JoinSet<anyhow::Result<()>>,
-        msg: Request,
-        chan: RpcChannel<RpcService, E>,
+        accepting: quic_rpc::server::Accepting<RpcService, E>,
     ) {
         let handler = Self::new(inner);
         join_set.spawn(async move {
+            let (msg, chan) = accepting.read_first().await?;
             if let Err(err) = handler.handle_rpc_request(msg, chan).await {
                 warn!("rpc request handler error: {err:?}");
             }


### PR DESCRIPTION
## Description

fix(iroh): use two stage accept from quic-rpc to make the accept process cancel-safe

Needs https://github.com/n0-computer/quic-rpc/pull/87

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
