### PR TITLE
ci(*): Try use external beta workflow

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -16,28 +16,8 @@ env:
   IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
-  tests:
-    uses: './.github/workflows/tests.yaml'
+  beta:
+    uses: 'n0-computer/workflows/.github/workflows/beta.yaml@main'
     with:
-      rust-version: beta
-  notify:
-    needs: tests
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Extract test results
-        run: |
-          printf '${{ toJSON(needs) }}\n'
-          result=$(echo '${{ toJSON(needs) }}' | jq -r .tests.result)
-          echo TESTS_RESULT=$result
-          echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
-      - name: Notify discord on failure
-        uses: n0-computer/discord-webhook-notify@v1
-        if: ${{ env.TESTS_RESULT == 'failure' }}
-        with:
-          severity: error
-          details: |
-            Rustc beta tests failed
-            See https://github.com/n0-computer/iroh/actions/workflows/beta.yaml
-          webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
+      tests: 'n0-computer/iroh/.github.workflows/tests.yaml'
 


### PR DESCRIPTION
## Description

Experiment with using a shared beta workflow.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

This isn't very nice to be honest.  There currently seems a rather
tight integration between the beta workflow and the tests it runs.

Maybe it's possible to replace only the notify action somehow?
E.g. if in the beta.yaml you could write:

``` yaml
jobs:
  tests:
    # as before
    uses: './.github/workflows/tests.yaml'
    with:
      rust-version: beta
  notify:
    needs: tests
    if: $${{ always() }}
    runs-on: ubuntu-latest
    steps:
      # this is new
      - uses: n0-computer/action-notify-beta@main
```

I'm not sure how realistic this is or how much work it would be.

I'm also not even sure how to test this without merging it?

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.