### PR TITLE
fix: docker image builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,112 @@
+name: Docker
+
+on:
+    workflow_dispatch:
+      inputs:
+        release_version:
+          description: "Release version"
+          required: true
+          type: string
+          default: ""
+        base_hash:
+          description: "Commit hash from which to build"
+          required: true
+          type: string
+          default: ""
+        publish:
+          description: "Publish to Docker Hub"
+          required: true
+          type: boolean
+          default: false
+    workflow_call:
+      inputs:
+        release_version:
+          description: "Release version"
+          required: true
+          type: string
+          default: ""
+        base_hash:
+          description: "Commit hash from which to build"
+          required: true
+          type: string
+          default: ""
+        publish:
+          description: "Publish to Docker Hub"
+          required: true
+          type: boolean
+          default: false
+
+jobs:
+    build_and_publish:
+      timeout-minutes: 30
+      name: Docker
+      runs-on: [self-hosted, linux, X64]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+
+        - name: Login to Docker Hub
+          uses: docker/login-action@v3
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+        
+        - name: Prep dirs
+          run: |
+            mkdir -p bins/linux/amd64
+            mkdir -p bins/linux/arm64
+
+        - name: Setup awscli on linux
+          run: |
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            sudo ./aws/install --update
+    
+        - name: Set aws credentials
+          run: |
+              echo "AWS_ACCESS_KEY_ID=${{secrets.S3_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+              echo "AWS_SECRET_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}" >> $GITHUB_ENV
+              echo "AWS_DEFAULT_REGION=us-west-2" >> $GITHUB_ENV
+
+        - name: Fetch release binaries
+          run: |
+            aws s3 cp s3://vorc/iroh-linux-amd64-${{ github.event.inputs.base_hash }} bins/linux/amd64/iroh
+            aws s3 cp s3://vorc/iroh-relay-linux-amd64-${{ github.event.inputs.base_hash }} bins/linux/amd64/iroh-relay
+            aws s3 cp s3://vorc/iroh-dns-server-linux-amd64-${{ github.event.inputs.base_hash }} bins/linux/amd64/iroh-dns-server
+
+            aws s3 cp s3://vorc/iroh-linux-aarch64-${{ github.event.inputs.base_hash }} bins/linux/arm64/iroh
+            aws s3 cp s3://vorc/iroh-relay-linux-aarch64-${{ github.event.inputs.base_hash }} bins/linux/arm64/iroh-relay
+            aws s3 cp s3://vorc/iroh-dns-server-linux-aarch64-${{ github.event.inputs.base_hash }} bins/linux/arm64/iroh-dns-server
+
+        - name: Build Docker image (iroh)
+          uses: docker/build-push-action@v6
+          with:
+            context: .
+            push: true
+            tags: n0computer/iroh:latest,n0computer/iroh:${{ github.event.inputs.release_version }}
+            target: iroh
+            platforms: linux/amd64,linux/arm64/v8
+            file: docker/Dockerfile.ci
+        
+        - name: Build Docker image (iroh-relay)
+          uses: docker/build-push-action@v6
+          with:
+            context: .
+            push: true
+            tags: n0computer/iroh-relay:latest,n0computer/iroh-relay:${{ github.event.inputs.release_version }}
+            target: iroh-relay
+            platforms: linux/amd64,linux/arm64/v8
+            file: docker/Dockerfile.ci
+
+        - name: Build Docker image (iroh-dns-server)
+          uses: docker/build-push-action@v6
+          with:
+            context: .
+            push: true
+            tags: n0computer/iroh-dns-server:latest,n0computer/iroh-dns-server:${{ github.event.inputs.release_version }}
+            target: iroh-dns-server
+            platforms: linux/amd64,linux/arm64/v8
+            file: docker/Dockerfile.ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,9 @@ jobs:
         name: Build release binaries
         needs: create-release
         runs-on: ${{ matrix.runner }}
+        outputs:
+          release_version: ${{ needs.create-release.outputs.release_version }}
+          base_hash: ${{ steps.define_hash.outputs.base_hash }}
         continue-on-error: false
         strategy:
           fail-fast: false
@@ -126,6 +129,12 @@ jobs:
           run: |
             echo "RELEASE_ARCH=${{ matrix.release-arch }}" >> $GITHUB_ENV
             echo "RELEASE_OS=${{ matrix.release-os }}" >> $GITHUB_ENV
+        
+        - name: Define hash
+          if: matrix.os == 'ubuntu-latest'
+          id: define_hash
+          run: |
+            echo "base_hash=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
         - name: Ensure musl support
           if: ${{ contains(matrix.cargo_targets, '-musl') }}
@@ -255,76 +264,10 @@ jobs:
             asset_path: ${{ env.ASSET }}
 
     docker:
-      timeout-minutes: 30
       needs: build_release
-      name: Docker
-      runs-on: [self-hosted, linux, X64]
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
-
-        - name: Login to Docker Hub
-          uses: docker/login-action@v3
-          with:
-            username: ${{ secrets.DOCKERHUB_USERNAME }}
-            password: ${{ secrets.DOCKERHUB_TOKEN }}
+      uses: './.github/workflows/docker.yaml'
+      with:
+        release_version: ${{ needs.build_release.outputs.release_version }}
+        base_hash: ${{ needs.build_release.outputs.base_hash }}
+        publish: true
         
-        - name: Prep dirs
-          run: |
-            mkdir -p bins/linux/amd64
-            mkdir -p bins/linux/arm64
-
-        - name: Setup awscli on linux
-          run: |
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-            unzip awscliv2.zip
-            sudo ./aws/install --update
-    
-        - name: Set aws credentials
-          run: |
-              echo "AWS_ACCESS_KEY_ID=${{secrets.S3_ACCESS_KEY_ID}}" >> $GITHUB_ENV
-              echo "AWS_SECRET_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}" >> $GITHUB_ENV
-              echo "AWS_DEFAULT_REGION=us-west-2" >> $GITHUB_ENV
-
-        - name: Fetch release binaries
-          run: |
-            aws s3 cp s3://vorc/iroh-linux-amd64-${GITHUB_SHA::7} bins/linux/amd64/iroh
-            aws s3 cp s3://vorc/iroh-relay-linux-amd64-${GITHUB_SHA::7} bins/linux/amd64/iroh-relay
-            aws s3 cp s3://vorc/iroh-dns-server-linux-amd64-${GITHUB_SHA::7} bins/linux/amd64/iroh-dns-server
-
-            aws s3 cp s3://vorc/iroh-linux-aarch64-${GITHUB_SHA::7} bins/linux/arm64/iroh
-            aws s3 cp s3://vorc/iroh-relay-linux-aarch64-${GITHUB_SHA::7} bins/linux/arm64/iroh-relay
-            aws s3 cp s3://vorc/iroh-dns-server-linux-aarch64-${GITHUB_SHA::7} bins/linux/arm64/iroh-dns-server
-
-        - name: Build Docker image (iroh)
-          uses: docker/build-push-action@v6
-          with:
-            context: .
-            push: true
-            tags: n0computer/iroh:latest,n0computer/iroh:${{ needs.create-release.outputs.release_version }}
-            target: iroh
-            platforms: linux/amd64,linux/arm64/v8
-            file: docker/Dockerfile.ci
-        
-        - name: Build Docker image (iroh-relay)
-          uses: docker/build-push-action@v6
-          with:
-            context: .
-            push: true
-            tags: n0computer/iroh-relay:latest,n0computer/iroh-relay:${{ needs.create-release.outputs.release_version }}
-            target: iroh-relay
-            platforms: linux/amd64,linux/arm64/v8
-            file: docker/Dockerfile.ci
-
-        - name: Build Docker image (iroh-dns-server)
-          uses: docker/build-push-action@v6
-          with:
-            context: .
-            push: true
-            tags: n0computer/iroh-dns-server:latest,n0computer/iroh-dns-server:${{ needs.create-release.outputs.release_version }}
-            target: iroh-dns-server
-            platforms: linux/amd64,linux/arm64/v8
-            file: docker/Dockerfile.ci


### PR DESCRIPTION
## Description

This will allow us to trigger manual builds (we can re-build old releases) and should fix the issue moving forward with building the docker images. 

The original failure in https://github.com/n0-computer/iroh/actions/runs/10046498425/job/27766736564 was due to the fact that the `needs` variables are not propagated down the graph but only seem to be directly passed from parent to child.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
