### PR TITLE
fix(ci): try to reuse msys2 dep

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -202,6 +202,8 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.6
 
     - uses: msys2/setup-msys2@v2
+      with:
+        release: false
 
     - name: build tests
       run: |


### PR DESCRIPTION
## Description

According to https://github.com/msys2/setup-msys2?tab=readme-ov-file#release this should try to reuse an existing msys2 installation (though seems to reference a default fallback to the one installed on the GH hosted runners, unsure if it works for self hosted)

Edit: seems to be working

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
