### PR TITLE
docs(iroh-net): Document default relay servers a bit more

### DIFF
--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -193,7 +193,7 @@ impl Builder {
     /// They also perform various functions related to hole punching, see the [crate docs]
     /// for more details.
     ///
-    /// By default the Number0 relay servers are used.
+    /// By default the [number 0] relay servers are used, see [`RelayMode::Default`].
     ///
     /// When using [RelayMode::Custom], the provided `relay_map` must contain at least one
     /// configured relay node.  If an invalid RelayMap is provided [`bind`]
@@ -201,6 +201,7 @@ impl Builder {
     ///
     /// [`bind`]: Builder::bind
     /// [crate docs]: crate
+    /// [number 0]: https://n0.computer
     pub fn relay_mode(mut self, relay_mode: RelayMode) -> Self {
         self.relay_mode = relay_mode;
         self

--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -58,6 +58,8 @@
 //! nodes understand their own network situation.  This includes offering a [STUN] server,
 //! but also a few HTTP extra endpoints as well as responding to ICMP echo requests.
 //!
+//! By default the [number 0] relay servers are used, see [`RelayMode::Default`].
+//!
 //!
 //! # Connections and Streams
 //!
@@ -113,6 +115,8 @@
 //! [`RelayUrl`]: crate::relay::RelayUrl
 //! [`discovery`]: crate::endpoint::Builder::discovery
 //! [`DnsDiscovery`]: crate::discovery::dns::DnsDiscovery
+//! [number 0]: https://n0.computer
+//! [`RelayMode::Default`]: crate::relay::RelayMode::Default
 
 #![recursion_limit = "256"]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]


### PR DESCRIPTION
## Description

These were just some places where I was looking for this information
but did not find it easily.

## Breaking Changes

None

## Notes & open questions

It is docs Friday after all!

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~