### PR TITLE
fix(iroh-blobs): Turn `println!` into `tracing::debug!`

### DIFF
--- a/iroh-blobs/src/store/fs.rs
+++ b/iroh-blobs/src/store/fs.rs
@@ -1814,11 +1814,11 @@ impl ActorState {
                         data.size(),
                         &hash,
                     )?;
-                    println!("creating complete entry for {}", hash.to_hex());
+                    tracing::debug!("creating complete entry for {}", hash.to_hex());
                     BaoFileHandle::new_complete(self.create_options.clone(), hash, data, outboard)
                 }
                 EntryState::Partial { .. } => {
-                    println!("creating partial entry for {}", hash.to_hex());
+                    tracing::debug!("creating partial entry for {}", hash.to_hex());
                     BaoFileHandle::incomplete_file(self.create_options.clone(), hash)?
                 }
             }


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
@divagant-martian noticed there's a `println!` in iroh-blobs. I turned this into a `tracing::debug!` instead.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
