### PR TITLE
test(Iroh-net): increase timeout for pkarr publishing

### DIFF
--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -575,6 +575,8 @@ mod test_dns_pkarr {
         AddrInfo, Endpoint, NodeAddr,
     };
 
+    const PUBLISH_TIMEOUT: Duration = Duration::from_secs(10);
+
     #[tokio::test]
     async fn dns_resolve() -> Result<()> {
         let _logging_guard = iroh_test::logging::setup();
@@ -605,7 +607,6 @@ mod test_dns_pkarr {
         let _logging_guard = iroh_test::logging::setup();
 
         let origin = "testdns.example".to_string();
-        let timeout = Duration::from_secs(2);
 
         let dns_pkarr_server = DnsPkarrServer::run_with_origin(origin.clone()).await?;
 
@@ -622,7 +623,7 @@ mod test_dns_pkarr {
         // does not block, update happens in background task
         publisher.update_addr_info(&addr_info);
         // wait until our shared state received the update from pkarr publishing
-        dns_pkarr_server.on_node(&node_id, timeout).await?;
+        dns_pkarr_server.on_node(&node_id, PUBLISH_TIMEOUT).await?;
         let resolved = resolver.lookup_by_id(&node_id, &origin).await?;
 
         let expected = NodeAddr {
@@ -640,8 +641,6 @@ mod test_dns_pkarr {
     async fn pkarr_publish_dns_discover() -> Result<()> {
         let _logging_guard = iroh_test::logging::setup();
 
-        let timeout = Duration::from_secs(2);
-
         let dns_pkarr_server = DnsPkarrServer::run().await?;
         let (relay_map, _relay_url, _relay_guard) = run_relay_server().await?;
 
@@ -649,7 +648,9 @@ mod test_dns_pkarr {
         let ep2 = ep_with_discovery(&relay_map, &dns_pkarr_server).await?;
 
         // wait until our shared state received the update from pkarr publishing
-        dns_pkarr_server.on_node(&ep1.node_id(), timeout).await?;
+        dns_pkarr_server
+            .on_node(&ep1.node_id(), PUBLISH_TIMEOUT)
+            .await?;
 
         // we connect only by node id!
         let res = ep2.connect(ep1.node_id().into(), TEST_ALPN).await;
@@ -661,8 +662,6 @@ mod test_dns_pkarr {
     async fn pkarr_publish_dns_discover_empty_node_addr() -> Result<()> {
         let _logging_guard = iroh_test::logging::setup();
 
-        let timeout = Duration::from_secs(2);
-
         let dns_pkarr_server = DnsPkarrServer::run().await?;
         let (relay_map, _relay_url, _relay_guard) = run_relay_server().await?;
 
@@ -670,7 +669,9 @@ mod test_dns_pkarr {
         let ep2 = ep_with_discovery(&relay_map, &dns_pkarr_server).await?;
 
         // wait until our shared state received the update from pkarr publishing
-        dns_pkarr_server.on_node(&ep1.node_id(), timeout).await?;
+        dns_pkarr_server
+            .on_node(&ep1.node_id(), PUBLISH_TIMEOUT)
+            .await?;
 
         // we connect only by node id!
         let res = ep2.connect(ep1.node_id().into(), TEST_ALPN).await;


### PR DESCRIPTION
## Description

In some tests, we publish node info to a test pkarr server. The tests have a timeout of 2 seconds currently for the node info to arrive at the test pkarr server after the endpoint is bound. This sometimes makes them flaky if CI is slow.
This increases the timeout to 10 seconds.

Hopefully fixes #2221 

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
