### PR TITLE
refactor(iroh): log inner errors

### DIFF
--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -308,9 +308,15 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
                 },
                 // handle task terminations and quit on panics.
                 res = join_set.join_next(), if !join_set.is_empty() => {
-                    if let Some(Err(err)) = res {
-                        error!("Task failed: {err:?}");
-                        break;
+                    match res {
+                        Some(Err(outer)) => {
+                            error!("Task failed: {outer:?}");
+                            break;
+                        }
+                        Some(Ok(Err(inner))) => {
+                            debug!("Task errored: {inner:?}");
+                        }
+                        _ => {}
                     }
                 },
                 else => break,

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -310,8 +310,15 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
                 res = join_set.join_next(), if !join_set.is_empty() => {
                     match res {
                         Some(Err(outer)) => {
-                            error!("Task failed: {outer:?}");
-                            break;
+                            if outer.is_panic() {
+                                error!("Task panicked: {outer:?}");
+                                break;
+                            } else if outer.is_cancelled() {
+                                debug!("Task cancelled: {outer:?}");
+                            } else {
+                                error!("Task failed: {outer:?}");
+                                break;
+                            }
                         }
                         Some(Ok(Err(inner))) => {
                             debug!("Task errored: {inner:?}");


### PR DESCRIPTION
## Description

we currently abort the loop on outer errors (errors from spawn). But we do not look at inner errors (task returns properly but returns an error) at all.

This logs the inner errors as debug! and coninues.

Also checks if the outer error is actually a panic, and continues the loop otherwise.

## Breaking Changes

## Notes & open questions

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
