### PR TITLE
feat(iroh): Allow setting a custom `quinn::TransportConfig`

### DIFF
--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -23,6 +23,7 @@ use iroh_net::discovery::local_swarm_discovery::LocalSwarmDiscovery;
 use iroh_net::{
     discovery::{dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery},
     dns::DnsResolver,
+    endpoint::TransportConfig,
     relay::RelayMode,
     Endpoint,
 };
@@ -125,7 +126,7 @@ where
     #[debug("callback")]
     gc_done_callback: Option<Box<dyn Fn() + Send>>,
     blob_events: EventSender,
-    transport_config: Option<quinn::TransportConfig>,
+    transport_config: Option<TransportConfig>,
 }
 
 /// Configuration for storage.
@@ -495,11 +496,11 @@ where
         self
     }
 
-    /// Sets a custom [`quinn::TransportConfig`] to be used by the [`Endpoint`].
+    /// Sets a custom [`TransportConfig`] to be used by the [`Endpoint`].
     ///
-    /// If not set, the [`Endpoint`] will use its default [`quinn::TransportConfig`]. See
-    /// [`iroh_net::endpoint::Builder::transport_config`] for details.
-    pub fn transport_config(mut self, config: quinn::TransportConfig) -> Self {
+    /// If not set, the [`Endpoint`] will use its default [`TransportConfig`]. See
+    /// [`crate::net::endpoint::Builder::transport_config`] for details.
+    pub fn transport_config(mut self, config: TransportConfig) -> Self {
         self.transport_config = Some(config);
         self
     }

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -498,7 +498,7 @@ where
     /// Sets a custom [`quinn::TransportConfig`] to be used by the [`Endpoint`].
     ///
     /// If not set, the [`Endpoint`] will use its default [`quinn::TransportConfig`]. See
-    /// [`iroh::net::endpoint::Builder::transport_config`] for details.
+    /// [`iroh_net::endpoint::Builder::transport_config`] for details.
     pub fn transport_config(mut self, config: quinn::TransportConfig) -> Self {
         self.transport_config = Some(config);
         self

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -498,7 +498,7 @@ where
     /// Sets a custom [`quinn::TransportConfig`] to be used by the [`Endpoint`].
     ///
     /// If not set, the [`Endpoint`] will use its default [`quinn::TransportConfig`]. See
-    /// [`iroh_net::endpoint::Builder::transport_config`] for details.
+    /// [`iroh::net::endpoint::Builder::transport_config`] for details.
     pub fn transport_config(mut self, config: quinn::TransportConfig) -> Self {
         self.transport_config = Some(config);
         self


### PR DESCRIPTION
## Description

Allows setting a custom configuration in the Iroh Node

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] ~Tests if relevant.~
- [ ] ~All breaking changes documented.~
