### PR TITLE
feat(iroh-net)!: Create our own connection struct

### DIFF
--- a/iroh-blobs/examples/connect/mod.rs
+++ b/iroh-blobs/examples/connect/mod.rs
@@ -1,94 +1,32 @@
-//! Common code used to created quinn connections in the examples
-use anyhow::{bail, Context, Result};
-use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
-use std::{path::PathBuf, sync::Arc};
-use tokio::fs;
+//! Common code used to created connections in the examples
+
+use anyhow::{Context, Result};
+use futures_lite::StreamExt;
+use iroh_net::discovery::dns::DnsDiscovery;
+use iroh_net::discovery::local_swarm_discovery::LocalSwarmDiscovery;
+use iroh_net::discovery::pkarr::PkarrPublisher;
+use iroh_net::discovery::ConcurrentDiscovery;
+use iroh_net::key::SecretKey;
 
 pub const EXAMPLE_ALPN: &[u8] = b"n0/iroh/examples/bytes/0";
 
-// Path where the tls certificates are saved. This example expects that you have run the `provide-bytes` example first, which generates the certificates.
-pub const CERT_PATH: &str = "./certs";
-
-// derived from `quinn/examples/client.rs`
-// load the certificates from CERT_PATH
-// Assumes that you have already run the `provide-bytes` example, that generates the certificates
-#[allow(unused)]
-pub async fn load_certs() -> Result<rustls::RootCertStore> {
-    let mut roots = rustls::RootCertStore::empty();
-    let path = PathBuf::from(CERT_PATH).join("cert.der");
-    match fs::read(path).await {
-        Ok(cert) => {
-            roots.add(rustls::pki_types::CertificateDer::from(cert))?;
-        }
-        Err(e) => {
-            bail!("failed to open local server certificate: {}\nYou must run the `provide-bytes` example to create the certificate.\n\tcargo run --example provide-bytes", e);
-        }
-    }
-    Ok(roots)
-}
-
-// derived from `quinn/examples/server.rs`
-// creates a self signed certificate and saves it to "./certs"
-#[allow(unused)]
-pub async fn make_and_write_certs() -> Result<(
-    rustls::pki_types::PrivateKeyDer<'static>,
-    rustls::pki_types::CertificateDer<'static>,
-)> {
-    let path = std::path::PathBuf::from(CERT_PATH);
-    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-    let key_path = path.join("key.der");
-    let cert_path = path.join("cert.der");
-
-    let key = cert.serialize_private_key_der();
-    let cert = cert.serialize_der().unwrap();
-    tokio::fs::create_dir_all(path)
+pub async fn make_iroh_endpoint() -> Result<iroh_net::Endpoint> {
+    let secret_key = SecretKey::generate();
+    let discovery = ConcurrentDiscovery::from_services(vec![
+        Box::new(PkarrPublisher::n0_dns(secret_key.clone())),
+        Box::new(DnsDiscovery::n0_dns()),
+        Box::new(LocalSwarmDiscovery::new(secret_key.public())?),
+    ]);
+    let ep = iroh_net::Endpoint::builder()
+        .secret_key(secret_key)
+        .discovery(Box::new(discovery))
+        .alpns(vec![EXAMPLE_ALPN.to_vec()])
+        .bind()
+        .await?;
+    // Wait for full connectivity
+    ep.direct_addresses()
+        .next()
         .await
-        .context("failed to create certificate directory")?;
-    tokio::fs::write(cert_path, &cert)
-        .await
-        .context("failed to write certificate")?;
-    tokio::fs::write(key_path, &key)
-        .await
-        .context("failed to write private key")?;
-
-    Ok((
-        rustls::pki_types::PrivateKeyDer::try_from(key).unwrap(),
-        rustls::pki_types::CertificateDer::from(cert),
-    ))
-}
-
-// derived from `quinn/examples/client.rs`
-// Creates a client quinn::Endpoint
-#[allow(unused)]
-pub fn make_client_endpoint(roots: rustls::RootCertStore) -> Result<quinn::Endpoint> {
-    let mut client_crypto = rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
-
-    client_crypto.alpn_protocols = vec![EXAMPLE_ALPN.to_vec()];
-    let client_config: QuicClientConfig = client_crypto.try_into()?;
-    let client_config = quinn::ClientConfig::new(Arc::new(client_config));
-    let mut endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap())?;
-    endpoint.set_default_client_config(client_config);
-    Ok(endpoint)
-}
-
-// derived from `quinn/examples/server.rs`
-// makes a quinn server endpoint
-#[allow(unused)]
-pub fn make_server_endpoint(
-    key: rustls::pki_types::PrivateKeyDer<'static>,
-    cert: rustls::pki_types::CertificateDer<'static>,
-) -> Result<quinn::Endpoint> {
-    let mut server_crypto = rustls::ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(vec![cert], key)?;
-    server_crypto.alpn_protocols = vec![EXAMPLE_ALPN.to_vec()];
-    let server_config: QuicServerConfig = server_crypto.try_into()?;
-    let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(server_config));
-    let transport_config = Arc::get_mut(&mut server_config.transport).unwrap();
-    transport_config.max_concurrent_uni_streams(0_u8.into());
-
-    let endpoint = quinn::Endpoint::server(server_config, "[::1]:4433".parse()?)?;
-    Ok(endpoint)
+        .context("no direct addrs")?;
+    Ok(ep)
 }

--- a/iroh-blobs/examples/fetch-stream.rs
+++ b/iroh-blobs/examples/fetch-stream.rs
@@ -3,9 +3,10 @@
 //! Since this example does not use [`iroh-net::Endpoint`], it does not do any holepunching, and so will only work locally or between two processes that have public IP addresses.
 //!
 //! Run the provide-bytes example first. It will give instructions on how to run this example properly.
-use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
+use connect::EXAMPLE_ALPN;
+use iroh_net::ticket::NodeTicket;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 use std::io;
@@ -25,7 +26,7 @@ use iroh_blobs::{
 };
 
 mod connect;
-use connect::{load_certs, make_client_endpoint};
+use connect::make_iroh_endpoint;
 
 // set the RUST_LOG env var to one of {debug,info,warn} to see logging info
 pub fn setup_logging() {
@@ -42,10 +43,10 @@ async fn main() -> Result<()> {
     setup_logging();
     let args: Vec<_> = std::env::args().collect();
     if args.len() != 4 {
-        anyhow::bail!("usage: fetch-bytes [HASH] [SOCKET_ADDR] [FORMAT]");
+        anyhow::bail!("usage: fetch-bytes HASH NODE_TICKET FORMAT");
     }
     let hash: Hash = args[1].parse().context("unable to parse [HASH]")?;
-    let addr: SocketAddr = args[2].parse().context("unable to parse [SOCKET_ADDR]")?;
+    let ticket: NodeTicket = args[2].parse().context("unable to parse NODE_TICKET")?;
     let format = {
         if args[3] != "blob" && args[3] != "collection" {
             anyhow::bail!(
@@ -56,17 +57,15 @@ async fn main() -> Result<()> {
         args[3].clone()
     };
 
-    // load tls certificates
-    // This will error if you have not run the `provide-bytes` example
-    let roots = load_certs().await?;
-
     // create an endpoint to listen for incoming connections
-    let endpoint = make_client_endpoint(roots)?;
-    println!("\nlistening on {}", endpoint.local_addr()?);
-    println!("fetching hash {hash} from {addr}");
+    let endpoint = make_iroh_endpoint().await?;
+    println!("\nlistening as NodeId {}", endpoint.node_id());
+    println!("fetching hash {hash} from {ticket}");
 
     // connect
-    let connection = endpoint.connect(addr, "localhost")?.await?;
+    let connection = endpoint
+        .connect(ticket.node_addr().clone(), EXAMPLE_ALPN)
+        .await?;
 
     let mut stream = if format == "collection" {
         // create a request for a collection

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -792,7 +792,7 @@ async fn accept(
             match connecting.await {
                 Ok(connection) => {
                     if n == 0 {
-                        let Ok(remote_peer_id) = endpoint::get_remote_node_id(&connection) else {
+                        let Ok(remote_peer_id) = connection.remote_node_id() else {
                             return;
                         };
                         println!("Accepted connection from {}", remote_peer_id);

--- a/iroh-docs/src/net.rs
+++ b/iroh-docs/src/net.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use iroh_net::{endpoint::get_remote_node_id, key::PublicKey, Endpoint, NodeAddr};
+use iroh_net::{key::PublicKey, Endpoint, NodeAddr};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error_span, trace, Instrument};
 
@@ -116,7 +116,7 @@ where
 {
     let t_start = Instant::now();
     let connection = connecting.await.map_err(AcceptError::connect)?;
-    let peer = get_remote_node_id(&connection).map_err(AcceptError::connect)?;
+    let peer = connection.remote_node_id().map_err(AcceptError::connect)?;
     let (mut send_stream, mut recv_stream) = connection
         .accept_bi()
         .await

--- a/iroh-gossip/examples/chat.rs
+++ b/iroh-gossip/examples/chat.rs
@@ -221,7 +221,7 @@ async fn handle_connection(
 ) -> anyhow::Result<()> {
     let alpn = conn.alpn().await?;
     let conn = conn.await?;
-    let peer_id = iroh_net::endpoint::get_remote_node_id(&conn)?;
+    let peer_id = conn.remote_node_id()?;
     match alpn.as_ref() {
         GOSSIP_ALPN => gossip.handle_connection(conn).await.context(format!(
             "connection to {peer_id} with ALPN {} failed",

--- a/iroh-gossip/src/net.rs
+++ b/iroh-gossip/src/net.rs
@@ -11,7 +11,7 @@ use futures_util::TryFutureExt;
 use iroh_metrics::inc;
 use iroh_net::{
     dialer::Dialer,
-    endpoint::{get_remote_node_id, Connection, DirectAddr},
+    endpoint::{Connection, DirectAddr},
     key::PublicKey,
     AddrInfo, Endpoint, NodeAddr, NodeId,
 };
@@ -147,7 +147,7 @@ impl Gossip {
     ///
     /// Make sure to check the ALPN protocol yourself before passing the connection.
     pub async fn handle_connection(&self, conn: Connection) -> anyhow::Result<()> {
-        let peer_id = get_remote_node_id(&conn)?;
+        let peer_id = conn.remote_node_id()?;
         self.send(ToActor::HandleConnection(peer_id, ConnOrigin::Accept, conn))
             .await?;
         Ok(())

--- a/iroh-net/examples/dht_discovery.rs
+++ b/iroh-net/examples/dht_discovery.rs
@@ -11,7 +11,7 @@
 use std::str::FromStr;
 
 use clap::Parser;
-use iroh_net::{endpoint::get_remote_node_id, Endpoint, NodeId};
+use iroh_net::{Endpoint, NodeId};
 use tracing::warn;
 use url::Url;
 
@@ -88,7 +88,7 @@ async fn chat_server(args: Args) -> anyhow::Result<()> {
         };
         tokio::spawn(async move {
             let connection = connecting.await?;
-            let remote_node_id = get_remote_node_id(&connection)?;
+            let remote_node_id = connection.remote_node_id()?;
             println!("got connection from {}", remote_node_id);
             // just leave the tasks hanging. this is just an example.
             let (mut writer, mut reader) = connection.accept_bi().await?;

--- a/iroh-net/examples/listen-unreliable.rs
+++ b/iroh-net/examples/listen-unreliable.rs
@@ -74,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
         };
         let alpn = connecting.alpn().await?;
         let conn = connecting.await?;
-        let node_id = iroh_net::endpoint::get_remote_node_id(&conn)?;
+        let node_id = conn.remote_node_id()?;
         info!(
             "new (unreliable) connection from {node_id} with ALPN {} (coming from {})",
             String::from_utf8_lossy(&alpn),

--- a/iroh-net/examples/listen.rs
+++ b/iroh-net/examples/listen.rs
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
         };
         let alpn = connecting.alpn().await?;
         let conn = connecting.await?;
-        let node_id = iroh_net::endpoint::get_remote_node_id(&conn)?;
+        let node_id = conn.remote_node_id()?;
         info!(
             "new connection from {node_id} with ALPN {} (coming from {})",
             String::from_utf8_lossy(&alpn),

--- a/iroh-net/src/dialer.rs
+++ b/iroh-net/src/dialer.rs
@@ -8,6 +8,7 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
+use crate::endpoint::Connection;
 use crate::{Endpoint, NodeId};
 
 /// Dials nodes and maintains a queue of pending dials.
@@ -19,7 +20,7 @@ use crate::{Endpoint, NodeId};
 #[derive(Debug)]
 pub struct Dialer {
     endpoint: Endpoint,
-    pending: JoinSet<(NodeId, anyhow::Result<quinn::Connection>)>,
+    pending: JoinSet<(NodeId, anyhow::Result<Connection>)>,
     pending_dials: HashMap<NodeId, CancellationToken>,
 }
 
@@ -70,7 +71,7 @@ impl Dialer {
     }
 
     /// Waits for the next dial operation to complete.
-    pub async fn next_conn(&mut self) -> (NodeId, anyhow::Result<quinn::Connection>) {
+    pub async fn next_conn(&mut self) -> (NodeId, anyhow::Result<Connection>) {
         match self.pending_dials.is_empty() {
             false => {
                 let (node_id, res) = loop {
@@ -107,7 +108,7 @@ impl Dialer {
 }
 
 impl Stream for Dialer {
-    type Item = (NodeId, anyhow::Result<quinn::Connection>);
+    type Item = (NodeId, anyhow::Result<Connection>);
 
     fn poll_next(
         mut self: Pin<&mut Self>,

--- a/iroh/examples/custom-protocol.rs
+++ b/iroh/examples/custom-protocol.rs
@@ -46,10 +46,7 @@ use futures_lite::future::Boxed as BoxedFuture;
 use iroh::{
     blobs::Hash,
     client::blobs,
-    net::{
-        endpoint::{get_remote_node_id, Connecting},
-        Endpoint, NodeId,
-    },
+    net::{endpoint::Connecting, Endpoint, NodeId},
     node::ProtocolHandler,
 };
 use tracing_subscriber::{prelude::*, EnvFilter};
@@ -146,7 +143,7 @@ impl ProtocolHandler for BlobSearch {
             // Wait for the connection to be fully established.
             let connection = connecting.await?;
             // We can get the remote's node id from the connection.
-            let node_id = get_remote_node_id(&connection)?;
+            let node_id = connection.remote_node_id()?;
             println!("accepted connection from {node_id}");
 
             // Our protocol is a simple request-response protocol, so we expect the

--- a/iroh/tests/provide.rs
+++ b/iroh/tests/provide.rs
@@ -10,7 +10,10 @@ use bytes::Bytes;
 use futures_lite::FutureExt;
 use iroh::node::{Builder, DocsStorage};
 use iroh_base::node_addr::AddrInfoOptions;
-use iroh_net::{defaults::staging::default_relay_map, key::SecretKey, NodeAddr, NodeId};
+use iroh_net::defaults::staging::default_relay_map;
+use iroh_net::endpoint::Connection;
+use iroh_net::key::SecretKey;
+use iroh_net::{NodeAddr, NodeId};
 use rand::RngCore;
 
 use bao_tree::{blake3, ChunkNum, ChunkRanges};
@@ -27,7 +30,7 @@ use iroh_blobs::{
 };
 
 /// Create a new endpoint and dial a peer, returning the connection.
-async fn dial(secret_key: SecretKey, peer: NodeAddr) -> anyhow::Result<quinn::Connection> {
+async fn dial(secret_key: SecretKey, peer: NodeAddr) -> anyhow::Result<Connection> {
     let endpoint = iroh_net::Endpoint::builder()
         .secret_key(secret_key)
         .bind()


### PR DESCRIPTION
## Description

We used to re-export quinn::Connection, this makes this an owned
connection so we can add our own methods to this.  This adds the
`.remote_peer_id()` method and removes the helper function for this.

## Breaking Changes

`iroh_net::endpoint::get_remote_node_id` has been removed.  Use
`iroh_net::endpoint::Connection::remote_node_id` instead.

## Notes & open questions

- We have talked about wanting to do this for so long, decided to just
  give this a go.

- Strictly speaking we do not need to remove `get_remote_node_id`
  right now.
  
- This completely removes the ability of iroh-blobs to work with
  upstream Quinn connections.  It now only works with iroh.  We could
  probably use the `h3::quic` traits in iroh-blobs to make it generic
  over QUIC implementation.
  
- The code just lives in `iroh_net::endpoint` now.  That's probably
  fine, but it's a large file by now.  Easy enough to move it later
  though.
  
- The public API is at `iroh_net::endpoint::Connection`.  Perhaps it
  should also be exported at `iroh_net::Connection` just like
  `Endpoint` is.  Though what belongs there?  What about all the other
  types?  Hence I'm leaving this as the status quo for this PR and
  leave it where it is.
  
- There are a bunch of new Quinn structs exported.  This probably
  should have happened earlier, we knew we were not exporting enough
  of those but never did a proper check on what is needed.  Now maybe
  everything is there, bar possibly some things from quinn-udp still
  missing.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.