### PR TITLE
test(iroh): Reduce entry amount in `sync_gossip_bulk`

### DIFF
--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -156,7 +156,7 @@ async fn sync_subscribe_no_sync() -> Result<()> {
 async fn sync_gossip_bulk() -> Result<()> {
     let n_entries: usize = std::env::var("N_ENTRIES")
         .map(|x| x.parse().expect("N_ENTRIES must be a number"))
-        .unwrap_or(1000);
+        .unwrap_or(100);
     let mut rng = test_rng(b"sync_gossip_bulk");
     setup_logging();
 


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
The test currently runs 55s on our windows CI machines, it runs 40s when I run it on my laptop locally.
If anyone is curious: In release mode, the test runs 0.4s. :upside_down_face: 

The test basically sync 1000 entries twice. The number is configurable and the default was arbitrarily chosen according to @Frando, so I've reduced it by a factor of 10. With `n_entries = 100` the test runs ~4.5s for me, much more reasonable.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [x] Tests if relevant.
- [x] All breaking changes documented.
