### PR TITLE
feat!(iroh): Vec<u8> instead of static bytes for ALPNs

### DIFF
--- a/iroh/examples/custom-protocol.rs
+++ b/iroh/examples/custom-protocol.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
     let proto = BlobSearch::new(builder.client().blobs().clone(), builder.endpoint().clone());
 
     // Add our protocol, identified by our ALPN, to the node, and spawn the node.
-    let node = builder.accept(ALPN, proto.clone()).spawn().await?;
+    let node = builder.accept(ALPN.to_vec(), proto.clone()).spawn().await?;
 
     match args.command {
         Command::Listen { text } => {

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -737,7 +737,7 @@ impl<D: iroh_blobs::store::Store> ProtocolBuilder<D> {
     /// let handler = MyProtocol { client };
     ///
     /// let node = unspawned_node
-    ///     .accept(MY_ALPN, Arc::new(handler))
+    ///     .accept(MY_ALPN.to_vec(), Arc::new(handler))
     ///     .spawn()
     ///     .await?;
     /// # node.shutdown().await?;

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -746,7 +746,7 @@ impl<D: iroh_blobs::store::Store> ProtocolBuilder<D> {
     /// ```
     ///
     ///
-    pub fn accept(mut self, alpn: &'static [u8], handler: Arc<dyn ProtocolHandler>) -> Self {
+    pub fn accept(mut self, alpn: Vec<u8>, handler: Arc<dyn ProtocolHandler>) -> Self {
         self.protocols.insert(alpn, handler);
         self
     }
@@ -800,15 +800,15 @@ impl<D: iroh_blobs::store::Store> ProtocolBuilder<D> {
             self.local_pool_handle().clone(),
             blob_events,
         );
-        self = self.accept(iroh_blobs::protocol::ALPN, Arc::new(blobs_proto));
+        self = self.accept(iroh_blobs::protocol::ALPN.to_vec(), Arc::new(blobs_proto));
 
         // Register gossip.
         let gossip = self.gossip().clone();
-        self = self.accept(GOSSIP_ALPN, Arc::new(gossip));
+        self = self.accept(GOSSIP_ALPN.to_vec(), Arc::new(gossip));
 
         // Register docs, if enabled.
         if let Some(docs) = self.inner.docs.clone() {
-            self = self.accept(DOCS_ALPN, Arc::new(docs));
+            self = self.accept(DOCS_ALPN.to_vec(), Arc::new(docs));
         }
 
         self

--- a/iroh/src/node/protocol.rs
+++ b/iroh/src/node/protocol.rs
@@ -42,7 +42,7 @@ impl<T: Send + Sync + 'static> IntoArcAny for T {
 }
 
 #[derive(Debug, Clone, Default)]
-pub(super) struct ProtocolMap(BTreeMap<&'static [u8], Arc<dyn ProtocolHandler>>);
+pub(super) struct ProtocolMap(BTreeMap<Vec<u8>, Arc<dyn ProtocolHandler>>);
 
 impl ProtocolMap {
     /// Returns the registered protocol handler for an ALPN as a concrete type.
@@ -59,12 +59,12 @@ impl ProtocolMap {
     }
 
     /// Inserts a protocol handler.
-    pub(super) fn insert(&mut self, alpn: &'static [u8], handler: Arc<dyn ProtocolHandler>) {
+    pub(super) fn insert(&mut self, alpn: Vec<u8>, handler: Arc<dyn ProtocolHandler>) {
         self.0.insert(alpn, handler);
     }
 
     /// Returns an iterator of all registered ALPN protocol identifiers.
-    pub(super) fn alpns(&self) -> impl Iterator<Item = &&[u8]> {
+    pub(super) fn alpns(&self) -> impl Iterator<Item = &Vec<u8>> {
         self.0.keys()
     }
 


### PR DESCRIPTION
Otherwise it is not possible to dynamically assign ALPN names.

## Breaking Changes

- `ProtocolBuilder::accept` uses a `Vec<u8>` instead of `&'static [u8]`