### PR TITLE
refactor(iroh-relay): Rename DerpCodec to RelayCodec

### DIFF
--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -44,7 +44,7 @@ use url::Url;
 use crate::{
     defaults::timeouts::*,
     http::{Protocol, RELAY_PATH},
-    protos::relay::DerpCodec,
+    protos::relay::RelayCodec,
     KeyCache,
 };
 
@@ -699,8 +699,8 @@ impl Actor {
 
         let cache = self.key_cache.clone();
 
-        let reader = ConnReader::Derp(FramedRead::new(reader, DerpCodec::new(cache.clone())));
-        let writer = ConnWriter::Derp(FramedWrite::new(writer, DerpCodec::new(cache)));
+        let reader = ConnReader::Derp(FramedRead::new(reader, RelayCodec::new(cache.clone())));
+        let writer = ConnWriter::Derp(FramedWrite::new(writer, RelayCodec::new(cache)));
 
         Ok((reader, writer, local_addr))
     }

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -32,7 +32,7 @@ use crate::{
     client::streams::{MaybeTlsStreamReader, MaybeTlsStreamWriter},
     defaults::timeouts::CLIENT_RECV_TIMEOUT,
     protos::relay::{
-        write_frame, ClientInfo, DerpCodec, Frame, MAX_PACKET_SIZE, PER_CLIENT_READ_QUEUE_DEPTH,
+        write_frame, ClientInfo, Frame, RelayCodec, MAX_PACKET_SIZE, PER_CLIENT_READ_QUEUE_DEPTH,
         PER_CLIENT_SEND_QUEUE_DEPTH, PROTOCOL_VERSION,
     },
 };
@@ -270,12 +270,12 @@ pub struct ConnBuilder {
 }
 
 pub(crate) enum ConnReader {
-    Derp(FramedRead<MaybeTlsStreamReader, DerpCodec>),
+    Derp(FramedRead<MaybeTlsStreamReader, RelayCodec>),
     Ws(SplitStream<WebSocketStream>, KeyCache),
 }
 
 pub(crate) enum ConnWriter {
-    Derp(FramedWrite<MaybeTlsStreamWriter, DerpCodec>),
+    Derp(FramedWrite<MaybeTlsStreamWriter, RelayCodec>),
     Ws(SplitSink<WebSocketStream, tokio_tungstenite_wasm::Message>),
 }
 

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -224,7 +224,7 @@ impl RelayCodec {
     }
 }
 
-/// The frames in the [`DerpCodec`].
+/// The frames in the [`RelayCodec`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Frame {
     ClientInfo {

--- a/iroh-relay/src/server/actor.rs
+++ b/iroh-relay/src/server/actor.rs
@@ -250,7 +250,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        protos::relay::{recv_frame, DerpCodec, Frame, FrameType},
+        protos::relay::{recv_frame, Frame, FrameType, RelayCodec},
         server::{
             client_conn::ClientConnConfig,
             streams::{MaybeTlsStream, RelayedStream},
@@ -260,21 +260,21 @@ mod tests {
     fn test_client_builder(
         node_id: NodeId,
         server_channel: mpsc::Sender<Message>,
-    ) -> (ClientConnConfig, Framed<DuplexStream, DerpCodec>) {
+    ) -> (ClientConnConfig, Framed<DuplexStream, RelayCodec>) {
         let (test_io, io) = tokio::io::duplex(1024);
         (
             ClientConnConfig {
                 node_id,
                 stream: RelayedStream::Derp(Framed::new(
                     MaybeTlsStream::Test(io),
-                    DerpCodec::test(),
+                    RelayCodec::test(),
                 )),
                 write_timeout: Duration::from_secs(1),
                 channel_capacity: 10,
                 rate_limit: None,
                 server_channel,
             },
-            Framed::new(test_io, DerpCodec::test()),
+            Framed::new(test_io, RelayCodec::test()),
         )
     }
 

--- a/iroh-relay/src/server/client_conn.rs
+++ b/iroh-relay/src/server/client_conn.rs
@@ -518,7 +518,7 @@ mod tests {
     use super::*;
     use crate::{
         client::conn,
-        protos::relay::{recv_frame, DerpCodec, FrameType},
+        protos::relay::{recv_frame, FrameType, RelayCodec},
         server::streams::MaybeTlsStream,
     };
 
@@ -530,9 +530,9 @@ mod tests {
 
         let key = SecretKey::generate(rand::thread_rng()).public();
         let (io, io_rw) = tokio::io::duplex(1024);
-        let mut io_rw = Framed::new(io_rw, DerpCodec::test());
+        let mut io_rw = Framed::new(io_rw, RelayCodec::test());
         let (server_channel_s, mut server_channel_r) = mpsc::channel(10);
-        let stream = RelayedStream::Derp(Framed::new(MaybeTlsStream::Test(io), DerpCodec::test()));
+        let stream = RelayedStream::Derp(Framed::new(MaybeTlsStream::Test(io), RelayCodec::test()));
 
         let actor = Actor {
             stream: RateLimitedRelayedStream::unlimited(stream),
@@ -670,9 +670,9 @@ mod tests {
 
         let key = SecretKey::generate(rand::thread_rng()).public();
         let (io, io_rw) = tokio::io::duplex(1024);
-        let mut io_rw = Framed::new(io_rw, DerpCodec::test());
+        let mut io_rw = Framed::new(io_rw, RelayCodec::test());
         let (server_channel_s, mut server_channel_r) = mpsc::channel(10);
-        let stream = RelayedStream::Derp(Framed::new(MaybeTlsStream::Test(io), DerpCodec::test()));
+        let stream = RelayedStream::Derp(Framed::new(MaybeTlsStream::Test(io), RelayCodec::test()));
 
         println!("-- create client conn");
         let actor = Actor {
@@ -750,10 +750,10 @@ mod tests {
 
         // Build the rate limited stream.
         let (io_read, io_write) = tokio::io::duplex((LIMIT * MAX_FRAMES) as _);
-        let mut frame_writer = Framed::new(io_write, DerpCodec::test());
+        let mut frame_writer = Framed::new(io_write, RelayCodec::test());
         let stream = RelayedStream::Derp(Framed::new(
             MaybeTlsStream::Test(io_read),
-            DerpCodec::test(),
+            RelayCodec::test(),
         ));
         let mut stream = RateLimitedRelayedStream::new(stream, limiter);
 

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -234,11 +234,13 @@ mod tests {
 
     use super::*;
     use crate::{
-        protos::relay::{recv_frame, DerpCodec, Frame, FrameType},
+        protos::relay::{recv_frame, Frame, FrameType, RelayCodec},
         server::streams::{MaybeTlsStream, RelayedStream},
     };
 
-    fn test_client_builder(key: NodeId) -> (ClientConnConfig, FramedRead<DuplexStream, DerpCodec>) {
+    fn test_client_builder(
+        key: NodeId,
+    ) -> (ClientConnConfig, FramedRead<DuplexStream, RelayCodec>) {
         let (test_io, io) = tokio::io::duplex(1024);
         let (server_channel, _) = mpsc::channel(10);
         (
@@ -246,14 +248,14 @@ mod tests {
                 node_id: key,
                 stream: RelayedStream::Derp(Framed::new(
                     MaybeTlsStream::Test(io),
-                    DerpCodec::test(),
+                    RelayCodec::test(),
                 )),
                 write_timeout: Duration::from_secs(1),
                 channel_capacity: 10,
                 rate_limit: None,
                 server_channel,
             },
-            FramedRead::new(test_io, DerpCodec::test()),
+            FramedRead::new(test_io, RelayCodec::test()),
         )
     }
 

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -30,7 +30,7 @@ use tracing::{debug, debug_span, error, info, info_span, trace, warn, Instrument
 use crate::{
     defaults::DEFAULT_KEY_CACHE_CAPACITY,
     http::{Protocol, LEGACY_RELAY_PATH, RELAY_PATH, SUPPORTED_WEBSOCKET_VERSION},
-    protos::relay::{recv_client_key, DerpCodec, PER_CLIENT_SEND_QUEUE_DEPTH, PROTOCOL_VERSION},
+    protos::relay::{recv_client_key, RelayCodec, PER_CLIENT_SEND_QUEUE_DEPTH, PROTOCOL_VERSION},
     server::{
         actor::{Message, ServerActorTask},
         client_conn::ClientConnConfig,
@@ -504,7 +504,7 @@ impl Inner {
         let mut io = match protocol {
             Protocol::Relay => {
                 inc!(Metrics, derp_accepts);
-                RelayedStream::Derp(Framed::new(io, DerpCodec::new(self.key_cache.clone())))
+                RelayedStream::Derp(Framed::new(io, RelayCodec::new(self.key_cache.clone())))
             }
             Protocol::Websocket => {
                 inc!(Metrics, websocket_accepts);
@@ -918,8 +918,8 @@ mod tests {
         let client_reader = MaybeTlsStreamReader::Mem(client_reader);
         let client_writer = MaybeTlsStreamWriter::Mem(client_writer);
 
-        let client_reader = ConnReader::Derp(FramedRead::new(client_reader, DerpCodec::test()));
-        let client_writer = ConnWriter::Derp(FramedWrite::new(client_writer, DerpCodec::test()));
+        let client_reader = ConnReader::Derp(FramedRead::new(client_reader, RelayCodec::test()));
+        let client_writer = ConnWriter::Derp(FramedWrite::new(client_writer, RelayCodec::test()));
 
         (
             server,

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -13,7 +13,7 @@ use tokio_tungstenite::{tungstenite, WebSocketStream};
 use tokio_util::codec::Framed;
 
 use crate::{
-    protos::relay::{DerpCodec, Frame},
+    protos::relay::{Frame, RelayCodec},
     KeyCache,
 };
 
@@ -22,7 +22,7 @@ use crate::{
 /// The stream receives message from the client while the sink sends them to the client.
 #[derive(Debug)]
 pub(crate) enum RelayedStream {
-    Derp(Framed<MaybeTlsStream, DerpCodec>),
+    Derp(Framed<MaybeTlsStream, RelayCodec>),
     Ws(WebSocketStream<MaybeTlsStream>, KeyCache),
 }
 


### PR DESCRIPTION
## Description

The module is already called relay and all the text talks about the
relay protocol.  Might as well rename this.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

The "RelayCodec protocol" is pretty lame for a name.  Any
music-inspired bikeshedding welcome.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.