### PR TITLE
refactor: cleanup internal dependency references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cast"
@@ -1109,18 +1109,6 @@ name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
-
-[[package]]
-name = "duct"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
-dependencies = [
- "libc",
- "once_cell",
- "os_pipe",
- "shared_child",
-]
 
 [[package]]
 name = "dyn-clone"
@@ -2437,7 +2425,7 @@ dependencies = [
  "iroh-quinn-proto",
  "iroh-quinn-udp",
  "iroh-relay",
- "iroh-test",
+ "iroh-test 0.28.0",
  "libc",
  "netdev",
  "netlink-packet-core",
@@ -2505,7 +2493,7 @@ dependencies = [
  "getrandom",
  "hex",
  "iroh-blake3",
- "iroh-test",
+ "iroh-test 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
  "postcard",
  "proptest",
@@ -2556,7 +2544,7 @@ dependencies = [
  "http 1.1.0",
  "iroh",
  "iroh-metrics",
- "iroh-test",
+ "iroh-test 0.28.0",
  "lru",
  "parking_lot",
  "pkarr",
@@ -2635,7 +2623,7 @@ dependencies = [
  "iroh-base",
  "iroh-metrics",
  "iroh-relay",
- "iroh-test",
+ "iroh-test 0.28.0",
  "netwatch",
  "once_cell",
  "portmapper",
@@ -2740,7 +2728,6 @@ dependencies = [
  "clap",
  "crypto_box",
  "derive_more",
- "duct",
  "futures-buffered",
  "futures-lite 2.5.0",
  "futures-sink",
@@ -2756,7 +2743,7 @@ dependencies = [
  "hyper-util",
  "iroh-base",
  "iroh-metrics",
- "iroh-test",
+ "iroh-test 0.28.0",
  "libc",
  "num_enum",
  "once_cell",
@@ -2797,6 +2784,18 @@ dependencies = [
 [[package]]
 name = "iroh-test"
 version = "0.28.0"
+dependencies = [
+ "anyhow",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "iroh-test"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f909a839e5aafd4c4ca473e6e143bacdd6a8483385e64186cacfa62e91f4081d"
 dependencies = [
  "anyhow",
  "tokio",
@@ -3464,16 +3463,6 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "os_pipe"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "overload"
@@ -4889,16 +4878,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shared_child"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,3 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 
 [workspace.lints.clippy]
 unused-async = "warn"
-
-# Temporary fix for dependencies
-[patch.crates-io]
-iroh = { path = "./iroh" }
-iroh-base = { path = "./iroh-base" }
-iroh-metrics = { path = "./iroh-metrics" }
-iroh-test = { path = "./iroh-test" }

--- a/iroh-base/src/relay_url.rs
+++ b/iroh-base/src/relay_url.rs
@@ -84,7 +84,7 @@ impl fmt::Debug for RelayUrl {
 /// output.
 struct DbgStr<'a>(&'a str);
 
-impl<'a> fmt::Debug for DbgStr<'a> {
+impl fmt::Debug for DbgStr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, r#""{}""#, self.0)
     }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -29,7 +29,7 @@ governor = "0.6.3" #needs new release of tower_governor for 0.7.0
 hickory-proto = "=0.25.0-alpha.2"
 hickory-server = { version = "=0.25.0-alpha.2", features = ["dns-over-rustls"] }
 http = "1.0.0"
-iroh-metrics = { version = "0.28.0" }
+iroh-metrics = { version = "0.28.0", path = "../iroh-metrics" }
 lru = "0.12.3"
 parking_lot = "0.12.1"
 pkarr = { version = "2.2.0", features = [ "async", "relay", "dht"], default-features = false }
@@ -60,8 +60,8 @@ z32 = "1.1.1"
 
 [dev-dependencies]
 hickory-resolver = "=0.25.0-alpha.2"
-iroh = { version = "0.28.0" }
-iroh-test = "0.28.0"
+iroh = { version = "0.28.0", path = "../iroh" }
+iroh-test = { version = "0.28.0", path = "../iroh-test" }
 pkarr = { version = "2.2.0", features = ["rand"] }
 
 [package.metadata.docs.rs]

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -22,8 +22,8 @@ derive_more = { version = "1.0.0", features = ["display"] }
 futures-buffered = "0.2.8"
 futures-lite = "2.3"
 hickory-resolver = "=0.25.0-alpha.2"
-iroh-base = { version = "0.28.0", default-features = false, features = ["relay"] }
-iroh-metrics = { version = "0.28.0", default-features = false, optional = true }
+iroh-base = { version = "0.28.0", path = "../iroh-base", default-features = false, features = ["relay"] }
+iroh-metrics = { version = "0.28.0", path = "../iroh-metrics", default-features = false, optional = true }
 iroh-relay = { version = "0.28", path = "../iroh-relay" }
 netwatch = { version = "0.1.0", path = "../net-tools/netwatch" }
 portmapper = { version = "0.1.0", path = "../net-tools/portmapper" }
@@ -39,7 +39,7 @@ url = { version = "2.4" }
 
 [dev-dependencies]
 iroh-relay = { version = "0.28", path = "../iroh-relay", features = ["test-utils", "server"] }
-iroh-test = "0.28.0"
+iroh-test = { version = "0.28.0", path = "../iroh-test" }
 once_cell = "1.18.0"
 pretty_assertions = "1.4"
 testresult = "0.4.0"

--- a/iroh-node-util/Cargo.toml
+++ b/iroh-node-util/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 anyhow = "1"
 clap = { version = "4", features = ["derive"], optional = true }
 tokio = "1"
-iroh = { path = "../iroh" }
+iroh = { version = "0.28.1", path = "../iroh" }
 tempfile = "3"
 strum = "0.26"
 nested_enum_utils = "0.1.0"

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -38,8 +38,8 @@ http = "1"
 http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
-iroh-base = { version = "0.28.0", features = ["key"] }
-iroh-metrics = { version = "0.28.0", default-features = false }
+iroh-base = { version = "0.28.0", path = "../iroh-base", features = ["key"] }
+iroh-metrics = { version = "0.28.0", path = "../iroh-metrics", default-features = false }
 libc = "0.2.139"
 num_enum = "0.7"
 once_cell = "1.18.0"
@@ -110,11 +110,8 @@ tokio = { version = "1", features = [
     "test-util",
 ] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-iroh-test = "0.28.0"
+iroh-test = { version = "0.28.0", path = "../iroh-test" }
 serde_json = "1"
-
-[build-dependencies]
-duct = "0.13.6"
 
 [features]
 default = ["metrics", "server"]

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -1,4 +1,16 @@
 //! This module implements the relaying protocol used the [`crate::server`] and [`crate::client`].
+//!
+//! Protocol flow:
+//!
+//! Login:
+//!  * client connects
+//!  * -> client sends `FrameType::ClientInfo`
+//!
+//!  Steady state:
+//!  * server occasionally sends `FrameType::KeepAlive` (or `FrameType::Ping`)
+//!  * client responds to any `FrameType::Ping` with a `FrameType::Pong`
+//!  * clients sends `FrameType::SendPacket`
+//!  * server then sends `FrameType::RecvPacket` to recipient
 
 use std::time::Duration;
 
@@ -51,21 +63,9 @@ pub(crate) const PER_CLIENT_READ_QUEUE_DEPTH: usize = 512;
 /// with nodes running earlier protocol versions.
 pub(crate) const PROTOCOL_VERSION: usize = 3;
 
-///
-/// Protocol flow:
-///
-/// Login:
-///  * client connects
-///  * -> client sends FrameType::ClientInfo
-///
-///  Steady state:
-///  * server occasionally sends FrameType::KeepAlive (or FrameType::Ping)
-///  * client responds to any FrameType::Ping with a FrameType::Pong
-///  * clients sends FrameType::SendPacket
-///  * server then sends FrameType::RecvPacket to recipient
-
+/// Indicates this IS the client's home node
 const PREFERRED: u8 = 1u8;
-/// indicates this is NOT the client's home node
+/// Indicates this IS NOT the client's home node
 const NOT_PREFERRED: u8 = 0u8;
 
 /// The one byte frame type at the beginning of the frame

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -44,7 +44,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
-iroh-base = { version = "0.28.0", features = ["key"] }
+iroh-base = { version = "0.28.0", features = ["key"], path = "../iroh-base" }
 iroh-relay = { version = "0.28", path = "../iroh-relay" }
 libc = "0.2.139"
 netdev = "0.31.0"
@@ -110,7 +110,7 @@ z32 = "1.0.3"
 net-report = { package = "iroh-net-report", path = "../iroh-net-report", version = "0.28" }
 
 # metrics
-iroh-metrics = { version = "0.28.0", default-features = false }
+iroh-metrics = { version = "0.28.0", path = "../iroh-metrics", default-features = false }
 strum = { version = "0.26", features = ["derive"] }
 
 # local-swarm-discovery
@@ -166,7 +166,7 @@ tokio = { version = "1", features = [
     "test-util",
 ] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-iroh-test = "0.28.0"
+iroh-test = { version = "0.28.0", path = "../iroh-test" }
 serde_json = "1"
 testresult = "0.4.0"
 iroh-relay = { version = "0.28", path = "../iroh-relay", features = ["test-utils", "server"] }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1070,7 +1070,7 @@ pub struct Accept<'a> {
     ep: Endpoint,
 }
 
-impl<'a> Future for Accept<'a> {
+impl Future for Accept<'_> {
     type Output = Option<Incoming>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {

--- a/net-tools/portmapper/Cargo.toml
+++ b/net-tools/portmapper/Cargo.toml
@@ -20,7 +20,7 @@ derive_more = { version = "1.0.0", features = ["debug", "display", "from", "try_
 futures-lite = "2.5"
 futures-util = "0.3.25"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
-iroh-metrics = { version = "0.28.0", default-features = false }
+iroh-metrics = { version = "0.28.0", path = "../../iroh-metrics", default-features = false }
 libc = "0.2.139"
 netwatch = { version = "0.1.0", path = "../netwatch" }
 num_enum = "0.7"


### PR DESCRIPTION
## Description

- no more patching
- always use local path deps for workspace dependencies
- fix clippy complaints on rust `1.83`

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
