### PR TITLE
docs(iroh-cli): update `console` command documentation

### DIFF
--- a/iroh-cli/src/commands/console.rs
+++ b/iroh-cli/src/commands/console.rs
@@ -11,7 +11,7 @@ use iroh::{base::base32::fmt_short, client::Iroh};
 use rustyline::{error::ReadlineError, Config, DefaultEditor};
 use tokio::sync::{mpsc, oneshot};
 
-/// Run the iroh console
+/// Runs the iroh console
 pub async fn run(iroh: &Iroh, env: &ConsoleEnv) -> Result<()> {
     println!("{}", "Welcome to the Iroh console!".purple().bold());
     println!("Type `{}` for a list of commands.", "help".bold());
@@ -39,7 +39,7 @@ pub struct Repl {
 }
 
 impl Repl {
-    /// Create a new REPL environment.
+    /// Creates a new REPL environment.
     pub fn spawn(env: ConsoleEnv) -> mpsc::Receiver<(RpcCommands, oneshot::Sender<()>)> {
         let (cmd_tx, cmd_rx) = mpsc::channel(1);
         let repl = Repl { env, cmd_tx };
@@ -87,7 +87,7 @@ impl Repl {
         Ok(())
     }
 
-    /// Return the prompt for the REPL as a `String`.
+    /// Returns the prompt for the REPL as a `String`.
     pub fn prompt(&self) -> String {
         let mut pwd = String::new();
         let author = self.env.author();
@@ -121,7 +121,7 @@ pub enum ReplCmd {
     Exit,
 }
 
-/// Try to convert a `&str`ing into a `clap` [`Subcommand`], and error if it fails.
+/// Tries to convert a `&str`ing into a `clap` [`Subcommand`], and error if it fails.
 fn try_parse_cmd<C: Subcommand>(s: &str) -> anyhow::Result<C> {
     let args = shell_words::split(s)?;
     let cmd = clap::Command::new("repl");
@@ -134,7 +134,7 @@ fn try_parse_cmd<C: Subcommand>(s: &str) -> anyhow::Result<C> {
     Ok(cmd)
 }
 
-/// Parse a `&str`ing into a `clap` [`Subcommand`].
+/// Parses a `&str`ing into a `clap` [`Subcommand`].
 fn parse_cmd<C: Subcommand>(s: &str) -> Option<C> {
     match try_parse_cmd::<C>(s) {
         Ok(cmd) => Some(cmd),

--- a/iroh-cli/src/commands/console.rs
+++ b/iroh-cli/src/commands/console.rs
@@ -1,16 +1,17 @@
-use anyhow::Result;
-use clap::{Parser, Subcommand};
-use colored::Colorize;
-use iroh::base::base32::fmt_short;
-use iroh::client::Iroh;
-use rustyline::{error::ReadlineError, Config, DefaultEditor};
-use tokio::sync::{mpsc, oneshot};
+//! Define commands for the iroh console.
 
 use crate::{
     commands::rpc::RpcCommands,
     config::{ConsoleEnv, ConsolePaths},
 };
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use colored::Colorize;
+use iroh::{base::base32::fmt_short, client::Iroh};
+use rustyline::{error::ReadlineError, Config, DefaultEditor};
+use tokio::sync::{mpsc, oneshot};
 
+/// Run the iroh console
 pub async fn run(iroh: &Iroh, env: &ConsoleEnv) -> Result<()> {
     println!("{}", "Welcome to the Iroh console!".purple().bold());
     println!("Type `{}` for a list of commands.", "help".bold());
@@ -31,11 +32,14 @@ pub async fn run(iroh: &Iroh, env: &ConsoleEnv) -> Result<()> {
     Ok(())
 }
 
+/// All the information for the REPL environment.
 pub struct Repl {
     env: ConsoleEnv,
     cmd_tx: mpsc::Sender<(RpcCommands, oneshot::Sender<()>)>,
 }
+
 impl Repl {
+    /// Create a new REPL environment.
     pub fn spawn(env: ConsoleEnv) -> mpsc::Receiver<(RpcCommands, oneshot::Sender<()>)> {
         let (cmd_tx, cmd_rx) = mpsc::channel(1);
         let repl = Repl { env, cmd_tx };
@@ -46,6 +50,8 @@ impl Repl {
         });
         cmd_rx
     }
+
+    /// Run the REPL environment.
     pub fn run(self) -> anyhow::Result<()> {
         let mut rl =
             DefaultEditor::with_config(Config::builder().check_cursor_position(true).build())?;
@@ -81,6 +87,7 @@ impl Repl {
         Ok(())
     }
 
+    /// Return the prompt for the REPL as a `String`.
     pub fn prompt(&self) -> String {
         let mut pwd = String::new();
         let author = self.env.author();
@@ -103,8 +110,10 @@ impl Repl {
     }
 }
 
+/// The REPL commands.
 #[derive(Debug, Parser)]
 pub enum ReplCmd {
+    /// Run an RPC command in the REPL.
     #[clap(flatten)]
     Rpc(#[clap(subcommand)] RpcCommands),
     /// Quit the Iroh console
@@ -112,6 +121,7 @@ pub enum ReplCmd {
     Exit,
 }
 
+/// Try to convert a `&str`ing into a `clap` [`Subcommand`], and error if it fails.
 fn try_parse_cmd<C: Subcommand>(s: &str) -> anyhow::Result<C> {
     let args = shell_words::split(s)?;
     let cmd = clap::Command::new("repl");
@@ -124,6 +134,7 @@ fn try_parse_cmd<C: Subcommand>(s: &str) -> anyhow::Result<C> {
     Ok(cmd)
 }
 
+/// Parse a `&str`ing into a `clap` [`Subcommand`].
 fn parse_cmd<C: Subcommand>(s: &str) -> Option<C> {
     match try_parse_cmd::<C>(s) {
         Ok(cmd) => Some(cmd),


### PR DESCRIPTION
## Description

Update documentation to `console` command.

This partially addresses #2660, and belongs to a series of PRs to complete it

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Imports have been formated to be grouped.

## Change checklist

- [ ] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
