### PR TITLE
fix: disable docs preview on forks

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,7 @@ jobs:
   preview_docs:
     timeout-minutes: 30
     name: Docs preview
-    if: "github.event_name == 'pull_request'"
+    if: "github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork"
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: "sccache"


### PR DESCRIPTION
## Description

We disable docs previews on forks because otherwise external contributors cant get a ✅  on CI. The reason for it being is that those forks don't get write permissions to the branch where docs are hosted and the alternative would be to manually juggle a lot of tokens for each user.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
