### PR TITLE
refactor: remove count field from ReconciliationAnnounceEntries

### DIFF
--- a/iroh-willow/src/proto/wgps/messages.rs
+++ b/iroh-willow/src/proto/wgps/messages.rs
@@ -354,8 +354,8 @@ impl ReconciliationSendFingerprint {
 pub struct ReconciliationAnnounceEntries {
     /// The 3dRange whose LengthyEntries to transmit.
     pub range: SerdeRange3d,
-    /// The number of Entries the sender has in the range.
-    pub count: u64,
+    /// True if and only if the the sender has zero Entries in the range.
+    pub is_empty: bool,
     /// A boolean flag to indicate whether the sender wishes to receive a ReconciliationAnnounceEntries message for the same 3dRange in return.
     pub want_response: bool,
     /// Whether the sender promises to send the Entries in the range sorted from oldest to newest.
@@ -397,7 +397,11 @@ pub struct ReconciliationSendPayload {
 
 /// Indicate that no more bytes will be transmitted for the currently transmitted Payload as part of set reconciliation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReconciliationTerminatePayload;
+pub struct ReconciliationTerminatePayload {
+    /// True if and only if no further ReconciliationSendEntry message will be sent as part of
+    /// reconciling the current 3dRange.
+    pub is_final: bool,
+}
 
 /// Transmit an AuthorisedEntry to the other peer, and optionally prepare transmission of its Payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Description

@AljoschaMeyer on Discord:

> Drafted the changes for peers to not have to specify the number of entries they will send in a 3dRange in advance.
>
> The [ReconciliationAnnounceEntries](https://macromania--channelclosing.deno.dev/specs/sync/index.html#ReconciliationAnnounceEntries) now does not specify the number of entries, but merely states whether there are zero or more. If there are more, then the [ReconciliationTerminatePayload](https://macromania--channelclosing.deno.dev/specs/sync/index.html#ReconciliationTerminatePayload) indicates for each entry whether it was the final one or whether there are more to follow. This should make @Frando (and now, by proxy, Philipp) happy.
> 

This PR adapts for these changes. 
## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
