### PR TITLE
chore: Remove `cc` version requirement & update lockfile to cc v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,9 +522,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "shlex",
 ]
@@ -2512,7 +2512,6 @@ dependencies = [
  "async-channel",
  "bao-tree",
  "bytes",
- "cc",
  "clap",
  "derive_more",
  "futures-buffered",
@@ -2564,7 +2563,6 @@ version = "0.28.0"
 dependencies = [
  "aead",
  "anyhow",
- "cc",
  "crypto_box",
  "data-encoding",
  "derive_more",
@@ -2691,7 +2689,6 @@ dependencies = [
  "backoff",
  "base64",
  "bytes",
- "cc",
  "clap",
  "criterion",
  "crypto_box",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.76"
 workspace = true
 
 [dependencies]
-cc = "=1.1.31" # enforce cc version, because of https://github.com/rust-lang/cc-rs/issues/1278
 anyhow = { version = "1" }
 blake3 = { version = "1.4.5", package = "iroh-blake3", optional = true }
 data-encoding = { version = "2.3.3", optional = true }

--- a/iroh-net/Cargo.toml
+++ b/iroh-net/Cargo.toml
@@ -16,8 +16,6 @@ rust-version = "1.76"
 workspace = true
 
 [dependencies]
-cc = "=1.1.31" # enforce cc version, because of https://github.com/rust-lang/cc-rs/issues/1278
-
 anyhow = { version = "1" }
 axum = { version = "0.7", optional = true }
 backoff = "0.4.0"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = "1.76"
 workspace = true
 
 [dependencies]
-cc = "=1.1.31" # enforce cc version, because of https://github.com/rust-lang/cc-rs/issues/1278
 anyhow = { version = "1" }
 async-channel = "2.3.1"
 bytes = "1.7"


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

This was getting in my way when I was trying to install both iroh & iroh-blobs from their main branches in a project.

<details>
<summary>cargo check output</summary>

```sh
$ cargo check
    Updating git repository `https://github.com/n0-computer/iroh`
    Updating git repository `https://github.com/n0-computer/iroh-blobs`
    Updating crates.io index
error: failed to select a version for `cc`.
    ... required by package `ring v0.17.8`
    ... which satisfies dependency `ring = "^0.17"` (locked to 0.17.8) of package `iroh-net v0.28.1`
    ... which satisfies dependency `iroh-net = "^0.28.1"` (locked to 0.28.1) of package `iroh v0.28.1 (https://github.com/n0-computer/iroh?branch=main#e675bbaf)`
    ... which satisfies dependency `iroh = "^0.28.1"` (locked to 0.28.1) of package `quickstart-iroh v0.1.0 (/home/philipp/program/work/quickstart-iroh)`
versions that meet the requirements `^1.0.83` (locked to 1.2.1) are: 1.2.1

all possible versions conflict with previously selected packages.

  previously selected package `cc v1.1.31`
    ... which satisfies dependency `cc = "=1.1.31"` of package `iroh v0.28.1 (https://github.com/n0-computer/iroh?branch=main#e675bbaf)`
    ... which satisfies dependency `iroh = "^0.28.1"` (locked to 0.28.1) of package `quickstart-iroh v0.1.0 (/home/philipp/program/work/quickstart-iroh)`

failed to select a version for `cc` which could resolve this conflict
```

</details>

Version 1.2 should now fix all the issues we had with it. @dignifiedquire can you check again that this doesn't break your build pretty please (I remember you [having issues before](https://discord.com/channels/949724860232392765/950683937661935667/1304050364076527646)).

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~
