### PR TITLE
refactor: normalize feature names

### DIFF
--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -90,7 +90,7 @@ tokio-rustls-acme = { version = "0.3", optional = true }
 iroh-metrics = { version = "0.22.0", path = "../iroh-metrics", default-features = false }
 strum = { version = "0.26.2", features = ["derive"] }
 
-# local_swarm_discovery
+# local-swarm-discovery
 swarm-discovery = { version = "0.2.1", optional = true }
 tokio-stream = { version = "0.1.15", optional = true }
 
@@ -143,7 +143,7 @@ iroh-relay = [
 ]
 metrics = ["iroh-metrics/metrics"]
 test-utils = ["iroh-relay"]
-local_swarm_discovery = ["dep:swarm-discovery", "dep:tokio-stream"]
+local-swarm-discovery = ["dep:swarm-discovery", "dep:tokio-stream"]
 
 [[bin]]
 name = "iroh-relay"

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -51,7 +51,7 @@ use crate::{AddrInfo, Endpoint, NodeId};
 
 pub mod dns;
 
-#[cfg(feature = "local_swarm_discovery")]
+#[cfg(feature = "local-swarm-discovery")]
 pub mod local_swarm_discovery;
 pub mod pkarr;
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -30,7 +30,7 @@ iroh-blobs = { version = "0.22.0", path = "../iroh-blobs", features = ["download
 iroh-base = { version = "0.22.0", path = "../iroh-base", features = ["key"] }
 iroh-io = { version = "0.6.0", features = ["stats"] }
 iroh-metrics = { version = "0.22.0", path = "../iroh-metrics", optional = true }
-iroh-net = { version = "0.22.0", path = "../iroh-net", features = ["local_swarm_discovery"] }
+iroh-net = { version = "0.22.0", path = "../iroh-net", features = ["local-swarm-discovery"] }
 nested_enum_utils = "0.1.0"
 num_cpus = { version = "1.15.0" }
 portable-atomic = "1"
@@ -67,7 +67,7 @@ metrics = ["iroh-metrics", "iroh-blobs/metrics"]
 fs-store = ["iroh-blobs/fs-store"]
 test = []
 examples = ["dep:clap", "dep:indicatif"]
-local_swarm_discovery = ["iroh-net/local_swarm_discovery", "examples", "dep:console"]
+local-swarm-discovery = ["iroh-net/local-swarm-discovery", "examples", "dep:console"]
 test-utils = ["iroh-net/test-utils"]
 
 [dev-dependencies]
@@ -117,4 +117,4 @@ required-features = ["examples"]
 
 [[example]]
 name = "local_swarm_discovery"
-required-features = ["local_swarm_discovery"]
+required-features = ["local-swarm-discovery"]

--- a/iroh/examples/local_swarm_discovery.rs
+++ b/iroh/examples/local_swarm_discovery.rs
@@ -1,9 +1,9 @@
 //! Example that runs and iroh node with local node discovery and no relay server
 //!
 //! Run the follow command to run the "accept" side, that hosts the content:
-//!  $ cargo run --example local_swarm_discovery --features="local_swarm_discovery" -- accept [FILE_PATH]
+//!  $ cargo run --example local_swarm_discovery --features="local-swarm-discovery" -- accept [FILE_PATH]
 //! Wait for output that looks like the following:
-//!  $ cargo run --example local_swarm_discovery --features="local_swarm_discovery" -- connect [NODE_ID] [HASH] -o [FILE_PATH]
+//!  $ cargo run --example local_swarm_discovery --features="local-swarm-discovery" -- connect [NODE_ID] [HASH] -o [FILE_PATH]
 //! Run that command on another machine in the same local network, replacing [FILE_PATH] to the path on which you want to save the transferred content.
 use std::path::PathBuf;
 
@@ -93,7 +93,7 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .await?;
             let outcome = stream.finish().await?;
-            println!("To fetch the blob:\n\tcargo run --example local_swarm_discovery --features=\"local_swarm_discovery\" -- connect {} {} -o [FILE_PATH]", node.node_id(), outcome.hash);
+            println!("To fetch the blob:\n\tcargo run --example local_swarm_discovery --features=\"local-swarm-discovery\" -- connect {} {} -o [FILE_PATH]", node.node_id(), outcome.hash);
             tokio::signal::ctrl_c().await?;
             node.shutdown().await?;
             std::process::exit(0);


### PR DESCRIPTION
All feature names should be named with `-`.

## Breaking Changes

- `iroh-net/local_swarm_discovery` -> `iroh-net/local-swarm-discovery`
- `iroh/local_swarm_discovery` -> `iroh/local-swarm-discovery`

