### PR TITLE
fix(iroh-cli): Also test for "minutes" in transfer time regex :grimacing: 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "postcard",
  "quic-rpc",
  "rand",
+ "rand_xorshift",
  "ratatui",
  "regex",
  "reqwest 0.12.5",

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -69,6 +69,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 duct = "0.13.6"
 nix = { version = "0.27", features = ["signal", "process"] }
+rand_xorshift = "0.3.0"
 regex = "1.10.3"
 testdir = "0.9.1"
 walkdir = "2"

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -904,7 +904,7 @@ fn match_get_stderr(stderr: Vec<u8>) -> Result<Vec<(usize, Vec<String>)>> {
             (r"", 1),
             (r"Fetching: [\da-z]{52}", 1),
             (
-                r"Transferred (\d*.?\d*? ?[BKMGT]i?B?) in \d* seconds?, \d*.?\d* ?(?:B|KiB|MiB|GiB|TiB)/s",
+                r"Transferred (\d*.?\d*? ?[BKMGT]i?B?) in \d* (second|minute)s?, \d*.?\d* ?(?:B|KiB|MiB|GiB|TiB)/s",
                 1,
             ),
         ],


### PR DESCRIPTION
## Description

Windows CI was so slow, the transfer was measured in *minutes*, not *seconds* and printed as such to the CLI.

The CLI tests only expected "seconds" to be printed though. :grimacing: 

Also went ahead and improved performance of `make_test_file` because damn this test is already slow enough.

## Breaking Changes

None

## Notes & open questions

Idk, do you have any? :P

## Change checklist

- [X] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~
