### PR TITLE
feat(iroh-net): allow customizing republish delay for the pkarr publisher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,7 +2651,7 @@ dependencies = [
  "iroh-metrics",
  "nix 0.27.1",
  "parking_lot",
- "pkarr 1.1.5",
+ "pkarr",
  "portable-atomic",
  "postcard",
  "quic-rpc",
@@ -2704,7 +2704,7 @@ dependencies = [
  "lru",
  "mainline",
  "parking_lot",
- "pkarr 2.1.0",
+ "pkarr",
  "rcgen 0.12.1",
  "redb 2.1.1",
  "regex",
@@ -2881,7 +2881,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pin-project",
- "pkarr 2.1.0",
+ "pkarr",
  "postcard",
  "pretty_assertions",
  "proptest",
@@ -3818,25 +3818,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "1.1.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242ae92dfb9d2ba3aaa9caf4723e72043bc50729ad05a763771771ba03196ffb"
-dependencies = [
- "bytes",
- "ed25519-dalek",
- "rand",
- "self_cell",
- "simple-dns",
- "thiserror",
- "url",
- "z32",
-]
-
-[[package]]
-name = "pkarr"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4548c673cbf8c91b69f7a17d3a042710aa73cffe5e82351db5378f26c3be64d8"
+checksum = "a8ffdac8b4b7ea5240c46b28f88de799e0efaa2b93ccb08eaae6e50835dfe137"
 dependencies = [
  "bytes",
  "document-features",

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -44,7 +44,7 @@ iroh = { version = "0.22.0", path = "../iroh", features = ["metrics"] }
 iroh-gossip = { version = "0.22.0", path = "../iroh-gossip" }
 iroh-metrics = { version = "0.22.0", path = "../iroh-metrics" }
 parking_lot = "0.12.1"
-pkarr = { version = "1.1.5", default-features = false }
+pkarr = { version = "2.0.0", default-features = false }
 portable-atomic = "1"
 postcard = "1.0.8"
 quic-rpc = { version = "0.11", features = ["flume-transport", "quinn-transport"] }

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -1015,7 +1015,7 @@ fn bold<T: Display>(x: T) -> String {
 }
 
 fn to_z32(node_id: NodeId) -> String {
-    pkarr::PublicKey::try_from(*node_id.as_bytes())
+    pkarr::PublicKey::try_from(node_id.as_bytes())
         .unwrap()
         .to_z32()
 }


### PR DESCRIPTION
## Description

The pkarr dht publisher has two delays, the initial delay and the republish delay. These were constants so far, but now are configurable in the builder.

This allows us to set the delay to 0s in the dht_discovery_smoke test.

## Breaking Changes

None

## Notes & open questions

Will this fix the flakiness?

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
