### PR TITLE
feat: override to staging relays

### DIFF
--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -27,8 +27,6 @@ const ENV_AUTHOR: &str = "IROH_AUTHOR";
 const ENV_DOC: &str = "IROH_DOC";
 const ENV_CONFIG_DIR: &str = "IROH_CONFIG_DIR";
 const ENV_FILE_RUST_LOG: &str = "IROH_FILE_RUST_LOG";
-#[allow(dead_code)]
-const ENV_FORCE_STAGING_RELAYS: &str = "IROH_FORCE_STAGING_RELAYS";
 
 /// CONFIG_FILE_NAME is the name of the optional config file located in the iroh home directory
 pub(crate) const CONFIG_FILE_NAME: &str = "iroh.config.toml";
@@ -72,7 +70,8 @@ impl Default for NodeConfig {
     fn default() -> Self {
         let relay_nodes = {
             #[cfg(not(test))]
-            let force_staging_relays = match env::var(ENV_FORCE_STAGING_RELAYS) {
+            let force_staging_relays = match env::var(iroh::net::endpoint::ENV_FORCE_STAGING_RELAYS)
+            {
                 Ok(value) => value == "1",
                 Err(_) => false,
             };

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -66,7 +66,10 @@ pub(crate) struct NodeConfig {
 impl Default for NodeConfig {
     fn default() -> Self {
         let relay_map = iroh::net::endpoint::default_relay_mode().relay_map();
-        let relay_nodes = relay_map.nodes().map(|v| v.copied()).collect();
+        let relay_nodes = relay_map
+            .nodes()
+            .map(|v| Arc::unwrap_or_clone(v.clone()))
+            .collect();
         Self {
             relay_nodes,
             gc_policy: GcPolicyConfig::default(),

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -59,7 +59,8 @@ pub use iroh_base::node_addr::{AddrInfo, NodeAddr};
 const DISCOVERY_WAIT_PERIOD: Duration = Duration::from_millis(500);
 
 /// Environment variable to force the use of staging relays.
-pub const ENV_FORCE_STAGING_RELAYS: &str = "IROH_FORCE_STAGING_RELAYS";
+#[cfg(not(any(test, feature = "test-utils")))]
+const ENV_FORCE_STAGING_RELAYS: &str = "IROH_FORCE_STAGING_RELAYS";
 
 /// Builder for [`Endpoint`].
 ///

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -179,7 +179,7 @@ impl Builder {
     /// By default the Number0 relay servers are used.
     ///
     /// When using [RelayMode::Custom], the provided `relay_map` must contain at least one
-    /// configured relay node.  If an invalid [`RelayMap`] is provided [`bind`]
+    /// configured relay node.  If an invalid RelayMap is provided [`bind`]
     /// will result in an error.
     ///
     /// [`bind`]: Builder::bind

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, ensure, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use derive_more::Debug;
 use futures_lite::{Stream, StreamExt};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
@@ -27,12 +27,11 @@ use tracing::{debug, info_span, trace, warn};
 use url::Url;
 
 use crate::{
-    defaults,
     discovery::{Discovery, DiscoveryTask},
     dns::{default_resolver, DnsResolver},
     key::{PublicKey, SecretKey},
     magicsock::{self, Handle},
-    relay::{RelayMap, RelayMode, RelayUrl},
+    relay::{RelayMode, RelayUrl},
     tls, NodeId,
 };
 
@@ -87,23 +86,9 @@ pub struct Builder {
 
 impl Default for Builder {
     fn default() -> Self {
-        // Use staging in testing
-        #[cfg(not(any(test, feature = "test-utils")))]
-        let force_staging_relays = match std::env::var(ENV_FORCE_STAGING_RELAYS) {
-            Ok(value) => value == "1",
-            Err(_) => false,
-        };
-        #[cfg(not(any(test, feature = "test-utils")))]
-        let relay_mode = match force_staging_relays {
-            true => RelayMode::Staging,
-            false => RelayMode::Default,
-        };
-        #[cfg(any(test, feature = "test-utils"))]
-        let relay_mode = RelayMode::Staging;
-
         Self {
             secret_key: Default::default(),
-            relay_mode,
+            relay_mode: default_relay_mode(),
             alpn_protocols: Default::default(),
             transport_config: Default::default(),
             concurrent_connections: Default::default(),
@@ -132,15 +117,7 @@ impl Builder {
     ///
     /// NOTE: This will be improved soon to add support for binding on specific addresses.
     pub async fn bind(self, bind_port: u16) -> Result<Endpoint> {
-        let relay_map = match self.relay_mode {
-            RelayMode::Disabled => RelayMap::empty(),
-            RelayMode::Default => defaults::prod::default_relay_map(),
-            RelayMode::Staging => defaults::staging::default_relay_map(),
-            RelayMode::Custom(relay_map) => {
-                ensure!(!relay_map.is_empty(), "Empty custom relay server map",);
-                relay_map
-            }
-        };
+        let relay_map = self.relay_mode.relay_map();
         let secret_key = self.secret_key.unwrap_or_else(SecretKey::generate);
         let static_config = StaticConfig {
             transport_config: Arc::new(self.transport_config.unwrap_or_default()),
@@ -1092,6 +1069,26 @@ fn proxy_url_from_env() -> Option<Url> {
     }
 
     None
+}
+
+/// Returns the default relay mode.
+///
+/// If the `IROH_FORCE_STAGING_RELAYS` environment variable is set to `1`, it will return `RelayMode::Staging`.
+/// Otherwise, it will return `RelayMode::Default`.
+pub fn default_relay_mode() -> RelayMode {
+    // Use staging in testing
+    #[cfg(not(any(test, feature = "test-utils")))]
+    let force_staging_relays = match std::env::var(ENV_FORCE_STAGING_RELAYS) {
+        Ok(value) => value == "1",
+        Err(_) => false,
+    };
+    #[cfg(any(test, feature = "test-utils"))]
+    let force_staging_relays = true;
+
+    match force_staging_relays {
+        true => RelayMode::Staging,
+        false => RelayMode::Default,
+    }
 }
 
 /// Check if we are being executed in a CGI context.

--- a/iroh-net/src/relay/map.rs
+++ b/iroh-net/src/relay/map.rs
@@ -146,7 +146,7 @@ pub struct RelayNode {
 }
 
 impl RelayNode {
-    /// Creates a new relay node from itself.
+    /// Creates a new instance of a RelayNode from itself.
     pub fn copied(&self) -> Self {
         Self {
             url: self.url.clone(),

--- a/iroh-net/src/relay/map.rs
+++ b/iroh-net/src/relay/map.rs
@@ -145,17 +145,6 @@ pub struct RelayNode {
     pub stun_port: u16,
 }
 
-impl RelayNode {
-    /// Creates a new instance of a RelayNode from itself.
-    pub fn copied(&self) -> Self {
-        Self {
-            url: self.url.clone(),
-            stun_only: self.stun_only,
-            stun_port: self.stun_port,
-        }
-    }
-}
-
 impl fmt::Display for RelayNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.url)

--- a/iroh-net/src/relay/map.rs
+++ b/iroh-net/src/relay/map.rs
@@ -22,6 +22,18 @@ pub enum RelayMode {
     Custom(RelayMap),
 }
 
+impl RelayMode {
+    /// Returns the relay map for this mode.
+    pub fn relay_map(&self) -> RelayMap {
+        match self {
+            RelayMode::Disabled => RelayMap::empty(),
+            RelayMode::Default => crate::defaults::prod::default_relay_map(),
+            RelayMode::Staging => crate::defaults::staging::default_relay_map(),
+            RelayMode::Custom(relay_map) => relay_map.clone(),
+        }
+    }
+}
+
 /// Configuration of all the relay servers that can be used.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RelayMap {
@@ -131,6 +143,17 @@ pub struct RelayNode {
     ///
     /// Setting this to `0` means the default STUN port is used.
     pub stun_port: u16,
+}
+
+impl RelayNode {
+    /// Creates a new relay node from itself.
+    pub fn copied(&self) -> Self {
+        Self {
+            url: self.url.clone(),
+            stun_only: self.stun_only,
+            stun_port: self.stun_port,
+        }
+    }
 }
 
 impl fmt::Display for RelayNode {


### PR DESCRIPTION
## Description

While I'm not a huge fan of this piece of code, I don't really see much of an alternative as we want to be able to force the override to use staging relays even in "prod" environments or when it's deeply integrated such as the FFI library cases. 

This should allow us to override the default relay maps for all of our CI setups in all of our repos.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
