### PR TITLE
fix(iroh-blobs): Timeout based on correct `max_write_duration` option

### DIFF
--- a/iroh-blobs/src/store/fs.rs
+++ b/iroh-blobs/src/store/fs.rs
@@ -1495,7 +1495,7 @@ impl Actor {
                     let mut delete_after_commit = Default::default();
                     let mut tables = Tables::new(&txn, &mut delete_after_commit)?;
                     let count = self.state.options.batch.max_write_batch;
-                    let timeout = tokio::time::sleep(self.state.options.batch.max_read_duration);
+                    let timeout = tokio::time::sleep(self.state.options.batch.max_write_duration);
                     tokio::pin!(timeout);
                     for _ in 0..count {
                         tokio::select! {


### PR DESCRIPTION
## Description

This fixes a small copy and paste bug that was introduced in #2622, here: https://github.com/n0-computer/iroh/pull/2622/files?diff=unified&w=0#diff-bbe46ca272a808bb1c94619ab3264586a47a6ec6e0f7cd5a63dba5e99099241bL1521-R1526 (You need to load the diff for the `fs.rs` file) 
<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
Tests would be nice, but I'm looking at other things right now, so I'd prefer to merge this first :S

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
