### PR TITLE
docs: example requires `example` feature to run

### DIFF
--- a/iroh/README.md
+++ b/iroh/README.md
@@ -19,7 +19,7 @@ iroh = { version = "...", default-features = false }
 
 ## Running Examples
 
-Examples are located in `iroh/examples`. Run them with `cargo run --example`. eg: `cargo run --example hello-world`. At the top of each example file is a comment describing how to run the example.
+Examples are located in `iroh/examples`. Run them with `cargo run --features=examples --example`. eg: `cargo run --features=examples --example hello-world`. At the top of each example file is a comment describing how to run the example.
 
 # License
 

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -4,7 +4,7 @@
 //! The iroh node that creates the document is backed by an in-memory database and a random node ID
 //!
 //! run this example from the project root:
-//!     $ cargo run --example client
+//!     $ cargo run --features=examples --example client
 use indicatif::HumanBytes;
 use iroh::{base::base32, client::docs::Entry, docs::store::Query, node::Node};
 use tokio_stream::StreamExt;

--- a/iroh/examples/rpc.rs
+++ b/iroh/examples/rpc.rs
@@ -1,7 +1,7 @@
 //! An example that runs an iroh node that can be controlled via RPC.
 //!
 //! Run this example with
-//!   $ cargo run --example rpc
+//!   $ cargo run --features=examples --example rpc
 //! Then in another terminal, run any of the normal iroh CLI commands, which you can run from
 //! cargo as well:
 //!   $ cargo run node stats


### PR DESCRIPTION
## Description

You will get this error without passing `--features=examples`.

```bash
🐡 ❯ cargo run --example client
error: target `client` in package `iroh` requires the features: `examples`
Consider enabling them by passing, e.g., `--features="examples"
```

## Breaking Changes

No.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.


Closes #2431