### PR TITLE
feat(iroh-net): Export the Ticket trait

### DIFF
--- a/iroh-base/src/ticket.rs
+++ b/iroh-base/src/ticket.rs
@@ -7,9 +7,11 @@ mod node;
 #[cfg(feature = "key")]
 pub use self::{blob::BlobTicket, node::NodeTicket};
 
-/// A ticket is a serializable object that combines all information required
-/// for an operation. E.g. an iroh blob ticket would contain the hash of the
-/// data as well as information about how to reach the provider.
+/// A ticket is a serializable object combining information required for an operation.
+///
+/// Typically tickets contain all information required for an operation, e.g. an iroh blob
+/// ticket would contain the hash of the data as well as information about how to reach the
+/// provider.
 ///
 /// Tickets support serialization to a string using base32 encoding. The kind of
 /// ticket will be prepended to the string to make it somewhat self describing.

--- a/iroh-base/src/ticket/node.rs
+++ b/iroh-base/src/ticket/node.rs
@@ -20,7 +20,9 @@ use crate::{
 /// This allows establishing a connection to the node in most circumstances where it is
 /// possible to do so.
 ///
-/// This [`NodeTicket`] is a single item which can be easily serialized and deserialized.
+/// This [`NodeTicket`] is a single item which can be easily serialized and deserialized and
+/// implements the [`Ticket`] trait.  The [`Display`] and [`FromStr`] traits can also be
+/// used to round-trip the ticket to sting.
 ///
 /// [`NodeId`]: crate::key::NodeId
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]

--- a/iroh-base/src/ticket/node.rs
+++ b/iroh-base/src/ticket/node.rs
@@ -22,7 +22,7 @@ use crate::{
 ///
 /// This [`NodeTicket`] is a single item which can be easily serialized and deserialized and
 /// implements the [`Ticket`] trait.  The [`Display`] and [`FromStr`] traits can also be
-/// used to round-trip the ticket to sting.
+/// used to round-trip the ticket to string.
 ///
 /// [`NodeId`]: crate::key::NodeId
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]

--- a/iroh-net/src/ticket.rs
+++ b/iroh-net/src/ticket.rs
@@ -1,2 +1,3 @@
 //! Tickets supported by iroh-net
 pub use iroh_base::ticket::NodeTicket;
+pub use iroh_base::ticket::Ticket;


### PR DESCRIPTION
## Description

This exports the Ticket trait, which is kind of needed to work with
the NodeTicket.  Since NodeTicket is already provided directly in
iroh-net it is very strange to force users to pull in iroh-base to get
the ticket trait.

Also updates the docs of tickets a little.

## Breaking Changes

None

## Notes & open questions

None

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~