### PR TITLE
refactor(iroh-net): No portmapper is not a warning

### DIFF
--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -438,7 +438,7 @@ impl Actor {
                 match port_mapper.probe().await {
                     Ok(Ok(res)) => Some(res),
                     Ok(Err(err)) => {
-                        warn!("skipping port mapping: {err:?}");
+                        debug!("skipping port mapping: {err:?}");
                         None
                     }
                     Err(recv_err) => {


### PR DESCRIPTION
## Description

It is normal for there to be no portmapper, there's no point in
logging this as a warning.

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.