### PR TITLE
deps(iroh-gossip): Do not depend directly on Quinn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,6 @@ dependencies = [
  "iroh-blake3",
  "iroh-metrics",
  "iroh-net",
- "iroh-quinn",
  "iroh-test",
  "postcard",
  "rand",

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -30,7 +30,6 @@ rand_core = "0.6.4"
 serde = { version = "1.0.164", features = ["derive"] }
 
 # net dependencies (optional)
-quinn = { package = "iroh-quinn", version = "0.11", optional = true }
 futures-lite = { version = "2.3", optional = true }
 futures-concurrency = { version = "7.6.1", optional = true }
 futures-util = { version = "0.3.30", optional = true }


### PR DESCRIPTION
## Description

iroh-gossip has a direct dependency on Quinn but does not need it. Remove this.

## Breaking Changes

none

## Notes & open questions

Please do not merge before #2595 is merged.  I'm trying to not modify that PR any further.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~
