### PR TITLE
feat(benchmark): iroh-dns-server write benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,6 +2528,7 @@ dependencies = [
  "base64-url",
  "bytes",
  "clap",
+ "criterion",
  "derive_more",
  "dirs-next",
  "futures-lite 2.5.0",

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -41,7 +41,7 @@ rustls-pemfile = { version = "2.1" }
 serde = { version = "1", features = ["derive"] }
 struct_iterable = "0.1.1"
 strum = { version = "0.26", features = ["derive"] }
-tokio = { version = "1.36.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = [
     "logging",
     "ring",
@@ -59,10 +59,15 @@ url = "2.5"
 z32 = "1.1.1"
 
 [dev-dependencies]
+criterion = "0.5.1"
 hickory-resolver = "=0.25.0-alpha.2"
 iroh = { version = "0.28.0", path = "../iroh" }
 iroh-test = { version = "0.28.0", path = "../iroh-test" }
 pkarr = { version = "2.2.0", features = ["rand"] }
+
+[[bench]]
+name = "write"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -1,0 +1,54 @@
+use anyhow::Result;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use iroh::discovery::pkarr::PkarrRelayClient;
+use iroh::dns::node_info::NodeInfo;
+use iroh::key::SecretKey;
+use iroh_dns_server::config::Config;
+use iroh_dns_server::server::Server;
+use iroh_dns_server::store::ZoneStore;
+use tokio::runtime::Runtime;
+
+const LOCALHOST_PKARR: &str = "http://localhost:8080/pkarr";
+
+async fn start_dns_server(config: Config) -> Result<Server> {
+    let store = ZoneStore::persistent(Config::signed_packet_store_path()?)?;
+    Server::spawn(config, store).await
+}
+
+fn benchmark_dns_server(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dns_server_writes");
+    for iters in [10 as u64, 100 as u64, 500 as u64].iter() {
+        group.throughput(Throughput::Elements(*iters));
+        group.bench_with_input(BenchmarkId::from_parameter(iters), iters, |b, &iters| {
+            b.iter(|| {
+                let rt = Runtime::new().unwrap();
+                rt.block_on(async move {
+                    let config = Config::load("./config.dev.toml").await.unwrap();
+                    let server = start_dns_server(config).await.unwrap();
+
+                    let secret_key = SecretKey::generate();
+                    let node_id = secret_key.public();
+
+                    let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");
+                    let relay_url = Some("http://localhost:8080".parse().unwrap());
+                    let pkarr = PkarrRelayClient::new(pkarr_relay);
+                    let node_info = NodeInfo::new(node_id, relay_url, Default::default());
+                    let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30).unwrap();
+
+                    let start = std::time::Instant::now();
+                    for _ in 0..iters {
+                        pkarr.publish(&signed_packet).await.unwrap();
+                    }
+                    let duration = start.elapsed();
+
+                    server.shutdown().await.unwrap();
+
+                    duration
+                })
+            });
+        });
+    }
+}
+
+criterion_group!(benches, benchmark_dns_server);
+criterion_main!(benches);

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -1,11 +1,7 @@
 use anyhow::Result;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use iroh::discovery::pkarr::PkarrRelayClient;
-use iroh::dns::node_info::NodeInfo;
-use iroh::key::SecretKey;
-use iroh_dns_server::config::Config;
-use iroh_dns_server::server::Server;
-use iroh_dns_server::store::ZoneStore;
+use iroh::{discovery::pkarr::PkarrRelayClient, dns::node_info::NodeInfo, key::SecretKey};
+use iroh_dns_server::{config::Config, server::Server, ZoneStore};
 use tokio::runtime::Runtime;
 
 const LOCALHOST_PKARR: &str = "http://localhost:8080/pkarr";

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -17,7 +17,8 @@ async fn start_dns_server(config: Config) -> Result<Server> {
 
 fn benchmark_dns_server(c: &mut Criterion) {
     let mut group = c.benchmark_group("dns_server_writes");
-    for iters in [10 as u64, 100 as u64, 500 as u64].iter() {
+    group.sample_size(10);
+    for iters in [10_u64, 100_u64, 250_u64, 1000_u64].iter() {
         group.throughput(Throughput::Elements(*iters));
         group.bench_with_input(BenchmarkId::from_parameter(iters), iters, |b, &iters| {
             b.iter(|| {

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -8,7 +8,7 @@ pub mod http;
 pub mod metrics;
 pub mod server;
 pub mod state;
-mod store;
+pub mod store;
 mod util;
 
 #[cfg(test)]

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -8,8 +8,11 @@ pub mod http;
 pub mod metrics;
 pub mod server;
 pub mod state;
-pub mod store;
+mod store;
 mod util;
+
+// Re-export to be able to construct your own dns-server
+pub use store::ZoneStore;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Description

Looking at the code paths I think this should give a decent benchmark for publishing dns records. 
On my M1 Max I get about 3k IOPS and 25-30 MB/s written in all the test runs and sit at ~165-170 publishes per second, which is far from ideal. This holds true even without the fixes in the parent branch.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
