### PR TITLE
fix(netwatch): hold on to netmon sender reference in android

### DIFF
--- a/net-tools/netwatch/src/netmon/android.rs
+++ b/net-tools/netwatch/src/netmon/android.rs
@@ -4,13 +4,15 @@ use tokio::sync::mpsc;
 use super::actor::NetworkMessage;
 
 #[derive(Debug)]
-pub(super) struct RouteMonitor {}
+pub(super) struct RouteMonitor {
+    _sender: mpsc::Sender<NetworkMessage>,
+}
 
 impl RouteMonitor {
     pub(super) fn new(_sender: mpsc::Sender<NetworkMessage>) -> Result<Self> {
         // Very sad monitor. Android doesn't allow us to do this
 
-        Ok(RouteMonitor {})
+        Ok(RouteMonitor { _sender })
     }
 }
 


### PR DESCRIPTION
## Description

With #2913, the netmon actor properly exits when the channel sender is dropped, but the android implementation never kept the sender around. The magicsock actor would then error when trying to subscribe to the network monitor, and the `Endpoint` would be unusable.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
