### PR TITLE
feat(iroh-net): Add holepunching events

### DIFF
--- a/iroh-net/README.md
+++ b/iroh-net/README.md
@@ -12,6 +12,58 @@ Peers can also connect directly without using a relay server. For this, however 
 
 Examples for `iroh-net` are in `iroh-net/examples`, run them with `cargo run --example $NAME`. Details for each example are in the file/directory itself.
 
+## Structured Events
+
+The library uses [tracing](https://docs.rs/tracing) to for logging as
+well as for **structured events**.  Events are different from normal
+logging by convention:
+
+- The [target] has a prefix of `events` and target names are dot-separated.
+
+  For this library the target will always start with `events.net.`.
+
+- There is **no message**.
+
+  Each event has a unique [target] which indicates the meaning.
+
+- The event [fields] are exclusively used for structured data.
+
+- The [Level] is always `DEBUG`.
+
+[target]: https://docs.rs/tracing/latest/tracing/struct.Metadata.html#method.target
+[fields]: https://docs.rs/tracing/latest/tracing/#recording-fields
+[Level]: https://docs.rs/tracing/latest/tracing/struct.Level.html
+
+### Using events
+
+If desired an application can use the `events.*` target to handle
+events by a different subscriber.  However with the default file
+logging it is already easy to search for all events, e.g. using
+ripgrep:
+
+`rg 'events\.[a-z_\-.]+' path/to/iroh/logs/iroh.YYYY-MM-DD-NN.log`
+
+Which will also highlight the full target name by default on a colour
+supporting terminal.
+
+### Development
+
+Be cautious about adding new events.  Events aim for a high
+signal-to-noise ratio.  Events should be designed to be able to
+extract in an automated way.  If multiple events need to be related,
+fields with special values can be used.
+
+To make events distinct from normal logging in the code it is
+recommended to write them using the `event!()` macro:
+
+```rust
+event!(
+    target: "event.net.subject",
+    Level::DEBUG,
+    field = value,
+);
+```
+
 # License
 
 This project is licensed under either of

--- a/iroh-net/src/disco.rs
+++ b/iroh-net/src/disco.rs
@@ -159,6 +159,18 @@ impl SendAddr {
     }
 }
 
+impl From<SocketAddr> for SendAddr {
+    fn from(source: SocketAddr) -> Self {
+        SendAddr::Udp(source)
+    }
+}
+
+impl From<RelayUrl> for SendAddr {
+    fn from(source: RelayUrl) -> Self {
+        SendAddr::Relay(source)
+    }
+}
+
 impl PartialEq<SocketAddr> for SendAddr {
     fn eq(&self, other: &SocketAddr) -> bool {
         match self {

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -877,7 +877,7 @@ impl MagicSock {
                 match src {
                     DiscoMessageSource::Relay { url, .. } => {
                         event!(
-                            target: "holepunch.call-me-maybe.recv",
+                            target: "events.net.call-me-maybe.recv",
                             Level::DEBUG,
                             src_node = sender.fmt_short(),
                             via = ?url,
@@ -933,7 +933,7 @@ impl MagicSock {
             ping_observed_addr: addr.clone(),
         });
         event!(
-            target: "holepunch.pong.sent",
+            target: "events.net.pong.sent",
             Level::DEBUG,
             dst_node = %sender.fmt_short(),
             dst = ?addr,
@@ -1205,7 +1205,7 @@ impl MagicSock {
         if endpoints.fresh_enough() {
             let addrs: Vec<_> = endpoints.iter().collect();
             event!(
-                target: "holepunch.call-me-maybe.sent",
+                target: "events.net.call-me-maybe.sent",
                 Level::DEBUG,
                 dst_node = %node_id.fmt_short(),
                 via = ?url,
@@ -2511,7 +2511,7 @@ impl DiscoveredEndpoints {
 
     fn log_endpoint_change(&self) {
         event!(
-            target: "holepunch.direct_addrs",
+            target: "events.net.direct_addrs",
             Level::DEBUG,
             addrs = ?self.last_endpoints,
         );

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -45,7 +45,8 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{
-    debug, error, error_span, info, info_span, instrument, trace, trace_span, warn, Instrument,
+    debug, error, error_span, event, info, info_span, instrument, trace, trace_span, warn,
+    Instrument, Level, Span,
 };
 use url::Url;
 use watchable::Watchable;
@@ -865,7 +866,7 @@ impl MagicSock {
         match dm {
             disco::Message::Ping(ping) => {
                 inc!(MagicsockMetrics, recv_disco_ping);
-                self.handle_ping(ping, &sender, src);
+                self.handle_ping(ping, sender, src);
             }
             disco::Message::Pong(pong) => {
                 inc!(MagicsockMetrics, recv_disco_pong);
@@ -873,10 +874,21 @@ impl MagicSock {
             }
             disco::Message::CallMeMaybe(cm) => {
                 inc!(MagicsockMetrics, recv_disco_call_me_maybe);
-                if !matches!(src, DiscoMessageSource::Relay { .. }) {
-                    warn!("call-me-maybe packets should only come via relay");
-                    return;
-                };
+                match src {
+                    DiscoMessageSource::Relay { url, .. } => {
+                        event!(
+                            target: "holepunch.call-me-maybe.recv",
+                            Level::DEBUG,
+                            src_node = sender.fmt_short(),
+                            via = ?url,
+                            their_addrs = ?cm.my_numbers,
+                        );
+                    }
+                    _ => {
+                        warn!("call-me-maybe packets should only come via relay");
+                        return;
+                    }
+                }
                 let ping_actions = self.node_map.handle_call_me_maybe(sender, cm);
                 for action in ping_actions {
                     match action {
@@ -894,11 +906,11 @@ impl MagicSock {
     }
 
     /// Handle a ping message.
-    fn handle_ping(&self, dm: disco::Ping, sender: &PublicKey, src: DiscoMessageSource) {
+    fn handle_ping(&self, dm: disco::Ping, sender: NodeId, src: DiscoMessageSource) {
         // Insert the ping into the node map, and return whether a ping with this tx_id was already
         // received.
         let addr: SendAddr = src.clone().into();
-        let handled = self.node_map.handle_ping(*sender, addr.clone(), dm.tx_id);
+        let handled = self.node_map.handle_ping(sender, addr.clone(), dm.tx_id);
         match handled.role {
             PingRole::Duplicate => {
                 debug!(%src, tx = %hex::encode(dm.tx_id), "received ping: path already confirmed, skip");
@@ -908,7 +920,7 @@ impl MagicSock {
             PingRole::NewPath => {
                 debug!(%src, tx = %hex::encode(dm.tx_id), "received ping: new path");
             }
-            PingRole::Reactivate => {
+            PingRole::Activate => {
                 debug!(%src, tx = %hex::encode(dm.tx_id), "received ping: path active");
             }
         }
@@ -920,8 +932,15 @@ impl MagicSock {
             tx_id: dm.tx_id,
             ping_observed_addr: addr.clone(),
         });
+        event!(
+            target: "holepunch.pong.sent",
+            Level::DEBUG,
+            dst_node = %sender.fmt_short(),
+            dst = ?addr,
+            txn = ?dm.tx_id,
+        );
 
-        if !self.send_disco_message_queued(addr.clone(), *sender, pong) {
+        if !self.send_disco_message_queued(addr.clone(), sender, pong) {
             warn!(%addr, "failed to queue pong");
         }
 
@@ -1181,21 +1200,29 @@ impl MagicSock {
         }
     }
 
-    fn send_or_queue_call_me_maybe(&self, url: &RelayUrl, dst_key: PublicKey) {
+    fn send_or_queue_call_me_maybe(&self, url: &RelayUrl, node_id: NodeId) {
         let endpoints = self.endpoints.read();
         if endpoints.fresh_enough() {
+            let addrs: Vec<_> = endpoints.iter().collect();
+            event!(
+                target: "holepunch.call-me-maybe.sent",
+                Level::DEBUG,
+                dst_node = %node_id.fmt_short(),
+                via = ?url,
+                ?addrs,
+            );
             let msg = endpoints.to_call_me_maybe_message();
             let msg = disco::Message::CallMeMaybe(msg);
-            if !self.send_disco_message_relay(url, dst_key, msg) {
-                warn!(dstkey = %dst_key.fmt_short(), relayurl = ?url,
+            if !self.send_disco_message_relay(url, node_id, msg) {
+                warn!(dstkey = %node_id.fmt_short(), relayurl = ?url,
                       "relay channel full, dropping call-me-maybe");
             } else {
-                debug!(dstkey = %dst_key.fmt_short(), relayurl = ?url, "call-me-maybe sent");
+                debug!(dstkey = %node_id.fmt_short(), relayurl = ?url, "call-me-maybe sent");
             }
         } else {
             self.pending_call_me_maybes
                 .lock()
-                .insert(dst_key, url.clone());
+                .insert(node_id, url.clone());
             debug!(
                 last_refresh_ago = ?endpoints.last_endpoints_time.map(|x| x.elapsed()),
                 "want call-me-maybe but endpoints stale; queuing after restun",
@@ -2049,99 +2076,102 @@ impl Actor {
 
         let msock = self.msock.clone();
 
-        tokio::spawn(async move {
-            // Depending on the OS and network interfaces attached and their state enumerating
-            // the local interfaces can take a long time.  Especially Windows is very slow.
-            let LocalAddresses {
-                regular: mut ips,
-                loopback,
-            } = tokio::task::spawn_blocking(LocalAddresses::new)
-                .await
-                .unwrap();
+        tokio::spawn(
+            async move {
+                // Depending on the OS and network interfaces attached and their state enumerating
+                // the local interfaces can take a long time.  Especially Windows is very slow.
+                let LocalAddresses {
+                    regular: mut ips,
+                    loopback,
+                } = tokio::task::spawn_blocking(LocalAddresses::new)
+                    .await
+                    .unwrap();
 
-            if is_unspecified_v4 || is_unspecified_v6 {
-                if ips.is_empty() && eps.is_empty() {
-                    // Only include loopback addresses if we have no
-                    // interfaces at all to use as endpoints and don't
-                    // have a public IPv4 or IPv6 address. This allows
-                    // for localhost testing when you're on a plane and
-                    // offline, for example.
-                    ips = loopback;
-                }
-                let v4_port = local_addr_v4.and_then(|addr| {
-                    if addr.ip().is_unspecified() {
-                        Some(addr.port())
-                    } else {
-                        None
+                if is_unspecified_v4 || is_unspecified_v6 {
+                    if ips.is_empty() && eps.is_empty() {
+                        // Only include loopback addresses if we have no
+                        // interfaces at all to use as endpoints and don't
+                        // have a public IPv4 or IPv6 address. This allows
+                        // for localhost testing when you're on a plane and
+                        // offline, for example.
+                        ips = loopback;
                     }
-                });
+                    let v4_port = local_addr_v4.and_then(|addr| {
+                        if addr.ip().is_unspecified() {
+                            Some(addr.port())
+                        } else {
+                            None
+                        }
+                    });
 
-                let v6_port = local_addr_v6.and_then(|addr| {
-                    if addr.ip().is_unspecified() {
-                        Some(addr.port())
-                    } else {
-                        None
-                    }
-                });
+                    let v6_port = local_addr_v6.and_then(|addr| {
+                        if addr.ip().is_unspecified() {
+                            Some(addr.port())
+                        } else {
+                            None
+                        }
+                    });
 
-                for ip in ips {
-                    match ip {
-                        IpAddr::V4(_) => {
-                            if let Some(port) = v4_port {
-                                add_addr!(
-                                    already,
-                                    eps,
-                                    SocketAddr::new(ip, port),
-                                    DirectAddrType::Local
-                                );
+                    for ip in ips {
+                        match ip {
+                            IpAddr::V4(_) => {
+                                if let Some(port) = v4_port {
+                                    add_addr!(
+                                        already,
+                                        eps,
+                                        SocketAddr::new(ip, port),
+                                        DirectAddrType::Local
+                                    );
+                                }
+                            }
+                            IpAddr::V6(_) => {
+                                if let Some(port) = v6_port {
+                                    add_addr!(
+                                        already,
+                                        eps,
+                                        SocketAddr::new(ip, port),
+                                        DirectAddrType::Local
+                                    );
+                                }
                             }
                         }
-                        IpAddr::V6(_) => {
-                            if let Some(port) = v6_port {
-                                add_addr!(
-                                    already,
-                                    eps,
-                                    SocketAddr::new(ip, port),
-                                    DirectAddrType::Local
-                                );
-                            }
-                        }
                     }
                 }
-            }
 
-            if !is_unspecified_v4 {
-                if let Some(addr) = local_addr_v4 {
-                    // Our local endpoint is bound to a particular address.
-                    // Do not offer addresses on other local interfaces.
-                    add_addr!(already, eps, addr, DirectAddrType::Local);
+                if !is_unspecified_v4 {
+                    if let Some(addr) = local_addr_v4 {
+                        // Our local endpoint is bound to a particular address.
+                        // Do not offer addresses on other local interfaces.
+                        add_addr!(already, eps, addr, DirectAddrType::Local);
+                    }
                 }
-            }
 
-            if !is_unspecified_v6 {
-                if let Some(addr) = local_addr_v6 {
-                    // Our local endpoint is bound to a particular address.
-                    // Do not offer addresses on other local interfaces.
-                    add_addr!(already, eps, addr, DirectAddrType::Local);
+                if !is_unspecified_v6 {
+                    if let Some(addr) = local_addr_v6 {
+                        // Our local endpoint is bound to a particular address.
+                        // Do not offer addresses on other local interfaces.
+                        add_addr!(already, eps, addr, DirectAddrType::Local);
+                    }
                 }
+
+                // Note: the endpoints are intentionally returned in priority order,
+                // from "farthest but most reliable" to "closest but least
+                // reliable." Addresses returned from STUN should be globally
+                // addressable, but might go farther on the network than necessary.
+                // Local interface addresses might have lower latency, but not be
+                // globally addressable.
+                //
+                // The STUN address(es) are always first.
+                // Despite this sorting, clients are not relying on this sorting for decisions;
+
+                msock.update_direct_addresses(eps);
+
+                // Regardless of whether our local endpoints changed, we now want to send any queued
+                // call-me-maybe messages.
+                msock.send_queued_call_me_maybes();
             }
-
-            // Note: the endpoints are intentionally returned in priority order,
-            // from "farthest but most reliable" to "closest but least
-            // reliable." Addresses returned from STUN should be globally
-            // addressable, but might go farther on the network than necessary.
-            // Local interface addresses might have lower latency, but not be
-            // globally addressable.
-            //
-            // The STUN address(es) are always first.
-            // Despite this sorting, clients are not relying on this sorting for decisions;
-
-            msock.update_direct_addresses(eps);
-
-            // Regardless of whether our local endpoints changed, we now want to send any queued
-            // call-me-maybe messages.
-            msock.send_queued_call_me_maybes();
-        });
+            .instrument(Span::current()),
+        );
     }
 
     /// Called when an endpoints update is done, no matter if it was successful or not.
@@ -2480,16 +2510,11 @@ impl DiscoveredEndpoints {
     }
 
     fn log_endpoint_change(&self) {
-        debug!("endpoints changed: {}", {
-            let mut s = String::new();
-            for (i, ep) in self.last_endpoints.iter().enumerate() {
-                if i > 0 {
-                    s += ", ";
-                }
-                s += &format!("{} ({})", ep.addr, ep.typ);
-            }
-            s
-        });
+        event!(
+            target: "holepunch.direct_addrs",
+            Level::DEBUG,
+            addrs = ?self.last_endpoints,
+        );
     }
 }
 

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1290,7 +1290,7 @@ impl PathState {
     ///
     /// This is the most recent instant between:
     /// - when last pong was received.
-    /// - when the last CallMeMaybe was received.  WRONG
+    /// - when this path was last advertised in a received CallMeMaybe message.
     /// - When the last payload transmission occurred.
     /// - when the last ping from them was received.
     pub(super) fn last_alive(&self) -> Option<Instant> {

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -312,7 +312,7 @@ impl NodeState {
         if self.conn_type.update(typ).is_ok() {
             let typ = self.conn_type.get();
             event!(
-                target: "holepunch.conn_type.changed",
+                target: "events.net.conn_type.changed",
                 Level::DEBUG,
                 node = %self.node_id.fmt_short(),
                 conn_type = ?typ,
@@ -480,7 +480,7 @@ impl NodeState {
         trace!(tx = %hex::encode(tx_id), %dst, ?purpose,
                dst = %self.node_id.fmt_short(), "start ping");
         event!(
-            target: "holepunch.ping.sent",
+            target: "events.net.ping.sent",
             Level::DEBUG,
             dst_node = %self.node_id.fmt_short(),
             ?dst,
@@ -743,7 +743,7 @@ impl NodeState {
             }
         };
         event!(
-            target: "holepunch.ping.recv",
+            target: "events.net.ping.recv",
             Level::DEBUG,
             src_node = %self.node_id.fmt_short(),
             src = ?path,
@@ -844,7 +844,7 @@ impl NodeState {
         src: SendAddr,
     ) -> Option<(SocketAddr, PublicKey)> {
         event!(
-            target: "holepunch.pong.recv",
+            target: "events.net.pong.recv",
             Level::DEBUG,
             src_node = self.node_id.fmt_short(),
             ?src,
@@ -1239,7 +1239,7 @@ impl PathState {
         if let SendAddr::Udp(ref path) = self.path {
             if self.recent_pong.is_none() {
                 event!(
-                    target: "holepunch.holepunched",
+                    target: "events.net.holepunched",
                     Level::DEBUG,
                     node = %self.node_id.fmt_short(),
                     path = ?path,
@@ -1372,7 +1372,7 @@ impl PathState {
                 None => {
                     if let SendAddr::Udp(ref addr) = self.path {
                         event!(
-                            target: "holepunch.holepunched",
+                            target: "events.net.holepunched",
                             Level::DEBUG,
                             node = %self.node_id.fmt_short(),
                             path = ?addr,

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -625,7 +625,6 @@ impl Actor {
 
         event!(
             target: "events.net.relay.connected",
-            // parent: &span!(Level::TRACE, "events"),
             Level::DEBUG,
             home = self.is_preferred,
             url = %self.url,

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -23,7 +23,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::Instant;
 use tokio_util::codec::{FramedRead, FramedWrite};
-use tracing::{debug, error, info_span, trace, warn, Instrument};
+use tracing::{debug, error, event, info_span, trace, warn, Instrument, Level};
 use url::Url;
 
 use crate::dns::{DnsResolver, ResolverExt};
@@ -622,6 +622,14 @@ impl Actor {
             relay_client.close().await;
             return Err(ClientError::Send);
         }
+
+        event!(
+            target: "holepunch.relay.connected",
+            // parent: &span!(Level::TRACE, "events"),
+            Level::DEBUG,
+            home = self.is_preferred,
+            url = %self.url,
+        );
 
         trace!("connect_0 done");
         Ok((relay_client, receiver))

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -624,7 +624,7 @@ impl Actor {
         }
 
         event!(
-            target: "holepunch.relay.connected",
+            target: "events.net.relay.connected",
             // parent: &span!(Level::TRACE, "events"),
             Level::DEBUG,
             home = self.is_preferred,


### PR DESCRIPTION
## Description

The aim here is to make users' reports about holepunching problems
actionable.  For this it creates a curated set of events.  This is
much more efficient than trawling through the entire logfile.

The events are emitted for logical reasons.  This means they might not
be emitted in a place where they are guaranteed to have happened, but
rather are emitted where it logically makes sense and all the information
is available.  This is fine since they are not meant to debug the code
itself.  E.g. after a `call-me-maybe.sent` event has been emitted the
packet could still be dropped in the queue of the relay client.  From
the event point of view this is fine, the event happened but the peer
may not have seen the result of this event, which will be visible in the
peer's own events.

Events have all their info in the fiels (and the target itself) and
do not rely on spans geneerally.  However the exception is the `NodeId`
of the endpoint emitting the event which has to be supplied somewhere in
a span.

See also the README for some design behind the events.

Because emitting useful events reveals bugs, this also fixes some:

- `store_endpoints_update` spawned without attaching a span, it now
  preserves the span.

- Since pings are sent at `HEARTBEAT_INTERVAL` they can often be received
  a little later.  This was immediately interpreted as a missed ping,
  which was too eager and resulted in the `PathState` flip-flopping too
  much.  The time window to receive heartbeat pings has been extended a
  little.

Other changes:

- `PingRole::Reactivate` is called `Activate` for now.  This is most of
  the time more accurate.  If needed we can add `Reactivate` as an
  additional role, but I'm not yet sure this is helpful.

- `PathState` now keeps track of the `NodeId` and path (`SendAddr`) it
  applies to.  This makes it easier to reason about things, however
  duplicates this information from where it is stored in the parent struct.

- `DiscoPingPurpose::PingBack` has been explicitly added to make the
  events a bit more meaningful.

## Breaking Changes

none

## Notes & open questions

It is arguable whether this becomes just a different log file source
over time.  I hope that with some effort we can avoid this.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
