### PR TITLE
feat(iroh-dns-server)!: Make http rate limit configurable

### DIFF
--- a/iroh-dns-server/config.dev.toml
+++ b/iroh-dns-server/config.dev.toml
@@ -1,7 +1,7 @@
 [http]
 port = 8080
 bind_addr = "127.0.0.1"
-rate_limit = false
+rate_limit = "disabled"
 
 [https]
 port = 8443

--- a/iroh-dns-server/config.dev.toml
+++ b/iroh-dns-server/config.dev.toml
@@ -1,6 +1,7 @@
 [http]
 port = 8080
 bind_addr = "127.0.0.1"
+rate_limit = false
 
 [https]
 port = 8443

--- a/iroh-dns-server/config.dev.toml
+++ b/iroh-dns-server/config.dev.toml
@@ -1,7 +1,8 @@
+pkarr_put_rate_limit = "disabled"
+
 [http]
 port = 8080
 bind_addr = "127.0.0.1"
-rate_limit = "disabled"
 
 [https]
 port = 8443

--- a/iroh-dns-server/config.prod.toml
+++ b/iroh-dns-server/config.prod.toml
@@ -1,3 +1,6 @@
+[http]
+rate_limit = true
+
 [https]
 port = 443
 domains = ["irohdns.example.org"]

--- a/iroh-dns-server/config.prod.toml
+++ b/iroh-dns-server/config.prod.toml
@@ -1,5 +1,5 @@
 [http]
-rate_limit = true
+rate_limit = "smart"
 
 [https]
 port = 443

--- a/iroh-dns-server/config.prod.toml
+++ b/iroh-dns-server/config.prod.toml
@@ -1,10 +1,8 @@
-[http]
-rate_limit = "smart"
-
 [https]
 port = 443
 domains = ["irohdns.example.org"]
 cert_mode = "lets_encrypt"
+rate_limit = "smart"
 letsencrypt_prod = true
 
 [dns]

--- a/iroh-dns-server/config.prod.toml
+++ b/iroh-dns-server/config.prod.toml
@@ -1,8 +1,9 @@
+pkarr_put_rate_limit = "smart"
+
 [https]
 port = 443
 domains = ["irohdns.example.org"]
 cert_mode = "lets_encrypt"
-rate_limit = "smart"
 letsencrypt_prod = true
 
 [dns]

--- a/iroh-dns-server/src/config.rs
+++ b/iroh-dns-server/src/config.rs
@@ -161,6 +161,7 @@ impl Default for Config {
             http: Some(HttpConfig {
                 port: 8080,
                 bind_addr: None,
+                rate_limit: None,
             }),
             https: Some(HttpsConfig {
                 port: 8443,

--- a/iroh-dns-server/src/config.rs
+++ b/iroh-dns-server/src/config.rs
@@ -170,6 +170,7 @@ impl Default for Config {
                 cert_mode: CertMode::SelfSigned,
                 letsencrypt_contact: None,
                 letsencrypt_prod: None,
+                rate_limit: None,
             }),
             dns: DnsConfig {
                 port: 5300,

--- a/iroh-dns-server/src/config.rs
+++ b/iroh-dns-server/src/config.rs
@@ -12,7 +12,7 @@ use tracing::info;
 
 use crate::{
     dns::DnsConfig,
-    http::{CertMode, HttpConfig, HttpsConfig},
+    http::{CertMode, HttpConfig, HttpsConfig, RateLimitConfig},
 };
 
 const DEFAULT_METRICS_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9117);
@@ -161,7 +161,7 @@ impl Default for Config {
             http: Some(HttpConfig {
                 port: 8080,
                 bind_addr: None,
-                rate_limit: None,
+                rate_limit: RateLimitConfig::default(),
             }),
             https: Some(HttpsConfig {
                 port: 8443,

--- a/iroh-dns-server/src/config.rs
+++ b/iroh-dns-server/src/config.rs
@@ -43,6 +43,10 @@ pub struct Config {
 
     /// Config for the mainline lookup.
     pub mainline: Option<MainlineConfig>,
+
+    /// Config for pkarr rate limit
+    #[serde(default)]
+    pub pkarr_put_rate_limit: RateLimitConfig,
 }
 
 /// The config for the metrics server.
@@ -161,7 +165,6 @@ impl Default for Config {
             http: Some(HttpConfig {
                 port: 8080,
                 bind_addr: None,
-                rate_limit: RateLimitConfig::default(),
             }),
             https: Some(HttpsConfig {
                 port: 8443,
@@ -170,7 +173,6 @@ impl Default for Config {
                 cert_mode: CertMode::SelfSigned,
                 letsencrypt_contact: None,
                 letsencrypt_prod: None,
-                rate_limit: None,
             }),
             dns: DnsConfig {
                 port: 5300,
@@ -187,6 +189,7 @@ impl Default for Config {
             },
             metrics: None,
             mainline: None,
+            pkarr_put_rate_limit: RateLimitConfig::default(),
         }
     }
 }

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -1,7 +1,6 @@
 //! HTTP server part of iroh-dns-server
 
 use std::{
-    fmt,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     time::Instant,
 };
@@ -17,7 +16,7 @@ use axum::{
     Router,
 };
 use iroh_metrics::{inc, inc_by};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use tokio::{net::TcpListener, task::JoinSet};
 use tower_http::{
     cors::{self, CorsLayer},
@@ -31,54 +30,8 @@ mod pkarr;
 mod rate_limiting;
 mod tls;
 
-pub use self::tls::CertMode;
+pub use self::{rate_limiting::RateLimitConfig, tls::CertMode};
 use crate::{config::Config, metrics::Metrics, state::AppState};
-
-/// Config for http rate limit
-#[derive(Debug, Serialize, Clone)]
-pub enum RateLimitConfig {
-    /// Enable or disable rate limiting
-    Boolean(bool),
-    /// Enable rate limiting with SmartIP key extractor, to support reverse proxies
-    Smart,
-}
-
-impl<'a> Deserialize<'a> for RateLimitConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'a>,
-    {
-        struct ModeVisitor;
-
-        impl<'de> de::Visitor<'de> for ModeVisitor {
-            type Value = RateLimitConfig;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a boolean or the string 'smart'")
-            }
-
-            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(RateLimitConfig::Boolean(value))
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                if value == "smart" {
-                    Ok(RateLimitConfig::Smart)
-                } else {
-                    Err(de::Error::invalid_value(de::Unexpected::Str(value), &self))
-                }
-            }
-        }
-
-        deserializer.deserialize_any(ModeVisitor)
-    }
-}
 
 /// Config for the HTTP server
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -88,7 +41,8 @@ pub struct HttpConfig {
     /// Optionally set a custom bind address (will use 0.0.0.0 if unset)
     pub bind_addr: Option<IpAddr>,
     /// Config for http rate limit
-    pub rate_limit: Option<RateLimitConfig>,
+    #[serde(default)]
+    pub rate_limit: RateLimitConfig,
 }
 
 /// Config for the HTTPS server
@@ -128,7 +82,10 @@ impl HttpServer {
 
         let app = create_app(
             state,
-            http_config.as_ref().and_then(|h| h.rate_limit.clone()),
+            http_config
+                .as_ref()
+                .map(|h| h.rate_limit.clone())
+                .unwrap_or_default(),
         );
 
         let mut tasks = JoinSet::new();
@@ -236,7 +193,7 @@ impl HttpServer {
     }
 }
 
-pub(crate) fn create_app(state: AppState, rate_limit_config: Option<RateLimitConfig>) -> Router {
+pub(crate) fn create_app(state: AppState, rate_limit_config: RateLimitConfig) -> Router {
     // configure cors middleware
     let cors = CorsLayer::new()
         // allow `GET` and `POST` when accessing the resource

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -60,6 +60,8 @@ pub struct HttpsConfig {
     pub letsencrypt_contact: Option<String>,
     /// Whether to use the letsenrypt production servers (only applies to [`CertMode::LetsEncrypt`])
     pub letsencrypt_prod: Option<bool>,
+    /// Config for https rate limit
+    pub rate_limit: Option<RateLimitConfig>,
 }
 
 /// The HTTP(S) server part of iroh-dns-server
@@ -82,9 +84,10 @@ impl HttpServer {
 
         let app = create_app(
             state,
-            http_config
+            https_config
                 .as_ref()
-                .map(|h| h.rate_limit.clone())
+                .and_then(|h| h.rate_limit.as_ref())
+                .or_else(|| http_config.as_ref().map(|h| &h.rate_limit))
                 .unwrap_or_default(),
         );
 
@@ -193,7 +196,7 @@ impl HttpServer {
     }
 }
 
-pub(crate) fn create_app(state: AppState, rate_limit_config: RateLimitConfig) -> Router {
+pub(crate) fn create_app(state: AppState, rate_limit_config: &RateLimitConfig) -> Router {
     // configure cors middleware
     let cors = CorsLayer::new()
         // allow `GET` and `POST` when accessing the resource

--- a/iroh-dns-server/src/http/rate_limiting.rs
+++ b/iroh-dns-server/src/http/rate_limiting.rs
@@ -40,7 +40,6 @@ pub fn create(
             tracing::info!("Rate limiting disabled");
             return None;
         }
-        // By default apply rate limit
         RateLimitConfig::Simple => false,
         RateLimitConfig::Smart => true,
     };

--- a/iroh-dns-server/src/server.rs
+++ b/iroh-dns-server/src/server.rs
@@ -52,7 +52,13 @@ impl Server {
             }
             Ok(())
         });
-        let http_server = HttpServer::spawn(config.http, config.https, state.clone()).await?;
+        let http_server = HttpServer::spawn(
+            config.http,
+            config.https,
+            config.pkarr_put_rate_limit,
+            state.clone(),
+        )
+        .await?;
         let dns_server = DnsServer::spawn(config.dns, state.dns_handler.clone()).await?;
         Ok(Self {
             http_server,


### PR DESCRIPTION
Hello,

We are currently testing some new cloud features at [Spacedrive](https://github.com/spacedriveapp/spacedrive), and our implementation relies heavily on iroh. As part of this, we are deploying our own iroh-dns-server. However, since all of our backend services operate behind a reverse proxy, we noticed that the iroh-dns-server was frequently hitting its rate limit because it wasn’t aware of the proxy setup. To address this, I decided to implement a configurable rate limit for the iroh-dns-server.

## Description

This PR adds a new entry to the `iroh-dns-server` TOML file for configuring the HTTP rate limit. The new configuration allows for disabling the rate limit and also supports configuring it to use the [SmartIPKeyExtract](https://github.com/benwis/tower-governor/blob/v0.4.2/src/key_extractor.rs#L85-L119), making it compatible with reverse proxies.

## Breaking Changes

- `iroh-dns-server`'s configuration structure now has a new field allowing to choose the rate limiting algorithms.

## Notes & open questions

:)

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
