### PR TITLE
feat(iroh-net): Log the crate version number

### DIFF
--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -405,7 +405,7 @@ impl Endpoint {
             Arc::new(quinn::TokioRuntime),
         )?;
         trace!("created quinn endpoint");
-
+        debug!(version = env!("CARGO_PKG_VERSION"), "iroh Endpoint created");
         Ok(Self {
             msock,
             endpoint,


### PR DESCRIPTION
## Description

This adds a DEBUG-level log logging the crate version number.

## Breaking Changes

None

## Notes & open questions

This is not the first log message appearing, the MagicSock and a few
other pieces already have been logging by this time.  Also I'm not
particularly bound to this wording.  Maybe there are other things that
should be added to this line?

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~