### PR TITLE
chore: Break long strings in the formatter

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,7 +10,11 @@ args = [
      "--config",
      "unstable_features=true",
      "--config",
-     "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true",
+     "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true",
+     "--config",
+     "format_code_in_doc_comments=true",
+     "--config",
+     "format_strings=true",
 ]
 
 [tasks.format-check]
@@ -24,5 +28,9 @@ args = [
      "--config",
      "unstable_features=true",
      "--config",
-     "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true",
+     "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true",
+     "--config",
+     "format_code_in_doc_comments=true",
+     "--config",
+     "format_strings=true",
 ]

--- a/iroh-base/src/ticket/blob.rs
+++ b/iroh-base/src/ticket/blob.rs
@@ -168,14 +168,19 @@ mod tests {
             hash,
         };
         let base32 = base32::parse_vec(ticket.to_string().strip_prefix("blob").unwrap()).unwrap();
-        let expected = parse_hexdump("
+        let expected = parse_hexdump(
+            "
             00 # discriminator for variant 0
-            ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6 # node id, 32 bytes, see above
+            ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6 # node id, 32 bytes, \
+             see above
             00 # relay url
             00 # number of addresses (0)
             00 # format (raw)
-            0b84d358e4c8be6c38626b2182ff575818ba6bd3f4b90464994be14cb354a072 # hash, 32 bytes, see above
-        ").unwrap();
+            0b84d358e4c8be6c38626b2182ff575818ba6bd3f4b90464994be14cb354a072 # hash, 32 bytes, see \
+             above
+        ",
+        )
+        .unwrap();
         assert_eq_hex!(base32, expected);
     }
 }

--- a/iroh-base/src/ticket/node.rs
+++ b/iroh-base/src/ticket/node.rs
@@ -162,15 +162,19 @@ mod tests {
             ),
         };
         let base32 = base32::parse_vec(ticket.to_string().strip_prefix("node").unwrap()).unwrap();
-        let expected = parse_hexdump("
+        let expected = parse_hexdump(
+            "
             00 # variant
-            ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6 # node id, 32 bytes, see above
+            ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6 # node id, 32 bytes, \
+             see above
             01 # relay url present
             10 687474703a2f2f646572702e6d652e2f # relay url, 16 bytes, see above
             01 # one direct address
             00 # ipv4
             7f000001 8008 # address, see above
-        ").unwrap();
+        ",
+        )
+        .unwrap();
         assert_eq_hex!(base32, expected);
     }
 }

--- a/iroh-cli/src/commands/blobs.rs
+++ b/iroh-cli/src/commands/blobs.rs
@@ -248,7 +248,10 @@ impl BlobCommands {
                 };
 
                 if format != BlobFormat::Raw && out == Some(OutputTarget::Stdout) {
-                    return Err(anyhow::anyhow!("The input arguments refer to a collection of blobs and output is set to STDOUT. Only single blobs may be passed in this case."));
+                    return Err(anyhow::anyhow!(
+                        "The input arguments refer to a collection of blobs and output is set to \
+                         STDOUT. Only single blobs may be passed in this case."
+                    ));
                 }
 
                 let tag = match tag {
@@ -717,9 +720,15 @@ impl ValidateProgressState {
     /// Adds a message to the progress bar in the given `id`.
     fn add_entry(&mut self, id: u64, hash: Hash, path: Option<String>, size: u64) {
         let pb = self.mp.insert_before(&self.overall, ProgressBar::new(size));
-        pb.set_style(ProgressStyle::default_bar()
-            .template("{spinner:.green} [{bar:40.cyan/blue}] {msg} {bytes}/{total_bytes} ({bytes_per_sec}, eta {eta})").unwrap()
-            .progress_chars("=>-"));
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "{spinner:.green} [{bar:40.cyan/blue}] {msg} {bytes}/{total_bytes} \
+                     ({bytes_per_sec}, eta {eta})",
+                )
+                .unwrap()
+                .progress_chars("=>-"),
+        );
         let msg = if let Some(path) = path {
             format!("{} {}", hash.to_hex(), path)
         } else {
@@ -1003,9 +1012,15 @@ impl ProvideProgressState {
     /// Inserts a new progress bar with the given id, name, and size.
     fn found(&mut self, name: String, id: u64, size: u64) {
         let pb = self.mp.add(ProgressBar::new(size));
-        pb.set_style(ProgressStyle::default_bar()
-            .template("{spinner:.green} [{bar:40.cyan/blue}] {msg} {bytes}/{total_bytes} ({bytes_per_sec}, eta {eta})").unwrap()
-            .progress_chars("=>-"));
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "{spinner:.green} [{bar:40.cyan/blue}] {msg} {bytes}/{total_bytes} \
+                     ({bytes_per_sec}, eta {eta})",
+                )
+                .unwrap()
+                .progress_chars("=>-"),
+        );
         pb.set_message(name);
         pb.set_length(size);
         pb.set_position(0);
@@ -1174,15 +1189,18 @@ fn make_individual_progress() -> ProgressBar {
     let pb = ProgressBar::hidden();
     pb.enable_steady_tick(std::time::Duration::from_millis(100));
     pb.set_style(
-        ProgressStyle::with_template("{msg}{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
-            .unwrap()
-            .with_key(
-                "eta",
-                |state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                    write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
-                },
-            )
-            .progress_chars("#>-"),
+        ProgressStyle::with_template(
+            "{msg}{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] \
+             {bytes}/{total_bytes} ({eta})",
+        )
+        .unwrap()
+        .with_key(
+            "eta",
+            |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
+            },
+        )
+        .progress_chars("#>-"),
     );
     pb
 }

--- a/iroh-cli/src/commands/docs.rs
+++ b/iroh-cli/src/commands/docs.rs
@@ -527,9 +527,15 @@ impl DocCommands {
                             }
                         };
                         let pb = ProgressBar::new(content.size());
-                        pb.set_style(ProgressStyle::default_bar()
-                                .template("{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, eta {eta})").unwrap()
-                                .progress_chars("=>-"));
+                        pb.set_style(
+                            ProgressStyle::default_bar()
+                                .template(
+                                    "{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} \
+                                     ({bytes_per_sec}, eta {eta})",
+                                )
+                                .unwrap()
+                                .progress_chars("=>-"),
+                        );
                         let file = tokio::fs::File::create(path.clone()).await?;
                         if let Err(err) =
                             tokio::io::copy(&mut content, &mut pb.wrap_async_write(file)).await
@@ -622,8 +628,9 @@ impl DocCommands {
             Self::Drop { doc } => {
                 let doc = get_doc(iroh, env, doc).await?;
                 println!(
-                    "Deleting a document will permanently remove the document secret key, all document entries, \n\
-                    and all content blobs which are not referenced from other docs or tags."
+                    "Deleting a document will permanently remove the document secret key, all \
+                     document entries, \nand all content blobs which are not referenced from \
+                     other docs or tags."
                 );
                 let prompt = format!("Delete document {}?", fmt_short(doc.id()));
                 if Confirm::new()
@@ -900,9 +907,15 @@ impl ImportProgressBar {
     fn new(source: &str, doc_id: NamespaceId, expected_size: u64, expected_entries: u64) -> Self {
         let mp = MultiProgress::new();
         let add = mp.add(ProgressBar::new(0));
-        add.set_style(ProgressStyle::default_bar()
-            .template("{msg}\n{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, eta {eta})").unwrap()
-            .progress_chars("=>-"));
+        add.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "{msg}\n{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} \
+                     ({bytes_per_sec}, eta {eta})",
+                )
+                .unwrap()
+                .progress_chars("=>-"),
+        );
         add.set_message(format!("Importing from {source}..."));
         add.set_length(expected_size);
         add.set_position(0);
@@ -910,9 +923,15 @@ impl ImportProgressBar {
 
         let doc_id = fmt_short(doc_id.to_bytes());
         let import = mp.add(ProgressBar::new(0));
-        import.set_style(ProgressStyle::default_bar()
-            .template("{msg}\n{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} ({per_sec}, eta {eta})").unwrap()
-            .progress_chars("=>-"));
+        import.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "{msg}\n{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} ({per_sec}, eta \
+                     {eta})",
+                )
+                .unwrap()
+                .progress_chars("=>-"),
+        );
         import.set_message(format!("Adding to doc {doc_id}..."));
         import.set_length(expected_entries);
         import.set_position(0);

--- a/iroh-cli/src/commands/doctor.rs
+++ b/iroh-cli/src/commands/doctor.rs
@@ -400,9 +400,15 @@ impl Gui {
         counters.set_style(style);
         let pb = mp.add(indicatif::ProgressBar::hidden());
         pb.enable_steady_tick(Duration::from_millis(100));
-        pb.set_style(indicatif::ProgressStyle::default_bar()
-            .template("{spinner:.green} [{bar:80.cyan/blue}] {msg} {bytes}/{total_bytes} ({bytes_per_sec})").unwrap()
-            .progress_chars("█▉▊▋▌▍▎▏ "));
+        pb.set_style(
+            indicatif::ProgressStyle::default_bar()
+                .template(
+                    "{spinner:.green} [{bar:80.cyan/blue}] {msg} {bytes}/{total_bytes} \
+                     ({bytes_per_sec})",
+                )
+                .unwrap()
+                .progress_chars("█▉▊▋▌▍▎▏ "),
+        );
         let counters2 = counters.clone();
         let counter_task = tokio::spawn(async move {
             loop {

--- a/iroh-cli/src/commands/gossip.rs
+++ b/iroh-cli/src/commands/gossip.rs
@@ -71,9 +71,14 @@ impl GossipCommands {
             } => {
                 let bootstrap = bootstrap
                     .into_iter()
-                    .map(|node_id| NodeId::from_str(&node_id).map_err(|e| {
-                        anyhow::anyhow!("Failed to parse bootstrap node id \"{node_id}\": {e}\nMust be a valid base32-encoded iroh node id.")
-                    }))
+                    .map(|node_id| {
+                        NodeId::from_str(&node_id).map_err(|e| {
+                            anyhow::anyhow!(
+                                "Failed to parse bootstrap node id \"{node_id}\": {e}\nMust be a \
+                                 valid base32-encoded iroh node id."
+                            )
+                        })
+                    })
                     .collect::<Result<_, _>>()?;
 
                 let topic = match (topic, raw_topic) {

--- a/iroh-cli/src/config.rs
+++ b/iroh-cli/src/config.rs
@@ -241,7 +241,10 @@ impl ConsoleEnv {
         let author_path = ConsolePaths::CurrentAuthor.with_iroh_data_dir(self.iroh_data_dir());
         let mut inner = self.0.write();
         if !inner.is_console {
-            bail!("Switching the author is only supported within the Iroh console, not on the command line");
+            bail!(
+                "Switching the author is only supported within the Iroh console, not on the \
+                 command line"
+            );
         }
         inner.author = author;
         std::fs::write(author_path, author.to_string().as_bytes())?;
@@ -255,7 +258,10 @@ impl ConsoleEnv {
     pub(crate) fn set_doc(&self, doc: NamespaceId) -> anyhow::Result<()> {
         let mut inner = self.0.write();
         if !inner.is_console {
-            bail!("Switching the document is only supported within the Iroh console, not on the command line");
+            bail!(
+                "Switching the document is only supported within the Iroh console, not on the \
+                 command line"
+            );
         }
         inner.doc = Some(doc);
         Ok(())
@@ -266,8 +272,9 @@ impl ConsoleEnv {
         let inner = self.0.read();
         let doc_id = arg.or(inner.doc).ok_or_else(|| {
             anyhow!(
-                "Missing document id. Set the active document with the `IROH_DOC` environment variable or the `-d` option.\n\
-                In the console, you can also set the active document with `doc switch`."
+                "Missing document id. Set the active document with the `IROH_DOC` environment \
+                 variable or the `-d` option.\nIn the console, you can also set the active \
+                 document with `doc switch`."
             )
         })?;
         Ok(doc_id)

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -60,7 +60,10 @@ async fn main() -> Result<()> {
             s
         }
         Err(_) => {
-            bail!("Environment variable IROH_SECRET is not set. To create a new secret, use the --create option.")
+            bail!(
+                "Environment variable IROH_SECRET is not set. To create a new secret, use the \
+                 --create option."
+            )
         }
     };
 

--- a/iroh-net/examples/connect-unreliable.rs
+++ b/iroh-net/examples/connect-unreliable.rs
@@ -68,9 +68,11 @@ async fn main() -> anyhow::Result<()> {
         println!("\t{}", local_endpoint.addr)
     }
 
-    let relay_url = endpoint
-        .home_relay()
-        .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
+    let relay_url = endpoint.home_relay().expect(
+        "should be connected to a relay server, try calling `endpoint.local_endpoints()` or \
+         `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection \
+         before checking for the connected relay server",
+    );
     println!("node relay server url: {relay_url}\n");
     // Build a `NodeAddr` from the node_id, relay url, and UDP addresses.
     let addr = NodeAddr::from_parts(args.node_id, Some(args.relay_url), args.addrs);

--- a/iroh-net/examples/connect.rs
+++ b/iroh-net/examples/connect.rs
@@ -68,9 +68,11 @@ async fn main() -> anyhow::Result<()> {
         println!("\t{}", local_endpoint.addr)
     }
 
-    let relay_url = endpoint
-        .home_relay()
-        .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
+    let relay_url = endpoint.home_relay().expect(
+        "should be connected to a relay server, try calling `endpoint.local_endpoints()` or \
+         `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection \
+         before checking for the connected relay server",
+    );
     println!("node relay server url: {relay_url}\n");
     // Build a `NodeAddr` from the node_id, relay url, and UDP addresses.
     let addr = NodeAddr::from_parts(args.node_id, Some(args.relay_url), args.addrs);

--- a/iroh-net/examples/listen-unreliable.rs
+++ b/iroh-net/examples/listen-unreliable.rs
@@ -51,14 +51,17 @@ async fn main() -> anyhow::Result<()> {
         .collect::<Vec<_>>()
         .join(" ");
 
-    let relay_url = endpoint
-        .home_relay()
-        .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
+    let relay_url = endpoint.home_relay().expect(
+        "should be connected to a relay server, try calling `endpoint.local_endpoints()` or \
+         `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection \
+         before checking for the connected relay server",
+    );
     println!("node relay server url: {relay_url}");
     println!("\nin a separate terminal run:");
 
     println!(
-        "\tcargo run --example connect-unreliable -- --node-id {me} --addrs \"{local_addrs}\" --relay-url {relay_url}\n"
+        "\tcargo run --example connect-unreliable -- --node-id {me} --addrs \"{local_addrs}\" \
+         --relay-url {relay_url}\n"
     );
     // accept incoming connections, returns a normal QUIC connection
 

--- a/iroh-net/examples/listen.rs
+++ b/iroh-net/examples/listen.rs
@@ -53,14 +53,17 @@ async fn main() -> anyhow::Result<()> {
         .collect::<Vec<_>>()
         .join(" ");
 
-    let relay_url = endpoint
-        .home_relay()
-        .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
+    let relay_url = endpoint.home_relay().expect(
+        "should be connected to a relay server, try calling `endpoint.local_endpoints()` or \
+         `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection \
+         before checking for the connected relay server",
+    );
     println!("node relay server url: {relay_url}");
     println!("\nin a separate terminal run:");
 
     println!(
-        "\tcargo run --example connect -- --node-id {me} --addrs \"{local_addrs}\" --relay-url {relay_url}\n"
+        "\tcargo run --example connect -- --node-id {me} --addrs \"{local_addrs}\" --relay-url \
+         {relay_url}\n"
     );
     // accept incoming connections, returns a normal QUIC connection
     while let Some(incoming) = endpoint.accept().await {

--- a/iroh-net/src/disco.rs
+++ b/iroh-net/src/disco.rs
@@ -418,18 +418,26 @@ mod tests {
                 name: "ping_with_nodekey_src",
                 m: Message::Ping(Ping {
                     tx_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into(),
-                    node_key: PublicKey::try_from(&[
-                        190, 243, 65, 104, 37, 102, 175, 75, 243, 22, 69, 200, 167, 107, 24, 63, 216, 140, 120, 43, 4, 112, 16, 62, 117, 155, 45, 215, 72, 175, 40, 189][..]).unwrap(),
+                    node_key: PublicKey::try_from(
+                        &[
+                            190, 243, 65, 104, 37, 102, 175, 75, 243, 22, 69, 200, 167, 107, 24,
+                            63, 216, 140, 120, 43, 4, 112, 16, 62, 117, 155, 45, 215, 72, 175, 40,
+                            189,
+                        ][..],
+                    )
+                    .unwrap(),
                 }),
-                want: "01 00 01 02 03 04 05 06 07 08 09 0a 0b 0c be f3 41 68 25 66 af 4b f3 16 45 c8 a7 6b 18 3f d8 8c 78 2b 04 70 10 3e 75 9b 2d d7 48 af 28 bd",
+                want: "01 00 01 02 03 04 05 06 07 08 09 0a 0b 0c be f3 41 68 25 66 af 4b f3 16 45 \
+                       c8 a7 6b 18 3f d8 8c 78 2b 04 70 10 3e 75 9b 2d d7 48 af 28 bd",
             },
             Test {
                 name: "pong",
-                m: Message::Pong(Pong{
+                m: Message::Pong(Pong {
                     tx_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into(),
-                    ping_observed_addr:  SendAddr::Udp("2.3.4.5:1234".parse().unwrap()),
+                    ping_observed_addr: SendAddr::Udp("2.3.4.5:1234".parse().unwrap()),
                 }),
-                want: "02 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 00 00 00 00 00 00 00 00 00 00 ff ff 02 03 04 05 d2 04",
+                want: "02 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 00 00 00 00 00 00 00 00 00 00 \
+                       ff ff 02 03 04 05 d2 04",
             },
             Test {
                 name: "pongv6",
@@ -437,11 +445,14 @@ mod tests {
                     tx_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into(),
                     ping_observed_addr: SendAddr::Udp("[fed0::12]:6666".parse().unwrap()),
                 }),
-                want: "02 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 fe d0 00 00 00 00 00 00 00 00 00 00 00 00 00 12 0a 1a",
+                want: "02 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 fe d0 00 00 00 00 00 00 00 00 \
+                       00 00 00 00 00 12 0a 1a",
             },
             Test {
                 name: "call_me_maybe",
-                m: Message::CallMeMaybe(CallMeMaybe { my_numbers: Vec::new() }),
+                m: Message::CallMeMaybe(CallMeMaybe {
+                    my_numbers: Vec::new(),
+                }),
                 want: "03 00",
             },
             Test {
@@ -452,7 +463,8 @@ mod tests {
                         "[2001::3456]:789".parse().unwrap(),
                     ],
                 }),
-                want: "03 00 00 00 00 00 00 00 00 00 00 00 ff ff 01 02 03 04 37 02 20 01 00 00 00 00 00 00 00 00 00 00 00 00 34 56 15 03",
+                want: "03 00 00 00 00 00 00 00 00 00 00 00 ff ff 01 02 03 04 37 02 20 01 00 00 00 \
+                       00 00 00 00 00 00 00 00 00 34 56 15 03",
             },
         ];
         for test in tests {

--- a/iroh-net/src/magicsock.rs
+++ b/iroh-net/src/magicsock.rs
@@ -2356,7 +2356,12 @@ impl Actor {
             Some((source, sealed_box)) => {
                 if relay_node_src != source {
                     // TODO: return here?
-                    warn!("Received relay disco message from connection for {}, but with message from {}", relay_node_src.fmt_short(), source.fmt_short());
+                    warn!(
+                        "Received relay disco message from connection for {}, but with message \
+                         from {}",
+                        relay_node_src.fmt_short(),
+                        source.fmt_short()
+                    );
                 }
                 self.msock.handle_disco_message(
                     source,

--- a/iroh-net/src/magicsock/node_map/node_state.rs
+++ b/iroh-net/src/magicsock/node_map/node_state.rs
@@ -278,7 +278,10 @@ impl NodeState {
         have_ipv6: bool,
     ) -> (Option<SocketAddr>, Option<RelayUrl>) {
         if relay_only_mode() {
-            debug!("in `DEV_relay_ONLY` mode, giving the relay address as the only viable address for this endpoint");
+            debug!(
+                "in `DEV_relay_ONLY` mode, giving the relay address as the only viable address \
+                 for this endpoint"
+            );
             return (None, self.relay_url());
         }
         let (best_addr, relay_url) = match self.udp_paths.send_addr(*now, have_ipv6) {

--- a/iroh-net/src/relay/client.rs
+++ b/iroh-net/src/relay/client.rs
@@ -326,7 +326,10 @@ impl ClientBuilder {
         .with_no_client_auth();
         #[cfg(any(test, feature = "test-utils"))]
         if self.insecure_skip_cert_verify {
-            warn!("Insecure config: SSL certificates from relay servers will be trusted without verification");
+            warn!(
+                "Insecure config: SSL certificates from relay servers will be trusted without \
+                 verification"
+            );
             config
                 .dangerous()
                 .set_certificate_verifier(Arc::new(NoCertVerifier));

--- a/iroh-net/src/relay/client/streams.rs
+++ b/iroh-net/src/relay/client/streams.rs
@@ -131,7 +131,8 @@ pub fn downcast_upgrade(
             }
 
             bail!(
-                "could not downcast the upgraded connection to a TcpStream or client::TlsStream<TcpStream>"
+                "could not downcast the upgraded connection to a TcpStream or \
+                 client::TlsStream<TcpStream>"
             )
         }
     }

--- a/iroh-net/src/relay/server.rs
+++ b/iroh-net/src/relay/server.rs
@@ -57,8 +57,15 @@ const INDEX: &[u8] = br#"<html><body>
 </p>
 "#;
 const TLS_HEADERS: [(&str, &str); 2] = [
-    ("Strict-Transport-Security", "max-age=63072000; includeSubDomains"),
-    ("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'")
+    (
+        "Strict-Transport-Security",
+        "max-age=63072000; includeSubDomains",
+    ),
+    (
+        "Content-Security-Policy",
+        "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'self'; \
+         block-all-mixed-content; plugin-types 'none'",
+    ),
 ];
 
 type BytesBody = http_body_util::Full<hyper::body::Bytes>;

--- a/iroh-net/src/relay/server/clients.rs
+++ b/iroh-net/src/relay/server/clients.rs
@@ -243,7 +243,10 @@ impl Clients {
                 tracing::warn!("client {key:?} too busy to receive packet, dropping packet");
             }
             Err(SendError::SenderClosed) => {
-                tracing::warn!("Can no longer write to client {key:?}, dropping message and pruning connection");
+                tracing::warn!(
+                    "Can no longer write to client {key:?}, dropping message and pruning \
+                     connection"
+                );
                 self.unregister(key);
             }
         }

--- a/iroh-net/src/relay/server/http_server.rs
+++ b/iroh-net/src/relay/server/http_server.rs
@@ -578,7 +578,10 @@ impl std::fmt::Debug for Handlers {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = self.0.keys().fold(String::new(), |curr, next| {
             let (method, uri) = next;
-            format!("{curr}\n({method},{uri}): Box<Fn(ResponseBuilder) -> Result<Response<Body>> + Send + Sync + 'static>")
+            format!(
+                "{curr}\n({method},{uri}): Box<Fn(ResponseBuilder) -> Result<Response<Body>> + \
+                 Send + Sync + 'static>"
+            )
         });
         write!(f, "HashMap<{s}>")
     }

--- a/iroh/examples/collection-fetch.rs
+++ b/iroh/examples/collection-fetch.rs
@@ -26,12 +26,17 @@ async fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {
-        bail!("expected one argument [BLOB_TICKET]\n\nGet a ticket by running the follow command in a separate terminal:\n\n`cargo run --example collection-provide`");
+        bail!(
+            "expected one argument [BLOB_TICKET]\n\nGet a ticket by running the follow command in \
+             a separate terminal:\n\n`cargo run --example collection-provide`"
+        );
     }
 
     // deserialize ticket string into a ticket
-    let ticket =
-        BlobTicket::from_str(&args[1]).context("failed parsing blob ticket\n\nGet a ticket by running the follow command in a separate terminal:\n\n`cargo run --example collection-provide`")?;
+    let ticket = BlobTicket::from_str(&args[1]).context(
+        "failed parsing blob ticket\n\nGet a ticket by running the follow command in a separate \
+         terminal:\n\n`cargo run --example collection-provide`",
+    )?;
 
     // create a new node
     let node = iroh::node::Node::memory().spawn().await?;
@@ -53,7 +58,8 @@ async fn main() -> Result<()> {
     // Get the content we have just fetched from the iroh database.
     ensure!(
         ticket.format() == BlobFormat::HashSeq,
-        "'collection' example expects to fetch a collection, but the ticket indicates a single blob."
+        "'collection' example expects to fetch a collection, but the ticket indicates a single \
+         blob."
     );
 
     // `download` returns a stream of `DownloadProgress` events. You can iterate through these updates to get progress

--- a/iroh/examples/hello-world-fetch.rs
+++ b/iroh/examples/hello-world-fetch.rs
@@ -26,12 +26,17 @@ async fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {
-        bail!("expected one argument [BLOB_TICKET]\n\nGet a ticket by running the follow command in a separate terminal:\n\n`cargo run --example hello-world-provide`");
+        bail!(
+            "expected one argument [BLOB_TICKET]\n\nGet a ticket by running the follow command in \
+             a separate terminal:\n\n`cargo run --example hello-world-provide`"
+        );
     }
 
     // deserialize ticket string into a ticket
-    let ticket =
-        BlobTicket::from_str(&args[1]).context("failed parsing blob ticket\n\nGet a ticket by running the follow command in a separate terminal:\n\n`cargo run --example hello-world-provide`")?;
+    let ticket = BlobTicket::from_str(&args[1]).context(
+        "failed parsing blob ticket\n\nGet a ticket by running the follow command in a separate \
+         terminal:\n\n`cargo run --example hello-world-provide`",
+    )?;
 
     // create a new node
     let node = iroh::node::Node::memory().spawn().await?;
@@ -53,7 +58,8 @@ async fn main() -> Result<()> {
     // If the `BlobFormat` is `Raw`, we have the hash for a single blob, and simply need to read the blob using the `blobs` API on the client to get the content.
     ensure!(
         ticket.format() == BlobFormat::Raw,
-        "'Hello World' example expects to fetch a single blob, but the ticket indicates a collection.",
+        "'Hello World' example expects to fetch a single blob, but the ticket indicates a \
+         collection.",
     );
 
     // `download` returns a stream of `DownloadProgress` events. You can iterate through these updates to get progress

--- a/iroh/examples/local-swarm-discovery.rs
+++ b/iroh/examples/local-swarm-discovery.rs
@@ -94,7 +94,12 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .await?;
             let outcome = stream.finish().await?;
-            println!("To fetch the blob:\n\tcargo run --example local_swarm_discovery --features=\"local-swarm-discovery\" -- connect {} {} -o [FILE_PATH]", node.node_id(), outcome.hash);
+            println!(
+                "To fetch the blob:\n\tcargo run --example local_swarm_discovery \
+                 --features=\"local-swarm-discovery\" -- connect {} {} -o [FILE_PATH]",
+                node.node_id(),
+                outcome.hash
+            );
             tokio::signal::ctrl_c().await?;
             node.shutdown().await?;
             std::process::exit(0);
@@ -253,7 +258,10 @@ mod progress {
         let pb = ProgressBar::hidden();
         pb.enable_steady_tick(std::time::Duration::from_millis(100));
         pb.set_style(
-        ProgressStyle::with_template("{msg}{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+            ProgressStyle::with_template(
+                "{msg}{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] \
+                 {bytes}/{total_bytes} ({eta})",
+            )
             .unwrap()
             .with_key(
                 "eta",
@@ -262,7 +270,7 @@ mod progress {
                 },
             )
             .progress_chars("#>-"),
-    );
+        );
         pb
     }
 }

--- a/net-tools/portmapper/src/pcp.rs
+++ b/net-tools/portmapper/src/pcp.rs
@@ -107,7 +107,10 @@ impl Mapping {
 
                 let sent_port: u16 = local_port.into();
                 if received_local_port != sent_port {
-                    anyhow::bail!("received mapping is for a local port that does not match the requested one");
+                    anyhow::bail!(
+                        "received mapping is for a local port that does not match the requested \
+                         one"
+                    );
                 }
                 let external_port = external_port
                     .try_into()


### PR DESCRIPTION
## Description

This configures rustfmt to break long strings.


## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

This one is probably more open to opinions.  I don't feel very
strongly about this, but thought the result does look a little nicer
so thought I'd submit it anyway.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.