### PR TITLE
refactor(iroh-net,iroh)!: rename to remote_info_iter, fixup some docs

### DIFF
--- a/iroh-cli/src/commands/node.rs
+++ b/iroh-cli/src/commands/node.rs
@@ -49,7 +49,7 @@ impl NodeCommands {
     pub async fn run(self, iroh: &Iroh) -> Result<()> {
         match self {
             Self::RemoteList => {
-                let connections = iroh.remote_infos_iter().await?;
+                let connections = iroh.remote_info_iter().await?;
                 let timestamp = time::OffsetDateTime::now_utc()
                     .format(&time::format_description::well_known::Rfc2822)
                     .unwrap_or_else(|_| String::from("failed to get current time"));

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -717,7 +717,7 @@ impl Endpoint {
     /// calls may return different information. Furthermore, node information may even be
     /// completely evicted as it becomes stale.
     ///
-    /// See also [`Endpoint::remote_infos_iter`] which returns information on all nodes known
+    /// See also [`Endpoint::remote_info_iter`] which returns information on all nodes known
     /// by this [`Endpoint`].
     pub fn remote_info(&self, node_id: NodeId) -> Option<RemoteInfo> {
         self.msock.remote_info(node_id)
@@ -733,7 +733,7 @@ impl Endpoint {
     /// connection was ever made or is even possible.
     ///
     /// See also [`Endpoint::remote_info`] to only retrieve information about a single node.
-    pub fn remote_infos_iter(&self) -> impl Iterator<Item = RemoteInfo> {
+    pub fn remote_info_iter(&self) -> impl Iterator<Item = RemoteInfo> {
         self.msock.list_remote_infos().into_iter()
     }
 
@@ -1286,11 +1286,11 @@ mod tests {
         // first time, create a magic endpoint without peers but a peers file and add addressing
         // information for a peer
         let endpoint = new_endpoint(secret_key.clone(), None).await;
-        assert_eq!(endpoint.remote_infos_iter().count(), 0);
+        assert_eq!(endpoint.remote_info_iter().count(), 0);
         endpoint.add_node_addr(node_addr.clone()).unwrap();
 
         // Grab the current addrs
-        let node_addrs: Vec<NodeAddr> = endpoint.remote_infos_iter().map(Into::into).collect();
+        let node_addrs: Vec<NodeAddr> = endpoint.remote_info_iter().map(Into::into).collect();
         assert_eq!(node_addrs.len(), 1);
         assert_eq!(node_addrs[0], node_addr);
 

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1219,9 +1219,9 @@ pub struct DirectAddrInfo {
     pub last_payload: Option<Duration>,
     /// Elapsed time since this network path was known to exist.
     ///
-    /// A network path be considered to exist only because the remote node advertised it.
-    /// It may not mean the path is usable.  However if there was any communication with the
-    /// remote node over this network path it also means the path exists.
+    /// A network path is considered to exist only because the remote node advertised it.
+    /// It may not mean the path is usable.  However, if there was any communication with
+    /// the remote node over this network path it also means the path exists.
     ///
     /// The elapsed time since *any* confirmation of the path's existence was received is
     /// returned.  If the remote node moved networks and no longer has this path, this could
@@ -1262,9 +1262,9 @@ impl From<RelayUrlInfo> for RelayUrl {
 /// Details about a remote iroh-net node which is known to this node.
 ///
 /// Having details of a node does not mean it can be connected to, nor that it has ever been
-/// connected to in the past. There are various reasons a node might be known: it could have been
-/// manually added via [`Endpoint::add_node_addr`], it could have been added by some discovery
-/// mechanism, or the node could have contacted this node.
+/// connected to in the past. There are various reasons a node might be known: it could have
+/// been manually added via [`Endpoint::add_node_addr`], it could have been added by some
+/// discovery mechanism, the node could have contacted this node, etc.
 ///
 /// [`Endpoint::add_node_addr`]: crate::endpoint::Endpoint::add_node_addr
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -1311,7 +1311,7 @@ impl RemoteInfo {
 
     /// Whether there is a possible known network path to the remote node.
     ///
-    /// Note that this does not provide any guarantees of whether this network path is
+    /// Note that this does not provide any guarantees of whether any network path is
     /// usable.
     pub fn has_send_address(&self) -> bool {
         self.relay_url.is_some() || !self.addrs.is_empty()

--- a/iroh/src/client/node.rs
+++ b/iroh/src/client/node.rs
@@ -127,8 +127,8 @@ impl Client {
     /// This streams a *current snapshot*. It does not keep the stream open after finishing
     /// transferring the snapshot.
     ///
-    /// See also [`Endpoint::remote_infos_iter`](crate::net::Endpoint::remote_infos_iter).
-    pub async fn remote_infos_iter(&self) -> Result<impl Stream<Item = Result<RemoteInfo>>> {
+    /// See also [`Endpoint::remote_info_iter`](crate::net::Endpoint::remote_info_iter).
+    pub async fn remote_info_iter(&self) -> Result<impl Stream<Item = Result<RemoteInfo>>> {
         let stream = self.rpc.server_streaming(RemoteInfosIterRequest {}).await?;
         Ok(flatten(stream).map(|res| res.map(|res| res.info)))
     }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -618,7 +618,7 @@ async fn handle_connection(
 }
 
 fn node_addresses_for_storage(ep: &Endpoint) -> Vec<NodeAddr> {
-    ep.remote_infos_iter()
+    ep.remote_info_iter()
         .filter_map(node_address_for_storage)
         .collect()
 }

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -1276,7 +1276,7 @@ impl<D: BaoStore> Handler<D> {
     ) -> impl Stream<Item = RpcResult<RemoteInfosIterResponse>> + Send + 'static {
         // provide a little buffer so that we don't slow down the sender
         let (tx, rx) = async_channel::bounded(32);
-        let mut infos: Vec<_> = self.inner.endpoint.remote_infos_iter().collect();
+        let mut infos: Vec<_> = self.inner.endpoint.remote_info_iter().collect();
         infos.sort_by_key(|n| n.node_id.to_string());
         self.local_pool_handle().spawn_detached(|| async move {
             for info in infos {


### PR DESCRIPTION
## Description

This renames remote_infos_iter to remote_info_iter.  This returns an
iterator of remote_info items.  Using plural for "info" adds a double
plural together with "iter", creating something of a pleonasm.

## Breaking Changes

None right now, this is unreleased.

But `Endpoint::remote_infos_iter` -> `Endpoint::remote_info_iter` from
previous breaking changes.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~Tests if relevant.~~
- [x] All breaking changes documented.