### PR TITLE
deps(bytes): bytes v1.6.0 was yanked so upgrade to bytes v1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,9 +534,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
GitHub Actions `cargo deny` is failing at https://github.com/n0-computer/iroh/actions/runs/9928231752/job/27438879671

% `cargo update -p bytes`
```
    Updating crates.io index
     Locking 1 package to latest compatible version
    Updating bytes v1.6.0 -> v1.6.1
note: pass `--verbose` to see 152 unchanged dependencies behind latest
```
https://github.com/tokio-rs/bytes/blob/master/CHANGELOG.md to get the fix in
* tokio-rs/bytes#718
## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
