### PR TITLE
fix(iroh-docs): ensure docs db write txn gets closed regularly under all circumstances

### DIFF
--- a/iroh-docs/src/actor.rs
+++ b/iroh-docs/src/actor.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 const ACTION_CAP: usize = 1024;
-const MAX_COMMIT_DELAY: Duration = Duration::from_millis(500);
+pub(crate) const MAX_COMMIT_DELAY: Duration = Duration::from_millis(500);
 
 #[derive(derive_more::Debug, derive_more::Display)]
 enum Action {

--- a/iroh-docs/src/store/fs.rs
+++ b/iroh-docs/src/store/fs.rs
@@ -7,7 +7,6 @@ use std::{
     num::NonZeroU64,
     ops::Bound,
     path::Path,
-    time::Duration,
 };
 
 use anyhow::{anyhow, Result};
@@ -17,6 +16,7 @@ use rand_core::CryptoRngCore;
 use redb::{Database, DatabaseError, ReadableMultimapTable, ReadableTable, ReadableTableMetadata};
 
 use crate::{
+    actor::MAX_COMMIT_DELAY,
     keys::Author,
     ranger::{Fingerprint, Range, RangeEntry},
     sync::{Entry, EntrySignature, Record, RecordIdentifier, Replica, SignedEntry},
@@ -188,7 +188,7 @@ impl Store {
                 TransactionAndTables::new(tx)?
             }
             CurrentTransaction::Write(w) => {
-                if w.since.elapsed() > Duration::from_millis(500) {
+                if w.since.elapsed() > MAX_COMMIT_DELAY {
                     tracing::debug!("committing transaction because it's too old");
                     w.commit()?;
                     let tx = self.db.begin_write()?;
@@ -225,7 +225,7 @@ impl Store {
                 TransactionAndTables::new(tx)?
             }
             CurrentTransaction::Write(w) => {
-                if w.since.elapsed() > Duration::from_millis(500) {
+                if w.since.elapsed() > MAX_COMMIT_DELAY {
                     tracing::debug!("committing transaction because it's too old");
                     w.commit()?;
                     let tx = self.db.begin_write()?;


### PR DESCRIPTION
## Description

The docs db uses batching to reduce the number of write transactions. Before this, under certain circumstances (lots of activity, exclusively writes) the transaction would remain open for a long time.

This adds logic to modify to make sure that transactions will be committed when they get too old in any case.

## Breaking Changes

None

## Notes & open questions

## Change checklist

- [x] Self-review.
- [x] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [x] ~~Tests if relevant.~~
- [x] ~~All breaking changes documented.~~
