### PR TITLE
feat(iroh-willow): verified payoad streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,6 +3026,7 @@ dependencies = [
  "hex",
  "iroh-base",
  "iroh-blobs",
+ "iroh-io",
  "iroh-metrics",
  "iroh-net",
  "iroh-quinn",

--- a/iroh-willow/Cargo.toml
+++ b/iroh-willow/Cargo.toml
@@ -29,6 +29,7 @@ genawaiter = "0.99.1"
 hex = "0.4.3"
 iroh-base = { version = "0.22.0", path = "../iroh-base" }
 iroh-blobs = { version = "0.22.0", path = "../iroh-blobs" }
+iroh-io = { version = "0.6.0", features = ["stats"] }
 iroh-metrics = { version = "0.22.0", path = "../iroh-metrics", optional = true }
 iroh-net = { version = "0.22.0", path = "../iroh-net" }
 meadowcap = "0.1.0"

--- a/iroh-willow/src/proto/wgps.rs
+++ b/iroh-willow/src/proto/wgps.rs
@@ -12,11 +12,11 @@ pub use fingerprint::*;
 pub use handles::*;
 pub use messages::*;
 
-pub const MAX_PAYLOAD_SIZE_POWER: u8 = 12;
+pub const MAX_PAYLOAD_SIZE_POWER: u8 = 18;
 
 /// The maximum payload size limits when the other peer may include Payloads directly when transmitting Entries:
 /// when an Entry’s payload_length is strictly greater than the maximum payload size,
 /// its Payload may only be transmitted when explicitly requested.
 ///
-/// The value is 4096.
+/// The value is 256KiB.
 pub const MAX_PAYLOAD_SIZE: usize = 2usize.pow(MAX_PAYLOAD_SIZE_POWER as u32);

--- a/iroh-willow/src/util.rs
+++ b/iroh-willow/src/util.rs
@@ -4,6 +4,7 @@ pub mod channel;
 pub mod codec;
 pub mod codec2;
 pub mod gen_stream;
+pub mod pipe;
 pub mod queue;
 pub mod stream;
 pub mod time;

--- a/iroh-willow/src/util/pipe.rs
+++ b/iroh-willow/src/util/pipe.rs
@@ -1,0 +1,154 @@
+use std::{
+    cell::RefCell,
+    future::poll_fn,
+    io,
+    rc::Rc,
+    task::{Context, Poll, Waker},
+};
+
+use bytes::{Bytes, BytesMut};
+use futures_lite::Stream;
+use iroh_io::AsyncStreamWriter;
+
+/// In-memory local-io async pipe between a [`AsyncStreamWriter`] and a [`Stream`] of [`Bytes`].
+///
+/// The pipe maintains a shared in-memory buffer of `chunk_size`
+///
+/// [`PipeWriter`] is a [`AsyncStreamWriter`] that writes into the shared buffer.
+///
+/// [`PipeReader`] is [`Stream`] that emits [`Bytes`] of `chunk_size` length. The last chunk may be
+/// smaller than `chunk_size`.
+///
+/// The pipe is closed once either the reader or the writer are dropped. If the reader is dropped,
+/// subsequent writes will fail with [`io::ErrorKind::BrokenPipe`].
+// TODO: Move to iroh-io?
+pub fn chunked_pipe(chunk_size: usize) -> (PipeWriter, PipeReader) {
+    let shared = Shared {
+        buf: BytesMut::new(),
+        chunk_size,
+        read_waker: None,
+        write_waker: None,
+        closed: false,
+    };
+    let shared = Rc::new(RefCell::new(shared));
+    let writer = PipeWriter {
+        shared: shared.clone(),
+    };
+    let reader = PipeReader { shared };
+    (writer, reader)
+}
+
+#[derive(Debug)]
+struct Shared {
+    buf: BytesMut,
+    chunk_size: usize,
+    read_waker: Option<Waker>,
+    write_waker: Option<Waker>,
+    closed: bool,
+}
+
+impl Shared {
+    fn poll_write(&mut self, data: &[u8], cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+        if self.closed {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "write after close",
+            )));
+        }
+        let remaining = self.chunk_size - self.buf.len();
+        let amount = data.len().min(remaining);
+        if amount > 0 {
+            self.buf.extend_from_slice(&data[..amount]);
+            if let Some(waker) = self.read_waker.take() {
+                waker.wake();
+            }
+            Poll::Ready(Ok(amount))
+        } else {
+            self.write_waker = Some(cx.waker().to_owned());
+            Poll::Pending
+        }
+    }
+
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<io::Result<Bytes>>> {
+        if self.buf.len() == self.chunk_size {
+            if let Some(write_waker) = self.write_waker.take() {
+                write_waker.wake();
+            }
+            Poll::Ready(Some(Ok(self.buf.split().freeze())))
+        } else if self.closed && !self.buf.is_empty() {
+            Poll::Ready(Some(Ok(self.buf.split().freeze())))
+        } else if self.closed {
+            Poll::Ready(None)
+        } else {
+            self.read_waker = Some(cx.waker().to_owned());
+            Poll::Pending
+        }
+    }
+
+    fn close(&mut self) {
+        self.closed = true;
+        if let Some(waker) = self.read_waker.take() {
+            waker.wake();
+        }
+        if let Some(waker) = self.write_waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+/// The writer returned from [`chunked_pipe`].
+#[derive(Debug)]
+pub struct PipeWriter {
+    shared: Rc<RefCell<Shared>>,
+}
+
+/// The reader returned from [`chunked_pipe`].
+#[derive(Debug)]
+pub struct PipeReader {
+    shared: Rc<RefCell<Shared>>,
+}
+
+impl Drop for PipeWriter {
+    fn drop(&mut self) {
+        let mut shared = self.shared.borrow_mut();
+        shared.close();
+    }
+}
+
+impl Drop for PipeReader {
+    fn drop(&mut self) {
+        let mut shared = self.shared.borrow_mut();
+        shared.close();
+    }
+}
+
+impl AsyncStreamWriter for PipeWriter {
+    async fn write(&mut self, data: &[u8]) -> io::Result<()> {
+        let mut written = 0;
+        while written < data.len() {
+            written += poll_fn(|cx| {
+                let mut shared = self.shared.borrow_mut();
+                shared.poll_write(&data[written..], cx)
+            })
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn write_bytes(&mut self, data: bytes::Bytes) -> io::Result<()> {
+        self.write(&data[..]).await
+    }
+
+    async fn sync(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Stream for PipeReader {
+    type Item = io::Result<Bytes>;
+
+    fn poll_next(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut shared = self.shared.borrow_mut();
+        shared.poll_next(cx)
+    }
+}


### PR DESCRIPTION
## Description

* In `iroh_blobs` adds `Store::import_verifiable_stream` and `MapEntry::write_verifiable_stream` to import and export a stream of data with bao metadata interleaved. The format is the same as in the iroh blobs protocol. (@rklaehn is the format written down somewhere?). So it switches between parent nodes and leaf nodes as needed by the bao tree.
* Uses these to encode the payload for `DataSendEntry` and `ReconciliationSendEntry` with proper support for offsets. The verifiable stream of bytes is cut into chunks after each 32KiB and wrapped in the WGPS message.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
