### PR TITLE
fix: pin derive_more to avoid sudden breakages

### DIFF
--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1"
 
 # key module
 aead = { version = "0.5.2", features = ["bytes"], optional = true }
-derive_more = { version = "1.0.0-beta.6", features = ["debug", "display", "from_str"], optional = true }
+derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "from_str"], optional = true }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"], optional = true }
 once_cell = { version = "1.18.0", optional = true }
 rand = { version = "0.8", optional = true }

--- a/iroh-blobs/Cargo.toml
+++ b/iroh-blobs/Cargo.toml
@@ -21,7 +21,7 @@ async-channel = "2.3.1"
 bao-tree = {  version = "0.13", features = ["tokio_fsm", "validate"], default-features = false }
 bytes = { version = "1.4", features = ["serde"] }
 chrono = "0.4.31"
-derive_more = { version = "1.0.0-beta.6", features = ["debug", "display", "deref", "deref_mut", "from", "try_into", "into"] }
+derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "deref", "deref_mut", "from", "try_into", "into"] }
 flume = "0.11"
 futures-buffered = "0.2.4"
 futures-lite = "2.3"

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -31,7 +31,7 @@ colored = "2.0.4"
 comfy-table = "7.0.1"
 console = "0.15.5"
 crossterm = "0.27.0"
-derive_more = { version = "1.0.0-beta.1", features = ["display"] }
+derive_more = { version = "=1.0.0-beta.7", features = ["display"] }
 dialoguer = { version = "0.11.0", default-features = false }
 dirs-next = "2.0.0"
 futures-buffered = "0.2.4"

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -17,7 +17,7 @@ axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 base64-url = "2.0.2"
 bytes = "1.5.0"
 clap = { version = "4.5.1", features = ["derive"] }
-derive_more = { version = "1.0.0-beta.6", features = ["debug", "display", "into", "from"] }
+derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "into", "from"] }
 dirs-next = "2.0.0"
 futures-lite = "2.3.0"
 governor = "0.6.3"

--- a/iroh-docs/Cargo.toml
+++ b/iroh-docs/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1"
 async-channel = "2.3.1"
 blake3 = { package = "iroh-blake3", version = "1.4.5"}
 bytes = { version = "1.4", features = ["serde"] }
-derive_more = { version = "1.0.0-beta.6", features = ["debug", "deref", "display", "from", "try_into", "into", "as_ref"] }
+derive_more = { version = "=1.0.0-beta.7", features = ["debug", "deref", "display", "from", "try_into", "into", "as_ref"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 futures-buffered = "0.2.4"
 futures-lite = "2.3.0"

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { version = "1" }
 blake3 = { package = "iroh-blake3", version = "1.4.5"}
 bytes = { version = "1.4.0", features = ["serde"] }
-derive_more = { version = "1.0.0-beta.6", features = ["add", "debug", "deref", "display", "from", "try_into", "into"] }
+derive_more = { version = "=1.0.0-beta.7", features = ["add", "debug", "deref", "display", "from", "try_into", "into"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 indexmap = "2.0"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -23,7 +23,7 @@ backoff = "0.4.0"
 bytes = "1"
 netdev = "0.30.0"
 der = { version = "0.7", features = ["alloc", "derive"] }
-derive_more = { version = "1.0.0-beta.6", features = ["debug", "display", "from", "try_into", "deref"] }
+derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "from", "try_into", "deref"] }
 futures-buffered = "0.2.4"
 futures-concurrency = "7.6.0"
 futures-lite = "2.3"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { version = "1" }
 async-channel = "2.3.1"
 bao-tree = { version = "0.13", features = ["tokio_fsm"], default-features = false }
 bytes = "1"
-derive_more = { version = "1.0.0-beta.6", features = ["debug", "display", "from", "try_into", "from_str"] }
+derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "from", "try_into", "from_str"] }
 flume = "0.11"
 futures-buffered = "0.2.4"
 futures-lite = "2.3"


### PR DESCRIPTION
To avoid sudden breakages in new releases, pin `deriver_more` to a specific `beta`

