### PR TITLE
refactor(iroh-net)!: Rename the local-swarm-discovery feature to discovery-local-network

### DIFF
--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -146,7 +146,7 @@ iroh-relay = [
 ]
 metrics = ["iroh-metrics/metrics"]
 test-utils = ["iroh-relay"]
-local-swarm-discovery = ["dep:swarm-discovery", "dep:tokio-stream"]
+discovery-local-network = ["dep:swarm-discovery", "dep:tokio-stream"]
 discovery-pkarr-dht = ["pkarr/dht", "dep:genawaiter"]
 
 [[bin]]

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -51,7 +51,7 @@ use crate::{AddrInfo, Endpoint, NodeId};
 
 pub mod dns;
 
-#[cfg(feature = "local-swarm-discovery")]
+#[cfg(feature = "discovery-local-network")]
 pub mod local_swarm_discovery;
 pub mod pkarr;
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -30,7 +30,7 @@ iroh-blobs = { version = "0.22.0", path = "../iroh-blobs", features = ["download
 iroh-base = { version = "0.22.0", path = "../iroh-base", features = ["key"] }
 iroh-io = { version = "0.6.0", features = ["stats"] }
 iroh-metrics = { version = "0.22.0", path = "../iroh-metrics", optional = true }
-iroh-net = { version = "0.22.0", path = "../iroh-net", features = ["local-swarm-discovery"] }
+iroh-net = { version = "0.22.0", path = "../iroh-net", features = ["discovery-local-network"] }
 nested_enum_utils = "0.1.0"
 num_cpus = { version = "1.15.0" }
 portable-atomic = "1"
@@ -67,7 +67,8 @@ metrics = ["iroh-metrics", "iroh-blobs/metrics"]
 fs-store = ["iroh-blobs/fs-store"]
 test = []
 examples = ["dep:clap", "dep:indicatif"]
-local-swarm-discovery = ["iroh-net/local-swarm-discovery", "examples", "dep:console"]
+discovery-local-network = ["iroh-net/discovery-local-network", "examples", "dep:console"]
+discovery-pkarr-dht = ["iroh-net/discovery-pkarr-dht"]
 test-utils = ["iroh-net/test-utils"]
 
 [dev-dependencies]
@@ -117,4 +118,4 @@ required-features = ["examples"]
 
 [[example]]
 name = "local_swarm_discovery"
-required-features = ["local-swarm-discovery"]
+required-features = ["discovery-local-network"]

--- a/iroh/examples/local_swarm_discovery.rs
+++ b/iroh/examples/local_swarm_discovery.rs
@@ -1,9 +1,9 @@
 //! Example that runs and iroh node with local node discovery and no relay server
 //!
 //! Run the follow command to run the "accept" side, that hosts the content:
-//!  $ cargo run --example local_swarm_discovery --features="local-swarm-discovery" -- accept [FILE_PATH]
+//!  $ cargo run --example local_swarm_discovery --features="discovery-local-network" -- accept [FILE_PATH]
 //! Wait for output that looks like the following:
-//!  $ cargo run --example local_swarm_discovery --features="local-swarm-discovery" -- connect [NODE_ID] [HASH] -o [FILE_PATH]
+//!  $ cargo run --example local_swarm_discovery --features="discovery-local-network" -- connect [NODE_ID] [HASH] -o [FILE_PATH]
 //! Run that command on another machine in the same local network, replacing [FILE_PATH] to the path on which you want to save the transferred content.
 use std::path::PathBuf;
 


### PR DESCRIPTION
## Description

Rename the local-swarm-discovery feature to discovery-local-network to be consistent with discovery-pkarr-dht

## Breaking Changes

renames the `local-swarm-discovery` feature flag in iroh-net to `discovery-local-network`

## Notes & open questions

Naming is hard. Pretty sure the ff should start with `discovery-`, but should it be `discovery-local-network` or `discovery-local-swarm` or just -local...?

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
