### PR TITLE
fix(iroh-blobs): do not skip empty partial blobs in migration

### DIFF
--- a/iroh-blobs/src/store/fs/import_flat_store.rs
+++ b/iroh-blobs/src/store/fs/import_flat_store.rs
@@ -310,11 +310,15 @@ impl ActorState {
             if let Some(((data_path, data_size), outboard)) = largest_partial {
                 let needs_outboard = data_size >= IROH_BLOCK_SIZE.bytes() as u64;
                 let outboard_path = if needs_outboard {
-                    let Some((outboard_path, _)) = outboard else {
-                        tracing::warn!("missing outboard file for {}", hash.to_hex());
-                        continue;
-                    };
-                    Some(outboard_path)
+                    if let Some((outboard_path, _)) = outboard {
+                        Some(outboard_path)
+                    } else {
+                        tracing::warn!(
+                            hash = hash.fmt_short(),
+                            "missing outboard file. assuming empty partial"
+                        );
+                        None
+                    }
                 } else {
                     None
                 };

--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -350,7 +350,6 @@ fn run_cli(
 }
 
 #[test]
-#[ignore = "flaky"]
 fn cli_bao_store_migration() -> anyhow::Result<()> {
     let dir = testdir!();
     let iroh_data_dir = dir.join("iroh_data_dir");


### PR DESCRIPTION
## Description

When a blob found during migration is missing an outboard, according to the
`cli_bao_store_migration` test, we should still migrate it. Before this change
the blob would be ignored. This makes the test no longer broken.

## Breaking Changes

n/a

## Notes & open questions

1. I can reproduce the failure 100% of the time, so before this change **I consider the test broken, not flaky.**
2. I reproduced the failure by running an iroh node with the exact v0 data the test uses. After the change, I did this again, and also ran both `validate` and `consistency-check` and got no errors.

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [ ] ~~Tests if relevant.~~
- [ ] ~~All breaking changes documented.~~
