### PR TITLE
chore: Fix important readme design issue (flat square style consistency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A toolkit for building distributed applications
 [![Youtube](https://img.shields.io/badge/YouTube-red?logo=youtube&logoColor=white&style=flat-square)](https://www.youtube.com/@n0computer)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE-MIT)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](LICENSE-APACHE)
-[![CI](https://github.com/n0-computer/iroh/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/n0-computer/iroh/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/n0-computer/iroh/ci.yml?branch=main&style=flat-square)](https://github.com/n0-computer/iroh/actions/workflows/ci.yml)
 
 <div align="center">
   <h3>


### PR DESCRIPTION
## Description

It's important.
Before:
![image](https://github.com/user-attachments/assets/6128793d-6162-4dbd-9688-cca16dacebe1)
After:
![image](https://github.com/user-attachments/assets/14e65c02-d26c-4840-90ac-c52d0dc75ff0)

See? A much better "failing" badge :|

## Breaking Changes

If at all, this un-breaks me tbh.

## Notes & open questions

How come I look this rarely at the readme.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.