### PR TITLE
[IGNORE] flub/connection-info-wtf bkp

### DIFF
--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -30,7 +30,7 @@ use iroh::{
         defaults::DEFAULT_STUN_PORT,
         discovery::{dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery},
         dns::default_resolver,
-        endpoint::{self, Connection, ConnectionTypeStream, RecvStream, SendStream},
+        endpoint::{self, Connection, ConnectionTypeStream, NodeInfo, RecvStream, SendStream},
         key::{PublicKey, SecretKey},
         netcheck, portmapper,
         relay::{RelayMap, RelayMode, RelayUrl},
@@ -424,8 +424,8 @@ impl Gui {
             x.map(|x| format!("{:.6}s", x.as_secs_f64()))
                 .unwrap_or_else(|| "unknown".to_string())
         };
-        let msg = match endpoint.connection_info(*node_id) {
-            Some(endpoint::ConnectionInfo {
+        let msg = match endpoint.node_info(*node_id) {
+            Some(NodeInfo {
                 relay_url,
                 conn_type,
                 latency,

--- a/iroh-cli/src/commands/node.rs
+++ b/iroh-cli/src/commands/node.rs
@@ -9,7 +9,7 @@ use comfy_table::{presets::NOTHING, Cell};
 use futures_lite::{Stream, StreamExt};
 use human_time::ToHumanTimeString;
 use iroh::client::Iroh;
-use iroh::net::endpoint::{ConnectionInfo, DirectAddrInfo};
+use iroh::net::endpoint::{DirectAddrInfo, NodeInfo};
 use iroh::net::relay::RelayUrl;
 use iroh::net::{NodeAddr, NodeId};
 
@@ -127,7 +127,7 @@ impl NodeCommands {
 }
 
 async fn fmt_connections(
-    mut infos: impl Stream<Item = Result<ConnectionInfo, anyhow::Error>> + Unpin,
+    mut infos: impl Stream<Item = Result<NodeInfo, anyhow::Error>> + Unpin,
 ) -> String {
     let mut table = Table::new();
     table.load_preset(NOTHING).set_header(
@@ -157,9 +157,8 @@ async fn fmt_connections(
     table.to_string()
 }
 
-fn fmt_connection(info: ConnectionInfo) -> String {
-    let ConnectionInfo {
-        id: _,
+fn fmt_connection(info: NodeInfo) -> String {
+    let NodeInfo {
         node_id,
         relay_url,
         addrs,
@@ -196,6 +195,7 @@ fn fmt_connection(info: ConnectionInfo) -> String {
 }
 
 fn direct_addr_row(info: DirectAddrInfo) -> comfy_table::Row {
+    #[allow(deprecated)]
     let DirectAddrInfo {
         addr,
         latency,

--- a/iroh-cli/src/commands/node.rs
+++ b/iroh-cli/src/commands/node.rs
@@ -16,10 +16,10 @@ use iroh::net::{NodeAddr, NodeId};
 #[derive(Subcommand, Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum NodeCommands {
-    /// Get information about the different connections we have made
-    Connections,
-    /// Get connection information about a particular node
-    ConnectionInfo { node_id: NodeId },
+    /// Get information about the different remote nodes.
+    NodeInfoList,
+    /// Get information about a particular remote node.
+    NodeInfo { node_id: NodeId },
     /// Get status of the running node.
     Status,
     /// Get statistics and metrics from the running node.
@@ -48,8 +48,8 @@ pub enum NodeCommands {
 impl NodeCommands {
     pub async fn run(self, iroh: &Iroh) -> Result<()> {
         match self {
-            Self::Connections => {
-                let connections = iroh.connections().await?;
+            Self::NodeInfoList => {
+                let connections = iroh.node_info_iter().await?;
                 let timestamp = time::OffsetDateTime::now_utc()
                     .format(&time::format_description::well_known::Rfc2822)
                     .unwrap_or_else(|_| String::from("failed to get current time"));
@@ -61,8 +61,8 @@ impl NodeCommands {
                     fmt_connections(connections).await
                 );
             }
-            Self::ConnectionInfo { node_id } => {
-                let conn_info = iroh.connection_info(node_id).await?;
+            Self::NodeInfo { node_id } => {
+                let conn_info = iroh.node_info(node_id).await?;
                 match conn_info {
                     Some(info) => println!("{}", fmt_connection(info)),
                     None => println!("Not Found"),

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -259,8 +259,11 @@ impl DiscoveryTask {
 
     /// We need discovery if we have no paths to the node, or if the paths we do have
     /// have timed out.
+    // TODO: info.last_received() and info.last_alive_relay() are deprecated, avoid using
+    // them.
+    #[allow(deprecated)]
     fn needs_discovery(ep: &Endpoint, node_id: NodeId) -> bool {
-        match ep.connection_info(node_id) {
+        match ep.node_info(node_id) {
             // No connection info means no path to node -> start discovery.
             None => true,
             Some(info) => {

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -49,16 +49,7 @@ pub use super::magicsock::{
     DirectAddrsStream, NodeInfo,
 };
 
-#[allow(deprecated)]
-pub use super::magicsock::ControlMsg;
-
 pub use iroh_base::node_addr::{AddrInfo, NodeAddr};
-
-/// Details about a remote iroh-net node which is known to this node.
-///
-/// See [`NodeInfo`] for documentation, which should be used instead.
-#[deprecated(since = "0.23", note = "use `NodeInfo` instead")]
-pub type ConnectionInfo = NodeInfo;
 
 /// The delay to fall back to discovery when direct addresses fail.
 ///
@@ -744,26 +735,6 @@ impl Endpoint {
     /// See also [`Endpoint::node_info`] to only retrieve information about a single node.
     pub fn node_info_iter(&self) -> impl Iterator<Item = NodeInfo> {
         self.msock.node_info_all_nodes().into_iter()
-    }
-
-    /// Returns information about a specific remote node know to this [`Endpoint`].
-    ///
-    /// See [`Endpoint::node_info`] for documentation, which should be preferred as this
-    /// method will be removed in a future release.
-    #[allow(deprecated)] // The return type is also deprecated
-    #[deprecated(since = "0.23", note = "please use `node_info` instead")]
-    pub fn connection_info(&self, node_id: NodeId) -> Option<ConnectionInfo> {
-        self.msock.node_info(node_id)
-    }
-
-    /// Returns information about all the remote nodes this [`Endpoint`] knows about.
-    ///
-    /// See [`Endpoint::iter_node_info`] for documentation, which should be preferred as
-    /// this method will be removed in a future release.
-    #[allow(deprecated)] // The return type is also deprecated
-    #[deprecated(since = "0.23", note = "please use `iter_node_info` instead")]
-    pub fn connection_infos(&self) -> Vec<ConnectionInfo> {
-        self.msock.node_info_all_nodes()
     }
 
     // # Methods for less common getters.

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -45,7 +45,7 @@ pub use quinn::{
 };
 
 pub use super::magicsock::{
-    ConnectionType, ConnectionTypeStream, DirectAddr, DirectAddrInfo, DirectAddrType,
+    ConnectionType, ConnectionTypeStream, ControlMsg, DirectAddr, DirectAddrInfo, DirectAddrType,
     DirectAddrsStream, NodeInfo,
 };
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -80,7 +80,9 @@ pub(crate) use node_map::Source;
 pub(super) use self::timer::Timer;
 
 pub use self::metrics::Metrics;
-pub use self::node_map::{ConnectionType, ConnectionTypeStream, DirectAddrInfo, NodeInfo};
+pub use self::node_map::{
+    ConnectionType, ConnectionTypeStream, ControlMsg, DirectAddrInfo, NodeInfo,
+};
 
 /// How long we consider a STUN-derived endpoint valid for. UDP NAT mappings typically
 /// expire at 30 seconds, so this is a few seconds shy of that.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -80,8 +80,6 @@ pub(crate) use node_map::Source;
 pub(super) use self::timer::Timer;
 
 pub use self::metrics::Metrics;
-#[allow(deprecated)]
-pub use self::node_map::ControlMsg;
 pub use self::node_map::{ConnectionType, ConnectionTypeStream, DirectAddrInfo, NodeInfo};
 
 /// How long we consider a STUN-derived endpoint valid for. UDP NAT mappings typically

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -34,8 +34,6 @@ mod udp_paths;
 
 pub(super) use node_state::{DiscoPingPurpose, PingAction, PingRole, SendPing};
 
-#[allow(deprecated)]
-pub use node_state::ControlMsg;
 pub use node_state::{ConnectionType, DirectAddrInfo, NodeInfo};
 
 /// Number of nodes that are inactive for which we keep info about. This limit is enforced

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -35,7 +35,7 @@ mod udp_paths;
 
 pub(super) use node_state::{DiscoPingPurpose, PingAction, PingRole, SendPing};
 
-pub use node_state::{ConnectionType, DirectAddrInfo, NodeInfo};
+pub use node_state::{ConnectionType, ControlMsg, DirectAddrInfo, NodeInfo};
 
 /// Number of nodes that are inactive for which we keep info about. This limit is enforced
 /// periodically via [`NodeMap::prune_inactive`].

--- a/iroh-net/src/magicsock/node_map.rs
+++ b/iroh-net/src/magicsock/node_map.rs
@@ -32,8 +32,11 @@ mod best_addr;
 mod node_state;
 mod udp_paths;
 
-pub use node_state::{ConnectionType, ControlMsg, DirectAddrInfo, NodeInfo};
 pub(super) use node_state::{DiscoPingPurpose, PingAction, PingRole, SendPing};
+
+#[allow(deprecated)]
+pub use node_state::ControlMsg;
+pub use node_state::{ConnectionType, DirectAddrInfo, NodeInfo};
 
 /// Number of nodes that are inactive for which we keep info about. This limit is enforced
 /// periodically via [`NodeMap::prune_inactive`].
@@ -223,7 +226,7 @@ impl NodeMap {
             .collect()
     }
 
-    /// Gets the [`NodeInfo`]s for each endpoint
+    /// Returns the [`NodeInfo`]s for each node in the node map.
     pub(super) fn node_infos(&self, now: Instant) -> Vec<NodeInfo> {
         self.inner.lock().node_infos(now)
     }

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1297,7 +1297,7 @@ pub struct NodeInfo {
     /// Time elapsed time since last sending to, or received from the node.
     ///
     /// This is the duration since *any* data was sent or receive from the remote node,
-    /// payload or control messsages.  Note that sending to the remote node does not imply
+    /// payload or control messages.  Note that sending to the remote node does not imply
     /// the remote node received anything.
     pub last_used: Option<Duration>,
 }

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1237,6 +1237,8 @@ pub struct DirectAddrInfo {
     /// returned.  If the remote node moved network and no longer has this path, this could
     /// be a long duration.  If the path was added via [`Endpoint::add_node_addr`] or some
     /// node discovery the path may never have been known to exist.
+    ///
+    /// [`Endpoint::add_node_addr`]: crate::endpoint::Endpoint::add_node_addr
     // TODO: deprecate this as it is **so** confusing a name.  But we don't have a
     // replacement yet and I"m only documenting things in this PR."
     pub last_alive: Option<Duration>,
@@ -1275,6 +1277,8 @@ impl From<RelayUrlInfo> for RelayUrl {
 /// been connected to in the past.  There are various reasons a node might be known: it
 /// could have been manually added via [`Endpoint::add_node_addr`], it could have been added
 /// by some discovery mechanism.
+///
+/// [`Endpoint::add_node_addr`]: crate::endpoint::Endpoint::add_node_addr
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NodeInfo {
     /// The globally unique public identifier for this node.

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -221,9 +221,7 @@ impl NodeState {
             ConnectionType::None => None,
         };
 
-        // .last_control_msg() is deprecated but we need it to populate the deprecated
-        // field.
-        #[allow(deprecated)]
+        #[allow(deprecated)] // last_control field is deprecated
         let addrs = self
             .udp_paths
             .paths
@@ -242,10 +240,7 @@ impl NodeState {
             })
             .collect();
 
-        // id is deprecated, but we need to populate it.
-        #[allow(deprecated)]
         NodeInfo {
-            id: self.id,
             node_id: self.node_id,
             relay_url: self.relay_url.clone().map(|r| r.into()),
             addrs,
@@ -1458,10 +1453,6 @@ pub enum DiscoPingPurpose {
 
 /// The type of control message we have received.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, derive_more::Display)]
-// TODO: This should really be deprecated, but we still use it in other fields and this
-//   becomes impossible.  All fields and functions which return it are already deprecated so
-//   that will do.  Should be removed once those uses are removed.
-//#[deprecated(since = "0.23", note = "internal information")]
 pub enum ControlMsg {
     /// We received a Ping from the node.
     #[display("ping←")]
@@ -1503,9 +1494,7 @@ pub struct DirectAddrInfo {
     /// Note that [`ControlMsg::CallMeMaybe`] is received via a relay path, while
     /// [`ControlMsg::Ping`] and [`ControlMsg::Pong`] are received on the path to
     /// [`DirectAddrInfo::addr`] itself and thus convey very different information.
-    // NOTE(flub): marking this for removal, this information is not used at all internally
-    // and is very weird and heterogeneous, advertising in a call-me-maybe is totally
-    // different from receiving a ping or pong.
+    // TODO: Remove this!  It is a totally useless piece of information.
     #[deprecated(since = "0.23", note = "this is confusing internal information")]
     pub last_control: Option<(Duration, ControlMsg)>,
     /// Elapsed time since the last payload message was received on this network path.
@@ -1564,9 +1553,6 @@ impl From<RelayUrlInfo> for RelayUrl {
 /// by some discovery mechanism.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NodeInfo {
-    /// The id in the node_map.
-    #[deprecated(since = "0.23", note = "this is internal information, use `node_id`")]
-    pub id: usize,
     /// The globally unique public identifier for this node.
     pub node_id: NodeId,
     /// Relay server information, if available.
@@ -1580,7 +1566,7 @@ pub struct NodeInfo {
     pub conn_type: ConnectionType,
     /// The latency of the current network path to the remote node.
     pub latency: Option<Duration>,
-    /// Time elapsed time since last sending to or receiving from the node.
+    /// Time elapsed time since last sending to, or received from the node.
     ///
     /// This is the duration since *any* data was sent or receive from the remote node,
     /// payload or control messsages.  Note that sending to the remote node does not imply
@@ -1591,11 +1577,8 @@ pub struct NodeInfo {
 impl NodeInfo {
     /// Get the duration since the last activity we received from this endpoint
     /// on any of its direct addresses.
-    // TODO: We need to fix this, but in a different PR.
-    #[deprecated(
-        since = "0.23",
-        note = "this does not contain the supposed information"
-    )]
+    // TODO: This does not contain what it claims to contain!  It can not be fixed easily.
+    #[deprecated(since = "0.23", note = "this is broken")]
     pub fn last_received(&self) -> Option<Duration> {
         #[allow(deprecated)]
         self.addrs
@@ -1802,7 +1785,6 @@ mod tests {
         #[allow(deprecated)]
         let mut expect = Vec::from([
             NodeInfo {
-                id: a_endpoint.id,
                 node_id: a_endpoint.node_id,
                 relay_url: None,
                 addrs: Vec::from([DirectAddrInfo {
@@ -1817,7 +1799,6 @@ mod tests {
                 last_used: Some(elapsed),
             },
             NodeInfo {
-                id: b_endpoint.id,
                 node_id: b_endpoint.node_id,
                 relay_url: Some(RelayUrlInfo {
                     relay_url: b_endpoint.relay_url.as_ref().unwrap().0.clone(),
@@ -1830,7 +1811,6 @@ mod tests {
                 last_used: Some(elapsed),
             },
             NodeInfo {
-                id: c_endpoint.id,
                 node_id: c_endpoint.node_id,
                 relay_url: Some(RelayUrlInfo {
                     relay_url: c_endpoint.relay_url.as_ref().unwrap().0.clone(),
@@ -1843,7 +1823,6 @@ mod tests {
                 last_used: Some(elapsed),
             },
             NodeInfo {
-                id: d_endpoint.id,
                 node_id: d_endpoint.node_id,
                 relay_url: Some(RelayUrlInfo {
                     relay_url: d_endpoint.relay_url.as_ref().unwrap().0.clone(),

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1495,7 +1495,7 @@ pub struct DirectAddrInfo {
     /// [`ControlMsg::Ping`] and [`ControlMsg::Pong`] are received on the path to
     /// [`DirectAddrInfo::addr`] itself and thus convey very different information.
     // TODO: Remove this!  It is a totally useless piece of information.
-    #[deprecated(since = "0.23", note = "this is confusing internal information")]
+    #[deprecated(since = "0.23.0", note = "this is confusing internal information")]
     pub last_control: Option<(Duration, ControlMsg)>,
     /// Elapsed time since the last payload message was received on this network path.
     ///
@@ -1578,7 +1578,7 @@ impl NodeInfo {
     /// Get the duration since the last activity we received from this endpoint
     /// on any of its direct addresses.
     // TODO: This does not contain what it claims to contain!  It can not be fixed easily.
-    #[deprecated(since = "0.23", note = "this is broken")]
+    #[deprecated(since = "0.23.0", note = "this is broken")]
     pub fn last_received(&self) -> Option<Duration> {
         #[allow(deprecated)]
         self.addrs
@@ -1588,7 +1588,10 @@ impl NodeInfo {
     }
 
     /// Returns the elapsed time since the relay path to the node last received data.
-    #[deprecated(since = "0.23", note = "access relay_url.last_alive directly instead")]
+    #[deprecated(
+        since = "0.23.0",
+        note = "access relay_url.last_alive directly instead"
+    )]
     pub fn last_alive_relay(&self) -> Option<Duration> {
         self.relay_url.as_ref().and_then(|r| r.last_alive)
     }

--- a/iroh-net/src/magicsock/node_map/path_state.rs
+++ b/iroh-net/src/magicsock/node_map/path_state.rs
@@ -11,8 +11,8 @@ use crate::disco::SendAddr;
 use crate::magicsock::HEARTBEAT_INTERVAL;
 use crate::stun;
 
-use super::node_state::{PongReply, SESSION_ACTIVE_TIMEOUT};
-use super::{ControlMsg, IpPort, PingRole};
+use super::node_state::{ControlMsg, PongReply, SESSION_ACTIVE_TIMEOUT};
+use super::{IpPort, PingRole};
 
 /// The minimum time between pings to an endpoint.
 ///

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -135,7 +135,7 @@ impl Client {
 
     /// Fetches node information about a remote iroh node identified by its [`NodeId`].
     ///
-    /// See also [`Endpoint::connection_info`](crate::net::Endpoint::connection_info).
+    /// See also [`Endpoint::node_info`](crate::net::Endpoint::node_info).
     pub async fn node_info(&self, node_id: NodeId) -> Result<Option<NodeInfo>> {
         let NodeInfoResponse { info: conn_info } =
             self.rpc.rpc(NodeInfoRequest { node_id }).await??;

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -18,7 +18,7 @@ use std::{collections::BTreeMap, net::SocketAddr};
 
 use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
-use iroh_net::{endpoint::ConnectionInfo, relay::RelayUrl, NodeAddr, NodeId};
+use iroh_net::{endpoint::NodeInfo, relay::RelayUrl, NodeAddr, NodeId};
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 
@@ -128,7 +128,8 @@ impl Client {
     /// transferring the snapshot.
     ///
     /// See also [`Endpoint::connection_infos`](crate::net::Endpoint::connection_infos).
-    pub async fn connections(&self) -> Result<impl Stream<Item = Result<ConnectionInfo>>> {
+    // TODO: Bad bad name.  fix me
+    pub async fn connections(&self) -> Result<impl Stream<Item = Result<NodeInfo>>> {
         let stream = self.rpc.server_streaming(ConnectionsRequest {}).await?;
         Ok(flatten(stream).map(|res| res.map(|res| res.conn_info)))
     }
@@ -136,7 +137,8 @@ impl Client {
     /// Fetches connection information about a connection to another node identified by its [`NodeId`].
     ///
     /// See also [`Endpoint::connection_info`](crate::net::Endpoint::connection_info).
-    pub async fn connection_info(&self, node_id: NodeId) -> Result<Option<ConnectionInfo>> {
+    // TODO: Bad bad name.  fix me
+    pub async fn connection_info(&self, node_id: NodeId) -> Result<Option<NodeInfo>> {
         let ConnectionInfoResponse { conn_info } =
             self.rpc.rpc(ConnectionInfoRequest { node_id }).await??;
         Ok(conn_info)

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -23,8 +23,8 @@ use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 
 use crate::rpc_protocol::node::{
-    AddAddrRequest, AddrRequest, ConnectionInfoRequest, ConnectionInfoResponse, ConnectionsRequest,
-    CounterStats, IdRequest, RelayRequest, ShutdownRequest, StatsRequest, StatusRequest,
+    AddAddrRequest, AddrRequest, AllNodeInfoRequest, CounterStats, IdRequest, NodeInfoRequest,
+    NodeInfoResponse, RelayRequest, ShutdownRequest, StatsRequest, StatusRequest,
 };
 
 use super::{flatten, RpcClient};
@@ -130,8 +130,8 @@ impl Client {
     /// See also [`Endpoint::connection_infos`](crate::net::Endpoint::connection_infos).
     // TODO: Bad bad name.  fix me
     pub async fn connections(&self) -> Result<impl Stream<Item = Result<NodeInfo>>> {
-        let stream = self.rpc.server_streaming(ConnectionsRequest {}).await?;
-        Ok(flatten(stream).map(|res| res.map(|res| res.conn_info)))
+        let stream = self.rpc.server_streaming(AllNodeInfoRequest {}).await?;
+        Ok(flatten(stream).map(|res| res.map(|res| res.info)))
     }
 
     /// Fetches connection information about a connection to another node identified by its [`NodeId`].
@@ -139,8 +139,8 @@ impl Client {
     /// See also [`Endpoint::connection_info`](crate::net::Endpoint::connection_info).
     // TODO: Bad bad name.  fix me
     pub async fn connection_info(&self, node_id: NodeId) -> Result<Option<NodeInfo>> {
-        let ConnectionInfoResponse { conn_info } =
-            self.rpc.rpc(ConnectionInfoRequest { node_id }).await??;
+        let NodeInfoResponse { info: conn_info } =
+            self.rpc.rpc(NodeInfoRequest { node_id }).await??;
         Ok(conn_info)
     }
 

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -122,23 +122,21 @@ impl Client {
         Ok(res.stats)
     }
 
-    /// Fetches information about currently known connections.
+    /// Fetches information about currently known remote nodes.
     ///
     /// This streams a *current snapshot*. It does not keep the stream open after finishing
     /// transferring the snapshot.
     ///
-    /// See also [`Endpoint::connection_infos`](crate::net::Endpoint::connection_infos).
-    // TODO: Bad bad name.  fix me
-    pub async fn connections(&self) -> Result<impl Stream<Item = Result<NodeInfo>>> {
+    /// See also [`Endpoint::node_info_iter`](crate::net::Endpoint::node_info_iter).
+    pub async fn node_info_iter(&self) -> Result<impl Stream<Item = Result<NodeInfo>>> {
         let stream = self.rpc.server_streaming(AllNodeInfoRequest {}).await?;
         Ok(flatten(stream).map(|res| res.map(|res| res.info)))
     }
 
-    /// Fetches connection information about a connection to another node identified by its [`NodeId`].
+    /// Fetches node information about a remote iroh node identified by its [`NodeId`].
     ///
     /// See also [`Endpoint::connection_info`](crate::net::Endpoint::connection_info).
-    // TODO: Bad bad name.  fix me
-    pub async fn connection_info(&self, node_id: NodeId) -> Result<Option<NodeInfo>> {
+    pub async fn node_info(&self, node_id: NodeId) -> Result<Option<NodeInfo>> {
         let NodeInfoResponse { info: conn_info } =
             self.rpc.rpc(NodeInfoRequest { node_id }).await??;
         Ok(conn_info)

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -563,8 +563,7 @@ async fn handle_connection(
 }
 
 fn node_addresses_for_storage(ep: &Endpoint) -> Vec<NodeAddr> {
-    ep.connection_infos()
-        .into_iter()
+    ep.node_info_iter()
         .filter_map(node_address_for_storage)
         .collect()
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -47,11 +47,9 @@ use iroh_blobs::store::{GcMarkEvent, GcSweepEvent, Store as BaoStore};
 use iroh_blobs::util::local_pool::{LocalPool, LocalPoolHandle};
 use iroh_blobs::{downloader::Downloader, protocol::Closed};
 use iroh_gossip::net::Gossip;
+use iroh_net::endpoint::{DirectAddrsStream, NodeInfo};
 use iroh_net::key::SecretKey;
-use iroh_net::{
-    endpoint::{ConnectionInfo, DirectAddrsStream},
-    util::SharedAbortingJoinHandle,
-};
+use iroh_net::util::SharedAbortingJoinHandle;
 use iroh_net::{AddrInfo, Endpoint, NodeAddr};
 use quic_rpc::transport::ServerEndpoint as _;
 use quic_rpc::RpcServer;
@@ -576,7 +574,7 @@ fn node_addresses_for_storage(ep: &Endpoint) -> Vec<NodeAddr> {
 /// If the endpoint was used, only the paths that were in use will be returned.
 ///
 /// Returns `None` if the resulting [`NodeAddr`] would be empty.
-fn node_address_for_storage(info: ConnectionInfo) -> Option<NodeAddr> {
+fn node_address_for_storage(info: NodeInfo) -> Option<NodeAddr> {
     let direct_addresses = if info.last_used.is_none() {
         info.addrs
             .into_iter()

--- a/iroh/src/rpc_protocol/node.rs
+++ b/iroh/src/rpc_protocol/node.rs
@@ -29,10 +29,10 @@ pub enum Request {
     Stats(StatsRequest),
     #[rpc(response = ())]
     Shutdown(ShutdownRequest),
-    #[server_streaming(response = RpcResult<ConnectionsResponse>)]
-    Connections(ConnectionsRequest),
-    #[rpc(response = RpcResult<ConnectionInfoResponse>)]
-    ConnectionInfo(ConnectionInfoRequest),
+    #[server_streaming(response = RpcResult<AllNodeInfoResponse>)]
+    Connections(AllNodeInfoRequest),
+    #[rpc(response = RpcResult<NodeInfoResponse>)]
+    ConnectionInfo(NodeInfoRequest),
     #[server_streaming(response = WatchResponse)]
     Watch(NodeWatchRequest),
 }
@@ -46,38 +46,39 @@ pub enum Response {
     Addr(RpcResult<NodeAddr>),
     Relay(RpcResult<Option<RelayUrl>>),
     Stats(RpcResult<StatsResponse>),
-    Connections(RpcResult<ConnectionsResponse>),
-    ConnectionInfo(RpcResult<ConnectionInfoResponse>),
+    Connections(RpcResult<AllNodeInfoResponse>),
+    ConnectionInfo(RpcResult<NodeInfoResponse>),
     Shutdown(()),
     Watch(WatchResponse),
 }
 
-/// List connection information about all the nodes we know about
+/// List network path information about all the remote nodes know by this node.
 ///
-/// These can be nodes that we have explicitly connected to or nodes
-/// that have initiated connections to us.
+/// There may never have been connections to these nodes, and connections may not even be
+/// possible.  As well due to connections nodes can become known due to discovery mechanims
+/// or be added manually.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ConnectionsRequest;
+pub struct AllNodeInfoRequest;
 
 /// A response to a connections request
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ConnectionsResponse {
+pub struct AllNodeInfoResponse {
     /// Information about a connection
-    pub conn_info: ConnectionInfo,
+    pub info: NodeInfo,
 }
 
 /// Get connection information about a specific node
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConnectionInfoRequest {
+pub struct NodeInfoRequest {
     /// The node identifier
     pub node_id: PublicKey,
 }
 
 /// A response to a connection request
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ConnectionInfoResponse {
+pub struct NodeInfoResponse {
     /// Information about a connection to a node
-    pub conn_info: Option<ConnectionInfo>,
+    pub info: Option<NodeInfo>,
 }
 
 /// A request to shutdown the node

--- a/iroh/src/rpc_protocol/node.rs
+++ b/iroh/src/rpc_protocol/node.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use iroh_base::rpc::RpcResult;
-use iroh_net::{endpoint::ConnectionInfo, key::PublicKey, relay::RelayUrl, NodeAddr, NodeId};
+use iroh_net::{endpoint::NodeInfo, key::PublicKey, relay::RelayUrl, NodeAddr, NodeId};
 use nested_enum_utils::enum_conversions;
 use quic_rpc_derive::rpc_requests;
 use serde::{Deserialize, Serialize};

--- a/iroh/src/rpc_protocol/node.rs
+++ b/iroh/src/rpc_protocol/node.rs
@@ -55,7 +55,7 @@ pub enum Response {
 /// List network path information about all the remote nodes know by this node.
 ///
 /// There may never have been connections to these nodes, and connections may not even be
-/// possible.  As well due to connections nodes can become known due to discovery mechanims
+/// possible.  As well due to connections nodes can become known due to discovery mechanisms
 /// or be added manually.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AllNodeInfoRequest;


### PR DESCRIPTION
**copy-pasted from original**
## Description

This migrates Endpoint::connection_info and Endpoint::connection_infos to Endpoint::node_info and Endpoint::node_info_iter.  This returns information about nodes in the node map.  This has not that much to do with connections.  Calling this connections is rather misleading.

It documents all types below it properly, deprecating some problematic fields and functions.

## Breaking Changes

### iroh-net

- `Endpoint::connection_info` -> `Endpoint::node_info`
- `Endpoint::connection_infos` -> `Endpoint::node_info_iter` (returns `Iterator` instead of `Vec`.
- `ConnectionInfo` -> `NodeInfo`
- `DirectAddrInfo::last_control` is deprecated, it contains misleading information.
- `NodeInfo::id` is removed, it was internal information.
- `NodeInfo::last_received` is deprecated as this information is wrong and can not currently be provided.
- `NodeInfo::last_alive_relay` is deprecated as it is a simple accessor for an already public field.

### iroh

- `Client::connections` -> `Client::node_info_iter`
- `Client::connection_info` -> `Client::node_info`

## Notes & open questions

This started as a documentation PR, so really concentrates on doing the
documentation right.  It could not avoid doing some fixes to the API though.

The `node_info_iter()` API is potentially a weird naming and API choice.  It
is a `Vec` returned as an iter.  I think this is ok for several reasons:
- The API name is much better than e.g. a single-letter difference: `node_infos`.  This would be a lot more prone to typos.
- Returning things as an iterator is kind of rust-like.
- If some place collects it into a `Vec` again the compiler will optimise it away.

The node discovery uses some deprecated APIs.  This is the reason I have left
those around as deprecated instead of entirely removing them.  The information
provided by these APIs is not what it claims to be and finding the right way to
fix the usage is better done as a follow-up: #2621.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
