### PR TITLE
feat!: update to iroh-metrics@0.30.0 and portmapper@0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
  "netlink-packet-route 0.19.0",
  "netlink-packet-route 0.21.0",
  "netlink-sys",
- "netwatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netwatch",
  "num_enum",
  "once_cell",
  "parse-size",
@@ -2268,7 +2268,7 @@ dependencies = [
  "iroh-quinn",
  "iroh-relay",
  "iroh-test 0.29.0",
- "netwatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netwatch",
  "once_cell",
  "portmapper",
  "pretty_assertions",
@@ -2827,38 +2827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "netwatch"
-version = "0.2.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=feat-iroh-metrics-0-30#226326bcbeae9cfdd33c4576b9f40a4c8cab90c3"
-dependencies = [
- "anyhow",
- "atomic-waker",
- "bytes",
- "derive_more",
- "futures-lite 2.5.0",
- "futures-sink",
- "futures-util",
- "iroh-quinn-udp",
- "libc",
- "netdev",
- "netlink-packet-core",
- "netlink-packet-route 0.19.0",
- "netlink-sys",
- "once_cell",
- "rtnetlink 0.13.1",
- "rtnetlink 0.14.1",
- "serde",
- "socket2",
- "thiserror 2.0.7",
- "time",
- "tokio",
- "tokio-util",
- "tracing",
- "windows 0.58.0",
- "wmi",
-]
-
-[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,8 +3270,9 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "portmapper"
-version = "0.2.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=feat-iroh-metrics-0-30#226326bcbeae9cfdd33c4576b9f40a4c8cab90c3"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6b2058e5b2c829b7dcc62bb94ec223e2fdf07cad157b09ab05c5520af6f5b6"
 dependencies = [
  "anyhow",
  "base64",
@@ -3314,7 +3283,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.2.0 (git+https://github.com/n0-computer/net-tools?branch=feat-iroh-metrics-0-30)",
+ "netwatch",
  "num_enum",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,18 +378,18 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -444,9 +444,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "shlex",
 ]
@@ -604,15 +604,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -715,18 +715,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -901,7 +901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -1058,9 +1057,9 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-as-inner"
@@ -1561,7 +1560,7 @@ dependencies = [
  "rand",
  "rustls",
  "serde",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -1587,7 +1586,7 @@ dependencies = [
  "rustls",
  "serde",
  "smallvec",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -1613,7 +1612,7 @@ dependencies = [
  "prefix-trie",
  "rustls",
  "serde",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "time",
  "tokio",
  "tokio-rustls",
@@ -1749,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2008,7 +2007,7 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "tokio",
- "unicode-width 0.2.0",
+ "unicode-width",
  "web-time",
 ]
 
@@ -2096,7 +2095,7 @@ dependencies = [
  "netlink-packet-route 0.19.0",
  "netlink-packet-route 0.21.0",
  "netlink-sys",
- "netwatch",
+ "netwatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum",
  "once_cell",
  "parse-size",
@@ -2124,7 +2123,7 @@ dependencies = [
  "surge-ping",
  "swarm-discovery",
  "testresult",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "time",
  "tokio",
  "tokio-rustls",
@@ -2159,7 +2158,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "url",
 ]
 
@@ -2236,11 +2235,10 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a242381d5da20bb4a6cc7482b5cc687a739da8371aff0ea8c12aaf499801886b"
+checksum = "d7efd9d7437db258f4d44852beea820cd872e4db976928ee0c2bc615b8c4fe5a"
 dependencies = [
- "anyhow",
  "erased_set",
  "http-body-util",
  "hyper",
@@ -2250,7 +2248,7 @@ dependencies = [
  "reqwest",
  "serde",
  "struct_iterable",
- "time",
+ "thiserror 2.0.7",
  "tokio",
  "tracing",
 ]
@@ -2270,7 +2268,7 @@ dependencies = [
  "iroh-quinn",
  "iroh-relay",
  "iroh-test 0.29.0",
- "netwatch",
+ "netwatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
  "portmapper",
  "pretty_assertions",
@@ -2387,7 +2385,7 @@ dependencies = [
  "socket2",
  "stun-rs",
  "testresult",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "time",
  "tokio",
  "tokio-rustls",
@@ -2497,12 +2495,6 @@ name = "libc"
 version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
-
-[[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -2825,7 +2817,39 @@ dependencies = [
  "rtnetlink 0.14.1",
  "serde",
  "socket2",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "windows 0.58.0",
+ "wmi",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.2.0"
+source = "git+https://github.com/n0-computer/net-tools?branch=feat-iroh-metrics-0-30#226326bcbeae9cfdd33c4576b9f40a4c8cab90c3"
+dependencies = [
+ "anyhow",
+ "atomic-waker",
+ "bytes",
+ "derive_more",
+ "futures-lite 2.5.0",
+ "futures-sink",
+ "futures-util",
+ "iroh-quinn-udp",
+ "libc",
+ "netdev",
+ "netlink-packet-core",
+ "netlink-packet-route 0.19.0",
+ "netlink-sys",
+ "once_cell",
+ "rtnetlink 0.13.1",
+ "rtnetlink 0.14.1",
+ "serde",
+ "socket2",
+ "thiserror 2.0.7",
  "time",
  "tokio",
  "tokio-util",
@@ -2932,7 +2956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3083,7 +3106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "ucd-trie",
 ]
 
@@ -3280,8 +3303,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ea24e7552a28ee4a3478ae116c89080957d6816526d0a533bee6cd67048279"
+source = "git+https://github.com/n0-computer/net-tools?branch=feat-iroh-metrics-0-30#226326bcbeae9cfdd33c4576b9f40a4c8cab90c3"
 dependencies = [
  "anyhow",
  "base64",
@@ -3292,13 +3314,13 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch",
+ "netwatch 0.2.0 (git+https://github.com/n0-computer/net-tools?branch=feat-iroh-metrics-0-30)",
  "num_enum",
  "rand",
  "serde",
  "smallvec",
  "socket2",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "time",
  "tokio",
  "tokio-util",
@@ -3443,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -3463,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+checksum = "773ce68d0bb9bc7ef20be3536ffe94e223e1f365bd374108b2659fac0c65cfe6"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -3495,7 +3517,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
  "tracing",
 ]
@@ -3514,7 +3536,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3900,7 +3922,7 @@ dependencies = [
  "rustls-cert-read",
  "rustls-pemfile",
  "rustls-pki-types",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
 ]
 
@@ -3923,7 +3945,7 @@ dependencies = [
  "reloadable-state",
  "rustls",
  "rustls-cert-read",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
 ]
 
 [[package]]
@@ -3950,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
  "web-time",
 ]
@@ -4090,9 +4112,9 @@ checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
@@ -4547,11 +4569,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.7",
 ]
 
 [[package]]
@@ -4567,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4714,7 +4736,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "time",
  "tokio",
  "tokio-rustls",
@@ -5031,12 +5053,6 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5591,7 +5607,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "windows 0.58.0",
  "windows-core 0.58.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "feat-iroh-metrics-0-30"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,3 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
-
-[patch.crates-io]
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "feat-iroh-metrics-0-30"}

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -29,7 +29,7 @@ governor = "0.6.3" #needs new release of tower_governor for 0.7.0
 hickory-server = { version = "=0.25.0-alpha.4", features = ["dns-over-rustls", "dns-over-https-rustls"] }
 http = "1.0.0"
 humantime-serde = "1.1.1"
-iroh-metrics = { version = "0.29.0" }
+iroh-metrics = { version = "0.30.0" }
 lru = "0.12.3"
 pkarr = { version = "2.2.0", features = [ "async", "relay", "dht"], default-features = false }
 rcgen = "0.13"

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -26,7 +26,7 @@ iroh-base = { version = "0.29.0", path = "../iroh-base", default-features = fals
 iroh-metrics = { version = "0.30.0", default-features = false }
 iroh-relay = { version = "0.29", path = "../iroh-relay" }
 netwatch = { version = "0.2.0" }
-portmapper = { version = "0.2.0", default-features = false }
+portmapper = { version = "0.3.0", default-features = false }
 quinn = { package = "iroh-quinn", version = "0.12.0" }
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false }

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -23,7 +23,7 @@ futures-buffered = "0.2.8"
 futures-lite = "2.3"
 hickory-resolver = "=0.25.0-alpha.4"
 iroh-base = { version = "0.29.0", path = "../iroh-base", default-features = false, features = ["relay"] }
-iroh-metrics = { version = "0.29.0", default-features = false }
+iroh-metrics = { version = "0.30.0", default-features = false }
 iroh-relay = { version = "0.29", path = "../iroh-relay" }
 netwatch = { version = "0.2.0" }
 portmapper = { version = "0.2.0", default-features = false }

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -38,7 +38,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 iroh-base = { version = "0.29.0", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
-iroh-metrics = { version = "0.29.0", default-features = false }
+iroh-metrics = { version = "0.30.0", default-features = false }
 libc = "0.2.139"
 num_enum = "0.7"
 once_cell = "1.18.0"

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -254,8 +254,11 @@ impl Server {
                 metrics.insert(StunMetrics::new(reg));
             });
             tasks.spawn(
-                iroh_metrics::metrics::start_metrics_server(addr)
-                    .instrument(info_span!("metrics-server")),
+                async move {
+                    iroh_metrics::metrics::start_metrics_server(addr).await?;
+                    anyhow::Ok(())
+                }
+                .instrument(info_span!("metrics-server")),
             );
         }
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -60,7 +60,7 @@ pkarr = { version = "2", default-features = false, features = [
     "async",
     "relay",
 ] }
-portmapper = { version = "0.2.0", default-features = false }
+portmapper = { version = "0.3.0", default-features = false }
 postcard = { version = "1", default-features = false, features = [
     "alloc",
     "use-std",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -113,7 +113,7 @@ z32 = "1.0.3"
 net-report = { package = "iroh-net-report", path = "../iroh-net-report", version = "0.29", default-features = false }
 
 # metrics
-iroh-metrics = { version = "0.29", default-features = false }
+iroh-metrics = { version = "0.30", default-features = false }
 
 # local-swarm-discovery
 swarm-discovery = { version = "0.3.0-alpha.1", optional = true }

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.22"
 bytes = "1.7"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh = { path = ".." }
-iroh-metrics = "0.29"
+iroh-metrics = "0.30"
 quinn = { package = "iroh-quinn", version = "0.12" }
 rcgen = "0.13"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }


### PR DESCRIPTION
## Description

Updates `iroh-metrics` to `0.30.0` and `portmapper` to `0.3.0`

## Breaking Changes

- `iroh-metrics` needs now to be `0.30.0`

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
