### PR TITLE
feat(iroh): disable docs by default

### DIFF
--- a/iroh-cli/src/commands/start.rs
+++ b/iroh-cli/src/commands/start.rs
@@ -156,6 +156,7 @@ pub(crate) async fn start_node(
     Node::persistent(iroh_data_root)
         .await?
         .relay_mode(relay_mode)
+        .enable_docs()
         .enable_rpc_with_addr(rpc_addr)
         .await?
         .spawn()

--- a/iroh/examples/client.rs
+++ b/iroh/examples/client.rs
@@ -11,7 +11,7 @@ use tokio_stream::StreamExt;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let node = Node::memory().spawn().await?;
+    let node = Node::memory().enable_docs().spawn().await?;
 
     // Could also use `node` directly, as it derefs to the client.
     let client = node.client();

--- a/iroh/src/client/authors.rs
+++ b/iroh/src/client/authors.rs
@@ -100,7 +100,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_authors() -> Result<()> {
-        let node = Node::memory().spawn().await?;
+        let node = Node::memory().enable_docs().spawn().await?;
 
         // default author always exists
         let authors: Vec<_> = node.authors().list().await?.try_collect().await?;

--- a/iroh/src/client/docs.rs
+++ b/iroh/src/client/docs.rs
@@ -757,7 +757,7 @@ mod tests {
     async fn test_drop_doc_client_sync() -> Result<()> {
         let _guard = iroh_test::logging::setup();
 
-        let node = crate::node::Node::memory().spawn().await?;
+        let node = crate::node::Node::memory().enable_docs().spawn().await?;
 
         let client = node.client();
         let doc = client.docs().create().await?;
@@ -778,7 +778,7 @@ mod tests {
     async fn test_doc_close() -> Result<()> {
         let _guard = iroh_test::logging::setup();
 
-        let node = crate::node::Node::memory().spawn().await?;
+        let node = crate::node::Node::memory().enable_docs().spawn().await?;
         let author = node.authors().default().await?;
         // open doc two times
         let doc1 = node.docs().create().await?;
@@ -801,7 +801,7 @@ mod tests {
     async fn test_doc_import_export() -> Result<()> {
         let _guard = iroh_test::logging::setup();
 
-        let node = crate::node::Node::memory().spawn().await?;
+        let node = crate::node::Node::memory().enable_docs().spawn().await?;
 
         // create temp file
         let temp_dir = tempfile::tempdir().context("tempdir")?;

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -642,7 +642,11 @@ mod tests {
 
         let iroh_root = tempfile::TempDir::new()?;
         {
-            let iroh = Node::persistent(iroh_root.path()).await?.spawn().await?;
+            let iroh = Node::persistent(iroh_root.path())
+                .await?
+                .enable_docs()
+                .spawn()
+                .await?;
             let doc = iroh.docs().create().await?;
             drop(doc);
             iroh.shutdown().await?;
@@ -734,7 +738,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_default_author_memory() -> Result<()> {
-        let iroh = Node::memory().spawn().await?;
+        let iroh = Node::memory().enable_docs().spawn().await?;
         let author = iroh.authors().default().await?;
         assert!(iroh.authors().export(author).await?.is_some());
         assert!(iroh.authors().delete(author).await.is_err());
@@ -756,6 +760,7 @@ mod tests {
             let iroh = Node::persistent(iroh_root)
                 .await
                 .unwrap()
+                .enable_docs()
                 .spawn()
                 .await
                 .unwrap();
@@ -771,6 +776,7 @@ mod tests {
             let iroh = Node::persistent(iroh_root)
                 .await
                 .unwrap()
+                .enable_docs()
                 .spawn()
                 .await
                 .unwrap();

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -652,7 +652,11 @@ mod tests {
             iroh.shutdown().await?;
         }
 
-        let iroh = Node::persistent(iroh_root.path()).await?.spawn().await?;
+        let iroh = Node::persistent(iroh_root.path())
+            .await?
+            .enable_docs()
+            .spawn()
+            .await?;
         let _doc = iroh.docs().create().await?;
 
         Ok(())
@@ -796,6 +800,7 @@ mod tests {
             let iroh = Node::persistent(iroh_root)
                 .await
                 .unwrap()
+                .enable_docs()
                 .spawn()
                 .await
                 .unwrap();
@@ -816,8 +821,12 @@ mod tests {
             docs_store.delete_author(default_author).unwrap();
             docs_store.flush().unwrap();
             drop(docs_store);
-            let iroh = Node::persistent(iroh_root).await.unwrap().spawn().await;
-            dbg!(&iroh);
+            let iroh = Node::persistent(iroh_root)
+                .await
+                .unwrap()
+                .enable_docs()
+                .spawn()
+                .await;
             assert!(iroh.is_err());
 
             // somehow the blob store is not shutdown correctly (yet?) on macos.
@@ -829,7 +838,12 @@ mod tests {
                 .await
                 .unwrap();
             drop(iroh);
-            let iroh = Node::persistent(iroh_root).await.unwrap().spawn().await;
+            let iroh = Node::persistent(iroh_root)
+                .await
+                .unwrap()
+                .enable_docs()
+                .spawn()
+                .await;
             assert!(iroh.is_ok());
             iroh.unwrap().shutdown().await.unwrap();
         }
@@ -839,6 +853,7 @@ mod tests {
             let iroh = Node::persistent(iroh_root)
                 .await
                 .unwrap()
+                .enable_docs()
                 .spawn()
                 .await
                 .unwrap();
@@ -852,6 +867,7 @@ mod tests {
             let iroh = Node::persistent(iroh_root)
                 .await
                 .unwrap()
+                .enable_docs()
                 .spawn()
                 .await
                 .unwrap();

--- a/iroh/tests/sync.rs
+++ b/iroh/tests/sync.rs
@@ -34,6 +34,7 @@ const TIMEOUT: Duration = Duration::from_secs(60);
 fn test_node(secret_key: SecretKey) -> Builder<iroh_blobs::store::mem::Store> {
     Node::memory()
         .secret_key(secret_key)
+        .enable_docs()
         .relay_mode(RelayMode::Disabled)
 }
 
@@ -493,6 +494,7 @@ async fn test_sync_via_relay() -> Result<()> {
     let node1 = Node::memory()
         .relay_mode(RelayMode::Custom(relay_map.clone()))
         .insecure_skip_relay_cert_verify(true)
+        .enable_docs()
         .spawn()
         .await?;
     let node1_id = node1.node_id();
@@ -500,6 +502,7 @@ async fn test_sync_via_relay() -> Result<()> {
         .bind_random_port()
         .relay_mode(RelayMode::Custom(relay_map.clone()))
         .insecure_skip_relay_cert_verify(true)
+        .enable_docs()
         .spawn()
         .await?;
 
@@ -593,6 +596,7 @@ async fn sync_restart_node() -> Result<()> {
         .relay_mode(RelayMode::Custom(relay_map.clone()))
         .dns_resolver(discovery_server.dns_resolver())
         .node_discovery(discovery_server.discovery(secret_key_1.clone()).into())
+        .enable_docs()
         .spawn()
         .await?;
     let id1 = node1.node_id();
@@ -612,6 +616,7 @@ async fn sync_restart_node() -> Result<()> {
         .insecure_skip_relay_cert_verify(true)
         .dns_resolver(discovery_server.dns_resolver())
         .node_discovery(discovery_server.discovery(secret_key_2.clone()).into())
+        .enable_docs()
         .spawn()
         .await?;
     let id2 = node2.node_id();
@@ -658,6 +663,7 @@ async fn sync_restart_node() -> Result<()> {
         .relay_mode(RelayMode::Custom(relay_map.clone()))
         .dns_resolver(discovery_server.dns_resolver())
         .node_discovery(discovery_server.discovery(secret_key_1.clone()).into())
+        .enable_docs()
         .spawn()
         .await?;
     assert_eq!(id1, node1.node_id());
@@ -979,6 +985,7 @@ async fn test_list_docs_stream() -> Result<()> {
     let node = Node::memory()
         .node_discovery(iroh::node::DiscoveryConfig::None)
         .relay_mode(iroh::net::relay::RelayMode::Disabled)
+        .enable_docs()
         .spawn()
         .await?;
     let count = 200;
@@ -1148,6 +1155,7 @@ impl PartialEq<ExpectedEntry> for (Entry, Bytes) {
 async fn doc_delete() -> Result<()> {
     let node = Node::memory()
         .gc_policy(iroh::node::GcPolicy::Interval(Duration::from_millis(100)))
+        .enable_docs()
         .spawn()
         .await?;
     let client = node.client();


### PR DESCRIPTION
## Breaking Changes

- removed: `iroh::node::Builder::disable_docs`
- added: `iroh::node::Builder::enable_docs`
- by default `iroh::node::Node::memory` & `persistent` have docs disabled

