### PR TITLE
[ignore] chore(ci): ci warnings stuff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: beta-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
 jobs:
   tests:
     uses: './.github/workflows/tests.yaml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.76"
   SCCACHE_CACHE_SIZE: "50G"
+  IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
   tests:
@@ -82,7 +83,7 @@ jobs:
           - armv7-linux-androideabi
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
@@ -92,13 +93,13 @@ jobs:
       run: rustup target add ${{ matrix.target }}
 
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'
     
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v2
+      uses: android-actions/setup-android@v3
 
     - name: Setup Android NDK
       uses: arqu/setup-ndk@main
@@ -173,7 +174,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Setup Environment (PR)
         if: ${{ github.event_name == 'pull_request' }}
@@ -208,7 +209,7 @@ jobs:
         components: rustfmt
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.5
 
     - name: fmt
       run: cargo fmt --all -- --check
@@ -226,7 +227,7 @@ jobs:
       with:
         toolchain: nightly-2024-05-02
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.5
 
     - name: Docs
       run: cargo doc --workspace --all-features --no-deps --document-private-items
@@ -245,7 +246,7 @@ jobs:
       with:
         components: clippy
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.5
 
     # TODO: We have a bunch of platform-dependent code so should
     #    probably run this job on the full platform matrix
@@ -286,7 +287,7 @@ jobs:
       with:
         toolchain: ${{ env.MSRV }}
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.5
 
     - name: Check MSRV all features
       run: |
@@ -425,7 +426,7 @@ jobs:
           toolchain: stable
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -450,3 +451,10 @@ jobs:
         continue-on-error: true
         run: |
           docker kill $(docker ps -q)
+
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - run: pip install --user codespell[toml]
+    - run: codespell --ignore-words-list=ans,crate,inout,ratatui,ser,stayin,swarmin,worl --skip=CHANGELOG.md

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -5,12 +5,15 @@ on:
     branches: [main]
     types: [opened, edited, synchronize]
 
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
 jobs:
   check-for-cc:
     runs-on: ubuntu-latest
     steps:
       - name: check-for-cc
         id: check-for-cc
-        uses: agenthunt/conventional-commit-checker-action@v1.0.0
+        uses: agenthunt/conventional-commit-checker-action@v2.0.0
         with:
           pr-title-regex: "^(.+)(?:(([^)s]+)))?!?: (.+)"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,115 @@
+name: Docker
+
+on:
+    workflow_dispatch:
+      inputs:
+        release_version:
+          description: "Release version"
+          required: true
+          type: string
+          default: ""
+        base_hash:
+          description: "Commit hash from which to build"
+          required: true
+          type: string
+          default: ""
+        publish:
+          description: "Publish to Docker Hub"
+          required: true
+          type: boolean
+          default: false
+    workflow_call:
+      inputs:
+        release_version:
+          description: "Release version"
+          required: true
+          type: string
+          default: ""
+        base_hash:
+          description: "Commit hash from which to build"
+          required: true
+          type: string
+          default: ""
+        publish:
+          description: "Publish to Docker Hub"
+          required: true
+          type: boolean
+          default: false
+
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
+jobs:
+    build_and_publish:
+      timeout-minutes: 30
+      name: Docker
+      runs-on: [self-hosted, linux, X64]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+
+        - name: Login to Docker Hub
+          uses: docker/login-action@v3
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+        
+        - name: Prep dirs
+          run: |
+            mkdir -p bins/linux/amd64
+            mkdir -p bins/linux/arm64
+
+        - name: Setup awscli on linux
+          run: |
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            sudo ./aws/install --update
+    
+        - name: Set aws credentials
+          run: |
+              echo "AWS_ACCESS_KEY_ID=${{secrets.S3_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+              echo "AWS_SECRET_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}" >> $GITHUB_ENV
+              echo "AWS_DEFAULT_REGION=us-west-2" >> $GITHUB_ENV
+
+        - name: Fetch release binaries
+          run: |
+            aws s3 cp s3://vorc/iroh-linux-amd64-${{ github.event.inputs.base_hash }} bins/linux/amd64/iroh
+            aws s3 cp s3://vorc/iroh-relay-linux-amd64-${{ github.event.inputs.base_hash }} bins/linux/amd64/iroh-relay
+            aws s3 cp s3://vorc/iroh-dns-server-linux-amd64-${{ github.event.inputs.base_hash }} bins/linux/amd64/iroh-dns-server
+
+            aws s3 cp s3://vorc/iroh-linux-aarch64-${{ github.event.inputs.base_hash }} bins/linux/arm64/iroh
+            aws s3 cp s3://vorc/iroh-relay-linux-aarch64-${{ github.event.inputs.base_hash }} bins/linux/arm64/iroh-relay
+            aws s3 cp s3://vorc/iroh-dns-server-linux-aarch64-${{ github.event.inputs.base_hash }} bins/linux/arm64/iroh-dns-server
+
+        - name: Build Docker image (iroh)
+          uses: docker/build-push-action@v6
+          with:
+            context: .
+            push: true
+            tags: n0computer/iroh:latest,n0computer/iroh:${{ github.event.inputs.release_version }}
+            target: iroh
+            platforms: linux/amd64,linux/arm64/v8
+            file: docker/Dockerfile.ci
+        
+        - name: Build Docker image (iroh-relay)
+          uses: docker/build-push-action@v6
+          with:
+            context: .
+            push: true
+            tags: n0computer/iroh-relay:latest,n0computer/iroh-relay:${{ github.event.inputs.release_version }}
+            target: iroh-relay
+            platforms: linux/amd64,linux/arm64/v8
+            file: docker/Dockerfile.ci
+
+        - name: Build Docker image (iroh-dns-server)
+          uses: docker/build-push-action@v6
+          with:
+            context: .
+            push: true
+            tags: n0computer/iroh-dns-server:latest,n0computer/iroh-dns-server:${{ github.event.inputs.release_version }}
+            target: iroh-dns-server
+            platforms: linux/amd64,linux/arm64/v8
+            file: docker/Dockerfile.ci

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,59 @@
+name: Docs Preview
+
+on:
+  pull_request:
+
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
+jobs:
+  preview_docs:
+    timeout-minutes: 30
+    name: Docs preview
+    if: "github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork"
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
+      SCCACHE_CACHE_SIZE: "50G"
+      PREVIEW_PATH: pr/${{ github.event.pull_request.number }}/docs
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2024-05-02
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.5
+
+    - name: Generate Docs
+      run: cargo doc --workspace --all-features --no-deps
+      env:
+        RUSTDOCFLAGS: --cfg docsrs
+
+    - name: Deploy Docs to Preview Branch
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/doc/
+        destination_dir: ${{ env.PREVIEW_PATH }}
+        publish_branch: generated-docs-preview
+
+    - name: Find Docs Comment
+      uses: peter-evans/find-comment@v3
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: Documentation for this PR has been generated
+
+    - name: Create or Update Docs Comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        body: |
+          Documentation for this PR has been generated and is available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.PREVIEW_PATH }}/iroh/
+          
+          Last updated: ${{ github.event.pull_request.updated_at }}
+        edit-mode: replace

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -37,6 +37,9 @@ concurrency:
   group: flaky-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
 jobs:
   tests:
     if: "contains(github.event.pull_request.labels.*.name, 'flaky-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'"
@@ -55,12 +58,42 @@ jobs:
           result=$(echo '${{ toJSON(needs) }}' | jq -r .tests.result)
           echo TESTS_RESULT=$result
           echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
+      - name: download nextest reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-*
+          merge-multiple: true
+          path: nextest-results
+      - name: create summary report
+        id: make_summary
+        run: |
+          # prevent the glob expression in the loop to match on itself when the dir is empty
+          shopt -s nullglob
+          # to deal with multiline outputs it's recommended to use a random EOF, the syntax is based on
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          EOF=aP51VriWCxNJ1JjvmO9i
+          echo "summary<<$EOF" >> $GITHUB_OUTPUT
+          for report in nextest-results/*.json; do
+            # remove the name prefix and extension, and split the parts
+            name=$(echo ${report:16:-5} | tr _ ' ')
+            echo $name
+            echo "- **$name**" >> $GITHUB_OUTPUT
+            # select the failed tests
+            # the tests have this format "crate::module$test_name", the sed expressions remove the quotes and replace $ for ::
+            failure=$(jq --slurp '.[] | select(.["type"] == "test" and .["event"] == "failed" ) | .["name"]' $report | sed -e 's/^"//g' -e 's/\$/::/' -e 's/"//')
+            echo "$failure"
+            echo "$failure" >> $GITHUB_OUTPUT
+          done
+          echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
           severity: warn
           details: |
-            Flaky tests failed again, why don't you go fix them?
+            Flaky tests failure:
+
+            ${{ steps.make_summary.outputs.summary }}
+
             See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -13,6 +13,7 @@ env:
   MSRV: "1.66"
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
   netsim:
@@ -52,7 +53,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
     
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.5
 
     - name: Build iroh
       run: |
@@ -173,7 +174,7 @@ jobs:
         echo "HEAD_REF=${{ github.ref }}" >> ${GITHUB_ENV}
 
     - name: Respond Issue
-      uses: peter-evans/create-or-update-comment@v2
+      uses: peter-evans/create-or-update-comment@v4
       if: github.event_name == 'issue_comment'
       with:
         issue-number: ${{ github.event.issue.number }}
@@ -183,7 +184,7 @@ jobs:
           ${{ steps.generate_report.outputs.NETSIM_REPORT }}
 
     - name: Respond PR
-      uses: peter-evans/create-or-update-comment@v2
+      uses: peter-evans/create-or-update-comment@v4
       if: github.event.pull_request
       with:
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ env:
   SCCACHE_CACHE_SIZE: "50G"
   BIN_NAMES: "iroh,iroh-relay,iroh-dns-server"
   RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+  IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
     create-release:
@@ -72,6 +73,9 @@ jobs:
         name: Build release binaries
         needs: create-release
         runs-on: ${{ matrix.runner }}
+        outputs:
+          release_version: ${{ needs.create-release.outputs.release_version }}
+          base_hash: ${{ steps.define_hash.outputs.base_hash }}
         continue-on-error: false
         strategy:
           fail-fast: false
@@ -126,6 +130,12 @@ jobs:
           run: |
             echo "RELEASE_ARCH=${{ matrix.release-arch }}" >> $GITHUB_ENV
             echo "RELEASE_OS=${{ matrix.release-os }}" >> $GITHUB_ENV
+        
+        - name: Define hash
+          if: matrix.os == 'ubuntu-latest'
+          id: define_hash
+          run: |
+            echo "base_hash=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
         - name: Ensure musl support
           if: ${{ contains(matrix.cargo_targets, '-musl') }}
@@ -253,3 +263,12 @@ jobs:
           with:
             upload_url: ${{ needs.create-release.outputs.upload_url }}
             asset_path: ${{ env.ASSET }}
+
+    docker:
+      needs: build_release
+      uses: './.github/workflows/docker.yaml'
+      with:
+        release_version: ${{ needs.build_release.outputs.release_version }}
+        base_hash: ${{ needs.build_release.outputs.base_hash }}
+        publish: true
+        

--- a/.github/workflows/test_relay_server.yml
+++ b/.github/workflows/test_relay_server.yml
@@ -15,6 +15,7 @@ env:
     RUSTDOCFLAGS: -Dwarnings
     MSRV: "1.76"
     SCCACHE_CACHE_SIZE: "50G"
+    IROH_FORCE_STAGING_RELAYS: "1"
     
 jobs:
     build_relay_server:
@@ -31,7 +32,7 @@ jobs:
         - name: Install rust stable
           uses: dtolnay/rust-toolchain@stable
         - name: Install sccache
-          uses: mozilla-actions/sccache-action@v0.0.4
+          uses: mozilla-actions/sccache-action@v0.0.5
     
         - name: build release
           run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   SCCACHE_CACHE_SIZE: "50G"
   CRATES_LIST: "iroh,iroh-blobs,iroh-gossip,iroh-metrics,iroh-net,iroh-net-bench,iroh-docs,iroh-test,iroh-cli,iroh-dns-server"
+  IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
   build_and_test_nix:
@@ -68,7 +69,7 @@ jobs:
         tool: nextest
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.5
 
     - name: Select features
       run: |
@@ -112,9 +113,20 @@ jobs:
 
     - name: run tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
+        mkdir -p output
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+
+    - name: upload results
+      if: ${{ failure() && inputs.flaky }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        path: output
+        retention-days: 45
+        compression-level: 0
 
     - name: doctests
       if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}
@@ -186,7 +198,7 @@ jobs:
         }
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.5
 
     - uses: msys2/setup-msys2@v2
 
@@ -200,6 +212,17 @@ jobs:
 
     - name: tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast
+        mkdir -p output
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+  
+    - name: upload results
+      if: ${{ failure() && inputs.flaky }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        path: output
+        retention-days: 1
+        compression-level: 0


### PR DESCRIPTION
## Description

this is commit `980b53d: refactor(iroh-bytes): Rewrite the blob store to use redb (#2051)`
with two commits on top: `git restore .github --source main`
and `cargo update -p time` because of some regression in type inference or something

This generates some warnings:

Now quickly about the trait Io is never used and others, I kinda ignored them at the point because that's not what I wanted to check but those should ofc make ci fail as well.

About the cfg. This not unification or anything like that, not related to features of dependencies, etc. There is a line in that commit (two lines actually) that put some tests behind said feature with
```
warning: unexpected `cfg` condition value: `file-db`
   --> iroh-cli/tests/cli.rs:216:7
    |
216 | #[cfg(feature = "file-db")]
```

this is an issue because those tests have not been compiled at all in the last 4-5 months since that line was added. So, I wanted to understand how is that we didn't realize

My question here is **why are the test workflows not failing now if I'm using the latest github folder**

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
