### PR TITLE
fix(iroh): don't hit network for complete blobs&collections

### DIFF
--- a/iroh-blobs/src/downloader.rs
+++ b/iroh-blobs/src/downloader.rs
@@ -892,7 +892,6 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     ) {
         self.progress_tracker.remove(&kind);
         self.remove_hash_if_not_queued(&kind.hash());
-        let result = result.map_err(|_| DownloadError::DownloadFailed);
         for (_id, handlers) in intents.into_iter() {
             handlers.on_finish.send(result.clone()).ok();
         }

--- a/iroh-blobs/src/downloader/get.rs
+++ b/iroh-blobs/src/downloader/get.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     get::{db::get_to_db, error::GetError},
-    store::Store,
+    store::{MapEntry, Store},
 };
 use futures_lite::FutureExt;
 #[cfg(feature = "metrics")]
@@ -80,5 +80,14 @@ impl<S: Store> Getter for IoGetter<S> {
             }
         };
         fut.boxed_local()
+    }
+
+    async fn has_complete(&mut self, kind: DownloadKind) -> Option<u64> {
+        let entry = self.store.get(&kind.hash()).await.ok().flatten()?;
+        if entry.is_complete() {
+            Some(entry.size().value())
+        } else {
+            None
+        }
     }
 }

--- a/iroh-blobs/src/downloader/test/dialer.rs
+++ b/iroh-blobs/src/downloader/test/dialer.rs
@@ -21,6 +21,8 @@ struct TestingDialerInner {
     dial_duration: Duration,
     /// Fn deciding if a dial is successful.
     dial_outcome: Box<dyn Fn(NodeId) -> bool + Send + Sync + 'static>,
+    /// Our own node id
+    node_id: NodeId,
 }
 
 impl Default for TestingDialerInner {
@@ -31,6 +33,7 @@ impl Default for TestingDialerInner {
             dial_history: Vec::default(),
             dial_duration: Duration::from_millis(10),
             dial_outcome: Box::new(|_| true),
+            node_id: NodeId::from_bytes(&[0u8; 32]).unwrap(),
         }
     }
 }
@@ -54,6 +57,10 @@ impl Dialer for TestingDialer {
 
     fn is_pending(&self, node: NodeId) -> bool {
         self.0.read().dialing.contains(&node)
+    }
+
+    fn node_id(&self) -> NodeId {
+        self.0.read().node_id
     }
 }
 

--- a/iroh-blobs/src/downloader/test/getter.rs
+++ b/iroh-blobs/src/downloader/test/getter.rs
@@ -55,6 +55,10 @@ impl Getter for TestingGetter {
         }
         .boxed_local()
     }
+
+    async fn has_complete(&mut self, _kind: DownloadKind) -> Option<u64> {
+        None
+    }
 }
 
 impl TestingGetter {

--- a/iroh-blobs/src/downloader/test/getter.rs
+++ b/iroh-blobs/src/downloader/test/getter.rs
@@ -56,8 +56,12 @@ impl Getter for TestingGetter {
         .boxed_local()
     }
 
-    async fn has_complete(&mut self, _kind: DownloadKind) -> Option<u64> {
-        None
+    async fn check_local(
+        &mut self,
+        _kind: DownloadKind,
+        _progress: Option<ProgressSubscriber>,
+    ) -> anyhow::Result<bool> {
+        Ok(false)
     }
 }
 

--- a/iroh-net/src/dialer.rs
+++ b/iroh-net/src/dialer.rs
@@ -99,6 +99,11 @@ impl Dialer {
     pub fn pending_count(&self) -> usize {
         self.pending_dials.len()
     }
+
+    /// Returns a reference to the endpoint used in this dialer.
+    pub fn endpoint(&self) -> &Endpoint {
+        &self.endpoint
+    }
 }
 
 impl Stream for Dialer {

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -948,6 +948,7 @@ mod tests {
     use iroh_net::NodeId;
     use rand::RngCore;
     use tokio::io::AsyncWriteExt;
+    use testresult::TestResult;
 
     #[tokio::test]
     async fn test_blob_create_collection() -> Result<()> {
@@ -1253,7 +1254,7 @@ mod tests {
 
     /// Download a existing blob from oneself
     #[tokio::test]
-    async fn test_blob_get_self_existing() -> Result<()> {
+    async fn test_blob_get_self_existing() -> TestResult<()> {
         let _guard = iroh_test::logging::setup();
 
         let node = crate::node::Node::memory().spawn().await?;
@@ -1261,7 +1262,7 @@ mod tests {
         let client = node.client();
 
         let AddOutcome { hash, size, .. } =
-            client.blobs().add_bytes("foo").await.context("add bytes")?;
+            client.blobs().add_bytes("foo").await?;
 
         // Direct
         let res = client
@@ -1276,8 +1277,7 @@ mod tests {
                 },
             )
             .await?
-            .await
-            .context("direct (download)")?;
+            .await?;
 
         assert_eq!(res.local_size, size);
         assert_eq!(res.downloaded_size, 0);
@@ -1295,8 +1295,7 @@ mod tests {
                 },
             )
             .await?
-            .await
-            .context("queued")?;
+            .await?;
 
         assert_eq!(res.local_size, size);
         assert_eq!(res.downloaded_size, 0);
@@ -1306,7 +1305,7 @@ mod tests {
 
     /// Download a missing blob from oneself
     #[tokio::test]
-    async fn test_blob_get_self_missing() -> Result<()> {
+    async fn test_blob_get_self_missing() -> TestResult<()> {
         let _guard = iroh_test::logging::setup();
 
         let node = crate::node::Node::memory().spawn().await?;
@@ -1360,7 +1359,7 @@ mod tests {
 
     /// Download a existing collection. Check that things succeed and no download is performed.
     #[tokio::test]
-    async fn test_blob_get_existing_collection() -> Result<()> {
+    async fn test_blob_get_existing_collection() -> TestResult<()> {
         let _guard = iroh_test::logging::setup();
 
         let node = crate::node::Node::memory().spawn().await?;

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -1249,49 +1249,17 @@ mod tests {
         Ok(())
     }
 
-    /// Download a blob from oneself
+    /// Download a existing blob from oneself
     #[tokio::test]
-    async fn test_blob_get_self() -> Result<()> {
+    async fn test_blob_get_self_existing() -> Result<()> {
         let _guard = iroh_test::logging::setup();
 
         let node = crate::node::Node::memory().spawn().await?;
-
-        // create temp file
-        let temp_dir = tempfile::tempdir().context("tempdir")?;
-
-        let in_root = temp_dir.path().join("in");
-        tokio::fs::create_dir_all(in_root.clone())
-            .await
-            .context("create dir all")?;
-
-        let path = in_root.join("test-blob");
-        let size = 1024 * 128;
-        let buf: Vec<u8> = (0..size).map(|i| i as u8).collect();
-        let mut file = tokio::fs::File::create(path.clone())
-            .await
-            .context("create file")?;
-        file.write_all(&buf.clone()).await.context("write_all")?;
-        file.flush().await.context("flush")?;
-
+        let node_id = node.node_id();
         let client = node.client();
 
-        let import_outcome = client
-            .blobs()
-            .add_from_path(
-                path.to_path_buf(),
-                false,
-                SetTagOption::Auto,
-                WrapOption::NoWrap,
-            )
-            .await
-            .context("import file")?
-            .finish()
-            .await
-            .context("import finish")?;
-
-        let hash = import_outcome.hash;
-
-        let node_id = node.node_id();
+        let AddOutcome { hash, size, .. } =
+            client.blobs().add_bytes("foo").await.context("add bytes")?;
 
         // Direct
         let res = client
@@ -1305,10 +1273,9 @@ mod tests {
                     mode: DownloadMode::Direct,
                 },
             )
+            .await?
             .await
-            .context("direct")?
-            .await
-            .context("direct")?;
+            .context("direct (download)")?;
 
         assert_eq!(res.local_size, size);
         assert_eq!(res.downloaded_size, 0);
@@ -1325,13 +1292,66 @@ mod tests {
                     mode: DownloadMode::Queued,
                 },
             )
-            .await
-            .context("queued")?
+            .await?
             .await
             .context("queued")?;
 
         assert_eq!(res.local_size, size);
         assert_eq!(res.downloaded_size, 0);
+
+        Ok(())
+    }
+
+    /// Download a missing blob from oneself
+    #[tokio::test]
+    async fn test_blob_get_self_missing() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
+
+        let node = crate::node::Node::memory().spawn().await?;
+        let node_id = node.node_id();
+        let client = node.client();
+
+        let hash = Hash::from_bytes([0u8; 32]);
+
+        // Direct
+        let res = client
+            .blobs()
+            .download_with_opts(
+                hash,
+                DownloadOptions {
+                    format: BlobFormat::Raw,
+                    nodes: vec![node_id.into()],
+                    tag: SetTagOption::Auto,
+                    mode: DownloadMode::Direct,
+                },
+            )
+            .await?
+            .await;
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string().as_str(),
+            "No nodes to download from provided"
+        );
+
+        // Queued
+        let res = client
+            .blobs()
+            .download_with_opts(
+                hash,
+                DownloadOptions {
+                    format: BlobFormat::Raw,
+                    nodes: vec![node_id.into()],
+                    tag: SetTagOption::Auto,
+                    mode: DownloadMode::Queued,
+                },
+            )
+            .await?
+            .await;
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string().as_str(),
+            "No provider nodes found"
+        );
 
         Ok(())
     }

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -944,6 +944,8 @@ mod tests {
     use super::*;
 
     use anyhow::Context as _;
+    use iroh_blobs::hashseq::HashSeq;
+    use iroh_net::NodeId;
     use rand::RngCore;
     use tokio::io::AsyncWriteExt;
 
@@ -1352,6 +1354,83 @@ mod tests {
             res.err().unwrap().to_string().as_str(),
             "No provider nodes found"
         );
+
+        Ok(())
+    }
+
+    /// Download a existing collection. Check that things succeed and no download is performed.
+    #[tokio::test]
+    async fn test_blob_get_existing_collection() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
+
+        let node = crate::node::Node::memory().spawn().await?;
+        // We use a nonexisting node id because we just want to check that this succeeds without
+        // hitting the network.
+        let node_id = NodeId::from_bytes(&[0u8; 32])?;
+        let client = node.client();
+
+        let mut collection = Collection::default();
+        let mut tags = Vec::new();
+        let mut size = 0;
+        for value in ["f", "fo", "foo"] {
+            let import_outcome = client.blobs().add_bytes(value).await.context("add bytes")?;
+            collection.push(value.to_string(), import_outcome.hash);
+            tags.push(import_outcome.tag);
+            size += import_outcome.size;
+        }
+
+        let (hash, _tag) = client
+            .blobs()
+            .create_collection(collection, SetTagOption::Auto, tags)
+            .await?;
+
+        // load the hashseq and collection header manually to calculate our expected size
+        let hashseq_bytes = client.blobs().read_to_bytes(hash).await?;
+        size += hashseq_bytes.len() as u64;
+        let hashseq = HashSeq::try_from(hashseq_bytes)?;
+        let collection_header_bytes = client
+            .blobs()
+            .read_to_bytes(hashseq.into_iter().next().expect("header to exist"))
+            .await?;
+        size += collection_header_bytes.len() as u64;
+
+        // Direct
+        let res = client
+            .blobs()
+            .download_with_opts(
+                hash,
+                DownloadOptions {
+                    format: BlobFormat::HashSeq,
+                    nodes: vec![node_id.into()],
+                    tag: SetTagOption::Auto,
+                    mode: DownloadMode::Direct,
+                },
+            )
+            .await?
+            .await
+            .context("direct (download)")?;
+
+        assert_eq!(res.local_size, size);
+        assert_eq!(res.downloaded_size, 0);
+
+        // Queued
+        let res = client
+            .blobs()
+            .download_with_opts(
+                hash,
+                DownloadOptions {
+                    format: BlobFormat::HashSeq,
+                    nodes: vec![node_id.into()],
+                    tag: SetTagOption::Auto,
+                    mode: DownloadMode::Queued,
+                },
+            )
+            .await?
+            .await
+            .context("queued")?;
+
+        assert_eq!(res.local_size, size);
+        assert_eq!(res.downloaded_size, 0);
 
         Ok(())
     }

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -947,8 +947,8 @@ mod tests {
     use iroh_blobs::hashseq::HashSeq;
     use iroh_net::NodeId;
     use rand::RngCore;
-    use tokio::io::AsyncWriteExt;
     use testresult::TestResult;
+    use tokio::io::AsyncWriteExt;
 
     #[tokio::test]
     async fn test_blob_create_collection() -> Result<()> {
@@ -1261,8 +1261,7 @@ mod tests {
         let node_id = node.node_id();
         let client = node.client();
 
-        let AddOutcome { hash, size, .. } =
-            client.blobs().add_bytes("foo").await?;
+        let AddOutcome { hash, size, .. } = client.blobs().add_bytes("foo").await?;
 
         // Direct
         let res = client
@@ -1371,7 +1370,7 @@ mod tests {
         let mut collection = Collection::default();
         let mut tags = Vec::new();
         let mut size = 0;
-        for value in ["f", "fo", "foo"] {
+        for value in ["iroh", "is", "cool"] {
             let import_outcome = client.blobs().add_bytes(value).await.context("add bytes")?;
             collection.push(value.to_string(), import_outcome.hash);
             tags.push(import_outcome.tag);


### PR DESCRIPTION
## Description

Two changes to the downloader:

* Never try to download from ourselves. If the only provider node added is our own node, fail with error "no providers".
* Check if we have the blob already available locally *before* starting to open any connections

The second point turned out to be a bit more complicated:
* For hashseqs (collections) we have to check that we have *all* children completely available to not start a download
* We should still emit the `FoundLocal` events so that the state tracking at the client works the same no matter if an actual download was performed or not.

Both these things are now implemented, through a new function `check_local_with_progress_if_complete` in iroh_blobs that is called before starting the download. It checks if the blob is fully available locally (and all children too for hashseqs) and if so returns `true`, and emits the  `FoundLocal` events. No events are emitted if the blob is not completely available, as in that case we start the actual download machinery, which will emit the `FoundLocal` events too on the go.




Adds three tests:

* Downloading a missing blob from the local node fails without trying to connect to ourselves
* Downloading an existing blob succeeds without trying to download
* Downloading an existing collection succeeds without trying to download

Closes #2575

## Notes and open questions

The API around the new function and the exisitng `get_to_db` could be improved, and we could skip the double-checking, but that would be a more involved change to a public API that I didn't want to make.


## Breaking changes

None, only an API addition to the public API of  iroh_blobs: `iroh_blobs::get::check_local_with_progress_if_complete`

