### PR TITLE
fix(iroh-blobs): use async_channel instead of flume for local_pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1525,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener 5.3.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,6 +2576,7 @@ name = "iroh-blobs"
 version = "0.21.0"
 dependencies = [
  "anyhow",
+ "async-channel",
  "bao-tree",
  "bytes",
  "chrono",
@@ -6461,7 +6495,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45b42a2f611916b5965120a9cde2b60f2db4454826dd9ad5e6f47c24a5b3b259"
 dependencies = [
- "event-listener",
+ "event-listener 4.0.3",
  "futures-util",
  "parking_lot",
  "thiserror",

--- a/iroh-blobs/Cargo.toml
+++ b/iroh-blobs/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
+async-channel = "2.3.1"
 bao-tree = {  version = "0.13", features = ["tokio_fsm", "validate"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"

--- a/iroh-blobs/src/util/local_pool.rs
+++ b/iroh-blobs/src/util/local_pool.rs
@@ -247,7 +247,7 @@ impl LocalPool {
 
     /// Immediately stop polling all tasks and wait for all threads to finish.
     ///
-    /// This is like droo, but waits for thread completion asynchronously.
+    /// This is like drop, but waits for thread completion asynchronously.
     ///
     /// If there was a panic on any of the threads, it will be re-thrown here.
     pub async fn shutdown(self) {
@@ -270,7 +270,6 @@ impl LocalPool {
         // we assume that there are exactly as many threads as there are handles.
         // also, we assume that the threads are still running.
         for _ in 0..self.threads_u32() {
-            println!("sending shutdown message");
             // send the shutdown message
             // sending will fail if all threads are already finished, but
             // in that case we don't need to do anything.


### PR DESCRIPTION
## Description

During soft shutdown of the local pool, a Finish message is sent to all threads. On main, this occasionally hangs. Further investigation showed that this is a message that is being sent but not received despite being in the channel. Adding a simple timeout to the select! so the flume recv call is executed again fixes it.

So it seems that there is a bug in flume that occasionally leads to notifications being dropped.

This PR just does a 1:1 replacement of flume with async_channel.

Before this change, I can get the test_shutdown test to fail easily by running it 1000 times:

```
for i in $(seq 1 1000); do cargo test --release -p iroh-blobs test_shutdown -- --nocapture >> log.txt; done
```

Result:
```
...
sending shutdown message
sending shutdown message
sending shutdown message
sending shutdown message
test util::local_pool::tests::test_shutdown has been running for over 60 seconds
```

After this change, I can not get test_finish (renamed because it tests finish, not shutdown) to fail at all even after several 1000 tests.

## Breaking Changes

None

## Notes & open questions

Can somebody talk me out of this? I would prefer to keep flume, but the evidence above seems conclusive...

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
