### PR TITLE
fix: make netsim run from examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
       branch: ${{ github.ref }}
       max_workers: 4
       netsim_branch: "main"
-      sim_paths: "sims/iroh/iroh_v2.json,sims/integration_v2"
+      sim_paths: "sims/iroh_v2/iroh.json,sims/integration_v2"
       pr_number: ${{ github.event.pull_request.number || '' }}
 
   codespell:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
       branch: ${{ github.ref }}
       max_workers: 4
       netsim_branch: "main"
-      sim_paths: "sims/iroh/iroh.json,sims/integration"
+      sim_paths: "sims/iroh/iroh_v2.json,sims/integration_v2"
       pr_number: ${{ github.event.pull_request.number || '' }}
 
   codespell:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,13 +246,13 @@ jobs:
       # TODO: We have a bunch of platform-dependent code so should
       #    probably run this job on the full platform matrix
       - name: clippy check (all features)
-        run: cargo clippy --workspace --all-features --all-targets --bins --tests --benches
+        run: cargo clippy --workspace --all-features --all-targets --bins --tests --benches --examples
 
       - name: clippy check (no features)
-        run: cargo clippy --workspace --no-default-features --lib --bins --tests
+        run: cargo clippy --workspace --no-default-features --lib --bins --tests --examples
 
       - name: clippy check (default features)
-        run: cargo clippy --workspace --all-targets
+        run: cargo clippy --workspace --all-targets --examples
 
   msrv:
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,13 +246,13 @@ jobs:
       # TODO: We have a bunch of platform-dependent code so should
       #    probably run this job on the full platform matrix
       - name: clippy check (all features)
-        run: cargo clippy --workspace --all-features --all-targets --bins --tests --benches --examples
+        run: cargo clippy --workspace --all-features --all-targets --lib --bins --tests --benches --examples
 
       - name: clippy check (no features)
-        run: cargo clippy --workspace --no-default-features --lib --bins --tests --examples
+        run: cargo clippy --workspace --no-default-features --all-targets --lib --bins --tests --benches --examples
 
       - name: clippy check (default features)
-        run: cargo clippy --workspace --all-targets --examples
+        run: cargo clippy --workspace --all-targets --lib --bins --tests --benches --examples
 
   msrv:
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -39,7 +39,7 @@ jobs:
       branch: "main"
       max_workers: 1
       netsim_branch: "main"
-      sim_paths: "sims/iroh,sims/integration"
+      sim_paths: "sims/iroh_v2,sims/integration_v2"
       pr_number: ""
       publish_metrics: true
       build_profile: "optimized-release"
@@ -53,7 +53,7 @@ jobs:
       branch: ${{inputs.branch}}
       max_workers: 1
       netsim_branch: ${{inputs.netsim_branch}}
-      sim_paths: "sims/iroh"
+      sim_paths: "sims/iroh_v2"
       pr_number: ${{inputs.pr_number}}
       publish_metrics: false
       build_profile: "optimized-release"

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -133,7 +133,8 @@ jobs:
     - name: Copy binaries to right location
       run: |
         cp target/${{inputs.build_profile}}/examples/* ../chuck/netsim/bins/
-        cp target/${{inputs.build_profile}}/iroh ../chuck/netsim/bins/iroh
+        cp target/${{inputs.build_profile}}/examples/new ../chuck/netsim/bins/iroh-transfer
+        # cp target/${{inputs.build_profile}}/iroh ../chuck/netsim/bins/iroh
         cp target/${{inputs.build_profile}}/iroh-relay ../chuck/netsim/bins/iroh-relay
         cp ../chuck/target/release/chuck ../chuck/netsim/bins/chuck
 

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -133,7 +133,7 @@ jobs:
     - name: Copy binaries to right location
       run: |
         cp target/${{inputs.build_profile}}/examples/* ../chuck/netsim/bins/
-        cp target/${{inputs.build_profile}}/examples/new ../chuck/netsim/bins/iroh-transfer
+        cp target/${{inputs.build_profile}}/examples/transfer ../chuck/netsim/bins/iroh-transfer
         cp target/${{inputs.build_profile}}/iroh-relay ../chuck/netsim/bins/iroh-relay
         cp ../chuck/target/release/chuck ../chuck/netsim/bins/chuck
 

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -134,7 +134,6 @@ jobs:
       run: |
         cp target/${{inputs.build_profile}}/examples/* ../chuck/netsim/bins/
         cp target/${{inputs.build_profile}}/examples/new ../chuck/netsim/bins/iroh-transfer
-        # cp target/${{inputs.build_profile}}/iroh ../chuck/netsim/bins/iroh
         cp target/${{inputs.build_profile}}/iroh-relay ../chuck/netsim/bins/iroh-relay
         cp ../chuck/target/release/chuck ../chuck/netsim/bins/chuck
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,7 @@ dependencies = [
  "nested_enum_utils",
  "num_cpus",
  "parking_lot",
+ "parse-size",
  "postcard",
  "proptest",
  "quic-rpc",
@@ -3654,6 +3655,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "paste"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "parse-size"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+checksum = "944553dd59c802559559161f9816429058b869003836120e262e8caec061b7ae"
 
 [[package]]
 name = "paste"

--- a/iroh-net/bench/src/lib.rs
+++ b/iroh-net/bench/src/lib.rs
@@ -21,7 +21,7 @@ pub mod s2n;
 pub mod stats;
 
 #[derive(Parser, Debug, Clone, Copy)]
-#[clap(name = "bulk")]
+#[clap(name = "iroh-net-bench")]
 pub enum Commands {
     Iroh(Opt),
     #[cfg(not(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd")))]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -62,6 +62,7 @@ ref-cast = "1.0.23"
 # Examples
 clap = { version = "4", features = ["derive"], optional = true }
 indicatif = { version = "0.17", features = ["tokio"], optional = true }
+parse-size = { version = "1.1.0", optional = true }
 
 # Documentation tests
 url = { version = "2.5.0", features = ["serde"] }
@@ -74,7 +75,7 @@ test = []
 discovery-pkarr-dht = ["iroh-net/discovery-pkarr-dht"]
 test-utils = ["iroh-net/test-utils"]
 
-examples = ["dep:clap", "dep:indicatif"]
+examples = ["dep:clap", "dep:indicatif", "dep:parse-size"]
 
 [dev-dependencies]
 anyhow = { version = "1" }
@@ -100,4 +101,8 @@ rustdoc-args = ["--cfg", "iroh_docsrs"]
 
 [[example]]
 name = "rpc"
+required-features = ["examples"]
+
+[[example]]
+name = "transfer"
 required-features = ["examples"]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -62,7 +62,7 @@ ref-cast = "1.0.23"
 # Examples
 clap = { version = "4", features = ["derive"], optional = true }
 indicatif = { version = "0.17", features = ["tokio"], optional = true }
-parse-size = { version = "1.1.0", optional = true }
+parse-size = { version = "=1.0.0", optional = true } # pinned version to avoid bumping msrv to 1.81
 
 # Documentation tests
 url = { version = "2.5.0", features = ["serde"] }

--- a/iroh/examples/new.rs
+++ b/iroh/examples/new.rs
@@ -1,0 +1,292 @@
+use anyhow::{Context,Result};
+use bytes::Bytes;
+use clap::{Parser, Subcommand};
+use futures_lite::StreamExt;
+use iroh_net::{key::SecretKey, ticket::NodeTicket, Endpoint, NodeAddr, RelayMode};
+use std::time::{Duration, Instant};
+use tracing::info;
+use std::str::FromStr;
+
+// Transfer ALPN that we are using to communicate over the `Endpoint`
+const TRANSFER_ALPN: &[u8] = b"n0/iroh/transfer/example/0";
+
+#[derive(Parser, Debug)]
+#[command(name = "provide_fetch")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Provide {
+        #[clap(long, default_value = "1G", value_parser = parse_byte_size)]
+        size: u64,
+    },
+    Fetch {
+        #[arg(long)]
+        ticket: String,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Provide { size } => provide(size.clone()).await?,
+        Commands::Fetch { ticket } => fetch(&ticket).await?,
+    }
+
+    Ok(())
+}
+
+async fn provide(size: u64) -> anyhow::Result<()> {
+    let secret_key = SecretKey::generate();
+    let endpoint = Endpoint::builder()
+        .secret_key(secret_key)
+        .alpns(vec![TRANSFER_ALPN.to_vec()])
+        .relay_mode(RelayMode::Default)
+        .bind()
+        .await?;
+
+    let node_id = endpoint.node_id();
+
+    for local_endpoint in endpoint
+        .direct_addresses()
+        .next()
+        .await
+        .context("no endpoints")?
+    {
+        println!("\t{}", local_endpoint.addr)
+    }
+
+
+    let relay_url = endpoint
+        .home_relay()
+        .expect("should be connected to a relay server");
+    let local_addrs = endpoint
+        .direct_addresses()
+        .next()
+        .await
+        .context("no endpoints")?
+        .into_iter()
+        .map(|endpoint| {
+            let addr = endpoint.addr;
+            addr
+        })
+        .collect::<Vec<_>>();
+
+    let node_addr = NodeAddr::from_parts(node_id, Some(relay_url), local_addrs);
+    let ticket = NodeTicket::new(node_addr);
+
+    println!("NodeTicket: {}", ticket);
+
+    // accept incoming connections, returns a normal QUIC connection
+    while let Some(incoming) = endpoint.accept().await {
+        let mut connecting = match incoming.accept() {
+            Ok(connecting) => connecting,
+            Err(err) => {
+                tracing::warn!("incoming connection failed: {err:#}");
+                // we can carry on in these cases:
+                // this can be caused by retransmitted datagrams
+                continue;
+            }
+        };
+        let alpn = connecting.alpn().await?;
+        let conn = connecting.await?;
+        let node_id = iroh_net::endpoint::get_remote_node_id(&conn)?;
+        info!(
+            "new connection from {node_id} with ALPN {} (coming from {})",
+            String::from_utf8_lossy(&alpn),
+            conn.remote_address()
+        );
+
+        // spawn a task to handle reading and writing off of the connection
+        tokio::spawn(async move {
+            // accept a bi-directional QUIC connection
+            // use the `quinn` APIs to send and recv content
+            let (mut send, mut recv) = conn.accept_bi().await?;
+            tracing::debug!("accepted bi stream, waiting for data...");
+            let message = recv.read_to_end(100).await?;
+            let message = String::from_utf8(message)?;
+            println!("received: {message}");
+
+            send_data_on_stream(&mut send, size).await?;
+
+            // We sent the last message, so wait for the client to close the connection once
+            // it received this message.
+            let res = tokio::time::timeout(Duration::from_secs(3), async move {
+                let closed = conn.closed().await;
+                if !matches!(closed, quinn::ConnectionError::ApplicationClosed(_)) {
+                    println!("node {node_id} disconnected with an error: {closed:#}");
+                }
+            })
+            .await;
+            if res.is_err() {
+                println!("node {node_id} did not disconnect within 3 seconds");
+            }
+            Ok::<_, anyhow::Error>(())
+        });
+    }
+
+    // stop with SIGINT (ctrl-c)
+    Ok(())
+}
+
+async fn fetch(ticket: &str) -> anyhow::Result<()> {
+    let ticket: NodeTicket = ticket.parse()?;
+    let secret_key = SecretKey::generate();
+    let endpoint = Endpoint::builder()
+        .secret_key(secret_key)
+        .alpns(vec![TRANSFER_ALPN.to_vec()])
+        .relay_mode(RelayMode::Default)
+        .bind()
+        .await?;
+
+    let start = Instant::now();
+
+    let me = endpoint.node_id();
+    println!("node id: {me}");
+    println!("node listening addresses:");
+    for local_endpoint in endpoint
+        .direct_addresses()
+        .next()
+        .await
+        .context("no endpoints")?
+    {
+        println!("\t{}", local_endpoint.addr)
+    }
+
+    let relay_url = endpoint
+        .home_relay()
+        .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
+    println!("node relay server url: {relay_url}\n");
+    
+    // Attempt to connect, over the given ALPN.
+    // Returns a Quinn connection.
+    let conn = endpoint.connect(ticket.node_addr().clone(), TRANSFER_ALPN).await?;
+    info!("connected");
+
+    // Use the Quinn API to send and recv content.
+    let (mut send, mut recv) = conn.open_bi().await?;
+
+    let message = format!("{me} is saying 'hello!'");
+    send.write_all(message.as_bytes()).await?;
+
+    // Call `finish` to close the send side of the connection gracefully.
+    send.finish()?;
+
+    let (len, dur, chnk) = drain_stream(&mut recv, false).await?;
+
+    // We received the last message: close all connections and allow for the close
+    // message to be sent.
+    endpoint.close(0u8.into(), b"bye").await?;
+
+    let duration = start.elapsed();
+    println!("Received {} B in {:?}/{:?} in {} chunks", len, dur, duration, chnk);
+    println!("Transferred {} B in {} seconds, {} B/s", len, duration.as_secs_f64(), len as f64 / duration.as_secs_f64());
+
+    Ok(())
+}
+
+async fn drain_stream(
+    stream: &mut iroh_net::endpoint::RecvStream,
+    read_unordered: bool,
+) -> Result<(usize, Duration, u64)> {
+    let mut read = 0;
+
+    let download_start = Instant::now();
+    let mut first_byte = true;
+    let mut ttfb = download_start.elapsed();
+
+    let mut num_chunks: u64 = 0;
+
+    if read_unordered {
+        while let Some(chunk) = stream.read_chunk(usize::MAX, false).await? {
+            if first_byte {
+                ttfb = download_start.elapsed();
+                first_byte = false;
+            }
+            read += chunk.bytes.len();
+            num_chunks += 1;
+        }
+    } else {
+        // These are 32 buffers, for reading approximately 32kB at once
+        #[rustfmt::skip]
+        let mut bufs = [
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+            Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        ];
+
+        while let Some(n) = stream.read_chunks(&mut bufs[..]).await? {
+            if first_byte {
+                ttfb = download_start.elapsed();
+                first_byte = false;
+            }
+            read += bufs.iter().take(n).map(|buf| buf.len()).sum::<usize>();
+            num_chunks += 1;
+        }
+    }
+
+    Ok((read, ttfb, num_chunks))
+}
+
+async fn send_data_on_stream(stream: &mut iroh_net::endpoint::SendStream, stream_size: u64) -> Result<()> {
+    const DATA: &[u8] = &[0xAB; 7*1024 * 1024];
+    let bytes_data = Bytes::from_static(DATA);
+
+    let full_chunks = stream_size / (DATA.len() as u64);
+    let remaining = (stream_size % (DATA.len() as u64)) as usize;
+
+    for _ in 0..full_chunks {
+        stream
+            .write_chunk(bytes_data.clone())
+            .await
+            .context("failed sending data")?;
+    }
+
+    if remaining != 0 {
+        stream
+            .write_chunk(bytes_data.slice(0..remaining))
+            .await
+            .context("failed sending data")?;
+    }
+
+    stream.finish().context("failed finishing stream")?;
+    stream
+        .stopped()
+        .await
+        .context("failed to wait for stream to be stopped")?;
+
+    Ok(())
+}
+
+fn parse_byte_size(s: &str) -> Result<u64, std::num::ParseIntError> {
+    let s = s.trim();
+
+    let multiplier = match s.chars().last() {
+        Some('T') => 1024 * 1024 * 1024 * 1024,
+        Some('G') => 1024 * 1024 * 1024,
+        Some('M') => 1024 * 1024,
+        Some('k') => 1024,
+        _ => 1,
+    };
+
+    let s = if multiplier != 1 {
+        &s[..s.len() - 1]
+    } else {
+        s
+    };
+
+    let base: u64 = u64::from_str(s)?;
+
+    Ok(base * multiplier)
+}

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -211,7 +211,10 @@ async fn fetch(ticket: &str, relay_url: Option<String>) -> anyhow::Result<()> {
     let duration = start.elapsed();
     println!(
         "Received {} B in {:.4}s with ttfb {}s in {} chunks",
-        HumanBytes(len as u64), duration.as_secs_f64(), ttfb.as_secs_f64(), chnk
+        HumanBytes(len as u64),
+        duration.as_secs_f64(),
+        ttfb.as_secs_f64(),
+        chnk
     );
     println!(
         "Transferred {} in {:.4}, {}/s",
@@ -306,5 +309,5 @@ async fn send_data_on_stream(
 
 fn parse_byte_size(s: &str) -> Result<u64> {
     let cfg = parse_size::Config::new().with_binary();
-    cfg.parse_size(s).map_err(Into::into)
+    cfg.parse_size(s).map_err(|e| anyhow::anyhow!(e))
 }

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -202,7 +202,7 @@ async fn fetch(ticket: &str, relay_url: Option<String>) -> anyhow::Result<()> {
     // Call `finish` to close the send side of the connection gracefully.
     send.finish()?;
 
-    let (len, dur, chnk) = drain_stream(&mut recv, false).await?;
+    let (len, ttfb, chnk) = drain_stream(&mut recv, false).await?;
 
     // We received the last message: close all connections and allow for the close
     // message to be sent.
@@ -210,8 +210,8 @@ async fn fetch(ticket: &str, relay_url: Option<String>) -> anyhow::Result<()> {
 
     let duration = start.elapsed();
     println!(
-        "Received {} B in {:?}/{:?} in {} chunks",
-        len, dur, duration, chnk
+        "Received {} B in {:.4}s with ttfb {}s in {} chunks",
+        HumanBytes(len as u64), duration.as_secs_f64(), ttfb.as_secs_f64(), chnk
     );
     println!(
         "Transferred {} in {:.4}, {}/s",


### PR DESCRIPTION
## Description

Moves our netsim tests to run from an example and only test the lib part of the code, not the full CLI & blobs.

Things left to do:
- [x] rename the example from `new` to anything that makes more sense `netsim` runs it under `iroh-transfer`
- [x] clean up the example code
- [x] add the option to provide either a relay config or pass in at least the relay url as an argument
- [x] continue the CI adjustment and move all invocations of the netsim runner to run from `iroh_v2` and `integration_v2` sims (we want a less abrupt netsim switchover)
- [x] convert the remaining sims in `chuck/netsim/sims` to the new format
- [ ] after some time flip back the CI invocations to be regular `iroh` and `integration` sims which includes doing the same on `netsim` and removing the old ones

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
