### PR TITLE
ci: Pin an older nextest version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest
+          tool: nextest@0.9.80
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.7


### PR DESCRIPTION
## Description

We get very weird errors from nextest, I suspect this is a regression.
This version is 3 months old, which is probably something nice to try.

This does not yet do this everywhere, e.g. windows still installs the
latest.  But this is enough to see if it helps.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.