### PR TITLE
bug: `LocalPool` swallowing logs in `iroh-blobs` tests

### DIFF
--- a/iroh-test/src/logging.rs
+++ b/iroh-test/src/logging.rs
@@ -40,6 +40,21 @@ pub fn setup() -> tracing::subscriber::DefaultGuard {
     testing_subscriber().set_default()
 }
 
+/// Enable test tracing on all threads.
+pub fn setup_global() {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        match handle.runtime_flavor() {
+            RuntimeFlavor::CurrentThread => (),
+            RuntimeFlavor::MultiThread => {
+                panic!("setup_logging() does not work in a multi-threaded tokio runtime");
+            }
+            _ => panic!("unknown runtime flavour"),
+        }
+    }
+    // Errors when a global one has already been set before.
+    tracing::subscriber::set_global_default(testing_subscriber()).ok();
+}
+
 /// The first call to this function will install a global logger.
 ///
 /// The logger uses the `RUST_LOG` environment variable to decide on what level to log


### PR DESCRIPTION
## Description

While investigating the flaky CI failure of the `localpool::test_drop` test, I found an example of `LocalPool` eating logging.

The logs inside the `test_drop` print, but any logs written in `LocalPool::spawn_detached` are lost.

run `cargo test --package iroh-blobs test_drop -- --nocapture` to view.

I also had to change from using `tracing_subscriber::fmt::try_init()` to `iroh_test::logging::setup()` in the test to get ANY logging to show.

Related to #2577

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
