### PR TITLE
chore(iroh, iroh-relay): Avoid a duplicate tungstenite dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,7 +2257,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tokio-tungstenite-wasm",
  "tokio-util",
  "tracing",
@@ -2538,7 +2538,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-rustls-acme",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tokio-tungstenite-wasm",
  "tokio-util",
  "toml",
@@ -5054,19 +5054,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.21.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5082,7 +5070,7 @@ dependencies = [
  "js-sys",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite 0.21.0",
+ "tokio-tungstenite",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -5305,24 +5293,6 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.1.0",
- "httparse",
- "log",
- "rand",
- "sha1",
- "thiserror 1.0.69",
  "utf-8",
 ]
 

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -83,7 +83,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
     "ring",
 ] }
 tokio-rustls-acme = { version = "0.6", optional = true }
-tokio-tungstenite = "0.24"
+tokio-tungstenite = "0.21" # avoid duplicating this dependency as long as tokio-tungstenite-wasm isn't updated
 tokio-tungstenite-wasm = "0.3"
 tokio-util = { version = "0.7", features = ["io-util", "io", "codec", "rt"] }
 toml = { version = "0.8", optional = true }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -97,7 +97,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
     "ring",
 ] }
 tokio-stream = { version = "0.1.15" }
-tokio-tungstenite = "0.24"
+tokio-tungstenite = "0.21" # avoid duplicating this dependency as long as tokio-tungstenite-wasm isn't updated
 tokio-tungstenite-wasm = "0.3"
 tokio-util = { version = "0.7", features = ["io-util", "io", "codec", "rt"] }
 tracing = "0.1"


### PR DESCRIPTION
## Description

Before we used to depend on both tungstenite version 0.21 as well as 0.24, because:
```
tungstenite v0.21.0
└── tokio-tungstenite v0.21.0
    └── tokio-tungstenite-wasm v0.3.1
        ├── iroh v0.29.0 (/home/philipp/program/work/iroh/iroh)
        └── iroh-relay v0.29.0 (/home/philipp/program/work/iroh/iroh-relay)
            ├── iroh v0.29.0 (/home/philipp/program/work/iroh/iroh)
            └── iroh-net-report v0.29.0 (/home/philipp/program/work/iroh/iroh-net-report)
                └── iroh v0.29.0 (/home/philipp/program/work/iroh/iroh)
tungstenite v0.24.0
└── tokio-tungstenite v0.24.0
    ├── iroh v0.29.0 (/home/philipp/program/work/iroh/iroh)
    └── iroh-relay v0.29.0 (/home/philipp/program/work/iroh/iroh-relay)
        ├── iroh v0.29.0 (/home/philipp/program/work/iroh/iroh)
        └── iroh-net-report v0.29.0 (/home/philipp/program/work/iroh/iroh-net-report)
            └── iroh v0.29.0 (/home/philipp/program/work/iroh/iroh)
```

Basically, `tokio-tungstenite-wasm` pulls in `0.21` and there's no newer version of it yet.
But we updated all our dependencies including `tungstenite`, duplicating it.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

I want this to be temporary until we can finally switch to `fasterwebsockets` entirely once it implements [`poll`-based methods](https://github.com/denoland/fastwebsockets/pull/78) (but I worry the project's maintenance is ... unclear).

I checked the [tungstenite changelog](https://github.com/snapview/tungstenite-rs/blob/master/CHANGELOG.md), and it doesn't look like there's anything critical in there. The `rustls` update doesn't affect us - we don't duplicate rustls versions after this rollback.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
