### PR TITLE
feat(bench): Add `--with-relay` option to allow testing relay throughput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2937,6 +2937,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "futures-lite 2.3.0",
  "hdrhistogram",
  "iroh-net",
  "quinn 0.10.2",

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0.22"
 bytes = "1"
 hdrhistogram = { version = "7.2", default-features = false }
-iroh-net = { path = ".." }
+iroh-net = { path = "..", features = ["test-utils"] }
 rcgen = "0.11.1"
 rustls = { version = "0.21.0", default-features = false, features = ["quic"] }
 clap = { version = "4", features = ["derive"] }
@@ -17,6 +17,7 @@ tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 socket2 = "0.5"
+futures-lite = "2.3.0"
 
 [target.'cfg(not(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd")))'.dependencies]
 quinn = "0.10"

--- a/iroh-net/bench/src/bin/bulk.rs
+++ b/iroh-net/bench/src/bin/bulk.rs
@@ -43,7 +43,7 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
 
     let (server_addr, endpoint) = {
         let _guard = server_span.enter();
-        iroh::server_endpoint(&runtime, relay_url.clone(), &opt)
+        iroh::server_endpoint(&runtime, &relay_url, &opt)
     };
 
     let server_thread = std::thread::spawn(move || {

--- a/iroh-net/bench/src/bin/bulk.rs
+++ b/iroh-net/bench/src/bin/bulk.rs
@@ -32,9 +32,18 @@ fn main() {
 pub fn run_iroh(opt: Opt) -> Result<()> {
     let server_span = tracing::error_span!("server");
     let runtime = rt();
+
+    let (relay_url, _guard) = if opt.with_relay {
+        let (_, relay_url, _guard) = runtime.block_on(iroh_net::test_utils::run_relay_server())?;
+
+        (Some(relay_url), Some(_guard))
+    } else {
+        (None, None)
+    };
+
     let (server_addr, endpoint) = {
         let _guard = server_span.enter();
-        iroh::server_endpoint(&runtime, &opt)
+        iroh::server_endpoint(&runtime, relay_url.clone(), &opt)
     };
 
     let server_thread = std::thread::spawn(move || {
@@ -47,10 +56,11 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
     let mut handles = Vec::new();
     for id in 0..opt.clients {
         let server_addr = server_addr.clone();
+        let relay_url = relay_url.clone();
         handles.push(std::thread::spawn(move || {
             let _guard = tracing::error_span!("client", id).entered();
             let runtime = rt();
-            match runtime.block_on(iroh::client(server_addr, opt)) {
+            match runtime.block_on(iroh::client(server_addr, relay_url.clone(), opt)) {
                 Ok(stats) => Ok(stats),
                 Err(e) => {
                     eprintln!("client failed: {e:#}");

--- a/iroh-net/bench/src/iroh.rs
+++ b/iroh-net/bench/src/iroh.rs
@@ -5,9 +5,10 @@ use std::{
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
+use futures_lite::StreamExt as _;
 use iroh_net::{
     endpoint::{Connection, ConnectionError, RecvStream, SendStream, TransportConfig},
-    relay::RelayMode,
+    relay::{RelayMap, RelayMode, RelayUrl},
     Endpoint, NodeAddr,
 };
 use tracing::trace;
@@ -19,27 +20,47 @@ use crate::{
 pub const ALPN: &[u8] = b"n0/iroh-net-bench/0";
 
 /// Creates a server endpoint which runs on the given runtime
-pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (NodeAddr, Endpoint) {
+pub fn server_endpoint(
+    rt: &tokio::runtime::Runtime,
+    relay_url: Option<RelayUrl>,
+    opt: &Opt,
+) -> (NodeAddr, Endpoint) {
     let _guard = rt.enter();
     rt.block_on(async move {
+        let relay_mode = relay_url.clone().map_or(RelayMode::Disabled, |url| {
+            RelayMode::Custom(RelayMap::from_url(url))
+        });
         let ep = Endpoint::builder()
             .alpns(vec![ALPN.to_vec()])
-            .relay_mode(RelayMode::Disabled)
+            .insecure_skip_relay_cert_verify(relay_url.is_some())
+            .relay_mode(relay_mode)
             .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
             .bind(0)
             .await
             .unwrap();
+
+        if relay_url.is_some() {
+            ep.watch_home_relay().next().await;
+        }
+
         let addr = ep.bound_sockets();
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
-        let addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
+        let mut addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
+        if let Some(relay_url) = relay_url {
+            addr = addr.with_relay_url(relay_url);
+        }
         (addr, ep)
     })
 }
 
 /// Create and run a client
-pub async fn client(server_addr: NodeAddr, opt: Opt) -> Result<ClientStats> {
+pub async fn client(
+    server_addr: NodeAddr,
+    relay_url: Option<RelayUrl>,
+    opt: Opt,
+) -> Result<ClientStats> {
     let client_start = std::time::Instant::now();
-    let (endpoint, connection) = connect_client(server_addr, opt).await?;
+    let (endpoint, connection) = connect_client(server_addr, relay_url, opt).await?;
     let client_connect_time = client_start.elapsed();
     let mut res = client_handler(
         EndpointSelector::Iroh(endpoint),
@@ -52,14 +73,26 @@ pub async fn client(server_addr: NodeAddr, opt: Opt) -> Result<ClientStats> {
 }
 
 /// Create a client endpoint and client connection
-pub async fn connect_client(server_addr: NodeAddr, opt: Opt) -> Result<(Endpoint, Connection)> {
+pub async fn connect_client(
+    server_addr: NodeAddr,
+    relay_url: Option<RelayUrl>,
+    opt: Opt,
+) -> Result<(Endpoint, Connection)> {
+    let relay_mode = relay_url.clone().map_or(RelayMode::Disabled, |url| {
+        RelayMode::Custom(RelayMap::from_url(url))
+    });
     let endpoint = Endpoint::builder()
         .alpns(vec![ALPN.to_vec()])
-        .relay_mode(RelayMode::Disabled)
+        .insecure_skip_relay_cert_verify(relay_url.is_some())
+        .relay_mode(relay_mode)
         .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
         .bind(0)
         .await
         .unwrap();
+
+    if relay_url.is_some() {
+        endpoint.watch_home_relay().next().await;
+    }
 
     // TODO: We don't support passing client transport config currently
     // let mut client_config = quinn::ClientConfig::new(Arc::new(crypto));

--- a/iroh-net/bench/src/iroh.rs
+++ b/iroh-net/bench/src/iroh.rs
@@ -22,7 +22,7 @@ pub const ALPN: &[u8] = b"n0/iroh-net-bench/0";
 /// Creates a server endpoint which runs on the given runtime
 pub fn server_endpoint(
     rt: &tokio::runtime::Runtime,
-    relay_url: Option<RelayUrl>,
+    relay_url: &Option<RelayUrl>,
     opt: &Opt,
 ) -> (NodeAddr, Endpoint) {
     let _guard = rt.enter();
@@ -47,7 +47,7 @@ pub fn server_endpoint(
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
         let mut addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
         if let Some(relay_url) = relay_url {
-            addr = addr.with_relay_url(relay_url);
+            addr = addr.with_relay_url(relay_url.clone());
         }
         (addr, ep)
     })

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -60,6 +60,13 @@ pub struct Opt {
     /// Starting guess for maximum UDP payload size
     #[clap(long, default_value = "1200")]
     pub initial_mtu: u16,
+    /// Whether to run a local relay and have the server and clients connect to that.
+    ///
+    /// Can be combined with the `DEV_RELAY_ONLY` environment variable (at compile time)
+    /// to test throughput for relay-only traffic locally.
+    /// (e.g. `DEV_RELAY_ONLY=true cargo run --release -- iroh --with-relay`)
+    #[clap(long, default_value_t = false)]
+    pub with_relay: bool,
 }
 
 pub enum EndpointSelector {


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
I did these changes to allow me to test relay throughput differences between the `dig/quinn11` and `main` branches.

The way I test relay throughput now is:
```sh
$ cd iroh-net/bench
$ DEV_RELAY_ONLY=true cargo run --release -- iroh --with-relay
```

Otherwise it simply allows testing iroh with a relay enabled, too, which is nice I think.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
I think it's pretty obvious one could expand this to enable testing throughput not only with local relays, but also with any relay one wants to test with (e.g. testing euw1 relay for fun). I worked on this for a couple of minutes, then deemed it out of scope.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
