### PR TITLE
feat(iroh, iroh-relay)!: Remove `Endpoint::connect_by_node_id` and add `#[doc(cfg(...))]` annotations

### DIFF
--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -289,6 +289,7 @@ impl Frame {
 
     /// Serialized length with frame header.
     #[cfg(feature = "server")]
+    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "server")))]
     pub(crate) fn len_with_header(&self) -> usize {
         self.len() + HEADER_LEN
     }

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -13,6 +13,7 @@ pub const QUIC_ADDR_DISC_CLOSE_CODE: VarInt = VarInt::from_u32(1);
 pub const QUIC_ADDR_DISC_CLOSE_REASON: &[u8] = b"finished";
 
 #[cfg(feature = "server")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "server")))]
 pub(crate) mod server {
     use quinn::{crypto::rustls::QuicServerConfig, ApplicationClose};
     use tokio::task::JoinSet;

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -48,6 +48,7 @@ mod http_server;
 mod metrics;
 pub(crate) mod streams;
 #[cfg(feature = "test-utils")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "test-utils")))]
 pub mod testing;
 
 pub use self::{
@@ -447,6 +448,7 @@ impl Server {
     ///
     /// This uses [`Self::https_addr`] so it's mostly useful for local development.
     #[cfg(feature = "test-utils")]
+    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "test-utils")))]
     pub fn https_url(&self) -> Option<RelayUrl> {
         self.https_addr.map(|addr| {
             url::Url::parse(&format!("https://{addr}"))
@@ -459,6 +461,7 @@ impl Server {
     ///
     /// This uses [`Self::http_addr`] so it's mostly useful for local development.
     #[cfg(feature = "test-utils")]
+    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "test-utils")))]
     pub fn http_url(&self) -> Option<RelayUrl> {
         self.http_addr.map(|addr| {
             url::Url::parse(&format!("http://{addr}"))

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -307,6 +307,7 @@ impl Builder {
     }
 
     #[cfg(feature = "discovery-pkarr-dht")]
+    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "discovery-pkarr-dht")))]
     /// Configures the endpoint to also use the mainline DHT with default settings.
     ///
     /// This is equivalent to adding a [`crate::discovery::pkarr::dht::DhtDiscovery`]
@@ -327,6 +328,7 @@ impl Builder {
     }
 
     #[cfg(feature = "discovery-local-network")]
+    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "discovery-local-network")))]
     /// Configures the endpoint to also use local network discovery.
     ///
     /// This is equivalent to adding a [`crate::discovery::local_swarm_discovery::LocalSwarmDiscovery`]

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -620,21 +620,6 @@ impl Endpoint {
         conn
     }
 
-    /// Connects to a remote endpoint, using just the nodes's [`NodeId`].
-    ///
-    /// This is a convenience function for [`Endpoint::connect`].  It relies on addressing
-    /// information being provided by either the discovery service or using
-    /// [`Endpoint::add_node_addr`].  See [`Endpoint::connect`] for the details of how it
-    /// uses the discovery service to establish a connection to a remote node.
-    #[deprecated(
-        since = "0.27.0",
-        note = "Please use `connect` directly with a NodeId. This fn will be removed in 0.28.0."
-    )]
-    pub async fn connect_by_node_id(&self, node_id: NodeId, alpn: &[u8]) -> Result<Connection> {
-        let addr = NodeAddr::new(node_id);
-        self.connect(addr, alpn).await
-    }
-
     #[instrument(
         skip_all,
         fields(remote_node = node_id.fmt_short(), alpn = %String::from_utf8_lossy(alpn))


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
We've deprecated this method a while ago, said to remove it in v0.28.0, but didn't. Let's do that now.

Also, I noticed some `#[doc(cfg(..))]`s were missing, I tried to find and add all missing ones.

## Breaking Changes

- Removed deprecated `iroh::Endpoint::connect_by_node_id`. Use `iroh::Endpoint::connect` with a `NodeId` instead.


## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
