### PR TITLE
feat(iroh-net)!: Make relay protocol configurable on `ClientBuilder` instead of defined by the relay url scheme

### DIFF
--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -258,7 +258,8 @@ impl ClientBuilder {
         self
     }
 
-    /// Sets the protocol used
+    /// Sets whether to connect to the relay via websockets or not.
+    /// Set to use non-websocket, normal relaying by default.
     pub fn protocol(mut self, protocol: Protocol) -> Self {
         self.protocol = protocol;
         self
@@ -628,10 +629,12 @@ impl Actor {
 
     async fn connect_ws(&self) -> Result<(ConnReader, ConnWriter), ClientError> {
         let mut dial_url = (*self.url).clone();
+        dial_url.set_path("/derp");
+        // The relay URL is exchanged with the http(s) scheme in tickets and similar.
+        // We need to use the ws:// or wss:// schemes when connecting with websockets, though.
         dial_url
             .set_scheme(if self.use_tls() { "wss" } else { "ws" })
             .map_err(|()| ClientError::InvalidUrl(self.url.to_string()))?;
-        dial_url.set_path("/derp");
 
         debug!(%dial_url, "Dialing relay by websocket");
 

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -15,7 +15,6 @@ use hyper::header::{HeaderValue, UPGRADE};
 use hyper::service::Service;
 use hyper::upgrade::Upgraded;
 use hyper::{HeaderMap, Method, Request, Response, StatusCode};
-use iroh_base::node_addr::RelayUrl;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 use tokio_rustls_acme::AcmeAcceptor;
@@ -78,20 +77,6 @@ impl Protocol {
         match self {
             Protocol::Relay => HTTP_UPGRADE_PROTOCOL,
             Protocol::Websocket => WEBSOCKET_UPGRADE_PROTOCOL,
-        }
-    }
-
-    /// Determines which protocol to use depending on a URL.
-    ///
-    /// `ws(s)` parses as websockets, `http(s)` parses to the custom relay protocol.
-    pub fn from_url_scheme(url: &RelayUrl) -> Self {
-        match url.scheme() {
-            "ws" => Protocol::Websocket,
-            "wss" => Protocol::Websocket,
-            "http" => Protocol::Relay,
-            "https" => Protocol::Relay,
-            // We default to relay in case of weird URLs.
-            _ => Protocol::Relay,
         }
     }
 


### PR DESCRIPTION
## Description

Details in #2442 

## Breaking Changes

- `iroh_net::relay::http::ClientBuilder`: Added `.protocol()` function to the builder for choosing whether to connect to the relay via websockets or not

## Change checklist

- [X] Self-review.
- [X] Documentation updates if relevant.
- [X] Tests if relevant.
- [X] All breaking changes documented.
