### PR TITLE
fix: force CI to use staging relays

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: beta-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
 jobs:
   tests:
     uses: './.github/workflows/tests.yaml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.76"
   SCCACHE_CACHE_SIZE: "50G"
+  IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
   tests:

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     types: [opened, edited, synchronize]
 
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
 jobs:
   check-for-cc:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -36,6 +36,9 @@ on:
           type: boolean
           default: false
 
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
 jobs:
     build_and_publish:
       timeout-minutes: 30

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,9 @@ name: Docs Preview
 on:
   pull_request:
 
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
 jobs:
   preview_docs:
     timeout-minutes: 30

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -37,6 +37,9 @@ concurrency:
   group: flaky-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
 jobs:
   tests:
     if: "contains(github.event.pull_request.labels.*.name, 'flaky-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'"

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -13,6 +13,7 @@ env:
   MSRV: "1.66"
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
   netsim:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ env:
   SCCACHE_CACHE_SIZE: "50G"
   BIN_NAMES: "iroh,iroh-relay,iroh-dns-server"
   RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+  IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
     create-release:

--- a/.github/workflows/test_relay_server.yml
+++ b/.github/workflows/test_relay_server.yml
@@ -15,6 +15,7 @@ env:
     RUSTDOCFLAGS: -Dwarnings
     MSRV: "1.76"
     SCCACHE_CACHE_SIZE: "50G"
+    IROH_FORCE_STAGING_RELAYS: "1"
     
 jobs:
     build_relay_server:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   SCCACHE_CACHE_SIZE: "50G"
   CRATES_LIST: "iroh,iroh-blobs,iroh-gossip,iroh-metrics,iroh-net,iroh-net-bench,iroh-docs,iroh-test,iroh-cli,iroh-dns-server"
+  IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
   build_and_test_nix:


### PR DESCRIPTION
## Description

Now that https://github.com/n0-computer/iroh/pull/2551 is landed, time to force all our repos to set this env var.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
