### PR TITLE
feat(relay)!: relay only mode now configurable

### DIFF
--- a/iroh/bench/src/bin/bulk.rs
+++ b/iroh/bench/src/bin/bulk.rs
@@ -45,13 +45,6 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
         })?;
     }
 
-    #[cfg(not(feature = "local-relay"))]
-    if opt.only_relay {
-        anyhow::bail!(
-            "Must compile the benchmark with the `local-relay` feature flag to use this option"
-        );
-    }
-
     let server_span = tracing::error_span!("server");
     let runtime = rt();
 

--- a/iroh/bench/src/bin/bulk.rs
+++ b/iroh/bench/src/bin/bulk.rs
@@ -39,14 +39,14 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
             metrics.insert(::iroh::metrics::NetReportMetrics::new(reg));
             metrics.insert(::iroh::metrics::PortmapMetrics::new(reg));
             #[cfg(feature = "local-relay")]
-            if opt.with_relay {
+            if opt.only_relay {
                 metrics.insert(::iroh::metrics::RelayMetrics::new(reg));
             }
         })?;
     }
 
     #[cfg(not(feature = "local-relay"))]
-    if opt.with_relay {
+    if opt.only_relay {
         anyhow::bail!(
             "Must compile the benchmark with the `local-relay` feature flag to use this option"
         );
@@ -56,7 +56,7 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
     let runtime = rt();
 
     #[cfg(feature = "local-relay")]
-    let (relay_url, _guard) = if opt.with_relay {
+    let (relay_url, _guard) = if opt.only_relay {
         let (_, relay_url, _guard) = runtime.block_on(::iroh::test_utils::run_relay_server())?;
 
         (Some(relay_url), Some(_guard))
@@ -120,7 +120,7 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
             "PortmapMetrics",
             core.get_collector::<::iroh::metrics::PortmapMetrics>(),
         );
-        // if None, (this is the case if opt.with_relay is false), then this is skipped internally:
+        // if None, (this is the case if opt.only_relay is false), then this is skipped internally:
         #[cfg(feature = "local-relay")]
         collect_and_print(
             "RelayMetrics",

--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -34,7 +34,6 @@ pub fn server_endpoint(
         #[cfg(feature = "local-relay")]
         {
             builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some());
-            #[cfg(any(test, feature = "test-utils"))]
             builder = builder.relay_only(opt.only_relay);
         }
         let ep = builder
@@ -92,7 +91,6 @@ pub async fn connect_client(
     #[cfg(feature = "local-relay")]
     {
         builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some());
-        #[cfg(any(test, feature = "test-utils"))]
         builder = builder.relay_only(opt.only_relay);
     }
     let endpoint = builder

--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -34,7 +34,11 @@ pub fn server_endpoint(
         #[cfg(feature = "local-relay")]
         {
             builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some());
-            builder = builder.relay_only(opt.only_relay);
+            let path_selection = match opt.only_relay {
+                true => iroh::endpoint::PathSelection::RelayOnly,
+                false => iroh::endpoint::PathSelection::default(),
+            };
+            builder = builder.path_selection(path_selection);
         }
         let ep = builder
             .alpns(vec![ALPN.to_vec()])
@@ -91,7 +95,11 @@ pub async fn connect_client(
     #[cfg(feature = "local-relay")]
     {
         builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some());
-        builder = builder.relay_only(opt.only_relay);
+        let path_selection = match opt.only_relay {
+            true => iroh::endpoint::PathSelection::RelayOnly,
+            false => iroh::endpoint::PathSelection::default(),
+        };
+        builder = builder.path_selection(path_selection);
     }
     let endpoint = builder
         .alpns(vec![ALPN.to_vec()])

--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -33,7 +33,9 @@ pub fn server_endpoint(
         let mut builder = Endpoint::builder();
         #[cfg(feature = "local-relay")]
         {
-            builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some())
+            builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some());
+            #[cfg(any(test, feature = "test-utils"))]
+            builder = builder.relay_only(opt.only_relay);
         }
         let ep = builder
             .alpns(vec![ALPN.to_vec()])
@@ -89,7 +91,9 @@ pub async fn connect_client(
     let mut builder = Endpoint::builder();
     #[cfg(feature = "local-relay")]
     {
-        builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some())
+        builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some());
+        #[cfg(any(test, feature = "test-utils"))]
+        builder = builder.relay_only(opt.only_relay);
     }
     let endpoint = builder
         .alpns(vec![ALPN.to_vec()])

--- a/iroh/bench/src/lib.rs
+++ b/iroh/bench/src/lib.rs
@@ -71,6 +71,7 @@ pub struct Opt {
     /// Whether to run a local relay and have the server and clients connect to that.
     /// This will force all traffic over the relay and can be used to test
     /// throughput for relay-only traffic.
+    #[cfg(feature = "local-relay")]
     #[clap(long, default_value_t = false)]
     pub only_relay: bool,
 }

--- a/iroh/bench/src/lib.rs
+++ b/iroh/bench/src/lib.rs
@@ -70,9 +70,8 @@ pub struct Opt {
     pub initial_mtu: u16,
     /// Whether to run a local relay and have the server and clients connect to that.
     ///
-    /// Can be combined with the `DEV_RELAY_ONLY` environment variable (at compile time)
+    /// Can be combined with the `relay_only` configuration option on the endpoint
     /// to test throughput for relay-only traffic locally.
-    /// (e.g. `DEV_RELAY_ONLY=true cargo run --release -- iroh --with-relay`)
     #[clap(long, default_value_t = false)]
     pub with_relay: bool,
 }

--- a/iroh/bench/src/lib.rs
+++ b/iroh/bench/src/lib.rs
@@ -69,11 +69,10 @@ pub struct Opt {
     #[clap(long, default_value = "1200")]
     pub initial_mtu: u16,
     /// Whether to run a local relay and have the server and clients connect to that.
-    ///
-    /// Can be combined with the `relay_only` configuration option on the endpoint
-    /// to test throughput for relay-only traffic locally.
+    /// This will force all traffic over the relay and can be used to test
+    /// throughput for relay-only traffic.
     #[clap(long, default_value_t = false)]
-    pub with_relay: bool,
+    pub only_relay: bool,
 }
 
 pub enum EndpointSelector {

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -8,7 +8,8 @@ use bytes::Bytes;
 use clap::{Parser, Subcommand};
 use indicatif::HumanBytes;
 use iroh::{
-    endpoint::ConnectionError, Endpoint, NodeAddr, RelayMap, RelayMode, RelayUrl, SecretKey,
+    endpoint::{ConnectionError, PathSelection},
+    Endpoint, NodeAddr, RelayMap, RelayMode, RelayUrl, SecretKey,
 };
 use iroh_base::ticket::NodeTicket;
 use tracing::info;
@@ -73,11 +74,15 @@ async fn provide(size: u64, relay_url: Option<String>, relay_only: bool) -> anyh
         }
         None => RelayMode::Default,
     };
+    let path_selection = match relay_only {
+        true => PathSelection::RelayOnly,
+        false => PathSelection::default(),
+    };
     let endpoint = Endpoint::builder()
         .secret_key(secret_key)
         .alpns(vec![TRANSFER_ALPN.to_vec()])
         .relay_mode(relay_mode)
-        .relay_only(relay_only)
+        .path_selection(path_selection)
         .bind()
         .await?;
 
@@ -166,11 +171,15 @@ async fn fetch(ticket: &str, relay_url: Option<String>, relay_only: bool) -> any
         }
         None => RelayMode::Default,
     };
+    let path_selection = match relay_only {
+        true => PathSelection::RelayOnly,
+        false => PathSelection::default(),
+    };
     let endpoint = Endpoint::builder()
         .secret_key(secret_key)
         .alpns(vec![TRANSFER_ALPN.to_vec()])
         .relay_mode(relay_mode)
-        .relay_only(relay_only)
+        .path_selection(path_selection)
         .bind()
         .await?;
 

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -52,12 +52,12 @@ async fn main() -> anyhow::Result<()> {
             size,
             relay_url,
             relay_only,
-        } => provide(*size, relay_url.clone(), relay_only).await?,
+        } => provide(*size, relay_url.clone(), *relay_only).await?,
         Commands::Fetch {
             ticket,
             relay_url,
             relay_only,
-        } => fetch(ticket, relay_url.clone(), relay_only).await?,
+        } => fetch(ticket, relay_url.clone(), *relay_only).await?,
     }
 
     Ok(())

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -76,6 +76,7 @@ type DiscoveryBuilder = Box<dyn FnOnce(&SecretKey) -> Option<Box<dyn Discovery>>
 
 /// Defines the mode of path selection for all traffic flowing through
 /// the endpoint.
+#[cfg(any(test, feature = "test-utils"))]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub enum PathSelection {
     /// Uses all available paths

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -164,8 +164,6 @@ impl Builder {
             dns_resolver,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
-            #[cfg(any(test, feature = "test-utils"))]
-            relay_only: self.relay_only,
         };
         Endpoint::bind(static_config, msock_opts, self.alpn_protocols).await
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -97,6 +97,8 @@ pub struct Builder {
     insecure_skip_relay_cert_verify: bool,
     addr_v4: Option<SocketAddrV4>,
     addr_v6: Option<SocketAddrV6>,
+    #[cfg(any(test, feature = "test-utils"))]
+    relay_only: bool,
 }
 
 impl Default for Builder {
@@ -115,6 +117,8 @@ impl Default for Builder {
             insecure_skip_relay_cert_verify: false,
             addr_v4: None,
             addr_v6: None,
+            #[cfg(any(test, feature = "test-utils"))]
+            relay_only: false,
         }
     }
 }
@@ -160,6 +164,8 @@ impl Builder {
             dns_resolver,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
+            #[cfg(any(test, feature = "test-utils"))]
+            relay_only: self.relay_only,
         };
         Endpoint::bind(static_config, msock_opts, self.alpn_protocols).await
     }
@@ -415,6 +421,14 @@ impl Builder {
     #[cfg(any(test, feature = "test-utils"))]
     pub fn insecure_skip_relay_cert_verify(mut self, skip_verify: bool) -> Self {
         self.insecure_skip_relay_cert_verify = skip_verify;
+        self
+    }
+
+    /// "relay_only" mode implies we only use the relay to communicate
+    /// and do not attempt to do any hole punching.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn relay_only(mut self, relay_only: bool) -> Self {
+        self.relay_only = relay_only;
         self
     }
 }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -164,6 +164,8 @@ impl Builder {
             dns_resolver,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
+            #[cfg(any(test, feature = "test-utils"))]
+            relay_only: self.relay_only,
         };
         Endpoint::bind(static_config, msock_opts, self.alpn_protocols).await
     }
@@ -422,7 +424,7 @@ impl Builder {
         self
     }
 
-    /// "relay_only" mode implies we only use the relay to communicate
+    /// This implies we only use the relay to communicate
     /// and do not attempt to do any hole punching.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn relay_only(mut self, relay_only: bool) -> Self {

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -128,11 +128,6 @@ pub(crate) struct Options {
     /// May only be used in tests.
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) insecure_skip_relay_cert_verify: bool,
-
-    /// "relay_only" mode implies we only use the relay to communicate
-    /// and do not attempt to do any hole punching.
-    #[cfg(any(test, feature = "test-utils"))]
-    pub(crate) relay_only: bool,
 }
 
 impl Default for Options {
@@ -148,8 +143,6 @@ impl Default for Options {
             dns_resolver: crate::dns::default_resolver().clone(),
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
-            #[cfg(any(test, feature = "test-utils"))]
-            relay_only: false,
         }
     }
 }
@@ -254,11 +247,6 @@ pub(crate) struct MagicSock {
     /// May only be used in tests.
     #[cfg(any(test, feature = "test-utils"))]
     insecure_skip_relay_cert_verify: bool,
-
-    /// "relay_only" mode implies we only use the relay to communicate
-    /// and do not attempt to do any hole punching.
-    #[cfg(any(test, feature = "test-utils"))]
-    relay_only: bool,
 }
 
 impl MagicSock {
@@ -1505,12 +1493,6 @@ impl Handle {
     /// Creates a magic [`MagicSock`] listening on [`Options::addr_v4`] and [`Options::addr_v6`].
     async fn new(opts: Options) -> Result<Self> {
         let me = opts.secret_key.public().fmt_short();
-        #[cfg(any(test, feature = "test-utils"))]
-        if opts.relay_only {
-            warn!(
-                "creating a MagicSock that will only send packets over a relay relay connection."
-            );
-        }
 
         Self::with_name(me, opts)
             .instrument(error_span!("magicsock"))
@@ -1531,8 +1513,6 @@ impl Handle {
             proxy_url,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify,
-            #[cfg(any(test, feature = "test-utils"))]
-            relay_only,
         } = opts;
 
         let relay_datagram_recv_queue = Arc::new(RelayDatagramRecvQueue::new());
@@ -1596,8 +1576,6 @@ impl Handle {
             dns_resolver,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify,
-            #[cfg(any(test, feature = "test-utils"))]
-            relay_only,
         });
 
         let mut actor_tasks = JoinSet::default();
@@ -3832,7 +3810,6 @@ mod tests {
             dns_resolver: crate::dns::default_resolver().clone(),
             proxy_url: None,
             insecure_skip_relay_cert_verify: true,
-            relay_only: false,
         };
         let msock = MagicSock::spawn(opts).await?;
         let server_config = crate::endpoint::make_server_config(

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2,9 +2,9 @@
 //!
 //! Based on tailscale/wgengine/magicsock
 //!
-//! ### `DEV_RELAY_ONLY` env var:
-//! When present at *compile time*, this env var will force all packets
-//! to be sent over the relay connection, regardless of whether or
+//! ### `relay_only` config option:
+//! When present this will force all packets to be sent over
+//! the relay connection, regardless of whether or
 //! not we have a direct UDP address for the given node.
 //!
 //! The intended use is for testing the relay protocol inside the MagicSock
@@ -1505,10 +1505,8 @@ impl Handle {
     /// Creates a magic [`MagicSock`] listening on [`Options::addr_v4`] and [`Options::addr_v6`].
     async fn new(opts: Options) -> Result<Self> {
         let me = opts.secret_key.public().fmt_short();
-        let relay_only = crate::util::relay_only_mode();
         #[cfg(any(test, feature = "test-utils"))]
-        let relay_only = relay_only || opts.relay_only;
-        if relay_only {
+        if opts.relay_only {
             warn!(
                 "creating a MagicSock that will only send packets over a relay relay connection."
             );

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -61,12 +61,13 @@ use self::{
     relay_actor::{RelayActor, RelayActorMessage, RelayRecvDatagram},
     udp_conn::UdpConn,
 };
+#[cfg(any(test, feature = "test-utils"))]
+use crate::endpoint::PathSelection;
 use crate::{
     defaults::timeouts::NET_REPORT_TIMEOUT,
     disco::{self, CallMeMaybe, SendAddr},
     discovery::{Discovery, DiscoveryItem},
     dns::DnsResolver,
-    endpoint::PathSelection,
     key::{public_ed_box, secret_ed_box, DecryptionError, SharedSecret},
     watchable::{Watchable, Watcher},
 };

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -128,6 +128,11 @@ pub(crate) struct Options {
     /// May only be used in tests.
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) insecure_skip_relay_cert_verify: bool,
+
+    /// This implies we only use the relay to communicate
+    /// and do not attempt to do any hole punching.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub(crate) relay_only: bool,
 }
 
 impl Default for Options {
@@ -143,6 +148,8 @@ impl Default for Options {
             dns_resolver: crate::dns::default_resolver().clone(),
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
+            #[cfg(any(test, feature = "test-utils"))]
+            relay_only: false,
         }
     }
 }
@@ -1513,6 +1520,8 @@ impl Handle {
             proxy_url,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify,
+            #[cfg(any(test, feature = "test-utils"))]
+            relay_only,
         } = opts;
 
         let relay_datagram_recv_queue = Arc::new(RelayDatagramRecvQueue::new());
@@ -1543,6 +1552,9 @@ impl Handle {
 
         // load the node data
         let node_map = node_map.unwrap_or_default();
+        #[cfg(any(test, feature = "test-utils"))]
+        let node_map = NodeMap::load_from_vec(node_map, relay_only);
+        #[cfg(not(any(test, feature = "test-utils")))]
         let node_map = NodeMap::load_from_vec(node_map);
 
         let secret_encryption_key = secret_ed_box(secret_key.secret());
@@ -3810,6 +3822,7 @@ mod tests {
             dns_resolver: crate::dns::default_resolver().clone(),
             proxy_url: None,
             insecure_skip_relay_cert_verify: true,
+            relay_only: false,
         };
         let msock = MagicSock::spawn(opts).await?;
         let server_config = crate::endpoint::make_server_config(

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2,8 +2,8 @@
 //!
 //! Based on tailscale/wgengine/magicsock
 //!
-//! ### `relay_only` config option:
-//! When present this will force all packets to be sent over
+//! ### `RelayOnly` path selection:
+//! When set this will force all packets to be sent over
 //! the relay connection, regardless of whether or
 //! not we have a direct UDP address for the given node.
 //!

--- a/iroh/src/magicsock/node_map.rs
+++ b/iroh/src/magicsock/node_map.rs
@@ -19,9 +19,10 @@ use self::{
 use super::{
     metrics::Metrics as MagicsockMetrics, ActorMessage, DiscoMessageSource, QuicMappedAddr,
 };
+#[cfg(any(test, feature = "test-utils"))]
+use crate::endpoint::PathSelection;
 use crate::{
     disco::{CallMeMaybe, Pong, SendAddr},
-    endpoint::PathSelection,
     watchable::Watcher,
 };
 

--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -135,7 +135,7 @@ pub(super) struct NodeState {
     ///
     /// Used for metric reporting.
     has_been_direct: bool,
-    /// "relay_only" mode implies we only use the relay to communicate
+    /// This implies we only use the relay to communicate
     /// and do not attempt to do any hole punching.
     #[cfg(any(test, feature = "test-utils"))]
     relay_only: bool,

--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -149,6 +149,8 @@ pub(super) struct Options {
     /// Is this endpoint currently active (sending data)?
     pub(super) active: bool,
     pub(super) source: super::Source,
+    #[cfg(any(test, feature = "test-utils"))]
+    pub(super) relay_only: bool,
 }
 
 impl NodeState {
@@ -180,7 +182,7 @@ impl NodeState {
             conn_type: Watchable::new(ConnectionType::None),
             has_been_direct: false,
             #[cfg(any(test, feature = "test-utils"))]
-            relay_only: false,
+            relay_only: options.relay_only,
         }
     }
 
@@ -1687,6 +1689,7 @@ mod tests {
                 (d_endpoint.id, d_endpoint),
             ]),
             next_id: 5,
+            relay_only: false,
         });
         let mut got = node_map.list_remote_infos(later);
         got.sort_by_key(|p| p.node_id);
@@ -1716,6 +1719,7 @@ mod tests {
             source: crate::magicsock::Source::NamedApp {
                 name: "test".into(),
             },
+            relay_only: false,
         };
         let mut ep = NodeState::new(0, opts);
 

--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -20,9 +20,10 @@ use super::{
     udp_paths::{NodeUdpPaths, UdpSendAddr},
     IpPort, Source,
 };
+#[cfg(any(test, feature = "test-utils"))]
+use crate::endpoint::PathSelection;
 use crate::{
     disco::{self, SendAddr},
-    endpoint::PathSelection,
     magicsock::{ActorMessage, MagicsockMetrics, QuicMappedAddr, Timer, HEARTBEAT_INTERVAL},
     watchable::{Watchable, Watcher},
 };

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -69,7 +69,6 @@ impl<T: Future> Future for MaybeFuture<T> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use std::pin::pin;

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -69,14 +69,6 @@ impl<T: Future> Future for MaybeFuture<T> {
     }
 }
 
-/// Check if we are running in "relay only" mode, as informed
-/// by the compile time env var `DEV_RELAY_ONLY`.
-///
-/// "relay only" mode implies we only use the relay to communicate
-/// and do not attempt to do any hole punching.
-pub(crate) fn relay_only_mode() -> bool {
-    std::option_env!("DEV_RELAY_ONLY").is_some()
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Description

This will allow us to configure relay only mode at runtime. ~~Useful for easy testing without having to rebuild with the `DEV_RELAY_ONLY` environment variable set.~~

The `DEV_RELAY_ONLY` compile time env var has been completely dropped and a `relay_only` option has been threaded through the entire stack when `test-utils` is enabled. An example of it can be followed with the `iroh/examples/transfer.rs` where you can set up a provide and fetch node with `--relay-only`. 

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
