### PR TITLE
refactor!: Migrate to tokio's AbortOnDropHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5848,13 +5848,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "slab",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-appender",

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -61,6 +61,7 @@ tempfile = "3.10.1"
 thiserror = "1.0.58"
 time = { version = "0.3", features = ["formatting"] }
 tokio = { version = "1.36.0", features = ["full"] }
+tokio-util = { version = "0.7.12", features = ["rt"] }
 toml = { version = "0.8.12", features = ["preserve_order"] }
 tracing = "0.1.40"
 tracing-appender = "0.2.3"

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -35,7 +35,6 @@ use iroh::{
         netcheck, portmapper,
         relay::{RelayMap, RelayMode, RelayUrl},
         ticket::NodeTicket,
-        util::CancelOnDrop,
         Endpoint, NodeAddr, NodeId,
     },
     util::{path::IrohPaths, progress::ProgressWriter},
@@ -44,6 +43,7 @@ use portable_atomic::AtomicU64;
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncWriteExt, sync};
+use tokio_util::task::AbortOnDropHandle;
 
 use iroh::net::metrics::MagicsockMetrics;
 use iroh_metrics::core::Core;
@@ -372,7 +372,7 @@ struct Gui {
     recv_pb: ProgressBar,
     echo_pb: ProgressBar,
     #[allow(dead_code)]
-    counter_task: Option<CancelOnDrop>,
+    counter_task: Option<AbortOnDropHandle<()>>,
 }
 
 impl Gui {
@@ -412,10 +412,7 @@ impl Gui {
             send_pb,
             recv_pb,
             echo_pb,
-            counter_task: Some(CancelOnDrop::new(
-                "counter_task",
-                counter_task.abort_handle(),
-            )),
+            counter_task: Some(AbortOnDropHandle::new(counter_task)),
         }
     }
 

--- a/iroh-docs/Cargo.toml
+++ b/iroh-docs/Cargo.toml
@@ -44,7 +44,7 @@ tempfile = { version = "3.4" }
 thiserror = "1"
 tokio = { version = "1", features = ["sync", "rt", "time", "macros"] }
 tokio-stream = { version = "0.1", optional = true, features = ["sync"]}
-tokio-util = { version = "0.7", optional = true, features = ["codec", "io-util", "io"] }
+tokio-util = { version = "0.7.12", optional = true, features = ["codec", "io-util", "io", "rt"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -35,7 +35,7 @@ futures-concurrency = { version = "7.6.1", optional = true }
 futures-util = { version = "0.3.30", optional = true }
 iroh-net = { path = "../iroh-net", version = "0.24.0", optional = true, default-features = false }
 tokio = { version = "1", optional = true, features = ["io-util", "sync", "rt", "macros", "net", "fs"] }
-tokio-util = { version = "0.7.8", optional = true, features = ["codec"] }
+tokio-util = { version = "0.7.12", optional = true, features = ["codec", "rt"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -13,7 +13,6 @@ use iroh_net::{
     dialer::Dialer,
     endpoint::{get_remote_node_id, Connection},
     key::PublicKey,
-    util::SharedAbortingJoinHandle,
     AddrInfo, Endpoint, NodeAddr, NodeId,
 };
 use rand::rngs::StdRng;
@@ -21,10 +20,12 @@ use rand_core::SeedableRng;
 use std::{
     collections::{BTreeSet, HashMap, HashSet, VecDeque},
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
     time::Instant,
 };
 use tokio::{sync::mpsc, task::JoinSet};
+use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error_span, trace, warn, Instrument};
 
 use self::util::{read_message, write_message, Timers};
@@ -90,7 +91,7 @@ type ProtoMessage = proto::Message<PublicKey>;
 pub struct Gossip {
     to_actor_tx: mpsc::Sender<ToActor>,
     on_direct_addrs_tx: mpsc::Sender<Vec<iroh_net::endpoint::DirectAddr>>,
-    _actor_handle: SharedAbortingJoinHandle<()>,
+    _actor_handle: Arc<AbortOnDropHandle<()>>,
     max_message_size: usize,
 }
 
@@ -138,7 +139,7 @@ impl Gossip {
         Self {
             to_actor_tx,
             on_direct_addrs_tx: on_endpoints_tx,
-            _actor_handle: actor_handle.into(),
+            _actor_handle: Arc::new(AbortOnDropHandle::new(actor_handle)),
             max_message_size,
         }
     }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "1", features = ["io-util", "macros", "sync", "rt", "net", "
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring"] }
 tokio-tungstenite = "0.21"
 tokio-tungstenite-wasm = "0.3"
-tokio-util = { version = "0.7", features = ["io-util", "io", "codec"] }
+tokio-util = { version = "0.7", features = ["io-util", "io", "codec", "rt"] }
 tracing = "0.1"
 tungstenite = "0.21"
 url = { version = "2.4", features = ["serde"] }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "1", features = ["io-util", "macros", "sync", "rt", "net", "
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring"] }
 tokio-tungstenite = "0.21"
 tokio-tungstenite-wasm = "0.3"
-tokio-util = { version = "0.7", features = ["io-util", "io", "codec", "rt"] }
+tokio-util = { version = "0.7.12", features = ["io-util", "io", "codec", "rt"] }
 tracing = "0.1"
 tungstenite = "0.21"
 url = { version = "2.4", features = ["serde"] }

--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -343,8 +343,9 @@ mod tests {
 
     use parking_lot::Mutex;
     use rand::Rng;
+    use tokio_util::task::AbortOnDropHandle;
 
-    use crate::{key::SecretKey, relay::RelayMode, util::AbortingJoinHandle};
+    use crate::{key::SecretKey, relay::RelayMode};
 
     use super::*;
 
@@ -588,7 +589,7 @@ mod tests {
     async fn new_endpoint(
         secret: SecretKey,
         disco: impl Discovery + 'static,
-    ) -> (Endpoint, AbortingJoinHandle<anyhow::Result<()>>) {
+    ) -> (Endpoint, AbortOnDropHandle<anyhow::Result<()>>) {
         let ep = Endpoint::builder()
             .secret_key(secret)
             .discovery(Box::new(disco))
@@ -611,7 +612,7 @@ mod tests {
             }
         });
 
-        (ep, AbortingJoinHandle::from(handle))
+        (ep, AbortOnDropHandle::new(handle))
     }
 
     fn system_time_now() -> u64 {
@@ -632,6 +633,7 @@ mod test_dns_pkarr {
 
     use anyhow::Result;
     use iroh_base::key::SecretKey;
+    use tokio_util::task::AbortOnDropHandle;
 
     use crate::{
         discovery::pkarr::PkarrPublisher,
@@ -642,7 +644,6 @@ mod test_dns_pkarr {
             pkarr_dns_state::State,
             run_relay_server, DnsPkarrServer,
         },
-        util::AbortingJoinHandle,
         AddrInfo, Endpoint, NodeAddr,
     };
 
@@ -753,7 +754,7 @@ mod test_dns_pkarr {
     async fn ep_with_discovery(
         relay_map: &RelayMap,
         dns_pkarr_server: &DnsPkarrServer,
-    ) -> Result<(Endpoint, AbortingJoinHandle<Result<()>>)> {
+    ) -> Result<(Endpoint, AbortOnDropHandle<Result<()>>)> {
         let secret_key = SecretKey::generate();
         let ep = Endpoint::builder()
             .relay_mode(RelayMode::Custom(relay_map.clone()))
@@ -778,6 +779,6 @@ mod test_dns_pkarr {
             }
         });
 
-        Ok((ep, AbortingJoinHandle::from(handle)))
+        Ok((ep, AbortOnDropHandle::new(handle)))
     }
 }

--- a/iroh-net/src/discovery/local_swarm_discovery.rs
+++ b/iroh-net/src/discovery/local_swarm_discovery.rs
@@ -17,10 +17,10 @@ use tracing::{debug, error, trace, warn};
 use iroh_base::key::PublicKey;
 use swarm_discovery::{Discoverer, DropGuard, IpClass, Peer};
 use tokio::{sync::mpsc, task::JoinSet};
+use tokio_util::task::AbortOnDropHandle;
 
 use crate::{
     discovery::{Discovery, DiscoveryItem},
-    util::AbortingJoinHandle,
     AddrInfo, Endpoint, NodeId,
 };
 
@@ -37,7 +37,7 @@ const DISCOVERY_DURATION: Duration = Duration::from_secs(10);
 #[derive(Debug)]
 pub struct LocalSwarmDiscovery {
     #[allow(dead_code)]
-    handle: AbortingJoinHandle<()>,
+    handle: AbortOnDropHandle<()>,
     sender: mpsc::Sender<Message>,
 }
 
@@ -192,7 +192,7 @@ impl LocalSwarmDiscovery {
             }
         });
         Ok(Self {
-            handle: handle.into(),
+            handle: AbortOnDropHandle::new(handle),
             sender: send,
         })
     }

--- a/iroh-net/src/discovery/pkarr/dht.rs
+++ b/iroh-net/src/discovery/pkarr/dht.rs
@@ -60,7 +60,7 @@ struct Inner {
     pkarr_relay: Option<PkarrRelayClientAsync>,
     /// The background task that periodically publishes the node address.
     ///
-    /// Due to [`ChildTask`], this will be aborted when the discovery is dropped.
+    /// Due to [`AbortOnDropHandle`], this will be aborted when the discovery is dropped.
     task: Mutex<Option<AbortOnDropHandle<()>>>,
     /// Optional keypair for signing the DNS packets.
     ///

--- a/iroh-net/src/discovery/pkarr/dht.rs
+++ b/iroh-net/src/discovery/pkarr/dht.rs
@@ -18,7 +18,6 @@ use crate::{
     },
     dns::node_info::NodeInfo,
     key::SecretKey,
-    util::AbortingJoinHandle,
     AddrInfo, Endpoint, NodeId,
 };
 use futures_lite::StreamExt;
@@ -27,6 +26,7 @@ use pkarr::{
     PkarrClient, PkarrClientAsync, PkarrRelayClient, PkarrRelayClientAsync, PublicKey,
     RelaySettings, SignedPacket,
 };
+use tokio_util::task::AbortOnDropHandle;
 use url::Url;
 
 /// Republish delay for the DHT. This is only for when the info does not change.
@@ -59,8 +59,9 @@ struct Inner {
     #[debug("Option<PkarrRelayClientAsync>")]
     pkarr_relay: Option<PkarrRelayClientAsync>,
     /// The background task that periodically publishes the node address.
-    /// Due to AbortingJoinHandle, this will be aborted when the discovery is dropped.
-    task: Mutex<Option<AbortingJoinHandle<()>>>,
+    ///
+    /// Due to [`ChildTask`], this will be aborted when the discovery is dropped.
+    task: Mutex<Option<AbortOnDropHandle<()>>>,
     /// Optional keypair for signing the DNS packets.
     ///
     /// If this is None, the node will not publish its address to the DHT.
@@ -370,7 +371,7 @@ impl Discovery for DhtDiscovery {
         let this = self.clone();
         let curr = tokio::spawn(this.publish_loop(keypair.clone(), signed_packet));
         let mut task = self.0.task.lock().unwrap();
-        *task = Some(curr.into());
+        *task = Some(AbortOnDropHandle::new(curr));
     }
 
     fn resolve(

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -133,7 +133,7 @@ pub mod relay;
 pub mod stun;
 pub mod ticket;
 pub mod tls;
-pub mod util;
+pub(crate) mod util;
 
 pub use endpoint::{AddrInfo, Endpoint, NodeAddr};
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2803,11 +2803,11 @@ mod tests {
     use anyhow::Context;
     use iroh_test::CallOnDrop;
     use rand::RngCore;
+    use tokio_util::task::AbortOnDropHandle;
 
     use crate::defaults::staging::EU_RELAY_HOSTNAME;
     use crate::relay::RelayMode;
     use crate::tls;
-    use crate::util::AbortingJoinHandle;
     use crate::Endpoint;
 
     use super::*;
@@ -3747,7 +3747,7 @@ mod tests {
             }
             .instrument(info_span!("ep2.accept, me = node_id_2.fmt_short()"))
         });
-        let _accept_task = AbortingJoinHandle::from(accept_task);
+        let _accept_task = AbortOnDropHandle::new(accept_task);
 
         let node_addr_2 = NodeAddr {
             node_id: node_id_2,
@@ -3812,7 +3812,7 @@ mod tests {
             }
             .instrument(info_span!("ep2.accept", me = node_id_2.fmt_short()))
         });
-        let _accept_task = AbortingJoinHandle::from(accept_task);
+        let _accept_task = AbortOnDropHandle::new(accept_task);
 
         // Add an empty entry in the NodeMap of ep_1
         msock_1.node_map.add_node_addr(

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -28,6 +28,7 @@ use rand::seq::IteratorRandom;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::{self, Instant};
+use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, debug_span, error, info_span, trace, warn, Instrument, Span};
 
 use super::NetcheckMetrics;
@@ -38,7 +39,7 @@ use crate::net::UdpSocket;
 use crate::netcheck::{self, Report};
 use crate::ping::{PingError, Pinger};
 use crate::relay::{RelayMap, RelayNode, RelayUrl};
-use crate::util::{CancelOnDrop, MaybeFuture};
+use crate::util::MaybeFuture;
 use crate::{portmapper, stun};
 
 mod hairpin;
@@ -62,7 +63,7 @@ const DNS_STAGGERING_MS: &[u64] = &[200, 300];
 #[derive(Debug)]
 pub(super) struct Client {
     // Addr is currently only used by child actors, so not yet exposed here.
-    _drop_guard: CancelOnDrop,
+    _drop_guard: AbortOnDropHandle<()>,
 }
 
 impl Client {
@@ -101,7 +102,7 @@ impl Client {
             async move { actor.run().await }.instrument(info_span!("reportgen.actor")),
         );
         Self {
-            _drop_guard: CancelOnDrop::new("reportgen actor", task.abort_handle()),
+            _drop_guard: AbortOnDropHandle::new(task),
         }
     }
 }

--- a/iroh-net/src/relay/server/http_server.rs
+++ b/iroh-net/src/relay/server/http_server.rs
@@ -103,7 +103,7 @@ impl Server {
         self.cancel_server_loop.cancel();
     }
 
-    /// Returns the [`AbortingJoinHandle`] for the supervisor task managing the server.
+    /// Returns the [`AbortOnDropHandle`] for the supervisor task managing the server.
     ///
     /// This is the root of all the tasks for the server.  Aborting it will abort all the
     /// other tasks for the server.  Awaiting it will complete when all the server tasks are

--- a/iroh-net/src/relay/server/http_server.rs
+++ b/iroh-net/src/relay/server/http_server.rs
@@ -18,6 +18,7 @@ use hyper::{HeaderMap, Method, Request, Response, StatusCode};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls_acme::AcmeAcceptor;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, debug_span, error, info, info_span, warn, Instrument};
 use tungstenite::handshake::derive_accept_key;
 
@@ -25,7 +26,6 @@ use crate::key::SecretKey;
 use crate::relay::http::{Protocol, LEGACY_RELAY_PATH, RELAY_PATH, SUPPORTED_WEBSOCKET_VERSION};
 use crate::relay::server::actor::{ClientConnHandler, ServerActorTask};
 use crate::relay::server::streams::MaybeTlsStream;
-use crate::util::AbortingJoinHandle;
 
 type BytesBody = http_body_util::Full<hyper::body::Bytes>;
 type HyperError = Box<dyn std::error::Error + Send + Sync>;
@@ -83,7 +83,7 @@ async fn relay_connection_handler(
 #[derive(Debug)]
 pub struct Server {
     addr: SocketAddr,
-    http_server_task: AbortingJoinHandle<()>,
+    http_server_task: AbortOnDropHandle<()>,
     cancel_server_loop: CancellationToken,
 }
 
@@ -108,7 +108,7 @@ impl Server {
     /// This is the root of all the tasks for the server.  Aborting it will abort all the
     /// other tasks for the server.  Awaiting it will complete when all the server tasks are
     /// completed.
-    pub fn task_handle(&mut self) -> &mut AbortingJoinHandle<()> {
+    pub fn task_handle(&mut self) -> &mut AbortOnDropHandle<()> {
         &mut self.http_server_task
     }
 
@@ -369,7 +369,7 @@ impl ServerState {
 
         Ok(Server {
             addr,
-            http_server_task: AbortingJoinHandle::from(task),
+            http_server_task: AbortOnDropHandle::new(task),
             cancel_server_loop,
         })
     }

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -6,11 +6,11 @@ use std::{
     task::{Context, Poll},
 };
 
-pub mod chain;
+pub(crate) mod chain;
 
 /// Resolves to pending if the inner is `None`.
 #[derive(Debug)]
-pub struct MaybeFuture<T> {
+pub(crate) struct MaybeFuture<T> {
     /// Future to be polled.
     pub inner: Option<T>,
 }

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -48,30 +48,6 @@ impl<T: Clone + Send> Drop for SharedAbortingJoinHandle<T> {
     }
 }
 
-/// Holds a handle to a task and aborts it on drop.
-///
-/// See [`tokio::task::AbortHandle`].
-#[derive(derive_more::Debug)]
-pub struct CancelOnDrop {
-    task_name: &'static str,
-    #[debug(skip)]
-    handle: tokio::task::AbortHandle,
-}
-
-impl CancelOnDrop {
-    /// Create a [`CancelOnDrop`] with a name and a handle to a task.
-    pub fn new(task_name: &'static str, handle: tokio::task::AbortHandle) -> Self {
-        CancelOnDrop { task_name, handle }
-    }
-}
-
-impl Drop for CancelOnDrop {
-    fn drop(&mut self) {
-        self.handle.abort();
-        tracing::trace!("{} completed (aborted)", self.task_name);
-    }
-}
-
 /// Resolves to pending if the inner is `None`.
 #[derive(Debug)]
 pub struct MaybeFuture<T> {

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -3,50 +3,10 @@
 use std::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
-use futures_lite::future::Boxed as BoxFuture;
-use futures_util::{future::Shared, FutureExt};
-
 pub mod chain;
-
-/// A join handle that owns the task it is running, and aborts it when dropped.
-/// It is cloneable and will abort when the last instance is dropped.
-#[derive(Debug, Clone)]
-pub struct SharedAbortingJoinHandle<T: Clone + Send> {
-    fut: Shared<BoxFuture<std::result::Result<T, String>>>,
-    abort: Arc<tokio::task::AbortHandle>,
-}
-
-impl<T: Clone + Send + 'static> From<tokio::task::JoinHandle<T>> for SharedAbortingJoinHandle<T> {
-    fn from(handle: tokio::task::JoinHandle<T>) -> Self {
-        let abort = handle.abort_handle();
-        let fut: BoxFuture<std::result::Result<T, String>> =
-            Box::pin(async move { handle.await.map_err(|e| e.to_string()) });
-        Self {
-            fut: fut.shared(),
-            abort: Arc::new(abort),
-        }
-    }
-}
-
-impl<T: Clone + Send> Future for SharedAbortingJoinHandle<T> {
-    type Output = std::result::Result<T, String>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.fut).poll(cx)
-    }
-}
-
-impl<T: Clone + Send> Drop for SharedAbortingJoinHandle<T> {
-    fn drop(&mut self) {
-        if Arc::strong_count(&self.abort) == 1 {
-            self.abort.abort();
-        }
-    }
-}
 
 /// Resolves to pending if the inner is `None`.
 #[derive(Debug)]

--- a/iroh-net/src/util.rs
+++ b/iroh-net/src/util.rs
@@ -13,33 +13,6 @@ use futures_util::{future::Shared, FutureExt};
 pub mod chain;
 
 /// A join handle that owns the task it is running, and aborts it when dropped.
-#[derive(Debug, derive_more::Deref)]
-#[must_use = "Aborting join handles abort the task when dropped"]
-pub struct AbortingJoinHandle<T> {
-    handle: tokio::task::JoinHandle<T>,
-}
-
-impl<T> From<tokio::task::JoinHandle<T>> for AbortingJoinHandle<T> {
-    fn from(handle: tokio::task::JoinHandle<T>) -> Self {
-        Self { handle }
-    }
-}
-
-impl<T> Future for AbortingJoinHandle<T> {
-    type Output = std::result::Result<T, tokio::task::JoinError>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.handle).poll(cx)
-    }
-}
-
-impl<T> Drop for AbortingJoinHandle<T> {
-    fn drop(&mut self) {
-        self.handle.abort();
-    }
-}
-
-/// A join handle that owns the task it is running, and aborts it when dropped.
 /// It is cloneable and will abort when the last instance is dropped.
 #[derive(Debug, Clone)]
 pub struct SharedAbortingJoinHandle<T: Clone + Send> {

--- a/iroh-net/src/util/chain.rs
+++ b/iroh-net/src/util/chain.rs
@@ -14,7 +14,7 @@ use tokio::io::{AsyncBufRead, AsyncRead, ReadBuf};
 /// Stream for the [`chain`] method.
 #[must_use = "streams do nothing unless polled"]
 #[pin_project]
-pub struct Chain<T, U> {
+pub(crate) struct Chain<T, U> {
     #[pin]
     first: T,
     #[pin]
@@ -23,7 +23,7 @@ pub struct Chain<T, U> {
 }
 
 /// Chain two `AsyncRead`s together.
-pub fn chain<T, U>(first: T, second: U) -> Chain<T, U>
+pub(crate) fn chain<T, U>(first: T, second: U) -> Chain<T, U>
 where
     T: AsyncRead,
     U: AsyncRead,
@@ -41,7 +41,7 @@ where
     U: AsyncRead,
 {
     /// Gets references to the underlying readers in this `Chain`.
-    pub fn get_ref(&self) -> (&T, &U) {
+    pub(crate) fn get_ref(&self) -> (&T, &U) {
         (&self.first, &self.second)
     }
 
@@ -50,23 +50,8 @@ where
     /// Care should be taken to avoid modifying the internal I/O state of the
     /// underlying readers as doing so may corrupt the internal state of this
     /// `Chain`.
-    pub fn get_mut(&mut self) -> (&mut T, &mut U) {
+    pub(crate) fn get_mut(&mut self) -> (&mut T, &mut U) {
         (&mut self.first, &mut self.second)
-    }
-
-    /// Gets pinned mutable references to the underlying readers in this `Chain`.
-    ///
-    /// Care should be taken to avoid modifying the internal I/O state of the
-    /// underlying readers as doing so may corrupt the internal state of this
-    /// `Chain`.
-    pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut T>, Pin<&mut U>) {
-        let me = self.project();
-        (me.first, me.second)
-    }
-
-    /// Consumes the `Chain`, returning the wrapped readers.
-    pub fn into_inner(self) -> (T, U) {
-        (self.first, self.second)
     }
 }
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -35,14 +35,20 @@
 //! well, without going through [`client`](crate::client::Iroh))
 //!
 //! To shut down the node, call [`Node::shutdown`].
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Debug;
+use std::future::Future;
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
-use std::{collections::BTreeSet, net::SocketAddr};
-use std::{fmt::Debug, time::Duration};
+use std::task::{Context, Poll};
+use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+use futures_lite::future::Boxed as BoxFuture;
 use futures_lite::StreamExt;
+use futures_util::{future::Shared, FutureExt};
 use iroh_base::key::PublicKey;
 use iroh_blobs::store::Store as BaoStore;
 use iroh_blobs::util::local_pool::{LocalPool, LocalPoolHandle};
@@ -51,7 +57,6 @@ use iroh_blobs::{HashAndFormat, TempTag};
 use iroh_gossip::net::Gossip;
 use iroh_net::endpoint::{DirectAddrsStream, RemoteInfo};
 use iroh_net::key::SecretKey;
-use iroh_net::util::SharedAbortingJoinHandle;
 use iroh_net::{AddrInfo, Endpoint, NodeAddr};
 use quic_rpc::transport::ServerEndpoint as _;
 use quic_rpc::RpcServer;
@@ -616,6 +621,45 @@ fn node_address_for_storage(info: RemoteInfo) -> Option<NodeAddr> {
                 direct_addresses,
             },
         })
+    }
+}
+
+/// A join handle that owns the task it is running, and aborts it when dropped.
+/// It is cloneable and will abort when the last instance is dropped.
+///
+/// Please do not copy/use this elsewhere, try and use
+/// [`tokio_util::task::AbortOnDropHandle`] instead.
+#[derive(Debug, Clone)]
+struct SharedAbortingJoinHandle<T: Clone + Send> {
+    fut: Shared<BoxFuture<std::result::Result<T, String>>>,
+    abort: Arc<tokio::task::AbortHandle>,
+}
+
+impl<T: Clone + Send + 'static> From<tokio::task::JoinHandle<T>> for SharedAbortingJoinHandle<T> {
+    fn from(handle: tokio::task::JoinHandle<T>) -> Self {
+        let abort = handle.abort_handle();
+        let fut: BoxFuture<std::result::Result<T, String>> =
+            Box::pin(async move { handle.await.map_err(|e| e.to_string()) });
+        Self {
+            fut: fut.shared(),
+            abort: Arc::new(abort),
+        }
+    }
+}
+
+impl<T: Clone + Send> Future for SharedAbortingJoinHandle<T> {
+    type Output = std::result::Result<T, String>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.fut).poll(cx)
+    }
+}
+
+impl<T: Clone + Send> Drop for SharedAbortingJoinHandle<T> {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.abort) == 1 {
+            self.abort.abort();
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This migrates us to tokio's AbortOnDropHandle from the various
versions we had for this ourselves.  Only for iroh::node::Node we keep
a local version around since it is both Clone *and* awaits the tasks.
Generally it's probably better to not make this kind of design though,
if possible.

## Breaking Changes

Removes the `iroh_net::util` module.  This only contained utilities
that should have been internal in the first place.  If you were using
one of the tools to abort tasks on drop, we recommend migrating to
`tokio_util::task::AbortOnDropHandle`.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.