### PR TITLE
feat(iroh-blobs): Add outboard creation progress to the mem store

### DIFF
--- a/iroh-blobs/src/store/fs/tests.rs
+++ b/iroh-blobs/src/store/fs/tests.rs
@@ -7,6 +7,7 @@ use crate::store::bao_file::test_support::{
 };
 use crate::store::{Map as _, MapEntryMut, MapMut, ReadableStore, Store as _};
 use crate::util::raw_outboard;
+use crate::IROH_BLOCK_SIZE;
 
 macro_rules! assert_matches {
         ($expression:expr, $pattern:pat) => {

--- a/iroh-blobs/src/store/fs/util.rs
+++ b/iroh-blobs/src/store/fs/util.rs
@@ -5,32 +5,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-/// A reader that calls a callback with the number of bytes read after each read.
-pub(crate) struct ProgressReader<R, F: Fn(u64) -> io::Result<()>> {
-    inner: R,
-    offset: u64,
-    cb: F,
-}
-
-impl<R: io::Read, F: Fn(u64) -> io::Result<()>> ProgressReader<R, F> {
-    pub fn new(inner: R, cb: F) -> Self {
-        Self {
-            inner,
-            offset: 0,
-            cb,
-        }
-    }
-}
-
-impl<R: io::Read, F: Fn(u64) -> io::Result<()>> io::Read for ProgressReader<R, F> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let read = self.inner.read(buf)?;
-        self.offset += read as u64;
-        (self.cb)(self.offset)?;
-        Ok(read)
-    }
-}
-
 /// overwrite a file with the given data.
 ///
 /// This is almost like `std::fs::write`, but it does not truncate the file.

--- a/iroh-blobs/src/store/mem.rs
+++ b/iroh-blobs/src/store/mem.rs
@@ -83,7 +83,12 @@ impl Store {
         progress: impl ProgressSender<Msg = ImportProgress> + IdGenerator,
     ) -> io::Result<TempTag> {
         progress.blocking_send(ImportProgress::OutboardProgress { id, offset: 0 })?;
-        let (storage, hash) = MutableMemStorage::complete(bytes);
+        let progress2 = progress.clone();
+        let cb = move |offset| {
+            progress2.try_send(ImportProgress::OutboardProgress { id, offset })
+                .ok();
+        };
+        let (storage, hash) = MutableMemStorage::complete(bytes, cb);
         progress.blocking_send(ImportProgress::OutboardDone { id, hash })?;
         use super::Store;
         let tag = self.temp_tag(HashAndFormat { hash, format });

--- a/iroh-blobs/src/store/mem.rs
+++ b/iroh-blobs/src/store/mem.rs
@@ -85,7 +85,8 @@ impl Store {
         progress.blocking_send(ImportProgress::OutboardProgress { id, offset: 0 })?;
         let progress2 = progress.clone();
         let cb = move |offset| {
-            progress2.try_send(ImportProgress::OutboardProgress { id, offset })
+            progress2
+                .try_send(ImportProgress::OutboardProgress { id, offset })
                 .ok();
         };
         let (storage, hash) = MutableMemStorage::complete(bytes, cb);

--- a/iroh-blobs/src/store/mutable_mem_storage.rs
+++ b/iroh-blobs/src/store/mutable_mem_storage.rs
@@ -65,7 +65,7 @@ impl MutableMemStorage {
     /// Create a new mutable mem storage from the given data
     pub fn complete(
         bytes: Bytes,
-        cb: impl Fn(u64) -> () + Send + Sync + 'static,
+        cb: impl Fn(u64) + Send + Sync + 'static,
     ) -> (Self, iroh_base::hash::Hash) {
         let (hash, outboard) = compute_outboard(&bytes[..], bytes.len() as u64, move |offset| {
             cb(offset);

--- a/iroh-blobs/src/store/mutable_mem_storage.rs
+++ b/iroh-blobs/src/store/mutable_mem_storage.rs
@@ -5,7 +5,7 @@ use bao_tree::{
 use bytes::Bytes;
 
 use crate::{
-    util::{copy_limited_slice, raw_outboard, SparseMemFile},
+    util::{compute_outboard, copy_limited_slice, SparseMemFile},
     IROH_BLOCK_SIZE,
 };
 
@@ -63,8 +63,16 @@ impl SizeInfo {
 
 impl MutableMemStorage {
     /// Create a new mutable mem storage from the given data
-    pub fn complete(bytes: Bytes) -> (Self, iroh_base::hash::Hash) {
-        let (outboard, hash) = raw_outboard(bytes.as_ref());
+    pub fn complete(
+        bytes: Bytes,
+        cb: impl Fn(u64) -> () + Send + Sync + 'static,
+    ) -> (Self, iroh_base::hash::Hash) {
+        let (hash, outboard) = compute_outboard(&bytes[..], bytes.len() as u64, move |offset| {
+            cb(offset);
+            Ok(())
+        })
+        .unwrap();
+        let outboard = outboard.unwrap_or_default();
         let res = Self {
             data: bytes.to_vec().into(),
             outboard: outboard.into(),


### PR DESCRIPTION
## Description

Add outboard creation progress to the mem store

just move compute_outboard from fs to util and use it from both fs and mem.

## Breaking Changes

None, hopefully

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
