### PR TITLE
feat(iroh): Add `spaces`  RPC and client to interact with willow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,6 +2502,7 @@ dependencies = [
  "iroh-net",
  "iroh-quinn",
  "iroh-test",
+ "iroh-willow",
  "nested_enum_utils",
  "num_cpus",
  "parking_lot",
@@ -3012,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-willow"
-version = "0.18.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/iroh-willow/Cargo.toml
+++ b/iroh-willow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-willow"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 readme = "README.md"
 description = "willow protocol implementation for iroh"

--- a/iroh-willow/Cargo.toml
+++ b/iroh-willow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-willow"
-version = "0.18.0"
+version = "0.22.0"
 edition = "2021"
 readme = "README.md"
 description = "willow protocol implementation for iroh"

--- a/iroh-willow/examples/bench.rs
+++ b/iroh-willow/examples/bench.rs
@@ -86,6 +86,8 @@ async fn main() -> Result<()> {
     info!("betty has now {} entries", betty_count);
     assert_eq!(alfie_count, n_alfie + n_betty);
     assert_eq!(betty_count, n_alfie + n_betty);
+    alfie.shutdown().await?;
+    betty.shutdown().await?;
 
     Ok(())
 }

--- a/iroh-willow/examples/bench.rs
+++ b/iroh-willow/examples/bench.rs
@@ -229,7 +229,7 @@ mod util {
 
         let cap_for_betty = alfie
             .delegate_caps(
-                CapSelector::widest(namespace_id),
+                CapSelector::any(namespace_id),
                 AccessMode::Write,
                 DelegateTo::new(user_betty, RestrictArea::None),
             )

--- a/iroh-willow/src/engine.rs
+++ b/iroh-willow/src/engine.rs
@@ -104,14 +104,14 @@ impl Engine {
     ///
     /// This will try to close all connections gracefully for up to 10 seconds,
     /// and abort them otherwise.
-    pub async fn shutdown(self) -> Result<()> {
+    pub async fn shutdown(mut self) -> Result<()> {
         debug!("shutdown engine");
         let (reply, reply_rx) = oneshot::channel();
         self.peer_manager_inbox
             .send(peer_manager::Input::Shutdown { reply })
             .await?;
         reply_rx.await?;
-        let res = self.peer_manager_task.await;
+        let res = (&mut self.peer_manager_task).await;
         match res {
             Err(err) => error!(?err, "peer manager task panicked"),
             Ok(Err(err)) => error!(?err, "peer manager task failed"),

--- a/iroh-willow/src/engine/peer_manager.rs
+++ b/iroh-willow/src/engine/peer_manager.rs
@@ -27,7 +27,7 @@ use crate::{
     },
     proto::wgps::AccessChallenge,
     session::{
-        intents::{EventKind, Intent},
+        intents::{EventKind, EventReceiver, Intent},
         Error, InitialTransmission, Role, SessionEvent, SessionHandle, SessionInit, SessionUpdate,
     },
 };
@@ -709,7 +709,7 @@ impl AcceptHandlers {
 #[derive(Debug)]
 struct EventForwarder {
     _join_handle: AbortingJoinHandle<()>,
-    stream_sender: mpsc::Sender<(NodeId, ReceiverStream<EventKind>)>,
+    stream_sender: mpsc::Sender<(NodeId, EventReceiver)>,
 }
 
 impl EventForwarder {
@@ -737,7 +737,7 @@ impl EventForwarder {
         }
     }
 
-    pub async fn add_intent(&self, peer: NodeId, event_stream: ReceiverStream<EventKind>) {
+    pub async fn add_intent(&self, peer: NodeId, event_stream: EventReceiver) {
         self.stream_sender.send((peer, event_stream)).await.ok();
     }
 }

--- a/iroh-willow/src/form.rs
+++ b/iroh-willow/src/form.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io::AsyncRead;
 
 use crate::proto::{
-    data_model::{self, Entry, NamespaceId, Path, SubspaceId, Timestamp},
+    data_model::{Entry, NamespaceId, Path, SubspaceId, Timestamp},
     keys::UserId,
     meadowcap::{self, WriteCapability},
 };
@@ -156,61 +156,4 @@ pub enum TimestampForm {
     Now,
     /// Set the timestamp to the provided value.
     Exact(Timestamp),
-}
-
-/// Either a [`Entry`] or a [`EntryForm`].
-#[derive(Debug, Serialize, Deserialize)]
-pub enum SerdeEntryOrForm {
-    Entry(#[serde(with = "data_model::serde_encoding::entry")] Entry),
-    Form(SerdeEntryForm),
-}
-
-impl From<SerdeEntryOrForm> for EntryOrForm {
-    fn from(value: SerdeEntryOrForm) -> Self {
-        match value {
-            SerdeEntryOrForm::Entry(entry) => EntryOrForm::Entry(entry),
-            SerdeEntryOrForm::Form(form) => EntryOrForm::Form(form.into()),
-        }
-    }
-}
-
-/// Creates an entry while setting some fields automatically.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SerdeEntryForm {
-    pub namespace_id: NamespaceId,
-    pub subspace_id: SubspaceForm,
-    #[serde(with = "data_model::serde_encoding::path")]
-    pub path: Path,
-    pub timestamp: TimestampForm,
-    pub payload: PayloadForm2,
-}
-
-///
-#[derive(Debug, Serialize, Deserialize)]
-pub enum PayloadForm2 {
-    /// Make sure the hash is available in the blob store, and use the length from the blob store.
-    Checked(Hash),
-    /// Insert with the specified hash and length, without checking if the blob is in the local blob store.
-    Unchecked(Hash, u64),
-}
-
-impl From<PayloadForm2> for PayloadForm {
-    fn from(value: PayloadForm2) -> Self {
-        match value {
-            PayloadForm2::Checked(hash) => PayloadForm::Hash(hash),
-            PayloadForm2::Unchecked(hash, len) => PayloadForm::HashUnchecked(hash, len),
-        }
-    }
-}
-
-impl From<SerdeEntryForm> for EntryForm {
-    fn from(value: SerdeEntryForm) -> Self {
-        EntryForm {
-            namespace_id: value.namespace_id,
-            subspace_id: value.subspace_id,
-            path: value.path,
-            timestamp: value.timestamp,
-            payload: value.payload.into(),
-        }
-    }
 }

--- a/iroh-willow/src/interest.rs
+++ b/iroh-willow/src/interest.rs
@@ -29,7 +29,7 @@ pub enum Interests {
 }
 
 impl Interests {
-    /// Returns a [`SelectBuilder`] to build our [`Interests`].
+    /// Returns a [`InterestBuilder`] to build our [`Interests`].
     pub fn builder() -> InterestBuilder {
         InterestBuilder::default()
     }

--- a/iroh-willow/src/net.rs
+++ b/iroh-willow/src/net.rs
@@ -476,7 +476,7 @@ mod tests {
 
         let cap_for_betty = handle_alfie
             .delegate_caps(
-                CapSelector::widest(namespace_id),
+                CapSelector::any(namespace_id),
                 AccessMode::Write,
                 DelegateTo::new(user_betty, RestrictArea::None),
             )
@@ -607,7 +607,7 @@ mod tests {
 
         let cap_for_betty = handle_alfie
             .delegate_caps(
-                CapSelector::widest(namespace_id),
+                CapSelector::any(namespace_id),
                 AccessMode::Write,
                 DelegateTo::new(user_betty, RestrictArea::None),
             )
@@ -778,6 +778,7 @@ mod tests {
         let entries: Result<BTreeSet<_>> = store
             .get_entries(namespace, Range3d::new_full())
             .await?
+            .map(|entry| entry.map(|entry| entry.into_parts().0))
             .try_collect()
             .await;
         entries
@@ -804,7 +805,7 @@ mod tests {
             };
             let (entry, inserted) = handle.insert_entry(entry, AuthForm::Any(user_id)).await?;
             assert!(inserted);
-            track_entries.extend([entry]);
+            track_entries.extend([entry.into_parts().0]);
         }
         Ok(())
     }

--- a/iroh-willow/src/net.rs
+++ b/iroh-willow/src/net.rs
@@ -802,7 +802,7 @@ mod tests {
                 timestamp: TimestampForm::Now,
                 payload: PayloadForm::Bytes(payload.into()),
             };
-            let (entry, inserted) = handle.insert(entry, AuthForm::Any(user_id)).await?;
+            let (entry, inserted) = handle.insert_entry(entry, AuthForm::Any(user_id)).await?;
             assert!(inserted);
             track_entries.extend([entry]);
         }

--- a/iroh-willow/src/proto/data_model.rs
+++ b/iroh-willow/src/proto/data_model.rs
@@ -303,7 +303,7 @@ pub mod serde_encoding {
             let (entry, capability, signature): (SerdeEntry, SerdeMcCapability, UserSignature) =
                 Deserialize::deserialize(deserializer)?;
             let token = AuthorisationToken::new(capability.0, signature);
-            Ok(AuthorisedEntry::new(entry.0, token).map_err(de::Error::custom)?)
+            AuthorisedEntry::new(entry.0, token).map_err(de::Error::custom)
         }
     }
 

--- a/iroh-willow/src/proto/data_model.rs
+++ b/iroh-willow/src/proto/data_model.rs
@@ -227,30 +227,95 @@ mod encoding {
 }
 
 pub mod serde_encoding {
-    use serde::{de, Deserialize, Deserializer, Serialize};
+    use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
     use crate::util::codec2::{from_bytes, to_vec};
 
     use super::*;
 
-    /// [`Entry`] wrapper that can be serialized with [`serde`].
-    #[derive(Debug, Clone, derive_more::From, derive_more::Into, derive_more::Deref)]
-    pub struct SerdeEntry(pub Entry);
+    pub mod path {
 
-    impl Serialize for SerdeEntry {
-        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            to_vec(&self.0).serialize(serializer)
+        use super::*;
+        pub fn serialize<S: Serializer>(path: &Path, serializer: S) -> Result<S::Ok, S::Error> {
+            to_vec(path).serialize(serializer)
         }
-    }
 
-    impl<'de> Deserialize<'de> for SerdeEntry {
-        fn deserialize<D>(deserializer: D) -> Result<SerdeEntry, D::Error>
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Path, D::Error>
         where
             D: Deserializer<'de>,
         {
             let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
             let decoded = from_bytes(&bytes).map_err(de::Error::custom)?;
-            Ok(Self(decoded))
+            Ok(decoded)
         }
     }
+
+    pub mod entry {
+        use super::*;
+        pub fn serialize<S: Serializer>(entry: &Entry, serializer: S) -> Result<S::Ok, S::Error> {
+            to_vec(entry).serialize(serializer)
+        }
+
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Entry, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
+            let decoded = from_bytes(&bytes).map_err(de::Error::custom)?;
+            Ok(decoded)
+        }
+    }
+
+    /// [`Entry`] wrapper that can be serialized with [`serde`].
+    #[derive(
+        Debug,
+        Clone,
+        derive_more::From,
+        derive_more::Into,
+        derive_more::Deref,
+        Serialize,
+        Deserialize,
+    )]
+    pub struct SerdeEntry(#[serde(with = "entry")] pub Entry);
+
+    pub mod authorised_entry {
+        use crate::proto::meadowcap::serde_encoding::SerdeMcCapability;
+        use keys::UserSignature;
+
+        use super::*;
+        pub fn serialize<S: Serializer>(
+            entry: &AuthorisedEntry,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error> {
+            let (entry, token) = entry.clone().into_parts();
+            (
+                SerdeEntry(entry),
+                SerdeMcCapability(token.capability),
+                token.signature,
+            )
+                .serialize(serializer)
+        }
+
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<AuthorisedEntry, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let (entry, capability, signature): (SerdeEntry, SerdeMcCapability, UserSignature) =
+                Deserialize::deserialize(deserializer)?;
+            let token = AuthorisationToken::new(capability.0, signature);
+            Ok(AuthorisedEntry::new(entry.0, token).map_err(de::Error::custom)?)
+        }
+    }
+
+    /// [`AuthorisedEntry`] wrapper that can be serialized with [`serde`].
+    #[derive(
+        Debug,
+        Clone,
+        derive_more::From,
+        derive_more::Into,
+        derive_more::Deref,
+        Serialize,
+        Deserialize,
+    )]
+    pub struct SerdeAuthorisedEntry(#[serde(with = "authorised_entry")] pub AuthorisedEntry);
 }

--- a/iroh-willow/src/proto/data_model.rs
+++ b/iroh-willow/src/proto/data_model.rs
@@ -48,7 +48,7 @@ pub type Component<'a> = willow_data_model::Component<'a, MAX_COMPONENT_LENGTH>;
 
 /// A payload digest used in entries.
 ///
-/// This wraps a [`Hash`] blake3 hash.
+/// This wraps a [`iroh_blobs::Hash`] blake3 hash.
 #[derive(
     Debug,
     Clone,

--- a/iroh-willow/src/proto/keys.rs
+++ b/iroh-willow/src/proto/keys.rs
@@ -65,9 +65,9 @@ impl IsCommunal for NamespacePublicKey {
 /// and if the last bit is zero it is an owned namespace.
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 pub enum NamespaceKind {
-    /// Communal namespace, needs [`super::meadowcap::CommunalCapability`] to authorizse.
+    /// Communal namespace.
     Communal,
-    /// Owned namespace, needs [`super::meadowcap::OwnedCapability`] to authorize.
+    /// Owned namespace.
     Owned,
 }
 

--- a/iroh-willow/src/proto/keys.rs
+++ b/iroh-willow/src/proto/keys.rs
@@ -63,7 +63,7 @@ impl IsCommunal for NamespacePublicKey {
 ///
 /// A [`NamespacePublicKey`] whose last bit is 1 is defined to be a communal namespace,
 /// and if the last bit is zero it is an owned namespace.
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 pub enum NamespaceKind {
     /// Communal namespace, needs [`super::meadowcap::CommunalCapability`] to authorizse.
     Communal,

--- a/iroh-willow/src/proto/wgps/handles.rs
+++ b/iroh-willow/src/proto/wgps/handles.rs
@@ -9,16 +9,16 @@ pub enum HandleType {
     /// * completed (both peers performed scalar multiplication).
     Intersection,
 
-    /// Resource handle for [`ReadCapability`] that certify access to some Entries.
+    /// Resource handle for [`crate::proto::meadowcap::ReadAuthorisation`] that certify access to some Entries.
     Capability,
 
-    /// Resource handle for [`AreaOfInterest`]s that peers wish to sync.
+    /// Resource handle for [`crate::proto::grouping::AreaOfInterest`]s that peers wish to sync.
     AreaOfInterest,
 
     /// Resource handle that controls the matching from Payload transmissions to Payload requests.
     PayloadRequest,
 
-    /// Resource handle for [`StaticToken`]s that peers need to transmit.
+    /// Resource handle for [`super::StaticToken`]s that peers need to transmit.
     StaticToken,
 }
 

--- a/iroh-willow/src/session.rs
+++ b/iroh-willow/src/session.rs
@@ -118,8 +118,6 @@ impl EventSender {
 }
 
 /// Events emitted from a session.
-///
-/// These are handled in the [`PeerManager`](crate::engine::peer_manager::PeerManager).
 #[derive(derive_more::Debug)]
 pub(crate) enum SessionEvent {
     Established,

--- a/iroh-willow/src/session.rs
+++ b/iroh-willow/src/session.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 
 use channels::ChannelSenders;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
 use crate::{
@@ -65,7 +66,7 @@ impl Role {
 /// * [`Self::Continuous`] will enable the live data channels to synchronize updates in real-time.
 /// * [`Self::ReconcileOnce`] will run a single reconciliation of the interests declared at session
 ///   start, and then close the session.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SessionMode {
     /// Run a single, full reconciliation, and then quit.
     ReconcileOnce,
@@ -81,7 +82,7 @@ impl SessionMode {
 }
 
 /// Options to initialize a session.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionInit {
     /// Selects the areas we wish to synchronize.
     pub interests: Interests,

--- a/iroh-willow/src/session/pai_finder.rs
+++ b/iroh-willow/src/session/pai_finder.rs
@@ -2,13 +2,14 @@
 //!
 //! As defined by the willow spec: [Private Area Intersection](https://willowprotocol.org/specs/pai/index.html)
 //!
-//! Partly ported from the implementation in earthstar and willow:
-//!
-//! * https://github.com/earthstar-project/willow-js/blob/0db4b9ec7710fb992ab75a17bd8557040d9a1062/src/wgps/pai/pai_finder.ts
-//! * https://github.com/earthstar-project/earthstar/blob/16d6d4028c22fdbb72f7395013b29be7dcd9217a/src/schemes/schemes.ts#L662
+//! Partly ported from the implementation in [earthstar] and [willow].
 //!
 //! Licensed under LGPL and ported into this MIT/Apache codebase with explicit permission
 //! from the original author (gwil).
+//!
+//! [earthstar]: https://github.com/earthstar-project/willow-js/blob/0db4b9ec7710fb992ab75a17bd8557040d9a1062/src/wgps/pai/pai_finder.ts
+//! [willow]: https://github.com/earthstar-project/earthstar/blob/16d6d4028c22fdbb72f7395013b29be7dcd9217a/src/schemes/schemes.ts#L662
+//!
 
 use std::collections::{HashMap, HashSet};
 

--- a/iroh-willow/src/session/reconciler.rs
+++ b/iroh-willow/src/session/reconciler.rs
@@ -565,7 +565,7 @@ impl<S: Storage> Target<S> {
 
         for authorised_entry in self
             .snapshot
-            .get_entries_with_authorisation(self.namespace(), range)
+            .get_authorised_entries(self.namespace(), range)
         {
             let authorised_entry = authorised_entry?;
             let (entry, token) = authorised_entry.into_parts();

--- a/iroh-willow/src/store.rs
+++ b/iroh-willow/src/store.rs
@@ -1,7 +1,5 @@
 //! Store for entries, secrets, and capabilities used in the Willow engine.
 //!
-//! The [`Store`] is the high-level wrapper for the different stores we need.
-//!
 //! The storage backend is defined in the [`Storage`] trait and its associated types.
 //!
 //! The only implementation is currently an in-memory store at [`memory`].

--- a/iroh-willow/src/store.rs
+++ b/iroh-willow/src/store.rs
@@ -11,7 +11,7 @@ use rand_core::CryptoRngCore;
 
 use crate::{
     form::{AuthForm, EntryForm, EntryOrForm, SubspaceForm, TimestampForm},
-    interest::{CapSelector, ReceiverSelector},
+    interest::{CapSelector, UserSelector},
     proto::{
         data_model::Entry,
         data_model::{AuthorisedEntry, PayloadDigest},
@@ -66,16 +66,20 @@ impl<S: Storage> Store<S> {
         &self.auth
     }
 
-    pub async fn insert_entry(&self, entry: EntryOrForm, auth: AuthForm) -> Result<(Entry, bool)> {
+    pub async fn insert_entry(
+        &self,
+        entry: EntryOrForm,
+        auth: AuthForm,
+    ) -> Result<(AuthorisedEntry, bool)> {
         let user_id = auth.user_id();
         let entry = match entry {
             EntryOrForm::Entry(entry) => Ok(entry),
             EntryOrForm::Form(form) => self.form_to_entry(form, user_id).await,
         }?;
         let capability = match auth {
-            AuthForm::Exact(cap) => cap.0,
+            AuthForm::Exact(cap) => cap,
             AuthForm::Any(user_id) => {
-                let selector = CapSelector::for_entry(&entry, ReceiverSelector::Exact(user_id));
+                let selector = CapSelector::for_entry(&entry, UserSelector::Exact(user_id));
                 self.auth()
                     .get_write_cap(&selector)?
                     .ok_or_else(|| anyhow!("no write capability available"))?
@@ -96,8 +100,7 @@ impl<S: Storage> Store<S> {
         let inserted = self
             .entries()
             .ingest(&authorised_entry, EntryOrigin::Local)?;
-        let (entry, _token) = authorised_entry.into_parts();
-        Ok((entry, inserted))
+        Ok((authorised_entry, inserted))
     }
 
     pub fn create_namespace(

--- a/iroh-willow/src/store/auth.rs
+++ b/iroh-willow/src/store/auth.rs
@@ -220,7 +220,7 @@ impl<S: Storage> Auth<S> {
             .secrets
             .get_user(user_id)
             .ok_or(AuthError::MissingUserSecret(*user_id))?;
-        let area = restrict_area.with_default(read_cap.granted_area());
+        let area = restrict_area.or_default(read_cap.granted_area());
         let new_read_cap = read_cap.delegate(&user_secret, &to, &area)?;
 
         let new_subspace_cap = if let Some(subspace_cap) = subspace_cap {
@@ -252,7 +252,7 @@ impl<S: Storage> Auth<S> {
             .secrets
             .get_user(cap.receiver())
             .ok_or(AuthError::MissingUserSecret(*cap.receiver()))?;
-        let area = restrict_area.with_default(cap.granted_area());
+        let area = restrict_area.or_default(cap.granted_area());
         let new_cap = cap.delegate(&user_secret, &to, &area)?;
         Ok(CapabilityPack::Write(new_cap.into()))
     }

--- a/iroh-willow/src/store/auth.rs
+++ b/iroh-willow/src/store/auth.rs
@@ -117,8 +117,7 @@ impl<S: Storage> Auth<S> {
                     }
                 }
                 Ok(out)
-            }
-            Interests::Exact(interests) => Ok(interests),
+            } // Interests::Exact(interests) => Ok(interests),
         }
     }
 

--- a/iroh-willow/src/store/auth.rs
+++ b/iroh-willow/src/store/auth.rs
@@ -154,7 +154,7 @@ impl<S: Storage> Auth<S> {
             McCapability::new_owned(namespace_key, &namespace_secret, user_key, AccessMode::Read)?
         };
         // TODO: Subspace capability.
-        let pack = CapabilityPack::Read(ReadAuthorisation::new(cap, None).into());
+        let pack = CapabilityPack::Read(ReadAuthorisation::new(cap, None));
         Ok(pack)
     }
 
@@ -177,7 +177,7 @@ impl<S: Storage> Auth<S> {
                 AccessMode::Write,
             )?
         };
-        let pack = CapabilityPack::Write(cap.into());
+        let pack = CapabilityPack::Write(cap);
         Ok(pack)
     }
 
@@ -237,7 +237,7 @@ impl<S: Storage> Auth<S> {
             None
         };
         let pack =
-            CapabilityPack::Read(ReadAuthorisation::new(new_read_cap, new_subspace_cap).into());
+            CapabilityPack::Read(ReadAuthorisation::new(new_read_cap, new_subspace_cap));
         Ok(pack)
     }
 
@@ -254,7 +254,7 @@ impl<S: Storage> Auth<S> {
             .ok_or(AuthError::MissingUserSecret(*cap.receiver()))?;
         let area = restrict_area.or_default(cap.granted_area());
         let new_cap = cap.delegate(&user_secret, &to, &area)?;
-        Ok(CapabilityPack::Write(new_cap.into()))
+        Ok(CapabilityPack::Write(new_cap))
     }
 }
 

--- a/iroh-willow/src/store/entry.rs
+++ b/iroh-willow/src/store/entry.rs
@@ -69,6 +69,11 @@ impl<ES: EntryStorage> WatchableEntryStore<ES> {
         self.storage.snapshot()
     }
 
+    /// Returns a store reader.
+    pub fn reader(&self) -> ES::Reader {
+        self.storage.reader()
+    }
+
     /// Ingest a new entry.
     ///
     /// Returns `true` if the entry was stored, and `false` if the entry already exists or is

--- a/iroh-willow/src/store/memory.rs
+++ b/iroh-willow/src/store/memory.rs
@@ -24,15 +24,15 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Default)]
-pub struct Store {
+pub struct Store<PS> {
     secrets: Rc<RefCell<SecretStore>>,
     entries: Rc<RefCell<EntryStore>>,
-    payloads: iroh_blobs::store::mem::Store,
+    payloads: PS,
     caps: Rc<RefCell<CapsStore>>,
 }
 
-impl Store {
-    pub fn new(payloads: iroh_blobs::store::mem::Store) -> Self {
+impl<PS: iroh_blobs::store::Store> Store<PS> {
+    pub fn new(payloads: PS) -> Self {
         Self {
             payloads,
             secrets: Default::default(),
@@ -42,10 +42,10 @@ impl Store {
     }
 }
 
-impl traits::Storage for Store {
+impl<PS: iroh_blobs::store::Store> traits::Storage for Store<PS> {
     type Entries = Rc<RefCell<EntryStore>>;
     type Secrets = Rc<RefCell<SecretStore>>;
-    type Payloads = iroh_blobs::store::mem::Store;
+    type Payloads = PS;
     type Caps = Rc<RefCell<CapsStore>>;
 
     fn entries(&self) -> &Self::Entries {

--- a/iroh-willow/src/store/memory.rs
+++ b/iroh-willow/src/store/memory.rs
@@ -348,13 +348,13 @@ impl CapsStore {
                 self.read_caps
                     .entry(*cap.read_cap().granted_namespace())
                     .or_default()
-                    .push(cap.into());
+                    .push(cap);
             }
             CapabilityPack::Write(cap) => {
                 self.write_caps
                     .entry(*cap.granted_namespace())
                     .or_default()
-                    .push(cap.into());
+                    .push(cap);
             }
         }
     }

--- a/iroh-willow/src/store/traits.rs
+++ b/iroh-willow/src/store/traits.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use crate::{
     interest::{CapSelector, CapabilityPack},
     proto::{
-        data_model::{AuthorisedEntry, Entry, NamespaceId, WriteCapability},
+        data_model::{AuthorisedEntry, Entry, NamespaceId, Path, SubspaceId, WriteCapability},
         grouping::Range3d,
         keys::{NamespaceSecretKey, NamespaceSignature, UserId, UserSecretKey, UserSignature},
         meadowcap::{self, ReadAuthorisation},
@@ -98,7 +98,14 @@ pub trait EntryReader: Debug + 'static {
 
     fn count(&self, namespace: NamespaceId, range: &Range3d) -> Result<u64>;
 
-    fn get_entries_with_authorisation<'a>(
+    fn get_entry(
+        &self,
+        namespace: NamespaceId,
+        subspace: SubspaceId,
+        path: &Path,
+    ) -> Result<Option<AuthorisedEntry>>;
+
+    fn get_authorised_entries<'a>(
         &'a self,
         namespace: NamespaceId,
         range: &Range3d,
@@ -109,7 +116,7 @@ pub trait EntryReader: Debug + 'static {
         namespace: NamespaceId,
         range: &Range3d,
     ) -> impl Iterator<Item = Result<Entry>> {
-        self.get_entries_with_authorisation(namespace, range)
+        self.get_authorised_entries(namespace, range)
             .map(|e| e.map(|e| e.into_parts().0))
     }
 }

--- a/iroh-willow/src/util/channel.rs
+++ b/iroh-willow/src/util/channel.rs
@@ -115,7 +115,7 @@ impl Guarantees {
 
 /// Shared state for a in-memory pipe.
 ///
-/// Roughly modeled after https://docs.rs/tokio/latest/src/tokio/io/util/mem.rs.html#58
+/// Roughly modeled after [tokio](https://docs.rs/tokio/latest/src/tokio/io/util/mem.rs.html#58)
 #[derive(Debug)]
 struct Shared {
     inner: Mutex<Inner>,

--- a/iroh-willow/tests/basic.rs
+++ b/iroh-willow/tests/basic.rs
@@ -435,7 +435,7 @@ mod util {
     ) -> Result<()> {
         let path = Path::from_bytes(path)?;
         let entry = EntryForm::new_bytes(namespace_id, path, bytes);
-        handle.insert(entry, user).await?;
+        handle.insert_entry(entry, user).await?;
         Ok(())
     }
 }

--- a/iroh-willow/tests/basic.rs
+++ b/iroh-willow/tests/basic.rs
@@ -416,7 +416,7 @@ mod util {
 
         let cap_for_betty = alfie
             .delegate_caps(
-                CapSelector::widest(namespace_id),
+                CapSelector::any(namespace_id),
                 AccessMode::Write,
                 DelegateTo::new(user_betty, RestrictArea::None),
             )
@@ -508,7 +508,7 @@ async fn peer_manager_big_payload() -> Result<()> {
     let entries: Vec<_> = entries.try_collect().await?;
     assert_eq!(entries.len(), 1);
     let entry = &entries[0];
-    let hash: iroh_blobs::Hash = (*entry.payload_digest()).into();
+    let hash: iroh_blobs::Hash = (*entry.entry().payload_digest()).into();
     let blob = alfie.blobs.get(&hash).await?.expect("missing blob");
     let actual = blob.data_reader().await?.read_to_end().await?;
     assert_eq!(actual.len(), payload.len());

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -31,6 +31,7 @@ iroh-base = { version = "0.23.0", path = "../iroh-base", features = ["key"] }
 iroh-io = { version = "0.6.0", features = ["stats"] }
 iroh-metrics = { version = "0.23.0", path = "../iroh-metrics", optional = true }
 iroh-net = { version = "0.23.0", path = "../iroh-net", features = ["discovery-local-network"] }
+iroh-willow = { version = "0.23.0", path = "../iroh-willow", optional = true }
 nested_enum_utils = "0.1.0"
 num_cpus = { version = "1.15.0" }
 portable-atomic = "1"
@@ -62,7 +63,7 @@ console = { version = "0.15.5", optional = true }
 url = { version = "2.5.0", features = ["serde"] }
 
 [features]
-default = ["metrics", "fs-store"]
+default = ["metrics", "fs-store", "willow"]
 metrics = ["iroh-metrics", "iroh-blobs/metrics"]
 fs-store = ["iroh-blobs/fs-store"]
 test = []
@@ -70,6 +71,7 @@ examples = ["dep:clap", "dep:indicatif"]
 discovery-local-network = ["iroh-net/discovery-local-network", "examples", "dep:console"]
 discovery-pkarr-dht = ["iroh-net/discovery-pkarr-dht"]
 test-utils = ["iroh-net/test-utils"]
+willow = ["dep:iroh-willow"]
 
 [dev-dependencies]
 anyhow = { version = "1" }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -31,7 +31,7 @@ iroh-base = { version = "0.23.0", path = "../iroh-base", features = ["key"] }
 iroh-io = { version = "0.6.0", features = ["stats"] }
 iroh-metrics = { version = "0.23.0", path = "../iroh-metrics", optional = true }
 iroh-net = { version = "0.23.0", path = "../iroh-net", features = ["discovery-local-network"] }
-iroh-willow = { version = "0.23.0", path = "../iroh-willow", optional = true }
+iroh-willow = { version = "0.23.0", path = "../iroh-willow" }
 nested_enum_utils = "0.1.0"
 num_cpus = { version = "1.15.0" }
 portable-atomic = "1"
@@ -63,7 +63,7 @@ console = { version = "0.15.5", optional = true }
 url = { version = "2.5.0", features = ["serde"] }
 
 [features]
-default = ["metrics", "fs-store", "willow"]
+default = ["metrics", "fs-store"]
 metrics = ["iroh-metrics", "iroh-blobs/metrics"]
 fs-store = ["iroh-blobs/fs-store"]
 test = []
@@ -71,7 +71,6 @@ examples = ["dep:clap", "dep:indicatif"]
 discovery-local-network = ["iroh-net/discovery-local-network", "examples", "dep:console"]
 discovery-pkarr-dht = ["iroh-net/discovery-pkarr-dht"]
 test-utils = ["iroh-net/test-utils"]
-willow = ["dep:iroh-willow"]
 
 [dev-dependencies]
 anyhow = { version = "1" }

--- a/iroh/src/client.rs
+++ b/iroh/src/client.rs
@@ -24,6 +24,7 @@ pub mod blobs;
 pub mod docs;
 pub mod gossip;
 pub mod net;
+pub mod spaces;
 pub mod tags;
 
 /// Iroh rpc connection - boxed so that we can have a concrete type.
@@ -70,6 +71,11 @@ impl Iroh {
     /// Returns the docs client.
     pub fn docs(&self) -> &docs::Client {
         docs::Client::ref_cast(&self.rpc)
+    }
+
+    /// Returns the spaces client.
+    pub fn spaces(&self) -> &spaces::Client {
+        spaces::Client::ref_cast(&self.rpc)
     }
 
     /// Returns the authors client.

--- a/iroh/src/client/spaces.rs
+++ b/iroh/src/client/spaces.rs
@@ -8,20 +8,27 @@
 //! [Willow]: https://willowprotocol.org/
 
 use std::{
+    collections::HashMap,
+    path::PathBuf,
     pin::Pin,
     task::{Context, Poll},
 };
 
 use anyhow::Result;
+use bytes::Bytes;
 use futures_lite::{Stream, StreamExt};
 use futures_util::{Sink, SinkExt};
 use iroh_base::key::NodeId;
+use iroh_blobs::Hash;
+use iroh_net::NodeAddr;
 use iroh_willow::{
-    form::{AuthForm, SerdeEntryOrForm as EntryOrForm},
-    interest::{CapSelector, CapabilityPack, DelegateTo, Interests},
+    form::{AuthForm, PayloadForm2, SerdeEntryForm, SubspaceForm, TimestampForm},
+    interest::{
+        AreaOfInterestSelector, CapSelector, CapabilityPack, DelegateTo, Interests, RestrictArea,
+    },
     proto::{
-        data_model::{AuthorisedEntry, Entry},
-        grouping::Range3d,
+        data_model::{AuthorisedEntry, Path, SubspaceId},
+        grouping::{Area, Range3d},
         keys::{NamespaceId, NamespaceKind, UserId},
         meadowcap::{AccessMode, SecretKey},
     },
@@ -31,6 +38,9 @@ use iroh_willow::{
     },
 };
 use ref_cast::RefCast;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncRead;
+use tokio_stream::StreamMap;
 
 use crate::client::RpcClient;
 use crate::rpc_protocol::spaces::*;
@@ -43,54 +53,14 @@ pub struct Client {
 }
 
 impl Client {
-    /// Insert a new entry.
-    ///
-    /// `entry` can be a [`EntryForm`] or a `Entry`.
-    /// `auth` can either be a [`AuthForm`] or simply a [`UserId`].
-    /// When passing a [`UserId`], a matching capability will be selected for the user.
-    /// If you want to select the capability to use more specifically, use the methods on [`AuthForm`].
-    // TODO: Not sure I like the impl Into, better change to two methods.
-    pub async fn insert_entry(
-        &self,
-        entry: impl Into<EntryOrForm>,
-        auth: impl Into<AuthForm>,
-    ) -> Result<()> {
-        let req = InsertEntryRequest {
-            entry: entry.into(),
-            auth: auth.into(),
-        };
-        let _res: InsertEntryResponse = self.rpc.rpc(req).await??;
-        Ok(())
+    fn net(&self) -> &super::net::Client {
+        super::net::Client::ref_cast(&self.rpc)
     }
-
-    /// Ingest an authorised entry.
-    // TODO: Not sure if we should expose this on the client at all.
-    pub async fn ingest_entry(&self, authorised_entry: AuthorisedEntry) -> Result<()> {
-        let req = IngestEntryRequest { authorised_entry };
-        self.rpc.rpc(req).await??;
-        Ok(())
-    }
-
-    /// Get entries from the Willow store.
-    pub async fn get_entries(
-        &self,
-        namespace: NamespaceId,
-        range: Range3d,
-    ) -> Result<impl Stream<Item = Result<Entry>>> {
-        let req = GetEntriesRequest { namespace, range };
-        let stream = self.rpc.try_server_streaming(req).await?;
-        Ok(stream.map(|res| res.map(|r| r.0.into()).map_err(Into::into)))
-    }
-
     /// Create a new namespace in the Willow store.
-    pub async fn create_namespace(
-        &self,
-        kind: NamespaceKind,
-        owner: UserId,
-    ) -> Result<NamespaceId> {
+    pub async fn create(&self, kind: NamespaceKind, owner: UserId) -> Result<Space> {
         let req = CreateNamespaceRequest { kind, owner };
-        let res: CreateNamespaceResponse = self.rpc.rpc(req).await??;
-        Ok(res.0)
+        let res = self.rpc.rpc(req).await??;
+        Ok(Space::new(self.rpc.clone(), res.0))
     }
 
     /// Create a new user in the Willow store.
@@ -123,6 +93,34 @@ impl Client {
         let req = ImportCapsRequest { caps };
         self.rpc.rpc(req).await??;
         Ok(())
+    }
+
+    /// Import a ticket and start to synchronize.
+    pub async fn import_and_sync(
+        &self,
+        ticket: SpaceTicket,
+    ) -> Result<(Space, MergedIntentHandle)> {
+        if ticket.caps.is_empty() {
+            anyhow::bail!("Invalid ticket: Does not include any capabilities");
+        }
+        let mut namespaces = ticket.caps.iter().map(|pack| pack.namespace());
+        let namespace = namespaces.next().expect("just checked");
+        if !namespaces.all(|n| n == namespace) {
+            anyhow::bail!("Invalid ticket: Capabilities do not all refer to the same namespace");
+        }
+
+        self.import_caps(ticket.caps).await?;
+        let interests = Interests::builder().add_full_cap(CapSelector::any(namespace));
+        let init = SessionInit::reconcile_once(interests);
+        let mut intents = MergedIntentHandle::default();
+        for addr in ticket.nodes {
+            let node_id = addr.node_id;
+            self.net().add_node_addr(addr).await?;
+            let intent = self.sync_with_peer(node_id, init.clone()).await?;
+            intents.insert(node_id, intent);
+        }
+        let space = Space::new(self.rpc.clone(), namespace);
+        Ok((space, intents))
     }
 
     /// Synchronize with a peer.
@@ -159,6 +157,265 @@ impl Client {
         Ok(())
     }
 }
+
+/// A space to store entries in.
+#[derive(Debug, Clone)]
+pub struct Space {
+    rpc: RpcClient,
+    namespace_id: NamespaceId,
+}
+
+impl Space {
+    fn new(rpc: RpcClient, namespace_id: NamespaceId) -> Self {
+        Self { rpc, namespace_id }
+    }
+
+    fn blobs(&self) -> &super::blobs::Client {
+        super::blobs::Client::ref_cast(&self.rpc)
+    }
+
+    fn spaces(&self) -> &Client {
+        Client::ref_cast(&self.rpc)
+    }
+
+    fn net(&self) -> &super::net::Client {
+        super::net::Client::ref_cast(&self.rpc)
+    }
+
+    /// Returns the identifier for this space.
+    pub fn namespace_id(&self) -> NamespaceId {
+        self.namespace_id
+    }
+
+    async fn insert(&self, entry: EntryForm, payload: PayloadForm2) -> Result<InsertEntrySuccess> {
+        let form = SerdeEntryForm {
+            namespace_id: self.namespace_id,
+            subspace_id: entry.subspace_id,
+            path: entry.path,
+            timestamp: entry.timestamp,
+            payload,
+        };
+        let auth = entry.auth;
+        let req = InsertEntryRequest {
+            entry: form.into(),
+            auth,
+        };
+        let res = self.rpc.rpc(req).await??;
+        Ok(res)
+    }
+
+    // Insert a new entry.
+
+    // `entry` can be a [`EntryForm`] or a `Entry`.
+    // `auth` can either be a [`AuthForm`] or simply a [`UserId`].
+    // When passing a [`UserId`], a matching capability will be selected for the user.
+    // If you want to select the capability to use more specifically, use the methods on [`AuthForm`].
+    // TODO: Not sure I like the impl Into, better change to two methods.
+    /// Inserts a new entry, with the payload digest set to a hash.
+    ///
+    /// Note that the payload must exist in the local blob store, otherwise the operation will fail.
+    pub async fn insert_hash(&self, entry: EntryForm, payload: Hash) -> Result<InsertEntrySuccess> {
+        let payload = PayloadForm2::Checked(payload);
+        self.insert(entry, payload).await
+    }
+
+    /// Inserts a new entry, with the payload imported from a byte string.
+    pub async fn insert_bytes(
+        &self,
+        entry: EntryForm,
+        payload: impl Into<Bytes>,
+    ) -> Result<InsertEntrySuccess> {
+        let batch = self.blobs().batch().await?;
+        let tag = batch.add_bytes(payload).await?;
+        self.insert_hash(entry, *tag.hash()).await
+    }
+
+    /// Inserts a new entry, with the payload imported from a byte reader.
+    pub async fn insert_reader(
+        &self,
+        entry: EntryForm,
+        payload: impl AsyncRead + Send + Unpin + 'static,
+    ) -> Result<InsertEntrySuccess> {
+        let batch = self.blobs().batch().await?;
+        let tag = batch.add_reader(payload).await?;
+        self.insert_hash(entry, *tag.hash()).await
+    }
+
+    /// Inserts a new entry, with the payload imported from a byte stream.
+    pub async fn insert_stream(
+        &self,
+        entry: EntryForm,
+        payload: impl Stream<Item = std::io::Result<Bytes>> + Send + Unpin + 'static,
+    ) -> Result<InsertEntrySuccess> {
+        let batch = self.blobs().batch().await?;
+        let tag = batch.add_stream(payload).await?;
+        self.insert_hash(entry, *tag.hash()).await
+    }
+
+    /// Inserts a new entry, with the payload imported from a file.
+    pub async fn insert_from_path(
+        &self,
+        entry: EntryForm,
+        payload: PathBuf,
+    ) -> Result<InsertEntrySuccess> {
+        let batch = self.blobs().batch().await?;
+        let (tag, _len) = batch.add_file(payload).await?;
+        self.insert_hash(entry, *tag.hash()).await
+    }
+
+    /// Ingest an authorised entry.
+    // TODO: Not sure if we should expose this on the client at all.
+    pub async fn ingest(&self, authorised_entry: AuthorisedEntry) -> Result<()> {
+        let req = IngestEntryRequest { authorised_entry };
+        self.rpc.rpc(req).await??;
+        Ok(())
+    }
+
+    /// Get a single entry.
+    pub async fn get_one(
+        &self,
+        subspace: SubspaceId,
+        path: Path,
+    ) -> Result<Option<AuthorisedEntry>> {
+        let req = GetEntryRequest {
+            namespace: self.namespace_id,
+            subspace,
+            path,
+        };
+        let entry = self.rpc.rpc(req).await??;
+        Ok(entry.0.map(Into::into))
+    }
+
+    /// Get entries by range.
+    pub async fn get_many(
+        &self,
+        range: Range3d,
+    ) -> Result<impl Stream<Item = Result<AuthorisedEntry>>> {
+        let req = GetEntriesRequest {
+            namespace: self.namespace_id,
+            range,
+        };
+        let stream = self.rpc.try_server_streaming(req).await?;
+        Ok(stream.map(|res| res.map(|r| r.0).map_err(Into::into)))
+    }
+
+    /// Syncs with a peer and quit the session after a single reconciliation of the selected areas.
+    ///
+    /// Returns an [`IntentHandle`] that emits events for the reconciliation. If you want to wait for everything to complete,
+    /// await [`IntentHandle::complete`].
+    ///
+    /// This will connect to the node, start a sync session, and submit all our capabilities for this namespace,
+    /// constrained to the selected areas.
+    ///
+    /// If you want to specify the capabilities to submit more concretely, use [`Client::sync_with_peer`].
+    pub async fn sync_once(
+        &self,
+        node: NodeId,
+        areas: AreaOfInterestSelector,
+    ) -> Result<IntentHandle> {
+        let cap = CapSelector::any(self.namespace_id);
+        let interests = Interests::builder().add(cap, areas);
+        let init = SessionInit::reconcile_once(interests);
+        self.spaces().sync_with_peer(node, init).await
+    }
+
+    /// Sync with a peer and keep sending and receiving live updates for the selected areas.
+    ///
+    /// Returns an [`IntentHandle`] that emits events for the reconciliation. If you want to wait for everything to complete,
+    /// await [`IntentHandle::complete`].
+    ///
+    /// This will connect to the node, start a sync session, and submit all our capabilities for this namespace,
+    /// constrained to the selected areas.
+    ///
+    /// If you want to specify the capabilities to submit more concretely, use [`Client::sync_with_peer`].
+    pub async fn sync_continuously(
+        &self,
+        node: NodeId,
+        areas: AreaOfInterestSelector,
+    ) -> Result<IntentHandle> {
+        let cap = CapSelector::any(self.namespace_id);
+        let interests = Interests::builder().add(cap, areas);
+        let init = SessionInit::continuous(interests);
+        self.spaces().sync_with_peer(node, init).await
+    }
+
+    /// Share access to this space, or parts of this space, with another user.
+    ///
+    /// This will use any matching capability as the source of the capability delegation.
+    /// If you want to specify more options, use [`Client::delegate_caps`].
+    pub async fn share(
+        &self,
+        receiver: UserId,
+        access_mode: AccessMode,
+        restrict_area: RestrictArea,
+    ) -> Result<SpaceTicket> {
+        let caps = self
+            .spaces()
+            .delegate_caps(
+                CapSelector::any(self.namespace_id),
+                access_mode,
+                DelegateTo::new(receiver, restrict_area),
+            )
+            .await?;
+        let node_addr = self.net().node_addr().await?;
+        Ok(SpaceTicket {
+            caps,
+            nodes: vec![node_addr],
+        })
+    }
+
+    /// TODO
+    pub async fn subscribe(&self, _area: Area) {
+        todo!()
+    }
+
+    /// TODO
+    pub async fn subscribe_offset(&self, _area: Area, _offset: u64) {
+        todo!()
+    }
+}
+
+/// A ticket to import and sync a space.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SpaceTicket {
+    /// Capabilities for a space.
+    pub caps: Vec<CapabilityPack>,
+    /// List of nodes to sync with.
+    pub nodes: Vec<NodeAddr>,
+}
+
+/// Form to insert a new entry
+#[derive(Debug)]
+pub struct EntryForm {
+    /// The authorisation, either an exact capability, or a user id to select a capability for automatically.
+    pub auth: AuthForm,
+    /// The subspace, either exact or automatically set to the authorising user.
+    pub subspace_id: SubspaceForm,
+    /// The path
+    pub path: Path,
+    /// The timestamp, either exact or automatically set current time.
+    pub timestamp: TimestampForm,
+}
+
+impl EntryForm {
+    /// Creates a new entry form with the specified user and path.
+    ///
+    /// The subspace will be set to the specified user id.
+    /// The timestamp will be set to the current system time.
+    /// To authorise the entry, any applicable capability issued to the specified user id
+    /// that covers this path will be used, or return an error if no such capability is available.
+    pub fn new(user: UserId, path: Path) -> Self {
+        Self {
+            auth: AuthForm::Any(user),
+            path,
+            subspace_id: Default::default(),
+            timestamp: Default::default(),
+        }
+    }
+
+    // TODO: Add builder methods for auth, subspace_id, timestamp
+}
+
 /// Handle to a synchronization intent.
 ///
 /// The `IntentHandle` is a `Stream` of `Event`s. It *must* be progressed in a loop,
@@ -212,25 +469,7 @@ impl IntentHandle {
     /// Note that successful completion of this future does not guarantee that all interests were
     /// fulfilled.
     pub async fn complete(&mut self) -> Result<Completion> {
-        let mut complete = false;
-        let mut partial = false;
-        while let Some(event) = self.event_rx.next().await {
-            match event {
-                Event::ReconciledAll => complete = true,
-                Event::Reconciled { .. } => partial = true,
-                Event::Abort { error } => return Err(anyhow::anyhow!(error)),
-                _ => {}
-            }
-        }
-        let completion = if complete {
-            Completion::Complete
-        } else if partial {
-            Completion::Partial
-        } else {
-            Completion::Nothing
-        };
-
-        Ok(completion)
+        complete(&mut self.event_rx).await
     }
 
     /// Submit new synchronisation interests into the session.
@@ -253,6 +492,73 @@ impl IntentHandle {
 
 impl Stream for IntentHandle {
     type Item = Event;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.event_rx).poll_next(cx)
+    }
+}
+
+async fn complete(event_rx: &mut EventReceiver) -> Result<Completion> {
+    let mut complete = false;
+    let mut partial = false;
+    while let Some(event) = event_rx.next().await {
+        match event {
+            Event::ReconciledAll => complete = true,
+            Event::Reconciled { .. } => partial = true,
+            Event::Abort { error } => return Err(anyhow::anyhow!(error)),
+            _ => {}
+        }
+    }
+    let completion = if complete {
+        Completion::Complete
+    } else if partial {
+        Completion::Partial
+    } else {
+        Completion::Nothing
+    };
+
+    Ok(completion)
+}
+
+/// Merges synchronisation intent handles into one struct.
+#[derive(Default, derive_more::Debug)]
+#[debug("MergedIntentHandle({:?})", self.event_rx.keys().collect::<Vec<_>>())]
+pub struct MergedIntentHandle {
+    event_rx: StreamMap<NodeId, EventReceiver>,
+    update_tx: HashMap<NodeId, UpdateSender>,
+}
+
+impl MergedIntentHandle {
+    /// Add an intent to this merged handle.
+    pub fn insert(&mut self, peer: NodeId, handle: IntentHandle) {
+        let (update_tx, event_rx) = handle.split();
+        self.event_rx.insert(peer, event_rx);
+        self.update_tx.insert(peer, update_tx);
+    }
+
+    /// Submit new synchronisation interests into all sessions.
+    pub async fn add_interests(&mut self, interests: impl Into<Interests>) -> Result<()> {
+        let interests: Interests = interests.into();
+        let futs = self
+            .update_tx
+            .values_mut()
+            .map(|tx| tx.send(IntentUpdate::AddInterests(interests.clone())));
+        futures_buffered::try_join_all(futs).await?;
+        Ok(())
+    }
+
+    /// Wait for all intents to complete.
+    pub async fn complete_all(mut self) -> HashMap<NodeId, Result<Completion>> {
+        let streams = self.event_rx.iter_mut();
+        let futs =
+            streams.map(|(node_id, stream)| async move { (*node_id, complete(stream).await) });
+        let res = futures_buffered::join_all(futs).await;
+        res.into_iter().collect()
+    }
+}
+
+impl Stream for MergedIntentHandle {
+    type Item = (NodeId, Event);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Pin::new(&mut self.event_rx).poll_next(cx)

--- a/iroh/src/client/spaces.rs
+++ b/iroh/src/client/spaces.rs
@@ -7,6 +7,8 @@
 //!
 //! [Willow]: https://willowprotocol.org/
 
+// TODO: Reexport everything that is needed from iroh_willow.
+
 use std::{
     collections::HashMap,
     path::PathBuf,
@@ -196,10 +198,7 @@ impl Space {
             payload,
         };
         let auth = entry.auth;
-        let req = InsertEntryRequest {
-            entry: form.into(),
-            auth,
-        };
+        let req = InsertEntryRequest { entry: form, auth };
         let res = self.rpc.rpc(req).await??;
         Ok(res)
     }

--- a/iroh/src/client/spaces.rs
+++ b/iroh/src/client/spaces.rs
@@ -1,0 +1,260 @@
+//! API for managing iroh spaces
+//!
+//! iroh spaces is an implementation of the [Willow] protocol.
+//! The main entry point is the [`Client`].
+//!
+//! You obtain a [`Client`] via [`Iroh::spaces()`](crate::client::Iroh::spaces).
+//!
+//! [Willow]: https://willowprotocol.org/
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use anyhow::Result;
+use futures_lite::{Stream, StreamExt};
+use futures_util::{Sink, SinkExt};
+use iroh_base::key::NodeId;
+use iroh_willow::{
+    form::{AuthForm, SerdeEntryOrForm as EntryOrForm},
+    interest::{CapSelector, CapabilityPack, DelegateTo, Interests},
+    proto::{
+        data_model::{AuthorisedEntry, Entry},
+        grouping::Range3d,
+        keys::{NamespaceId, NamespaceKind, UserId},
+        meadowcap::{AccessMode, SecretKey},
+    },
+    session::{
+        intents::{serde_encoding::Event, Completion, IntentUpdate},
+        SessionInit,
+    },
+};
+use ref_cast::RefCast;
+
+use crate::client::RpcClient;
+use crate::rpc_protocol::spaces::*;
+
+/// Iroh Willow client.
+#[derive(Debug, Clone, RefCast)]
+#[repr(transparent)]
+pub struct Client {
+    pub(super) rpc: RpcClient,
+}
+
+impl Client {
+    /// Insert a new entry.
+    ///
+    /// `entry` can be a [`EntryForm`] or a `Entry`.
+    /// `auth` can either be a [`AuthForm`] or simply a [`UserId`].
+    /// When passing a [`UserId`], a matching capability will be selected for the user.
+    /// If you want to select the capability to use more specifically, use the methods on [`AuthForm`].
+    // TODO: Not sure I like the impl Into, better change to two methods.
+    pub async fn insert_entry(
+        &self,
+        entry: impl Into<EntryOrForm>,
+        auth: impl Into<AuthForm>,
+    ) -> Result<()> {
+        let req = InsertEntryRequest {
+            entry: entry.into(),
+            auth: auth.into(),
+        };
+        let _res: InsertEntryResponse = self.rpc.rpc(req).await??;
+        Ok(())
+    }
+
+    /// Ingest an authorised entry.
+    // TODO: Not sure if we should expose this on the client at all.
+    pub async fn ingest_entry(&self, authorised_entry: AuthorisedEntry) -> Result<()> {
+        let req = IngestEntryRequest { authorised_entry };
+        self.rpc.rpc(req).await??;
+        Ok(())
+    }
+
+    /// Get entries from the Willow store.
+    pub async fn get_entries(
+        &self,
+        namespace: NamespaceId,
+        range: Range3d,
+    ) -> Result<impl Stream<Item = Result<Entry>>> {
+        let req = GetEntriesRequest { namespace, range };
+        let stream = self.rpc.try_server_streaming(req).await?;
+        Ok(stream.map(|res| res.map(|r| r.0.into()).map_err(Into::into)))
+    }
+
+    /// Create a new namespace in the Willow store.
+    pub async fn create_namespace(
+        &self,
+        kind: NamespaceKind,
+        owner: UserId,
+    ) -> Result<NamespaceId> {
+        let req = CreateNamespaceRequest { kind, owner };
+        let res: CreateNamespaceResponse = self.rpc.rpc(req).await??;
+        Ok(res.0)
+    }
+
+    /// Create a new user in the Willow store.
+    pub async fn create_user(&self) -> Result<UserId> {
+        let req = CreateUserRequest;
+        let res: CreateUserResponse = self.rpc.rpc(req).await??;
+        Ok(res.0)
+    }
+
+    /// Delegate capabilities to another user.
+    ///
+    /// Returns a `Vec` of [`CapabilityPack`]s, which can be serialized.
+    pub async fn delegate_caps(
+        &self,
+        from: CapSelector,
+        access_mode: AccessMode,
+        to: DelegateTo,
+    ) -> Result<Vec<CapabilityPack>> {
+        let req = DelegateCapsRequest {
+            from,
+            access_mode,
+            to,
+        };
+        let res = self.rpc.rpc(req).await??;
+        Ok(res.0)
+    }
+
+    /// Import capabilities.
+    pub async fn import_caps(&self, caps: Vec<CapabilityPack>) -> Result<()> {
+        let req = ImportCapsRequest { caps };
+        self.rpc.rpc(req).await??;
+        Ok(())
+    }
+
+    /// Synchronize with a peer.
+    pub async fn sync_with_peer(&self, peer: NodeId, init: SessionInit) -> Result<IntentHandle> {
+        let req = SyncWithPeerRequest { peer, init };
+        let (update_tx, event_rx) = self.rpc.bidi(req).await?;
+
+        let update_tx = SinkExt::with(
+            update_tx,
+            |update| async move { Ok(SyncWithPeerUpdate(update)) },
+        );
+        let update_tx: UpdateSender = Box::pin(update_tx);
+
+        let event_rx = Box::pin(event_rx.map(|res| match res {
+            Ok(Ok(SyncWithPeerResponse::Event(event))) => event,
+            Ok(Ok(SyncWithPeerResponse::Started)) => Event::ReconciledAll, // or another appropriate event
+            Err(e) => Event::Abort {
+                error: e.to_string(),
+            },
+            Ok(Err(e)) => Event::Abort {
+                error: e.to_string(),
+            },
+        }));
+
+        Ok(IntentHandle::new(update_tx, event_rx))
+    }
+
+    /// Import a secret into the Willow store.
+    pub async fn import_secret(&self, secret: impl Into<SecretKey>) -> Result<()> {
+        let req = InsertSecretRequest {
+            secret: secret.into(),
+        };
+        self.rpc.rpc(req).await??;
+        Ok(())
+    }
+}
+/// Handle to a synchronization intent.
+///
+/// The `IntentHandle` is a `Stream` of `Event`s. It *must* be progressed in a loop,
+/// otherwise the session will be blocked from progressing.
+///
+/// The `IntentHandle` can also submit new interests into the session.
+///
+// This version of IntentHandle differs from the one in iroh-willow intents module
+// by using the Event type instead of EventKind, which serializes the error to a string
+// to cross the RPC boundary. Maybe look into making the main iroh_willow Error type
+// serializable instead.
+#[derive(derive_more::Debug)]
+pub struct IntentHandle {
+    #[debug("UpdateSender")]
+    update_tx: UpdateSender,
+    #[debug("EventReceiver")]
+    event_rx: EventReceiver,
+}
+
+/// Sends updates into a reconciliation intent.
+///
+/// Can be obtained from [`IntentHandle::split`].
+pub type UpdateSender = Pin<Box<dyn Sink<IntentUpdate, Error = anyhow::Error> + Send + 'static>>;
+
+/// Receives events for a reconciliation intent.
+///
+/// Can be obtained from [`IntentHandle::split`].
+pub type EventReceiver = Pin<Box<dyn Stream<Item = Event> + Send + 'static>>;
+
+impl IntentHandle {
+    /// Creates a new `IntentHandle` with the given update sender and event receiver.
+    fn new(update_tx: UpdateSender, event_rx: EventReceiver) -> Self {
+        Self {
+            update_tx,
+            event_rx,
+        }
+    }
+
+    /// Splits the `IntentHandle` into a update sender sink and event receiver stream.
+    ///
+    /// The intent will be dropped once both the sender and receiver are dropped.
+    pub fn split(self) -> (UpdateSender, EventReceiver) {
+        (self.update_tx, self.event_rx)
+    }
+
+    /// Waits for the intent to be completed.
+    ///
+    /// This future completes either if the session terminated, or if all interests of the intent
+    /// are reconciled and the intent is not in live data mode.
+    ///
+    /// Note that successful completion of this future does not guarantee that all interests were
+    /// fulfilled.
+    pub async fn complete(&mut self) -> Result<Completion> {
+        let mut complete = false;
+        let mut partial = false;
+        while let Some(event) = self.event_rx.next().await {
+            match event {
+                Event::ReconciledAll => complete = true,
+                Event::Reconciled { .. } => partial = true,
+                Event::Abort { error } => return Err(anyhow::anyhow!(error)),
+                _ => {}
+            }
+        }
+        let completion = if complete {
+            Completion::Complete
+        } else if partial {
+            Completion::Partial
+        } else {
+            Completion::Nothing
+        };
+
+        Ok(completion)
+    }
+
+    /// Submit new synchronisation interests into the session.
+    ///
+    /// The `IntentHandle` will then receive events for these interests in addition to already
+    /// submitted interests.
+    pub async fn add_interests(&mut self, interests: impl Into<Interests>) -> Result<()> {
+        self.update_tx
+            .send(IntentUpdate::AddInterests(interests.into()))
+            .await?;
+        Ok(())
+    }
+
+    // TODO: I think all should work via dropping, but let's make sure that is the case.
+    // /// Close the intent.
+    // pub async fn close(&mut self) {
+    //     self.update_tx.send(IntentUpdate::Close).await.ok();
+    // }
+}
+
+impl Stream for IntentHandle {
+    type Item = Event;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.event_rx).poll_next(cx)
+    }
+}

--- a/iroh/src/client/spaces.rs
+++ b/iroh/src/client/spaces.rs
@@ -245,13 +245,13 @@ impl Space {
     }
 
     /// Inserts a new entry, with the payload imported from a file.
-    pub async fn insert_from_path(
+    pub async fn insert_from_file(
         &self,
         entry: EntryForm,
-        payload: PathBuf,
+        file_path: PathBuf,
     ) -> Result<InsertEntrySuccess> {
         let batch = self.blobs().batch().await?;
-        let (tag, _len) = batch.add_file(payload).await?;
+        let (tag, _len) = batch.add_file(file_path).await?;
         self.insert_hash(entry, *tag.hash()).await
     }
 

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -102,6 +102,8 @@ pub use iroh_docs as docs;
 pub use iroh_gossip as gossip;
 #[doc(inline)]
 pub use iroh_net as net;
+#[doc(inline)]
+pub use iroh_willow as spaces;
 
 pub mod client;
 pub mod node;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -498,6 +498,11 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
             }
         };
 
+        // Shutdown willow gracefully.
+        if let Err(error) = self.willow.clone().shutdown().await {
+            warn!(?error, "Error while shutting down willow");
+        }
+
         // We ignore all errors during shutdown.
         let _ = tokio::join!(
             // Close the endpoint.

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -118,6 +118,7 @@ struct NodeInner<D> {
     downloader: Downloader,
     blob_batches: tokio::sync::Mutex<BlobBatches>,
     local_pool_handle: LocalPoolHandle,
+    willow: iroh_willow::Engine,
 }
 
 /// Keeps track of all the currently active batch operations of the blobs api.

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -588,6 +588,16 @@ where
         )
         .await?;
 
+        // Spawn the willow engine.
+        // TODO: Allow to disable.
+        let blobs_store = self.blobs_store.clone();
+        let create_store = move || iroh_willow::store::memory::Store::new(blobs_store);
+        let willow = iroh_willow::Engine::spawn(
+            endpoint.clone(),
+            create_store,
+            iroh_willow::engine::AcceptOpts::default(),
+        );
+
         // Initialize the internal RPC connection.
         let (internal_rpc, controller) = quic_rpc::transport::flume::connection::<RpcService>(32);
         let internal_rpc = quic_rpc::transport::boxed::ServerEndpoint::new(internal_rpc);
@@ -608,6 +618,7 @@ where
             gossip,
             local_pool_handle: lp.handle().clone(),
             blob_batches: Default::default(),
+            willow,
         });
 
         let protocol_builder = ProtocolBuilder {

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -773,6 +773,10 @@ impl<D: iroh_blobs::store::Store> ProtocolBuilder<D> {
             self = self.accept(DOCS_ALPN, Arc::new(docs));
         }
 
+        // TODO: Make willow optional.
+        let willow_engine = self.inner.willow.clone();
+        self = self.accept(iroh_willow::ALPN, Arc::new(willow_engine));
+
         self
     }
 

--- a/iroh/src/node/protocol.rs
+++ b/iroh/src/node/protocol.rs
@@ -110,3 +110,9 @@ impl ProtocolHandler for iroh_gossip::net::Gossip {
         Box::pin(async move { self.handle_connection(conn.await?).await })
     }
 }
+
+impl ProtocolHandler for iroh_willow::Engine {
+    fn accept(self: Arc<Self>, conn: Connecting) -> BoxedFuture<Result<()>> {
+        Box::pin(async move { self.handle_connection(conn.await?).await })
+    }
+}

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -77,6 +77,7 @@ use crate::rpc_protocol::{
 use super::IrohServerEndpoint;
 
 mod docs;
+mod spaces;
 
 const HEALTH_POLL_WAIT: Duration = Duration::from_secs(1);
 /// Chunk size for getting blobs over RPC
@@ -463,6 +464,9 @@ impl<D: BaoStore> Handler<D> {
             Authors(msg) => self.handle_authors_request(msg, chan).await,
             Docs(msg) => self.handle_docs_request(msg, chan).await,
             Gossip(msg) => self.handle_gossip_request(msg, chan).await,
+            Spaces(msg) => {
+                self::spaces::handle_rpc_request(self.inner.willow.clone(), msg, chan).await
+            }
         }
     }
 

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -464,9 +464,7 @@ impl<D: BaoStore> Handler<D> {
             Authors(msg) => self.handle_authors_request(msg, chan).await,
             Docs(msg) => self.handle_docs_request(msg, chan).await,
             Gossip(msg) => self.handle_gossip_request(msg, chan).await,
-            Spaces(msg) => {
-                self::spaces::handle_rpc_request(self.inner.willow.clone(), msg, chan).await
-            }
+            Spaces(msg) => self::spaces::handle_rpc_request(&self.inner.willow, msg, chan).await,
         }
     }
 

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -103,6 +103,10 @@ impl<D: BaoStore> Handler<D> {
         self.inner.docs.as_ref()
     }
 
+    fn spaces(&self) -> Result<&iroh_willow::Engine, RpcError> {
+        self.inner.willow.as_ref().ok_or_else(spaces_disabled)
+    }
+
     async fn with_docs<T, F, Fut>(self, f: F) -> RpcResult<T>
     where
         T: Send + 'static,
@@ -464,7 +468,7 @@ impl<D: BaoStore> Handler<D> {
             Authors(msg) => self.handle_authors_request(msg, chan).await,
             Docs(msg) => self.handle_docs_request(msg, chan).await,
             Gossip(msg) => self.handle_gossip_request(msg, chan).await,
-            Spaces(msg) => self::spaces::handle_rpc_request(&self.inner.willow, msg, chan).await,
+            Spaces(msg) => self.handle_spaces_request(msg, chan).await,
         }
     }
 
@@ -1493,4 +1497,8 @@ where
 
 fn docs_disabled() -> RpcError {
     anyhow!("docs are disabled").into()
+}
+
+fn spaces_disabled() -> RpcError {
+    anyhow::anyhow!("spaces are disabled").into()
 }

--- a/iroh/src/node/rpc/spaces.rs
+++ b/iroh/src/node/rpc/spaces.rs
@@ -73,7 +73,7 @@ pub(crate) async fn handle_rpc_request(
                     .get_entries(req.namespace, req.range)
                     .await
                     .map_err(map_err)?;
-                Ok(stream.map(|res| res.map(|e| GetEntriesResponse(e)).map_err(map_err)))
+                Ok(stream.map(|res| res.map(GetEntriesResponse).map_err(map_err)))
             })
             .await
         }

--- a/iroh/src/node/rpc/spaces.rs
+++ b/iroh/src/node/rpc/spaces.rs
@@ -3,8 +3,8 @@ use futures_lite::Stream;
 use futures_util::SinkExt;
 use futures_util::StreamExt;
 use iroh_base::rpc::{RpcError, RpcResult};
+use iroh_blobs::store::Store;
 use iroh_willow::form::EntryOrForm;
-use iroh_willow::Engine;
 use quic_rpc::server::{RpcChannel, RpcServerError};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -13,147 +13,160 @@ use crate::node::IrohServerEndpoint;
 use crate::rpc_protocol::spaces::*;
 use crate::rpc_protocol::RpcService;
 
+use super::Handler;
+
 fn map_err(err: anyhow::Error) -> RpcError {
     RpcError::from(err)
 }
 
-pub(crate) async fn handle_rpc_request(
-    engine: &Engine,
-    msg: Request,
-    chan: RpcChannel<RpcService, IrohServerEndpoint>,
-) -> Result<(), RpcServerError<IrohServerEndpoint>> {
-    use Request::*;
-    match msg {
-        IngestEntry(msg) => {
-            chan.rpc(msg, engine, |engine, req| async move {
-                engine
-                    .ingest_entry(req.authorised_entry)
-                    .await
-                    .map(|inserted| {
-                        if inserted {
-                            IngestEntrySuccess::Inserted
-                        } else {
-                            IngestEntrySuccess::Obsolete
+impl<D: Store> Handler<D> {
+    pub(crate) async fn handle_spaces_request(
+        self,
+        msg: Request,
+        chan: RpcChannel<RpcService, IrohServerEndpoint>,
+    ) -> Result<(), RpcServerError<IrohServerEndpoint>> {
+        use Request::*;
+        match msg {
+            IngestEntry(msg) => {
+                chan.rpc(msg, self, |handler, req| async move {
+                    handler
+                        .spaces()?
+                        .ingest_entry(req.authorised_entry)
+                        .await
+                        .map(|inserted| {
+                            if inserted {
+                                IngestEntrySuccess::Inserted
+                            } else {
+                                IngestEntrySuccess::Obsolete
+                            }
+                        })
+                        .map_err(map_err)
+                })
+                .await
+            }
+            InsertEntry(msg) => {
+                chan.rpc(msg, self, |handler, req| async move {
+                    let entry = EntryOrForm::Form(req.entry.into());
+                    handler
+                        .spaces()?
+                        .insert_entry(entry, req.auth)
+                        .await
+                        .map(|(entry, inserted)| {
+                            if inserted {
+                                InsertEntrySuccess::Inserted(entry)
+                            } else {
+                                InsertEntrySuccess::Obsolete
+                            }
+                        })
+                        .map_err(map_err)
+                })
+                .await
+            }
+            InsertSecret(msg) => {
+                chan.rpc(msg, self, |handler, req| async move {
+                    handler
+                        .spaces()?
+                        .insert_secret(req.secret)
+                        .await
+                        .map(|_| InsertSecretResponse)
+                        .map_err(map_err)
+                })
+                .await
+            }
+            GetEntries(msg) => {
+                chan.try_server_streaming(msg, self, |handler, req| async move {
+                    let stream = handler
+                        .spaces()?
+                        .get_entries(req.namespace, req.range)
+                        .await
+                        .map_err(map_err)?;
+                    Ok(stream.map(|res| res.map(GetEntriesResponse).map_err(map_err)))
+                })
+                .await
+            }
+            GetEntry(msg) => {
+                chan.rpc(msg, self, |handler, req| async move {
+                    handler
+                        .spaces()?
+                        .get_entry(req.namespace, req.subspace, req.path)
+                        .await
+                        .map(|entry| GetEntryResponse(entry.map(Into::into)))
+                        .map_err(map_err)
+                })
+                .await
+            }
+            CreateNamespace(msg) => {
+                chan.rpc(msg, self, |handler, req| async move {
+                    handler
+                        .spaces()?
+                        .create_namespace(req.kind, req.owner)
+                        .await
+                        .map(CreateNamespaceResponse)
+                        .map_err(map_err)
+                })
+                .await
+            }
+            CreateUser(msg) => {
+                chan.rpc(msg, self, |handler, _| async move {
+                    handler
+                        .spaces()?
+                        .create_user()
+                        .await
+                        .map(CreateUserResponse)
+                        .map_err(map_err)
+                })
+                .await
+            }
+            DelegateCaps(msg) => {
+                chan.rpc(msg, self, |handler, req| async move {
+                    handler
+                        .spaces()?
+                        .delegate_caps(req.from, req.access_mode, req.to)
+                        .await
+                        .map(DelegateCapsResponse)
+                        .map_err(map_err)
+                })
+                .await
+            }
+            ImportCaps(msg) => {
+                chan.rpc(msg, self, |handler, req| async move {
+                    handler
+                        .spaces()?
+                        .import_caps(req.caps)
+                        .await
+                        .map(|_| ImportCapsResponse)
+                        .map_err(map_err)
+                })
+                .await
+            }
+            SyncWithPeer(msg) => {
+                chan.bidi_streaming(msg, self, |handler, req, update_stream| {
+                    // TODO: refactor to use less tasks
+                    let (events_tx, events_rx) = tokio::sync::mpsc::channel(32);
+                    tokio::task::spawn(async move {
+                        if let Err(err) =
+                            sync_with_peer(handler, req, events_tx.clone(), update_stream).await
+                        {
+                            let _ = events_tx.send(Err(err.into())).await;
                         }
-                    })
-                    .map_err(map_err)
-            })
-            .await
+                    });
+                    ReceiverStream::new(events_rx)
+                })
+                .await
+            }
+            SyncWithPeerUpdate(_) => Err(RpcServerError::UnexpectedStartMessage),
         }
-        InsertEntry(msg) => {
-            chan.rpc(msg, engine, |engine, req| async move {
-                let entry = EntryOrForm::Form(req.entry.into());
-                engine
-                    .insert_entry(entry, req.auth)
-                    .await
-                    .map(|(entry, inserted)| {
-                        if inserted {
-                            InsertEntrySuccess::Inserted(entry)
-                        } else {
-                            InsertEntrySuccess::Obsolete
-                        }
-                    })
-                    .map_err(map_err)
-            })
-            .await
-        }
-        InsertSecret(msg) => {
-            chan.rpc(msg, engine, |engine, req| async move {
-                engine
-                    .insert_secret(req.secret)
-                    .await
-                    .map(|_| InsertSecretResponse)
-                    .map_err(map_err)
-            })
-            .await
-        }
-        GetEntries(msg) => {
-            chan.try_server_streaming(msg, engine, |engine, req| async move {
-                let stream = engine
-                    .get_entries(req.namespace, req.range)
-                    .await
-                    .map_err(map_err)?;
-                Ok(stream.map(|res| res.map(GetEntriesResponse).map_err(map_err)))
-            })
-            .await
-        }
-        GetEntry(msg) => {
-            chan.rpc(msg, engine, |engine, req| async move {
-                engine
-                    .get_entry(req.namespace, req.subspace, req.path)
-                    .await
-                    .map(|entry| GetEntryResponse(entry.map(Into::into)))
-                    .map_err(map_err)
-            })
-            .await
-        }
-        CreateNamespace(msg) => {
-            chan.rpc(msg, engine, |engine, req| async move {
-                engine
-                    .create_namespace(req.kind, req.owner)
-                    .await
-                    .map(CreateNamespaceResponse)
-                    .map_err(map_err)
-            })
-            .await
-        }
-        CreateUser(msg) => {
-            chan.rpc(msg, engine, |engine, _| async move {
-                engine
-                    .create_user()
-                    .await
-                    .map(CreateUserResponse)
-                    .map_err(map_err)
-            })
-            .await
-        }
-        DelegateCaps(msg) => {
-            chan.rpc(msg, engine, |engine, req| async move {
-                engine
-                    .delegate_caps(req.from, req.access_mode, req.to)
-                    .await
-                    .map(DelegateCapsResponse)
-                    .map_err(map_err)
-            })
-            .await
-        }
-        ImportCaps(msg) => {
-            chan.rpc(msg, engine, |engine, req| async move {
-                engine
-                    .import_caps(req.caps)
-                    .await
-                    .map(|_| ImportCapsResponse)
-                    .map_err(map_err)
-            })
-            .await
-        }
-        SyncWithPeer(msg) => {
-            chan.bidi_streaming(msg, engine, |engine, req, update_stream| {
-                // TODO: refactor to use less tasks
-                let (events_tx, events_rx) = tokio::sync::mpsc::channel(32);
-                let engine = engine.clone();
-                tokio::task::spawn(async move {
-                    if let Err(err) =
-                        sync_with_peer(engine, req, events_tx.clone(), update_stream).await
-                    {
-                        let _ = events_tx.send(Err(err.into())).await;
-                    }
-                });
-                ReceiverStream::new(events_rx)
-            })
-            .await
-        }
-        SyncWithPeerUpdate(_) => Err(RpcServerError::UnexpectedStartMessage),
     }
 }
 
 // TODO: Try to use the streams directly instead of spawning two tasks.
-async fn sync_with_peer(
-    engine: Engine,
+async fn sync_with_peer<D: Store>(
+    handler: Handler<D>,
     req: SyncWithPeerRequest,
     events_tx: mpsc::Sender<RpcResult<SyncWithPeerResponse>>,
     mut update_stream: impl Stream<Item = SyncWithPeerUpdate> + Unpin + Send + 'static,
 ) -> anyhow::Result<()> {
+    let engine = handler.spaces()?;
     let handle = engine
         .sync_with_peer(req.peer, req.init)
         .await

--- a/iroh/src/node/rpc/spaces.rs
+++ b/iroh/src/node/rpc/spaces.rs
@@ -1,0 +1,164 @@
+use anyhow::Result;
+use futures_lite::Stream;
+use futures_util::SinkExt;
+use futures_util::StreamExt;
+use iroh_base::rpc::{RpcError, RpcResult};
+use iroh_willow::Engine;
+use quic_rpc::server::{RpcChannel, RpcServerError};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::node::IrohServerEndpoint;
+use crate::rpc_protocol::spaces::*;
+use crate::rpc_protocol::RpcService;
+
+fn map_err(err: anyhow::Error) -> RpcError {
+    RpcError::from(err)
+}
+
+pub(crate) async fn handle_rpc_request(
+    engine: Engine,
+    msg: Request,
+    chan: RpcChannel<RpcService, IrohServerEndpoint>,
+) -> Result<(), RpcServerError<IrohServerEndpoint>> {
+    use Request::*;
+    match msg {
+        IngestEntry(msg) => {
+            chan.rpc(msg, engine, |engine, req| async move {
+                engine
+                    .ingest_entry(req.authorised_entry)
+                    .await
+                    .map(|_| IngestEntryResponse)
+                    .map_err(map_err)
+            })
+            .await
+        }
+        InsertEntry(msg) => {
+            chan.rpc(msg, engine, |engine, req| async move {
+                engine
+                    .insert_entry(req.entry, req.auth)
+                    .await
+                    .map(|_| InsertEntryResponse)
+                    .map_err(map_err)
+            })
+            .await
+        }
+        InsertSecret(msg) => {
+            chan.rpc(msg, engine, |engine, req| async move {
+                engine
+                    .insert_secret(req.secret)
+                    .await
+                    .map(|_| InsertSecretResponse)
+                    .map_err(map_err)
+            })
+            .await
+        }
+        GetEntries(msg) => {
+            chan.try_server_streaming(msg, engine, |engine, req| async move {
+                let stream = engine
+                    .get_entries(req.namespace, req.range)
+                    .await
+                    .map_err(map_err)?;
+                Ok(stream.map(|res| res.map(|e| GetEntriesResponse(e.into())).map_err(map_err)))
+            })
+            .await
+        }
+        CreateNamespace(msg) => {
+            chan.rpc(msg, engine, |engine, req| async move {
+                engine
+                    .create_namespace(req.kind, req.owner)
+                    .await
+                    .map(CreateNamespaceResponse)
+                    .map_err(map_err)
+            })
+            .await
+        }
+        CreateUser(msg) => {
+            chan.rpc(msg, engine, |engine, _| async move {
+                engine
+                    .create_user()
+                    .await
+                    .map(CreateUserResponse)
+                    .map_err(map_err)
+            })
+            .await
+        }
+        DelegateCaps(msg) => {
+            chan.rpc(msg, engine, |engine, req| async move {
+                engine
+                    .delegate_caps(req.from, req.access_mode, req.to)
+                    .await
+                    .map(DelegateCapsResponse)
+                    .map_err(map_err)
+            })
+            .await
+        }
+        ImportCaps(msg) => {
+            chan.rpc(msg, engine, |engine, req| async move {
+                engine
+                    .import_caps(req.caps)
+                    .await
+                    .map(|_| ImportCapsResponse)
+                    .map_err(map_err)
+            })
+            .await
+        }
+        // ResolveInterests(msg) => {
+        //     chan.rpc(msg, engine, |engine, req| async move {
+        //         engine
+        //             .resolve_interests(req.interests)
+        //             .await
+        //             .map(ResolveInterestsResponse)
+        //             .map_err(map_err)
+        //     })
+        //     .await
+        // }
+        SyncWithPeer(msg) => {
+            chan.bidi_streaming(msg, engine, |engine, req, update_stream| {
+                // TODO: refactor to use less tasks
+                let (events_tx, events_rx) = tokio::sync::mpsc::channel(32);
+                tokio::task::spawn(async move {
+                    if let Err(err) =
+                        sync_with_peer(engine, req, events_tx.clone(), update_stream).await
+                    {
+                        let _ = events_tx.send(Err(err.into())).await;
+                    }
+                });
+                ReceiverStream::new(events_rx)
+            })
+            .await
+        }
+        SyncWithPeerUpdate(_) => Err(RpcServerError::UnexpectedStartMessage),
+    }
+}
+
+async fn sync_with_peer(
+    engine: Engine,
+    req: SyncWithPeerRequest,
+    events_tx: mpsc::Sender<RpcResult<SyncWithPeerResponse>>,
+    mut update_stream: impl Stream<Item = SyncWithPeerUpdate> + Unpin + Send + 'static,
+) -> anyhow::Result<()> {
+    let handle = engine
+        .sync_with_peer(req.peer, req.init)
+        .await
+        .map_err(map_err)?;
+    let (mut update_sink, mut events) = handle.split();
+    tokio::task::spawn(async move {
+        while let Some(update) = update_stream.next().await {
+            if let Err(_) = update_sink.send(update.0).await {
+                break;
+            }
+        }
+    });
+    tokio::task::spawn(async move {
+        while let Some(event) = events.next().await {
+            if let Err(_) = events_tx
+                .send(Ok(SyncWithPeerResponse::Event(event.into())))
+                .await
+            {
+                break;
+            }
+        }
+    });
+    Ok(())
+}

--- a/iroh/src/rpc_protocol.rs
+++ b/iroh/src/rpc_protocol.rs
@@ -23,6 +23,7 @@ pub mod docs;
 pub mod gossip;
 pub mod net;
 pub mod node;
+pub mod spaces;
 pub mod tags;
 
 /// The RPC service for the iroh provider process.
@@ -41,6 +42,7 @@ pub enum Request {
     Tags(tags::Request),
     Authors(authors::Request),
     Gossip(gossip::Request),
+    Spaces(spaces::Request),
 }
 
 /// The response enum, listing all possible responses.
@@ -55,6 +57,7 @@ pub enum Response {
     Docs(docs::Response),
     Authors(authors::Response),
     Gossip(gossip::Response),
+    Spaces(spaces::Response),
 }
 
 impl quic_rpc::Service for RpcService {

--- a/iroh/src/rpc_protocol/spaces.rs
+++ b/iroh/src/rpc_protocol/spaces.rs
@@ -1,4 +1,5 @@
 use iroh_base::rpc::{RpcError, RpcResult};
+use iroh_blobs::Hash;
 use iroh_net::NodeId;
 use iroh_willow::{
     form::{AuthForm, SubspaceForm, TimestampForm},
@@ -20,8 +21,6 @@ use iroh_willow::{
 use nested_enum_utils::enum_conversions;
 use quic_rpc_derive::rpc_requests;
 use serde::{Deserialize, Serialize};
-
-use crate::client::spaces::PayloadForm;
 
 use super::RpcService;
 
@@ -228,6 +227,24 @@ impl From<FullEntryForm> for iroh_willow::form::EntryForm {
             path: value.path,
             timestamp: value.timestamp,
             payload: value.payload.into(),
+        }
+    }
+}
+
+/// Options for setting the payload on the a new entry.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum PayloadForm {
+    /// Make sure the hash is available in the blob store, and use the length from the blob store.
+    Checked(Hash),
+    /// Insert with the specified hash and length, without checking if the blob is in the local blob store.
+    Unchecked(Hash, u64),
+}
+
+impl From<PayloadForm> for iroh_willow::form::PayloadForm {
+    fn from(value: PayloadForm) -> Self {
+        match value {
+            PayloadForm::Checked(hash) => Self::Hash(hash),
+            PayloadForm::Unchecked(hash, len) => Self::HashUnchecked(hash, len),
         }
     }
 }

--- a/iroh/src/rpc_protocol/spaces.rs
+++ b/iroh/src/rpc_protocol/spaces.rs
@@ -193,7 +193,7 @@ pub enum SyncWithPeerResponse {
     Event(Event),
 }
 
-/// Either a [`Entry`] or a [`EntryForm`].
+/// Either a complete [`Entry`] or a [`FullEntryForm`].
 #[derive(Debug, Serialize, Deserialize)]
 pub enum EntryOrForm {
     Entry(#[serde(with = "data_model::serde_encoding::entry")] Entry),

--- a/iroh/src/rpc_protocol/spaces.rs
+++ b/iroh/src/rpc_protocol/spaces.rs
@@ -1,0 +1,158 @@
+use iroh_base::rpc::{RpcError, RpcResult};
+use iroh_net::NodeId;
+use iroh_willow::{
+    form::{AuthForm, SerdeEntryOrForm},
+    interest::{CapSelector, CapabilityPack, DelegateTo},
+    proto::{
+        data_model::{self, serde_encoding::SerdeEntry, AuthorisedEntry},
+        grouping::{self, Range3d},
+        keys::{NamespaceId, NamespaceKind, UserId},
+        meadowcap::{self, AccessMode, SecretKey},
+    },
+    session::{
+        intents::{serde_encoding::Event, IntentUpdate},
+        SessionInit,
+    },
+};
+use nested_enum_utils::enum_conversions;
+use quic_rpc_derive::rpc_requests;
+use serde::{Deserialize, Serialize};
+
+use super::RpcService;
+
+#[allow(missing_docs)]
+#[derive(strum::Display, Debug, Serialize, Deserialize)]
+#[enum_conversions(super::Request)]
+#[rpc_requests(RpcService)]
+pub enum Request {
+    #[rpc(response = RpcResult<IngestEntryResponse>)]
+    IngestEntry(IngestEntryRequest),
+    #[rpc(response = RpcResult<InsertEntryResponse>)]
+    InsertEntry(InsertEntryRequest),
+    #[rpc(response = RpcResult<InsertSecretResponse>)]
+    InsertSecret(InsertSecretRequest),
+    #[try_server_streaming(create_error = RpcError, item_error = RpcError, item = GetEntriesResponse)]
+    GetEntries(GetEntriesRequest),
+    #[rpc(response = RpcResult<CreateNamespaceResponse>)]
+    CreateNamespace(CreateNamespaceRequest),
+    #[rpc(response = RpcResult<CreateUserResponse>)]
+    CreateUser(CreateUserRequest),
+    #[rpc(response = RpcResult<DelegateCapsResponse>)]
+    DelegateCaps(DelegateCapsRequest),
+    #[rpc(response = RpcResult<ImportCapsResponse>)]
+    ImportCaps(ImportCapsRequest),
+    // #[rpc(response = RpcResult<ResolveInterestsResponse>)]
+    // ResolveInterests(ResolveInterestsRequest),
+    #[bidi_streaming(update = SyncWithPeerUpdate, response = RpcResult<SyncWithPeerResponse>)]
+    SyncWithPeer(SyncWithPeerRequest),
+    SyncWithPeerUpdate(SyncWithPeerUpdate),
+}
+
+#[allow(missing_docs)]
+#[derive(strum::Display, Debug, Serialize, Deserialize)]
+#[enum_conversions(super::Response)]
+pub enum Response {
+    IngestEntry(RpcResult<IngestEntryResponse>),
+    InsertEntry(RpcResult<InsertEntryResponse>),
+    InsertSecret(RpcResult<InsertSecretResponse>),
+    GetEntries(RpcResult<GetEntriesResponse>),
+    CreateNamespace(RpcResult<CreateNamespaceResponse>),
+    CreateUser(RpcResult<CreateUserResponse>),
+    DelegateCaps(RpcResult<DelegateCapsResponse>),
+    ImportCaps(RpcResult<ImportCapsResponse>),
+    // ResolveInterests(RpcResult<ResolveInterestsResponse>),
+    SyncWithPeer(RpcResult<SyncWithPeerResponse>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IngestEntryRequest {
+    #[serde(with = "data_model::serde_encoding::authorised_entry")]
+    pub authorised_entry: AuthorisedEntry,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IngestEntryResponse;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InsertEntryRequest {
+    pub entry: SerdeEntryOrForm,
+    pub auth: AuthForm,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InsertEntryResponse;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InsertSecretRequest {
+    pub secret: SecretKey,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InsertSecretResponse;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetEntriesRequest {
+    pub namespace: NamespaceId,
+    #[serde(with = "grouping::serde_encoding::range_3d")]
+    pub range: Range3d,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetEntriesResponse(pub SerdeEntry);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateNamespaceRequest {
+    pub kind: NamespaceKind,
+    pub owner: UserId,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateNamespaceResponse(pub NamespaceId);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateUserRequest;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateUserResponse(pub UserId);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DelegateCapsRequest {
+    pub from: CapSelector,
+    #[serde(with = "meadowcap::serde_encoding::access_mode")]
+    pub access_mode: AccessMode,
+    pub to: DelegateTo,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DelegateCapsResponse(pub Vec<CapabilityPack>);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportCapsRequest {
+    pub caps: Vec<CapabilityPack>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportCapsResponse;
+
+// #[derive(Debug, Serialize, Deserialize)]
+// pub struct ResolveInterestsRequest {
+//     pub interests: Interests,
+// }
+
+// #[derive(Debug, Serialize, Deserialize)]
+// pub struct ResolveInterestsResponse(pub InterestMap);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncWithPeerRequest {
+    pub peer: NodeId,
+    pub init: SessionInit,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncWithPeerUpdate(pub IntentUpdate);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum SyncWithPeerResponse {
+    Started,
+    Event(Event),
+}

--- a/iroh/tests/spaces.rs
+++ b/iroh/tests/spaces.rs
@@ -1,0 +1,134 @@
+use anyhow::Result;
+use futures_lite::StreamExt;
+use iroh::client::{spaces::EntryForm, Iroh};
+use iroh_net::{key::SecretKey, NodeAddr};
+use iroh_willow::{
+    interest::{CapSelector, DelegateTo, RestrictArea},
+    proto::{
+        data_model::{Path, PathExt},
+        grouping::{Area, Range3d},
+        keys::NamespaceKind,
+        meadowcap::AccessMode,
+    },
+    session::intents::Completion,
+};
+use tracing::info;
+
+/// Spawn an iroh node in a separate thread and tokio runtime, and return
+/// the address and client.
+async fn spawn_node() -> (NodeAddr, Iroh) {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(async move {
+            let secret_key = SecretKey::generate();
+            let node = iroh::node::Builder::default()
+                .secret_key(secret_key)
+                .relay_mode(iroh_net::relay::RelayMode::Disabled)
+                .node_discovery(iroh::node::DiscoveryConfig::None)
+                .spawn()
+                .await?;
+            let addr = node.net().node_addr().await?;
+            sender.send((addr, node.client().clone())).unwrap();
+            node.cancel_token().cancelled().await;
+            anyhow::Ok(())
+        })?;
+        anyhow::Ok(())
+    });
+    receiver.await.unwrap()
+}
+
+#[tokio::test]
+async fn spaces_smoke() -> Result<()> {
+    iroh_test::logging::setup_multithreaded();
+    let (alfie_addr, alfie) = spawn_node().await;
+    let (betty_addr, betty) = spawn_node().await;
+    info!("alfie is {}", alfie_addr.node_id.fmt_short());
+    info!("betty is {}", betty_addr.node_id.fmt_short());
+
+    let betty_user = betty.spaces().create_user().await?;
+    let alfie_user = alfie.spaces().create_user().await?;
+    let alfie_space = alfie
+        .spaces()
+        .create(NamespaceKind::Owned, alfie_user)
+        .await?;
+
+    let namespace = alfie_space.namespace_id();
+
+    alfie_space
+        .insert_bytes(
+            EntryForm::new(alfie_user, Path::from_bytes(&[b"foo", b"bar"])?),
+            "hello betty",
+        )
+        .await?;
+    alfie_space
+        .insert_bytes(
+            EntryForm::new(alfie_user, Path::from_bytes(&[b"foo", b"boo"])?),
+            "this is alfie",
+        )
+        .await?;
+
+    let ticket = alfie_space
+        .share(betty_user, AccessMode::Read, RestrictArea::None)
+        .await?;
+
+    println!("ticket {ticket:?}");
+    let (betty_space, betty_sync_intent) = betty.spaces().import_and_sync(ticket).await?;
+
+    let mut completion = betty_sync_intent.complete_all().await;
+    assert_eq!(completion.len(), 1);
+    let alfie_completion = completion.remove(&alfie_addr.node_id).unwrap();
+    assert_eq!(alfie_completion?, Completion::Complete);
+
+    let betty_entries: Vec<_> = betty_space
+        .get_many(Range3d::new_full())
+        .await?
+        .try_collect()
+        .await?;
+    assert_eq!(betty_entries.len(), 2);
+
+    let res = betty_space
+        .insert_bytes(
+            EntryForm::new(betty_user, Path::from_bytes(&[b"hello"])?),
+            "this is betty",
+        )
+        .await;
+    println!("insert without cap: {res:?}");
+    assert!(res.is_err());
+
+    let area = Area::new_subspace(betty_user);
+    let caps = alfie
+        .spaces()
+        .delegate_caps(
+            CapSelector::any(namespace),
+            AccessMode::Write,
+            DelegateTo::new(betty_user, RestrictArea::Restrict(area)),
+        )
+        .await?;
+    betty.spaces().import_caps(caps).await?;
+
+    let res = betty_space
+        .insert_bytes(
+            EntryForm::new(betty_user, Path::from_bytes(&[b"hello"])?),
+            "this is betty",
+        )
+        .await;
+    assert!(res.is_ok());
+
+    alfie.net().add_node_addr(betty_addr.clone()).await?;
+    let mut alfie_sync_intent = alfie_space
+        .sync_once(betty_addr.node_id, Default::default())
+        .await?;
+    alfie_sync_intent.complete().await?;
+
+    let alfie_entries: Vec<_> = alfie_space
+        .get_many(Range3d::new_full())
+        .await?
+        .try_collect()
+        .await?;
+    assert_eq!(alfie_entries.len(), 3);
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

* Adds better serde compat to willow
* Integrates willow engine in iroh
* Integrates willow in iroh as `spaces` RPC
* Add `spaces` client

Based on #2231 

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
