### PR TITLE
docs(iroh): Expand module level documentation in iroh

### DIFF
--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -9,8 +9,16 @@ pub use crate::rpc_protocol::RpcService;
 
 mod quic;
 
+#[deprecated]
+pub use self::docs::Doc as MemDoc;
+#[deprecated]
+pub use self::docs::Doc as QuicDoc;
 pub use self::docs::Doc;
 pub use self::node::NodeStatus;
+#[deprecated]
+pub use self::Iroh as MemIroh;
+#[deprecated]
+pub use self::Iroh as QuicIroh;
 
 pub(crate) use self::quic::{connect_raw as quic_connect_raw, RPC_ALPN};
 

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -9,16 +9,8 @@ pub use crate::rpc_protocol::RpcService;
 
 mod quic;
 
-#[deprecated]
-pub use self::docs::Doc as MemDoc;
-#[deprecated]
-pub use self::docs::Doc as QuicDoc;
 pub use self::docs::Doc;
 pub use self::node::NodeStatus;
-#[deprecated]
-pub use self::Iroh as MemIroh;
-#[deprecated]
-pub use self::Iroh as QuicIroh;
 
 pub(crate) use self::quic::{connect_raw as quic_connect_raw, RPC_ALPN};
 

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -9,15 +9,15 @@
 //! There are several ways to import data into the local blob store:
 //!
 //! - [`add_bytes`](Client::add_bytes)
-//!   allows importing in memory data.
+//!   imports in memory data.
 //! - [`add_stream`](Client::add_stream)
-//!   allows importing data from a stream of bytes.
+//!   imports data from a stream of bytes.
 //! - [`add_reader`](Client::add_reader)
-//!   allows importing data from an async reader.
+//!   imports data from an [async reader](tokio::io::AsyncRead).
 //! - [`add_from_path`](Client::add_from_path)
-//!   allows importing data from a file.
+//!   imports data from a file.
 //!
-//! The last method allows importing data from a file on the local filesystem.
+//! The last method imports data from a file on the local filesystem.
 //! This is the most efficient way to import large amounts of data.
 //!
 //! ### Exporting data
@@ -25,15 +25,14 @@
 //! There are several ways to export data from the local blob store:
 //!
 //! - [`read_to_bytes`](Client::read_to_bytes) reads data into memory.
-//! - [`read`](Client::read) creates a reader to read data from.
-//! - [`export`](Client::export)
-//!   allows exporting data to a file on the local filesystem.
+//! - [`read`](Client::read) creates a [reader](Reader) to read data from.
+//! - [`export`](Client::export) eports data to a file on the local filesystem.
 //!
 //! ## Interacting with remote nodes
 //!
 //! - [`download`](Client::download) downloads data from a remote node.
-//! - [`share`](Client::share)
-//!   allows creating a ticket to share data with a remote node.
+//! - [`share`](Client::share) allows creating a ticket to share data with a
+//!   remote node.
 //!
 //! ## Interacting with the blob store itself
 //!

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -2,12 +2,6 @@
 //!
 //! The main entry point is the [`Client`].
 //!
-//! It can be used to interact with the local blob store, e.g. to import
-//! and export data.
-//!
-//! It can also be used to interact with remote nodes, e.g. to download
-//! data from them.
-//!
 //! ## Interacting with the local blob store
 //!
 //! ### Importing data

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -1,5 +1,56 @@
 //! API for blobs management.
-
+//!
+//! The main entry point is the [`Client`].
+//!
+//! It can be used to interact with the local blob store, e.g. to import
+//! and export data.
+//!
+//! It can also be used to interact with remote nodes, e.g. to download
+//! data from them.
+//!
+//! ## Interacting with the local blob store
+//!
+//! ### Importing data
+//!
+//! There are several ways to import data into the local blob store:
+//!
+//! - [`add_bytes`](Client::add_bytes)
+//!   allows importing in memory data.
+//! - [`add_stream`](Client::add_stream)
+//!   allows importing data from a stream of bytes.
+//! - [`add_reader`](Client::add_reader)
+//!   allows importing data from an async reader.
+//! - [`add_from_path`](Client::add_from_path)
+//!   allows importing data from a file.
+//!
+//! The last method allows importing data from a file on the local filesystem.
+//! This is the most efficient way to import large amounts of data.
+//!
+//! ### Exporting data
+//!
+//! There are several ways to export data from the local blob store:
+//!
+//! - [`read_to_bytes`](Client::read_to_bytes) reads data into memory.
+//! - [`read`](Client::read) creates a reader to read data from.
+//! - [`export`](Client::export)
+//!   allows exporting data to a file on the local filesystem.
+//!
+//! ## Interacting with remote nodes
+//!
+//! - [`download`](Client::download) downloads data from a remote node.
+//! - [`share`](Client::share)
+//!   allows creating a ticket to share data with a remote node.
+//!
+//! ## Interacting with the blob store itself
+//!
+//! These are more advanced operations that are usually not needed in normal
+//! operation.
+//!
+//! - [`consistency_check`](Client::consistency_check) checks the internal
+//!   consistency of the local blob store.
+//! - [`validate`](Client::validate) validates the locally stored data against
+//!   their BLAKE3 hashes.
+//! - [`delete_blob`](Client::delete_blob) deletes a blob from the local store.
 use std::{
     future::Future,
     io,
@@ -355,6 +406,10 @@ impl Client {
     }
 
     /// Delete a blob.
+    ///
+    /// **Warning**: this operation deletes the blob from the local store even
+    /// if it is tagged. You should usually not do this manually, but rely on the
+    /// node to remove data that is not tagged.
     pub async fn delete_blob(&self, hash: Hash) -> Result<()> {
         self.rpc.rpc(DeleteRequest { hash }).await??;
         Ok(())

--- a/iroh/src/client/gossip.rs
+++ b/iroh/src/client/gossip.rs
@@ -1,4 +1,15 @@
 //! Gossip client.
+//!
+//! The gossip client allows you to subscribe to gossip topics and send updates to them.
+//!
+//! The main entry point is the [`Client`].
+//!
+//! The gossip API is extremely simple. You use [`subscribe`](Client::subscribe)
+//! to subscribe to a topic. This returns a sink to send updates to the topic
+//! and a stream of responses.
+//!
+//! [`Client::subscribe_with_opts`] allows you to specify advanced options
+//! such as the buffer size.
 use std::collections::BTreeSet;
 
 use anyhow::Result;

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -1,5 +1,15 @@
 //! API to manage the iroh node itself.
-
+//!
+//! The main entry point is the [Client].
+//!
+//! The client can be used to get information about the node, such as the
+//! [status](Client::status), [node id](Client::node_id) or
+//! [node address](Client::node_addr).
+//!
+//! It can also be used to provide additional information to the node, e.g.
+//! using the [add_node_addr](Client::add_node_addr) method.
+//!
+//! It provides a way to [shutdown](Client::shutdown) the entire node.
 use std::{collections::BTreeMap, net::SocketAddr};
 
 use anyhow::Result;

--- a/iroh/src/client/tags.rs
+++ b/iroh/src/client/tags.rs
@@ -1,5 +1,14 @@
 //! API for tag management.
-
+//!
+//! The purpose of tags is to mark information as important. Currently this is
+//! used for blobs.
+//!
+//! The main entry point is the [Client].
+//!
+//! [Client::list] can be used to list all tags.
+//! [Client::list_hash_seq] can be used to list all tags with a hash_seq format.
+//!
+//! [Client::delete] can be used to delete a tag.
 use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
 use iroh_blobs::{BlobFormat, Hash, Tag};

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -1,5 +1,76 @@
 //! Send data over the internet.
 //!
+//! # Getting started
+//!
+//! ## Example
+//!
+//! Create a new node and add some data to the blobs store. This data will be
+//! available over the network.
+//!
+//! ```rust
+//! let node = iroh::node::Node::memory().spawn().await?;
+//! let client = node.client();
+//! let hash = client.blobs().add_bytes(b"some data".to_vec()).await?.hash;
+//! println!("hash: {}", hash);
+//! ```
+//!
+//! ## Explanation
+//!
+//! ### Iroh node
+//!
+//! To create an iroh [Node](crate::node::Node), you use the
+//! [Builder](crate::node::Builder) to configure the node and to spawn it.
+//!
+//! There are also shortcuts to create an in [memory](crate::node::Node::memory)
+//! or [persistent](crate::node::Node::persistent) node with default settings.
+//!
+//! ## Iroh client
+//!
+//! A node is controlled via a **client**. The client provides the main API to
+//! interact with a node, no matter if it is a local in-process node or a node
+//! in a different process. All clients are cheaply cloneable and can be shared
+//! across threads.
+//!
+//! A handle to the client is available via the
+//! [client](crate::node::Node::client) method on the node.
+//!
+//! Node also implements [Deref](std::ops::Deref) to the client, so you can call
+//! client methods directly on the node.
+//!
+//! ## Subsystems
+//!
+//! The client provides access to various subsystems:
+//! - [node](crate::client::node):
+//!   information and control of the iroh node itself
+//! - [blobs](crate::client::blobs):
+//!   content-addressed blobs
+//! - [tags](crate::client::tags):
+//!   tags to tell iroh what data is important
+//! - [gossip](crate::client::gossip):
+//!   exchange data with other nodes via a gossip protocol
+//!
+//! - [authors](crate::client::authors):
+//!   interact with document authors
+//! - [docs](crate::client::docs):
+//!   interact with documents
+//!
+//! The subsystem clients can be obtained cheaply from the main iroh client.
+//! They are also cheaply cloneable and can be shared across threads.
+//!
+//! So if you have code that only needs to interact with one subsystem, pass
+//! it just the subsystem client.
+//!
+//! ## Remote nodes
+//!
+//! To obtain a client to a remote node, you can use
+//! [connect](crate::client::Iroh::connect_path) to connect to a node running on
+//! the same machine, using the given data directory, or
+//! [connect_addr](crate::client::Iroh::connect_addr) to connect to a node at a
+//! known address.
+//!
+//! **Important**: the protocol to a remote node is not stable will frequently
+//! change. So the client and server must be running the same version of iroh.
+//!
 //! ## Feature Flags
 //!
 //! - `metrics`: Enable metrics collection. Enabled by default.

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -46,7 +46,7 @@
 //! - [node](crate::client::node):
 //!   information and control of the iroh node itself
 //! - [blobs](crate::client::blobs):
-//!   content-addressed blobs
+//!   manage and share content-addressed blobs of data
 //! - [tags](crate::client::tags):
 //!   tags to tell iroh what data is important
 //! - [gossip](crate::client::gossip):
@@ -71,8 +71,8 @@
 //! [connect_addr](crate::client::Iroh::connect_addr) to connect to a node at a
 //! known address.
 //!
-//! **Important**: the protocol to a remote node is not stable will frequently
-//! change. So the client and server must be running the same version of iroh.
+//! **Important**: the protocol to a remote node is not stable and will
+//! frequently change. So the client and server must be running the same version of iroh.
 //!
 //! ## Feature Flags
 //!

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -35,7 +35,9 @@ mod protocol;
 mod rpc;
 mod rpc_status;
 
-pub use self::builder::{Builder, ProtocolBuilder, DiscoveryConfig, DocsStorage, GcPolicy, StorageConfig};
+pub use self::builder::{
+    Builder, DiscoveryConfig, DocsStorage, GcPolicy, ProtocolBuilder, StorageConfig,
+};
 pub use self::rpc_status::RpcStatus;
 pub use protocol::ProtocolHandler;
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -1,6 +1,34 @@
 //! Node API
 //!
-//! A node is a server that serves various protocols.
+//! An iroh node is a server that is identified by an Ed25519 keypair and is
+//! globally reachable via the [node id](crate::net::NodeId), which is the
+//! public key of the keypair.
+//!
+//! By default, an iroh node speaks a number of built-in protocols. You can
+//! *extend* the node with custom protocols or *disable* built-in protocols.
+//!
+//! # Building a node
+//!
+//! Nodes get created using the [`Builder`] which provides a very powerful API
+//! to configure every aspect of the node.
+//!
+//! When using the default set of protocols, use [spawn](Builder::spawn)
+//! to spawn a node directly from the builder.
+//!
+//! When adding custom protocols, use [build](Builder::build) to get a
+//! [`ProtocolBuilder`] that allows to add custom protocols, then call
+//! [spawn](ProtocolBuilder::spawn) to spawn the fully configured node.
+//!
+//! To implement a custom protocol, implement the [`ProtocolHandler`] trait
+//! and use [`ProtocolBuilder::accept`] to add it to the node.
+//!
+//! # Using a node
+//!
+//! Once created, a node offers a small number of methods to interact with it,
+//! most notably the iroh-net [endpoint](Node::endpoint) it is bound to.
+//!
+//! But the main way to interact with a node is through the
+//! [`client`](crate::client::Iroh).
 //!
 //! To shut down the node, call [`Node::shutdown`].
 use std::path::Path;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -35,7 +35,7 @@ mod protocol;
 mod rpc;
 mod rpc_status;
 
-pub use self::builder::{Builder, DiscoveryConfig, DocsStorage, GcPolicy, StorageConfig};
+pub use self::builder::{Builder, ProtocolBuilder, DiscoveryConfig, DocsStorage, GcPolicy, StorageConfig};
 pub use self::rpc_status::RpcStatus;
 pub use protocol::ProtocolHandler;
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -27,8 +27,12 @@
 //! Once created, a node offers a small number of methods to interact with it,
 //! most notably the iroh-net [endpoint](Node::endpoint) it is bound to.
 //!
-//! But the main way to interact with a node is through the
+//! The main way to interact with a node is through the
 //! [`client`](crate::client::Iroh).
+//!
+//! (The Node implements [Deref](std::ops::Deref) for client, which means that
+//! methods defined on [Client](crate::client::Iroh) can be called on Node as
+//! well, without going through [`client`](crate::client::Iroh))
 //!
 //! To shut down the node, call [`Node::shutdown`].
 use std::path::Path;

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -460,7 +460,7 @@ where
 
     /// Builds a node without spawning it.
     ///
-    /// Returns an [`ProtocolBuilder`], on which custom protocols can be registered with
+    /// Returns a [`ProtocolBuilder`], on which custom protocols can be registered with
     /// [`ProtocolBuilder::accept`]. To spawn the node, call [`ProtocolBuilder::spawn`].
     pub async fn build(self) -> Result<ProtocolBuilder<D>> {
         // Clone the blob store to shutdown in case of error.


### PR DESCRIPTION
## Description

- Actually export the second stage buider.
- Expand the module level docs for iroh and the various client modules.

## Breaking Changes

None, I am going to do those in a separate PR

## Notes & open questions

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] ~~Tests if relevant.~~
- [x] ~~All breaking changes documented.~~
