### PR TITLE
docs(iroh-cli): update `authors` command documentation

### DIFF
--- a/iroh-cli/src/commands/authors.rs
+++ b/iroh-cli/src/commands/authors.rs
@@ -40,6 +40,7 @@ pub enum AuthorCommands {
 }
 
 impl AuthorCommands {
+    /// Runs the author command given an iroh client and console environment.
     pub async fn run(self, iroh: &Iroh, env: &ConsoleEnv) -> Result<()> {
         match self {
             Self::Switch { author } => {

--- a/iroh-cli/src/commands/authors.rs
+++ b/iroh-cli/src/commands/authors.rs
@@ -1,33 +1,36 @@
+//! Define the commands to manage authors.
+
+use crate::config::ConsoleEnv;
 use anyhow::{bail, Result};
 use clap::Parser;
 use derive_more::FromStr;
 use futures_lite::StreamExt;
-use iroh::base::base32::fmt_short;
+use iroh::{
+    base::base32::fmt_short,
+    client::Iroh,
+    docs::{Author, AuthorId},
+};
 
-use iroh::client::Iroh;
-use iroh::docs::{Author, AuthorId};
-
-use crate::config::ConsoleEnv;
-
+/// Commands to manage authors.
 #[derive(Debug, Clone, Parser)]
 pub enum AuthorCommands {
-    /// Set the active author (only works within the Iroh console).
+    /// Set the active author (Note: only works within the Iroh console).
     Switch { author: AuthorId },
     /// Create a new author.
     Create {
-        /// Switch to the created author (only in the Iroh console).
+        /// Switch to the created author (Note: only works in the Iroh console).
         #[clap(long)]
         switch: bool,
     },
     /// Delete an author.
     Delete { author: AuthorId },
-    /// Export an author
+    /// Export an author.
     Export { author: AuthorId },
-    /// Import an author
+    /// Import an author.
     Import { author: String },
     /// Print the default author for this node.
     Default {
-        /// Switch to the default author (only in the Iroh console).
+        /// Switch to the default author (Note: only works in the Iroh console).
         #[clap(long)]
         switch: bool,
     },


### PR DESCRIPTION
## Description

Update documentation to RPC's subcommand `authors`.

This partially addresses #2660, and belongs to a series of PRs to complete it.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

The imports have been formatted to join similar `use` paths.

## Change checklist

- [ ] Self-review.
- [X] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
