### PR TITLE
fix(iroh): Do not set low max streams in builder

### DIFF
--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -54,7 +54,6 @@ const ENDPOINT_WAIT: Duration = Duration::from_secs(5);
 const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60 * 5);
 
 const MAX_CONNECTIONS: u32 = 1024;
-const MAX_STREAMS: u64 = 10;
 
 /// Storage backend for documents.
 #[derive(Debug, Clone)]
@@ -458,11 +457,6 @@ where
             ..Default::default()
         });
         let (endpoint, nodes_data_path) = {
-            let mut transport_config = quinn::TransportConfig::default();
-            transport_config
-                .max_concurrent_bidi_streams(MAX_STREAMS.try_into()?)
-                .max_concurrent_uni_streams(0u32.into());
-
             let discovery: Option<Box<dyn Discovery>> = match self.node_discovery {
                 DiscoveryConfig::None => None,
                 DiscoveryConfig::Custom(discovery) => Some(discovery),
@@ -501,7 +495,6 @@ where
                 .secret_key(self.secret_key.clone())
                 .proxy_from_env()
                 .keylog(self.keylog)
-                .transport_config(transport_config)
                 .concurrent_connections(MAX_CONNECTIONS)
                 .relay_mode(self.relay_mode);
             let endpoint = match discovery {


### PR DESCRIPTION
## Description

This removes the max streams in the builder.  This makes little sense
when users are allowed to create their custom protocol.

right now both uni and bidirectional streams default to 100 max, which
is reasonable for now.  We should allow fully customising the
TransportConfig later.

## Breaking Changes

I don't think this counts as a breaking change.  If we want to lower
one of these later it would be, but we're probably fine with 100 by
default?

## Notes & open questions

See #2592

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.