### PR TITLE
refactor(iroh)!: attempt make naming more consistent

### DIFF
--- a/iroh/examples/collection-fetch.rs
+++ b/iroh/examples/collection-fetch.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
     println!("fetching hash:  {}", ticket.hash());
     println!("node id:        {}", node.node_id());
     println!("node listening addresses:");
-    let addrs = node.my_addr().await?;
+    let addrs = node.node_addr().await?;
     for addr in addrs.direct_addresses() {
         println!("\t{:?}", addr);
     }

--- a/iroh/examples/collection-fetch.rs
+++ b/iroh/examples/collection-fetch.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     }
     println!(
         "node relay server url: {:?}",
-        node.my_relay()
+        node.home_relay()
             .expect("a default relay url should be provided")
             .to_string()
     );

--- a/iroh/examples/hello-world-fetch.rs
+++ b/iroh/examples/hello-world-fetch.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
     println!("fetching hash:  {}", ticket.hash());
     println!("node id:        {}", node.node_id());
     println!("node listening addresses:");
-    let addrs = node.my_addr().await?;
+    let addrs = node.node_addr().await?;
     for addr in addrs.direct_addresses() {
         println!("\t{:?}", addr);
     }

--- a/iroh/examples/hello-world-fetch.rs
+++ b/iroh/examples/hello-world-fetch.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     }
     println!(
         "node relay server url: {:?}",
-        node.my_relay()
+        node.home_relay()
             .expect("a default relay url should be provided")
             .to_string()
     );

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -57,7 +57,7 @@ impl Iroh {
     }
 
     /// Get the relay server we are connected to.
-    pub async fn my_relay(&self) -> Result<Option<RelayUrl>> {
+    pub async fn home_relay(&self) -> Result<Option<RelayUrl>> {
         let relay = self.rpc.rpc(NodeRelayRequest).await??;
         Ok(relay)
     }

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -51,7 +51,7 @@ impl Iroh {
     }
 
     /// Return the [`NodeAddr`] for this node.
-    pub async fn my_addr(&self) -> Result<NodeAddr> {
+    pub async fn node_addr(&self) -> Result<NodeAddr> {
         let addr = self.rpc.rpc(NodeAddrRequest).await??;
         Ok(addr)
     }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -147,7 +147,7 @@ impl<D: BaoStore> Node<D> {
     }
 
     /// Get the relay server we are connected to.
-    pub fn my_relay(&self) -> Option<iroh_net::relay::RelayUrl> {
+    pub fn home_relay(&self) -> Option<iroh_net::relay::RelayUrl> {
         self.inner.endpoint.home_relay()
     }
 


### PR DESCRIPTION
## Description

Attempt make naming more consistent between iroh-net endpoint, the iroh node, and the iroh client.

## Breaking Changes

- rename iroh::client::Iroh::my_relay to home_relay
- rename iroh::client::Iroh::my_addr to node_addr
- rename iroh::node::Node::my_relay to home_relay

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
