### PR TITLE
feat(iroh): Add rpc request to add an AddrInfo

### DIFF
--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -2,6 +2,7 @@
 
 use futures_lite::{Stream, StreamExt};
 use ref_cast::RefCast;
+use std::ops::Deref;
 
 #[doc(inline)]
 pub use crate::rpc_protocol::RpcService;
@@ -24,9 +25,8 @@ pub(crate) use self::quic::{connect_raw as quic_connect_raw, RPC_ALPN};
 pub mod authors;
 pub mod blobs;
 pub mod docs;
+pub mod node;
 pub mod tags;
-
-mod node;
 
 /// Iroh rpc client - boxed so that we can have a concrete type.
 pub(crate) type RpcClient =
@@ -36,6 +36,14 @@ pub(crate) type RpcClient =
 #[derive(Debug, Clone)]
 pub struct Iroh {
     rpc: RpcClient,
+}
+
+impl Deref for Iroh {
+    type Target = node::Client;
+
+    fn deref(&self) -> &Self::Target {
+        self.node()
+    }
 }
 
 impl Iroh {
@@ -62,6 +70,11 @@ impl Iroh {
     /// Tags client
     pub fn tags(&self) -> &tags::Client {
         tags::Client::ref_cast(&self.rpc)
+    }
+
+    /// Node client
+    pub fn node(&self) -> &node::Client {
+        node::Client::ref_cast(&self.rpc)
     }
 }
 

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -9,9 +9,9 @@ use iroh_net::{endpoint::ConnectionInfo, relay::RelayUrl, NodeAddr, NodeId};
 use serde::{Deserialize, Serialize};
 
 use crate::rpc_protocol::{
-    CounterStats, NodeAddrRequest, NodeConnectionInfoRequest, NodeConnectionInfoResponse,
-    NodeConnectionsRequest, NodeIdRequest, NodeRelayRequest, NodeShutdownRequest, NodeStatsRequest,
-    NodeStatusRequest,
+    CounterStats, NodeAddAddrRequest, NodeAddrRequest, NodeConnectionInfoRequest,
+    NodeConnectionInfoResponse, NodeConnectionsRequest, NodeIdRequest, NodeRelayRequest,
+    NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest,
 };
 
 use super::{flatten, Iroh};
@@ -54,6 +54,12 @@ impl Iroh {
     pub async fn my_addr(&self) -> Result<NodeAddr> {
         let addr = self.rpc.rpc(NodeAddrRequest).await??;
         Ok(addr)
+    }
+
+    /// Add a known node address to the node.
+    pub async fn add_node_addr(&self, addr: NodeAddr) -> Result<()> {
+        self.rpc.rpc(NodeAddAddrRequest { addr }).await??;
+        Ok(())
     }
 
     /// Get the relay server we are connected to.

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
 use iroh_base::key::PublicKey;
 use iroh_net::{endpoint::ConnectionInfo, relay::RelayUrl, NodeAddr, NodeId};
+use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 
 use crate::rpc_protocol::{
@@ -14,9 +15,16 @@ use crate::rpc_protocol::{
     NodeShutdownRequest, NodeStatsRequest, NodeStatusRequest,
 };
 
-use super::{flatten, Iroh};
+use super::{flatten, RpcClient};
 
-impl Iroh {
+/// Iroh node client.
+#[derive(Debug, Clone, RefCast)]
+#[repr(transparent)]
+pub struct Client {
+    pub(super) rpc: RpcClient,
+}
+
+impl Client {
     /// Get statistics of the running node.
     pub async fn stats(&self) -> Result<BTreeMap<String, CounterStats>> {
         let res = self.rpc.rpc(NodeStatsRequest {}).await??;

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -997,6 +997,8 @@ impl<D: BaoStore> Handler<D> {
         Ok(NodeConnectionInfoResponse { conn_info })
     }
 
+    // This method is called as an RPC method, which have to be async
+    #[allow(clippy::unused_async)]
     async fn node_add_addr(self, req: NodeAddAddrRequest) -> RpcResult<()> {
         let NodeAddAddrRequest { addr } = req;
         self.inner.endpoint.add_node_addr(addr)?;

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -46,10 +46,10 @@ use crate::rpc_protocol::{
     BlobListRequest, BlobReadAtRequest, BlobReadAtResponse, BlobValidateRequest,
     CreateCollectionRequest, CreateCollectionResponse, DeleteTagRequest, DocExportFileRequest,
     DocExportFileResponse, DocImportFileRequest, DocImportFileResponse, DocSetHashRequest,
-    ListTagsRequest, NodeAddrRequest, NodeConnectionInfoRequest, NodeConnectionInfoResponse,
-    NodeConnectionsRequest, NodeConnectionsResponse, NodeIdRequest, NodeRelayRequest,
-    NodeShutdownRequest, NodeStatsRequest, NodeStatsResponse, NodeStatusRequest, NodeWatchRequest,
-    NodeWatchResponse, Request, RpcService, SetTagOption,
+    ListTagsRequest, NodeAddAddrRequest, NodeAddrRequest, NodeConnectionInfoRequest,
+    NodeConnectionInfoResponse, NodeConnectionsRequest, NodeConnectionsResponse, NodeIdRequest,
+    NodeRelayRequest, NodeShutdownRequest, NodeStatsRequest, NodeStatsResponse, NodeStatusRequest,
+    NodeWatchRequest, NodeWatchResponse, Request, RpcService, SetTagOption,
 };
 
 mod docs;
@@ -141,6 +141,7 @@ impl<D: BaoStore> Handler<D> {
                     .await
             }
             NodeConnectionInfo(msg) => chan.rpc(msg, self, Self::node_connection_info).await,
+            NodeAddAddr(msg) => chan.rpc(msg, self, Self::node_add_addr).await,
             BlobList(msg) => chan.server_streaming(msg, self, Self::blob_list).await,
             BlobListIncomplete(msg) => {
                 chan.server_streaming(msg, self, Self::blob_list_incomplete)
@@ -994,6 +995,12 @@ impl<D: BaoStore> Handler<D> {
         let NodeConnectionInfoRequest { node_id } = req;
         let conn_info = self.inner.endpoint.connection_info(node_id);
         Ok(NodeConnectionInfoResponse { conn_info })
+    }
+
+    async fn node_add_addr(self, req: NodeAddAddrRequest) -> RpcResult<()> {
+        let NodeAddAddrRequest { addr } = req;
+        self.inner.endpoint.add_node_addr(addr)?;
+        Ok(())
     }
 
     async fn create_collection(

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -366,6 +366,15 @@ impl RpcMsg<RpcService> for NodeAddrRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct NodeAddAddrRequest {
+    pub addr: NodeAddr,
+}
+
+impl RpcMsg<RpcService> for NodeAddAddrRequest {
+    type Response = RpcResult<()>;
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct NodeRelayRequest;
 
 impl RpcMsg<RpcService> for NodeRelayRequest {
@@ -1046,6 +1055,7 @@ pub enum Request {
     NodeStatus(NodeStatusRequest),
     NodeId(NodeIdRequest),
     NodeAddr(NodeAddrRequest),
+    NodeAddAddr(NodeAddAddrRequest),
     NodeRelay(NodeRelayRequest),
     NodeStats(NodeStatsRequest),
     NodeShutdown(NodeShutdownRequest),


### PR DESCRIPTION
## Description

Add rpc request to add an addr to an endpoint. Without this it is not possible to write some tests using just the client.
Move all node related fns into a separate "node client" and impl deref for it so the fns remain available on Iroh.

## Breaking Changes

- iroh::client::Iroh: stats only available via deref from iroh::client::node::Client
- iroh::client::Iroh: connections only available via deref from iroh::client::node::Client
- iroh::client::Iroh: connection_info only available via deref from iroh::client::node::Client
- iroh::client::Iroh: status only available via deref from iroh::client::node::Client
- iroh::client::Iroh: node_id only available via deref from iroh::client::node::Client
- iroh::client::Iroh: node_addr only available via deref from iroh::client::node::Client
- iroh::client::Iroh: home_addr only available via deref from iroh::client::node::Client
- iroh::client::Iroh: shutdown only available via deref from iroh::client::node::Client

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
