### PR TITLE
fix(iroh-net): Document the keylog environment variable correctly

### DIFF
--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -259,7 +259,7 @@ impl Builder {
     /// This key should normally remain secret but can be useful to debug networking issues
     /// by decrypting captured traffic.
     ///
-    /// If *keylog* is `true` then setting the `KEYLOGFILE` environment variable to a
+    /// If *keylog* is `true` then setting the `SSLKEYLOGFILE` environment variable to a
     /// filename will result in this file being used to log the TLS pre-master keys.
     pub fn keylog(mut self, keylog: bool) -> Self {
         self.keylog = keylog;

--- a/iroh-net/src/tls.rs
+++ b/iroh-net/src/tls.rs
@@ -5,6 +5,8 @@
 
 use std::sync::Arc;
 
+use tracing::warn;
+
 use crate::key::{PublicKey, SecretKey};
 
 pub mod certificate;
@@ -35,6 +37,7 @@ pub fn make_client_config(
         .expect("Client cert key DER is valid; qed");
     crypto.alpn_protocols = alpn_protocols;
     if keylog {
+        warn!("enabling SSLKEYLOGFILE for TLS pre-master keys");
         crypto.key_log = Arc::new(rustls::KeyLogFile::new());
     }
 
@@ -63,6 +66,7 @@ pub fn make_server_config(
         .expect("Server cert key DER is valid; qed");
     crypto.alpn_protocols = alpn_protocols;
     if keylog {
+        warn!("enabling SSLKEYLOGFILE for TLS pre-master keys");
         crypto.key_log = Arc::new(rustls::KeyLogFile::new());
     }
     Ok(crypto)


### PR DESCRIPTION
## Description

Also log the fact this is enabled on WARN level.  This is pretty
important to notice.

## Breaking Changes

none

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~