### PR TITLE
fix: Put `--with-relay` feature in iroh-net bench behind `local-relay` feature flag

### DIFF
--- a/iroh-net/bench/Cargo.toml
+++ b/iroh-net/bench/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0.22"
 bytes = "1.7"
 hdrhistogram = { version = "7.2", default-features = false }
-iroh-net = { path = "..", features = ["test-utils"] }
+iroh-net = { path = ".." }
 iroh-metrics = { path = "../../iroh-metrics" }
 quinn = { package = "iroh-quinn", version = "0.11" }
 rcgen = "0.12"
@@ -20,3 +20,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 socket2 = "0.5"
 futures-lite = "2.3.0"
+
+[features]
+default = []
+local-relay = ["iroh-net/test-utils"]

--- a/iroh-net/bench/src/iroh.rs
+++ b/iroh-net/bench/src/iroh.rs
@@ -30,9 +30,15 @@ pub fn server_endpoint(
         let relay_mode = relay_url.clone().map_or(RelayMode::Disabled, |url| {
             RelayMode::Custom(RelayMap::from_url(url))
         });
-        let ep = Endpoint::builder()
+
+        #[allow(unused_mut)]
+        let mut builder = Endpoint::builder();
+        #[cfg(feature = "local-relay")]
+        {
+            builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some())
+        }
+        let ep = builder
             .alpns(vec![ALPN.to_vec()])
-            .insecure_skip_relay_cert_verify(relay_url.is_some())
             .relay_mode(relay_mode)
             .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
             .bind(0)
@@ -81,9 +87,14 @@ pub async fn connect_client(
     let relay_mode = relay_url.clone().map_or(RelayMode::Disabled, |url| {
         RelayMode::Custom(RelayMap::from_url(url))
     });
-    let endpoint = Endpoint::builder()
+    #[allow(unused_mut)]
+    let mut builder = Endpoint::builder();
+    #[cfg(feature = "local-relay")]
+    {
+        builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some())
+    }
+    let endpoint = builder
         .alpns(vec![ALPN.to_vec()])
-        .insecure_skip_relay_cert_verify(relay_url.is_some())
         .relay_mode(relay_mode)
         .transport_config(transport_config(opt.max_streams, opt.initial_mtu))
         .bind(0)


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
Now, to test relay-only throughput do this:
```sh
$ cd iroh-net/bench
$ DEV_RELAY_ONLY=t cargo run --features local-relay --release -- iroh --with-relay
```

Putting this behind a feature flag means we don't get weird feature flag workspace unification with the `test-utils` feature. Before this change, we would basically disable DNS discovery for everything in the workspace.

## Breaking Changes

None.
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
Quite a few toggles now with `DEV_RELAY_ONLY`, the `local-relay` feature and the `--with-relay` cli flag. I think each has its own meaning though (the `--with-relay` meaning can be expanded in the future).

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
