### PR TITLE
feat(iroh-relay)!: add a QUIC server for QUIC address discovery to the iroh relay.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -175,7 +175,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -187,7 +187,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -198,7 +198,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -209,7 +209,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -299,7 +299,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -447,9 +447,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "shlex",
 ]
@@ -565,7 +565,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -890,7 +890,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -914,7 +914,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -925,7 +925,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -994,7 +994,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1024,7 +1024,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "unicode-xid",
 ]
 
@@ -1081,7 +1081,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1226,7 +1226,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1239,7 +1239,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1259,7 +1259,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1285,12 +1285,12 @@ checksum = "a02a5d186d7bf1cb21f1f95e1a9cfa5c1f2dcd803a47aad454423ceec13525c5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1522,7 +1522,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1705,7 +1705,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1760,12 +1760,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -2241,7 +2235,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2325,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -2743,6 +2737,8 @@ dependencies = [
  "hyper-util",
  "iroh-base",
  "iroh-metrics",
+ "iroh-quinn",
+ "iroh-quinn-proto",
  "iroh-test 0.28.0",
  "libc",
  "num_enum",
@@ -2809,7 +2805,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2857,10 +2853,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2875,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.166"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libm"
@@ -2909,9 +2906,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "litrs"
@@ -3042,11 +3039,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -3404,7 +3400,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3605,7 +3601,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3636,7 +3632,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3745,7 +3741,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3817,9 +3813,9 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63d01def49fc815900a83e7a4a5083d2abc81b7ddd569a3fa0477778ae9b3ec"
+checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -3987,7 +3983,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4448,9 +4444,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc_version"
@@ -4748,7 +4744,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4813,7 +4809,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4830,7 +4826,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5053,7 +5049,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5081,7 +5077,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5158,9 +5154,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5201,7 +5197,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5270,7 +5266,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5281,7 +5277,7 @@ checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5388,7 +5384,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5526,7 +5522,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5640,7 +5636,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5666,9 +5662,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5825,17 +5821,20 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "b30e6f97efe1fa43535ee241ee76967d3ff6ff3953ebb430d8d55c5393029e7b"
 dependencies = [
  "base64",
+ "litemap",
  "log",
  "once_cell",
  "rustls",
  "rustls-pki-types",
  "url",
  "webpki-roots",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
@@ -5928,9 +5927,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5939,36 +5938,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5976,22 +5976,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "watchable"
@@ -6007,9 +6007,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6130,7 +6130,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6141,7 +6141,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6417,9 +6417,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6435,7 +6435,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -6463,14 +6463,14 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -6483,7 +6483,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -6512,5 +6512,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,4 +1,4 @@
-[[derp_nodes]]
+[[relay_nodes]]
 url = "https://foo.bar"
 stun_only = false
 stun_port = 1244

--- a/iroh-base/src/relay_map.rs
+++ b/iroh-base/src/relay_map.rs
@@ -16,7 +16,7 @@ pub const DEFAULT_STUN_PORT: u16 = 3478;
 /// for QUIC address discovery
 ///
 /// The port is "QUIC" typed on a phone keypad.
-pub const DEFAULT_QUIC_PORT: u16 = 7842;
+pub const DEFAULT_RELAY_QUIC_PORT: u16 = 7842;
 
 /// Configuration of all the relay servers that can be used.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,7 +68,7 @@ impl RelayMap {
     /// Allows to set a custom STUN port and different IP addresses for IPv4 and IPv6.
     /// If IP addresses are provided, no DNS lookup will be performed.
     ///
-    /// Sets the port to the default [`DEFAULT_QUIC_PORT`].
+    /// Sets the port to the default [`DEFAULT_RELAY_QUIC_PORT`].
     pub fn default_from_node(url: RelayUrl, stun_port: u16) -> Self {
         let mut nodes = BTreeMap::new();
         nodes.insert(
@@ -155,7 +155,7 @@ pub struct QuicConfig {
 impl Default for QuicConfig {
     fn default() -> Self {
         Self {
-            port: DEFAULT_QUIC_PORT,
+            port: DEFAULT_RELAY_QUIC_PORT,
         }
     }
 }

--- a/iroh-base/src/relay_map.rs
+++ b/iroh-base/src/relay_map.rs
@@ -141,7 +141,7 @@ pub struct RelayNode {
 }
 
 fn quic_port() -> u16 {
-    0
+    DEFAULT_QUIC_PORT
 }
 
 impl fmt::Display for RelayNode {

--- a/iroh-base/src/relay_map.rs
+++ b/iroh-base/src/relay_map.rs
@@ -77,7 +77,7 @@ impl RelayMap {
                 url,
                 stun_only: false,
                 stun_port,
-                quic_port: DEFAULT_QUIC_PORT,
+                quic: Some(QuicConfig::default()),
             }
             .into(),
         );
@@ -133,15 +133,31 @@ pub struct RelayNode {
     ///
     /// Setting this to `0` means the default STUN port is used.
     pub stun_port: u16,
-    /// The QUIC endpoint port of the relay server.
+    /// Configuration to speak to the QUIC endpoint on the relay server.
     ///
-    /// Setting this to `0` means the default QUIC port is used.
-    #[serde(default = "quic_port")]
-    pub quic_port: u16,
+    /// When `None`, we will not attempt to do QUIC address discovery
+    /// with this relay server.
+    #[serde(default = "quic_config")]
+    pub quic: Option<QuicConfig>,
 }
 
-fn quic_port() -> u16 {
-    DEFAULT_QUIC_PORT
+fn quic_config() -> Option<QuicConfig> {
+    Some(QuicConfig::default())
+}
+
+/// Configuration for speaking to the QUIC endpoint on the relay
+/// server to do QUIC address discovery.
+#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub struct QuicConfig {
+    pub port: u16,
+}
+
+impl Default for QuicConfig {
+    fn default() -> Self {
+        Self {
+            port: DEFAULT_QUIC_PORT,
+        }
+    }
 }
 
 impl fmt::Display for RelayNode {

--- a/iroh-base/src/relay_map.rs
+++ b/iroh-base/src/relay_map.rs
@@ -134,7 +134,12 @@ pub struct RelayNode {
     /// The QUIC endpoint port of the relay server.
     ///
     /// Setting this to `0` means the default QUIC port is used.
+    #[serde(default = "quic_port")]
     pub quic_port: u16,
+}
+
+fn quic_port() -> u16 {
+    0
 }
 
 impl fmt::Display for RelayNode {

--- a/iroh-base/src/relay_map.rs
+++ b/iroh-base/src/relay_map.rs
@@ -67,7 +67,9 @@ impl RelayMap {
     ///
     /// Allows to set a custom STUN port and different IP addresses for IPv4 and IPv6.
     /// If IP addresses are provided, no DNS lookup will be performed.
-    pub fn default_from_node(url: RelayUrl, stun_port: u16, quic_port: u16) -> Self {
+    ///
+    /// Sets the port to the default [`DEFAULT_QUIC_PORT`].
+    pub fn default_from_node(url: RelayUrl, stun_port: u16) -> Self {
         let mut nodes = BTreeMap::new();
         nodes.insert(
             url.clone(),
@@ -75,7 +77,7 @@ impl RelayMap {
                 url,
                 stun_only: false,
                 stun_port,
-                quic_port,
+                quic_port: DEFAULT_QUIC_PORT,
             }
             .into(),
         );
@@ -92,7 +94,7 @@ impl RelayMap {
     /// resolved from the URL's host name via DNS.
     /// relay nodes are specified at <../../docs/relay_nodes.md>
     pub fn from_url(url: RelayUrl) -> Self {
-        Self::default_from_node(url, DEFAULT_STUN_PORT, DEFAULT_QUIC_PORT)
+        Self::default_from_node(url, DEFAULT_STUN_PORT)
     }
 
     /// Constructs the [`RelayMap`] from an iterator of [`RelayNode`]s.

--- a/iroh-base/src/relay_map.rs
+++ b/iroh-base/src/relay_map.rs
@@ -10,7 +10,13 @@ pub use crate::relay_url::RelayUrl;
 /// The default STUN port used by the Relay server.
 ///
 /// The STUN port as defined by [RFC 8489](<https://www.rfc-editor.org/rfc/rfc8489#section-18.6>)
-const DEFAULT_STUN_PORT: u16 = 3478;
+pub const DEFAULT_STUN_PORT: u16 = 3478;
+
+/// The default QUIC port used by the Relay server to accept QUIC connections
+/// for QUIC address discovery
+///
+/// The port is "QUIC" typed on a phone keypad.
+pub const DEFAULT_QUIC_PORT: u16 = 7842;
 
 /// Configuration of all the relay servers that can be used.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,7 +67,7 @@ impl RelayMap {
     ///
     /// Allows to set a custom STUN port and different IP addresses for IPv4 and IPv6.
     /// If IP addresses are provided, no DNS lookup will be performed.
-    pub fn default_from_node(url: RelayUrl, stun_port: u16) -> Self {
+    pub fn default_from_node(url: RelayUrl, stun_port: u16, quic_port: u16) -> Self {
         let mut nodes = BTreeMap::new();
         nodes.insert(
             url.clone(),
@@ -69,6 +75,7 @@ impl RelayMap {
                 url,
                 stun_only: false,
                 stun_port,
+                quic_port,
             }
             .into(),
         );
@@ -80,10 +87,12 @@ impl RelayMap {
 
     /// Returns a [`RelayMap`] from a [`RelayUrl`].
     ///
-    /// This will use the default STUN port and IP addresses resolved from the URL's host name via DNS.
+    /// This will use the default STUN port, the default QUIC port
+    /// (as defined by the `iroh-relay` crate) and IP addresses
+    /// resolved from the URL's host name via DNS.
     /// relay nodes are specified at <../../docs/relay_nodes.md>
     pub fn from_url(url: RelayUrl) -> Self {
-        Self::default_from_node(url, DEFAULT_STUN_PORT)
+        Self::default_from_node(url, DEFAULT_STUN_PORT, DEFAULT_QUIC_PORT)
     }
 
     /// Constructs the [`RelayMap`] from an iterator of [`RelayNode`]s.
@@ -122,6 +131,10 @@ pub struct RelayNode {
     ///
     /// Setting this to `0` means the default STUN port is used.
     pub stun_port: u16,
+    /// The QUIC endpoint port of the relay server.
+    ///
+    /// Setting this to `0` means the default QUIC port is used.
+    pub quic_port: u16,
 }
 
 impl fmt::Display for RelayNode {

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -793,7 +793,7 @@ mod test_utils {
             .await
             .expect("should serve relay");
         let quic = Some(QuicConfig {
-            port: server.quic_addr().expect("server sould run quic").port(),
+            port: server.quic_addr().expect("server should run quic").port(),
         });
         let node_desc = RelayNode {
             url: server.https_url().expect("should work as relay"),

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -795,6 +795,10 @@ mod test_utils {
             url: server.https_url().expect("should work as relay"),
             stun_only: false, // the checks above and below guarantee both stun and relay
             stun_port: server.stun_addr().expect("server should serve stun").port(),
+            quic_port: server
+                .quic_addr()
+                .expect("server should server_stun")
+                .port(),
         };
 
         (server, Arc::new(node_desc))
@@ -879,6 +883,7 @@ mod tests {
                     url,
                     stun_port: port,
                     stun_only,
+                    quic_port: 0,
                 }
             });
             RelayMap::from_nodes(nodes).expect("generated invalid nodes")

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -783,6 +783,7 @@ mod test_utils {
 
     use std::sync::Arc;
 
+    use iroh_base::relay_map::QuicConfig;
     use iroh_relay::server;
 
     use crate::RelayNode;
@@ -791,14 +792,14 @@ mod test_utils {
         let server = server::Server::spawn(server::testing::server_config())
             .await
             .expect("should serve relay");
+        let quic = Some(QuicConfig {
+            port: server.quic_addr().expect("server sould run quic").port(),
+        });
         let node_desc = RelayNode {
             url: server.https_url().expect("should work as relay"),
             stun_only: false, // the checks above and below guarantee both stun and relay
             stun_port: server.stun_addr().expect("server should serve stun").port(),
-            quic_port: server
-                .quic_addr()
-                .expect("server should server_stun")
-                .port(),
+            quic,
         };
 
         (server, Arc::new(node_desc))
@@ -883,7 +884,7 @@ mod tests {
                     url,
                     stun_port: port,
                     stun_only,
-                    quic_port: 0,
+                    quic: None,
                 }
             });
             RelayMap::from_nodes(nodes).expect("generated invalid nodes")

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -128,7 +128,6 @@ server = [
 ]
 metrics = ["iroh-metrics/metrics", "server"]
 test-utils = []
-dangerous-certs = []
 
 [[bin]]
 name = "iroh-relay"

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -133,7 +133,7 @@ dangerous-certs = []
 [[bin]]
 name = "iroh-relay"
 path = "src/main.rs"
-required-features = ["server", "dangerous-certs"]
+required-features = ["server"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -50,6 +50,8 @@ postcard = { version = "1", default-features = false, features = [
     "use-std",
     "experimental-derive",
 ] }
+quinn = { package = "iroh-quinn", version = "0.12.0" }
+quinn-proto = { package = "iroh-quinn-proto", version = "0.12.0" }
 rand = "0.8"
 rcgen = { version = "0.13", optional = true }
 regex = { version = "1.7.1", optional = true }
@@ -126,11 +128,12 @@ server = [
 ]
 metrics = ["iroh-metrics/metrics", "server"]
 test-utils = []
+dangerous-certs = []
 
 [[bin]]
 name = "iroh-relay"
 path = "src/main.rs"
-required-features = ["server"]
+required-features = ["server", "dangerous-certs"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -60,7 +60,7 @@ Then run the server with the `--dev-quic` flag:
 
 The relay server will run over http on port 3340, as it does using the `--dev` flag, but it will also run a QUIC server on port 7824.
 
-The relay will use the configured TLS certificates for the QUIC connection, but use http (rather than https) for the server; the local certificates that we generate using `rcgen` may not work properly for the TCP relay connections.
+The relay will use the configured TLS certificates for the QUIC connection, but use http (rather than https) for the server.
 
 # License
 

--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -23,6 +23,45 @@ relays, including:
 
 Used in [iroh], created with love by the [n0 team](https://n0.computer/).
 
+## Local testing
+
+Advice for testing your application that uses `iroh` with a locally running `iroh-relay` server
+
+### dev mode
+When running the relay server using the `--dev` flag, you will:
+- only run the server over http, not https
+- will NOT run the QUIC endpoint that enables QUIC address discovery
+
+The relay can be contacted at "http://localhost:3340".
+
+Both https and QUIC address discovery require TLS certificates. It's possible to run QUIC address discovery using locally generated TLS certificates, but it takes a few extra steps and so, is disabled by default for now.
+
+### dev mode with QUIC address discovery
+
+So you want to test out QUIC address discovery locally?
+
+In order to do that you need TLS certificates.
+
+The easiest get that is to generate self-signed certificates using `rcgen`
+  - get rcgen (`git clone https://github.com/rustls/rcgen`)
+  - cd to the `rcgen` directory
+  - generate local certs using `cargo run -- -o path/to/certs`
+
+Next, add the certificate paths to your iroh-relay config, here is an example of a config.toml file that will enable quic address discovery.
+```toml
+[tlsconfig]
+cert_mode = "Manual"
+manual_cert_path = "/path/to/certs/cert.pem"
+manual_key_path = "/path/to/certs/cert.key.pem"
+```
+
+Then run the server with the `--dev-quic` flag:
+`cargo run --bin iroh-relay -- --config-path=/path/to/config.toml --dev-quic`
+
+The relay server will run over http on port 3340, as it does using the `--dev` flag, but it will also run a QUIC server on port 7824.
+
+The relay will use the configured TLS certificates for the QUIC connection, but use http (rather than https) for the server; the local certificates that we generate using `rcgen` may not work properly for the TCP relay connections.
+
 # License
 
 This project is licensed under either of

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -377,11 +377,11 @@ impl ClientBuilder {
     }
 }
 
-#[cfg(any(test, feature = "test-utils", feature = "dangerous-certs"))]
+#[cfg(test)]
 /// Creates a client config that trusts any servers without verifying their TLS certificate.
 ///
 /// Should be used for testing local relay setups only.
-pub fn make_dangerous_client_config() -> rustls::ClientConfig {
+pub(crate) fn make_dangerous_client_config() -> rustls::ClientConfig {
     warn!(
         "Insecure config: SSL certificates from relay servers will be trusted without verification"
     );
@@ -1128,15 +1128,12 @@ impl DnsExt for DnsResolver {
 }
 
 /// Used to allow self signed certificates in tests
-#[cfg(any(test, feature = "test-utils", feature = "dangerous-certs"))]
-#[cfg_attr(
-    iroh_docsrs,
-    doc(cfg(any(test, feature = "test-utils", feature = "dangerous-certs")))
-)]
+#[cfg(any(test, feature = "test-utils"))]
+#[cfg_attr(iroh_docsrs, doc(cfg(any(test, feature = "test-utils"))))]
 #[derive(Debug)]
 struct NoCertVerifier;
 
-#[cfg(any(test, feature = "test-utils", feature = "dangerous-certs"))]
+#[cfg(any(test, feature = "test-utils"))]
 impl rustls::client::danger::ServerCertVerifier for NoCertVerifier {
     fn verify_server_cert(
         &self,

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -377,7 +377,7 @@ impl ClientBuilder {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test))]
 /// Creates a client config that trusts any servers without verifying their TLS certificate.
 ///
 /// Should be used for testing local relay setups only.

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -377,7 +377,7 @@ impl ClientBuilder {
     }
 }
 
-#[cfg(any(test))]
+#[cfg(test)]
 /// Creates a client config that trusts any servers without verifying their TLS certificate.
 ///
 /// Should be used for testing local relay setups only.
@@ -638,7 +638,7 @@ impl Actor {
         }
 
         event!(
-            target: "iroh::_events::relay::connected",
+            target: "events.net.relay.connected",
             Level::DEBUG,
             home = self.is_preferred,
             url = %self.url,

--- a/iroh-relay/src/defaults.rs
+++ b/iroh-relay/src/defaults.rs
@@ -1,6 +1,6 @@
 //! Default values used in the relay.
 
-pub use iroh_base::relay_map::{DEFAULT_QUIC_PORT, DEFAULT_STUN_PORT};
+pub use iroh_base::relay_map::{DEFAULT_RELAY_QUIC_PORT, DEFAULT_STUN_PORT};
 
 /// The default HTTP port used by the Relay server.
 pub const DEFAULT_HTTP_PORT: u16 = 80;

--- a/iroh-relay/src/defaults.rs
+++ b/iroh-relay/src/defaults.rs
@@ -1,10 +1,6 @@
 //! Default values used in the relay.
 
-/// The efault STUN port used by the Relay server.
-///
-/// The STUN port as defined by [RFC
-/// 8489](<https://www.rfc-editor.org/rfc/rfc8489#section-18.6>)
-pub const DEFAULT_STUN_PORT: u16 = 3478;
+pub use iroh_base::relay_map::{DEFAULT_QUIC_PORT, DEFAULT_STUN_PORT};
 
 /// The default HTTP port used by the Relay server.
 pub const DEFAULT_HTTP_PORT: u16 = 80;

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -25,6 +25,7 @@ pub mod client;
 pub mod defaults;
 pub mod http;
 pub mod protos;
+pub mod quic;
 #[cfg(feature = "server")]
 #[cfg_attr(iroh_docsrs, doc(cfg(feature = "server")))]
 pub mod server;

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -283,9 +283,8 @@ struct TlsConfig {
 
 impl TlsConfig {
     fn https_bind_addr(&self, cfg: &Config) -> SocketAddr {
-        self.https_bind_addr.unwrap_or_else(|| {
-            SocketAddr::new(cfg.http_bind_addr().ip().clone(), DEFAULT_HTTPS_PORT)
-        })
+        self.https_bind_addr
+            .unwrap_or_else(|| SocketAddr::new(cfg.http_bind_addr().ip(), DEFAULT_HTTPS_PORT))
     }
 
     fn cert_dir(&self) -> PathBuf {
@@ -443,7 +442,7 @@ async fn maybe_load_tls(
         }
     };
     Ok(Some(relay::TlsConfig {
-        https_bind_addr: tls.https_bind_addr(&cfg),
+        https_bind_addr: tls.https_bind_addr(cfg),
         cert: cert_config,
         server_config,
     }))
@@ -458,7 +457,7 @@ async fn build_relay_config(cfg: Config) -> Result<relay::ServerConfig<std::io::
         if let Some(ref tls) = relay_tls {
             quic_config = Some(QuicConfig::new(
                 tls.server_config.clone(),
-                tls.https_bind_addr.ip().clone(),
+                tls.https_bind_addr.ip(),
                 cfg.quic_bind_port,
             )?);
         } else if cfg.enable_quic_local_cert {

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -150,7 +150,7 @@ struct Config {
     stun_bind_addr: Option<SocketAddr>,
     /// Whether to allow QUIC connections for QUIC address discovery
     ///
-    /// If no `tls` is set, this will cause building the server to erorr.
+    /// If no `tls` is set, this will error.
     ///
     /// Defaults to `true`
     #[serde(default = "cfg_defaults::enable_quic_addr_discovery")]
@@ -597,6 +597,8 @@ mod tests {
     #[tokio::test]
     async fn test_rate_limit_config() -> TestResult {
         let config = "
+            enable_quic_addr_discovery = false
+
             [limits.client.rx]
             bytes_per_second = 400
             max_burst_bytes = 800
@@ -619,7 +621,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rate_limit_default() -> TestResult {
-        let config = Config::from_str("")?;
+        let config = Config::from_str("enable_quic_addr_discovery = false")?;
         let relay_config = build_relay_config(config).await?;
 
         let relay = relay_config.relay.expect("no relay config");

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -8,8 +8,6 @@ use tokio::task::JoinSet;
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
 use tracing::{debug, info, info_span, warn, Instrument};
 
-use crate::server::QuicConfig;
-
 /// ALPN for our quic addr discovery
 pub const ALPN_QUIC_ADDR_DISC: &[u8] = b"quic";
 /// Endpoint close error code
@@ -18,63 +16,66 @@ pub const QUIC_ADDR_DISC_CLOSE_CODE: VarInt = VarInt::from_u32(0);
 pub const QUIC_ADDR_DISC_CLOSE_REASON: &[u8] = b"finished";
 
 #[cfg(feature = "server")]
-pub(crate) struct QuicServer {
-    bind_addr: SocketAddr,
-    cancel: CancellationToken,
-    handle: AbortOnDropHandle<()>,
-}
+pub(crate) mod server {
+    use super::*;
+    pub use crate::server::QuicConfig;
 
-#[cfg(feature = "server")]
-impl QuicServer {
-    /// Returns a handle for this server.
-    ///
-    /// The server runs in the background as several async tasks.  This allows controlling
-    /// the server, in particular it allows gracefully shutting down the server.
-    pub fn handle(&self) -> ServerHandle {
-        ServerHandle {
-            cancel_token: self.cancel.clone(),
+    pub struct QuicServer {
+        bind_addr: SocketAddr,
+        cancel: CancellationToken,
+        handle: AbortOnDropHandle<()>,
+    }
+
+    impl QuicServer {
+        /// Returns a handle for this server.
+        ///
+        /// The server runs in the background as several async tasks.  This allows controlling
+        /// the server, in particular it allows gracefully shutting down the server.
+        pub fn handle(&self) -> ServerHandle {
+            ServerHandle {
+                cancel_token: self.cancel.clone(),
+            }
         }
-    }
 
-    /// Returns the [`AbortOnDropHandle`] for the supervisor task managing the endpoint.
-    ///
-    /// This is the root of all the tasks for the QUIC address discovery service.  Aborting it will abort all the
-    /// other tasks for the service.  Awaiting it will complete when all the service tasks are
-    /// completed.[]
-    pub fn task_handle(&mut self) -> &mut AbortOnDropHandle<()> {
-        &mut self.handle
-    }
+        /// Returns the [`AbortOnDropHandle`] for the supervisor task managing the endpoint.
+        ///
+        /// This is the root of all the tasks for the QUIC address discovery service.  Aborting it will abort all the
+        /// other tasks for the service.  Awaiting it will complete when all the service tasks are
+        /// completed.[]
+        pub fn task_handle(&mut self) -> &mut AbortOnDropHandle<()> {
+            &mut self.handle
+        }
 
-    /// Returns the socket address for this QUIC server.
-    pub fn bind_addr(&self) -> &SocketAddr {
-        &self.bind_addr
-    }
+        /// Returns the socket address for this QUIC server.
+        pub fn bind_addr(&self) -> &SocketAddr {
+            &self.bind_addr
+        }
 
-    /// Spawns a QUIC server that creates and QUIC endpoint and listens
-    /// for QUIC connections for address discovery
-    ///
-    /// # Panics
-    /// If there is a panic during a connection, it will be propagated
-    /// up here. Any other errors in a connection will be logged as a
-    ///  warning.
-    pub(crate) fn spawn(quic_config: QuicConfig) -> Result<Self> {
-        let mut server_config =
-            quinn::ServerConfig::with_crypto(Arc::new(quic_config.server_config));
-        let transport_config = Arc::get_mut(&mut server_config.transport).unwrap();
-        transport_config
-            .max_concurrent_uni_streams(0_u8.into())
-            // enable sending quic address discovery frames
-            .send_observed_address_reports(true);
+        /// Spawns a QUIC server that creates and QUIC endpoint and listens
+        /// for QUIC connections for address discovery
+        ///
+        /// # Panics
+        /// If there is a panic during a connection, it will be propagated
+        /// up here. Any other errors in a connection will be logged as a
+        ///  warning.
+        pub(crate) fn spawn(quic_config: QuicConfig) -> Result<Self> {
+            let mut server_config =
+                quinn::ServerConfig::with_crypto(Arc::new(quic_config.server_config));
+            let transport_config = Arc::get_mut(&mut server_config.transport).unwrap();
+            transport_config
+                .max_concurrent_uni_streams(0_u8.into())
+                // enable sending quic address discovery frames
+                .send_observed_address_reports(true);
 
-        let endpoint = quinn::Endpoint::server(server_config, quic_config.bind_addr)?;
-        let bind_addr = endpoint.local_addr()?;
+            let endpoint = quinn::Endpoint::server(server_config, quic_config.bind_addr)?;
+            let bind_addr = endpoint.local_addr()?;
 
-        info!("QUIC server bound on {bind_addr:?}");
+            info!("QUIC server bound on {bind_addr:?}");
 
-        let cancel = CancellationToken::new();
-        let cancel_accept_loop = cancel.clone();
+            let cancel = CancellationToken::new();
+            let cancel_accept_loop = cancel.clone();
 
-        let task = tokio::task::spawn(async move {
+            let task = tokio::task::spawn(async move {
             let mut set = JoinSet::new();
             debug!("waiting for connections...");
             loop {
@@ -115,54 +116,55 @@ impl QuicServer {
             endpoint.wait_idle().await;
             debug!("quic endpoint has been shutdown.");
         }.instrument(info_span!("quic-endpoint")),);
-        Ok(Self {
-            bind_addr,
-            cancel,
-            handle: AbortOnDropHandle::new(task),
-        })
-    }
-
-    /// Closes the underlying QUIC endpoint and the tasks running the
-    /// QUIC connections.
-    pub fn shutdown(&self) {
-        self.cancel.cancel();
-    }
-}
-
-/// A handle for the Server side of QUIC address discovery.
-///
-/// This does not allow access to the task but can communicate with it.
-#[derive(Debug, Clone)]
-pub struct ServerHandle {
-    cancel_token: CancellationToken,
-}
-
-impl ServerHandle {
-    /// Gracefully shut down the quic endpoint.
-    pub fn shutdown(&self) {
-        self.cancel_token.cancel()
-    }
-}
-
-async fn handle_connection(conn: quinn::Incoming) -> Result<()> {
-    let connection = conn.await?;
-    info!("established");
-    // wait for the client to close the connection
-    let connection_err = connection.closed().await;
-    match connection_err {
-        quinn::ConnectionError::ApplicationClosed(ApplicationClose { error_code, .. })
-            if error_code == QUIC_ADDR_DISC_CLOSE_CODE =>
-        {
-            return Ok(());
+            Ok(Self {
+                bind_addr,
+                cancel,
+                handle: AbortOnDropHandle::new(task),
+            })
         }
-        _ => {
-            warn!(
-                "{} - error closing connection {connection_err:?}",
-                connection.remote_address()
-            );
+
+        /// Closes the underlying QUIC endpoint and the tasks running the
+        /// QUIC connections.
+        pub fn shutdown(&self) {
+            self.cancel.cancel();
         }
     }
-    Ok(())
+
+    /// A handle for the Server side of QUIC address discovery.
+    ///
+    /// This does not allow access to the task but can communicate with it.
+    #[derive(Debug, Clone)]
+    pub struct ServerHandle {
+        cancel_token: CancellationToken,
+    }
+
+    impl ServerHandle {
+        /// Gracefully shut down the quic endpoint.
+        pub fn shutdown(&self) {
+            self.cancel_token.cancel()
+        }
+    }
+
+    async fn handle_connection(conn: quinn::Incoming) -> Result<()> {
+        let connection = conn.await?;
+        info!("established");
+        // wait for the client to close the connection
+        let connection_err = connection.closed().await;
+        match connection_err {
+            quinn::ConnectionError::ApplicationClosed(ApplicationClose { error_code, .. })
+                if error_code == QUIC_ADDR_DISC_CLOSE_CODE =>
+            {
+                return Ok(());
+            }
+            _ => {
+                warn!(
+                    "{} - error closing connection {connection_err:?}",
+                    connection.remote_address()
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Handles the client side of QUIC address discovery.
@@ -245,6 +247,7 @@ impl QuicClient {
 mod tests {
     use std::{net::Ipv4Addr, sync::Arc};
 
+    use super::server::{QuicConfig, QuicServer};
     use super::*;
 
     /// Generates a [`quinn::ClientConfig`] that has quic address discovery enabled.
@@ -281,7 +284,7 @@ mod tests {
         let quic_client = QuicClient::new(client_endpoint.clone(), client_config);
 
         let (addr, _latency) = quic_client
-            .get_addr_and_latency(quic_server.bind_addr, &host.to_string())
+            .get_addr_and_latency(*quic_server.bind_addr(), &host.to_string())
             .await?;
         // wait until the endpoint delivers the closing message to the server
         client_endpoint.wait_idle().await;

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -3,10 +3,7 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
-use quinn::{ApplicationClose, VarInt};
-use tokio::task::JoinSet;
-use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-use tracing::{debug, info, info_span, warn, Instrument};
+use quinn::VarInt;
 
 /// ALPN for our quic addr discovery
 pub const ALPN_QUIC_ADDR_DISC: &[u8] = b"quic";
@@ -19,6 +16,10 @@ pub const QUIC_ADDR_DISC_CLOSE_REASON: &[u8] = b"finished";
 pub(crate) mod server {
     use super::*;
     pub use crate::server::QuicConfig;
+    use quinn::ApplicationClose;
+    use tokio::task::JoinSet;
+    use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
+    use tracing::{debug, info, info_span, warn, Instrument};
 
     pub struct QuicServer {
         bind_addr: SocketAddr,
@@ -247,8 +248,10 @@ impl QuicClient {
 mod tests {
     use std::{net::Ipv4Addr, sync::Arc};
 
-    use super::server::{QuicConfig, QuicServer};
-    use super::*;
+    use super::{
+        server::{QuicConfig, QuicServer},
+        *,
+    };
 
     /// Generates a [`quinn::ClientConfig`] that has quic address discovery enabled.
     fn generate_quic_addr_disc_client_config(

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -17,12 +17,14 @@ pub const QUIC_ADDR_DISC_CLOSE_CODE: VarInt = VarInt::from_u32(0);
 /// Endpoint close reason
 pub const QUIC_ADDR_DISC_CLOSE_REASON: &[u8] = b"finished";
 
+#[cfg(feature = "server")]
 pub(crate) struct QuicServer {
     bind_addr: SocketAddr,
     cancel: CancellationToken,
     handle: AbortOnDropHandle<()>,
 }
 
+#[cfg(feature = "server")]
 impl QuicServer {
     /// Returns a handle for this server.
     ///
@@ -144,16 +146,6 @@ impl ServerHandle {
 
 async fn handle_connection(conn: quinn::Incoming) -> Result<()> {
     let connection = conn.await?;
-    // let span = info_span!(
-    //     "connection",
-    //     remote = %connection.remote_address(),
-    //     protocol = %connection
-    //         .handshake_data()
-    //         .unwrap()
-    //         .downcast::<quinn::crypto::rustls::HandshakeData>().unwrap()
-    //         .protocol
-    //         .map_or_else(|| "<none>".into(), |x| String::from_utf8_lossy(&x).into_owned())
-    // );
     info!("established");
     // wait for the client to close the connection
     let connection_err = connection.closed().await;

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -3,21 +3,21 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
-use quinn::VarInt;
+use quinn::{crypto::rustls::QuicClientConfig, VarInt};
 
 /// ALPN for our quic addr discovery
-pub const ALPN_QUIC_ADDR_DISC: &[u8] = b"quic";
+pub const ALPN_QUIC_ADDR_DISC: &[u8] = b"n0/qad";
 /// Endpoint close error code
-pub const QUIC_ADDR_DISC_CLOSE_CODE: VarInt = VarInt::from_u32(0);
+pub const QUIC_ADDR_DISC_CLOSE_CODE: VarInt = VarInt::from_u32(1);
 /// Endpoint close reason
 pub const QUIC_ADDR_DISC_CLOSE_REASON: &[u8] = b"finished";
 
 #[cfg(feature = "server")]
 pub(crate) mod server {
-    use quinn::ApplicationClose;
+    use quinn::{crypto::rustls::QuicServerConfig, ApplicationClose};
     use tokio::task::JoinSet;
     use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-    use tracing::{debug, info, info_span, warn, Instrument};
+    use tracing::{debug, info, info_span, Instrument};
 
     use super::*;
     pub use crate::server::QuicConfig;
@@ -49,75 +49,92 @@ pub(crate) mod server {
         }
 
         /// Returns the socket address for this QUIC server.
-        pub fn bind_addr(&self) -> &SocketAddr {
-            &self.bind_addr
+        pub fn bind_addr(&self) -> SocketAddr {
+            self.bind_addr
         }
 
         /// Spawns a QUIC server that creates and QUIC endpoint and listens
         /// for QUIC connections for address discovery
         ///
+        /// # Errors
+        /// If the given `quic_config` contains a [`rustls::ServerConfig`] that cannot
+        /// be converted to a [`QuicServerConfig`], usually because it does not support
+        /// TLS 1.3, this method will error.
+        ///
         /// # Panics
         /// If there is a panic during a connection, it will be propagated
         /// up here. Any other errors in a connection will be logged as a
         ///  warning.
-        pub(crate) fn spawn(quic_config: QuicConfig) -> Result<Self> {
-            let mut server_config =
-                quinn::ServerConfig::with_crypto(Arc::new(quic_config.server_config));
+        pub(crate) fn spawn(mut quic_config: QuicConfig) -> Result<Self> {
+            quic_config.server_config.alpn_protocols =
+                vec![crate::quic::ALPN_QUIC_ADDR_DISC.to_vec()];
+            let server_config = QuicServerConfig::try_from(quic_config.server_config)?;
+            let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(server_config));
             let transport_config = Arc::get_mut(&mut server_config.transport).unwrap();
             transport_config
                 .max_concurrent_uni_streams(0_u8.into())
+                .max_concurrent_bidi_streams(0_u8.into())
                 // enable sending quic address discovery frames
                 .send_observed_address_reports(true);
 
             let endpoint = quinn::Endpoint::server(server_config, quic_config.bind_addr)?;
             let bind_addr = endpoint.local_addr()?;
 
-            info!("QUIC server bound on {bind_addr:?}");
+            info!(?bind_addr, "QUIC server bound");
 
             let cancel = CancellationToken::new();
             let cancel_accept_loop = cancel.clone();
 
-            let task = tokio::task::spawn(async move {
-            let mut set = JoinSet::new();
-            debug!("waiting for connections...");
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = cancel_accept_loop.cancelled() => {
-                        break;
-                    }
-                    Some(res) = set.join_next(), if !set.is_empty() => {
-                        if let Err(err) = res {
-                            if err.is_panic() {
-                                panic!("task panicked: {:#?}", err);
+            let task = tokio::task::spawn(
+                async move {
+                    let mut set = JoinSet::new();
+                    debug!("waiting for connections...");
+                    loop {
+                        tokio::select! {
+                            biased;
+                            _ = cancel_accept_loop.cancelled() => {
+                                break;
                             }
-                            warn!("connection failed: {err}");
+                            Some(res) = set.join_next(), if !set.is_empty() => {
+                                if let Err(err) = res {
+                                    // panic if necessary, otherwise, this error has already
+                                    // been logged in `handle_connection`
+                                    if err.is_panic() {
+                                        panic!("task panicked: {:#?}", err);
+                                    }
+                                }
+                            }
+                            res = endpoint.accept() => match res {
+                                Some(conn) => {
+                                     debug!("accepting connection");
+                                     let remote_addr = conn.remote_address();
+                                     set.spawn(async move {
+                                         handle_connection(conn).await
+                                     }.instrument(info_span!("qad-conn", %remote_addr)));
+                                }
+                                None => {
+                                    debug!("endpoint closed");
+                                    break;
+                                }
+                            }
                         }
                     }
-                    res = endpoint.accept() => match res {
-                        Some(conn) => {
-                             debug!("accepting connection from {:?}", conn.remote_address())       ;
-                             set.spawn(async move {
-                                 let remote_addr = conn.remote_address();
-                                 let res = handle_connection(conn).await;
-                                 if let Err(ref err) = res {
-                                     warn!(remote_address = ?remote_addr, "error handling connection {err:?}")
-                                 }
-                                 res
-                             });
-                        }
-                        None => {
-                            debug!("endpoint closed");
-                            break;
-                        }
+                    // close all connections and wait until they have all grace
+                    // fully closed.
+                    endpoint.close(QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON);
+                    endpoint.wait_idle().await;
+
+                    // all tasks should be closed, since the endpoint has shutdown
+                    // all connections, but await to ensure they are finished.
+                    set.abort_all();
+                    while !set.is_empty() {
+                        _ = set.join_next().await;
                     }
+
+                    debug!("quic endpoint has been shutdown.");
                 }
-            }
-            endpoint
-                .close(QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON);
-            endpoint.wait_idle().await;
-            debug!("quic endpoint has been shutdown.");
-        }.instrument(info_span!("quic-endpoint")),);
+                .instrument(info_span!("quic-endpoint")),
+            );
             Ok(Self {
                 bind_addr,
                 cancel,
@@ -127,8 +144,12 @@ pub(crate) mod server {
 
         /// Closes the underlying QUIC endpoint and the tasks running the
         /// QUIC connections.
-        pub fn shutdown(&self) {
+        pub async fn shutdown(mut self) -> Result<()> {
             self.cancel.cancel();
+            if !self.task_handle().is_finished() {
+                self.task_handle().await?
+            }
+            Ok(())
         }
     }
 
@@ -147,25 +168,32 @@ pub(crate) mod server {
         }
     }
 
-    async fn handle_connection(conn: quinn::Incoming) -> Result<()> {
-        let connection = conn.await?;
-        info!("established");
+    /// Handle the connection from the client.
+    ///
+    /// Any errors that happen during this connection do not need to be handled,
+    /// and will be logged at the debug level in this function.
+    async fn handle_connection(incoming: quinn::Incoming) -> Result<()> {
+        let connection = match incoming.await {
+            Ok(conn) => conn,
+            Err(e) => {
+                debug!("error accepting incoming connection: {e:#?}");
+                return Err(e.into());
+            }
+        };
+        debug!("established");
         // wait for the client to close the connection
         let connection_err = connection.closed().await;
         match connection_err {
             quinn::ConnectionError::ApplicationClosed(ApplicationClose { error_code, .. })
                 if error_code == QUIC_ADDR_DISC_CLOSE_CODE =>
             {
-                return Ok(());
+                Ok(())
             }
             _ => {
-                warn!(
-                    "{} - error closing connection {connection_err:?}",
-                    connection.remote_address()
-                );
+                debug!("error closing connection {connection_err:#?}",);
+                Err(connection_err.into())
             }
         }
-        Ok(())
     }
 }
 
@@ -181,14 +209,20 @@ pub struct QuicClient {
 impl QuicClient {
     /// Create a new QuicClient to handle the client side of QUIC
     /// address discovery.
-    pub fn new(ep: quinn::Endpoint, mut client_config: quinn::ClientConfig) -> Self {
+    pub fn new(ep: quinn::Endpoint, mut client_config: rustls::ClientConfig) -> Result<Self> {
+        // add QAD alpn
+        client_config.alpn_protocols = vec![ALPN_QUIC_ADDR_DISC.into()];
+        // go from rustls client config to rustls QUIC specific client config to
+        // a quinn client config
+        let mut client_config =
+            quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(client_config)?));
+
+        // enable the receive side of address discovery
         let mut transport = quinn_proto::TransportConfig::default();
-        // enable address discovery
-        transport
-            .send_observed_address_reports(true)
-            .receive_observed_address_reports(true);
+        transport.receive_observed_address_reports(true);
         client_config.transport_config(Arc::new(transport));
-        Self { ep, client_config }
+
+        Ok(Self { ep, client_config })
     }
 
     /// Client side of QUIC address discovery.
@@ -247,53 +281,43 @@ impl QuicClient {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::Ipv4Addr, sync::Arc};
+    use std::net::Ipv4Addr;
 
     use super::{
         server::{QuicConfig, QuicServer},
         *,
     };
 
-    /// Generates a [`quinn::ClientConfig`] that has quic address discovery enabled.
-    fn generate_quic_addr_disc_client_config(
-        cert: rustls::pki_types::CertificateDer<'static>,
-    ) -> Result<quinn::ClientConfig> {
-        let mut roots = rustls::RootCertStore::empty();
-        roots.add(cert)?;
-        let config =
-            rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-                .with_root_certificates(roots)
-                .with_no_client_auth();
-        let config = quinn_proto::crypto::rustls::QuicClientConfig::try_from(config).unwrap();
-
-        let client_config = quinn::ClientConfig::new(Arc::new(config));
-        Ok(client_config)
-    }
-
     #[tokio::test]
     async fn quic_endpoint_basic() -> anyhow::Result<()> {
         let host: Ipv4Addr = "127.0.0.1".parse()?;
         let _guard = iroh_test::logging::setup();
 
-        let (certs, server_config) =
-            super::super::server::testing::self_signed_tls_certs_and_config();
+        // create a server config with self signed certificates
+        let (_, server_config) = super::super::server::testing::self_signed_tls_certs_and_config();
+        let bind_addr = SocketAddr::new(host.into(), 0);
+        let quic_server = QuicServer::spawn(QuicConfig {
+            server_config,
+            bind_addr,
+        })?;
 
-        let quic_server = QuicServer::spawn(QuicConfig::new(server_config, host.into(), Some(0))?)?;
-
-        let client_config = generate_quic_addr_disc_client_config(certs[0].clone())?;
+        // create a client-side endpoint
         let client_endpoint = quinn::Endpoint::client(SocketAddr::new(host.into(), 0))?;
-
         let client_addr = client_endpoint.local_addr()?;
-        println!("{client_addr}");
-        let quic_client = QuicClient::new(client_endpoint.clone(), client_config);
+
+        // create the client configuration used for the client endpoint when they
+        // initiate a connection with the server
+        let client_config = crate::client::make_dangerous_client_config();
+        let quic_client = QuicClient::new(client_endpoint.clone(), client_config)?;
 
         let (addr, _latency) = quic_client
-            .get_addr_and_latency(*quic_server.bind_addr(), &host.to_string())
+            .get_addr_and_latency(quic_server.bind_addr(), &host.to_string())
             .await?;
+
         // wait until the endpoint delivers the closing message to the server
         client_endpoint.wait_idle().await;
         // shut down the quic server
-        quic_server.shutdown();
+        quic_server.shutdown().await?;
 
         assert_eq!(client_addr, addr);
         Ok(())

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -1,10 +1,8 @@
 //! Create a QUIC server that accepts connections
 //! for QUIC address discovery.
-use std::net::SocketAddr;
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
-
 use quinn::{ApplicationClose, VarInt};
 use tokio::task::JoinSet;
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -1,0 +1,308 @@
+//! Create a QUIC server that accepts connections
+//! for QUIC address discovery.
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use quinn::{ApplicationClose, VarInt};
+use tokio::task::JoinSet;
+use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
+use tracing::{debug, info, info_span, warn, Instrument};
+
+use crate::server::QuicConfig;
+
+/// ALPN for our quic addr discovery
+pub const ALPN_QUIC_ADDR_DISC: &[u8] = b"quic";
+/// Endpoint close error code
+pub const QUIC_ADDR_DISC_CLOSE_CODE: VarInt = VarInt::from_u32(0);
+/// Endpoint close reason
+pub const QUIC_ADDR_DISC_CLOSE_REASON: &[u8] = b"finished";
+
+pub(crate) struct QuicServer {
+    bind_addr: SocketAddr,
+    cancel: CancellationToken,
+    handle: AbortOnDropHandle<()>,
+}
+
+impl QuicServer {
+    /// Returns a handle for this server.
+    ///
+    /// The server runs in the background as several async tasks.  This allows controlling
+    /// the server, in particular it allows gracefully shutting down the server.
+    pub fn handle(&self) -> ServerHandle {
+        ServerHandle {
+            cancel_token: self.cancel.clone(),
+        }
+    }
+
+    /// Returns the [`AbortOnDropHandle`] for the supervisor task managing the endpoint.
+    ///
+    /// This is the root of all the tasks for the QUIC address discovery service.  Aborting it will abort all the
+    /// other tasks for the service.  Awaiting it will complete when all the service tasks are
+    /// completed.[]
+    pub fn task_handle(&mut self) -> &mut AbortOnDropHandle<()> {
+        &mut self.handle
+    }
+
+    /// Returns the socket address for this QUIC server.
+    pub fn bind_addr(&self) -> &SocketAddr {
+        &self.bind_addr
+    }
+
+    /// Spawns a QUIC server that creates and QUIC endpoint and listens
+    /// for QUIC connections for address discovery
+    ///
+    /// # Panics
+    /// If there is a panic during a connection, it will be propagated
+    /// up here. Any other errors in a connection will be logged as a
+    ///  warning.
+    pub(crate) fn spawn(quic_config: QuicConfig) -> Result<Self> {
+        let mut server_config =
+            quinn::ServerConfig::with_crypto(Arc::new(quic_config.server_config));
+        let transport_config = Arc::get_mut(&mut server_config.transport).unwrap();
+        transport_config
+            .max_concurrent_uni_streams(0_u8.into())
+            // enable sending quic address discovery frames
+            .send_observed_address_reports(true);
+
+        let endpoint = quinn::Endpoint::server(server_config, quic_config.bind_addr)?;
+        let bind_addr = endpoint.local_addr()?;
+
+        info!("QUIC server bound on {bind_addr:?}");
+
+        let cancel = CancellationToken::new();
+        let cancel_accept_loop = cancel.clone();
+
+        let task = tokio::task::spawn(async move {
+            let mut set = JoinSet::new();
+            debug!("waiting for connections...");
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancel_accept_loop.cancelled() => {
+                        break;
+                    }
+                    Some(res) = set.join_next(), if !set.is_empty() => {
+                        if let Err(err) = res {
+                            if err.is_panic() {
+                                panic!("task panicked: {:#?}", err);
+                            }
+                            warn!("connection failed: {err}");
+                        }
+                    }
+                    res = endpoint.accept() => match res {
+                        Some(conn) => {
+                             debug!("accepting connection from {:?}", conn.remote_address())       ;
+                             set.spawn(async move {
+                                 let remote_addr = conn.remote_address();
+                                 let res = handle_connection(conn).await;
+                                 if let Err(ref err) = res {
+                                     warn!(remote_address = ?remote_addr, "error handling connection {err:?}")
+                                 }
+                                 res
+                             });
+                        }
+                        None => {
+                            debug!("endpoint closed");
+                            break;
+                        }
+                    }
+                }
+            }
+            endpoint
+                .close(QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON);
+            endpoint.wait_idle().await;
+            debug!("quic endpoint has been shutdown.");
+        }.instrument(info_span!("quic-endpoint")),);
+        Ok(Self {
+            bind_addr,
+            cancel,
+            handle: AbortOnDropHandle::new(task),
+        })
+    }
+
+    /// Closes the underlying QUIC endpoint and the tasks running the
+    /// QUIC connections.
+    pub fn shutdown(&self) {
+        self.cancel.cancel();
+    }
+}
+
+/// A handle for the Server side of QUIC address discovery.
+///
+/// This does not allow access to the task but can communicate with it.
+#[derive(Debug, Clone)]
+pub struct ServerHandle {
+    cancel_token: CancellationToken,
+}
+
+impl ServerHandle {
+    /// Gracefully shut down the quic endpoint.
+    pub fn shutdown(&self) {
+        self.cancel_token.cancel()
+    }
+}
+
+async fn handle_connection(conn: quinn::Incoming) -> Result<()> {
+    let connection = conn.await?;
+    // let span = info_span!(
+    //     "connection",
+    //     remote = %connection.remote_address(),
+    //     protocol = %connection
+    //         .handshake_data()
+    //         .unwrap()
+    //         .downcast::<quinn::crypto::rustls::HandshakeData>().unwrap()
+    //         .protocol
+    //         .map_or_else(|| "<none>".into(), |x| String::from_utf8_lossy(&x).into_owned())
+    // );
+    info!("established");
+    // wait for the client to close the connection
+    let connection_err = connection.closed().await;
+    match connection_err {
+        quinn::ConnectionError::ApplicationClosed(ApplicationClose { error_code, .. })
+            if error_code == QUIC_ADDR_DISC_CLOSE_CODE =>
+        {
+            return Ok(());
+        }
+        _ => {
+            warn!(
+                "{} - error closing connection {connection_err:?}",
+                connection.remote_address()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Handles the client side of QUIC address discovery.
+#[derive(Debug)]
+pub struct QuicClient {
+    /// A QUIC Endpoint.
+    ep: quinn::Endpoint,
+    /// A client config.
+    client_config: quinn::ClientConfig,
+}
+
+impl QuicClient {
+    /// Create a new QuicClient to handle the client side of QUIC
+    /// address discovery.
+    pub fn new(ep: quinn::Endpoint, mut client_config: quinn::ClientConfig) -> Self {
+        let mut transport = quinn_proto::TransportConfig::default();
+        // enable address discovery
+        transport
+            .send_observed_address_reports(true)
+            .receive_observed_address_reports(true);
+        client_config.transport_config(Arc::new(transport));
+        Self { ep, client_config }
+    }
+
+    /// Client side of QUIC address discovery.
+    ///
+    /// Creates a connection and returns the observed address
+    /// and estimated latency of the connection.
+    ///
+    /// Consumes and gracefully closes the connection.
+    pub async fn get_addr_and_latency(
+        &self,
+        server_addr: SocketAddr,
+        host: &str,
+    ) -> Result<(SocketAddr, std::time::Duration)> {
+        let connecting = self
+            .ep
+            .connect_with(self.client_config.clone(), server_addr, host);
+        let conn = connecting?.await?;
+        let mut external_addresses = conn.observed_external_addr();
+        // TODO(ramfox): I'd like to be able to cancel this so we can close cleanly
+        // if there the task that runs this function gets aborted.
+        // tokio::select! {
+        //     _ = cancel.cancelled() => {
+        //         conn.close(QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON);
+        //         anyhow::bail!("QUIC address discovery canceled early");
+        //     },
+        //     res = external_addresses.wait_for(|addr| addr.is_some()) => {
+        //         let addr = res?.expect("checked");
+        //         let latency = conn.rtt() / 2;
+        //         // gracefully close the connections
+        //         conn.close(QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON);
+        //         Ok((addr, latency))
+        //     }
+
+        let res = match external_addresses.wait_for(|addr| addr.is_some()).await {
+            Ok(res) => res,
+            Err(err) => {
+                // attempt to gracefully close the connections
+                conn.close(QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON);
+                return Err(err.into());
+            }
+        };
+        let mut observed_addr = res.expect("checked");
+        // if we've sent an to an ipv4 address, but
+        // received an observed address that is ivp6
+        // then the address is an [IPv4-Mapped IPv6 Addresses](https://doc.rust-lang.org/beta/std/net/struct.Ipv6Addr.html#ipv4-mapped-ipv6-addresses)
+        if server_addr.is_ipv4() && observed_addr.is_ipv6() {
+            observed_addr =
+                SocketAddr::new(observed_addr.ip().to_canonical(), observed_addr.port());
+        }
+        let latency = conn.rtt() / 2;
+        // gracefully close the connections
+        conn.close(QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON);
+        Ok((observed_addr, latency))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::Ipv4Addr, sync::Arc};
+
+    use super::*;
+
+    /// Generates a [`quinn::ClientConfig`] that has quic address discovery enabled.
+    fn generate_quic_addr_disc_client_config(
+        cert: rustls::pki_types::CertificateDer<'static>,
+    ) -> Result<quinn::ClientConfig> {
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(cert)?;
+        let config =
+            rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+                .with_root_certificates(roots)
+                .with_no_client_auth();
+        let config = quinn_proto::crypto::rustls::QuicClientConfig::try_from(config).unwrap();
+
+        let client_config = quinn::ClientConfig::new(Arc::new(config));
+        Ok(client_config)
+    }
+
+    #[tokio::test]
+    async fn quic_endpoint_basic() -> anyhow::Result<()> {
+        let host: Ipv4Addr = "127.0.0.1".parse()?;
+        let _guard = iroh_test::logging::setup();
+
+        let (certs, server_config) =
+            super::super::server::testing::self_signed_tls_certs_and_config();
+
+        let quic_server = QuicServer::spawn(QuicConfig::new(
+            server_config,
+            host.clone().into(),
+            Some(0),
+        )?)?;
+
+        let client_config = generate_quic_addr_disc_client_config(certs[0].clone())?;
+        let client_endpoint = quinn::Endpoint::client(SocketAddr::new(host.into(), 0))?;
+
+        let client_addr = client_endpoint.local_addr()?;
+        println!("{client_addr}");
+        let quic_client = QuicClient::new(client_endpoint.clone(), client_config);
+
+        let (addr, _latency) = quic_client
+            .get_addr_and_latency(quic_server.bind_addr.clone(), &host.to_string())
+            .await?;
+        // wait until the endpoint delivers the closing message to the server
+        client_endpoint.wait_idle().await;
+        // shut down the quic server
+        quic_server.shutdown();
+
+        assert_eq!(client_addr, addr);
+        Ok(())
+    }
+}

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -279,11 +279,7 @@ mod tests {
         let (certs, server_config) =
             super::super::server::testing::self_signed_tls_certs_and_config();
 
-        let quic_server = QuicServer::spawn(QuicConfig::new(
-            server_config,
-            host.clone().into(),
-            Some(0),
-        )?)?;
+        let quic_server = QuicServer::spawn(QuicConfig::new(server_config, host.into(), Some(0))?)?;
 
         let client_config = generate_quic_addr_disc_client_config(certs[0].clone())?;
         let client_endpoint = quinn::Endpoint::client(SocketAddr::new(host.into(), 0))?;
@@ -293,7 +289,7 @@ mod tests {
         let quic_client = QuicClient::new(client_endpoint.clone(), client_config);
 
         let (addr, _latency) = quic_client
-            .get_addr_and_latency(quic_server.bind_addr.clone(), &host.to_string())
+            .get_addr_and_latency(quic_server.bind_addr, &host.to_string())
             .await?;
         // wait until the endpoint delivers the closing message to the server
         client_endpoint.wait_idle().await;

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -14,12 +14,13 @@ pub const QUIC_ADDR_DISC_CLOSE_REASON: &[u8] = b"finished";
 
 #[cfg(feature = "server")]
 pub(crate) mod server {
-    use super::*;
-    pub use crate::server::QuicConfig;
     use quinn::ApplicationClose;
     use tokio::task::JoinSet;
     use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
     use tracing::{debug, info, info_span, warn, Instrument};
+
+    use super::*;
+    pub use crate::server::QuicConfig;
 
     pub struct QuicServer {
         bind_addr: SocketAddr,

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -134,7 +134,7 @@ pub struct StunConfig {
 pub struct QuicConfig {
     /// The socket address on which the QUIC server should bind.
     ///
-    /// Normally you'd chose port `7842`, see [`crate::defaults::DEFAULT_QUIC_PORT`].
+    /// Normally you'd chose port `7842`, see [`crate::defaults::DEFAULT_RELAY_QUIC_PORT`].
     pub bind_addr: SocketAddr,
     /// The TLS server configuration for the QUIC server.
     ///
@@ -263,7 +263,7 @@ impl Server {
                 match UdpSocket::bind(stun.bind_addr).await {
                     Ok(sock) => {
                         let addr = sock.local_addr()?;
-                        info!("STUN server bound on {addr}");
+                        info!("STUN server listening on {addr}");
                         tasks.spawn(
                             server_stun_listener(sock).instrument(info_span!("stun-server", %addr)),
                         );

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -47,11 +47,9 @@ mod clients;
 mod http_server;
 mod metrics;
 pub(crate) mod streams;
-#[cfg(any(feature = "test-utils", feature = "dangerous-certs"))]
+#[cfg(feature = "test-utils")]
 pub mod testing;
 
-#[cfg(feature = "dangerous-certs")]
-pub use self::testing::self_signed_tls_certs_and_config;
 pub use self::{
     metrics::{Metrics, StunMetrics},
     streams::MaybeTlsStream as MaybeTlsStreamServer,

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -156,7 +156,7 @@ pub struct TlsConfig<EC: fmt::Debug, EA: fmt::Debug = EC> {
     ///
     /// Normally you'd choose port `80`.
     pub https_bind_addr: SocketAddr,
-    /// The socket address on which to server the QUIC server.
+    /// The socket address on which to server the QUIC server is QUIC is enabled.
     pub quic_bind_addr: SocketAddr,
     /// Mode for getting a cert.
     pub cert: CertConfig<EC, EA>,

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -493,6 +493,7 @@ async fn relay_supervisor(
         ret = tasks.join_next(), if tasks.len() > 0 => ret.expect("checked"),
         ret = &mut quic_fut, if quic_enabled => ret.map(anyhow::Ok),
         ret = &mut relay_fut, if relay_enabled => ret.map(anyhow::Ok),
+        else => Ok(Err(anyhow!("No relay services are enabled."))),
     };
     let ret = match res {
         Ok(Ok(())) => {

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -46,7 +46,7 @@ use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument
 use crate::{
     http::RELAY_PROBE_PATH,
     protos,
-    quic::{QuicServer, ServerHandle as QuicServerHandle},
+    quic::server::{QuicServer, ServerHandle as QuicServerHandle},
 };
 
 pub(crate) mod actor;
@@ -497,7 +497,7 @@ impl Server {
 async fn relay_supervisor(
     mut tasks: JoinSet<Result<()>>,
     mut relay_http_server: Option<http_server::Server>,
-    mut quic_server: Option<crate::quic::QuicServer>,
+    mut quic_server: Option<QuicServer>,
 ) -> Result<()> {
     let res = match (
         relay_http_server.as_mut(),

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -490,7 +490,7 @@ async fn relay_supervisor(
     };
     let res = tokio::select! {
         biased;
-        ret = tasks.join_next(), if tasks.len() > 0 => ret.expect("checked"),
+        ret = tasks.join_next(), if !tasks.is_empty() => ret.expect("checked"),
         ret = &mut quic_fut, if quic_enabled => ret.map(anyhow::Ok),
         ret = &mut relay_fut, if relay_enabled => ret.map(anyhow::Ok),
         else => Ok(Err(anyhow!("No relay services are enabled."))),

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -60,7 +60,6 @@ pub mod testing;
 
 #[cfg(feature = "dangerous-certs")]
 pub use self::testing::self_signed_tls_certs_and_config;
-
 pub use self::{
     metrics::{Metrics, StunMetrics},
     streams::MaybeTlsStream as MaybeTlsStreamServer,

--- a/iroh-relay/src/server/testing.rs
+++ b/iroh-relay/src/server/testing.rs
@@ -1,8 +1,6 @@
 //! Exposes functions to quickly configure a server suitable for testing.
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use quinn::crypto::rustls::QuicServerConfig;
-
 use super::{CertConfig, QuicConfig, RelayConfig, ServerConfig, StunConfig, TlsConfig};
 
 /// Creates a [`StunConfig`] suitable for testing.
@@ -17,7 +15,6 @@ pub fn stun_config() -> StunConfig {
 /// Creates a [`rustls::ServerConfig`] and certificates suitable for testing.
 ///
 /// - Uses a self signed certificate valid for the `"localhost"` and `"127.0.0.1"` domains.
-#[cfg(any(feature = "dangerous-certs", feature = "test-utils"))]
 pub fn self_signed_tls_certs_and_config() -> (
     Vec<rustls::pki_types::CertificateDer<'static>>,
     rustls::ServerConfig,
@@ -55,6 +52,7 @@ pub fn tls_config() -> TlsConfig<()> {
         server_config,
         cert: CertConfig::<(), ()>::Manual { certs },
         https_bind_addr: (Ipv4Addr::LOCALHOST, 0).into(),
+        quic_bind_addr: (Ipv4Addr::UNSPECIFIED, 0).into(),
     }
 }
 
@@ -77,7 +75,6 @@ pub fn relay_config() -> RelayConfig<()> {
 /// - Uses [`self_signed_tls_certs_and_config`] to create tls certificates
 pub fn quic_config() -> QuicConfig {
     let (_, server_config) = self_signed_tls_certs_and_config();
-    let server_config = QuicServerConfig::try_from(server_config).unwrap();
     QuicConfig {
         bind_addr: (Ipv6Addr::UNSPECIFIED, 0).into(),
         server_config,

--- a/iroh-relay/src/server/testing.rs
+++ b/iroh-relay/src/server/testing.rs
@@ -1,7 +1,9 @@
 //! Exposes functions to quickly configure a server suitable for testing.
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
-use super::{CertConfig, RelayConfig, ServerConfig, StunConfig, TlsConfig};
+use quinn::crypto::rustls::QuicServerConfig;
+
+use super::{CertConfig, QuicConfig, RelayConfig, ServerConfig, StunConfig, TlsConfig};
 
 /// Creates a [`StunConfig`] suitable for testing.
 ///
@@ -12,20 +14,46 @@ pub fn stun_config() -> StunConfig {
     }
 }
 
+/// Creates a [`rustls::ServerConfig`] and certificates suitable for testing.
+///
+/// - Uses a self signed certificate valid for the `"localhost"` and `"127.0.0.1"` domains.
+#[cfg(any(feature = "dangerous-certs", feature = "test-utils"))]
+pub fn self_signed_tls_certs_and_config() -> (
+    Vec<rustls::pki_types::CertificateDer<'static>>,
+    rustls::ServerConfig,
+) {
+    let cert = rcgen::generate_simple_self_signed(vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ])
+    .expect("valid");
+    let rustls_cert = cert.cert.der();
+    let private_key = rustls::pki_types::PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+    let private_key = rustls::pki_types::PrivateKeyDer::from(private_key);
+    let certs = vec![rustls_cert.clone()];
+    let server_config = rustls::ServerConfig::builder_with_provider(std::sync::Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("protocols supported by ring")
+    .with_no_client_auth();
+
+    let server_config = server_config
+        .with_single_cert(certs.clone(), private_key)
+        .expect("valid");
+    (certs, server_config)
+}
+
 /// Creates a [`TlsConfig`] suitable for testing.
 ///
 /// - Uses a self signed certificate valid for the `"localhost"` and `"127.0.0.1"` domains.
 /// - Configures https to be served on an OS assigned port on ipv4.
 pub fn tls_config() -> TlsConfig<()> {
-    let cert =
-        rcgen::generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
-            .expect("valid");
-    let rustls_cert = cert.cert.der();
-    let private_key = rustls::pki_types::PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
-    let private_key = rustls::pki_types::PrivateKeyDer::from(private_key);
-    let certs = vec![rustls_cert.clone()];
+    let (certs, server_config) = self_signed_tls_certs_and_config();
     TlsConfig {
-        cert: CertConfig::<(), ()>::Manual { private_key, certs },
+        server_config,
+        cert: CertConfig::<(), ()>::Manual { certs },
         https_bind_addr: (Ipv4Addr::LOCALHOST, 0).into(),
     }
 }
@@ -43,15 +71,30 @@ pub fn relay_config() -> RelayConfig<()> {
     }
 }
 
+/// Creates a [`QuicConfig`] suitable for testing.
+///
+/// - Binds to an OS assigned port on ipv6 and ipv4, if dual stack is enabled.
+/// - Uses [`self_signed_tls_certs_and_config`] to create tls certificates
+pub fn quic_config() -> QuicConfig {
+    let (_, server_config) = self_signed_tls_certs_and_config();
+    let server_config = QuicServerConfig::try_from(server_config).unwrap();
+    QuicConfig {
+        bind_addr: (Ipv6Addr::UNSPECIFIED, 0).into(),
+        server_config,
+    }
+}
+
 /// Creates a [`ServerConfig`] suitable for testing.
 ///
 /// - Relaying is enabled using [`relay_config`]
 /// - Stun is enabled using [`stun_config`]
+/// - QUIC addr discovery is disabled.
 /// - Metrics are not enabled.
 pub fn server_config() -> ServerConfig<()> {
     ServerConfig {
         relay: Some(relay_config()),
         stun: Some(stun_config()),
+        quic: Some(quic_config()),
         #[cfg(feature = "metrics")]
         metrics_addr: None,
     }

--- a/iroh/src/defaults.rs
+++ b/iroh/src/defaults.rs
@@ -8,7 +8,13 @@ use crate::{RelayMap, RelayNode};
 ///
 /// The STUN port as defined by [RFC
 /// 8489](<https://www.rfc-editor.org/rfc/rfc8489#section-18.6>)
-pub const DEFAULT_STUN_PORT: u16 = 3478;
+pub use iroh_base::relay_map::DEFAULT_STUN_PORT;
+
+/// The default QUIC port used by the Relay server to accept QUIC connections
+/// for QUIC address discovery
+///
+/// The port is "QUIC" typed on a phone keypad.
+pub use iroh_base::relay_map::DEFAULT_QUIC_PORT;
 
 /// The default HTTP port used by the Relay server.
 pub const DEFAULT_HTTP_PORT: u16 = 80;
@@ -50,6 +56,7 @@ pub mod prod {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
+            quic_port: DEFAULT_QUIC_PORT,
         }
     }
 
@@ -63,6 +70,7 @@ pub mod prod {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
+            quic_port: DEFAULT_QUIC_PORT,
         }
     }
 
@@ -76,6 +84,7 @@ pub mod prod {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
+            quic_port: DEFAULT_QUIC_PORT,
         }
     }
 }
@@ -109,6 +118,7 @@ pub mod staging {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
+            quic_port: DEFAULT_QUIC_PORT,
         }
     }
 
@@ -122,6 +132,7 @@ pub mod staging {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
+            quic_port: DEFAULT_QUIC_PORT,
         }
     }
 }

--- a/iroh/src/defaults.rs
+++ b/iroh/src/defaults.rs
@@ -5,7 +5,7 @@ use iroh_base::relay_map::QuicConfig;
 /// for QUIC address discovery
 ///
 /// The port is "QUIC" typed on a phone keypad.
-pub use iroh_base::relay_map::DEFAULT_QUIC_PORT as DEFAULT_RELAY_QUIC_PORT;
+pub use iroh_base::relay_map::DEFAULT_RELAY_QUIC_PORT;
 /// The default STUN port used by the Relay server.
 ///
 /// The STUN port as defined by [RFC

--- a/iroh/src/defaults.rs
+++ b/iroh/src/defaults.rs
@@ -1,5 +1,6 @@
 //! Default values used in [`iroh`][`crate`]
 
+use iroh_base::relay_map::QuicConfig;
 /// The default QUIC port used by the Relay server to accept QUIC connections
 /// for QUIC address discovery
 ///
@@ -25,6 +26,8 @@ pub const DEFAULT_METRICS_PORT: u16 = 9090;
 
 /// Production configuration.
 pub mod prod {
+    use iroh_base::relay_map::QuicConfig;
+
     use super::*;
 
     /// Hostname of the default NA relay.
@@ -54,7 +57,7 @@ pub mod prod {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
-            quic_port: DEFAULT_QUIC_PORT,
+            quic: Some(QuicConfig::default()),
         }
     }
 
@@ -68,7 +71,7 @@ pub mod prod {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
-            quic_port: DEFAULT_QUIC_PORT,
+            quic: Some(QuicConfig::default()),
         }
     }
 
@@ -82,7 +85,7 @@ pub mod prod {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
-            quic_port: DEFAULT_QUIC_PORT,
+            quic: Some(QuicConfig::default()),
         }
     }
 }
@@ -116,7 +119,7 @@ pub mod staging {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
-            quic_port: DEFAULT_QUIC_PORT,
+            quic: Some(QuicConfig::default()),
         }
     }
 
@@ -130,7 +133,7 @@ pub mod staging {
             url: url.into(),
             stun_only: false,
             stun_port: DEFAULT_STUN_PORT,
-            quic_port: DEFAULT_QUIC_PORT,
+            quic: Some(QuicConfig::default()),
         }
     }
 }

--- a/iroh/src/defaults.rs
+++ b/iroh/src/defaults.rs
@@ -5,7 +5,7 @@ use iroh_base::relay_map::QuicConfig;
 /// for QUIC address discovery
 ///
 /// The port is "QUIC" typed on a phone keypad.
-pub use iroh_base::relay_map::DEFAULT_QUIC_PORT;
+pub use iroh_base::relay_map::DEFAULT_QUIC_PORT as DEFAULT_RELAY_QUIC_PORT;
 /// The default STUN port used by the Relay server.
 ///
 /// The STUN port as defined by [RFC

--- a/iroh/src/defaults.rs
+++ b/iroh/src/defaults.rs
@@ -1,20 +1,18 @@
 //! Default values used in [`iroh`][`crate`]
 
-use url::Url;
-
-use crate::{RelayMap, RelayNode};
-
-/// The default STUN port used by the Relay server.
-///
-/// The STUN port as defined by [RFC
-/// 8489](<https://www.rfc-editor.org/rfc/rfc8489#section-18.6>)
-pub use iroh_base::relay_map::DEFAULT_STUN_PORT;
-
 /// The default QUIC port used by the Relay server to accept QUIC connections
 /// for QUIC address discovery
 ///
 /// The port is "QUIC" typed on a phone keypad.
 pub use iroh_base::relay_map::DEFAULT_QUIC_PORT;
+/// The default STUN port used by the Relay server.
+///
+/// The STUN port as defined by [RFC
+/// 8489](<https://www.rfc-editor.org/rfc/rfc8489#section-18.6>)
+pub use iroh_base::relay_map::DEFAULT_STUN_PORT;
+use url::Url;
+
+use crate::{RelayMap, RelayNode};
 
 /// The default HTTP port used by the Relay server.
 pub const DEFAULT_HTTP_PORT: u16 = 80;

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1894,7 +1894,7 @@ mod tests {
     #[tokio::test]
     async fn test_direct_addresses_no_stun_relay() {
         let _guard = iroh_test::logging::setup();
-        let (relay_map, _, _guard) = run_relay_server_with(None).await.unwrap();
+        let (relay_map, _, _guard) = run_relay_server_with(None, false).await.unwrap();
 
         let ep = Endpoint::builder()
             .alpns(vec![TEST_ALPN.to_vec()])

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1636,7 +1636,7 @@ mod tests {
                         .await
                         .unwrap();
                     let eps = ep.bound_sockets();
-                    info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "server bound");
+                    info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "server listening on");
                     for i in 0..n_clients {
                         let now = Instant::now();
                         println!("[server] round {}", i + 1);

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -92,10 +92,9 @@ pub async fn run_relay_server_with(
     let url: RelayUrl = format!("https://{}", server.https_addr().expect("configured"))
         .parse()
         .unwrap();
-    let quic = match server.quic_addr() {
-        Some(addr) => Some(iroh_base::relay_map::QuicConfig { port: addr.port() }),
-        None => None,
-    };
+    let quic = server
+        .quic_addr()
+        .map(|addr| iroh_base::relay_map::QuicConfig { port: addr.port() });
     let m = RelayMap::from_nodes([RelayNode {
         url: url.clone(),
         stun_only: false,

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -4,6 +4,7 @@ use std::net::Ipv4Addr;
 use anyhow::Result;
 pub use dns_and_pkarr_servers::DnsPkarrServer;
 pub use dns_server::create_dns_resolver;
+use iroh_base::relay_map::DEFAULT_QUIC_PORT;
 use iroh_relay::server::{
     CertConfig, QuicConfig, RelayConfig, Server, ServerConfig, StunConfig, TlsConfig,
 };
@@ -67,7 +68,7 @@ pub async fn run_relay_server_with(
         Some(QuicConfig::new(
             server_config.clone(),
             "127.0.0.1".parse()?,
-            None,
+            Some(0),
         )?)
     } else {
         None
@@ -95,7 +96,7 @@ pub async fn run_relay_server_with(
         url: url.clone(),
         stun_only: false,
         stun_port: server.stun_addr().map_or(DEFAULT_STUN_PORT, |s| s.port()),
-        quic_port: 0,
+        quic_port: server.quic_addr().map_or(DEFAULT_QUIC_PORT, |s| s.port()),
     }])
     .unwrap();
     Ok((m, url, server))

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -92,11 +92,14 @@ pub async fn run_relay_server_with(
     let url: RelayUrl = format!("https://{}", server.https_addr().expect("configured"))
         .parse()
         .unwrap();
+    let quic = Some(iroh_base::relay_map::QuicConfig {
+        port: server.quic_addr().map_or(DEFAULT_QUIC_PORT, |s| s.port()),
+    });
     let m = RelayMap::from_nodes([RelayNode {
         url: url.clone(),
         stun_only: false,
         stun_port: server.stun_addr().map_or(DEFAULT_STUN_PORT, |s| s.port()),
-        quic_port: server.quic_addr().map_or(DEFAULT_QUIC_PORT, |s| s.port()),
+        quic,
     }])
     .unwrap();
     Ok((m, url, server))


### PR DESCRIPTION
## Description

This PR adds a QUIC endpoint to the relay server that can do QUIC address discovery. It also contains structs/functions for properly doing the Client side interaction for this process.

Also, this adjust the `RelayNode` to include configuration on how to speak to the QUIC endpoint on the relay server.

QUIC is disabled by default and requires a `TlsConfig` to be configured in order to work.

closes #2964 

## Breaking Changes

- `iroh_base::relay_map::RelayNode` now has field `quic` that takes a `Option<iroh_base::relay_map::QuicConfig>`
- `iroh::test_utils::run_relay_server_with(stun: Option<StunConfig>)` => `iroh::test_utils::run_relay_server_with(stun: Option<StunConfig>, quic: bool)`
    - when `quic` is `true`, it will start a quic server for QUIC address discovery, that has self signed tls certs for testing.
- `iroh_relay::server::ServerConfig` has field `quic` that takes a `Option<iroh_relay::server::QuicConfig>`
- `iroh_relay::server::TlsConfig.quic_bind_addr` is a new field that takes a `SocketAddr`
- `iroh_relay::server::TlsConfig.server_config` is a new field that takes a `rustls::ServerConfig`
- field `config` has been removed from variant `iroh_relay::server::CertConfig::LetsEncrypt`
- variant `iroh_relay::server::CertConfig::LetsEncrypt` has a new field `state` that takes a `tokio_rustls_acme::AcmeState<EC, EA>`
- variant `iroh_relay::server::CertConfig::Manual` no longer has field `private_key`

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
