### PR TITLE
refactor(iroh): ActiveRelayActor terminates itself

### DIFF
--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -479,8 +479,9 @@ impl RelayActor {
         }
 
         // try shutdown
-        if let Err(_) =
-            tokio::time::timeout(Duration::from_secs(3), self.close_all_active_relays()).await
+        if tokio::time::timeout(Duration::from_secs(3), self.close_all_active_relays())
+            .await
+            .is_err()
         {
             warn!("Failed to shut down all ActiveRelayActors");
         }

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -604,8 +604,7 @@ impl RelayActor {
                     .inbox_addr
                     .try_send(ActiveRelayMessage::SetHomeRelay(true))
                 {
-                    error!("Send to newly started active relay failed: {err:#}.");
-                    warn!("Home relay not set");
+                    error!("Home relay not set, send to new actor failed: {err:#}.");
                 }
             }
             self.active_relays.insert(url.clone(), handle);

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -480,7 +480,7 @@ impl RelayActor {
 
         // try shutdown
         if let Err(_) =
-            tokio::time::timeout(Duration::from_secs(3), self.close_all_relay("conn-close")).await
+            tokio::time::timeout(Duration::from_secs(3), self.close_all_active_relays()).await
         {
             warn!("Failed to shut down all ActiveRelayActors");
         }
@@ -689,9 +689,9 @@ impl RelayActor {
     }
 
     /// Stops all [`ActiveRelayActor`]s and awaits for them to finish.
-    async fn close_all_relay(&mut self, why: &'static str) {
+    async fn close_all_active_relays(&mut self) {
         let send_futs = self.active_relays.iter().map(|(url, handle)| async move {
-            debug!(%url, why, "closing connection");
+            debug!(%url, "Shutting down ActiveRelayActor");
             handle
                 .inbox_addr
                 .send(ActiveRelayMessage::Shutdown)

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -671,15 +671,8 @@ impl RelayActor {
 
     /// Cleans up [`ActiveRelayActor`]s which have stopped running.
     fn reap_active_relays(&mut self) {
-        let mut stopped_actors = Vec::with_capacity(self.active_relays.len());
-        for (url, handle) in self.active_relays.iter() {
-            if handle.inbox_addr.is_closed() {
-                stopped_actors.push(url.clone());
-            }
-        }
-        for url in stopped_actors {
-            self.active_relays.remove(&url);
-        }
+        self.active_relays
+            .retain(|_url, handle| !handle.inbox_addr.is_closed());
 
         // Make sure home relay exists
         if let Some(ref url) = self.msock.my_relay() {

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -179,6 +179,7 @@ impl ActiveRelayActor {
         // the last datagrams sent to the relay, received datagrams will trigger ACKs which
         // is sufficient to keep active connections open.
         let mut inactive_timeout = tokio::time::interval(RELAY_INACTIVE_CLEANUP_TIME);
+        inactive_timeout.reset(); // skip immediate tick
 
         loop {
             // If a read error occurred on the connection it might have been lost.  But we
@@ -1092,6 +1093,7 @@ mod tests {
 
         // We now have an idling ActiveRelayActor.  If we advance time just a little it
         // should stay alive.
+        info!("Stepping time forwards by RELAY_INACTIVE_CLEANUP_TIME / 2");
         tokio::time::pause();
         tokio::time::advance(RELAY_INACTIVE_CLEANUP_TIME / 2).await;
         tokio::time::resume();
@@ -1104,6 +1106,7 @@ mod tests {
         );
 
         // If we advance time a lot it should finish.
+        info!("Stepping time forwards by RELAY_INACTIVE_CLEANUP_TIME");
         tokio::time::pause();
         tokio::time::advance(RELAY_INACTIVE_CLEANUP_TIME).await;
         tokio::time::resume();

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -465,7 +465,7 @@ impl RelayActor {
                     if !err.is_cancelled() {
                         error!("ActiveRelayActor failed: {err:?}");
                     }
-                    self.clean_stopped_active_relays();
+                    self.reap_active_relays();
                 }
                 msg = receiver.recv() => {
                     let Some(msg) = msg else {
@@ -670,7 +670,7 @@ impl RelayActor {
     }
 
     /// Cleans up [`ActiveRelayActor`]s which have stopped running.
-    fn clean_stopped_active_relays(&mut self) {
+    fn reap_active_relays(&mut self) {
         let mut stopped_actors = Vec::with_capacity(self.active_relays.len());
         for (url, handle) in self.active_relays.iter() {
             if handle.inbox_addr.is_closed() {


### PR DESCRIPTION
## Description

This moves the logic of terminating an ActiveRelayActor from the
RelayActor to the ActiveRelayActor itself.  This is nice for two
reasons:

- The interactions between ActiveRelayActor and RelayActor are even
  simpler.  RelayActor logic is now easy to reason about.

- It will allow ActiveRelayActor to manage reconnections with
  exponential backoff better.  Currently this behaviour is not changed
  but the RelayActor getting involved meant the backoff behaviour was
  influcenced in two places.

Now that the ActiveRelayActor lifecyle is much more straight forward
the RelayActor's terminating is tidied up as well.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.