### PR TITLE
test(iroh-cli): increase wait on windows resumption tests

### DIFF
--- a/iroh-cli/tests/cli.rs
+++ b/iroh-cli/tests/cli.rs
@@ -154,8 +154,12 @@ fn cli_provide_tree_resume() -> Result<()> {
     {
         // import the files into an ephemeral iroh to use the generated blobs db in tests
         let provider = make_provider_in(&src_iroh_data_dir_pre, Input::Path(src.clone()), false)?;
-        // small synchronization points: allow iroh to be ready for transfer
-        std::thread::sleep(std::time::Duration::from_secs(5));
+        // small synchronization point: allow iroh to be ready for transfer
+        #[cfg(target_os = "windows")]
+        let wait = 10u64;
+        #[cfg(not(target_os = "windows"))]
+        let wait = 5u64;
+        std::thread::sleep(std::time::Duration::from_secs(wait));
         let _ticket = match_provide_output(&provider, count, BlobOrCollection::Collection)?;
     }
 
@@ -236,8 +240,12 @@ fn cli_provide_file_resume() -> Result<()> {
     {
         // import the files into an ephemeral iroh to use the generated blobs db in tests
         let provider = make_provider_in(&src_iroh_data_dir_pre, Input::Path(file.clone()), false)?;
-        // small synchronization points: allow iroh to be ready for transfer
-        std::thread::sleep(std::time::Duration::from_secs(5));
+        // small synchronization point: allow iroh to be ready for transfer
+        #[cfg(target_os = "windows")]
+        let wait = 10u64;
+        #[cfg(not(target_os = "windows"))]
+        let wait = 5u64;
+        std::thread::sleep(std::time::Duration::from_secs(wait));
         let _ticket = match_provide_output(&provider, count, BlobOrCollection::Blob)?;
     }
 


### PR DESCRIPTION
## Description

These tests fail when windows is too slow writing and copying the files needed. To avoid ignoring the tests, this PR increases the time we give it to be ready on windows runs to double the original value.

## Breaking Changes

n/a

## Notes & open questions

It would still be good to try to identify if anything changed in our code to make iroh slower on windows. This is however very low priority so this offers a workaround.

## Change checklist

- [x] Self-review.
- [ ] ~~Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- [x] Tests if relevant.
- [ ] ~~All breaking changes documented.~~
