### PR TITLE
feat(iroh-net): Add helper fn to enable n0 discovery publishing and resolving

### DIFF
--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -264,7 +264,7 @@ impl Builder {
         self
     }
 
-    /// Configure the endpoint to use the default n0 discovery service.
+    /// Configures the endpoint to use the default n0 DNS discovery service.
     ///
     /// The default discovery service publishes to and resolves from the
     /// n0.computer dns server `iroh.link`.

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -246,7 +246,7 @@ impl Builder {
 
     /// Adds a discovery mechanism for this endpoint.
     ///
-    /// If you have multiple discovery services, they will be combined using a
+    /// If you have multiple discovery services, they will be combined using
     /// [`crate::discovery::ConcurrentDiscovery`].
     ///
     /// If no discovery service is set, connecting to a node without providing its

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -245,7 +245,9 @@ impl Builder {
         self
     }
 
-    /// Adds a discovery mechanism for this endpoint. The function `discovery`
+    /// Adds a discovery mechanism for this endpoint.
+    ///
+    /// The function `discovery`
     /// will be called on endpoint creation with the configured secret key of
     /// the endpoint. Discovery services that need to publish information need
     /// to use this secret key to sign the information.

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -78,7 +78,7 @@ pub struct Builder {
     transport_config: Option<quinn::TransportConfig>,
     keylog: bool,
     #[debug(skip)]
-    discovery: Vec<Box<dyn FnOnce(&SecretKey) -> Box<dyn Discovery> + Send + 'static>>,
+    discovery: Vec<Box<dyn FnOnce(&SecretKey) -> Box<dyn Discovery> + Send + Sync + 'static>>,
     proxy_url: Option<Url>,
     /// List of known nodes. See [`Builder::known_nodes`].
     node_map: Option<Vec<NodeAddr>>,
@@ -266,7 +266,7 @@ impl Builder {
     /// See the documentation of the [`Discovery`] trait for details.
     pub fn add_discovery(
         mut self,
-        discovery: Box<dyn FnOnce(&SecretKey) -> Box<dyn Discovery> + Send + 'static>,
+        discovery: Box<dyn FnOnce(&SecretKey) -> Box<dyn Discovery> + Send + Sync + 'static>,
     ) -> Self {
         self.discovery.push(discovery);
         self

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -281,9 +281,12 @@ impl Builder {
     /// and a [`crate::discovery::dns::DnsDiscovery`], both configured to use the
     /// n0.computer dns server.
     ///
-    /// This will by default use [`crate::discovery::pkarr::N0_DNS_PKARR_RELAY_PROD`].
+    /// This will by default use [`N0_DNS_PKARR_RELAY_PROD`].
     /// When in tests, or when the `test-utils` feature is enabled, this will use the
-    /// [`crate::discovery::pkarr::N0_DNS_PKARR_RELAY_STAGING`].
+    /// [`N0_DNS_PKARR_RELAY_STAGING`].
+    ///
+    /// [`N0_DNS_PKARR_RELAY_PROD`]: crate::discovery::pkarr::N0_DNS_PKARR_RELAY_PROD
+    /// [`N0_DNS_PKARR_RELAY_STAGING`]: crate::discovery::pkarr::N0_DNS_PKARR_RELAY_STAGING
     pub fn discovery_n0(mut self) -> Self {
         self.discovery.push(Box::new(|secret_key| {
             Some(Box::new(PkarrPublisher::n0_dns(secret_key.clone())))

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -223,7 +223,7 @@ impl Builder {
         self
     }
 
-    /// Remove all discovery services.
+    /// Removes all discovery services from the builder.
     pub fn clear_discovery(mut self) -> Self {
         self.discovery.clear();
         self

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -297,7 +297,7 @@ impl Builder {
     }
 
     #[cfg(feature = "discovery-pkarr-dht")]
-    /// Configure the endpoint to also use the mainline DHT with default settings.
+    /// Configures the endpoint to also use the mainline DHT with default settings.
     ///
     /// This is equivalent to adding a [`crate::discovery::pkarr::dht::DhtDiscovery`]
     /// with default settings. Note that DhtDiscovery has various more advanced


### PR DESCRIPTION
## Description

Add a helper fn to configure n0 default discovery without having to resort to having to combine a custom discovery service.

```rust
let secret_key = SecretKey::generate();
let discovery = ConcurrentDiscovery::from_services(vec![
    Box::new(PkarrPublisher::n0_dns(secret_key.clone())),
    Box::new(DnsDiscovery::n0_dns()),
    Box::new(LocalSwarmDiscovery::new(secret_key.public())?),
]);
let ep = iroh_net::Endpoint::builder()
    .secret_key(secret_key)
    .discovery(Box::new(discovery))
    .alpns(vec![EXAMPLE_ALPN.to_vec()])
    .bind()
     .await
```

becomes


```rust
let ep = iroh_net::Endpoint::builder()
    .discovery_n0() // still have to do this to enable discovery!
    .alpns(vec![EXAMPLE_ALPN.to_vec()])
    .bind()
     .await
```

## Breaking Changes

None

## Notes & open questions

Should this be on or off by default?
Does anybody hate the name?
Should we also add fns for "just publish" or "just resolve" that I frequently need?

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
