### PR TITLE
refactor(iroh, iroh-relay): JoinSet disabling in tokio::select!

### DIFF
--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -96,7 +96,7 @@ pub(crate) mod server {
                             _ = cancel_accept_loop.cancelled() => {
                                 break;
                             }
-                            Some(res) = set.join_next(), if !set.is_empty() => {
+                            Some(res) = set.join_next() => {
                                 if let Err(err) = res {
                                     if err.is_panic() {
                                         panic!("task panicked: {err:#?}");

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -494,7 +494,7 @@ async fn relay_supervisor(
     };
     let res = tokio::select! {
         biased;
-        ret = tasks.join_next(), if !tasks.is_empty() => ret.expect("checked"),
+        Some(ret) = tasks.join_next() => ret,
         ret = &mut quic_fut, if quic_enabled => ret.map(anyhow::Ok),
         ret = &mut relay_fut, if relay_enabled => ret.map(anyhow::Ok),
         else => Ok(Err(anyhow!("No relay services are enabled."))),
@@ -547,7 +547,7 @@ async fn server_stun_listener(sock: UdpSocket) -> Result<()> {
         tokio::select! {
             biased;
 
-            Some(res) = tasks.join_next(), if !tasks.is_empty() => {
+            Some(res) = tasks.join_next() => {
                 if let Err(err) = res {
                     if err.is_panic() {
                         panic!("task panicked: {:#?}", err);
@@ -695,7 +695,7 @@ async fn run_captive_portal_service(http_listener: TcpListener) -> Result<()> {
         tokio::select! {
             biased;
 
-            Some(res) = tasks.join_next(), if !tasks.is_empty() => {
+            Some(res) = tasks.join_next() => {
                 if let Err(err) = res {
                     if err.is_panic() {
                         panic!("task panicked: {:#?}", err);

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -247,7 +247,7 @@ impl ServerBuilder {
                         _ = cancel.cancelled() => {
                             break;
                         }
-                        Some(res) = set.join_next(), if !set.is_empty() => {
+                        Some(res) = set.join_next() => {
                             if let Err(err) = res {
                                 if err.is_panic() {
                                     panic!("task panicked: {:#?}", err);

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -264,9 +264,9 @@ impl RouterBuilder {
                         break;
                     },
                     // handle task terminations and quit on panics.
-                    res = join_set.join_next(), if !join_set.is_empty() => {
+                    Some(res) = join_set.join_next() => {
                         match res {
-                            Some(Err(outer)) => {
+                            Err(outer) => {
                                 if outer.is_panic() {
                                     error!("Task panicked: {outer:?}");
                                     break;
@@ -277,13 +277,12 @@ impl RouterBuilder {
                                     break;
                                 }
                             }
-                            Some(Ok(Some(()))) => {
+                            Ok(Some(())) => {
                                 trace!("Task finished");
                             }
-                            Some(Ok(None)) => {
+                            Ok(None) => {
                                 trace!("Task cancelled");
                             }
-                            _ => {}
                         }
                     },
 


### PR DESCRIPTION
## Description

This changes the disabling of JoinSet::join_next branches in
tokio::select! calls to rely on pattern matching alone.  This changes
nothing to the logic executing in the select! call, but often results
in less code.

A branch is disabled if the pattern does not match, and the remaining
futures are still awaited.  Once the branch is disabled the logic of
tokio::select! is exactly the same regardless of whether it was
disabled because of an if condition or because of a mismatched pattern.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.