### PR TITLE
fix(metrics): allow external crates to encode their metrics

### DIFF
--- a/iroh-metrics/src/core.rs
+++ b/iroh-metrics/src/core.rs
@@ -183,8 +183,10 @@ impl Core {
         self.metrics_map.get::<T>()
     }
 
+    /// Encodes the current metrics registry to a string in
+    /// the prometheus text exposition format.
     #[cfg(feature = "metrics")]
-    pub(crate) fn encode(&self) -> Result<String, std::fmt::Error> {
+    pub fn encode(&self) -> Result<String, std::fmt::Error> {
         let mut buf = String::new();
         encode(&mut buf, &self.registry)?;
         Ok(buf)


### PR DESCRIPTION
## Description

Allows external crates to easily encode metrics.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
