### PR TITLE
fix(iroh-blobs): Demote `warn!` to `trace!` logs

### DIFF
--- a/iroh-blobs/src/downloader/progress.rs
+++ b/iroh-blobs/src/downloader/progress.rs
@@ -137,9 +137,9 @@ impl ProgressSender for BroadcastProgressSender {
         // making sure that the lock is not held across an await point.
         let futs = {
             let mut inner = self.shared.lock();
-            tracing::warn!(?msg, state_pre=?inner.state, "send to {}", inner.subscribers.len());
+            tracing::trace!(?msg, state_pre = ?inner.state, "send to {}", inner.subscribers.len());
             inner.on_progress(msg.clone());
-            tracing::warn!(state_post=?inner.state, "send");
+            tracing::trace!(state_post = ?inner.state, "send");
             let futs = inner
                 .subscribers
                 .iter_mut()


### PR DESCRIPTION
## Description

I don't think these logs were meant to be `warn!` logs. I suspect those were originally added for debugging.
<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
Should we remove them altogether?

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
