### PR TITLE
refactor(iroh-net): Attach Relay URL to a connecting client span

### DIFF
--- a/iroh-net/src/relay/client.rs
+++ b/iroh-net/src/relay/client.rs
@@ -570,6 +570,7 @@ impl Actor {
         if self.is_closed {
             return Err(ClientError::Closed);
         }
+        let url = self.url.clone();
         async move {
             if self.relay_conn.is_none() {
                 trace!("no connection, trying to connect");
@@ -589,7 +590,7 @@ impl Actor {
 
             Ok((conn, receiver))
         }
-        .instrument(info_span!("connect"))
+        .instrument(info_span!("connect", %url))
         .await
     }
 


### PR DESCRIPTION
## Description

The client already has a connecting span tying together everything
that is happening for connect.  But it doesn't yet say which relay
this is for.  Add the RelayURL as a span field.

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.