### PR TITLE
feat(deps): use derive_more@1.0.0 (no more beta!)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,18 +1153,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0-beta.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3249c0372e72f5f93b5c0ca54c0ab76bbf6216b6f718925476fd9bc4ffabb4fe"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0-beta.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d919ced7590fc17b5d5a3c63b662e8a7d2324212c4e4dbbed975cafd22d16d"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1"
 
 # key module
 aead = { version = "0.5.2", features = ["bytes"], optional = true }
-derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "from_str"], optional = true }
+derive_more = { version = "1.0.0", features = ["debug", "display", "from_str"], optional = true }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"], optional = true }
 once_cell = { version = "1.18.0", optional = true }
 rand = { version = "0.8", optional = true }

--- a/iroh-blobs/Cargo.toml
+++ b/iroh-blobs/Cargo.toml
@@ -21,7 +21,7 @@ async-channel = "2.3.1"
 bao-tree = {  version = "0.13", features = ["tokio_fsm", "validate"], default-features = false }
 bytes = { version = "1.7", features = ["serde"] }
 chrono = "0.4.31"
-derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "deref", "deref_mut", "from", "try_into", "into"] }
+derive_more = { version = "1.0.0", features = ["debug", "display", "deref", "deref_mut", "from", "try_into", "into"] }
 futures-buffered = "0.2.4"
 futures-lite = "2.3"
 genawaiter = { version = "0.99.1", features = ["futures03"] }

--- a/iroh-cli/Cargo.toml
+++ b/iroh-cli/Cargo.toml
@@ -31,7 +31,7 @@ colored = "2.0.4"
 comfy-table = "7.0.1"
 console = "0.15.5"
 crossterm = "0.27.0"
-derive_more = { version = "=1.0.0-beta.7", features = ["display"] }
+derive_more = { version = "1.0.0", features = ["display"] }
 dialoguer = { version = "0.11.0", default-features = false }
 dirs-next = "2.0.0"
 futures-buffered = "0.2.4"

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -17,7 +17,7 @@ axum-server = { version = "0.7", features = ["tls-rustls-no-provider"] }
 base64-url = "2.0.2"
 bytes = "1.7"
 clap = { version = "4.5.1", features = ["derive"] }
-derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "into", "from"] }
+derive_more = { version = "1.0.0", features = ["debug", "display", "into", "from"] }
 dirs-next = "2.0.0"
 futures-lite = "2.3.0"
 governor = "0.6.3"

--- a/iroh-docs/Cargo.toml
+++ b/iroh-docs/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1"
 async-channel = "2.3.1"
 blake3 = { package = "iroh-blake3", version = "1.4.5"}
 bytes = { version = "1.7", features = ["serde"] }
-derive_more = { version = "=1.0.0-beta.7", features = ["debug", "deref", "display", "from", "try_into", "into", "as_ref"] }
+derive_more = { version = "1.0.0", features = ["debug", "deref", "display", "from", "try_into", "into", "as_ref"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 futures-buffered = "0.2.4"
 futures-lite = "2.3.0"

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = { version = "1" }
 async-channel = { version = "2.3.1", optional = true }
 blake3 = { package = "iroh-blake3", version = "1.4.5"}
 bytes = { version = "1.7", features = ["serde"] }
-derive_more = { version = "=1.0.0-beta.7", features = ["add", "debug", "deref", "display", "from", "try_into", "into"] }
+derive_more = { version = "1.0.0", features = ["add", "debug", "deref", "display", "from", "try_into", "into"] }
 ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 indexmap = "2.0"
 iroh-base = { version = "0.25.0", path = "../iroh-base" }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -22,7 +22,7 @@ backoff = "0.4.0"
 bytes = "1.7"
 netdev = "0.30.0"
 der = { version = "0.7", features = ["alloc", "derive"] }
-derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "from", "try_into", "deref"] }
+derive_more = { version = "1.0.0", features = ["debug", "display", "from", "try_into", "deref"] }
 futures-buffered = "0.2.4"
 futures-concurrency = "7.6.0"
 futures-lite = "2.3"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { version = "1" }
 async-channel = "2.3.1"
 bao-tree = { version = "0.13", features = ["tokio_fsm"], default-features = false }
 bytes = "1.7"
-derive_more = { version = "=1.0.0-beta.7", features = ["debug", "display", "from", "try_into", "from_str"] }
+derive_more = { version = "1.0.0", features = ["debug", "display", "from", "try_into", "from_str"] }
 futures-buffered = "0.2.4"
 futures-lite = "2.3"
 futures-util = "0.3"


### PR DESCRIPTION
Apparently, derive_more is out of beta.

Please, update your deps.