### PR TITLE
refactor(iroh-blobs, iroh)!: deprecate flat stores

### DIFF
--- a/iroh-blobs/src/store/fs.rs
+++ b/iroh-blobs/src/store/fs.rs
@@ -765,6 +765,10 @@ impl Store {
     }
 
     /// Import from a v0 or v1 flat store, for backwards compatibility.
+    #[deprecated(
+        since = "0.23.0",
+        note = "Flat stores are deprecated and future versions will not be able to migrate."
+    )]
     pub async fn import_flat_store(&self, paths: FlatStorePaths) -> io::Result<bool> {
         Ok(self.0.import_flat_store(paths).await?)
     }

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -307,6 +307,7 @@ where
             })?;
         let docs_storage = DocsStorage::Persistent(IrohPaths::DocsDatabase.with_root(root));
 
+        #[allow(deprecated)]
         let v0 = blobs_store
             .import_flat_store(iroh_blobs::store::fs::FlatStorePaths {
                 complete: root.join("blobs.v0"),
@@ -314,6 +315,7 @@ where
                 meta: root.join("blobs-meta.v0"),
             })
             .await?;
+        #[allow(deprecated)]
         let v1 = blobs_store
             .import_flat_store(iroh_blobs::store::fs::FlatStorePaths {
                 complete: root.join("blobs.v1").join("complete"),
@@ -322,7 +324,7 @@ where
             })
             .await?;
         if v0 || v1 {
-            tracing::info!("flat data was imported - reapply inline options");
+            tracing::warn!("Imported deprecated flat data. Future versions will stop supporting migrations from flat stores");
             blobs_store
                 .update_inline_options(iroh_blobs::store::fs::InlineOptions::default(), true)
                 .await?;


### PR DESCRIPTION
## Description

In vein of promoting doing things TheRightWay™, this PR deprecates flat stores for their removal in a later iroh version. This is probably a low stakes deprecation and removal but imo gets us in the flow of being kind(er) with our users. Issue #2630 is created as a reminder to remove this.

## Breaking Changes

- `iroh_blobs::store::fs::Store::import_flat_store` is deprecated. Ensure all data is migrated before future versions, which won't support this.
- `iroh_blobs::store::fs::FlatStorePaths` is deprecated. Ensure all data is migrated before future versions, which won't support this.
- `iroh`: Flat stores are deprecated. Ensure all data is migrated before future versions, which won't support this.

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [ ] ~~Tests if relevant.~~
- [x] All breaking changes documented.
