### PR TITLE
refactor(iroh): magical pin projections

### DIFF
--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -182,8 +182,7 @@ impl ActiveRelayActor {
         // When this future has an inner, it is a future which is currently sending
         // something to the relay server.  Nothing else can be sent to the relay server at
         // the same time.
-        let mut relay_send_fut = MaybeFuture::none();
-        let mut relay_send_fut = std::pin::pin!(relay_send_fut);
+        let mut relay_send_fut = std::pin::pin!(MaybeFuture::default());
 
         loop {
             // If a read error occurred on the connection it might have been lost.  But we

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -182,7 +182,7 @@ impl ActiveRelayActor {
         // When this future has an inner, it is a future which is currently sending
         // something to the relay server.  Nothing else can be sent to the relay server at
         // the same time.
-        let mut relay_send_fut = std::pin::pin!(MaybeFuture::default());
+        let mut relay_send_fut = std::pin::pin!(MaybeFuture::none());
 
         loop {
             // If a read error occurred on the connection it might have been lost.  But we

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -1,11 +1,12 @@
 //! Utilities used in [`iroh`][`crate`]
 
-use pin_project::pin_project;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use pin_project::pin_project;
 
 /// A future which may not be present.
 ///
@@ -23,6 +24,11 @@ pub(crate) enum MaybeFuture<T> {
 }
 
 impl<T> MaybeFuture<T> {
+    /// Creates a [`MaybeFuture`] without an inner future.
+    pub(crate) fn none() -> Self {
+        Self::default()
+    }
+
     /// Clears the value
     pub(crate) fn set_none(mut self: Pin<&mut Self>) {
         self.as_mut().project_replace(Self::None);

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -13,20 +13,16 @@ use std::{
 /// future polling will always return [`Poll::Pending`].
 ///
 /// The [`Default`] impl will create a [`MaybeFuture`] without an inner.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 #[pin_project(project = MaybeFutureProj, project_replace = MaybeFutureProjReplace)]
 pub(crate) enum MaybeFuture<T> {
     /// Future to be polled.
     Some(#[pin] T),
+    #[default]
     None,
 }
 
 impl<T> MaybeFuture<T> {
-    /// Creates a [`MaybeFuture`] without an inner future.
-    pub(crate) fn none() -> Self {
-        Self::None
-    }
-
     /// Clears the value
     pub(crate) fn set_none(mut self: Pin<&mut Self>) {
         self.as_mut().project_replace(Self::None);
@@ -45,13 +41,6 @@ impl<T> MaybeFuture<T> {
     /// Returns `true` if the inner contains a future.
     pub(crate) fn is_some(&self) -> bool {
         matches!(self, Self::Some(_))
-    }
-}
-
-// NOTE: explicit implementation to bypass derive unnecessary bounds
-impl<T> Default for MaybeFuture<T> {
-    fn default() -> Self {
-        Self::none()
     }
 }
 

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -27,11 +27,6 @@ impl<T> MaybeFuture<T> {
         Self::None
     }
 
-    /// Creates a [`MaybeFuture`] with an inner future.
-    pub(crate) fn with_future(fut: T) -> Self {
-        Self::Some(fut)
-    }
-
     /// Clears the value
     pub(crate) fn set_none(mut self: Pin<&mut Self>) {
         self.as_mut().project_replace(Self::None);


### PR DESCRIPTION
## Description

Avoids the `Box::pin` inside of the loop

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
