### PR TITLE
refactor(iroh-net): Remove PathState::recent_pong()

### DIFF
--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -222,15 +222,15 @@ impl NodeState {
             .udp_paths
             .paths
             .iter()
-            .map(|(addr, endpoint_state)| DirectAddrInfo {
+            .map(|(addr, path_state)| DirectAddrInfo {
                 addr: SocketAddr::from(*addr),
-                latency: endpoint_state.recent_pong().map(|pong| pong.latency),
-                last_control: endpoint_state.last_control_msg(now),
-                last_payload: endpoint_state
+                latency: path_state.recent_pong.as_ref().map(|pong| pong.latency),
+                last_control: path_state.last_control_msg(now),
+                last_payload: path_state
                     .last_payload_msg
                     .as_ref()
                     .map(|instant| now.duration_since(*instant)),
-                last_alive: endpoint_state
+                last_alive: path_state
                     .last_alive()
                     .map(|instant| now.duration_since(instant)),
             })

--- a/iroh-net/src/magicsock/node_map/path_state.rs
+++ b/iroh-net/src/magicsock/node_map/path_state.rs
@@ -152,7 +152,8 @@ impl PathState {
     /// - When the last payload transmission occurred.
     /// - when the last ping from them was received.
     pub(super) fn last_alive(&self) -> Option<Instant> {
-        self.recent_pong()
+        self.recent_pong
+            .as_ref()
             .map(|pong| &pong.pong_at)
             .into_iter()
             .chain(self.last_payload_msg.as_ref())
@@ -173,7 +174,8 @@ impl PathState {
     pub(super) fn last_control_msg(&self, now: Instant) -> Option<(Duration, ControlMsg)> {
         // get every control message and assign it its kind
         let last_pong = self
-            .recent_pong()
+            .recent_pong
+            .as_ref()
             .map(|pong| (pong.pong_at, ControlMsg::Pong));
         let last_call_me_maybe = self
             .call_me_maybe_time
@@ -189,11 +191,6 @@ impl PathState {
             .chain(last_ping)
             .max_by_key(|(instant, _kind)| *instant)
             .map(|(instant, kind)| (now.duration_since(instant), kind))
-    }
-
-    /// Returns the most recent pong if available.
-    pub(super) fn recent_pong(&self) -> Option<&PongReply> {
-        self.recent_pong.as_ref()
     }
 
     /// Returns the latency from the most recent pong, if available.

--- a/iroh-net/src/magicsock/node_map/udp_paths.rs
+++ b/iroh-net/src/magicsock/node_map/udp_paths.rs
@@ -151,10 +151,10 @@ impl NodeUdpPaths {
             let best_latency = best_pong
                 .map(|p: &PongReply| p.latency)
                 .unwrap_or(MAX_LATENCY);
-            match state.recent_pong() {
+            match state.recent_pong {
                 // This pong is better if it has a lower latency, or if it has the same
                 // latency but on an IPv6 path.
-                Some(pong)
+                Some(ref pong)
                     if pong.latency < best_latency
                         || (pong.latency == best_latency && ipp.ip().is_ipv6()) =>
                 {


### PR DESCRIPTION
## Description

The field itself is also directly accessible with the same visibility
as this function.  Having two ways to get to this value is a bit
confusing.  And directly using the field makes it easier when checking
users by following the references from rust-analyzer.


## Breaking Changes

None

## Notes & open questions

None

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~