### PR TITLE
ref(iroh-net): Remove need for relay info in best_addr

### DIFF
--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -295,8 +295,8 @@ impl NodeState {
             (None, Some(relay_url)) => ConnectionType::Relay(relay_url),
             (None, None) => ConnectionType::None,
         };
-        if self.conn_type.update(typ).is_ok() {
-            let typ = self.conn_type.get();
+        if let Ok(prev_typ) = self.conn_type.update(typ.clone()) {
+            // The connection type has changed.
             event!(
                 target: "events.net.conn_type.changed",
                 Level::DEBUG,
@@ -304,6 +304,30 @@ impl NodeState {
                 conn_type = ?typ,
             );
             info!(%typ, "new connection type");
+
+            // Update some metrics
+            if matches!(prev_typ, ConnectionType::Direct(_)) {
+                inc!(MagicsockMetrics, num_direct_conns_removed);
+            }
+            if matches!(typ, ConnectionType::Direct(_)) {
+                inc!(MagicsockMetrics, num_direct_conns_added);
+            }
+            if matches!(typ, ConnectionType::Relay(_) | ConnectionType::Mixed(_, _))
+                && !matches!(
+                    prev_typ,
+                    ConnectionType::Relay(_) | ConnectionType::Mixed(_, _)
+                )
+            {
+                inc!(MagicsockMetrics, num_relay_conns_added);
+            }
+            if matches!(typ, ConnectionType::Direct(_) | ConnectionType::None)
+                && matches!(
+                    prev_typ,
+                    ConnectionType::Relay(_) | ConnectionType::Mixed(_, _)
+                )
+            {
+                inc!(MagicsockMetrics, num_relay_conns_removed);
+            }
         }
         (best_addr, relay_url)
     }
@@ -367,7 +391,6 @@ impl NodeState {
                     pong.latency,
                     best_addr::Source::BestCandidate,
                     pong.pong_at,
-                    self.relay_url.is_some(),
                 )
             }
         }
@@ -916,7 +939,6 @@ impl NodeState {
                         latency,
                         best_addr::Source::ReceivedPong,
                         now,
-                        self.relay_url.is_some(),
                     );
                 }
 


### PR DESCRIPTION
## Description

This moves metrics for when switches between direct connections and
relayed connections to the NodeState.  This is after all where this
decision is made.  BestAddr only knows about the best UDP address, it
has no business keeping track of relays.

Cleaning this up enables further refactoring of BestAddr and PathState
which need to improve because they depend on each other, but are
hindered by the relay state sneaking into there.

## Breaking Changes

None

## Notes & open questions

These metrics ignore the fact that we have mixed as a possibility so
over-simplify the situation.  This makes the logic to increment them
complex, which in turn makes it no one will really know what they
mean.

I need this to move on with #2546 so don't really want to get into
designing our metrics though.  I believe this way the keep the same
behaviour.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.