### PR TITLE
refactor(iroh-relay)!: Remove `relay_endpoint` config option & rename `/derp` route to `/relay`

### DIFF
--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -12,6 +12,10 @@ pub(crate) const HTTP_UPGRADE_PROTOCOL: &str = "iroh derp http";
 pub(crate) const WEBSOCKET_UPGRADE_PROTOCOL: &str = "websocket";
 pub(crate) const SUPPORTED_WEBSOCKET_VERSION: &str = "13";
 
+/// The path under which the relay accepts relaying connections
+/// (over websockets and a custom upgrade protocol).
+pub const RELAY_HTTP_PATH: &str = "/relay";
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -15,6 +15,8 @@ pub(crate) const SUPPORTED_WEBSOCKET_VERSION: &str = "13";
 /// The path under which the relay accepts relaying connections
 /// (over websockets and a custom upgrade protocol).
 pub const RELAY_HTTP_PATH: &str = "/relay";
+/// The path under which the relay allows doing latency queries for testing.
+pub const RELAY_PROBE_HTTP_PATH: &str = "/relay/probe";
 
 #[cfg(test)]
 mod tests {

--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -12,11 +12,17 @@ pub(crate) const HTTP_UPGRADE_PROTOCOL: &str = "iroh derp http";
 pub(crate) const WEBSOCKET_UPGRADE_PROTOCOL: &str = "websocket";
 pub(crate) const SUPPORTED_WEBSOCKET_VERSION: &str = "13";
 
-/// The path under which the relay accepts relaying connections
+/// The HTTP path under which the relay accepts relaying connections
 /// (over websockets and a custom upgrade protocol).
-pub const RELAY_HTTP_PATH: &str = "/relay";
-/// The path under which the relay allows doing latency queries for testing.
-pub const RELAY_PROBE_HTTP_PATH: &str = "/relay/probe";
+pub const RELAY_PATH: &str = "/relay";
+/// The HTTP path under which the relay allows doing latency queries for testing.
+pub const RELAY_PROBE_PATH: &str = "/relay/probe";
+/// The legacy HTTP path under which the relay used to accept relaying connections.
+/// We keep this for backwards compatibility.
+pub(crate) const LEGACY_RELAY_PATH: &str = "/derp";
+/// The legacy HTTP path under which the relay used to allow latency queries.
+/// We keep this for backwards compatibility.
+pub(crate) const LEGACY_RELAY_PROBE_PATH: &str = "/derp/probe";
 
 #[cfg(test)]
 mod tests {

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -31,7 +31,7 @@ use crate::key::{PublicKey, SecretKey};
 use crate::relay::client::{ConnReader, ConnWriter};
 use crate::relay::codec::DerpCodec;
 use crate::relay::http::streams::{downcast_upgrade, MaybeTlsStream};
-use crate::relay::http::RELAY_HTTP_PATH;
+use crate::relay::http::RELAY_PATH;
 use crate::relay::RelayUrl;
 use crate::relay::{
     client::Client as RelayClient, client::ClientBuilder as RelayClientBuilder,
@@ -613,7 +613,7 @@ impl Actor {
 
     async fn connect_ws(&self) -> Result<(ConnReader, ConnWriter), ClientError> {
         let mut dial_url = (*self.url).clone();
-        dial_url.set_path(RELAY_HTTP_PATH);
+        dial_url.set_path(RELAY_PATH);
 
         debug!(%dial_url, "Dialing relay by websocket");
 
@@ -699,7 +699,7 @@ impl Actor {
         );
         debug!("Sending upgrade request");
         let req = Request::builder()
-            .uri(RELAY_HTTP_PATH)
+            .uri(RELAY_PATH)
             .header(UPGRADE, Protocol::Relay.upgrade_header())
             .body(http_body_util::Empty::<hyper::body::Bytes>::new())?;
         request_sender.send_request(req).await.map_err(From::from)

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -31,7 +31,6 @@ use crate::key::{PublicKey, SecretKey};
 use crate::relay::client::{ConnReader, ConnWriter};
 use crate::relay::codec::DerpCodec;
 use crate::relay::http::streams::{downcast_upgrade, MaybeTlsStream};
-use crate::relay::http::RELAY_PATH;
 use crate::relay::RelayUrl;
 use crate::relay::{
     client::Client as RelayClient, client::ClientBuilder as RelayClientBuilder,
@@ -203,14 +202,12 @@ impl PingTracker {
 }
 
 /// Build a Client.
-#[derive(derive_more::Debug)]
 pub struct ClientBuilder {
     /// Default is false
     can_ack_pings: bool,
     /// Default is false
     is_preferred: bool,
     /// Default is None
-    #[debug("address family selector callback")]
     address_family_selector: Option<Box<dyn Fn() -> BoxFuture<bool> + Send + Sync + 'static>>,
     /// Default is false
     is_prober: bool,
@@ -223,6 +220,16 @@ pub struct ClientBuilder {
     insecure_skip_cert_verify: bool,
     /// HTTP Proxy
     proxy_url: Option<Url>,
+}
+
+impl std::fmt::Debug for ClientBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let address_family_selector_txt = match self.address_family_selector {
+            Some(_) => "Some(Box<dyn Fn() -> BoxFuture<'static, bool> + Send + Sync + 'static>)",
+            None => "None",
+        };
+        write!(f, "ClientBuilder {{ can_ack_pings: {}, is_preferred: {}, address_family_selector: {address_family_selector_txt} }}", self.can_ack_pings, self.is_preferred)
+    }
 }
 
 impl ClientBuilder {
@@ -613,7 +620,7 @@ impl Actor {
 
     async fn connect_ws(&self) -> Result<(ConnReader, ConnWriter), ClientError> {
         let mut dial_url = (*self.url).clone();
-        dial_url.set_path(RELAY_PATH);
+        dial_url.set_path("/derp");
 
         debug!(%dial_url, "Dialing relay by websocket");
 
@@ -699,7 +706,7 @@ impl Actor {
         );
         debug!("Sending upgrade request");
         let req = Request::builder()
-            .uri(RELAY_PATH)
+            .uri("/derp")
             .header(UPGRADE, Protocol::Relay.upgrade_header())
             .body(http_body_util::Empty::<hyper::body::Bytes>::new())?;
         request_sender.send_request(req).await.map_err(From::from)

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -31,6 +31,7 @@ use crate::key::{PublicKey, SecretKey};
 use crate::relay::client::{ConnReader, ConnWriter};
 use crate::relay::codec::DerpCodec;
 use crate::relay::http::streams::{downcast_upgrade, MaybeTlsStream};
+use crate::relay::http::RELAY_HTTP_PATH;
 use crate::relay::RelayUrl;
 use crate::relay::{
     client::Client as RelayClient, client::ClientBuilder as RelayClientBuilder,
@@ -620,7 +621,7 @@ impl Actor {
 
     async fn connect_ws(&self) -> Result<(ConnReader, ConnWriter), ClientError> {
         let mut dial_url = (*self.url).clone();
-        dial_url.set_path("/derp");
+        dial_url.set_path(RELAY_HTTP_PATH);
 
         debug!(%dial_url, "Dialing relay by websocket");
 
@@ -706,7 +707,7 @@ impl Actor {
         );
         debug!("Sending upgrade request");
         let req = Request::builder()
-            .uri("/derp")
+            .uri(RELAY_HTTP_PATH)
             .header(UPGRADE, Protocol::Relay.upgrade_header())
             .body(http_body_util::Empty::<hyper::body::Bytes>::new())?;
         request_sender.send_request(req).await.map_err(From::from)

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -30,7 +30,7 @@ use crate::relay::http::{
 use crate::relay::server::{ClientConnHandler, MaybeTlsStream};
 use crate::relay::MaybeTlsStreamServer;
 
-use super::RELAY_HTTP_PATH;
+use super::{LEGACY_RELAY_PATH, RELAY_PATH};
 
 type BytesBody = http_body_util::Full<hyper::body::Bytes>;
 type HyperError = Box<dyn std::error::Error + Send + Sync>;
@@ -552,7 +552,7 @@ impl Service<Request<Incoming>> for RelayService {
         // or /derp for backwards compat
         if matches!(
             (req.method(), req.uri().path()),
-            (&hyper::Method::GET, "/derp" | RELAY_HTTP_PATH)
+            (&hyper::Method::GET, LEGACY_RELAY_PATH | RELAY_PATH)
         ) {
             match &self.0.relay_handler {
                 RelayHandler::Override(f) => {

--- a/iroh-net/src/relay/iroh_relay.rs
+++ b/iroh-net/src/relay/iroh_relay.rs
@@ -27,7 +27,7 @@ use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument
 
 use crate::key::SecretKey;
 use crate::relay;
-use crate::relay::http::{ServerBuilder as RelayServerBuilder, TlsAcceptor};
+use crate::relay::http::{ServerBuilder as RelayServerBuilder, TlsAcceptor, RELAY_PROBE_HTTP_PATH};
 use crate::stun;
 use crate::util::AbortingJoinHandle;
 
@@ -236,7 +236,7 @@ impl Server {
                     .request_handler(Method::GET, "/", Box::new(root_handler))
                     .request_handler(Method::GET, "/index.html", Box::new(root_handler))
                     .request_handler(Method::GET, "/derp/probe", Box::new(probe_handler)) // backwards compat
-                    .request_handler(Method::GET, "/relay/probe", Box::new(probe_handler))
+                    .request_handler(Method::GET, RELAY_PROBE_HTTP_PATH, Box::new(probe_handler))
                     .request_handler(Method::GET, "/robots.txt", Box::new(robots_handler));
                 let http_addr = match relay_config.tls {
                     Some(tls_config) => {

--- a/iroh-net/src/relay/iroh_relay.rs
+++ b/iroh-net/src/relay/iroh_relay.rs
@@ -76,7 +76,7 @@ pub struct ServerConfig<EC: fmt::Debug, EA: fmt::Debug = EC> {
 
 /// Configuration for the Relay HTTP and HTTPS server.
 ///
-/// This includes the HTTP services hosted by the Relay server, the Relay `/derp` HTTP
+/// This includes the HTTP services hosted by the Relay server, the Relay `/relay` HTTP
 /// endpoint is only one of the services served.
 #[derive(Debug)]
 pub struct RelayConfig<EC: fmt::Debug, EA: fmt::Debug = EC> {
@@ -235,7 +235,8 @@ impl Server {
                     .relay_override(Box::new(relay_disabled_handler))
                     .request_handler(Method::GET, "/", Box::new(root_handler))
                     .request_handler(Method::GET, "/index.html", Box::new(root_handler))
-                    .request_handler(Method::GET, "/derp/probe", Box::new(probe_handler))
+                    .request_handler(Method::GET, "/derp/probe", Box::new(probe_handler)) // backwards compat
+                    .request_handler(Method::GET, "/relay/probe", Box::new(probe_handler))
                     .request_handler(Method::GET, "/robots.txt", Box::new(robots_handler));
                 let http_addr = match relay_config.tls {
                     Some(tls_config) => {

--- a/iroh-net/src/relay/iroh_relay.rs
+++ b/iroh-net/src/relay/iroh_relay.rs
@@ -27,7 +27,9 @@ use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument
 
 use crate::key::SecretKey;
 use crate::relay;
-use crate::relay::http::{ServerBuilder as RelayServerBuilder, TlsAcceptor, RELAY_PROBE_HTTP_PATH};
+use crate::relay::http::{
+    ServerBuilder as RelayServerBuilder, TlsAcceptor, LEGACY_RELAY_PROBE_PATH, RELAY_PROBE_PATH,
+};
 use crate::stun;
 use crate::util::AbortingJoinHandle;
 
@@ -235,8 +237,12 @@ impl Server {
                     .relay_override(Box::new(relay_disabled_handler))
                     .request_handler(Method::GET, "/", Box::new(root_handler))
                     .request_handler(Method::GET, "/index.html", Box::new(root_handler))
-                    .request_handler(Method::GET, "/derp/probe", Box::new(probe_handler)) // backwards compat
-                    .request_handler(Method::GET, RELAY_PROBE_HTTP_PATH, Box::new(probe_handler))
+                    .request_handler(
+                        Method::GET,
+                        LEGACY_RELAY_PROBE_PATH,
+                        Box::new(probe_handler),
+                    ) // backwards compat
+                    .request_handler(Method::GET, RELAY_PROBE_PATH, Box::new(probe_handler))
                     .request_handler(Method::GET, "/robots.txt", Box::new(robots_handler));
                 let http_addr = match relay_config.tls {
                     Some(tls_config) => {


### PR DESCRIPTION
## Description

- Removes `relay_endpoint` config option from `ServerBuilder`
- Makes `iroh-relay` accept both `/derp` and `/relay` as paths for relaying
- Makes `/relay` the default path used in the iroh-net client

TODO:
- [x] Test both URLs

## Breaking Changes

- `iroh_net::relay::http::ServerBuilder`: Removed `relay_endpoint` function

## Notes & open questions

Closes #2378 

:white_check_mark: Merge this after #2387 

## Change checklist

- [X] Self-review.
- [X] Documentation updates if relevant.
- [X] Tests if relevant.
- [X] All breaking changes documented.
