### PR TITLE
refactor(iroh-net): Failing to bind is not a Warning log

### DIFF
--- a/iroh-net/src/magicsock/udp_conn.rs
+++ b/iroh-net/src/magicsock/udp_conn.rs
@@ -12,7 +12,7 @@ use anyhow::{bail, Context as _};
 use quinn::AsyncUdpSocket;
 use quinn_udp::{Transmit, UdpSockRef};
 use tokio::io::Interest;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 use crate::net::UdpSocket;
 

--- a/iroh-net/src/magicsock/udp_conn.rs
+++ b/iroh-net/src/magicsock/udp_conn.rs
@@ -137,7 +137,7 @@ fn bind(mut addr: SocketAddr) -> anyhow::Result<UdpSocket> {
                 return Ok(pconn);
             }
             Err(err) => {
-                warn!(%addr, "failed to bind: {:#?}", err);
+                debug!(%addr, "failed to bind: {err:#}");
                 continue;
             }
         }


### PR DESCRIPTION
## Description

If the bind is required the call stack already makes sure that this is
surfaced correctly.  It is in fact entirely normal if IPv6 to fail to
bind and this is already logged on INFO level.  We do not need an
additional WARN log for this.

This also doesn't need to debug-log the error, anyhow's alternate
logging mechanism is perfect for this.

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.