### PR TITLE
refactor!: metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-util",
@@ -329,7 +329,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -362,7 +362,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-util",
@@ -586,9 +586,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
 dependencies = [
  "rustversion",
 ]
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1076,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
@@ -1145,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
 dependencies = [
  "litrs",
 ]
@@ -2142,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -2159,7 +2159,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2229,7 +2229,7 @@ dependencies = [
  "futures-util",
  "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2247,7 +2247,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2281,7 +2281,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
@@ -2351,7 +2351,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "log",
  "rand",
  "tokio",
@@ -2996,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3657,7 +3657,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4073,9 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ca959da22a332509f2a73ae9e5f23f9dcfc31fd3a54d71f159495bd5909baa"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
 dependencies = [
  "dtoa",
  "itoa",
@@ -4354,19 +4354,20 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.26.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
  "crossterm",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "stability",
  "strum 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -4374,9 +4375,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.0.2"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4454,9 +4455,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4567,7 +4568,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
@@ -4605,7 +4606,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
@@ -4959,9 +4960,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
@@ -4972,9 +4973,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5722,18 +5723,18 @@ checksum = "d72e255c0541f86589b0287139b70bd941a197ea4cea8fd8f87afe9c965a99e4"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5810,9 +5811,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5961,15 +5962,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.14",
+ "toml_edit 0.22.16",
 ]
 
 [[package]]
@@ -5994,9 +5995,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -6030,7 +6031,7 @@ dependencies = [
  "bitflags 2.6.0",
  "bytes",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "tower-layer",
@@ -6241,11 +6242,12 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5fbabedabe362c618c714dbefda9927b5afc8e2a8102f47f081089a9019226"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools 0.12.1",
+ "itertools 0.13.0",
+ "unicode-segmentation",
  "unicode-width",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -4353,20 +4362,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.27.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
+checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
  "crossterm",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "lru",
  "paste",
  "stability",
  "strum 0.26.3",
- "strum_macros 0.26.4",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
@@ -215,7 +215,7 @@ checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "synstructure 0.13.1",
 ]
 
@@ -238,7 +238,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -249,7 +249,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 
 [[package]]
 name = "cfg-if"
@@ -700,7 +700,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1047,7 +1047,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1071,7 +1071,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1082,7 +1082,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1151,7 +1151,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "unicode-xid",
 ]
 
@@ -1264,7 +1264,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1424,7 +1424,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1437,7 +1437,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1457,7 +1457,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1713,7 +1713,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2263,7 +2263,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2302,7 +2302,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.51.1",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3504,7 +3504,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3724,7 +3724,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3755,7 +3755,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3880,7 +3880,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3917,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "positioned-io"
@@ -4091,7 +4091,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4197,9 +4197,9 @@ dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto 0.11.3",
- "quinn-udp 0.5.2",
+ "quinn-udp 0.5.3",
  "rustc-hash",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "thiserror",
  "tokio",
  "tracing",
@@ -4233,7 +4233,7 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "slab",
  "thiserror",
  "tinyvec",
@@ -4255,14 +4255,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+checksum = "25a78e6f726d84fcf960409f509ae354a32648f090c8d32a2ea8b1a1bc3bab14"
 dependencies = [
  "libc",
  "once_cell",
  "socket2",
- "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -4490,7 +4489,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4619,7 +4618,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn 0.11.2",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -4783,15 +4782,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.5",
+ "rustls-webpki 0.102.6",
  "subtle",
  "zeroize",
 ]
@@ -4845,9 +4844,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.5"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -5041,7 +5040,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5122,7 +5121,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5148,9 +5147,9 @@ dependencies = [
 
 [[package]]
 name = "sha1_smol"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -5363,7 +5362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5410,7 +5409,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5428,7 +5427,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5439,7 +5438,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5470,7 +5469,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5483,7 +5482,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5560,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5612,7 +5611,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5698,7 +5697,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5717,9 +5716,9 @@ dependencies = [
 
 [[package]]
 name = "testresult"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72e255c0541f86589b0287139b70bd941a197ea4cea8fd8f87afe9c965a99e4"
+checksum = "614b328ff036a4ef882c61570f72918f7e9c5bee1da33f8e7f91e01daee7e56c"
 
 [[package]]
 name = "thiserror"
@@ -5738,7 +5737,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5836,7 +5835,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5855,7 +5854,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6003,7 +6002,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.13",
+ "winnow 0.6.14",
 ]
 
 [[package]]
@@ -6099,7 +6098,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6294,7 +6293,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "once_cell",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.3",
@@ -6403,7 +6402,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -6437,7 +6436,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6604,7 +6603,7 @@ checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6615,7 +6614,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6626,7 +6625,7 @@ checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6637,7 +6636,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6809,9 +6808,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "374ec40a2d767a3c1b4972d9475ecd557356637be906f2cb3f7fe17a6eb5e22f"
 dependencies = [
  "memchr",
 ]
@@ -6946,7 +6945,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/iroh-blobs/Cargo.toml
+++ b/iroh-blobs/Cargo.toml
@@ -29,7 +29,7 @@ hashlink = { version = "0.9.0", optional = true }
 hex = "0.4.3"
 iroh-base = { version = "0.20.0", features = ["redb"], path = "../iroh-base" }
 iroh-io = { version = "0.6.0", features = ["stats"] }
-iroh-metrics = { version = "0.20.0", path = "../iroh-metrics", optional = true }
+iroh-metrics = { version = "0.20.0", path = "../iroh-metrics", default-features = false }
 iroh-net = { version = "0.20.0", path = "../iroh-net" }
 num_cpus = "1.15.0"
 parking_lot = { version = "0.12.1", optional = true }
@@ -74,10 +74,10 @@ package = "iroh-quinn"
 version = "0.10"
 
 [features]
-default = ["fs-store", "metrics"]
+default = ["fs-store"]
 downloader = ["dep:parking_lot", "tokio-util/time", "dep:hashlink"]
 fs-store = ["dep:reflink-copy", "redb", "dep:redb_v1", "dep:tempfile"]
-metrics = ["dep:iroh-metrics"]
+metrics = ["iroh-metrics/metrics"]
 redb = ["dep:redb"]
 
 [package.metadata.docs.rs]

--- a/iroh-blobs/Cargo.toml
+++ b/iroh-blobs/Cargo.toml
@@ -74,7 +74,7 @@ package = "iroh-quinn"
 version = "0.10"
 
 [features]
-default = ["fs-store"]
+default = ["fs-store", "metrics"]
 downloader = ["dep:parking_lot", "tokio-util/time", "dep:hashlink"]
 fs-store = ["dep:reflink-copy", "redb", "dep:redb_v1", "dep:tempfile"]
 metrics = ["dep:iroh-metrics"]

--- a/iroh-blobs/src/lib.rs
+++ b/iroh-blobs/src/lib.rs
@@ -9,7 +9,6 @@ pub mod export;
 pub mod format;
 pub mod get;
 pub mod hashseq;
-#[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod protocol;
 pub mod provider;

--- a/iroh-blobs/src/metrics.rs
+++ b/iroh-blobs/src/metrics.rs
@@ -14,6 +14,14 @@ pub struct Metrics {
     pub downloads_success: Counter,
     pub downloads_error: Counter,
     pub downloads_notfound: Counter,
+
+    pub downloader_tick_main: Counter,
+    pub downloader_tick_connection_ready: Counter,
+    pub downloader_tick_message_received: Counter,
+    pub downloader_tick_transfer_completed: Counter,
+    pub downloader_tick_transfer_failed: Counter,
+    pub downloader_tick_retry_node: Counter,
+    pub downloader_tick_goodbye_node: Counter,
 }
 
 impl Default for Metrics {
@@ -24,6 +32,28 @@ impl Default for Metrics {
             downloads_success: Counter::new("Total number of successful downloads"),
             downloads_error: Counter::new("Total number of downloads failed with error"),
             downloads_notfound: Counter::new("Total number of downloads failed with not found"),
+
+            downloader_tick_main: Counter::new(
+                "Number of times the main downloader actor loop ticked",
+            ),
+            downloader_tick_connection_ready: Counter::new(
+                "Number of times the downloader actor ticked for a connection ready",
+            ),
+            downloader_tick_message_received: Counter::new(
+                "Number of times the downloader actor ticked for a message received",
+            ),
+            downloader_tick_transfer_completed: Counter::new(
+                "Number of times the downloader actor ticked for a transfer completed",
+            ),
+            downloader_tick_transfer_failed: Counter::new(
+                "Number of times the downloader actor ticked for a transfer failed",
+            ),
+            downloader_tick_retry_node: Counter::new(
+                "Number of times the downloader actor ticked for a retry node",
+            ),
+            downloader_tick_goodbye_node: Counter::new(
+                "Number of times the downloader actor ticked for a goodbye node",
+            ),
         }
     }
 }

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -49,7 +49,7 @@ portable-atomic = "1"
 postcard = "1.0.8"
 quic-rpc = { version = "0.11", features = ["flume-transport", "quinn-transport"] }
 rand = "0.8.5"
-ratatui = "0.27"
+ratatui = "0.26.2"
 reqwest = { version = "0.12.4", default-features = false, features = ["json", "rustls-tls"] }
 rustyline = "12.0.0"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -49,7 +49,7 @@ portable-atomic = "1"
 postcard = "1.0.8"
 quic-rpc = { version = "0.11", features = ["flume-transport", "quinn-transport"] }
 rand = "0.8.5"
-ratatui = "0.26.2"
+ratatui = "0.27"
 reqwest = { version = "0.12.4", default-features = false, features = ["json", "rustls-tls"] }
 rustyline = "12.0.0"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -46,6 +46,10 @@ pub(crate) struct Cli {
     /// Address to serve RPC on.
     #[clap(long)]
     pub(crate) rpc_addr: Option<SocketAddr>,
+
+    /// If set, metrics will be dumped in CSV format to the specified path at regular intervals (100ms).
+    #[clap(long)]
+    pub(crate) metrics_dump_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -1397,7 +1397,7 @@ impl PlotterApp {
             return;
         }
         let data = req.unwrap().text().await.unwrap();
-        let metrics_response = parse_prometheus_metrics(&data);
+        let metrics_response = iroh_metrics::parse_prometheus_metrics(&data);
         if metrics_response.is_err() {
             return;
         }
@@ -1422,24 +1422,4 @@ impl PlotterApp {
             }
         }
     }
-}
-
-fn parse_prometheus_metrics(data: &str) -> anyhow::Result<HashMap<String, f64>> {
-    let mut metrics = HashMap::new();
-    for line in data.lines() {
-        if line.starts_with('#') {
-            continue;
-        }
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() < 2 {
-            continue;
-        }
-        let metric = parts[0];
-        let value = parts[1].parse::<f64>();
-        if value.is_err() {
-            continue;
-        }
-        metrics.insert(metric.to_string(), value.unwrap());
-    }
-    Ok(metrics)
 }

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -55,6 +55,7 @@ use crossterm::{
 };
 use rand::Rng;
 use ratatui::{prelude::*, widgets::*};
+use tracing::warn;
 
 #[derive(Debug, Clone, derive_more::Display)]
 pub enum SecretKeyOption {
@@ -232,6 +233,9 @@ pub enum Commands {
         /// Endpoint to scrape for prometheus metrics
         #[clap(long, default_value = "http://localhost:9090")]
         scrape_url: String,
+        /// File to read the metrics from. Takes precedence over scrape_url.
+        #[clap(long)]
+        file: Option<PathBuf>,
     },
 }
 
@@ -1172,6 +1176,7 @@ pub async fn run(command: Commands, config: &NodeConfig) -> anyhow::Result<()> {
             metrics,
             timeframe,
             scrape_url,
+            file,
         } => {
             let metrics: Vec<String> = metrics.split(',').map(|s| s.to_string()).collect();
             let interval = Duration::from_millis(interval);
@@ -1182,7 +1187,7 @@ pub async fn run(command: Commands, config: &NodeConfig) -> anyhow::Result<()> {
             let backend = CrosstermBackend::new(stdout);
             let mut terminal = Terminal::new(backend)?;
 
-            let app = PlotterApp::new(metrics, timeframe, scrape_url);
+            let app = PlotterApp::new(metrics, timeframe, scrape_url, file);
             let res = run_plotter(&mut terminal, app, interval).await;
             disable_raw_mode()?;
             execute!(
@@ -1214,7 +1219,7 @@ async fn run_plotter<B: Backend>(
     loop {
         terminal.draw(|f| plotter_draw(f, &mut app))?;
 
-        if crossterm::event::poll(Duration::from_millis(100))? {
+        if crossterm::event::poll(Duration::from_millis(10))? {
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
                     if let KeyCode::Char(c) = key.code {
@@ -1283,8 +1288,16 @@ fn plot_chart(frame: &mut Frame, area: Rect, app: &PlotterApp, metric: &str) {
     let y_start = data_y_range.0;
     let y_end = data_y_range.1;
 
+    let last_val = data.last();
+    let name = match last_val {
+        Some(val) => {
+            let val_y = val.1;
+            format!("{metric}: {val_y:.0}")
+        }
+        None => metric.to_string(),
+    };
     let datasets = vec![Dataset::default()
-        .name(metric)
+        .name(name)
         .marker(symbols::Marker::Dot)
         .graph_type(GraphType::Line)
         .style(Style::default().fg(Color::Cyan))
@@ -1304,19 +1317,19 @@ fn plot_chart(frame: &mut Frame, area: Rect, app: &PlotterApp, metric: &str) {
     ];
 
     let mut y_labels = vec![Span::styled(
-        format!("{:.1}", y_start),
+        format!("{:.0}", y_start),
         Style::default().add_modifier(Modifier::BOLD),
     )];
 
     for i in 1..=10 {
         y_labels.push(Span::raw(format!(
-            "{:.1}",
+            "{:.0}",
             y_start + (y_end - y_start) / 10.0 * i as f64
         )));
     }
 
     y_labels.push(Span::styled(
-        format!("{:.1}", y_end),
+        format!("{:.0}", y_end),
         Style::default().add_modifier(Modifier::BOLD),
     ));
 
@@ -1355,23 +1368,64 @@ struct PlotterApp {
     freeze: bool,
     internal_ts: Duration,
     scrape_url: String,
+    file_data: Vec<String>,
+    file_header: Vec<String>,
 }
 
 impl PlotterApp {
-    fn new(metrics: Vec<String>, timeframe: usize, scrape_url: String) -> Self {
+    fn new(
+        metrics: Vec<String>,
+        timeframe: usize,
+        scrape_url: String,
+        file: Option<PathBuf>,
+    ) -> Self {
         let data = metrics.iter().map(|m| (m.clone(), vec![])).collect();
         let data_y_range = metrics.iter().map(|m| (m.clone(), (0.0, 0.0))).collect();
+        let mut file_data: Vec<String> = file
+            .map(|f| std::fs::read_to_string(f).unwrap())
+            .unwrap_or_default()
+            .split('\n')
+            .map(|s| s.to_string())
+            .collect();
+        let mut file_header = vec![];
+        let mut timeframe = timeframe;
+        if !file_data.is_empty() {
+            file_header = file_data[0].split(',').map(|s| s.to_string()).collect();
+            file_data.remove(0);
+
+            while file_data.last().unwrap().is_empty() {
+                file_data.pop();
+            }
+
+            let first_line: Vec<String> = file_data[0].split(',').map(|s| s.to_string()).collect();
+            let last_line: Vec<String> = file_data
+                .last()
+                .unwrap()
+                .split(',')
+                .map(|s| s.to_string())
+                .collect();
+
+            let start_time: usize = first_line.first().unwrap().parse().unwrap();
+            let end_time: usize = last_line.first().unwrap().parse().unwrap();
+
+            timeframe = (end_time - start_time) / 1000;
+        }
+        timeframe = timeframe.clamp(30, 90);
+
+        file_data.reverse();
         Self {
             should_quit: false,
             metrics,
             start_ts: Instant::now(),
             data,
             data_y_range,
-            timeframe: timeframe - 25,
+            timeframe,
             rng: rand::thread_rng(),
             freeze: false,
             internal_ts: Duration::default(),
             scrape_url,
+            file_data,
+            file_header,
         }
     }
 
@@ -1392,16 +1446,34 @@ impl PlotterApp {
             return;
         }
 
-        let req = reqwest::Client::new().get(&self.scrape_url).send().await;
-        if req.is_err() {
-            return;
-        }
-        let data = req.unwrap().text().await.unwrap();
-        let metrics_response = iroh_metrics::parse_prometheus_metrics(&data);
-        if metrics_response.is_err() {
-            return;
-        }
-        let metrics_response = metrics_response.unwrap();
+        let metrics_response = match self.file_data.is_empty() {
+            true => {
+                let req = reqwest::Client::new().get(&self.scrape_url).send().await;
+                if req.is_err() {
+                    return;
+                }
+                let data = req.unwrap().text().await.unwrap();
+                let metrics_response = iroh_metrics::parse_prometheus_metrics(&data);
+                if metrics_response.is_err() {
+                    return;
+                }
+                metrics_response.unwrap()
+            }
+            false => {
+                if self.file_data.len() == 1 {
+                    self.freeze = true;
+                    return;
+                }
+                let data = self.file_data.pop().unwrap();
+                let r = parse_csv_metrics(&self.file_header, &data);
+                if let Ok(mr) = r {
+                    mr
+                } else {
+                    warn!("Failed to parse csv metrics: {:?}", r.err());
+                    HashMap::new()
+                }
+            }
+        };
         self.internal_ts = self.start_ts.elapsed();
         for metric in &self.metrics {
             let val = if metric.eq("random") {
@@ -1412,7 +1484,12 @@ impl PlotterApp {
                 0.0
             };
             let e = self.data.entry(metric.clone()).or_default();
-            e.push((self.internal_ts.as_secs_f64(), val));
+            let mut ts = self.internal_ts.as_secs_f64();
+            if metrics_response.contains_key("time") {
+                ts = *metrics_response.get("time").unwrap() / 1000.0;
+            }
+            self.internal_ts = Duration::from_secs_f64(ts);
+            e.push((ts, val));
             let yr = self.data_y_range.get_mut(metric).unwrap();
             if val * 1.1 < yr.0 {
                 yr.0 = val * 1.2;
@@ -1422,4 +1499,20 @@ impl PlotterApp {
             }
         }
     }
+}
+
+fn parse_csv_metrics(header: &[String], data: &str) -> anyhow::Result<HashMap<String, f64>> {
+    let mut metrics = HashMap::new();
+    let data = data.split(',').collect::<Vec<&str>>();
+    for (i, h) in header.iter().enumerate() {
+        let val = match h.as_str() {
+            "time" => {
+                let ts = data[i].parse::<u64>()?;
+                ts as f64
+            }
+            _ => data[i].parse::<f64>()?,
+        };
+        metrics.insert(h.clone(), val);
+    }
+    Ok(metrics)
 }

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -58,6 +58,8 @@ pub(crate) struct NodeConfig {
     /// Bind address on which to serve Prometheus metrics
     pub(crate) metrics_addr: Option<SocketAddr>,
     pub(crate) file_logs: super::logging::FileLogging,
+    /// Path to dump metrics to in CSV format.
+    pub(crate) metrics_dump_path: Option<PathBuf>,
 }
 
 impl Default for NodeConfig {
@@ -83,6 +85,7 @@ impl Default for NodeConfig {
             gc_policy: GcPolicy::Disabled,
             metrics_addr: Some(([127, 0, 0, 1], 9090).into()),
             file_logs: Default::default(),
+            metrics_dump_path: None,
         }
     }
 }

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -9,7 +9,7 @@ use struct_iterable::Iterable;
 pub struct Metrics {
     pub pkarr_publish_update: Counter,
     pub pkarr_publish_noop: Counter,
-    pub pkarr_publish_error: Counter,
+    // pub pkarr_publish_error: Counter,
     pub dns_requests: Counter,
     pub dns_requests_udp: Counter,
     pub dns_requests_https: Counter,
@@ -32,7 +32,7 @@ impl Default for Metrics {
             pkarr_publish_noop: Counter::new(
                 "Number of pkarr relay puts that did not update the state",
             ),
-            pkarr_publish_error: Counter::new("Number of pkarr relay puts that failed"),
+            // pkarr_publish_error: Counter::new("Number of pkarr relay puts that failed"),
             dns_requests: Counter::new("DNS requests (total)"),
             dns_requests_udp: Counter::new("DNS requests via UDP"),
             dns_requests_https: Counter::new("DNS requests via HTTPS (DoH)"),

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -9,7 +9,6 @@ use struct_iterable::Iterable;
 pub struct Metrics {
     pub pkarr_publish_update: Counter,
     pub pkarr_publish_noop: Counter,
-    // pub pkarr_publish_error: Counter,
     pub dns_requests: Counter,
     pub dns_requests_udp: Counter,
     pub dns_requests_https: Counter,
@@ -32,7 +31,6 @@ impl Default for Metrics {
             pkarr_publish_noop: Counter::new(
                 "Number of pkarr relay puts that did not update the state",
             ),
-            // pkarr_publish_error: Counter::new("Number of pkarr relay puts that failed"),
             dns_requests: Counter::new("DNS requests (total)"),
             dns_requests_udp: Counter::new("DNS requests via UDP"),
             dns_requests_https: Counter::new("DNS requests via HTTPS (DoH)"),

--- a/iroh-docs/Cargo.toml
+++ b/iroh-docs/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4"
 iroh-base = { version = "0.20.0", path = "../iroh-base" }
 iroh-blobs = { version = "0.20.0", path = "../iroh-blobs", optional = true, features = ["downloader"] }
 iroh-gossip = { version = "0.20.0", path = "../iroh-gossip", optional = true }
-iroh-metrics = { version = "0.20.0", path = "../iroh-metrics", optional = true }
+iroh-metrics = { version = "0.20.0", path = "../iroh-metrics", default-features = false }
 iroh-net = { version = "0.20.0", optional = true, path = "../iroh-net" }
 lru = "0.12"
 num_enum = "0.7"
@@ -58,7 +58,7 @@ test-strategy = "0.3.1"
 [features]
 default = ["net", "metrics", "engine"]
 net = ["dep:iroh-net", "tokio/io-util", "dep:tokio-stream", "dep:tokio-util"]
-metrics = ["dep:iroh-metrics"]
+metrics = ["iroh-metrics/metrics"]
 engine = ["net", "dep:iroh-gossip", "dep:iroh-blobs"]
 
 [package.metadata.docs.rs]

--- a/iroh-docs/src/actor.rs
+++ b/iroh-docs/src/actor.rs
@@ -12,11 +12,13 @@ use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use futures_util::FutureExt;
 use iroh_base::hash::Hash;
+use iroh_metrics::inc;
 use serde::{Deserialize, Serialize};
 use tokio::{sync::oneshot, task::JoinSet};
 use tracing::{debug, error, error_span, trace, warn};
 
 use crate::{
+    metrics::Metrics,
     ranger::Message,
     store::{
         fs::{ContentHashesIterator, StoreInstance},
@@ -629,6 +631,7 @@ impl Actor {
                 }
             };
             trace!(%action, "tick");
+            inc!(Metrics, actor_tick_main);
             match action {
                 Action::Shutdown { reply } => {
                     break reply;

--- a/iroh-docs/src/engine/gossip.rs
+++ b/iroh-docs/src/engine/gossip.rs
@@ -16,8 +16,8 @@ use tokio_stream::{
 };
 use tracing::{debug, error, trace, warn};
 
-use crate::{actor::SyncHandle, ContentStatus, NamespaceId};
 use crate::metrics::Metrics;
+use crate::{actor::SyncHandle, ContentStatus, NamespaceId};
 
 use super::live::{Op, ToLiveActor};
 

--- a/iroh-docs/src/lib.rs
+++ b/iroh-docs/src/lib.rs
@@ -33,7 +33,6 @@
 //! [paper]: https://arxiv.org/abs/2212.13567
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
-#[cfg(feature = "metrics")]
 pub mod metrics;
 #[cfg(feature = "net")]
 pub mod net;

--- a/iroh-docs/src/metrics.rs
+++ b/iroh-docs/src/metrics.rs
@@ -17,6 +17,20 @@ pub struct Metrics {
     pub sync_via_connect_failure: Counter,
     pub sync_via_accept_success: Counter,
     pub sync_via_accept_failure: Counter,
+
+    pub actor_tick_main: Counter,
+
+    pub doc_gossip_tick_main: Counter,
+    pub doc_gossip_tick_event: Counter,
+    pub doc_gossip_tick_actor: Counter,
+    pub doc_gossip_tick_pending_join: Counter,
+
+    pub doc_live_tick_main: Counter,
+    pub doc_live_tick_actor: Counter,
+    pub doc_live_tick_replica_event: Counter,
+    pub doc_live_tick_running_sync_connect: Counter,
+    pub doc_live_tick_running_sync_accept: Counter,
+    pub doc_live_tick_pending_downloads: Counter,
 }
 
 impl Default for Metrics {
@@ -30,6 +44,36 @@ impl Default for Metrics {
             sync_via_accept_failure: Counter::new("Number of failed syncs (via accept)"),
             sync_via_connect_success: Counter::new("Number of successful syncs (via connect)"),
             sync_via_connect_failure: Counter::new("Number of failed syncs (via connect)"),
+
+            actor_tick_main: Counter::new("Number of times the main actor loop ticked"),
+
+            doc_gossip_tick_main: Counter::new("Number of times the gossip actor loop ticked"),
+            doc_gossip_tick_event: Counter::new(
+                "Number of times the gossip actor processed an event",
+            ),
+            doc_gossip_tick_actor: Counter::new(
+                "Number of times the gossip actor processed an actor event",
+            ),
+            doc_gossip_tick_pending_join: Counter::new(
+                "Number of times the gossip actor processed a pending join",
+            ),
+
+            doc_live_tick_main: Counter::new("Number of times the live actor loop ticked"),
+            doc_live_tick_actor: Counter::new(
+                "Number of times the live actor processed an actor event",
+            ),
+            doc_live_tick_replica_event: Counter::new(
+                "Number of times the live actor processed a replica event",
+            ),
+            doc_live_tick_running_sync_connect: Counter::new(
+                "Number of times the live actor processed a running sync connect",
+            ),
+            doc_live_tick_running_sync_accept: Counter::new(
+                "Number of times the live actor processed a running sync accept",
+            ),
+            doc_live_tick_pending_downloads: Counter::new(
+                "Number of times the live actor processed a pending download",
+            ),
         }
     }
 }

--- a/iroh-gossip/src/metrics.rs
+++ b/iroh-gossip/src/metrics.rs
@@ -21,6 +21,14 @@ pub struct Metrics {
     pub neighbor_down: Counter,
     // pub topics_joined: Counter,
     // pub topics_left: Counter,
+    pub actor_tick_main: Counter,
+    pub actor_tick_rx: Counter,
+    pub actor_tick_endpoint: Counter,
+    pub actor_tick_dialer: Counter,
+    pub actor_tick_dialer_success: Counter,
+    pub actor_tick_dialer_failure: Counter,
+    pub actor_tick_in_event_rx: Counter,
+    pub actor_tick_timers: Counter,
 }
 
 impl Default for Metrics {
@@ -38,6 +46,22 @@ impl Default for Metrics {
             neighbor_down: Counter::new("Number of times we disconnected from a peer"),
             // topics_joined: Counter::new("Number of times we joined a topic"),
             // topics_left: Counter::new("Number of times we left a topic"),
+            actor_tick_main: Counter::new("Number of times the main actor loop ticked"),
+            actor_tick_rx: Counter::new("Number of times the actor ticked for a message received"),
+            actor_tick_endpoint: Counter::new(
+                "Number of times the actor ticked for an endpoint event",
+            ),
+            actor_tick_dialer: Counter::new("Number of times the actor ticked for a dialer event"),
+            actor_tick_dialer_success: Counter::new(
+                "Number of times the actor ticked for a successful dialer event",
+            ),
+            actor_tick_dialer_failure: Counter::new(
+                "Number of times the actor ticked for a failed dialer event",
+            ),
+            actor_tick_in_event_rx: Counter::new(
+                "Number of times the actor ticked for an incoming event",
+            ),
+            actor_tick_timers: Counter::new("Number of times the actor ticked for a timer event"),
         }
     }
 }

--- a/iroh-gossip/src/metrics.rs
+++ b/iroh-gossip/src/metrics.rs
@@ -19,8 +19,6 @@ pub struct Metrics {
     pub msgs_ctrl_recv_size: Counter,
     pub neighbor_up: Counter,
     pub neighbor_down: Counter,
-    // pub topics_joined: Counter,
-    // pub topics_left: Counter,
     pub actor_tick_main: Counter,
     pub actor_tick_rx: Counter,
     pub actor_tick_endpoint: Counter,
@@ -44,8 +42,6 @@ impl Default for Metrics {
             msgs_ctrl_recv_size: Counter::new("Total size of all control messages received"),
             neighbor_up: Counter::new("Number of times we connected to a peer"),
             neighbor_down: Counter::new("Number of times we disconnected from a peer"),
-            // topics_joined: Counter::new("Number of times we joined a topic"),
-            // topics_left: Counter::new("Number of times we left a topic"),
             actor_tick_main: Counter::new("Number of times the main actor loop ticked"),
             actor_tick_rx: Counter::new("Number of times the actor ticked for a message received"),
             actor_tick_endpoint: Counter::new(

--- a/iroh-metrics/Cargo.toml
+++ b/iroh-metrics/Cargo.toml
@@ -21,12 +21,12 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1.1", features = ["tokio"] }
 once_cell = "1.17.0"
-prometheus-client = { version = "0.22.0", optional = true }
+prometheus-client = { version = "0.22", optional = true }
 reqwest = { version = "0.12.4", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 struct_iterable = "0.1"
 time = { version = "0.3.21", features = ["serde-well-known"] }
-tokio = { version = "1", features = ["rt", "net"]}
+tokio = { version = "1", features = ["rt", "net", "fs"]}
 tracing = "0.1"
 
 [dev-dependencies]

--- a/iroh-metrics/src/core.rs
+++ b/iroh-metrics/src/core.rs
@@ -60,6 +60,23 @@ impl Counter {
         self.counter.inc_by(v)
     }
 
+    /// Set the [`Counter`] value.
+    /// Warning: this is not default behavior for a counter that should always be monotonically increasing.
+    #[cfg(feature = "metrics")]
+    pub fn set(&self, v: u64) -> u64 {
+        self.counter
+            .inner()
+            .store(v, std::sync::atomic::Ordering::Relaxed);
+        v
+    }
+
+    /// Set the [`Counter`] value.
+    /// Warning: this is not default behavior for a counter that should always be monotonically increasing.
+    #[cfg(not(feature = "metrics"))]
+    pub fn set(&self, _v: u64) -> u64 {
+        0
+    }
+
     /// Increase the [`Counter`] by `u64`, returning the previous value.
     #[cfg(not(feature = "metrics"))]
     pub fn inc_by(&self, _v: u64) -> u64 {

--- a/iroh-metrics/src/lib.rs
+++ b/iroh-metrics/src/lib.rs
@@ -11,6 +11,7 @@ pub mod core;
 mod service;
 
 use core::UsageStatsReport;
+use std::collections::HashMap;
 
 /// Reexport to make matching versions easier.
 pub use struct_iterable;
@@ -45,4 +46,25 @@ pub async fn report_usage_stats(report: &UsageStatsReport) {
                 });
         }
     }
+}
+
+/// Parse Prometheus metrics from a string.
+pub fn parse_prometheus_metrics(data: &str) -> anyhow::Result<HashMap<String, f64>> {
+    let mut metrics = HashMap::new();
+    for line in data.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 2 {
+            continue;
+        }
+        let metric = parts[0];
+        let value = parts[1].parse::<f64>();
+        if value.is_err() {
+            continue;
+        }
+        metrics.insert(metric.to_string(), value.unwrap());
+    }
+    Ok(metrics)
 }

--- a/iroh-metrics/src/lib.rs
+++ b/iroh-metrics/src/lib.rs
@@ -32,6 +32,14 @@ macro_rules! inc_by {
     };
 }
 
+/// Set the given counter to `n`.
+#[macro_export]
+macro_rules! set {
+    ($m:ty, $f:ident, $n:expr) => {
+        <$m as $crate::core::Metric>::with_metric(|m| m.$f.set($n));
+    };
+}
+
 /// Report usage statistics to the configured endpoint.
 #[allow(unused_variables)]
 pub async fn report_usage_stats(report: &UsageStatsReport) {

--- a/iroh-metrics/src/metrics.rs
+++ b/iroh-metrics/src/metrics.rs
@@ -53,3 +53,12 @@ use std::net::SocketAddr;
 pub async fn start_metrics_server(addr: SocketAddr) -> anyhow::Result<()> {
     crate::service::run(addr).await
 }
+
+/// Start a metrics dumper service.
+#[cfg(feature = "metrics")]
+pub async fn start_metrics_dumper(
+    path: std::path::PathBuf,
+    interval: std::time::Duration,
+) -> anyhow::Result<()> {
+    crate::service::dumper(&path, interval).await
+}

--- a/iroh-metrics/src/service.rs
+++ b/iroh-metrics/src/service.rs
@@ -1,12 +1,16 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use hyper::service::service_fn;
 use hyper::{Request, Response};
+use tokio::io::AsyncWriteExt as _;
 use tokio::net::TcpListener;
 use tracing::{error, info};
 
 use crate::core::Core;
+use crate::parse_prometheus_metrics;
 
 type BytesBody = http_body_util::Full<hyper::body::Bytes>;
 
@@ -44,4 +48,72 @@ async fn handler(_req: Request<hyper::body::Incoming>) -> Result<Response<BytesB
 /// Creates a new [`BytesBody`] with given content.
 fn body_full(content: impl Into<hyper::body::Bytes>) -> BytesBody {
     http_body_util::Full::new(content.into())
+}
+
+/// Start a metrics dumper loop to write metrics to an output file.
+pub async fn dumper(path: &PathBuf, interval_ms: Duration) -> Result<()> {
+    info!(file = %path.display(), ?interval_ms, "running metrics dumper");
+    let _ = Core::get().ok_or_else(|| anyhow!("metrics disabled"))?;
+
+    let start = Instant::now();
+
+    let file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .await?;
+
+    let mut file = tokio::io::BufWriter::new(file);
+
+    // Dump metrics once with a header
+    dump_metrics(&mut file, &start, true).await?;
+    loop {
+        dump_metrics(&mut file, &start, false).await?;
+        tokio::time::sleep(interval_ms).await;
+    }
+}
+
+/// Dump metrics to a file.
+async fn dump_metrics(
+    file: &mut tokio::io::BufWriter<tokio::fs::File>,
+    start: &Instant,
+    write_header: bool,
+) -> Result<()> {
+    let core = Core::get().ok_or_else(|| anyhow!("metrics disabled"))?;
+    let m = core.encode();
+    match m {
+        Err(e) => error!("Failed to encode metrics: {e:#}"),
+        Ok(m) => {
+            let m = parse_prometheus_metrics(&m)?;
+            let time_since_start = start.elapsed().as_millis() as f64;
+
+            // take the keys from m and sort them
+            let mut keys: Vec<&String> = m.keys().collect();
+            keys.sort();
+
+            let mut metrics = String::new();
+            if write_header {
+                metrics.push_str("time");
+                for key in keys.iter() {
+                    metrics.push(',');
+                    metrics.push_str(key);
+                }
+                metrics.push('\n');
+            }
+
+            metrics.push_str(&format!("{}", time_since_start));
+            for key in keys.iter() {
+                let value = m[*key];
+                let formatted_value = format!("{:.3}", value);
+                metrics.push(',');
+                metrics.push_str(&formatted_value);
+            }
+            metrics.push('\n');
+
+            file.write_all(metrics.as_bytes()).await?;
+            file.flush().await?;
+        }
+    }
+    Ok(())
 }

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1791,16 +1791,6 @@ impl Actor {
                         self.update_direct_addrs(reason).await;
                     }
                 }
-                _ = save_nodes_timer.tick(), if self.nodes_path.is_some() => {
-                    trace!("tick: nodes_timer");
-                    let path = self.nodes_path.as_ref().expect("precondition: `is_some()`");
-                    inc!(Metrics, actor_tick_nodes_timer);
-                    self.msock.node_map.prune_inactive();
-                    match self.msock.node_map.save_to_file(path).await {
-                        Ok(count) => debug!(count, "nodes persisted"),
-                        Err(e) => debug!(%e, "failed to persist known nodes"),
-                    }
-                }
                 Some(is_major) = link_change_r.recv() => {
                     trace!("tick: link change {}", is_major);
                     inc!(Metrics, actor_link_change);

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1776,7 +1776,7 @@ impl Actor {
                         "tick: direct addr heartbeat {} direct addrs",
                         self.msock.node_map.node_count(),
                     );
-		    inc!(Metrics, actor_tick_endpoint_heartbeat);
+                    inc!(Metrics, actor_tick_direct_addr_heartbeat);
                     // TODO: this might trigger too many packets at once, pace this
 
                     self.msock.node_map.prune_inactive();
@@ -1786,7 +1786,7 @@ impl Actor {
                 _ = direct_addr_update_receiver.changed() => {
                     let reason = *direct_addr_update_receiver.borrow();
                     trace!("tick: direct addr update receiver {:?}", reason);
-		    inc!(Metrics, actor_tick_endpoints_update_receiver);
+                    inc!(Metrics, actor_tick_direct_addr_update_receiver);
                     if let Some(reason) = reason {
                         self.update_direct_addrs(reason).await;
                     }

--- a/iroh-net/src/magicsock/metrics.rs
+++ b/iroh-net/src/magicsock/metrics.rs
@@ -7,19 +7,19 @@ use iroh_metrics::{
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Iterable)]
 pub struct Metrics {
-    pub rebind_calls: Counter,
+    // pub rebind_calls: Counter,
     pub re_stun_calls: Counter,
     pub update_direct_addrs: Counter,
 
     // Sends (data or disco)
-    pub send_relay_queued: Counter,
-    pub send_relay_error_chan: Counter,
-    pub send_relay_error_closed: Counter,
-    pub send_relay_error_queue: Counter,
+    // pub send_relay_queued: Counter,
+    // pub send_relay_error_chan: Counter,
+    // pub send_relay_error_closed: Counter,
+    // pub send_relay_error_queue: Counter,
     pub send_ipv4: Counter,
-    pub send_ipv4_error: Counter,
+    // pub send_ipv4_error: Counter,
     pub send_ipv6: Counter,
-    pub send_ipv6_error: Counter,
+    // pub send_ipv6_error: Counter,
     pub send_relay: Counter,
     pub send_relay_error: Counter,
 
@@ -40,7 +40,7 @@ pub struct Metrics {
     pub sent_disco_ping: Counter,
     pub sent_disco_pong: Counter,
     pub sent_disco_call_me_maybe: Counter,
-    pub recv_disco_bad_peer: Counter,
+    // pub recv_disco_bad_peer: Counter,
     pub recv_disco_bad_key: Counter,
     pub recv_disco_bad_parse: Counter,
 
@@ -49,7 +49,7 @@ pub struct Metrics {
     pub recv_disco_ping: Counter,
     pub recv_disco_pong: Counter,
     pub recv_disco_call_me_maybe: Counter,
-    pub recv_disco_call_me_maybe_bad_node: Counter,
+    // pub recv_disco_call_me_maybe_bad_node: Counter,
     pub recv_disco_call_me_maybe_bad_disco: Counter,
 
     // How many times our relay home node DI has changed from non-zero to a different non-zero.
@@ -66,6 +66,16 @@ pub struct Metrics {
     pub num_relay_conns_added: Counter,
     /// The number of connections to peers we have removed over relay.
     pub num_relay_conns_removed: Counter,
+
+    pub actor_tick_main: Counter,
+    pub actor_tick_msg: Counter,
+    pub actor_tick_re_stun: Counter,
+    pub actor_tick_portmap_changed: Counter,
+    pub actor_tick_endpoint_heartbeat: Counter,
+    pub actor_tick_endpoints_update_receiver: Counter,
+    pub actor_tick_nodes_timer: Counter,
+    pub actor_link_change: Counter,
+    pub actor_tick_other: Counter,
 }
 
 impl Default for Metrics {
@@ -74,19 +84,19 @@ impl Default for Metrics {
             num_relay_conns_added: Counter::new("num_relay_conns added"),
             num_relay_conns_removed: Counter::new("num_relay_conns removed"),
 
-            rebind_calls: Counter::new("rebind_calls"),
+            // rebind_calls: Counter::new("rebind_calls"),
             re_stun_calls: Counter::new("restun_calls"),
             update_direct_addrs: Counter::new("update_endpoints"),
 
             // Sends (data or disco)
-            send_relay_queued: Counter::new("send_relay_queued"),
-            send_relay_error_chan: Counter::new("send_relay_error_chan"),
-            send_relay_error_closed: Counter::new("send_relay_error_closed"),
-            send_relay_error_queue: Counter::new("send_relay_error_queue"),
+            // send_relay_queued: Counter::new("send_relay_queued"),
+            // send_relay_error_chan: Counter::new("send_relay_error_chan"),
+            // send_relay_error_closed: Counter::new("send_relay_error_closed"),
+            // send_relay_error_queue: Counter::new("send_relay_error_queue"),
             send_ipv4: Counter::new("send_ipv4"),
-            send_ipv4_error: Counter::new("send_ipv4_error"),
+            // send_ipv4_error: Counter::new("send_ipv4_error"),
             send_ipv6: Counter::new("send_ipv6"),
-            send_ipv6_error: Counter::new("send_ipv6_error"),
+            // send_ipv6_error: Counter::new("send_ipv6_error"),
             send_relay: Counter::new("send_relay"),
             send_relay_error: Counter::new("send_relay_error"),
 
@@ -106,7 +116,7 @@ impl Default for Metrics {
             sent_disco_ping: Counter::new("disco_sent_ping"),
             sent_disco_pong: Counter::new("disco_sent_pong"),
             sent_disco_call_me_maybe: Counter::new("disco_sent_callmemaybe"),
-            recv_disco_bad_peer: Counter::new("disco_recv_bad_peer"),
+            // recv_disco_bad_peer: Counter::new("disco_recv_bad_peer"),
             recv_disco_bad_key: Counter::new("disco_recv_bad_key"),
             recv_disco_bad_parse: Counter::new("disco_recv_bad_parse"),
 
@@ -115,7 +125,7 @@ impl Default for Metrics {
             recv_disco_ping: Counter::new("disco_recv_ping"),
             recv_disco_pong: Counter::new("disco_recv_pong"),
             recv_disco_call_me_maybe: Counter::new("disco_recv_callmemaybe"),
-            recv_disco_call_me_maybe_bad_node: Counter::new("disco_recv_callmemaybe_bad_node"),
+            // recv_disco_call_me_maybe_bad_node: Counter::new("disco_recv_callmemaybe_bad_node"),
             recv_disco_call_me_maybe_bad_disco: Counter::new("disco_recv_callmemaybe_bad_disco"),
 
             // How many times our relay home node DI has changed from non-zero to a different non-zero.
@@ -127,6 +137,18 @@ impl Default for Metrics {
             num_direct_conns_removed: Counter::new(
                 "number of direct connections to a peer we have removed",
             ),
+
+            actor_tick_main: Counter::new("actor_tick_main"),
+            actor_tick_msg: Counter::new("actor_tick_msg"),
+            actor_tick_re_stun: Counter::new("actor_tick_re_stun"),
+            actor_tick_portmap_changed: Counter::new("actor_tick_portmap_changed"),
+            actor_tick_endpoint_heartbeat: Counter::new("actor_tick_endpoint_heartbeat"),
+            actor_tick_endpoints_update_receiver: Counter::new(
+                "actor_tick_endpoints_update_receiver",
+            ),
+            actor_tick_nodes_timer: Counter::new("actor_tick_nodes_timer"),
+            actor_link_change: Counter::new("actor_link_change"),
+            actor_tick_other: Counter::new("actor_tick_other"),
         }
     }
 }

--- a/iroh-net/src/magicsock/metrics.rs
+++ b/iroh-net/src/magicsock/metrics.rs
@@ -7,19 +7,12 @@ use iroh_metrics::{
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Iterable)]
 pub struct Metrics {
-    // pub rebind_calls: Counter,
     pub re_stun_calls: Counter,
     pub update_direct_addrs: Counter,
 
     // Sends (data or disco)
-    // pub send_relay_queued: Counter,
-    // pub send_relay_error_chan: Counter,
-    // pub send_relay_error_closed: Counter,
-    // pub send_relay_error_queue: Counter,
     pub send_ipv4: Counter,
-    // pub send_ipv4_error: Counter,
     pub send_ipv6: Counter,
-    // pub send_ipv6_error: Counter,
     pub send_relay: Counter,
     pub send_relay_error: Counter,
 
@@ -40,7 +33,6 @@ pub struct Metrics {
     pub sent_disco_ping: Counter,
     pub sent_disco_pong: Counter,
     pub sent_disco_call_me_maybe: Counter,
-    // pub recv_disco_bad_peer: Counter,
     pub recv_disco_bad_key: Counter,
     pub recv_disco_bad_parse: Counter,
 
@@ -49,7 +41,6 @@ pub struct Metrics {
     pub recv_disco_ping: Counter,
     pub recv_disco_pong: Counter,
     pub recv_disco_call_me_maybe: Counter,
-    // pub recv_disco_call_me_maybe_bad_node: Counter,
     pub recv_disco_call_me_maybe_bad_disco: Counter,
 
     // How many times our relay home node DI has changed from non-zero to a different non-zero.
@@ -84,19 +75,12 @@ impl Default for Metrics {
             num_relay_conns_added: Counter::new("num_relay_conns added"),
             num_relay_conns_removed: Counter::new("num_relay_conns removed"),
 
-            // rebind_calls: Counter::new("rebind_calls"),
             re_stun_calls: Counter::new("restun_calls"),
             update_direct_addrs: Counter::new("update_endpoints"),
 
             // Sends (data or disco)
-            // send_relay_queued: Counter::new("send_relay_queued"),
-            // send_relay_error_chan: Counter::new("send_relay_error_chan"),
-            // send_relay_error_closed: Counter::new("send_relay_error_closed"),
-            // send_relay_error_queue: Counter::new("send_relay_error_queue"),
             send_ipv4: Counter::new("send_ipv4"),
-            // send_ipv4_error: Counter::new("send_ipv4_error"),
             send_ipv6: Counter::new("send_ipv6"),
-            // send_ipv6_error: Counter::new("send_ipv6_error"),
             send_relay: Counter::new("send_relay"),
             send_relay_error: Counter::new("send_relay_error"),
 
@@ -116,7 +100,6 @@ impl Default for Metrics {
             sent_disco_ping: Counter::new("disco_sent_ping"),
             sent_disco_pong: Counter::new("disco_sent_pong"),
             sent_disco_call_me_maybe: Counter::new("disco_sent_callmemaybe"),
-            // recv_disco_bad_peer: Counter::new("disco_recv_bad_peer"),
             recv_disco_bad_key: Counter::new("disco_recv_bad_key"),
             recv_disco_bad_parse: Counter::new("disco_recv_bad_parse"),
 
@@ -125,7 +108,6 @@ impl Default for Metrics {
             recv_disco_ping: Counter::new("disco_recv_ping"),
             recv_disco_pong: Counter::new("disco_recv_pong"),
             recv_disco_call_me_maybe: Counter::new("disco_recv_callmemaybe"),
-            // recv_disco_call_me_maybe_bad_node: Counter::new("disco_recv_callmemaybe_bad_node"),
             recv_disco_call_me_maybe_bad_disco: Counter::new("disco_recv_callmemaybe_bad_disco"),
 
             // How many times our relay home node DI has changed from non-zero to a different non-zero.

--- a/iroh-net/src/magicsock/metrics.rs
+++ b/iroh-net/src/magicsock/metrics.rs
@@ -71,8 +71,8 @@ pub struct Metrics {
     pub actor_tick_msg: Counter,
     pub actor_tick_re_stun: Counter,
     pub actor_tick_portmap_changed: Counter,
-    pub actor_tick_endpoint_heartbeat: Counter,
-    pub actor_tick_endpoints_update_receiver: Counter,
+    pub actor_tick_direct_addr_heartbeat: Counter,
+    pub actor_tick_direct_addr_update_receiver: Counter,
     pub actor_tick_nodes_timer: Counter,
     pub actor_link_change: Counter,
     pub actor_tick_other: Counter,
@@ -142,9 +142,9 @@ impl Default for Metrics {
             actor_tick_msg: Counter::new("actor_tick_msg"),
             actor_tick_re_stun: Counter::new("actor_tick_re_stun"),
             actor_tick_portmap_changed: Counter::new("actor_tick_portmap_changed"),
-            actor_tick_endpoint_heartbeat: Counter::new("actor_tick_endpoint_heartbeat"),
-            actor_tick_endpoints_update_receiver: Counter::new(
-                "actor_tick_endpoints_update_receiver",
+            actor_tick_direct_addr_heartbeat: Counter::new("actor_tick_direct_addr_heartbeat"),
+            actor_tick_direct_addr_update_receiver: Counter::new(
+                "actor_tick_direct_addr_update_receiver",
             ),
             actor_tick_nodes_timer: Counter::new("actor_tick_nodes_timer"),
             actor_link_change: Counter::new("actor_link_change"),

--- a/iroh-net/src/magicsock/metrics.rs
+++ b/iroh-net/src/magicsock/metrics.rs
@@ -64,7 +64,6 @@ pub struct Metrics {
     pub actor_tick_portmap_changed: Counter,
     pub actor_tick_direct_addr_heartbeat: Counter,
     pub actor_tick_direct_addr_update_receiver: Counter,
-    pub actor_tick_nodes_timer: Counter,
     pub actor_link_change: Counter,
     pub actor_tick_other: Counter,
 }
@@ -128,7 +127,6 @@ impl Default for Metrics {
             actor_tick_direct_addr_update_receiver: Counter::new(
                 "actor_tick_direct_addr_update_receiver",
             ),
-            actor_tick_nodes_timer: Counter::new("actor_tick_nodes_timer"),
             actor_link_change: Counter::new("actor_link_change"),
             actor_tick_other: Counter::new("actor_tick_other"),
         }

--- a/iroh-net/src/netcheck/metrics.rs
+++ b/iroh-net/src/netcheck/metrics.rs
@@ -14,7 +14,7 @@ pub struct Metrics {
     pub stun_packets_recv_ipv6: Counter,
     pub reports: Counter,
     pub reports_full: Counter,
-    pub reports_error: Counter,
+    // pub reports_error: Counter,
 }
 
 impl Default for Metrics {
@@ -29,7 +29,7 @@ impl Default for Metrics {
             stun_packets_recv_ipv6: Counter::new("Number of IPv6 STUN packets received"),
             reports: Counter::new("Number of reports executed by netcheck, including full reports"),
             reports_full: Counter::new("Number of full reports executed by netcheck"),
-            reports_error: Counter::new("Number of executed reports resulting in an error"),
+            // reports_error: Counter::new("Number of executed reports resulting in an error"),
         }
     }
 }

--- a/iroh-net/src/netcheck/metrics.rs
+++ b/iroh-net/src/netcheck/metrics.rs
@@ -14,7 +14,6 @@ pub struct Metrics {
     pub stun_packets_recv_ipv6: Counter,
     pub reports: Counter,
     pub reports_full: Counter,
-    // pub reports_error: Counter,
 }
 
 impl Default for Metrics {
@@ -29,7 +28,6 @@ impl Default for Metrics {
             stun_packets_recv_ipv6: Counter::new("Number of IPv6 STUN packets received"),
             reports: Counter::new("Number of reports executed by netcheck, including full reports"),
             reports_full: Counter::new("Number of full reports executed by netcheck"),
-            // reports_error: Counter::new("Number of executed reports resulting in an error"),
         }
     }
 }

--- a/iroh-net/src/relay/metrics.rs
+++ b/iroh-net/src/relay/metrics.rs
@@ -36,11 +36,10 @@ pub struct Metrics {
     /// Packets of other `FrameType`s dropped
     pub other_packets_dropped: Counter,
 
-    /// Number of packets we have forwarded out to another packet forwarder
-    pub packets_forwarded_out: Counter,
-    /// Number of packets we have been asked to forward
-    pub packets_forwarded_in: Counter,
-
+    // /// Number of packets we have forwarded out to another packet forwarder
+    // pub packets_forwarded_out: Counter,
+    // /// Number of packets we have been asked to forward
+    // pub packets_forwarded_in: Counter,
     /// Number of `FrameType::Ping`s received
     pub got_ping: Counter,
     /// Number of `FrameType::Pong`s sent
@@ -48,14 +47,13 @@ pub struct Metrics {
     /// Number of `FrameType::Unknown` received
     pub unknown_frames: Counter,
 
-    /*
-     * Metrics about peers
-     */
-    /// Number of packet forwarders added
-    pub added_pkt_fwder: Counter,
-    /// Number of packet forwarders removed
-    pub removed_pkt_fwder: Counter,
-
+    // /*
+    //  * Metrics about peers
+    //  */
+    // /// Number of packet forwarders added
+    // pub added_pkt_fwder: Counter,
+    // /// Number of packet forwarders removed
+    // pub removed_pkt_fwder: Counter,
     /// Number of connections we have accepted
     pub accepts: Counter,
     /// Number of connections we have removed because of an error
@@ -97,27 +95,25 @@ impl Default for Metrics {
                 "Number of times a non-disco, non-'send; packet was dropped.",
             ),
 
-            packets_forwarded_out: Counter::new(
-                "Number of times the server has sent a forwarded packet",
-            ),
-            packets_forwarded_in: Counter::new(
-                "Number of times the server has received a forwarded packet.",
-            ),
-
+            // packets_forwarded_out: Counter::new(
+            //     "Number of times the server has sent a forwarded packet",
+            // ),
+            // packets_forwarded_in: Counter::new(
+            //     "Number of times the server has received a forwarded packet.",
+            // ),
             got_ping: Counter::new("Number of times the server has received a Ping from a client."),
             sent_pong: Counter::new("Number of times the server has sent a Pong to a client."),
             unknown_frames: Counter::new("Number of unknown frames sent to this server."),
 
-            /*
-             * Metrics about peers
-             */
-            added_pkt_fwder: Counter::new(
-                "Number of times a packeted forwarded was added to this server.",
-            ),
-            removed_pkt_fwder: Counter::new(
-                "Number of times a packet forwarded was removed to this server.",
-            ),
-
+            // /*
+            //  * Metrics about peers
+            //  */
+            // added_pkt_fwder: Counter::new(
+            //     "Number of times a packeted forwarded was added to this server.",
+            // ),
+            // removed_pkt_fwder: Counter::new(
+            //     "Number of times a packet forwarded was removed to this server.",
+            // ),
             accepts: Counter::new("Number of times this server has accepted a connection."),
             disconnects: Counter::new("Number of clients that have then disconnected."),
 

--- a/iroh-net/src/relay/metrics.rs
+++ b/iroh-net/src/relay/metrics.rs
@@ -36,10 +36,6 @@ pub struct Metrics {
     /// Packets of other `FrameType`s dropped
     pub other_packets_dropped: Counter,
 
-    // /// Number of packets we have forwarded out to another packet forwarder
-    // pub packets_forwarded_out: Counter,
-    // /// Number of packets we have been asked to forward
-    // pub packets_forwarded_in: Counter,
     /// Number of `FrameType::Ping`s received
     pub got_ping: Counter,
     /// Number of `FrameType::Pong`s sent
@@ -47,13 +43,9 @@ pub struct Metrics {
     /// Number of `FrameType::Unknown` received
     pub unknown_frames: Counter,
 
-    // /*
-    //  * Metrics about peers
-    //  */
-    // /// Number of packet forwarders added
-    // pub added_pkt_fwder: Counter,
-    // /// Number of packet forwarders removed
-    // pub removed_pkt_fwder: Counter,
+    /*
+     * Metrics about peers
+     */
     /// Number of connections we have accepted
     pub accepts: Counter,
     /// Number of connections we have removed because of an error
@@ -94,26 +86,13 @@ impl Default for Metrics {
             other_packets_dropped: Counter::new(
                 "Number of times a non-disco, non-'send; packet was dropped.",
             ),
-
-            // packets_forwarded_out: Counter::new(
-            //     "Number of times the server has sent a forwarded packet",
-            // ),
-            // packets_forwarded_in: Counter::new(
-            //     "Number of times the server has received a forwarded packet.",
-            // ),
             got_ping: Counter::new("Number of times the server has received a Ping from a client."),
             sent_pong: Counter::new("Number of times the server has sent a Pong to a client."),
             unknown_frames: Counter::new("Number of unknown frames sent to this server."),
 
-            // /*
-            //  * Metrics about peers
-            //  */
-            // added_pkt_fwder: Counter::new(
-            //     "Number of times a packeted forwarded was added to this server.",
-            // ),
-            // removed_pkt_fwder: Counter::new(
-            //     "Number of times a packet forwarded was removed to this server.",
-            // ),
+            /*
+             * Metrics about peers
+             */
             accepts: Counter::new("Number of times this server has accepted a connection."),
             disconnects: Counter::new("Number of clients that have then disconnected."),
 

--- a/iroh-net/src/relay/metrics.rs
+++ b/iroh-net/src/relay/metrics.rs
@@ -51,6 +51,9 @@ pub struct Metrics {
     /// Number of connections we have removed because of an error
     pub disconnects: Counter,
 
+    /// Number of unique client keys per day
+    pub unique_client_keys: Counter,
+
     /// Number of accepted websocket connections
     pub websocket_accepts: Counter,
     /// Number of accepted 'iroh derp http' connection upgrades
@@ -95,6 +98,8 @@ impl Default for Metrics {
              */
             accepts: Counter::new("Number of times this server has accepted a connection."),
             disconnects: Counter::new("Number of clients that have then disconnected."),
+
+            unique_client_keys: Counter::new("Number of unique client keys per day."),
 
             websocket_accepts: Counter::new("Number of accepted websocket connections"),
             derp_accepts: Counter::new("Number of accepted 'iroh derp http' connection upgrades"),

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -11,17 +11,55 @@ use crate::rpc_protocol::node::CounterStats;
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Iterable)]
 pub struct Metrics {
-    pub requests_total: Counter,
-    pub bytes_sent: Counter,
-    pub bytes_received: Counter,
+    // pub requests_total: Counter,
+    // pub bytes_sent: Counter,
+    // pub bytes_received: Counter,
+    pub doc_gossip_tick_main: Counter,
+    pub doc_gossip_tick_event: Counter,
+    pub doc_gossip_tick_actor: Counter,
+    pub doc_gossip_tick_pending_join: Counter,
+
+    pub doc_live_tick_main: Counter,
+    pub doc_live_tick_actor: Counter,
+    pub doc_live_tick_replica_event: Counter,
+    pub doc_live_tick_running_sync_connect: Counter,
+    pub doc_live_tick_running_sync_accept: Counter,
+    pub doc_live_tick_pending_downloads: Counter,
 }
 
 impl Default for Metrics {
     fn default() -> Self {
         Self {
-            requests_total: Counter::new("Total number of requests received"),
-            bytes_sent: Counter::new("Number of bytes streamed"),
-            bytes_received: Counter::new("Number of bytes received"),
+            // requests_total: Counter::new("Total number of requests received"),
+            // bytes_sent: Counter::new("Number of bytes streamed"),
+            // bytes_received: Counter::new("Number of bytes received"),
+            doc_gossip_tick_main: Counter::new("Number of times the main gossip actor loop ticked"),
+            doc_gossip_tick_event: Counter::new(
+                "Number of times the gossip actor ticked for an event",
+            ),
+            doc_gossip_tick_actor: Counter::new(
+                "Number of times the gossip actor ticked for an actor message",
+            ),
+            doc_gossip_tick_pending_join: Counter::new(
+                "Number of times the gossip actor ticked pending join",
+            ),
+
+            doc_live_tick_main: Counter::new("Number of times the main live actor loop ticked"),
+            doc_live_tick_actor: Counter::new(
+                "Number of times the live actor ticked for an actor message",
+            ),
+            doc_live_tick_replica_event: Counter::new(
+                "Number of times the live actor ticked for a replica event",
+            ),
+            doc_live_tick_running_sync_connect: Counter::new(
+                "Number of times the live actor ticked for a running sync connect",
+            ),
+            doc_live_tick_running_sync_accept: Counter::new(
+                "Number of times the live actor ticked for a running sync accept",
+            ),
+            doc_live_tick_pending_downloads: Counter::new(
+                "Number of times the live actor ticked for a pending download",
+            ),
         }
     }
 }

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -11,9 +11,6 @@ use crate::rpc_protocol::node::CounterStats;
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Iterable)]
 pub struct Metrics {
-    // pub requests_total: Counter,
-    // pub bytes_sent: Counter,
-    // pub bytes_received: Counter,
     pub doc_gossip_tick_main: Counter,
     pub doc_gossip_tick_event: Counter,
     pub doc_gossip_tick_actor: Counter,
@@ -30,9 +27,6 @@ pub struct Metrics {
 impl Default for Metrics {
     fn default() -> Self {
         Self {
-            // requests_total: Counter::new("Total number of requests received"),
-            // bytes_sent: Counter::new("Number of bytes streamed"),
-            // bytes_received: Counter::new("Number of bytes received"),
             doc_gossip_tick_main: Counter::new("Number of times the main gossip actor loop ticked"),
             doc_gossip_tick_event: Counter::new(
                 "Number of times the gossip actor ticked for an event",


### PR DESCRIPTION
## Description

- Cleans up stale counters
- Introduces unique daily node counts on relays
- Introduces a metrics dumper so we can create dumps of metrics and also view them in doctor plot
- Introduces new trace level counters

## Breaking Changes

- Introduces `metrics_dump_path` on the top level CLI parameters, which if set will make sure metrics are collected at regular intervals and written to the provided path in CSV format.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
