### PR TITLE
test(iroh-cli): Replace `cli_provide_one_file_large` with a faster test

### DIFF
--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -50,10 +50,20 @@ fn cli_provide_one_file_basic() -> Result<()> {
 }
 
 #[test]
-fn cli_provide_one_file_large() -> Result<()> {
+fn cli_provide_one_file_external_outboard() -> Result<()> {
     let dir = testdir!();
     let path = dir.join("foo");
-    make_rand_file(1024 * 1024 * 1024, &path)?;
+    // The cutoff point at which an outboard is stored externally is 16KiB by default.
+    // Outboards end up approaching ~1/256th the size of the source file.
+    // So if the source file is 16 KiB * 256, we *almost* have a file big enough that
+    // causes its outboard to be stored externally.
+    // We add a bit of margin, just to be safe.
+    let outboard_size_to_file_size = 256;
+    let safety_margin = 20;
+    let file_size = iroh::blobs::store::fs::InlineOptions::default().max_outboard_inlined
+        * (outboard_size_to_file_size + safety_margin);
+    // At current defaults, `file_size` ends up being ~4.5MB
+    make_rand_file(file_size as usize, &path)?;
     // provide a path to a file, do not pipe from stdin, do not pipe to stdout
     test_provide_get_loop(Input::Path(path), Output::Path)
 }


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

The `cli_provide_one_file_large` test takes multiple minutes to complete.

We talked about removing it altogether in the discord.
The reasoning for removing it is that we already exercise big file provide & get loops via netsim. So there is no need to run the same code in debug mode taking >3 minutes in CI.

However, I ended up not removing the test but instead changing it, because the other tests test really small file sizes, e.g. `1000` bytes. At those sizes, outboards aren't even generated and files are put inline into the database.
So instead I worked out the file size required for exercising the whole external-outboard (and external-file) machinery of iroh-blobs.
The cutoff point is at ~4.1MB, which is really far away from the 1GB size and should transfer within seconds.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
Should we just delete the test altogether?

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
