### PR TITLE
refactor(iroh-net): Debug logging should not be per packet set

### DIFF
--- a/iroh-net/src/magicsock/relay_actor.rs
+++ b/iroh-net/src/magicsock/relay_actor.rs
@@ -422,7 +422,7 @@ impl RelayActor {
         url: &RelayUrl,
         remote_node: Option<&NodeId>,
     ) -> relay::client::Client {
-        debug!(%url, ?remote_node, "connect relay");
+        trace!(%url, ?remote_node, "connect relay");
         // See if we have a connection open to that relay node ID first. If so, might as
         // well use it. (It's a little arbitrary whether we use this one vs. the reverse route
         // below when we have both.)

--- a/iroh-net/src/relay/client.rs
+++ b/iroh-net/src/relay/client.rs
@@ -561,12 +561,6 @@ impl Actor {
         &mut self,
         why: &'static str,
     ) -> Result<(Conn, &'_ mut ConnReceiver), ClientError> {
-        debug!(
-            "connect: {}, current client {}",
-            why,
-            self.relay_conn.is_some()
-        );
-
         if self.is_closed {
             return Err(ClientError::Closed);
         }
@@ -590,7 +584,7 @@ impl Actor {
 
             Ok((conn, receiver))
         }
-        .instrument(info_span!("connect", %url))
+        .instrument(info_span!("connect", %url, %why))
         .await
     }
 


### PR DESCRIPTION
## Description

These are logged for each packet on the relay path.  That's not what
we do on debug logging.  One case is already covered by other trace
logging, so just move the "why", the other case can be a trace log.

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.