### PR TITLE
deps(iroh-net): Remove direct dependency on rand_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,6 @@ dependencies = [
  "proptest",
  "rand",
  "rand_chacha",
- "rand_core",
  "rcgen",
  "regex",
  "reqwest",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -50,7 +50,6 @@ quinn = { package = "iroh-quinn", version = "0.11" }
 quinn-proto = { package = "iroh-quinn-proto", version = "0.11" }
 quinn-udp = { package = "iroh-quinn-udp", version = "0.5" }
 rand = "0.8"
-rand_core = "0.6.4"
 rcgen = "0.12"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 ring = "0.17"

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -1251,7 +1251,7 @@ mod tests {
     use std::time::Instant;
 
     use iroh_test::CallOnDrop;
-    use rand_core::SeedableRng;
+    use rand::SeedableRng;
     use tracing::{error_span, info, info_span, Instrument};
 
     use crate::test_utils::run_relay_server;


### PR DESCRIPTION
## Description

This is small and doesn't really affect anything, but removes the
direct dependency on rand_core.  There's no need for it.

## Breaking Changes

None

## Notes & open questions

I was looking for easy wins on the dependencies.  I guess this wasn't 
really it...

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~