### PR TITLE
refactor: display the socket addr and relay for a `ConnectionType::Mixed`

### DIFF
--- a/iroh-net/src/discovery/local_swarm_discovery.rs
+++ b/iroh-net/src/discovery/local_swarm_discovery.rs
@@ -22,7 +22,7 @@
 //!              .iter()
 //!              .any(|(source, duration)| {
 //!                  if let Source::Discovery { name } = source {
-//!                      name == iroh_net::discovery::local_swarm_discovery::NAME && *duration >= recent
+//!                      name == iroh_net::discovery::local_swarm_discovery::NAME && *duration <= recent
 //!                  } else {
 //!                      false
 //!                  }

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1389,10 +1389,10 @@ impl RemoteInfo {
 #[derive(derive_more::Display, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ConnectionType {
     /// Direct UDP connection
-    #[display("direct")]
+    #[display("direct({_0})")]
     Direct(SocketAddr),
     /// Relay connection over relay
-    #[display("relay")]
+    #[display("relay({_0})")]
     Relay(RelayUrl),
     /// Both a UDP and a relay connection are used.
     ///

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -1398,7 +1398,7 @@ pub enum ConnectionType {
     ///
     /// This is the case if we do have a UDP address, but are missing a recent confirmation that
     /// the address works.
-    #[display("mixed")]
+    #[display("mixed(udp: {_0}, relay: {_1})")]
     Mixed(SocketAddr, RelayUrl),
     /// We have no verified connection to this PublicKey
     #[display("none")]


### PR DESCRIPTION
## Description

Each time a `ConnectionType::Mixed` has a different SocketAddr or RelayUrl, we correctly resend a `ConnectionType::Mixed` event to `Endpoint::conn_type_stream`. However, when we print those changes in something like `iroh doctor`, we only print the name of the connection type, we don't print the socket address or relay url, so it looke like we are sending extra `Mixed` events erroneously.

Adding more details to the `Display` of `ConnectionType`, so that it prints the socket addrs and or relay urls.

## Change checklist

- [x] Self-review.
