### PR TITLE
[wip] feat(iroh-willow): refactor peer manager to properly close connections and drop duplicates

### DIFF
--- a/iroh-willow/src/auth.rs
+++ b/iroh-willow/src/auth.rs
@@ -36,14 +36,14 @@ impl DelegateTo {
 #[derive(Debug, Clone)]
 pub enum RestrictArea {
     None,
-    Restrict(Area)
+    Restrict(Area),
 }
 
 impl RestrictArea {
     pub fn with_default(self, default: Area) -> Area {
         match self {
             RestrictArea::None => default.clone(),
-            RestrictArea::Restrict(area) => area
+            RestrictArea::Restrict(area) => area,
         }
     }
 }

--- a/iroh-willow/src/engine.rs
+++ b/iroh-willow/src/engine.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use iroh_net::{endpoint::Connection, util::SharedAbortingJoinHandle, Endpoint, NodeId};
-use tokio::sync::mpsc;
-use tracing::{error_span, Instrument};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, error, error_span, Instrument};
 
 use crate::{
     session::{
@@ -25,7 +25,7 @@ const PEER_MANAGER_INBOX_CAP: usize = 128;
 pub struct Engine {
     actor_handle: ActorHandle,
     peer_manager_inbox: mpsc::Sender<peer_manager::Input>,
-    _peer_manager_task: SharedAbortingJoinHandle<Result<(), String>>,
+    peer_manager_task: SharedAbortingJoinHandle<Result<(), String>>,
 }
 
 impl Engine {
@@ -37,7 +37,8 @@ impl Engine {
         let me = endpoint.node_id();
         let actor_handle = ActorHandle::spawn(create_store, me);
         let (pm_inbox_tx, pm_inbox_rx) = mpsc::channel(PEER_MANAGER_INBOX_CAP);
-        let peer_manager = PeerManager::new(actor_handle.clone(), endpoint, pm_inbox_rx, accept_opts);
+        let peer_manager =
+            PeerManager::new(actor_handle.clone(), endpoint, pm_inbox_rx, accept_opts);
         let peer_manager_task = tokio::task::spawn(
             async move { peer_manager.run().await.map_err(|err| format!("{err:?}")) }
                 .instrument(error_span!("peer_manager", me=%me.fmt_short())),
@@ -45,7 +46,7 @@ impl Engine {
         Engine {
             actor_handle,
             peer_manager_inbox: pm_inbox_tx,
-            _peer_manager_task: peer_manager_task.into(),
+            peer_manager_task: peer_manager_task.into(),
         }
     }
 
@@ -62,6 +63,25 @@ impl Engine {
             .send(peer_manager::Input::SubmitIntent { peer, intent })
             .await?;
         Ok(handle)
+    }
+
+    pub async fn shutdown(self) -> Result<()> {
+        debug!("shutdown engine");
+        let (reply, reply_rx) = oneshot::channel();
+        self.peer_manager_inbox
+            .send(peer_manager::Input::Shutdown { reply })
+            .await?;
+        reply_rx.await?;
+        let res = self.peer_manager_task.await;
+        match res {
+            Err(err) => error!(?err, "peer manager task panicked"),
+            Ok(Err(err)) => error!(?err, "peer manager task failed"),
+            Ok(Ok(())) => {}
+        };
+        debug!("shutdown engine: peer manager terminated");
+        self.actor_handle.shutdown().await?;
+        debug!("shutdown engine: willow actor terminated");
+        Ok(())
     }
 }
 

--- a/iroh-willow/src/engine/actor.rs
+++ b/iroh-willow/src/engine/actor.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, error_span, trace, warn, Instrument};
 use crate::{
     auth::{CapSelector, CapabilityPack, DelegateTo, InterestMap},
     form::{AuthForm, EntryForm, EntryOrForm},
-    net::WillowConn,
+    net::ConnHandle,
     proto::{
         grouping::ThreeDRange,
         keys::{NamespaceId, NamespaceKind, UserId, UserSecretKey},
@@ -135,9 +135,9 @@ impl ActorHandle {
         Ok(rx.into_stream())
     }
 
-    pub async fn init_session(
+    pub(crate) async fn init_session(
         &self,
-        conn: WillowConn,
+        conn: ConnHandle,
         intents: Vec<Intent>,
     ) -> Result<SessionHandle> {
         let (reply, reply_rx) = oneshot::channel();
@@ -224,7 +224,7 @@ impl Drop for ActorHandle {
 #[derive(derive_more::Debug, strum::Display)]
 pub enum Input {
     InitSession {
-        conn: WillowConn,
+        conn: ConnHandle,
         intents: Vec<Intent>,
         reply: oneshot::Sender<Result<SessionHandle>>,
     },

--- a/iroh-willow/src/engine/peer_manager.rs
+++ b/iroh-willow/src/engine/peer_manager.rs
@@ -1,35 +1,42 @@
-use std::{collections::HashMap, future::Future, sync::Arc};
+use std::{collections::HashMap, future::Future, sync::Arc, time::Duration};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use futures_buffered::join_all;
 
 use futures_lite::{future::Boxed, StreamExt};
-use futures_util::FutureExt;
+use futures_util::{FutureExt, TryFutureExt};
 use iroh_net::{
-    endpoint::{get_remote_node_id, Connection, VarInt},
+    endpoint::{Connection, ConnectionError},
     util::AbortingJoinHandle,
     Endpoint, NodeId,
 };
 use tokio::{
-    sync::mpsc,
+    sync::{mpsc, oneshot},
     task::{AbortHandle, JoinSet},
 };
 use tokio_stream::{wrappers::ReceiverStream, StreamMap};
 
-use tracing::{debug, trace};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, error_span, instrument, trace, warn, Instrument, Span};
 
 use crate::{
-    net::{WillowConn, ALPN},
-    proto::sync::AccessChallenge,
+    net::{establish, setup, ConnRunFut, PeerConn, WillowConn, ALPN},
+    proto::sync::{AccessChallenge, InitialTransmission},
     session::{
         intents::{EventKind, Intent},
-        Error, Interests, Role, SessionEvent, SessionHandle, SessionInit, SessionUpdate,
+        Channels, Error, Interests, Role, SessionEvent, SessionHandle, SessionInit, SessionUpdate,
     },
 };
 
 use super::actor::ActorHandle;
 
-const ERROR_CODE_IGNORE_CONN: VarInt = VarInt::from_u32(1);
+/// Our QUIC application error code for graceful connection termination.
+const ERROR_CODE_OK: u32 = 1;
+/// Our QUIC application error code when closing connections during establishment
+/// because we prefer another existing connection to the same peer.
+const ERROR_CODE_IGNORE_CONN: u32 = 2;
+/// Timeout at shutdown after which we abort connections that failed to terminate gracefully.
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Customize what to do with incoming connections.
 ///
@@ -53,13 +60,16 @@ impl AcceptOpts {
     /// Registers a callback to determine the fate of incoming connections.
     ///
     /// The callback gets the connecting peer's [`NodeId`] as argument, and must return a future
-    /// that resolves to `Option<`[SessionInit]``>`. When returning `None`, the session will not be
-    /// accepted. When returning a `SessionInit`, the session will be accepted with these
-    /// interests.
+    /// that resolves to `None` or Some(`[SessionInit]`).
+    /// When returning `None`, the session will not be  accepted.
+    /// When returning a `SessionInit`, the session will be accepted with these interests.
+    ///
+    /// The default behavior, if not registering a callback, is to accept all incoming connections with
+    /// interests in everything we have and in live session mode.
     pub fn accept_custom<F, Fut>(mut self, cb: F) -> Self
     where
-        F: Fn(NodeId) -> Fut + 'static + Send + Sync,
-        Fut: 'static + Send + Future<Output = Option<SessionInit>>,
+        F: Fn(NodeId) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Option<SessionInit>> + Send + 'static,
     {
         let cb = Box::new(move |peer: NodeId| {
             let fut: Boxed<Option<SessionInit>> = Box::pin((cb)(peer));
@@ -83,6 +93,7 @@ impl AcceptOpts {
     }
 }
 
+/// Input commands for the [`PeerManager`] actor.
 #[derive(derive_more::Debug)]
 pub(super) enum Input {
     SubmitIntent {
@@ -93,19 +104,23 @@ pub(super) enum Input {
         #[debug("Connection")]
         conn: Connection,
     },
+    Shutdown {
+        reply: oneshot::Sender<()>,
+    },
 }
 
 type AcceptCb = Box<dyn Fn(NodeId) -> Boxed<Option<SessionInit>> + Send + Sync + 'static>;
 
-#[derive(derive_more::Debug)]
+/// Manages incoming and outgoing connections.
+#[derive(Debug)]
 pub(super) struct PeerManager {
     actor: ActorHandle,
     endpoint: Endpoint,
     inbox: mpsc::Receiver<Input>,
     session_events_rx: StreamMap<NodeId, ReceiverStream<SessionEvent>>,
-    tasks: JoinSet<(NodeId, Result<WillowConn>)>,
-    peers: HashMap<NodeId, PeerState>,
+    peers: HashMap<NodeId, PeerInfo>,
     accept_handlers: AcceptHandlers,
+    conn_tasks: JoinSet<(NodeId, Result<ConnStep>)>,
 }
 
 impl PeerManager {
@@ -120,9 +135,9 @@ impl PeerManager {
             actor: actor_handle,
             inbox,
             session_events_rx: Default::default(),
-            tasks: Default::default(),
             peers: Default::default(),
             accept_handlers: AcceptHandlers::new(accept_opts),
+            conn_tasks: Default::default(),
         }
     }
 
@@ -131,19 +146,26 @@ impl PeerManager {
             tokio::select! {
                 Some(input) = self.inbox.recv() => {
                     trace!(?input, "tick: inbox");
-                    self.handle_input(input).await;
+                    match input {
+                        Input::SubmitIntent { peer, intent } => self.submit_intent(peer, intent).await,
+                        Input::HandleConnection { conn } => self.handle_connection(conn).await,
+                        Input::Shutdown { reply } => {
+                            self.handle_shutdown().await;
+                            reply.send(()).ok();
+                            break;
+                        }
+                    }
                 }
                 Some((session_id, event)) = self.session_events_rx.next(), if !self.session_events_rx.is_empty() => {
                     trace!(?session_id, ?event, "tick: event");
-                    self.handle_event(session_id, event);
+                    self.handle_session_event(session_id, event);
                 }
-                Some(res) = self.tasks.join_next(), if !self.tasks.is_empty() => {
-                    trace!("tick: task joined");
+                Some(res) = self.conn_tasks.join_next(), if !self.conn_tasks.is_empty() => {
+                    trace!("tick: conn task joined");
                     match res {
                         Err(err) if err.is_cancelled() => continue,
-                        Err(err) => Err(err).context("establish task paniced")?,
-                        Ok((_peer, Ok(conn))) => self.on_established(conn).await?,
-                        Ok((peer, Err(err))) => self.on_establish_failed(peer, Arc::new(Error::Net(err))).await,
+                        Err(err) => Err(err).context("conn task panicked")?,
+                        Ok((peer, out)) => self.handle_conn_output(peer, out).await?,
                     }
                 }
                 else => break,
@@ -152,170 +174,355 @@ impl PeerManager {
         Ok(())
     }
 
-    async fn handle_input(&mut self, input: Input) {
-        match input {
-            Input::SubmitIntent { peer, intent } => self.submit_intent(peer, intent).await,
-            Input::HandleConnection { conn } => self.handle_connection(conn).await,
-        }
-    }
-
     async fn handle_connection(&mut self, conn: Connection) {
-        let peer = match get_remote_node_id(&conn) {
-            Ok(node_id) => node_id,
+        let conn = match PeerConn::new(conn, Role::Betty, self.endpoint.node_id()) {
+            Ok(conn) => conn,
             Err(err) => {
-                tracing::debug!("ignore incoming connection (failed to get remote node id: {err})");
+                debug!("ignore incoming connection (failed to get remote node id: {err})");
                 return;
             }
         };
-        let me = self.endpoint.node_id();
+        let peer = conn.peer();
+        let Some(intent) = self.accept_handlers.accept(peer).await else {
+            debug!("ignore incoming connection (accept handler returned none)");
+            return;
+        };
+        let peer_info = self
+            .peers
+            .entry(peer)
+            .or_insert_with(|| PeerInfo::new(Role::Betty, peer));
 
-        match self.peers.get_mut(&peer) {
-            None => {
-                if let Some(intent) = self.accept_handlers.accept(peer).await {
-                    let abort_handle = self.tasks.spawn(
-                        WillowConn::betty(conn, me, AccessChallenge::generate())
-                            .map(move |res| (peer, res)),
-                    );
-                    self.peers.insert(
-                        peer,
-                        PeerState::Pending {
-                            our_role: Role::Betty,
-                            intents: vec![intent],
-                            abort_handle,
-                        },
-                    );
-                }
+        match peer_info.state {
+            PeerState::None => {
+                let our_nonce = AccessChallenge::generate();
+                let fut = async move {
+                    let initial_transmission = establish(&conn, our_nonce).await?;
+                    Ok(ConnStep::Established {
+                        conn,
+                        initial_transmission,
+                    })
+                };
+                let abort_handle = spawn_conn_task(&mut self.conn_tasks, &peer_info, fut);
+                peer_info.abort_handle = Some(abort_handle);
+                peer_info.our_role = Role::Betty;
+                peer_info.pending_intents.push(intent);
+                peer_info.state = PeerState::Pending;
             }
-            Some(PeerState::Pending {
-                our_role,
-                abort_handle,
-                intents,
-            }) => {
-                if *our_role == Role::Betty {
-                    tracing::debug!("ignore incoming connection (already accepting)");
-                    conn.close(ERROR_CODE_IGNORE_CONN, b"duplicate-already-accepting");
-                } else if me > peer {
-                    tracing::debug!(
-                        "ignore incoming connection (already dialing and our dial wins)"
-                    );
-                    conn.close(ERROR_CODE_IGNORE_CONN, b"duplicate-our-dial-wins");
-                } else if let Some(intent) = self.accept_handlers.accept(peer).await {
-                    // Abort our dial attempt and insert the new abort handle and intent.
-                    abort_handle.abort();
-                    *abort_handle = self.tasks.spawn(
-                        WillowConn::betty(conn, me, AccessChallenge::generate())
-                            .map(move |res| (peer, res)),
-                    );
-                    *our_role = Role::Betty;
-                    intents.push(intent);
-                }
+            PeerState::Pending => {
+                peer_info.pending_intents.push(intent);
+                debug!("ignore incoming connection (already pending)");
+                conn.close(ERROR_CODE_IGNORE_CONN.into(), b"duplicate-already-active");
             }
-            Some(PeerState::Active { .. }) => {
-                tracing::debug!("ignore incoming connection (already connected)");
-                conn.close(ERROR_CODE_IGNORE_CONN, b"duplicate-already-accepting");
+            PeerState::Active { .. } => {
+                // TODO: push betty intent to session?
+                debug!("ignore incoming connection (already active)");
+                conn.close(ERROR_CODE_IGNORE_CONN.into(), b"duplicate-already-active");
             }
         }
     }
 
-    async fn on_establish_failed(&mut self, peer: NodeId, error: Arc<Error>) {
-        let Some(peer_state) = self.peers.remove(&peer) else {
-            tracing::warn!(?peer, "connection failure for unknown peer");
-            return;
-        };
-        match peer_state {
-            PeerState::Pending { intents, .. } => {
-                join_all(
-                    intents
-                        .into_iter()
-                        .map(|intent| intent.send_abort(error.clone())),
-                )
-                .await;
-            }
-            PeerState::Active { .. } => {
-                unreachable!("we never handle connections for active peers")
-            }
-        };
-    }
-
-    async fn on_established(&mut self, conn: WillowConn) -> anyhow::Result<()> {
-        let peer = conn.peer;
-        let state = self
-            .peers
-            .remove(&peer)
-            .ok_or_else(|| anyhow!("unreachable: on_established called for unknown peer"))?;
-
-        let PeerState::Pending { intents, .. } = state else {
-            anyhow::bail!("unreachable: on_established called for peer in wrong state")
-        };
-
-        let session_handle = self.actor.init_session(conn, intents).await?;
-
-        let SessionHandle {
-            cancel_token: _,
-            update_tx,
-            event_rx,
-        } = session_handle;
-        self.session_events_rx
-            .insert(peer, ReceiverStream::new(event_rx));
-        self.peers.insert(peer, PeerState::Active { update_tx });
-        Ok(())
-    }
-
     async fn submit_intent(&mut self, peer: NodeId, intent: Intent) {
-        match self.peers.get_mut(&peer) {
-            None => {
+        let peer_info = self
+            .peers
+            .entry(peer)
+            .or_insert_with(|| PeerInfo::new(Role::Alfie, peer));
+
+        match peer_info.state {
+            PeerState::None => {
                 let our_nonce = AccessChallenge::generate();
-                let abort_handle = self.tasks.spawn({
-                    let endpoint = self.endpoint.clone();
-                    async move {
-                        let conn = endpoint.connect_by_node_id(peer, ALPN).await?;
-                        WillowConn::alfie(conn, endpoint.node_id(), our_nonce).await
-                    }
-                    .map(move |res| (peer, res))
-                });
-                let state = PeerState::Pending {
-                    intents: vec![intent],
-                    abort_handle,
-                    our_role: Role::Alfie,
+                let endpoint = self.endpoint.clone();
+                let fut = async move {
+                    let conn = endpoint.connect_by_node_id(&peer, ALPN).await?;
+                    let conn = PeerConn::new(conn, Role::Alfie, endpoint.node_id())?;
+                    let initial_transmission = establish(&conn, our_nonce).await?;
+                    Ok(ConnStep::Established {
+                        conn,
+                        initial_transmission,
+                    })
                 };
-                self.peers.insert(peer, state);
+                let abort_handle = spawn_conn_task(&mut self.conn_tasks, &peer_info, fut);
+                peer_info.abort_handle = Some(abort_handle);
+                peer_info.pending_intents.push(intent);
+                peer_info.state = PeerState::Pending;
             }
-            Some(PeerState::Pending { intents, .. }) => {
-                intents.push(intent);
+            PeerState::Pending => {
+                peer_info.pending_intents.push(intent);
             }
-            Some(PeerState::Active { update_tx, .. }) => {
-                if let Err(message) = update_tx.send(SessionUpdate::SubmitIntent(intent)).await {
-                    let SessionUpdate::SubmitIntent(intent) = message.0;
+            PeerState::Active { ref update_tx, .. } => {
+                if let Err(err) = update_tx.send(SessionUpdate::SubmitIntent(intent)).await {
+                    let SessionUpdate::SubmitIntent(intent) = err.0;
                     intent.send_abort(Arc::new(Error::ActorFailed)).await;
                 }
             }
-        };
+        }
     }
 
-    fn handle_event(&mut self, peer: NodeId, event: SessionEvent) {
-        tracing::info!(?event, "event");
+    #[instrument("conn", skip_all, fields(peer=%peer.fmt_short()))]
+    fn handle_session_event(&mut self, peer: NodeId, event: SessionEvent) {
+        trace!(peer=%peer.fmt_short(), ?event, "session event");
         match event {
             SessionEvent::Established => {}
-            SessionEvent::Complete { .. } => {
-                let state = self.peers.remove(&peer);
-                debug_assert!(matches!(state, Some(PeerState::Active { .. })));
+            SessionEvent::Complete { result } => {
+                debug!(?result, "session complete");
+                // TODO: I don't think we need to do anything here. The connection tasks terminate by themselves:
+                // The send loops are closed from `session::run` via `ChannelSenders::close_all`,
+                // and the receive loops terminate once the other side closes their send loops.
             }
+        }
+    }
+
+    #[instrument("conn", skip_all, fields(peer=%peer.fmt_short()))]
+    async fn handle_conn_output(&mut self, peer: NodeId, out: Result<ConnStep>) -> Result<()> {
+        let peer_info = self
+            .peers
+            .get_mut(&peer)
+            .context("got conn task output for unknown peer")?;
+        trace!(?peer, out=?out.as_ref().map(|o| format!("{o}")), "conn task output");
+        match out {
+            Err(err) => {
+                debug!(peer=%peer.fmt_short(), ?err, "conn task failed");
+                let err = Arc::new(Error::Net(err));
+                let peer = self.peers.remove(&peer).expect("just checked");
+                join_all(
+                    peer.pending_intents
+                        .into_iter()
+                        .map(|intent| intent.send_abort(err.clone())),
+                )
+                .await;
+                // We don't need to cancel the session here. It will terminate because all receiver channels are closed.
+                return Ok(());
+            }
+            Ok(ConnStep::Established {
+                conn,
+                initial_transmission,
+            }) => {
+                // TODO: Check if we want to continue.
+                let fut = async move {
+                    let result = setup(&conn).await;
+                    result.map(|(channels, fut)| ConnStep::Ready {
+                        conn,
+                        channels,
+                        fut: fut.boxed(),
+                    })
+                };
+                let abort_handle = spawn_conn_task(&mut self.conn_tasks, &peer_info, fut);
+                peer_info.state = PeerState::Pending;
+                peer_info.abort_handle = Some(abort_handle);
+                peer_info.initial_transmission = Some(initial_transmission);
+            }
+            Ok(ConnStep::Ready {
+                conn,
+                channels,
+                fut,
+            }) => {
+                let initial_transmission = peer_info
+                    .initial_transmission
+                    .take()
+                    .context("expedted initial transmission for peer in ready state")?;
+                debug!("connection ready: init session");
+                let willow_conn = WillowConn {
+                    initial_transmission,
+                    channels,
+                    our_role: conn.our_role(),
+                    peer,
+                };
+                let intents = std::mem::take(&mut peer_info.pending_intents);
+                let session_handle = self.actor.init_session(willow_conn, intents).await?;
+
+                let fut = fut.map_ok(move |()| ConnStep::Done { conn });
+                let abort_handle = spawn_conn_task(&mut self.conn_tasks, &peer_info, fut);
+
+                let SessionHandle {
+                    cancel_token,
+                    update_tx,
+                    event_rx,
+                } = session_handle;
+                self.session_events_rx
+                    .insert(peer, ReceiverStream::new(event_rx));
+
+                peer_info.state = PeerState::Active {
+                    update_tx,
+                    cancel_token,
+                };
+                peer_info.abort_handle = Some(abort_handle);
+            }
+            Ok(ConnStep::Done { conn }) => {
+                debug!("connection loop finished");
+                // TODO: Instead of using our role (alfie vs. betty), the party who sent the last
+                // meaningful message should wait for the other end to terminate the connection, I think.
+                //
+                // In other words, the connection may only be closed by the party who received the last meaningful message.
+                if conn.our_role() == Role::Alfie {
+                    conn.close(ERROR_CODE_OK.into(), b"bye");
+                }
+                let fut = async move {
+                    let reason = conn.closed().await;
+                    Ok(ConnStep::Closed { conn, reason })
+                };
+                let abort_handle = spawn_conn_task(&mut self.conn_tasks, &peer_info, fut);
+                peer_info.abort_handle = Some(abort_handle);
+            }
+            Ok(ConnStep::Closed { reason, conn }) => {
+                // TODO: Instead of using our role (alfie vs. betty), the party who sent the last
+                // meaningful message should wait for the other end to terminate the connection, I think.
+                let locally_closed = conn.our_role() == Role::Alfie;
+                let is_graceful = match &reason {
+                    ConnectionError::LocallyClosed if locally_closed => true,
+                    ConnectionError::ApplicationClosed(frame)
+                        if !locally_closed && frame.error_code == ERROR_CODE_OK.into() =>
+                    {
+                        true
+                    }
+                    _ => false,
+                };
+                if !is_graceful {
+                    warn!(?reason, "connection was not closed gracefully");
+                } else {
+                    debug!("connection closed gracefully");
+                }
+
+                self.peers.remove(&peer);
+                drop(conn);
+            }
+        }
+        Ok(())
+    }
+
+    /// Shuts down all connection tasks.
+    ///
+    /// Attempts to shutdown connections for active peers gracefully within [`GRACEFUL_SHUTDOWN_TIMEOUT`].
+    /// Aborts connections for not-yet-active peers immediately.
+    /// Aborts all connections after the graceful timeout elapsed.
+    async fn handle_shutdown(&mut self) {
+        for peer in self.peers.values() {
+            match &peer.state {
+                PeerState::None => {}
+                PeerState::Pending => {
+                    // We are in pending state, which means the session has not yet been started.
+                    // Hard-abort the task and let the other peer handle the error.
+                    if let Some(abort_handle) = &peer.abort_handle {
+                        abort_handle.abort();
+                    }
+                }
+                PeerState::Active { cancel_token, .. } => {
+                    // We are in active state. We cancel our session, which leads to graceful connection termination.
+                    cancel_token.cancel();
+                }
+            }
+        }
+
+        let join_conns_fut = async {
+            while let Some(res) = self.conn_tasks.join_next().await {
+                trace!("tick: conn task joined");
+                match res {
+                    Err(err) if err.is_cancelled() => continue,
+                    Err(err) => {
+                        error!(?err, "conn task panicked during shutdown");
+                    }
+                    Ok((peer, out)) => {
+                        match &out {
+                            Err(_) | Ok(ConnStep::Done { .. }) | Ok(ConnStep::Closed { .. }) => {
+                                if let Err(err) = self.handle_conn_output(peer, out).await {
+                                    error!(?err, "conn task output error during shutdown");
+                                }
+                            }
+                            _ => {
+                                // We should not reach this state, as we abort all tasks that lead to output other than done or close.
+                                // However, tokio docs for `AbortHandle::abort` state that cancelling a task that might
+                                // already have been completed only triggers a cancelled JoinError *most likely*...
+                                warn!(?peer, ?out, "expected tasks that lead to output other than done or close to be aborted");
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        match tokio::time::timeout(GRACEFUL_SHUTDOWN_TIMEOUT, join_conns_fut).await {
+            Ok(()) => {
+                debug!("all connections gracefully terminated");
+            }
+            Err(_) => {
+                debug!(
+                    remaining=self.conn_tasks.len(),
+                    "terminating all connections at shutdown timed out, abort remaining connections"
+                );
+                // TODO: We do not catch panics here.
+                self.conn_tasks.shutdown().await;
+            }
+        }
+    }
+}
+
+fn spawn_conn_task(
+    conn_tasks: &mut JoinSet<(NodeId, Result<ConnStep>)>,
+    peer_info: &PeerInfo,
+    fut: impl Future<Output = Result<ConnStep>> + Send + 'static,
+) -> AbortHandle {
+    let node_id = peer_info.node_id;
+    let fut = fut
+        .map(move |res| (node_id, res))
+        .instrument(peer_info.span.clone());
+    conn_tasks.spawn(fut)
+}
+
+#[derive(Debug)]
+struct PeerInfo {
+    node_id: NodeId,
+    our_role: Role,
+    abort_handle: Option<AbortHandle>,
+    state: PeerState,
+    pending_intents: Vec<Intent>,
+    initial_transmission: Option<InitialTransmission>,
+    span: Span,
+}
+
+impl PeerInfo {
+    fn new(our_role: Role, peer: NodeId) -> Self {
+        Self {
+            node_id: peer,
+            our_role,
+            abort_handle: None,
+            state: PeerState::None,
+            pending_intents: Vec::new(),
+            initial_transmission: None,
+            span: error_span!("conn", peer=%peer.fmt_short()),
         }
     }
 }
 
 #[derive(Debug)]
 enum PeerState {
-    Pending {
-        our_role: Role,
-        intents: Vec<Intent>,
-        abort_handle: AbortHandle,
-    },
+    None,
+    Pending,
     Active {
+        cancel_token: CancellationToken,
         update_tx: mpsc::Sender<SessionUpdate>,
     },
 }
 
+#[derive(derive_more::Debug, strum::Display)]
+enum ConnStep {
+    Established {
+        conn: PeerConn,
+        initial_transmission: InitialTransmission,
+    },
+    Ready {
+        conn: PeerConn,
+        channels: Channels,
+        #[debug("ConnRunFut")]
+        fut: ConnRunFut,
+    },
+    Done {
+        conn: PeerConn,
+    },
+    Closed {
+        conn: PeerConn,
+        reason: ConnectionError,
+    },
+}
+
+/// The internal handlers for the [`AcceptOpts].
 #[derive(derive_more::Debug)]
 struct AcceptHandlers {
     #[debug("{:?}", accept_cb.as_ref().map(|_| "_"))]
@@ -352,28 +559,35 @@ impl AcceptHandlers {
     }
 }
 
+/// Simple event forwarder to combine the intent event receivers for all betty sessions
+/// and send to the event sender configured via [`AcceptOpts].
+///
+/// Runs a forwarding loop in a task. The task is aborted on drop.
 #[derive(Debug)]
 struct EventForwarder {
     _join_handle: AbortingJoinHandle<()>,
     stream_sender: mpsc::Sender<(NodeId, ReceiverStream<EventKind>)>,
 }
 
-#[derive(Debug)]
-struct EventForwarderActor {
-    stream_receiver: mpsc::Receiver<(NodeId, ReceiverStream<EventKind>)>,
-    streams: StreamMap<NodeId, ReceiverStream<EventKind>>,
-    event_sender: mpsc::Sender<(NodeId, EventKind)>,
-}
-
 impl EventForwarder {
     fn new(event_sender: mpsc::Sender<(NodeId, EventKind)>) -> EventForwarder {
-        let (stream_sender, stream_receiver) = mpsc::channel(16);
-        let forwarder = EventForwarderActor {
-            stream_receiver,
-            streams: Default::default(),
-            event_sender,
-        };
-        let join_handle = tokio::task::spawn(forwarder.run());
+        let (stream_sender, mut stream_receiver) = mpsc::channel(16);
+        let join_handle = tokio::task::spawn(async move {
+            let mut streams = StreamMap::new();
+            loop {
+                tokio::select! {
+                    Some((peer, receiver)) = stream_receiver.recv() => {
+                        streams.insert(peer, receiver);
+                    },
+                    Some((peer, event)) = streams.next() => {
+                        if let Err(_receiver_dropped) = event_sender.send((peer, event)).await {
+                            break;
+                        }
+                    },
+                    else => break,
+                }
+            }
+        });
         EventForwarder {
             _join_handle: join_handle.into(),
             stream_sender,
@@ -382,23 +596,5 @@ impl EventForwarder {
 
     pub async fn add_intent(&self, peer: NodeId, event_stream: ReceiverStream<EventKind>) {
         self.stream_sender.send((peer, event_stream)).await.ok();
-    }
-}
-
-impl EventForwarderActor {
-    async fn run(mut self) {
-        loop {
-            tokio::select! {
-                Some((peer, receiver)) = self.stream_receiver.recv() => {
-                    self.streams.insert(peer, receiver);
-                },
-                Some((peer, event)) = self.streams.next() => {
-                    if let Err(_receiver_dropped) = self.event_sender.send((peer, event)).await {
-                        break;
-                    }
-                },
-                else => break,
-            }
-        }
     }
 }

--- a/iroh-willow/src/engine/peer_manager.rs
+++ b/iroh-willow/src/engine/peer_manager.rs
@@ -317,7 +317,7 @@ impl PeerManager {
                 // Future that dials and establishes the connection. Can be cancelled for simultaneous connection.
                 let fut = async move {
                     let conn = tokio::select! {
-                        res = endpoint.connect_by_node_id(&peer, ALPN) => res,
+                        res = endpoint.connect_by_node_id(peer, ALPN) => res,
                         _ = cancel_dial.cancelled() => {
                             debug!("dial cancelled during dial");
                             return Err(ConnectionError::LocallyClosed.into());

--- a/iroh-willow/src/lib.rs
+++ b/iroh-willow/src/lib.rs
@@ -1,6 +1,7 @@
 //! Implementation of willow
 
 #![allow(missing_docs)]
+#![deny(unsafe_code)]
 
 pub mod auth;
 pub mod engine;
@@ -9,4 +10,4 @@ pub mod net;
 pub mod proto;
 pub mod session;
 pub mod store;
-pub mod util;
+mod util;

--- a/iroh-willow/src/lib.rs
+++ b/iroh-willow/src/lib.rs
@@ -10,4 +10,4 @@ pub mod net;
 pub mod proto;
 pub mod session;
 pub mod store;
-mod util;
+pub mod util;

--- a/iroh-willow/src/net.rs
+++ b/iroh-willow/src/net.rs
@@ -662,17 +662,8 @@ mod tests {
             .complete()
             .await
             .expect("failed to close alfie session");
+        info!("close alfie session");
         senders_alfie.close_all();
-
-        let (res_alfie, res_betty) = tokio::join!(
-            intent_handle_alfie.complete(),
-            intent_handle_betty.complete()
-        );
-        info!(time=?start.elapsed(), "reconciliation finished");
-        info!("alfie intent res {:?}", res_alfie);
-        info!("betty intent res {:?}", res_betty);
-        assert!(res_alfie.is_ok());
-        assert!(res_betty.is_ok());
 
         let (senders_betty, betty_cancelled) = session_betty
             .complete()
@@ -684,6 +675,16 @@ mod tests {
             .expect("failed to close connection loops");
         r1.unwrap();
         r2.unwrap();
+
+        let (res_alfie, res_betty) = tokio::join!(
+            intent_handle_alfie.complete(),
+            intent_handle_betty.complete()
+        );
+        info!(time=?start.elapsed(), "reconciliation finished");
+        info!("alfie intent res {:?}", res_alfie);
+        info!("betty intent res {:?}", res_betty);
+        assert!(res_alfie.is_ok());
+        assert!(res_betty.is_ok());
 
         let (error_alfie, error_betty) = tokio::try_join!(
             terminate_gracefully(&conn_alfie, node_id_alfie, node_id_betty, alfie_cancelled),

--- a/iroh-willow/src/net.rs
+++ b/iroh-willow/src/net.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, ensure, Context as _, Result};
 use futures_concurrency::future::TryJoin;
 use futures_util::future::TryFutureExt;
 use iroh_base::key::NodeId;
-use iroh_net::endpoint::{Connection, ConnectionError, RecvStream, SendStream};
+use iroh_net::endpoint::{Connection, ConnectionError, RecvStream, SendStream, VarInt};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, trace};
 
@@ -31,10 +31,10 @@ pub const CHANNEL_CAP: usize = 1024 * 64;
 pub const ALPN: &[u8] = b"iroh-willow/0";
 
 /// Our QUIC application error code for graceful connection termination.
-pub const ERROR_CODE_OK: u32 = 1;
+pub const ERROR_CODE_OK: VarInt = VarInt::from_u32(1);
 /// Our QUIC application error code when closing connections during establishment
 /// because we prefer another existing connection to the same peer.
-pub const ERROR_CODE_IGNORE_CONN: u32 = 2;
+pub const ERROR_CODE_DUPLICATE_CONN: VarInt = VarInt::from_u32(2);
 
 /// The handle to an active peer connection.
 ///

--- a/iroh-willow/src/proto/sync.rs
+++ b/iroh-willow/src/proto/sync.rs
@@ -192,6 +192,19 @@ pub enum Channel {
 }
 
 impl Channel {
+    pub const COUNT: usize = LogicalChannel::COUNT + 1;
+
+    pub fn all() -> [Channel; LogicalChannel::COUNT + 1] {
+        // TODO: do this without allocation
+        // https://users.rust-lang.org/t/how-to-concatenate-array-literals-in-compile-time/21141/3
+        [Self::Control]
+            .into_iter()
+            .chain(LogicalChannel::VARIANTS.iter().copied().map(Self::Logical))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("static length")
+    }
+
     pub fn fmt_short(&self) -> &'static str {
         match self {
             Channel::Control => "Ctl",
@@ -206,7 +219,7 @@ impl Channel {
         }
     }
 
-    pub fn from_id(self, id: u8) -> Result<Self, InvalidChannelId> {
+    pub fn from_id(id: u8) -> Result<Self, InvalidChannelId> {
         match id {
             0 => Ok(Self::Control),
             _ => {

--- a/iroh-willow/src/proto/sync.rs
+++ b/iroh-willow/src/proto/sync.rs
@@ -429,8 +429,6 @@ pub enum Message {
     ControlApologise(ControlApologise),
     #[debug("{:?}", _0)]
     ControlFreeHandle(ControlFreeHandle),
-    RequestClose,
-    ConfirmClose,
 }
 
 impl Message {
@@ -522,9 +520,7 @@ impl Message {
             | Message::ControlPlead(_)
             | Message::ControlAnnounceDropping(_)
             | Message::ControlApologise(_)
-            | Message::ControlFreeHandle(_)
-            | Message::RequestClose
-            | Message::ConfirmClose => Channel::Control,
+            | Message::ControlFreeHandle(_) => Channel::Control,
         }
     }
 }

--- a/iroh-willow/src/proto/sync.rs
+++ b/iroh-willow/src/proto/sync.rs
@@ -429,6 +429,8 @@ pub enum Message {
     ControlApologise(ControlApologise),
     #[debug("{:?}", _0)]
     ControlFreeHandle(ControlFreeHandle),
+    RequestClose,
+    ConfirmClose,
 }
 
 impl Message {
@@ -520,7 +522,9 @@ impl Message {
             | Message::ControlPlead(_)
             | Message::ControlAnnounceDropping(_)
             | Message::ControlApologise(_)
-            | Message::ControlFreeHandle(_) => Channel::Control,
+            | Message::ControlFreeHandle(_)
+            | Message::RequestClose
+            | Message::ConfirmClose => Channel::Control,
         }
     }
 }

--- a/iroh-willow/src/session.rs
+++ b/iroh-willow/src/session.rs
@@ -190,6 +190,9 @@ pub enum SessionEvent {
         we_cancelled: bool,
         #[debug("ChannelSenders")]
         senders: ChannelSenders,
+        remaining_intents: Vec<Intent>,
+        #[debug("Receiver<SessionUpdate>")]
+        update_receiver: mpsc::Receiver<SessionUpdate>,
     },
 }
 
@@ -211,6 +214,7 @@ impl SessionHandle {
                 result,
                 senders,
                 we_cancelled,
+                ..
             } = event
             {
                 return result.map(|()| (senders, we_cancelled));

--- a/iroh-willow/src/session.rs
+++ b/iroh-willow/src/session.rs
@@ -25,9 +25,9 @@ mod resource;
 mod run;
 mod static_tokens;
 
-pub use self::channels::Channels;
-pub use self::error::Error;
-pub use self::run::run_session;
+pub(crate) use self::channels::Channels;
+pub(crate) use self::error::Error;
+pub(crate) use self::run::run_session;
 
 pub type SessionId = u64;
 

--- a/iroh-willow/src/session.rs
+++ b/iroh-willow/src/session.rs
@@ -186,18 +186,11 @@ pub enum SessionEvent {
     Established,
     Complete {
         result: Result<(), Arc<Error>>,
-        who_cancelled: WhoCancelled,
+        // who_cancelled: WhoCancelled,
+        we_cancelled: bool,
         #[debug("ChannelSenders")]
         senders: ChannelSenders,
     },
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum WhoCancelled {
-    WeDid,
-    TheyDid,
-    BothDid,
-    NoneDid,
 }
 
 #[derive(Debug)]

--- a/iroh-willow/src/session/data.rs
+++ b/iroh-willow/src/session/data.rs
@@ -81,7 +81,6 @@ impl<S: Storage> DataSender<S> {
                 }
             }
         }
-        tracing::debug!("data sender done");
         Ok(())
     }
 

--- a/iroh-willow/src/session/error.rs
+++ b/iroh-willow/src/session/error.rs
@@ -73,6 +73,8 @@ pub enum Error {
     Net(anyhow::Error),
     #[error("channel receiver dropped")]
     ChannelDropped,
+    #[error("our node is shutting down")]
+    ShuttingDown,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/iroh-willow/src/session/intents.rs
+++ b/iroh-willow/src/session/intents.rs
@@ -144,7 +144,7 @@ impl Intent {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Completion {
     /// All interests were reconciled.
     Complete,

--- a/iroh-willow/src/session/reconciler.rs
+++ b/iroh-willow/src/session/reconciler.rs
@@ -29,9 +29,10 @@ use crate::{
         grouping::{AreaOfInterest, ThreeDRange},
         keys::NamespaceId,
         sync::{
-            AreaOfInterestHandle, Fingerprint, LengthyEntry, ReconciliationAnnounceEntries,
-            ReconciliationMessage, ReconciliationSendEntry, ReconciliationSendFingerprint,
-            ReconciliationSendPayload, ReconciliationTerminatePayload,
+            AreaOfInterestHandle, Fingerprint, IsHandle, LengthyEntry,
+            ReconciliationAnnounceEntries, ReconciliationMessage, ReconciliationSendEntry,
+            ReconciliationSendFingerprint, ReconciliationSendPayload,
+            ReconciliationTerminatePayload,
         },
         willow::PayloadDigest,
     },
@@ -188,6 +189,11 @@ impl<S: Storage> Reconciler<S> {
             .map
             .remove(&id)
             .ok_or(Error::InvalidMessageInCurrentState)?;
+        debug!(
+            our_handle = id.0.value(),
+            their_handle = id.1.value(),
+            "reconciled area"
+        );
         self.out(Output::ReconciledArea {
             area: target.intersection.intersection.clone(),
             namespace: target.namespace(),
@@ -256,7 +262,11 @@ impl<S: Storage> TargetMap<S> {
         let snapshot = shared.store.entries().snapshot()?;
         let target = Target::init(snapshot, shared, intersection).await?;
         let id = target.id();
-        tracing::info!("init {id:?}");
+        debug!(
+            our_handle = id.0.value(),
+            their_handle = id.1.value(),
+            "init area"
+        );
         self.map.insert(id, target);
         Ok(id)
     }

--- a/iroh-willow/src/session/reconciler.rs
+++ b/iroh-willow/src/session/reconciler.rs
@@ -125,13 +125,6 @@ impl<S: Storage> Reconciler<S> {
                 target
                     .received_send_fingerprint(&self.shared, message)
                     .await?;
-                tracing::warn!(
-                    is_complete = target.is_complete(),
-                    started = target.started,
-                    our_uncovered_ranges = ?target.our_uncovered_ranges,
-                    current_entry_none = self.current_entry.is_none(),
-                    "received_send_fingerprint done"
-                );
                 if target.is_complete() && self.current_entry.is_none() {
                     self.complete_target(target_id).await?;
                 }

--- a/iroh-willow/src/session/run.rs
+++ b/iroh-willow/src/session/run.rs
@@ -1,10 +1,4 @@
-use std::{
-    future::Future,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{future::Future, sync::Arc};
 
 use futures_concurrency::{future::TryJoin, stream::StreamExt as _};
 use futures_lite::{Stream, StreamExt as _};
@@ -26,7 +20,7 @@ use crate::{
         pai_finder::{self as pai, PaiFinder},
         reconciler,
         static_tokens::StaticTokens,
-        Channels, Error, EventSender, Role, SessionEvent, SessionId, SessionUpdate, WhoCancelled,
+        Channels, Error, EventSender, Role, SessionEvent, SessionId, SessionUpdate,
     },
     store::{traits::Storage, Store},
     util::{channel::Receiver, stream::Cancelable},
@@ -87,7 +81,7 @@ pub(crate) async fn run_session<S: Storage>(
     debug!(role = ?our_role, ?mode, "start session");
 
     // Make all our receivers close once the cancel_token is triggered.
-    // let control_recv = Cancelable::new(control_recv, cancel_token.clone());
+    let control_recv = Cancelable::new(control_recv, cancel_token.clone());
     let reconciliation_recv = Cancelable::new(reconciliation_recv, cancel_token.clone());
     let intersection_recv = Cancelable::new(intersection_recv, cancel_token.clone());
     let mut static_tokens_recv = Cancelable::new(static_tokens_recv, cancel_token.clone());
@@ -297,8 +291,7 @@ pub(crate) async fn run_session<S: Storage>(
         Ok(())
     });
 
-    let we_cancelled = AtomicBool::new(false);
-    let mut who_cancelled = WhoCancelled::NoneDid;
+    let mut we_cancelled = false;
 
     let control_loop = with_span(error_span!("control"), async {
         let res = control_loop(
@@ -308,23 +301,15 @@ pub(crate) async fn run_session<S: Storage>(
             &channel_sender,
             &pai_inbox,
             &event_sender,
-            &we_cancelled,
         )
         .await;
         if !cancel_token.is_cancelled() {
             debug!("close session (closed by peer)");
             cancel_token.cancel();
+        } else {
+            we_cancelled = true;
         }
-        match res {
-            Ok(who) => {
-                who_cancelled = who;
-                Ok(())
-            }
-            Err(err) => {
-                who_cancelled = WhoCancelled::NoneDid;
-                Err(err)
-            }
-        }
+        res
     });
 
     let aoi_recv_loop = with_span(error_span!("aoi_recv"), async {
@@ -346,13 +331,6 @@ pub(crate) async fn run_session<S: Storage>(
         Ok(())
     });
 
-    let cancel_fut = async {
-        cancel_token.cancelled().await;
-        we_cancelled.store(true, Ordering::Relaxed);
-        channel_sender.send(Message::RequestClose).await?;
-        Ok(())
-    };
-
     let result = (
         intents_fut,
         control_loop,
@@ -364,7 +342,6 @@ pub(crate) async fn run_session<S: Storage>(
         token_recv_loop,
         caps_recv_loop,
         aoi_recv_loop,
-        cancel_fut,
     )
         .try_join()
         .await;
@@ -380,19 +357,16 @@ pub(crate) async fn run_session<S: Storage>(
     event_sender
         .send(SessionEvent::Complete {
             result: result.clone(),
-            who_cancelled,
+            we_cancelled,
             senders: channel_sender,
         })
         .await
         .ok();
 
+    debug!(error=?result.as_ref().err(), ?we_cancelled, "session complete");
     match result {
-        Ok(_) => {
-            debug!(?who_cancelled, "session complete");
-            Ok(())
-        }
+        Ok(()) => Ok(()),
         Err(error) => {
-            debug!(?error, "session failed");
             intents.abort_all(error.clone()).await;
             Err(error)
         }
@@ -400,14 +374,13 @@ pub(crate) async fn run_session<S: Storage>(
 }
 
 async fn control_loop(
-    mut control_recv: Receiver<Message>,
+    mut control_recv: Cancelable<Receiver<Message>>,
     our_role: Role,
     caps: &Capabilities,
     sender: &ChannelSenders,
     pai_inbox: &Sender<pai::Input>,
     event_sender: &EventSender,
-    we_cancelled: &AtomicBool,
-) -> Result<WhoCancelled, Error> {
+) -> Result<(), Error> {
     // Reveal our nonce.
     let reveal_message = caps.reveal_commitment()?;
     sender.send(reveal_message).await?;
@@ -420,8 +393,6 @@ async fn control_loop(
         };
         sender.send(msg).await?;
     }
-
-    let mut who_cancelled = WhoCancelled::NoneDid;
 
     // Handle incoming messages on the control channel.
     while let Some(message) = control_recv.try_next().await? {
@@ -456,26 +427,11 @@ async fn control_loop(
                     ))
                     .await?;
             }
-            Message::RequestClose => {
-                debug!("received close request");
-                if we_cancelled.load(Ordering::Relaxed) {
-                    who_cancelled = WhoCancelled::BothDid;
-                    break;
-                } else {
-                    who_cancelled = WhoCancelled::TheyDid;
-                    sender.send(Message::ConfirmClose).await?;
-                    break;
-                }
-            }
-            Message::ConfirmClose => {
-                who_cancelled = WhoCancelled::WeDid;
-                break;
-            }
             _ => return Err(Error::UnsupportedMessage),
         }
     }
 
-    Ok(who_cancelled)
+    Ok(())
 }
 
 fn cancelable_channel<T: Send + 'static>(

--- a/iroh-willow/src/session/run.rs
+++ b/iroh-willow/src/session/run.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error_span, trace, Instrument, Span};
 
 use crate::{
-    net::WillowConn,
+    net::ConnHandle,
     proto::sync::{ControlIssueGuarantee, LogicalChannel, Message, SetupBindAreaOfInterest},
     session::{
         aoi_finder::{self, IntersectionFinder},
@@ -36,16 +36,16 @@ use super::{
 
 const INITIAL_GUARANTEES: u64 = u64::MAX;
 
-pub async fn run_session<S: Storage>(
+pub(crate) async fn run_session<S: Storage>(
     store: Store<S>,
-    conn: WillowConn,
+    conn: ConnHandle,
     initial_intents: Vec<Intent>,
     cancel_token: CancellationToken,
     session_id: SessionId,
     event_sender: EventSender,
     update_receiver: impl Stream<Item = SessionUpdate> + Unpin + 'static,
 ) -> Result<(), Arc<Error>> {
-    let WillowConn {
+    let ConnHandle {
         peer: _,
         initial_transmission,
         our_role,

--- a/iroh-willow/src/session/run.rs
+++ b/iroh-willow/src/session/run.rs
@@ -115,19 +115,6 @@ pub(crate) async fn run_session<S: Storage>(
         (None, None)
     };
 
-    // let net_fut = with_span(error_span!("net"), async {
-    //     // TODO: awaiting the net task handle hangs
-    //     drop(join_handle);
-    //     // let res = join_handle.await;
-    //     // debug!(?res, "net tasks finished");
-    //     // match res {
-    //     //     Ok(Ok(())) => Ok(()),
-    //     //     Ok(Err(err)) => Err(Error::Net(err)),
-    //     //     Err(err) => Err(Error::Net(err.into())),
-    //     // }
-    //     Ok(())
-    // });
-
     let mut intents = intents::IntentDispatcher::new(store.auth().clone(), initial_intents);
     let intents_fut = with_span(error_span!("intents"), async {
         use intents::Output;
@@ -341,7 +328,6 @@ pub(crate) async fn run_session<S: Storage>(
     });
 
     let result = (
-        // net_fut,
         intents_fut,
         control_loop,
         data_loop,

--- a/iroh-willow/src/util/channel.rs
+++ b/iroh-willow/src/util/channel.rs
@@ -14,15 +14,15 @@ use tokio::io::AsyncWrite;
 
 use crate::util::codec::{DecodeOutcome, Decoder, Encoder};
 
-/// Create an in-memory pipe.
-pub fn pipe(cap: usize) -> (Writer, Reader) {
-    let shared = Shared::new(cap, Guarantees::Unlimited);
-    let writer = Writer {
-        shared: shared.clone(),
-    };
-    let reader = Reader { shared };
-    (writer, reader)
-}
+// /// Create an in-memory pipe.
+// pub fn pipe(cap: usize) -> (Writer, Reader) {
+//     let shared = Shared::new(cap, Guarantees::Unlimited);
+//     let writer = Writer {
+//         shared: shared.clone(),
+//     };
+//     let reader = Reader { shared };
+//     (writer, reader)
+// }
 
 /// Create a new channel with a message [`Sender`] on the transmit side and a byte [`Reader`] on
 /// the receive side.

--- a/iroh-willow/src/util/stream.rs
+++ b/iroh-willow/src/util/stream.rs
@@ -26,6 +26,9 @@ impl<S> Cancelable<S> {
             is_cancelled: false,
         }
     }
+    pub fn into_inner(self) -> S {
+        self.stream
+    }
 }
 
 impl<S: Stream + Unpin> Stream for Cancelable<S> {

--- a/iroh-willow/tests/basic.rs
+++ b/iroh-willow/tests/basic.rs
@@ -1,17 +1,15 @@
+use std::time::Duration;
 
 use anyhow::Result;
 use futures_concurrency::future::TryJoin;
 use futures_lite::StreamExt;
 
 use iroh_willow::{
-    proto::{
-        grouping::Area,
-        willow::Path,
-    },
+    proto::{grouping::Area, willow::Path},
     session::{intents::EventKind, Interests, SessionInit, SessionMode},
 };
 
-use self::util::{create_rng, spawn_two, insert, setup_and_delegate, Peer};
+use self::util::{create_rng, insert, setup_and_delegate, spawn_two, Peer};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peer_manager_two_intents() -> Result<()> {

--- a/iroh-willow/tests/basic.rs
+++ b/iroh-willow/tests/basic.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use anyhow::Result;
 use futures_concurrency::future::TryJoin;
 use futures_lite::StreamExt;


### PR DESCRIPTION
## Description

Major refactor of `net` and `peer_manager` modules to enable the following:

* Properly terminate connections gracefully 
* Properly deal with simultaenous connections by only using one of them deterministically
* Do not drop intents if the session is about to be closed when submitting a new intent 

Plus other fixes and cleanups.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
