### PR TITLE
feat!: reduce default feature dependents

### DIFF
--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -23,7 +23,7 @@ futures-buffered = "0.2.8"
 futures-lite = "2.3"
 hickory-resolver = "=0.25.0-alpha.2"
 iroh-base = { version = "0.29.0", path = "../iroh-base", default-features = false, features = ["relay"] }
-iroh-metrics = { version = "0.29.0", default-features = false, optional = true }
+iroh-metrics = { version = "0.29.0", default-features = false }
 iroh-relay = { version = "0.29", path = "../iroh-relay" }
 netwatch = { version = "0.2.0" }
 portmapper = { version = "0.2.0" }
@@ -47,7 +47,7 @@ tokio = { version = "1", default-features = false, features = ["test-util"] }
 
 [features]
 default = ["metrics"]
-metrics = ["dep:iroh-metrics"]
+metrics = ["iroh-metrics/metrics"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -26,7 +26,7 @@ iroh-base = { version = "0.29.0", path = "../iroh-base", default-features = fals
 iroh-metrics = { version = "0.29.0", default-features = false }
 iroh-relay = { version = "0.29", path = "../iroh-relay" }
 netwatch = { version = "0.2.0" }
-portmapper = { version = "0.2.0" }
+portmapper = { version = "0.2.0", default-features = false }
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false }
 rustls = { version = "0.23", default-features = false }
@@ -47,7 +47,7 @@ tokio = { version = "1", default-features = false, features = ["test-util"] }
 
 [features]
 default = ["metrics"]
-metrics = ["iroh-metrics/metrics"]
+metrics = ["iroh-metrics/metrics", "portmapper/metrics"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -29,12 +29,10 @@ use tracing::{debug, error, info_span, trace, warn, Instrument};
 
 mod defaults;
 mod dns;
-#[cfg(feature = "metrics")]
 mod metrics;
 mod ping;
 mod reportgen;
 
-#[cfg(feature = "metrics")]
 pub use metrics::Metrics;
 
 const FULL_REPORT_INTERVAL: Duration = Duration::from_secs(5 * 60);

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -116,7 +116,7 @@ iroh-test = { version = "0.29.0", path = "../iroh-test" }
 serde_json = "1"
 
 [features]
-default = ["metrics", "server"]
+default = ["metrics"]
 server = [
     "dep:tokio-rustls-acme",
     "dep:clap",
@@ -126,7 +126,7 @@ server = [
     "dep:tracing-subscriber",
     "dep:rcgen",
 ]
-metrics = ["iroh-metrics/metrics", "server"]
+metrics = ["iroh-metrics/metrics"]
 test-utils = []
 
 [[bin]]

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -11,8 +11,16 @@
 //! - [`protos::relay`]: The protocol used to communicate between relay servers and clients. It's a
 //!   revised version of the Designated Encrypted Relay for Packets (DERP) protocol written by
 //!   Tailscale.
-//! - [`server`]: A fully-fledged iroh-relay server over HTTP or HTTPS. Optionally will also
-//!   expose a stun endpoint and metrics.
+#![cfg_attr(
+    feature = "server",
+    doc = "- [`server`]: A fully-fledged iroh-relay server over HTTP or HTTPS."
+)]
+#![cfg_attr(
+    not(feature = "server"),
+    doc = "- `server`: A fully-fledged iroh-relay server over HTTP or HTTPS."
+)]
+//!
+//!    Optionally will also expose a stun endpoint and metrics. (requires the feature flag `server`)
 //! - [`client`]: A client for establishing connections to the relay.
 //! - *Server Binary*: A CLI for running your own relay server. It can be configured to also offer
 //!   STUN support and expose metrics.

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -1,4 +1,4 @@
-//! This module implements the relaying protocol used the [`crate::server`] and [`crate::client`].
+//! This module implements the relaying protocol used by the `server` and `client`.
 //!
 //! Protocol flow:
 //!

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -46,7 +46,7 @@ hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 iroh-base = { version = "0.29.0", features = ["key"], path = "../iroh-base" }
-iroh-relay = { version = "0.29", path = "../iroh-relay" }
+iroh-relay = { version = "0.29", path = "../iroh-relay", default-features = false }
 libc = "0.2.139"
 netdev = "0.31.0"
 netwatch = { version = "0.2.0" }
@@ -108,7 +108,7 @@ webpki = { package = "rustls-webpki", version = "0.102" }
 webpki-roots = "0.26"
 x509-parser = "0.16"
 z32 = "1.0.3"
-net-report = { package = "iroh-net-report", path = "../iroh-net-report", version = "0.29" }
+net-report = { package = "iroh-net-report", path = "../iroh-net-report", version = "0.29", default-features = false }
 
 # metrics
 iroh-metrics = { version = "0.29", default-features = false }
@@ -170,7 +170,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 iroh-test = { version = "0.29.0", path = "../iroh-test" }
 serde_json = "1"
 testresult = "0.4.0"
-iroh-relay = { version = "0.29", path = "../iroh-relay", features = ["test-utils", "server"] }
+iroh-relay = { version = "0.29", path = "../iroh-relay", default-features = false, features = ["test-utils", "server"] }
 
 [[bench]]
 name = "key"
@@ -178,7 +178,7 @@ harness = false
 
 [features]
 default = ["metrics", "discovery-pkarr-dht"]
-metrics = ["iroh-metrics/metrics"]
+metrics = ["iroh-metrics/metrics", "iroh-relay/metrics", "net-report/metrics"]
 test-utils = ["iroh-relay/test-utils", "iroh-relay/server", "dep:axum"]
 discovery-local-network = ["dep:swarm-discovery"]
 discovery-pkarr-dht = ["pkarr/dht", "dep:genawaiter"]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -77,6 +77,7 @@ ring = "0.17"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { version = "1", features = ["derive", "rc"] }
 smallvec = "1.11.1"
+strum = { version = "0.26", features = ["derive"] }
 socket2 = "0.5.3"
 stun-rs = "0.1.5"
 surge-ping = "0.8.0"
@@ -112,7 +113,6 @@ net-report = { package = "iroh-net-report", path = "../iroh-net-report", version
 
 # metrics
 iroh-metrics = { version = "0.29", default-features = false }
-strum = { version = "0.26", features = ["derive"] }
 
 # local-swarm-discovery
 swarm-discovery = { version = "0.2.1", optional = true }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -58,7 +58,7 @@ pkarr = { version = "2", default-features = false, features = [
     "async",
     "relay",
 ] }
-portmapper = { version = "0.2.0" }
+portmapper = { version = "0.2.0", default-features = false }
 postcard = { version = "1", default-features = false, features = [
     "alloc",
     "use-std",
@@ -178,7 +178,7 @@ harness = false
 
 [features]
 default = ["metrics", "discovery-pkarr-dht"]
-metrics = ["iroh-metrics/metrics", "iroh-relay/metrics", "net-report/metrics"]
+metrics = ["iroh-metrics/metrics", "iroh-relay/metrics", "net-report/metrics", "portmapper/metrics"]
 test-utils = ["iroh-relay/test-utils", "iroh-relay/server", "dep:axum"]
 discovery-local-network = ["dep:swarm-discovery"]
 discovery-pkarr-dht = ["pkarr/dht", "dep:genawaiter"]


### PR DESCRIPTION
## Description

- remove `relay/server` default feature
- set `metrics` feature as necessary

## Breaking Changes

- `server` is not a default feature in `iroh-relay` anymore

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
