### PR TITLE
chore(ci): Deny aws-lc backend to sneak in

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,9 @@
 [bans]
 multiple-versions = "allow"
 deny = [
-     "openssl",
+     "aws-lc",
      "native-tls",
+     "openssl",
 ]
 
 [licenses]

--- a/iroh-cli/src/commands/start.rs
+++ b/iroh-cli/src/commands/start.rs
@@ -189,6 +189,7 @@ mod tests {
     use iroh::util::path::IrohPaths;
 
     #[tokio::test]
+    #[ignore = "flaky"]
     async fn test_run_rpc_lock_file() -> Result<()> {
         let data_dir = tempfile::TempDir::with_prefix("rpc-lock-file-")?;
         let lock_file_path = data_dir


### PR DESCRIPTION
## Description

Because of the platforms we support we want to stay with the ring
backend for rustls for now.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

https://github.com/n0-computer/iroh/issues/2438 for the flaky test.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~