### PR TITLE
feat(iroh-blobs): Add `tokio::io::Buf{Reader,Writer}` to `iroh_blobs::{get,provider}`

### DIFF
--- a/iroh-blobs/src/protocol.rs
+++ b/iroh-blobs/src/protocol.rs
@@ -351,6 +351,13 @@ pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 100;
 /// The ALPN used with quic for the iroh bytes protocol.
 pub const ALPN: &[u8] = b"/iroh-bytes/4";
 
+/// Default capacity for buffered readers & writers.
+/// This constant can be changed without breaking the protocol. Here is
+/// just a good place to put it.
+/// In local testing values above 256KiB have shown greatly diminished
+/// returns. 128KiB ended up ~5% slower. 64KiB ended up ~10% slower.
+pub(crate) const DEFAULT_BUFFER_CAPACITY: usize = 256 * 1024;
+
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, From)]
 /// A request to the provider
 pub enum Request {


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

While trying to diagnose performance differences between the `dig/quinn11` branch and `main`, I've stumbled upon this performance improvement for blob transfer.

This basically just introduces a `tokio::io::BufReader` to `iroh_blobs::get` and a `tokio::io::BufWriter` to `iroh_blobs::provider`.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None, all the types for this are internal.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
- What should the buffer size be?
  In my tests locally, anything above ~256KiB gave me diminishing returns, but values like 128KiB were still much worse. The default value for `tokio::io::BufWriter` is 8KiB, though, so significantly lower. What do people think?
- Why is this faster?
  Usually these buffered readers help when the writes are small. I haven't looked at it in detail, but I could see how outboard data could consist of a bunch of smaller `write`s. Or perhaps there's a bunch of frame size `u64`s we're writing? Not sure.
- Is `iroh_blobs::protocol` the right place for putting the `DEFAULT_BUFFER_CAPACITY` constant? It's one of the few modules which is common between the `get` and `provide` sides. FWIW, the constant is not exposed.
- I'm interested in seeing the netsim numbers.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
