### PR TITLE
chore(ci): add back macOS x64 tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [ubuntu-latest, macOS-arm-latest]
+        name: [ubuntu-latest, macOS-arm-latest, maxOS-x64-latest]
         rust: [ '${{ inputs.rust-version }}' ]
         features: [all, none, default]
         include:
@@ -42,11 +42,19 @@ jobs:
             os: ubuntu-latest
             release-os: linux
             release-arch: amd64
+            cargo_targets: "x86_64-unknown-linux-musl"
             runner: [self-hosted, linux, X64]
           - name: macOS-arm-latest
             os: macOS-latest
             release-os: darwin
             release-arch: aarch64
+            cargo_targets: "aarch64-apple-darwin"
+            runner: [self-hosted, macOS, ARM64]
+          - name: macOS-x64-latest
+            os: macOS-latest
+            release-os: darwin
+            release-arch: x86_64
+            cargo_targets: "x86_64-apple-darwin"
             runner: [self-hosted, macOS, ARM64]
     env:
       # Using self-hosted runners so use local cache for sccache and
@@ -58,10 +66,15 @@ jobs:
       with:
         ref: ${{ inputs.git-ref }}
 
+    - name: Ensure musl support
+      if: ${{ contains(matrix.cargo_targets, '-musl') }}
+      run: sudo apt-get install musl-tools -y
+
     - name: Install ${{ matrix.rust }} rust
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
+        targets: ${{ matrix.cargo_targets }}
 
     - name: Install cargo-nextest
       uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Description

Test running CI by setting the x86_64 target or arm mac runners to see if we can reproduce https://github.com/n0-computer/iroh/issues/2844

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
