### PR TITLE
fix(iroh-willow): Remove `flume` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,7 +3017,6 @@ dependencies = [
  "curve25519-dalek",
  "derive_more",
  "ed25519-dalek",
- "flume",
  "futures-buffered",
  "futures-concurrency",
  "futures-lite 2.3.0",

--- a/iroh-willow/Cargo.toml
+++ b/iroh-willow/Cargo.toml
@@ -20,7 +20,6 @@ bytes = { version = "1.4", features = ["serde"] }
 curve25519-dalek = { version = "4.1.3", features = [ "digest", "rand_core", "serde", ] }
 derive_more = { version = "1.0.0-beta.6", features = [ "debug", "deref", "display", "from", "try_into", "into", "as_ref", "try_from", ] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
-flume = "0.11"
 futures-buffered = "0.2.6"
 futures-concurrency = "7.6.0"
 futures-lite = "2.3.0"


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
Purging `flume` as a dependency from `iroh-willow`.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Well, there's the whole "make a last send in `impl Drop`" thing.
<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
