### PR TITLE
chore(iroh-relay): fixup docs feature config

### DIFF
--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -18,6 +18,7 @@
 //!   STUN support and expose metrics.
 // Based on tailscale/derp/derp.go
 
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 pub mod client;


### PR DESCRIPTION
This is needed to make the `cfg_attry` work.