### PR TITLE
refactor(iroh-net): Various logging improvements

### DIFF
--- a/iroh-net/src/discovery/local_swarm_discovery.rs
+++ b/iroh-net/src/discovery/local_swarm_discovery.rs
@@ -12,7 +12,7 @@ use std::{
 use anyhow::Result;
 use derive_more::FromStr;
 use futures_lite::stream::Boxed as BoxStream;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info_span, trace, warn, Instrument};
 
 use iroh_base::key::PublicKey;
 use swarm_discovery::{Discoverer, DropGuard, IpClass, Peer};
@@ -71,126 +71,130 @@ impl LocalSwarmDiscovery {
             &rt,
         )?;
 
-        let handle = tokio::spawn(async move {
-            let mut node_addrs: HashMap<PublicKey, Peer> = HashMap::default();
-            let mut last_id = 0;
-            let mut senders: HashMap<
-                PublicKey,
-                HashMap<usize, mpsc::Sender<Result<DiscoveryItem>>>,
-            > = HashMap::default();
-            let mut timeouts = JoinSet::new();
-            loop {
-                trace!(?node_addrs, "LocalSwarmDiscovery Service loop tick");
-                let msg = match recv.recv().await {
-                    None => {
-                        error!("LocalSwarmDiscovery channel closed");
-                        error!("closing LocalSwarmDiscovery");
-                        timeouts.abort_all();
-                        return;
-                    }
-                    Some(msg) => msg,
-                };
-                match msg {
-                    Message::Discovery(discovered_node_id, peer_info) => {
-                        trace!(
-                            ?discovered_node_id,
-                            ?peer_info,
-                            "LocalSwarmDiscovery Message::Discovery"
-                        );
-                        let discovered_node_id = match PublicKey::from_str(&discovered_node_id) {
-                            Ok(node_id) => node_id,
-                            Err(e) => {
-                                warn!(
-                                    discovered_node_id,
-                                    "couldn't parse node_id from mdns discovery service: {e:?}"
-                                );
-                                continue;
-                            }
-                        };
-
-                        if discovered_node_id == node_id {
-                            continue;
+        let handle = tokio::spawn(
+            async move {
+                let mut node_addrs: HashMap<PublicKey, Peer> = HashMap::default();
+                let mut last_id = 0;
+                let mut senders: HashMap<
+                    PublicKey,
+                    HashMap<usize, mpsc::Sender<Result<DiscoveryItem>>>,
+                > = HashMap::default();
+                let mut timeouts = JoinSet::new();
+                loop {
+                    trace!(?node_addrs, "LocalSwarmDiscovery Service loop tick");
+                    let msg = match recv.recv().await {
+                        None => {
+                            error!("LocalSwarmDiscovery channel closed");
+                            error!("closing LocalSwarmDiscovery");
+                            timeouts.abort_all();
+                            return;
                         }
-
-                        if peer_info.is_expiry() {
+                        Some(msg) => msg,
+                    };
+                    match msg {
+                        Message::Discovery(discovered_node_id, peer_info) => {
                             trace!(
                                 ?discovered_node_id,
-                                "removing node from LocalSwarmDiscovery address book"
+                                ?peer_info,
+                                "LocalSwarmDiscovery Message::Discovery"
                             );
-                            node_addrs.remove(&discovered_node_id);
-                            continue;
-                        }
+                            let discovered_node_id = match PublicKey::from_str(&discovered_node_id)
+                            {
+                                Ok(node_id) => node_id,
+                                Err(e) => {
+                                    warn!(
+                                        discovered_node_id,
+                                        "couldn't parse node_id from mdns discovery service: {e:?}"
+                                    );
+                                    continue;
+                                }
+                            };
 
-                        let entry = node_addrs.entry(discovered_node_id);
-                        if let std::collections::hash_map::Entry::Occupied(ref entry) = entry {
-                            if entry.get() == &peer_info {
-                                // this is a republish we already know about
+                            if discovered_node_id == node_id {
                                 continue;
                             }
+
+                            if peer_info.is_expiry() {
+                                trace!(
+                                    ?discovered_node_id,
+                                    "removing node from LocalSwarmDiscovery address book"
+                                );
+                                node_addrs.remove(&discovered_node_id);
+                                continue;
+                            }
+
+                            let entry = node_addrs.entry(discovered_node_id);
+                            if let std::collections::hash_map::Entry::Occupied(ref entry) = entry {
+                                if entry.get() == &peer_info {
+                                    // this is a republish we already know about
+                                    continue;
+                                }
+                            }
+
+                            debug!(
+                                ?discovered_node_id,
+                                ?peer_info,
+                                "adding node to LocalSwarmDiscovery address book"
+                            );
+
+                            if let Some(senders) = senders.get(&discovered_node_id) {
+                                let item: DiscoveryItem = (&peer_info).into();
+                                trace!(?item, senders = senders.len(), "sending DiscoveryItem");
+                                for sender in senders.values() {
+                                    sender.send(Ok(item.clone())).await.ok();
+                                }
+                            }
+                            entry.or_insert(peer_info);
                         }
-
-                        debug!(
-                            ?discovered_node_id,
-                            ?peer_info,
-                            "adding node to LocalSwarmDiscovery address book"
-                        );
-
-                        if let Some(senders) = senders.get(&discovered_node_id) {
-                            let item: DiscoveryItem = (&peer_info).into();
-                            trace!(?item, senders = senders.len(), "sending DiscoveryItem");
-                            for sender in senders.values() {
-                                sender.send(Ok(item.clone())).await.ok();
+                        Message::SendAddrs(node_id, sender) => {
+                            let id = last_id + 1;
+                            last_id = id;
+                            trace!(?node_id, "LocalSwarmDiscovery Message::SendAddrs");
+                            if let Some(peer_info) = node_addrs.get(&node_id) {
+                                let item: DiscoveryItem = peer_info.into();
+                                debug!(?item, "sending DiscoveryItem");
+                                sender.send(Ok(item)).await.ok();
+                            }
+                            if let Some(senders_for_node_id) = senders.get_mut(&node_id) {
+                                senders_for_node_id.insert(id, sender);
+                            } else {
+                                let mut senders_for_node_id = HashMap::new();
+                                senders_for_node_id.insert(id, sender);
+                                senders.insert(node_id, senders_for_node_id);
+                            }
+                            let timeout_sender = task_sender.clone();
+                            timeouts.spawn(async move {
+                                tokio::time::sleep(DISCOVERY_DURATION).await;
+                                trace!(?node_id, "discovery timeout");
+                                timeout_sender
+                                    .send(Message::Timeout(node_id, id))
+                                    .await
+                                    .ok();
+                            });
+                        }
+                        Message::Timeout(node_id, id) => {
+                            trace!(?node_id, "LocalSwarmDiscovery Message::Timeout");
+                            if let Some(senders_for_node_id) = senders.get_mut(&node_id) {
+                                senders_for_node_id.remove(&id);
+                                if senders_for_node_id.is_empty() {
+                                    senders.remove(&node_id);
+                                }
                             }
                         }
-                        entry.or_insert(peer_info);
-                    }
-                    Message::SendAddrs(node_id, sender) => {
-                        let id = last_id + 1;
-                        last_id = id;
-                        trace!(?node_id, "LocalSwarmDiscovery Message::SendAddrs");
-                        if let Some(peer_info) = node_addrs.get(&node_id) {
-                            let item: DiscoveryItem = peer_info.into();
-                            debug!(?item, "sending DiscoveryItem");
-                            sender.send(Ok(item)).await.ok();
-                        }
-                        if let Some(senders_for_node_id) = senders.get_mut(&node_id) {
-                            senders_for_node_id.insert(id, sender);
-                        } else {
-                            let mut senders_for_node_id = HashMap::new();
-                            senders_for_node_id.insert(id, sender);
-                            senders.insert(node_id, senders_for_node_id);
-                        }
-                        let timeout_sender = task_sender.clone();
-                        timeouts.spawn(async move {
-                            tokio::time::sleep(DISCOVERY_DURATION).await;
-                            trace!(?node_id, "discovery timeout");
-                            timeout_sender
-                                .send(Message::Timeout(node_id, id))
-                                .await
-                                .ok();
-                        });
-                    }
-                    Message::Timeout(node_id, id) => {
-                        trace!(?node_id, "LocalSwarmDiscovery Message::Timeout");
-                        if let Some(senders_for_node_id) = senders.get_mut(&node_id) {
-                            senders_for_node_id.remove(&id);
-                            if senders_for_node_id.is_empty() {
-                                senders.remove(&node_id);
+                        Message::ChangeLocalAddrs(addrs) => {
+                            trace!(?addrs, "LocalSwarmDiscovery Message::ChangeLocalAddrs");
+                            discovery.remove_all();
+                            let addrs =
+                                LocalSwarmDiscovery::socketaddrs_to_addrs(addrs.direct_addresses);
+                            for addr in addrs {
+                                discovery.add(addr.0, addr.1)
                             }
-                        }
-                    }
-                    Message::ChangeLocalAddrs(addrs) => {
-                        trace!(?addrs, "LocalSwarmDiscovery Message::ChangeLocalAddrs");
-                        discovery.remove_all();
-                        let addrs =
-                            LocalSwarmDiscovery::socketaddrs_to_addrs(addrs.direct_addresses);
-                        for addr in addrs {
-                            discovery.add(addr.0, addr.1)
                         }
                     }
                 }
             }
-        });
+            .instrument(info_span!("swarm-discovery.actor")),
+        );
         Ok(Self {
             handle: AbortOnDropHandle::new(handle),
             sender: send,

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -507,12 +507,17 @@ impl Endpoint {
         self.connect(addr, alpn).await
     }
 
+    #[instrument(
+        skip_all,
+        fields(remote_node = node_id.fmt_short(), alpn = %String::from_utf8_lossy(alpn))
+    )]
     async fn connect_quinn(
         &self,
         node_id: NodeId,
         alpn: &[u8],
         addr: QuicMappedAddr,
     ) -> Result<quinn::Connection> {
+        debug!("Attempting connection...");
         let client_config = {
             let alpn_protocols = vec![alpn.to_vec()];
             let quic_client_config = tls::make_client_config(
@@ -546,7 +551,7 @@ impl Endpoint {
             // If this actor is dead, that's not great but we can still function.
             warn!("rtt-actor not reachable: {err:#}");
         }
-
+        debug!("Connection established");
         Ok(connection)
     }
 

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -891,7 +891,7 @@ impl MagicSock {
                         event!(
                             target: "events.net.call-me-maybe.recv",
                             Level::DEBUG,
-                            src_node = sender.fmt_short(),
+                            remote_node = sender.fmt_short(),
                             via = ?url,
                             their_addrs = ?cm.my_numbers,
                         );
@@ -947,7 +947,7 @@ impl MagicSock {
         event!(
             target: "events.net.pong.sent",
             Level::DEBUG,
-            dst_node = %sender.fmt_short(),
+            remote_node = %sender.fmt_short(),
             dst = ?addr,
             txn = ?dm.tx_id,
         );
@@ -1225,7 +1225,7 @@ impl MagicSock {
             event!(
                 target: "events.net.call-me-maybe.sent",
                 Level::DEBUG,
-                dst_node = %dst_node.fmt_short(),
+                remote_node = %dst_node.fmt_short(),
                 via = ?url,
                 ?addrs,
             );

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -296,7 +296,7 @@ impl NodeState {
             event!(
                 target: "events.net.conn_type.changed",
                 Level::DEBUG,
-                node = %self.node_id.fmt_short(),
+                remote_node = %self.node_id.fmt_short(),
                 conn_type = ?typ,
             );
             info!(%typ, "new connection type");
@@ -384,7 +384,7 @@ impl NodeState {
                     );
                     true
                 } else {
-                    trace!(?now, "not needed");
+                    trace!(?now, "best_addr valid: not needed");
                     false
                 }
             }
@@ -448,7 +448,7 @@ impl NodeState {
         event!(
             target: "events.net.ping.sent",
             Level::DEBUG,
-            dst_node = %self.node_id.fmt_short(),
+            remote_node = %self.node_id.fmt_short(),
             ?dst,
             txn = ?tx_id,
             ?purpose,
@@ -714,7 +714,7 @@ impl NodeState {
         event!(
             target: "events.net.ping.recv",
             Level::DEBUG,
-            src_node = %self.node_id.fmt_short(),
+            remote_node = %self.node_id.fmt_short(),
             src = ?path,
             txn = ?tx_id,
             ?role,
@@ -816,7 +816,7 @@ impl NodeState {
         event!(
             target: "events.net.pong.recv",
             Level::DEBUG,
-            src_node = self.node_id.fmt_short(),
+            remote_node = self.node_id.fmt_short(),
             ?src,
             txn = ?m.tx_id,
         );

--- a/iroh-net/src/magicsock/node_map/path_state.rs
+++ b/iroh-net/src/magicsock/node_map/path_state.rs
@@ -99,7 +99,7 @@ impl PathState {
                 event!(
                     target: "events.net.holepunched",
                     Level::DEBUG,
-                    node = %self.node_id.fmt_short(),
+                    remote_node = %self.node_id.fmt_short(),
                     path = ?path,
                     direction = "outgoing",
                 );
@@ -240,7 +240,7 @@ impl PathState {
                         event!(
                             target: "events.net.holepunched",
                             Level::DEBUG,
-                            node = %self.node_id.fmt_short(),
+                            remote_node = %self.node_id.fmt_short(),
                             path = ?addr,
                             direction = "incoming",
                         );


### PR DESCRIPTION
## Description

- Attach the spans when spawning the local-swarm-discovery.  We should
  always use .instrument() when spawning.

- Clearly log the start and end of connection establishment.

- In the events.net.* events always use remote_node when showing the
  NodeId of the remote node.  These were introduced before we settled
  on the "remote node" terminology, now it makes more sense to double
  down on this as it makes the logs clearer.

## Breaking Changes

None, events.net is not considered part of the public API.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~