### PR TITLE
feat: allow to bind to a specific address

### DIFF
--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -668,7 +668,7 @@ async fn make_endpoint(
         Some(relay_map) => endpoint.relay_mode(RelayMode::Custom(relay_map)),
         None => endpoint,
     };
-    let endpoint = endpoint.bind(None, None).await?;
+    let endpoint = endpoint.bind().await?;
 
     tokio::time::timeout(Duration::from_secs(10), endpoint.direct_addresses().next())
         .await

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -668,7 +668,7 @@ async fn make_endpoint(
         Some(relay_map) => endpoint.relay_mode(RelayMode::Custom(relay_map)),
         None => endpoint,
     };
-    let endpoint = endpoint.bind(0).await?;
+    let endpoint = endpoint.bind(None, None).await?;
 
     tokio::time::timeout(Duration::from_secs(10), endpoint.direct_addresses().next())
         .await

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -111,10 +111,8 @@ async fn main() -> Result<()> {
         .secret_key(secret_key)
         .alpns(vec![GOSSIP_ALPN.to_vec()])
         .relay_mode(relay_mode)
-        .bind(
-            Some(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, args.bind_port)),
-            None,
-        )
+        .bind_addr_v4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, args.bind_port))
+        .bind()
         .await?;
     println!("> our node id: {}", endpoint.node_id());
 

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, fmt, str::FromStr};
+use std::{
+    collections::HashMap,
+    fmt,
+    net::{Ipv4Addr, SocketAddrV4},
+    str::FromStr,
+};
 
 use anyhow::{bail, Context, Result};
 use bytes::Bytes;
@@ -106,7 +111,10 @@ async fn main() -> Result<()> {
         .secret_key(secret_key)
         .alpns(vec![GOSSIP_ALPN.to_vec()])
         .relay_mode(relay_mode)
-        .bind(args.bind_port)
+        .bind(
+            Some(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, args.bind_port)),
+            None,
+        )
         .await?;
     println!("> our node id: {}", endpoint.node_id());
 

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -845,7 +845,7 @@ mod test {
             .alpns(vec![GOSSIP_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map))
             .insecure_skip_relay_cert_verify(true)
-            .bind(None, None)
+            .bind()
             .await?;
 
         ep.watch_home_relay().next().await;

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -845,7 +845,7 @@ mod test {
             .alpns(vec![GOSSIP_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map))
             .insecure_skip_relay_cert_verify(true)
-            .bind(0)
+            .bind(None, None)
             .await?;
 
         ep.watch_home_relay().next().await;

--- a/iroh-net/bench/src/iroh.rs
+++ b/iroh-net/bench/src/iroh.rs
@@ -41,7 +41,7 @@ pub fn server_endpoint(
             .alpns(vec![ALPN.to_vec()])
             .relay_mode(relay_mode)
             .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
-            .bind(0)
+            .bind(None, None)
             .await
             .unwrap();
 
@@ -97,7 +97,7 @@ pub async fn connect_client(
         .alpns(vec![ALPN.to_vec()])
         .relay_mode(relay_mode)
         .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
-        .bind(0)
+        .bind(None, None)
         .await
         .unwrap();
 

--- a/iroh-net/bench/src/iroh.rs
+++ b/iroh-net/bench/src/iroh.rs
@@ -41,7 +41,7 @@ pub fn server_endpoint(
             .alpns(vec![ALPN.to_vec()])
             .relay_mode(relay_mode)
             .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
-            .bind(None, None)
+            .bind()
             .await
             .unwrap();
 
@@ -97,7 +97,7 @@ pub async fn connect_client(
         .alpns(vec![ALPN.to_vec()])
         .relay_mode(relay_mode)
         .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
-        .bind(None, None)
+        .bind()
         .await
         .unwrap();
 

--- a/iroh-net/examples/connect-unreliable.rs
+++ b/iroh-net/examples/connect-unreliable.rs
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
         // If you want to experiment with relaying using your own relay server, you must pass in the same custom relay url to both the `listen` code AND the `connect` code
         .relay_mode(RelayMode::Default)
         // You can choose an address to bind to, but passing in `None` will bind the socket to a random available port
-        .bind(None, None)
+        .bind()
         .await?;
 
     let me = endpoint.node_id();

--- a/iroh-net/examples/connect-unreliable.rs
+++ b/iroh-net/examples/connect-unreliable.rs
@@ -52,8 +52,8 @@ async fn main() -> anyhow::Result<()> {
         // Use `RelayMode::Disable` to disable holepunching and relaying over HTTPS
         // If you want to experiment with relaying using your own relay server, you must pass in the same custom relay url to both the `listen` code AND the `connect` code
         .relay_mode(RelayMode::Default)
-        // You can choose a port to bind to, but passing in `0` will bind the socket to a random available port
-        .bind(0)
+        // You can choose an address to bind to, but passing in `None` will bind the socket to a random available port
+        .bind(None, None)
         .await?;
 
     let me = endpoint.node_id();

--- a/iroh-net/examples/connect.rs
+++ b/iroh-net/examples/connect.rs
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
         // If you want to experiment with relaying using your own relay server, you must pass in the same custom relay url to both the `listen` code AND the `connect` code
         .relay_mode(RelayMode::Default)
         // You can choose an address to bind to, but passing in `None` will bind the socket to a random available port
-        .bind(None, None)
+        .bind()
         .await?;
 
     let me = endpoint.node_id();

--- a/iroh-net/examples/connect.rs
+++ b/iroh-net/examples/connect.rs
@@ -49,8 +49,8 @@ async fn main() -> anyhow::Result<()> {
         // Use `RelayMode::Disable` to disable holepunching and relaying over HTTPS
         // If you want to experiment with relaying using your own relay server, you must pass in the same custom relay url to both the `listen` code AND the `connect` code
         .relay_mode(RelayMode::Default)
-        // You can choose a port to bind to, but passing in `0` will bind the socket to a random available port
-        .bind(0)
+        // You can choose an addr to bind to, but passing in `None` will bind the socket to a random available port
+        .bind(None, None)
         .await?;
 
     let me = endpoint.node_id();

--- a/iroh-net/examples/connect.rs
+++ b/iroh-net/examples/connect.rs
@@ -49,7 +49,7 @@ async fn main() -> anyhow::Result<()> {
         // Use `RelayMode::Disable` to disable holepunching and relaying over HTTPS
         // If you want to experiment with relaying using your own relay server, you must pass in the same custom relay url to both the `listen` code AND the `connect` code
         .relay_mode(RelayMode::Default)
-        // You can choose an addr to bind to, but passing in `None` will bind the socket to a random available port
+        // You can choose an address to bind to, but passing in `None` will bind the socket to a random available port
         .bind(None, None)
         .await?;
 

--- a/iroh-net/examples/dht_discovery.rs
+++ b/iroh-net/examples/dht_discovery.rs
@@ -70,7 +70,7 @@ async fn chat_server(args: Args) -> anyhow::Result<()> {
         .alpns(vec![CHAT_ALPN.to_vec()])
         .secret_key(secret_key)
         .discovery(Box::new(discovery))
-        .bind(None, None)
+        .bind()
         .await?;
     let zid = pkarr::PublicKey::try_from(node_id.as_bytes())?.to_z32();
     println!("Listening on {}", node_id);
@@ -115,7 +115,7 @@ async fn chat_client(args: Args) -> anyhow::Result<()> {
     let endpoint = Endpoint::builder()
         .secret_key(secret_key)
         .discovery(Box::new(discovery))
-        .bind(None, None)
+        .bind()
         .await?;
     println!("We are {} and connecting to {}", node_id, remote_node_id);
     let connection = endpoint

--- a/iroh-net/examples/dht_discovery.rs
+++ b/iroh-net/examples/dht_discovery.rs
@@ -70,7 +70,7 @@ async fn chat_server(args: Args) -> anyhow::Result<()> {
         .alpns(vec![CHAT_ALPN.to_vec()])
         .secret_key(secret_key)
         .discovery(Box::new(discovery))
-        .bind(0)
+        .bind(None, None)
         .await?;
     let zid = pkarr::PublicKey::try_from(node_id.as_bytes())?.to_z32();
     println!("Listening on {}", node_id);
@@ -115,7 +115,7 @@ async fn chat_client(args: Args) -> anyhow::Result<()> {
     let endpoint = Endpoint::builder()
         .secret_key(secret_key)
         .discovery(Box::new(discovery))
-        .bind(0)
+        .bind(None, None)
         .await?;
     println!("We are {} and connecting to {}", node_id, remote_node_id);
     let connection = endpoint

--- a/iroh-net/examples/listen-unreliable.rs
+++ b/iroh-net/examples/listen-unreliable.rs
@@ -30,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
         // If you want to experiment with relaying using your own relay server, you must pass in the same custom relay url to both the `listen` code AND the `connect` code
         .relay_mode(RelayMode::Default)
         // you can choose a port to bind to, but passing in `0` will bind the socket to a random available port
-        .bind(0)
+        .bind(None, None)
         .await?;
 
     let me = endpoint.node_id();

--- a/iroh-net/examples/listen-unreliable.rs
+++ b/iroh-net/examples/listen-unreliable.rs
@@ -30,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
         // If you want to experiment with relaying using your own relay server, you must pass in the same custom relay url to both the `listen` code AND the `connect` code
         .relay_mode(RelayMode::Default)
         // you can choose a port to bind to, but passing in `0` will bind the socket to a random available port
-        .bind(None, None)
+        .bind()
         .await?;
 
     let me = endpoint.node_id();

--- a/iroh-net/examples/listen.rs
+++ b/iroh-net/examples/listen.rs
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
         // If you want to experiment with relaying using your own relay server, you must pass in the same custom relay url to both the `listen` code AND the `connect` code
         .relay_mode(RelayMode::Default)
         // you can choose a port to bind to, but passing in `0` will bind the socket to a random available port
-        .bind(None, None)
+        .bind()
         .await?;
 
     let me = endpoint.node_id();

--- a/iroh-net/examples/listen.rs
+++ b/iroh-net/examples/listen.rs
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
         // If you want to experiment with relaying using your own relay server, you must pass in the same custom relay url to both the `listen` code AND the `connect` code
         .relay_mode(RelayMode::Default)
         // you can choose a port to bind to, but passing in `0` will bind the socket to a random available port
-        .bind(0)
+        .bind(None, None)
         .await?;
 
     let me = endpoint.node_id();

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -594,7 +594,7 @@ mod tests {
             .discovery(Box::new(disco))
             .relay_mode(RelayMode::Disabled)
             .alpns(vec![TEST_ALPN.to_vec()])
-            .bind(None, None)
+            .bind()
             .await
             .unwrap();
 
@@ -762,7 +762,7 @@ mod test_dns_pkarr {
             .alpns(vec![TEST_ALPN.to_vec()])
             .dns_resolver(dns_pkarr_server.dns_resolver())
             .discovery(dns_pkarr_server.discovery(secret_key))
-            .bind(None, None)
+            .bind()
             .await?;
 
         let handle = tokio::spawn({

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -594,7 +594,7 @@ mod tests {
             .discovery(Box::new(disco))
             .relay_mode(RelayMode::Disabled)
             .alpns(vec![TEST_ALPN.to_vec()])
-            .bind(0)
+            .bind(None, None)
             .await
             .unwrap();
 
@@ -762,7 +762,7 @@ mod test_dns_pkarr {
             .alpns(vec![TEST_ALPN.to_vec()])
             .dns_resolver(dns_pkarr_server.dns_resolver())
             .discovery(dns_pkarr_server.discovery(secret_key))
-            .bind(0)
+            .bind(None, None)
             .await?;
 
         let handle = tokio::spawn({

--- a/iroh-net/src/discovery/local_swarm_discovery.rs
+++ b/iroh-net/src/discovery/local_swarm_discovery.rs
@@ -308,7 +308,7 @@ mod tests {
             };
 
             // pass in endpoint, this is never used
-            let ep = crate::endpoint::Builder::default().bind(None, None).await?;
+            let ep = crate::endpoint::Builder::default().bind().await?;
             // resolve twice to ensure we can create separate streams for the same node_id
             let mut s1 = discovery_a.resolve(ep.clone(), node_id_b).unwrap();
             let mut s2 = discovery_a.resolve(ep, node_id_b).unwrap();

--- a/iroh-net/src/discovery/local_swarm_discovery.rs
+++ b/iroh-net/src/discovery/local_swarm_discovery.rs
@@ -308,7 +308,7 @@ mod tests {
             };
 
             // pass in endpoint, this is never used
-            let ep = crate::endpoint::Builder::default().bind(0).await?;
+            let ep = crate::endpoint::Builder::default().bind(None, None).await?;
             // resolve twice to ensure we can create separate streams for the same node_id
             let mut s1 = discovery_a.resolve(ep.clone(), node_id_b).unwrap();
             let mut s2 = discovery_a.resolve(ep, node_id_b).unwrap();

--- a/iroh-net/src/discovery/pkarr/dht.rs
+++ b/iroh-net/src/discovery/pkarr/dht.rs
@@ -399,7 +399,7 @@ mod tests {
     #[ignore = "flaky"]
     async fn dht_discovery_smoke() -> TestResult {
         let _ = tracing_subscriber::fmt::try_init();
-        let ep = crate::Endpoint::builder().bind(None, None).await?;
+        let ep = crate::Endpoint::builder().bind().await?;
         let secret = ep.secret_key().clone();
         let testnet = mainline::dht::Testnet::new(2);
         let settings = pkarr::Settings {

--- a/iroh-net/src/discovery/pkarr/dht.rs
+++ b/iroh-net/src/discovery/pkarr/dht.rs
@@ -399,7 +399,7 @@ mod tests {
     #[ignore = "flaky"]
     async fn dht_discovery_smoke() -> TestResult {
         let _ = tracing_subscriber::fmt::try_init();
-        let ep = crate::Endpoint::builder().bind(0).await?;
+        let ep = crate::Endpoint::builder().bind(None, None).await?;
         let secret = ep.secret_key().clone();
         let testnet = mainline::dht::Testnet::new(2);
         let settings = pkarr::Settings {

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -710,7 +710,7 @@ impl Endpoint {
     ///
     /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
     /// # rt.block_on(async move {
-    /// let mep =  Endpoint::builder().bind(None, None).await.unwrap();
+    /// let mep =  Endpoint::builder().bind().await.unwrap();
     /// let _addrs = mep.direct_addresses().next().await;
     /// # });
     /// ```

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -111,7 +111,7 @@ impl Builder {
 
     // # The final constructor that everyone needs.
 
-    /// Binds the magic endpoint on the specified socket address.
+    /// Binds the magic endpoint.
     pub async fn bind(self) -> Result<Endpoint> {
         let relay_map = self.relay_mode.relay_map();
         let secret_key = self.secret_key.unwrap_or_else(SecretKey::generate);

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -119,7 +119,7 @@ impl Builder {
     ///
     /// The *addr_v6* is the address that should be bound locally on IPv6.
     ///
-    /// You can pass `None` to let the operating system choose a free port for you, and bind to `::1`.
+    /// You can pass `None` to let the operating system choose a free port for you, and bind to `[::]`.
     pub async fn bind(self) -> Result<Endpoint> {
         let relay_map = self.relay_mode.relay_map();
         let secret_key = self.secret_key.unwrap_or_else(SecretKey::generate);
@@ -163,7 +163,7 @@ impl Builder {
     ///
     /// Setting the port to `0` will use a random port.
     ///
-    /// By default will use `::1:0` to bind to.
+    /// By default will use `[::]:0` to bind to.
     pub fn bind_addr_v6(mut self, addr: SocketAddrV6) -> Self {
         self.addr_v6.replace(addr);
         self

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -690,7 +690,7 @@ impl Endpoint {
     ///
     /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
     /// # rt.block_on(async move {
-    /// let mep =  Endpoint::builder().bind(0).await.unwrap();
+    /// let mep =  Endpoint::builder().bind(None, None).await.unwrap();
     /// let _addrs = mep.direct_addresses().next().await;
     /// # });
     /// ```

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -112,14 +112,6 @@ impl Builder {
     // # The final constructor that everyone needs.
 
     /// Binds the magic endpoint on the specified socket address.
-    ///
-    /// The *addr_v4* is the address that should be bound locally on IPv4.
-    ///
-    /// You can pass `None` to let the operating system choose a free port for you, and bind to `0.0.0.0`.
-    ///
-    /// The *addr_v6* is the address that should be bound locally on IPv6.
-    ///
-    /// You can pass `None` to let the operating system choose a free port for you, and bind to `[::]`.
     pub async fn bind(self) -> Result<Endpoint> {
         let relay_map = self.relay_mode.relay_map();
         let secret_key = self.secret_key.unwrap_or_else(SecretKey::generate);

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -152,6 +152,7 @@ impl Builder {
     /// Set the IPv4 bind address.
     ///
     /// Setting the port to `0` will use a random port.
+    /// If the port specified is already in use, it will fallback to choosing a random port.
     ///
     /// By default will use `0.0.0.0:0` to bind to.
     pub fn bind_addr_v4(mut self, addr: SocketAddrV4) -> Self {
@@ -162,6 +163,7 @@ impl Builder {
     /// Set the IPv6 bind address.
     ///
     /// Setting the port to `0` will use a random port.
+    /// If the port specified is already in use, it will fallback to choosing a random port.
     ///
     /// By default will use `[::]:0` to bind to.
     pub fn bind_addr_v6(mut self, addr: SocketAddrV6) -> Self {

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -160,7 +160,7 @@ impl Builder {
         self
     }
 
-    /// Set the IPv6 bind address.
+    /// Sets the IPv6 bind address.
     ///
     /// Setting the port to `0` will use a random port.
     /// If the port specified is already in use, it will fallback to choosing a random port.

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -149,7 +149,7 @@ impl Builder {
 
     // # The very common methods everyone basically needs.
 
-    /// Set the IPv4 bind address.
+    /// Sets the IPv4 bind address.
     ///
     /// Setting the port to `0` will use a random port.
     /// If the port specified is already in use, it will fallback to choosing a random port.

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -81,6 +81,8 @@ pub struct Builder {
     dns_resolver: Option<DnsResolver>,
     #[cfg(any(test, feature = "test-utils"))]
     insecure_skip_relay_cert_verify: bool,
+    addr_v4: Option<SocketAddrV4>,
+    addr_v6: Option<SocketAddrV6>,
 }
 
 impl Default for Builder {
@@ -97,6 +99,8 @@ impl Default for Builder {
             dns_resolver: None,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
+            addr_v4: None,
+            addr_v6: None,
         }
     }
 }
@@ -116,11 +120,7 @@ impl Builder {
     /// The *addr_v6* is the address that should be bound locally on IPv6.
     ///
     /// You can pass `None` to let the operating system choose a free port for you, and bind to `::1`.
-    pub async fn bind(
-        self,
-        addr_v4: Option<SocketAddrV4>,
-        addr_v6: Option<SocketAddrV6>,
-    ) -> Result<Endpoint> {
+    pub async fn bind(self) -> Result<Endpoint> {
         let relay_map = self.relay_mode.relay_map();
         let secret_key = self.secret_key.unwrap_or_else(SecretKey::generate);
         let static_config = StaticConfig {
@@ -133,8 +133,8 @@ impl Builder {
             .unwrap_or_else(|| default_resolver().clone());
 
         let msock_opts = magicsock::Options {
-            addr_v4,
-            addr_v6,
+            addr_v4: self.addr_v4,
+            addr_v6: self.addr_v6,
             secret_key,
             relay_map,
             node_map: self.node_map,
@@ -148,6 +148,26 @@ impl Builder {
     }
 
     // # The very common methods everyone basically needs.
+
+    /// Set the IPv4 bind address.
+    ///
+    /// Setting the port to `0` will use a random port.
+    ///
+    /// By default will use `0.0.0.0:0` to bind to.
+    pub fn bind_addr_v4(mut self, addr: SocketAddrV4) -> Self {
+        self.addr_v4.replace(addr);
+        self
+    }
+
+    /// Set the IPv6 bind address.
+    ///
+    /// Setting the port to `0` will use a random port.
+    ///
+    /// By default will use `::1:0` to bind to.
+    pub fn bind_addr_v6(mut self, addr: SocketAddrV6) -> Self {
+        self.addr_v6.replace(addr);
+        self
+    }
 
     /// Sets a secret key to authenticate with other peers.
     ///
@@ -1265,7 +1285,7 @@ mod tests {
         let _guard = iroh_test::logging::setup();
         let ep = Endpoint::builder()
             .alpns(vec![TEST_ALPN.to_vec()])
-            .bind(None, None)
+            .bind()
             .await
             .unwrap();
         let my_addr = ep.node_addr().await.unwrap();
@@ -1296,7 +1316,7 @@ mod tests {
                         .alpns(vec![TEST_ALPN.to_vec()])
                         .relay_mode(RelayMode::Custom(relay_map))
                         .insecure_skip_relay_cert_verify(true)
-                        .bind(None, None)
+                        .bind()
                         .await
                         .unwrap();
                     info!("accepting connection");
@@ -1331,7 +1351,7 @@ mod tests {
                     .alpns(vec![TEST_ALPN.to_vec()])
                     .relay_mode(RelayMode::Custom(relay_map))
                     .insecure_skip_relay_cert_verify(true)
-                    .bind(None, None)
+                    .bind()
                     .await
                     .unwrap();
                 info!("client connecting");
@@ -1393,7 +1413,7 @@ mod tests {
             }
             builder
                 .alpns(vec![TEST_ALPN.to_vec()])
-                .bind(None, None)
+                .bind()
                 .await
                 .unwrap()
         }
@@ -1450,7 +1470,7 @@ mod tests {
                         .secret_key(server_secret_key)
                         .alpns(vec![TEST_ALPN.to_vec()])
                         .relay_mode(RelayMode::Custom(relay_map))
-                        .bind(None, None)
+                        .bind()
                         .await
                         .unwrap();
                     let eps = ep.bound_sockets();
@@ -1496,7 +1516,7 @@ mod tests {
                     .insecure_skip_relay_cert_verify(true)
                     .relay_mode(RelayMode::Custom(relay_map))
                     .secret_key(client_secret_key)
-                    .bind(None, None)
+                    .bind()
                     .await
                     .unwrap();
                 let eps = ep.bound_sockets();
@@ -1541,13 +1561,13 @@ mod tests {
         let ep1 = Endpoint::builder()
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Disabled)
-            .bind(None, None)
+            .bind()
             .await
             .unwrap();
         let ep2 = Endpoint::builder()
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Disabled)
-            .bind(None, None)
+            .bind()
             .await
             .unwrap();
         let ep1_nodeaddr = ep1.node_addr().await.unwrap();
@@ -1638,7 +1658,7 @@ mod tests {
             .insecure_skip_relay_cert_verify(true)
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map.clone()))
-            .bind(None, None)
+            .bind()
             .await
             .unwrap();
         let ep2 = Endpoint::builder()
@@ -1646,7 +1666,7 @@ mod tests {
             .insecure_skip_relay_cert_verify(true)
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map))
-            .bind(None, None)
+            .bind()
             .await
             .unwrap();
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -100,7 +100,7 @@ pub(crate) struct Options {
     pub(crate) addr_v4: Option<SocketAddrV4>,
     /// The IPv6 address to listen on.
     ///
-    /// If set to `None` it will choose a random port and listen on `::1`.
+    /// If set to `None` it will choose a random port and listen on `[::]:0`.
     pub(crate) addr_v6: Option<SocketAddrV6>,
 
     /// Secret key for this node.

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2854,7 +2854,7 @@ mod tests {
                 .transport_config(transport_config)
                 .relay_mode(relay_mode)
                 .alpns(vec![ALPN.to_vec()])
-                .bind(None, None)
+                .bind()
                 .await?;
 
             Ok(Self {

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -246,7 +246,7 @@ pub(crate) struct MagicSock {
 }
 
 impl MagicSock {
-    /// Creates a magic [`MagicSock`] listening on [`Options::port`].
+    /// Creates a magic [`MagicSock`] listening on [`Options::addr_v4`] adn [`Options::addr_v6`].
     pub(crate) async fn spawn(opts: Options) -> Result<Handle> {
         Handle::new(opts).await
     }
@@ -1368,7 +1368,7 @@ impl DirectAddrUpdateState {
 }
 
 impl Handle {
-    /// Creates a magic [`MagicSock`] listening on [`Options::port`].
+    /// Creates a magic [`MagicSock`] listening on [`Options::addr_v4`] adn [`Options::addr_v6`].
     async fn new(opts: Options) -> Result<Self> {
         let me = opts.secret_key.public().fmt_short();
         if crate::util::relay_only_mode() {

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -19,7 +19,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     fmt::Display,
     io,
-    net::{IpAddr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     pin::Pin,
     sync::{
         atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering},
@@ -57,7 +57,7 @@ use crate::{
     dns::DnsResolver,
     endpoint::NodeAddr,
     key::{PublicKey, SecretKey, SharedSecret},
-    net::{interfaces, ip::LocalAddresses, netmon, IpFamily},
+    net::{interfaces, ip::LocalAddresses, netmon},
     netcheck, portmapper,
     relay::{RelayMap, RelayUrl},
     stun, AddrInfo,
@@ -94,9 +94,14 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 /// Contains options for `MagicSock::listen`.
 #[derive(derive_more::Debug)]
 pub(crate) struct Options {
-    /// The port to listen on.
-    /// Zero means to pick one automatically.
-    pub(crate) port: u16,
+    /// The IPv4 address to listen on.
+    ///
+    /// If set to `None` it will choose a random port and listen on `0.0.0.0`.
+    pub(crate) addr_v4: Option<SocketAddrV4>,
+    /// The IPv6 address to listen on.
+    ///
+    /// If set to `None` it will choose a random port and listen on `::1`.
+    pub(crate) addr_v6: Option<SocketAddrV6>,
 
     /// Secret key for this node.
     pub(crate) secret_key: SecretKey,
@@ -129,7 +134,8 @@ pub(crate) struct Options {
 impl Default for Options {
     fn default() -> Self {
         Options {
-            port: 0,
+            addr_v4: None,
+            addr_v6: None,
             secret_key: SecretKey::generate(),
             relay_map: RelayMap::empty(),
             node_map: None,
@@ -1380,7 +1386,8 @@ impl Handle {
         let port_mapper = portmapper::Client::default();
 
         let Options {
-            port,
+            addr_v4,
+            addr_v6,
             secret_key,
             relay_map,
             node_map,
@@ -1393,7 +1400,7 @@ impl Handle {
 
         let (relay_recv_sender, relay_recv_receiver) = mpsc::channel(128);
 
-        let (pconn4, pconn6) = bind(port)?;
+        let (pconn4, pconn6) = bind(addr_v4, addr_v6)?;
         let port = pconn4.port();
 
         // NOTE: we can end up with a zero port if `std::net::UdpSocket::socket_addr` fails
@@ -2468,12 +2475,18 @@ fn new_re_stun_timer(initial_delay: bool) -> time::Interval {
 }
 
 /// Initial connection setup.
-fn bind(port: u16) -> Result<(UdpConn, Option<UdpConn>)> {
-    let pconn4 = UdpConn::bind(port, IpFamily::V4).context("bind IPv4 failed")?;
+fn bind(
+    addr_v4: Option<SocketAddrV4>,
+    addr_v6: Option<SocketAddrV6>,
+) -> Result<(UdpConn, Option<UdpConn>)> {
+    let addr_v4 = addr_v4.unwrap_or_else(|| SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0));
+    let pconn4 = UdpConn::bind(SocketAddr::V4(addr_v4)).context("bind IPv4 failed")?;
+
     let ip4_port = pconn4.local_addr()?.port();
     let ip6_port = ip4_port.checked_add(1).unwrap_or(ip4_port - 1);
-
-    let pconn6 = match UdpConn::bind(ip6_port, IpFamily::V6) {
+    let addr_v6 =
+        addr_v6.unwrap_or_else(|| SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, ip6_port, 0, 0));
+    let pconn6 = match UdpConn::bind(SocketAddr::V6(addr_v6)) {
         Ok(conn) => Some(conn),
         Err(err) => {
             info!("bind ignoring IPv6 bind failure: {:?}", err);
@@ -2841,7 +2854,7 @@ mod tests {
                 .transport_config(transport_config)
                 .relay_mode(relay_mode)
                 .alpns(vec![ALPN.to_vec()])
-                .bind(0)
+                .bind(None, None)
                 .await?;
 
             Ok(Self {
@@ -3379,7 +3392,7 @@ mod tests {
 
         fn make_conn(addr: SocketAddr) -> anyhow::Result<quinn::Endpoint> {
             let key = SecretKey::generate();
-            let conn = UdpConn::bind(addr.port(), addr.ip().into())?;
+            let conn = UdpConn::bind(addr)?;
 
             let quic_server_config = tls::make_server_config(&key, vec![ALPN.to_vec()], false)?;
             let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_server_config));
@@ -3623,7 +3636,8 @@ mod tests {
     #[instrument(name = "ep", skip_all, fields(me = secret_key.public().fmt_short()))]
     async fn magicsock_ep(secret_key: SecretKey) -> anyhow::Result<(quinn::Endpoint, Handle)> {
         let opts = Options {
-            port: 0,
+            addr_v4: None,
+            addr_v6: None,
             secret_key: secret_key.clone(),
             relay_map: RelayMap::empty(),
             node_map: None,

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -96,7 +96,7 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 pub(crate) struct Options {
     /// The IPv4 address to listen on.
     ///
-    /// If set to `None` it will choose a random port and listen on `0.0.0.0`.
+    /// If set to `None` it will choose a random port and listen on `0.0.0.0:0`.
     pub(crate) addr_v4: Option<SocketAddrV4>,
     /// The IPv6 address to listen on.
     ///

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -246,7 +246,7 @@ pub(crate) struct MagicSock {
 }
 
 impl MagicSock {
-    /// Creates a magic [`MagicSock`] listening on [`Options::addr_v4`] adn [`Options::addr_v6`].
+    /// Creates a magic [`MagicSock`] listening on [`Options::addr_v4`] and [`Options::addr_v6`].
     pub(crate) async fn spawn(opts: Options) -> Result<Handle> {
         Handle::new(opts).await
     }
@@ -1368,7 +1368,7 @@ impl DirectAddrUpdateState {
 }
 
 impl Handle {
-    /// Creates a magic [`MagicSock`] listening on [`Options::addr_v4`] adn [`Options::addr_v6`].
+    /// Creates a magic [`MagicSock`] listening on [`Options::addr_v4`] and [`Options::addr_v6`].
     async fn new(opts: Options) -> Result<Self> {
         let me = opts.secret_key.public().fmt_short();
         if crate::util::relay_only_mode() {

--- a/iroh/examples/local_swarm_discovery.rs
+++ b/iroh/examples/local_swarm_discovery.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
     let node = Node::memory()
         .secret_key(key)
         .node_discovery(cfg)
-        .bind_port(0)
+        .bind_random_port()
         .relay_mode(iroh_net::relay::RelayMode::Disabled)
         .spawn()
         .await?;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -659,7 +659,7 @@ mod tests {
         let _guard = iroh_test::logging::setup();
 
         use std::io::Cursor;
-        let node = Node::memory().bind_port(0).spawn().await?;
+        let node = Node::memory().bind_random_port().spawn().await?;
 
         let _drop_guard = node.cancel_token().drop_guard();
         let client = node.client();
@@ -680,7 +680,7 @@ mod tests {
     async fn test_node_add_tagged_blob_event() -> Result<()> {
         let _guard = iroh_test::logging::setup();
 
-        let node = Node::memory().bind_port(0).spawn().await?;
+        let node = Node::memory().bind_random_port().spawn().await?;
 
         let _drop_guard = node.cancel_token().drop_guard();
 
@@ -740,13 +740,13 @@ mod tests {
         let (relay_map, relay_url, _guard) = iroh_net::test_utils::run_relay_server().await?;
 
         let node1 = Node::memory()
-            .bind_port(0)
+            .bind_random_port()
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .insecure_skip_relay_cert_verify(true)
             .spawn()
             .await?;
         let node2 = Node::memory()
-            .bind_port(0)
+            .bind_random_port()
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .insecure_skip_relay_cert_verify(true)
             .spawn()
@@ -778,7 +778,7 @@ mod tests {
         let secret1 = SecretKey::generate();
         let node1 = Node::memory()
             .secret_key(secret1.clone())
-            .bind_port(0)
+            .bind_random_port()
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .insecure_skip_relay_cert_verify(true)
             .dns_resolver(dns_pkarr_server.dns_resolver())
@@ -788,7 +788,7 @@ mod tests {
         let secret2 = SecretKey::generate();
         let node2 = Node::memory()
             .secret_key(secret2.clone())
-            .bind_port(0)
+            .bind_random_port()
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .insecure_skip_relay_cert_verify(true)
             .dns_resolver(dns_pkarr_server.dns_resolver())

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -578,7 +578,9 @@ where
 
             (
                 endpoint
-                    .bind(Some(self.addr_v4), Some(self.addr_v6))
+                    .bind_addr_v4(self.addr_v4)
+                    .bind_addr_v6(self.addr_v6)
+                    .bind()
                     .await?,
                 nodes_data_path,
             )

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -427,6 +427,9 @@ where
     }
 
     /// Binds the node service to a specific socket IPv4 address.
+    ///
+    /// If the port used in the bind address is not free, a random different
+    /// port will be used.
     pub fn bind_addr_v4(mut self, addr: SocketAddrV4) -> Self {
         self.addr_v4 = addr;
         self

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -95,7 +95,8 @@ where
     D: Map,
 {
     storage: StorageConfig,
-    bind_port: Option<u16>,
+    addr_v4: SocketAddrV4,
+    addr_v6: SocketAddrV6,
     secret_key: SecretKey,
     rpc_endpoint: IrohServerEndpoint,
     rpc_addr: Option<SocketAddr>,
@@ -223,7 +224,8 @@ impl Default for Builder<iroh_blobs::store::mem::Store> {
 
         Self {
             storage: StorageConfig::Mem,
-            bind_port: None,
+            addr_v4: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, DEFAULT_BIND_PORT),
+            addr_v6: SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, DEFAULT_BIND_PORT + 1, 0, 0),
             secret_key: SecretKey::generate(),
             blobs_store: Default::default(),
             keylog: false,
@@ -257,7 +259,8 @@ impl<D: Map> Builder<D> {
 
         Self {
             storage,
-            bind_port: None,
+            addr_v4: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, DEFAULT_BIND_PORT),
+            addr_v6: SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, DEFAULT_BIND_PORT + 1, 0, 0),
             secret_key: SecretKey::generate(),
             blobs_store,
             keylog: false,
@@ -310,7 +313,8 @@ where
 
         Ok(Builder {
             storage: StorageConfig::Persistent(root.into()),
-            bind_port: self.bind_port,
+            addr_v4: self.addr_v4,
+            addr_v6: self.addr_v6,
             secret_key,
             blobs_store,
             keylog: self.keylog,
@@ -422,11 +426,22 @@ where
         self
     }
 
-    /// Binds the node service to a different socket.
-    ///
-    /// By default it binds to `127.0.0.1:11204`.
-    pub fn bind_port(mut self, port: u16) -> Self {
-        self.bind_port.replace(port);
+    /// Binds the node service to a specific socket IPv4 address.
+    pub fn bind_addr_v4(mut self, addr: SocketAddrV4) -> Self {
+        self.addr_v4 = addr;
+        self
+    }
+
+    /// Binds the node service to a specific socket IPv6 address.
+    pub fn bind_addr_v6(mut self, addr: SocketAddrV6) -> Self {
+        self.addr_v6 = addr;
+        self
+    }
+
+    /// Use a random port for both IPv4 and IPv6.
+    pub fn bind_random_port(mut self) -> Self {
+        self.addr_v4.set_port(0);
+        self.addr_v6.set_port(0);
         self
     }
 
@@ -560,8 +575,13 @@ where
                 }
                 StorageConfig::Mem => None,
             };
-            let bind_port = self.bind_port.unwrap_or(DEFAULT_BIND_PORT);
-            (endpoint.bind(bind_port).await?, nodes_data_path)
+
+            (
+                endpoint
+                    .bind(Some(self.addr_v4), Some(self.addr_v6))
+                    .await?,
+                nodes_data_path,
+            )
         };
         trace!("created endpoint");
 

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -54,6 +54,14 @@ const ENDPOINT_WAIT: Duration = Duration::from_secs(5);
 /// Default interval between GC runs.
 const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60 * 5);
 
+/// The default bind address for the iroh IPv4 socket.
+pub const DEFAULT_BIND_ADDR_V4: SocketAddrV4 =
+    SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, DEFAULT_BIND_PORT);
+
+/// The default bind address for the iroh IPv6 socket.
+pub const DEFAULT_BIND_ADDR_V6: SocketAddrV6 =
+    SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, DEFAULT_BIND_PORT + 1, 0, 0);
+
 /// Storage backend for documents.
 #[derive(Debug, Clone)]
 pub enum DocsStorage {
@@ -224,8 +232,8 @@ impl Default for Builder<iroh_blobs::store::mem::Store> {
 
         Self {
             storage: StorageConfig::Mem,
-            addr_v4: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, DEFAULT_BIND_PORT),
-            addr_v6: SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, DEFAULT_BIND_PORT + 1, 0, 0),
+            addr_v4: DEFAULT_BIND_ADDR_V4,
+            addr_v6: DEFAULT_BIND_ADDR_V6,
             secret_key: SecretKey::generate(),
             blobs_store: Default::default(),
             keylog: false,
@@ -428,20 +436,35 @@ where
 
     /// Binds the node service to a specific socket IPv4 address.
     ///
-    /// If the port used in the bind address is not free, a random different
-    /// port will be used.
+    /// By default this will be set to `0.0.0.0:11204`
+    ///
+    /// Setting the port to `0` will assign a random port.
+    /// If the port used is not free, a random different port will be used.
     pub fn bind_addr_v4(mut self, addr: SocketAddrV4) -> Self {
         self.addr_v4 = addr;
         self
     }
 
     /// Binds the node service to a specific socket IPv6 address.
+    ///
+    /// By default this will be set to `[::]:11205`
+    ///
+    /// Setting the port to `0` will assign a random port.
+    /// If the port used is not free, a random different port will be used.
     pub fn bind_addr_v6(mut self, addr: SocketAddrV6) -> Self {
         self.addr_v6 = addr;
         self
     }
 
     /// Use a random port for both IPv4 and IPv6.
+    ///
+    /// This is a convenience function useful when you do not need a specific port
+    /// and want to avoid conflicts when running multiple instances, e.g. in tests.
+    ///
+    /// This overrides the ports of the socket addresses provided by [`Builder::bind_addr_v4`]
+    /// and [`Builder::bind_addr_v6`].  By default both of those bind to the
+    /// unspecified address, which would result in `0.0.0.0:11204` and `[::]:11205` as bind
+    /// addresses unless they are changed.
     pub fn bind_random_port(mut self) -> Self {
         self.addr_v4.set_port(0);
         self.addr_v6.set_port(0);

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -30,7 +30,7 @@ use iroh_blobs::{
 async fn dial(secret_key: SecretKey, peer: NodeAddr) -> anyhow::Result<quinn::Connection> {
     let endpoint = iroh_net::Endpoint::builder()
         .secret_key(secret_key)
-        .bind(None, None)
+        .bind()
         .await?;
     endpoint
         .connect(peer, iroh::blobs::protocol::ALPN)

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -30,7 +30,7 @@ use iroh_blobs::{
 async fn dial(secret_key: SecretKey, peer: NodeAddr) -> anyhow::Result<quinn::Connection> {
     let endpoint = iroh_net::Endpoint::builder()
         .secret_key(secret_key)
-        .bind(0)
+        .bind(None, None)
         .await?;
     endpoint
         .connect(peer, iroh::blobs::protocol::ALPN)
@@ -40,7 +40,7 @@ async fn dial(secret_key: SecretKey, peer: NodeAddr) -> anyhow::Result<quinn::Co
 
 fn test_node<D: Store>(db: D) -> Builder<D> {
     iroh::node::Builder::with_db_and_store(db, DocsStorage::Memory, iroh::node::StorageConfig::Mem)
-        .bind_port(0)
+        .bind_random_port()
 }
 
 #[tokio::test]

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -491,14 +491,13 @@ async fn test_sync_via_relay() -> Result<()> {
     let (relay_map, _relay_url, _guard) = iroh_net::test_utils::run_relay_server().await?;
 
     let node1 = Node::memory()
-        .bind_port(0)
         .relay_mode(RelayMode::Custom(relay_map.clone()))
         .insecure_skip_relay_cert_verify(true)
         .spawn()
         .await?;
     let node1_id = node1.node_id();
     let node2 = Node::memory()
-        .bind_port(0)
+        .bind_random_port()
         .relay_mode(RelayMode::Custom(relay_map.clone()))
         .insecure_skip_relay_cert_verify(true)
         .spawn()


### PR DESCRIPTION
## Description

Allows to specify the IPv4 and IPv6 addresses where iroh should bind to.

Closes #2565

## Breaking Changes

- changed 
  - `iroh_net::endpoint::Endpoint::bind` now takes  no arguments
- removed
  -  `iroh::node::Builder::bind_port`
- added
  -  `iroh_net::endpoint::Builder::bind_addr_v4`
  -  `iroh_net::endpoint::Builder::bind_addr_v6`
  -  `iroh::node::Builder::bind_addr_v4`
  -  `iroh::node::Builder::bind_addr_v6`
  -  `iroh::node::Builder::bind_random_port`

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
