### PR TITLE
refactor(iroh-net)!: Move relay implemention in `iroh-net` behind `iroh-relay` cfg flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
  "synstructure 0.13.1",
 ]
 
@@ -238,7 +238,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -249,7 +249,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -298,7 +298,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -349,7 +349,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
@@ -586,18 +586,18 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.106"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 
 [[package]]
 name = "cfg-if"
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.8"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.8"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -700,7 +700,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1047,7 +1047,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1071,7 +1071,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1082,7 +1082,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1151,7 +1151,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
  "unicode-xid",
 ]
 
@@ -1264,7 +1264,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1424,7 +1424,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1437,7 +1437,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1457,7 +1457,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1713,7 +1713,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2220,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2261,7 +2261,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.10",
  "rustls-pki-types",
@@ -2282,7 +2282,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2302,7 +2302,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -2667,7 +2667,7 @@ dependencies = [
  "lru",
  "mainline",
  "parking_lot",
- "pkarr 2.0.3",
+ "pkarr 2.1.0",
  "rcgen 0.12.1",
  "redb 2.1.1",
  "regex",
@@ -2783,7 +2783,7 @@ dependencies = [
  "anyhow",
  "erased_set",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "once_cell",
  "prometheus-client",
@@ -2799,7 +2799,6 @@ dependencies = [
 name = "iroh-net"
 version = "0.20.0"
 dependencies = [
- "aead",
  "anyhow",
  "axum",
  "backoff",
@@ -2824,11 +2823,12 @@ dependencies = [
  "hostname",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "igd-next",
  "iroh-base",
  "iroh-metrics",
+ "iroh-net",
  "iroh-quinn",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
@@ -2843,7 +2843,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pin-project",
- "pkarr 2.0.3",
+ "pkarr 2.1.0",
  "postcard",
  "pretty_assertions",
  "proptest",
@@ -3502,7 +3502,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3722,7 +3722,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3753,7 +3753,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3786,9 +3786,9 @@ dependencies = [
 
 [[package]]
 name = "pkarr"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f9e12544b00f5561253bbd3cb72a85ff3bc398483dc1bf82bdf095c774136b"
+checksum = "4548c673cbf8c91b69f7a17d3a042710aa73cffe5e82351db5378f26c3be64d8"
 dependencies = [
  "bytes",
  "document-features",
@@ -3878,7 +3878,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4089,7 +4089,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4475,7 +4475,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4593,7 +4593,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
@@ -5026,7 +5026,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5082,9 +5082,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.3"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73139bc5ec2d45e6c5fd85be5a46949c1c39a4c18e56915f5eb4c12f975e377"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5100,14 +5100,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.3"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80d3d6b56b64335c0180e5ffde23b3c5e08c14c585b51a15bd0e95393f46703"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5348,7 +5348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5395,7 +5395,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5413,7 +5413,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5424,7 +5424,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5455,7 +5455,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5468,7 +5468,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5545,9 +5545,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.69"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201fcda3845c23e8212cd466bfebf0bd20694490fc0356ae8e428e0824a915a6"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5597,7 +5597,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5683,7 +5683,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5723,7 +5723,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5781,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6b6a2fb3a985e99cebfaefa9faa3024743da73304ca1c683a36429613d3d22"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5821,7 +5821,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6086,7 +6086,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6389,7 +6389,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -6423,7 +6423,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6590,7 +6590,7 @@ checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6601,7 +6601,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6612,7 +6612,7 @@ checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6623,7 +6623,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6932,7 +6932,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -16,8 +16,6 @@ rust-version = "1.76"
 workspace = true
 
 [dependencies]
-axum = { version = "0.7.4", optional = true }
-aead = { version = "0.5.2", features = ["bytes"] }
 anyhow = { version = "1" }
 base64 = "0.22.1"
 backoff = "0.4.0"
@@ -68,7 +66,6 @@ thiserror = "1"
 time = "0.3.20"
 tokio = { version = "1", features = ["io-util", "macros", "sync", "rt", "net", "fs", "io-std", "signal", "process"] }
 tokio-rustls = { version = "0.24" }
-tokio-rustls-acme = { version = "0.3" }
 tokio-tungstenite = "0.21"
 tokio-tungstenite-wasm = "0.3"
 tokio-util = { version = "0.7", features = ["io-util", "io", "codec"] }
@@ -82,12 +79,14 @@ x509-parser = "0.15"
 z32 = "1.0.3"
 
 # iroh-relay
+axum = { version = "0.7.4", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 regex = { version = "1.7.1", optional = true }
 rustls-pemfile = { version = "1.0.2", optional = true }
 serde_with = { version = "3.3", optional = true }
 toml = { version = "0.8", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+tokio-rustls-acme = { version = "0.3", optional = true }
 
 # metrics
 iroh-metrics = { version = "0.20.0", path = "../iroh-metrics", default-features = false }
@@ -116,6 +115,7 @@ testdir = "0.9.1"
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 iroh-test = { path = "../iroh-test" }
+iroh-net = { path = ".", features = ["iroh-relay"] }
 serde_json = "1.0.107"
 testresult = "0.4.0"
 
@@ -128,9 +128,18 @@ duct = "0.13.6"
 
 [features]
 default = ["metrics"]
-iroh-relay = ["clap", "toml", "rustls-pemfile", "regex", "serde_with", "tracing-subscriber"]
+iroh-relay = [
+    "dep:tokio-rustls-acme",
+    "dep:axum",
+    "clap",
+    "toml",
+    "rustls-pemfile",
+    "regex",
+    "serde_with",
+    "tracing-subscriber"
+]
 metrics = ["iroh-metrics/metrics"]
-test-utils = ["axum"]
+test-utils = ["dep:axum", "iroh-relay"]
 local_swarm_discovery = ["swarm-discovery"]
 
 [[bin]]

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -131,16 +131,16 @@ default = ["metrics"]
 iroh-relay = [
     "dep:tokio-rustls-acme",
     "dep:axum",
-    "clap",
-    "toml",
-    "rustls-pemfile",
-    "regex",
-    "serde_with",
-    "tracing-subscriber"
+    "dep:clap",
+    "dep:toml",
+    "dep:rustls-pemfile",
+    "dep:regex",
+    "dep:serde_with",
+    "dep:tracing-subscriber"
 ]
 metrics = ["iroh-metrics/metrics"]
-test-utils = ["dep:axum", "iroh-relay"]
-local_swarm_discovery = ["swarm-discovery"]
+test-utils = ["iroh-relay"]
+local_swarm_discovery = ["dep:swarm-discovery"]
 
 [[bin]]
 name = "iroh-relay"

--- a/iroh-net/src/relay.rs
+++ b/iroh-net/src/relay.rs
@@ -15,6 +15,7 @@ pub(crate) mod client_conn;
 pub(crate) mod clients;
 pub(crate) mod codec;
 pub mod http;
+#[cfg(feature = "iroh-relay")]
 pub mod iroh_relay;
 mod map;
 mod metrics;

--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -41,7 +41,7 @@ pub enum Protocol {
 }
 
 impl Protocol {
-    /// The HTTP upgrade header used or expected
+    /// The HTTP upgrade header used or expected.
     pub const fn upgrade_header(&self) -> &'static str {
         match self {
             Protocol::Relay => HTTP_UPGRADE_PROTOCOL,

--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -2,14 +2,17 @@
 //! upgrades.
 //!
 mod client;
+#[cfg(feature = "iroh-relay")]
 mod server;
 pub(crate) mod streams;
 
 pub use self::client::{Client, ClientBuilder, ClientError, ClientReceiver};
-pub use self::server::{Protocol, Server, ServerBuilder, ServerHandle, TlsAcceptor, TlsConfig};
+#[cfg(feature = "iroh-relay")]
+pub use self::server::{Server, ServerBuilder, ServerHandle, TlsAcceptor, TlsConfig};
 
 pub(crate) const HTTP_UPGRADE_PROTOCOL: &str = "iroh derp http";
 pub(crate) const WEBSOCKET_UPGRADE_PROTOCOL: &str = "websocket";
+#[cfg(feature = "iroh-relay")] // only used in the server for now
 pub(crate) const SUPPORTED_WEBSOCKET_VERSION: &str = "13";
 
 /// The HTTP path under which the relay accepts relaying connections
@@ -19,10 +22,45 @@ pub const RELAY_PATH: &str = "/relay";
 pub const RELAY_PROBE_PATH: &str = "/relay/probe";
 /// The legacy HTTP path under which the relay used to accept relaying connections.
 /// We keep this for backwards compatibility.
+#[cfg(feature = "iroh-relay")] // legacy paths only used on server-side for backwards compat
 pub(crate) const LEGACY_RELAY_PATH: &str = "/derp";
 /// The legacy HTTP path under which the relay used to allow latency queries.
 /// We keep this for backwards compatibility.
+#[cfg(feature = "iroh-relay")] // legacy paths only used on server-side for backwards compat
 pub(crate) const LEGACY_RELAY_PROBE_PATH: &str = "/derp/probe";
+
+/// The HTTP upgrade protocol used for relaying.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Protocol {
+    /// Relays over the custom relaying protocol with a custom HTTP upgrade header.
+    Relay,
+    /// Relays over websockets.
+    ///
+    /// Originally introduced to support browser connections.
+    Websocket,
+}
+
+impl Protocol {
+    /// The HTTP upgrade header used or expected
+    pub const fn upgrade_header(&self) -> &'static str {
+        match self {
+            Protocol::Relay => HTTP_UPGRADE_PROTOCOL,
+            Protocol::Websocket => WEBSOCKET_UPGRADE_PROTOCOL,
+        }
+    }
+
+    /// Tries to match the value of an HTTP upgrade header to figure out which protocol should be initiated.
+    pub fn parse_header(header: &http::HeaderValue) -> Option<Self> {
+        let header_bytes = header.as_bytes();
+        if header_bytes == Protocol::Relay.upgrade_header().as_bytes() {
+            Some(Protocol::Relay)
+        } else if header_bytes == Protocol::Websocket.upgrade_header().as_bytes() {
+            Some(Protocol::Websocket)
+        } else {
+            None
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/iroh-net/src/relay/http/client.rs
+++ b/iroh-net/src/relay/http/client.rs
@@ -39,8 +39,8 @@ use crate::relay::{
 use crate::util::chain;
 use crate::util::AbortingJoinHandle;
 
-use super::server::Protocol;
 use super::streams::ProxyStream;
+use super::Protocol;
 
 const DIAL_NODE_TIMEOUT: Duration = Duration::from_millis(1500);
 const PING_TIMEOUT: Duration = Duration::from_secs(5);

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -23,13 +23,11 @@ use tracing::{debug, debug_span, error, info, info_span, warn, Instrument};
 use tungstenite::handshake::derive_accept_key;
 
 use crate::key::SecretKey;
-use crate::relay::http::{
-    HTTP_UPGRADE_PROTOCOL, SUPPORTED_WEBSOCKET_VERSION, WEBSOCKET_UPGRADE_PROTOCOL,
-};
+use crate::relay::http::SUPPORTED_WEBSOCKET_VERSION;
 use crate::relay::server::{ClientConnHandler, MaybeTlsStream};
 use crate::relay::MaybeTlsStreamServer;
 
-use super::{LEGACY_RELAY_PATH, RELAY_PATH};
+use super::{Protocol, LEGACY_RELAY_PATH, RELAY_PATH};
 
 type BytesBody = http_body_util::Full<hyper::body::Bytes>;
 type HyperError = Box<dyn std::error::Error + Send + Sync>;
@@ -60,54 +58,21 @@ fn downcast_upgrade(upgraded: Upgraded) -> Result<(MaybeTlsStream, Bytes)> {
     }
 }
 
-/// The HTTP upgrade protocol used for relaying.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Protocol {
-    /// Relays over the custom relaying protocol with a custom HTTP upgrade header.
-    Relay,
-    /// Relays over websockets.
-    ///
-    /// Originally introduced to support browser connections.
-    Websocket,
-}
+/// The server HTTP handler to do HTTP upgrades
+async fn relay_connection_handler(
+    protocol: Protocol,
+    conn_handler: &ClientConnHandler,
+    upgraded: Upgraded,
+) -> Result<()> {
+    debug!(?protocol, "relay_connection upgraded");
+    let (io, read_buf) = downcast_upgrade(upgraded)?;
+    ensure!(
+        read_buf.is_empty(),
+        "can not deal with buffered data yet: {:?}",
+        read_buf
+    );
 
-impl Protocol {
-    /// The HTTP upgrade header used or expected
-    pub const fn upgrade_header(&self) -> &'static str {
-        match self {
-            Protocol::Relay => HTTP_UPGRADE_PROTOCOL,
-            Protocol::Websocket => WEBSOCKET_UPGRADE_PROTOCOL,
-        }
-    }
-
-    /// Tries to match the value of an HTTP upgrade header to figure out which protocol should be initiated.
-    pub fn parse_header(header: &HeaderValue) -> Option<Self> {
-        let header_bytes = header.as_bytes();
-        if header_bytes == Protocol::Relay.upgrade_header().as_bytes() {
-            Some(Protocol::Relay)
-        } else if header_bytes == Protocol::Websocket.upgrade_header().as_bytes() {
-            Some(Protocol::Websocket)
-        } else {
-            None
-        }
-    }
-
-    /// The server HTTP handler to do HTTP upgrades
-    async fn relay_connection_handler(
-        self,
-        conn_handler: &ClientConnHandler,
-        upgraded: Upgraded,
-    ) -> Result<()> {
-        debug!(protocol = ?self, "relay_connection upgraded");
-        let (io, read_buf) = downcast_upgrade(upgraded)?;
-        ensure!(
-            read_buf.is_empty(),
-            "can not deal with buffered data yet: {:?}",
-            read_buf
-        );
-
-        conn_handler.accept(self, io).await
-    }
+    conn_handler.accept(protocol, io).await
 }
 
 /// The Relay HTTP server.
@@ -487,9 +452,12 @@ impl Service<Request<Incoming>> for ClientConnHandler {
                     async move {
                         match hyper::upgrade::on(&mut req).await {
                             Ok(upgraded) => {
-                                if let Err(e) = protocol
-                                    .relay_connection_handler(&closure_conn_handler, upgraded)
-                                    .await
+                                if let Err(e) = relay_connection_handler(
+                                    protocol,
+                                    &closure_conn_handler,
+                                    upgraded,
+                                )
+                                .await
                                 {
                                     warn!(
                                         "upgrade to \"{}\": io error: {:?}",

--- a/iroh-net/src/relay/http/server.rs
+++ b/iroh-net/src/relay/http/server.rs
@@ -58,7 +58,7 @@ fn downcast_upgrade(upgraded: Upgraded) -> Result<(MaybeTlsStream, Bytes)> {
     }
 }
 
-/// The server HTTP handler to do HTTP upgrades
+/// The server HTTP handler to do HTTP upgrades.
 async fn relay_connection_handler(
     protocol: Protocol,
     conn_handler: &ClientConnHandler,


### PR DESCRIPTION
## Description

We had an `iroh-relay` cfg flag, but it was unused.

Enabling it is useful for working towards building iroh-net for Wasm (we won't be able to compile the server bits to Wasm, sorry :stuck_out_tongue:  )

This moves the `axum` and `tokio-rustls-acme` dependencies behind that feature flag as well as the modules `iroh_net::relay::http::server` and `iroh_net::relay::iroh_relay`.

I also had to move the `relay::http::server::Protocol` one module up.

## Breaking Changes

- iroh-relay *implementation*-specific features are now behind an `iroh-relay` feature flag in iroh-net.

## Notes & open questions

LMK!

## Change checklist

- [X] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~ I ran `cargo test -p iroh-net`. That enables the `iroh-relay` feature and runs successfully.
- [X] All breaking changes documented.
