### PR TITLE
fix(ci): report flaky outupt only on success and failure

### DIFF
--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -91,7 +91,7 @@ jobs:
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ env.TESTS_RESULT != 'cancelled' }}
+        if: ${{ env.TESTS_RESULT == 'failure' || env.TESTS_RESULT == 'success' }}
         with:
           severity: ${{ env.TESTS_RESULT == 'failure' && 'warn' || 'info' }}
           details: ${{ env.TESTS_RESULT == 'failure' && steps.make_summary.outputs.summary || 'No flaky failures!' }}


### PR DESCRIPTION
## Description

in #2623 the condition for `notify` is not being cancelled, but a job can also be skipped. This is the output when a PR is not even running the tests. So, we get a good report in cases where there was no output. This fixes that issue

## Breaking Changes
n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [ ] ~~Tests if relevant.~~
- [ ] ~~All breaking changes documented.~~
