### PR TITLE
deprecation(iroh)!: remove deprecated type aliases

### DIFF
--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -9,16 +9,8 @@ pub use crate::rpc_protocol::RpcService;
 
 mod quic;
 
-#[deprecated]
-pub use self::docs::Doc as MemDoc;
-#[deprecated]
-pub use self::docs::Doc as QuicDoc;
 pub use self::docs::Doc;
 pub use self::node::NodeStatus;
-#[deprecated]
-pub use self::Iroh as MemIroh;
-#[deprecated]
-pub use self::Iroh as QuicIroh;
 
 pub(crate) use self::quic::{connect_raw as quic_connect_raw, RPC_ALPN};
 

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -74,6 +74,14 @@
 //! **Important**: the protocol to a remote node is not stable and will
 //! frequently change. So the client and server must be running the same version of iroh.
 //!
+//! ## Reexports
+//!
+//! The iroh crate re-exports the following crates:
+//! - [iroh_base](iroh_base) as [`base`]
+//! - [iroh_blobs](iroh_blobs) as [`blobs`]
+//! - [iroh_docs](iroh_docs) as [`docs`]
+//! - [iroh_net](iroh_net) as [`net`]
+//!
 //! ## Feature Flags
 //!
 //! - `metrics`: Enable metrics collection. Enabled by default.
@@ -82,7 +90,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
-// re-export the iroh crates
+/// re-export the iroh crates
 #[doc(inline)]
 pub use iroh_base as base;
 #[doc(inline)]

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -90,7 +90,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
-/// re-export the iroh crates
+// re-export the iroh crates
 #[doc(inline)]
 pub use iroh_base as base;
 #[doc(inline)]


### PR DESCRIPTION
## Description

Remove type aliases for the mem and quic node types that are no longer necessary due to boxing of the rpc channel.

Also document reexports

## Breaking Changes

- iroh: remove client::MemIroh
- iroh: remove client::QuicIroh
- iroh: remove client::MemDoc
- iroh: remove client::QuicDoc

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [x] ~~Tests if relevant.~~
- [x] All breaking changes documented.
