### PR TITLE
refactor(iroh-relay)!: Client without actors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,12 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
+ "futures-core",
  "getrandom",
  "instant",
+ "pin-project-lite",
  "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -119,7 +119,7 @@ iroh-test = { path = "../iroh-test" }
 serde_json = "1"
 
 [features]
-default = ["metrics", "server", "test-utils"]
+default = ["metrics"]
 server = [
     "dep:tokio-rustls-acme",
     "dep:clap",

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -119,7 +119,7 @@ iroh-test = { path = "../iroh-test" }
 serde_json = "1"
 
 [features]
-default = ["metrics"]
+default = ["metrics", "server", "test-utils"]
 server = [
     "dep:tokio-rustls-acme",
     "dep:clap",

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -358,8 +358,7 @@ impl Client {
     ///
     /// Returns [`ClientError::Closed`] if the [`Client`] is closed.
     ///
-    /// If there is already an active relay connection, returns the already
-    /// connected [`crate::RelayConn`].
+    /// If there is already an active relay connection, returns `Ok(())`.
     pub async fn connect(&mut self) -> Result<(), ClientError> {
         self.connect_inner("public api").await?;
         Ok(())

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -246,7 +246,7 @@ impl ClientBuilder {
     }
 
     /// Build the [`Client`]
-    pub async fn build(self, key: SecretKey, dns_resolver: DnsResolver) -> Client {
+    pub fn build(self, key: SecretKey, dns_resolver: DnsResolver) -> Client {
         // TODO: review TLS config
         let roots = rustls::RootCertStore {
             roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
@@ -270,7 +270,7 @@ impl ClientBuilder {
 
         let tls_connector: tokio_rustls::TlsConnector = Arc::new(config).into();
 
-        let mut client = Client {
+        Client {
             secret_key: key,
             is_preferred: false,
             relay_conn: None,
@@ -283,13 +283,7 @@ impl ClientBuilder {
             dns_resolver,
             proxy_url: self.proxy_url,
             key_cache: KeyCache::new(self.key_cache_capacity),
-        };
-
-        // Add an initial connection attempt.
-        if let Err(err) = client.connect_inner("initial connect").await {
-            warn!("failed initial connection: {:?}", err);
         }
-        client
     }
 
     /// The expected [`PublicKey`] of the relay server we are connecting to.

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -12,7 +12,7 @@ use std::{
 
 use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use bytes::Bytes;
-use conn::{Conn, ReceivedMessage};
+use conn::Conn;
 use futures_util::StreamExt;
 use hickory_resolver::TokioResolver as DnsResolver;
 use http_body_util::Empty;
@@ -36,6 +36,7 @@ use tokio::{
 use tracing::{debug, error, event, info_span, trace, warn, Instrument, Level};
 use url::Url;
 
+pub use self::conn::ReceivedMessage;
 use crate::{
     defaults::timeouts::*,
     http::{Protocol, RELAY_PATH},

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -311,8 +311,6 @@ impl Client {
 
     /// Connects to a relay Server and returns the underlying relay connection.
     ///
-    /// Returns [`ClientError::Closed`] if the [`Client`] is closed.
-    ///
     /// If there is already an active relay connection, returns `Ok(())`.
     pub async fn connect(&mut self) -> Result<(), ClientError> {
         self.connect_inner("public api").await?;

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -400,7 +400,7 @@ impl Client {
                 (conn, local_addr)
             }
             Protocol::Relay => {
-                let (conn, local_addr) = self.connect_derp().await?;
+                let (conn, local_addr) = self.connect_relay().await?;
                 (conn, Some(local_addr))
             }
         };
@@ -439,7 +439,7 @@ impl Client {
         Ok(conn)
     }
 
-    async fn connect_derp(&self) -> Result<(Conn, SocketAddr), ClientError> {
+    async fn connect_relay(&self) -> Result<(Conn, SocketAddr), ClientError> {
         let url = self.url.clone();
         let tcp_stream = self.dial_url().await?;
 

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -12,7 +12,9 @@ use std::{
 
 use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use bytes::Bytes;
-use conn::{Conn, ConnBuilder, ConnFrameStream, ConnMessageStream, ConnWriter, ReceivedMessage};
+use conn::{
+    create_connection, Conn, ConnFrameStream, ConnMessageStream, ConnWriter, ReceivedMessage,
+};
 use futures_util::StreamExt;
 use hickory_resolver::TokioResolver as DnsResolver;
 use http_body_util::Empty;
@@ -594,8 +596,7 @@ impl Actor {
             }
         };
 
-        let (mut conn, receiver) = ConnBuilder::new(self.secret_key.clone(), reader, writer)
-            .build()
+        let (mut conn, receiver) = create_connection(reader, writer, &self.secret_key)
             .await
             .map_err(|e| ClientError::Build(e.to_string()))?;
 

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -301,7 +301,7 @@ impl Client {
     /// Reads a message from the server.
     ///
     /// Any [`ReceivedMessage::Pong`] messages which are in response to a pong we sent will
-    /// wake up the future returned by [`Client::start_ping`] and not be returned here.  Any
+    /// wake up the future returned by [`Client::send_ping`] and not be returned here.  Any
     /// unknown ping messages are returned.
     ///
     /// # Cancel safety

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -76,7 +76,6 @@ impl Conn {
     /// Errors if the packet is larger than [`MAX_PACKET_SIZE`]
     pub(crate) async fn send(&mut self, dst: NodeId, packet: Bytes) -> Result<()> {
         trace!(dst = dst.fmt_short(), len = packet.len(), "[RELAY] send");
-
         send_packet(&mut *self, dst, packet).await?;
         Ok(())
     }

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::{bail, ensure, Result};
 use bytes::Bytes;
-use futures_lite::{Stream, StreamExt};
+use futures_lite::Stream;
 use futures_sink::Sink;
 use futures_util::SinkExt;
 use iroh_base::{NodeId, SecretKey};
@@ -120,18 +120,6 @@ async fn server_handshake(writer: &mut Conn, secret_key: &SecretKey) -> Result<(
     };
     debug!("server_handshake: sending client_key: {:?}", &client_info);
     crate::protos::relay::send_client_key(&mut *writer, secret_key, &client_info).await?;
-
-    debug!("server_handshake: recv ing");
-    match writer.next().await {
-        Some(Ok(frame)) => {
-            let ReceivedMessage::Ping(data) = frame else {
-                bail!("expected pong, got: {:?}", frame);
-            };
-            ensure!(data == [1u8; 8], "unexpected ping data");
-        }
-        Some(Err(err)) => return Err(err),
-        None => bail!("EOF: unexpected stream end"),
-    }
 
     debug!("server_handshake: done");
     Ok(())

--- a/iroh-relay/src/client/streams.rs
+++ b/iroh-relay/src/client/streams.rs
@@ -15,19 +15,14 @@ use tokio::{
 
 use super::util;
 
-pub enum MaybeTlsStreamReader {
-    Raw(util::Chain<std::io::Cursor<Bytes>, tokio::io::ReadHalf<ProxyStream>>),
-    Tls(
-        util::Chain<
-            std::io::Cursor<Bytes>,
-            tokio::io::ReadHalf<tokio_rustls::client::TlsStream<ProxyStream>>,
-        >,
-    ),
+pub enum MaybeTlsStreamChained {
+    Raw(util::Chain<std::io::Cursor<Bytes>, ProxyStream>),
+    Tls(util::Chain<std::io::Cursor<Bytes>, tokio_rustls::client::TlsStream<ProxyStream>>),
     #[cfg(all(test, feature = "server"))]
-    Mem(tokio::io::ReadHalf<tokio::io::DuplexStream>),
+    Mem(tokio::io::DuplexStream),
 }
 
-impl AsyncRead for MaybeTlsStreamReader {
+impl AsyncRead for MaybeTlsStreamChained {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -42,23 +37,15 @@ impl AsyncRead for MaybeTlsStreamReader {
     }
 }
 
-#[derive(Debug)]
-pub enum MaybeTlsStreamWriter {
-    Raw(tokio::io::WriteHalf<ProxyStream>),
-    Tls(tokio::io::WriteHalf<tokio_rustls::client::TlsStream<ProxyStream>>),
-    #[cfg(all(test, feature = "server"))]
-    Mem(tokio::io::WriteHalf<tokio::io::DuplexStream>),
-}
-
-impl AsyncWrite for MaybeTlsStreamWriter {
+impl AsyncWrite for MaybeTlsStreamChained {
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
         match &mut *self {
-            Self::Raw(stream) => Pin::new(stream).poll_write(cx, buf),
-            Self::Tls(stream) => Pin::new(stream).poll_write(cx, buf),
+            Self::Raw(stream) => Pin::new(stream.get_mut().1).poll_write(cx, buf),
+            Self::Tls(stream) => Pin::new(stream.get_mut().1).poll_write(cx, buf),
             #[cfg(all(test, feature = "server"))]
             Self::Mem(stream) => Pin::new(stream).poll_write(cx, buf),
         }
@@ -69,8 +56,8 @@ impl AsyncWrite for MaybeTlsStreamWriter {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
         match &mut *self {
-            Self::Raw(stream) => Pin::new(stream).poll_flush(cx),
-            Self::Tls(stream) => Pin::new(stream).poll_flush(cx),
+            Self::Raw(stream) => Pin::new(stream.get_mut().1).poll_flush(cx),
+            Self::Tls(stream) => Pin::new(stream.get_mut().1).poll_flush(cx),
             #[cfg(all(test, feature = "server"))]
             Self::Mem(stream) => Pin::new(stream).poll_flush(cx),
         }
@@ -81,8 +68,8 @@ impl AsyncWrite for MaybeTlsStreamWriter {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
         match &mut *self {
-            Self::Raw(stream) => Pin::new(stream).poll_shutdown(cx),
-            Self::Tls(stream) => Pin::new(stream).poll_shutdown(cx),
+            Self::Raw(stream) => Pin::new(stream.get_mut().1).poll_shutdown(cx),
+            Self::Tls(stream) => Pin::new(stream.get_mut().1).poll_shutdown(cx),
             #[cfg(all(test, feature = "server"))]
             Self::Mem(stream) => Pin::new(stream).poll_shutdown(cx),
         }
@@ -94,41 +81,31 @@ impl AsyncWrite for MaybeTlsStreamWriter {
         bufs: &[std::io::IoSlice<'_>],
     ) -> Poll<Result<usize, std::io::Error>> {
         match &mut *self {
-            Self::Raw(stream) => Pin::new(stream).poll_write_vectored(cx, bufs),
-            Self::Tls(stream) => Pin::new(stream).poll_write_vectored(cx, bufs),
+            Self::Raw(stream) => Pin::new(stream.get_mut().1).poll_write_vectored(cx, bufs),
+            Self::Tls(stream) => Pin::new(stream.get_mut().1).poll_write_vectored(cx, bufs),
             #[cfg(all(test, feature = "server"))]
             Self::Mem(stream) => Pin::new(stream).poll_write_vectored(cx, bufs),
         }
     }
 }
 
-pub fn downcast_upgrade(
-    upgraded: Upgraded,
-) -> Result<(MaybeTlsStreamReader, MaybeTlsStreamWriter)> {
+pub fn downcast_upgrade(upgraded: Upgraded) -> Result<MaybeTlsStreamChained> {
     match upgraded.downcast::<TokioIo<ProxyStream>>() {
         Ok(Parts { read_buf, io, .. }) => {
-            let inner = io.into_inner();
-            let (reader, writer) = tokio::io::split(inner);
+            let conn = io.into_inner();
             // Prepend data to the reader to avoid data loss
-            let reader = util::chain(std::io::Cursor::new(read_buf), reader);
-            Ok((
-                MaybeTlsStreamReader::Raw(reader),
-                MaybeTlsStreamWriter::Raw(writer),
-            ))
+            let conn = util::chain(std::io::Cursor::new(read_buf), conn);
+            Ok(MaybeTlsStreamChained::Raw(conn))
         }
         Err(upgraded) => {
             if let Ok(Parts { read_buf, io, .. }) =
                 upgraded.downcast::<TokioIo<tokio_rustls::client::TlsStream<ProxyStream>>>()
             {
-                let inner = io.into_inner();
-                let (reader, writer) = tokio::io::split(inner);
-                // Prepend data to the reader to avoid data loss
-                let reader = util::chain(std::io::Cursor::new(read_buf), reader);
+                let conn = io.into_inner();
 
-                return Ok((
-                    MaybeTlsStreamReader::Tls(reader),
-                    MaybeTlsStreamWriter::Tls(writer),
-                ));
+                // Prepend data to the reader to avoid data loss
+                let conn = util::chain(std::io::Cursor::new(read_buf), conn);
+                return Ok(MaybeTlsStreamChained::Tls(conn));
             }
 
             bail!(

--- a/iroh-relay/src/client/streams.rs
+++ b/iroh-relay/src/client/streams.rs
@@ -42,6 +42,7 @@ impl AsyncRead for MaybeTlsStreamReader {
     }
 }
 
+#[derive(Debug)]
 pub enum MaybeTlsStreamWriter {
     Raw(tokio::io::WriteHalf<ProxyStream>),
     Tls(tokio::io::WriteHalf<tokio_rustls::client::TlsStream<ProxyStream>>),
@@ -137,6 +138,7 @@ pub fn downcast_upgrade(
     }
 }
 
+#[derive(Debug)]
 pub enum ProxyStream {
     Raw(TcpStream),
     Proxied(util::Chain<std::io::Cursor<Bytes>, MaybeTlsStream>),
@@ -214,6 +216,7 @@ impl ProxyStream {
     }
 }
 
+#[derive(Debug)]
 pub enum MaybeTlsStream {
     Raw(TcpStream),
     Tls(tokio_rustls::client::TlsStream<TcpStream>),

--- a/iroh-relay/src/defaults.rs
+++ b/iroh-relay/src/defaults.rs
@@ -34,18 +34,8 @@ pub(crate) mod timeouts {
     /// Timeout used by the relay client while connecting to the relay server,
     /// using `TcpStream::connect`
     pub(crate) const DIAL_NODE_TIMEOUT: Duration = Duration::from_millis(1500);
-    /// Timeout for expecting a pong from the relay server
-    pub(crate) const PING_TIMEOUT: Duration = Duration::from_secs(5);
-    /// Timeout for the entire relay connection, which includes dns, dialing
-    /// the server, upgrading the connection, and completing the handshake
-    pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
     /// Timeout for our async dns resolver
     pub(crate) const DNS_TIMEOUT: Duration = Duration::from_secs(1);
-
-    /// Maximum time the client will wait to receive on the connection, since
-    /// the last message. Longer than this time and the client will consider
-    /// the connection dead.
-    pub(crate) const CLIENT_RECV_TIMEOUT: Duration = Duration::from_secs(120);
 
     /// Maximum time the server will attempt to get a successful write to the connection.
     #[cfg(feature = "server")]

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -49,9 +49,8 @@ pub use protos::relay::MAX_PACKET_SIZE;
 
 pub use self::{
     client::{
-        conn::{Conn as RelayConn, ReceivedMessage},
-        Client as HttpClient, ClientBuilder as HttpClientBuilder, ClientError as HttpClientError,
-        ClientReceiver as HttpClientReceiver,
+        conn::ReceivedMessage, Client as HttpClient, ClientBuilder as HttpClientBuilder,
+        ClientError as HttpClientError, ClientReceiver as HttpClientReceiver,
     },
     relay_map::{RelayMap, RelayNode, RelayQuicConfig},
 };

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -47,10 +47,4 @@ mod dns;
 
 pub use protos::relay::MAX_PACKET_SIZE;
 
-pub use self::{
-    client::{
-        conn::ReceivedMessage, Client as HttpClient, ClientBuilder as HttpClientBuilder,
-        ClientError as HttpClientError,
-    },
-    relay_map::{RelayMap, RelayNode, RelayQuicConfig},
-};
+pub use self::relay_map::{RelayMap, RelayNode, RelayQuicConfig};

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -50,7 +50,7 @@ pub use protos::relay::MAX_PACKET_SIZE;
 pub use self::{
     client::{
         conn::ReceivedMessage, Client as HttpClient, ClientBuilder as HttpClientBuilder,
-        ClientError as HttpClientError, ClientReceiver as HttpClientReceiver,
+        ClientError as HttpClientError,
     },
     relay_map::{RelayMap, RelayNode, RelayQuicConfig},
 };

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -45,6 +45,9 @@ pub(crate) const KEEP_ALIVE: Duration = Duration::from_secs(60);
 // TODO: what should this be?
 #[cfg(feature = "server")]
 pub(crate) const SERVER_CHANNEL_SIZE: usize = 1024 * 100;
+/// The number of packets buffered for sending per client
+#[cfg(feature = "server")]
+pub(crate) const PER_CLIENT_SEND_QUEUE_DEPTH: usize = 512; //32;
 
 /// ProtocolVersion is bumped whenever there's a wire-incompatible change.
 ///  - version 1 (zero on wire): consistent box headers, in use by employee dev nodes a bit

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -45,8 +45,6 @@ pub(crate) const KEEP_ALIVE: Duration = Duration::from_secs(60);
 // TODO: what should this be?
 #[cfg(feature = "server")]
 pub(crate) const SERVER_CHANNEL_SIZE: usize = 1024 * 100;
-/// The number of packets buffered for sending per client
-pub(crate) const PER_CLIENT_SEND_QUEUE_DEPTH: usize = 512; //32;
 
 /// ProtocolVersion is bumped whenever there's a wire-incompatible change.
 ///  - version 1 (zero on wire): consistent box headers, in use by employee dev nodes a bit

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -12,6 +12,7 @@
 //!  * clients sends `FrameType::SendPacket`
 //!  * server then sends `FrameType::RecvPacket` to recipient
 
+#[cfg(feature = "server")]
 use std::time::Duration;
 
 use anyhow::{bail, ensure};
@@ -25,7 +26,7 @@ use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::KeyCache;
+use crate::{client::conn::ConnSendError, KeyCache};
 
 /// The maximum size of a packet sent over relay.
 /// (This only includes the data bytes visible to magicsock, not
@@ -130,6 +131,7 @@ pub(crate) struct ClientInfo {
 /// Ignores the timeout if `None`
 ///
 /// Does not flush.
+#[cfg(feature = "server")]
 pub(crate) async fn write_frame<S: Sink<Frame, Error = std::io::Error> + Unpin>(
     mut writer: S,
     frame: Frame,
@@ -148,7 +150,7 @@ pub(crate) async fn write_frame<S: Sink<Frame, Error = std::io::Error> + Unpin>(
 /// and the client's [`ClientInfo`], sealed using the server's [`PublicKey`].
 ///
 /// Flushes after writing.
-pub(crate) async fn send_client_key<S: Sink<Frame, Error = std::io::Error> + Unpin>(
+pub(crate) async fn send_client_key<S: Sink<Frame, Error = ConnSendError> + Unpin>(
     mut writer: S,
     client_secret_key: &SecretKey,
     client_info: &ClientInfo,
@@ -614,7 +616,8 @@ mod tests {
     async fn test_send_recv_client_key() -> anyhow::Result<()> {
         let (reader, writer) = tokio::io::duplex(1024);
         let mut reader = FramedRead::new(reader, RelayCodec::test());
-        let mut writer = FramedWrite::new(writer, RelayCodec::test());
+        let mut writer =
+            FramedWrite::new(writer, RelayCodec::test()).sink_map_err(ConnSendError::from);
 
         let client_key = SecretKey::generate(rand::thread_rng());
         let client_info = ClientInfo {

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -886,7 +886,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_relay_clients_both_derp() {
+    async fn test_relay_clients_both_relay() {
         let _guard = iroh_test::logging::setup();
         let server = spawn_local_relay().await.unwrap();
         let relay_url = format!("http://{}", server.http_addr().unwrap());
@@ -1039,7 +1039,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_relay_clients_websocket_and_derp() {
+    async fn test_relay_clients_websocket_and_relay() {
         let _guard = iroh_test::logging::setup();
         let server = spawn_local_relay().await.unwrap();
 

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -976,24 +976,8 @@ mod tests {
             .protocol(Protocol::Websocket)
             .build(a_secret_key, resolver)
             .await;
-        let connect_client = &mut client_a;
-
-        // give the relay server some time to accept connections
-        if let Err(err) = tokio::time::timeout(Duration::from_secs(10), async move {
-            loop {
-                match connect_client.connect().await {
-                    Ok(_) => break,
-                    Err(err) => {
-                        warn!("client unable to connect to relay server: {err:#}");
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                    }
-                }
-            }
-        })
-        .await
-        {
-            panic!("error connecting to relay server: {err:#}");
-        }
+        // should already be connected after building the client
+        client_a.connect().await.unwrap();
 
         // set up client b
         let b_secret_key = SecretKey::generate(rand::thread_rng());
@@ -1003,6 +987,8 @@ mod tests {
             .protocol(Protocol::Websocket) // another websocket client
             .build(b_secret_key, resolver)
             .await;
+
+        // should already be connected after building the client
         client_b.connect().await.unwrap();
 
         // send message from a to b
@@ -1053,24 +1039,9 @@ mod tests {
         let mut client_a = ClientBuilder::new(relay_url.clone())
             .build(a_secret_key, resolver)
             .await;
-        let connect_client = &mut client_a;
 
-        // give the relay server some time to accept connections
-        if let Err(err) = tokio::time::timeout(Duration::from_secs(10), async move {
-            loop {
-                match connect_client.connect().await {
-                    Ok(_) => break,
-                    Err(err) => {
-                        warn!("client unable to connect to relay server: {err:#}");
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                    }
-                }
-            }
-        })
-        .await
-        {
-            panic!("error connecting to relay server: {err:#}");
-        }
+        // should already be connected after building the client
+        client_a.connect().await.unwrap();
 
         // set up client b
         let b_secret_key = SecretKey::generate(rand::thread_rng());
@@ -1080,6 +1051,8 @@ mod tests {
             .protocol(Protocol::Websocket) // Use websockets
             .build(b_secret_key, resolver)
             .await;
+
+        // should already be connected after building the client
         client_b.connect().await.unwrap();
 
         // send message from a to b

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -989,6 +989,9 @@ mod tests {
         info!("client b connect");
         client_b.connect().await?;
 
+        // wait a moment for the relay server to connect
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
         info!("sending a -> b");
 
         // send message from a to b

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -896,7 +896,9 @@ mod tests {
         let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let mut client_a = ClientBuilder::new(relay_url.clone()).build(a_secret_key, resolver);
+        let mut client_a = ClientBuilder::new(relay_url.clone())
+            .build(a_secret_key, resolver)
+            .await;
         let connect_client = &mut client_a;
 
         // give the relay server some time to accept connections
@@ -920,7 +922,9 @@ mod tests {
         let b_secret_key = SecretKey::generate(rand::thread_rng());
         let b_key = b_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let mut client_b = ClientBuilder::new(relay_url.clone()).build(b_secret_key, resolver);
+        let mut client_b = ClientBuilder::new(relay_url.clone())
+            .build(b_secret_key, resolver)
+            .await;
         client_b.connect().await.unwrap();
 
         // send message from a to b
@@ -970,7 +974,8 @@ mod tests {
         let resolver = crate::dns::default_resolver().clone();
         let mut client_a = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket)
-            .build(a_secret_key, resolver);
+            .build(a_secret_key, resolver)
+            .await;
         let connect_client = &mut client_a;
 
         // give the relay server some time to accept connections
@@ -996,7 +1001,8 @@ mod tests {
         let resolver = crate::dns::default_resolver().clone();
         let mut client_b = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket) // another websocket client
-            .build(b_secret_key, resolver);
+            .build(b_secret_key, resolver)
+            .await;
         client_b.connect().await.unwrap();
 
         // send message from a to b
@@ -1044,7 +1050,9 @@ mod tests {
         let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let mut client_a = ClientBuilder::new(relay_url.clone()).build(a_secret_key, resolver);
+        let mut client_a = ClientBuilder::new(relay_url.clone())
+            .build(a_secret_key, resolver)
+            .await;
         let connect_client = &mut client_a;
 
         // give the relay server some time to accept connections
@@ -1070,7 +1078,8 @@ mod tests {
         let resolver = crate::dns::default_resolver().clone();
         let mut client_b = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket) // Use websockets
-            .build(b_secret_key, resolver);
+            .build(b_secret_key, resolver)
+            .await;
         client_b.connect().await.unwrap();
 
         // send message from a to b

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -896,9 +896,8 @@ mod tests {
         let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let (client_a, mut client_a_receiver) =
-            ClientBuilder::new(relay_url.clone()).build(a_secret_key, resolver);
-        let connect_client = client_a.clone();
+        let mut client_a = ClientBuilder::new(relay_url.clone()).build(a_secret_key, resolver);
+        let connect_client = &mut client_a;
 
         // give the relay server some time to accept connections
         if let Err(err) = tokio::time::timeout(Duration::from_secs(10), async move {
@@ -921,15 +920,14 @@ mod tests {
         let b_secret_key = SecretKey::generate(rand::thread_rng());
         let b_key = b_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let (client_b, mut client_b_receiver) =
-            ClientBuilder::new(relay_url.clone()).build(b_secret_key, resolver);
+        let mut client_b = ClientBuilder::new(relay_url.clone()).build(b_secret_key, resolver);
         client_b.connect().await.unwrap();
 
         // send message from a to b
         let msg = Bytes::from("hello, b");
         client_a.send(b_key, msg.clone()).await.unwrap();
 
-        let res = client_b_receiver.recv().await.unwrap().unwrap();
+        let res = client_b.recv().await.unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -945,7 +943,7 @@ mod tests {
         let msg = Bytes::from("howdy, a");
         client_b.send(a_key, msg.clone()).await.unwrap();
 
-        let res = client_a_receiver.recv().await.unwrap().unwrap();
+        let res = client_a.recv().await.unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -970,10 +968,10 @@ mod tests {
         let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let (client_a, mut client_a_receiver) = ClientBuilder::new(relay_url.clone())
+        let mut client_a = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket)
             .build(a_secret_key, resolver);
-        let connect_client = client_a.clone();
+        let connect_client = &mut client_a;
 
         // give the relay server some time to accept connections
         if let Err(err) = tokio::time::timeout(Duration::from_secs(10), async move {
@@ -996,7 +994,7 @@ mod tests {
         let b_secret_key = SecretKey::generate(rand::thread_rng());
         let b_key = b_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let (client_b, mut client_b_receiver) = ClientBuilder::new(relay_url.clone())
+        let mut client_b = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket) // another websocket client
             .build(b_secret_key, resolver);
         client_b.connect().await.unwrap();
@@ -1005,7 +1003,7 @@ mod tests {
         let msg = Bytes::from("hello, b");
         client_a.send(b_key, msg.clone()).await.unwrap();
 
-        let res = client_b_receiver.recv().await.unwrap().unwrap();
+        let res = client_b.recv().await.unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -1021,7 +1019,7 @@ mod tests {
         let msg = Bytes::from("howdy, a");
         client_b.send(a_key, msg.clone()).await.unwrap();
 
-        let res = client_a_receiver.recv().await.unwrap().unwrap();
+        let res = client_a.recv().await.unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -1046,9 +1044,8 @@ mod tests {
         let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let (client_a, mut client_a_receiver) =
-            ClientBuilder::new(relay_url.clone()).build(a_secret_key, resolver);
-        let connect_client = client_a.clone();
+        let mut client_a = ClientBuilder::new(relay_url.clone()).build(a_secret_key, resolver);
+        let connect_client = &mut client_a;
 
         // give the relay server some time to accept connections
         if let Err(err) = tokio::time::timeout(Duration::from_secs(10), async move {
@@ -1071,7 +1068,7 @@ mod tests {
         let b_secret_key = SecretKey::generate(rand::thread_rng());
         let b_key = b_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let (client_b, mut client_b_receiver) = ClientBuilder::new(relay_url.clone())
+        let mut client_b = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket) // Use websockets
             .build(b_secret_key, resolver);
         client_b.connect().await.unwrap();
@@ -1080,7 +1077,7 @@ mod tests {
         let msg = Bytes::from("hello, b");
         client_a.send(b_key, msg.clone()).await.unwrap();
 
-        let res = client_b_receiver.recv().await.unwrap().unwrap();
+        let res = client_b.recv().await.unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -1096,7 +1093,7 @@ mod tests {
         let msg = Bytes::from("howdy, a");
         client_b.send(a_key, msg.clone()).await.unwrap();
 
-        let res = client_a_receiver.recv().await.unwrap().unwrap();
+        let res = client_a.recv().await.unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -896,9 +896,7 @@ mod tests {
         let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let mut client_a = ClientBuilder::new(relay_url.clone())
-            .build(a_secret_key, resolver)
-            .await;
+        let mut client_a = ClientBuilder::new(relay_url.clone()).build(a_secret_key, resolver);
         let connect_client = &mut client_a;
 
         // give the relay server some time to accept connections
@@ -922,9 +920,7 @@ mod tests {
         let b_secret_key = SecretKey::generate(rand::thread_rng());
         let b_key = b_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let mut client_b = ClientBuilder::new(relay_url.clone())
-            .build(b_secret_key, resolver)
-            .await;
+        let mut client_b = ClientBuilder::new(relay_url.clone()).build(b_secret_key, resolver);
         client_b.connect().await.unwrap();
 
         // send message from a to b
@@ -975,8 +971,7 @@ mod tests {
         info!("client a build");
         let mut client_a = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket)
-            .build(a_secret_key, resolver.clone())
-            .await;
+            .build(a_secret_key, resolver.clone());
 
         // should already be connected after building the client
         info!("client a connect");
@@ -988,8 +983,7 @@ mod tests {
         info!("client b build");
         let mut client_b = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket) // another websocket client
-            .build(b_secret_key, resolver.clone())
-            .await;
+            .build(b_secret_key, resolver.clone());
 
         // should already be connected after building the client
         info!("client b connect");
@@ -1045,9 +1039,7 @@ mod tests {
         let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
-        let mut client_a = ClientBuilder::new(relay_url.clone())
-            .build(a_secret_key, resolver)
-            .await;
+        let mut client_a = ClientBuilder::new(relay_url.clone()).build(a_secret_key, resolver);
 
         // should already be connected after building the client
         client_a.connect().await.unwrap();
@@ -1058,8 +1050,7 @@ mod tests {
         let resolver = crate::dns::default_resolver().clone();
         let mut client_b = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket) // Use websockets
-            .build(b_secret_key, resolver)
-            .await;
+            .build(b_secret_key, resolver);
 
         // should already be connected after building the client
         client_b.connect().await.unwrap();

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -972,25 +972,31 @@ mod tests {
         let a_secret_key = SecretKey::generate(rand::thread_rng());
         let a_key = a_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
+        info!("client a build");
         let mut client_a = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket)
             .build(a_secret_key, resolver)
             .await;
+
         // should already be connected after building the client
+        info!("client a connect");
         client_a.connect().await.unwrap();
 
         // set up client b
         let b_secret_key = SecretKey::generate(rand::thread_rng());
         let b_key = b_secret_key.public();
         let resolver = crate::dns::default_resolver().clone();
+        info!("client b build");
         let mut client_b = ClientBuilder::new(relay_url.clone())
             .protocol(Protocol::Websocket) // another websocket client
             .build(b_secret_key, resolver)
             .await;
 
         // should already be connected after building the client
+        info!("client b connect");
         client_b.connect().await.unwrap();
 
+        info!("sending a -> b");
         // send message from a to b
         let msg = Bytes::from("hello, b");
         client_a.send(b_key, msg.clone()).await.unwrap();
@@ -1007,6 +1013,7 @@ mod tests {
             panic!("client_b received unexpected message {res:?}");
         }
 
+        info!("sending b -> a");
         // send message from b to a
         let msg = Bytes::from("howdy, a");
         client_b.send(a_key, msg.clone()).await.unwrap();

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -927,7 +927,7 @@ mod tests {
         let msg = Bytes::from("hello, b");
         client_a.send(b_key, msg.clone()).await.unwrap();
 
-        let res = client_b.recv().await.unwrap().unwrap();
+        let res = client_b.recv().await.unwrap().unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -943,7 +943,7 @@ mod tests {
         let msg = Bytes::from("howdy, a");
         client_b.send(a_key, msg.clone()).await.unwrap();
 
-        let res = client_a.recv().await.unwrap().unwrap();
+        let res = client_a.recv().await.unwrap().unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -995,7 +995,7 @@ mod tests {
         let msg = Bytes::from("hello, b");
         client_a.send(b_key, msg.clone()).await?;
 
-        let res = client_b.recv().await.unwrap()?;
+        let res = client_b.recv().await?.unwrap()?;
         let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -1012,7 +1012,7 @@ mod tests {
         let msg = Bytes::from("howdy, a");
         client_b.send(a_key, msg.clone()).await?;
 
-        let res = client_a.recv().await.unwrap()?;
+        let res = client_a.recv().await?.unwrap()?;
         let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -1059,7 +1059,7 @@ mod tests {
         let msg = Bytes::from("hello, b");
         client_a.send(b_key, msg.clone()).await.unwrap();
 
-        let res = client_b.recv().await.unwrap().unwrap();
+        let res = client_b.recv().await.unwrap().unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,
@@ -1075,7 +1075,7 @@ mod tests {
         let msg = Bytes::from("howdy, a");
         client_b.send(a_key, msg.clone()).await.unwrap();
 
-        let res = client_a.recv().await.unwrap().unwrap();
+        let res = client_a.recv().await.unwrap().unwrap().unwrap();
         if let ReceivedMessage::ReceivedPacket {
             remote_node_id,
             data,

--- a/iroh-relay/src/server/actor.rs
+++ b/iroh-relay/src/server/actor.rs
@@ -270,7 +270,7 @@ mod tests {
         (
             ClientConnConfig {
                 node_id,
-                stream: RelayedStream::Derp(Framed::new(
+                stream: RelayedStream::Relay(Framed::new(
                     MaybeTlsStream::Test(io),
                     RelayCodec::test(),
                 )),

--- a/iroh-relay/src/server/actor.rs
+++ b/iroh-relay/src/server/actor.rs
@@ -52,7 +52,7 @@ pub(super) struct Packet {
 /// Will forcefully abort the server actor loop when dropped.
 /// For stopping gracefully, use [`ServerActorTask::close`].
 ///
-/// Responsible for managing connections to relay [`Conn`](crate::RelayConn)s, sending packets from one client to another.
+/// Responsible for managing connections to a relay, sending packets from one client to another.
 #[derive(Debug)]
 pub(super) struct ServerActorTask {
     /// Specifies how long to wait before failing when writing to a client.

--- a/iroh-relay/src/server/actor.rs
+++ b/iroh-relay/src/server/actor.rs
@@ -249,6 +249,7 @@ impl ClientCounter {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
+    use futures_util::SinkExt;
     use iroh_base::SecretKey;
     use tokio::io::DuplexStream;
     use tokio_util::codec::Framed;
@@ -316,7 +317,11 @@ mod tests {
 
         // write message from b to a
         let msg = b"hello world!";
-        crate::client::conn::send_packet(&mut b_io, node_id_a, Bytes::from_static(msg)).await?;
+        b_io.send(Frame::SendPacket {
+            dst_key: node_id_a,
+            packet: Bytes::from_static(msg),
+        })
+        .await?;
 
         // get message on a's reader
         let frame = recv_frame(FrameType::RecvPacket, &mut a_io).await?;

--- a/iroh-relay/src/server/client_conn.rs
+++ b/iroh-relay/src/server/client_conn.rs
@@ -532,7 +532,8 @@ mod tests {
         let (io, io_rw) = tokio::io::duplex(1024);
         let mut io_rw = Framed::new(io_rw, RelayCodec::test());
         let (server_channel_s, mut server_channel_r) = mpsc::channel(10);
-        let stream = RelayedStream::Derp(Framed::new(MaybeTlsStream::Test(io), RelayCodec::test()));
+        let stream =
+            RelayedStream::Relay(Framed::new(MaybeTlsStream::Test(io), RelayCodec::test()));
 
         let actor = Actor {
             stream: RateLimitedRelayedStream::unlimited(stream),
@@ -672,7 +673,8 @@ mod tests {
         let (io, io_rw) = tokio::io::duplex(1024);
         let mut io_rw = Framed::new(io_rw, RelayCodec::test());
         let (server_channel_s, mut server_channel_r) = mpsc::channel(10);
-        let stream = RelayedStream::Derp(Framed::new(MaybeTlsStream::Test(io), RelayCodec::test()));
+        let stream =
+            RelayedStream::Relay(Framed::new(MaybeTlsStream::Test(io), RelayCodec::test()));
 
         println!("-- create client conn");
         let actor = Actor {
@@ -751,7 +753,7 @@ mod tests {
         // Build the rate limited stream.
         let (io_read, io_write) = tokio::io::duplex((LIMIT * MAX_FRAMES) as _);
         let mut frame_writer = Framed::new(io_write, RelayCodec::test());
-        let stream = RelayedStream::Derp(Framed::new(
+        let stream = RelayedStream::Relay(Framed::new(
             MaybeTlsStream::Test(io_read),
             RelayCodec::test(),
         ));

--- a/iroh-relay/src/server/client_conn.rs
+++ b/iroh-relay/src/server/client_conn.rs
@@ -517,7 +517,6 @@ mod tests {
 
     use super::*;
     use crate::{
-        client::conn,
         protos::relay::{recv_frame, FrameType, RelayCodec},
         server::streams::MaybeTlsStream,
     };
@@ -618,7 +617,12 @@ mod tests {
         // send packet
         println!("  send packet");
         let data = b"hello world!";
-        conn::send_packet(&mut io_rw, target, Bytes::from_static(data)).await?;
+        io_rw
+            .send(Frame::SendPacket {
+                dst_key: target,
+                packet: Bytes::from_static(data),
+            })
+            .await?;
         let msg = server_channel_r.recv().await.unwrap();
         match msg {
             actor::Message::SendPacket {
@@ -641,7 +645,12 @@ mod tests {
         let mut disco_data = disco::MAGIC.as_bytes().to_vec();
         disco_data.extend_from_slice(target.as_bytes());
         disco_data.extend_from_slice(data);
-        conn::send_packet(&mut io_rw, target, disco_data.clone().into()).await?;
+        io_rw
+            .send(Frame::SendPacket {
+                dst_key: target,
+                packet: disco_data.clone().into(),
+            })
+            .await?;
         let msg = server_channel_r.recv().await.unwrap();
         match msg {
             actor::Message::SendDiscoPacket {
@@ -700,7 +709,12 @@ mod tests {
         let data = b"hello world!";
         let target = SecretKey::generate(rand::thread_rng()).public();
 
-        conn::send_packet(&mut io_rw, target, Bytes::from_static(data)).await?;
+        io_rw
+            .send(Frame::SendPacket {
+                dst_key: target,
+                packet: Bytes::from_static(data),
+            })
+            .await?;
         let msg = server_channel_r.recv().await.unwrap();
         match msg {
             actor::Message::SendPacket {

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -246,7 +246,7 @@ mod tests {
         (
             ClientConnConfig {
                 node_id: key,
-                stream: RelayedStream::Derp(Framed::new(
+                stream: RelayedStream::Relay(Framed::new(
                     MaybeTlsStream::Test(io),
                     RelayCodec::test(),
                 )),

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -746,13 +746,13 @@ mod tests {
         let (a_key, mut client_a) = {
             let span = info_span!("client-a");
             let _guard = span.enter();
-            create_test_client(a_key, relay_addr.clone()).await
+            create_test_client(a_key, relay_addr.clone())
         };
         info!("created client {a_key:?}");
         let (b_key, mut client_b) = {
             let span = info_span!("client-b");
             let _guard = span.enter();
-            create_test_client(b_key, relay_addr).await
+            create_test_client(b_key, relay_addr)
         };
         info!("created client {b_key:?}");
 
@@ -799,10 +799,10 @@ mod tests {
         Ok(())
     }
 
-    async fn create_test_client(key: SecretKey, server_url: Url) -> (PublicKey, Client) {
+    fn create_test_client(key: SecretKey, server_url: Url) -> (PublicKey, Client) {
         let client = ClientBuilder::new(server_url).insecure_skip_cert_verify(true);
         let dns_resolver = crate::dns::default_resolver();
-        let client = client.build(key.clone(), dns_resolver.clone()).await;
+        let client = client.build(key.clone(), dns_resolver.clone());
         let public_key = key.public();
 
         (public_key, client)
@@ -871,9 +871,9 @@ mod tests {
         let url: Url = format!("https://localhost:{port}").parse().unwrap();
 
         // create clients
-        let (a_key, mut client_a) = create_test_client(a_key, url.clone()).await;
+        let (a_key, mut client_a) = create_test_client(a_key, url.clone());
         info!("created client {a_key:?}");
-        let (b_key, mut client_b) = create_test_client(b_key, url).await;
+        let (b_key, mut client_b) = create_test_client(b_key, url);
         info!("created client {b_key:?}");
 
         info!("ping a");

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, ensure, Context as _, Result};
 use bytes::Bytes;
 use derive_more::Debug;
 use futures_lite::FutureExt;
+use futures_util::SinkExt;
 use http::{header::CONNECTION, response::Builder as ResponseBuilder};
 use hyper::{
     body::Incoming,
@@ -518,6 +519,9 @@ impl Inner {
         let (client_key, info) = recv_client_key(&mut io)
             .await
             .context("unable to receive client information")?;
+
+        io.send(crate::protos::relay::Frame::Ping { data: [1u8; 8] })
+            .await?;
 
         if info.version != PROTOCOL_VERSION {
             bail!(

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -759,13 +759,19 @@ mod tests {
         info!("ping a");
         let ping_a = client_a.start_ping().await?;
         let msg = client_a.recv().await.unwrap()?;
-        assert!(matches!(msg, ReceivedMessage::Pong(_)));
+        let ReceivedMessage::Pong(ping) = msg else {
+            panic!("invalid msg: {:?}", msg);
+        };
+        client_a.finish_ping(ping);
         let _dur = ping_a.await?;
 
         info!("ping b");
         let ping_b = client_b.start_ping().await?;
         let msg = client_b.recv().await.unwrap()?;
-        assert!(matches!(msg, ReceivedMessage::Pong(_)));
+        let ReceivedMessage::Pong(ping) = msg else {
+            panic!("invalid msg: {:?}", msg);
+        };
+        client_b.finish_ping(ping);
         let _dur = ping_b.await?;
 
         info!("sending message from a to b");
@@ -873,13 +879,19 @@ mod tests {
         info!("ping a");
         let ping_a = client_a.start_ping().await?;
         let msg = client_a.recv().await.unwrap()?;
-        assert!(matches!(msg, ReceivedMessage::Pong(_)));
+        let ReceivedMessage::Pong(ping) = msg else {
+            panic!("invalid msg: {:?}", msg);
+        };
+        client_a.finish_ping(ping);
         let _dur = ping_a.await?;
 
         info!("ping b");
         let ping_b = client_b.start_ping().await?;
         let msg = client_b.recv().await.unwrap()?;
-        assert!(matches!(msg, ReceivedMessage::Pong(_)));
+        let ReceivedMessage::Pong(ping) = msg else {
+            panic!("invalid msg: {:?}", msg);
+        };
+        client_b.finish_ping(ping);
         let _dur = ping_b.await?;
 
         info!("sending message from a to b");

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -6,7 +6,6 @@ use anyhow::{bail, ensure, Context as _, Result};
 use bytes::Bytes;
 use derive_more::Debug;
 use futures_lite::FutureExt;
-use futures_util::SinkExt;
 use http::{header::CONNECTION, response::Builder as ResponseBuilder};
 use hyper::{
     body::Incoming,
@@ -519,9 +518,6 @@ impl Inner {
         let (client_key, info) = recv_client_key(&mut io)
             .await
             .context("unable to receive client information")?;
-
-        io.send(crate::protos::relay::Frame::Ping { data: [1u8; 8] })
-            .await?;
 
         if info.version != PROTOCOL_VERSION {
             bail!(

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -758,7 +758,7 @@ mod tests {
 
         info!("ping a");
         let ping_a = client_a.start_ping().await?;
-        let msg = client_a.recv().await.unwrap()?;
+        let msg = client_a.recv().await?.unwrap()?;
         let ReceivedMessage::Pong(ping) = msg else {
             panic!("invalid msg: {:?}", msg);
         };
@@ -767,7 +767,7 @@ mod tests {
 
         info!("ping b");
         let ping_b = client_b.start_ping().await?;
-        let msg = client_b.recv().await.unwrap()?;
+        let msg = client_b.recv().await?.unwrap()?;
         let ReceivedMessage::Pong(ping) = msg else {
             panic!("invalid msg: {:?}", msg);
         };
@@ -809,18 +809,18 @@ mod tests {
     }
 
     fn process_msg(
-        msg: Option<std::result::Result<ReceivedMessage, crate::client::ClientError>>,
+        msg: std::result::Result<Option<Result<ReceivedMessage>>, tokio::time::error::Elapsed>,
     ) -> Option<(PublicKey, Bytes)> {
         match msg {
-            None => {
+            Ok(None) => {
                 info!("client received nothing");
                 None
             }
-            Some(Err(e)) => {
+            Ok(Some(Err(e))) => {
                 info!("client `recv` error {e}");
                 None
             }
-            Some(Ok(msg)) => {
+            Ok(Some(Ok(msg))) => {
                 info!("got message on: {msg:?}");
                 if let ReceivedMessage::ReceivedPacket {
                     remote_node_id: source,
@@ -831,6 +831,10 @@ mod tests {
                 } else {
                     None
                 }
+            }
+            Err(_) => {
+                info!("client `recv` time out");
+                None
             }
         }
     }
@@ -878,7 +882,7 @@ mod tests {
 
         info!("ping a");
         let ping_a = client_a.start_ping().await?;
-        let msg = client_a.recv().await.unwrap()?;
+        let msg = client_a.recv().await?.unwrap()?;
         let ReceivedMessage::Pong(ping) = msg else {
             panic!("invalid msg: {:?}", msg);
         };
@@ -887,7 +891,7 @@ mod tests {
 
         info!("ping b");
         let ping_b = client_b.start_ping().await?;
-        let msg = client_b.recv().await.unwrap()?;
+        let msg = client_b.recv().await?.unwrap()?;
         let ReceivedMessage::Pong(ping) = msg else {
             panic!("invalid msg: {:?}", msg);
         };

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -503,8 +503,8 @@ impl Inner {
         trace!(?protocol, "accept: start");
         let mut io = match protocol {
             Protocol::Relay => {
-                inc!(Metrics, derp_accepts);
-                RelayedStream::Derp(Framed::new(io, RelayCodec::new(self.key_cache.clone())))
+                inc!(Metrics, relay_accepts);
+                RelayedStream::Relay(Framed::new(io, RelayCodec::new(self.key_cache.clone())))
             }
             Protocol::Websocket => {
                 inc!(Metrics, websocket_accepts);

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -925,7 +925,7 @@ mod tests {
 
         (
             server,
-            ConnBuilder::new(secret_key, None, client_reader, client_writer),
+            ConnBuilder::new(secret_key, client_reader, client_writer),
         )
     }
 
@@ -953,7 +953,7 @@ mod tests {
             s.0.accept(Protocol::Relay, MaybeTlsStream::Test(rw_a))
                 .await
         });
-        let (client_a, mut client_receiver_a) = client_a_builder.build().await?;
+        let (mut client_a, mut client_receiver_a) = client_a_builder.build().await?;
         handler_task.await??;
 
         info!("Create client B and connect it to the server.");
@@ -965,7 +965,7 @@ mod tests {
             s.0.accept(Protocol::Relay, MaybeTlsStream::Test(rw_b))
                 .await
         });
-        let (client_b, mut client_receiver_b) = client_b_builder.build().await?;
+        let (mut client_b, mut client_receiver_b) = client_b_builder.build().await?;
         handler_task.await??;
 
         info!("Send message from A to B.");
@@ -1042,7 +1042,7 @@ mod tests {
             s.0.accept(Protocol::Relay, MaybeTlsStream::Test(rw_a))
                 .await
         });
-        let (client_a, mut client_receiver_a) = client_a_builder.build().await?;
+        let (mut client_a, mut client_receiver_a) = client_a_builder.build().await?;
         handler_task.await??;
 
         info!("Create client B and connect it to the server.");
@@ -1054,7 +1054,7 @@ mod tests {
             s.0.accept(Protocol::Relay, MaybeTlsStream::Test(rw_b))
                 .await
         });
-        let (client_b, mut client_receiver_b) = client_b_builder.build().await?;
+        let (mut client_b, mut client_receiver_b) = client_b_builder.build().await?;
         handler_task.await??;
 
         info!("Send message from A to B.");
@@ -1096,7 +1096,7 @@ mod tests {
             s.0.accept(Protocol::Relay, MaybeTlsStream::Test(new_rw_b))
                 .await
         });
-        let (new_client_b, mut new_client_receiver_b) = new_client_b_builder.build().await?;
+        let (mut new_client_b, mut new_client_receiver_b) = new_client_b_builder.build().await?;
         handler_task.await??;
 
         // assert!(client_b.recv().await.is_err());

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -61,7 +61,7 @@ pub struct Metrics {
     /// Number of accepted websocket connections
     pub websocket_accepts: Counter,
     /// Number of accepted 'iroh derp http' connection upgrades
-    pub derp_accepts: Counter,
+    pub relay_accepts: Counter,
     // TODO: enable when we can have multiple connections for one node id
     // pub duplicate_client_keys: Counter,
     // pub duplicate_client_conns: Counter,
@@ -112,7 +112,7 @@ impl Default for Metrics {
             unique_client_keys: Counter::new("Number of unique client keys per day."),
 
             websocket_accepts: Counter::new("Number of accepted websocket connections"),
-            derp_accepts: Counter::new("Number of accepted 'iroh derp http' connection upgrades"),
+            relay_accepts: Counter::new("Number of accepted 'iroh derp http' connection upgrades"),
             // TODO: enable when we can have multiple connections for one node id
             // pub duplicate_client_keys: Counter::new("Number of duplicate client keys."),
             // pub duplicate_client_conns: Counter::new("Number of duplicate client connections."),
@@ -128,7 +128,7 @@ impl Metric for Metrics {
     }
 }
 
-/// StunMetrics tracked for the DERPER
+/// StunMetrics tracked for the relay server
 #[derive(Debug, Clone, Iterable)]
 pub struct StunMetrics {
     /*

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -20,7 +20,7 @@ aead = { version = "0.5.2", features = ["bytes"] }
 anyhow = { version = "1" }
 concurrent-queue = "2.5"
 axum = { version = "0.7", optional = true }
-backoff = "0.4.0"
+backoff = { version = "0.4.0", features = ["futures", "tokio"]}
 base64 = "0.22.1"
 bytes = "1.7"
 crypto_box = { version = "0.9.1", features = ["serde", "chacha20"] }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1622,8 +1622,8 @@ mod tests {
                     let eps = ep.bound_sockets();
                     info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "server listening on");
                     for i in 0..n_clients {
-                        let now = Instant::now();
-                        println!("[server] round {}", i + 1);
+                        let round_start = Instant::now();
+                        info!("[server] round {i}");
                         let incoming = ep.accept().await.unwrap();
                         let conn = incoming.await.unwrap();
                         let peer_id = get_remote_node_id(&conn).unwrap();
@@ -1638,7 +1638,7 @@ mod tests {
                         send.stopped().await.unwrap();
                         recv.read_to_end(0).await.unwrap();
                         info!(%i, peer = %peer_id.fmt_short(), "finished");
-                        println!("[server] round {} done in {:?}", i + 1, now.elapsed());
+                        info!("[server] round {i} done in {:?}", round_start.elapsed());
                     }
                 }
                 .instrument(error_span!("server")),
@@ -1650,8 +1650,8 @@ mod tests {
         });
 
         for i in 0..n_clients {
-            let now = Instant::now();
-            println!("[client] round {}", i + 1);
+            let round_start = Instant::now();
+            info!("[client] round {}", i);
             let relay_map = relay_map.clone();
             let client_secret_key = SecretKey::generate(&mut rng);
             let relay_url = relay_url.clone();
@@ -1688,7 +1688,7 @@ mod tests {
             }
             .instrument(error_span!("client", %i))
             .await;
-            println!("[client] round {} done in {:?}", i + 1, now.elapsed());
+            info!("[client] round {i} done in {:?}", round_start.elapsed());
         }
 
         server.await.unwrap();

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -22,7 +22,11 @@ use futures_buffered::FuturesUnorderedBounded;
 use futures_lite::StreamExt;
 use iroh_base::{NodeId, PublicKey, RelayUrl, SecretKey};
 use iroh_metrics::{inc, inc_by};
-use iroh_relay::{self as relay, client::ClientError, ReceivedMessage, MAX_PACKET_SIZE};
+use iroh_relay::{
+    self as relay,
+    client::{ClientError, ReceivedMessage},
+    MAX_PACKET_SIZE,
+};
 use tokio::{
     sync::{mpsc, oneshot},
     task::JoinSet,

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -412,6 +412,10 @@ impl ActiveRelayActor {
                         }
                         ReadResult::Continue
                     }
+                    ReceivedMessage::Pong(ping) => {
+                        self.relay_client.finish_ping(ping);
+                        ReadResult::Continue
+                    }
                     ReceivedMessage::Health { .. } => ReadResult::Continue,
                     ReceivedMessage::NodeGone(key) => {
                         self.node_present.remove(&key);

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -199,9 +199,9 @@ impl ActiveRelayActor {
                         }
                         ActiveRelayMessage::CheckConnection(local_ips) => {
                             if let Some(fut) = self.handle_check_connection(local_ips).await {
-                                if ping_future.is_none() {
-                                    ping_future.as_mut().set_future(fut);
-                                }
+                                // We always override the future, to make sure the latest connection
+                                // details are used.
+                                ping_future.as_mut().set_future(fut);
                             }
                         }
                         ActiveRelayMessage::Shutdown => {

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -326,9 +326,6 @@ impl ActiveRelayActor {
             Ok(Some(Err(err))) => {
                 warn!("recv error: {:?}", err);
                 self.relay_client.close_for_reconnect().await;
-                if !self.relay_client.is_closed() {
-                    conn_is_closed = true;
-                }
                 None
             }
             Ok(None) => {

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -29,7 +29,7 @@ impl<T> MaybeFuture<T> {
         Self::default()
     }
 
-    /// Clears the value
+    /// Sets the future to None again.
     pub(crate) fn set_none(mut self: Pin<&mut Self>) {
         self.as_mut().project_replace(Self::None);
     }


### PR DESCRIPTION
## Description

- local_addr is directly stored
- `Conn` is not clone anymore, and is only used via mutable reference
- no more buffering of writes
- removes `ClientConnBuilder` in favor of just a function `Conn::new`
- `Conn` is now private
- `Conn` is no longer an actor
- no more splitting of the TcpStream
- no more splitting of the Websocket stream
- `Client` is no longer an actor

Reworks the relay client and ActiveRelayActor.

- The relay Client is now a Stream and Sink, but a thin layer over the internal Conn.
- Most of the client work is now deferred to the ActiveRelayActor which can behave much better around this.
- The ActiveRelayActor now sends to the relay server in a future, so it can still respond to other events while sending.
- The ActiveRelayActor now handles HasNodeRoute without blocking, so that the RelayActor is not blocked on this message.
- ActiveRelayActor handless exponential backoff correctly now in it's new "dialing" state since this now only happens in one place.
- All errors with the connection in ActiveRelayActor now result in immediately going back to the "dialing" state, abandoning the current connection.


## Breaking Changes

### iroh-relay

- `Conn` is no longer public.
- Some metrics are renamed `derp` -> `relay`.
- iroh_relay::client::Client has completely changed. See module docs.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
