### PR TITLE
test(iroh-cli): reduce flakyness of cli_provide_file_resume

### DIFF
--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -209,6 +209,7 @@ fn cli_provide_tree_resume() -> Result<()> {
     Ok(())
 }
 
+#[ignore = "flaky"]
 #[test]
 fn cli_provide_file_resume() -> Result<()> {
     use iroh::blobs::store::fs::test_support::{make_partial, MakePartialResult};

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -245,6 +245,7 @@ fn cli_provide_file_resume() -> Result<()> {
         assert_eq!(Hash::new(std::fs::read(&tgt)?), hash);
         // compare_files(&src, &tgt)?;
         std::fs::remove_file(&tgt)?;
+        drop(provider);
     }
 
     // second test - full work dir
@@ -258,6 +259,7 @@ fn cli_provide_file_resume() -> Result<()> {
         assert_eq!(matches, vec!["0 B"]);
         assert_eq!(Hash::new(std::fs::read(&tgt)?), hash);
         std::fs::remove_file(&tgt)?;
+        drop(provider);
     }
 
     // third test - partial work dir - truncate some large files
@@ -274,6 +276,7 @@ fn cli_provide_file_resume() -> Result<()> {
         assert_eq!(matches, vec!["65.98 KiB"]);
         assert_eq!(Hash::new(std::fs::read(&tgt)?), hash);
         std::fs::remove_file(&tgt)?;
+        drop(provider);
     }
     Ok(())
 }

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -210,7 +210,6 @@ fn cli_provide_tree_resume() -> Result<()> {
 }
 
 #[test]
-#[ignore = "flaky"]
 fn cli_provide_file_resume() -> Result<()> {
     use iroh::blobs::store::fs::test_support::{make_partial, MakePartialResult};
 

--- a/iroh-net/src/netcheck.rs
+++ b/iroh-net/src/netcheck.rs
@@ -327,7 +327,7 @@ pub(crate) enum Message {
     /// A report produced by the [`reportgen`] actor.
     ReportReady { report: Box<Report> },
     /// The [`reportgen`] actor failed to produce a report.
-    ReportAborted,
+    ReportAborted { err: anyhow::Error },
     /// An incoming STUN packet to parse.
     StunPacket {
         /// The raw UDP payload.
@@ -458,8 +458,8 @@ impl Actor {
                 Message::ReportReady { report } => {
                     self.handle_report_ready(report);
                 }
-                Message::ReportAborted => {
-                    self.handle_report_aborted();
+                Message::ReportAborted { err } => {
+                    self.handle_report_aborted(err);
                 }
                 Message::StunPacket { payload, from_addr } => {
                     self.handle_stun_packet(&payload, from_addr);
@@ -547,10 +547,10 @@ impl Actor {
         }
     }
 
-    fn handle_report_aborted(&mut self) {
+    fn handle_report_aborted(&mut self, err: anyhow::Error) {
         self.in_flight_stun_requests.clear();
         if let Some(ReportRun { report_tx, .. }) = self.current_report_run.take() {
-            report_tx.send(Err(anyhow!("report aborted"))).ok();
+            report_tx.send(Err(anyhow!("report aborted: {err}"))).ok();
         }
     }
 

--- a/iroh-net/src/netcheck.rs
+++ b/iroh-net/src/netcheck.rs
@@ -550,7 +550,7 @@ impl Actor {
     fn handle_report_aborted(&mut self, err: anyhow::Error) {
         self.in_flight_stun_requests.clear();
         if let Some(ReportRun { report_tx, .. }) = self.current_report_run.take() {
-            report_tx.send(Err(anyhow!("report aborted: {err}"))).ok();
+            report_tx.send(Err(err.context("report aborted"))).ok();
         }
     }
 

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -211,7 +211,7 @@ impl Actor {
             Ok(_) => debug!("reportgen actor finished"),
             Err(err) => {
                 self.netcheck
-                    .send(netcheck::Message::ReportAborted)
+                    .send(netcheck::Message::ReportAborted { err })
                     .await
                     .ok();
             }
@@ -256,7 +256,6 @@ impl Actor {
             tokio::select! {
                 biased;
                 _ = &mut total_timer => {
-                    if self.
                     trace!("tick: total_timer expired");
                     bail!("report timed out");
                 }

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -210,7 +210,6 @@ impl Actor {
         match self.run_inner().await {
             Ok(_) => debug!("reportgen actor finished"),
             Err(err) => {
-                error!("reportgen actor failed: {err:#}");
                 self.netcheck
                     .send(netcheck::Message::ReportAborted)
                     .await
@@ -257,6 +256,7 @@ impl Actor {
             tokio::select! {
                 biased;
                 _ = &mut total_timer => {
+                    if self.
                     trace!("tick: total_timer expired");
                     bail!("report timed out");
                 }


### PR DESCRIPTION
## Description

In windows there is no way to copy a file being accessed by another process in an accessible way. This is what makes this test fail since it attempt to copy the blobs.db folder a couple of times while the iroh instance that handles is running.

The change is simple: shutdown the provider, copy the files, re-start the provider. From my perspective, this does not affect what the test is attempting to assert.

Now, since this includes re-starting the iroh instance that provides the files several times, and we match on output, sometimes we can get weird logs related to shutdown. One of those (and the only one I have seen so far) is for a netcheck report and didn't finish on time. Instead of logging this in the reportgen actor, the error is bubbled up to be handled by the netcheck actor (which will have shutdown by then) thus reducing noise and allowing for better error handling in the future

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [x] Tests if relevant.
- [ ] ~~All breaking changes documented.~~
