### PR TITLE
Very WIP Experiment: don't require Box in protocol handler accept

### DIFF
--- a/iroh/examples/echo.rs
+++ b/iroh/examples/echo.rs
@@ -7,10 +7,9 @@
 //!     cargo run --example echo --features=examples
 
 use anyhow::Result;
-use futures_lite::future::Boxed as BoxedFuture;
 use iroh::{
     endpoint::Connecting,
-    protocol::{ProtocolHandler, Router},
+    protocol::{Router, UnboxedProtocolHandler},
     Endpoint, NodeAddr,
 };
 
@@ -66,37 +65,35 @@ async fn accept_side() -> Result<Router> {
 #[derive(Debug, Clone)]
 struct Echo;
 
-impl ProtocolHandler for Echo {
+impl UnboxedProtocolHandler for Echo {
     /// The `accept` method is called for each incoming connection for our ALPN.
     ///
     /// The returned future runs on a newly spawned tokio task, so it can run as long as
     /// the connection lasts.
-    fn accept(&self, connecting: Connecting) -> BoxedFuture<Result<()>> {
+    async fn accept(self, connecting: Connecting) -> Result<()> {
         // We have to return a boxed future from the handler.
-        Box::pin(async move {
-            // Wait for the connection to be fully established.
-            let connection = connecting.await?;
-            // We can get the remote's node id from the connection.
-            let node_id = iroh::endpoint::get_remote_node_id(&connection)?;
-            println!("accepted connection from {node_id}");
+        // Wait for the connection to be fully established.
+        let connection = connecting.await?;
+        // We can get the remote's node id from the connection.
+        let node_id = iroh::endpoint::get_remote_node_id(&connection)?;
+        println!("accepted connection from {node_id}");
 
-            // Our protocol is a simple request-response protocol, so we expect the
-            // connecting peer to open a single bi-directional stream.
-            let (mut send, mut recv) = connection.accept_bi().await?;
+        // Our protocol is a simple request-response protocol, so we expect the
+        // connecting peer to open a single bi-directional stream.
+        let (mut send, mut recv) = connection.accept_bi().await?;
 
-            // Echo any bytes received back directly.
-            let bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
-            println!("Copied over {bytes_sent} byte(s)");
+        // Echo any bytes received back directly.
+        let bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
+        println!("Copied over {bytes_sent} byte(s)");
 
-            // By calling `finish` on the send stream we signal that we will not send anything
-            // further, which makes the receive stream on the other end terminate.
-            send.finish()?;
+        // By calling `finish` on the send stream we signal that we will not send anything
+        // further, which makes the receive stream on the other end terminate.
+        send.finish()?;
 
-            // Wait until the remote closes the connection, which it does once it
-            // received the response.
-            connection.closed().await;
+        // Wait until the remote closes the connection, which it does once it
+        // received the response.
+        connection.closed().await;
 
-            Ok(())
-        })
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description

Add an UnboxedProtocolHandler trait and try it out in the examples.

## Breaking Changes

The blanket impls for Box and Arc conflict with this, so I had to comment them out

## Notes & open questions

Is this worth the effort in simplifying writing protocols?
Should ProtocolHandler always be like this, and we do the transformation to something boxable internally?

Maybe the following would be good:

- rename UnboxedProtocolHandler to just ProtocolHandler (or Protocol if we want to go this way)
- keep ProtocolHandler as BoxedProtocolHandler but hide it away a bit

That way by default people get the simple interface, but if somebody has special requirements such as
- they have an already boxed future and want to avoid boxing it again
- they don't want owned self because they want to clone not all of self but only a part
they can still do it by implementing BoxedProtocolHandler manually. All ProtocolHandler impls get a default BoxedProtocolHandler impl.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
