### PR TITLE
docs(iroh-net): Improve last_pong field docs

### DIFF
--- a/iroh-net/src/magicsock/node_map/path_state.rs
+++ b/iroh-net/src/magicsock/node_map/path_state.rs
@@ -44,8 +44,8 @@ pub(super) struct PathState {
 
     /// The most recent [`PongReply`].
     ///
-    /// Previous replies are cleared when the remote node can no longer be reached on this
-    /// path.
+    /// Previous replies are cleared when they are no longer relevant to determine whether
+    /// this path can still be used to reach the remote node.
     pub(super) recent_pong: Option<PongReply>,
     /// When the last payload data was **received** via this path.
     ///

--- a/iroh-net/src/magicsock/node_map/path_state.rs
+++ b/iroh-net/src/magicsock/node_map/path_state.rs
@@ -42,7 +42,9 @@ pub(super) struct PathState {
     /// The time this endpoint was last advertised via a call-me-maybe DISCO message.
     pub(super) call_me_maybe_time: Option<Instant>,
 
-    /// Last [`PongReply`] received.
+    /// The most recent [`PongReply`].
+    ///
+    /// Previous replies are cleared when the path is no longer considered alive.
     pub(super) recent_pong: Option<PongReply>,
     /// When the last payload data was **received** via this path.
     ///

--- a/iroh-net/src/magicsock/node_map/path_state.rs
+++ b/iroh-net/src/magicsock/node_map/path_state.rs
@@ -44,7 +44,8 @@ pub(super) struct PathState {
 
     /// The most recent [`PongReply`].
     ///
-    /// Previous replies are cleared when the path is no longer considered alive.
+    /// Previous replies are cleared when the remote node can no longer be reached on this
+    /// path.
     pub(super) recent_pong: Option<PongReply>,
     /// When the last payload data was **received** via this path.
     ///


### PR DESCRIPTION
## Description

This is a bit confusing, at least this description is closer to the
reality.

## Breaking Changes

None

## Notes & open questions

Not mentioning PING_TIMEOUT_DURATION since that is not strictly true,
if the socket has signs of being alive but a pong is lost it will
still be considered alive and the pong timeout will not be cleared.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
-  ~~[ ] All breaking changes documented.~~