### PR TITLE
refactor(iroh-net): replace flume in iroh-net with async_channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2836,6 +2836,7 @@ name = "iroh-net"
 version = "0.21.0"
 dependencies = [
  "anyhow",
+ "async-channel",
  "axum",
  "backoff",
  "base64 0.22.1",
@@ -2846,7 +2847,6 @@ dependencies = [
  "der",
  "derive_more",
  "duct",
- "flume",
  "futures-buffered",
  "futures-concurrency",
  "futures-lite 2.3.0",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -17,13 +17,13 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
+async-channel = "2.3.1"
 base64 = "0.22.1"
 backoff = "0.4.0"
 bytes = "1"
 netdev = "0.30.0"
 der = { version = "0.7", features = ["alloc", "derive"] }
 derive_more = { version = "1.0.0-beta.6", features = ["debug", "display", "from", "try_into", "deref"] }
-flume = "0.11"
 futures-buffered = "0.2.4"
 futures-concurrency = "7.6.0"
 futures-lite = "2.3"

--- a/iroh-net/src/net/netmon/actor.rs
+++ b/iroh-net/src/net/netmon/actor.rs
@@ -57,7 +57,7 @@ pub(super) struct Actor {
     /// OS specific monitor.
     #[allow(dead_code)]
     route_monitor: RouteMonitor,
-    mon_receiver: flume::Receiver<NetworkMessage>,
+    mon_receiver: async_channel::Receiver<NetworkMessage>,
     actor_receiver: mpsc::Receiver<ActorMessage>,
     actor_sender: mpsc::Sender<ActorMessage>,
     /// Callback registry.
@@ -84,7 +84,7 @@ impl Actor {
         let wall_time = Instant::now();
 
         // Use flume channels, as tokio::mpsc is not safe to use across ffi boundaries.
-        let (mon_sender, mon_receiver) = flume::bounded(MON_CHAN_CAPACITY);
+        let (mon_sender, mon_receiver) = async_channel::bounded(MON_CHAN_CAPACITY);
         let route_monitor = RouteMonitor::new(mon_sender)?;
         let (actor_sender, actor_receiver) = mpsc::channel(ACTOR_CHAN_CAPACITY);
 
@@ -129,7 +129,7 @@ impl Actor {
                         debounce_interval.reset_immediately();
                     }
                 }
-                Ok(_event) = self.mon_receiver.recv_async() => {
+                Ok(_event) = self.mon_receiver.recv() => {
                     trace!("network activity detected");
                     last_event.replace(false);
                     debounce_interval.reset_immediately();

--- a/iroh-net/src/net/netmon/android.rs
+++ b/iroh-net/src/net/netmon/android.rs
@@ -6,7 +6,7 @@ use super::actor::NetworkMessage;
 pub(super) struct RouteMonitor {}
 
 impl RouteMonitor {
-    pub(super) fn new(_sender: flume::Sender<NetworkMessage>) -> Result<Self> {
+    pub(super) fn new(_sender: async_channel::Sender<NetworkMessage>) -> Result<Self> {
         // Very sad monitor. Android doesn't allow us to do this
 
         Ok(RouteMonitor {})

--- a/iroh-net/src/net/netmon/bsd.rs
+++ b/iroh-net/src/net/netmon/bsd.rs
@@ -23,7 +23,7 @@ impl Drop for RouteMonitor {
 }
 
 impl RouteMonitor {
-    pub(super) fn new(sender: flume::Sender<NetworkMessage>) -> Result<Self> {
+    pub(super) fn new(sender: async_channel::Sender<NetworkMessage>) -> Result<Self> {
         let socket = socket2::Socket::new(libc::AF_ROUTE.into(), socket2::Type::RAW, None)?;
         socket.set_nonblocking(true)?;
         let socket_std: std::os::unix::net::UnixStream = socket.into();
@@ -44,7 +44,7 @@ impl RouteMonitor {
                         ) {
                             Ok(msgs) => {
                                 if contains_interesting_message(&msgs) {
-                                    sender.send_async(NetworkMessage::Change).await.ok();
+                                    sender.send(NetworkMessage::Change).await.ok();
                                 }
                             }
                             Err(err) => {

--- a/iroh-net/src/net/netmon/linux.rs
+++ b/iroh-net/src/net/netmon/linux.rs
@@ -49,7 +49,7 @@ macro_rules! get_nla {
 }
 
 impl RouteMonitor {
-    pub(super) fn new(sender: flume::Sender<NetworkMessage>) -> Result<Self> {
+    pub(super) fn new(sender: async_channel::Sender<NetworkMessage>) -> Result<Self> {
         let (mut conn, mut _handle, mut messages) = new_connection()?;
 
         // Specify flags to listen on.
@@ -87,7 +87,7 @@ impl RouteMonitor {
                                     continue;
                                 } else {
                                     addrs.insert(addr.clone());
-                                    sender.send_async(NetworkMessage::Change).await.ok();
+                                    sender.send(NetworkMessage::Change).await.ok();
                                 }
                             }
                         }
@@ -97,7 +97,7 @@ impl RouteMonitor {
                             if let Some(addr) = get_nla!(msg, address::Nla::Address) {
                                 addrs.remove(addr);
                             }
-                            sender.send_async(NetworkMessage::Change).await.ok();
+                            sender.send(NetworkMessage::Change).await.ok();
                         }
                         RtnlMessage::NewRoute(msg) | RtnlMessage::DelRoute(msg) => {
                             trace!("ROUTE:: {:?}", msg);
@@ -124,15 +124,15 @@ impl RouteMonitor {
                                     }
                                 }
                             }
-                            sender.send_async(NetworkMessage::Change).await.ok();
+                            sender.send(NetworkMessage::Change).await.ok();
                         }
                         RtnlMessage::NewRule(msg) => {
                             trace!("NEWRULE: {:?}", msg);
-                            sender.send_async(NetworkMessage::Change).await.ok();
+                            sender.send(NetworkMessage::Change).await.ok();
                         }
                         RtnlMessage::DelRule(msg) => {
                             trace!("DELRULE: {:?}", msg);
-                            sender.send_async(NetworkMessage::Change).await.ok();
+                            sender.send(NetworkMessage::Change).await.ok();
                         }
                         RtnlMessage::NewLink(msg) => {
                             trace!("NEWLINK: {:?}", msg);

--- a/iroh-net/src/net/netmon/windows.rs
+++ b/iroh-net/src/net/netmon/windows.rs
@@ -19,21 +19,21 @@ pub(super) struct RouteMonitor {
 }
 
 impl RouteMonitor {
-    pub(super) fn new(sender: flume::Sender<NetworkMessage>) -> Result<Self> {
+    pub(super) fn new(sender: async_channel::Sender<NetworkMessage>) -> Result<Self> {
         // Register two callbacks with the windows api
         let mut cb_handler = CallbackHandler::default();
 
         // 1. Unicast Address Changes
         let s = sender.clone();
         cb_handler.register_unicast_address_change_callback(Box::new(move || {
-            if let Err(err) = s.send(NetworkMessage::Change) {
+            if let Err(err) = s.send_blocking(NetworkMessage::Change) {
                 warn!("unable to send: unicast change notification: {:?}", err);
             }
         }))?;
 
         // 2. Route Changes
         cb_handler.register_route_change_callback(Box::new(move || {
-            if let Err(err) = sender.send(NetworkMessage::Change) {
+            if let Err(err) = sender.send_blocking(NetworkMessage::Change) {
                 warn!("unable to send: route change notification: {:?}", err);
             }
         }))?;


### PR DESCRIPTION
## Description

refactor(iroh-net): replace flume in iroh-net with async_channel

Rationale: see https://github.com/n0-computer/iroh/pull/2536

This is the first in a series of PRs that will replace flume with async_channel. In this case it is very close to a drop in replacement without any need for changes.

Only noteable changes:

send_async becomes send
send becomes send_blocking
Receiver implements Stream, so no need for .into_stream()
Receiver is not Unpin, so to make it unpin you need to do `Box::pin(recv)` or use `.boxed()`

## Breaking Changes

None

## Notes & open questions

- Anything specific from flume we were relying on here?

## Change checklist

- [x] Self-review.
- [x] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [x] ~~Tests if relevant.~~
- [x] ~~All breaking changes documented.~~
