### PR TITLE
feat(iroh-dns-server): Add evictable dns store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,6 +2347,7 @@ dependencies = [
  "serde",
  "struct_iterable",
  "strum",
+ "timedmap",
  "tokio",
  "tokio-rustls",
  "tokio-rustls-acme",
@@ -4928,6 +4929,12 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
+
+[[package]]
+name = "timedmap"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc430736149d1428180bd452a3fdc981a29e818ee7513929c7d4c73f24df778"
 
 [[package]]
 name = "tinystr"

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -32,7 +32,11 @@ http = "1.0.0"
 iroh-metrics = "0.29"
 lru = "0.12.3"
 parking_lot = "0.12.1"
-pkarr = { version = "2.2.0", features = [ "async", "relay", "dht"], default-features = false }
+pkarr = { version = "2.2.0", features = [
+    "async",
+    "relay",
+    "dht",
+], default-features = false }
 rcgen = "0.13"
 redb = "2.0.0"
 regex = "1.10.3"
@@ -41,6 +45,7 @@ rustls-pemfile = { version = "2.1" }
 serde = { version = "1", features = ["derive"] }
 struct_iterable = "0.1.1"
 strum = { version = "0.26", features = ["derive"] }
+timedmap = "1.0"
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = [
     "logging",

--- a/iroh-dns-server/src/config.rs
+++ b/iroh-dns-server/src/config.rs
@@ -44,9 +44,24 @@ pub struct Config {
     /// Config for the mainline lookup.
     pub mainline: Option<MainlineConfig>,
 
+    /// Type of store to use
+    pub store_type: StoreType,
+
     /// Config for pkarr rate limit
     #[serde(default)]
     pub pkarr_put_rate_limit: RateLimitConfig,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+/// Type of store what do I even write here
+pub enum StoreType {
+    /// A persistent store, packets are saved to disk.
+    Persistent,
+    /// An in-memory store, packets are not saved.
+    Memory,
+    /// An in-memory store, with a max age, in seconds, for packets. After this duration,
+    /// packets are removed.
+    Evictable(u32),
 }
 
 /// The config for the metrics server.
@@ -187,6 +202,7 @@ impl Default for Config {
                 rr_aaaa: None,
                 rr_ns: Some("ns1.irohdns.example.".to_string()),
             },
+            store_type: StoreType::Persistent,
             metrics: None,
             mainline: None,
             pkarr_put_rate_limit: RateLimitConfig::default(),

--- a/iroh-dns-server/src/store/evictable.rs
+++ b/iroh-dns-server/src/store/evictable.rs
@@ -1,0 +1,62 @@
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Result;
+use iroh_metrics::inc;
+use pkarr::SignedPacket;
+use timedmap::TimedMap;
+
+use crate::{metrics::Metrics, util::PublicKeyBytes};
+
+use super::SignedPacketStore;
+
+#[derive(Debug)]
+pub struct EvictableStore {
+    store: Arc<TimedMap<PublicKeyBytes, SignedPacket>>,
+    max_age: Duration,
+}
+
+impl EvictableStore {
+    pub fn new(max_age: Duration) -> Self {
+        let store = Arc::new(TimedMap::new());
+        Self { store, max_age }
+    }
+}
+
+impl SignedPacketStore for EvictableStore {
+    fn upsert(&self, packet: SignedPacket) -> Result<bool> {
+        let key = PublicKeyBytes::from_signed_packet(&packet);
+
+        let mut replaced = false;
+        if let Some(existing) = self.store.get(&key) {
+            if existing.more_recent_than(&packet) {
+                return Ok(false);
+            } else {
+                replaced = true;
+            }
+        }
+
+        self.store.insert(key, packet, self.max_age);
+
+        if replaced {
+            inc!(Metrics, store_packets_updated);
+        } else {
+            inc!(Metrics, store_packets_inserted);
+        }
+
+        Ok(true)
+    }
+
+    fn get(&self, key: &PublicKeyBytes) -> Result<Option<SignedPacket>> {
+        Ok(self.store.get(key))
+    }
+
+    fn remove(&self, key: &PublicKeyBytes) -> Result<bool> {
+        let updated = self.store.remove(key).is_some();
+
+        if updated {
+            inc!(Metrics, store_packets_removed)
+        }
+
+        Ok(updated)
+    }
+}

--- a/iroh-dns-server/src/store/persistent.rs
+++ b/iroh-dns-server/src/store/persistent.rs
@@ -1,0 +1,107 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use iroh_metrics::inc;
+use pkarr::SignedPacket;
+use redb::{Database, ReadableTable, TableDefinition};
+use tracing::info;
+
+use crate::{metrics::Metrics, util::PublicKeyBytes};
+
+use super::SignedPacketStore;
+
+pub type SignedPacketsKey = [u8; 32];
+const SIGNED_PACKETS_TABLE: TableDefinition<&SignedPacketsKey, &[u8]> =
+    TableDefinition::new("signed-packets-1");
+
+#[derive(Debug)]
+pub struct PersistentStore {
+    db: Database,
+}
+
+impl PersistentStore {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        info!("loading packet database from {}", path.to_string_lossy());
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create database directory at {}",
+                    path.to_string_lossy()
+                )
+            })?;
+        }
+        let db = Database::builder()
+            .create(path)
+            .context("failed to open packet database")?;
+        Self::open(db)
+    }
+
+    fn open(db: Database) -> Result<Self> {
+        let write_tx = db.begin_write()?;
+        {
+            let _table = write_tx.open_table(SIGNED_PACKETS_TABLE)?;
+        }
+        write_tx.commit()?;
+        Ok(Self { db })
+    }
+}
+
+impl SignedPacketStore for PersistentStore {
+    fn upsert(&self, packet: SignedPacket) -> Result<bool> {
+        let key = PublicKeyBytes::from_signed_packet(&packet);
+        let tx = self.db.begin_write()?;
+        let mut replaced = false;
+        {
+            let mut table = tx.open_table(SIGNED_PACKETS_TABLE)?;
+            if let Some(existing) = get_packet(&table, &key)? {
+                if existing.more_recent_than(&packet) {
+                    return Ok(false);
+                } else {
+                    replaced = true;
+                }
+            }
+            let value = packet.as_bytes();
+            table.insert(key.as_bytes(), &value[..])?;
+        }
+        tx.commit()?;
+        if replaced {
+            inc!(Metrics, store_packets_updated);
+        } else {
+            inc!(Metrics, store_packets_inserted);
+        }
+        Ok(true)
+    }
+
+    fn get(&self, key: &PublicKeyBytes) -> Result<Option<SignedPacket>> {
+        let tx = self.db.begin_read()?;
+        let table = tx.open_table(SIGNED_PACKETS_TABLE)?;
+        get_packet(&table, key)
+    }
+
+    fn remove(&self, key: &PublicKeyBytes) -> Result<bool> {
+        let tx = self.db.begin_write()?;
+        let updated = {
+            let mut table = tx.open_table(SIGNED_PACKETS_TABLE)?;
+            let did_remove = table.remove(key.as_bytes())?.is_some();
+            #[allow(clippy::let_and_return)]
+            did_remove
+        };
+        tx.commit()?;
+        if updated {
+            inc!(Metrics, store_packets_removed)
+        }
+        Ok(updated)
+    }
+}
+
+fn get_packet(
+    table: &impl ReadableTable<&'static SignedPacketsKey, &'static [u8]>,
+    key: &PublicKeyBytes,
+) -> Result<Option<SignedPacket>> {
+    let Some(row) = table.get(key.as_ref())? else {
+        return Ok(None);
+    };
+    let packet = SignedPacket::from_bytes(&row.value().to_vec().into())?;
+    Ok(Some(packet))
+}


### PR DESCRIPTION
## Description

Sort of some progress towards #2912, although for an in-memory store only. I don't think these changes can really be extended to a persistent one so it might be better to come up with a strategy that works for persistent and in-memory stores instead of this.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

To be honest I'm not sure why I refactored the store to be a trait - I think it's unlikely this dns server will actually be extended by others.  
I have also not tested this change at all, and I'm also not sure how the `StoreType` actually looks in a config file (but this is definitely something that should be configurable - a user can't use the existing in-memory store without modifying the hardcoded value and recompiling the server).

I'm not even particularly advocating for the `timedmap` crate here, I think we could use any implementation of a hashmap with eviction (https://crates.io/crates/delay_map, our own, etc.).  
Like previously mentioned, I'm more interested in trying to figure out if we think it's worth adding something of this kind now and figuring out a solution for cleaning up the persistent store later, or if we want to figure out a solution entirely built on `redb` to keep the differences in the implementation small

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
