### PR TITLE
fix(iroh): Poll all AsyncUdpSocket sources fairly

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -721,7 +721,7 @@ impl MagicSock {
 
     /// Process datagrams received from UDP sockets.
     ///
-    /// All the `bufs` and `metas` should have initialised packets in them.
+    /// All the `bufs` and `metas` should have initialized packets in them.
     ///
     /// This fixes up the datagrams to use the correct [`QuicMappedAddr`] and extracts DISCO
     /// packets, processing them inside the magic socket.

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -22,7 +22,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicUsize, Ordering},
         Arc, RwLock,
     },
     task::{Context, Poll, Waker},
@@ -187,7 +187,7 @@ pub(crate) struct MagicSock {
     network_recv_wakers: parking_lot::Mutex<Option<Waker>>,
     network_send_wakers: Arc<parking_lot::Mutex<Option<Waker>>>,
     /// Counter for ordering of [`MagicSock::poll_recv`] polling order.
-    poll_recv_counter: AtomicU64,
+    poll_recv_counter: AtomicUsize,
 
     /// The DNS resolver to be used in this magicsock.
     dns_resolver: DnsResolver,
@@ -1463,7 +1463,7 @@ impl Handle {
             relay_recv_receiver: parking_lot::Mutex::new(relay_recv_receiver),
             network_recv_wakers: parking_lot::Mutex::new(None),
             network_send_wakers: Arc::new(parking_lot::Mutex::new(None)),
-            poll_recv_counter: AtomicU64::new(0),
+            poll_recv_counter: AtomicUsize::new(0),
             actor_sender: actor_sender.clone(),
             ipv6_reported: Arc::new(AtomicBool::new(false)),
             relay_map,


### PR DESCRIPTION
## Description

The existing AsyncUdpSocket::poll_recv polled the UDP IPv4 socket
first, only if that has no datagrams would it poll UDP IPv6 and only
also that had no datagrams to deliver was the relay socket polled.

This highly favoured IPv4 relay traffic, potentially starving the
relay traffic.

This change makes it prefer a different source on each poll.  Meaning
if multiple sockets have data to deliver a fairer delivery happens.

Closes #2981.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

- Using Ordering::Relaxed is probably fine.  I believe normally
  this polling would only happen from a single task (the Quinn
  endpoint driver) and even if it was polled concurrently from
  different threads it would not be that bad and still an improvement
  on the current order.
  
- I'm not particularly fond of the implementation, but the macros is
  the best I could come up with.  Maybe there's something cleverer
  which can be done.  

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.