### PR TITLE
fix(iroh-net): Magic sock `recv_data_ipv4` and `recv_data_ipv6` metrics numbers

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -725,9 +725,9 @@ impl MagicSock {
                 } else {
                     trace!(src = %meta.addr, len = %meta.stride, "UDP recv: quic packet");
                     if from_ipv4 {
-                        inc_by!(MagicsockMetrics, recv_data_ipv4, buf.len() as _);
+                        inc_by!(MagicsockMetrics, recv_data_ipv4, packet.len() as _);
                     } else {
-                        inc_by!(MagicsockMetrics, recv_data_ipv6, buf.len() as _);
+                        inc_by!(MagicsockMetrics, recv_data_ipv6, packet.len() as _);
                     }
                     true
                 };


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
Previously, when I edited the iroh-net benchmark to print metrics, it'd show (on a 1GB transfer):
```rs
// ...
    send_ipv4: 1104880201,
// ...
    recv_data_ipv4: 88912756736,
```

Clearly, the 89GB received data is wrong. The reason is that we record the *buffer size* when we record metrics instead of recording the *received packet size*.
The buffer tends to be around ~90kB for me, while the received packets are around 1-2kB. This explains the 90x factor.

With this fix, I now get:
```rs
// ...
    send_ipv4: 1104885110,
// ...
    recv_data_ipv4: 1104882621,
```

## Breaking Changes

None.
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
