### PR TITLE
tests(iroh-net): Give this a longer timeout

### DIFF
--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -1505,7 +1505,7 @@ mod tests {
         );
 
         let (server, client) = tokio::time::timeout(
-            Duration::from_secs(5),
+            Duration::from_secs(30),
             futures_lite::future::zip(server, client),
         )
         .await


### PR DESCRIPTION
## Description

On windows this sometimes times out.  But the timeout was only 5
seconds and we know our windows CI runners are slow usually.  5s
really isn't enough.  If this timeout still occurs with a 30s timeout
maybe we can do some more debugging, but it is rather likely just a
slow machine.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.