### PR TITLE
feat(iroh-net): Removeable discovery

### DIFF
--- a/iroh-net/src/discovery.rs
+++ b/iroh-net/src/discovery.rs
@@ -206,7 +206,7 @@ pub struct DiscoveryItem {
     pub addr_info: AddrInfo,
 }
 
-/// A map of discovery services that allows insertion and removal
+/// A map of discovery services that allows insertion and removal.
 #[derive(Debug, Default)]
 #[repr(transparent)]
 pub struct DiscoveryServiceMap {


### PR DESCRIPTION
## Description

Adds a version of ConcurrentDiscovery where the individual discovery services are identified by ids.

That way you can dynamically add them, remove them, and even get a reference.

## Breaking Changes

None, this just adds something. In the long term we would probably deprecate and then remove ConcurrentDiscovery however, since the functionality is quite overlapping.

## Notes & open questions

The current implementation uses an `Arc<Mutex<HashMap>>`. When using the services in the service trait implementation, we hold the lock while e.g. calling publish. This is OK for a properly implemented discovery service that does not do anything expensive during publish, but you could come up with a convoluted discovery impl that would e.g. try to remove a discovery service during publish, which would cause a deadlock. Also, people might block in publish, meaning that another code path that calls remove would be blocked.

Sooo. The safe solution for this is to not hold the lock at all while executing code that can be influenced by the user. To do that there are two approaches:

- make a deep copy. Not the end of the world, but also not nice. You would allocate during every call to resolve.
- use a persistent data structure for the inside of the Arc<Mutex<...>> and do a zero cost snapshot. This means having a dependency on [rpds](https://crates.io/crates/rpds).

What do you think?

1. hope that people won't do totally broken and convoluted impls of discovery
2. do a defensive deep copy and eat the overhead
3. use persistent data structures

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
