### PR TITLE
refactor!(iroh): move protocol specific fields in NodeInner into protocols

### DIFF
--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -533,16 +533,6 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
     async fn shutdown(&self, protocols: Arc<ProtocolMap>) {
         let error_code = Closed::ProviderTerminating;
 
-        // Shutdown future for the docs engine, if enabled.
-        let docs_shutdown = {
-            let docs = protocols.get_typed::<DocsEngine>(DOCS_ALPN);
-            async move {
-                if let Some(docs) = docs {
-                    docs.shutdown().await
-                }
-            }
-        };
-
         // We ignore all errors during shutdown.
         let _ = tokio::join!(
             // Close the endpoint.
@@ -552,8 +542,6 @@ impl<D: iroh_blobs::store::Store> NodeInner<D> {
             self.endpoint
                 .clone()
                 .close(error_code.into(), error_code.reason()),
-            // Shutdown docs engine.
-            docs_shutdown,
             // Shutdown blobs store engine.
             self.db.shutdown(),
             // Shutdown protocol handlers.

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -53,7 +53,6 @@ use iroh_blobs::{downloader::Downloader, protocol::Closed};
 use iroh_blobs::{HashAndFormat, TempTag};
 use iroh_gossip::net::{Gossip, GOSSIP_ALPN};
 use iroh_net::endpoint::{DirectAddrsStream, RemoteInfo};
-use iroh_net::key::SecretKey;
 use iroh_net::{AddrInfo, Endpoint, NodeAddr};
 use quic_rpc::transport::ServerEndpoint as _;
 use quic_rpc::RpcServer;
@@ -122,7 +121,6 @@ struct NodeInner<D> {
     rpc_addr: Option<SocketAddr>,
     docs: Option<DocsEngine>,
     endpoint: Endpoint,
-    secret_key: SecretKey,
     cancel_token: CancellationToken,
     client: crate::client::Iroh,
     downloader: Downloader,
@@ -244,7 +242,7 @@ impl<D: BaoStore> Node<D> {
 
     /// Returns the [`PublicKey`] of the node.
     pub fn node_id(&self) -> PublicKey {
-        self.inner.secret_key.public()
+        self.inner.endpoint.secret_key().public()
     }
 
     /// Return a client to control this node over an in-memory channel.
@@ -639,7 +637,7 @@ mod tests {
     use bytes::Bytes;
     use iroh_base::node_addr::AddrInfoOptions;
     use iroh_blobs::{provider::AddProgress, util::SetTagOption, BlobFormat};
-    use iroh_net::{relay::RelayMode, test_utils::DnsPkarrServer, NodeAddr};
+    use iroh_net::{key::SecretKey, relay::RelayMode, test_utils::DnsPkarrServer, NodeAddr};
 
     use crate::client::blobs::{AddOutcome, WrapOption};
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -47,9 +47,9 @@ use futures_lite::StreamExt;
 use futures_util::future::MapErr;
 use futures_util::future::Shared;
 use iroh_base::key::PublicKey;
+use iroh_blobs::protocol::Closed;
 use iroh_blobs::store::Store as BaoStore;
 use iroh_blobs::util::local_pool::{LocalPool, LocalPoolHandle};
-use iroh_blobs::{downloader::Downloader, protocol::Closed};
 use iroh_blobs::{HashAndFormat, TempTag};
 use iroh_gossip::net::{Gossip, GOSSIP_ALPN};
 use iroh_net::endpoint::{DirectAddrsStream, RemoteInfo};
@@ -123,7 +123,7 @@ struct NodeInner<D> {
     endpoint: Endpoint,
     cancel_token: CancellationToken,
     client: crate::client::Iroh,
-    downloader: Downloader,
+    // downloader: Downloader,
     blob_batches: tokio::sync::Mutex<BlobBatches>,
     local_pool_handle: LocalPoolHandle,
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -35,7 +35,7 @@
 //! well, without going through [`client`](crate::client::Iroh))
 //!
 //! To shut down the node, call [`Node::shutdown`].
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
@@ -51,7 +51,6 @@ use iroh_base::key::PublicKey;
 use iroh_blobs::protocol::Closed;
 use iroh_blobs::store::Store as BaoStore;
 use iroh_blobs::util::local_pool::{LocalPool, LocalPoolHandle};
-use iroh_blobs::{HashAndFormat, TempTag};
 use iroh_docs::net::DOCS_ALPN;
 use iroh_gossip::net::{Gossip, GOSSIP_ALPN};
 use iroh_net::endpoint::{DirectAddrsStream, RemoteInfo};
@@ -66,7 +65,6 @@ use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 
 use crate::node::nodes_storage::store_node_addrs;
 use crate::node::{docs::DocsEngine, protocol::ProtocolMap};
-use crate::rpc_protocol::blobs::BatchId;
 
 mod builder;
 mod docs;
@@ -125,59 +123,7 @@ struct NodeInner<D> {
     endpoint: Endpoint,
     cancel_token: CancellationToken,
     client: crate::client::Iroh,
-    blob_batches: tokio::sync::Mutex<BlobBatches>,
     local_pool_handle: LocalPoolHandle,
-}
-
-/// Keeps track of all the currently active batch operations of the blobs api.
-#[derive(Debug, Default)]
-struct BlobBatches {
-    /// Currently active batches
-    batches: BTreeMap<BatchId, BlobBatch>,
-    /// Used to generate new batch ids.
-    max: u64,
-}
-
-/// A single batch of blob operations
-#[derive(Debug, Default)]
-struct BlobBatch {
-    /// The tags in this batch.
-    tags: BTreeMap<HashAndFormat, Vec<TempTag>>,
-}
-
-impl BlobBatches {
-    /// Create a new unique batch id.
-    fn create(&mut self) -> BatchId {
-        let id = self.max;
-        self.max += 1;
-        BatchId(id)
-    }
-
-    /// Store a temp tag in a batch identified by a batch id.
-    fn store(&mut self, batch: BatchId, tt: TempTag) {
-        let entry = self.batches.entry(batch).or_default();
-        entry.tags.entry(tt.hash_and_format()).or_default().push(tt);
-    }
-
-    /// Remove a tag from a batch.
-    fn remove_one(&mut self, batch: BatchId, content: &HashAndFormat) -> Result<()> {
-        if let Some(batch) = self.batches.get_mut(&batch) {
-            if let Some(tags) = batch.tags.get_mut(content) {
-                tags.pop();
-                if tags.is_empty() {
-                    batch.tags.remove(content);
-                }
-                return Ok(());
-            }
-        }
-        // this can happen if we try to upgrade a tag from an expired batch
-        anyhow::bail!("tag not found in batch");
-    }
-
-    /// Remove an entire batch.
-    fn remove(&mut self, batch: BatchId) {
-        self.batches.remove(&batch);
-    }
 }
 
 /// In memory node.

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -650,7 +650,6 @@ where
             db: self.blobs_store,
             docs,
             endpoint,
-            secret_key: self.secret_key,
             client,
             cancel_token: CancellationToken::new(),
             downloader,

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -648,7 +648,6 @@ where
         let inner = Arc::new(NodeInner {
             rpc_addr: self.rpc_addr,
             db: self.blobs_store,
-            docs,
             endpoint,
             client,
             cancel_token: CancellationToken::new(),
@@ -668,7 +667,7 @@ where
         };
 
         let protocol_builder =
-            protocol_builder.register_iroh_protocols(self.blob_events, gossip, downloader);
+            protocol_builder.register_iroh_protocols(self.blob_events, gossip, downloader, docs);
 
         Ok(protocol_builder)
     }
@@ -798,6 +797,7 @@ impl<D: iroh_blobs::store::Store> ProtocolBuilder<D> {
         blob_events: EventSender,
         gossip: Gossip,
         downloader: Downloader,
+        docs: Option<DocsEngine>,
     ) -> Self {
         // Register blobs.
         let blobs_proto = BlobsProtocol::new_with_events(
@@ -812,7 +812,7 @@ impl<D: iroh_blobs::store::Store> ProtocolBuilder<D> {
         self = self.accept(GOSSIP_ALPN.to_vec(), Arc::new(gossip));
 
         // Register docs, if enabled.
-        if let Some(docs) = self.inner.docs.clone() {
+        if let Some(docs) = docs {
             self = self.accept(DOCS_ALPN.to_vec(), Arc::new(docs));
         }
 

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -652,7 +652,6 @@ where
             client,
             cancel_token: CancellationToken::new(),
             local_pool_handle: lp.handle().clone(),
-            blob_batches: Default::default(),
         });
 
         let protocol_builder = ProtocolBuilder {

--- a/iroh/src/node/docs.rs
+++ b/iroh/src/node/docs.rs
@@ -52,4 +52,13 @@ impl ProtocolHandler for DocsEngine {
     fn accept(self: Arc<Self>, conn: Connecting) -> BoxedFuture<Result<()>> {
         Box::pin(async move { self.handle_connection(conn).await })
     }
+
+    fn shutdown(self: Arc<Self>) -> BoxedFuture<()> {
+        Box::pin(async move {
+            let this: &Self = &self;
+            if let Err(err) = this.shutdown().await {
+                tracing::warn!("shutdown error: {:?}", err);
+            }
+        })
+    }
 }

--- a/iroh/src/node/protocol.rs
+++ b/iroh/src/node/protocol.rs
@@ -1,10 +1,28 @@
 use std::{any::Any, collections::BTreeMap, fmt, sync::Arc};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use futures_lite::future::Boxed as BoxedFuture;
 use futures_util::future::join_all;
-use iroh_blobs::{provider::EventSender, util::local_pool::LocalPoolHandle};
-use iroh_net::endpoint::Connecting;
+use iroh_blobs::{
+    downloader::{DownloadRequest, Downloader},
+    get::{
+        db::{DownloadProgress, GetState},
+        Stats,
+    },
+    provider::EventSender,
+    util::{
+        local_pool::LocalPoolHandle,
+        progress::{AsyncChannelProgressSender, ProgressSender},
+        SetTagOption,
+    },
+    HashAndFormat,
+};
+use iroh_net::{endpoint::Connecting, Endpoint, NodeAddr};
+use tracing::{debug, warn};
+
+use crate::{
+    client::blobs::DownloadMode, rpc_protocol::blobs::DownloadRequest as BlobDownloadRequest,
+};
 
 /// Handler for incoming connections.
 ///
@@ -82,11 +100,158 @@ pub(crate) struct BlobsProtocol<S> {
     rt: LocalPoolHandle,
     store: S,
     events: EventSender,
+    downloader: Downloader,
 }
 
+/// Name used for logging when new node addresses are added from gossip.
+const BLOB_DOWNLOAD_SOURCE_NAME: &str = "blob_download";
+
 impl<S: iroh_blobs::store::Store> BlobsProtocol<S> {
-    pub fn new_with_events(store: S, rt: LocalPoolHandle, events: EventSender) -> Self {
-        Self { rt, store, events }
+    pub fn new_with_events(
+        store: S,
+        rt: LocalPoolHandle,
+        events: EventSender,
+        downloader: Downloader,
+    ) -> Self {
+        Self {
+            rt,
+            store,
+            events,
+            downloader,
+        }
+    }
+
+    pub async fn download(
+        &self,
+        endpoint: Endpoint,
+        req: BlobDownloadRequest,
+        progress: AsyncChannelProgressSender<DownloadProgress>,
+    ) -> Result<()> {
+        let BlobDownloadRequest {
+            hash,
+            format,
+            nodes,
+            tag,
+            mode,
+        } = req;
+        let hash_and_format = HashAndFormat { hash, format };
+        let temp_tag = self.store.temp_tag(hash_and_format);
+        let stats = match mode {
+            DownloadMode::Queued => {
+                self.download_queued(endpoint, hash_and_format, nodes, progress.clone())
+                    .await?
+            }
+            DownloadMode::Direct => {
+                self.download_direct_from_nodes(endpoint, hash_and_format, nodes, progress.clone())
+                    .await?
+            }
+        };
+
+        progress.send(DownloadProgress::AllDone(stats)).await.ok();
+        match tag {
+            SetTagOption::Named(tag) => {
+                self.store.set_tag(tag, Some(hash_and_format)).await?;
+            }
+            SetTagOption::Auto => {
+                self.store.create_tag(hash_and_format).await?;
+            }
+        }
+        drop(temp_tag);
+
+        Ok(())
+    }
+
+    async fn download_queued(
+        &self,
+        endpoint: Endpoint,
+        hash_and_format: HashAndFormat,
+        nodes: Vec<NodeAddr>,
+        progress: AsyncChannelProgressSender<DownloadProgress>,
+    ) -> Result<Stats> {
+        let mut node_ids = Vec::with_capacity(nodes.len());
+        let mut any_added = false;
+        for node in nodes {
+            node_ids.push(node.node_id);
+            if !node.info.is_empty() {
+                endpoint.add_node_addr_with_source(node, BLOB_DOWNLOAD_SOURCE_NAME)?;
+                any_added = true;
+            }
+        }
+        let can_download = !node_ids.is_empty() && (any_added || endpoint.discovery().is_some());
+        anyhow::ensure!(can_download, "no way to reach a node for download");
+        let req = DownloadRequest::new(hash_and_format, node_ids).progress_sender(progress);
+        let handle = self.downloader.queue(req).await;
+        let stats = handle.await?;
+        Ok(stats)
+    }
+
+    #[tracing::instrument("download_direct", skip_all, fields(hash=%hash_and_format.hash.fmt_short()))]
+    async fn download_direct_from_nodes(
+        &self,
+        endpoint: Endpoint,
+        hash_and_format: HashAndFormat,
+        nodes: Vec<NodeAddr>,
+        progress: AsyncChannelProgressSender<DownloadProgress>,
+    ) -> Result<Stats> {
+        let mut last_err = None;
+        let mut remaining_nodes = nodes.len();
+        let mut nodes_iter = nodes.into_iter();
+        'outer: loop {
+            match iroh_blobs::get::db::get_to_db_in_steps(
+                self.store.clone(),
+                hash_and_format,
+                progress.clone(),
+            )
+            .await?
+            {
+                GetState::Complete(stats) => return Ok(stats),
+                GetState::NeedsConn(needs_conn) => {
+                    let (conn, node_id) = 'inner: loop {
+                        match nodes_iter.next() {
+                            None => break 'outer,
+                            Some(node) => {
+                                remaining_nodes -= 1;
+                                let node_id = node.node_id;
+                                if node_id == endpoint.node_id() {
+                                    debug!(
+                                        ?remaining_nodes,
+                                        "skip node {} (it is the node id of ourselves)",
+                                        node_id.fmt_short()
+                                    );
+                                    continue 'inner;
+                                }
+                                match endpoint.connect(node, iroh_blobs::protocol::ALPN).await {
+                                    Ok(conn) => break 'inner (conn, node_id),
+                                    Err(err) => {
+                                        debug!(
+                                            ?remaining_nodes,
+                                            "failed to connect to {}: {err}",
+                                            node_id.fmt_short()
+                                        );
+                                        continue 'inner;
+                                    }
+                                }
+                            }
+                        }
+                    };
+                    match needs_conn.proceed(conn).await {
+                        Ok(stats) => return Ok(stats),
+                        Err(err) => {
+                            warn!(
+                                ?remaining_nodes,
+                                "failed to download from {}: {err}",
+                                node_id.fmt_short()
+                            );
+                            last_err = Some(err);
+                        }
+                    }
+                }
+            }
+        }
+        match last_err {
+            Some(err) => Err(err.into()),
+            None => Err(anyhow!("No nodes to download from provided")),
+        }
     }
 }
 

--- a/iroh/src/node/protocol.rs
+++ b/iroh/src/node/protocol.rs
@@ -121,6 +121,10 @@ impl<S: iroh_blobs::store::Store> BlobsProtocol<S> {
         }
     }
 
+    pub fn store(&self) -> &S {
+        &self.store
+    }
+
     pub async fn download(
         &self,
         endpoint: Endpoint,
@@ -266,6 +270,12 @@ impl<S: iroh_blobs::store::Store> ProtocolHandler for BlobsProtocol<S> {
             )
             .await;
             Ok(())
+        })
+    }
+
+    fn shutdown(self: Arc<Self>) -> BoxedFuture<()> {
+        Box::pin(async move {
+            self.store.shutdown().await;
         })
     }
 }

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -942,7 +942,7 @@ impl<D: BaoStore> Handler<D> {
 
     #[allow(clippy::unused_async)]
     async fn node_id(self, _: IdRequest) -> RpcResult<NodeId> {
-        Ok(self.inner.secret_key.public())
+        Ok(self.inner.endpoint.secret_key().public())
     }
 
     async fn node_addr(self, _: AddrRequest) -> RpcResult<NodeAddr> {


### PR DESCRIPTION
- refactor(iroh): store gossip in protocolmap
- refactor(iroh): avoid duplicate SecretKey storage
- refactor(iroh): store downloader as part of the blobs
- refactor(iroh): store DocsEngine in protocols
- refactor(iroh): move blobs store into BlobsProtocol
- refactor(iroh): move BlobsBatches into BlobsProtocol

## Breaking Changes

- removed
  - `iroh::node::ProtocolBuilder::downloader`
  - `iroh::node::ProtocolBuilder::blobs_db`
  - `iroh::node::ProtocolBuilder::gossip`