### PR TITLE
fix(iroh-blobs): do not hit the network when downloading blobs which are complete

### DIFF
--- a/iroh-blobs/src/downloader.rs
+++ b/iroh-blobs/src/downloader.rs
@@ -892,7 +892,6 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     ) {
         self.progress_tracker.remove(&kind);
         self.remove_hash_if_not_queued(&kind.hash());
-        let result = result.map_err(|_| DownloadError::DownloadFailed);
         for (_id, handlers) in intents.into_iter() {
             handlers.on_finish.send(result.clone()).ok();
         }

--- a/iroh-blobs/src/downloader.rs
+++ b/iroh-blobs/src/downloader.rs
@@ -125,7 +125,7 @@ pub trait Getter {
 
 /// Trait modelling the intermediary state when a connection is needed to proceed.
 pub trait NeedsConn<C>: std::fmt::Debug + 'static {
-    /// Proceeds the download with the given conneciton.
+    /// Proceeds the download with the given connection. 
     fn proceed(self, conn: C) -> GetProceedFut;
 }
 
@@ -134,7 +134,7 @@ pub trait NeedsConn<C>: std::fmt::Debug + 'static {
 pub enum GetOutput<N> {
     /// The request is already complete in the local store.
     Complete(Stats),
-    /// The request needs a connetion to continue.
+    /// The request needs a connection to continue.
     NeedsConn(N),
 }
 
@@ -1179,10 +1179,9 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             // > this means that a super slow node would block a download from succeeding for a long
             // > time, while faster nodes could be readily available.
             // As a conclusion, timeouts should be added only after downloads are known to be bounded
-            let fut = get_state.proceed(conn);
             let res = tokio::select! {
                 _ = cancellation.cancelled() => Err(FailureAction::AllIntentsDropped),
-                res = fut => res
+                res = get_state.proceed(conn) => res
             };
             trace!("transfer finished");
 

--- a/iroh-blobs/src/downloader.rs
+++ b/iroh-blobs/src/downloader.rs
@@ -125,7 +125,7 @@ pub trait Getter {
 
 /// Trait modelling the intermediary state when a connection is needed to proceed.
 pub trait NeedsConn<C>: std::fmt::Debug + 'static {
-    /// Proceeds the download with the given connection. 
+    /// Proceeds the download with the given connection.
     fn proceed(self, conn: C) -> GetProceedFut;
 }
 

--- a/iroh-blobs/src/downloader.rs
+++ b/iroh-blobs/src/downloader.rs
@@ -50,7 +50,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     task::JoinSet,
 };
-use tokio_util::{sync::CancellationToken, time::delay_queue};
+use tokio_util::{either::Either, sync::CancellationToken, time::delay_queue};
 use tracing::{debug, error_span, trace, warn, Instrument};
 
 use crate::{
@@ -449,10 +449,12 @@ struct IntentHandlers {
 }
 
 /// Information about a request.
-#[derive(Debug, Default)]
-struct RequestInfo {
+#[derive(Debug)]
+struct RequestInfo<NC> {
     /// Registered intents with progress senders and result callbacks.
     intents: HashMap<IntentId, IntentHandlers>,
+    progress_sender: BroadcastProgressSender,
+    get_state: Option<NC>,
 }
 
 /// Information about a request in progress.
@@ -554,11 +556,9 @@ struct Service<G: Getter, D: Dialer> {
     /// Queue of pending downloads.
     queue: Queue,
     /// Information about pending and active requests.
-    requests: HashMap<DownloadKind, RequestInfo>,
+    requests: HashMap<DownloadKind, RequestInfo<G::NeedsConn>>,
     /// State of running downloads.
     active_requests: HashMap<DownloadKind, ActiveRequestInfo>,
-    /// State of queued downloads.
-    queued_requests: HashMap<DownloadKind, G::NeedsConn>,
     /// Tasks for currently running downloads.
     in_progress_downloads: JoinSet<(DownloadKind, InternalDownloadResult)>,
     /// Progress tracker
@@ -585,7 +585,6 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             retry_nodes_queue: delay_queue::DelayQueue::default(),
             goodbye_nodes_queue: delay_queue::DelayQueue::default(),
             active_requests: Default::default(),
-            queued_requests: Default::default(),
             in_progress_downloads: Default::default(),
             progress_tracker: ProgressTracker::new(),
             queue: Default::default(),
@@ -703,91 +702,76 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         let updated = self.providers.add_hash_with_nodes(kind.hash(), node_ids);
 
         // queue the transfer (if not running) or attach to transfer progress (if already running)
-        if self.active_requests.contains_key(&kind) {
-            // the transfer is already running, so attach the progress sender
-            if let Some(on_progress) = &intent_handlers.on_progress {
-                // this is async because it sends the current state over the progress channel
-                if let Err(err) = self
-                    .progress_tracker
-                    .subscribe(kind, on_progress.clone())
-                    .await
-                {
-                    debug!(?err, %kind, "failed to subscribe progress sender to transfer");
-                }
-            }
-        } else {
-            match self.queued_requests.entry(kind) {
-                hash_map::Entry::Occupied(_entry) => {
-                    if let Some(on_progress) = &intent_handlers.on_progress {
-                        // this is async because it sends the current state over the progress channel
-                        if let Err(err) = self
-                            .progress_tracker
-                            .subscribe(kind, on_progress.clone())
-                            .await
-                        {
-                            debug!(?err, %kind, "failed to subscribe progress sender to transfer");
-                        }
+        match self.requests.entry(kind) {
+            hash_map::Entry::Occupied(mut entry) => {
+                if let Some(on_progress) = &intent_handlers.on_progress {
+                    // this is async because it sends the current state over the progress channel
+                    if let Err(err) = self
+                        .progress_tracker
+                        .subscribe(kind, on_progress.clone())
+                        .await
+                    {
+                        debug!(?err, %kind, "failed to subscribe progress sender to transfer");
                     }
                 }
-                hash_map::Entry::Vacant(entry) => {
-                    let progress_sender = self.progress_tracker.track(
-                        kind,
-                        intent_handlers
-                            .on_progress
-                            .clone()
-                            .into_iter()
-                            .collect::<Vec<_>>(),
-                    );
+                entry.get_mut().intents.insert(intent_id, intent_handlers);
+            }
+            hash_map::Entry::Vacant(entry) => {
+                tracing::warn!("is new, queue");
+                let progress_sender = self.progress_tracker.track(
+                    kind,
+                    intent_handlers
+                        .on_progress
+                        .clone()
+                        .into_iter()
+                        .collect::<Vec<_>>(),
+                );
 
-                    let state = match self.getter.get(kind, progress_sender).await {
-                        Err(_err) => {
+                let get_state = match self.getter.get(kind, progress_sender.clone()).await {
+                    Err(_err) => {
+                        self.finalize_download(
+                            kind,
+                            [(intent_id, intent_handlers)].into(),
+                            // TODO: add better error variant? this is only triggered if the local
+                            // store failed with local IO.
+                            Err(DownloadError::DownloadFailed),
+                        );
+                        return;
+                    }
+                    Ok(GetOutput::Complete(stats)) => {
+                        self.finalize_download(
+                            kind,
+                            [(intent_id, intent_handlers)].into(),
+                            Ok(stats),
+                        );
+                        return;
+                    }
+                    Ok(GetOutput::NeedsConn(state)) => {
+                        // early exit if no providers.
+                        if self.providers.get_candidates(&kind.hash()).next().is_none() {
                             self.finalize_download(
                                 kind,
                                 [(intent_id, intent_handlers)].into(),
-                                // TODO: add better error variant? this is only triggered if the local
-                                // store failed with local IO.
-                                Err(DownloadError::DownloadFailed),
+                                Err(DownloadError::NoProviders),
                             );
                             return;
                         }
-                        Ok(GetOutput::Complete(stats)) => {
-                            self.finalize_download(
-                                kind,
-                                [(intent_id, intent_handlers)].into(),
-                                Ok(stats),
-                            );
-                            return;
-                        }
-                        Ok(GetOutput::NeedsConn(state)) => {
-                            // early exit if no providers.
-                            if self.providers.get_candidates(&kind.hash()).next().is_none() {
-                                self.finalize_download(
-                                    kind,
-                                    [(intent_id, intent_handlers)].into(),
-                                    Err(DownloadError::NoProviders),
-                                );
-                                return;
-                            }
-                            state
-                        }
-                    };
-                    entry.insert(state);
-                }
+                        state
+                    }
+                };
+                entry.insert(RequestInfo {
+                    intents: [(intent_id, intent_handlers)].into_iter().collect(),
+                    progress_sender,
+                    get_state: Some(get_state),
+                });
+                self.queue.insert(kind);
             }
         }
 
-        // the transfer is not running.
         if updated && self.queue.is_parked(&kind) {
             // the transfer is on hold for pending retries, and we added new nodes, so move back to queue.
             self.queue.unpark(&kind);
-        } else if !self.queue.contains(&kind) {
-            // the transfer is not yet queued: add to queue.
-            self.queue.insert(kind);
         }
-
-        // store the request info
-        let request_info = self.requests.entry(kind).or_default();
-        request_info.intents.insert(intent_id, intent_handlers);
     }
 
     /// Cancels a download intent.
@@ -1161,10 +1145,9 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     /// Panics if hash is not in self.requests or node is not in self.nodes.
     fn start_download(&mut self, kind: DownloadKind, node: NodeId) {
         let node_info = self.connected_nodes.get_mut(&node).expect("node exists");
-        let get_state = self
-            .queued_requests
-            .remove(&kind)
-            .expect("queued state exists");
+        let request_info = self.requests.get_mut(&kind).expect("request exists");
+        let progress = request_info.progress_sender.clone();
+        // .expect("queued state exists");
 
         // create the active request state
         let cancellation = CancellationToken::new();
@@ -1173,6 +1156,15 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             node,
         };
         let conn = node_info.conn.clone();
+
+        // If this is the first provider node we try, we have an initial state
+        // from starting the generator in Self::handle_queue_new_download.
+        // If this not the first provider node we try, we have to recreate the generator, because
+        // we can only resume it once.
+        let get_state = match request_info.get_state.take() {
+            Some(state) => Either::Left(async move { Ok(GetOutput::NeedsConn(state)) }),
+            None => Either::Right(self.getter.get(kind, progress)),
+        };
         let fut = async move {
             // NOTE: it's an open question if we should do timeouts at this point. Considerations from @Frando:
             // > at this stage we do not know the size of the download, so the timeout would have
@@ -1180,9 +1172,16 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
             // > this means that a super slow node would block a download from succeeding for a long
             // > time, while faster nodes could be readily available.
             // As a conclusion, timeouts should be added only after downloads are known to be bounded
+            let fut = async move {
+                match get_state.await? {
+                    GetOutput::Complete(stats) => Ok(stats),
+                    GetOutput::NeedsConn(state) => state.proceed(conn).await,
+                }
+            };
+            tokio::pin!(fut);
             let res = tokio::select! {
                 _ = cancellation.cancelled() => Err(FailureAction::AllIntentsDropped),
-                res = get_state.proceed(conn) => res
+                res = &mut fut => res
             };
             trace!("transfer finished");
 

--- a/iroh-blobs/src/downloader/get.rs
+++ b/iroh-blobs/src/downloader/get.rs
@@ -7,12 +7,7 @@ use crate::{
     store::Store,
 };
 use futures_lite::FutureExt;
-#[cfg(feature = "metrics")]
-use iroh_metrics::{inc, inc_by};
 use iroh_net::endpoint;
-
-#[cfg(feature = "metrics")]
-use crate::metrics::Metrics;
 
 use super::{progress::BroadcastProgressSender, DownloadKind, FailureAction, GetStartFut, Getter};
 
@@ -77,7 +72,10 @@ impl super::NeedsConn<endpoint::Connection> for crate::get::db::GetStateNeedsCon
     }
 }
 
+#[cfg(feature = "metrics")]
 fn track_metrics(res: &Result<Stats, GetError>) {
+    use crate::metrics::Metrics;
+    use iroh_metrics::{inc, inc_by};
     match res {
         Ok(stats) => {
             let crate::get::Stats {

--- a/iroh-blobs/src/downloader/get.rs
+++ b/iroh-blobs/src/downloader/get.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     get::{db::get_to_db, error::GetError},
-    store::Store,
+    store::{MapEntry, Store},
 };
 use futures_lite::FutureExt;
 #[cfg(feature = "metrics")]
@@ -80,5 +80,14 @@ impl<S: Store> Getter for IoGetter<S> {
             }
         };
         fut.boxed_local()
+    }
+
+    async fn has_complete(&mut self, kind: DownloadKind) -> Option<u64> {
+        let entry = self.store.get(&kind.hash()).await.ok().flatten()?;
+        if entry.is_complete() {
+            Some(entry.size().value())
+        } else {
+            None
+        }
     }
 }

--- a/iroh-blobs/src/downloader/get.rs
+++ b/iroh-blobs/src/downloader/get.rs
@@ -3,7 +3,7 @@
 //! [`Connection`]: iroh_net::endpoint::Connection
 
 use crate::{
-    get::{db::get_to_db_in_steps, error::GetError, Stats},
+    get::{db::get_to_db_in_steps, error::GetError},
     store::Store,
 };
 use futures_lite::FutureExt;
@@ -73,7 +73,7 @@ impl super::NeedsConn<endpoint::Connection> for crate::get::db::GetStateNeedsCon
 }
 
 #[cfg(feature = "metrics")]
-fn track_metrics(res: &Result<Stats, GetError>) {
+fn track_metrics(res: &Result<crate::get::Stats, GetError>) {
     use crate::metrics::Metrics;
     use iroh_metrics::{inc, inc_by};
     match res {

--- a/iroh-blobs/src/downloader/invariants.rs
+++ b/iroh-blobs/src/downloader/invariants.rs
@@ -77,8 +77,8 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
         // check that the count of futures we are polling for downloads is consistent with the
         // number of requests
         assert_eq!(
-            self.in_progress_downloads.len(),
             self.active_requests.len(),
+            self.in_progress_downloads.len(),
             "active_requests and in_progress_downloads are out of sync"
         );
         // check that the count of requests per peer matches the number of requests that have that

--- a/iroh-blobs/src/downloader/progress.rs
+++ b/iroh-blobs/src/downloader/progress.rs
@@ -103,6 +103,7 @@ struct Inner {
 
 impl Inner {
     fn subscribe(&mut self, subscriber: ProgressSubscriber) -> DownloadProgress {
+        tracing::warn!(state=?self.state, "subscribe! emit initial");
         let msg = DownloadProgress::InitialState(self.state.clone());
         self.subscribers.push(subscriber);
         msg
@@ -136,7 +137,9 @@ impl ProgressSender for BroadcastProgressSender {
         // making sure that the lock is not held across an await point.
         let futs = {
             let mut inner = self.shared.lock();
+            tracing::warn!(?msg, state_pre=?inner.state, "send to {}", inner.subscribers.len());
             inner.on_progress(msg.clone());
+            tracing::warn!(state_post=?inner.state, "send");
             let futs = inner
                 .subscribers
                 .iter_mut()

--- a/iroh-blobs/src/downloader/test/dialer.rs
+++ b/iroh-blobs/src/downloader/test/dialer.rs
@@ -21,6 +21,8 @@ struct TestingDialerInner {
     dial_duration: Duration,
     /// Fn deciding if a dial is successful.
     dial_outcome: Box<dyn Fn(NodeId) -> bool + Send + Sync + 'static>,
+    /// Our own node id
+    node_id: NodeId,
 }
 
 impl Default for TestingDialerInner {
@@ -31,6 +33,7 @@ impl Default for TestingDialerInner {
             dial_history: Vec::default(),
             dial_duration: Duration::from_millis(10),
             dial_outcome: Box::new(|_| true),
+            node_id: NodeId::from_bytes(&[0u8; 32]).unwrap(),
         }
     }
 }
@@ -54,6 +57,10 @@ impl Dialer for TestingDialer {
 
     fn is_pending(&self, node: NodeId) -> bool {
         self.0.read().dialing.contains(&node)
+    }
+
+    fn node_id(&self) -> NodeId {
+        self.0.read().node_id
     }
 }
 

--- a/iroh-blobs/src/downloader/test/getter.rs
+++ b/iroh-blobs/src/downloader/test/getter.rs
@@ -55,6 +55,10 @@ impl Getter for TestingGetter {
         }
         .boxed_local()
     }
+
+    async fn has_complete(&mut self, _kind: DownloadKind) -> Option<u64> {
+        None
+    }
 }
 
 impl TestingGetter {

--- a/iroh-blobs/src/downloader/test/getter.rs
+++ b/iroh-blobs/src/downloader/test/getter.rs
@@ -3,9 +3,12 @@
 use futures_lite::{future::Boxed as BoxFuture, FutureExt};
 use parking_lot::RwLock;
 
+use crate::downloader;
+
 use super::*;
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, derive_more::Debug)]
+#[debug("TestingGetter")]
 pub(super) struct TestingGetter(Arc<RwLock<TestingGetterInner>>);
 
 pub(super) type RequestHandlerFn = Arc<
@@ -34,14 +37,29 @@ impl Getter for TestingGetter {
     // since for testing we don't need a real connection, just keep track of what peer is the
     // request being sent to
     type Connection = NodeId;
+    type NeedsConn = GetStateNeedsConn;
 
     fn get(
         &mut self,
         kind: DownloadKind,
-        peer: NodeId,
         progress_sender: BroadcastProgressSender,
-    ) -> GetFut {
-        let mut inner = self.0.write();
+    ) -> GetStartFut<Self::NeedsConn> {
+        std::future::ready(Ok(downloader::GetOutput::NeedsConn(GetStateNeedsConn(
+            self.clone(),
+            kind,
+            progress_sender,
+        ))))
+        .boxed_local()
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct GetStateNeedsConn(TestingGetter, DownloadKind, BroadcastProgressSender);
+
+impl downloader::NeedsConn<NodeId> for GetStateNeedsConn {
+    fn proceed(self, peer: NodeId) -> super::GetProceedFut {
+        let GetStateNeedsConn(getter, kind, progress_sender) = self;
+        let mut inner = getter.0.write();
         inner.request_history.push((kind, peer));
         let request_duration = inner.request_duration;
         let handler = inner.request_handler.clone();
@@ -54,14 +72,6 @@ impl Getter for TestingGetter {
             }
         }
         .boxed_local()
-    }
-
-    async fn check_local(
-        &mut self,
-        _kind: DownloadKind,
-        _progress: Option<ProgressSubscriber>,
-    ) -> anyhow::Result<bool> {
-        Ok(false)
     }
 }
 

--- a/iroh-blobs/src/downloader/test/getter.rs
+++ b/iroh-blobs/src/downloader/test/getter.rs
@@ -56,8 +56,12 @@ impl Getter for TestingGetter {
         .boxed_local()
     }
 
-    async fn has_complete(&mut self, _kind: DownloadKind) -> Option<u64> {
-        None
+    async fn check_local(
+        &mut self,
+        _kind: DownloadKind,
+        _progress: Option<ProgressSubscriber>,
+    ) -> anyhow::Result<bool> {
+        Ok(false)
     }
 }
 

--- a/iroh-blobs/src/get/db.rs
+++ b/iroh-blobs/src/get/db.rs
@@ -59,9 +59,9 @@ pub async fn get_to_db<
     db: &D,
     get_conn: C,
     hash_and_format: &HashAndFormat,
-    progress: impl ProgressSender<Msg = DownloadProgress> + IdGenerator,
+    progress_sender: impl ProgressSender<Msg = DownloadProgress> + IdGenerator,
 ) -> Result<Stats, GetError> {
-    match get_to_db_in_steps(db.clone(), *hash_and_format, progress).await? {
+    match get_to_db_in_steps(db.clone(), *hash_and_format, progress_sender).await? {
         GetState::Complete(res) => Ok(res),
         GetState::NeedsConn(state) => {
             let conn = get_conn().await.map_err(GetError::Io)?;
@@ -86,10 +86,10 @@ pub async fn get_to_db_in_steps<
 >(
     db: D,
     hash_and_format: HashAndFormat,
-    progress: P,
+    progress_sender: P,
 ) -> Result<GetState, GetError> {
     let mut gen: GetGenerator = genawaiter::rc::Gen::new(move |co| {
-        let fut = async move { producer(co, &db, &hash_and_format, progress).await };
+        let fut = async move { producer(co, &db, &hash_and_format, progress_sender).await };
         let fut: GetFuture = Box::pin(fut);
         fut
     });

--- a/iroh-net/src/dialer.rs
+++ b/iroh-net/src/dialer.rs
@@ -99,6 +99,11 @@ impl Dialer {
     pub fn pending_count(&self) -> usize {
         self.pending_dials.len()
     }
+
+    /// Returns a reference to the endpoint used in this dialer.
+    pub fn endpoint(&self) -> &Endpoint {
+        &self.endpoint
+    }
 }
 
 impl Stream for Dialer {

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -948,6 +948,7 @@ mod tests {
     use iroh_net::NodeId;
     use rand::RngCore;
     use tokio::io::AsyncWriteExt;
+    use testresult::TestResult;
 
     #[tokio::test]
     async fn test_blob_create_collection() -> Result<()> {
@@ -1253,7 +1254,7 @@ mod tests {
 
     /// Download a existing blob from oneself
     #[tokio::test]
-    async fn test_blob_get_self_existing() -> Result<()> {
+    async fn test_blob_get_self_existing() -> TestResult<()> {
         let _guard = iroh_test::logging::setup();
 
         let node = crate::node::Node::memory().spawn().await?;
@@ -1261,7 +1262,7 @@ mod tests {
         let client = node.client();
 
         let AddOutcome { hash, size, .. } =
-            client.blobs().add_bytes("foo").await.context("add bytes")?;
+            client.blobs().add_bytes("foo").await?;
 
         // Direct
         let res = client
@@ -1276,8 +1277,7 @@ mod tests {
                 },
             )
             .await?
-            .await
-            .context("direct (download)")?;
+            .await?;
 
         assert_eq!(res.local_size, size);
         assert_eq!(res.downloaded_size, 0);
@@ -1295,8 +1295,7 @@ mod tests {
                 },
             )
             .await?
-            .await
-            .context("queued")?;
+            .await?;
 
         assert_eq!(res.local_size, size);
         assert_eq!(res.downloaded_size, 0);
@@ -1306,7 +1305,7 @@ mod tests {
 
     /// Download a missing blob from oneself
     #[tokio::test]
-    async fn test_blob_get_self_missing() -> Result<()> {
+    async fn test_blob_get_self_missing() -> TestResult<()> {
         let _guard = iroh_test::logging::setup();
 
         let node = crate::node::Node::memory().spawn().await?;
@@ -1360,7 +1359,7 @@ mod tests {
 
     /// Download a existing collection. Check that things succeed and no download is performed.
     #[tokio::test]
-    async fn test_blob_get_existing_collection() -> Result<()> {
+    async fn test_blob_get_existing_collection() -> TestResult<()> {
         let _guard = iroh_test::logging::setup();
 
         let node = crate::node::Node::memory().spawn().await?;

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -1249,49 +1249,17 @@ mod tests {
         Ok(())
     }
 
-    /// Download a blob from oneself
+    /// Download a existing blob from oneself
     #[tokio::test]
-    async fn test_blob_get_self() -> Result<()> {
+    async fn test_blob_get_self_existing() -> Result<()> {
         let _guard = iroh_test::logging::setup();
 
         let node = crate::node::Node::memory().spawn().await?;
-
-        // create temp file
-        let temp_dir = tempfile::tempdir().context("tempdir")?;
-
-        let in_root = temp_dir.path().join("in");
-        tokio::fs::create_dir_all(in_root.clone())
-            .await
-            .context("create dir all")?;
-
-        let path = in_root.join("test-blob");
-        let size = 1024 * 128;
-        let buf: Vec<u8> = (0..size).map(|i| i as u8).collect();
-        let mut file = tokio::fs::File::create(path.clone())
-            .await
-            .context("create file")?;
-        file.write_all(&buf.clone()).await.context("write_all")?;
-        file.flush().await.context("flush")?;
-
+        let node_id = node.node_id();
         let client = node.client();
 
-        let import_outcome = client
-            .blobs()
-            .add_from_path(
-                path.to_path_buf(),
-                false,
-                SetTagOption::Auto,
-                WrapOption::NoWrap,
-            )
-            .await
-            .context("import file")?
-            .finish()
-            .await
-            .context("import finish")?;
-
-        let hash = import_outcome.hash;
-
-        let node_id = node.node_id();
+        let AddOutcome { hash, size, .. } =
+            client.blobs().add_bytes("foo").await.context("add bytes")?;
 
         // Direct
         let res = client
@@ -1305,10 +1273,9 @@ mod tests {
                     mode: DownloadMode::Direct,
                 },
             )
+            .await?
             .await
-            .context("direct")?
-            .await
-            .context("direct")?;
+            .context("direct (download)")?;
 
         assert_eq!(res.local_size, size);
         assert_eq!(res.downloaded_size, 0);
@@ -1325,13 +1292,66 @@ mod tests {
                     mode: DownloadMode::Queued,
                 },
             )
-            .await
-            .context("queued")?
+            .await?
             .await
             .context("queued")?;
 
         assert_eq!(res.local_size, size);
         assert_eq!(res.downloaded_size, 0);
+
+        Ok(())
+    }
+
+    /// Download a missing blob from oneself
+    #[tokio::test]
+    async fn test_blob_get_self_missing() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
+
+        let node = crate::node::Node::memory().spawn().await?;
+        let node_id = node.node_id();
+        let client = node.client();
+
+        let hash = Hash::from_bytes([0u8; 32]);
+
+        // Direct
+        let res = client
+            .blobs()
+            .download_with_opts(
+                hash,
+                DownloadOptions {
+                    format: BlobFormat::Raw,
+                    nodes: vec![node_id.into()],
+                    tag: SetTagOption::Auto,
+                    mode: DownloadMode::Direct,
+                },
+            )
+            .await?
+            .await;
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string().as_str(),
+            "No nodes to download from provided"
+        );
+
+        // Queued
+        let res = client
+            .blobs()
+            .download_with_opts(
+                hash,
+                DownloadOptions {
+                    format: BlobFormat::Raw,
+                    nodes: vec![node_id.into()],
+                    tag: SetTagOption::Auto,
+                    mode: DownloadMode::Queued,
+                },
+            )
+            .await?
+            .await;
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string().as_str(),
+            "No provider nodes found"
+        );
 
         Ok(())
     }

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -944,6 +944,8 @@ mod tests {
     use super::*;
 
     use anyhow::Context as _;
+    use iroh_blobs::hashseq::HashSeq;
+    use iroh_net::NodeId;
     use rand::RngCore;
     use tokio::io::AsyncWriteExt;
 
@@ -1352,6 +1354,83 @@ mod tests {
             res.err().unwrap().to_string().as_str(),
             "No provider nodes found"
         );
+
+        Ok(())
+    }
+
+    /// Download a existing collection. Check that things succeed and no download is performed.
+    #[tokio::test]
+    async fn test_blob_get_existing_collection() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
+
+        let node = crate::node::Node::memory().spawn().await?;
+        // We use a nonexisting node id because we just want to check that this succeeds without
+        // hitting the network.
+        let node_id = NodeId::from_bytes(&[0u8; 32])?;
+        let client = node.client();
+
+        let mut collection = Collection::default();
+        let mut tags = Vec::new();
+        let mut size = 0;
+        for value in ["f", "fo", "foo"] {
+            let import_outcome = client.blobs().add_bytes(value).await.context("add bytes")?;
+            collection.push(value.to_string(), import_outcome.hash);
+            tags.push(import_outcome.tag);
+            size += import_outcome.size;
+        }
+
+        let (hash, _tag) = client
+            .blobs()
+            .create_collection(collection, SetTagOption::Auto, tags)
+            .await?;
+
+        // load the hashseq and collection header manually to calculate our expected size
+        let hashseq_bytes = client.blobs().read_to_bytes(hash).await?;
+        size += hashseq_bytes.len() as u64;
+        let hashseq = HashSeq::try_from(hashseq_bytes)?;
+        let collection_header_bytes = client
+            .blobs()
+            .read_to_bytes(hashseq.into_iter().next().expect("header to exist"))
+            .await?;
+        size += collection_header_bytes.len() as u64;
+
+        // Direct
+        let res = client
+            .blobs()
+            .download_with_opts(
+                hash,
+                DownloadOptions {
+                    format: BlobFormat::HashSeq,
+                    nodes: vec![node_id.into()],
+                    tag: SetTagOption::Auto,
+                    mode: DownloadMode::Direct,
+                },
+            )
+            .await?
+            .await
+            .context("direct (download)")?;
+
+        assert_eq!(res.local_size, size);
+        assert_eq!(res.downloaded_size, 0);
+
+        // Queued
+        let res = client
+            .blobs()
+            .download_with_opts(
+                hash,
+                DownloadOptions {
+                    format: BlobFormat::HashSeq,
+                    nodes: vec![node_id.into()],
+                    tag: SetTagOption::Auto,
+                    mode: DownloadMode::Queued,
+                },
+            )
+            .await?
+            .await
+            .context("queued")?;
+
+        assert_eq!(res.local_size, size);
+        assert_eq!(res.downloaded_size, 0);
 
         Ok(())
     }

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -947,8 +947,8 @@ mod tests {
     use iroh_blobs::hashseq::HashSeq;
     use iroh_net::NodeId;
     use rand::RngCore;
-    use tokio::io::AsyncWriteExt;
     use testresult::TestResult;
+    use tokio::io::AsyncWriteExt;
 
     #[tokio::test]
     async fn test_blob_create_collection() -> Result<()> {
@@ -1261,8 +1261,7 @@ mod tests {
         let node_id = node.node_id();
         let client = node.client();
 
-        let AddOutcome { hash, size, .. } =
-            client.blobs().add_bytes("foo").await?;
+        let AddOutcome { hash, size, .. } = client.blobs().add_bytes("foo").await?;
 
         // Direct
         let res = client
@@ -1371,7 +1370,7 @@ mod tests {
         let mut collection = Collection::default();
         let mut tags = Vec::new();
         let mut size = 0;
-        for value in ["f", "fo", "foo"] {
+        for value in ["iroh", "is", "cool"] {
             let import_outcome = client.blobs().add_bytes(value).await.context("add bytes")?;
             collection.push(value.to_string(), import_outcome.hash);
             tags.push(import_outcome.tag);

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -1221,7 +1221,11 @@ where
                             remaining_nodes -= 1;
                             let node_id = node.node_id;
                             if node_id == endpoint.node_id() {
-                                debug!(?remaining_nodes, "skip node {} (it is the node id of ourselves)",                                    node_id.fmt_short());
+                                debug!(
+                                    ?remaining_nodes,
+                                    "skip node {} (it is the node id of ourselves)",
+                                    node_id.fmt_short()
+                                );
                                 continue 'inner;
                             }
                             match endpoint.connect(node, iroh_blobs::protocol::ALPN).await {


### PR DESCRIPTION
## Description

Two changes to the downloader:

* Never try to download from ourselves. If the only provider node added is our own node, fail with error "no providers".
* The actual download request flow is turned into a generator (while keeping API compatibility for the existing `get_to_db` public function). A new `get_to_db_in_steps` function either runs to completion if the requested data is fully available locally, or yields a `NeedsConn` struct at the point where it needs a network connection to proceed. The `NeedsConn` has an `async proceed(self, conn: Connection)`, which must be called with a connection for the actual download to start.

This two-step process allows the downloader to check if we should dial nodes at all, or are already done without doing anything, while emitting the exact same flow of events (because we run the same loop) to the client.

To achieve this, `get_to_db` now uses a genawaiter generator internally. This means that the big loop that is the iroh-blobs protocol request flow does not have to be changed at all, only that instead of a closure we yield and resume, which makes this much easier to integrate into an external state machine like the downloader.

The changes needed for this for the downloader are a bit verbose because the downloader itself is generic over a `Getter`, with impls for the actual impl and a test impl that does not use networking; therefore the new `NeedsConn` state has to be modeled with an additional associated type and trait here.

This PR adds three tests:

* Downloading a missing blob from the local node fails without trying to connect to ourselves
* Downloading an existing blob succeeds without trying to download
* Downloading an existing collection succeeds without trying to download

Closes #2575
Replaced #2576

## Notes and open questions



## Breaking changes

None, only an API addition to the public API of  iroh_blobs: `iroh_blobs::get::check_local_with_progress_if_complete`

