### PR TITLE
fix(iroh-dns-server): remove accidental blocking from store

### DIFF
--- a/iroh-dns-server/src/store/signed_packets.rs
+++ b/iroh-dns-server/src/store/signed_packets.rs
@@ -81,7 +81,7 @@ impl SignedPacketStore {
 
     pub async fn get(&self, key: &PublicKeyBytes) -> Result<Option<SignedPacket>> {
         let db = self.db.clone();
-        let key = key.clone();
+        let key = *key;
         let res = tokio::task::spawn_blocking(move || {
             let tx = db.begin_read()?;
             let table = tx.open_table(SIGNED_PACKETS_TABLE)?;
@@ -93,7 +93,7 @@ impl SignedPacketStore {
 
     pub async fn remove(&self, key: &PublicKeyBytes) -> Result<bool> {
         let db = self.db.clone();
-        let key = key.clone();
+        let key = *key;
         tokio::task::spawn_blocking(move || {
             let tx = db.begin_write()?;
             let updated = {


### PR DESCRIPTION
## Description

I found this during investigations of #2972. It turned out that both blocking locks and blocking IO calls are being made in the dns servers store implementation

## Breaking Changes

None

## Notes & open questions

This might be not optimal, but it is the safest way to get rid of blocking the whole runtime for now.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
