### PR TITLE
ref(iroh-net): Do not add the NodeId in the magicsock span field

### DIFF
--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -1244,7 +1244,7 @@ impl MagicSock {
     }
 
     /// Triggers an address discovery. The provided why string is for debug logging only.
-    #[instrument(skip_all, fields(me = %self.me))]
+    #[instrument(skip_all)]
     fn re_stun(&self, why: &'static str) {
         debug!("re_stun: {}", why);
         inc!(MagicsockMetrics, re_stun_calls);
@@ -1371,8 +1371,8 @@ impl Handle {
             );
         }
 
-        Self::with_name(me.clone(), opts)
-            .instrument(error_span!("magicsock", %me))
+        Self::with_name(me, opts)
+            .instrument(error_span!("magicsock"))
             .await
     }
 


### PR DESCRIPTION
## Description

Since we have made MagicSock private it should always be created via the Endpoint, unless we are internally messing around with tests or so.  Because of this we can make sure that the Endpoint always attaches the correct "me" field to the span.  Reducing the amount of noise in the default log output.

## Breaking Changes

None

## Notes & open questions

Please do not merge before #2595 is merged.  I'm trying to not add any further changes to that PR.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~
