### PR TITLE
docs(*): Document cargo features in docs

### DIFF
--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -56,3 +56,4 @@ wasm = ["getrandom?/js"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "iroh_docsrs"]

--- a/iroh-base/src/hash.rs
+++ b/iroh-base/src/hash.rs
@@ -231,6 +231,7 @@ pub struct HashAndFormat {
 }
 
 #[cfg(feature = "redb")]
+#[cfg_attr(iroh_docsrs, cfg(feature = "redb"))]
 mod redb_support {
     use super::{Hash, HashAndFormat};
     use postcard::experimental::max_size::MaxSize;

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -1,13 +1,19 @@
 //! Base types and utilities for Iroh
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "base32")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "base32")))]
 pub mod base32;
 #[cfg(feature = "hash")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "hash")))]
 pub mod hash;
 #[cfg(feature = "key")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "key")))]
 pub mod key;
 #[cfg(feature = "key")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "key")))]
 pub mod node_addr;
 pub mod rpc;
 #[cfg(feature = "base32")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "base32")))]
 pub mod ticket;

--- a/iroh-base/src/ticket.rs
+++ b/iroh-base/src/ticket.rs
@@ -1,10 +1,13 @@
 use crate::base32;
 
 #[cfg(feature = "key")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "key")))]
 mod blob;
 #[cfg(feature = "key")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "key")))]
 mod node;
 #[cfg(feature = "key")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "key")))]
 pub use self::{blob::BlobTicket, node::NodeTicket};
 
 /// A ticket is a serializable object that combines all information required

--- a/iroh-blobs/Cargo.toml
+++ b/iroh-blobs/Cargo.toml
@@ -77,6 +77,7 @@ redb = ["dep:redb"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "iroh_docsrs"]
 
 [[example]]
 name = "provide-bytes"

--- a/iroh-blobs/src/lib.rs
+++ b/iroh-blobs/src/lib.rs
@@ -25,8 +25,10 @@
 //! [iroh]: https://docs.rs/iroh
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![recursion_limit = "256"]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "downloader")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "downloader")))]
 pub mod downloader;
 pub mod export;
 pub mod format;

--- a/iroh-docs/Cargo.toml
+++ b/iroh-docs/Cargo.toml
@@ -63,3 +63,4 @@ engine = ["net", "dep:iroh-gossip", "dep:iroh-blobs"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "iroh_docsrs"]

--- a/iroh-docs/src/lib.rs
+++ b/iroh-docs/src/lib.rs
@@ -32,14 +32,18 @@
 //!
 //! [paper]: https://arxiv.org/abs/2212.13567
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 
 pub mod metrics;
 #[cfg(feature = "net")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "net")))]
 pub mod net;
 #[cfg(feature = "net")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "net")))]
 mod ticket;
 
 #[cfg(feature = "engine")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "engine")))]
 pub mod engine;
 
 pub mod actor;
@@ -54,4 +58,5 @@ pub use self::heads::*;
 pub use self::keys::*;
 pub use self::sync::*;
 #[cfg(feature = "net")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "net")))]
 pub use self::ticket::DocTicket;

--- a/iroh-gossip/Cargo.toml
+++ b/iroh-gossip/Cargo.toml
@@ -64,3 +64,4 @@ required-features = ["net"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "iroh_docsrs"]

--- a/iroh-gossip/src/lib.rs
+++ b/iroh-gossip/src/lib.rs
@@ -6,8 +6,10 @@
 //!
 //! [iroh]: https://docs.rs/iroh
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 
 pub mod metrics;
 #[cfg(feature = "net")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "net")))]
 pub mod net;
 pub mod proto;


### PR DESCRIPTION
## Description

This adds the features needed for an API to the generated docs for the
remaining workspace crates.  Only the iroh crate itself does not yet
document this.

## Breaking Changes

none

## Notes & open questions

I can for the life of me not get this to work for the iroh crate
itself...  No idea why.  Feel free to give it a try.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~