### PR TITLE
chore: (Deps) Update swarm-discovery to avoid idna <= 0.5 dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,30 +1627,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
 version = "0.25.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d063c0692ee669aa6d261988aa19ca5510f1cc40e4f211024f50c888499a35d7"
@@ -1666,7 +1642,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 1.1.0",
- "idna 1.0.3",
+ "idna",
  "ipnet",
  "once_cell",
  "rand",
@@ -1688,7 +1664,7 @@ checksum = "42bc352e4412fb657e795f79b4efcf2bd60b59ee5ca0187f3554194cd1107a27"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto 0.25.0-alpha.4",
+ "hickory-proto",
  "ipconfig",
  "moka",
  "once_cell",
@@ -1717,7 +1693,7 @@ dependencies = [
  "enum-as-inner",
  "futures-util",
  "h2",
- "hickory-proto 0.25.0-alpha.4",
+ "hickory-proto",
  "hickory-resolver",
  "http 1.1.0",
  "ipnet",
@@ -2055,16 +2031,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
-]
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -2494,7 +2460,7 @@ dependencies = [
  "futures-util",
  "governor 0.7.0",
  "hex",
- "hickory-proto 0.25.0-alpha.4",
+ "hickory-proto",
  "hickory-resolver",
  "hostname 0.4.0",
  "http 1.1.0",
@@ -4741,13 +4707,13 @@ dependencies = [
 
 [[package]]
 name = "swarm-discovery"
-version = "0.2.1"
+version = "0.3.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39769914108ae68e261d85ceac7bce7095947130f79c29d4535e9b31fc702a40"
+checksum = "58b529764e2f746ef954505dd7cb3c03331bd678c52a387e4a86540577f41e45"
 dependencies = [
  "acto",
  "anyhow",
- "hickory-proto 0.24.1",
+ "hickory-proto",
  "rand",
  "socket2",
  "tokio",
@@ -5342,12 +5308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5421,7 +5381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna",
  "percent-encoding",
  "serde",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -26,5 +26,4 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 ignore = [
     "RUSTSEC-2024-0370", # unmaintained, no upgrade available
     "RUSTSEC-2024-0384", # unmaintained, no upgrade available
-    "RUSTSEC-2024-0421", # dependency from swarm-discovery, see https://github.com/rkuhn/swarm-discovery/issues/9
 ]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -114,7 +114,7 @@ net-report = { package = "iroh-net-report", path = "../iroh-net-report", version
 iroh-metrics = { version = "0.29", default-features = false }
 
 # local-swarm-discovery
-swarm-discovery = { version = "0.2.1", optional = true }
+swarm-discovery = { version = "0.3.0-alpha.1", optional = true }
 
 # dht_discovery
 genawaiter = { version = "0.99", features = ["futures03"], optional = true }


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
- Updates to latest `swarm-discovery` alpha, so that `cargo deny` is happy again

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
None, swarm-discovery isn't exposed in the API.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
It might be questionable if we want to depend on *more* alphas, but IMHO, this case is fine to avoid a security vulnerability.
Hopefully this is the last alpha. The next version of hickory we depend on should be 0.25.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
