### PR TITLE
docs(iroh-net): Link to Endpoint in the first few paragraphs

### DIFF
--- a/iroh-net/src/lib.rs
+++ b/iroh-net/src/lib.rs
@@ -4,7 +4,8 @@
 //! interface to [QUIC] connections and streams to the user, while implementing direct
 //! connectivity using [hole punching] complemented by relay servers under the hood.
 //!
-//! Connecting to a remote node looks roughly like this:
+//! An iroh-net node is created and controlled by the [`Endpoint`], e.g. connecting to
+//! another node:
 //!
 //! ```no_run
 //! # use iroh_net::{Endpoint, NodeAddr};
@@ -18,7 +19,7 @@
 //! # }
 //! ```
 //!
-//! The other side can accept incoming connections like this:
+//! The other node can accept incoming connections using the [`Endpoint`] as well:
 //!
 //! ```no_run
 //! # use iroh_net::{Endpoint, NodeAddr};


### PR DESCRIPTION
## Description

The Endpoint is the central struct.  I think it should be linked
really early on as the most obvious link to follow.

I myself rely on this link being at the start of docs page, but
introducing this early example moved it down rather far.  So move it
back up.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.