### PR TITLE
fix(iroh-net): fix memory leaks in the iroh-relay server

### DIFF
--- a/iroh-relay/src/server/actor.rs
+++ b/iroh-relay/src/server/actor.rs
@@ -291,8 +291,8 @@ impl ServerActor {
                                 None, // TODO(arqu): attribute to user id; possibly with the re-introduction of request tokens or other auth
                                 Some(key.to_string()),
                             )).await;
-                            // let nc = self.client_counter.update(key);
-                            // inc_by!(Metrics, unique_client_keys, nc);
+                            let nc = self.client_counter.update(key);
+                            inc_by!(Metrics, unique_client_keys, nc);
 
                             // build and register client, starting up read & write loops for the
                             // client connection

--- a/iroh-relay/src/server/actor.rs
+++ b/iroh-relay/src/server/actor.rs
@@ -291,8 +291,8 @@ impl ServerActor {
                                 None, // TODO(arqu): attribute to user id; possibly with the re-introduction of request tokens or other auth
                                 Some(key.to_string()),
                             )).await;
-                            let nc = self.client_counter.update(key);
-                            inc_by!(Metrics, unique_client_keys, nc);
+                            // let nc = self.client_counter.update(key);
+                            // inc_by!(Metrics, unique_client_keys, nc);
 
                             // build and register client, starting up read & write loops for the
                             // client connection

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -265,7 +265,6 @@ impl ServerState {
                             debug!("[{http_str}] relay: Connection opened from {peer_addr}");
                             let tls_config = tls_config.clone();
                             let service = service.clone();
-
                             // spawn a task to handle the connection
                             set.spawn(async move {
                                 if let Err(error) = service
@@ -550,12 +549,10 @@ impl RelayService {
     where
         I: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync + 'static,
     {
-        let conn = hyper::server::conn::http1::Builder::new()
+        hyper::server::conn::http1::Builder::new()
             .serve_connection(hyper_util::rt::TokioIo::new(io), self)
-            .with_upgrades();
-
-        conn.await?;
-
+            .with_upgrades()
+            .await?;
         Ok(())
     }
 }

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -265,7 +265,7 @@ impl ServerState {
                             debug!("[{http_str}] relay: Connection opened from {peer_addr}");
                             let tls_config = tls_config.clone();
                             let service = service.clone();
-                            println!("spawning new accept task, currently handling {} tasks", set.len());
+
                             // spawn a task to handle the connection
                             set.spawn(async move {
                                 if let Err(error) = service
@@ -281,7 +281,6 @@ impl ServerState {
                                         }
                                     }
                                 }
-                                println!("spawn done");
                             }.instrument(info_span!("conn", peer = %peer_addr)));
                         }
                         Err(err) => {
@@ -551,13 +550,11 @@ impl RelayService {
     where
         I: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync + 'static,
     {
-        let mut builder = hyper::server::conn::http1::Builder::new();
-        let conn = builder
+        let conn = hyper::server::conn::http1::Builder::new()
             .serve_connection(hyper_util::rt::TokioIo::new(io), self)
             .with_upgrades();
 
         conn.await?;
-        println!("connection shutdwon");
 
         Ok(())
     }


### PR DESCRIPTION
We observed continous memory increase on the relays, this fixes the main offenders we have found. Mainly the issue was not cleaning up tasks that were spawned into `JoinSet`s.