### PR TITLE
fix(iroh-net): Fix a compiler error with newer `derive_more` versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,18 +1178,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
+checksum = "3249c0372e72f5f93b5c0ca54c0ab76bbf6216b6f718925476fd9bc4ffabb4fe"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
+checksum = "27d919ced7590fc17b5d5a3c63b662e8a7d2324212c4e4dbbed975cafd22d16d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/iroh-docs/src/store/fs/tables.rs
+++ b/iroh-docs/src/store/fs/tables.rs
@@ -118,6 +118,7 @@ pub struct Tables<'tx> {
     pub records_by_key: Table<'tx, RecordsByKeyId<'static>, ()>,
     pub namespaces: Table<'tx, &'static [u8; 32], (u8, &'static [u8; 32])>,
     pub latest_per_author: Table<'tx, LatestPerAuthorKey<'static>, LatestPerAuthorValue<'static>>,
+    #[debug("MultimapTable")]
     pub namespace_peers: MultimapTable<'tx, &'static [u8; 32], (Nanos, &'static PeerIdBytes)>,
     pub download_policy: Table<'tx, &'static [u8; 32], &'static [u8]>,
     pub authors: Table<'tx, &'static [u8; 32], &'static [u8; 32]>,

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -898,6 +898,7 @@ impl Endpoint {
 #[pin_project::pin_project]
 pub struct Accept<'a> {
     #[pin]
+    #[debug("quinn::Accept")]
     inner: quinn::Accept<'a>,
     magic_ep: Endpoint,
 }


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
The `#[derive(Debug)]` used to generate an impl like this:
```rust
#[automatically_derived]
impl<'a> ::core::fmt::Debug for Accept<'a>
where
    quinn::Accept<'a>: ::core::fmt::Debug,
    Endpoint: ::core::fmt::Debug,
{
// ...
}
```

But `quinn::Accept` doesn't implement `Debug`.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
I'm... Really stumped on what changed in `derive_more`. When I expand the macro, in both versions there's a `Debug` bound on `quinn::Accept`, which just can't be right... Anyhow.

## Change checklist

- [X] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [X] All breaking changes documented.
