### PR TITLE
fix(iroh-net): Stable select of direct address guess

### DIFF
--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -2004,7 +2004,7 @@ mod tests {
                     break;
                 }
                 // Didn't select a different one, that's possible since we still use a
-                // random one out of the possiblities.  Let's try again.
+                // random one out of the possibilities.  Let's try again.
             }
         }
     }

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -330,15 +330,15 @@ impl NodeState {
                 IpAddr::V6(_) => have_ipv6,
             })
         };
-        let candidate_len = dbg!(candidate_iter().count());
-        let candidate_idx = match dbg!(self.guess_direct_addr_index) {
-            Some(idx) if Some(candidate_len) == dbg!(self.guess_direct_addr_len) => dbg!(idx),
+        let candidate_len = candidate_iter().count();
+        let candidate_idx = match self.guess_direct_addr_index {
+            Some(idx) if Some(candidate_len) == self.guess_direct_addr_len => idx,
             _ => {
                 self.guess_direct_addr_len = Some(candidate_len);
                 match candidate_len {
                     0 => return None,
                     _ => {
-                        let idx = dbg!(rand::thread_rng().gen_range(0..candidate_len));
+                        let idx = rand::thread_rng().gen_range(0..candidate_len);
                         self.guess_direct_addr_index = Some(idx);
                         idx
                     }


### PR DESCRIPTION
## Description

When there are direct addresses but no best address a random one is
chosen just in case it happens to work (this could be because it was
added manually and is the only one).  However it is important to
select the same destination each time an address is needed in this
situation, so that all packets are sent to the same address instead of
only a fraction of the packets being delivered there.

The previous implementation did not result in a stable selection.
This version does work stably.  It stores the selection as NodeState
so that it is cheaper to find it again, compared to invoking an RNG,
since this is on the hot path of poll_send.  However the selection
still needs to be random since otherwise it could be used to direct
phoney traffic.

The state is never cleared, only updated when the number of direct
addresses change.  This is sufficient to ensure a reasonable
unpredictable address is selected.

## Breaking Changes

none

## Notes & open questions

Fixes #2480.

I don't particularly like the extra state/fields on NodeState for
this.  It feels like the abstraction should be moved to another
level as there are already plenty of things on NodeState that do
not need to interact with each other.  But that refactor would
likely involve BestAddr so I shied away from this.  Maybe that's
a bit lazy.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.