### PR TITLE
chore(ci): use pre-compiled binary on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,8 @@ jobs:
       run: |
         docker kill $(docker ps -q)
 
-    - name: Install cross
       # See https://github.com/cross-rs/cross/issues/1222
-      run: cargo install cross --git https://github.com/cross-rs/cross
+    - uses: taiki-e/install-action@cross
 
     - name: build
       # cross tests are currently broken vor armv7 and aarch64
@@ -92,9 +91,8 @@ jobs:
       run: |
         docker kill $(docker ps -q)
 
-    - name: Install cross
       # See https://github.com/cross-rs/cross/issues/1222
-      run: cargo install cross --git https://github.com/cross-rs/cross
+    - uses: taiki-e/install-action@cross
 
     - name: test
       run: cross test --all --target ${{ matrix.target }} -- --test-threads=12


### PR DESCRIPTION
## Description

Quoting from #2394 

> Compiling `cross` on CI takes more time compared to pulling the binary directly from a GitHub release.

> We can use [taiki-e/install-action](https://github.com/taiki-e/install-action) to pull the binary directly from the GitHub release. This action supports tagging a specific release or using the latest version.

## Breaking Changes

No.

## Notes & open questions


## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.

Closes #2394 
