### PR TITLE
fix(iroh-dns-server): actually use async fs in load_secret_key

### DIFF
--- a/iroh-dns-server/src/http/tls.rs
+++ b/iroh-dns-server/src/http/tls.rs
@@ -148,7 +148,9 @@ async fn load_certs(
 async fn load_secret_key(
     filename: impl AsRef<Path>,
 ) -> Result<rustls::pki_types::PrivateKeyDer<'static>> {
-    let keyfile = std::fs::read(filename.as_ref()).context("cannot open secret key file")?;
+    let keyfile = tokio::fs::read(filename.as_ref())
+        .await
+        .context("cannot open secret key file")?;
     let mut reader = std::io::Cursor::new(keyfile);
 
     loop {


### PR DESCRIPTION
## Description

Fix up the missed change from https://github.com/n0-computer/iroh/pull/2941/files#r1846266661

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
