### PR TITLE
docs(iroh): Enable iroh_docsrs feature

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Generate Docs
       run: cargo doc --workspace --all-features --no-deps
       env:
-        RUSTDOCFLAGS: --cfg docsrs
+        RUSTDOCFLAGS: --cfg iroh_docsrs
 
     - name: Deploy Docs to Preview Branch
       uses: peaceiris/actions-gh-pages@v4

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -87,9 +87,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [package.metadata.docs.rs]
 all-features = true
-# enable unstable features in the documentation
-rustdoc-args = ["--cfg", "docsrs"]
-
+rustdoc-args = ["--cfg", "iroh_docsrs"]
 
 [[example]]
 name = "hello-world-provide"

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -88,7 +88,7 @@
 //! - `metrics`: Enable metrics collection. Enabled by default.
 //! - `fs-store`: Enables the disk based storage backend for `iroh-blobs`. Enabled by default.
 //!
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 // re-export the iroh crates
@@ -111,5 +111,5 @@ mod rpc_protocol;
 
 /// Expose metrics module
 #[cfg(feature = "metrics")]
-#[cfg_attr(all(docsrs, feature = "metrics"), doc(cfg(feature = "metrics")))]
+#[cfg_attr(all(iroh_docsrs, feature = "metrics"), doc(cfg(feature = "metrics")))]
 pub mod metrics;


### PR DESCRIPTION
## Description

This uses the same iroh_docsrs cfg as the other crates and updates the
preview CI job to also use this.  Now we get the features documented
everywhere and get to see it in the preview.


## Breaking Changes

None

## Notes & open questions

None

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~