### PR TITLE
fix(iroh-relay): Respect `enable_stun` setting in `iroh-relay::Config`

### DIFF
--- a/iroh-net/src/bin/iroh-relay.rs
+++ b/iroh-net/src/bin/iroh-relay.rs
@@ -424,13 +424,9 @@ async fn build_relay_config(cfg: Config) -> Result<iroh_relay::ServerConfig<std:
     };
     Ok(iroh_relay::ServerConfig {
         relay: Some(relay_config),
-        stun: Some(stun_config),
+        stun: Some(stun_config).filter(|_| cfg.enable_stun),
         #[cfg(feature = "metrics")]
-        metrics_addr: if cfg.enable_metrics {
-            Some(cfg.metrics_bind_addr())
-        } else {
-            None
-        },
+        metrics_addr: Some(cfg.metrics_bind_addr()).filter(|_| cfg.enable_metrics),
     })
 }
 


### PR DESCRIPTION
## Description

Previously, the `Config::enable_stun` value was written but never read, so you couldn't actually disable stun using your iroh config.

## Breaking Changes

- For anyone deploying their relay server: The relay server now *actually* respects the `enable_stun` config value. If you set it to `false` previously, that did not have an effect, but now *will* have an effect.

## Notes & Open Questions

LMK if you hate my `Option::filter` fuckery :P

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
