### PR TITLE
refactor!(iroh-net): remove relay secret key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,7 +2857,6 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_json",
- "serde_with",
  "smallvec",
  "socket2",
  "strum 0.26.3",

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -81,7 +81,6 @@ axum = { version = "0.7.4", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 regex = { version = "1.7.1", optional = true }
 rustls-pemfile = { version = "2.1", optional = true }
-serde_with = { version = "3.3", optional = true }
 toml = { version = "0.8", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 tokio-rustls-acme = { version = "0.4", optional = true }
@@ -140,7 +139,6 @@ iroh-relay = [
     "dep:toml",
     "dep:rustls-pemfile",
     "dep:regex",
-    "dep:serde_with",
     "dep:tracing-subscriber"
 ]
 metrics = ["iroh-metrics/metrics"]

--- a/iroh-net/src/bin/iroh-relay.rs
+++ b/iroh-net/src/bin/iroh-relay.rs
@@ -12,13 +12,11 @@ use anyhow::{anyhow, bail, Context as _, Result};
 use clap::Parser;
 use iroh_net::{
     defaults::{DEFAULT_HTTPS_PORT, DEFAULT_HTTP_PORT, DEFAULT_METRICS_PORT, DEFAULT_STUN_PORT},
-    key::SecretKey,
     relay::server as iroh_relay,
 };
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr};
 use tokio_rustls_acme::{caches::DirCache, AcmeConfig};
-use tracing::{debug, info};
+use tracing::debug;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 /// The default `http_bind_port` when using `--dev`.
@@ -94,16 +92,8 @@ fn load_secret_key(
 /// Configuration for the relay-server.
 ///
 /// This is (de)serialised to/from a TOML config file.
-#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Config {
-    /// The iroh [`SecretKey`] for this relay server.
-    ///
-    /// If not specified a new key will be generated and the config file will be re-written
-    /// using it.
-    #[serde_as(as = "DisplayFromStr")]
-    #[serde(default = "SecretKey::generate")]
-    secret_key: SecretKey,
     /// Whether to enable the Relay server.
     ///
     /// Defaults to `true`.
@@ -178,7 +168,6 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            secret_key: SecretKey::generate(),
             enable_relay: true,
             http_bind_addr: None,
             tls: None,
@@ -321,10 +310,6 @@ impl Config {
             .await
             .context("unable to read config")?;
         let config: Self = toml::from_str(&config_ser).context("config file must be valid toml")?;
-        if !config_ser.contains("secret_key") {
-            info!("generating new secret key and updating config file");
-            config.write_to_file(path).await?;
-        }
 
         Ok(config)
     }
@@ -430,7 +415,6 @@ async fn build_relay_config(cfg: Config) -> Result<iroh_relay::ServerConfig<std:
             .unwrap_or_default(),
     };
     let relay_config = iroh_relay::RelayConfig {
-        secret_key: cfg.secret_key.clone(),
         http_bind_addr: cfg.http_bind_addr(),
         tls,
         limits,

--- a/iroh-net/src/relay/server/actor.rs
+++ b/iroh-net/src/relay/server/actor.rs
@@ -90,7 +90,7 @@ impl Default for ServerActorTask {
 }
 
 impl ServerActorTask {
-    /// Creates a new defualt `ServerActorTask`.
+    /// Creates a new default `ServerActorTask`.
     pub fn new() -> Self {
         Self::default()
     }

--- a/iroh-net/src/test_utils.rs
+++ b/iroh-net/src/test_utils.rs
@@ -6,12 +6,9 @@ pub use dns_and_pkarr_servers::DnsPkarrServer;
 pub use dns_server::create_dns_resolver;
 use tokio::sync::oneshot;
 
-use crate::{
-    key::SecretKey,
-    relay::{
-        server::{CertConfig, RelayConfig, Server, ServerConfig, StunConfig, TlsConfig},
-        RelayMap, RelayNode, RelayUrl,
-    },
+use crate::relay::{
+    server::{CertConfig, RelayConfig, Server, ServerConfig, StunConfig, TlsConfig},
+    RelayMap, RelayNode, RelayUrl,
 };
 
 /// A drop guard to clean up test infrastructure.
@@ -29,7 +26,6 @@ pub struct CleanupDropGuard(pub(crate) oneshot::Sender<()>);
 /// The returned `Url` is the url of the relay server in the returned [`RelayMap`].
 /// When dropped, the returned [`Server`] does will stop running.
 pub async fn run_relay_server() -> Result<(RelayMap, RelayUrl, Server)> {
-    let secret_key = SecretKey::generate();
     let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
     let rustls_cert = rustls::pki_types::CertificateDer::from(cert.serialize_der().unwrap());
     let private_key =
@@ -39,7 +35,6 @@ pub async fn run_relay_server() -> Result<(RelayMap, RelayUrl, Server)> {
     let config = ServerConfig {
         relay: Some(RelayConfig {
             http_bind_addr: (Ipv4Addr::LOCALHOST, 0).into(),
-            secret_key,
             tls: Some(TlsConfig {
                 cert: CertConfig::<(), ()>::Manual {
                     private_key,


### PR DESCRIPTION
The `secret_key` configuration of the relay server was actually dead code at this point, this removes it from the config and all associated dead code.
This also removes the need to write to the config file of the `iroh-relay`, making deployments easier to secure.


## Breaking Changes

- removed 
  - the `secret_key` property of the `iroh-relay` config
  - `iroh_net::relay::server::ServerActorTask::secret_key`
  - `iroh_net::relay::server::ServerActorTask::public_key`
  - `iroh_net::relay::server::ServerActorTask::meta_cert`
  - field `secret_key` in `iroh_net::relay::server::RelayConfig`
- changed
  - `iroh_net::relay::server::ServerActorTask::new` now takes no arguments

Closes https://github.com/n0-computer/iroh/issues/2845

