### PR TITLE
docs(iroh-cli): update `start` command documentation

### DIFF
--- a/iroh-cli/src/commands.rs
+++ b/iroh-cli/src/commands.rs
@@ -1,15 +1,16 @@
-use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
-
+use self::{
+    blobs::{BlobAddOptions, BlobSource},
+    rpc::RpcCommands,
+    start::RunType,
+};
+use crate::config::{ConsoleEnv, NodeConfig};
 use anyhow::{ensure, Context, Result};
 use clap::Parser;
 use iroh::client::Iroh;
-
-use crate::config::{ConsoleEnv, NodeConfig};
-
-use self::blobs::{BlobAddOptions, BlobSource};
-use self::rpc::RpcCommands;
-use self::start::RunType;
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+};
 
 pub(crate) mod authors;
 pub(crate) mod blobs;
@@ -22,8 +23,9 @@ pub(crate) mod rpc;
 pub(crate) mod start;
 pub(crate) mod tags;
 
-/// iroh is a tool for building distributed apps
-/// https://iroh.computer/docs
+/// iroh is a tool for building distributed apps.
+///
+/// For more information, visit: <https://iroh.computer/docs>.
 #[derive(Parser, Debug, Clone)]
 #[clap(version, verbatim_doc_comment)]
 pub(crate) struct Cli {
@@ -51,14 +53,15 @@ pub(crate) struct Cli {
     pub(crate) metrics_dump_path: Option<PathBuf>,
 }
 
+/// Possible commands to run with the iroh CLI.
 #[derive(Parser, Debug, Clone)]
 pub(crate) enum Commands {
-    /// Start an iroh node
+    /// Start an iroh node.
     ///
     /// A node is a long-running process that serves data and connects to other nodes.
     /// The console, doc, author, blob, node, and tag commands require a running node.
     ///
-    /// start optionally takes a `--add SOURCE` option, which can be a file or a folder
+    /// `start` optionally takes a `--add SOURCE` option, which can be a file or a folder
     /// to serve on startup. Data can also be added after startup with commands like
     /// `iroh blob add` or by adding content to documents.
     ///
@@ -77,14 +80,15 @@ pub(crate) enum Commands {
         add_options: BlobAddOptions,
     },
 
-    /// Open the iroh console
+    /// Open the iroh console.
     ///
     /// The console is a REPL for interacting with a running iroh node.
-    /// For more info on available commands, see https://iroh.computer/docs/api
+    /// For more info on available commands, see <https://iroh.computer/docs/api>.
     ///
     /// For general configuration options see <https://iroh.computer/docs/reference/config>.
     Console,
 
+    /// Manage the RPC.
     #[clap(flatten)]
     Rpc(#[clap(subcommand)] RpcCommands),
 
@@ -97,6 +101,7 @@ pub(crate) enum Commands {
 }
 
 impl Cli {
+    /// Run the CLI.
     pub(crate) async fn run(self, data_dir: &Path) -> Result<()> {
         // Initialize the metrics collection.
         //
@@ -190,7 +195,6 @@ impl Cli {
                 )
                 .await
             }
-
             Commands::Doctor { command } => {
                 let config = Self::load_config(self.config, self.metrics_addr).await?;
                 self::doctor::run(command, &config).await
@@ -198,6 +202,7 @@ impl Cli {
         }
     }
 
+    /// Loads the configuration file or creates the default one, and sets the given metrics address.
     async fn load_config(
         config: Option<PathBuf>,
         metrics_addr: Option<SocketAddr>,

--- a/iroh-cli/src/commands/start.rs
+++ b/iroh-cli/src/commands/start.rs
@@ -32,7 +32,7 @@ pub enum RunType {
 #[error("iroh is already running on port {0}")]
 pub struct AlreadyRunningError(u16);
 
-/// Run an iroh node with a given command.
+/// Runs an iroh node with a given command.
 pub async fn run_with_command<F, T>(
     config: &NodeConfig,
     iroh_data_root: &Path,
@@ -76,7 +76,7 @@ where
     res
 }
 
-/// Private function to run an iroh node with the given command.
+/// Runs an iroh node with the given command (private function).
 async fn run_with_command_inner<F, T>(
     config: &NodeConfig,
     iroh_data_root: &Path,
@@ -131,7 +131,7 @@ where
     Ok(())
 }
 
-/// Start an iroh node.
+/// Starts an iroh node.
 pub(crate) async fn start_node(
     iroh_data_root: &Path,
     rpc_addr: Option<SocketAddr>,
@@ -162,7 +162,7 @@ pub(crate) async fn start_node(
         .await
 }
 
-/// Create a welcome message for the given [`Node`].
+/// Creates a welcome message for the given [`Node`].
 fn welcome_message<B: iroh::blobs::store::Store>(node: &Node<B>) -> Result<String> {
     let msg = format!(
         "{}\nNode ID: {}\n",
@@ -173,7 +173,7 @@ fn welcome_message<B: iroh::blobs::store::Store>(node: &Node<B>) -> Result<Strin
     Ok(msg)
 }
 
-/// Create a nice spinner.
+/// Creates a nice spinner.
 fn create_spinner(msg: &'static str) -> ProgressBar {
     let pb = ProgressBar::new_spinner();
     pb.enable_steady_tick(Duration::from_millis(80));
@@ -207,7 +207,7 @@ pub fn start_metrics_server(
     None
 }
 
-/// Start an iroh metrics dumper service.
+/// Starts an iroh metrics dumper service.
 ///
 /// Returns `None` if succeded; otherwise, returns the `JoinHandle` with which the task can be aborted.
 pub fn start_metrics_dumper(

--- a/iroh-cli/src/commands/start.rs
+++ b/iroh-cli/src/commands/start.rs
@@ -1,14 +1,18 @@
-use std::path::PathBuf;
-use std::{future::Future, net::SocketAddr, path::Path, time::Duration};
+//! Define commands to manage the start of the iroh node.
 
 use crate::config::NodeConfig;
 use anyhow::Result;
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use iroh::node::{Node, DEFAULT_RPC_ADDR};
 use iroh::{
     net::relay::{RelayMap, RelayMode},
-    node::RpcStatus,
+    node::{Node, RpcStatus, DEFAULT_RPC_ADDR},
+};
+use std::{
+    future::Future,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    time::Duration,
 };
 use tracing::{info_span, trace, Instrument};
 
@@ -23,10 +27,12 @@ pub enum RunType {
     UntilStopped,
 }
 
+/// Error to show that iroh is already running in some port.
 #[derive(thiserror::Error, Debug)]
 #[error("iroh is already running on port {0}")]
 pub struct AlreadyRunningError(u16);
 
+/// Run an iroh node with a given command.
 pub async fn run_with_command<F, T>(
     config: &NodeConfig,
     iroh_data_root: &Path,
@@ -45,9 +51,11 @@ where
 
     let res = run_with_command_inner(config, iroh_data_root, rpc_addr, run_type, command).await;
 
+    // If `Some`thing is returned, it means the starting has failed and the tasks should be aborted.
     if let Some(metrics_fut) = metrics_fut {
         metrics_fut.abort();
     }
+    // If `Some`thing is returned, it means the starting has failed and the tasks should be aborted.
     if let Some(metrics_dumper_fut) = metrics_dumper_fut {
         metrics_dumper_fut.abort();
     }
@@ -68,6 +76,7 @@ where
     res
 }
 
+/// Private function to run an iroh node with the given command.
 async fn run_with_command_inner<F, T>(
     config: &NodeConfig,
     iroh_data_root: &Path,
@@ -122,6 +131,7 @@ where
     Ok(())
 }
 
+/// Start an iroh node.
 pub(crate) async fn start_node(
     iroh_data_root: &Path,
     rpc_addr: Option<SocketAddr>,
@@ -133,7 +143,7 @@ pub(crate) async fn start_node(
             return Err(AlreadyRunningError(port).into());
         }
         RpcStatus::Stopped => {
-            // all good, we can go ahead
+            // all good, we can start the node
         }
     }
 
@@ -152,6 +162,7 @@ pub(crate) async fn start_node(
         .await
 }
 
+/// Create a welcome message for the given [`Node`].
 fn welcome_message<B: iroh::blobs::store::Store>(node: &Node<B>) -> Result<String> {
     let msg = format!(
         "{}\nNode ID: {}\n",
@@ -176,6 +187,9 @@ fn create_spinner(msg: &'static str) -> ProgressBar {
     pb.with_finish(indicatif::ProgressFinish::AndClear)
 }
 
+/// Start an iroh metrics server to serve the OpenMetrics endpoint.
+///
+/// Returns `None` if succeded; otherwise, returns the `JoinHandle` with which the task can be aborted.
 pub fn start_metrics_server(
     metrics_addr: Option<SocketAddr>,
 ) -> Option<tokio::task::JoinHandle<()>> {
@@ -193,6 +207,9 @@ pub fn start_metrics_server(
     None
 }
 
+/// Start an iroh metrics dumper service.
+///
+/// Returns `None` if succeded; otherwise, returns the `JoinHandle` with which the task can be aborted.
 pub fn start_metrics_dumper(
     path: Option<PathBuf>,
     interval: Duration,

--- a/iroh-cli/src/commands/start.rs
+++ b/iroh-cli/src/commands/start.rs
@@ -189,7 +189,7 @@ fn create_spinner(msg: &'static str) -> ProgressBar {
 
 /// Start an iroh metrics server to serve the OpenMetrics endpoint.
 ///
-/// Returns `None` if succeded; otherwise, returns the `JoinHandle` with which the task can be aborted.
+/// Returns `None` if succeeded; otherwise, returns the `JoinHandle` with which the task can be aborted.
 pub fn start_metrics_server(
     metrics_addr: Option<SocketAddr>,
 ) -> Option<tokio::task::JoinHandle<()>> {
@@ -209,7 +209,7 @@ pub fn start_metrics_server(
 
 /// Starts an iroh metrics dumper service.
 ///
-/// Returns `None` if succeded; otherwise, returns the `JoinHandle` with which the task can be aborted.
+/// Returns `None` if succeeded; otherwise, returns the `JoinHandle` with which the task can be aborted.
 pub fn start_metrics_dumper(
     path: Option<PathBuf>,
     interval: Duration,


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
Update documentation to `start` command.

This partially addresses #2660, and belongs to a series of PRs to complete it.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Imports have been formated to be grouped.

## Change checklist

- [ ] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
