### PR TITLE
fix(iroh-net): use staging URL for pkarr publish in dev mode

### DIFF
--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -4,8 +4,8 @@ use anyhow::{bail, Result};
 use clap::{Parser, ValueEnum};
 use iroh_net::{
     discovery::{
-        dns::N0_DNS_NODE_ORIGIN_PROD,
-        pkarr::{PkarrRelayClient, N0_DNS_PKARR_RELAY},
+        dns::{N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING},
+        pkarr::{PkarrRelayClient, N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING},
     },
     dns::node_info::{to_z32, NodeInfo, IROH_TXT_NAME},
     key::SecretKey,
@@ -19,9 +19,11 @@ const EXAMPLE_ORIGIN: &str = "irohdns.example";
 #[derive(ValueEnum, Clone, Debug, Default, Copy, strum::Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Env {
-    /// Use the pkarr relay run by number0.
+    /// Use the staging pkarr relay run by number0.
     #[default]
-    Default,
+    Staging,
+    /// Use the production pkarr relay run by number0.
+    Prod,
     /// Use a relay listening at http://localhost:8080
     Dev,
 }
@@ -32,7 +34,7 @@ pub enum Env {
 #[derive(Parser, Debug)]
 struct Cli {
     /// Environment to publish to.
-    #[clap(value_enum, short, long, default_value_t = Env::Default)]
+    #[clap(value_enum, short, long, default_value_t = Env::Staging)]
     env: Env,
     /// Pkarr Relay URL. If set, the --env option will be ignored.
     #[clap(long, conflicts_with = "env")]
@@ -65,7 +67,8 @@ async fn main() -> Result<()> {
     let node_id = secret_key.public();
     let pkarr_relay = match (args.pkarr_relay, args.env) {
         (Some(pkarr_relay), _) => pkarr_relay,
-        (None, Env::Default) => N0_DNS_PKARR_RELAY.parse().expect("valid url"),
+        (None, Env::Staging) => N0_DNS_PKARR_RELAY_STAGING.parse().expect("valid url"),
+        (None, Env::Prod) => N0_DNS_PKARR_RELAY_PROD.parse().expect("valid url"),
         (None, Env::Dev) => LOCALHOST_PKARR.parse().expect("valid url"),
     };
 
@@ -83,8 +86,18 @@ async fn main() -> Result<()> {
     println!("resolve with:");
 
     match args.env {
-        Env::Default => {
+        Env::Staging => {
             println!("   cargo run --example resolve -- node {}", node_id);
+            println!(
+                "   dig {} TXT",
+                fmt_domain(&node_id, N0_DNS_NODE_ORIGIN_STAGING)
+            )
+        }
+        Env::Prod => {
+            println!(
+                "   cargo run --example resolve -- --env prod node {}",
+                node_id
+            );
             println!(
                 "   dig {} TXT",
                 fmt_domain(&node_id, N0_DNS_NODE_ORIGIN_PROD)

--- a/iroh-dns-server/examples/resolve.rs
+++ b/iroh-dns-server/examples/resolve.rs
@@ -6,7 +6,7 @@ use hickory_resolver::{
     AsyncResolver,
 };
 use iroh_net::{
-    discovery::dns::N0_DNS_NODE_ORIGIN_PROD,
+    discovery::dns::{N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING},
     dns::{node_info::TxtAttrs, DnsResolver},
     NodeId,
 };
@@ -16,16 +16,18 @@ const EXAMPLE_ORIGIN: &str = "irohdns.example";
 
 #[derive(ValueEnum, Clone, Debug, Default)]
 pub enum Env {
-    /// Use the system's nameservers with origin domain dns.iroh.link
+    /// Use the system's nameservers with origin domain of the n0 staging DNS server
     #[default]
-    Default,
+    Staging,
+    /// Use the system's nameservers with origin domain of the n0 production DNS server
+    Prod,
     /// Use a localhost DNS server listening on port 5300
     Dev,
 }
 
 #[derive(Debug, Parser)]
 struct Cli {
-    #[clap(value_enum, short, long, default_value_t = Env::Default)]
+    #[clap(value_enum, short, long, default_value_t = Env::Staging)]
     env: Env,
     #[clap(subcommand)]
     command: Command,
@@ -43,7 +45,11 @@ enum Command {
 async fn main() -> anyhow::Result<()> {
     let args = Cli::parse();
     let (resolver, origin) = match args.env {
-        Env::Default => (
+        Env::Staging => (
+            iroh_net::dns::default_resolver().clone(),
+            N0_DNS_NODE_ORIGIN_STAGING,
+        ),
+        Env::Prod => (
             iroh_net::dns::default_resolver().clone(),
             N0_DNS_NODE_ORIGIN_PROD,
         ),

--- a/iroh-net/src/discovery/pkarr.rs
+++ b/iroh-net/src/discovery/pkarr.rs
@@ -212,9 +212,15 @@ impl PkarrResolver {
         }
     }
 
-    /// Create a config that resolves using the n0 dns server through [`N0_DNS_PKARR_RELAY`].
+    /// Create a pkarr resolver which uses the [`N0_DNS_PKARR_RELAY_PROD`] pkarr relay and in testing
+    /// uses [`N0_DNS_PKARR_RELAY_STAGING`].
     pub fn n0_dns() -> Self {
-        let pkarr_relay: Url = N0_DNS_PKARR_RELAY_PROD.parse().expect("url is valid");
+        #[cfg(not(any(test, feature = "test-utils")))]
+        let pkarr_relay = N0_DNS_PKARR_RELAY_PROD;
+        #[cfg(any(test, feature = "test-utils"))]
+        let pkarr_relay = N0_DNS_PKARR_RELAY_STAGING;
+
+        let pkarr_relay: Url = pkarr_relay.parse().expect("url is valid");
         Self::new(pkarr_relay)
     }
 }

--- a/iroh-net/src/discovery/pkarr.rs
+++ b/iroh-net/src/discovery/pkarr.rs
@@ -22,8 +22,10 @@ use crate::{
     AddrInfo, Endpoint, NodeId,
 };
 
-/// The pkarr relay run by n0.
-pub const N0_DNS_PKARR_RELAY: &str = "https://dns.iroh.link/pkarr";
+/// The pkarr relay run by n0, for production.
+pub const N0_DNS_PKARR_RELAY_PROD: &str = "https://dns.iroh.link/pkarr";
+/// The pkarr relay run by n0, for testing.
+pub const N0_DNS_PKARR_RELAY_STAGING: &str = "https://staging-dns.iroh.link/pkarr";
 
 /// Default TTL for the records in the pkarr signed packet. TTL tells DNS caches
 /// how long to store a record. It is ignored by the iroh-dns-server as the home
@@ -67,6 +69,7 @@ impl PkarrPublisher {
         ttl: u32,
         republish_interval: std::time::Duration,
     ) -> Self {
+        debug!("creating pkarr publisher that publishes to {pkarr_relay}");
         let node_id = secret_key.public();
         let pkarr_client = PkarrRelayClient::new(pkarr_relay);
         let watchable = Watchable::default();
@@ -89,9 +92,15 @@ impl PkarrPublisher {
         }
     }
 
-    /// Create a config that publishes to the n0 dns server through [`N0_DNS_PKARR_RELAY`].
+    /// Create a pkarr publisher which uses the [`N0_DNS_PKARR_RELAY_PROD`] pkarr relay and in testing
+    /// uses [`N0_DNS_PKARR_RELAY_STAGING`].
     pub fn n0_dns(secret_key: SecretKey) -> Self {
-        let pkarr_relay: Url = N0_DNS_PKARR_RELAY.parse().expect("url is valid");
+        #[cfg(not(any(test, feature = "test-utils")))]
+        let pkarr_relay = N0_DNS_PKARR_RELAY_PROD;
+        #[cfg(any(test, feature = "test-utils"))]
+        let pkarr_relay = N0_DNS_PKARR_RELAY_STAGING;
+
+        let pkarr_relay: Url = pkarr_relay.parse().expect("url is valid");
         Self::new(secret_key, pkarr_relay)
     }
 
@@ -205,7 +214,7 @@ impl PkarrResolver {
 
     /// Create a config that resolves using the n0 dns server through [`N0_DNS_PKARR_RELAY`].
     pub fn n0_dns() -> Self {
-        let pkarr_relay: Url = N0_DNS_PKARR_RELAY.parse().expect("url is valid");
+        let pkarr_relay: Url = N0_DNS_PKARR_RELAY_PROD.parse().expect("url is valid");
         Self::new(pkarr_relay)
     }
 }


### PR DESCRIPTION
## Description

We switched DNS discovery to a staging server when run with `cfg(test)` but did NOT switch pkarr publish. This means node discovery is not working on main once `cfg(any(test, feature = "test_utils"))` triggers.

This fixes this. It also means that there is no test for this atm (we always run local? which would be good too).

## Breaking Changes

* Renamed `iroh_net::discovery::pkarr::N0_DNS_PKARR_RELAY` to `N0_DNS_PKARR_RELAY_PROD`

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
