### PR TITLE
Not even WIP - protocol and protocolhandler split

### DIFF
--- a/iroh-router/src/lib.rs
+++ b/iroh-router/src/lib.rs
@@ -1,5 +1,5 @@
 mod protocol;
 mod router;
 
-pub use protocol::{ProtocolHandler, ProtocolMap};
+pub use protocol::{Protocol, ProtocolHandler, ProtocolMap};
 pub use router::{Router, RouterBuilder};

--- a/iroh-router/src/protocol.rs
+++ b/iroh-router/src/protocol.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use anyhow::Result;
 use futures_buffered::join_all;
@@ -14,7 +14,7 @@ use iroh_net::endpoint::Connecting;
 /// Implement this trait on a struct that should handle incoming connections.
 /// The protocol handler must then be registered on the node for an ALPN protocol with
 /// [`crate::RouterBuilder::accept`].
-pub trait ProtocolHandler: Send + Sync + IntoArcAny + std::fmt::Debug + 'static {
+pub trait ProtocolHandler: Send + Sync + std::fmt::Debug + 'static {
     /// Handle an incoming connection.
     ///
     /// This runs on a freshly spawned tokio task so this can be long-running.
@@ -28,19 +28,6 @@ pub trait ProtocolHandler: Send + Sync + IntoArcAny + std::fmt::Debug + 'static 
 
 pub trait Protocol: Sized {
     fn protocol_handler(&self) -> Arc<dyn ProtocolHandler>;
-}
-
-/// Helper trait to facilite casting from `Arc<dyn T>` to `Arc<dyn Any>`.
-///
-/// This trait has a blanket implementation so there is no need to implement this yourself.
-pub trait IntoArcAny {
-    fn into_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
-}
-
-impl<T: Send + Sync + 'static> IntoArcAny for T {
-    fn into_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
-        self
-    }
 }
 
 /// A typed map of protocol handlers, mapping them from ALPNs.

--- a/iroh-router/src/protocol.rs
+++ b/iroh-router/src/protocol.rs
@@ -28,14 +28,6 @@ pub trait ProtocolHandler: Send + Sync + IntoArcAny + std::fmt::Debug + 'static 
 
 pub trait Protocol: Sized {
     fn protocol_handler(&self) -> Arc<dyn ProtocolHandler>;
-    fn from_protocol_handler(handler: Arc<dyn ProtocolHandler>) -> Option<Self>;
-
-    fn downcast_via<T: Any + Send + Sync>(handler: Arc<dyn ProtocolHandler>) -> Option<Self>
-    where
-        Self: From<Arc<T>>
-    {
-        Some(Self::from(handler.into_arc_any().downcast::<T>().ok()?))
-    }
 }
 
 /// Helper trait to facilite casting from `Arc<dyn T>` to `Arc<dyn Any>`.
@@ -56,12 +48,6 @@ impl<T: Send + Sync + 'static> IntoArcAny for T {
 pub struct ProtocolMap(BTreeMap<Vec<u8>, Arc<dyn ProtocolHandler>>);
 
 impl ProtocolMap {
-    /// Returns the registered protocol handler for an ALPN as a concrete type.
-    pub fn get_typed<P: Protocol>(&self, alpn: &[u8]) -> Option<P> {
-        let protocol: Arc<dyn ProtocolHandler> = self.0.get(alpn)?.clone();
-        P::from_protocol_handler(protocol)
-    }
-
     /// Returns the registered protocol handler for an ALPN as a [`Arc<dyn ProtocolHandler>`].
     pub fn get(&self, alpn: &[u8]) -> Option<Arc<dyn ProtocolHandler>> {
         self.0.get(alpn).cloned()

--- a/iroh-router/src/protocol.rs
+++ b/iroh-router/src/protocol.rs
@@ -29,6 +29,13 @@ pub trait ProtocolHandler: Send + Sync + IntoArcAny + std::fmt::Debug + 'static 
 pub trait Protocol: Sized {
     fn protocol_handler(&self) -> Arc<dyn ProtocolHandler>;
     fn from_protocol_handler(handler: Arc<dyn ProtocolHandler>) -> Option<Self>;
+
+    fn downcast_via<T: Any + Send + Sync>(handler: Arc<dyn ProtocolHandler>) -> Option<Self>
+    where
+        Self: From<Arc<T>>
+    {
+        Some(Self::from(handler.into_arc_any().downcast::<T>().ok()?))
+    }
 }
 
 /// Helper trait to facilite casting from `Arc<dyn T>` to `Arc<dyn Any>`.

--- a/iroh-router/src/router.rs
+++ b/iroh-router/src/router.rs
@@ -10,7 +10,7 @@ use tokio::task::{JoinError, JoinSet};
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
 use tracing::{debug, error, warn};
 
-use crate::{Protocol, ProtocolHandler, ProtocolMap};
+use crate::{Protocol, ProtocolMap};
 
 #[derive(Clone, Debug)]
 pub struct Router {

--- a/iroh/examples/ping.rs
+++ b/iroh/examples/ping.rs
@@ -1,0 +1,82 @@
+use std::{str::FromStr, sync::Arc};
+
+use futures_lite::future;
+use iroh_net::{endpoint, Endpoint, NodeId};
+use iroh_router::{Protocol, ProtocolHandler};
+
+#[derive(Debug)]
+struct Ping(Arc<PingInner>);
+
+const ALPN: &[u8] = b"ping";
+
+impl Ping {
+    fn new(endpoint: Endpoint) -> Self {
+        Self(Arc::new(PingInner { endpoint }))
+    }
+
+    async fn ping(&self, target: NodeId) -> anyhow::Result<()> {
+        let conn = self.0.endpoint.connect(target, ALPN).await?;
+        let (mut send, mut recv) = conn.open_bi().await?;
+        let request = b"Ping".to_vec();
+        send.write_all(&request).await?;
+        send.finish()?;
+        let response = recv.read_to_end(1024).await?;
+        println!("got response: {:?}", String::from_utf8_lossy(&response));
+        Ok(())
+    }
+}
+
+impl ProtocolHandler for PingInner {
+    fn accept(self: Arc<Self>, conn: iroh_net::endpoint::Connecting) -> future::Boxed<anyhow::Result<()>> {
+        Box::pin(async move {
+            let conn = conn.await?;
+            let (mut send, mut recv) = conn.accept_bi().await?;
+            let request = recv.read_to_end(1024).await?;
+            println!("got request: {:?}", String::from_utf8_lossy(&request));
+            let response = b"Pong".to_vec();
+            send.write_all(&response).await?;
+            send.finish()?;
+            conn.closed().await;
+            Ok(())
+        })
+    }
+}
+
+// todo: figure out a way to derive this?
+impl Protocol for Ping {
+    fn protocol_handler(&self) -> Arc<dyn iroh_router::ProtocolHandler> {
+        self.0.clone()
+    }
+
+    fn from_protocol_handler(handler: Arc<dyn iroh_router::ProtocolHandler>) -> Option<Self> {
+        Some(Self(handler.into_arc_any().downcast::<PingInner>().ok()?))
+    }
+}
+
+#[derive(Debug)]
+struct PingInner {
+    endpoint: Endpoint,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+    if let Some(target) = std::env::args().nth(1) {
+        let nodeid = iroh::net::NodeId::from_str(&target)?;
+        let endpoint = iroh::net::Endpoint::builder().discovery_n0().bind().await?;
+        let ping = Ping::new(endpoint);
+        ping.ping(nodeid).await?;
+    } else {
+        println!("Staring ping server");
+        let endpoint = iroh::net::Endpoint::builder().discovery_n0().bind().await?;
+        let builder = iroh::router::Router::builder(endpoint.clone());
+        let ping = Ping::new(endpoint);
+        let builder = builder.accept(ALPN, &ping);
+        let router = builder.spawn().await?;
+        let t = router.get_protocol::<Ping>(&ALPN).unwrap();
+        println!("Listening for pings on {}", router.endpoint().node_id());
+        tokio::signal::ctrl_c().await?;
+        router.shutdown().await?;
+    }
+    Ok(())
+}

--- a/iroh/examples/ping.rs
+++ b/iroh/examples/ping.rs
@@ -5,9 +5,15 @@ use iroh_net::{endpoint, Endpoint, NodeId};
 use iroh_router::{Protocol, ProtocolHandler};
 
 #[derive(Debug)]
-struct Ping(Arc<PingInner>);
+pub struct Ping(Arc<PingInner>);
 
 const ALPN: &[u8] = b"ping";
+
+impl From<Arc<PingInner>> for Ping {
+    fn from(inner: Arc<PingInner>) -> Self {
+        Self(inner)
+    }
+}
 
 impl Ping {
     fn new(endpoint: Endpoint) -> Self {
@@ -49,7 +55,7 @@ impl Protocol for Ping {
     }
 
     fn from_protocol_handler(handler: Arc<dyn iroh_router::ProtocolHandler>) -> Option<Self> {
-        Some(Self(handler.into_arc_any().downcast::<PingInner>().ok()?))
+        Self::downcast_via::<PingInner>(handler)
     }
 }
 

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -52,7 +52,7 @@ use iroh_net::{
     endpoint::{DirectAddrsStream, RemoteInfo},
     AddrInfo, Endpoint, NodeAddr,
 };
-use iroh_router::{ProtocolHandler, Router};
+use iroh_router::{Protocol, ProtocolHandler, Router};
 use quic_rpc::{transport::Listener as _, RpcServer};
 use tokio::task::{JoinError, JoinSet};
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
@@ -210,7 +210,7 @@ impl Node {
     ///
     /// This downcasts to the concrete type and returns `None` if the handler registered for `alpn`
     /// does not match the passed type.
-    pub fn get_protocol<P: ProtocolHandler>(&self, alpn: &[u8]) -> Option<Arc<P>> {
+    pub fn get_protocol<P: Protocol>(&self, alpn: &[u8]) -> Option<P> {
         self.router.get_protocol(alpn)
     }
 }

--- a/iroh/src/node.rs
+++ b/iroh/src/node.rs
@@ -52,7 +52,7 @@ use iroh_net::{
     endpoint::{DirectAddrsStream, RemoteInfo},
     AddrInfo, Endpoint, NodeAddr,
 };
-use iroh_router::{Protocol, ProtocolHandler, Router};
+use iroh_router::Router;
 use quic_rpc::{transport::Listener as _, RpcServer};
 use tokio::task::{JoinError, JoinSet};
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
@@ -101,6 +101,7 @@ pub struct Node {
     // - `AbortOnDropHandle` to make sure that the `task` is cancelled when all `Node`s are dropped
     //   (`Shared` acts like an `Arc` around its inner future).
     task: Shared<MapErr<AbortOnDropHandle<()>, JoinErrToStr>>,
+    #[allow(dead_code)]
     router: Router,
 }
 
@@ -204,14 +205,6 @@ impl Node {
     /// Returns a token that can be used to cancel the node.
     pub fn cancel_token(&self) -> CancellationToken {
         self.inner.cancel_token.clone()
-    }
-
-    /// Returns a protocol handler for an ALPN.
-    ///
-    /// This downcasts to the concrete type and returns `None` if the handler registered for `alpn`
-    /// does not match the passed type.
-    pub fn get_protocol<P: Protocol>(&self, alpn: &[u8]) -> Option<P> {
-        self.router.get_protocol(alpn)
     }
 }
 

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -604,14 +604,6 @@ impl ProtocolBuilder {
         &self.inner.endpoint
     }
 
-    /// Returns a protocol handler for an ALPN.
-    ///
-    /// This downcasts to the concrete type and returns `None` if the handler registered for `alpn`
-    /// does not match the passed type.
-    pub fn get_protocol<P: Protocol>(&self, alpn: &[u8]) -> Option<P> {
-        self.router.get_protocol::<P>(alpn)
-    }
-
     /// Spawns the node and starts accepting connections.
     pub async fn spawn(self) -> Result<Node> {
         let Self {

--- a/iroh/src/node/builder.rs
+++ b/iroh/src/node/builder.rs
@@ -17,7 +17,7 @@ use iroh_net::{
     endpoint::{force_staging_infra, TransportConfig},
     Endpoint, RelayMode,
 };
-use iroh_router::{ProtocolHandler, RouterBuilder};
+use iroh_router::{Protocol, RouterBuilder};
 use quic_rpc::transport::{boxed::BoxableListener, quinn::QuinnListener};
 use tokio::task::JoinError;
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
@@ -586,8 +586,8 @@ impl ProtocolBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn accept(mut self, alpn: impl AsRef<[u8]>, handler: Arc<dyn ProtocolHandler>) -> Self {
-        self.router = self.router.accept(alpn, handler);
+    pub fn accept(mut self, alpn: impl AsRef<[u8]>, protocol: &impl Protocol) -> Self {
+        self.router = self.router.accept(alpn, protocol);
         self
     }
 
@@ -608,7 +608,7 @@ impl ProtocolBuilder {
     ///
     /// This downcasts to the concrete type and returns `None` if the handler registered for `alpn`
     /// does not match the passed type.
-    pub fn get_protocol<P: ProtocolHandler>(&self, alpn: &[u8]) -> Option<Arc<P>> {
+    pub fn get_protocol<P: Protocol>(&self, alpn: &[u8]) -> Option<P> {
         self.router.get_protocol::<P>(alpn)
     }
 


### PR DESCRIPTION
## Description

I find it quite annoying that the natural form of ProtocolHandlers is Arced. Very frequently there are good reasons to have a split between an outer type and an inner type. Protocol structs are no exception.

So you will often have a situation where the protocol *itself* will consist of an Arc<ProtocolInner> and be cheaply cloneable, but also you need to wrap it in an Arc to make it work with the router accept. The alternative is having all methods in the protocol handler, even those that are unrelated to the protocol handling, take a `self: Arc<Self>`. The latter is super ugly and also requires lots of .clone()

So the idea here is:

a protocol *has* a protocol handler instead of *being* a protocol handler. RouterBuilder accept just takes a `&impl Protocol`, and calls a fn to get the handler. For the reverse direction, there is a fn on Protocol to get back from an Arc<dyn ProtocolHandler> to the *outer* type by downcasting to the inner type and then newtype wrapping.

```rust
pub fn accept(mut self, alpn: impl AsRef<[u8]>, protocol: &impl Protocol) -> Self
```

The result is that you don't have all these Arc<Self> in the public api of the protocol. It is just a struct that has an Arc<Inner> and is therefore cheaply cloneable if desired.

```rust
struct Ping(Arc<PingInner>);

impl Protocol for Ping { ...
```

The downside is that you have 2 concepts instead of one (Protocol and ProtocolHandler), and that you need to impl Protocol to do the downcast stuff (you could get rid of the latter somehow though).

```rust
pub fn get_protocol<P: Protocol>(&self, alpn: &[u8]) -> Option<P> // no arc!
```

Two more points to motivate why this ^ is good despite being a bit more complex.

1. Sometimes it is useful to have a Foo/FooInner split via a Box<dyn ...> or Arc<dyn ...> for *within* the protocol handler, e.g. to get rid of type parameters, e.g. go from Blobs<S> to just Blobs. By letting a protocol *have* a protocol handler instead of being a protocol handler, you allow handing out this inner arc instead of having a double dyn.

2. I think ergonomics and flexibility favours letting Protocols be cheaply cloneable newtypes around Arc<ProtocolInner> instead of wrapping in Arc by default. See https://github.com/n0-computer/iroh.computer/pull/232/files

---

As a second thought: I am not sure how useful the ability to get a concrete protocol struct by alpn and type is at all. In the situations where I have had protocol dependencies (docs building on gossip and blobs, most notably), you can look up the default blobs and gossip impl under the default ALPN, but I think there are many reasons for why you might want to have blobs and/or gossip for docs under a non-standard ALPN. And what then? Pass in the ALPNs to use? In that case you might as well pass in the protocol structs themselves.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
