### PR TITLE
docs(iroh-cli): fix help text for incomplete blobs

### DIFF
--- a/iroh-cli/src/commands/blobs.rs
+++ b/iroh-cli/src/commands/blobs.rs
@@ -436,7 +436,7 @@ pub struct BlobAddOptions {
 pub enum ListCommands {
     /// List the available blobs on the running provider.
     Blobs,
-    /// List the available blobs on the running provider.
+    /// List the blobs on the running provider that are not full files.
     IncompleteBlobs,
     /// List the available collections on the running provider.
     Collections,


### PR DESCRIPTION
## Description

Aligns the help text for `blobs list incomplete-blobs` with the docs in iroh.computer.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] ~~Tests if relevant.~~
- [ ] ~~All breaking changes documented.~~
