### PR TITLE
feat(ci): notify discord of successfull flaky runs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,10 +1,10 @@
 [test-groups]
-run-in-isolation = { max-threads = 16 } 
+run-in-isolation = { max-threads = 32 } 
 # these are tests that must not run with other tests concurrently. All tests in
-# this group can take up at most 16 threads among them, but each one requiring
+# this group can take up at most 32 threads among them, but each one requiring
 # 16 threads also. The effect should be that tests run isolated.
 
 [[profile.ci.overrides]]
 filter = 'test(::run_in_isolation::)'
 test-group = 'run-in-isolation'
-threads-required = 16
+threads-required = 32

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -91,7 +91,7 @@ jobs:
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ env.TESTS_RESULT =! 'cancelled' }}
+        if: ${{ env.TESTS_RESULT != 'cancelled' }}
         with:
           severity: ${{ env.TESTS_RESULT == 'failure' && 'warn' || 'info' }}
           details: ${{ env.TESTS_RESULT == 'failure' && steps.make_summary.outputs.summary || 'No flaky failure!' }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -94,5 +94,5 @@ jobs:
         if: ${{ env.TESTS_RESULT != 'cancelled' }}
         with:
           severity: ${{ env.TESTS_RESULT == 'failure' && 'warn' || 'info' }}
-          details: ${{ env.TESTS_RESULT == 'failure' && steps.make_summary.outputs.summary || 'No flaky failure!' }}
+          details: ${{ env.TESTS_RESULT == 'failure' && steps.make_summary.outputs.summary || 'No flaky failures!' }}
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -73,6 +73,8 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           EOF=aP51VriWCxNJ1JjvmO9i
           echo "summary<<$EOF" >> $GITHUB_OUTPUT
+          echo "Flaky tests failure:" >> $GITHUB_OUTPUT
+          echo " " >> $GITHUB_OUTPUT
           for report in nextest-results/*.json; do
             # remove the name prefix and extension, and split the parts
             name=$(echo ${report:16:-5} | tr _ ' ')
@@ -84,16 +86,13 @@ jobs:
             echo "$failure"
             echo "$failure" >> $GITHUB_OUTPUT
           done
+          echo "" >> $GITHUB_OUTPUT
+          echo "See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
         if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
-          severity: warn
-          details: |
-            Flaky tests failure:
-
-            ${{ steps.make_summary.outputs.summary }}
-
-            See https://github.com/n0-computer/iroh/actions/workflows/flaky.yaml
+          severity: ${{ env.TESTS_RESULT == 'failure' && 'warn' || 'info' }}
+          details: ${{ env.TESTS_RESULT == 'failure' && steps.make_summary.outputs.summary || 'No flaky failure!' }}
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -91,7 +91,6 @@ jobs:
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
           severity: ${{ env.TESTS_RESULT == 'failure' && 'warn' || 'info' }}
           details: ${{ env.TESTS_RESULT == 'failure' && steps.make_summary.outputs.summary || 'No flaky failure!' }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -91,6 +91,7 @@ jobs:
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
+        if: ${{ env.TESTS_RESULT =! 'cancelled' }}
         with:
           severity: ${{ env.TESTS_RESULT == 'failure' && 'warn' || 'info' }}
           details: ${{ env.TESTS_RESULT == 'failure' && steps.make_summary.outputs.summary || 'No flaky failure!' }}

--- a/iroh-net/src/discovery/local_swarm_discovery.rs
+++ b/iroh-net/src/discovery/local_swarm_discovery.rs
@@ -299,10 +299,10 @@ mod tests {
             tracing::debug!(?node_id_b, "Discovering node id b");
             // publish discovery_b's address
             discovery_b.publish(&addr_info);
-            let s1_res = tokio::time::timeout(Duration::from_secs(10), s1.next())
+            let s1_res = tokio::time::timeout(Duration::from_secs(5), s1.next())
                 .await?
                 .unwrap()?;
-            let s2_res = tokio::time::timeout(Duration::from_secs(10), s2.next())
+            let s2_res = tokio::time::timeout(Duration::from_secs(5), s2.next())
                 .await?
                 .unwrap()?;
             assert_eq!(s1_res.addr_info, addr_info);

--- a/iroh-net/src/discovery/local_swarm_discovery.rs
+++ b/iroh-net/src/discovery/local_swarm_discovery.rs
@@ -299,10 +299,10 @@ mod tests {
             tracing::debug!(?node_id_b, "Discovering node id b");
             // publish discovery_b's address
             discovery_b.publish(&addr_info);
-            let s1_res = tokio::time::timeout(Duration::from_secs(5), s1.next())
+            let s1_res = tokio::time::timeout(Duration::from_secs(10), s1.next())
                 .await?
                 .unwrap()?;
-            let s2_res = tokio::time::timeout(Duration::from_secs(5), s2.next())
+            let s2_res = tokio::time::timeout(Duration::from_secs(10), s2.next())
                 .await?
                 .unwrap()?;
             assert_eq!(s1_res.addr_info, addr_info);


### PR DESCRIPTION
## Description

In pro of being a bit more positive, this PR makes the notify action tell us when there were no ci failures as well.

## Breaking Changes
n/a

## Notes & open questions

Also increases the required threads for the isolation tests

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
