### PR TITLE
fix(ci): netsim commenting fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,7 @@ jobs:
           command-arguments: "-Dwarnings"
 
   netsim-integration-tests:
+    permissions: write-all
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
     uses: './.github/workflows/netsim_runner.yaml'
     secrets: inherit

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,9 +17,7 @@ env:
 
 jobs:
   preview_docs:
-    permissions:
-      issues: write
-      contents: write
+    permissions: write-all
     timeout-minutes: 30
     name: Docs preview
     if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' ) && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -31,6 +31,9 @@ env:
 
 jobs:
   netsim-release:
+    permissions:
+      issues: write
+      contents: write
     if: ${{github.ref_name=='main' && github.event_name == 'push'}}
     uses: './.github/workflows/netsim_runner.yaml'
     secrets: inherit
@@ -44,6 +47,9 @@ jobs:
       build_profile: "optimized-release"
 
   netsim-perf:
+    permissions:
+      issues: write
+      contents: write
     if: ${{github.event_name != 'push'}}
     uses: './.github/workflows/netsim_runner.yaml'
     secrets: inherit

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -31,9 +31,7 @@ env:
 
 jobs:
   netsim-release:
-    permissions:
-      issues: write
-      contents: write
+    permissions: write-all
     if: ${{github.ref_name=='main' && github.event_name == 'push'}}
     uses: './.github/workflows/netsim_runner.yaml'
     secrets: inherit
@@ -47,9 +45,7 @@ jobs:
       build_profile: "optimized-release"
 
   netsim-perf:
-    permissions:
-      issues: write
-      contents: write
+    permissions: write-all
     if: ${{github.event_name != 'push'}}
     uses: './.github/workflows/netsim_runner.yaml'
     secrets: inherit

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -94,6 +94,10 @@ env:
 
 jobs:
   netsim:
+    permissions:
+      issues: write
+      contents: write
+      packages: write
     name: Netsim
     timeout-minutes: 45
     runs-on: [self-hosted, linux, X64]
@@ -112,7 +116,7 @@ jobs:
 
     - name: Build iroh
       run: |
-        cargo build --profile ${{ inputs.build_profile }} --workspace --all-features
+        cargo build --profile ${{ inputs.build_profile }} --workspace --all-features --examples --bins
 
     - name: Fetch and build chuck
       run: |
@@ -131,6 +135,7 @@ jobs:
 
     - name: Copy binaries to right location
       run: |
+        cp target/${{inputs.build_profile}}/examples/* ../chuck/netsim/bins/
         cp target/${{inputs.build_profile}}/iroh ../chuck/netsim/bins/iroh
         cp target/${{inputs.build_profile}}/iroh-relay ../chuck/netsim/bins/iroh-relay
         cp ../chuck/target/release/chuck ../chuck/netsim/bins/chuck
@@ -196,13 +201,13 @@ jobs:
       with:
         issue-number: ${{ inputs.pr_number }}
         comment-author: 'github-actions[bot]'
-        body-includes: Netsim report for this PR has been generated
+        body-includes: Netsim report & logs for this PR have been generated
 
     - name: Create or Update Docs Comment
       if: ${{ inputs.pr_number != '' }}
       uses: peter-evans/create-or-update-comment@v4
       with:
-        issue-number: ${{ github.event.pull_request.number }}
+        issue-number: ${{ inputs.pr_number }}
         comment-id: ${{ steps.fc.outputs.comment-id }}
         body: |
           Netsim report & logs for this PR have been generated and is available at: [LOGS](${{steps.upload-report.outputs.artifact-url}})

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -94,10 +94,7 @@ env:
 
 jobs:
   netsim:
-    permissions:
-      issues: write
-      contents: write
-      packages: write
+    permissions: write-all
     name: Netsim
     timeout-minutes: 45
     runs-on: [self-hosted, linux, X64]


### PR DESCRIPTION
## Description

Adjusts permissions, uses proper input vars & the search & replace for comments is now aligned.
Also adds examples to the list of possible executables for the job.

Note: Docs still seem to fail in this PR with the set permissions. However write-all in a public repo is very constrained so it should be perfectly fine. The GITHUB_TOKEN has it by default, however I think since we're running sub jobs etc it's not propagating correctly.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
