### PR TITLE
feat(iroh-net): Implement the https probe

### DIFF
--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -43,7 +43,7 @@ use crate::{
     dns::{DnsResolver, ResolverExt},
     netcheck::{self, Report},
     ping::{PingError, Pinger},
-    relay::{RelayMap, RelayNode, RelayUrl},
+    relay::{http::RELAY_PROBE_PATH, RelayMap, RelayNode, RelayUrl},
     stun,
     util::MaybeFuture,
 };
@@ -1053,8 +1053,7 @@ async fn measure_https_latency(
     node: &RelayNode,
     certs: Option<Vec<rustls::pki_types::CertificateDer<'static>>>,
 ) -> Result<(Duration, IpAddr)> {
-    // TODO: I would prefer a different URL, `/ping` probably.
-    let url = node.url.join("/relay/probe")?;
+    let url = node.url.join(RELAY_PROBE_PATH)?;
 
     // TODO: uses threadpool with getaddrinfo for DNS resolution.  other options are:
     // - enable reqwest's built-in trust-dns support

--- a/iroh-net/src/netcheck/reportgen.rs
+++ b/iroh-net/src/netcheck/reportgen.rs
@@ -1055,11 +1055,6 @@ async fn measure_https_latency(
 ) -> Result<(Duration, IpAddr)> {
     let url = node.url.join(RELAY_PROBE_PATH)?;
 
-    // TODO: uses threadpool with getaddrinfo for DNS resolution.  other options are:
-    // - enable reqwest's built-in trust-dns support
-    // - hook up our own crate::dns::DNS_RESOLVER
-    // The captive portal check is in the same boat.
-    //
     // This should also use same connection establishment as relay client itself, which
     // needs to be more configurable so users can do more crazy things:
     // https://github.com/n0-computer/iroh/issues/2901

--- a/iroh-net/src/relay/http.rs
+++ b/iroh-net/src/relay/http.rs
@@ -10,17 +10,12 @@ pub(crate) const SUPPORTED_WEBSOCKET_VERSION: &str = "13";
 /// (over websockets and a custom upgrade protocol).
 pub const RELAY_PATH: &str = "/relay";
 /// The HTTP path under which the relay allows doing latency queries for testing.
-pub const RELAY_PROBE_PATH: &str = "/relay/probe";
+pub const RELAY_PROBE_PATH: &str = "/ping";
 /// The legacy HTTP path under which the relay used to accept relaying connections.
 /// We keep this for backwards compatibility.
 #[cfg(feature = "iroh-relay")] // legacy paths only used on server-side for backwards compat
 #[cfg_attr(iroh_docsrs, doc(cfg(feature = "iroh-relay")))]
 pub(crate) const LEGACY_RELAY_PATH: &str = "/derp";
-/// The legacy HTTP path under which the relay used to allow latency queries.
-/// We keep this for backwards compatibility.
-#[cfg(feature = "iroh-relay")] // legacy paths only used on server-side for backwards compat
-#[cfg_attr(iroh_docsrs, doc(cfg(feature = "iroh-relay")))]
-pub(crate) const LEGACY_RELAY_PROBE_PATH: &str = "/derp/probe";
 
 /// The HTTP upgrade protocol used for relaying.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/iroh-net/src/relay/server.rs
+++ b/iroh-net/src/relay/server.rs
@@ -8,6 +8,13 @@
 //! always attached to a handle and when the handle is dropped the tasks abort.  So tasks
 //! can not outlive their handle.  It is also always possible to await for completion of a
 //! task.  Some tasks additionally have a method to do graceful shutdown.
+//!
+//! The relay server hosts the following services:
+//!
+//! - HTTPS `/relay`: The main URL endpoint to which clients connect and sends traffic over.
+//! - HTTPS `/ping`: Used for netcheck probes.
+//! - HTTPS `/generate_204`: Used for netcheck probes.
+//! - STUN: UDP port for STUN requests/responses.
 
 use std::{fmt, future::Future, net::SocketAddr, pin::Pin, sync::Arc};
 

--- a/iroh-net/src/relay/server.rs
+++ b/iroh-net/src/relay/server.rs
@@ -27,10 +27,7 @@ use tokio::{
 use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
 
-use crate::{
-    relay::http::{LEGACY_RELAY_PROBE_PATH, RELAY_PROBE_PATH},
-    stun,
-};
+use crate::{relay::http::RELAY_PROBE_PATH, stun};
 
 pub(crate) mod actor;
 pub(crate) mod client_conn;
@@ -254,11 +251,6 @@ impl Server {
                     .headers(headers)
                     .request_handler(Method::GET, "/", Box::new(root_handler))
                     .request_handler(Method::GET, "/index.html", Box::new(root_handler))
-                    .request_handler(
-                        Method::GET,
-                        LEGACY_RELAY_PROBE_PATH,
-                        Box::new(probe_handler),
-                    ) // backwards compat
                     .request_handler(Method::GET, RELAY_PROBE_PATH, Box::new(probe_handler))
                     .request_handler(Method::GET, "/robots.txt", Box::new(robots_handler));
                 let http_addr = match relay_config.tls {

--- a/iroh-net/src/test_utils.rs
+++ b/iroh-net/src/test_utils.rs
@@ -44,7 +44,9 @@ pub async fn run_relay_server() -> Result<(RelayMap, RelayUrl, Server)> {
 pub async fn run_relay_server_with(
     stun: Option<StunConfig>,
 ) -> Result<(RelayMap, RelayUrl, Server)> {
-    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .expect("valid");
     let rustls_cert = rustls::pki_types::CertificateDer::from(cert.serialize_der().unwrap());
     let private_key =
         rustls::pki_types::PrivatePkcs8KeyDer::from(cert.get_key_pair().serialize_der());
@@ -67,7 +69,7 @@ pub async fn run_relay_server_with(
         metrics_addr: None,
     };
     let server = Server::spawn(config).await.unwrap();
-    let url: RelayUrl = format!("https://localhost:{}", server.https_addr().unwrap().port())
+    let url: RelayUrl = format!("https://{}", server.https_addr().expect("configured"))
         .parse()
         .unwrap();
     let m = RelayMap::from_nodes([RelayNode {


### PR DESCRIPTION
## Description

This implements the https probe.

There does not need to be separate IPv4 or IPv6 HTTPS probes, because we just go with whatever the HTTPS connection works over.  This is what we need to establish a relay connection after all, this also does not care.  The only reason for this is to get some kind of latency to be able to chose a relay server.

Luckily the https probes have been integrated in the probe plan a long time so nothing to do there.

## Breaking Changes

The URLs served by the relay changed:
- `/relay/probe` has moved to `/ping`
- `/derp/probe` has been removed.

Unless you were manually using those URLs you will not notice these changes, nothing in the iroh codebase ever used the changed URLs.

## Notes & open questions


Currently this uses reqwest with it's default DNS resolution.  This is not great as it is not the same DNS resolution used everywhere else. It is however the same as done in the captive portal check.  This is worth at least looking at before merging this.

## Change checklist

- [x] Use common DNS resolver.
- [x] Update URL
- [x] Write docs for URLs of relay server.
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
