### PR TITLE
fix(ci): add cleanup workflow to retain `generated-docs-preview` for only the last 25 PRs

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -18,6 +18,7 @@ env:
 jobs:
   clean_docs_branch:
     permissions:
+      issues: write
       contents: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,42 @@
+# Run tests using the beta Rust compiler
+
+name: Cleanup
+
+on:
+  schedule:
+    # 06:50 UTC every Monday
+    - cron: '50 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: beta-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IROH_FORCE_STAGING_RELAYS: "1"
+
+jobs:
+  clean_docs_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: generated-docs-preview
+      - name: Clean docs branch
+        run: |
+          cd pr/
+          # keep the last 25 prs
+          dirs=$(ls -1d [0-9]* | sort -n)
+          total_dirs=$(echo "$dirs" | wc -l)
+          dirs_to_remove=$(echo "$dirs" | head -n $(($total_dirs - 25)))
+          if [ -n "$dirs_to_remove" ]; then
+            echo "$dirs_to_remove" | xargs rm -rf
+          fi
+          git add .
+          git commit -m "Cleanup old docs"
+          git push
+
+
+
+

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -17,6 +17,8 @@ env:
 
 jobs:
   clean_docs_branch:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,7 +37,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./target/doc/
         destination_dir: ${{ env.PREVIEW_PATH }}
-        publish_branch: generated-docs-preview
+        publish_branch: generated-docs-preview-${{ github.event.pull_request.number }}
 
     - name: Find Docs Comment
       uses: peter-evans/find-comment@v3

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,10 @@ name: Docs Preview
 on:
   pull_request:
 
+# ensure job runs sequentially so pushing to the preview branch doesn't conflict
+concurrency:
+  group: ci-docs-preview
+
 env:
   IROH_FORCE_STAGING_RELAYS: "1"
 
@@ -37,7 +41,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./target/doc/
         destination_dir: ${{ env.PREVIEW_PATH }}
-        publish_branch: generated-docs-preview-${{ github.event.pull_request.number }}
+        publish_branch: generated-docs-preview
 
     - name: Find Docs Comment
       uses: peter-evans/find-comment@v3

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,6 +18,7 @@ env:
 jobs:
   preview_docs:
     permissions:
+      issues: write
       contents: write
     timeout-minutes: 30
     name: Docs preview

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,6 +2,11 @@ name: Docs Preview
 
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+        type: string
 
 # ensure job runs sequentially so pushing to the preview branch doesn't conflict
 concurrency:
@@ -12,15 +17,17 @@ env:
 
 jobs:
   preview_docs:
+    permissions:
+      contents: write
     timeout-minutes: 30
     name: Docs preview
-    if: "github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork"
+    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' ) && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
       SCCACHE_CACHE_SIZE: "50G"
-      PREVIEW_PATH: pr/${{ github.event.pull_request.number }}/docs
+      PREVIEW_PATH: pr/${{ github.event.pull_request.number || inputs.pr_number }}/docs
 
     steps:
     - uses: actions/checkout@v4
@@ -47,17 +54,21 @@ jobs:
       uses: peter-evans/find-comment@v3
       id: fc
       with:
-        issue-number: ${{ github.event.pull_request.number }}
+        issue-number: ${{ github.event.pull_request.number || inputs.pr_number }}
         comment-author: 'github-actions[bot]'
         body-includes: Documentation for this PR has been generated
+
+    - name: Get current timestamp
+      id: get_timestamp
+      run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
 
     - name: Create or Update Docs Comment
       uses: peter-evans/create-or-update-comment@v4
       with:
-        issue-number: ${{ github.event.pull_request.number }}
+        issue-number: ${{ github.event.pull_request.number || inputs.pr_number }}
         comment-id: ${{ steps.fc.outputs.comment-id }}
         body: |
           Documentation for this PR has been generated and is available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.PREVIEW_PATH }}/iroh/
           
-          Last updated: ${{ github.event.pull_request.updated_at }}
+          Last updated: ${{ env.TIMESTAMP }}
         edit-mode: replace


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
