### PR TITLE
refactor(iroh): rename ConnectedRelayActor to ActiveRelayActor

### DIFF
--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -1,7 +1,7 @@
 //! The relay actor.
 //!
 //! The [`RelayActor`] handles all the relay connections.  It is helped by the
-//! [`ConnectedRelayActor`] which handles a single relay connection.
+//! [`ActiveRelayActor`] which handles a single relay connection.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -501,7 +501,7 @@ impl RelayActor {
         self.active_relay_handle(url).await
     }
 
-    /// Returns the address of a [`ConnectedRelayActor`].
+    /// Returns the address of a [`ActiveRelayActor`].
     async fn active_relay_handle(&mut self, url: &RelayUrl) -> &ActiveRelayHandle {
         if !self.active_relays.contains_key(url) {
             self.connect_relay(url, None).await;
@@ -795,7 +795,7 @@ impl RelayActor {
     }
 }
 
-/// Handle to one [`ConnectedRelayActor`].
+/// Handle to one [`ActiveRelayActor`].
 #[derive(Debug)]
 struct ActiveRelayHandle {
     inbox_addr: mpsc::Sender<ActiveRelayMessage>,

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -35,26 +35,17 @@ const RELAY_INACTIVE_CLEANUP_TIME: Duration = Duration::from_secs(60);
 /// How often `clean_stale_relay` runs when there are potentially-stale relay connections to close.
 const RELAY_CLEAN_STALE_INTERVAL: Duration = Duration::from_secs(15);
 
-pub(super) enum RelayActorMessage {
-    Send {
-        url: RelayUrl,
-        contents: RelayContents,
-        remote_node: NodeId,
-    },
-    MaybeCloseRelaysOnRebind(Vec<IpAddr>),
-    SetHome {
-        url: RelayUrl,
-    },
-}
-
-/// An actor which handles a single relay connection.
+/// An actor which handles the connection to a single relay server.
+///
+/// It is responsible for maintaining the connection to the relay server and handling all
+/// communication with it.
 #[derive(Debug)]
-struct ConnectedRelayActor {
+struct ActiveRelayActor {
     /// The time of the last request for its write
     /// channel (currently even if there was no write).
     last_write: Instant,
     /// Queue to send received relay datagrams on.
-    relay_datagrams_queue: Arc<RelayDatagramsQueue>,
+    relay_datagrams_recv: Arc<RelayDatagramsQueue>,
     /// Channel on which we receive packets to send to the relay.
     relay_datagrams_send: mpsc::Receiver<(NodeId, Bytes)>,
     url: RelayUrl,
@@ -72,7 +63,7 @@ struct ConnectedRelayActor {
 
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
-enum ConnectedRelayMessage {
+enum ActiveRelayMessage {
     GetLastWrite(oneshot::Sender<Instant>),
     Ping(oneshot::Sender<Result<Duration, ClientError>>),
     GetLocalAddr(oneshot::Sender<Option<SocketAddr>>),
@@ -82,17 +73,17 @@ enum ConnectedRelayMessage {
     Shutdown,
 }
 
-impl ConnectedRelayActor {
+impl ActiveRelayActor {
     fn new(
         url: RelayUrl,
         relay_client: relay::client::Client,
         relay_client_receiver: relay::client::ClientReceiver,
-        relay_datagrams_queue: Arc<RelayDatagramsQueue>,
+        relay_datagrams_recv: Arc<RelayDatagramsQueue>,
         relay_datagrams_send: mpsc::Receiver<(NodeId, Bytes)>,
     ) -> Self {
-        ConnectedRelayActor {
+        ActiveRelayActor {
             last_write: Instant::now(),
-            relay_datagrams_queue,
+            relay_datagrams_recv,
             relay_datagrams_send,
             url,
             node_present: BTreeSet::new(),
@@ -107,7 +98,7 @@ impl ConnectedRelayActor {
         }
     }
 
-    async fn run(mut self, mut inbox: mpsc::Receiver<ConnectedRelayMessage>) -> anyhow::Result<()> {
+    async fn run(mut self, mut inbox: mpsc::Receiver<ActiveRelayMessage>) -> anyhow::Result<()> {
         debug!("initial dial {}", self.url);
         let relay_client = self.relay_client.clone();
         relay_client.connect().await.context("initial connection")?;
@@ -163,26 +154,26 @@ impl ConnectedRelayActor {
         Ok(())
     }
 
-    async fn handle_actor_msg(&mut self, msg: ConnectedRelayMessage) -> bool {
+    async fn handle_actor_msg(&mut self, msg: ActiveRelayMessage) -> bool {
         trace!("tick: inbox: {:?}", msg);
         match msg {
-            ConnectedRelayMessage::GetLastWrite(r) => {
+            ActiveRelayMessage::GetLastWrite(r) => {
                 r.send(self.last_write).ok();
             }
-            ConnectedRelayMessage::Ping(r) => {
+            ActiveRelayMessage::Ping(r) => {
                 r.send(self.relay_client.ping().await).ok();
             }
-            ConnectedRelayMessage::GetLocalAddr(r) => {
+            ActiveRelayMessage::GetLocalAddr(r) => {
                 r.send(self.relay_client.local_addr().await).ok();
             }
-            ConnectedRelayMessage::GetClient(r) => {
+            ActiveRelayMessage::GetClient(r) => {
                 self.last_write = Instant::now();
                 r.send(self.relay_client.clone()).ok();
             }
-            ConnectedRelayMessage::NotePreferred(is_preferred) => {
+            ActiveRelayMessage::NotePreferred(is_preferred) => {
                 self.relay_client.note_preferred(is_preferred).await;
             }
-            ConnectedRelayMessage::GetNodeRoute(peer, r) => {
+            ActiveRelayMessage::GetNodeRoute(peer, r) => {
                 let client = if self.node_present.contains(&peer) {
                     Some(self.relay_client.clone())
                 } else {
@@ -190,7 +181,7 @@ impl ConnectedRelayActor {
                 };
                 r.send(client).ok();
             }
-            ConnectedRelayMessage::Shutdown => {
+            ActiveRelayMessage::Shutdown => {
                 debug!("shutdown");
                 return true;
             }
@@ -271,7 +262,7 @@ impl ConnectedRelayActor {
                                 src: remote_node_id,
                                 buf: datagram,
                             };
-                            if let Err(err) = self.relay_datagrams_queue.try_send(res) {
+                            if let Err(err) = self.relay_datagrams_recv.try_send(res) {
                                 warn!("dropping received relay packet: {err:#}");
                             }
                         }
@@ -305,11 +296,23 @@ impl ConnectedRelayActor {
     }
 }
 
+pub(super) enum RelayActorMessage {
+    Send {
+        url: RelayUrl,
+        contents: RelayContents,
+        remote_node: NodeId,
+    },
+    MaybeCloseRelaysOnRebind(Vec<IpAddr>),
+    SetHome {
+        url: RelayUrl,
+    },
+}
+
 pub(super) struct RelayActor {
     msock: Arc<MagicSock>,
     relay_datagram_recv_queue: Arc<RelayDatagramsQueue>,
     /// relay Url -> connection to the node
-    connected_relays: BTreeMap<RelayUrl, ConnectedRelayHandle>,
+    active_relays: BTreeMap<RelayUrl, ActiveRelayHandle>,
     ping_tasks: JoinSet<(RelayUrl, bool)>,
     cancel_token: CancellationToken,
 }
@@ -323,7 +326,7 @@ impl RelayActor {
         Self {
             msock,
             relay_datagram_recv_queue,
-            connected_relays: Default::default(),
+            active_relays: Default::default(),
             ping_tasks: Default::default(),
             cancel_token,
         }
@@ -411,18 +414,14 @@ impl RelayActor {
     }
 
     async fn note_preferred(&self, my_url: &RelayUrl) {
-        futures_buffered::join_all(
-            self.connected_relays
-                .iter()
-                .map(|(url, handle)| async move {
-                    let is_preferred = url == my_url;
-                    handle
-                        .inbox_addr
-                        .send(ConnectedRelayMessage::NotePreferred(is_preferred))
-                        .await
-                        .ok()
-                }),
-        )
+        futures_buffered::join_all(self.active_relays.iter().map(|(url, handle)| async move {
+            let is_preferred = url == my_url;
+            handle
+                .inbox_addr
+                .send(ActiveRelayMessage::NotePreferred(is_preferred))
+                .await
+                .ok()
+        }))
         .await;
     }
 
@@ -435,9 +434,7 @@ impl RelayActor {
             len = total_bytes,
             "sending over relay",
         );
-        let handle = self
-            .connected_relay_handle_for_node(url, &remote_node)
-            .await;
+        let handle = self.active_relay_handle_for_node(url, &remote_node).await;
 
         // When Quinn sends a GSO Transmit magicsock::split_packets will make us receive
         // more than one packet to send in a single call.  We join all packets back together
@@ -461,12 +458,8 @@ impl RelayActor {
     }
 
     /// Returns `true`if the message was sent successfully.
-    async fn send_to_connected_relay(
-        &mut self,
-        url: &RelayUrl,
-        msg: ConnectedRelayMessage,
-    ) -> bool {
-        match self.connected_relays.get(url) {
+    async fn send_to_active_relay(&mut self, url: &RelayUrl, msg: ActiveRelayMessage) -> bool {
+        match self.active_relays.get(url) {
             Some(handle) => match handle.inbox_addr.send(msg).await {
                 Ok(_) => true,
                 Err(mpsc::error::SendError(_)) => {
@@ -478,17 +471,17 @@ impl RelayActor {
         }
     }
 
-    async fn connected_relay_handle_for_node(
+    async fn active_relay_handle_for_node(
         &mut self,
         url: &RelayUrl,
         remote_node: &NodeId,
-    ) -> &ConnectedRelayHandle {
-        if !self.connected_relays.contains_key(url) {
+    ) -> &ActiveRelayHandle {
+        if !self.active_relays.contains_key(url) {
             // If we don't have an open connection to the remote node's home relay, see if
             // we have an open connection to a relay node where we'd heard from that peer
             // already.  E.g. maybe they dialed our home relay recently.
             for url in self
-                .connected_relays
+                .active_relays
                 .keys()
                 .cloned()
                 .collect::<Vec<_>>()
@@ -496,27 +489,24 @@ impl RelayActor {
             {
                 let (tx, rx) = oneshot::channel();
                 if self
-                    .send_to_connected_relay(
-                        url,
-                        ConnectedRelayMessage::GetNodeRoute(*remote_node, tx),
-                    )
+                    .send_to_active_relay(url, ActiveRelayMessage::GetNodeRoute(*remote_node, tx))
                     .await
                 {
                     if let Ok(Some(_client)) = rx.await {
-                        return self.connected_relays.get(url).expect("just checked");
+                        return self.active_relays.get(url).expect("just checked");
                     }
                 }
             }
         }
-        self.connected_relay_handle(url).await
+        self.active_relay_handle(url).await
     }
 
     /// Returns the address of a [`ConnectedRelayActor`].
-    async fn connected_relay_handle(&mut self, url: &RelayUrl) -> &ConnectedRelayHandle {
-        if !self.connected_relays.contains_key(url) {
+    async fn active_relay_handle(&mut self, url: &RelayUrl) -> &ActiveRelayHandle {
+        if !self.active_relays.contains_key(url) {
             self.connect_relay(url, None).await;
         }
-        self.connected_relays.get(url).expect("just inserted")
+        self.active_relays.get(url).expect("just inserted")
     }
 
     /// Returns a relay client to a given relay.
@@ -536,7 +526,7 @@ impl RelayActor {
         {
             let (os, or) = oneshot::channel();
             if self
-                .send_to_connected_relay(url, ConnectedRelayMessage::GetClient(os))
+                .send_to_active_relay(url, ActiveRelayMessage::GetClient(os))
                 .await
             {
                 if let Ok(client) = or.await {
@@ -553,7 +543,7 @@ impl RelayActor {
         // SF connection rather than dialing Frankfurt.
         if let Some(node) = remote_node {
             for url in self
-                .connected_relays
+                .active_relays
                 .keys()
                 .cloned()
                 .collect::<Vec<_>>()
@@ -561,7 +551,7 @@ impl RelayActor {
             {
                 let (os, or) = oneshot::channel();
                 if self
-                    .send_to_connected_relay(&url, ConnectedRelayMessage::GetNodeRoute(*node, os))
+                    .send_to_active_relay(&url, ActiveRelayMessage::GetNodeRoute(*node, os))
                     .await
                 {
                     if let Ok(Some(client)) = or.await {
@@ -610,7 +600,7 @@ impl RelayActor {
             let relay_datagrams_queue = self.relay_datagram_recv_queue.clone();
             let span = info_span!("conn-relay-actor", %url);
             async move {
-                let conn_actor = ConnectedRelayActor::new(
+                let conn_actor = ActiveRelayActor::new(
                     url,
                     relay_client,
                     relay_receiver,
@@ -624,14 +614,14 @@ impl RelayActor {
             }
             .instrument(span)
         });
-        let actor_handle = ConnectedRelayHandle {
+        let actor_handle = ActiveRelayHandle {
             inbox_addr: conn_actor_inbox_tx,
             datagrams_send_queue: relay_send_datagram_tx,
             actor_task: handle,
         };
 
         // Insert, to make sure we do not attempt to double connect.
-        self.connected_relays.insert(url.clone(), actor_handle);
+        self.active_relays.insert(url.clone(), actor_handle);
 
         inc!(MagicsockMetrics, num_relay_conns_added);
 
@@ -648,7 +638,7 @@ impl RelayActor {
     async fn maybe_close_relays_on_rebind(&mut self, okay_local_ips: &[IpAddr]) {
         let mut tasks = Vec::new();
         for url in self
-            .connected_relays
+            .active_relays
             .keys()
             .cloned()
             .collect::<Vec<_>>()
@@ -656,7 +646,7 @@ impl RelayActor {
         {
             let (os, or) = oneshot::channel();
             let la = if self
-                .send_to_connected_relay(&url, ConnectedRelayMessage::GetLocalAddr(os))
+                .send_to_active_relay(&url, ActiveRelayMessage::GetLocalAddr(os))
                 .await
             {
                 match or.await {
@@ -678,7 +668,7 @@ impl RelayActor {
 
             let (os, or) = oneshot::channel();
             let ping_sent = self
-                .send_to_connected_relay(&url, ConnectedRelayMessage::Ping(os))
+                .send_to_active_relay(&url, ActiveRelayMessage::Ping(os))
                 .await;
 
             self.ping_tasks.spawn(async move {
@@ -713,21 +703,18 @@ impl RelayActor {
     }
 
     async fn clean_stale_relay(&mut self) {
-        trace!(
-            "checking {} relays for staleness",
-            self.connected_relays.len()
-        );
+        trace!("checking {} relays for staleness", self.active_relays.len());
         let now = Instant::now();
 
         let mut to_close = Vec::new();
-        for (url, handle) in &self.connected_relays {
+        for (url, handle) in &self.active_relays {
             if Some(url) == self.msock.my_relay().as_ref() {
                 continue;
             }
             let (os, or) = oneshot::channel();
             match handle
                 .inbox_addr
-                .send(ConnectedRelayMessage::GetLastWrite(os))
+                .send(ActiveRelayMessage::GetLastWrite(os))
                 .await
             {
                 Ok(_) => match or.await {
@@ -750,7 +737,7 @@ impl RelayActor {
         trace!(
             "closing {} of {} relays",
             to_close.len(),
-            self.connected_relays.len()
+            self.active_relays.len()
         );
         for i in to_close {
             self.close_relay(&i, "idle").await;
@@ -761,11 +748,11 @@ impl RelayActor {
     }
 
     async fn close_all_relay(&mut self, why: &'static str) {
-        if self.connected_relays.is_empty() {
+        if self.active_relays.is_empty() {
             return;
         }
         // Need to collect to avoid double borrow
-        let urls: Vec<_> = self.connected_relays.keys().cloned().collect();
+        let urls: Vec<_> = self.active_relays.keys().cloned().collect();
         for url in urls {
             self.close_relay(&url, why).await;
         }
@@ -773,12 +760,12 @@ impl RelayActor {
     }
 
     async fn close_relay(&mut self, url: &RelayUrl, why: &'static str) {
-        if let Some(handle) = self.connected_relays.remove(url) {
+        if let Some(handle) = self.active_relays.remove(url) {
             debug!(%url, "closing connection: {}", why);
 
             handle
                 .inbox_addr
-                .send(ConnectedRelayMessage::Shutdown)
+                .send(ActiveRelayMessage::Shutdown)
                 .await
                 .ok();
             handle.actor_task.abort(); // ensure the task is shutdown
@@ -788,9 +775,9 @@ impl RelayActor {
     }
 
     fn log_active_relay(&self) {
-        debug!("{} active relay conns{}", self.connected_relays.len(), {
+        debug!("{} active relay conns{}", self.active_relays.len(), {
             let mut s = String::new();
-            if !self.connected_relays.is_empty() {
+            if !self.active_relays.is_empty() {
                 s += ":";
                 for node in self.active_relay_sorted() {
                     s += &format!(" relay-{}", node,);
@@ -801,7 +788,7 @@ impl RelayActor {
     }
 
     fn active_relay_sorted(&self) -> impl Iterator<Item = RelayUrl> {
-        let mut ids: Vec<_> = self.connected_relays.keys().cloned().collect();
+        let mut ids: Vec<_> = self.active_relays.keys().cloned().collect();
         ids.sort();
 
         ids.into_iter()
@@ -810,8 +797,8 @@ impl RelayActor {
 
 /// Handle to one [`ConnectedRelayActor`].
 #[derive(Debug)]
-struct ConnectedRelayHandle {
-    inbox_addr: mpsc::Sender<ConnectedRelayMessage>,
+struct ActiveRelayHandle {
+    inbox_addr: mpsc::Sender<ActiveRelayMessage>,
     datagrams_send_queue: mpsc::Sender<(NodeId, Bytes)>,
     actor_task: JoinHandle<()>,
 }


### PR DESCRIPTION
## Description

Yes, that's (almost) back to what it was called...

The name has grown on me and it is better because the relay is not always connected.  This does also fit better with what it should be doing: keep the connection alive if possible.  Currently this functionality is mixed up in the RelayActor itself.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

- Just a plain rename.
- Base is `flub/relay-send-channel-1`, be aware of github when merging things.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
