### PR TITLE
refactor(iroh): Remove custom impl of `SharedAbortingJoinHandle`

### DIFF
--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -107,7 +107,7 @@ pub struct Node<D> {
     // `Node` needs to be `Clone + Send`, and we need to `task.await` in its `shutdown()` impl.
     // So we need
     // - `Shared` so we can `task.await` from all `Node` clones
-    // - `MapErr` to map the `JoinError` to a `String`, because `JoinError` is `!Send`
+    // - `MapErr` to map the `JoinError` to a `String`, because `JoinError` is `!Clone`
     // - `AbortOnDropHandle` to make sure that the `task` is cancelled when all `Node`s are dropped
     //   (`Shared` acts like an `Arc` around its inner future).
     task: Shared<MapErr<AbortOnDropHandle<()>, JoinErrToStr>>,

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -37,18 +37,15 @@
 //! To shut down the node, call [`Node::shutdown`].
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
-use std::future::Future;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
-use futures_lite::future::Boxed as BoxFuture;
 use futures_lite::StreamExt;
-use futures_util::{future::Shared, FutureExt};
+use futures_util::future::MapErr;
+use futures_util::future::Shared;
 use iroh_base::key::PublicKey;
 use iroh_blobs::store::Store as BaoStore;
 use iroh_blobs::util::local_pool::{LocalPool, LocalPoolHandle};
@@ -60,8 +57,9 @@ use iroh_net::key::SecretKey;
 use iroh_net::{AddrInfo, Endpoint, NodeAddr};
 use quic_rpc::transport::ServerEndpoint as _;
 use quic_rpc::RpcServer;
-use tokio::task::JoinSet;
+use tokio::task::{JoinError, JoinSet};
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 
 use crate::node::nodes_storage::store_node_addrs;
@@ -106,9 +104,11 @@ pub type IrohServerEndpoint = quic_rpc::transport::boxed::ServerEndpoint<
 #[derive(Debug, Clone)]
 pub struct Node<D> {
     inner: Arc<NodeInner<D>>,
-    task: SharedAbortingJoinHandle<()>,
+    task: Shared<MapErr<AbortOnDropHandle<()>, JoinErrToStr>>,
     protocols: Arc<ProtocolMap>,
 }
+
+pub(crate) type JoinErrToStr = Box<dyn Fn(JoinError) -> String + Send + Sync + 'static>;
 
 #[derive(derive_more::Debug)]
 struct NodeInner<D> {
@@ -621,45 +621,6 @@ fn node_address_for_storage(info: RemoteInfo) -> Option<NodeAddr> {
                 direct_addresses,
             },
         })
-    }
-}
-
-/// A join handle that owns the task it is running, and aborts it when dropped.
-/// It is cloneable and will abort when the last instance is dropped.
-///
-/// Please do not copy/use this elsewhere, try and use
-/// [`tokio_util::task::AbortOnDropHandle`] instead.
-#[derive(Debug, Clone)]
-struct SharedAbortingJoinHandle<T: Clone + Send> {
-    fut: Shared<BoxFuture<std::result::Result<T, String>>>,
-    abort: Arc<tokio::task::AbortHandle>,
-}
-
-impl<T: Clone + Send + 'static> From<tokio::task::JoinHandle<T>> for SharedAbortingJoinHandle<T> {
-    fn from(handle: tokio::task::JoinHandle<T>) -> Self {
-        let abort = handle.abort_handle();
-        let fut: BoxFuture<std::result::Result<T, String>> =
-            Box::pin(async move { handle.await.map_err(|e| e.to_string()) });
-        Self {
-            fut: fut.shared(),
-            abort: Arc::new(abort),
-        }
-    }
-}
-
-impl<T: Clone + Send> Future for SharedAbortingJoinHandle<T> {
-    type Output = std::result::Result<T, String>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.fut).poll(cx)
-    }
-}
-
-impl<T: Clone + Send> Drop for SharedAbortingJoinHandle<T> {
-    fn drop(&mut self) {
-        if Arc::strong_count(&self.abort) == 1 {
-            self.abort.abort();
-        }
     }
 }
 


### PR DESCRIPTION
## Description

Removes our custom implementation of `SharedAbortingJoinHandle` in favor of a combination of
- `futures_util::future::Shared`
- `futures_util::future::MapErr` and
- `tokio_util::task::AbortOnDropHandle`
<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

Should all be internal, so none.
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

We need to turn the `JoinError` to a `String`, because `JoinError` is `!Send`, but `String` is.
This is exactly the same behavior as what our custom `SharedAbortingJoinHandle` was doing before.
<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
