### PR TITLE
chore: bump netsim setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
       branch: ${{ github.ref }}
       max_workers: 4
       netsim_branch: "main"
-      sim_paths: "sims/iroh_v2/iroh.json,sims/integration_v2"
+      sim_paths: "sims/iroh/iroh.json,sims/integration"
       pr_number: ${{ github.event.pull_request.number || '' }}
 
   codespell:

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -39,7 +39,7 @@ jobs:
       branch: "main"
       max_workers: 1
       netsim_branch: "main"
-      sim_paths: "sims/iroh_v2,sims/integration_v2"
+      sim_paths: "sims/iroh,sims/integration"
       pr_number: ""
       publish_metrics: true
       build_profile: "optimized-release"
@@ -53,7 +53,7 @@ jobs:
       branch: ${{inputs.branch}}
       max_workers: 1
       netsim_branch: ${{inputs.netsim_branch}}
-      sim_paths: "sims/iroh_v2"
+      sim_paths: "sims/iroh"
       pr_number: ${{inputs.pr_number}}
       publish_metrics: false
       build_profile: "optimized-release"


### PR DESCRIPTION
## Description

The sims on `netsim` have been promoted and are replacing the old ones. PRs older than 2 weeks from main no longer work with netsim. A simple rebase should fix it where necessary. I'll leave this as is for another 2 weeks and then do the cleanup pass. 

This has the neat benefit of also dropping old fixture generation scripts which should drop netsim execution time by ~1 min.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
