### PR TITLE
fix(iroh-blobs): unconditionally delete blobs

### DIFF
--- a/iroh-blobs/src/store/fs.rs
+++ b/iroh-blobs/src/store/fs.rs
@@ -79,6 +79,7 @@ use bao_tree::io::{
 use bytes::Bytes;
 use futures_lite::{Stream, StreamExt};
 
+use genawaiter::rc::{Co, Gen};
 use iroh_base::hash::{BlobFormat, Hash, HashAndFormat};
 use iroh_io::AsyncSliceReader;
 use redb::{AccessGuard, DatabaseError, ReadableTable, StorageError};
@@ -103,6 +104,7 @@ use crate::{
             tables::BaoFilePart,
             util::{overwrite_and_sync, read_and_remove},
         },
+        GcMarkEvent, GcSweepEvent,
     },
     util::{
         compute_outboard,
@@ -123,7 +125,7 @@ use self::test_support::EntryData;
 use super::{
     bao_file::{BaoFileConfig, BaoFileHandle, BaoFileHandleWeak, CreateCb},
     temp_name, BaoBatchWriter, BaoBlobSize, ConsistencyCheckProgress, EntryStatus, ExportMode,
-    ExportProgressCb, ImportMode, ImportProgress, Map, TempCounterMap,
+    ExportProgressCb, ImportMode, ImportProgress, Map, ReadableStore, TempCounterMap,
 };
 
 /// Location of the data.
@@ -628,6 +630,11 @@ pub(crate) enum ActorMessage {
         hashes: Vec<Hash>,
         tx: oneshot::Sender<ActorResult<()>>,
     },
+    /// Modification method: try to delete the data for a number of hashes
+    GcDelete {
+        hashes: Vec<Hash>,
+        tx: oneshot::Sender<ActorResult<()>>,
+    },
     /// Sync the entire database to disk.
     ///
     /// This just makes sure that there is no write transaction open.
@@ -671,7 +678,8 @@ impl ActorMessage {
             | Self::SetTag { .. }
             | Self::CreateTag { .. }
             | Self::SetFullEntryState { .. }
-            | Self::Delete { .. } => MessageCategory::ReadWrite,
+            | Self::Delete { .. }
+            | Self::GcDelete { .. } => MessageCategory::ReadWrite,
             Self::UpdateInlineOptions { .. }
             | Self::Sync { .. }
             | Self::Shutdown { .. }
@@ -885,6 +893,12 @@ impl StoreInner {
     async fn delete(&self, hashes: Vec<Hash>) -> OuterResult<()> {
         let (tx, rx) = oneshot::channel();
         self.tx.send(ActorMessage::Delete { hashes, tx }).await?;
+        Ok(rx.await??)
+    }
+
+    async fn gc_delete(&self, hashes: Vec<Hash>) -> OuterResult<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tx.send(ActorMessage::GcDelete { hashes, tx }).await?;
         Ok(rx.await??)
     }
 
@@ -1380,20 +1394,71 @@ impl super::Store for Store {
         G: Fn() -> Gut,
         Gut: Future<Output = BTreeSet<Hash>> + Send,
     {
-        let inner = self.0.clone();
-        super::gc_run_loop(
-            self,
-            config,
-            move || {
-                let inner = inner.clone();
-                async move {
-                    inner.gc_start().await?;
-                    Ok(())
+        tracing::info!("Starting GC task with interval {:?}", config.period);
+        let mut live = BTreeSet::new();
+        'outer: loop {
+            if let Err(cause) = self.0.gc_start().await {
+                tracing::debug!(
+                    "unable to notify the db of GC start: {cause}. Shutting down GC loop."
+                );
+                break;
+            }
+            // do delay before the two phases of GC
+            tokio::time::sleep(config.period).await;
+            tracing::debug!("Starting GC");
+            live.clear();
+
+            let p = protected_cb().await;
+            live.extend(p);
+
+            tracing::debug!("Starting GC mark phase");
+            let live_ref = &mut live;
+            let mut stream = Gen::new(|co| async move {
+                if let Err(e) = super::gc_mark_task(self, live_ref, &co).await {
+                    co.yield_(GcMarkEvent::Error(e)).await;
                 }
-            },
-            protected_cb,
-        )
-        .await
+            });
+            while let Some(item) = stream.next().await {
+                match item {
+                    GcMarkEvent::CustomDebug(text) => {
+                        tracing::debug!("{}", text);
+                    }
+                    GcMarkEvent::CustomWarning(text, _) => {
+                        tracing::warn!("{}", text);
+                    }
+                    GcMarkEvent::Error(err) => {
+                        tracing::error!("Fatal error during GC mark {}", err);
+                        continue 'outer;
+                    }
+                }
+            }
+            drop(stream);
+
+            tracing::debug!("Starting GC sweep phase");
+            let live_ref = &live;
+            let mut stream = Gen::new(|co| async move {
+                if let Err(e) = gc_sweep_task(self, live_ref, &co).await {
+                    co.yield_(GcSweepEvent::Error(e)).await;
+                }
+            });
+            while let Some(item) = stream.next().await {
+                match item {
+                    GcSweepEvent::CustomDebug(text) => {
+                        tracing::debug!("{}", text);
+                    }
+                    GcSweepEvent::CustomWarning(text, _) => {
+                        tracing::warn!("{}", text);
+                    }
+                    GcSweepEvent::Error(err) => {
+                        tracing::error!("Fatal error during GC mark {}", err);
+                        continue 'outer;
+                    }
+                }
+            }
+            if let Some(ref cb) = config.done_callback {
+                cb();
+            }
+        }
     }
 
     fn temp_tag(&self, value: HashAndFormat) -> TempTag {
@@ -1407,6 +1472,36 @@ impl super::Store for Store {
     async fn shutdown(&self) {
         self.0.shutdown().await;
     }
+}
+
+pub(super) async fn gc_sweep_task<'a>(
+    store: &'a Store,
+    live: &BTreeSet<Hash>,
+    co: &Co<GcSweepEvent>,
+) -> anyhow::Result<()> {
+    let blobs = store.blobs().await?.chain(store.partial_blobs().await?);
+    let mut count = 0;
+    let mut batch = Vec::new();
+    for hash in blobs {
+        let hash = hash?;
+        if !live.contains(&hash) {
+            batch.push(hash);
+            count += 1;
+        }
+        if batch.len() >= 100 {
+            store.0.gc_delete(batch.clone()).await?;
+            batch.clear();
+        }
+    }
+    if !batch.is_empty() {
+        store.0.gc_delete(batch).await?;
+    }
+    co.yield_(GcSweepEvent::CustomDebug(format!(
+        "deleted {} blobs",
+        count
+    )))
+    .await;
+    Ok(())
 }
 
 impl Actor {
@@ -2050,11 +2145,16 @@ impl ActorState {
         Ok(())
     }
 
-    fn delete(&mut self, tables: &mut Tables, hashes: Vec<Hash>) -> ActorResult<()> {
+    fn delete(&mut self, tables: &mut Tables, hashes: Vec<Hash>, force: bool) -> ActorResult<()> {
         for hash in hashes {
             if self.temp.as_ref().read().unwrap().contains(&hash) {
                 continue;
             }
+            if !force && self.protected.contains(&hash) {
+                tracing::debug!("protected hash, continuing {}", &hash.to_hex()[..8]);
+                continue;
+            }
+
             tracing::debug!("deleting {}", &hash.to_hex()[..8]);
             let handle = self.handles.remove(&hash);
             let entry = tables.blobs.remove(hash)?;
@@ -2271,7 +2371,11 @@ impl ActorState {
                 tx.send(res).ok();
             }
             ActorMessage::Delete { hashes, tx } => {
-                let res = self.delete(tables, hashes);
+                let res = self.delete(tables, hashes, true);
+                tx.send(res).ok();
+            }
+            ActorMessage::GcDelete { hashes, tx } => {
+                let res = self.delete(tables, hashes, false);
                 tx.send(res).ok();
             }
             ActorMessage::OnComplete { handle } => {

--- a/iroh-blobs/src/store/mem.rs
+++ b/iroh-blobs/src/store/mem.rs
@@ -228,8 +228,8 @@ impl super::Store for Store {
         self.inner.temp_tag(tag)
     }
 
-    async fn gc_start(&self) -> io::Result<()> {
-        Ok(())
+    async fn gc_run(&self, config: super::GcConfig) {
+        super::gc_run_loop(self, config, move || async { Ok(()) }).await
     }
 
     async fn delete(&self, hashes: Vec<Hash>) -> io::Result<()> {

--- a/iroh-blobs/src/store/mem.rs
+++ b/iroh-blobs/src/store/mem.rs
@@ -10,7 +10,8 @@ use futures_lite::{Stream, StreamExt};
 use iroh_base::hash::{BlobFormat, Hash, HashAndFormat};
 use iroh_io::AsyncSliceReader;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
     io,
     path::PathBuf,
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
@@ -228,8 +229,12 @@ impl super::Store for Store {
         self.inner.temp_tag(tag)
     }
 
-    async fn gc_run(&self, config: super::GcConfig) {
-        super::gc_run_loop(self, config, move || async { Ok(()) }).await
+    async fn gc_run<G, Gut>(&self, config: super::GcConfig, protected_cb: G)
+    where
+        G: Fn() -> Gut,
+        Gut: Future<Output = BTreeSet<Hash>> + Send,
+    {
+        super::gc_run_loop(self, config, move || async { Ok(()) }, protected_cb).await
     }
 
     async fn delete(&self, hashes: Vec<Hash>) -> io::Result<()> {

--- a/iroh-blobs/src/store/readonly_mem.rs
+++ b/iroh-blobs/src/store/readonly_mem.rs
@@ -2,7 +2,8 @@
 //!
 //! Main entry point is [Store].
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
+    future::Future,
     io,
     path::PathBuf,
     sync::Arc,
@@ -324,8 +325,12 @@ impl super::Store for Store {
         TempTag::new(inner, None)
     }
 
-    async fn gc_run(&self, config: super::GcConfig) {
-        super::gc_run_loop(self, config, move || async { Ok(()) }).await
+    async fn gc_run<G, Gut>(&self, config: super::GcConfig, protected_cb: G)
+    where
+        G: Fn() -> Gut,
+        Gut: Future<Output = BTreeSet<Hash>> + Send,
+    {
+        super::gc_run_loop(self, config, move || async { Ok(()) }, protected_cb).await
     }
 
     async fn delete(&self, _hashes: Vec<Hash>) -> io::Result<()> {

--- a/iroh-blobs/src/store/readonly_mem.rs
+++ b/iroh-blobs/src/store/readonly_mem.rs
@@ -324,8 +324,8 @@ impl super::Store for Store {
         TempTag::new(inner, None)
     }
 
-    async fn gc_start(&self) -> io::Result<()> {
-        Ok(())
+    async fn gc_run(&self, config: super::GcConfig) {
+        super::gc_run_loop(self, config, move || async { Ok(()) }).await
     }
 
     async fn delete(&self, _hashes: Vec<Hash>) -> io::Result<()> {

--- a/iroh-blobs/src/store/traits.rs
+++ b/iroh-blobs/src/store/traits.rs
@@ -1,5 +1,5 @@
 //! Traits for in-memory or persistent maps of blob with bao encoded outboards.
-use std::{collections::BTreeSet, future::Future, io, path::PathBuf};
+use std::{collections::BTreeSet, future::Future, io, path::PathBuf, time::Duration};
 
 use bao_tree::{
     io::fsm::{BaoContentItem, Outboard},
@@ -356,43 +356,10 @@ pub trait Store: ReadableStore + MapMut + std::fmt::Debug {
     /// Create a temporary pin for this store
     fn temp_tag(&self, value: HashAndFormat) -> TempTag;
 
-    /// Notify the store that a new gc phase is about to start.
+    /// Start the GC loop
     ///
-    /// This should not fail unless the store is shut down or otherwise in a
-    /// bad state. The gc task will shut itself down if this fails.
-    fn gc_start(&self) -> impl Future<Output = io::Result<()>> + Send;
-
-    /// Traverse all roots recursively and mark them as live.
-    ///
-    /// Poll this stream to completion to perform a full gc mark phase.
-    ///
-    /// Not polling this stream to completion is dangerous, since it might lead
-    /// to some live data being missed.
-    ///
-    /// The implementation of this method should do the minimum amount of work
-    /// to determine the live set. Actual deletion of garbage should be done
-    /// in the gc_sweep phase.
-    fn gc_mark(&self, live: &mut BTreeSet<Hash>) -> impl Stream<Item = GcMarkEvent> + Unpin {
-        Gen::new(|co| async move {
-            if let Err(e) = gc_mark_task(self, live, &co).await {
-                co.yield_(GcMarkEvent::Error(e)).await;
-            }
-        })
-    }
-
-    /// Remove all blobs that are not marked as live.
-    ///
-    /// Poll this stream to completion to perform a full gc sweep. Not polling this stream
-    /// to completion just means that some garbage will remain in the database.
-    ///
-    /// Sweeping might take long, but it can safely be done in the background.
-    fn gc_sweep(&self, live: &BTreeSet<Hash>) -> impl Stream<Item = GcSweepEvent> + Unpin {
-        Gen::new(|co| async move {
-            if let Err(e) = gc_sweep_task(self, live, &co).await {
-                co.yield_(GcSweepEvent::Error(e)).await;
-            }
-        })
-    }
+    /// The gc task will shut down, when dropping the returned future.
+    fn gc_run(&self, config: GcConfig) -> impl Future<Output = ()>;
 
     /// physically delete the given hashes from the store.
     fn delete(&self, hashes: Vec<Hash>) -> impl Future<Output = io::Result<()>> + Send;
@@ -547,6 +514,85 @@ async fn validate_impl(
         ));
     }
     Ok(())
+}
+
+/// Configuration for the GC mark and sweep.
+#[derive(derive_more::Debug)]
+pub struct GcConfig {
+    /// The period at which to execute the GC.
+    pub period: Duration,
+    /// An optional callback called everytime a GC round finishes.
+    #[debug("callback")]
+    pub done_callback: Option<Box<dyn Fn() + Send>>,
+}
+
+/// Implementation of the gc loop.
+pub(super) async fn gc_run_loop<S, F, Fut>(store: &S, config: GcConfig, start_cb: F)
+where
+    S: Store,
+    F: Fn() -> Fut,
+    Fut: Future<Output = io::Result<()>> + Send + 'static,
+{
+    tracing::info!("Starting GC task with interval {:?}", config.period);
+    let mut live = BTreeSet::new();
+    'outer: loop {
+        if let Err(cause) = start_cb().await {
+            tracing::debug!("unable to notify the db of GC start: {cause}. Shutting down GC loop.");
+            break;
+        }
+        // do delay before the two phases of GC
+        tokio::time::sleep(config.period).await;
+        tracing::debug!("Starting GC");
+        live.clear();
+
+        tracing::debug!("Starting GC mark phase");
+        let live_ref = &mut live;
+        let mut stream = Gen::new(|co| async move {
+            if let Err(e) = gc_mark_task(store, live_ref, &co).await {
+                co.yield_(GcMarkEvent::Error(e)).await;
+            }
+        });
+        while let Some(item) = stream.next().await {
+            match item {
+                GcMarkEvent::CustomDebug(text) => {
+                    tracing::debug!("{}", text);
+                }
+                GcMarkEvent::CustomWarning(text, _) => {
+                    tracing::warn!("{}", text);
+                }
+                GcMarkEvent::Error(err) => {
+                    tracing::error!("Fatal error during GC mark {}", err);
+                    continue 'outer;
+                }
+            }
+        }
+        drop(stream);
+
+        tracing::debug!("Starting GC sweep phase");
+        let live_ref = &live;
+        let mut stream = Gen::new(|co| async move {
+            if let Err(e) = gc_sweep_task(store, live_ref, &co).await {
+                co.yield_(GcSweepEvent::Error(e)).await;
+            }
+        });
+        while let Some(item) = stream.next().await {
+            match item {
+                GcSweepEvent::CustomDebug(text) => {
+                    tracing::debug!("{}", text);
+                }
+                GcSweepEvent::CustomWarning(text, _) => {
+                    tracing::warn!("{}", text);
+                }
+                GcSweepEvent::Error(err) => {
+                    tracing::error!("Fatal error during GC mark {}", err);
+                    continue 'outer;
+                }
+            }
+        }
+        if let Some(ref cb) = config.done_callback {
+            cb();
+        }
+    }
 }
 
 /// Implementation of the gc method.

--- a/iroh-blobs/src/store/traits.rs
+++ b/iroh-blobs/src/store/traits.rs
@@ -608,7 +608,7 @@ pub(super) async fn gc_run_loop<S, F, Fut, G, Gut>(
 }
 
 /// Implementation of the gc method.
-async fn gc_mark_task<'a>(
+pub(super) async fn gc_mark_task<'a>(
     store: &'a impl Store,
     live: &'a mut BTreeSet<Hash>,
     co: &Co<GcMarkEvent>,

--- a/iroh-blobs/src/store/traits.rs
+++ b/iroh-blobs/src/store/traits.rs
@@ -524,7 +524,7 @@ async fn validate_impl(
 pub struct GcConfig {
     /// The period at which to execute the GC.
     pub period: Duration,
-    /// An optional callback called everytime a GC round finishes.
+    /// An optional callback called every time a GC round finishes.
     #[debug("done_callback")]
     pub done_callback: Option<Box<dyn Fn() + Send>>,
 }
@@ -538,7 +538,7 @@ pub(super) async fn gc_run_loop<S, F, Fut, G, Gut>(
 ) where
     S: Store,
     F: Fn() -> Fut,
-    Fut: Future<Output = io::Result<()>> + Send + 'static,
+    Fut: Future<Output = io::Result<()>> + Send,
     G: Fn() -> Gut,
     Gut: Future<Output = BTreeSet<Hash>> + Send,
 {

--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -1559,4 +1559,50 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_blob_delete_mem() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
+
+        let node = crate::node::Node::memory().spawn().await?;
+
+        let res = node.blobs().add_bytes(&b"hello world"[..]).await?;
+
+        let hashes: Vec<_> = node.blobs().list().await?.try_collect().await?;
+        assert_eq!(hashes.len(), 1);
+        assert_eq!(hashes[0].hash, res.hash);
+
+        // delete
+        node.blobs().delete_blob(res.hash).await?;
+
+        let hashes: Vec<_> = node.blobs().list().await?.try_collect().await?;
+        assert!(hashes.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_blob_delete_fs() -> Result<()> {
+        let _guard = iroh_test::logging::setup();
+
+        let dir = tempfile::tempdir()?;
+        let node = crate::node::Node::persistent(dir.path())
+            .await?
+            .spawn()
+            .await?;
+
+        let res = node.blobs().add_bytes(&b"hello world"[..]).await?;
+
+        let hashes: Vec<_> = node.blobs().list().await?.try_collect().await?;
+        assert_eq!(hashes.len(), 1);
+        assert_eq!(hashes[0].hash, res.hash);
+
+        // delete
+        node.blobs().delete_blob(res.hash).await?;
+
+        let hashes: Vec<_> = node.blobs().list().await?.try_collect().await?;
+        assert!(hashes.is_empty());
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
- always delete hashes, even if they are protected when calling `Store::delete`
- move gc loop implementation into the stores

## Breaking Changes

- removed `Store::gc_sweep`
- removed `Store::gc_mark`
- removed `Store::gc_start`
- added `Store::gc_run` which starts the full gc schedule

Closes #2657 