### PR TITLE
tests(iroh): Mark test_blob_delete_mem as flaky

### DIFF
--- a/iroh/src/client/blobs.rs
+++ b/iroh/src/client/blobs.rs
@@ -1639,6 +1639,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(target_os = "windows", ignore = "flaky")]
     async fn test_blob_delete_mem() -> Result<()> {
         let _guard = iroh_test::logging::setup();
 


### PR DESCRIPTION
## Description

Only observed on windows, probably because this machine is always
slower and triggers some race condition easier.  We can change this to
be flaky everywhere if we notice it happening on other platforms too.

See #2783.


## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [x] Tests if relevant.
- ~~[ ] All breaking changes documented.~~