### PR TITLE
refactor(iroh): remove genawaiter usage from dht discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,37 +1406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "futures-core",
- "genawaiter-macro",
- "genawaiter-proc-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
-
-[[package]]
-name = "genawaiter-proc-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
-dependencies = [
- "proc-macro-error",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "generator"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,7 +2137,6 @@ dependencies = [
  "futures-lite 2.5.0",
  "futures-sink",
  "futures-util",
- "genawaiter",
  "governor 0.7.0",
  "hickory-resolver",
  "hostname 0.4.0",
@@ -3608,38 +3576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "syn-mid",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4786,17 +4722,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,5 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [advisories]
 ignore = [
-    "RUSTSEC-2024-0370", # unmaintained, no upgrade available
     "RUSTSEC-2024-0384", # unmaintained, no upgrade available
 ]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -114,9 +114,6 @@ iroh-metrics = { version = "0.29", default-features = false }
 # local-swarm-discovery
 swarm-discovery = { version = "0.3.0-alpha.1", optional = true }
 
-# dht_discovery
-genawaiter = { version = "0.99", features = ["futures03"], optional = true }
-
 # Examples
 clap = { version = "4", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3", features = [
@@ -178,7 +175,7 @@ default = ["metrics", "discovery-pkarr-dht"]
 metrics = ["iroh-metrics/metrics", "iroh-relay/metrics", "net-report/metrics", "portmapper/metrics"]
 test-utils = ["iroh-relay/test-utils", "iroh-relay/server", "dep:axum"]
 discovery-local-network = ["dep:swarm-discovery"]
-discovery-pkarr-dht = ["pkarr/dht", "dep:genawaiter"]
+discovery-pkarr-dht = ["pkarr/dht"]
 examples = [
   "dep:clap",
   "dep:tracing-subscriber",

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -344,7 +344,7 @@ impl Discovery for DhtDiscovery {
                                         "discovered node info from relay {:?}",
                                         node_addr
                                     );
-                                    Some(anyhow::Ok(DiscoveryItem {
+                                    Some(Ok(DiscoveryItem {
                                         node_addr,
                                         provenance: "relay",
                                         last_updated: None,
@@ -409,10 +409,6 @@ impl Discovery for DhtDiscovery {
         }
 
         Some(stream.filter_map(|t| t).boxed())
-        // Some(Box::pin(ResolveStream {
-        //     dht_resolve,
-        //     relay_resolve,
-        // }))
     }
 }
 


### PR DESCRIPTION
## Description

One less dependency in the core of iroh

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
