### PR TITLE
feat(bench): Add `--metrics` option printing iroh-net library metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2937,6 +2937,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "futures-lite 2.3.0",
  "hdrhistogram",
  "iroh-net",
  "quinn 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2939,6 +2939,7 @@ dependencies = [
  "clap",
  "futures-lite 2.3.0",
  "hdrhistogram",
+ "iroh-metrics",
  "iroh-net",
  "quinn 0.10.2",
  "rcgen 0.11.3",

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.22"
 bytes = "1"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh-net = { path = "..", features = ["test-utils"] }
+iroh-metrics = { path = "../../iroh-metrics" }
 rcgen = "0.11.1"
 rustls = { version = "0.21.0", default-features = false, features = ["quic"] }
 clap = { version = "4", features = ["derive"] }

--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0.22"
 bytes = "1"
 hdrhistogram = { version = "7.2", default-features = false }
-iroh-net = { path = ".." }
+iroh-net = { path = "..", features = ["test-utils"] }
 rcgen = "0.11.1"
 rustls = { version = "0.21.0", default-features = false, features = ["quic"] }
 clap = { version = "4", features = ["derive"] }
@@ -17,6 +17,7 @@ tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 socket2 = "0.5"
+futures-lite = "2.3.0"
 
 [target.'cfg(not(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd")))'.dependencies]
 quinn = "0.10"

--- a/iroh-net/bench/src/bin/bulk.rs
+++ b/iroh-net/bench/src/bin/bulk.rs
@@ -43,7 +43,7 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
 
     let (server_addr, endpoint) = {
         let _guard = server_span.enter();
-        iroh::server_endpoint(&runtime, relay_url.clone(), &opt)
+        iroh::server_endpoint(&runtime, &relay_url, &opt)
     };
 
     let server_thread = std::thread::spawn(move || {

--- a/iroh-net/bench/src/bin/bulk.rs
+++ b/iroh-net/bench/src/bin/bulk.rs
@@ -32,9 +32,18 @@ fn main() {
 pub fn run_iroh(opt: Opt) -> Result<()> {
     let server_span = tracing::error_span!("server");
     let runtime = rt();
+
+    let (relay_url, _guard) = if opt.with_relay {
+        let (_, relay_url, _guard) = runtime.block_on(iroh_net::test_utils::run_relay_server())?;
+
+        (Some(relay_url), Some(_guard))
+    } else {
+        (None, None)
+    };
+
     let (server_addr, endpoint) = {
         let _guard = server_span.enter();
-        iroh::server_endpoint(&runtime, &opt)
+        iroh::server_endpoint(&runtime, relay_url.clone(), &opt)
     };
 
     let server_thread = std::thread::spawn(move || {
@@ -47,10 +56,11 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
     let mut handles = Vec::new();
     for id in 0..opt.clients {
         let server_addr = server_addr.clone();
+        let relay_url = relay_url.clone();
         handles.push(std::thread::spawn(move || {
             let _guard = tracing::error_span!("client", id).entered();
             let runtime = rt();
-            match runtime.block_on(iroh::client(server_addr, opt)) {
+            match runtime.block_on(iroh::client(server_addr, relay_url.clone(), opt)) {
                 Ok(stats) => Ok(stats),
                 Err(e) => {
                     eprintln!("client failed: {e:#}");

--- a/iroh-net/bench/src/iroh.rs
+++ b/iroh-net/bench/src/iroh.rs
@@ -5,9 +5,10 @@ use std::{
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
+use futures_lite::StreamExt as _;
 use iroh_net::{
     endpoint::{Connection, ConnectionError, RecvStream, SendStream, TransportConfig},
-    relay::RelayMode,
+    relay::{RelayMap, RelayMode, RelayUrl},
     Endpoint, NodeAddr,
 };
 use tracing::trace;
@@ -19,27 +20,47 @@ use crate::{
 pub const ALPN: &[u8] = b"n0/iroh-net-bench/0";
 
 /// Creates a server endpoint which runs on the given runtime
-pub fn server_endpoint(rt: &tokio::runtime::Runtime, opt: &Opt) -> (NodeAddr, Endpoint) {
+pub fn server_endpoint(
+    rt: &tokio::runtime::Runtime,
+    relay_url: Option<RelayUrl>,
+    opt: &Opt,
+) -> (NodeAddr, Endpoint) {
     let _guard = rt.enter();
     rt.block_on(async move {
+        let relay_mode = relay_url.clone().map_or(RelayMode::Disabled, |url| {
+            RelayMode::Custom(RelayMap::from_url(url))
+        });
         let ep = Endpoint::builder()
             .alpns(vec![ALPN.to_vec()])
-            .relay_mode(RelayMode::Disabled)
+            .insecure_skip_relay_cert_verify(relay_url.is_some())
+            .relay_mode(relay_mode)
             .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
             .bind(0)
             .await
             .unwrap();
+
+        if relay_url.is_some() {
+            ep.watch_home_relay().next().await;
+        }
+
         let addr = ep.bound_sockets();
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
-        let addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
+        let mut addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
+        if let Some(relay_url) = relay_url {
+            addr = addr.with_relay_url(relay_url);
+        }
         (addr, ep)
     })
 }
 
 /// Create and run a client
-pub async fn client(server_addr: NodeAddr, opt: Opt) -> Result<ClientStats> {
+pub async fn client(
+    server_addr: NodeAddr,
+    relay_url: Option<RelayUrl>,
+    opt: Opt,
+) -> Result<ClientStats> {
     let client_start = std::time::Instant::now();
-    let (endpoint, connection) = connect_client(server_addr, opt).await?;
+    let (endpoint, connection) = connect_client(server_addr, relay_url, opt).await?;
     let client_connect_time = client_start.elapsed();
     let mut res = client_handler(
         EndpointSelector::Iroh(endpoint),
@@ -52,14 +73,26 @@ pub async fn client(server_addr: NodeAddr, opt: Opt) -> Result<ClientStats> {
 }
 
 /// Create a client endpoint and client connection
-pub async fn connect_client(server_addr: NodeAddr, opt: Opt) -> Result<(Endpoint, Connection)> {
+pub async fn connect_client(
+    server_addr: NodeAddr,
+    relay_url: Option<RelayUrl>,
+    opt: Opt,
+) -> Result<(Endpoint, Connection)> {
+    let relay_mode = relay_url.clone().map_or(RelayMode::Disabled, |url| {
+        RelayMode::Custom(RelayMap::from_url(url))
+    });
     let endpoint = Endpoint::builder()
         .alpns(vec![ALPN.to_vec()])
-        .relay_mode(RelayMode::Disabled)
+        .insecure_skip_relay_cert_verify(relay_url.is_some())
+        .relay_mode(relay_mode)
         .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
         .bind(0)
         .await
         .unwrap();
+
+    if relay_url.is_some() {
+        endpoint.watch_home_relay().next().await;
+    }
 
     // TODO: We don't support passing client transport config currently
     // let mut client_config = quinn::ClientConfig::new(Arc::new(crypto));

--- a/iroh-net/bench/src/iroh.rs
+++ b/iroh-net/bench/src/iroh.rs
@@ -22,7 +22,7 @@ pub const ALPN: &[u8] = b"n0/iroh-net-bench/0";
 /// Creates a server endpoint which runs on the given runtime
 pub fn server_endpoint(
     rt: &tokio::runtime::Runtime,
-    relay_url: Option<RelayUrl>,
+    relay_url: &Option<RelayUrl>,
     opt: &Opt,
 ) -> (NodeAddr, Endpoint) {
     let _guard = rt.enter();
@@ -47,7 +47,7 @@ pub fn server_endpoint(
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr.0.port());
         let mut addr = NodeAddr::new(ep.node_id()).with_direct_addresses([addr]);
         if let Some(relay_url) = relay_url {
-            addr = addr.with_relay_url(relay_url);
+            addr = addr.with_relay_url(relay_url.clone());
         }
         (addr, ep)
     })

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -60,6 +60,13 @@ pub struct Opt {
     /// Starting guess for maximum UDP payload size
     #[clap(long, default_value = "1200")]
     pub initial_mtu: u16,
+    /// Whether to run a local relay and have the server and clients connect to that.
+    ///
+    /// Can be combined with the `DEV_RELAY_ONLY` environment variable (at compile time)
+    /// to test throughput for relay-only traffic locally.
+    /// (e.g. `DEV_RELAY_ONLY=true cargo run --release -- iroh --with-relay`)
+    #[clap(long, default_value_t = false)]
+    pub with_relay: bool,
 }
 
 pub enum EndpointSelector {

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -54,6 +54,12 @@ pub struct Opt {
     /// Show connection stats the at the end of the benchmark
     #[clap(long = "stats")]
     pub stats: bool,
+    /// Show iroh-net library counter metrics at the end of the benchmark
+    ///
+    /// These metrics are process-wide, so contain metrics for
+    /// clients and the server all summed up.
+    #[clap(long)]
+    pub metrics: bool,
     /// Whether to use the unordered read API
     #[clap(long = "unordered")]
     pub read_unordered: bool,

--- a/iroh-net/src/discovery/pkarr/dht.rs
+++ b/iroh-net/src/discovery/pkarr/dht.rs
@@ -396,6 +396,7 @@ mod tests {
     use testresult::TestResult;
 
     #[tokio::test]
+    #[ignore = "flaky"]
     async fn dht_discovery_smoke() -> TestResult {
         let _ = tracing_subscriber::fmt::try_init();
         let ep = crate::Endpoint::builder().bind(0).await?;


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
Used these changes to test #2667.

I think this is a decent tool. Output looks like this:

<details>
<summary><code>$ cd iroh-net/bench && cargo run --release -- iroh --metrics --with-relay</code></summary>

```
   Compiling iroh-net-bench v0.23.0 (/home/philipp/program/work/iroh/iroh-net/bench)
    Finished `release` profile [optimized + debuginfo] target(s) in 28.47s
     Running `/home/philipp/program/work/iroh/target/release/bulk iroh --metrics --with-relay`

Client 0 stats:
Connect time: 1008.829553ms
Overall download stats:

Transferred 1073741824 bytes on 1 streams in 1.70s (603.46 MiB/s)

Time to first byte (TTFB): 105.312ms

Total chunks: 36445

Average chunk time: 46.544ms

Average chunk size: 28.77KiB

Stream download metrics:

      │  Throughput   │ Duration 
──────┼───────────────┼──────────
 AVG  │  603.75 MiB/s │     1.70s
 P0   │  603.50 MiB/s │     1.70s
 P10  │  604.00 MiB/s │     1.70s
 P50  │  604.00 MiB/s │     1.70s
 P90  │  604.00 MiB/s │     1.70s
 P100 │  604.00 MiB/s │     1.70s

Metrics:
MagicsockMetrics: {
    "actor_link_change": 0,
    "actor_tick_direct_addr_heartbeat": 0,
    "actor_tick_direct_addr_update_receiver": 6,
    "actor_tick_main": 22,
    "actor_tick_msg": 13,
    "actor_tick_other": 0,
    "actor_tick_portmap_changed": 0,
    "actor_tick_re_stun": 2,
    "num_direct_conns_added": 3,
    "num_direct_conns_removed": 1,
    "num_relay_conns_added": 5,
    "num_relay_conns_removed": 3,
    "re_stun_calls": 3,
    "recv_data_ipv4": 88975499264,
    "recv_data_ipv6": 0,
    "recv_data_relay": 49200,
    "recv_datagrams": 944499,
    "recv_disco_bad_key": 0,
    "recv_disco_bad_parse": 0,
    "recv_disco_call_me_maybe": 2,
    "recv_disco_call_me_maybe_bad_disco": 0,
    "recv_disco_ping": 14,
    "recv_disco_pong": 14,
    "recv_disco_relay": 6,
    "recv_disco_udp": 24,
    "relay_home_change": 2,
    "send_data": 1104903421,
    "send_data_network_down": 0,
    "send_disco_relay": 6,
    "send_disco_udp": 24,
    "send_ipv4": 1104905771,
    "send_ipv6": 470,
    "send_relay": 49988,
    "send_relay_error": 0,
    "sent_disco_call_me_maybe": 2,
    "sent_disco_ping": 14,
    "sent_disco_pong": 14,
    "sent_disco_relay": 6,
    "sent_disco_udp": 24,
    "update_direct_addrs": 3,
}
NetcheckMetrics: {
    "reports": 3,
    "reports_full": 0,
    "stun_packets_dropped": 0,
    "stun_packets_recv_ipv4": 0,
    "stun_packets_recv_ipv6": 0,
    "stun_packets_sent_ipv4": 10,
    "stun_packets_sent_ipv6": 10,
}
PortmapMetrics: {
    "external_address_updated": 0,
    "local_port_updates": 3,
    "mapping_attempts": 5,
    "mapping_failures": 3,
    "pcp_available": 0,
    "pcp_probes": 3,
    "probes_started": 3,
    "upnp_available": 0,
    "upnp_gateway_updated": 0,
    "upnp_probes": 6,
    "upnp_probes_failed": 3,
}
RelayMetrics: {
    "accepts": 2,
    "bytes_recv": 50082,
    "bytes_sent": 50082,
    "derp_accepts": 2,
    "disco_packets_dropped": 0,
    "disco_packets_recv": 0,
    "disco_packets_sent": 0,
    "disconnects": 0,
    "got_ping": 0,
    "other_packets_dropped": 0,
    "other_packets_recv": 2,
    "other_packets_sent": 0,
    "send_packets_dropped": 0,
    "send_packets_recv": 9,
    "send_packets_sent": 9,
    "sent_pong": 0,
    "unique_client_keys": 2,
    "unknown_frames": 0,
    "websocket_accepts": 0,
}
```

</details>

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None. The semver check also checks for the "public API" of `iroh-net/bench`, and there's been another `Opt` addition.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
This PR is based on #2664 at the moment, let's merge that first.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
