### PR TITLE
feat(iroh-relay)!: implement authentication

### DIFF
--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -172,7 +172,9 @@ struct Config {
     metrics_bind_addr: Option<SocketAddr>,
     /// The capacity of the key cache.
     key_cache_capacity: Option<usize>,
-    /// Access control
+    /// Access control for relaying connections.
+    ///
+    /// This controls which nodes are allowed to relay connections, other endpoints, like STUN are not controlled by this.
     #[serde(default)]
     access: AccessConfig,
 }

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -172,13 +172,15 @@ struct Config {
     /// The capacity of the key cache.
     key_cache_capacity: Option<usize>,
     /// Access control
+    #[serde(default)]
     access: AccessConfig,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 enum AccessConfig {
     /// Allows everyone
     #[serde(rename = "everyone")]
+    #[default]
     Everyone,
     /// Allows only these nodes.
     #[serde(rename = "allowlist")]

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -96,10 +96,9 @@ pub(crate) enum FrameType {
     /// 8 byte payload, the contents of ping being replied to
     Pong = 13,
     /// Sent from server to client to tell the client if their connection is
-    /// unhealthy somehow. Currently the only unhealthy state is whether the
-    /// connection is detected as a duplicate.
-    /// The entire frame body is the text of the error message. An empty message
-    /// clears the error state.
+    /// unhealthy somehow.
+    ///
+    /// Currently this is used to indicate that the connection was closed beacause of authentication issues.
     Health = 14,
 
     /// Sent from server to client for the server to declare that it's restarting.

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -98,7 +98,7 @@ pub(crate) enum FrameType {
     /// Sent from server to client to tell the client if their connection is
     /// unhealthy somehow.
     ///
-    /// Currently this is used to indicate that the connection was closed beacause of authentication issues.
+    /// Currently this is used to indicate that the connection was closed because of authentication issues.
     Health = 14,
 
     /// Sent from server to client for the server to declare that it's restarting.

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -2,7 +2,7 @@
 
 use std::{future::Future, num::NonZeroU32, pin::Pin, sync::Arc, task::Poll, time::Duration};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use bytes::Bytes;
 use futures_lite::FutureExt;
 use futures_sink::Sink;
@@ -333,8 +333,8 @@ impl Actor {
                 self.write_frame(Frame::Pong { data }).await?;
                 inc!(Metrics, sent_pong);
             }
-            Frame::Health { .. } => {
-                inc!(Metrics, other_packets_recv);
+            Frame::Health { problem } => {
+                bail!("server issue: {:?}", problem);
             }
             _ => {
                 inc!(Metrics, unknown_frames);

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -525,7 +525,7 @@ impl Inner {
             .context("unable to receive client information")?;
 
         trace!("accept: checking access: {:?}", self.access);
-        if !self.access.is_allowed(client_key) {
+        if !self.access.is_allowed(client_key).await {
             io.send(Frame::Health {
                 problem: Bytes::from_static(b"not authenticated"),
             })

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -26,7 +26,6 @@ use tokio_util::{codec::Framed, sync::CancellationToken, task::AbortOnDropHandle
 use tracing::{debug, debug_span, error, info, info_span, trace, warn, Instrument};
 
 use super::{clients::Clients, AccessConfig};
-
 use crate::{
     defaults::{timeouts::SERVER_WRITE_TIMEOUT, DEFAULT_KEY_CACHE_CAPACITY},
     http::{Protocol, LEGACY_RELAY_PATH, RELAY_PATH, SUPPORTED_WEBSOCKET_VERSION},

--- a/iroh-relay/src/server/testing.rs
+++ b/iroh-relay/src/server/testing.rs
@@ -1,7 +1,9 @@
 //! Exposes functions to quickly configure a server suitable for testing.
 use std::net::Ipv4Addr;
 
-use super::{CertConfig, QuicConfig, RelayConfig, ServerConfig, StunConfig, TlsConfig};
+use super::{
+    AccessConfig, CertConfig, QuicConfig, RelayConfig, ServerConfig, StunConfig, TlsConfig,
+};
 
 /// Creates a [`StunConfig`] suitable for testing.
 ///
@@ -67,6 +69,7 @@ pub fn relay_config() -> RelayConfig<()> {
         tls: Some(tls_config()),
         limits: Default::default(),
         key_cache_capacity: Some(1024),
+        access: AccessConfig::Everyone,
     }
 }
 

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -6,7 +6,10 @@ pub use dns_and_pkarr_servers::DnsPkarrServer;
 pub use dns_server::create_dns_resolver;
 use iroh_base::RelayUrl;
 use iroh_relay::{
-    server::{CertConfig, QuicConfig, RelayConfig, Server, ServerConfig, StunConfig, TlsConfig},
+    server::{
+        AccessConfig, CertConfig, QuicConfig, RelayConfig, Server, ServerConfig, StunConfig,
+        TlsConfig,
+    },
     RelayMap, RelayNode, RelayQuicConfig,
 };
 use tokio::sync::oneshot;
@@ -85,6 +88,7 @@ pub async fn run_relay_server_with(
             tls: Some(tls),
             limits: Default::default(),
             key_cache_capacity: Some(1024),
+            access: AccessConfig::Everyone,
         }),
         quic,
         stun,


### PR DESCRIPTION
## Description

Design RFC:  https://www.notion.so/number-zero/Relay-Authentication-16f5df1306fb80ac9e31c1ccb04e026b?pvs=4

## Breaking Changes

- added: field `access` to `iroh_relay::server::RelayConfig`

## Notes & open questions

- This reuses the `health` frame in the relay protocol to indicate the authentcation issue. The frame was previously never sent in our code, but is now more explicitly interpreted to disconnect from the server. 
- ~~Should the callback be `async`? If this does more complex things like access a DB we probably want this to be `async`.~~ it is now async

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
