### PR TITLE
refactor(iroh): Remove flume from iroh gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,11 +2773,11 @@ name = "iroh-gossip"
 version = "0.21.0"
 dependencies = [
  "anyhow",
+ "async-channel",
  "bytes",
  "clap",
  "derive_more",
  "ed25519-dalek",
- "flume",
  "futures-lite 2.3.0",
  "futures-util",
  "genawaiter",

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -38,8 +38,8 @@ tokio-util = { version = "0.7.8", optional = true, features = ["codec"] }
 genawaiter = { version = "0.99.1", default-features = false, features = ["futures03"] }
 
 # dispatcher dependencies (optional)
+async-channel = { version = "2.3.1", optional = true }
 futures-util = { version = "0.3.30", optional = true }
-flume = { version = "0.11", optional = true }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -51,7 +51,7 @@ url = "2.4.0"
 [features]
 default = ["net", "dispatcher"]
 net = ["dep:futures-lite", "dep:iroh-net", "dep:tokio", "dep:tokio-util"]
-dispatcher = ["dep:flume", "dep:futures-util"]
+dispatcher = ["dep:async-channel", "dep:futures-util"]
 
 [[example]]
 name = "chat"


### PR DESCRIPTION
## Description

refactor(iroh): Remove flume from iroh gossip

Yes, I know there is a PR that touches gossip. But just let me do my purge.

## Breaking Changes

None

## Notes & open questions

None

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
