### PR TITLE
feat: add Asia Pacific relay url to the default relay url list in production

### DIFF
--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Result};
 use iroh::net::{
-    defaults,
+    defaults::{self},
     relay::{RelayMap, RelayNode},
 };
 use iroh::node::GcPolicy;
@@ -63,12 +63,23 @@ pub(crate) struct NodeConfig {
 impl Default for NodeConfig {
     fn default() -> Self {
         #[cfg(not(test))]
-        use defaults::prod::{default_eu_relay_node, default_na_relay_node};
+        let relay_nodes = {
+            use defaults::prod::{
+                default_ap_relay_node, default_eu_relay_node, default_na_relay_node,
+            };
+            [
+                default_na_relay_node(),
+                default_eu_relay_node(),
+                default_ap_relay_node(),
+            ]
+        };
         #[cfg(test)]
-        use defaults::staging::{default_eu_relay_node, default_na_relay_node};
+        let relay_nodes = {
+            use defaults::staging::{default_eu_relay_node, default_na_relay_node};
+            [default_na_relay_node(), default_eu_relay_node()]
+        };
         Self {
-            // TODO(ramfox): this should probably just be a relay map
-            relay_nodes: [default_na_relay_node(), default_eu_relay_node()].into(),
+            relay_nodes: relay_nodes.into(),
             gc_policy: GcPolicy::Disabled,
             metrics_addr: Some(([127, 0, 0, 1], 9090).into()),
             file_logs: Default::default(),

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Result};
 use iroh::net::{
-    defaults::{self},
+    defaults,
     relay::{RelayMap, RelayNode},
 };
 use iroh::node::GcPolicy;

--- a/iroh-net/src/defaults.rs
+++ b/iroh-net/src/defaults.rs
@@ -27,11 +27,17 @@ pub mod prod {
     pub const NA_RELAY_HOSTNAME: &str = "use1-1.relay.iroh.network.";
     /// Hostname of the default EU relay.
     pub const EU_RELAY_HOSTNAME: &str = "euw1-1.relay.iroh.network.";
+    /// Hostname of the default Asia-Pacific relay.
+    pub const AP_RELAY_HOSTNAME: &str = "aps1-1.relay.iroh.network.";
 
     /// Get the default [`RelayMap`].
     pub fn default_relay_map() -> RelayMap {
-        RelayMap::from_nodes([default_na_relay_node(), default_eu_relay_node()])
-            .expect("default nodes invalid")
+        RelayMap::from_nodes([
+            default_na_relay_node(),
+            default_eu_relay_node(),
+            default_ap_relay_node(),
+        ])
+        .expect("default nodes invalid")
     }
 
     /// Get the default [`RelayNode`] for NA.
@@ -59,11 +65,26 @@ pub mod prod {
             stun_port: DEFAULT_STUN_PORT,
         }
     }
+
+    /// Get the default [`RelayNode`] for Asia-Pacific
+    pub fn default_ap_relay_node() -> RelayNode {
+        // The default Asia-Pacific relay server run by number0.
+        let url: Url = format!("https://{AP_RELAY_HOSTNAME}")
+            .parse()
+            .expect("default_url");
+        RelayNode {
+            url: url.into(),
+            stun_only: false,
+            stun_port: DEFAULT_STUN_PORT,
+        }
+    }
 }
 
 /// Staging configuration.
 ///
 /// Used by tests and might have incompatible changes deployed
+///
+/// Note: we have staging servers in EU and NA, but no corresponding staging server for AP at this time.
 pub mod staging {
     use super::*;
 


### PR DESCRIPTION
## Description

Adds a new relay server to the default production list. `https://aps1-1.relay.iroh.network/` is the address for our newest server, located in Mumbai.

This does not affect any tests, as we do not have a corresponding Asia Pacific staging server, and so an additional server has not been added to our test-only list of default relay servers

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->


## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] ~Tests if relevant.~
- [ ] ~All breaking changes documented.~
