### PR TITLE
fix: correctly set publishing details for pkarr records

### DIFF
--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -194,7 +194,14 @@ impl PkarrPublisher {
     ///
     /// This is a nonblocking function, the actual update is performed in the background.
     pub fn update_addr_info(&self, url: Option<&RelayUrl>, addrs: &BTreeSet<SocketAddr>) {
-        let info = NodeInfo::new(self.node_id, url.cloned().map(Into::into), addrs.clone());
+        let (relay_url, direct_addresses) = if let Some(relay_url) = url {
+            // Only publish relay url, and no direct addrs
+            let url = relay_url.clone();
+            (Some(url.into()), Default::default())
+        } else {
+            (None, addrs.clone())
+        };
+        let info = NodeInfo::new(self.node_id, relay_url, direct_addresses);
         self.watchable.set(Some(info)).ok();
     }
 }

--- a/iroh/src/magicsock/node_map.rs
+++ b/iroh/src/magicsock/node_map.rs
@@ -709,7 +709,7 @@ mod tests {
             .into_iter()
             .filter_map(|info| {
                 let addr: NodeAddr = info.into();
-                if addr.direct_addresses.is_empty() && addr.relay_url.is_none() {
+                if addr.is_empty() {
                     return None;
                 }
                 Some(addr)
@@ -722,7 +722,7 @@ mod tests {
             .into_iter()
             .filter_map(|info| {
                 let addr: NodeAddr = info.into();
-                if addr.direct_addresses.is_empty() && addr.relay_url.is_none() {
+                if addr.is_empty() {
                     return None;
                 }
                 Some(addr)


### PR DESCRIPTION
Cleanup some changes from #3024

- Cleans up some `is_empty` logic and naming
- fixes DNS publishing to only publish the relay url if one is available, and not the IP addresses

Manual testing confirms, this fixes a regression of connections flip flopping between mixed and direct

Closes #3081
