### PR TITLE
fix(iroh-net): reduce noise in swarm discovery due to republish

### DIFF
--- a/iroh-blobs/src/downloader.rs
+++ b/iroh-blobs/src/downloader.rs
@@ -411,7 +411,7 @@ impl Downloader {
         }
     }
 
-    /// Declare that certains nodes can be used to download a hash.
+    /// Declare that certain nodes can be used to download a hash.
     ///
     /// Note that this does not start a download, but only provides new nodes to already queued
     /// downloads. Use [`Self::queue`] to queue a download.


### PR DESCRIPTION
## Description

Since republish occurs more or less every second, for every peer in the local network, every second we insert it in the node_map (which includes locking), print a debug line, and for requesters, re-send a value that was previously sent (since every time a new sender is added we immediately send known values). This pr makes it so that we do all this only when new values are found.

## Breaking Changes

- swarm discovery will no longer send consecutive repeated values

## Notes & open questions

the typo is unrelated to the pr but was flagged by ci

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [ ] ~~Tests if relevant.~~
- [x] All breaking changes documented.
