### PR TITLE
chore: adapt to latest main in iroh-gossip and iroh-docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
 ]
 
@@ -1166,7 +1166,7 @@ checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
  "shell-words",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1603,7 +1603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
 dependencies = [
  "nonempty",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -2011,7 +2011,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
- "thiserror",
+ "thiserror 1.0.68",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2041,7 +2041,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tinyvec",
  "tokio",
@@ -2067,7 +2067,7 @@ dependencies = [
  "lru-cache",
  "parking_lot",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -2090,7 +2090,7 @@ dependencies = [
  "rustls",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2114,7 +2114,7 @@ dependencies = [
  "prefix-trie",
  "rustls",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tokio",
  "tokio-rustls",
@@ -2649,7 +2649,7 @@ dependencies = [
  "tempfile",
  "testdir",
  "testresult",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2683,7 +2683,7 @@ dependencies = [
  "serde_json",
  "serde_test",
  "ssh-key",
- "thiserror",
+ "thiserror 1.0.68",
  "ttl_cache",
  "url",
  "zeroize",
@@ -2705,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "iroh-blobs"
 version = "0.28.1"
-source = "git+https://github.com/n0-computer/iroh-blobs?branch=main#2337e46d89d6f2f2fda512439890ab74bab24fb4"
+source = "git+https://github.com/n0-computer/iroh-blobs?branch=main#290eb42cfd2d13202208264c2674ce423829f571"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2729,7 +2729,6 @@ dependencies = [
  "num_cpus",
  "oneshot",
  "parking_lot",
- "pin-project",
  "portable-atomic",
  "postcard",
  "quic-rpc",
@@ -2746,7 +2745,7 @@ dependencies = [
  "smallvec",
  "strum 0.26.3",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2801,7 +2800,7 @@ dependencies = [
  "strum 0.26.3",
  "tempfile",
  "testdir",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tokio",
  "tokio-util",
@@ -2865,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "iroh-docs"
 version = "0.28.0"
-source = "git+https://github.com/n0-computer/iroh-docs?branch=main#9166b226fedc889218986eb6ef2a3d3cdcdee367"
+source = "git+https://github.com/n0-computer/iroh-docs?branch=main#6f1d8ebf7c344e31b2bcf77eb7e8dd72540c971b"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2883,7 +2882,6 @@ dependencies = [
  "iroh-metrics",
  "iroh-net",
  "iroh-router",
- "lru",
  "nested_enum_utils",
  "num_enum",
  "portable-atomic",
@@ -2899,7 +2897,7 @@ dependencies = [
  "serde-error",
  "strum 0.26.3",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2909,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "iroh-gossip"
 version = "0.28.1"
-source = "git+https://github.com/n0-computer/iroh-gossip?branch=main#3d6659daf326f57cbafec189be996b89c7f441bd"
+source = "git+https://github.com/n0-computer/iroh-gossip?branch=main#ba0f6b0f54a740d8eae7ee6683f4aa1d8d8c8eb2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3044,7 +3042,7 @@ dependencies = [
  "surge-ping",
  "swarm-discovery",
  "testresult",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tokio",
  "tokio-rustls",
@@ -3097,7 +3095,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -3115,7 +3113,7 @@ dependencies = [
  "rustls",
  "rustls-platform-verifier",
  "slab",
- "thiserror",
+ "thiserror 1.0.68",
  "tinyvec",
  "tracing",
 ]
@@ -3181,7 +3179,7 @@ dependencies = [
  "smallvec",
  "socket2",
  "stun-rs",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tokio",
  "tokio-rustls",
@@ -3283,7 +3281,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.68",
  "walkdir",
 ]
 
@@ -3420,7 +3418,7 @@ dependencies = [
  "serde_bencode",
  "serde_bytes",
  "sha1_smol",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
 ]
 
@@ -3580,7 +3578,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "paste",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -3594,7 +3592,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
 ]
 
@@ -3630,7 +3628,7 @@ dependencies = [
  "rtnetlink",
  "serde",
  "socket2",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tokio",
  "tokio-util",
@@ -4040,7 +4038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.68",
  "ucd-trie",
 ]
 
@@ -4128,7 +4126,7 @@ dependencies = [
  "rand",
  "self_cell",
  "simple-dns",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
  "ureq",
  "wasm-bindgen",
@@ -4266,7 +4264,7 @@ dependencies = [
  "serde",
  "smallvec",
  "socket2",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tokio",
  "tokio-util",
@@ -4497,9 +4495,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e131f594054d27d077162815db3b5e9ddd76a28fbb9091b68095971e75c286"
+checksum = "dc623a188942fc875926f7baeb2cb08ed4288b64f29072656eb051e360ee7623"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4551,7 +4549,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -4568,7 +4566,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "slab",
- "thiserror",
+ "thiserror 1.0.68",
  "tinyvec",
  "tracing",
 ]
@@ -4763,7 +4761,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4959,7 +4957,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "nix 0.26.4",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
 ]
 
@@ -5735,7 +5733,7 @@ dependencies = [
  "pnet_packet",
  "rand",
  "socket2",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -5888,7 +5886,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -5896,6 +5903,17 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6041,7 +6059,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tokio",
  "tokio-rustls",
@@ -6100,7 +6118,7 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "js-sys",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-tungstenite",
  "wasm-bindgen",
@@ -6229,7 +6247,7 @@ dependencies = [
  "governor",
  "http 1.1.0",
  "pin-project",
- "thiserror",
+ "thiserror 1.0.68",
  "tower 0.4.13",
  "tracing",
 ]
@@ -6253,7 +6271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tracing-subscriber",
 ]
@@ -6348,7 +6366,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.68",
  "url",
  "utf-8",
 ]
@@ -6631,7 +6649,7 @@ dependencies = [
  "event-listener 4.0.3",
  "futures-util",
  "parking_lot",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -6990,7 +7008,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
  "windows 0.58.0",
  "windows-core 0.58.0",
 ]
@@ -7020,7 +7038,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
 ]
 

--- a/iroh/src/node/rpc.rs
+++ b/iroh/src/node/rpc.rs
@@ -126,6 +126,8 @@ impl<D: BaoStore> Handler<D> {
             .expect("missing gossip");
         let chan = chan.map::<iroh_gossip::RpcService>();
         gossip
+            .as_ref()
+            .clone()
             .handle_rpc_request(msg, chan)
             .await
             .map_err(|e| e.errors_into())
@@ -141,7 +143,9 @@ impl<D: BaoStore> Handler<D> {
             .get_protocol::<iroh_docs::engine::Engine<D>>(DOCS_ALPN)
         {
             let chan = chan.map::<iroh_docs::rpc::proto::RpcService>();
-            docs.handle_rpc_request(msg, chan)
+            docs.as_ref()
+                .clone()
+                .handle_rpc_request(msg, chan)
                 .await
                 .map_err(|e| e.errors_into())
         } else {


### PR DESCRIPTION
## Description

adapt to latest main in iroh-gossip and iroh-docs

still not sure if handle_rpc_request should take an `Arc<Self>`, but for now just make it work

## Breaking Changes

none

## Notes & open questions

Should all fns that take self take an `Arc<Self>` in a protocol handler? The Arc kinda infects the entire code base. But maybe we have to do it.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
