### PR TITLE
fix(iroh-gossip): clarify docs and semantics of gossip joined event

### DIFF
--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -501,8 +501,9 @@ impl Actor {
                     neighbors,
                     event_senders,
                     command_rx_keys,
+                    joined,
                 } = state;
-                if !neighbors.is_empty() {
+                if *joined {
                     let neighbors = neighbors.iter().copied().collect();
                     channels
                         .event_tx
@@ -588,14 +589,15 @@ impl Actor {
                         continue;
                     };
                     let TopicState {
+                        joined,
                         neighbors,
                         event_senders,
                         command_rx_keys,
                     } = state;
                     let event = if let ProtoEvent::NeighborUp(neighbor) = event {
-                        let was_empty = neighbors.is_empty();
                         neighbors.insert(neighbor);
-                        if was_empty {
+                        if !*joined {
+                            *joined = true;
                             GossipEvent::Joined(vec![neighbor])
                         } else {
                             GossipEvent::NeighborUp(neighbor)
@@ -662,6 +664,7 @@ impl Default for PeerState {
 
 #[derive(Debug, Default)]
 struct TopicState {
+    joined: bool,
     neighbors: BTreeSet<NodeId>,
     event_senders: EventSenders,
     command_rx_keys: HashSet<stream_group::Key>,


### PR DESCRIPTION
## Description

Improves documentation around the `GossipEvent::Joined` event: It is only emitted once at the beginning of the stream, and the event will not be emitted when awaiting `GossipReceiver::joined`.

Also makes sure that the event is actually only emitted once per intent (it potentially could have been emitted multiple times before if the neighbor count first got down to 0 and then up again for `GossipTopics` subscribing inbetween).

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Inspired by the discussion in https://github.com/deltachat/deltachat-core-rust/pull/5860

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
