### PR TITLE
fix(iroh-gossip): gossip dispatcher: reliable events on join, allow dropping sinks or streams

### DIFF
--- a/iroh/tests/client.rs
+++ b/iroh/tests/client.rs
@@ -58,7 +58,6 @@ fn await_messages(
 }
 
 #[tokio::test]
-#[ignore = "flaky"]
 async fn gossip_smoke() -> TestResult {
     let _ = tracing_subscriber::fmt::try_init();
     let (addr1, node1) = spawn_node();
@@ -68,8 +67,32 @@ async fn gossip_smoke() -> TestResult {
     node1.add_node_addr(addr2.clone()).await?;
     node2.add_node_addr(addr1.clone()).await?;
     let topic = TopicId::from([0u8; 32]);
-    let (mut sink1, _stream2) = gossip1.subscribe(topic, [addr2.node_id]).await?;
+    let (mut sink1, _stream1) = gossip1.subscribe(topic, [addr2.node_id]).await?;
     let (_sink2, stream2) = gossip2.subscribe(topic, [addr1.node_id]).await?;
+    sink1.send(Command::Broadcast("hello".into())).await?;
+    let msgs = await_messages(stream2, 1).await?;
+    assert_eq!(msgs, vec![Bytes::from("hello")]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn gossip_drop_sink() -> TestResult {
+    let _ = tracing_subscriber::fmt::try_init();
+    let (addr1, node1) = spawn_node();
+    let (addr2, node2) = spawn_node();
+    let gossip1 = node1.gossip();
+    let gossip2 = node2.gossip();
+    node1.add_node_addr(addr2.clone()).await?;
+    node2.add_node_addr(addr1.clone()).await?;
+
+    let topic = TopicId::from([0u8; 32]);
+
+    let (mut sink1, stream1) = gossip1.subscribe(topic, [addr2.node_id]).await?;
+    let (sink2, stream2) = gossip2.subscribe(topic, [addr1.node_id]).await?;
+
+    drop(stream1);
+    drop(sink2);
+
     sink1.send(Command::Broadcast("hello".into())).await?;
     let msgs = await_messages(stream2, 1).await?;
     assert_eq!(msgs, vec![Bytes::from("hello")]);


### PR DESCRIPTION
## Description

This has 2 fixes to the gossip dispatcher:

* When a topic is joined, it can currently happen that the first few events on the newly joined topic are missed, because the events can start to arrive at the dispatcher's global subscription before the dispatcher's join task finished and changed the protocol state. If this happens, we now change the topic state to live before processing the incoming event. This should make the existing smoke test non-flaky.

* Currently a topic subscription is quitted when either the command stream (from client to gossip) or the event stream (from gossip to client) is dropped. Now we only quit the subscription if both the command and the event channels are dropped. This should fix the test in iroh-ffi.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.
