### PR TITLE
refactor(iroh-relay)!: Always allow acking pings

### DIFF
--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -116,9 +116,6 @@ pub enum ClientError {
     /// The ping request was aborted
     #[error("ping aborted")]
     PingAborted,
-    /// This [`Client`] cannot acknowledge pings
-    #[error("cannot acknowledge pings")]
-    CannotAckPings,
     /// The given [`Url`] is invalid
     #[error("invalid url: {0}")]
     InvalidUrl(String),

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -525,7 +525,6 @@ impl RelayActor {
                 let ipv6_reported = ipv6_reported.clone();
                 Box::pin(async move { ipv6_reported.load(Ordering::Relaxed) })
             })
-            .can_ack_pings(true)
             .is_preferred(my_relay.as_ref() == Some(url));
 
         #[cfg(any(test, feature = "test-utils"))]


### PR DESCRIPTION
## Description

The Client has a feature that stops it from sending pongs, it is
unused and I'm not sure when you'd need that functionality.  Remove it.

## Breaking Changes

### iroh-relay

- `ClientBuilder::can_ack_pings` is removed, sending pong messages is
  always allowed.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.