### PR TITLE
ci: add a flaky tests failure report to our discord notification

### DIFF
--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: read results
         run: |
           ls nextest-results
-          for result in nextest-results/*.json; do
+          for result in nextest-results/libtest_run_${{ github.run_number }}-${{ github.run_attempt }}*.json; do
             echo "$result"
             jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name' $result
           done

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -79,6 +79,8 @@ jobs:
           severity: warn
           details: |
             Flaky tests failure:
+
             ${{ steps.make_summary.outputs.summary }}
+
             See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -61,6 +61,7 @@ jobs:
           path: nextest-results
           pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-*
           merge-multiple: true
+      - name: read results
         run: |
           ls nextest-results
           for result in nextest-results/*.json; do

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -66,7 +66,7 @@ jobs:
           for report in nextest-results/*.json; do
             echo $report
             cat $report
-            jq '.[] | select(.type == "test" and .event == "failed" ) | .name' $report
+            jq '.[]' $report
           done
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -71,7 +71,7 @@ jobs:
             name=$(echo ${report:16:-5} | tr _ ' ')
             echo $name
             echo "- **$name**" >> $GITHUB_OUTPUT
-            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | ("`" + .["name"]) + "`"' $report | sed -e 's/"//g' -e 's/\$/::/')
+            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | ("`" + .["name"]) + "`\n"' $report | sed -e 's/"//g' -e 's/\$/::/')
             echo $failure
             echo $failure >> $GITHUB_OUTPUT
           done

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -68,10 +68,10 @@ jobs:
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
-            name=$(echo ${report:35:-5} | tr _ ' ')
+            name=$(echo ${report:17:-5} | tr _ ' ')
             echo $name
             echo "- **$name**" >> $GITHUB_OUTPUT
-            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | ("\t- " + .["name"])' $report | sed -e 's/"//g' -e 's/\$/::/')
+            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | ("`" + .["name"]) + "`"' $report | sed -e 's/"//g' -e 's/\$/::/')
             echo $failure
             echo $failure >> $GITHUB_OUTPUT
           done

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -66,8 +66,9 @@ jobs:
         run: |
           # prevent the glob expression in the loop to match on itself when the dir is empty
           shopt -s nullglob
-          # to deal with multiline outputs it's recommened to use a random EOF
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          # to deal with multiline outputs it's recommended to use a random EOF
+          # EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          EOF=aP51VriWCxNJ1JjvmO9i
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
             # remove the name prefix and extension, and split the parts

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -64,6 +64,7 @@ jobs:
       - name: create summary report
         id: make_summary
         run: |
+          shopt -s nullglob
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
@@ -77,7 +78,7 @@ jobs:
         with:
           severity: warn
           details: |
-            Falky tests failure:
+            Flaky tests failure:
             ${{ steps.make_summary.outputs.summary }}
             See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -68,7 +68,7 @@ jobs:
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
-            echo $report | sed -E 's/libtest_run_[^-]*-[^-]*-(.*)\.json/\1/' | tr _ ' ' >> $GITHUB_OUTPUT
+            echo $report | sed -E 's/nextest-results.libtest_run_[^-]*-[^-]*-(.*)\.json/\1/' | tr _ ' ' >> $GITHUB_OUTPUT
             jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/"//g' -e 's/\$/::/' >> $GITHUB_OUTPUT
           done
           echo "$EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -64,14 +64,19 @@ jobs:
       - name: create summary report
         id: make_summary
         run: |
+          # prevent the glob expression in the loop to match on itself when the dir is empty
           shopt -s nullglob
+          # to deal with multiline outputs it's recommened to use a random EOF
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
+            # remove the name prefix and extension, and split the parts
             name=$(echo ${report:16:-5} | tr _ ' ')
             echo $name
             echo "- **$name**" >> $GITHUB_OUTPUT
-            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"] $report | sed -e 's/"//g' -e 's/\$/::/')
+            # select the failed tests
+            # the tests have this format "crate::module$test_name", the sed expressions remove the quotes and replace $ for ::
+            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/"//g' -e 's/\$/::/')
             echo $failure
             echo $failure >> $GITHUB_OUTPUT
           done

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
           for report in nextest-results/*.json; do
             echo $report
-            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]'
+            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report
           done
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -60,9 +60,13 @@ jobs:
         with:
           pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-*
           merge-multiple: true
+          path: nextest-results
       - name: read results
         run: |
-          ls -R
+          for report in nextest-results/*.json; do
+            echo $report
+            jq '.[] | select(.type == "test" and .event == "failed" ) | .name' $report
+          done
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -69,7 +69,7 @@ jobs:
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
             echo $report | sed -E 's/libtest_run_[^-]*-[^-]*-(.*)\.json/\1/' | tr _ ' ' >> $GITHUB_OUTPUT
-            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed 's/"{.*}${}".json/g' >> $GITHUB_OUTPUT
+            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/"//g' -e 's/\$/::/' >> $GITHUB_OUTPUT
           done
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -65,6 +65,7 @@ jobs:
         run: |
           for report in nextest-results/*.json; do
             echo $report
+            cat $report
             jq '.[] | select(.type == "test" and .event == "failed" ) | .name' $report
           done
       - name: Notify discord on failure

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -75,6 +75,6 @@ jobs:
           severity: warn
           details: |
             Falky tests failure:
-            ${{join(steps.make_summary.outputs.*, '\n')}
+            ${{ join(steps.make_summary.outputs.*, '\n') }}
             See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -77,7 +77,7 @@ jobs:
             echo "- **$name**" >> $GITHUB_OUTPUT
             # select the failed tests
             # the tests have this format "crate::module$test_name", the sed expressions remove the quotes and replace $ for ::
-            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/^"/\t- /g' -e 's/\$/::/' -e 's/"//')
+            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/^"//g' -e 's/\$/::/' -e 's/"//')
             echo "$failure"
             echo "$failure" >> $GITHUB_OUTPUT
           done

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -68,7 +68,7 @@ jobs:
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
-            name=$(echo ${report:17:-5} | tr _ ' ')
+            name=$(echo ${report:16:-5} | tr _ ' ')
             echo $name
             echo "- **$name**" >> $GITHUB_OUTPUT
             failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | ("`" + .["name"]) + "`"' $report | sed -e 's/"//g' -e 's/\$/::/')

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -58,16 +58,11 @@ jobs:
       - name: download nextest reports
         uses: actions/download-artifact@v4
         with:
-          path: nextest-results
-          pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-*
+          pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-.*
           merge-multiple: true
       - name: read results
         run: |
-          ls nextest-results
-          for result in nextest-results/libtest_run_${{ github.run_number }}-${{ github.run_attempt }}.*.json; do
-            echo "$result"
-            jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name' $result
-          done
+          ls -R
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
           for report in nextest-results/*.json; do
             echo $report
-            jq --slurp '.[]' $report
+            jq --slurp '.[] | select( .type = "event" )' $report
           done
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -64,10 +64,13 @@ jobs:
       - name: create summary report
         id: make_summary
         run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
             echo $report | cut -c 17-44 | tr _ ' ' >> $GITHUB_OUTPUT
             jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report >> $GITHUB_OUTPUT
           done
+          echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}
@@ -75,6 +78,6 @@ jobs:
           severity: warn
           details: |
             Falky tests failure:
-            ${{ join(steps.make_summary.outputs.*, '\n') }}
+            ${{ steps.make_summary.outputs.summary }}
             See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: download nextest reports
         uses: actions/download-artifact@v4
         with:
-          pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-.*
+          pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-*
           merge-multiple: true
       - name: read results
         run: |

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -68,12 +68,12 @@ jobs:
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
-            name=$(echo $report | sed -E 's/nextest-results\/libtest_run_[^-]*-[^-]*-(.*)\.json/\1/' | tr _ ' ')
+            name=$(echo ${report:35:-5} | tr _ ' ')
             echo $name
-            echo "*$name*" >> $GITHUB_OUTPUT
-            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/"//g' -e 's/\$/::/')
+            echo "- **$name**" >> $GITHUB_OUTPUT
+            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | ("\t- " + .["name"])' $report | sed -e 's/"//g' -e 's/\$/::/')
             echo $failure
-            echo " - $failure" >> $GITHUB_OUTPUT
+            echo $failure >> $GITHUB_OUTPUT
           done
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -61,8 +61,12 @@ jobs:
           path: nextest-results
           pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-*
           merge-multiple: true
-        # run: ls nextest-results
-
+        run: |
+          ls nextest-results
+          for result in nextest-results/*.json; do
+            echo "$result"
+            jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name' $result
+          done
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -68,8 +68,8 @@ jobs:
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
-            echo $report | cut -c 17-44 | tr _ ' ' >> $GITHUB_OUTPUT
-            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report >> $GITHUB_OUTPUT
+            echo $report | sed -E 's/libtest_run_[^-]*-[^-]*-(.*)\.json/\1/' | tr _ ' ' >> $GITHUB_OUTPUT
+            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed 's/"{.*}${}".json/g' >> $GITHUB_OUTPUT
           done
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -55,6 +55,14 @@ jobs:
           result=$(echo '${{ toJSON(needs) }}' | jq -r .tests.result)
           echo TESTS_RESULT=$result
           echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
+      - name: download nextest reports
+        uses: actions/download-artifact@v4
+        with:
+          path: nextest-results
+          pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-*
+          merge-multiple: true
+        # run: ls nextest-results
+
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -71,7 +71,7 @@ jobs:
             name=$(echo ${report:16:-5} | tr _ ' ')
             echo $name
             echo "- **$name**" >> $GITHUB_OUTPUT
-            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | ("`" + .["name"]) + "`\n"' $report | sed -e 's/"//g' -e 's/\$/::/')
+            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"] $report | sed -e 's/"//g' -e 's/\$/::/')
             echo $failure
             echo $failure >> $GITHUB_OUTPUT
           done

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
           for report in nextest-results/*.json; do
             echo $report
-            jq --slurp '.[] | select( .type = "event" )' $report
+            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]'
           done
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -65,8 +65,7 @@ jobs:
         run: |
           for report in nextest-results/*.json; do
             echo $report
-            cat $report
-            jq '.[]' $report
+            jq --slurp '.[]' $report
           done
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -61,16 +61,13 @@ jobs:
           pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-*
           merge-multiple: true
           path: nextest-results
-      - name: read results
+      - name: create summary report
+        id: make_summary
         run: |
           for report in nextest-results/*.json; do
-            echo $report | cut -c 17-44 | tr _ ' ' >> summary.txt
-            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report >> summary.txt
+            echo $report | cut -c 17-44 | tr _ ' ' >> $GITHUB_OUTPUT
+            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report >> $GITHUB_OUTPUT
           done
-          cat summary.txt
-          summary=$(cat summary.txt)
-          echo FAILURE_SUMMARY=$summary
-          echo "FAILURE_SUMMARY=$summary" >>"$GITHUB_ENV"
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}
@@ -78,6 +75,6 @@ jobs:
           severity: warn
           details: |
             Falky tests failure:
-            ${{ env.FAILURE_SUMMARY }}
+            ${{join(steps.make_summary.outputs.*, '\n')}
             See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -64,15 +64,20 @@ jobs:
       - name: read results
         run: |
           for report in nextest-results/*.json; do
-            echo $report
-            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report
+            echo $report | cut -c 17-44 | tr _ ' ' >> summary.txt
+            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report >> summary.txt
           done
+          cat summary.txt
+          summary=$(cat summary.txt)
+          echo FAILURE_SUMMARY=$summary
+          echo "FAILURE_SUMMARY=$summary" >>"$GITHUB_ENV"
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
           severity: warn
           details: |
-            Flaky tests failed again, why don't you go fix them?
+            Falky tests failure:
+            ${{ env.FAILURE_SUMMARY }}
             See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -68,8 +68,12 @@ jobs:
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
-            echo $report | sed -E 's/nextest-results.libtest_run_[^-]*-[^-]*-(.*)\.json/\1/' | tr _ ' ' >> $GITHUB_OUTPUT
-            jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/"//g' -e 's/\$/::/' >> $GITHUB_OUTPUT
+            name=$(echo $report | sed -E 's/nextest-results\/libtest_run_[^-]*-[^-]*-(.*)\.json/\1/' | tr _ ' ')
+            echo $name
+            echo "*$name*" >> $GITHUB_OUTPUT
+            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/"//g' -e 's/\$/::/')
+            echo $failure
+            echo " - $failure" >> $GITHUB_OUTPUT
           done
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: read results
         run: |
           ls nextest-results
-          for result in nextest-results/libtest_run_${{ github.run_number }}-${{ github.run_attempt }}*.json; do
+          for result in nextest-results/libtest_run_${{ github.run_number }}-${{ github.run_attempt }}.*.json; do
             echo "$result"
             jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name' $result
           done

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -76,9 +76,9 @@ jobs:
             echo "- **$name**" >> $GITHUB_OUTPUT
             # select the failed tests
             # the tests have this format "crate::module$test_name", the sed expressions remove the quotes and replace $ for ::
-            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/"//g' -e 's/\$/::/')
-            echo $failure
-            echo $failure >> $GITHUB_OUTPUT
+            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/^"/\t- /g' -e 's/\$/::/' -e 's/"//')
+            echo "$failure"
+            echo "$failure" >> $GITHUB_OUTPUT
           done
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -66,8 +66,8 @@ jobs:
         run: |
           # prevent the glob expression in the loop to match on itself when the dir is empty
           shopt -s nullglob
-          # to deal with multiline outputs it's recommended to use a random EOF
-          # EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          # to deal with multiline outputs it's recommended to use a random EOF, the syntax is based on
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           EOF=aP51VriWCxNJ1JjvmO9i
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,12 +111,22 @@ jobs:
         cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
 
     - name: run tests
+      continue-on-error: true
       run: |
         mkdir -p outputs
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} | jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name'
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > outputs/${{ env.outputName }}
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        outputName: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+
+
+    - name: Upload results
+          uses: actions/upload-artifact@v4
+          with:
+            name: outputs/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+            path: outputs
+            retention-days: 1
 
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -113,14 +113,10 @@ jobs:
     - name: run tests
       run: |
         mkdir -p outputs
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > outputs/${{ env.outputName}}
-        ls outputs
-        jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name' outputs/${{ env.outputName }}
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} | jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name'
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
-        outputName: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-
 
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,9 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [ubuntu-latest, macOS-arm-latest]
+        name: [ubuntu-latest]
         rust: [ '${{ inputs.rust-version }}' ]
-        features: [all, none, default]
+        features: [ default]
         include:
           - name: ubuntu-latest
             os: ubuntu-latest
@@ -137,91 +137,91 @@ jobs:
         fi
         cargo test --workspace --all-features --doc
 
-  build_and_test_windows:
-    timeout-minutes: 30
-    name: "Tests"
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [windows-latest]
-        rust: [ '${{ inputs.rust-version}}' ]
-        features: [all, none, default]
-        target:
-          - x86_64-pc-windows-msvc
-        include:
-          - name: windows-latest
-            os: windows
-            runner: [self-hosted, windows, x64]
-    env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
-      RUSTC_WRAPPER: "sccache"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.git-ref }}
-
-    - name: Install ${{ matrix.rust }}
-      run: |
-        rustup toolchain install ${{ matrix.rust }}
-        rustup toolchain default ${{ matrix.rust }}
-        rustup target add ${{ matrix.target }}
-        rustup set default-host ${{ matrix.target }}
-
-    - name: Install cargo-nextest
-      shell: powershell
-      run: |
-        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
-        $tmp | Expand-Archive -DestinationPath $outputDir -Force
-        $tmp | Remove-Item
-
-    - name: Select features
-      run: |
-        switch ("${{ matrix.features }}") {
-            "all" {
-                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "none" {
-                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "default" {
-                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            default {
-                Exit 1
-            }
-        }
-
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.4
-
-    - uses: msys2/setup-msys2@v2
-
-    - name: build tests
-      run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
-
-    - name: list ignored tests
-      run: |
-        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
-
-    - name: tests
-      run: |
-        mkdir -p output
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-      env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
-        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
-
-    - name: upload results
-      if: ${{ failure() && inputs.flaky }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-        path: output
-        retention-days: 1
-        compression-level: 0
+  # build_and_test_windows:
+  #   timeout-minutes: 30
+  #   name: "Tests"
+  #   runs-on: ${{ matrix.runner }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       name: [windows-latest]
+  #       rust: [ '${{ inputs.rust-version}}' ]
+  #       features: [all, none, default]
+  #       target:
+  #         - x86_64-pc-windows-msvc
+  #       include:
+  #         - name: windows-latest
+  #           os: windows
+  #           runner: [self-hosted, windows, x64]
+  #   env:
+  #     # Using self-hosted runners so use local cache for sccache and
+  #     # not SCCACHE_GHA_ENABLED.
+  #     RUSTC_WRAPPER: "sccache"
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+  #     with:
+  #       ref: ${{ inputs.git-ref }}
+  # 
+  #   - name: Install ${{ matrix.rust }}
+  #     run: |
+  #       rustup toolchain install ${{ matrix.rust }}
+  #       rustup toolchain default ${{ matrix.rust }}
+  #       rustup target add ${{ matrix.target }}
+  #       rustup set default-host ${{ matrix.target }}
+  # 
+  #   - name: Install cargo-nextest
+  #     shell: powershell
+  #     run: |
+  #       $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+  #       Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+  #       $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+  #       $tmp | Expand-Archive -DestinationPath $outputDir -Force
+  #       $tmp | Remove-Item
+  # 
+  #   - name: Select features
+  #     run: |
+  #       switch ("${{ matrix.features }}") {
+  #           "all" {
+  #               echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           "none" {
+  #               echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           "default" {
+  #               echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           default {
+  #               Exit 1
+  #           }
+  #       }
+  # 
+  #   - name: Install sccache
+  #     uses: mozilla-actions/sccache-action@v0.0.4
+  # 
+  #   - uses: msys2/setup-msys2@v2
+  # 
+  #   - name: build tests
+  #     run: |
+  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+  # 
+  #   - name: list ignored tests
+  #     run: |
+  #       cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+  # 
+  #   - name: tests
+  #     run: |
+  #       mkdir -p output
+  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+  #     env:
+  #       RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+  #       NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+  # 
+  #   - name: upload results
+  #     if: ${{ failure() && inputs.flaky }}
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+  #       path: output
+  #       retention-days: 1
+  #       compression-level: 0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -116,7 +116,7 @@ jobs:
       continue-on-error: true
       run: |
         mkdir -p output
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'ignored-only' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'ignored-only' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -120,14 +120,6 @@ jobs:
         outputName: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
-
-    - name: Upload results
-          uses: actions/upload-artifact@v4
-          with:
-            name: outputs/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-            path: outputs
-            retention-days: 1
-
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,7 +111,6 @@ jobs:
         cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
 
     - name: run tests
-      continue-on-error: true
       run: |
         mkdir -p output
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
@@ -120,7 +119,7 @@ jobs:
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
     - name: upload results
-      if: always() && ${{ inputs.flaky }}
+      if: ${{ failure() && ${{ inputs.flaky }} }}
       uses: actions/upload-artifact@v4
       with:
         name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -120,7 +120,7 @@ jobs:
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
     - name: Upload results
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,7 +115,7 @@ jobs:
         mkdir -p outputs
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > outputs/${{ env.outputName}}
         ls outputs
-        cat outputs/${{ env.outputName }}
+        jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name' outputs/${{ env.outputName }}
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,7 +119,7 @@ jobs:
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
     - name: upload results
-      if: ${{ failure() && ${{ inputs.flaky }} }}
+      if: ${{ failure() && inputs.flaky }}
       uses: actions/upload-artifact@v4
       with:
         name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -112,9 +112,12 @@ jobs:
 
     - name: run tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
+        $outputName = ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} >> outputs/$outputName
+        cat outputs/$outputName
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,7 +123,7 @@ jobs:
       if: always() && ${{ inputs.flaky }}
       uses: actions/upload-artifact@v4
       with:
-        name: run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         path: output
         retention-days: 1
         compression-level: 0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -114,7 +114,6 @@ jobs:
       run: |
         $outputName = ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} >> outputs/$outputName
-        cat outputs/$outputName
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -113,17 +113,18 @@ jobs:
     - name: run tests
       continue-on-error: true
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > ${{ env.outputName }}
+        mkdir -p output
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/libtest.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
-        outputName: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
     - name: Upload results
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-        path: outputs
+        path: output
         retention-days: 1
 
     - name: doctests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,13 +119,18 @@ jobs:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
-    - name: Upload results
-      if: always()
+    - name: Filter and upload results
+      if: always() && {{ inputs.flaky }}
       uses: actions/upload-artifact@v4
+      run: |
+        echo "this should only run if the previous one failed, but if: failure() does not work for some reason"
+        jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name ' output/libtest.json > output/failures.json
+        rm output/libtest.json
       with:
-        name: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        name: run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         path: output
         retention-days: 1
+        compression-level: 0
 
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -211,6 +211,17 @@ jobs:
 
     - name: tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
+        mkdir -p output
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+
+    - name: upload results
+      if: ${{ failure() && inputs.flaky }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        path: output
+        retention-days: 1
+        compression-level: 0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,9 +33,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [ubuntu-latest, macOS-arm-latest]
+        # name: [ubuntu-latest, macOS-arm-latest]
+        name: [ubuntu-latest]
         rust: [ '${{ inputs.rust-version }}' ]
-        features: [all, none, default]
+        # features: [all, none, default]
+        features: [default]
         include:
           - name: ubuntu-latest
             os: ubuntu-latest
@@ -114,7 +116,7 @@ jobs:
       continue-on-error: true
       run: |
         mkdir -p output
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/libtest.json
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'ignored-only' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/libtest.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
@@ -138,80 +140,80 @@ jobs:
         fi
         cargo test --workspace --all-features --doc
 
-  build_and_test_windows:
-    timeout-minutes: 30
-    name: "Tests"
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [windows-latest]
-        rust: [ '${{ inputs.rust-version}}' ]
-        features: [all, none, default]
-        target:
-          - x86_64-pc-windows-msvc
-        include:
-          - name: windows-latest
-            os: windows
-            runner: [self-hosted, windows, x64]
-    env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
-      RUSTC_WRAPPER: "sccache"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.git-ref }}
-
-    - name: Install ${{ matrix.rust }}
-      run: |
-        rustup toolchain install ${{ matrix.rust }}
-        rustup toolchain default ${{ matrix.rust }}
-        rustup target add ${{ matrix.target }}
-        rustup set default-host ${{ matrix.target }}
-
-    - name: Install cargo-nextest
-      shell: powershell
-      run: |
-        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
-        $tmp | Expand-Archive -DestinationPath $outputDir -Force
-        $tmp | Remove-Item
-
-    - name: Select features
-      run: |
-        switch ("${{ matrix.features }}") {
-            "all" {
-                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "none" {
-                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "default" {
-                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            default {
-                Exit 1
-            }
-        }
-
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.4
-
-    - uses: msys2/setup-msys2@v2
-
-    - name: build tests
-      run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
-
-    - name: list ignored tests
-      run: |
-        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
-
-    - name: tests
-      run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
-      env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+  # build_and_test_windows:
+  #   timeout-minutes: 30
+  #   name: "Tests"
+  #   runs-on: ${{ matrix.runner }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       name: [windows-latest]
+  #       rust: [ '${{ inputs.rust-version}}' ]
+  #       features: [all, none, default]
+  #       target:
+  #         - x86_64-pc-windows-msvc
+  #       include:
+  #         - name: windows-latest
+  #           os: windows
+  #           runner: [self-hosted, windows, x64]
+  #   env:
+  #     # Using self-hosted runners so use local cache for sccache and
+  #     # not SCCACHE_GHA_ENABLED.
+  #     RUSTC_WRAPPER: "sccache"
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+  #     with:
+  #       ref: ${{ inputs.git-ref }}
+  # 
+  #   - name: Install ${{ matrix.rust }}
+  #     run: |
+  #       rustup toolchain install ${{ matrix.rust }}
+  #       rustup toolchain default ${{ matrix.rust }}
+  #       rustup target add ${{ matrix.target }}
+  #       rustup set default-host ${{ matrix.target }}
+  # 
+  #   - name: Install cargo-nextest
+  #     shell: powershell
+  #     run: |
+  #       $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+  #       Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+  #       $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+  #       $tmp | Expand-Archive -DestinationPath $outputDir -Force
+  #       $tmp | Remove-Item
+  # 
+  #   - name: Select features
+  #     run: |
+  #       switch ("${{ matrix.features }}") {
+  #           "all" {
+  #               echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           "none" {
+  #               echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           "default" {
+  #               echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+  #           }
+  #           default {
+  #               Exit 1
+  #           }
+  #       }
+  # 
+  #   - name: Install sccache
+  #     uses: mozilla-actions/sccache-action@v0.0.4
+  # 
+  #   - uses: msys2/setup-msys2@v2
+  # 
+  #   - name: build tests
+  #     run: |
+  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+  # 
+  #   - name: list ignored tests
+  #     run: |
+  #       cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+  # 
+  #   - name: tests
+  #     run: |
+  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
+  #     env:
+  #       RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -112,11 +112,14 @@ jobs:
 
     - name: run tests
       run: |
-        $outputName = ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} >> outputs/$outputName
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > outputs/${{ env.outputName}}
+        ls outputs
+        cat outputs/${{ env.outputName }}
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+        outputName: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+
 
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -113,8 +113,7 @@ jobs:
     - name: run tests
       continue-on-error: true
       run: |
-        mkdir -p outputs
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > outputs/${{ env.outputName }}
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > ${{ env.outputName }}
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         outputName: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
@@ -123,7 +122,7 @@ jobs:
     - name: Upload results
       uses: actions/upload-artifact@v4
       with:
-        name: outputs/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        name: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         path: outputs
         retention-days: 1
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,11 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # name: [ubuntu-latest, macOS-arm-latest]
-        name: [ubuntu-latest]
+        name: [ubuntu-latest, macOS-arm-latest]
         rust: [ '${{ inputs.rust-version }}' ]
-        # features: [all, none, default]
-        features: [default]
+        features: [all, none, default]
         include:
           - name: ubuntu-latest
             os: ubuntu-latest
@@ -116,7 +114,7 @@ jobs:
       continue-on-error: true
       run: |
         mkdir -p output
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'ignored-only' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
@@ -140,80 +138,80 @@ jobs:
         fi
         cargo test --workspace --all-features --doc
 
-  # build_and_test_windows:
-  #   timeout-minutes: 30
-  #   name: "Tests"
-  #   runs-on: ${{ matrix.runner }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       name: [windows-latest]
-  #       rust: [ '${{ inputs.rust-version}}' ]
-  #       features: [all, none, default]
-  #       target:
-  #         - x86_64-pc-windows-msvc
-  #       include:
-  #         - name: windows-latest
-  #           os: windows
-  #           runner: [self-hosted, windows, x64]
-  #   env:
-  #     # Using self-hosted runners so use local cache for sccache and
-  #     # not SCCACHE_GHA_ENABLED.
-  #     RUSTC_WRAPPER: "sccache"
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-  #     with:
-  #       ref: ${{ inputs.git-ref }}
-  # 
-  #   - name: Install ${{ matrix.rust }}
-  #     run: |
-  #       rustup toolchain install ${{ matrix.rust }}
-  #       rustup toolchain default ${{ matrix.rust }}
-  #       rustup target add ${{ matrix.target }}
-  #       rustup set default-host ${{ matrix.target }}
-  # 
-  #   - name: Install cargo-nextest
-  #     shell: powershell
-  #     run: |
-  #       $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-  #       Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-  #       $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
-  #       $tmp | Expand-Archive -DestinationPath $outputDir -Force
-  #       $tmp | Remove-Item
-  # 
-  #   - name: Select features
-  #     run: |
-  #       switch ("${{ matrix.features }}") {
-  #           "all" {
-  #               echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           "none" {
-  #               echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           "default" {
-  #               echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           default {
-  #               Exit 1
-  #           }
-  #       }
-  # 
-  #   - name: Install sccache
-  #     uses: mozilla-actions/sccache-action@v0.0.4
-  # 
-  #   - uses: msys2/setup-msys2@v2
-  # 
-  #   - name: build tests
-  #     run: |
-  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
-  # 
-  #   - name: list ignored tests
-  #     run: |
-  #       cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
-  # 
-  #   - name: tests
-  #     run: |
-  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
-  #     env:
-  #       RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+  build_and_test_windows:
+    timeout-minutes: 30
+    name: "Tests"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [windows-latest]
+        rust: [ '${{ inputs.rust-version}}' ]
+        features: [all, none, default]
+        target:
+          - x86_64-pc-windows-msvc
+        include:
+          - name: windows-latest
+            os: windows
+            runner: [self-hosted, windows, x64]
+    env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.git-ref }}
+
+    - name: Install ${{ matrix.rust }}
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup toolchain default ${{ matrix.rust }}
+        rustup target add ${{ matrix.target }}
+        rustup set default-host ${{ matrix.target }}
+
+    - name: Install cargo-nextest
+      shell: powershell
+      run: |
+        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+        $tmp | Expand-Archive -DestinationPath $outputDir -Force
+        $tmp | Remove-Item
+
+    - name: Select features
+      run: |
+        switch ("${{ matrix.features }}") {
+            "all" {
+                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "none" {
+                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "default" {
+                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            default {
+                Exit 1
+            }
+        }
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.4
+
+    - uses: msys2/setup-msys2@v2
+
+    - name: build tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+
+    - name: list ignored tests
+      run: |
+        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+
+    - name: tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,11 +121,11 @@ jobs:
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
     - name: Upload results
-        uses: actions/upload-artifact@v4
-        with:
-          name: outputs/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-          path: outputs
-          retention-days: 1
+      uses: actions/upload-artifact@v4
+      with:
+        name: outputs/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        path: outputs
+        retention-days: 1
 
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,10 +122,6 @@ jobs:
     - name: Filter and upload results
       if: always() && {{ inputs.flaky }}
       uses: actions/upload-artifact@v4
-      run: |
-        echo "this should only run if the previous one failed, but if: failure() does not work for some reason"
-        jq --slurp '.[] | select(.type == "test" and .event == "failed" ) | .name ' output/libtest.json > output/failures.json
-        rm output/libtest.json
       with:
         name: run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         path: output

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -116,12 +116,12 @@ jobs:
       continue-on-error: true
       run: |
         mkdir -p output
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'ignored-only' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/libtest.json
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'ignored-only' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
-    - name: Filter and upload results
+    - name: upload results
       if: always() && ${{ inputs.flaky }}
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -120,6 +120,13 @@ jobs:
         outputName: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
+    - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: outputs/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+          path: outputs
+          retention-days: 1
+
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -120,7 +120,7 @@ jobs:
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
     - name: Filter and upload results
-      if: always() && {{ inputs.flaky }}
+      if: always() && ${{ inputs.flaky }}
       uses: actions/upload-artifact@v4
       with:
         name: run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -112,6 +112,7 @@ jobs:
 
     - name: run tests
       run: |
+        mkdir -p outputs
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > outputs/${{ env.outputName}}
         ls outputs
         cat outputs/${{ env.outputName }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,9 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [ubuntu-latest]
+        name: [ubuntu-latest, macOS-arm-latest]
         rust: [ '${{ inputs.rust-version }}' ]
-        features: [ default]
+        features: [all, none, default]
         include:
           - name: ubuntu-latest
             os: ubuntu-latest
@@ -137,91 +137,91 @@ jobs:
         fi
         cargo test --workspace --all-features --doc
 
-  # build_and_test_windows:
-  #   timeout-minutes: 30
-  #   name: "Tests"
-  #   runs-on: ${{ matrix.runner }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       name: [windows-latest]
-  #       rust: [ '${{ inputs.rust-version}}' ]
-  #       features: [all, none, default]
-  #       target:
-  #         - x86_64-pc-windows-msvc
-  #       include:
-  #         - name: windows-latest
-  #           os: windows
-  #           runner: [self-hosted, windows, x64]
-  #   env:
-  #     # Using self-hosted runners so use local cache for sccache and
-  #     # not SCCACHE_GHA_ENABLED.
-  #     RUSTC_WRAPPER: "sccache"
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-  #     with:
-  #       ref: ${{ inputs.git-ref }}
-  # 
-  #   - name: Install ${{ matrix.rust }}
-  #     run: |
-  #       rustup toolchain install ${{ matrix.rust }}
-  #       rustup toolchain default ${{ matrix.rust }}
-  #       rustup target add ${{ matrix.target }}
-  #       rustup set default-host ${{ matrix.target }}
-  # 
-  #   - name: Install cargo-nextest
-  #     shell: powershell
-  #     run: |
-  #       $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-  #       Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-  #       $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
-  #       $tmp | Expand-Archive -DestinationPath $outputDir -Force
-  #       $tmp | Remove-Item
-  # 
-  #   - name: Select features
-  #     run: |
-  #       switch ("${{ matrix.features }}") {
-  #           "all" {
-  #               echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           "none" {
-  #               echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           "default" {
-  #               echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-  #           }
-  #           default {
-  #               Exit 1
-  #           }
-  #       }
-  # 
-  #   - name: Install sccache
-  #     uses: mozilla-actions/sccache-action@v0.0.4
-  # 
-  #   - uses: msys2/setup-msys2@v2
-  # 
-  #   - name: build tests
-  #     run: |
-  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
-  # 
-  #   - name: list ignored tests
-  #     run: |
-  #       cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
-  # 
-  #   - name: tests
-  #     run: |
-  #       mkdir -p output
-  #       cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-  #     env:
-  #       RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
-  #       NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
-  # 
-  #   - name: upload results
-  #     if: ${{ failure() && inputs.flaky }}
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-  #       path: output
-  #       retention-days: 1
-  #       compression-level: 0
+  build_and_test_windows:
+    timeout-minutes: 30
+    name: "Tests"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [windows-latest]
+        rust: [ '${{ inputs.rust-version}}' ]
+        features: [all, none, default]
+        target:
+          - x86_64-pc-windows-msvc
+        include:
+          - name: windows-latest
+            os: windows
+            runner: [self-hosted, windows, x64]
+    env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.git-ref }}
+
+    - name: Install ${{ matrix.rust }}
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup toolchain default ${{ matrix.rust }}
+        rustup target add ${{ matrix.target }}
+        rustup set default-host ${{ matrix.target }}
+
+    - name: Install cargo-nextest
+      shell: powershell
+      run: |
+        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+        $tmp | Expand-Archive -DestinationPath $outputDir -Force
+        $tmp | Remove-Item
+
+    - name: Select features
+      run: |
+        switch ("${{ matrix.features }}") {
+            "all" {
+                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "none" {
+                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "default" {
+                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            default {
+                Exit 1
+            }
+        }
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.4
+
+    - uses: msys2/setup-msys2@v2
+
+    - name: build tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+
+    - name: list ignored tests
+      run: |
+        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+
+    - name: tests
+      run: |
+        mkdir -p output
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+  
+    - name: upload results
+      if: ${{ failure() && inputs.flaky }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        path: output
+        retention-days: 1
+        compression-level: 0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -124,7 +124,7 @@ jobs:
       with:
         name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         path: output
-        retention-days: 1
+        retention-days: 45
         compression-level: 0
 
     - name: doctests

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -43,7 +43,11 @@ fn make_rand_file(size: usize, path: &Path) -> Result<Hash> {
 #[test]
 #[ignore = "flaky"]
 fn cli_provide_one_file_basic() -> Result<()> {
-    panic!("quick failures")
+    let dir = testdir!();
+    let path = dir.join("foo");
+    make_rand_file(1000, &path)?;
+    // provide a path to a file, do not pipe from stdin, do not pipe to stdout
+    test_provide_get_loop(Input::Path(path), Output::Path)
 }
 
 #[test]

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -43,11 +43,7 @@ fn make_rand_file(size: usize, path: &Path) -> Result<Hash> {
 #[test]
 #[ignore = "flaky"]
 fn cli_provide_one_file_basic() -> Result<()> {
-    let dir = testdir!();
-    let path = dir.join("foo");
-    make_rand_file(1000, &path)?;
-    // provide a path to a file, do not pipe from stdin, do not pipe to stdout
-    test_provide_get_loop(Input::Path(path), Output::Path)
+    panic!("quick failures")
 }
 
 #[test]

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -53,11 +53,12 @@ fn cli_provide_one_file_basic() -> Result<()> {
 #[test]
 #[ignore = "flaky"]
 fn cli_provide_one_file_large() -> Result<()> {
-    let dir = testdir!();
-    let path = dir.join("foo");
-    make_rand_file(1024 * 1024 * 1024, &path)?;
-    // provide a path to a file, do not pipe from stdin, do not pipe to stdout
-    test_provide_get_loop(Input::Path(path), Output::Path)
+    panic!("need something failing quickly")
+    // let dir = testdir!();
+    // let path = dir.join("foo");
+    // make_rand_file(1024 * 1024 * 1024, &path)?;
+    // // provide a path to a file, do not pipe from stdin, do not pipe to stdout
+    // test_provide_get_loop(Input::Path(path), Output::Path)
 }
 
 /// Test single file download to a path

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -53,12 +53,11 @@ fn cli_provide_one_file_basic() -> Result<()> {
 #[test]
 #[ignore = "flaky"]
 fn cli_provide_one_file_large() -> Result<()> {
-    panic!("need something failing quickly")
-    // let dir = testdir!();
-    // let path = dir.join("foo");
-    // make_rand_file(1024 * 1024 * 1024, &path)?;
-    // // provide a path to a file, do not pipe from stdin, do not pipe to stdout
-    // test_provide_get_loop(Input::Path(path), Output::Path)
+    let dir = testdir!();
+    let path = dir.join("foo");
+    make_rand_file(1024 * 1024 * 1024, &path)?;
+    // provide a path to a file, do not pipe from stdin, do not pipe to stdout
+    test_provide_get_loop(Input::Path(path), Output::Path)
 }
 
 /// Test single file download to a path


### PR DESCRIPTION
## Description

Modifies the `flaky` workflow to generate a report with all the tests that failed per matrix combo, so that we can receive it on discord. This requires to modify the `tests` workflow as well to generate `libtest` json reports.

Reports are uploaded as job artifacts with an unique name, and retained for a day.

From my last commit at the time of writing, this is the report we get:
```md
Flaky tests failure:

- **ubuntu-latest all stable**
iroh-net::iroh_net::discovery::local_swarm_discovery::tests::test_local_swarm_discovery
ubuntu-latest default stable
iroh-cli::cli::cli_bao_store_migration
- **windows-latest all stable**
iroh-cli::cli::cli_provide_file_resume
iroh-cli::cli::cli_provide_tree_resume
- **windows-latest default stable**
iroh-cli::cli::cli_provide_file_resume
iroh-cli::cli::cli_provide_tree_resume
- **windows-latest none stable**
iroh-cli::cli::cli_provide_tree_resume
iroh-cli::cli::cli_provide_file_resume

See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
```
which reads clear enough in discord imo

## Breaking Changes
n/a

## Notes & open questions

- there is another test report which is more widely used but for which there is not a single decent parser I could find. The format is Jenkins' junit xml format. From my searches, everyone knows how to produce these files, but not how to read them. Since this is xml, which is not exactly compatible with serde, reading these kind of files was a task I considered not worth doing for what we actually want to achieve, which is simply more visibility over flaky tests.
- That being said, `libtest` format is not stable, and the `nextest` feature to obtain it is unstable as well. It does not seem to change quickly or drastically at all, so I think we will be fine for some time. Being json the underlying format, it should be easy to adapt if necessary.

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [ ] ~~Tests if relevant.~~
- [ ] ~~All breaking changes documented.~~
