### PR TITLE
fix(ci): netsim does not interact with PR comments on forks

### DIFF
--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -201,7 +201,7 @@ jobs:
         body-includes: Netsim report & logs for this PR have been generated
 
     - name: Create or Update Docs Comment
-      if: ${{ inputs.pr_number != '' }}
+      if: ${{ inputs.pr_number != '' && !github.event.pull_request.head.repo.fork }}
       uses: peter-evans/create-or-update-comment@v4
       with:
         issue-number: ${{ inputs.pr_number }}
@@ -225,7 +225,7 @@ jobs:
 
     - name: Echo Report Table on PR
       uses: peter-evans/create-or-update-comment@v4
-      if: ${{ inputs.pr_number != '' && inputs.report_table }}
+      if: ${{ inputs.pr_number != '' && inputs.report_table && !github.event.pull_request.head.repo.fork }}
       with:
         issue-number: ${{ inputs.pr_number }}
         body: |
@@ -234,7 +234,7 @@ jobs:
           ${{ steps.generate_report_table.outputs.NETSIM_REPORT }}
 
     - name: Publish metrics
-      if: ${{ inputs.publish_metrics }}
+      if: ${{ inputs.publish_metrics && !github.event.pull_request.head.repo.fork }}
       run: |
         cd ../chuck/netsim
         d=$(cat report_metro.txt)


### PR DESCRIPTION
## Description

Seems like permissions are still messy and the netsim job fails on forks whenever it interacts with a PR from a fork, even though it's on our own repo and we allow it to run.

This simply drops any type of commenting on the PR from a fork.

Need to add back the required check for this job once it's merged.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
