### PR TITLE
feat(net-report)!: add `net_report::Options` to specify which probes you want to run

### DIFF
--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -34,7 +34,7 @@ pub enum PacketSource {
 
 /// A store for pkarr signed packets.
 ///
-/// Packets are stored in the persistent [`SignedPacketStore`], and cached on-demand in an in-memory LRU
+/// Packets are stored in the persistent `SignedPacketStore`, and cached on-demand in an in-memory LRU
 /// cache used for resolving DNS queries.
 #[derive(Debug, Clone)]
 pub struct ZoneStore {

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1", default-features = false, features = ["test-util"] }
 [features]
 default = ["metrics"]
 metrics = ["iroh-metrics/metrics", "portmapper/metrics"]
+stun-utils = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -38,8 +38,7 @@ mod ping;
 mod reportgen;
 
 pub use metrics::Metrics;
-pub use reportgen::ProbeProto as ProbeProtocol;
-pub use reportgen::QuicConfig;
+pub use reportgen::{ProbeProto as ProbeProtocol, QuicConfig};
 
 const FULL_REPORT_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
@@ -220,7 +219,8 @@ pub struct Options {
     ///
     /// If not provided and:
     /// - no probes are indicated in the *probes* field,
-    /// - or [`ProbeProto::StunIpv4`] probes are explicitly added to the *probes* list,
+    /// - or [`ProbeProtocol::StunIpv4`] probes are explicitly added to the *probes* list,
+    ///
     /// then the client will attempt to bind a suitable socket itself.
     pub stun_sock_v4: Option<Arc<UdpSocket>>,
     /// Socket to send IPv6 STUN probes from.
@@ -232,6 +232,7 @@ pub struct Options {
     /// If not provided and:
     /// - no probes are indicated in the *probes* field,
     /// - or [`ProbeProtocol::StunIpv6`] probes are explicitly added to the *probes* list,
+    ///
     /// then the client will attempt to bind a suitable socket itself.
     pub stun_sock_v6: Option<Arc<UdpSocket>>,
     /// Endpoint and client configuration to create a QUIC

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -265,8 +265,8 @@ impl Default for Options {
 }
 
 impl Options {
-    /// Create an empty Options that enables no probes
-    pub fn empty() -> Self {
+    /// Create an [`Options`] that disables all probes
+    pub fn disabled() -> Self {
         Self {
             stun_sock_v4: None,
             stun_sock_v6: None,

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -295,21 +295,21 @@ impl Options {
         self
     }
 
-    /// Enable icmp_v4 probe
-    pub fn enable_icmp_v4(mut self) -> Self {
-        self.icmp_v4 = true;
+    /// Enable or disable icmp_v4 probe
+    pub fn icmp_v4(mut self, enable: bool) -> Self {
+        self.icmp_v4 = enable;
         self
     }
 
-    /// Enable icmp_v6 probe
-    pub fn enable_icmp_v6(mut self) -> Self {
-        self.icmp_v6 = true;
+    /// Enable or disable icmp_v6 probe
+    pub fn icmp_v6(mut self, enable: bool) -> Self {
+        self.icmp_v6 = enable;
         self
     }
 
-    /// Enable https probe
-    pub fn enable_https(mut self) -> Self {
-        self.https = true;
+    /// Enable or disable https probe
+    pub fn https(mut self, enable: bool) -> Self {
+        self.https = enable;
         self
     }
 

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -867,11 +867,11 @@ pub fn os_has_ipv6() -> bool {
 
 #[cfg(any(test, feature = "stun-utils"))]
 pub(crate) mod stun_utils {
-    use super::*;
-
     use anyhow::Context as _;
     use netwatch::IpFamily;
     use tokio_util::sync::CancellationToken;
+
+    use super::*;
 
     /// Attempts to bind a local socket to send STUN packets from.
     ///

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -696,6 +696,10 @@ pub struct QuicConfig {
     pub ep: quinn::Endpoint,
     /// A client config.
     pub client_config: rustls::ClientConfig,
+    /// Enable ipv4 QUIC address discovery probes
+    pub ipv4: bool,
+    /// Enable ipv6 QUIC address discovery probes
+    pub ipv6: bool,
 }
 
 /// Executes a particular [`Probe`], including using a delayed start if needed.
@@ -1586,6 +1590,8 @@ mod tests {
         let quic_addr_disc = QuicConfig {
             ep: ep.clone(),
             client_config,
+            ipv4: true,
+            ipv6: true,
         };
         let url = relay.url.clone();
         let port = server.quic_addr().unwrap().port();

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -799,7 +799,7 @@ async fn run_probe(
             let url = node.url.clone();
             match quic_config {
                 Some(quic_config) => {
-                    run_quic_probe(quic_config, url, relay_addr, probe).await?;
+                    result = run_quic_probe(quic_config, url, relay_addr, probe).await?;
                 }
                 None => {
                     return Err(ProbeError::AbortSet(

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -17,6 +17,7 @@
 //! - Sends the completed report to the net_report actor.
 
 use std::{
+    collections::BTreeSet,
     future::Future,
     net::{IpAddr, SocketAddr},
     pin::Pin,
@@ -59,7 +60,8 @@ use crate::{
 mod hairpin;
 mod probes;
 
-use probes::{Probe, ProbePlan, ProbeProto};
+pub use probes::ProbeProto;
+use probes::{Probe, ProbePlan};
 
 use crate::defaults::timeouts::{
     CAPTIVE_PORTAL_DELAY, CAPTIVE_PORTAL_TIMEOUT, OVERALL_REPORT_TIMEOUT, PROBES_TIMEOUT,
@@ -91,6 +93,7 @@ impl Client {
         stun_sock6: Option<Arc<UdpSocket>>,
         quic_config: Option<QuicConfig>,
         dns_resolver: DnsResolver,
+        protocols: BTreeSet<ProbeProto>,
     ) -> Self {
         let (msg_tx, msg_rx) = mpsc::channel(32);
         let addr = Addr {
@@ -110,6 +113,7 @@ impl Client {
             hairpin_actor: hairpin::Client::new(net_report, addr),
             outstanding_tasks: OutstandingTasks::default(),
             dns_resolver,
+            protocols,
         };
         let task = tokio::spawn(
             async move { actor.run().await }.instrument(info_span!("reportgen.actor")),
@@ -193,6 +197,9 @@ struct Actor {
     outstanding_tasks: OutstandingTasks,
     /// The DNS resolver to use for probes that need to resolve DNS records.
     dns_resolver: DnsResolver,
+    /// Protocols we should attempt to create probes for, if we have the correct
+    /// configuration for that protocol.
+    protocols: BTreeSet<ProbeProto>,
 }
 
 impl Actor {
@@ -536,8 +543,10 @@ impl Actor {
         let if_state = interfaces::State::new().await;
         debug!(%if_state, "Local interfaces");
         let plan = match self.last_report {
-            Some(ref report) => ProbePlan::with_last_report(&self.relay_map, &if_state, report),
-            None => ProbePlan::initial(&self.relay_map, &if_state),
+            Some(ref report) => {
+                ProbePlan::with_last_report(&self.relay_map, &if_state, report, &self.protocols)
+            }
+            None => ProbePlan::initial(&self.relay_map, &if_state, &self.protocols),
         };
         trace!(%plan, "probe plan");
 

--- a/iroh-net-report/src/reportgen/probes.rs
+++ b/iroh-net-report/src/reportgen/probes.rs
@@ -289,7 +289,7 @@ impl ProbePlan {
                 // the highest probe delay and the next probes we create
                 // if there are no high priority probes, we don't need a buffer
                 if plan.has_priority_probes() {
-                    start = start + DEFAULT_INITIAL_RETRANSMIT;
+                    start += DEFAULT_INITIAL_RETRANSMIT;
                 }
                 let delay = start + DEFAULT_INITIAL_RETRANSMIT * attempt as u32;
                 https_probes
@@ -568,7 +568,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::{test_utils, Options, RelayLatencies};
+    use crate::{test_utils, RelayLatencies};
 
     /// Shorthand which declares a new ProbeSet.
     ///
@@ -590,13 +590,25 @@ mod tests {
         };
     }
 
+    fn default_protocols() -> BTreeSet<ProbeProto> {
+        BTreeSet::from([
+            ProbeProto::StunIpv4,
+            ProbeProto::StunIpv6,
+            ProbeProto::QuicIpv4,
+            ProbeProto::QuicIpv6,
+            ProbeProto::IcmpV4,
+            ProbeProto::IcmpV6,
+            ProbeProto::Https,
+        ])
+    }
+
     #[tokio::test]
     async fn test_initial_probeplan() {
         let (_servers, relay_map) = test_utils::relay_map(2).await;
         let relay_node_1 = relay_map.nodes().next().unwrap();
         let relay_node_2 = relay_map.nodes().nth(1).unwrap();
         let if_state = interfaces::State::fake();
-        let plan = ProbePlan::initial(&relay_map, &if_state, &Options::default_protocols());
+        let plan = ProbePlan::initial(&relay_map, &if_state, &default_protocols());
 
         let expected_plan: ProbePlan = [
             probeset! {
@@ -818,7 +830,7 @@ mod tests {
                 &relay_map,
                 &if_state,
                 &last_report,
-                &Options::default_protocols(),
+                &default_protocols(),
             );
             let expected_plan: ProbePlan = [
                 probeset! {

--- a/iroh-net-report/src/reportgen/probes.rs
+++ b/iroh-net-report/src/reportgen/probes.rs
@@ -268,7 +268,7 @@ impl ProbePlan {
                     .expect("adding QuicIpv6 probe to a QuicAddrIpv6 probe set");
             }
             plan.add_probes(
-                &protocols,
+                protocols,
                 vec![
                     stun_ipv4_probes,
                     stun_ipv6_probes,
@@ -317,7 +317,7 @@ impl ProbePlan {
             }
 
             plan.add_probes(
-                &protocols,
+                protocols,
                 vec![https_probes, icmp_probes_ipv4, icmp_probes_ipv6],
             );
         }
@@ -513,7 +513,7 @@ impl ProbePlan {
                 return true;
             }
         }
-        return false;
+        false
     }
 }
 

--- a/iroh-net-report/src/reportgen/probes.rs
+++ b/iroh-net-report/src/reportgen/probes.rs
@@ -610,7 +610,7 @@ mod tests {
         let if_state = interfaces::State::fake();
         let plan = ProbePlan::initial(&relay_map, &if_state, &default_protocols());
 
-        let expected_plan: ProbePlan = [
+        let mut expected_plan: ProbePlan = [
             probeset! {
                 proto: ProbeProto::StunIpv4,
                 relay: relay_node_1.clone(),
@@ -712,6 +712,7 @@ mod tests {
         ]
         .into_iter()
         .collect();
+        expected_plan.protocols = default_protocols();
 
         println!("expected:");
         println!("{expected_plan}");
@@ -735,7 +736,7 @@ mod tests {
             &BTreeSet::from([ProbeProto::Https, ProbeProto::IcmpV4, ProbeProto::IcmpV6]),
         );
 
-        let expected_plan: ProbePlan = [
+        let mut expected_plan: ProbePlan = [
             probeset! {
                 proto: ProbeProto::Https,
                 relay: relay_node_1.clone(),
@@ -781,6 +782,8 @@ mod tests {
         ]
         .into_iter()
         .collect();
+        expected_plan.protocols =
+            BTreeSet::from([ProbeProto::Https, ProbeProto::IcmpV4, ProbeProto::IcmpV6]);
 
         println!("expected:");
         println!("{expected_plan}");
@@ -832,7 +835,7 @@ mod tests {
                 &last_report,
                 &default_protocols(),
             );
-            let expected_plan: ProbePlan = [
+            let mut expected_plan: ProbePlan = [
                 probeset! {
                     proto: ProbeProto::StunIpv4,
                     relay: relay_node_1.clone(),
@@ -934,6 +937,7 @@ mod tests {
             ]
             .into_iter()
             .collect();
+            expected_plan.protocols = default_protocols();
 
             println!("{} round", i);
             println!("expected:");

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -260,10 +260,7 @@ impl QuicClient {
         let mut observed_addr = res.expect("checked");
         // if we've sent to an ipv4 address, but received an observed address
         // that is ivp6 then the address is an [IPv4-Mapped IPv6 Addresses](https://doc.rust-lang.org/beta/std/net/struct.Ipv6Addr.html#ipv4-mapped-ipv6-addresses)
-        if server_addr.is_ipv4() && observed_addr.is_ipv6() {
-            observed_addr =
-                SocketAddr::new(observed_addr.ip().to_canonical(), observed_addr.port());
-        }
+        observed_addr = SocketAddr::new(observed_addr.ip().to_canonical(), observed_addr.port());
         let latency = conn.rtt() / 2;
         // gracefully close the connections
         conn.close(QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON);

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -38,6 +38,7 @@ use futures_util::{stream::BoxStream, task::AtomicWaker};
 use iroh_base::{NodeAddr, NodeId, PublicKey, RelayUrl, SecretKey};
 use iroh_metrics::{inc, inc_by};
 use iroh_relay::{protos::stun, RelayMap};
+use net_report::Options as ReportOptions;
 use netwatch::{interfaces, ip::LocalAddresses, netmon, UdpSocket};
 use quinn::AsyncUdpSocket;
 use rand::{seq::SliceRandom, Rng, SeedableRng};
@@ -2360,7 +2361,13 @@ impl Actor {
         debug!("requesting net_report report");
         match self
             .net_reporter
-            .get_report_channel(relay_map, pconn4, pconn6, quic_config)
+            .get_report_channel(ReportOptions {
+                relay_map,
+                stun_sock_v4: pconn4,
+                stun_sock_v6: pconn6,
+                quic_config,
+                protocols: ReportOptions::default_protocols(),
+            })
             .await
         {
             Ok(rx) => {


### PR DESCRIPTION
## Description

Breaking change that allows you to specify which probe protocols you would like to run.

Really written so it is easier to test QUIC address discovery on `iroh doctor`, but this also allows us to test specific protocols in isolation.

## Breaking Changes

- `iroh-net-report`
    - added
        - `net_report::Client::get_report_with_options`
    - changed
        - `net_report::Client::get_report_channel` now takes an `opts: net_report::Options`
        - `net_report::Client` will no longer bind `UdpSocket`s when one is not provided for both STUN over IPv4 or STUN over IPv6.

## Notes & open questions

I'm open to adjustments on the `Options`. The whole "we build a UDP socket for you if one isn't provided" bit means that I couldn't rely on, for example, `stun_sock_v4 == None` to know whether the user wanted to run a stun ipv4 probe, so I needed the `protocols: BTreeSet<ProbeProtocol>` field. I think this is a decent compromise between annoying and useful, but would love feedback.

Edit:
Adjusted this so that the Options DO correlate to the protocols we want to run. This means that we will no longer bind a UdpSocket for you if one is not provided.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
