### PR TITLE
fix(iroh-net): Fix a hot-loop when the probes time out

### DIFF
--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -242,6 +242,10 @@ impl Actor {
 
                 _ = &mut probe_timer => {
                     warn!("tick: probes timed out");
+                    // Set new timeout to not go into this branch multiple times.  We need
+                    // the abort to finish all probes normally.  PROBES_TIMEOUT is
+                    // sufficiently far in the future.
+                    probe_timer.as_mut().reset(Instant::now() + PROBES_TIMEOUT);
                     probes.abort_all();
                     self.handle_abort_probes();
                 }


### PR DESCRIPTION
## Description

When all the probes time out the reportgen actor went into a hot-loop.
We slow this down by resetting the timer to be in the future again.
This way the actor loop can finish normally from the probes without
entering a hot-loop.  The actual timeout doesn't matter too much,
normally it should not happen twice as the actor should be finished by
the time another PROBES_TIMEOUT expires.

## Breaking Changes

None

## Notes & open questions

Fixes #2684.

I've never been very happy with the mainloop of the reportgen actor.
There is too much manual state-tracking also with the way
self.outstanding_tasks is structured.  Also the way that
Message::ProbeWouldHelp exists is not nice, the actor should be able
to abort any probes on it's own when they are no longer needed.  Maybe
I should sit down again sometime and think better about how to
structure this.  Nevertheless, this is a good fix for a real problem.

I'm not sure it's possible to write tests for this in a reasonable way
without manipulating the state entirely artificially.  Another reason
that this logic would be better expressed with more typesystem help.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [ ] Tests if relevant.
- ~~[ ] All breaking changes documented.~~