### PR TITLE
chore(ci): move mac builds over to arm box

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
                 release-os: darwin
                 release-arch: x86_64
                 cargo_targets: "x86_64-apple-darwin"
-                runner: [self-hosted, macOS, X64]
+                runner: [self-hosted, macOS, ARM64]
               - name: macOS-arm-latest
                 os: macOS-latest
                 release-os: darwin


### PR DESCRIPTION
## Description

Time to retire the x64 box. It's both slow and limits our bandwidth on the main CI pipe. This job is a relic from a time where we didn't yet have m1 runners.

I've tested the workflow manually and things seem to be fine.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [ ] All breaking changes documented.
