### PR TITLE
feat(iroh): Improve documentation and canonicalize docs in `iroh::client`

### DIFF
--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -23,11 +23,13 @@ pub mod gossip;
 pub mod node;
 pub mod tags;
 
+// Keep this type exposed, otherwise every occurance of `RpcClient` in the API
+// will show up as `RpcClient<RpcService, Connection<RpcService>>` in the docs.
 /// Iroh rpc client - boxed so that we can have a concrete type.
-pub(crate) type RpcClient =
+pub type RpcClient =
     quic_rpc::RpcClient<RpcService, quic_rpc::transport::boxed::Connection<RpcService>>;
 
-/// The iroh client.
+/// An iroh client.
 ///
 /// There are three ways to obtain this client, depending on which context
 /// you're running in relative to the main [`Node`](crate::node::Node):
@@ -52,37 +54,42 @@ impl Deref for Iroh {
 }
 
 impl Iroh {
-    /// Create a new high-level client to a Iroh node from the low-level RPC client.
+    /// Creates a new high-level client to a Iroh node from the low-level RPC client.
+    ///
+    /// Prefer using [`Node::client()`](crate::node::Node::client), [`Iroh::connect_path`]
+    /// or [`Iroh::connect_addr`] instead of calling this function.
+    ///
+    /// See also the [`Iroh`] struct documentation.
     pub fn new(rpc: RpcClient) -> Self {
         Self { rpc }
     }
 
-    /// Blobs client
+    /// Returns the blobs client.
     pub fn blobs(&self) -> &blobs::Client {
         blobs::Client::ref_cast(&self.rpc)
     }
 
-    /// Docs client
+    /// Returns the docs client.
     pub fn docs(&self) -> &docs::Client {
         docs::Client::ref_cast(&self.rpc)
     }
 
-    /// Authors client
+    /// Returns the authors client.
     pub fn authors(&self) -> &authors::Client {
         authors::Client::ref_cast(&self.rpc)
     }
 
-    /// Tags client
+    /// Returns the tags client.
     pub fn tags(&self) -> &tags::Client {
         tags::Client::ref_cast(&self.rpc)
     }
 
-    /// Gossip client
+    /// Returns the gossip client.
     pub fn gossip(&self) -> &gossip::Client {
         gossip::Client::ref_cast(&self.rpc)
     }
 
-    /// Node client
+    /// Returns the node client.
     pub fn node(&self) -> &node::Client {
         node::Client::ref_cast(&self.rpc)
     }

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -23,7 +23,7 @@ pub mod gossip;
 pub mod node;
 pub mod tags;
 
-// Keep this type exposed, otherwise every occurance of `RpcClient` in the API
+// Keep this type exposed, otherwise every occurrence of `RpcClient` in the API
 // will show up as `RpcClient<RpcService, Connection<RpcService>>` in the docs.
 /// Iroh rpc client - boxed so that we can have a concrete type.
 pub type RpcClient =

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -29,8 +29,8 @@ pub(crate) type RpcClient =
 
 /// The iroh client.
 ///
-/// There are three ways to obtain this client, depending on from which context
-/// you're running in, relative to the main [`Node`](crate::node::Node):
+/// There are three ways to obtain this client, depending on which context
+/// you're running in relative to the main [`Node`](crate::node::Node):
 ///
 /// 1. If you just spawned the client in rust the same process and have a reference to it:
 ///    Use [`Node::client()`](crate::node::Node::client).

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -1,4 +1,6 @@
 //! Client to an Iroh node.
+//!
+//! See the documentation for [`Iroh`] for more information.
 
 use futures_lite::{Stream, StreamExt};
 use ref_cast::RefCast;
@@ -25,7 +27,17 @@ pub mod tags;
 pub(crate) type RpcClient =
     quic_rpc::RpcClient<RpcService, quic_rpc::transport::boxed::Connection<RpcService>>;
 
-/// Iroh client.
+/// The iroh client.
+///
+/// There are three ways to obtain this client, depending on from which context
+/// you're running in, relative to the main [`Node`](crate::node::Node):
+///
+/// 1. If you just spawned the client in rust the same process and have a reference to it:
+///    Use [`Node::client()`](crate::node::Node::client).
+/// 2. If the main node wasn't spawned in the same process, but on the same machine:
+///    Use [`Iroh::connect_path`].
+/// 3. If the main node was spawned somewhere else and has been made accessible via IP:
+///    Use [`Iroh::connect_addr`].
 #[derive(Debug, Clone)]
 pub struct Iroh {
     rpc: RpcClient,

--- a/iroh/src/client/authors.rs
+++ b/iroh/src/client/authors.rs
@@ -1,4 +1,8 @@
 //! API for author management.
+//!
+//! The main entry point is the [`Client`].
+//!
+//! You obtain a [`Client`] via [`Iroh::authors()`](crate::client::Iroh::authors).
 
 use anyhow::Result;
 use futures_lite::{stream::StreamExt, Stream};

--- a/iroh/src/client/authors.rs
+++ b/iroh/src/client/authors.rs
@@ -54,6 +54,8 @@ impl Client {
     }
 
     /// Lists document authors for which we have a secret key.
+    ///
+    /// It's only possible to create writes from authors that we have the secret key of.
     pub async fn list(&self) -> Result<impl Stream<Item = Result<AuthorId>>> {
         let stream = self.rpc.server_streaming(ListRequest {}).await?;
         Ok(flatten(stream).map(|res| res.map(|res| res.author_id)))
@@ -61,7 +63,7 @@ impl Client {
 
     /// Exports the given author.
     ///
-    /// Warning: This contains sensitive data.
+    /// Warning: The [`Author`] struct contains sensitive data.
     pub async fn export(&self, author: AuthorId) -> Result<Option<Author>> {
         let res = self.rpc.rpc(ExportRequest { author }).await??;
         Ok(res.author)
@@ -69,7 +71,7 @@ impl Client {
 
     /// Imports the given author.
     ///
-    /// Warning: This contains sensitive data.
+    /// Warning: The [`Author`] struct contains sensitive data.
     pub async fn import(&self, author: Author) -> Result<()> {
         self.rpc.rpc(ImportRequest { author }).await??;
         Ok(())

--- a/iroh/src/client/authors.rs
+++ b/iroh/src/client/authors.rs
@@ -20,7 +20,7 @@ pub struct Client {
 }
 
 impl Client {
-    /// Create a new document author.
+    /// Creates a new document author.
     ///
     /// You likely want to save the returned [`AuthorId`] somewhere so that you can use this author
     /// again.
@@ -42,7 +42,7 @@ impl Client {
         Ok(res.author_id)
     }
 
-    /// Set the node-wide default author.
+    /// Sets the node-wide default author.
     ///
     /// If the author does not exist, an error is returned.
     ///
@@ -53,13 +53,13 @@ impl Client {
         Ok(())
     }
 
-    /// List document authors for which we have a secret key.
+    /// Lists document authors for which we have a secret key.
     pub async fn list(&self) -> Result<impl Stream<Item = Result<AuthorId>>> {
         let stream = self.rpc.server_streaming(ListRequest {}).await?;
         Ok(flatten(stream).map(|res| res.map(|res| res.author_id)))
     }
 
-    /// Export the given author.
+    /// Exports the given author.
     ///
     /// Warning: This contains sensitive data.
     pub async fn export(&self, author: AuthorId) -> Result<Option<Author>> {
@@ -67,7 +67,7 @@ impl Client {
         Ok(res.author)
     }
 
-    /// Import the given author.
+    /// Imports the given author.
     ///
     /// Warning: This contains sensitive data.
     pub async fn import(&self, author: Author) -> Result<()> {

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -2,6 +2,8 @@
 //!
 //! The main entry point is the [`Client`].
 //!
+//! You obtain a [`Client`] via [`Iroh::blobs()`](crate::client::Iroh::blobs).
+//!
 //! ## Interacting with the local blob store
 //!
 //! ### Importing data

--- a/iroh/src/client/docs.rs
+++ b/iroh/src/client/docs.rs
@@ -312,7 +312,7 @@ impl Doc {
         Ok(res.entry.map(|entry| entry.into()))
     }
 
-    /// Returns entries.
+    /// Returns all entries matching the query.
     pub async fn get_many(
         &self,
         query: impl Into<Query>,

--- a/iroh/src/client/docs.rs
+++ b/iroh/src/client/docs.rs
@@ -51,14 +51,14 @@ pub struct Client {
 }
 
 impl Client {
-    /// Create a new document.
+    /// Creates a new document.
     pub async fn create(&self) -> Result<Doc> {
         let res = self.rpc.rpc(CreateRequest {}).await??;
         let doc = Doc::new(self.rpc.clone(), res.id);
         Ok(doc)
     }
 
-    /// Delete a document from the local node.
+    /// Deletes a document from the local node.
     ///
     /// This is a destructive operation. Both the document secret key and all entries in the
     /// document will be permanently deleted from the node's storage. Content blobs will be deleted
@@ -68,7 +68,7 @@ impl Client {
         Ok(())
     }
 
-    /// Import a document from a namespace capability.
+    /// Imports a document from a namespace capability.
     ///
     /// This does not start sync automatically. Use [`Doc::start_sync`] to start sync.
     pub async fn import_namespace(&self, capability: Capability) -> Result<Doc> {
@@ -77,7 +77,7 @@ impl Client {
         Ok(doc)
     }
 
-    /// Import a document from a ticket and join all peers in the ticket.
+    /// Imports a document from a ticket and joins all peers in the ticket.
     pub async fn import(&self, ticket: DocTicket) -> Result<Doc> {
         let DocTicket { capability, nodes } = ticket;
         let doc = self.import_namespace(capability).await?;
@@ -85,9 +85,9 @@ impl Client {
         Ok(doc)
     }
 
-    /// Import a document from a ticket, create a subscription stream and join all peers in the ticket.
+    /// Imports a document from a ticket, creates a subscription stream and joins all peers in the ticket.
     ///
-    /// Returns the [`Doc`] and a [`Stream`] of [`LiveEvent`]s
+    /// Returns the [`Doc`] and a [`Stream`] of [`LiveEvent`]s.
     ///
     /// The subscription stream is created before the sync is started, so the first call to this
     /// method after starting the node is guaranteed to not miss any sync events.
@@ -103,13 +103,15 @@ impl Client {
         Ok((doc, events))
     }
 
-    /// List all documents.
+    /// Lists all documents.
     pub async fn list(&self) -> Result<impl Stream<Item = Result<(NamespaceId, CapabilityKind)>>> {
         let stream = self.rpc.server_streaming(DocListRequest {}).await?;
         Ok(flatten(stream).map(|res| res.map(|res| (res.id, res.capability))))
     }
 
-    /// Get a [`Doc`] client for a single document. Return None if the document cannot be found.
+    /// Returns a [`Doc`] client for a single document.
+    ///
+    /// Returns None if the document cannot be found.
     pub async fn open(&self, id: NamespaceId) -> Result<Option<Doc>> {
         self.rpc.rpc(OpenRequest { doc_id: id }).await??;
         let doc = Doc::new(self.rpc.clone(), id);
@@ -167,12 +169,12 @@ impl Doc {
         Ok(res)
     }
 
-    /// Get the document id of this doc.
+    /// Returns the document id of this doc.
     pub fn id(&self) -> NamespaceId {
         self.0.id
     }
 
-    /// Close the document.
+    /// Closes the document.
     pub async fn close(&self) -> Result<()> {
         if !self.0.closed.swap(true, Ordering::Relaxed) {
             self.rpc(CloseRequest { doc_id: self.id() }).await??;
@@ -188,7 +190,7 @@ impl Doc {
         }
     }
 
-    /// Set the content of a key to a byte array.
+    /// Sets the content of a key to a byte array.
     pub async fn set_bytes(
         &self,
         author_id: AuthorId,
@@ -207,7 +209,7 @@ impl Doc {
         Ok(res.entry.content_hash())
     }
 
-    /// Set an entries on the doc via its key, hash, and size.
+    /// Sets an entries on the doc via its key, hash, and size.
     pub async fn set_hash(
         &self,
         author_id: AuthorId,
@@ -227,7 +229,7 @@ impl Doc {
         Ok(())
     }
 
-    /// Add an entry from an absolute file path
+    /// Adds an entry from an absolute file path
     pub async fn import_file(
         &self,
         author: AuthorId,
@@ -250,7 +252,7 @@ impl Doc {
         Ok(ImportFileProgress::new(stream))
     }
 
-    /// Export an entry as a file to a given absolute path.
+    /// Exports an entry as a file to a given absolute path.
     pub async fn export_file(
         &self,
         entry: Entry,
@@ -270,7 +272,7 @@ impl Doc {
         Ok(ExportFileProgress::new(stream))
     }
 
-    /// Delete entries that match the given `author` and key `prefix`.
+    /// Deletes entries that match the given `author` and key `prefix`.
     ///
     /// This inserts an empty entry with the key set to `prefix`, effectively clearing all other
     /// entries whose key starts with or is equal to the given `prefix`.
@@ -289,9 +291,9 @@ impl Doc {
         Ok(removed)
     }
 
-    /// Get an entry for a key and author.
+    /// Returns an entry for a key and author.
     ///
-    /// Optionally also get the entry if it is empty (i.e. a deletion marker).
+    /// Optionally also returns the entry unless it is empty (i.e. a deletion marker).
     pub async fn get_exact(
         &self,
         author: AuthorId,
@@ -310,7 +312,7 @@ impl Doc {
         Ok(res.entry.map(|entry| entry.into()))
     }
 
-    /// Get entries.
+    /// Returns entries.
     pub async fn get_many(
         &self,
         query: impl Into<Query>,
@@ -327,12 +329,12 @@ impl Doc {
         Ok(flatten(stream).map(|res| res.map(|res| res.entry.into())))
     }
 
-    /// Get a single entry.
+    /// Returns a single entry.
     pub async fn get_one(&self, query: impl Into<Query>) -> Result<Option<Entry>> {
         self.get_many(query).await?.next().await.transpose()
     }
 
-    /// Share this document with peers over a ticket.
+    /// Shares this document with peers over a ticket.
     pub async fn share(
         &self,
         mode: ShareMode,
@@ -349,7 +351,7 @@ impl Doc {
         Ok(res.0)
     }
 
-    /// Start to sync this document with a list of peers.
+    /// Starts to sync this document with a list of peers.
     pub async fn start_sync(&self, peers: Vec<NodeAddr>) -> Result<()> {
         self.ensure_open()?;
         let _res = self
@@ -361,14 +363,14 @@ impl Doc {
         Ok(())
     }
 
-    /// Stop the live sync for this document.
+    /// Stops the live sync for this document.
     pub async fn leave(&self) -> Result<()> {
         self.ensure_open()?;
         let _res = self.rpc(LeaveRequest { doc_id: self.id() }).await??;
         Ok(())
     }
 
-    /// Subscribe to events for this document.
+    /// Subscribes to events for this document.
     pub async fn subscribe(&self) -> anyhow::Result<impl Stream<Item = anyhow::Result<LiveEvent>>> {
         self.ensure_open()?;
         let stream = self
@@ -382,14 +384,14 @@ impl Doc {
         }))
     }
 
-    /// Get status info for this document
+    /// Returns status info for this document
     pub async fn status(&self) -> anyhow::Result<OpenState> {
         self.ensure_open()?;
         let res = self.rpc(StatusRequest { doc_id: self.id() }).await??;
         Ok(res.status)
     }
 
-    /// Set the download policy for this document
+    /// Sets the download policy for this document
     pub async fn set_download_policy(&self, policy: DownloadPolicy) -> Result<()> {
         self.rpc(SetDownloadPolicyRequest {
             doc_id: self.id(),
@@ -399,7 +401,7 @@ impl Doc {
         Ok(())
     }
 
-    /// Get the download policy for this document
+    /// Returns the download policy for this document
     pub async fn get_download_policy(&self) -> Result<DownloadPolicy> {
         let res = self
             .rpc(GetDownloadPolicyRequest { doc_id: self.id() })
@@ -407,7 +409,7 @@ impl Doc {
         Ok(res.policy)
     }
 
-    /// Get sync peers for this document
+    /// Returns sync peers for this document
     pub async fn get_sync_peers(&self) -> Result<Option<Vec<PeerIdBytes>>> {
         let res = self
             .rpc(GetSyncPeersRequest { doc_id: self.id() })
@@ -439,44 +441,44 @@ impl From<iroh_docs::SignedEntry> for Entry {
 }
 
 impl Entry {
-    /// Get the [`RecordIdentifier`] for this entry.
+    /// Returns the [`RecordIdentifier`] for this entry.
     pub fn id(&self) -> &RecordIdentifier {
         self.0.id()
     }
 
-    /// Get the [`AuthorId`] of this entry.
+    /// Returns the [`AuthorId`] of this entry.
     pub fn author(&self) -> AuthorId {
         self.0.author()
     }
 
-    /// Get the [`struct@Hash`] of the content data of this record.
+    /// Returns the [`struct@Hash`] of the content data of this record.
     pub fn content_hash(&self) -> Hash {
         self.0.content_hash()
     }
 
-    /// Get the length of the data addressed by this record's content hash.
+    /// Returns the length of the data addressed by this record's content hash.
     pub fn content_len(&self) -> u64 {
         self.0.content_len()
     }
 
-    /// Get the key of this entry.
+    /// Returns the key of this entry.
     pub fn key(&self) -> &[u8] {
         self.0.key()
     }
 
-    /// Get the timestamp of this entry.
+    /// Returns the timestamp of this entry.
     pub fn timestamp(&self) -> u64 {
         self.0.timestamp()
     }
 
-    /// Read the content of an [`Entry`] as a streaming [`blobs::Reader`].
+    /// Reads the content of an [`Entry`] as a streaming [`blobs::Reader`].
     ///
     /// You can pass either a [`Doc`] or the `Iroh` client by reference as `client`.
     pub async fn content_reader(&self, client: impl Into<&RpcClient>) -> Result<blobs::Reader> {
         blobs::Reader::from_rpc_read(client.into(), self.content_hash()).await
     }
 
-    /// Read all content of an [`Entry`] into a buffer.
+    /// Reads all content of an [`Entry`] into a buffer.
     ///
     /// You can pass either a [`Doc`] or the `Iroh` client by reference as `client`.
     pub async fn content_bytes(&self, client: impl Into<&RpcClient>) -> Result<Bytes> {
@@ -494,7 +496,7 @@ impl Entry {
 /// file as an entry in the doc.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ImportProgress {
-    /// An item was found with name `name`, from now on referred to via `id`
+    /// An item was found with name `name`, from now on referred to via `id`.
     Found {
         /// A new unique id for this entry.
         id: u64,
@@ -517,7 +519,7 @@ pub enum ImportProgress {
         /// The hash of the entry.
         hash: Hash,
     },
-    /// We are done setting the entry to the doc
+    /// We are done setting the entry to the doc.
     AllDone {
         /// The key of the entry
         key: Bytes,
@@ -625,7 +627,7 @@ impl ImportFileProgress {
         }
     }
 
-    /// Finish writing the stream, ignoring all intermediate progress events.
+    /// Finishes writing the stream, ignoring all intermediate progress events.
     ///
     /// Returns a [`ImportFileOutcome`] which contains a tag, key, and hash and the size of the
     /// content.
@@ -697,8 +699,9 @@ impl ExportFileProgress {
             stream: Box::pin(stream),
         }
     }
-    /// Iterate through the export progress stream, returning when the stream has completed.
 
+    /// Iterates through the export progress stream, returning when the stream has completed.
+    ///
     /// Returns a [`ExportFileOutcome`] which contains a file path the data was written to and the size of the content.
     pub async fn finish(mut self) -> Result<ExportFileOutcome> {
         let mut total_size = 0;

--- a/iroh/src/client/docs.rs
+++ b/iroh/src/client/docs.rs
@@ -1,4 +1,8 @@
 //! API for document management.
+//!
+//! The main entry point is the [`Client`].
+//!
+//! You obtain a [`Client`] via [`Iroh::docs()`](crate::client::Iroh::docs).
 
 use std::{
     path::{Path, PathBuf},

--- a/iroh/src/client/gossip.rs
+++ b/iroh/src/client/gossip.rs
@@ -51,7 +51,7 @@ impl Default for SubscribeOpts {
 }
 
 impl Client {
-    /// Subscribe to a gossip topic.
+    /// Subscribes to a gossip topic.
     ///
     /// Returns a sink to send updates to the topic and a stream of responses.
     ///
@@ -68,7 +68,7 @@ impl Client {
     /// immediate neighbors of the node.
     ///
     /// A Lagged event indicates that the gossip stream has not been consumed quickly enough.
-    /// You can adjust the buffer size with the [] option.
+    /// You can adjust the buffer size with the [`SubscribeOpts::subscription_capacity`] option.
     pub async fn subscribe_with_opts(
         &self,
         topic: TopicId,
@@ -90,7 +90,7 @@ impl Client {
         Ok((sink, stream))
     }
 
-    /// Subscribe to a gossip topic with default options.
+    /// Subscribes to a gossip topic with default options.
     pub async fn subscribe(
         &self,
         topic: impl Into<TopicId>,

--- a/iroh/src/client/gossip.rs
+++ b/iroh/src/client/gossip.rs
@@ -4,6 +4,8 @@
 //!
 //! The main entry point is the [`Client`].
 //!
+//! You obtain a [`Client`] via [`Iroh::gossip()`](crate::client::Iroh::gossip).
+//!
 //! The gossip API is extremely simple. You use [`subscribe`](Client::subscribe)
 //! to subscribe to a topic. This returns a sink to send updates to the topic
 //! and a stream of responses.

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -14,7 +14,6 @@ use std::{collections::BTreeMap, net::SocketAddr};
 
 use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
-use iroh_base::key::PublicKey;
 use iroh_net::{endpoint::ConnectionInfo, relay::RelayUrl, NodeAddr, NodeId};
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -1,6 +1,10 @@
 //! API to manage the iroh node itself.
 //!
-//! The main entry point is the [Client].
+//! The main entry point is the [`Client`].
+//!
+//! You obtain a [`Client`] via [`Iroh::node()`](crate::client::Iroh::node),
+//! or just use [`Iroh`](crate::client::Iroh) directly,
+//! as it has a `Deref` implementation for this [`Client`].
 //!
 //! The client can be used to get information about the node, such as the
 //! [status](Client::status), [node id](Client::node_id) or

--- a/iroh/src/client/quic.rs
+++ b/iroh/src/client/quic.rs
@@ -21,7 +21,7 @@ use crate::{
 pub(crate) const RPC_ALPN: [u8; 17] = *b"n0/provider-rpc/1";
 
 impl Iroh {
-    /// Connect to an iroh node running on the same computer, but in a different process.
+    /// Connects to an iroh node running on the same computer, but in a different process.
     pub async fn connect_path(root: impl AsRef<Path>) -> anyhow::Result<Self> {
         let rpc_status = RpcStatus::load(root).await?;
         match rpc_status {
@@ -32,7 +32,7 @@ impl Iroh {
         }
     }
 
-    /// Connect to an iroh node at the given RPC address.
+    /// Connects to an iroh node at the given RPC address.
     pub async fn connect_addr(addr: SocketAddr) -> anyhow::Result<Self> {
         let client = connect_raw(addr).await?;
         Ok(Iroh::new(client))

--- a/iroh/src/client/tags.rs
+++ b/iroh/src/client/tags.rs
@@ -29,19 +29,19 @@ pub struct Client {
 }
 
 impl Client {
-    /// List all tags.
+    /// Lists all tags.
     pub async fn list(&self) -> Result<impl Stream<Item = Result<TagInfo>>> {
         let stream = self.rpc.server_streaming(ListRequest::all()).await?;
         Ok(stream.map(|res| res.map_err(anyhow::Error::from)))
     }
 
-    /// List all tags with a hash_seq format.
+    /// Lists all tags with a hash_seq format.
     pub async fn list_hash_seq(&self) -> Result<impl Stream<Item = Result<TagInfo>>> {
         let stream = self.rpc.server_streaming(ListRequest::hash_seq()).await?;
         Ok(stream.map(|res| res.map_err(anyhow::Error::from)))
     }
 
-    /// Delete a tag.
+    /// Deletes a tag.
     pub async fn delete(&self, name: Tag) -> Result<()> {
         self.rpc.rpc(DeleteRequest { name }).await??;
         Ok(())

--- a/iroh/src/client/tags.rs
+++ b/iroh/src/client/tags.rs
@@ -1,14 +1,17 @@
 //! API for tag management.
 //!
-//! The purpose of tags is to mark information as important. Currently this is
-//! used for blobs.
+//! The purpose of tags is to mark information as important to prevent it
+//! from being garbage-collected (if the garbage collector is turned on).
+//! Currently this is used for blobs.
 //!
-//! The main entry point is the [Client].
+//! The main entry point is the [`Client`].
 //!
-//! [Client::list] can be used to list all tags.
-//! [Client::list_hash_seq] can be used to list all tags with a hash_seq format.
+//! You obtain a [`Client`] via [`Iroh::tags()`](crate::client::Iroh::tags).
 //!
-//! [Client::delete] can be used to delete a tag.
+//! [`Client::list`] can be used to list all tags.
+//! [`Client::list_hash_seq`] can be used to list all tags with a hash_seq format.
+//!
+//! [`Client::delete`] can be used to delete a tag.
 use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
 use iroh_blobs::{BlobFormat, Hash, Tag};

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -77,10 +77,10 @@
 //! ## Reexports
 //!
 //! The iroh crate re-exports the following crates:
-//! - [iroh_base](iroh_base) as [`base`]
-//! - [iroh_blobs](iroh_blobs) as [`blobs`]
-//! - [iroh_docs](iroh_docs) as [`docs`]
-//! - [iroh_net](iroh_net) as [`net`]
+//! - [iroh_base] as [`base`]
+//! - [iroh_blobs] as [`blobs`]
+//! - [iroh_docs] as [`docs`]
+//! - [iroh_net] as [`net`]
 //!
 //! ## Feature Flags
 //!


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

- More pointers between individual modules to help people understand how they go from `A` to `B` (e.g. `Node` -> `Iroh`, `Iroh` -> `blobs::Client`, etc.)
- Documentation on how to initialize `client::Iroh`
- Generally make methods adhere to our documentation style.
- Expose the type alias `iroh::client::RpcClient`, so it doesn't show up as `RpcClient<RpcService, Connection<RpcService>>` everywhere it's used in the docs.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

None, but noteworthy:
- Expose the type alias `iroh::client::RpcClient`.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [X] Self-review.
- [X] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
- [X] All breaking changes documented.
