### PR TITLE
fix: docker CI performance & release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,6 +451,7 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           tags: n0computer/iroh-test:latest
           target: iroh
           platforms: linux/amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Build iroh
-        run: cargo build --release --workspace --all-features
+        run: cargo build --release --all-features
 
       - name: Prep bins
         run: |
@@ -459,7 +459,7 @@ jobs:
       - name: Run Docker image & stats test
         run: |
           docker run -p 9090:9090 -p 4919:4919/udp -Pd n0computer/iroh-test:latest --rpc-addr 0.0.0.0:4919 start
-          cargo run --bin iroh -- --rpc-addr 127.0.0.1:4919 stats
+          target/release/iroh --rpc-addr 127.0.0.1:4919 stats
 
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,7 +461,7 @@ jobs:
         run: |
           docker run -p 9090:9090 -p 4919:4919/udp -Pd n0computer/iroh-test:latest --rpc-addr 0.0.0.0:4919 start
           # Give the server time to start
-          sleep 5
+          sleep 10
           target/dev-ci/iroh --rpc-addr 127.0.0.1:4919 stats
 
   codespell:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,14 +429,14 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Build iroh
-        run: cargo build --release --all-features
+        run: cargo build --profile=dev-ci --all-features
 
       - name: Prep bins
         run: |
           mkdir -p bins/linux/amd64
-          cp target/release/iroh bins/linux/amd64/iroh
-          cp target/release/iroh-relay bins/linux/amd64/iroh-relay
-          cp target/release/iroh-dns-server bins/linux/amd64/iroh-dns-server
+          cp target/dev-ci/iroh bins/linux/amd64/iroh
+          cp target/dev-ci/iroh-relay bins/linux/amd64/iroh-relay
+          cp target/dev-ci/iroh-dns-server bins/linux/amd64/iroh-dns-server
 
       - name: Cleanup Docker
         continue-on-error: true
@@ -461,7 +461,7 @@ jobs:
           docker run -p 9090:9090 -p 4919:4919/udp -Pd n0computer/iroh-test:latest --rpc-addr 0.0.0.0:4919 start
           # Give the server time to start
           sleep 3
-          target/release/iroh --rpc-addr 127.0.0.1:4919 stats
+          target/dev-ci/iroh --rpc-addr 127.0.0.1:4919 stats
 
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,8 @@ jobs:
       - name: Run Docker image & stats test
         run: |
           docker run -p 9090:9090 -p 4919:4919/udp -Pd n0computer/iroh-test:latest --rpc-addr 0.0.0.0:4919 start
+          # Give the server time to start
+          sleep 3
           target/release/iroh --rpc-addr 127.0.0.1:4919 stats
 
   codespell:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,14 +432,12 @@ jobs:
         run: sudo apt-get install musl-tools -y
 
       - name: Build iroh
-        run: cargo build --profile=dev-ci --all-features --target x86_64-unknown-linux-musl
+        run: cargo build --profile=dev-ci --all-features --bin iroh --target x86_64-unknown-linux-musl
 
       - name: Prep bins
         run: |
           mkdir -p bins/linux/amd64
-          cp target/dev-ci/iroh bins/linux/amd64/iroh
-          cp target/dev-ci/iroh-relay bins/linux/amd64/iroh-relay
-          cp target/dev-ci/iroh-dns-server bins/linux/amd64/iroh-dns-server
+          cp target/x86_64-unknown-linux-musl/dev-ci/iroh bins/linux/amd64/iroh
 
       - name: Cleanup Docker
         continue-on-error: true
@@ -465,7 +463,7 @@ jobs:
           docker run -p 9090:9090 -p 4919:4919/udp -Pd n0computer/iroh-test:latest --rpc-addr 0.0.0.0:4919 start
           # Give the server time to start
           sleep 3
-          target/dev-ci/iroh --rpc-addr 127.0.0.1:4919 stats
+          target/x86_64-unknown-linux-musl/dev-ci/iroh --rpc-addr 127.0.0.1:4919 stats
 
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,7 +461,7 @@ jobs:
         run: |
           docker run -p 9090:9090 -p 4919:4919/udp -Pd n0computer/iroh-test:latest --rpc-addr 0.0.0.0:4919 start
           # Give the server time to start
-          sleep 3
+          sleep 5
           target/dev-ci/iroh --rpc-addr 127.0.0.1:4919 stats
 
   codespell:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,8 +428,11 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.5
 
+      - name: Prep
+        run: sudo apt-get install musl-tools -y
+
       - name: Build iroh
-        run: cargo build --profile=dev-ci --all-features
+        run: cargo build --profile=dev-ci --all-features --target x86_64-unknown-linux-musl
 
       - name: Prep bins
         run: |
@@ -461,7 +464,7 @@ jobs:
         run: |
           docker run -p 9090:9090 -p 4919:4919/udp -Pd n0computer/iroh-test:latest --rpc-addr 0.0.0.0:4919 start
           # Give the server time to start
-          sleep 10
+          sleep 3
           target/dev-ci/iroh --rpc-addr 127.0.0.1:4919 stats
 
   codespell:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,16 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.5
 
+      - name: Build iroh
+        run: cargo build --release --workspace --all-features
+
+      - name: Prep bins
+        run: |
+          mkdir -p bins/linux/amd64
+          cp target/release/iroh bins/linux/amd64/iroh
+          cp target/release/iroh-relay bins/linux/amd64/iroh-relay
+          cp target/release/iroh-dns-server bins/linux/amd64/iroh-dns-server
+
       - name: Cleanup Docker
         continue-on-error: true
         run: |
@@ -441,11 +451,10 @@ jobs:
         with:
           context: .
           push: false
-          load: true
           tags: n0computer/iroh-test:latest
           target: iroh
           platforms: linux/amd64
-          file: docker/Dockerfile
+          file: docker/Dockerfile.ci
 
       - name: Run Docker image & stats test
         run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -88,7 +88,7 @@ jobs:
           uses: docker/build-push-action@v6
           with:
             context: .
-            push: true
+            push: ${{ github.event.inputs.publish }}
             tags: n0computer/iroh:latest,n0computer/iroh:${{ github.event.inputs.release_version }}
             target: iroh
             platforms: linux/amd64,linux/arm64/v8
@@ -98,7 +98,7 @@ jobs:
           uses: docker/build-push-action@v6
           with:
             context: .
-            push: true
+            push: ${{ github.event.inputs.publish }}
             tags: n0computer/iroh-relay:latest,n0computer/iroh-relay:${{ github.event.inputs.release_version }}
             target: iroh-relay
             platforms: linux/amd64,linux/arm64/v8
@@ -108,7 +108,7 @@ jobs:
           uses: docker/build-push-action@v6
           with:
             context: .
-            push: true
+            push: ${{ github.event.inputs.publish }}
             tags: n0computer/iroh-dns-server:latest,n0computer/iroh-dns-server:${{ github.event.inputs.release_version }}
             target: iroh-dns-server
             platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,7 @@ jobs:
     docker:
       needs: build_release
       uses: './.github/workflows/docker.yaml'
+      secrets: inherit
       with:
         release_version: ${{ needs.build_release.outputs.release_version }}
         base_hash: ${{ needs.build_release.outputs.base_hash }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ resolver = "2"
 [profile.release]
 debug = true
 
+[profile.dev-ci]
+inherits = 'dev'
+opt-level = 1 
+
 [profile.optimized-release]
 inherits = 'release'
 debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ debug = true
 
 [profile.dev-ci]
 inherits = 'dev'
-opt-level = 1 
+opt-level = 2 
 
 [profile.optimized-release]
 inherits = 'release'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ debug = true
 
 [profile.dev-ci]
 inherits = 'dev'
-opt-level = 2 
+opt-level = 1 
 
 [profile.optimized-release]
 inherits = 'release'

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,10 +1,10 @@
 ### Base image for iroh-relay and iroh-dns-server
-FROM alpine:latest as base
+FROM alpine:latest AS base
 RUN apk update && apk add ca-certificates && update-ca-certificates
 
 
 ### Target image
-FROM base as iroh
+FROM base AS iroh
 ARG TARGETPLATFORM
 
 COPY bins/${TARGETPLATFORM}/iroh /iroh
@@ -20,7 +20,7 @@ ENTRYPOINT ["/iroh"]
 CMD ["start"]
 
 ### Target image
-FROM base as iroh-relay
+FROM base AS iroh-relay
 ARG TARGETPLATFORM
 
 COPY bins/${TARGETPLATFORM}/iroh-relay /iroh-relay
@@ -36,7 +36,7 @@ ENTRYPOINT ["/iroh-relay"]
 CMD [""]
 
 ### Target image
-FROM base as iroh-dns-server
+FROM base AS iroh-dns-server
 ARG TARGETPLATFORM
 
 COPY bins/${TARGETPLATFORM}/iroh-dns-server /iroh-dns-server


### PR DESCRIPTION
## Description

- We now build the docker test CI jobs in a way that more closely resembles the release process. It should compile the binaries and build the image significantly faster now. (down from 8+ min to 2 min)
- Secrets are properly passed in to the reusable workflow so [release docker builds should no longer fail](https://github.com/n0-computer/iroh/actions/runs/10473026816/job/29005092378)

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
