### PR TITLE
fix(iroh-net): use `try_send` rather than `send` so we dont block the local swarm discovery service

### DIFF
--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -158,6 +158,8 @@ pub trait Discovery: std::fmt::Debug + Send + Sync {
     /// until the stream is actually polled. To avoid missing discovered nodes,
     /// poll the stream as soon as possible.
     ///
+    /// If you do not regularly poll the stream, you may miss discovered nodes.
+    ///
     /// Any discovery systems that only discover when explicitly resolving a
     /// specific [`NodeId`] do not need to implement this method. Any nodes or
     /// addresses that are discovered by calling `resolve` should NOT be added


### PR DESCRIPTION
## Description

Using `subscriber.send().await` could block the entire discovery service if one of the subscribers polls too slow. Change to `try_send` that will drop the discovery item from that stream if it is closed.

## Notes & open questions

Added a line in the documentation to mention that if you do not poll enough, you may miss messages.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
