### PR TITLE
test(iroh-gossip): Wait for the relay to make `gossip_net_smoke` faster.

### DIFF
--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -840,13 +840,16 @@ mod test {
         rng: &mut rand_chacha::ChaCha12Rng,
         relay_map: RelayMap,
     ) -> anyhow::Result<Endpoint> {
-        Endpoint::builder()
+        let ep = Endpoint::builder()
             .secret_key(SecretKey::generate_with_rng(rng))
             .alpns(vec![GOSSIP_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map))
             .insecure_skip_relay_cert_verify(true)
             .bind(0)
-            .await
+            .await?;
+
+        ep.watch_home_relay().next().await;
+        Ok(ep)
     }
 
     async fn endpoint_loop(


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
Just a tiny change that improves performance from ~1s -> ~0.4s on my machine.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
One could argue we shouldn't make this change, because it doesn't cause that much erratic behavior. We should rather write tests that fail on "more bugs".
I'm not sure. Perhaps the gossip smoke test shouldn't be the test that we use to stress network edge cases.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [x] Tests if relevant.
- [x] All breaking changes documented.
