### PR TITLE
docs: pass `Doc` instead of `Iroh` in example

### DIFF
--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -24,7 +24,7 @@ async fn main() -> anyhow::Result<()> {
     let mut stream = doc.get_many(Query::all()).await?;
     while let Some(entry) = stream.try_next().await? {
         println!("entry {}", fmt_entry(&entry));
-        // You can pass either a `Doc` or the `Iroh client`.
+        // You can pass either `&doc` or the `client`.
         let content = entry.content_bytes(&doc).await?;
         println!("  content {}", std::str::from_utf8(&content)?)
     }

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -24,7 +24,8 @@ async fn main() -> anyhow::Result<()> {
     let mut stream = doc.get_many(Query::all()).await?;
     while let Some(entry) = stream.try_next().await? {
         println!("entry {}", fmt_entry(&entry));
-        let content = entry.content_bytes(client).await?;
+        // You can pass either a `Doc` or the `Iroh client`.
+        let content = entry.content_bytes(&doc).await?;
         println!("  content {}", std::str::from_utf8(&content)?)
     }
 


### PR DESCRIPTION
## Description

Since `iroh/examples/client.rs` is the first example users see, it's likely they will use this file as a starting point for their app skeleton. I find it easier to keep `Doc` in a struct and pass it around rather than using `iroh::client::Iroh`.

I've also added a comment about the `content_bytes()` method, noting its ability to accept either a `Doc` or `client::Iroh`.

Related:
- https://github.com/n0-computer/iroh/blob/17c654e59cc2069522a66b87355f52342b837b8c/iroh-cli/src/commands/doc.rs#L689
- https://github.com/n0-computer/iroh/blob/17c654e59cc2069522a66b87355f52342b837b8c/iroh/tests/sync.rs#L1024

## Breaking Changes

No.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
