### PR TITLE
refactor: remove `AddrInfo`

### DIFF
--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -46,8 +46,9 @@ serde_json = "1"
 serde_test = "1"
 
 [features]
-default = ["hash", "base32", "relay"]
+default = ["hash", "ticket", "relay"]
 hash = ["dep:blake3", "dep:data-encoding", "dep:postcard", "dep:derive_more", "base32"]
+ticket = ["base32", "key"]
 base32 = ["dep:data-encoding", "dep:postcard"]
 redb = ["dep:redb"]
 key = ["dep:ed25519-dalek", "dep:once_cell", "dep:rand", "dep:rand_core", "dep:ssh-key", "dep:ttl_cache", "dep:aead", "dep:crypto_box", "dep:zeroize", "dep:url", "dep:derive_more", "dep:getrandom"]

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -11,7 +11,7 @@ pub mod key;
 pub mod node_addr;
 #[cfg(feature = "relay")]
 pub mod relay_map;
-#[cfg(any(feature = "relay", feature = "key"))]
+#[cfg(feature = "relay")]
 mod relay_url;
-#[cfg(feature = "base32")]
+#[cfg(feature = "ticket")]
 pub mod ticket;

--- a/iroh-base/src/node_addr.rs
+++ b/iroh-base/src/node_addr.rs
@@ -85,6 +85,11 @@ impl NodeAddr {
         }
     }
 
+    /// Returns true, if only a [`NodeId`] is present.
+    pub fn is_empty(&self) -> bool {
+        self.relay_url.is_none() && self.direct_addresses.is_empty()
+    }
+
     /// Applies the options to `self`.
     ///
     /// This is used to more tightly control the information stored in a [`NodeAddr`]

--- a/iroh-base/src/node_addr.rs
+++ b/iroh-base/src/node_addr.rs
@@ -90,31 +90,6 @@ impl NodeAddr {
         self.relay_url.is_none() && self.direct_addresses.is_empty()
     }
 
-    /// Applies the options to `self`.
-    ///
-    /// This is used to more tightly control the information stored in a [`NodeAddr`]
-    /// received from another API.  E.g. to ensure a [discovery] service is used the
-    /// `AddrInfoOptions::Id`] option could be used to remove all other addressing details.
-    ///
-    /// [discovery]: https://docs.rs/iroh/*/iroh/index.html#node-discovery
-    pub fn apply_options(&mut self, opts: AddrInfoOptions) {
-        match opts {
-            AddrInfoOptions::Id => {
-                self.direct_addresses.clear();
-                self.relay_url = None;
-            }
-            AddrInfoOptions::RelayAndAddresses => {
-                // nothing to do
-            }
-            AddrInfoOptions::Relay => {
-                self.direct_addresses.clear();
-            }
-            AddrInfoOptions::Addresses => {
-                self.relay_url = None;
-            }
-        }
-    }
-
     /// Returns the direct addresses of this peer.
     pub fn direct_addresses(&self) -> impl Iterator<Item = &SocketAddr> {
         self.direct_addresses.iter()
@@ -141,31 +116,4 @@ impl From<NodeId> for NodeAddr {
     fn from(node_id: NodeId) -> Self {
         NodeAddr::new(node_id)
     }
-}
-
-/// Options to configure what is included in a [`NodeAddr`].
-#[derive(
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Default,
-    Debug,
-    derive_more::Display,
-    derive_more::FromStr,
-    Serialize,
-    Deserialize,
-)]
-pub enum AddrInfoOptions {
-    /// Only the Node ID is added.
-    ///
-    /// This usually means that iroh-dns discovery is used to find address information.
-    #[default]
-    Id,
-    /// Includes the Node ID and both the relay URL, and the direct addresses.
-    RelayAndAddresses,
-    /// Includes the Node ID and the relay URL.
-    Relay,
-    /// Includes the Node ID and the direct addresses.
-    Addresses,
 }

--- a/iroh-base/src/ticket.rs
+++ b/iroh-base/src/ticket.rs
@@ -2,13 +2,11 @@ use std::{collections::BTreeSet, net::SocketAddr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{base32, key::NodeId, node_addr::RelayUrl};
+use crate::{base32, key::NodeId, relay_url::RelayUrl};
 
-#[cfg(feature = "key")]
 mod blob;
-#[cfg(feature = "key")]
 mod node;
-#[cfg(feature = "key")]
+
 pub use self::{blob::BlobTicket, node::NodeTicket};
 
 /// A ticket is a serializable object combining information required for an operation.

--- a/iroh-base/src/ticket.rs
+++ b/iroh-base/src/ticket.rs
@@ -1,4 +1,8 @@
-use crate::base32;
+use std::{collections::BTreeSet, net::SocketAddr};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{base32, key::NodeId, node_addr::RelayUrl};
 
 #[cfg(feature = "key")]
 mod blob;
@@ -69,4 +73,16 @@ pub enum Error {
     /// Verification of the deserialized bytes failed.
     #[error("verification failed: {_0}")]
     Verify(&'static str),
+}
+
+#[derive(Serialize, Deserialize)]
+struct Variant0NodeAddr {
+    node_id: NodeId,
+    info: Variant0AddrInfo,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Variant0AddrInfo {
+    relay_url: Option<RelayUrl>,
+    direct_addresses: BTreeSet<SocketAddr>,
 }

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
         let res = resolver.lookup_by_id(&node_id, origin).await?;
 
         assert_eq!(res.node_id, node_id);
-        assert_eq!(res.info.relay_url.map(Url::from), Some(relay_url));
+        assert_eq!(res.relay_url.map(Url::from), Some(relay_url));
 
         server.shutdown().await?;
         Ok(())
@@ -255,7 +255,7 @@ mod tests {
         let res = resolver.lookup_by_id(&node_id, origin).await?;
 
         assert_eq!(res.node_id, node_id);
-        assert_eq!(res.info.relay_url.map(Url::from), Some(relay_url));
+        assert_eq!(res.relay_url.map(Url::from), Some(relay_url));
 
         server.shutdown().await?;
         for mut node in testnet.nodes {

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -176,7 +176,7 @@ name = "key"
 harness = false
 
 [features]
-default = ["metrics", "discovery-pkarr-dht", "discovery-local-network"]
+default = ["metrics", "discovery-pkarr-dht"]
 metrics = ["iroh-metrics/metrics", "iroh-relay/metrics", "net-report/metrics", "portmapper/metrics"]
 test-utils = ["iroh-relay/test-utils", "iroh-relay/server", "dep:axum"]
 discovery-local-network = ["dep:swarm-discovery"]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -176,7 +176,7 @@ name = "key"
 harness = false
 
 [features]
-default = ["metrics", "discovery-pkarr-dht"]
+default = ["metrics", "discovery-pkarr-dht", "discovery-local-network"]
 metrics = ["iroh-metrics/metrics", "iroh-relay/metrics", "net-report/metrics", "portmapper/metrics"]
 test-utils = ["iroh-relay/test-utils", "iroh-relay/server", "dep:axum"]
 discovery-local-network = ["dep:swarm-discovery"]

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -408,8 +408,7 @@ impl DiscoveryTask {
             };
             match next {
                 Some(Ok(r)) => {
-                    if r.node_addr.direct_addresses.is_empty() && r.node_addr.relay_url().is_none()
-                    {
+                    if r.node_addr.is_empty() {
                         debug!(provenance = %r.provenance, "discovery: empty address found");
                         continue;
                     }

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -156,7 +156,7 @@ pub trait Discovery: std::fmt::Debug + Send + Sync {
     /// These tasks will be run on the runtime of the [`super::Endpoint`].
     fn publish(&self, _url: Option<&RelayUrl>, _addrs: &BTreeSet<SocketAddr>) {}
 
-    /// Resolves the [`AddrInfo`] for the given [`NodeId`].
+    /// Resolves the [`DiscoveryItem`] for the given [`NodeId`].
     ///
     /// Once the returned [`BoxStream`] is dropped, the service should stop any pending
     /// work.
@@ -182,7 +182,7 @@ pub trait Discovery: std::fmt::Debug + Send + Sync {
     /// to the `subscribe` stream.
     ///
     /// Discovery systems that are capable of receiving information about [`NodeId`]s
-    /// and their [`AddrInfo`]s without explicitly calling `resolve`, i.e.,
+    /// and their addressing information without explicitly calling `resolve`, i.e.,
     /// systems that do "passive" discovery, should implement this method. If
     /// `subscribe` is called multiple times, the passively discovered addresses
     /// should be sent on all streams.

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -454,10 +454,13 @@ mod tests {
     use super::*;
     use crate::{key::SecretKey, RelayMode};
 
+    type InfoStore = HashMap<NodeId, (Option<RelayUrl>, BTreeSet<SocketAddr>, u64)>;
+
     #[derive(Debug, Clone, Default)]
     struct TestDiscoveryShared {
-        nodes: Arc<Mutex<HashMap<NodeId, (Option<RelayUrl>, BTreeSet<SocketAddr>, u64)>>>,
+        nodes: Arc<Mutex<InfoStore>>,
     }
+
     impl TestDiscoveryShared {
         pub fn create_discovery(&self, node_id: NodeId) -> TestDiscovery {
             TestDiscovery {

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -112,15 +112,16 @@
     doc = "[`LocalSwarmDiscovery`]: local_swarm_discovery::LocalSwarmDiscovery"
 )]
 
-use std::time::Duration;
+use std::{collections::BTreeSet, net::SocketAddr, time::Duration};
 
 use anyhow::{anyhow, ensure, Result};
 use futures_lite::stream::{Boxed as BoxStream, StreamExt};
 use iroh_base::node_addr::NodeAddr;
+use iroh_relay::RelayUrl;
 use tokio::{sync::oneshot, task::JoinHandle};
 use tracing::{debug, error_span, warn, Instrument};
 
-use crate::{AddrInfo, Endpoint, NodeId};
+use crate::{Endpoint, NodeId};
 
 pub mod dns;
 
@@ -146,14 +147,14 @@ pub mod static_provider;
 ///
 /// [`RelayUrl`]: crate::relay::RelayUrl
 pub trait Discovery: std::fmt::Debug + Send + Sync {
-    /// Publishes the given [`AddrInfo`] to the discovery mechanism.
+    /// Publishes the given [`RelayUrl`] and direct addreesses to the discovery mechanism.
     ///
     /// This is fire and forget, since the [`Endpoint`] can not wait for successful
     /// publishing. If publishing is async, the implementation should start it's own task.
     ///
     /// This will be called from a tokio task, so it is safe to spawn new tasks.
     /// These tasks will be run on the runtime of the [`super::Endpoint`].
-    fn publish(&self, _info: &AddrInfo) {}
+    fn publish(&self, _url: Option<&RelayUrl>, _addrs: &BTreeSet<SocketAddr>) {}
 
     /// Resolves the [`AddrInfo`] for the given [`NodeId`].
     ///
@@ -198,7 +199,7 @@ pub trait Discovery: std::fmt::Debug + Send + Sync {
 #[derive(Debug, Clone)]
 pub struct DiscoveryItem {
     /// The [`NodeId`] whose address we have discovered
-    pub node_id: NodeId,
+    pub node_addr: NodeAddr,
     /// A static string to identify the discovery source.
     ///
     /// Should be uniform per discovery service.
@@ -208,8 +209,6 @@ pub struct DiscoveryItem {
     /// Must be microseconds since the unix epoch.
     // TODO(ramfox): this is currently unused. As we develop more `DiscoveryService`s, we may discover that we do not need this. It is only truly relevant when comparing `relay_urls`, since we can attempt to dial any number of socket addresses, but expect each node to have one "home relay" that we will attempt to contact them on. This means we would need some way to determine which relay url to choose between, if more than one relay url is reported.
     pub last_updated: Option<u64>,
-    /// The address info for the node being resolved.
-    pub addr_info: AddrInfo,
 }
 
 /// A discovery service that combines multiple discovery sources.
@@ -248,9 +247,9 @@ where
 }
 
 impl Discovery for ConcurrentDiscovery {
-    fn publish(&self, info: &AddrInfo) {
+    fn publish(&self, url: Option<&RelayUrl>, addrs: &BTreeSet<SocketAddr>) {
         for service in &self.services {
-            service.publish(info);
+            service.publish(url, addrs);
         }
     }
 
@@ -409,16 +408,13 @@ impl DiscoveryTask {
             };
             match next {
                 Some(Ok(r)) => {
-                    if r.addr_info.is_empty() {
-                        debug!(provenance = %r.provenance, addr = ?r.addr_info, "discovery: empty address found");
+                    if r.node_addr.direct_addresses.is_empty() && r.node_addr.relay_url().is_none()
+                    {
+                        debug!(provenance = %r.provenance, "discovery: empty address found");
                         continue;
                     }
-                    debug!(provenance = %r.provenance, addr = ?r.addr_info, "discovery: new address found");
-                    let addr = NodeAddr {
-                        info: r.addr_info,
-                        node_id,
-                    };
-                    ep.add_node_addr_with_source(addr, r.provenance).ok();
+                    debug!(provenance = %r.provenance, addr = ?r.node_addr, "discovery: new address found");
+                    ep.add_node_addr_with_source(r.node_addr, r.provenance).ok();
                     if let Some(tx) = on_first_tx.take() {
                         tx.send(Ok(())).ok();
                     }
@@ -461,7 +457,7 @@ mod tests {
 
     #[derive(Debug, Clone, Default)]
     struct TestDiscoveryShared {
-        nodes: Arc<Mutex<HashMap<NodeId, (AddrInfo, u64)>>>,
+        nodes: Arc<Mutex<HashMap<NodeId, (Option<RelayUrl>, BTreeSet<SocketAddr>, u64)>>>,
     }
     impl TestDiscoveryShared {
         pub fn create_discovery(&self, node_id: NodeId) -> TestDiscovery {
@@ -494,7 +490,7 @@ mod tests {
     }
 
     impl Discovery for TestDiscovery {
-        fn publish(&self, info: &AddrInfo) {
+        fn publish(&self, url: Option<&RelayUrl>, addrs: &BTreeSet<SocketAddr>) {
             if !self.publish {
                 return;
             }
@@ -502,7 +498,7 @@ mod tests {
             self.shared
                 .nodes
                 .lock()
-                .insert(self.node_id, (info.clone(), now));
+                .insert(self.node_id, (url.cloned(), addrs.clone(), now));
         }
 
         fn resolve(
@@ -517,20 +513,19 @@ mod tests {
                     let port: u16 = rand::thread_rng().gen_range(10_000..20_000);
                     // "240.0.0.0/4" is reserved and unreachable
                     let addr: SocketAddr = format!("240.0.0.1:{port}").parse().unwrap();
-                    let addr_info = AddrInfo {
-                        relay_url: None,
-                        direct_addresses: BTreeSet::from([addr]),
-                    };
-                    Some((addr_info, ts))
+                    Some((None, BTreeSet::from([addr]), ts))
                 }
             };
             let stream = match addr_info {
-                Some((addr_info, ts)) => {
+                Some((url, addrs, ts)) => {
                     let item = DiscoveryItem {
-                        node_id,
+                        node_addr: NodeAddr {
+                            node_id,
+                            relay_url: url,
+                            direct_addresses: addrs,
+                        },
                         provenance: "test-disco",
                         last_updated: Some(ts),
-                        addr_info,
                     };
                     let delay = self.delay;
                     let fut = async move {
@@ -553,7 +548,7 @@ mod tests {
     #[derive(Debug)]
     struct EmptyDiscovery;
     impl Discovery for EmptyDiscovery {
-        fn publish(&self, _info: &AddrInfo) {}
+        fn publish(&self, _url: Option<&RelayUrl>, _addrs: &BTreeSet<SocketAddr>) {}
 
         fn resolve(
             &self,
@@ -688,10 +683,8 @@ mod tests {
         ep1.node_addr().await?;
         let ep1_wrong_addr = NodeAddr {
             node_id: ep1.node_id(),
-            info: AddrInfo {
-                relay_url: None,
-                direct_addresses: BTreeSet::from(["240.0.0.1:1000".parse().unwrap()]),
-            },
+            relay_url: None,
+            direct_addresses: BTreeSet::from(["240.0.0.1:1000".parse().unwrap()]),
         };
         let _conn = ep2.connect(ep1_wrong_addr, TEST_ALPN).await?;
         Ok(())
@@ -754,7 +747,7 @@ mod test_dns_pkarr {
             pkarr_dns_state::State,
             run_relay_server, DnsPkarrServer,
         },
-        AddrInfo, Endpoint, NodeAddr, RelayMap, RelayMode,
+        Endpoint, NodeAddr, RelayMap, RelayMode,
     };
 
     const PUBLISH_TIMEOUT: Duration = Duration::from_secs(10);
@@ -795,22 +788,20 @@ mod test_dns_pkarr {
         let secret_key = SecretKey::generate();
         let node_id = secret_key.public();
 
-        let addr_info = AddrInfo {
-            relay_url: Some("https://relay.example".parse().unwrap()),
-            ..Default::default()
-        };
+        let relay_url = Some("https://relay.example".parse().unwrap());
 
         let resolver = create_dns_resolver(dns_pkarr_server.nameserver)?;
         let publisher = PkarrPublisher::new(secret_key, dns_pkarr_server.pkarr_url.clone());
         // does not block, update happens in background task
-        publisher.update_addr_info(&addr_info);
+        publisher.update_addr_info(relay_url.as_ref(), &Default::default());
         // wait until our shared state received the update from pkarr publishing
         dns_pkarr_server.on_node(&node_id, PUBLISH_TIMEOUT).await?;
         let resolved = resolver.lookup_by_id(&node_id, &origin).await?;
 
         let expected = NodeAddr {
-            info: addr_info,
             node_id,
+            relay_url,
+            direct_addresses: Default::default(),
         };
 
         assert_eq!(resolved, expected);

--- a/iroh/src/discovery/dns.rs
+++ b/iroh/src/discovery/dns.rs
@@ -75,10 +75,9 @@ impl Discovery for DnsDiscovery {
                 .lookup_by_id_staggered(&node_id, &origin_domain, DNS_STAGGERING_MS)
                 .await?;
             Ok(DiscoveryItem {
-                node_id,
+                node_addr,
                 provenance: "dns",
                 last_updated: None,
-                addr_info: node_addr.info,
             })
         };
         let stream = futures_lite::stream::once_future(fut);

--- a/iroh/src/discovery/local_swarm_discovery.rs
+++ b/iroh/src/discovery/local_swarm_discovery.rs
@@ -40,7 +40,8 @@ use anyhow::Result;
 use derive_more::FromStr;
 use futures_lite::stream::Boxed as BoxStream;
 use futures_util::FutureExt;
-use iroh_base::key::PublicKey;
+use iroh_base::{key::PublicKey, node_addr::NodeAddr};
+use iroh_relay::RelayUrl;
 use swarm_discovery::{Discoverer, DropGuard, IpClass, Peer};
 use tokio::{
     sync::mpsc::{
@@ -55,7 +56,7 @@ use watchable::Watchable;
 
 use crate::{
     discovery::{Discovery, DiscoveryItem},
-    AddrInfo, Endpoint, NodeId,
+    Endpoint, NodeId,
 };
 
 /// The n0 local swarm node discovery name
@@ -77,8 +78,8 @@ pub struct LocalSwarmDiscovery {
     #[allow(dead_code)]
     handle: AbortOnDropHandle<()>,
     sender: mpsc::Sender<Message>,
-    /// When `local_addrs` changes, we re-publish our [`AddrInfo`]
-    local_addrs: Watchable<Option<AddrInfo>>,
+    /// When `local_addrs` changes, we re-publish our info.
+    local_addrs: Watchable<Option<(Option<RelayUrl>, BTreeSet<SocketAddr>)>>,
 }
 
 #[derive(Debug)]
@@ -151,7 +152,8 @@ impl LocalSwarmDiscovery {
             &rt,
         )?;
 
-        let local_addrs: Watchable<Option<AddrInfo>> = Watchable::new(None);
+        let local_addrs: Watchable<Option<(Option<RelayUrl>, BTreeSet<SocketAddr>)>> =
+            Watchable::new(None);
         let addrs_change = local_addrs.watch();
         let discovery_fut = async move {
             let mut node_addrs: HashMap<PublicKey, Peer> = HashMap::default();
@@ -168,11 +170,11 @@ impl LocalSwarmDiscovery {
                     msg = recv.recv() => {
                         msg
                     }
-                    Ok(Some(addrs))= addrs_change.next_value_async() => {
+                    Ok(Some((_url, addrs)))= addrs_change.next_value_async() => {
                         tracing::trace!(?addrs, "LocalSwarmDiscovery address changed");
                         discovery.remove_all();
                         let addrs =
-                            LocalSwarmDiscovery::socketaddrs_to_addrs(addrs.direct_addresses);
+                            LocalSwarmDiscovery::socketaddrs_to_addrs(addrs);
                         for addr in addrs {
                             discovery.add(addr.0, addr.1)
                         }
@@ -352,13 +354,13 @@ fn peer_to_discovery_item(peer: &Peer, node_id: &NodeId) -> DiscoveryItem {
         .map(|(ip, port)| SocketAddr::new(*ip, *port))
         .collect();
     DiscoveryItem {
-        node_id: *node_id,
-        provenance: NAME,
-        last_updated: None,
-        addr_info: AddrInfo {
+        node_addr: NodeAddr {
+            node_id: *node_id,
             relay_url: None,
             direct_addresses,
         },
+        provenance: NAME,
+        last_updated: None,
     }
 }
 
@@ -376,8 +378,9 @@ impl Discovery for LocalSwarmDiscovery {
         Some(Box::pin(stream.flatten_stream()))
     }
 
-    fn publish(&self, info: &AddrInfo) {
-        self.local_addrs.replace(Some(info.clone()));
+    fn publish(&self, url: Option<&RelayUrl>, addrs: &BTreeSet<SocketAddr>) {
+        self.local_addrs
+            .replace(Some((url.cloned(), addrs.clone())));
     }
 
     fn subscribe(&self) -> Option<BoxStream<DiscoveryItem>> {
@@ -409,10 +412,7 @@ mod tests {
             let (node_id_b, discovery_b) = make_discoverer()?;
 
             // make addr info for discoverer b
-            let addr_info = AddrInfo {
-                relay_url: None,
-                direct_addresses: BTreeSet::from(["0.0.0.0:11111".parse()?]),
-            };
+            let addr_info = (None, BTreeSet::from(["0.0.0.0:11111".parse()?]));
 
             // pass in endpoint, this is never used
             let ep = crate::endpoint::Builder::default().bind().await?;
@@ -423,15 +423,17 @@ mod tests {
 
             tracing::debug!(?node_id_b, "Discovering node id b");
             // publish discovery_b's address
-            discovery_b.publish(&addr_info);
+            discovery_b.publish(addr_info.0.as_ref(), &addr_info.1);
             let s1_res = tokio::time::timeout(Duration::from_secs(5), s1.next())
                 .await?
                 .unwrap()?;
             let s2_res = tokio::time::timeout(Duration::from_secs(5), s2.next())
                 .await?
                 .unwrap()?;
-            assert_eq!(s1_res.addr_info, addr_info);
-            assert_eq!(s2_res.addr_info, addr_info);
+            assert_eq!(s1_res.node_addr.relay_url, addr_info.0);
+            assert_eq!(s1_res.node_addr.direct_addresses, addr_info.1);
+            assert_eq!(s2_res.node_addr.relay_url, addr_info.0);
+            assert_eq!(s2_res.node_addr.direct_addresses, addr_info.1);
 
             Ok(())
         }
@@ -445,15 +447,12 @@ mod tests {
             let mut discoverers = vec![];
 
             let (_, discovery) = make_discoverer()?;
-            let addr_info = AddrInfo {
-                relay_url: None,
-                direct_addresses: BTreeSet::from(["0.0.0.0:11111".parse()?]),
-            };
+            let addr_info = (None, BTreeSet::from(["0.0.0.0:11111".parse()?]));
 
             for _ in 0..num_nodes {
                 let (node_id, discovery) = make_discoverer()?;
                 node_ids.insert(node_id);
-                discovery.publish(&addr_info);
+                discovery.publish(addr_info.0.as_ref(), &addr_info.1);
                 discoverers.push(discovery);
             }
 
@@ -463,8 +462,8 @@ mod tests {
                 let mut got_ids = BTreeSet::new();
                 while got_ids.len() != num_nodes {
                     if let Some(item) = events.next().await {
-                        if node_ids.contains(&item.node_id) {
-                            got_ids.insert(item.node_id);
+                        if node_ids.contains(&item.node_addr.node_id) {
+                            got_ids.insert(item.node_addr.node_id);
                         }
                     } else {
                         anyhow::bail!(

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -19,8 +19,8 @@
 //!   the Mainline DHT on behalf on the client as well as cache lookups performed on the DHT
 //!   to improve performance.
 //!
-//! For node discovery in iroh the pkarr Resource Records contain the [`AddrInfo`]
-//! information, providing nodes which retrieve the pkarr Resource Record with enough detail
+//! For node discovery in iroh the pkarr Resource Records contain the addressing information,
+//! providing nodes which retrieve the pkarr Resource Record with enough detail
 //! to contact the iroh node.
 //!
 //! There are several node discovery services built on top of pkarr, which can be composed
@@ -107,9 +107,7 @@ pub const DEFAULT_REPUBLISH_INTERVAL: Duration = Duration::from_secs(60 * 5);
 /// that it only publishes node discovery information, for the corresponding resolver use
 /// the [`PkarrResolver`] together with [`ConcurrentDiscovery`].
 ///
-/// This publisher will **only** publish the [`RelayUrl`] if the [`AddrInfo`] contains a
-/// [`RelayUrl`].  If the [`AddrInfo`] does not contain a [`RelayUrl`] the *direct
-/// addresses* are published instead.
+/// This publisher will **only** publish the [`RelayUrl`] if it is set, otherwise the *direct addresses* are published instead.
 ///
 /// [pkarr]: https://pkarr.org
 /// [module docs]: crate::discovery::pkarr
@@ -193,7 +191,7 @@ impl PkarrPublisher {
         Self::new(secret_key, pkarr_relay)
     }
 
-    /// Publishes [`AddrInfo`] about this node to a pkarr relay.
+    /// Publishes the addressing information about this node to a pkarr relay.
     ///
     /// This is a nonblocking function, the actual update is performed in the background.
     pub fn update_addr_info(&self, url: Option<&RelayUrl>, addrs: &BTreeSet<SocketAddr>) {

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -6,12 +6,16 @@
 //!
 //! [pkarr module]: super
 use std::{
+    collections::BTreeSet,
+    net::SocketAddr,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 use futures_lite::{stream::Boxed, StreamExt};
 use genawaiter::sync::{Co, Gen};
+use iroh_base::node_addr::NodeAddr;
+use iroh_relay::RelayUrl;
 use pkarr::{
     PkarrClient, PkarrClientAsync, PkarrRelayClient, PkarrRelayClientAsync, PublicKey,
     RelaySettings, SignedPacket,
@@ -26,7 +30,7 @@ use crate::{
     },
     dns::node_info::NodeInfo,
     key::SecretKey,
-    AddrInfo, Endpoint, NodeId,
+    Endpoint, NodeId,
 };
 
 /// Republish delay for the DHT.
@@ -290,14 +294,13 @@ impl DhtDiscovery {
         match response {
             Ok(Some(signed_packet)) => {
                 if let Ok(node_info) = NodeInfo::from_pkarr_signed_packet(&signed_packet) {
-                    let node_id = node_info.node_id;
-                    let addr_info = node_info.into();
-                    tracing::info!("discovered node info from relay {:?}", addr_info);
+                    let node_addr: NodeAddr = node_info.into();
+
+                    tracing::info!("discovered node info from relay {:?}", node_addr);
                     co.yield_(Ok(DiscoveryItem {
-                        node_id,
+                        node_addr,
                         provenance: "relay",
                         last_updated: None,
-                        addr_info,
                     }))
                     .await;
                 } else {
@@ -336,14 +339,12 @@ impl DhtDiscovery {
             return;
         };
         if let Ok(node_info) = NodeInfo::from_pkarr_signed_packet(&signed_packet) {
-            let node_id = node_info.node_id;
-            let addr_info = node_info.into();
-            tracing::info!("discovered node info from DHT {:?}", addr_info);
+            let node_addr: NodeAddr = node_info.into();
+            tracing::info!("discovered node info from DHT {:?}", node_addr);
             co.yield_(Ok(DiscoveryItem {
-                node_id,
+                node_addr,
                 provenance: "mainline",
                 last_updated: None,
-                addr_info,
             }))
             .await;
         } else {
@@ -362,17 +363,17 @@ impl DhtDiscovery {
 }
 
 impl Discovery for DhtDiscovery {
-    fn publish(&self, info: &AddrInfo) {
+    fn publish(&self, url: Option<&RelayUrl>, addrs: &BTreeSet<SocketAddr>) {
         let Some(keypair) = &self.0.secret_key else {
             tracing::debug!("no keypair set, not publishing");
             return;
         };
-        tracing::debug!("publishing {:?}", info);
+        tracing::debug!("publishing {:?}, {:?}", url, addrs);
         let info = NodeInfo {
             node_id: keypair.public(),
-            relay_url: info.relay_url.clone().map(Url::from),
+            relay_url: url.cloned().map(Url::from),
             direct_addresses: if self.0.include_direct_addresses {
-                info.direct_addresses.clone()
+                addrs.clone()
             } else {
                 Default::default()
             },
@@ -432,10 +433,7 @@ mod tests {
             .build()?;
         let relay_url: RelayUrl = Url::parse("https://example.com")?.into();
 
-        discovery.publish(&AddrInfo {
-            relay_url: Some(relay_url.clone()),
-            direct_addresses: Default::default(),
-        });
+        discovery.publish(Some(&relay_url), &Default::default());
 
         // publish is fire and forget, so we have no way to wait until it is done.
         tokio::time::timeout(Duration::from_secs(30), async move {
@@ -448,7 +446,7 @@ mod tests {
                     .collect::<Vec<_>>()
                     .await;
                 for item in items.into_iter().flatten() {
-                    if let Some(url) = item.addr_info.relay_url {
+                    if let Some(url) = item.node_addr.relay_url {
                         found_relay_urls.insert(url);
                     }
                 }

--- a/iroh/src/dns/node_info.rs
+++ b/iroh/src/dns/node_info.rs
@@ -44,7 +44,7 @@ use anyhow::{anyhow, ensure, Result};
 use hickory_resolver::{proto::ProtoError, Name, TokioResolver};
 use url::Url;
 
-use crate::{key::SecretKey, AddrInfo, NodeAddr, NodeId};
+use crate::{key::SecretKey, NodeAddr, NodeId};
 
 /// The DNS name for the iroh TXT record.
 pub const IROH_TXT_NAME: &str = "_iroh";
@@ -139,15 +139,7 @@ impl From<NodeInfo> for NodeAddr {
     fn from(value: NodeInfo) -> Self {
         NodeAddr {
             node_id: value.node_id,
-            info: value.into(),
-        }
-    }
-}
-
-impl From<NodeInfo> for AddrInfo {
-    fn from(value: NodeInfo) -> Self {
-        AddrInfo {
-            relay_url: value.relay_url.map(|u| u.into()),
+            relay_url: value.relay_url.map(Into::into),
             direct_addresses: value.direct_addresses,
         }
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -582,7 +582,7 @@ impl Endpoint {
             );
         }
 
-        if !(node_addr.direct_addresses.is_empty()) && node_addr.relay_url.is_none() {
+        if !node_addr.is_empty() {
             self.add_node_addr(node_addr.clone())?;
         }
         let node_id = node_addr.node_id;
@@ -1014,9 +1014,7 @@ impl Endpoint {
                 // If the user provided addresses in this connect call, we will add a delay
                 // followed by a recheck before starting the discovery, to give the magicsocket a
                 // chance to test the newly provided addresses.
-                let delay = (!node_addr.direct_addresses.is_empty()
-                    || node_addr.relay_url.is_some())
-                .then_some(DISCOVERY_WAIT_PERIOD);
+                let delay = (!node_addr.is_empty()).then_some(DISCOVERY_WAIT_PERIOD);
                 let discovery = DiscoveryTask::maybe_start_after_delay(self, node_id, delay)
                     .ok()
                     .flatten();

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -43,7 +43,7 @@ use crate::{
 mod rtt_actor;
 
 pub use bytes::Bytes;
-pub use iroh_base::node_addr::{AddrInfoOptions, NodeAddr};
+pub use iroh_base::node_addr::NodeAddr;
 // Missing still: SendDatagram and ConnectionClose::frame_type's Type.
 pub use quinn::{
     AcceptBi, AcceptUni, AckFrequencyConfig, ApplicationClose, Chunk, ClosedStream, Connection,

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -43,7 +43,7 @@ use crate::{
 mod rtt_actor;
 
 pub use bytes::Bytes;
-pub use iroh_base::node_addr::{AddrInfo, AddrInfoOptions, NodeAddr};
+pub use iroh_base::node_addr::{AddrInfoOptions, NodeAddr};
 // Missing still: SendDatagram and ConnectionClose::frame_type's Type.
 pub use quinn::{
     AcceptBi, AcceptUni, AckFrequencyConfig, ApplicationClose, Chunk, ClosedStream, Connection,
@@ -572,7 +572,7 @@ impl Endpoint {
     /// an error.
     #[instrument(skip_all, fields(me = %self.node_id().fmt_short(), alpn = ?String::from_utf8_lossy(alpn)))]
     pub async fn connect(&self, node_addr: impl Into<NodeAddr>, alpn: &[u8]) -> Result<Connection> {
-        let node_addr = node_addr.into();
+        let node_addr: NodeAddr = node_addr.into();
         tracing::Span::current().record("remote", node_addr.node_id.fmt_short());
         // Connecting to ourselves is not supported.
         if node_addr.node_id == self.node_id() {
@@ -582,11 +582,11 @@ impl Endpoint {
             );
         }
 
-        if !node_addr.info.is_empty() {
+        if !(node_addr.direct_addresses.is_empty()) && node_addr.relay_url.is_none() {
             self.add_node_addr(node_addr.clone())?;
         }
-
-        let NodeAddr { node_id, info } = node_addr.clone();
+        let node_id = node_addr.node_id;
+        let direct_addresses = node_addr.direct_addresses.clone();
 
         // Get the mapped IPv6 address from the magic socket. Quinn will connect to this address.
         // Start discovery for this node if it's enabled and we have no valid or verified
@@ -603,7 +603,7 @@ impl Endpoint {
 
         debug!(
             "connecting to {}: (via {} - {:?})",
-            node_id, addr, info.direct_addresses
+            node_id, addr, direct_addresses
         );
 
         // Start connecting via quinn. This will time out after 10 seconds if no reachable address
@@ -1014,7 +1014,9 @@ impl Endpoint {
                 // If the user provided addresses in this connect call, we will add a delay
                 // followed by a recheck before starting the discovery, to give the magicsocket a
                 // chance to test the newly provided addresses.
-                let delay = (!node_addr.info.is_empty()).then_some(DISCOVERY_WAIT_PERIOD);
+                let delay = (!node_addr.direct_addresses.is_empty()
+                    || node_addr.relay_url.is_some())
+                .then_some(DISCOVERY_WAIT_PERIOD);
                 let discovery = DiscoveryTask::maybe_start_after_delay(self, node_id, delay)
                     .ok()
                     .flatten();
@@ -1417,20 +1419,6 @@ mod tests {
     use crate::test_utils::{run_relay_server, run_relay_server_with};
 
     const TEST_ALPN: &[u8] = b"n0/iroh/test";
-
-    #[test]
-    fn test_addr_info_debug() {
-        let info = AddrInfo {
-            relay_url: Some("https://relay.example.com".parse().unwrap()),
-            direct_addresses: vec![SocketAddr::from(([1, 2, 3, 4], 1234))]
-                .into_iter()
-                .collect(),
-        };
-        assert_eq!(
-            format!("{:?}", info),
-            r#"AddrInfo { relay_url: Some(RelayUrl("https://relay.example.com./")), direct_addresses: {1.2.3.4:1234} }"#
-        );
-    }
 
     #[tokio::test]
     async fn test_connect_self() {

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -245,7 +245,7 @@ mod tls;
 
 pub(crate) mod util;
 
-pub use endpoint::{AddrInfo, AddrInfoOptions, Endpoint, NodeAddr, RelayMode};
+pub use endpoint::{AddrInfoOptions, Endpoint, NodeAddr, RelayMode};
 pub use iroh_base::{
     hash, key,
     key::NodeId,

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -245,7 +245,7 @@ mod tls;
 
 pub(crate) mod util;
 
-pub use endpoint::{AddrInfoOptions, Endpoint, NodeAddr, RelayMode};
+pub use endpoint::{Endpoint, NodeAddr, RelayMode};
 pub use iroh_base::{
     hash, key,
     key::NodeId,

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -67,7 +67,7 @@ use crate::{
     dns::DnsResolver,
     endpoint::NodeAddr,
     key::{PublicKey, SecretKey, SharedSecret},
-    AddrInfo, RelayMap, RelayUrl,
+    RelayMap, RelayUrl,
 };
 
 mod metrics;
@@ -369,12 +369,12 @@ impl MagicSock {
     pub fn add_node_addr(&self, mut addr: NodeAddr, source: node_map::Source) -> Result<()> {
         let mut pruned = 0;
         for my_addr in self.direct_addrs.sockaddrs() {
-            if addr.info.direct_addresses.remove(&my_addr) {
+            if addr.direct_addresses.remove(&my_addr) {
                 warn!( node_id=addr.node_id.fmt_short(), %my_addr, %source, "not adding our addr for node");
                 pruned += 1;
             }
         }
-        if !addr.info.is_empty() {
+        if !addr.direct_addresses.is_empty() || addr.relay_url.is_some() {
             self.node_map.add_node_addr(addr, source);
             Ok(())
         } else if pruned != 0 {
@@ -1395,11 +1395,7 @@ impl MagicSock {
     /// Called whenever our addresses or home relay node changes.
     fn publish_my_addr(&self) {
         if let Some(ref discovery) = self.discovery {
-            let info = AddrInfo {
-                relay_url: self.my_relay(),
-                direct_addresses: self.direct_addrs.sockaddrs(),
-            };
-            discovery.publish(&info);
+            discovery.publish(self.my_relay().as_ref(), &self.direct_addrs.sockaddrs());
         }
     }
 }
@@ -2055,9 +2051,12 @@ impl Actor {
                 // forever like we do with the other branches that yield `Option`s
                 Some(discovery_item) = discovery_events.next() => {
                     trace!("tick: discovery event, address discovered: {discovery_item:?}");
-                    let node_addr = NodeAddr {node_id: discovery_item.node_id, info: discovery_item.addr_info};
-                    if let Err(e) = self.msock.add_node_addr(node_addr.clone(), Source::Discovery { name: discovery_item.provenance.into() }) {
-                        warn!(?node_addr, "unable to add discovered node address to the node map: {e:?}");
+                    if let Err(e) = self.msock.add_node_addr(
+                        discovery_item.node_addr.clone(),
+                        Source::Discovery {
+                            name: discovery_item.provenance.into()
+                        }) {
+                        warn!(?discovery_item.node_addr, "unable to add discovered node address to the node map: {e:?}");
                     }
                 }
             }
@@ -2971,10 +2970,8 @@ mod tests {
 
                 let addr = NodeAddr {
                     node_id: me.public(),
-                    info: crate::AddrInfo {
-                        relay_url: None,
-                        direct_addresses: new_addrs.iter().map(|ep| ep.addr).collect(),
-                    },
+                    relay_url: None,
+                    direct_addresses: new_addrs.iter().map(|ep| ep.addr).collect(),
                 };
                 m.endpoint.magic_sock().add_test_addr(addr);
             }
@@ -3908,17 +3905,15 @@ mod tests {
 
         let node_addr_2 = NodeAddr {
             node_id: node_id_2,
-            info: AddrInfo {
-                relay_url: None,
-                direct_addresses: msock_2
-                    .direct_addresses()
-                    .next()
-                    .await
-                    .expect("no direct addrs")
-                    .into_iter()
-                    .map(|x| x.addr)
-                    .collect(),
-            },
+            relay_url: None,
+            direct_addresses: msock_2
+                .direct_addresses()
+                .next()
+                .await
+                .expect("no direct addrs")
+                .into_iter()
+                .map(|x| x.addr)
+                .collect(),
         };
         msock_1
             .add_node_addr(
@@ -3980,7 +3975,8 @@ mod tests {
         msock_1.node_map.add_node_addr(
             NodeAddr {
                 node_id: node_id_2,
-                info: AddrInfo::default(),
+                relay_url: None,
+                direct_addresses: Default::default(),
             },
             Source::NamedApp {
                 name: "test".into(),
@@ -4015,17 +4011,15 @@ mod tests {
         msock_1.node_map.add_node_addr(
             NodeAddr {
                 node_id: node_id_2,
-                info: AddrInfo {
-                    relay_url: None,
-                    direct_addresses: msock_2
-                        .direct_addresses()
-                        .next()
-                        .await
-                        .expect("no direct addrs")
-                        .into_iter()
-                        .map(|x| x.addr)
-                        .collect(),
-                },
+                relay_url: None,
+                direct_addresses: msock_2
+                    .direct_addresses()
+                    .next()
+                    .await
+                    .expect("no direct addrs")
+                    .into_iter()
+                    .map(|x| x.addr)
+                    .collect(),
             },
             Source::NamedApp {
                 name: "test".into(),

--- a/iroh/src/magicsock/node_map.rs
+++ b/iroh/src/magicsock/node_map.rs
@@ -301,18 +301,22 @@ impl NodeMapInner {
     /// Add the contact information for a node.
     #[instrument(skip_all, fields(node = %node_addr.node_id.fmt_short()))]
     fn add_node_addr(&mut self, node_addr: NodeAddr, source: Source) {
-        let NodeAddr { node_id, info } = node_addr;
-
         let source0 = source.clone();
+        let node_id = node_addr.node_id;
+        let relay_url = node_addr.relay_url.clone();
         let node_state = self.get_or_insert_with(NodeStateKey::NodeId(node_id), || Options {
             node_id,
-            relay_url: info.relay_url.clone(),
+            relay_url,
             active: false,
             source,
         });
-        node_state.update_from_node_addr(&info, source0);
+        node_state.update_from_node_addr(
+            node_addr.relay_url.as_ref(),
+            &node_addr.direct_addresses,
+            source0,
+        );
         let id = node_state.id();
-        for addr in &info.direct_addresses {
+        for addr in node_addr.direct_addresses() {
             self.set_node_state_for_ip_port(*addr, id);
         }
     }
@@ -700,7 +704,7 @@ mod tests {
             .into_iter()
             .filter_map(|info| {
                 let addr: NodeAddr = info.into();
-                if addr.info.is_empty() {
+                if addr.direct_addresses.is_empty() && addr.relay_url.is_none() {
                     return None;
                 }
                 Some(addr)
@@ -713,7 +717,7 @@ mod tests {
             .into_iter()
             .filter_map(|info| {
                 let addr: NodeAddr = info.into();
-                if addr.info.is_empty() {
+                if addr.direct_addresses.is_empty() && addr.relay_url.is_none() {
                     return None;
                 }
                 Some(addr)

--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -21,7 +21,6 @@ use super::{
 };
 use crate::{
     disco::{self, SendAddr},
-    endpoint::AddrInfo,
     key::PublicKey,
     magicsock::{ActorMessage, MagicsockMetrics, QuicMappedAddr, Timer, HEARTBEAT_INTERVAL},
     util::relay_only_mode,
@@ -637,14 +636,19 @@ impl NodeState {
         ping_msgs
     }
 
-    pub(super) fn update_from_node_addr(&mut self, n: &AddrInfo, source: super::Source) {
+    pub(super) fn update_from_node_addr(
+        &mut self,
+        relay_url: Option<&RelayUrl>,
+        addrs: &BTreeSet<SocketAddr>,
+        source: super::Source,
+    ) {
         if self.udp_paths.best_addr.is_empty() {
             // we do not have a direct connection, so changing the relay information may
             // have an effect on our connection status
-            if self.relay_url.is_none() && n.relay_url.is_some() {
+            if self.relay_url.is_none() && relay_url.is_some() {
                 // we did not have a relay connection before, but now we do
                 inc!(MagicsockMetrics, num_relay_conns_added)
-            } else if self.relay_url.is_some() && n.relay_url.is_none() {
+            } else if self.relay_url.is_some() && relay_url.is_none() {
                 // we had a relay connection before but do not have one now
                 inc!(MagicsockMetrics, num_relay_conns_removed)
             }
@@ -652,12 +656,12 @@ impl NodeState {
 
         let now = Instant::now();
 
-        if n.relay_url.is_some() && n.relay_url != self.relay_url() {
+        if relay_url.is_some() && relay_url != self.relay_url().as_ref() {
             debug!(
                 "Changing relay node from {:?} to {:?}",
-                self.relay_url, n.relay_url
+                self.relay_url, relay_url
             );
-            self.relay_url = n.relay_url.as_ref().map(|url| {
+            self.relay_url = relay_url.map(|url| {
                 (
                     url.clone(),
                     PathState::new(self.node_id, url.clone().into(), source.clone(), now),
@@ -665,7 +669,7 @@ impl NodeState {
             });
         }
 
-        for &addr in n.direct_addresses.iter() {
+        for &addr in addrs.iter() {
             self.udp_paths
                 .paths
                 .entry(addr.into())
@@ -677,7 +681,7 @@ impl NodeState {
                 });
         }
         let paths = summarize_node_paths(&self.udp_paths.paths);
-        debug!(new = ?n.direct_addresses , %paths, "added new direct paths for endpoint");
+        debug!(new = ?addrs , %paths, "added new direct paths for endpoint");
     }
 
     /// Clears all the endpoint's p2p state, reverting it to a relay-only endpoint.
@@ -1187,10 +1191,8 @@ impl From<RemoteInfo> for NodeAddr {
 
         NodeAddr {
             node_id: info.node_id,
-            info: AddrInfo {
-                relay_url: info.relay_url.map(Into::into),
-                direct_addresses,
-            },
+            relay_url: info.relay_url.map(Into::into),
+            direct_addresses,
         }
     }
 }


### PR DESCRIPTION
## Description

Simplify type structures

TODO

- [x] fix tests
- [x] resolve ticket breakage

## Breaking Changes

- remove `iroh_base::node_addr::AddrInfo`
- remove `iroh_base::node_addr::AddrInfoOptions`
- introduce `ticket` feature for `iroh_base`, to use `iroh_base::ticket`

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
