### PR TITLE
tests(iroh-net): Make some tests less flaky

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -3027,7 +3027,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[ignore = "flaky"]
     async fn test_two_devices_roundtrip_network_change() -> Result<()> {
         time::timeout(
             Duration::from_secs(50),


### PR DESCRIPTION
## Description

This removes the flaky marker from a test that I haven't seen being
flaky in a while.

It also tries to put some waiting time in another test to make it less
flaky.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates if relevant.~~
- [x] Tests if relevant.
- ~~[ ] All breaking changes documented.~~