### PR TITLE
fix(netwatch): BSD rebind socket on errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,6 +3626,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tokio-util",
  "tracing",
  "windows 0.51.1",
  "wmi",

--- a/net-tools/netwatch/Cargo.toml
+++ b/net-tools/netwatch/Cargo.toml
@@ -25,6 +25,7 @@ socket2 = "0.5.3"
 thiserror = "1"
 time = "0.3.20"
 tokio = { version = "1", features = ["io-util", "macros", "sync", "rt", "net", "fs", "io-std", "signal", "process", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]

--- a/net-tools/netwatch/src/netmon.rs
+++ b/net-tools/netwatch/src/netmon.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use futures_lite::future::Boxed as BoxFuture;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::task::AbortOnDropHandle;
-use tracing::warn;
 
 mod actor;
 #[cfg(target_os = "android")]
@@ -29,8 +28,7 @@ use self::actor::{Actor, ActorMessage};
 #[derive(Debug)]
 pub struct Monitor {
     /// Task handle for the monitor task.
-    #[allow(dead_code)]
-    handle: AbortOnDropHandle<()>,
+    _handle: AbortOnDropHandle<()>,
     actor_tx: mpsc::Sender<ActorMessage>,
 }
 
@@ -41,13 +39,11 @@ impl Monitor {
         let actor_tx = actor.subscribe();
 
         let handle = tokio::task::spawn(async move {
-            if let Err(err) = actor.run().await {
-                warn!("netmon actor died: {:?}", err);
-            }
+            actor.run().await;
         });
 
         Ok(Monitor {
-            handle: AbortOnDropHandle::new(handle),
+            _handle: AbortOnDropHandle::new(handle),
             actor_tx,
         })
     }

--- a/net-tools/netwatch/src/netmon/actor.rs
+++ b/net-tools/netwatch/src/netmon/actor.rs
@@ -33,6 +33,7 @@ use crate::{
 #[derive(Debug, Copy, Clone)]
 pub(super) enum NetworkMessage {
     /// A change was detected.
+    #[allow(dead_code)]
     Change,
 }
 

--- a/net-tools/netwatch/src/netmon/actor.rs
+++ b/net-tools/netwatch/src/netmon/actor.rs
@@ -101,7 +101,7 @@ impl Actor {
         self.actor_sender.clone()
     }
 
-    pub(super) async fn run(mut self) -> Result<()> {
+    pub(super) async fn run(mut self) {
         const DEBOUNCE: Duration = Duration::from_millis(250);
 
         let mut last_event = None;
@@ -111,6 +111,7 @@ impl Actor {
         loop {
             tokio::select! {
                 biased;
+
                 _ = debounce_interval.tick() => {
                     if let Some(time_jumped) = last_event.take() {
                         if let Err(err) = self.handle_potential_change(time_jumped).await {
@@ -126,38 +127,43 @@ impl Actor {
                         debounce_interval.reset_immediately();
                     }
                 }
-                Some(event) = self.mon_receiver.recv() => {
+                event = self.mon_receiver.recv() => {
                     match event {
-                        NetworkMessage::Change => {
+                        Some(NetworkMessage::Change) => {
                             trace!("network activity detected");
                             last_event.replace(false);
                             debounce_interval.reset_immediately();
                         }
+                        None => {
+                            debug!("shutting down, network monitor receiver gone");
+                            break;
+                        }
                     }
                 }
-                Some(msg) = self.actor_receiver.recv() => match msg {
-                    ActorMessage::Subscribe(callback, s) => {
-                        let token = self.next_callback_token();
-                        self.callbacks.insert(token, Arc::new(callback));
-                        s.send(token).ok();
+                msg = self.actor_receiver.recv() => {
+                    match msg {
+                        Some(ActorMessage::Subscribe(callback, s)) => {
+                            let token = self.next_callback_token();
+                            self.callbacks.insert(token, Arc::new(callback));
+                            s.send(token).ok();
+                        }
+                        Some(ActorMessage::Unsubscribe(token, s)) => {
+                            self.callbacks.remove(&token);
+                            s.send(()).ok();
+                        }
+                        Some(ActorMessage::NetworkChange) => {
+                            trace!("external network activity detected");
+                            last_event.replace(false);
+                            debounce_interval.reset_immediately();
+                        }
+                        None => {
+                            debug!("shutting down, actor receiver gone");
+                            break;
+                        }
                     }
-                    ActorMessage::Unsubscribe(token, s) => {
-                        self.callbacks.remove(&token);
-                        s.send(()).ok();
-                    }
-                    ActorMessage::NetworkChange => {
-                        trace!("external network activity detected");
-                        last_event.replace(false);
-                        debounce_interval.reset_immediately();
-                    }
-                },
-                else => {
-                    break;
                 }
             }
         }
-
-        Ok(())
     }
 
     fn next_callback_token(&mut self) -> CallbackToken {

--- a/net-tools/netwatch/src/netmon/bsd.rs
+++ b/net-tools/netwatch/src/netmon/bsd.rs
@@ -12,8 +12,7 @@ use crate::{interfaces::bsd::WireMessage, ip::is_link_local};
 
 #[derive(Debug)]
 pub(super) struct RouteMonitor {
-    #[allow(dead_code)]
-    handle: AbortOnDropHandle<()>,
+    _handle: AbortOnDropHandle<()>,
 }
 
 fn create_socket() -> Result<tokio::net::UnixStream> {
@@ -72,7 +71,7 @@ impl RouteMonitor {
         });
 
         Ok(RouteMonitor {
-            handle: AbortOnDropHandle::new(handle),
+            _handle: AbortOnDropHandle::new(handle),
         })
     }
 }

--- a/net-tools/netwatch/src/netmon/bsd.rs
+++ b/net-tools/netwatch/src/netmon/bsd.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use libc::{RTAX_DST, RTAX_IFP};
-use tokio::{io::AsyncReadExt, sync::mpsc, task::JoinHandle};
+use tokio::{io::AsyncReadExt, sync::mpsc};
+use tokio_util::task::AbortOnDropHandle;
 use tracing::{trace, warn};
 
 use super::actor::NetworkMessage;
@@ -11,22 +12,24 @@ use crate::{interfaces::bsd::WireMessage, ip::is_link_local};
 
 #[derive(Debug)]
 pub(super) struct RouteMonitor {
-    handle: JoinHandle<()>,
+    #[allow(dead_code)]
+    handle: AbortOnDropHandle<()>,
 }
 
-impl Drop for RouteMonitor {
-    fn drop(&mut self) {
-        self.handle.abort();
-    }
+fn create_socket() -> Result<tokio::net::UnixStream> {
+    let socket = socket2::Socket::new(libc::AF_ROUTE.into(), socket2::Type::RAW, None)?;
+    socket.set_nonblocking(true)?;
+    let socket_std: std::os::unix::net::UnixStream = socket.into();
+    let socket: tokio::net::UnixStream = socket_std.try_into()?;
+
+    trace!("AF_ROUTE socket bound");
+
+    Ok(socket)
 }
 
 impl RouteMonitor {
     pub(super) fn new(sender: mpsc::Sender<NetworkMessage>) -> Result<Self> {
-        let socket = socket2::Socket::new(libc::AF_ROUTE.into(), socket2::Type::RAW, None)?;
-        socket.set_nonblocking(true)?;
-        let socket_std: std::os::unix::net::UnixStream = socket.into();
-        let mut socket: tokio::net::UnixStream = socket_std.try_into()?;
-
+        let mut socket = create_socket()?;
         let handle = tokio::task::spawn(async move {
             trace!("AF_ROUTE monitor started");
 
@@ -52,12 +55,25 @@ impl RouteMonitor {
                     }
                     Err(err) => {
                         warn!("AF_ROUTE: error reading: {:?}", err);
+                        // recreate socket, as it is likely in an invalid state
+                        // TODO: distinguish between different errors?
+                        match create_socket() {
+                            Ok(new_socket) => {
+                                socket = new_socket;
+                            }
+                            Err(err) => {
+                                warn!("AF_ROUTE: unable to bind a new socket: {:?}", err);
+                                // TODO: what to do here?
+                            }
+                        }
                     }
                 }
             }
         });
 
-        Ok(RouteMonitor { handle })
+        Ok(RouteMonitor {
+            handle: AbortOnDropHandle::new(handle),
+        })
     }
 }
 


### PR DESCRIPTION
also uses `AbortOnDropHandle` to better cleanup tasks

Closes #2909

