### PR TITLE
refactor!: Make PUBLIC_KEY_LENGTH a const that is on PublicKey

### DIFF
--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-pub use ed25519_dalek::{Signature, PUBLIC_KEY_LENGTH};
+pub use ed25519_dalek::Signature;
 use ed25519_dalek::{SignatureError, SigningKey, VerifyingKey};
 use once_cell::sync::OnceCell;
 use rand_core::CryptoRngCore;
@@ -180,6 +180,8 @@ impl PublicKey {
     pub fn fmt_short(&self) -> String {
         data_encoding::HEXLOWER.encode(&self.as_bytes()[..5])
     }
+
+    pub const LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
 }
 
 impl TryFrom<&[u8]> for PublicKey {
@@ -422,7 +424,7 @@ impl TryFrom<&[u8]> for SecretKey {
 fn decode_base32_hex(s: &str) -> Result<[u8; 32], KeyParsingError> {
     let mut bytes = [0u8; 32];
 
-    let res = if s.len() == PUBLIC_KEY_LENGTH * 2 {
+    let res = if s.len() == PublicKey::LENGTH * 2 {
         // hex
         data_encoding::HEXLOWER.decode_mut(s.as_bytes(), &mut bytes)
     } else {
@@ -430,7 +432,7 @@ fn decode_base32_hex(s: &str) -> Result<[u8; 32], KeyParsingError> {
     };
     match res {
         Ok(len) => {
-            if len != PUBLIC_KEY_LENGTH {
+            if len != PublicKey::LENGTH {
                 return Err(KeyParsingError::DecodeInvalidLength);
             }
         }

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -13,9 +13,7 @@ mod node_addr;
 mod relay_url;
 
 #[cfg(feature = "key")]
-pub use self::key::{
-    KeyParsingError, NodeId, PublicKey, SecretKey, SharedSecret, Signature,
-};
+pub use self::key::{KeyParsingError, NodeId, PublicKey, SecretKey, SharedSecret, Signature};
 #[cfg(feature = "key")]
 pub use self::node_addr::NodeAddr;
 #[cfg(feature = "relay")]

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -14,7 +14,7 @@ mod relay_url;
 
 #[cfg(feature = "key")]
 pub use self::key::{
-    KeyParsingError, NodeId, PublicKey, SecretKey, SharedSecret, Signature, PUBLIC_KEY_LENGTH,
+    KeyParsingError, NodeId, PublicKey, SecretKey, SharedSecret, Signature,
 };
 #[cfg(feature = "key")]
 pub use self::node_addr::NodeAddr;

--- a/iroh/src/disco.rs
+++ b/iroh/src/disco.rs
@@ -44,7 +44,7 @@ const TX_LEN: usize = 12;
 /// Header: Type | Version
 const HEADER_LEN: usize = 2;
 
-const PING_LEN: usize = TX_LEN + iroh_base::PUBLIC_KEY_LENGTH;
+const PING_LEN: usize = TX_LEN + iroh_base::PublicKey::LENGTH;
 const EP_LENGTH: usize = 16 + 2; // 16 byte IP address + 2 byte port
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -206,7 +206,7 @@ impl Ping {
         // Deliberately lax on longer-than-expected messages, for future compatibility.
         ensure!(p.len() >= PING_LEN, "message too short");
         let tx_id: [u8; TX_LEN] = p[..TX_LEN].try_into().expect("length checked");
-        let raw_key = &p[TX_LEN..TX_LEN + iroh_base::PUBLIC_KEY_LENGTH];
+        let raw_key = &p[TX_LEN..TX_LEN + iroh_base::PublicKey::LENGTH];
         let node_key = PublicKey::try_from(raw_key)?;
         let tx_id = stun_rs::TransactionId::from(tx_id);
 

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -13,7 +13,7 @@ use std::{
 use anyhow::Context;
 use backoff::backoff::Backoff;
 use bytes::{Bytes, BytesMut};
-use iroh_base::{NodeId, RelayUrl, PUBLIC_KEY_LENGTH};
+use iroh_base::{NodeId, PublicKey, RelayUrl};
 use iroh_metrics::{inc, inc_by};
 use iroh_relay::{self as relay, client::ClientError, ReceivedMessage, MAX_PACKET_SIZE};
 use tokio::{
@@ -422,7 +422,7 @@ impl RelayActor {
     }
 
     async fn send_relay(&mut self, url: &RelayUrl, contents: RelayContents, remote_node: NodeId) {
-        const PAYLOAD_SIZE: usize = MAX_PACKET_SIZE - PUBLIC_KEY_LENGTH;
+        const PAYLOAD_SIZE: usize = MAX_PACKET_SIZE - PublicKey::LENGTH;
         let total_bytes = contents.iter().map(|c| c.len() as u64).sum::<u64>();
         trace!(
             %url,


### PR DESCRIPTION
## Description

Make PUBLIC_KEY_LENGTH a const that is on PublicKey

that way it is not so in your face

## Breaking Changes

- PUBLIC_KEY_LENGTH is moved from a top level constant to PublicKey::LENGTH
