### PR TITLE
refactor(iroh-base)!: reduce dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,18 +754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,7 +942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1024,20 +1011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,25 +1041,6 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "embedded-io"
@@ -1189,16 +1143,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "ff"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
-dependencies = [
- "rand_core",
- "subtle",
-]
 
 [[package]]
 name = "fiat-crypto"
@@ -1524,17 +1468,6 @@ dependencies = [
  "rand",
  "smallvec",
  "spinning_top",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -2243,14 +2176,12 @@ name = "iroh-base"
 version = "0.29.0"
 dependencies = [
  "aead",
- "anyhow",
  "crypto_box",
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
  "getrandom",
  "iroh-test 0.28.0",
- "once_cell",
  "postcard",
  "proptest",
  "rand",
@@ -2258,11 +2189,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
- "ssh-key",
  "thiserror 2.0.6",
  "ttl_cache",
  "url",
- "zeroize",
 ]
 
 [[package]]
@@ -2310,6 +2239,8 @@ dependencies = [
  "iroh-test 0.29.0",
  "lru",
  "pkarr",
+ "rand",
+ "rand_chacha",
  "rcgen",
  "redb",
  "regex",
@@ -2591,9 +2522,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libc"
@@ -3014,23 +2942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,17 +2953,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -3151,44 +3051,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p521"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
-dependencies = [
- "base16ct",
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "rand_core",
- "sha2",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,15 +3099,6 @@ checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
  "base64",
  "serde",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -3356,17 +3209,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "z32",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
 ]
 
 [[package]]
@@ -3587,15 +3429,6 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -4013,16 +3846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,27 +3858,6 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core",
- "sha2",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4320,20 +4122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4528,7 +4316,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
  "rand_core",
 ]
 
@@ -4598,48 +4385,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "ssh-cipher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
-dependencies = [
- "cipher",
- "ssh-encoding",
-]
-
-[[package]]
-name = "ssh-encoding"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
-dependencies = [
- "base64ct",
- "pem-rfc7468",
- "sha2",
-]
-
-[[package]]
-name = "ssh-key"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
-dependencies = [
- "ed25519-dalek",
- "p256",
- "p384",
- "p521",
- "rand_core",
- "rsa",
- "sec1",
- "sha2",
- "signature",
- "ssh-cipher",
- "ssh-encoding",
- "subtle",
- "zeroize",
 ]
 
 [[package]]

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -15,48 +15,39 @@ rust-version = "1.81"
 workspace = true
 
 [dependencies]
-anyhow = { version = "1", optional = true }
+aead = { version = "0.5.2", features = ["bytes"], optional = true }
+crypto_box = { version = "0.9.1", features = ["serde", "chacha20"], optional = true }
 data-encoding = { version = "2.3.3", optional = true }
+ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core", "zeroize"], optional = true }
+derive_more = { version = "1.0.0", features = ["display"], optional = true }
+url = { version = "2.5", features = ["serde"], optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"], optional = true }
+rand_core = { version = "0.6.4", optional = true }
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "2", optional = true }
-
-# key module
-aead = { version = "0.5.2", features = ["bytes"], optional = true }
-derive_more = { version = "1.0.0", features = ["debug", "display", "from_str"], optional = true }
-ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"], optional = true }
-once_cell = { version = "1.18.0", optional = true }
-rand = { version = "0.8", optional = true }
-rand_core = { version = "0.6.4", optional = true }
-ssh-key = { version = "0.6.0", features = ["ed25519", "std", "rand_core"], optional = true }
 ttl_cache = { version = "0.5.1", optional = true }
-crypto_box = { version = "0.9.1", features = ["serde", "chacha20"], optional = true }
-zeroize = { version = "1.5", optional = true }
-url = { version = "2.5", features = ["serde"], optional = true }
+
 # wasm
 getrandom = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 iroh-test = "0.28.0"
+postcard = { version = "1", features = ["use-std"] }
 proptest = "1.0.0"
+rand = "0.8"
 serde_json = "1"
 serde_test = "1"
-postcard = { version = "1", features = ["use-std"] }
+
 
 [features]
 default = ["ticket", "relay"]
 ticket = ["key", "dep:postcard", "dep:data-encoding"]
 key = [
-  "dep:anyhow",
   "dep:ed25519-dalek",
-  "dep:once_cell",
-  "dep:rand",
   "dep:rand_core",
-  "dep:ssh-key",
   "dep:ttl_cache",
   "dep:aead",
   "dep:crypto_box",
-  "dep:zeroize",
   "dep:url",
   "dep:derive_more",
   "dep:getrandom",
@@ -68,7 +59,6 @@ wasm = ["getrandom?/js"]
 relay = [
   "dep:url",
   "dep:derive_more",
-  "dep:anyhow",
   "dep:thiserror",
 ]
 

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -335,6 +335,12 @@ impl SecretKey {
     }
 
     /// Generate a new [`SecretKey`] with a randomness generator.
+    ///
+    /// ```rust
+    /// // use the OsRng option for OS depedndent most secure RNG.
+    /// let mut rng = rand::rngs::OsRng;
+    /// let _key = iroh_base::SecretKey::generate(&mut rng);
+    /// ```
     pub fn generate<R: CryptoRngCore>(mut csprng: R) -> Self {
         let secret = SigningKey::generate(&mut csprng);
 

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -6,20 +6,18 @@ use std::{
     fmt::{Debug, Display},
     hash::Hash,
     str::FromStr,
-    sync::Mutex,
+    sync::{Mutex, OnceLock},
     time::Duration,
 };
 
 pub use ed25519_dalek::Signature;
 use ed25519_dalek::{SignatureError, SigningKey, VerifyingKey};
-use once_cell::sync::OnceCell;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
-use ssh_key::LineEnding;
 use ttl_cache::TtlCache;
 
-pub use self::encryption::SharedSecret;
 use self::encryption::{public_ed_box, secret_ed_box};
+pub use self::encryption::{DecryptionError, SharedSecret};
 
 #[derive(Debug)]
 struct CryptoKeys {
@@ -48,7 +46,7 @@ const KEY_CACHE_TTL: Duration = Duration::from_secs(60);
 ///
 /// So that is about 4MB of max memory for the cache.
 const KEY_CACHE_CAPACITY: usize = 1024 * 16;
-static KEY_CACHE: OnceCell<Mutex<TtlCache<[u8; 32], CryptoKeys>>> = OnceCell::new();
+static KEY_CACHE: OnceLock<Mutex<TtlCache<[u8; 32], CryptoKeys>>> = OnceLock::new();
 
 fn lock_key_cache() -> std::sync::MutexGuard<'static, TtlCache<[u8; 32], CryptoKeys>> {
     let mutex = KEY_CACHE.get_or_init(|| Mutex::new(TtlCache::new(KEY_CACHE_CAPACITY)));
@@ -181,6 +179,7 @@ impl PublicKey {
         data_encoding::HEXLOWER.encode(&self.as_bytes()[..5])
     }
 
+    /// The length of an ed25519 `PublicKey`, in bytes.
     pub const LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
 }
 
@@ -259,6 +258,7 @@ pub enum KeyParsingError {
     /// Error when decoding the public key.
     #[error("key: {0}")]
     Key(#[from] ed25519_dalek::SignatureError),
+    /// The encoded information had the wrong length.
     #[error("invalid length")]
     DecodeInvalidLength,
 }
@@ -280,7 +280,7 @@ impl FromStr for PublicKey {
 #[derive(Clone)]
 pub struct SecretKey {
     secret: SigningKey,
-    secret_crypto_box: OnceCell<crypto_box::SecretKey>,
+    secret_crypto_box: OnceLock<crypto_box::SecretKey>,
 }
 
 impl Debug for SecretKey {
@@ -334,40 +334,13 @@ impl SecretKey {
         self.secret.verifying_key().into()
     }
 
-    /// Generate a new [`SecretKey`] with the default randomness generator.
-    pub fn generate() -> Self {
-        let mut rng = rand::rngs::OsRng;
-        Self::generate_with_rng(&mut rng)
-    }
-
     /// Generate a new [`SecretKey`] with a randomness generator.
-    pub fn generate_with_rng<R: CryptoRngCore + ?Sized>(csprng: &mut R) -> Self {
-        let secret = SigningKey::generate(csprng);
+    pub fn generate<R: CryptoRngCore>(mut csprng: R) -> Self {
+        let secret = SigningKey::generate(&mut csprng);
 
         Self {
             secret,
-            secret_crypto_box: OnceCell::default(),
-        }
-    }
-
-    /// Serialise this key to OpenSSH format.
-    pub fn to_openssh(&self) -> ssh_key::Result<zeroize::Zeroizing<String>> {
-        let ckey = ssh_key::private::Ed25519Keypair {
-            public: self.secret.verifying_key().into(),
-            private: self.secret.clone().into(),
-        };
-        ssh_key::private::PrivateKey::from(ckey).to_openssh(LineEnding::default())
-    }
-
-    /// Deserialise this key from OpenSSH format.
-    pub fn try_from_openssh<T: AsRef<[u8]>>(data: T) -> anyhow::Result<Self> {
-        let ser_key = ssh_key::private::PrivateKey::from_openssh(data)?;
-        match ser_key.key_data() {
-            ssh_key::private::KeypairData::Ed25519(kp) => Ok(SecretKey {
-                secret: kp.private.clone().into(),
-                secret_crypto_box: OnceCell::default(),
-            }),
-            _ => anyhow::bail!("invalid key format"),
+            secret_crypto_box: Default::default(),
         }
     }
 
@@ -400,7 +373,7 @@ impl From<SigningKey> for SecretKey {
     fn from(secret: SigningKey) -> Self {
         SecretKey {
             secret,
-            secret_crypto_box: OnceCell::default(),
+            secret_crypto_box: Default::default(),
         }
     }
 }
@@ -460,14 +433,6 @@ mod tests {
     }
 
     #[test]
-    fn test_secret_key_openssh_roundtrip() {
-        let kp = SecretKey::generate();
-        let ser = kp.to_openssh().unwrap();
-        let de = SecretKey::try_from_openssh(&ser).unwrap();
-        assert_eq!(kp.to_bytes(), de.to_bytes());
-    }
-
-    #[test]
     fn public_key_postcard() {
         let key = PublicKey::from_bytes(&[0; 32]).unwrap();
         let bytes = postcard::to_stdvec(&key).unwrap();
@@ -485,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_display_from_str() {
-        let key = SecretKey::generate();
+        let key = SecretKey::generate(&mut rand::thread_rng());
         assert_eq!(
             SecretKey::from_str(&key.to_string()).unwrap().to_bytes(),
             key.to_bytes()

--- a/iroh-base/src/key/encryption.rs
+++ b/iroh-base/src/key/encryption.rs
@@ -23,7 +23,7 @@ pub enum DecryptionError {
     /// The nonce had the wrong size.
     #[error("Invalid nonce")]
     InvalidNonce,
-    /// AEAD decrption faile.
+    /// AEAD decryption failed.
     #[error("Aead error")]
     Aead(aead::Error),
 }

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -1,5 +1,7 @@
 //! Base types and utilities for Iroh
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
 // TODO: move to own crate
 #[cfg(feature = "ticket")]
@@ -13,8 +15,10 @@ mod node_addr;
 mod relay_url;
 
 #[cfg(feature = "key")]
-pub use self::key::{KeyParsingError, NodeId, PublicKey, SecretKey, SharedSecret, Signature};
+pub use self::key::{
+    DecryptionError, KeyParsingError, NodeId, PublicKey, SecretKey, SharedSecret, Signature,
+};
 #[cfg(feature = "key")]
 pub use self::node_addr::NodeAddr;
 #[cfg(feature = "relay")]
-pub use self::relay_url::RelayUrl;
+pub use self::relay_url::{RelayUrl, RelayUrlParsingError};

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -21,4 +21,4 @@ pub use self::key::{
 #[cfg(feature = "key")]
 pub use self::node_addr::NodeAddr;
 #[cfg(feature = "relay")]
-pub use self::relay_url::{RelayUrl, RelayUrlParsingError};
+pub use self::relay_url::{RelayUrl, RelayUrlParseError};

--- a/iroh-base/src/relay_url.rs
+++ b/iroh-base/src/relay_url.rs
@@ -38,14 +38,14 @@ impl From<Url> for RelayUrl {
 /// Can occur when parsing a string into a [`RelayUrl`].
 #[derive(Debug, thiserror::Error)]
 #[error("Failed to parse: {0}")]
-pub struct RelayUrlParsingError(#[from] url::ParseError);
+pub struct RelayUrlParseError(#[from] url::ParseError);
 
 /// Support for parsing strings directly.
 ///
 /// If you need more control over the error first create a [`Url`] and use [`RelayUrl::from`]
 /// instead.
 impl FromStr for RelayUrl {
-    type Err = RelayUrlParsingError;
+    type Err = RelayUrlParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let inner = Url::from_str(s)?;

--- a/iroh-base/src/relay_url.rs
+++ b/iroh-base/src/relay_url.rs
@@ -1,6 +1,5 @@
 use std::{fmt, ops::Deref, str::FromStr};
 
-use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use url::Url;
 /// A URL identifying a relay server.
@@ -36,15 +35,20 @@ impl From<Url> for RelayUrl {
     }
 }
 
+/// Can occur when parsing a string into a [`RelayUrl`].
+#[derive(Debug, thiserror::Error)]
+#[error("Failed to parse: {0}")]
+pub struct RelayUrlParsingError(#[from] url::ParseError);
+
 /// Support for parsing strings directly.
 ///
 /// If you need more control over the error first create a [`Url`] and use [`RelayUrl::from`]
 /// instead.
 impl FromStr for RelayUrl {
-    type Err = anyhow::Error;
+    type Err = RelayUrlParsingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let inner = Url::from_str(s).context("invalid URL")?;
+        let inner = Url::from_str(s)?;
         Ok(RelayUrl::from(inner))
     }
 }

--- a/iroh-base/src/ticket.rs
+++ b/iroh-base/src/ticket.rs
@@ -1,3 +1,8 @@
+//! Tickets is a serializable object combining information required for an operation.
+//! Typically tickets contain all information required for an operation, e.g. an iroh blob
+//! ticket would contain the hash of the data as well as information about how to reach the
+//! provider.
+
 use std::{collections::BTreeSet, net::SocketAddr};
 
 use serde::{Deserialize, Serialize};
@@ -9,10 +14,6 @@ mod node;
 pub use self::node::NodeTicket;
 
 /// A ticket is a serializable object combining information required for an operation.
-///
-/// Typically tickets contain all information required for an operation, e.g. an iroh blob
-/// ticket would contain the hash of the data as well as information about how to reach the
-/// provider.
 ///
 /// Tickets support serialization to a string using base32 encoding. The kind of
 /// ticket will be prepended to the string to make it somewhat self describing.
@@ -60,7 +61,10 @@ pub trait Ticket: Sized {
 pub enum Error {
     /// Found a ticket of with the wrong prefix, indicating the wrong kind.
     #[error("wrong prefix, expected {expected}")]
-    Kind { expected: &'static str },
+    Kind {
+        /// The expected prefix.
+        expected: &'static str,
+    },
     /// This looks like a ticket, but postcard deserialization failed.
     #[error("deserialization failed: {_0}")]
     Postcard(#[from] postcard::Error),

--- a/iroh-base/src/ticket/node.rs
+++ b/iroh-base/src/ticket/node.rs
@@ -141,7 +141,7 @@ mod tests {
     use crate::key::{PublicKey, SecretKey};
 
     fn make_ticket() -> NodeTicket {
-        let peer = SecretKey::generate().public();
+        let peer = SecretKey::generate(&mut rand::thread_rng()).public();
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
         let relay_url = None;
         NodeTicket {

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -63,6 +63,8 @@ hickory-resolver = "=0.25.0-alpha.4"
 iroh = { version = "0.29.0", path = "../iroh" }
 iroh-test = { version = "0.29.0", path = "../iroh-test" }
 pkarr = { version = "2.2.0", features = ["rand"] }
+rand = "0.8"
+rand_chacha = "0.3.1"
 testresult = "0.4.1"
 
 [[bench]]

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use iroh::{discovery::pkarr::PkarrRelayClient, dns::node_info::NodeInfo, SecretKey};
 use iroh_dns_server::{config::Config, server::Server, ZoneStore};
+use rand_chacha::rand_core::SeedableRng;
 use tokio::runtime::Runtime;
 
 const LOCALHOST_PKARR: &str = "http://localhost:8080/pkarr";
@@ -23,7 +24,8 @@ fn benchmark_dns_server(c: &mut Criterion) {
                     let config = Config::load("./config.dev.toml").await.unwrap();
                     let server = start_dns_server(config).await.unwrap();
 
-                    let secret_key = SecretKey::generate();
+                    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+                    let secret_key = SecretKey::generate(&mut rng);
                     let node_id = secret_key.public();
 
                     let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     let secret_key = match std::env::var("IROH_SECRET") {
         Ok(s) => SecretKey::from_str(&s)?,
         Err(_) if args.create => {
-            let s = SecretKey::generate();
+            let s = SecretKey::generate(rand::rngs::OsRng);
             println!("Generated a new node secret. To reuse, set");
             println!("IROH_SECRET={s}");
             s

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -170,7 +170,7 @@ mod tests {
 
         let origin = "irohdns.example.";
 
-        let secret_key = SecretKey::generate();
+        let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
         let relay_url: Url = "https://relay.example.".parse()?;
         let pkarr = PkarrRelayClient::new(pkarr_relay);
@@ -235,7 +235,7 @@ mod tests {
         let origin = "irohdns.example.";
 
         // create a signed packet
-        let secret_key = SecretKey::generate();
+        let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
         let relay_url: Url = "https://relay.example.".parse()?;
         let node_info = NodeInfo::new(node_id, Some(relay_url.clone()), Default::default());
@@ -272,7 +272,7 @@ mod tests {
     }
 
     fn random_signed_packet() -> Result<SignedPacket> {
-        let secret_key = SecretKey::generate();
+        let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
         let relay_url: Url = "https://relay.example.".parse()?;
         let node_info = NodeInfo::new(node_id, Some(relay_url.clone()), Default::default());

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -1158,7 +1158,7 @@ mod tests {
     async fn test_recv_detail_connect_error() -> Result<()> {
         let _guard = iroh_test::logging::setup();
 
-        let key = SecretKey::generate();
+        let key = SecretKey::generate(rand::thread_rng());
         let bad_url: Url = "https://bad.url".parse().unwrap();
         let dns_resolver = default_resolver();
 

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -599,7 +599,7 @@ mod tests {
         let mut reader = FramedRead::new(reader, DerpCodec);
         let mut writer = FramedWrite::new(writer, DerpCodec);
 
-        let client_key = SecretKey::generate();
+        let client_key = SecretKey::generate(rand::thread_rng());
         let client_info = ClientInfo {
             version: PROTOCOL_VERSION,
         };

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -881,7 +881,7 @@ mod tests {
         let relay_url: RelayUrl = relay_url.parse().unwrap();
 
         // set up client a
-        let a_secret_key = SecretKey::generate();
+        let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
         let (client_a, mut client_a_receiver) =
@@ -906,7 +906,7 @@ mod tests {
         }
 
         // set up client b
-        let b_secret_key = SecretKey::generate();
+        let b_secret_key = SecretKey::generate(rand::thread_rng());
         let b_key = b_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
         let (client_b, mut client_b_receiver) =
@@ -955,7 +955,7 @@ mod tests {
         let relay_url: RelayUrl = relay_url.parse().unwrap();
 
         // set up client a
-        let a_secret_key = SecretKey::generate();
+        let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
         let (client_a, mut client_a_receiver) = ClientBuilder::new(relay_url.clone())
@@ -981,7 +981,7 @@ mod tests {
         }
 
         // set up client b
-        let b_secret_key = SecretKey::generate();
+        let b_secret_key = SecretKey::generate(rand::thread_rng());
         let b_key = b_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
         let (client_b, mut client_b_receiver) = ClientBuilder::new(relay_url.clone())
@@ -1031,7 +1031,7 @@ mod tests {
         let relay_url: RelayUrl = relay_url.parse().unwrap();
 
         // set up client a
-        let a_secret_key = SecretKey::generate();
+        let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
         let (client_a, mut client_a_receiver) =
@@ -1056,7 +1056,7 @@ mod tests {
         }
 
         // set up client b
-        let b_secret_key = SecretKey::generate();
+        let b_secret_key = SecretKey::generate(rand::thread_rng());
         let b_key = b_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
         let (client_b, mut client_b_receiver) = ClientBuilder::new(relay_url.clone())

--- a/iroh-relay/src/server/actor.rs
+++ b/iroh-relay/src/server/actor.rs
@@ -289,7 +289,7 @@ mod tests {
                 .instrument(info_span!("relay.server")),
         );
 
-        let node_id_a = SecretKey::generate().public();
+        let node_id_a = SecretKey::generate(rand::thread_rng()).public();
         let (client_a, mut a_io) = test_client_builder(node_id_a, server_channel.clone());
 
         // create client a
@@ -299,7 +299,7 @@ mod tests {
             .map_err(|_| anyhow::anyhow!("server gone"))?;
 
         // server message: create client b
-        let node_id_b = SecretKey::generate().public();
+        let node_id_b = SecretKey::generate(rand::thread_rng()).public();
         let (client_b, mut b_io) = test_client_builder(node_id_b, server_channel.clone());
         server_channel
             .send(Message::CreateClient(client_b))

--- a/iroh-relay/src/server/client_conn.rs
+++ b/iroh-relay/src/server/client_conn.rs
@@ -528,7 +528,7 @@ mod tests {
         let (disco_send_queue_s, disco_send_queue_r) = mpsc::channel(10);
         let (peer_gone_s, peer_gone_r) = mpsc::channel(10);
 
-        let key = SecretKey::generate().public();
+        let key = SecretKey::generate(rand::thread_rng()).public();
         let (io, io_rw) = tokio::io::duplex(1024);
         let mut io_rw = Framed::new(io_rw, DerpCodec);
         let (server_channel_s, mut server_channel_r) = mpsc::channel(10);
@@ -612,7 +612,7 @@ mod tests {
         // tokio::time::sleep(Duration::from_millis(100)).await;
         // assert!(preferred.fetch_and(true, Ordering::Relaxed));
 
-        let target = SecretKey::generate().public();
+        let target = SecretKey::generate(rand::thread_rng()).public();
 
         // send packet
         println!("  send packet");
@@ -668,7 +668,7 @@ mod tests {
         let (_disco_send_queue_s, disco_send_queue_r) = mpsc::channel(10);
         let (_peer_gone_s, peer_gone_r) = mpsc::channel(10);
 
-        let key = SecretKey::generate().public();
+        let key = SecretKey::generate(rand::thread_rng()).public();
         let (io, io_rw) = tokio::io::duplex(1024);
         let mut io_rw = Framed::new(io_rw, DerpCodec);
         let (server_channel_s, mut server_channel_r) = mpsc::channel(10);
@@ -696,7 +696,7 @@ mod tests {
         // send packet
         println!("   send packet");
         let data = b"hello world!";
-        let target = SecretKey::generate().public();
+        let target = SecretKey::generate(rand::thread_rng()).public();
 
         conn::send_packet(&mut io_rw, target, Bytes::from_static(data)).await?;
         let msg = server_channel_r.recv().await.unwrap();
@@ -756,7 +756,7 @@ mod tests {
 
         // Prepare a frame to send, assert its size.
         let data = Bytes::from_static(b"hello world!!");
-        let target = SecretKey::generate().public();
+        let target = SecretKey::generate(rand::thread_rng()).public();
         let frame = Frame::SendPacket {
             dst_key: target,
             packet: data.clone(),

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -256,8 +256,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_clients() -> Result<()> {
-        let a_key = SecretKey::generate().public();
-        let b_key = SecretKey::generate().public();
+        let a_key = SecretKey::generate(rand::thread_rng()).public();
+        let b_key = SecretKey::generate(rand::thread_rng()).public();
 
         let (builder_a, mut a_rw) = test_client_builder(a_key);
 

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -703,8 +703,8 @@ mod tests {
     async fn test_http_clients_and_server() -> Result<()> {
         let _guard = iroh_test::logging::setup();
 
-        let a_key = SecretKey::generate();
-        let b_key = SecretKey::generate();
+        let a_key = SecretKey::generate(rand::thread_rng());
+        let b_key = SecretKey::generate(rand::thread_rng());
 
         // start server
         let server = ServerBuilder::new("127.0.0.1:0".parse().unwrap())
@@ -832,8 +832,8 @@ mod tests {
             .try_init()
             .ok();
 
-        let a_key = SecretKey::generate();
-        let b_key = SecretKey::generate();
+        let a_key = SecretKey::generate(rand::thread_rng());
+        let b_key = SecretKey::generate(rand::thread_rng());
 
         // create tls_config
         let tls_config = make_tls_config();
@@ -924,7 +924,7 @@ mod tests {
         );
 
         // create client a and connect it to the server
-        let key_a = SecretKey::generate();
+        let key_a = SecretKey::generate(rand::thread_rng());
         let public_key_a = key_a.public();
         let (rw_a, client_a_builder) = make_test_client(key_a);
         let s = service.clone();
@@ -936,7 +936,7 @@ mod tests {
         handler_task.await??;
 
         // create client b and connect it to the server
-        let key_b = SecretKey::generate();
+        let key_b = SecretKey::generate(rand::thread_rng());
         let public_key_b = key_b.public();
         let (rw_b, client_b_builder) = make_test_client(key_b);
         let s = service.clone();
@@ -1010,7 +1010,7 @@ mod tests {
         );
 
         // create client a and connect it to the server
-        let key_a = SecretKey::generate();
+        let key_a = SecretKey::generate(rand::thread_rng());
         let public_key_a = key_a.public();
         let (rw_a, client_a_builder) = make_test_client(key_a);
         let s = service.clone();
@@ -1022,7 +1022,7 @@ mod tests {
         handler_task.await??;
 
         // create client b and connect it to the server
-        let key_b = SecretKey::generate();
+        let key_b = SecretKey::generate(rand::thread_rng());
         let public_key_b = key_b.public();
         let (rw_b, client_b_builder) = make_test_client(key_b.clone());
         let s = service.clone();

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -30,6 +30,7 @@ derive_more = { version = "1.0.0", features = [
     "from",
     "try_into",
     "deref",
+    "from_str"
 ] }
 futures-buffered = "0.2.8"
 futures-concurrency = "7.6"

--- a/iroh/examples/connect-unreliable.rs
+++ b/iroh/examples/connect-unreliable.rs
@@ -32,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     println!("\nconnect (unreliable) example!\n");
     let args = Cli::parse();
-    let secret_key = SecretKey::generate();
+    let secret_key = SecretKey::generate(rand::rngs::OsRng);
     println!("secret key: {secret_key}");
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay protocol and relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.

--- a/iroh/examples/connect.rs
+++ b/iroh/examples/connect.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     println!("\nconnect example!\n");
     let args = Cli::parse();
-    let secret_key = SecretKey::generate();
+    let secret_key = SecretKey::generate(rand::rngs::OsRng);
     println!("secret key: {secret_key}");
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay protocol and relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.

--- a/iroh/examples/dht_discovery.rs
+++ b/iroh/examples/dht_discovery.rs
@@ -61,7 +61,7 @@ fn build_discovery(args: Args) -> iroh::discovery::pkarr::dht::Builder {
 }
 
 async fn chat_server(args: Args) -> anyhow::Result<()> {
-    let secret_key = iroh::SecretKey::generate();
+    let secret_key = iroh::SecretKey::generate(rand::rngs::OsRng);
     let node_id = secret_key.public();
     let discovery = build_discovery(args)
         .secret_key(secret_key.clone())
@@ -107,7 +107,7 @@ async fn chat_server(args: Args) -> anyhow::Result<()> {
 
 async fn chat_client(args: Args) -> anyhow::Result<()> {
     let remote_node_id = args.node_id.unwrap();
-    let secret_key = iroh::SecretKey::generate();
+    let secret_key = iroh::SecretKey::generate(rand::rngs::OsRng);
     let node_id = secret_key.public();
     // note: we don't pass a secret key here, because we don't need to publish our address, don't spam the DHT
     let discovery = build_discovery(args).build()?;

--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -13,7 +13,7 @@ const EXAMPLE_ALPN: &[u8] = b"n0/iroh/examples/magic/0";
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     println!("\nlisten (unreliable) example!\n");
-    let secret_key = SecretKey::generate();
+    let secret_key = SecretKey::generate(rand::rngs::OsRng);
     println!("secret key: {secret_key}");
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -15,7 +15,7 @@ const EXAMPLE_ALPN: &[u8] = b"n0/iroh/examples/magic/0";
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     println!("\nlisten example!\n");
-    let secret_key = SecretKey::generate();
+    let secret_key = SecretKey::generate(rand::rngs::OsRng);
     println!("secret key: {secret_key}");
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay protocol and relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.

--- a/iroh/examples/locally-discovered-nodes.rs
+++ b/iroh/examples/locally-discovered-nodes.rs
@@ -13,7 +13,8 @@ use iroh::{
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     println!("locally discovered nodes example!\n");
-    let key = SecretKey::generate();
+    let mut rng = rand::rngs::OsRng;
+    let key = SecretKey::generate(&mut rng);
     let id = key.public();
     println!("creating endpoint {id:?}\n");
     let ep = Endpoint::builder()
@@ -26,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
     println!("creating {node_count} additional endpoints to discover locally:");
     let mut discoverable_eps = Vec::with_capacity(node_count);
     for _ in 0..node_count {
-        let key = SecretKey::generate();
+        let key = SecretKey::generate(&mut rng);
         let id = key.public();
         println!("\t{id:?}");
         let ep = Endpoint::builder()

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn provide(size: u64, relay_url: Option<String>) -> anyhow::Result<()> {
-    let secret_key = SecretKey::generate();
+    let secret_key = SecretKey::generate(rand::rngs::OsRng);
     let relay_mode = match relay_url {
         Some(relay_url) => {
             let relay_url = RelayUrl::from_str(&relay_url)?;
@@ -144,7 +144,7 @@ async fn provide(size: u64, relay_url: Option<String>) -> anyhow::Result<()> {
 
 async fn fetch(ticket: &str, relay_url: Option<String>) -> anyhow::Result<()> {
     let ticket: NodeTicket = ticket.parse()?;
-    let secret_key = SecretKey::generate();
+    let secret_key = SecretKey::generate(rand::rngs::OsRng);
     let relay_mode = match relay_url {
         Some(relay_url) => {
             let relay_url = RelayUrl::from_str(&relay_url)?;

--- a/iroh/src/disco.rs
+++ b/iroh/src/disco.rs
@@ -474,8 +474,8 @@ mod tests {
 
     #[test]
     fn test_extraction() {
-        let sender_key = SecretKey::generate();
-        let recv_key = SecretKey::generate();
+        let sender_key = SecretKey::generate(rand::thread_rng());
+        let recv_key = SecretKey::generate(rand::thread_rng());
 
         let msg = Message::Ping(Ping {
             tx_id: stun_rs::TransactionId::default(),

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -54,7 +54,7 @@
 //! };
 //!
 //! # async fn wrapper() -> anyhow::Result<()> {
-//! let secret_key = SecretKey::generate();
+//! let secret_key = SecretKey::generate(rand::rngs::OsRng);
 //! let discovery = ConcurrentDiscovery::from_services(vec![
 //!     Box::new(PkarrPublisher::n0_dns(secret_key.clone())),
 //!     Box::new(DnsDiscovery::n0_dns()),
@@ -87,7 +87,7 @@
 //! # use iroh::SecretKey;
 //! #
 //! # async fn wrapper() -> anyhow::Result<()> {
-//! # let secret_key = SecretKey::generate();
+//! # let secret_key = SecretKey::generate(rand::rngs::OsRng);
 //! let discovery = ConcurrentDiscovery::from_services(vec![
 //!     Box::new(PkarrPublisher::n0_dns(secret_key.clone())),
 //!     Box::new(DnsDiscovery::n0_dns()),
@@ -569,12 +569,12 @@ mod tests {
         let _guard = iroh_test::logging::setup();
         let disco_shared = TestDiscoveryShared::default();
         let (ep1, _guard1) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco = disco_shared.create_discovery(secret.public());
             new_endpoint(secret, disco).await
         };
         let (ep2, _guard2) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco = disco_shared.create_discovery(secret.public());
             new_endpoint(secret, disco).await
         };
@@ -591,12 +591,12 @@ mod tests {
         let _guard = iroh_test::logging::setup();
         let disco_shared = TestDiscoveryShared::default();
         let (ep1, _guard1) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco = disco_shared.create_discovery(secret.public());
             new_endpoint(secret, disco).await
         };
         let (ep2, _guard2) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco1 = EmptyDiscovery;
             let disco2 = disco_shared.create_discovery(secret.public());
             let mut disco = ConcurrentDiscovery::empty();
@@ -619,12 +619,12 @@ mod tests {
         let _guard = iroh_test::logging::setup();
         let disco_shared = TestDiscoveryShared::default();
         let (ep1, _guard1) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco = disco_shared.create_discovery(secret.public());
             new_endpoint(secret, disco).await
         };
         let (ep2, _guard2) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco1 = EmptyDiscovery;
             let disco2 = disco_shared.create_lying_discovery(secret.public());
             let disco3 = disco_shared.create_discovery(secret.public());
@@ -647,12 +647,12 @@ mod tests {
         let _guard = iroh_test::logging::setup();
         let disco_shared = TestDiscoveryShared::default();
         let (ep1, _guard1) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco = disco_shared.create_discovery(secret.public());
             new_endpoint(secret, disco).await
         };
         let (ep2, _guard2) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco1 = disco_shared.create_lying_discovery(secret.public());
             let disco = ConcurrentDiscovery::from_services(vec![Box::new(disco1)]);
             new_endpoint(secret, disco).await
@@ -672,12 +672,12 @@ mod tests {
         let _guard = iroh_test::logging::setup();
         let disco_shared = TestDiscoveryShared::default();
         let (ep1, _guard1) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco = disco_shared.create_discovery(secret.public());
             new_endpoint(secret, disco).await
         };
         let (ep2, _guard2) = {
-            let secret = SecretKey::generate();
+            let secret = SecretKey::generate(rand::thread_rng());
             let disco = disco_shared.create_discovery(secret.public());
             new_endpoint(secret, disco).await
         };
@@ -763,7 +763,7 @@ mod test_dns_pkarr {
         let state = State::new(origin.clone());
         let (nameserver, _dns_drop_guard) = run_dns_server(state.clone()).await?;
 
-        let secret_key = SecretKey::generate();
+        let secret_key = SecretKey::generate(rand::thread_rng());
         let node_info = NodeInfo::new(
             secret_key.public(),
             Some("https://relay.example".parse().unwrap()),
@@ -788,7 +788,7 @@ mod test_dns_pkarr {
 
         let dns_pkarr_server = DnsPkarrServer::run_with_origin(origin.clone()).await?;
 
-        let secret_key = SecretKey::generate();
+        let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
 
         let relay_url = Some("https://relay.example".parse().unwrap());
@@ -838,7 +838,7 @@ mod test_dns_pkarr {
         relay_map: &RelayMap,
         dns_pkarr_server: &DnsPkarrServer,
     ) -> Result<(Endpoint, AbortOnDropHandle<Result<()>>)> {
-        let secret_key = SecretKey::generate();
+        let secret_key = SecretKey::generate(rand::thread_rng());
         let ep = Endpoint::builder()
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .insecure_skip_relay_cert_verify(true)

--- a/iroh/src/discovery/local_swarm_discovery.rs
+++ b/iroh/src/discovery/local_swarm_discovery.rs
@@ -483,7 +483,7 @@ mod tests {
         }
 
         fn make_discoverer() -> Result<(PublicKey, LocalSwarmDiscovery)> {
-            let node_id = SecretKey::generate().public();
+            let node_id = SecretKey::generate(rand::thread_rng()).public();
             Ok((node_id, LocalSwarmDiscovery::new(node_id)?))
         }
     }

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -248,7 +248,9 @@ mod tls;
 pub mod watchable;
 
 pub use endpoint::{Endpoint, RelayMode};
-pub use iroh_base::{KeyParsingError, NodeAddr, NodeId, PublicKey, RelayUrl, SecretKey};
+pub use iroh_base::{
+    DecryptionError, KeyParsingError, NodeAddr, NodeId, PublicKey, RelayUrl, SecretKey,
+};
 pub use iroh_relay::{RelayMap, RelayNode};
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -249,7 +249,8 @@ pub mod watchable;
 
 pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{
-    DecryptionError, KeyParsingError, NodeAddr, NodeId, PublicKey, RelayUrl, SecretKey,
+    DecryptionError, KeyParsingError, NodeAddr, NodeId, PublicKey, RelayUrl, RelayUrlParseError,
+    SecretKey,
 };
 pub use iroh_relay::{RelayMap, RelayNode};
 

--- a/iroh/src/magicsock/node_map.rs
+++ b/iroh/src/magicsock/node_map.rs
@@ -680,10 +680,11 @@ mod tests {
 
         let node_map = NodeMap::default();
 
-        let node_a = SecretKey::generate().public();
-        let node_b = SecretKey::generate().public();
-        let node_c = SecretKey::generate().public();
-        let node_d = SecretKey::generate().public();
+        let mut rng = rand::thread_rng();
+        let node_a = SecretKey::generate(&mut rng).public();
+        let node_b = SecretKey::generate(&mut rng).public();
+        let node_c = SecretKey::generate(&mut rng).public();
+        let node_d = SecretKey::generate(&mut rng).public();
 
         let relay_x: RelayUrl = "https://my-relay-1.com".parse().unwrap();
         let relay_y: RelayUrl = "https://my-relay-2.com".parse().unwrap();
@@ -744,7 +745,7 @@ mod tests {
         let _guard = iroh_test::logging::setup();
 
         let node_map = NodeMap::default();
-        let public_key = SecretKey::generate().public();
+        let public_key = SecretKey::generate(rand::thread_rng()).public();
         let id = node_map
             .inner
             .lock()
@@ -817,7 +818,7 @@ mod tests {
     fn test_prune_inactive() {
         let node_map = NodeMap::default();
         // add one active node and more than MAX_INACTIVE_NODES inactive nodes
-        let active_node = SecretKey::generate().public();
+        let active_node = SecretKey::generate(rand::thread_rng()).public();
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 167);
         node_map.add_test_addr(NodeAddr::new(active_node).with_direct_addresses([addr]));
         node_map
@@ -828,7 +829,7 @@ mod tests {
             .expect("registered");
 
         for _ in 0..MAX_INACTIVE_NODES + 1 {
-            let node = SecretKey::generate().public();
+            let node = SecretKey::generate(rand::thread_rng()).public();
             node_map.add_test_addr(NodeAddr::new(node));
         }
 

--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -1456,7 +1456,7 @@ mod tests {
 
         // endpoint with a `best_addr` that has a latency but no relay
         let (a_endpoint, a_socket_addr) = {
-            let key = SecretKey::generate();
+            let key = SecretKey::generate(rand::thread_rng());
             let node_id = key.public();
             let ip_port = IpPort {
                 ip: Ipv4Addr::UNSPECIFIED.into(),
@@ -1502,7 +1502,7 @@ mod tests {
         // endpoint w/ no best addr but a relay w/ latency
         let b_endpoint = {
             // let socket_addr = "0.0.0.0:9".parse().unwrap();
-            let key = SecretKey::generate();
+            let key = SecretKey::generate(rand::thread_rng());
             NodeState {
                 id: 1,
                 quic_mapped_addr: QuicMappedAddr::generate(),
@@ -1521,7 +1521,7 @@ mod tests {
         // endpoint w/ no best addr but a relay w/ no latency
         let c_endpoint = {
             // let socket_addr = "0.0.0.0:8".parse().unwrap();
-            let key = SecretKey::generate();
+            let key = SecretKey::generate(rand::thread_rng());
             NodeState {
                 id: 2,
                 quic_mapped_addr: QuicMappedAddr::generate(),
@@ -1549,7 +1549,7 @@ mod tests {
         let (d_endpoint, d_socket_addr) = {
             let socket_addr: SocketAddr = "0.0.0.0:7".parse().unwrap();
             let expired = now.checked_sub(Duration::from_secs(100)).unwrap();
-            let key = SecretKey::generate();
+            let key = SecretKey::generate(rand::thread_rng());
             let node_id = key.public();
             let endpoint_state = BTreeMap::from([(
                 IpPort::from(socket_addr),
@@ -1693,7 +1693,7 @@ mod tests {
         // When we handle a call-me-maybe with more than MAX_INACTIVE_DIRECT_ADDRESSES we do
         // not want to prune them right away but send pings to all of them.
 
-        let key = SecretKey::generate();
+        let key = SecretKey::generate(rand::thread_rng());
         let opts = Options {
             node_id: key.public(),
             relay_url: None,

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -945,7 +945,7 @@ mod tests {
 
     #[test]
     fn test_packetize_iter() {
-        let node_id = SecretKey::generate().public();
+        let node_id = SecretKey::generate(rand::thread_rng()).public();
         let empty_vec: Vec<Bytes> = Vec::new();
         let mut iter = PacketizeIter::<_, MAX_PACKET_SIZE>::new(node_id, empty_vec);
         assert_eq!(None, iter.next());

--- a/iroh/src/magicsock/udp_conn.rs
+++ b/iroh/src/magicsock/udp_conn.rs
@@ -143,7 +143,7 @@ mod tests {
     const ALPN: &[u8] = b"n0/test/1";
 
     fn wrap_socket(conn: impl AsyncUdpSocket) -> Result<(quinn::Endpoint, SecretKey)> {
-        let key = SecretKey::generate();
+        let key = SecretKey::generate(rand::thread_rng());
         let quic_server_config = tls::make_server_config(&key, vec![ALPN.to_vec()], false)?;
         let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_server_config));
         let mut quic_ep = quinn::Endpoint::new_with_abstract_socket(

--- a/iroh/src/tls/certificate.rs
+++ b/iroh/src/tls/certificate.rs
@@ -433,7 +433,7 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-        let secret_key = SecretKey::generate();
+        let secret_key = SecretKey::generate(rand::thread_rng());
 
         let (cert, _) = generate(&secret_key).unwrap();
         let parsed_cert = parse(&cert).unwrap();


### PR DESCRIPTION
## Description

- ensure `zeroize` is used for `SecretKey`
- remove unused dependencies and features from `iroh-base`

## Breaking Changes

- `iroh_base::SecretKey::generate` now takes an rng
- removed `iroh_base::SecretKey::generate_with_rng`, use `generate` directly
- removed `iroh_base::SecretKey::to_openssh`
- removed `iroh_base::SecretKey::from_openssh`
- `anyhow::Error` is replaced with explicit errors for `RelayUrl::from_str`
- `anyhow::Error` is replaced with explicit errors for `SharedSecret::open`

## Notes & open questions

As a follow up, all usage of `SecretKey::generate` in tests should be changed to use a seeded rng, like chacha8, instead of `thread_rng`

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
