### PR TITLE
test(iroh-cli): Improve `bao_store_migration` test logging

### DIFF
--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{ensure, Context, Result};
 use bao_tree::blake3;
 use duct::{cmd, ReaderHandle};
 use iroh::{
@@ -361,9 +361,10 @@ fn run_cli(
     println!("STDOUT: {}", String::from_utf8_lossy(&output.stdout));
     println!("STDERR: {}", String::from_utf8_lossy(&output.stderr));
 
-    if !output.status.success() {
-        bail!("iroh command failed. See STDERR output above.");
-    }
+    ensure!(
+        output.status.success(),
+        "iroh command failed. See STDERR output above."
+    );
 
     let text = String::from_utf8(output.stdout)?;
     Ok(text)

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -358,8 +358,8 @@ fn run_cli(
         .run()?;
 
     // checking the output first, so you can still view any logging
-    println!("STDOUT: {:?}", std::str::from_utf8(&output.stdout),);
-    println!("STDERR: {}", std::str::from_utf8(&output.stderr).unwrap());
+    println!("STDOUT: {}", String::from_utf8_lossy(&output.stdout));
+    println!("STDERR: {}", String::from_utf8_lossy(&output.stderr));
 
     if !output.status.success() {
         bail!("iroh command failed. See STDERR output above.");
@@ -756,11 +756,9 @@ fn test_provide_get_loop(input: Input, output: Output) -> Result<()> {
     drop(provider);
 
     // checking the output first, so you can still view any logging
-    println!("STDOUT: {:?}", std::str::from_utf8(&get_output.stdout),);
-    println!(
-        "STDERR: {}",
-        std::str::from_utf8(&get_output.stderr).unwrap()
-    );
+    println!("STDOUT: {}", String::from_utf8_lossy(&get_output.stdout));
+    println!("STDERR: {}", String::from_utf8_lossy(&get_output.stderr));
+
     match_get_stderr(get_output.stderr)?;
     assert!(get_output.status.success());
 

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use bao_tree::blake3;
 use duct::{cmd, ReaderHandle};
 use iroh::{
@@ -352,9 +352,19 @@ fn run_cli(
     let output = cmd(iroh_bin(), args)
         .env_remove("RUST_LOG")
         .env("IROH_DATA_DIR", iroh_data_dir)
-        // .stderr_file(std::io::stderr().as_raw_fd()) // for debug output
+        .stderr_capture()
         .stdout_capture()
+        .unchecked()
         .run()?;
+
+    // checking the output first, so you can still view any logging
+    println!("STDOUT: {:?}", std::str::from_utf8(&output.stdout),);
+    println!("STDERR: {}", std::str::from_utf8(&output.stderr).unwrap());
+
+    if !output.status.success() {
+        bail!("iroh command failed. See STDERR output above.");
+    }
+
     let text = String::from_utf8(output.stdout)?;
     Ok(text)
 }
@@ -1049,16 +1059,12 @@ fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> anyhow::Result<
     std::fs::create_dir_all(dst)?;
     let mut len = 0;
     for entry in std::fs::read_dir(src)? {
-        let entry = entry.with_context(|| {
-            format!(
-                "failed to read directory entry in `{}`",
-                src.to_string_lossy()
-            )
-        })?;
+        let entry = entry
+            .with_context(|| format!("failed to read directory entry in `{}`", src.display()))?;
         let ty = entry.file_type().with_context(|| {
             format!(
                 "failed to get file type for file `{}`",
-                entry.path().to_string_lossy()
+                entry.path().display()
             )
         })?;
         let src = entry.path();
@@ -1067,16 +1073,16 @@ fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> anyhow::Result<
             len += copy_dir_all(&src, &dst).with_context(|| {
                 format!(
                     "failed to copy directory `{}` to `{}`",
-                    src.to_string_lossy(),
-                    dst.to_string_lossy()
+                    src.display(),
+                    dst.display()
                 )
             })?;
         } else {
             std::fs::copy(&src, &dst).with_context(|| {
                 format!(
                     "failed to copy file `{}` to `{}`",
-                    src.to_string_lossy(),
-                    dst.to_string_lossy()
+                    src.display(),
+                    dst.display()
                 )
             })?;
             len += 1;


### PR DESCRIPTION
## Description

We didn't get good logs on the `cli_bao_store_migration` test so far. Here's what it's output was in a failure case:
```
--- STDOUT:              iroh-cli::cli cli_bao_store_migration ---

running 1 test
|Iroh is running
|Node ID: cnzuojj4sbo2ulpqoo2riyrdsn2j4pnp3b5bgrjubsft72nutlca
iroh started up.
test cli_bao_store_migration ... FAILED

failures:

failures:
    cli_bao_store_migration

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 12 filtered out; finished in 2.71s


--- STDERR:              iroh-cli::cli cli_bao_store_migration ---
thread 'cli_bao_store_migration' panicked at iroh-cli/tests/cli.rs:394:5:
assertion `left == right` failed
  left: ""
 right: "4yny3v7anmzzsajv2amm3nxpqd2owfw4dqnjwq6anv7nj2djmt2q (0 B)\n"
 ```
 
 This was only capturing stdout from one of the four iroh commands.
 
 This PR changes that. Now stdout and stderr are captured by all iroh commands in the `cli_bao_store_migration` test.

## Breaking Changes

None

## Notes & open questions

I've also switched `PathBuf::to_string_lossy()` calls to be `PathBuf::display()` calls.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~
