### PR TITLE
fix(iroh-net): Make a single direct address in NodeAddr instant

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -499,7 +499,10 @@ impl MagicSock {
         let dest = QuicMappedAddr(dest);
 
         let mut transmits_sent = 0;
-        match self.node_map.get_send_addrs(dest) {
+        match self
+            .node_map
+            .get_send_addrs(dest, self.ipv6_reported.load(Ordering::Relaxed))
+        {
             Some((public_key, udp_addr, relay_url, mut msgs)) => {
                 let mut pings_sent = false;
                 // If we have pings to send, we *have* to send them out first.

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -30,6 +30,7 @@ use crate::{
 
 mod best_addr;
 mod node_state;
+mod udp_paths;
 
 pub use node_state::{ConnectionType, ControlMsg, DirectAddrInfo, NodeInfo};
 pub(super) use node_state::{DiscoPingPurpose, PingAction, PingRole, SendPing};
@@ -186,6 +187,7 @@ impl NodeMap {
     pub(super) fn get_send_addrs(
         &self,
         addr: QuicMappedAddr,
+        have_ipv6: bool,
     ) -> Option<(
         PublicKey,
         Option<SocketAddr>,
@@ -195,7 +197,7 @@ impl NodeMap {
         let mut inner = self.inner.lock();
         let ep = inner.get_mut(NodeStateKey::QuicMappedAddr(addr))?;
         let public_key = *ep.public_key();
-        let (udp_addr, relay_url, msgs) = ep.get_send_addrs();
+        let (udp_addr, relay_url, msgs) = ep.get_send_addrs(have_ipv6);
         Some((public_key, udp_addr, relay_url, msgs))
     }
 

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -25,7 +25,8 @@ use crate::{
 
 use crate::magicsock::{metrics::Metrics as MagicsockMetrics, ActorMessage, QuicMappedAddr};
 
-use super::best_addr::{self, BestAddr, ClearReason, Source};
+use super::best_addr::{self, ClearReason, Source};
+use super::udp_paths::NodeUdpPaths;
 use super::IpPort;
 
 /// Number of addresses that are not active that we keep around per node.
@@ -116,10 +117,7 @@ pub(super) struct NodeState {
     ///
     /// The fallback/bootstrap path, if non-zero (non-zero for well-behaved clients).
     relay_url: Option<(RelayUrl, PathState)>,
-    /// Best non-relay path, i.e. a UDP address.
-    best_addr: BestAddr,
-    /// State for each of this node's direct paths.
-    direct_addr_state: BTreeMap<IpPort, PathState>,
+    udp_paths: NodeUdpPaths,
     sent_pings: HashMap<stun::TransactionId, SentPing>,
     /// Last time this node was used.
     ///
@@ -169,9 +167,8 @@ impl NodeState {
                     PathState::new(options.node_id, SendAddr::Relay(url)),
                 )
             }),
-            best_addr: Default::default(),
+            udp_paths: NodeUdpPaths::new(),
             sent_pings: HashMap::new(),
-            direct_addr_state: BTreeMap::new(),
             last_used: options.active.then(Instant::now),
             last_call_me_maybe: None,
             conn_type: Watchable::new(ConnectionType::None),
@@ -203,7 +200,8 @@ impl NodeState {
         let conn_type = self.conn_type.get();
         let latency = match conn_type {
             ConnectionType::Direct(addr) => self
-                .direct_addr_state
+                .udp_paths
+                .paths
                 .get(&addr.into())
                 .and_then(|state| state.latency()),
             ConnectionType::Relay(ref url) => self
@@ -213,7 +211,8 @@ impl NodeState {
                 .and_then(|(_, state)| state.latency()),
             ConnectionType::Mixed(addr, ref url) => {
                 let addr_latency = self
-                    .direct_addr_state
+                    .udp_paths
+                    .paths
                     .get(&addr.into())
                     .and_then(|state| state.latency());
                 let relay_latency = self
@@ -226,7 +225,8 @@ impl NodeState {
             ConnectionType::None => None,
         };
         let addrs = self
-            .direct_addr_state
+            .udp_paths
+            .paths
             .iter()
             .map(|(addr, endpoint_state)| DirectAddrInfo {
                 addr: SocketAddr::from(*addr),
@@ -261,7 +261,11 @@ impl NodeState {
     /// Returns the address(es) that should be used for sending the next packet.
     ///
     /// This may return to send on one, both or no paths.
-    fn addr_for_send(&mut self, now: &Instant) -> (Option<SocketAddr>, Option<RelayUrl>) {
+    fn addr_for_send(
+        &mut self,
+        now: &Instant,
+        have_ipv6: bool,
+    ) -> (Option<SocketAddr>, Option<RelayUrl>) {
         if relay_only_mode() {
             debug!("in `DEV_relay_ONLY` mode, giving the relay address as the only viable address for this endpoint");
             return (None, self.relay_url());
@@ -269,23 +273,25 @@ impl NodeState {
         // Update our best addr from candidate addresses (only if it is empty and if we have
         // recent pongs).
         self.assign_best_addr_from_candidates_if_empty();
-        let (best_addr, relay_url) = match self.best_addr.state(*now) {
-            best_addr::State::Valid(best_addr) => {
+        let (best_addr, relay_url) = match self.udp_paths.send_addr(*now, have_ipv6) {
+            super::udp_paths::UdpSendAddr::Valid(addr) => {
                 // If we have a valid address we use it.
-                trace!(addr = %best_addr.addr, latency = ?best_addr.latency,
-                       "best_addr is set and valid, use best_addr only");
-                (Some(best_addr.addr), None)
+                trace!(%addr, "UdpSendAddr is valid, use it");
+                (Some(addr), None)
             }
-            best_addr::State::Outdated(best_addr) => {
+            super::udp_paths::UdpSendAddr::Outdated(addr) => {
                 // If the address is outdated we use it, but send via relay at the same time.
                 // We also send disco pings so that it will become valid again if it still
                 // works (i.e. we don't need to holepunch again).
-                trace!(addr = %best_addr.addr, latency = ?best_addr.latency,
-                       "best_addr is set but outdated, use best_addr and relay");
-                (Some(best_addr.addr), self.relay_url())
+                trace!(%addr, "UdpSendAddr is outdated, use it together with relay");
+                (Some(addr), self.relay_url())
             }
-            best_addr::State::Empty => {
-                trace!("best_addr is unset, use relay");
+            super::udp_paths::UdpSendAddr::Unconfirmed(addr) => {
+                trace!(%addr, "UdpSendAddr is unconfirmed, use it together with relay");
+                (Some(addr), self.relay_url())
+            }
+            super::udp_paths::UdpSendAddr::None => {
+                trace!("No UdpSendAddr, use relay");
                 (None, self.relay_url())
             }
         };
@@ -356,7 +362,7 @@ impl NodeState {
     ///
     /// If this is also the best address, it will be cleared as well.
     pub(super) fn remove_direct_addr(&mut self, ip_port: &IpPort, reason: ClearReason) {
-        let Some(state) = self.direct_addr_state.remove(ip_port) else {
+        let Some(state) = self.udp_paths.paths.remove(ip_port) else {
             return;
         };
 
@@ -365,8 +371,11 @@ impl NodeState {
             None => debug!(%ip_port, last_seen=%"never", ?reason, "pruning address"),
         }
 
-        self.best_addr
-            .clear_if_equals((*ip_port).into(), reason, self.relay_url.is_some());
+        self.udp_paths.best_addr.clear_if_equals(
+            (*ip_port).into(),
+            reason,
+            self.relay_url.is_some(),
+        );
     }
 
     /// Fixup best_adrr from candidates.
@@ -375,7 +384,7 @@ impl NodeState {
     /// valid candidates, this will chose a candidate and set best_addr again.  Most likely
     /// this is a bug elsewhere though.
     fn assign_best_addr_from_candidates_if_empty(&mut self) {
-        if !self.best_addr.is_empty() {
+        if !self.udp_paths.best_addr.is_empty() {
             return;
         }
 
@@ -383,7 +392,8 @@ impl NodeState {
         // then this the path will be ignored.
         const MAX_LATENCY: Duration = Duration::from_secs(60 * 60);
         let best_pong = self
-            .direct_addr_state
+            .udp_paths
+            .paths
             .iter()
             .fold(None, |best_pong, (ipp, state)| {
                 let best_latency = best_pong
@@ -406,7 +416,7 @@ impl NodeState {
         if let Some(pong) = best_pong {
             if let SendAddr::Udp(addr) = pong.from {
                 warn!(%addr, "No best_addr was set, choose candidate with lowest latency");
-                self.best_addr.insert_if_better_or_reconfirm(
+                self.udp_paths.best_addr.insert_if_better_or_reconfirm(
                     addr,
                     pong.latency,
                     best_addr::Source::BestCandidate,
@@ -430,7 +440,7 @@ impl NodeState {
             debug!("no previous full ping: need full ping");
             return true;
         };
-        match self.best_addr.state(*now) {
+        match self.udp_paths.best_addr.state(*now) {
             best_addr::State::Empty => {
                 debug!("best addr not set: need full ping");
                 true
@@ -461,7 +471,7 @@ impl NodeState {
             debug!(tx = %hex::encode(txid), addr = %sp.to, "pong not received in timeout");
             match sp.to {
                 SendAddr::Udp(addr) => {
-                    if let Some(path_state) = self.direct_addr_state.get_mut(&addr.into()) {
+                    if let Some(path_state) = self.udp_paths.paths.get_mut(&addr.into()) {
                         path_state.last_ping = None;
                         // only clear the best address if there was no sign of life from this path
                         // within the time the pong should have arrived
@@ -470,7 +480,7 @@ impl NodeState {
                             .map(|last_alive| last_alive.elapsed() <= PING_TIMEOUT_DURATION)
                             .unwrap_or(false);
                         if !consider_alive {
-                            self.best_addr.clear_if_equals(
+                            self.udp_paths.best_addr.clear_if_equals(
                                 addr,
                                 ClearReason::PongTimeout,
                                 self.relay_url().is_some(),
@@ -479,7 +489,7 @@ impl NodeState {
                     } else {
                         // If we have no state for the best addr it should have been cleared
                         // anyway.
-                        self.best_addr.clear_if_equals(
+                        self.udp_paths.best_addr.clear_if_equals(
                             addr,
                             ClearReason::PongTimeout,
                             self.relay_url.is_some(),
@@ -539,7 +549,7 @@ impl NodeState {
         let mut path_found = false;
         match to {
             SendAddr::Udp(addr) => {
-                if let Some(st) = self.direct_addr_state.get_mut(&addr.into()) {
+                if let Some(st) = self.udp_paths.paths.get_mut(&addr.into()) {
                     st.last_ping.replace(now);
                     path_found = true
                 }
@@ -633,7 +643,7 @@ impl NodeState {
     #[must_use = "actions must be handled"]
     fn send_pings(&mut self, now: Instant) -> Vec<PingAction> {
         // We allocate +1 in case the caller wants to add a call-me-maybe message.
-        let mut ping_msgs = Vec::with_capacity(self.direct_addr_state.len() + 1);
+        let mut ping_msgs = Vec::with_capacity(self.udp_paths.paths.len() + 1);
 
         if let Some((url, state)) = self.relay_url.as_ref() {
             if state.needs_ping(&now) {
@@ -653,7 +663,8 @@ impl NodeState {
         }
         self.prune_direct_addresses();
         let mut ping_dsts = String::from("[");
-        self.direct_addr_state
+        self.udp_paths
+            .paths
             .iter()
             .filter_map(|(ipp, state)| state.needs_ping(&now).then_some(*ipp))
             .filter_map(|ipp| {
@@ -668,7 +679,7 @@ impl NodeState {
         debug!(
             %ping_dsts,
             dst = %self.node_id.fmt_short(),
-            paths = %summarize_node_paths(&self.direct_addr_state),
+            paths = %summarize_node_paths(&self.udp_paths.paths),
             "sending pings to node",
         );
         self.last_full_ping.replace(now);
@@ -676,7 +687,7 @@ impl NodeState {
     }
 
     pub(super) fn update_from_node_addr(&mut self, n: &AddrInfo) {
-        if self.best_addr.is_empty() {
+        if self.udp_paths.best_addr.is_empty() {
             // we do not have a direct connection, so changing the relay information may
             // have an effect on our connection status
             if self.relay_url.is_none() && n.relay_url.is_some() {
@@ -702,11 +713,12 @@ impl NodeState {
         }
 
         for &addr in n.direct_addresses.iter() {
-            self.direct_addr_state
+            self.udp_paths
+                .paths
                 .entry(addr.into())
                 .or_insert_with(|| PathState::new(self.node_id, SendAddr::from(addr)));
         }
-        let paths = summarize_node_paths(&self.direct_addr_state);
+        let paths = summarize_node_paths(&self.udp_paths.paths);
         debug!(new = ?n.direct_addresses , %paths, "added new direct paths for endpoint");
     }
 
@@ -714,10 +726,11 @@ impl NodeState {
     #[instrument(skip_all, fields(node = %self.node_id.fmt_short()))]
     pub(super) fn reset(&mut self) {
         self.last_full_ping = None;
-        self.best_addr
+        self.udp_paths
+            .best_addr
             .clear(ClearReason::Reset, self.relay_url.is_some());
 
-        for es in self.direct_addr_state.values_mut() {
+        for es in self.udp_paths.paths.values_mut() {
             es.last_ping = None;
         }
     }
@@ -739,7 +752,7 @@ impl NodeState {
         let now = Instant::now();
 
         let role = match path {
-            SendAddr::Udp(addr) => match self.direct_addr_state.entry(addr.into()) {
+            SendAddr::Udp(addr) => match self.udp_paths.paths.entry(addr.into()) {
                 Entry::Occupied(mut occupied) => occupied.get_mut().handle_ping(tx_id, now),
                 Entry::Vacant(vacant) => {
                     info!(%addr, "new direct addr for node");
@@ -787,7 +800,7 @@ impl NodeState {
         // if the endpoint does not yet have a best_addrr
         let needs_ping_back = if matches!(path, SendAddr::Udp(_))
             && matches!(
-                self.best_addr.state(now),
+                self.udp_paths.best_addr.state(now),
                 best_addr::State::Empty | best_addr::State::Outdated(_)
             ) {
             // We also need to send a ping to make this path available to us as well.  This
@@ -803,7 +816,7 @@ impl NodeState {
         debug!(
             ?role,
             needs_ping_back = ?needs_ping_back.is_some(),
-            paths = %summarize_node_paths(&self.direct_addr_state),
+            paths = %summarize_node_paths(&self.udp_paths.paths),
             "endpoint handled ping",
         );
         PingHandled {
@@ -819,7 +832,8 @@ impl NodeState {
     pub(super) fn prune_direct_addresses(&mut self) {
         // prune candidates are addresses that are not active
         let mut prune_candidates: Vec<_> = self
-            .direct_addr_state
+            .udp_paths
+            .paths
             .iter()
             .filter(|(_ip_port, state)| !state.is_active())
             .map(|(ip_port, state)| (*ip_port, state.last_alive()))
@@ -834,7 +848,7 @@ impl NodeState {
         if prune_count == 0 {
             // nothing to do, within limits
             debug!(
-                paths = %summarize_node_paths(&self.direct_addr_state),
+                paths = %summarize_node_paths(&self.udp_paths.paths),
                 "prune addresses: {prune_count} pruned",
             );
             return;
@@ -848,7 +862,7 @@ impl NodeState {
             self.remove_direct_addr(&ip_port, ClearReason::Inactive)
         }
         debug!(
-            paths = %summarize_node_paths(&self.direct_addr_state),
+            paths = %summarize_node_paths(&self.udp_paths.paths),
             "prune addresses: {prune_count} pruned",
         );
     }
@@ -857,8 +871,8 @@ impl NodeState {
     /// assumptions about which paths work.
     #[instrument("disco", skip_all, fields(node = %self.node_id.fmt_short()))]
     pub(super) fn note_connectivity_change(&mut self) {
-        self.best_addr.clear_trust("connectivity changed");
-        for es in self.direct_addr_state.values_mut() {
+        self.udp_paths.best_addr.clear_trust("connectivity changed");
+        for es in self.udp_paths.paths.values_mut() {
             es.clear();
         }
     }
@@ -906,7 +920,7 @@ impl NodeState {
 
                 match src {
                     SendAddr::Udp(addr) => {
-                        match self.direct_addr_state.get_mut(&addr.into()) {
+                        match self.udp_paths.paths.get_mut(&addr.into()) {
                             None => {
                                 warn!("ignoring pong: no state for src addr");
                                 // This is no longer an endpoint we care about.
@@ -923,7 +937,7 @@ impl NodeState {
                             }
                         }
                         debug!(
-                            paths = %summarize_node_paths(&self.direct_addr_state),
+                            paths = %summarize_node_paths(&self.udp_paths.paths),
                             "handled pong",
                         );
                     }
@@ -954,7 +968,7 @@ impl NodeState {
                 // TODO(bradfitz): decide how latency vs. preference order affects decision
                 if let SendAddr::Udp(to) = sp.to {
                     debug_assert!(!is_relay, "mismatching relay & udp");
-                    self.best_addr.insert_if_better_or_reconfirm(
+                    self.udp_paths.best_addr.insert_if_better_or_reconfirm(
                         to,
                         latency,
                         best_addr::Source::ReceivedPong,
@@ -991,7 +1005,8 @@ impl NodeState {
             }
             let ipp = IpPort::from(*peer_sockaddr);
             call_me_maybe_ipps.insert(ipp);
-            self.direct_addr_state
+            self.udp_paths
+                .paths
                 .entry(ipp)
                 .or_insert_with(|| PathState::new(self.node_id, SendAddr::from(*peer_sockaddr)))
                 .call_me_maybe_time
@@ -1001,7 +1016,7 @@ impl NodeState {
         // Zero out all the last_ping times to force send_pings to send new ones, even if
         // it's been less than 5 seconds ago.  Also clear pongs for direct addresses not
         // included in the updated set.
-        for (ipp, st) in self.direct_addr_state.iter_mut() {
+        for (ipp, st) in self.udp_paths.paths.iter_mut() {
             st.last_ping = None;
             if !call_me_maybe_ipps.contains(ipp) {
                 // TODO: This seems like a weird way to signal that the endpoint no longer
@@ -1014,16 +1029,17 @@ impl NodeState {
         }
         // Clear trust on our best_addr if it is not included in the updated set.  Also
         // clear the last call-me-maybe send time so we will send one again.
-        if let Some(addr) = self.best_addr.addr() {
+        if let Some(addr) = self.udp_paths.best_addr.addr() {
             let ipp: IpPort = addr.into();
             if !call_me_maybe_ipps.contains(&ipp) {
-                self.best_addr
+                self.udp_paths
+                    .best_addr
                     .clear_trust("best_addr not in new call-me-maybe");
                 self.last_call_me_maybe = None;
             }
         }
         debug!(
-            paths = %summarize_node_paths(&self.direct_addr_state),
+            paths = %summarize_node_paths(&self.udp_paths.paths),
             "updated endpoint paths from call-me-maybe",
         );
         self.send_pings(now)
@@ -1031,13 +1047,14 @@ impl NodeState {
 
     /// Marks this endpoint as having received a UDP payload message.
     pub(super) fn receive_udp(&mut self, addr: IpPort, now: Instant) {
-        let Some(state) = self.direct_addr_state.get_mut(&addr) else {
+        let Some(state) = self.udp_paths.paths.get_mut(&addr) else {
             debug_assert!(false, "node map inconsistency by_ip_port <-> direct addr");
             return;
         };
         state.last_payload_msg = Some(now);
         self.last_used = Some(now);
-        self.best_addr
+        self.udp_paths
+            .best_addr
             .reconfirm_if_used(addr.into(), Source::Udp, now);
     }
 
@@ -1063,7 +1080,8 @@ impl NodeState {
     pub(super) fn last_ping(&self, addr: &SendAddr) -> Option<Instant> {
         match addr {
             SendAddr::Udp(addr) => self
-                .direct_addr_state
+                .udp_paths
+                .paths
                 .get(&(*addr).into())
                 .and_then(|ep| ep.last_ping),
             SendAddr::Relay(url) => self
@@ -1100,7 +1118,7 @@ impl NodeState {
         }
 
         // Send heartbeat ping to keep the current addr going as long as we need it.
-        if let Some(udp_addr) = self.best_addr.addr() {
+        if let Some(udp_addr) = self.udp_paths.best_addr.addr() {
             let elapsed = self.last_ping(&SendAddr::Udp(udp_addr)).map(|l| now - l);
             // Send a ping if the last ping is older than 2 seconds.
             let needs_ping = match elapsed {
@@ -1131,10 +1149,11 @@ impl NodeState {
     #[instrument("get_send_addrs", skip_all, fields(node = %self.node_id.fmt_short()))]
     pub(crate) fn get_send_addrs(
         &mut self,
+        have_ipv6: bool,
     ) -> (Option<SocketAddr>, Option<RelayUrl>, Vec<PingAction>) {
         let now = Instant::now();
         self.last_used.replace(now);
-        let (udp_addr, relay_url) = self.addr_for_send(&now);
+        let (udp_addr, relay_url) = self.addr_for_send(&now, have_ipv6);
         let mut ping_msgs = Vec::new();
 
         if self.want_call_me_maybe(&now) {
@@ -1153,12 +1172,12 @@ impl NodeState {
 
     /// Get the direct addresses for this endpoint.
     pub(super) fn direct_addresses(&self) -> impl Iterator<Item = IpPort> + '_ {
-        self.direct_addr_state.keys().copied()
+        self.udp_paths.paths.keys().copied()
     }
 
     #[cfg(test)]
     pub(super) fn direct_address_states(&self) -> impl Iterator<Item = (&IpPort, &PathState)> + '_ {
-        self.direct_addr_state.iter()
+        self.udp_paths.paths.iter()
     }
 
     pub(super) fn last_used(&self) -> Option<Instant> {
@@ -1220,6 +1239,13 @@ impl PathState {
             call_me_maybe_time: None,
             recent_pong: None,
             last_payload_msg: None,
+        }
+    }
+
+    pub(super) fn udp_addr(&self) -> Option<SocketAddr> {
+        match self.path {
+            SendAddr::Udp(addr) => Some(addr),
+            SendAddr::Relay(_) => None,
         }
     }
 
@@ -1337,7 +1363,7 @@ impl PathState {
     }
 
     /// Returns the most recent pong if available.
-    fn recent_pong(&self) -> Option<&PongReply> {
+    pub(super) fn recent_pong(&self) -> Option<&PongReply> {
         self.recent_pong.as_ref()
     }
 
@@ -1604,6 +1630,8 @@ pub enum ConnectionType {
 mod tests {
     use std::net::Ipv4Addr;
 
+    use best_addr::BestAddr;
+
     use super::{
         super::{NodeMap, NodeMapInner},
         *,
@@ -1659,13 +1687,15 @@ mod tests {
                     node_id: key.public(),
                     last_full_ping: None,
                     relay_url: None,
-                    best_addr: BestAddr::from_parts(
-                        ip_port.into(),
-                        latency,
-                        now,
-                        now + Duration::from_secs(100),
+                    udp_paths: NodeUdpPaths::from_parts(
+                        endpoint_state,
+                        BestAddr::from_parts(
+                            ip_port.into(),
+                            latency,
+                            now,
+                            now + Duration::from_secs(100),
+                        ),
                     ),
-                    direct_addr_state: endpoint_state,
                     sent_pings: HashMap::new(),
                     last_used: Some(now),
                     last_call_me_maybe: None,
@@ -1684,8 +1714,7 @@ mod tests {
                 node_id: key.public(),
                 last_full_ping: None,
                 relay_url: relay_and_state(key.public(), send_addr.clone()),
-                best_addr: BestAddr::default(),
-                direct_addr_state: BTreeMap::default(),
+                udp_paths: NodeUdpPaths::new(),
                 sent_pings: HashMap::new(),
                 last_used: Some(now),
                 last_call_me_maybe: None,
@@ -1696,7 +1725,6 @@ mod tests {
         // endpoint w/ no best addr but a relay w/ no latency
         let c_endpoint = {
             // let socket_addr = "0.0.0.0:8".parse().unwrap();
-            let endpoint_state = BTreeMap::new();
             let key = SecretKey::generate();
             NodeState {
                 id: 2,
@@ -1707,8 +1735,7 @@ mod tests {
                     send_addr.clone(),
                     PathState::new(key.public(), SendAddr::from(send_addr.clone())),
                 )),
-                best_addr: BestAddr::default(),
-                direct_addr_state: endpoint_state,
+                udp_paths: NodeUdpPaths::new(),
                 sent_pings: HashMap::new(),
                 last_used: Some(now),
                 last_call_me_maybe: None,
@@ -1741,13 +1768,10 @@ mod tests {
                     node_id: key.public(),
                     last_full_ping: None,
                     relay_url: relay_and_state(key.public(), send_addr.clone()),
-                    best_addr: BestAddr::from_parts(
-                        socket_addr,
-                        Duration::from_millis(80),
-                        now,
-                        expired,
+                    udp_paths: NodeUdpPaths::from_parts(
+                        endpoint_state,
+                        BestAddr::from_parts(socket_addr, Duration::from_millis(80), now, expired),
                     ),
-                    direct_addr_state: endpoint_state,
                     sent_pings: HashMap::new(),
                     last_used: Some(now),
                     last_call_me_maybe: None,

--- a/iroh-net/src/magicsock/node_map/udp_paths.rs
+++ b/iroh-net/src/magicsock/node_map/udp_paths.rs
@@ -133,7 +133,7 @@ impl NodeUdpPaths {
         }
     }
 
-    /// Fixup best_adrr from candidates.
+    /// Fixup best_addr from candidates.
     ///
     /// If somehow we end up in a state where we failed to set a best_addr, while we do have
     /// valid candidates, this will chose a candidate and set best_addr again.  Most likely

--- a/iroh-net/src/magicsock/node_map/udp_paths.rs
+++ b/iroh-net/src/magicsock/node_map/udp_paths.rs
@@ -122,7 +122,7 @@ impl NodeUdpPaths {
                             .filter_map(|path| path.udp_addr())
                             .filter(|addr| addr.is_ipv4() || have_ipv6)
                             .choose(&mut rand::thread_rng());
-                        self.chosen_candidate = addr.clone().map(IpPort::from);
+                        self.chosen_candidate = addr.map(IpPort::from);
                         addr
                     });
                 match addr {

--- a/iroh-net/src/magicsock/node_map/udp_paths.rs
+++ b/iroh-net/src/magicsock/node_map/udp_paths.rs
@@ -103,9 +103,9 @@ impl NodeUdpPaths {
             best_addr::State::Outdated(addr) => UdpSendAddr::Outdated(addr.addr),
             best_addr::State::Empty => {
                 // No direct connection has been used before.  If we know of any possible
-                // candidate addresses, randomlly try to use one.  This path is most
+                // candidate addresses, randomly try to use one.  This path is most
                 // effective when folks use a NodeAddr with exactly one direct address which
-                // they know to work, effectively like using a traditional socket or quic
+                // they know to work, effectively like using a traditional socket or QUIC
                 // endpoint.
                 let addr = self
                     .chosen_candidate

--- a/iroh-net/src/magicsock/node_map/udp_paths.rs
+++ b/iroh-net/src/magicsock/node_map/udp_paths.rs
@@ -122,7 +122,7 @@ impl NodeUdpPaths {
                             .filter_map(|path| path.udp_addr())
                             .filter(|addr| addr.is_ipv4() || have_ipv6)
                             .choose(&mut rand::thread_rng());
-                        self.chosen_candidate = addr.as_ref().map(|addr| IpPort::from(*addr));
+                        self.chosen_candidate = addr.clone().map(IpPort::from);
                         addr
                     });
                 match addr {

--- a/iroh-net/src/magicsock/node_map/udp_paths.rs
+++ b/iroh-net/src/magicsock/node_map/udp_paths.rs
@@ -29,7 +29,7 @@ use super::IpPort;
 ///
 /// See [`NodeUdpPaths::send_addr`].
 ///
-/// [`MagicSock`]: crate::magicsocket::MagicSock
+/// [`MagicSock`]: crate::magicsock::MagicSock
 /// [`NodeState`]: super::node_state::NodeState
 #[derive(Debug)]
 pub(super) enum UdpSendAddr {

--- a/iroh-net/src/magicsock/node_map/udp_paths.rs
+++ b/iroh-net/src/magicsock/node_map/udp_paths.rs
@@ -3,7 +3,8 @@
 //! This started as simply moving the [`NodeState`]'s `direct_addresses` and `best_addr`
 //! into one place together.  The aim is for external places to not directly interact with
 //! the inside and instead only notifies this struct of state changes to each path.
-
+//!
+//! [`NodeState`]: super::node_state::NodeState
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};

--- a/iroh-net/src/magicsock/node_map/udp_paths.rs
+++ b/iroh-net/src/magicsock/node_map/udp_paths.rs
@@ -1,0 +1,148 @@
+//! Path state for UDP addresses of a single peer node.
+//!
+//! This started as simply moving the [`NodeState`]'s `direct_addresses` and `best_addr`
+//! into one place together.  The aim is for external places to not directly interact with
+//! the inside and instead only notifies this struct of state changes to each path.
+
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use rand::seq::IteratorRandom;
+use tracing::warn;
+
+use crate::disco::SendAddr;
+
+use super::best_addr::{self, BestAddr};
+use super::node_state::{PathState, PongReply};
+use super::IpPort;
+
+#[derive(Debug)]
+pub(super) enum UdpSendAddr {
+    Valid(SocketAddr),
+    Outdated(SocketAddr),
+    Unconfirmed(SocketAddr),
+    None,
+}
+
+/// The UDP paths for a single node.
+///
+/// Paths are identified by the [`IpPort`] of their UDP address.
+///
+/// Initially this collects two structs directly from the [`NodeState`] into one place,
+/// leaving the APIs and astractions the same.  The goal is that this slowly migrates
+/// directly interacting with this data into only receiving [`PathState`] updates.  This
+/// will consolidate the logic of direct path selection and make this simpler to reason
+/// about.  However doing that all at once is too large a refactor.
+///
+/// [`NodeState`]: super::node_state::NodeState
+#[derive(Debug, Default)]
+pub(super) struct NodeUdpPaths {
+    /// The state for each of this node's direct paths.
+    pub(super) paths: BTreeMap<IpPort, PathState>,
+    /// Best UDP path currently selected.
+    pub(super) best_addr: BestAddr,
+    /// If we had to choose a path because we had no `best_addr` it is stored here.
+    chosen_candidate: Option<IpPort>,
+}
+
+impl NodeUdpPaths {
+    pub(super) fn new() -> Self {
+        Default::default()
+    }
+
+    #[cfg(test)]
+    pub(super) fn from_parts(paths: BTreeMap<IpPort, PathState>, best_addr: BestAddr) -> Self {
+        Self {
+            paths,
+            best_addr,
+            chosen_candidate: None,
+        }
+    }
+
+    /// Returns the current UDP address to send on.
+    ///
+    /// TODO: The goal here is for this to simply return the already known send address, so
+    /// it should be `&self` and not `&mut self`.  This is only possible once the state from
+    /// [`NodeUdpPaths`] is no longer modified from outside.
+    pub(super) fn send_addr(&mut self, now: Instant, have_ipv6: bool) -> UdpSendAddr {
+        self.assign_best_addr_from_candidates_if_empty();
+        match self.best_addr.state(now) {
+            best_addr::State::Valid(addr) => UdpSendAddr::Valid(addr.addr),
+            best_addr::State::Outdated(addr) => UdpSendAddr::Outdated(addr.addr),
+            best_addr::State::Empty => {
+                // No direct connection has been used before.  If we know of any possible
+                // candidate addresses, randomlly try to use one.  This path is most
+                // effective when folks use a NodeAddr with exactly one direct address which
+                // they know to work, effectively like using a traditional socket or quic
+                // endpoint.
+                let addr = self
+                    .chosen_candidate
+                    .and_then(|ipp| self.paths.get(&ipp))
+                    .and_then(|path| path.udp_addr())
+                    .filter(|addr| addr.is_ipv4() || have_ipv6)
+                    .or_else(|| {
+                        // Look for a new candidate in all the known paths.  This may look
+                        // like a RNG use on the hot-path but this is normally invoked at
+                        // most most once at startup.
+                        let addr = self
+                            .paths
+                            .values()
+                            .filter_map(|path| path.udp_addr())
+                            .filter(|addr| addr.is_ipv4() || have_ipv6)
+                            .choose(&mut rand::thread_rng());
+                        self.chosen_candidate = addr.as_ref().map(|addr| IpPort::from(*addr));
+                        addr
+                    });
+                match addr {
+                    Some(addr) => UdpSendAddr::Unconfirmed(addr),
+                    None => UdpSendAddr::None,
+                }
+            }
+        }
+    }
+
+    /// Fixup best_adrr from candidates.
+    ///
+    /// If somehow we end up in a state where we failed to set a best_addr, while we do have
+    /// valid candidates, this will chose a candidate and set best_addr again.  Most likely
+    /// this is a bug elsewhere though.
+    fn assign_best_addr_from_candidates_if_empty(&mut self) {
+        if !self.best_addr.is_empty() {
+            return;
+        }
+
+        // The highest acceptable latency for an endpoint path.  If the latency is higher
+        // then this the path will be ignored.
+        const MAX_LATENCY: Duration = Duration::from_secs(60 * 60);
+        let best_pong = self.paths.iter().fold(None, |best_pong, (ipp, state)| {
+            let best_latency = best_pong
+                .map(|p: &PongReply| p.latency)
+                .unwrap_or(MAX_LATENCY);
+            match state.recent_pong() {
+                // This pong is better if it has a lower latency, or if it has the same
+                // latency but on an IPv6 path.
+                Some(pong)
+                    if pong.latency < best_latency
+                        || (pong.latency == best_latency && ipp.ip().is_ipv6()) =>
+                {
+                    Some(pong)
+                }
+                _ => best_pong,
+            }
+        });
+
+        // If we found a candidate, set to best addr
+        if let Some(pong) = best_pong {
+            if let SendAddr::Udp(addr) = pong.from {
+                warn!(%addr, "No best_addr was set, choose candidate with lowest latency");
+                self.best_addr.insert_if_better_or_reconfirm(
+                    addr,
+                    pong.latency,
+                    best_addr::Source::BestCandidate,
+                    pong.pong_at,
+                )
+            }
+        }
+    }
+}

--- a/iroh-net/src/magicsock/node_map/udp_paths.rs
+++ b/iroh-net/src/magicsock/node_map/udp_paths.rs
@@ -46,7 +46,7 @@ pub(super) enum UdpSendAddr {
     /// The UDP address is not known to work, but it might.
     ///
     /// We know this UDP address belongs to the remote node, but we do not know if the path
-    /// already works or may need holepunching before it will start to work.  It migt even
+    /// already works or may need holepunching before it will start to work.  It might even
     /// never work.  It is still useful to send to this together with backup path,
     /// i.e. relay, in case the path works: if the path does not need holepunching it might
     /// be much faster.  And if there is no relay path at all it might be the only way to


### PR DESCRIPTION
## Description

In #2509 (c1c3539c0a07d8659979ffacdb5bd1fc23d6939c) we removed chosing
a random unconfirmed direct address and through both it and the relay
if we did not yet have any confirmed direct address.  This required
any direct address passed in via a NodeAddr to do a DISCO Ping-Pong
round trip before it would be used.

It turns out this is used a lot in the sense that a common socket
address is used: when you know an IP is reachable.  Requiring a ping
would mean the first QUIC packets would be dropped, Quinn would wait
to detect this before retrying and connections are delayed by an
observable second by the end of it all.  Not great for this scenario,
even if it can be argued that outside of tests this is not a common
scenario.

So this brings back the random selection of unconfirmed addresses.

It tries to do this without adding more complexity to the NodeState.
Instead it consolidates the path information and best address into the
NodeUdpState struct.  But **without any logic changes.**  It then adds
just this extra caching of the chosen address to this struct.

This is a huge simplification of a much larger refactor I was trying
to do first.  I believe that was the right track but resulted in too
many changes to do in one large PR.  So the long-term goal here is to
continue removing state manipulation outside of NodeUdpState struct so
that it gains more control of how to manage the UDP paths.  This will
help the logic of how UDP paths are chosen to be based entirely on the
PathState - which is the right model for this.

## Breaking Changes

None

## Notes & open questions

Fixed #2546

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.