### PR TITLE
refactor(iroh-base)!: No Result for creating new NodeTicket

### DIFF
--- a/iroh-base/src/ticket/node.rs
+++ b/iroh-base/src/ticket/node.rs
@@ -25,6 +25,8 @@ use crate::{
 /// used to round-trip the ticket to string.
 ///
 /// [`NodeId`]: crate::key::NodeId
+/// [`Display`]: std::fmt::Display
+/// [`FromStr`]: std::str::FromStr
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
 #[display("{}", Ticket::serialize(self))]
 pub struct NodeTicket {
@@ -104,7 +106,7 @@ impl<'de> Deserialize<'de> for NodeTicket {
             Self::from_str(&s).map_err(serde::de::Error::custom)
         } else {
             let peer = Deserialize::deserialize(deserializer)?;
-            Self::new(peer).map_err(serde::de::Error::custom)
+            Ok(Self::new(peer))
         }
     }
 }

--- a/iroh-base/src/ticket/node.rs
+++ b/iroh-base/src/ticket/node.rs
@@ -62,8 +62,8 @@ impl FromStr for NodeTicket {
 
 impl NodeTicket {
     /// Creates a new ticket.
-    pub fn new(node: NodeAddr) -> Result<Self> {
-        Ok(Self { node })
+    pub fn new(node: NodeAddr) -> Self {
+        Self { node }
     }
 
     /// The [`NodeAddr`] of the provider for this ticket.


### PR DESCRIPTION
## Description

There is no need for this to have a Result.  Also there's a From impl
anyway.  So clean this up.

## Breaking Changes

`NodeTicket::new` no longer returns `Result` but always succeeds (as
it already did).  This matches it's `From<NodeAddr>` impl which also
never fails.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~