### PR TITLE
feat: expose locally discovered node id and addresses

### DIFF
--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -136,6 +136,11 @@ impl ConcurrentDiscovery {
     pub fn add(&mut self, service: impl Discovery + 'static) {
         self.services.push(Box::new(service));
     }
+
+    /// Return a slice of the [`Discovery`] services we have available
+    pub fn services(&self) -> &[Box<dyn Discovery>] {
+        &self.services
+    }
 }
 
 impl<T> From<T> for ConcurrentDiscovery

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -51,8 +51,6 @@ use crate::{AddrInfo, Endpoint, NodeId};
 
 pub mod dns;
 
-#[cfg(feature = "local_swarm_discovery")]
-pub mod local_swarm_discovery;
 pub mod pkarr;
 
 /// Name used for logging when new node addresses are added from discovery.

--- a/iroh-net/src/discovery/local_swarm_discovery.rs
+++ b/iroh-net/src/discovery/local_swarm_discovery.rs
@@ -189,7 +189,7 @@ impl LocalSwarmDiscovery {
                                 .map(|(ipaddr, port)| SocketAddr::new(*ipaddr, *port))
                                 .collect();
                             sender
-                                .send(NodeAddr::from_parts(public_key.clone().into(), None, addrs))
+                                .send(NodeAddr::from_parts(*public_key, None, addrs))
                                 .await
                                 .ok();
                         }

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -730,6 +730,20 @@ impl Endpoint {
         self.msock.connection_infos()
     }
 
+    /// Return any [`NodeAddr`]s for nodes we have discovered in the local network.
+    ///
+    /// If no nodes have been discovered, or [`iroh-net::discovery::LocalSwarmDiscovery`]
+    /// has not been configured as a [`Discovery`] service, it will return an
+    /// empty list.
+    pub async fn locally_discovered_nodes(&self) -> Option<Vec<NodeAddr>> {
+        if let Some(discovery) = self.discovery() {
+            if let Some(addrs) = discovery.locally_discovered_nodes() {
+                return Some(addrs.collect().await);
+            }
+        }
+        None
+    }
+
     // # Methods for less common getters.
     //
     // Partially they return things passed into the builder.

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -3,6 +3,7 @@ use std::{
     hash::Hash,
     net::{IpAddr, SocketAddr},
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
     time::Instant,
 };
@@ -57,9 +58,9 @@ const MAX_INACTIVE_NODES: usize = 30;
 ///   These come and go as the node moves around on the internet
 ///
 /// An index of nodeInfos by node key, QuicMappedAddr, and discovered ip:port endpoints.
-#[derive(Default, Debug)]
-pub(super) struct NodeMap {
-    inner: Mutex<NodeMapInner>,
+#[derive(Default, Debug, Clone)]
+pub struct NodeMap {
+    inner: Arc<Mutex<NodeMapInner>>,
 }
 
 #[derive(Default, Debug)]
@@ -99,6 +100,8 @@ pub(crate) enum Source {
     App,
     #[strum(serialize = "{name}")]
     NamedApp { name: &'static str },
+    /// Node discovered locally using MDNS
+    Mdns,
 }
 
 impl NodeMap {
@@ -109,7 +112,7 @@ impl NodeMap {
 
     fn from_inner(inner: NodeMapInner) -> Self {
         Self {
-            inner: Mutex::new(inner),
+            inner: Arc::new(Mutex::new(inner)),
         }
     }
 

--- a/iroh/examples/local_swarm_discovery.rs
+++ b/iroh/examples/local_swarm_discovery.rs
@@ -11,7 +11,7 @@ use anyhow::ensure;
 use clap::{Parser, Subcommand};
 use iroh::base::key::SecretKey;
 use iroh::client::blobs::WrapOption;
-use iroh::net::discovery::local_swarm_discovery::LocalSwarmDiscovery;
+use iroh::net::endpoint::LocalSwarmDiscovery;
 use iroh::node::{DiscoveryConfig, Node};
 use iroh_blobs::Hash;
 use iroh_net::key::PublicKey;
@@ -62,7 +62,8 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     let key = SecretKey::generate();
-    let discovery = LocalSwarmDiscovery::new(key.public())?;
+    let local_swarm_discovery = LocalSwarmDiscovery::new(key.public(), None)?;
+    let discovery = local_swarm_discovery.client();
     let cfg = DiscoveryConfig::Custom(Box::new(discovery));
 
     println!("Starting iroh node with local node discovery...");

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -24,7 +24,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::rpc_protocol::node::{
     AddAddrRequest, AddrRequest, ConnectionInfoRequest, ConnectionInfoResponse, ConnectionsRequest,
-    CounterStats, IdRequest, RelayRequest, ShutdownRequest, StatsRequest, StatusRequest,
+    CounterStats, IdRequest, LocallyDiscoveredNodesRequest, LocallyDiscoveredNodesResponse,
+    RelayRequest, ShutdownRequest, StatsRequest, StatusRequest,
 };
 
 use super::{flatten, RpcClient};
@@ -140,6 +141,18 @@ impl Client {
         let ConnectionInfoResponse { conn_info } =
             self.rpc.rpc(ConnectionInfoRequest { node_id }).await??;
         Ok(conn_info)
+    }
+
+    /// Fetches a list of nodes that have been discovered on the local network.
+    ///
+    /// This will return and empty list if:
+    /// - no local nodes have been discovered
+    /// - `Discovery` is not enabled
+    /// -  none of the discovery services configured do discovery on the locally network.
+    pub async fn locally_discovered_nodes(&self) -> Result<Vec<NodeAddr>> {
+        let LocallyDiscoveredNodesResponse { node_addrs } =
+            self.rpc.rpc(LocallyDiscoveredNodesRequest).await??;
+        Ok(node_addrs.unwrap_or_default())
     }
 
     /// Fetches status information about this node.

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -16,8 +16,6 @@ use iroh_blobs::{
 use iroh_docs::engine::DefaultAuthorStorage;
 use iroh_docs::net::DOCS_ALPN;
 use iroh_gossip::net::{Gossip, GOSSIP_ALPN};
-#[cfg(not(test))]
-use iroh_net::discovery::local_swarm_discovery::LocalSwarmDiscovery;
 use iroh_net::{
     discovery::{dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery},
     dns::DnsResolver,
@@ -508,26 +506,6 @@ where
                 DiscoveryConfig::None => None,
                 DiscoveryConfig::Custom(discovery) => Some(discovery),
                 DiscoveryConfig::Default => {
-                    #[cfg(not(test))]
-                    let discovery = {
-                        let mut discovery_services: Vec<Box<dyn Discovery>> = vec![
-                            // Enable DNS discovery by default
-                            Box::new(DnsDiscovery::n0_dns()),
-                            // Enable pkarr publishing by default
-                            Box::new(PkarrPublisher::n0_dns(self.secret_key.clone())),
-                        ];
-                        // Enable local swarm discovery by default, but fail silently if it errors
-                        match LocalSwarmDiscovery::new(self.secret_key.public()) {
-                            Err(e) => {
-                                tracing::error!("unable to start LocalSwarmDiscoveryService: {e:?}")
-                            }
-                            Ok(service) => {
-                                discovery_services.push(Box::new(service));
-                            }
-                        }
-                        ConcurrentDiscovery::from_services(discovery_services)
-                    };
-                    #[cfg(test)]
                     let discovery = ConcurrentDiscovery::from_services(vec![
                         // Enable DNS discovery by default
                         Box::new(DnsDiscovery::n0_dns()),

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -40,6 +40,7 @@ use crate::client::{
     NodeStatus,
 };
 use crate::node::{docs::DocsEngine, NodeInner};
+use crate::rpc_protocol::node::{LocallyDiscoveredNodesRequest, LocallyDiscoveredNodesResponse};
 use crate::rpc_protocol::{
     authors, blobs,
     blobs::{
@@ -156,6 +157,7 @@ impl<D: BaoStore> Handler<D> {
             }
             ConnectionInfo(msg) => chan.rpc(msg, self, Self::node_connection_info).await,
             AddAddr(msg) => chan.rpc(msg, self, Self::node_add_addr).await,
+            LocallyDiscoveredNodes(msg) => chan.rpc(msg, self, Self::node_locally_discovered).await,
         }
     }
 
@@ -1087,6 +1089,15 @@ impl<D: BaoStore> Handler<D> {
         let AddAddrRequest { addr } = req;
         self.inner.endpoint.add_node_addr(addr)?;
         Ok(())
+    }
+
+    // This method is called as an RPC method, which have to be asy
+    async fn node_locally_discovered(
+        self,
+        _: LocallyDiscoveredNodesRequest,
+    ) -> RpcResult<LocallyDiscoveredNodesResponse> {
+        let node_addrs = self.inner.endpoint.locally_discovered_nodes().await;
+        Ok(LocallyDiscoveredNodesResponse { node_addrs })
     }
 
     async fn create_collection(

--- a/iroh/src/rpc_protocol/node.rs
+++ b/iroh/src/rpc_protocol/node.rs
@@ -33,6 +33,8 @@ pub enum Request {
     Connections(ConnectionsRequest),
     #[rpc(response = RpcResult<ConnectionInfoResponse>)]
     ConnectionInfo(ConnectionInfoRequest),
+    #[rpc(response = RpcResult<LocallyDiscoveredNodesResponse>)]
+    LocallyDiscoveredNodes(LocallyDiscoveredNodesRequest),
     #[server_streaming(response = WatchResponse)]
     Watch(NodeWatchRequest),
 }
@@ -48,6 +50,7 @@ pub enum Response {
     Stats(RpcResult<StatsResponse>),
     Connections(RpcResult<ConnectionsResponse>),
     ConnectionInfo(RpcResult<ConnectionInfoResponse>),
+    LocallyDiscoveredNodes(RpcResult<LocallyDiscoveredNodesResponse>),
     Shutdown(()),
     Watch(WatchResponse),
 }
@@ -78,6 +81,20 @@ pub struct ConnectionInfoRequest {
 pub struct ConnectionInfoResponse {
     /// Information about a connection to a node
     pub conn_info: Option<ConnectionInfo>,
+}
+
+/// Get a list of nodes that have been discovered on the local network.
+///
+/// If no [`Discovery`] service is enabled, or no [`Discovery`] service that is
+/// enabled discovers nodes on the local network, then this will return `None`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LocallyDiscoveredNodesRequest;
+
+/// A response to a locally node discovery request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LocallyDiscoveredNodesResponse {
+    /// [`NodeAddr`]s of nodes discovered on the local network
+    pub node_addrs: Option<Vec<NodeAddr>>,
 }
 
 /// A request to shutdown the node


### PR DESCRIPTION
## Description

We've had multiple requests for user to get a list of nodes that have been discovered on the local network when using `local-swarm-discovery`. This is my attempt.

## Breaking Changes

Adds `locally_discovered_nodes` method to `Discovery` trait

Adds `locally_discovered_nodes` method to the `Endpoint`

Adds rpc structs and a `locally_discovered_nodes` method on the client. 

## Notes & open questions

This may be a tragic addition to the `Discovery` trait, but wanted to get feedback. 

Essentially, this adds  a `locally_discovered_nodes` method to the `Discovery` trait, that returns `None`, unless your discovery mechanism discovers nodes locally. 

I'm not sure how else we would expose this, without a large `Discovery` refactor.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
