### PR TITLE
fix(examples): Make `collection-provide`, `hello-world-provide` and `rpc` work again

### DIFF
--- a/iroh/examples/collection-provide.rs
+++ b/iroh/examples/collection-provide.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
     println!("\tcargo run --example collection-fetch {}", ticket);
     // wait for the node to finish, this will block indefinitely
     // stop with SIGINT (ctrl+c)
-    tokio::signal::ctrl_c().await.ok();
+    tokio::signal::ctrl_c().await?;
     node.shutdown().await?;
     Ok(())
 }

--- a/iroh/examples/collection-provide.rs
+++ b/iroh/examples/collection-provide.rs
@@ -7,6 +7,7 @@
 //! run this example from the project root:
 //!     $ cargo run --example collection-provide
 use iroh::blobs::{format::collection::Collection, util::SetTagOption, BlobFormat};
+use iroh_base::node_addr::AddrInfoOptions;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 // set the RUST_LOG env var to one of {debug,info,warn} to see logging info
@@ -45,7 +46,11 @@ async fn main() -> anyhow::Result<()> {
     // tickets wrap all details needed to get a collection
     let ticket = node
         .blobs()
-        .share(hash, BlobFormat::HashSeq, Default::default())
+        .share(
+            hash,
+            BlobFormat::HashSeq,
+            AddrInfoOptions::RelayAndAddresses,
+        )
         .await?;
 
     // print some info about the node
@@ -68,6 +73,7 @@ async fn main() -> anyhow::Result<()> {
     println!("\tcargo run --example collection-fetch {}", ticket);
     // wait for the node to finish, this will block indefinitely
     // stop with SIGINT (ctrl+c)
+    tokio::signal::ctrl_c().await.ok();
     node.shutdown().await?;
     Ok(())
 }

--- a/iroh/examples/hello-world-provide.rs
+++ b/iroh/examples/hello-world-provide.rs
@@ -3,6 +3,7 @@
 //! This is using an in memory database and a random node id.
 //! run this example from the project root:
 //!     $ cargo run --example hello-world-provide
+use iroh_base::node_addr::AddrInfoOptions;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 // set the RUST_LOG env var to one of {debug,info,warn} to see logging info
@@ -28,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
     // create a ticket
     let ticket = node
         .blobs()
-        .share(res.hash, res.format, Default::default())
+        .share(res.hash, res.format, AddrInfoOptions::RelayAndAddresses)
         .await?;
 
     // print some info about the node
@@ -51,6 +52,7 @@ async fn main() -> anyhow::Result<()> {
     println!("\t cargo run --example hello-world-fetch {}", ticket);
     // wait for the node to finish, this will block indefinitely
     // stop with SIGINT (ctrl+c)
+    tokio::signal::ctrl_c().await?;
     node.shutdown().await?;
     Ok(())
 }

--- a/iroh/examples/rpc.rs
+++ b/iroh/examples/rpc.rs
@@ -38,8 +38,10 @@ where
     for addr in addrs {
         println!("    {}", addr);
     }
+    println!("Started node with RPC enabled. Exit with Ctrl+C");
     // wait for the node to finish, this will block indefinitely
     // stop with SIGINT (ctrl+c)
+    tokio::signal::ctrl_c().await?;
     node.shutdown().await?;
 
     Ok(())


### PR DESCRIPTION
## Description

They were broken, because
- we changed `.share` to default to a node-id-only ticket and
- `node.shutdown().await` doesn't wait for Ctrl+C anymore, instead it immediately shuts down the node.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None

## Notes & open questions

I basically restored the examples original behavior.
It's an open question whether we want to simplify the examples by making the tickets node-id-only.

Also: Testing. Not sure if we can/should. Ideas welcome! (To prevent this from happening again.)

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
