### PR TITLE
ci: Kill tests after 60s using nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,3 +8,6 @@ run-in-isolation = { max-threads = 32 }
 filter = 'test(::run_in_isolation::)'
 test-group = 'run-in-isolation'
 threads-required = 32
+
+[profile.default]
+slow-timeout = { period = "20s", terminate-after = 3 }

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -1426,7 +1426,6 @@ mod tests {
         assert!(res.is_err());
         let err = res.err().unwrap();
         assert!(err.to_string().starts_with("Adding our own address"));
-        tokio::time::sleep(Duration::from_secs(180)).await;
     }
 
     #[tokio::test]

--- a/iroh-net/src/endpoint.rs
+++ b/iroh-net/src/endpoint.rs
@@ -1426,6 +1426,7 @@ mod tests {
         assert!(res.is_err());
         let err = res.err().unwrap();
         assert!(err.to_string().starts_with("Adding our own address"));
+        tokio::time::sleep(Duration::from_secs(180)).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

By using nextest to kill slow tests we get logs when a test is killed. This is better than the github timeout kicking in as then we get no feedback on what was stuck.

Tests are now marked as slow after 20s and killed after 60s.


## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

discovery::tests::endpoint_discovery_combined_wrong_only seems like it is a slow tests needing about 30s to complete.  To be fair I think it's fine to call that out as a slow test, so I'm fine with that.

It is possible that this 60s timeout will introduce some new flakyness to the slow CI machines.  We'll have to see and potentially tweak this a bit.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
