### PR TITLE
ci: Remove double spellchecks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,20 +259,6 @@ jobs:
     - name: clippy check (default features)
       run: cargo clippy --workspace --all-targets
 
-  check_typos:
-    timeout-minutes: 30
-    name: Checking typos
-    runs-on: ubuntu-latest
-    env:
-      RUSTC_WRAPPER: "sccache"
-      SCCACHE_GHA_ENABLED: "on"
-    steps:
-    - uses: actions/checkout@v4
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: typos-cli
-    - run: typos
-
   msrv:
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
     timeout-minutes: 30
@@ -466,8 +452,9 @@ jobs:
           target/x86_64-unknown-linux-musl/dev-ci/iroh --rpc-addr 127.0.0.1:4919 stats
 
   codespell:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - run: pip install --user codespell[toml]
     - run: codespell --ignore-words-list=ans,crate,inout,ratatui,ser,stayin,swarmin,worl --skip=CHANGELOG.md


### PR DESCRIPTION
## Description

We somehow have 2 spellcheck actions.  Keep the 2nd one added as
apparently it found more stuff.

But switch it to use the checkout action from a tag, we should not be
using actions from @master (unless they're specifically designed for
this like the rust-toolchain one).

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~