### PR TITLE
docs(iroh-cli): point to the configuration refernce from each iroh subcommand

### DIFF
--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -81,6 +81,8 @@ pub(crate) enum Commands {
     /// start optionally takes a `--add SOURCE` option, which can be a file or a folder
     /// to serve on startup. Data can also be added after startup with commands like
     /// `iroh blob add` or by adding content to documents.
+    ///
+    /// For general configuration options see <https://iroh.computer/docs/reference/config>.
     Start {
         /// Optionally add a file or folder to the node.
         ///
@@ -99,6 +101,8 @@ pub(crate) enum Commands {
     ///
     /// The console is a REPL for interacting with a running iroh node.
     /// For more info on available commands, see https://iroh.computer/docs/api
+    ///
+    /// For general configuration options see <https://iroh.computer/docs/reference/config>.
     Console,
 
     #[clap(flatten)]

--- a/iroh-cli/src/commands/rpc.rs
+++ b/iroh-cli/src/commands/rpc.rs
@@ -16,6 +16,8 @@ pub enum RpcCommands {
     ///
     /// Documents are mutable, syncable key-value stores.
     /// For more on docs see https://iroh.computer/docs/layers/documents
+    ///
+    /// For general configuration options see <https://iroh.computer/docs/reference/config>.
     Docs {
         #[clap(subcommand)]
         command: DocCommands,
@@ -24,6 +26,8 @@ pub enum RpcCommands {
     /// Manage document authors
     ///
     /// Authors are keypairs that identify writers to documents.
+    ///
+    /// For general configuration options see <https://iroh.computer/docs/reference/config>.
     Authors {
         #[clap(subcommand)]
         command: AuthorCommands,
@@ -32,6 +36,8 @@ pub enum RpcCommands {
     ///
     /// Blobs are immutable, opaque chunks of arbitrary-sized data.
     /// For more on blobs see https://iroh.computer/docs/layers/blobs
+    ///
+    /// For general configuration options see <https://iroh.computer/docs/reference/config>.
     Blobs {
         #[clap(subcommand)]
         command: BlobCommands,
@@ -44,6 +50,8 @@ pub enum RpcCommands {
     /// Manage gossip
     ///
     /// Gossip is a way to broadcast messages to a group of nodes.
+    ///
+    /// For general configuration options see <https://iroh.computer/docs/reference/config>.
     Gossip {
         #[clap(subcommand)]
         command: GossipCommands,
@@ -57,6 +65,8 @@ pub enum RpcCommands {
     /// a tag.
     ///
     /// Any data iroh fetches without a tag will be periodically deleted.
+    ///
+    /// For general configuration options see <https://iroh.computer/docs/reference/config>.
     Tags {
         #[clap(subcommand)]
         command: TagCommands,


### PR DESCRIPTION
## Description

#2537 mentions someone not finding the configuration options after running `iroh start --help`. `iroh --help` already mentions both <https://iroh.computer/docs> in the second line and <https://iroh.computer/docs/reference/config> in the config flag (this one
being fairly recent addition to the help text). I'd say the only thing missing here is to be able to see the docs from the subcommands, which is what this pr does.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [ ] ~~Tests if relevant.~~
- [ ] ~~All breaking changes documented.~~
