### PR TITLE
fix(ci): make sure logs get uploaded on netsim failure

### DIFF
--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -143,6 +143,8 @@ jobs:
         echo "LAST_COMMIT_SHA=$(git rev-parse --short ${GITHUB_SHA})" >> ${GITHUB_ENV}
   
     - name: Run tests
+      id: run_tests
+      continue-on-error: true
       run: |
         cd ../chuck/netsim
         # split sim_paths by comma
@@ -153,6 +155,7 @@ jobs:
 
     - name: Generate report
       id: generate_report
+      if: always()
       run: |
         cd ../chuck/netsim
         python3 reports_csv.py --table > report_table.txt
@@ -161,6 +164,7 @@ jobs:
         python3 reports_csv.py --metro --integration --commit ${{ env.LAST_COMMIT_SHA }} > report_metro_integration.txt
     
     - name: Upload report
+      if: always()
       run: |
         export AWS_ACCESS_KEY_ID=${{secrets.S3_ACCESS_KEY_ID}}
         export AWS_SECRET_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}
@@ -179,10 +183,12 @@ jobs:
         fi        
 
     - name: Move report
+      if: always()
       run: |
         cp ../chuck/netsim/report.tar.gz ./report.tar.gz
 
     - name: Upload report
+      if: always()
       uses: actions/upload-artifact@v4
       id: upload-report
       with:
@@ -190,6 +196,10 @@ jobs:
         path: report.tar.gz
         retention-days: 3
         overwrite: true
+    
+    - name: Fail Job if Tests Failed
+      if: ${{ failure() && steps.run_tests.outcome == 'failure' }}
+      run: exit 1
 
     - name: Find Docs Comment
       if: ${{ inputs.pr_number != '' }}


### PR DESCRIPTION
## Description

When our netsim jobs fail, we have little visibility into the why of it. Logs can be inspected manually on the machine but that's really not convenient. This should make sure logs always get uploaded and attached to the job.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
