### PR TITLE
fix(iroh-willow): actually create subspace capability

### DIFF
--- a/iroh-willow/src/form.rs
+++ b/iroh-willow/src/form.rs
@@ -114,6 +114,12 @@ impl EntryForm {
             payload: PayloadForm::Bytes(payload.into()),
         }
     }
+
+    /// Sets the subspace for the entry.
+    pub fn subspace(mut self, subspace: SubspaceId) -> Self {
+        self.subspace_id = SubspaceForm::Exact(subspace);
+        self
+    }
 }
 
 /// Select which capability to use for authenticating a new entry.


### PR DESCRIPTION
## Description

Subspace capabilities were not created when creating owned namespaces. Fixed that.
Also adds a test written by @Voronar, thanks!

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
