### PR TITLE
experiment: try to only use tokio::mpsc in iroh-net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,7 +2839,6 @@ name = "iroh-net"
 version = "0.22.0"
 dependencies = [
  "anyhow",
- "async-channel",
  "axum",
  "backoff",
  "base64 0.22.1",
@@ -2913,6 +2912,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-rustls-acme",
+ "tokio-stream",
  "tokio-tungstenite",
  "tokio-tungstenite-wasm",
  "tokio-util",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1" }
-async-channel = "2.3.1"
 base64 = "0.22.1"
 backoff = "0.4.0"
 bytes = "1"
@@ -58,7 +57,6 @@ ring = "0.17"
 rustls = { version = "0.21.11", default-features = false, features = ["dangerous_configuration"] }
 serde = { version = "1", features = ["derive", "rc"] }
 smallvec = "1.11.1"
-swarm-discovery = { version = "0.2.1", optional = true }
 socket2 = "0.5.3"
 stun-rs = "0.1.5"
 surge-ping = "0.8.0"
@@ -91,6 +89,11 @@ tokio-rustls-acme = { version = "0.3", optional = true }
 # metrics
 iroh-metrics = { version = "0.22.0", path = "../iroh-metrics", default-features = false }
 strum = { version = "0.26.2", features = ["derive"] }
+
+# local_swarm_discovery
+swarm-discovery = { version = "0.2.1", optional = true }
+tokio-stream = { version = "0.1.15", optional = true }
+
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 netlink-packet-core = "0.7.0"
@@ -127,7 +130,7 @@ harness = false
 duct = "0.13.6"
 
 [features]
-default = ["metrics"]
+default = ["metrics", "local_swarm_discovery", "iroh-relay"]
 iroh-relay = [
     "dep:tokio-rustls-acme",
     "dep:axum",
@@ -140,7 +143,7 @@ iroh-relay = [
 ]
 metrics = ["iroh-metrics/metrics"]
 test-utils = ["iroh-relay"]
-local_swarm_discovery = ["dep:swarm-discovery"]
+local_swarm_discovery = ["dep:swarm-discovery", "dep:tokio-stream"]
 
 [[bin]]
 name = "iroh-relay"

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -177,7 +177,7 @@ pub(crate) struct MagicSock {
     proxy_url: Option<Url>,
 
     /// Used for receiving relay messages.
-    relay_recv_receiver: async_channel::Receiver<RelayRecvResult>,
+    relay_recv_receiver: parking_lot::Mutex<mpsc::Receiver<RelayRecvResult>>,
     /// Stores wakers, to be called when relay_recv_ch receives new data.
     network_recv_wakers: parking_lot::Mutex<Option<Waker>>,
     network_send_wakers: parking_lot::Mutex<Option<Waker>>,
@@ -788,12 +788,13 @@ impl MagicSock {
             if self.is_closed() {
                 break;
             }
-            match self.relay_recv_receiver.try_recv() {
-                Err(async_channel::TryRecvError::Empty) => {
+            let mut relay_recv_receiver = self.relay_recv_receiver.lock();
+            match relay_recv_receiver.try_recv() {
+                Err(mpsc::error::TryRecvError::Empty) => {
                     self.network_recv_wakers.lock().replace(cx.waker().clone());
                     break;
                 }
-                Err(async_channel::TryRecvError::Closed) => {
+                Err(mpsc::error::TryRecvError::Disconnected) => {
                     return Poll::Ready(Err(io::Error::new(
                         io::ErrorKind::NotConnected,
                         "connection closed",
@@ -1378,7 +1379,7 @@ impl Handle {
             insecure_skip_relay_cert_verify,
         } = opts;
 
-        let (relay_recv_sender, relay_recv_receiver) = async_channel::bounded(128);
+        let (relay_recv_sender, relay_recv_receiver) = mpsc::channel(128);
 
         let (pconn4, pconn6) = bind(port)?;
         let port = pconn4.port();
@@ -1412,7 +1413,7 @@ impl Handle {
             local_addrs: std::sync::RwLock::new((ipv4_addr, ipv6_addr)),
             closing: AtomicBool::new(false),
             closed: AtomicBool::new(false),
-            relay_recv_receiver,
+            relay_recv_receiver: parking_lot::Mutex::new(relay_recv_receiver),
             network_recv_wakers: parking_lot::Mutex::new(None),
             network_send_wakers: parking_lot::Mutex::new(None),
             actor_sender: actor_sender.clone(),
@@ -1704,7 +1705,7 @@ struct Actor {
     relay_actor_sender: mpsc::Sender<RelayActorMessage>,
     relay_actor_cancel_token: CancellationToken,
     /// Channel to send received relay messages on, for processing.
-    relay_recv_sender: async_channel::Sender<RelayRecvResult>,
+    relay_recv_sender: mpsc::Sender<RelayRecvResult>,
     /// When set, is an AfterFunc timer that will call MagicSock::do_periodic_stun.
     periodic_re_stun_timer: time::Interval,
     /// The `NetInfo` provided in the last call to `net_info_func`. It's used to deduplicate calls to netInfoFunc.

--- a/iroh-net/src/net/netmon/android.rs
+++ b/iroh-net/src/net/netmon/android.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use tokio::sync::mpsc;
 
 use super::actor::NetworkMessage;
 
@@ -6,7 +7,7 @@ use super::actor::NetworkMessage;
 pub(super) struct RouteMonitor {}
 
 impl RouteMonitor {
-    pub(super) fn new(_sender: async_channel::Sender<NetworkMessage>) -> Result<Self> {
+    pub(super) fn new(_sender: mpsc::Sender<NetworkMessage>) -> Result<Self> {
         // Very sad monitor. Android doesn't allow us to do this
 
         Ok(RouteMonitor {})

--- a/iroh-net/src/net/netmon/bsd.rs
+++ b/iroh-net/src/net/netmon/bsd.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use tokio::{io::AsyncReadExt, task::JoinHandle};
+use tokio::{io::AsyncReadExt, sync::mpsc, task::JoinHandle};
 use tracing::{trace, warn};
 
 #[cfg(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
@@ -23,7 +23,7 @@ impl Drop for RouteMonitor {
 }
 
 impl RouteMonitor {
-    pub(super) fn new(sender: async_channel::Sender<NetworkMessage>) -> Result<Self> {
+    pub(super) fn new(sender: mpsc::Sender<NetworkMessage>) -> Result<Self> {
         let socket = socket2::Socket::new(libc::AF_ROUTE.into(), socket2::Type::RAW, None)?;
         socket.set_nonblocking(true)?;
         let socket_std: std::os::unix::net::UnixStream = socket.into();

--- a/iroh-net/src/net/netmon/linux.rs
+++ b/iroh-net/src/net/netmon/linux.rs
@@ -9,7 +9,7 @@ use netlink_packet_core::NetlinkPayload;
 use netlink_packet_route::{address, constants::*, route, RtnlMessage};
 use netlink_sys::{AsyncSocket, SocketAddr};
 use rtnetlink::new_connection;
-use tokio::task::JoinHandle;
+use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{info, trace, warn};
 
 use crate::net::ip::is_link_local;
@@ -49,7 +49,7 @@ macro_rules! get_nla {
 }
 
 impl RouteMonitor {
-    pub(super) fn new(sender: async_channel::Sender<NetworkMessage>) -> Result<Self> {
+    pub(super) fn new(sender: mpsc::Sender<NetworkMessage>) -> Result<Self> {
         let (mut conn, mut _handle, mut messages) = new_connection()?;
 
         // Specify flags to listen on.

--- a/iroh-net/src/net/netmon/windows.rs
+++ b/iroh-net/src/net/netmon/windows.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 use libc::c_void;
+use tokio::sync::mpsc;
 use tracing::{trace, warn};
 use windows::Win32::{
     Foundation::{BOOLEAN, HANDLE as Handle},
@@ -19,7 +20,7 @@ pub(super) struct RouteMonitor {
 }
 
 impl RouteMonitor {
-    pub(super) fn new(sender: async_channel::Sender<NetworkMessage>) -> Result<Self> {
+    pub(super) fn new(sender: mpsc::Sender<NetworkMessage>) -> Result<Self> {
         // Register two callbacks with the windows api
         let mut cb_handler = CallbackHandler::default();
 

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -7,6 +7,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use tokio::sync::mpsc;
 use futures_lite::future::Boxed as BoxFuture;
 use futures_util::{future::Shared, FutureExt};
 
@@ -131,4 +132,48 @@ impl<T: Future + Unpin> Future for MaybeFuture<T> {
 /// and do not attempt to do any hole punching.
 pub(crate) fn relay_only_mode() -> bool {
     std::option_env!("DEV_RELAY_ONLY").is_some()
+}
+
+/// Send an element blocking, automtically handling the existence of a runtime.
+pub fn send_blocking<T: Send>(sender: &mpsc::Sender<T>, el: T) -> std::result::Result<(), mpsc::error::SendError<T>> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(h) => {
+            dbg!(&h);
+            h.spawn(sender.send(el));
+            // can not send result
+            Ok(())
+        }
+        Err(err) => {
+            dbg!(err);
+            sender.blocking_send(el)
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_send_blocking_no_runtime() {
+        let (sender, mut receiver) = mpsc::channel(2);
+
+        send_blocking(&sender, "hello").unwrap();
+        send_blocking(&sender, "world").unwrap();
+
+        assert_eq!(receiver.blocking_recv().unwrap(), "hello");
+        assert_eq!(receiver.blocking_recv().unwrap(), "world");
+    }
+
+    #[tokio::test]
+    async fn test_send_blocking_with_runtime() {
+        let (sender, mut receiver) = mpsc::channel(2);
+
+        send_blocking(&sender, "hello").unwrap();
+        send_blocking(&sender, "world").unwrap();
+
+        assert_eq!(receiver.recv().await.unwrap(), "hello");
+        assert_eq!(receiver.recv().await.unwrap(), "world");
+    }
 }

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -7,9 +7,9 @@ use std::{
     task::{Context, Poll},
 };
 
-use tokio::sync::mpsc;
 use futures_lite::future::Boxed as BoxFuture;
 use futures_util::{future::Shared, FutureExt};
+use tokio::sync::mpsc;
 
 pub mod chain;
 
@@ -134,11 +134,13 @@ pub(crate) fn relay_only_mode() -> bool {
     std::option_env!("DEV_RELAY_ONLY").is_some()
 }
 
-/// Send an element blocking, automtically handling the existence of a runtime.
-pub fn send_blocking<T: Send + 'static>(sender: &mpsc::Sender<T>, el: T) -> std::result::Result<(), mpsc::error::SendError<T>> {
+/// Send an element blocking, automatically handling the existence of a runtime.
+pub fn send_blocking<T: Send + 'static>(
+    sender: &mpsc::Sender<T>,
+    el: T,
+) -> std::result::Result<(), mpsc::error::SendError<T>> {
     match tokio::runtime::Handle::try_current() {
         Ok(h) => {
-            dbg!(&h);
             let sender = sender.clone();
             h.spawn(async move {
                 sender.send(el).await.ok();
@@ -152,7 +154,6 @@ pub fn send_blocking<T: Send + 'static>(sender: &mpsc::Sender<T>, el: T) -> std:
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
I am failing to implement the `send_blocking`, if anyone has ideas, I would love to hear them