### PR TITLE
refactor(iroh)!: Remove server channel type parameter

### DIFF
--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -14,6 +14,7 @@ pub mod chain;
 
 /// A join handle that owns the task it is running, and aborts it when dropped.
 #[derive(Debug, derive_more::Deref)]
+#[must_use = "Aborting join handles abort the task when dropped"]
 pub struct AbortingJoinHandle<T> {
     handle: tokio::task::JoinHandle<T>,
 }

--- a/iroh/src/client/quic.rs
+++ b/iroh/src/client/quic.rs
@@ -10,7 +10,7 @@ use std::{
 use anyhow::{bail, Context};
 use quic_rpc::transport::{boxed::Connection as BoxedConnection, quinn::QuinnConnection};
 
-use super::Iroh;
+use super::{Iroh, RpcClient};
 use crate::{
     node::RpcStatus,
     rpc_protocol::{node::StatusRequest, RpcService},
@@ -19,9 +19,6 @@ use crate::{
 /// ALPN used by irohs RPC mechanism.
 // TODO: Change to "/iroh-rpc/1"
 pub(crate) const RPC_ALPN: [u8; 17] = *b"n0/provider-rpc/1";
-
-/// RPC client to an iroh node running in a separate process.
-pub type RpcClient = quic_rpc::RpcClient<RpcService, BoxedConnection<RpcService>>;
 
 impl Iroh {
     /// Connect to an iroh node running on the same computer, but in a different process.

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -18,16 +18,14 @@ use iroh_gossip::net::Gossip;
 use iroh_net::key::SecretKey;
 use iroh_net::Endpoint;
 use iroh_net::{endpoint::DirectAddrsStream, util::SharedAbortingJoinHandle};
-use quic_rpc::{RpcServer, ServiceEndpoint};
+use quic_rpc::transport::ServerEndpoint as _;
+use quic_rpc::RpcServer;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::LocalPoolHandle;
 use tracing::{debug, error, info, warn};
 
-use crate::{
-    client::RpcService,
-    node::{docs::DocsEngine, protocol::ProtocolMap},
-};
+use crate::node::{docs::DocsEngine, protocol::ProtocolMap};
 
 mod builder;
 mod docs;
@@ -38,6 +36,11 @@ mod rpc_status;
 pub use self::builder::{Builder, DiscoveryConfig, DocsStorage, GcPolicy, StorageConfig};
 pub use self::rpc_status::RpcStatus;
 pub use protocol::ProtocolHandler;
+
+type IrohServerEndpoint = quic_rpc::transport::boxed::ServerEndpoint<
+    crate::rpc_protocol::Request,
+    crate::rpc_protocol::Response,
+>;
 
 /// A server which implements the iroh node.
 ///
@@ -211,8 +214,8 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
 
     async fn run(
         self: Arc<Self>,
-        external_rpc: impl ServiceEndpoint<RpcService>,
-        internal_rpc: impl ServiceEndpoint<RpcService>,
+        external_rpc: IrohServerEndpoint,
+        internal_rpc: IrohServerEndpoint,
         protocols: Arc<ProtocolMap>,
         gc_policy: GcPolicy,
         gc_done_callback: Option<Box<dyn Fn() + Send>>,

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -37,7 +37,10 @@ pub use self::builder::{Builder, DiscoveryConfig, DocsStorage, GcPolicy, Storage
 pub use self::rpc_status::RpcStatus;
 pub use protocol::ProtocolHandler;
 
-type IrohServerEndpoint = quic_rpc::transport::boxed::ServerEndpoint<
+/// The quic-rpc server endpoint for the iroh node.
+///
+/// We use a boxed endpoint here to allow having a concrete type for the server endpoint.
+pub type IrohServerEndpoint = quic_rpc::transport::boxed::ServerEndpoint<
     crate::rpc_protocol::Request,
     crate::rpc_protocol::Response,
 >;

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -592,7 +592,6 @@ where
 pub struct ProtocolBuilder<D> {
     inner: Arc<NodeInner<D>>,
     internal_rpc: IrohServerEndpoint,
-    #[debug("external rpc")]
     external_rpc: IrohServerEndpoint,
     protocols: ProtocolMap,
     #[debug("callback")]

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -301,30 +301,17 @@ where
         })
     }
 
-    /// Configure rpc endpoint, changing the type of the builder to the new endpoint type.
-    pub fn rpc_endpoint(self, value: IrohServerEndpoint, port: Option<u16>) -> Builder<D> {
-        // we can't use ..self here because the return type is different
-        Builder {
-            storage: self.storage,
-            bind_port: self.bind_port,
-            secret_key: self.secret_key,
-            blobs_store: self.blobs_store,
-            keylog: self.keylog,
+    /// Configure rpc endpoint.
+    pub fn rpc_endpoint(self, value: IrohServerEndpoint, port: Option<u16>) -> Self {
+        Self {
             rpc_endpoint: value,
             rpc_port: port,
-            relay_mode: self.relay_mode,
-            dns_resolver: self.dns_resolver,
-            gc_policy: self.gc_policy,
-            docs_storage: self.docs_storage,
-            node_discovery: self.node_discovery,
-            #[cfg(any(test, feature = "test-utils"))]
-            insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
-            gc_done_callback: self.gc_done_callback,
+            ..self
         }
     }
 
     /// Configure the default iroh rpc endpoint.
-    pub async fn enable_rpc(self) -> Result<Builder<D>> {
+    pub async fn enable_rpc(self) -> Result<Self> {
         let (ep, actual_rpc_port) = make_rpc_endpoint(&self.secret_key, DEFAULT_RPC_PORT)?;
         let ep = quic_rpc::transport::boxed::ServerEndpoint::new(ep);
         if let StorageConfig::Persistent(ref root) = self.storage {
@@ -332,22 +319,10 @@ where
             RpcStatus::store(root, actual_rpc_port).await?;
         }
 
-        Ok(Builder {
-            storage: self.storage,
-            bind_port: self.bind_port,
-            secret_key: self.secret_key,
-            blobs_store: self.blobs_store,
-            keylog: self.keylog,
+        Ok(Self {
             rpc_endpoint: ep,
             rpc_port: Some(actual_rpc_port),
-            relay_mode: self.relay_mode,
-            dns_resolver: self.dns_resolver,
-            gc_policy: self.gc_policy,
-            docs_storage: self.docs_storage,
-            node_discovery: self.node_discovery,
-            #[cfg(any(test, feature = "test-utils"))]
-            insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
-            gc_done_callback: self.gc_done_callback,
+            ..self
         })
     }
 


### PR DESCRIPTION
## Description

This is a followup to the modularize services PR. I did not want to do it in that one since it was big enough already.

## Breaking Changes

- A `#[must_use]` annotation was added to AbortingJoinHandle

```
     Checked [   0.095s] 75 checks; 74 passed, 1 failed, 0 unnecessary

--- failure struct_must_use_added: struct #[must_use] added ---

Description:
A struct is now #[must_use]. Downstream crates that did not use its value will get a compiler lint.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.32.0/src/lints/struct_must_use_added.ron

Failed in:
  struct AbortingJoinHandle in /home/runner/work/iroh/iroh/iroh-net/src/util.rs:18
     Summary semver requires new minor version: 0 major and 1 minor checks failed
```

## Notes & open questions

## Change checklist

- [x] Self-review.
- [x] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [x] ~~Tests if relevant.~~
- [x] All breaking changes documented.
