### PR TITLE
fix(iroh-net): unexpected `cfg` condition values / possible fix on netbsd

### DIFF
--- a/iroh-net/src/net/interfaces/bsd.rs
+++ b/iroh-net/src/net/interfaces/bsd.rs
@@ -374,9 +374,9 @@ impl WireFormat {
                     return Err(RouteError::InvalidMessage);
                 }
 
-                #[cfg(target_arch = "netbsd")]
+                #[cfg(target_os = "netbsd")]
                 let index = u16_from_ne_range(data, 16..18)?;
-                #[cfg(not(target_arch = "netbsd"))]
+                #[cfg(not(target_os = "netbsd"))]
                 let index = u16_from_ne_range(data, 12..14)?;
 
                 let addrs = parse_addrs(


### PR DESCRIPTION
## Description

We had some CLI tests that had `#[cfg(feature = "fs-store")]`, but that feature doesn't exist in `iroh-cli`... so they were never compiled (and some related code needed for these tests was deleted. I reintroduced it).

This also fixes what is likely a bug, where `#[cfg(target_arch = "netbsd")]` was used, but there is no "architecture" netbsd. Only an *OS* netbsd.

## Breaking Changes

None

## Notes & open questions

--

## Change checklist

- [X] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [X] All breaking changes documented.
