### PR TITLE
experiment with splitting this actor state a bit more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,12 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
+ "futures-core",
  "getrandom",
  "instant",
+ "pin-project-lite",
  "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -526,7 +526,7 @@ impl ConnectionBuilder {
         })
         .await
         .context("Timeout connecting")?
-        .context("Error connecting")?;
+        .context("Connecting")?;
 
         tcp_stream.set_nodelay(true)?;
 

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -3,17 +3,22 @@
 //! Based on tailscale/derp/derphttp/derphttp_client.go
 
 use std::{
-    collections::HashMap,
-    future,
+    future::Future,
     net::{IpAddr, SocketAddr},
+    pin::Pin,
     sync::Arc,
-    time::Duration,
+    task::{self, Poll},
 };
 
+use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use bytes::Bytes;
-use conn::{Conn, ConnBuilder, ConnReader, ConnReceiver, ConnWriter, ReceivedMessage};
-use futures_util::StreamExt;
+use conn::Conn;
+use futures_lite::Stream;
+use futures_util::{
+    stream::{SplitSink, SplitStream},
+    Sink, StreamExt,
+};
 use hickory_resolver::TokioResolver as DnsResolver;
 use http_body_util::Empty;
 use hyper::{
@@ -23,28 +28,22 @@ use hyper::{
     Request,
 };
 use hyper_util::rt::TokioIo;
-use iroh_base::{NodeId, PublicKey, RelayUrl, SecretKey};
-use rand::Rng;
+use iroh_base::{RelayUrl, SecretKey};
 use rustls::client::Resumption;
 use streams::{downcast_upgrade, MaybeTlsStream, ProxyStream};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpStream,
-    sync::{mpsc, oneshot},
-    task::JoinSet,
-    time::Instant,
 };
-use tokio_util::{
-    codec::{FramedRead, FramedWrite},
-    task::AbortOnDropHandle,
-};
-use tracing::{debug, error, event, info_span, trace, warn, Instrument, Level};
+#[cfg(any(test, feature = "test-utils"))]
+use tracing::warn;
+use tracing::{debug, error, event, info_span, trace, Instrument, Level};
 use url::Url;
 
+pub use self::conn::{ConnSendError, ReceivedMessage, SendMessage};
 use crate::{
     defaults::timeouts::*,
     http::{Protocol, RELAY_PATH},
-    protos::relay::RelayCodec,
     KeyCache,
 };
 
@@ -52,153 +51,14 @@ pub(crate) mod conn;
 pub(crate) mod streams;
 mod util;
 
-/// Possible connection errors on the [`Client`]
-#[derive(Debug, thiserror::Error)]
-pub enum ClientError {
-    /// The client is closed
-    #[error("client is closed")]
-    Closed,
-    /// There was an error sending a packet
-    #[error("error sending a packet")]
-    Send,
-    /// There was an error receiving a packet
-    #[error("error receiving a packet: {0:?}")]
-    Receive(anyhow::Error),
-    /// There was a connection timeout error
-    #[error("connect timeout")]
-    ConnectTimeout,
-    /// There was an error dialing
-    #[error("dial error")]
-    DialIO(#[from] std::io::Error),
-    /// Both IPv4 and IPv6 are disabled for this relay node
-    #[error("both IPv4 and IPv6 are explicitly disabled for this node")]
-    IPDisabled,
-    /// No local addresses exist
-    #[error("no local addr: {0}")]
-    NoLocalAddr(String),
-    /// There was http server [`hyper::Error`]
-    #[error("http connection error")]
-    Hyper(#[from] hyper::Error),
-    /// There was an http error [`http::Error`].
-    #[error("http error")]
-    Http(#[from] http::Error),
-    /// There was an unexpected status code
-    #[error("unexpected status code: expected {0}, got {1}")]
-    UnexpectedStatusCode(hyper::StatusCode, hyper::StatusCode),
-    /// The connection failed to upgrade
-    #[error("failed to upgrade connection: {0}")]
-    Upgrade(String),
-    /// The connection failed to proxy
-    #[error("failed to proxy connection: {0}")]
-    Proxy(String),
-    /// The relay [`super::client::Client`] failed to build
-    #[error("failed to build relay client: {0}")]
-    Build(String),
-    /// The ping request timed out
-    #[error("ping timeout")]
-    PingTimeout,
-    /// The ping request was aborted
-    #[error("ping aborted")]
-    PingAborted,
-    /// The given [`Url`] is invalid
-    #[error("invalid url: {0}")]
-    InvalidUrl(String),
-    /// There was an error with DNS resolution
-    #[error("dns: {0:?}")]
-    Dns(Option<anyhow::Error>),
-    /// The inner actor is gone, likely means things are shutdown.
-    #[error("actor gone")]
-    ActorGone,
-    /// An error related to websockets, either errors with parsing ws messages or the handshake
-    #[error("websocket error: {0}")]
-    WebsocketError(#[from] tokio_tungstenite_wasm::Error),
-}
-
-/// An HTTP Relay client.
-///
-/// Cheaply clonable.
-#[derive(Clone, Debug)]
-pub struct Client {
-    inner: mpsc::Sender<ActorMessage>,
-    public_key: PublicKey,
-    #[allow(dead_code)]
-    recv_loop: Arc<AbortOnDropHandle<()>>,
-}
-
-#[derive(Debug)]
-enum ActorMessage {
-    Connect(oneshot::Sender<Result<Conn, ClientError>>),
-    NotePreferred(bool),
-    LocalAddr(oneshot::Sender<Result<Option<SocketAddr>, ClientError>>),
-    Ping(oneshot::Sender<Result<Duration, ClientError>>),
-    Pong([u8; 8], oneshot::Sender<Result<(), ClientError>>),
-    Send(PublicKey, Bytes, oneshot::Sender<Result<(), ClientError>>),
-    Close(oneshot::Sender<Result<(), ClientError>>),
-    CloseForReconnect(oneshot::Sender<Result<(), ClientError>>),
-    IsConnected(oneshot::Sender<Result<bool, ClientError>>),
-}
-
-/// Receiving end of a [`Client`].
-#[derive(Debug)]
-pub struct ClientReceiver {
-    msg_receiver: mpsc::Receiver<Result<ReceivedMessage, ClientError>>,
-}
-
-#[derive(derive_more::Debug)]
-struct Actor {
-    secret_key: SecretKey,
-    is_preferred: bool,
-    relay_conn: Option<(Conn, ConnReceiver)>,
-    is_closed: bool,
-    #[debug("address family selector callback")]
-    address_family_selector: Option<Box<dyn Fn() -> bool + Send + Sync>>,
-    url: RelayUrl,
-    protocol: Protocol,
-    #[debug("TlsConnector")]
-    tls_connector: tokio_rustls::TlsConnector,
-    pings: PingTracker,
-    ping_tasks: JoinSet<()>,
-    dns_resolver: DnsResolver,
-    proxy_url: Option<Url>,
-    key_cache: KeyCache,
-}
-
-#[derive(Default, Debug)]
-struct PingTracker(HashMap<[u8; 8], oneshot::Sender<()>>);
-
-impl PingTracker {
-    /// Note that we have sent a ping, and store the [`oneshot::Sender`] we
-    /// must notify when the pong returns
-    fn register(&mut self) -> ([u8; 8], oneshot::Receiver<()>) {
-        let data = rand::thread_rng().gen::<[u8; 8]>();
-        let (send, recv) = oneshot::channel();
-        self.0.insert(data, send);
-        (data, recv)
-    }
-
-    /// Remove the associated [`oneshot::Sender`] for `data` & return it.
-    ///
-    /// If there is no [`oneshot::Sender`] in the tracker, return `None`.
-    fn unregister(&mut self, data: [u8; 8], why: &'static str) -> Option<oneshot::Sender<()>> {
-        trace!(
-            "removing ping {}: {}",
-            data_encoding::HEXLOWER.encode(&data),
-            why
-        );
-        self.0.remove(&data)
-    }
-}
-
 /// Build a Client.
-#[derive(derive_more::Debug)]
+#[derive(derive_more::Debug, Clone)]
 pub struct ClientBuilder {
     /// Default is None
     #[debug("address family selector callback")]
-    address_family_selector: Option<Box<dyn Fn() -> bool + Send + Sync>>,
+    address_family_selector: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
     /// Default is false
     is_prober: bool,
-    /// Expected PublicKey of the server
-    server_public_key: Option<PublicKey>,
     /// Server url.
     url: RelayUrl,
     /// Relay protocol
@@ -210,28 +70,27 @@ pub struct ClientBuilder {
     proxy_url: Option<Url>,
     /// Capacity of the key cache
     key_cache_capacity: usize,
+    /// The secret key of this client.
+    secret_key: SecretKey,
+    /// The DNS resolver to use.
+    dns_resolver: DnsResolver,
 }
 
 impl ClientBuilder {
     /// Create a new [`ClientBuilder`]
-    pub fn new(url: impl Into<RelayUrl>) -> Self {
+    pub fn new(url: impl Into<RelayUrl>, secret_key: SecretKey, dns_resolver: DnsResolver) -> Self {
         ClientBuilder {
             address_family_selector: None,
             is_prober: false,
-            server_public_key: None,
             url: url.into(),
             protocol: Protocol::Relay,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_cert_verify: false,
             proxy_url: None,
             key_cache_capacity: 128,
+            secret_key,
+            dns_resolver,
         }
-    }
-
-    /// Sets the server url
-    pub fn server_url(mut self, url: impl Into<RelayUrl>) -> Self {
-        self.url = url.into();
-        self
     }
 
     /// Sets whether to connect to the relay via websockets or not.
@@ -251,7 +110,7 @@ impl ClientBuilder {
     where
         S: Fn() -> bool + Send + Sync + 'static,
     {
-        self.address_family_selector = Some(Box::new(selector));
+        self.address_family_selector = Some(Arc::new(selector));
         self
     }
 
@@ -282,9 +141,8 @@ impl ClientBuilder {
         self
     }
 
-    /// Build the [`Client`]
-    pub fn build(self, key: SecretKey, dns_resolver: DnsResolver) -> (Client, ClientReceiver) {
-        // TODO: review TLS config
+    /// Establishes a new connection to the relay server.
+    pub async fn connect(&self) -> Result<Client> {
         let roots = rustls::RootCertStore {
             roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
         };
@@ -297,7 +155,7 @@ impl ClientBuilder {
         .with_no_client_auth();
         #[cfg(any(test, feature = "test-utils"))]
         if self.insecure_skip_cert_verify {
-            warn!("Insecure config: SSL certificates from relay servers will be trusted without verification");
+            warn!("Insecure config: SSL certificates from relay servers not verified");
             config
                 .dangerous()
                 .set_certificate_verifier(Arc::new(NoCertVerifier));
@@ -306,44 +164,135 @@ impl ClientBuilder {
         config.resumption = Resumption::default();
 
         let tls_connector: tokio_rustls::TlsConnector = Arc::new(config).into();
-        let public_key = key.public();
 
-        let inner = Actor {
-            secret_key: key,
-            is_preferred: false,
-            relay_conn: None,
-            is_closed: false,
-            address_family_selector: self.address_family_selector,
-            pings: PingTracker::default(),
-            ping_tasks: Default::default(),
-            url: self.url,
+        let builder = ConnectionBuilder {
+            secret_key: self.secret_key.clone(),
+            address_family_selector: self.address_family_selector.clone(),
+            url: self.url.clone(),
             protocol: self.protocol,
             tls_connector,
-            dns_resolver,
-            proxy_url: self.proxy_url,
+            dns_resolver: self.dns_resolver.clone(),
+            proxy_url: self.proxy_url.clone(),
             key_cache: KeyCache::new(self.key_cache_capacity),
         };
+        let (conn, local_addr) = builder.connect_0().await?;
 
-        let (msg_sender, inbox) = mpsc::channel(64);
-        let (s, r) = mpsc::channel(64);
-        let recv_loop = tokio::task::spawn(
-            async move { inner.run(inbox, s).await }.instrument(info_span!("client")),
-        );
+        Ok(Client { conn, local_addr })
+    }
+}
 
+/// A relay client.
+#[derive(Debug)]
+pub struct Client {
+    conn: Conn,
+    local_addr: Option<SocketAddr>,
+}
+
+impl Client {
+    /// Splits the client into a sink and a stream.
+    pub fn split(self) -> (ClientStream, ClientSink) {
+        let (sink, stream) = self.conn.split();
         (
-            Client {
-                public_key,
-                inner: msg_sender,
-                recv_loop: Arc::new(AbortOnDropHandle::new(recv_loop)),
+            ClientStream {
+                stream,
+                local_addr: self.local_addr,
             },
-            ClientReceiver { msg_receiver: r },
+            ClientSink { sink },
         )
     }
+}
 
-    /// The expected [`PublicKey`] of the relay server we are connecting to.
-    pub fn server_public_key(mut self, server_public_key: PublicKey) -> Self {
-        self.server_public_key = Some(server_public_key);
-        self
+impl Stream for Client {
+    type Item = Result<ReceivedMessage>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.conn).poll_next(cx)
+    }
+}
+
+impl Sink<SendMessage> for Client {
+    type Error = ConnSendError;
+
+    fn poll_ready(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        <Conn as Sink<SendMessage>>::poll_ready(Pin::new(&mut self.conn), cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: SendMessage) -> Result<(), Self::Error> {
+        Pin::new(&mut self.conn).start_send(item)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        <Conn as Sink<SendMessage>>::poll_flush(Pin::new(&mut self.conn), cx)
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        <Conn as Sink<SendMessage>>::poll_close(Pin::new(&mut self.conn), cx)
+    }
+}
+
+/// The send half of a relay client.
+#[derive(Debug)]
+pub struct ClientSink {
+    sink: SplitSink<Conn, SendMessage>,
+}
+
+impl Sink<SendMessage> for ClientSink {
+    type Error = ConnSendError;
+
+    fn poll_ready(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.sink).poll_ready(cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: SendMessage) -> Result<(), Self::Error> {
+        Pin::new(&mut self.sink).start_send(item)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.sink).poll_flush(cx)
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.sink).poll_close(cx)
+    }
+}
+
+/// The receive half of a relay client.
+#[derive(Debug)]
+pub struct ClientStream {
+    stream: SplitStream<Conn>,
+    local_addr: Option<SocketAddr>,
+}
+
+impl ClientStream {
+    /// Returns the local address of the client.
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.local_addr
+    }
+}
+
+impl Stream for ClientStream {
+    type Item = Result<ReceivedMessage>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.stream).poll_next(cx)
     }
 }
 
@@ -365,289 +314,72 @@ pub fn make_dangerous_client_config() -> rustls::ClientConfig {
     .with_no_client_auth()
 }
 
-impl ClientReceiver {
-    /// Reads a message from the server.
-    pub async fn recv(&mut self) -> Option<Result<ReceivedMessage, ClientError>> {
-        self.msg_receiver.recv().await
-    }
+/// Some state to build a new connection.
+///
+/// Not because this necessarily the best way to structure this code, but because it was
+/// easy to migrate existing code.
+#[derive(derive_more::Debug)]
+struct ConnectionBuilder {
+    secret_key: SecretKey,
+    #[debug("address family selector callback")]
+    address_family_selector: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    url: RelayUrl,
+    protocol: Protocol,
+    #[debug("TlsConnector")]
+    tls_connector: tokio_rustls::TlsConnector,
+    dns_resolver: DnsResolver,
+    proxy_url: Option<Url>,
+    key_cache: KeyCache,
 }
 
-impl Client {
-    /// The public key for this client
-    pub fn public_key(&self) -> PublicKey {
-        self.public_key
-    }
-
-    async fn send_actor<F, T>(&self, msg_create: F) -> Result<T, ClientError>
-    where
-        F: FnOnce(oneshot::Sender<Result<T, ClientError>>) -> ActorMessage,
-    {
-        let (s, r) = oneshot::channel();
-        let msg = msg_create(s);
-        match self.inner.send(msg).await {
-            Ok(_) => {
-                let res = r.await.map_err(|_| ClientError::ActorGone)??;
-                Ok(res)
-            }
-            Err(_) => Err(ClientError::ActorGone),
-        }
-    }
-
-    /// Connects to a relay Server and returns the underlying relay connection.
-    ///
-    /// Returns [`ClientError::Closed`] if the [`Client`] is closed.
-    ///
-    /// If there is already an active relay connection, returns the already
-    /// connected [`crate::RelayConn`].
-    pub async fn connect(&self) -> Result<Conn, ClientError> {
-        self.send_actor(ActorMessage::Connect).await
-    }
-
-    /// Let the server know that this client is the preferred client
-    pub async fn note_preferred(&self, is_preferred: bool) {
-        self.inner
-            .send(ActorMessage::NotePreferred(is_preferred))
-            .await
-            .ok();
-    }
-
-    /// Get the local addr of the connection. If there is no current underlying relay connection
-    /// or the [`Client`] is closed, returns `None`.
-    pub async fn local_addr(&self) -> Option<SocketAddr> {
-        self.send_actor(ActorMessage::LocalAddr)
-            .await
-            .ok()
-            .flatten()
-    }
-
-    /// Send a ping to the server. Return once we get an expected pong.
-    ///
-    /// This has a built-in timeout `crate::defaults::timeouts::PING_TIMEOUT`.
-    ///
-    /// There must be a task polling `recv_detail` to process the `pong` response.
-    pub async fn ping(&self) -> Result<Duration, ClientError> {
-        self.send_actor(ActorMessage::Ping).await
-    }
-
-    /// Send a pong back to the server.
-    ///
-    /// If there is no underlying active relay connection, it creates one before attempting to
-    /// send the pong message.
-    ///
-    /// If there is an error sending pong, it closes the underlying relay connection before
-    /// returning.
-    pub async fn send_pong(&self, data: [u8; 8]) -> Result<(), ClientError> {
-        self.send_actor(|s| ActorMessage::Pong(data, s)).await
-    }
-
-    /// Send a packet to the server.
-    ///
-    /// If there is no underlying active relay connection, it creates one before attempting to
-    /// send the message.
-    ///
-    /// If there is an error sending the packet, it closes the underlying relay connection before
-    /// returning.
-    pub async fn send(&self, dst_key: PublicKey, b: Bytes) -> Result<(), ClientError> {
-        self.send_actor(|s| ActorMessage::Send(dst_key, b, s)).await
-    }
-
-    /// Close the http relay connection.
-    pub async fn close(self) -> Result<(), ClientError> {
-        self.send_actor(ActorMessage::Close).await
-    }
-
-    /// Disconnect the http relay connection.
-    pub async fn close_for_reconnect(&self) -> Result<(), ClientError> {
-        self.send_actor(ActorMessage::CloseForReconnect).await
-    }
-
-    /// Returns `true` if the underlying relay connection is established.
-    pub async fn is_connected(&self) -> Result<bool, ClientError> {
-        self.send_actor(ActorMessage::IsConnected).await
-    }
-}
-
-impl Actor {
-    async fn run(
-        mut self,
-        mut inbox: mpsc::Receiver<ActorMessage>,
-        msg_sender: mpsc::Sender<Result<ReceivedMessage, ClientError>>,
-    ) {
-        // Add an initial connection attempt.
-        if let Err(err) = self.connect("initial connect").await {
-            msg_sender.send(Err(err)).await.ok();
-        }
-
-        loop {
-            tokio::select! {
-                res = self.recv_detail() => {
-                    if let Ok(ReceivedMessage::Pong(ping)) = res {
-                        match self.pings.unregister(ping, "pong") {
-                            Some(chan) => {
-                                if chan.send(()).is_err() {
-                                    warn!("pong received for ping {ping:?}, but the receiving channel was closed");
-                                }
-                            }
-                            None => {
-                                warn!("pong received for ping {ping:?}, but not registered");
-                            }
-                        }
-                        continue;
-                    }
-                    msg_sender.send(res).await.ok();
-                }
-                msg = inbox.recv() => {
-                    let Some(msg) = msg else {
-                        // Shutting down
-                        self.close().await;
-                        break;
-                    };
-
-                    match msg {
-                        ActorMessage::Connect(s) => {
-                            let res = self.connect("actor msg").await.map(|(client, _)| (client));
-                            s.send(res).ok();
-                        },
-                        ActorMessage::NotePreferred(is_preferred) => {
-                            self.note_preferred(is_preferred).await;
-                        },
-                        ActorMessage::LocalAddr(s) => {
-                            let res = self.local_addr();
-                            s.send(Ok(res)).ok();
-                        },
-                        ActorMessage::Ping(s) => {
-                            self.ping(s).await;
-                        },
-                        ActorMessage::Pong(data, s) => {
-                            let res = self.send_pong(data).await;
-                            s.send(res).ok();
-                        },
-                        ActorMessage::Send(key, data, s) => {
-                            let res = self.send(key, data).await;
-                            s.send(res).ok();
-                        },
-                        ActorMessage::Close(s) => {
-                            let res = self.close().await;
-                            s.send(Ok(res)).ok();
-                            // shutting down
-                            break;
-                        },
-                        ActorMessage::CloseForReconnect(s) => {
-                            let res = self.close_for_reconnect().await;
-                            s.send(Ok(res)).ok();
-                        },
-                        ActorMessage::IsConnected(s) => {
-                            let res = self.is_connected();
-                            s.send(Ok(res)).ok();
-                        },
-                    }
-                }
-            }
-        }
-    }
-
-    /// Returns a connection to the relay.
-    ///
-    /// If the client is currently connected, the existing connection is returned; otherwise,
-    /// a new connection is made.
-    ///
-    /// Returns:
-    /// - A clonable connection object which can send DISCO messages to the relay.
-    /// - A reference to a channel receiving DISCO messages from the relay.
-    async fn connect(
-        &mut self,
-        why: &'static str,
-    ) -> Result<(Conn, &'_ mut ConnReceiver), ClientError> {
-        if self.is_closed {
-            return Err(ClientError::Closed);
-        }
-        let url = self.url.clone();
-        async move {
-            if self.relay_conn.is_none() {
-                trace!("no connection, trying to connect");
-                let (conn, receiver) = tokio::time::timeout(CONNECT_TIMEOUT, self.connect_0())
-                    .await
-                    .map_err(|_| ClientError::ConnectTimeout)??;
-
-                self.relay_conn = Some((conn, receiver));
-            } else {
-                trace!("already had connection");
-            }
-            let (conn, receiver) = self
-                .relay_conn
-                .as_mut()
-                .map(|(c, r)| (c.clone(), r))
-                .expect("just checked");
-
-            Ok((conn, receiver))
-        }
-        .instrument(info_span!("connect", %url, %why))
-        .await
-    }
-
-    async fn connect_0(&self) -> Result<(Conn, ConnReceiver), ClientError> {
-        let (reader, writer, local_addr) = match self.protocol {
+impl ConnectionBuilder {
+    async fn connect_0(&self) -> Result<(Conn, Option<SocketAddr>)> {
+        let (conn, local_addr) = match self.protocol {
             Protocol::Websocket => {
-                let (reader, writer) = self.connect_ws().await?;
+                let conn = self.connect_ws().await?;
                 let local_addr = None;
-                (reader, writer, local_addr)
+                (conn, local_addr)
             }
             Protocol::Relay => {
-                let (reader, writer, local_addr) = self.connect_derp().await?;
-                (reader, writer, Some(local_addr))
+                let (conn, local_addr) = self.connect_relay().await?;
+                (conn, Some(local_addr))
             }
         };
-
-        let (conn, receiver) =
-            ConnBuilder::new(self.secret_key.clone(), local_addr, reader, writer)
-                .build()
-                .await
-                .map_err(|e| ClientError::Build(e.to_string()))?;
-
-        if self.is_preferred && conn.note_preferred(true).await.is_err() {
-            conn.close().await;
-            return Err(ClientError::Send);
-        }
 
         event!(
             target: "events.net.relay.connected",
             Level::DEBUG,
-            home = self.is_preferred,
             url = %self.url,
+            protocol = ?self.protocol,
         );
 
         trace!("connect_0 done");
-        Ok((conn, receiver))
+        Ok((conn, local_addr))
     }
 
-    async fn connect_ws(&self) -> Result<(ConnReader, ConnWriter), ClientError> {
+    async fn connect_ws(&self) -> Result<Conn> {
         let mut dial_url = (*self.url).clone();
         dial_url.set_path(RELAY_PATH);
         // The relay URL is exchanged with the http(s) scheme in tickets and similar.
         // We need to use the ws:// or wss:// schemes when connecting with websockets, though.
         dial_url
             .set_scheme(if self.use_tls() { "wss" } else { "ws" })
-            .map_err(|()| ClientError::InvalidUrl(self.url.to_string()))?;
+            .map_err(|()| anyhow!("Invalid URL"))?;
 
         debug!(%dial_url, "Dialing relay by websocket");
 
-        let (writer, reader) = tokio_tungstenite_wasm::connect(dial_url).await?.split();
-
-        let cache = self.key_cache.clone();
-
-        let reader = ConnReader::Ws(reader, cache);
-        let writer = ConnWriter::Ws(writer);
-
-        Ok((reader, writer))
+        let conn = tokio_tungstenite_wasm::connect(dial_url).await?;
+        let conn = Conn::new_ws(conn, self.key_cache.clone(), &self.secret_key).await?;
+        Ok(conn)
     }
 
-    async fn connect_derp(&self) -> Result<(ConnReader, ConnWriter, SocketAddr), ClientError> {
+    async fn connect_relay(&self) -> Result<(Conn, SocketAddr)> {
         let url = self.url.clone();
         let tcp_stream = self.dial_url().await?;
 
         let local_addr = tcp_stream
             .local_addr()
-            .map_err(|e| ClientError::NoLocalAddr(e.to_string()))?;
+            .context("No local addr for TCP stream")?;
 
         debug!(server_addr = ?tcp_stream.peer_addr(), %local_addr, "TCP stream connected");
 
@@ -655,7 +387,7 @@ impl Actor {
             debug!("Starting TLS handshake");
             let hostname = self
                 .tls_servername()
-                .ok_or_else(|| ClientError::InvalidUrl("No tls servername".into()))?;
+                .ok_or_else(|| anyhow!("No tls servername"))?;
             let hostname = hostname.to_owned();
             let tls_stream = self.tls_connector.connect(hostname, tcp_stream).await?;
             debug!("tls_connector connect success");
@@ -666,42 +398,28 @@ impl Actor {
         };
 
         if response.status() != hyper::StatusCode::SWITCHING_PROTOCOLS {
-            error!(
-                "expected status 101 SWITCHING_PROTOCOLS, got: {}",
-                response.status()
-            );
-            return Err(ClientError::UnexpectedStatusCode(
+            bail!(
+                "Unexpected status code: expected {}, actual: {}",
                 hyper::StatusCode::SWITCHING_PROTOCOLS,
                 response.status(),
-            ));
+            );
         }
 
         debug!("starting upgrade");
-        let upgraded = match hyper::upgrade::on(response).await {
-            Ok(upgraded) => upgraded,
-            Err(err) => {
-                warn!("upgrade failed: {:#}", err);
-                return Err(ClientError::Hyper(err));
-            }
-        };
+        let upgraded = hyper::upgrade::on(response)
+            .await
+            .context("Upgrade failed")?;
 
         debug!("connection upgraded");
-        let (reader, writer) =
-            downcast_upgrade(upgraded).map_err(|e| ClientError::Upgrade(e.to_string()))?;
+        let conn = downcast_upgrade(upgraded)?;
 
-        let cache = self.key_cache.clone();
+        let conn = Conn::new_relay(conn, self.key_cache.clone(), &self.secret_key).await?;
 
-        let reader = ConnReader::Derp(FramedRead::new(reader, RelayCodec::new(cache.clone())));
-        let writer = ConnWriter::Derp(FramedWrite::new(writer, RelayCodec::new(cache)));
-
-        Ok((reader, writer, local_addr))
+        Ok((conn, local_addr))
     }
 
     /// Sends the HTTP upgrade request to the relay server.
-    async fn start_upgrade<T>(
-        io: T,
-        relay_url: RelayUrl,
-    ) -> Result<hyper::Response<Incoming>, ClientError>
+    async fn start_upgrade<T>(io: T, relay_url: RelayUrl) -> Result<hyper::Response<Incoming>>
     where
         T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
     {
@@ -734,99 +452,6 @@ impl Actor {
         request_sender.send_request(req).await.map_err(From::from)
     }
 
-    async fn note_preferred(&mut self, is_preferred: bool) {
-        let old = &mut self.is_preferred;
-        if *old == is_preferred {
-            return;
-        }
-        *old = is_preferred;
-
-        // only send the preference if we already have a connection
-        let res = {
-            if let Some((ref conn, _)) = self.relay_conn {
-                conn.note_preferred(is_preferred).await
-            } else {
-                return;
-            }
-        };
-        // need to do this outside the above closure because they rely on the same lock
-        // if there was an error sending, close the underlying relay connection
-        if res.is_err() {
-            self.close_for_reconnect().await;
-        }
-    }
-
-    fn local_addr(&self) -> Option<SocketAddr> {
-        if self.is_closed {
-            return None;
-        }
-        if let Some((ref conn, _)) = self.relay_conn {
-            conn.local_addr()
-        } else {
-            None
-        }
-    }
-
-    async fn ping(&mut self, s: oneshot::Sender<Result<Duration, ClientError>>) {
-        let connect_res = self.connect("ping").await.map(|(c, _)| c);
-        let (ping, recv) = self.pings.register();
-        trace!("ping: {}", data_encoding::HEXLOWER.encode(&ping));
-
-        self.ping_tasks.spawn(async move {
-            let res = match connect_res {
-                Ok(conn) => {
-                    let start = Instant::now();
-                    if let Err(err) = conn.send_ping(ping).await {
-                        warn!("failed to send ping: {:?}", err);
-                        Err(ClientError::Send)
-                    } else {
-                        match tokio::time::timeout(PING_TIMEOUT, recv).await {
-                            Ok(Ok(())) => Ok(start.elapsed()),
-                            Err(_) => Err(ClientError::PingTimeout),
-                            Ok(Err(_)) => Err(ClientError::PingAborted),
-                        }
-                    }
-                }
-                Err(err) => Err(err),
-            };
-            s.send(res).ok();
-        });
-    }
-
-    async fn send(&mut self, remote_node: NodeId, payload: Bytes) -> Result<(), ClientError> {
-        trace!(remote_node = %remote_node.fmt_short(), len = payload.len(), "send");
-        let (conn, _) = self.connect("send").await?;
-        if conn.send(remote_node, payload).await.is_err() {
-            self.close_for_reconnect().await;
-            return Err(ClientError::Send);
-        }
-        Ok(())
-    }
-
-    async fn send_pong(&mut self, data: [u8; 8]) -> Result<(), ClientError> {
-        debug!("send_pong");
-        let (conn, _) = self.connect("send_pong").await?;
-        if conn.send_pong(data).await.is_err() {
-            self.close_for_reconnect().await;
-            return Err(ClientError::Send);
-        }
-        Ok(())
-    }
-
-    async fn close(mut self) {
-        if !self.is_closed {
-            self.is_closed = true;
-            self.close_for_reconnect().await;
-        }
-    }
-
-    fn is_connected(&self) -> bool {
-        if self.is_closed {
-            return false;
-        }
-        self.relay_conn.is_some()
-    }
-
     fn tls_servername(&self) -> Option<rustls::pki_types::ServerName> {
         self.url
             .host_str()
@@ -843,7 +468,7 @@ impl Actor {
         }
     }
 
-    async fn dial_url(&self) -> Result<ProxyStream, ClientError> {
+    async fn dial_url(&self) -> Result<ProxyStream> {
         if let Some(ref proxy) = self.proxy_url {
             let stream = self.dial_url_proxy(proxy.clone()).await?;
             Ok(ProxyStream::Proxied(stream))
@@ -853,7 +478,7 @@ impl Actor {
         }
     }
 
-    async fn dial_url_direct(&self) -> Result<TcpStream, ClientError> {
+    async fn dial_url_direct(&self) -> Result<TcpStream> {
         debug!(%self.url, "dial url");
         let prefer_ipv6 = self.prefer_ipv6();
         let dst_ip = self
@@ -861,8 +486,7 @@ impl Actor {
             .resolve_host(&self.url, prefer_ipv6)
             .await?;
 
-        let port = url_port(&self.url)
-            .ok_or_else(|| ClientError::InvalidUrl("missing url port".into()))?;
+        let port = url_port(&self.url).ok_or_else(|| anyhow!("Missing URL port"))?;
         let addr = SocketAddr::new(dst_ip, port);
 
         debug!("connecting to {}", addr);
@@ -872,9 +496,8 @@ impl Actor {
                 async move { TcpStream::connect(addr).await },
             )
             .await
-            .map_err(|_| ClientError::ConnectTimeout)?
-            .map_err(ClientError::DialIO)?;
-
+            .context("Timeout connecting")?
+            .context("Failed connecting")?;
         tcp_stream.set_nodelay(true)?;
 
         Ok(tcp_stream)
@@ -883,7 +506,7 @@ impl Actor {
     async fn dial_url_proxy(
         &self,
         proxy_url: Url,
-    ) -> Result<util::Chain<std::io::Cursor<Bytes>, MaybeTlsStream>, ClientError> {
+    ) -> Result<util::Chain<std::io::Cursor<Bytes>, MaybeTlsStream>> {
         debug!(%self.url, %proxy_url, "dial url via proxy");
 
         // Resolve proxy DNS
@@ -893,8 +516,7 @@ impl Actor {
             .resolve_host(&proxy_url, prefer_ipv6)
             .await?;
 
-        let proxy_port = url_port(&proxy_url)
-            .ok_or_else(|| ClientError::Proxy("missing proxy url port".into()))?;
+        let proxy_port = url_port(&proxy_url).ok_or_else(|| anyhow!("Missing proxy url port"))?;
         let proxy_addr = SocketAddr::new(proxy_ip, proxy_port);
 
         debug!(%proxy_addr, "connecting to proxy");
@@ -903,8 +525,8 @@ impl Actor {
             TcpStream::connect(proxy_addr).await
         })
         .await
-        .map_err(|_| ClientError::ConnectTimeout)?
-        .map_err(ClientError::DialIO)?;
+        .context("Timeout connecting")?
+        .context("Error connecting")?;
 
         tcp_stream.set_nodelay(true)?;
 
@@ -912,10 +534,8 @@ impl Actor {
         let io = if proxy_url.scheme() == "http" {
             MaybeTlsStream::Raw(tcp_stream)
         } else {
-            let hostname = proxy_url
-                .host_str()
-                .and_then(|s| rustls::pki_types::ServerName::try_from(s.to_string()).ok())
-                .ok_or_else(|| ClientError::InvalidUrl("No tls servername for proxy url".into()))?;
+            let hostname = proxy_url.host_str().context("No hostname in proxy URL")?;
+            let hostname = rustls::pki_types::ServerName::try_from(hostname.to_string())?;
             let tls_stream = self.tls_connector.connect(hostname, tcp_stream).await?;
             MaybeTlsStream::Tls(tls_stream)
         };
@@ -924,10 +544,9 @@ impl Actor {
         let target_host = self
             .url
             .host_str()
-            .ok_or_else(|| ClientError::Proxy("missing proxy host".into()))?;
+            .ok_or_else(|| anyhow!("Missing proxy host"))?;
 
-        let port =
-            url_port(&self.url).ok_or_else(|| ClientError::Proxy("invalid target port".into()))?;
+        let port = url_port(&self.url).ok_or_else(|| anyhow!("invalid target port"))?;
 
         // Establish Proxy Tunnel
         let mut req_builder = Request::builder()
@@ -963,15 +582,12 @@ impl Actor {
 
         let res = sender.send_request(req).await?;
         if !res.status().is_success() {
-            return Err(ClientError::Proxy(format!(
-                "failed to connect to proxy: {}",
-                res.status(),
-            )));
+            bail!("Failed to connect to proxy: {}", res.status());
         }
 
         let upgraded = hyper::upgrade::on(res).await?;
         let Ok(Parts { io, read_buf, .. }) = upgraded.downcast::<TokioIo<MaybeTlsStream>>() else {
-            return Err(ClientError::Proxy("invalid upgrade".to_string()));
+            bail!("Invalid upgrade");
         };
 
         let res = util::chain(std::io::Cursor::new(read_buf), io.into_inner());
@@ -990,42 +606,11 @@ impl Actor {
             None => false,
         }
     }
-
-    async fn recv_detail(&mut self) -> Result<ReceivedMessage, ClientError> {
-        if let Some((_conn, conn_receiver)) = self.relay_conn.as_mut() {
-            trace!("recv_detail tick");
-            match conn_receiver.recv().await {
-                Ok(msg) => {
-                    return Ok(msg);
-                }
-                Err(e) => {
-                    self.close_for_reconnect().await;
-                    if self.is_closed {
-                        return Err(ClientError::Closed);
-                    }
-                    // TODO(ramfox): more specific error?
-                    return Err(ClientError::Receive(e));
-                }
-            }
-        }
-        future::pending().await
-    }
-
-    /// Close the underlying relay connection. The next time the client takes some action that
-    /// requires a connection, it will call `connect`.
-    async fn close_for_reconnect(&mut self) {
-        debug!("close for reconnect");
-        if let Some((conn, _)) = self.relay_conn.take() {
-            conn.close().await
-        }
-    }
 }
 
-fn host_header_value(relay_url: RelayUrl) -> Result<String, ClientError> {
+fn host_header_value(relay_url: RelayUrl) -> Result<String> {
     // grab the host, turns e.g. https://example.com:8080/xyz -> example.com.
-    let relay_url_host = relay_url
-        .host_str()
-        .ok_or_else(|| ClientError::InvalidUrl(relay_url.to_string()))?;
+    let relay_url_host = relay_url.host_str().context("Invalid URL")?;
     // strip the trailing dot, if present: example.com. -> example.com
     let relay_url_host = relay_url_host.strip_suffix('.').unwrap_or(relay_url_host);
     // build the host header value (reserve up to 6 chars for the ":" and port digits):
@@ -1042,56 +627,42 @@ trait DnsExt {
     fn lookup_ipv4<N: hickory_resolver::IntoName>(
         &self,
         host: N,
-    ) -> impl future::Future<Output = anyhow::Result<Option<IpAddr>>>;
+    ) -> impl Future<Output = Result<Option<IpAddr>>>;
 
     fn lookup_ipv6<N: hickory_resolver::IntoName>(
         &self,
         host: N,
-    ) -> impl future::Future<Output = anyhow::Result<Option<IpAddr>>>;
+    ) -> impl Future<Output = Result<Option<IpAddr>>>;
 
-    fn resolve_host(
-        &self,
-        url: &Url,
-        prefer_ipv6: bool,
-    ) -> impl future::Future<Output = Result<IpAddr, ClientError>>;
+    fn resolve_host(&self, url: &Url, prefer_ipv6: bool) -> impl Future<Output = Result<IpAddr>>;
 }
 
 impl DnsExt for DnsResolver {
-    async fn lookup_ipv4<N: hickory_resolver::IntoName>(
-        &self,
-        host: N,
-    ) -> anyhow::Result<Option<IpAddr>> {
+    async fn lookup_ipv4<N: hickory_resolver::IntoName>(&self, host: N) -> Result<Option<IpAddr>> {
         let addrs = tokio::time::timeout(DNS_TIMEOUT, self.ipv4_lookup(host)).await??;
         Ok(addrs.into_iter().next().map(|ip| IpAddr::V4(ip.0)))
     }
 
-    async fn lookup_ipv6<N: hickory_resolver::IntoName>(
-        &self,
-        host: N,
-    ) -> anyhow::Result<Option<IpAddr>> {
+    async fn lookup_ipv6<N: hickory_resolver::IntoName>(&self, host: N) -> Result<Option<IpAddr>> {
         let addrs = tokio::time::timeout(DNS_TIMEOUT, self.ipv6_lookup(host)).await??;
         Ok(addrs.into_iter().next().map(|ip| IpAddr::V6(ip.0)))
     }
 
-    async fn resolve_host(&self, url: &Url, prefer_ipv6: bool) -> Result<IpAddr, ClientError> {
-        let host = url
-            .host()
-            .ok_or_else(|| ClientError::InvalidUrl("missing host".into()))?;
+    async fn resolve_host(&self, url: &Url, prefer_ipv6: bool) -> Result<IpAddr> {
+        let host = url.host().context("Invalid URL")?;
         match host {
             url::Host::Domain(domain) => {
                 // Need to do a DNS lookup
                 let lookup = tokio::join!(self.lookup_ipv4(domain), self.lookup_ipv6(domain));
                 let (v4, v6) = match lookup {
                     (Err(ipv4_err), Err(ipv6_err)) => {
-                        let err = anyhow::anyhow!("Ipv4: {:?}, Ipv6: {:?}", ipv4_err, ipv6_err);
-                        return Err(ClientError::Dns(Some(err)));
+                        bail!("Ipv4: {ipv4_err:?}, Ipv6: {ipv6_err:?}");
                     }
                     (Err(_), Ok(v6)) => (None, v6),
                     (Ok(v4), Err(_)) => (v4, None),
                     (Ok(v4), Ok(v6)) => (v4, v6),
                 };
-                if prefer_ipv6 { v6.or(v4) } else { v4.or(v6) }
-                    .ok_or_else(|| ClientError::Dns(None))
+                if prefer_ipv6 { v6.or(v4) } else { v4.or(v6) }.context("No response")
             }
             url::Host::Ipv4(ip) => Ok(IpAddr::V4(ip)),
             url::Host::Ipv6(ip) => Ok(IpAddr::V6(ip)),
@@ -1157,29 +728,9 @@ fn url_port(url: &Url) -> Option<u16> {
 mod tests {
     use std::str::FromStr;
 
-    use anyhow::{bail, Result};
+    use anyhow::Result;
 
     use super::*;
-    use crate::dns::default_resolver;
-
-    #[tokio::test]
-    async fn test_recv_detail_connect_error() -> Result<()> {
-        let _guard = iroh_test::logging::setup();
-
-        let key = SecretKey::generate(rand::thread_rng());
-        let bad_url: Url = "https://bad.url".parse().unwrap();
-        let dns_resolver = default_resolver();
-
-        let (_client, mut client_receiver) =
-            ClientBuilder::new(bad_url).build(key.clone(), dns_resolver.clone());
-
-        // ensure that the client will bubble up any connection error & not
-        // just loop ad infinitum attempting to connect
-        if client_receiver.recv().await.and_then(|s| s.ok()).is_some() {
-            bail!("expected client with bad relay node detail to return with an error");
-        }
-        Ok(())
-    }
 
     #[test]
     fn test_host_header_value() -> Result<()> {

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -3,280 +3,105 @@
 //! based on tailscale/derp/derp_client.go
 
 use std::{
-    net::SocketAddr,
+    io,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
 
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{bail, Result};
 use bytes::Bytes;
 use futures_lite::Stream;
-use futures_sink::Sink;
-use futures_util::{
-    stream::{SplitSink, SplitStream, StreamExt},
-    SinkExt,
-};
+use futures_util::Sink;
 use iroh_base::{NodeId, SecretKey};
-use tokio::sync::mpsc;
 use tokio_tungstenite_wasm::WebSocketStream;
-use tokio_util::{
-    codec::{FramedRead, FramedWrite},
-    task::AbortOnDropHandle,
-};
-use tracing::{debug, info_span, trace, Instrument};
+use tokio_util::codec::Framed;
+use tracing::debug;
 
 use super::KeyCache;
 use crate::{
-    client::streams::{MaybeTlsStreamReader, MaybeTlsStreamWriter},
-    defaults::timeouts::CLIENT_RECV_TIMEOUT,
-    protos::relay::{
-        write_frame, ClientInfo, Frame, RelayCodec, MAX_PACKET_SIZE, PER_CLIENT_READ_QUEUE_DEPTH,
-        PER_CLIENT_SEND_QUEUE_DEPTH, PROTOCOL_VERSION,
-    },
+    client::streams::MaybeTlsStreamChained,
+    protos::relay::{ClientInfo, Frame, RelayCodec, MAX_PACKET_SIZE, PROTOCOL_VERSION},
 };
 
-impl PartialEq for Conn {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.inner, &other.inner)
-    }
+/// Error for sending messages to the relay server.
+#[derive(Debug, thiserror::Error)]
+pub enum ConnSendError {
+    /// An IO error.
+    #[error("IO error")]
+    Io(#[from] io::Error),
+    /// A protocol error.
+    #[error("Protocol error")]
+    Protocol(&'static str),
 }
-
-impl Eq for Conn {}
 
 /// A connection to a relay server.
 ///
-/// Cheaply clonable.
-/// Call `close` to shut down the write loop and read functionality.
-#[derive(Debug, Clone)]
-pub struct Conn {
-    inner: Arc<ConnTasks>,
-}
-
-/// The channel on which a relay connection sends received messages.
+/// This holds a connection to a relay server.  It is:
 ///
-/// The [`Conn`] to a relay is easily clonable but can only send DISCO messages to a relay
-/// server.  This is the counterpart which receives DISCO messages from the relay server for
-/// a connection.  It is not clonable.
-#[derive(Debug)]
-pub struct ConnReceiver {
-    /// The reader channel, receiving incoming messages.
-    reader_channel: mpsc::Receiver<Result<ReceivedMessage>>,
-}
-
-impl ConnReceiver {
-    /// Reads a messages from a relay server.
-    ///
-    /// Once it returns an error, the [`Conn`] is dead forever.
-    pub async fn recv(&mut self) -> Result<ReceivedMessage> {
-        let msg = self
-            .reader_channel
-            .recv()
-            .await
-            .ok_or(anyhow!("shut down"))??;
-        Ok(msg)
-    }
-}
-
+/// - A [`Stream`] for [`ReceivedMessage`] to receive from the server.
+/// - A [`Sink`] for [`SendMessage`] to send to the server.
+/// - A [`Sink`] for [`Frame`] to send to the server.
+///
+/// The [`Frame`] sink is a more internal interface, it allows performing the handshake.
+/// The [`SendMessage`] and [`ReceivedMessage`] are safer wrappers enforcing some protocol
+/// invariants.
 #[derive(derive_more::Debug)]
-pub struct ConnTasks {
-    /// Our local address, if known.
-    ///
-    /// Is `None` in tests or when using websockets (because we don't control connection establishment in browsers).
-    local_addr: Option<SocketAddr>,
-    /// Channel on which to communicate to the server. The associated [`mpsc::Receiver`] will close
-    /// if there is ever an error writing to the server.
-    writer_channel: mpsc::Sender<ConnWriterMessage>,
-    /// JoinHandle for the [`ConnWriter`] task
-    writer_task: AbortOnDropHandle<Result<()>>,
-    reader_task: AbortOnDropHandle<()>,
+pub(crate) enum Conn {
+    Relay {
+        #[debug("Framed<MaybeTlsStreamChained, RelayCodec>")]
+        conn: Framed<MaybeTlsStreamChained, RelayCodec>,
+    },
+    Ws {
+        #[debug("WebSocketStream")]
+        conn: WebSocketStream,
+        key_cache: KeyCache,
+    },
 }
 
 impl Conn {
-    /// Sends a packet to the node identified by `dstkey`
-    ///
-    /// Errors if the packet is larger than [`MAX_PACKET_SIZE`]
-    pub async fn send(&self, dst: NodeId, packet: Bytes) -> Result<()> {
-        trace!(dst = dst.fmt_short(), len = packet.len(), "[RELAY] send");
+    /// Constructs a new websocket connection, including the initial server handshake.
+    pub(crate) async fn new_ws(
+        conn: WebSocketStream,
+        key_cache: KeyCache,
+        secret_key: &SecretKey,
+    ) -> Result<Self> {
+        let mut conn = Self::Ws { conn, key_cache };
 
-        self.inner
-            .writer_channel
-            .send(ConnWriterMessage::Packet((dst, packet)))
-            .await?;
-        Ok(())
+        // exchange information with the server
+        server_handshake(&mut conn, secret_key).await?;
+
+        Ok(conn)
     }
 
-    /// Send a ping with 8 bytes of random data.
-    pub async fn send_ping(&self, data: [u8; 8]) -> Result<()> {
-        self.inner
-            .writer_channel
-            .send(ConnWriterMessage::Ping(data))
-            .await?;
-        Ok(())
-    }
+    /// Constructs a new websocket connection, including the initial server handshake.
+    pub(crate) async fn new_relay(
+        conn: MaybeTlsStreamChained,
+        key_cache: KeyCache,
+        secret_key: &SecretKey,
+    ) -> Result<Self> {
+        let conn = Framed::new(conn, RelayCodec::new(key_cache));
 
-    /// Respond to a ping request. The `data` field should be filled
-    /// by the 8 bytes of random data send by the ping.
-    pub async fn send_pong(&self, data: [u8; 8]) -> Result<()> {
-        self.inner
-            .writer_channel
-            .send(ConnWriterMessage::Pong(data))
-            .await?;
-        Ok(())
-    }
+        let mut conn = Self::Relay { conn };
 
-    /// Sends a packet that tells the server whether this
-    /// connection is to the user's preferred server. This is only
-    /// used in the server for stats.
-    pub async fn note_preferred(&self, preferred: bool) -> Result<()> {
-        self.inner
-            .writer_channel
-            .send(ConnWriterMessage::NotePreferred(preferred))
-            .await?;
-        Ok(())
-    }
+        // exchange information with the server
+        server_handshake(&mut conn, secret_key).await?;
 
-    /// The local address that the [`Conn`] is listening on.
-    ///
-    /// `None`, when run in a testing environment or when using websockets.
-    pub fn local_addr(&self) -> Option<SocketAddr> {
-        self.inner.local_addr
-    }
-
-    /// Whether or not this [`Conn`] is closed.
-    ///
-    /// The [`Conn`] is considered closed if the write side of the connection is no longer running.
-    pub fn is_closed(&self) -> bool {
-        self.inner.writer_task.is_finished()
-    }
-
-    /// Close the connection
-    ///
-    /// Shuts down the write loop directly and marks the connection as closed. The [`Conn`] will
-    /// check if the it is closed before attempting to read from it.
-    pub async fn close(&self) {
-        if self.inner.writer_task.is_finished() && self.inner.reader_task.is_finished() {
-            return;
-        }
-
-        self.inner
-            .writer_channel
-            .send(ConnWriterMessage::Shutdown)
-            .await
-            .ok();
-        self.inner.reader_task.abort();
+        Ok(conn)
     }
 }
 
-fn process_incoming_frame(frame: Frame) -> Result<ReceivedMessage> {
-    match frame {
-        Frame::KeepAlive => {
-            // A one-way keep-alive message that doesn't require an ack.
-            // This predated FrameType::Ping/FrameType::Pong.
-            Ok(ReceivedMessage::KeepAlive)
-        }
-        Frame::NodeGone { node_id } => Ok(ReceivedMessage::NodeGone(node_id)),
-        Frame::RecvPacket { src_key, content } => {
-            let packet = ReceivedMessage::ReceivedPacket {
-                remote_node_id: src_key,
-                data: content,
-            };
-            Ok(packet)
-        }
-        Frame::Ping { data } => Ok(ReceivedMessage::Ping(data)),
-        Frame::Pong { data } => Ok(ReceivedMessage::Pong(data)),
-        Frame::Health { problem } => {
-            let problem = std::str::from_utf8(&problem)?.to_owned();
-            let problem = Some(problem);
-            Ok(ReceivedMessage::Health { problem })
-        }
-        Frame::Restarting {
-            reconnect_in,
-            try_for,
-        } => {
-            let reconnect_in = Duration::from_millis(reconnect_in as u64);
-            let try_for = Duration::from_millis(try_for as u64);
-            Ok(ReceivedMessage::ServerRestarting {
-                reconnect_in,
-                try_for,
-            })
-        }
-        _ => bail!("unexpected packet: {:?}", frame.typ()),
-    }
-}
+/// Sends the server handshake message.
+async fn server_handshake(writer: &mut Conn, secret_key: &SecretKey) -> Result<()> {
+    debug!("server_handshake: started");
+    let client_info = ClientInfo {
+        version: PROTOCOL_VERSION,
+    };
+    debug!("server_handshake: sending client_key: {:?}", &client_info);
+    crate::protos::relay::send_client_key(&mut *writer, secret_key, &client_info).await?;
 
-/// The kinds of messages we can send to the [`Server`](crate::server::Server)
-#[derive(Debug)]
-enum ConnWriterMessage {
-    /// Send a packet (addressed to the [`NodeId`]) to the server
-    Packet((NodeId, Bytes)),
-    /// Send a pong to the server
-    Pong([u8; 8]),
-    /// Send a ping to the server
-    Ping([u8; 8]),
-    /// Tell the server whether or not this client is the user's preferred client
-    NotePreferred(bool),
-    /// Shutdown the writer
-    Shutdown,
-}
-
-/// Call [`ConnWriterTasks::run`] to listen for messages to send to the connection.
-/// Should be used by the [`Conn`]
-///
-/// Shutsdown when you send a [`ConnWriterMessage::Shutdown`], or if there is an error writing to
-/// the server.
-struct ConnWriterTasks {
-    recv_msgs: mpsc::Receiver<ConnWriterMessage>,
-    writer: ConnWriter,
-}
-
-impl ConnWriterTasks {
-    async fn run(mut self) -> Result<()> {
-        while let Some(msg) = self.recv_msgs.recv().await {
-            match msg {
-                ConnWriterMessage::Packet((key, bytes)) => {
-                    send_packet(&mut self.writer, key, bytes).await?;
-                }
-                ConnWriterMessage::Pong(data) => {
-                    write_frame(&mut self.writer, Frame::Pong { data }, None).await?;
-                    self.writer.flush().await?;
-                }
-                ConnWriterMessage::Ping(data) => {
-                    write_frame(&mut self.writer, Frame::Ping { data }, None).await?;
-                    self.writer.flush().await?;
-                }
-                ConnWriterMessage::NotePreferred(preferred) => {
-                    write_frame(&mut self.writer, Frame::NotePreferred { preferred }, None).await?;
-                    self.writer.flush().await?;
-                }
-                ConnWriterMessage::Shutdown => {
-                    return Ok(());
-                }
-            }
-        }
-
-        bail!("channel unexpectedly closed");
-    }
-}
-
-/// The Builder returns a [`Conn`] and a [`ConnReceiver`] and
-/// runs a [`ConnWriterTasks`] in the background.
-pub struct ConnBuilder {
-    secret_key: SecretKey,
-    reader: ConnReader,
-    writer: ConnWriter,
-    local_addr: Option<SocketAddr>,
-}
-
-pub(crate) enum ConnReader {
-    Derp(FramedRead<MaybeTlsStreamReader, RelayCodec>),
-    Ws(SplitStream<WebSocketStream>, KeyCache),
-}
-
-pub(crate) enum ConnWriter {
-    Derp(FramedWrite<MaybeTlsStreamWriter, RelayCodec>),
-    Ws(SplitSink<WebSocketStream, tokio_tungstenite_wasm::Message>),
+    debug!("server_handshake: done");
+    Ok(())
 }
 
 fn tung_wasm_to_io_err(e: tokio_tungstenite_wasm::Error) -> std::io::Error {
@@ -286,15 +111,28 @@ fn tung_wasm_to_io_err(e: tokio_tungstenite_wasm::Error) -> std::io::Error {
     }
 }
 
-impl Stream for ConnReader {
-    type Item = Result<Frame>;
+impl Stream for Conn {
+    type Item = Result<ReceivedMessage>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match *self {
-            Self::Derp(ref mut ws) => Pin::new(ws).poll_next(cx),
-            Self::Ws(ref mut ws, ref cache) => match Pin::new(ws).poll_next(cx) {
+            Self::Relay { ref mut conn } => match Pin::new(conn).poll_next(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Some(Ok(frame))) => {
+                    let message = ReceivedMessage::try_from(frame);
+                    Poll::Ready(Some(message))
+                }
+                Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
+                Poll::Ready(None) => Poll::Ready(None),
+            },
+            Self::Ws {
+                ref mut conn,
+                ref key_cache,
+            } => match Pin::new(conn).poll_next(cx) {
                 Poll::Ready(Some(Ok(tokio_tungstenite_wasm::Message::Binary(vec)))) => {
-                    Poll::Ready(Some(Frame::decode_from_ws_msg(vec, cache)))
+                    let frame = Frame::decode_from_ws_msg(vec, key_cache);
+                    let message = frame.and_then(ReceivedMessage::try_from);
+                    Poll::Ready(Some(message))
                 }
                 Poll::Ready(Some(Ok(msg))) => {
                     tracing::warn!(?msg, "Got websocket message of unsupported type, skipping.");
@@ -308,140 +146,113 @@ impl Stream for ConnReader {
     }
 }
 
-impl Sink<Frame> for ConnWriter {
-    type Error = std::io::Error;
+impl Sink<Frame> for Conn {
+    type Error = ConnSendError;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
-            Self::Derp(ref mut ws) => Pin::new(ws).poll_ready(cx),
-            Self::Ws(ref mut ws) => Pin::new(ws).poll_ready(cx).map_err(tung_wasm_to_io_err),
+            Self::Relay { ref mut conn } => Pin::new(conn).poll_ready(cx).map_err(Into::into),
+            Self::Ws { ref mut conn, .. } => Pin::new(conn)
+                .poll_ready(cx)
+                .map_err(tung_wasm_to_io_err)
+                .map_err(Into::into),
         }
     }
 
-    fn start_send(mut self: Pin<&mut Self>, item: Frame) -> Result<(), Self::Error> {
+    fn start_send(mut self: Pin<&mut Self>, frame: Frame) -> Result<(), Self::Error> {
+        if let Frame::SendPacket { dst_key: _, packet } = &frame {
+            if packet.len() > MAX_PACKET_SIZE {
+                return Err(ConnSendError::Protocol("Packet exceeds MAX_PACKET_SIZE"));
+            }
+        }
         match *self {
-            Self::Derp(ref mut ws) => Pin::new(ws).start_send(item),
-            Self::Ws(ref mut ws) => Pin::new(ws)
+            Self::Relay { ref mut conn } => Pin::new(conn).start_send(frame).map_err(Into::into),
+            Self::Ws { ref mut conn, .. } => Pin::new(conn)
                 .start_send(tokio_tungstenite_wasm::Message::binary(
-                    item.encode_for_ws_msg(),
+                    frame.encode_for_ws_msg(),
                 ))
-                .map_err(tung_wasm_to_io_err),
+                .map_err(tung_wasm_to_io_err)
+                .map_err(Into::into),
         }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
-            Self::Derp(ref mut ws) => Pin::new(ws).poll_flush(cx),
-            Self::Ws(ref mut ws) => Pin::new(ws).poll_flush(cx).map_err(tung_wasm_to_io_err),
+            Self::Relay { ref mut conn } => Pin::new(conn).poll_flush(cx).map_err(Into::into),
+            Self::Ws { ref mut conn, .. } => Pin::new(conn)
+                .poll_flush(cx)
+                .map_err(tung_wasm_to_io_err)
+                .map_err(Into::into),
         }
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
-            Self::Derp(ref mut ws) => Pin::new(ws).poll_close(cx),
-            Self::Ws(ref mut ws) => Pin::new(ws).poll_close(cx).map_err(tung_wasm_to_io_err),
+            Self::Relay { ref mut conn } => Pin::new(conn).poll_close(cx).map_err(Into::into),
+            Self::Ws { ref mut conn, .. } => Pin::new(conn)
+                .poll_close(cx)
+                .map_err(tung_wasm_to_io_err)
+                .map_err(Into::into),
         }
     }
 }
 
-impl ConnBuilder {
-    pub fn new(
-        secret_key: SecretKey,
-        local_addr: Option<SocketAddr>,
-        reader: ConnReader,
-        writer: ConnWriter,
-    ) -> Self {
-        Self {
-            secret_key,
-            reader,
-            writer,
-            local_addr,
+impl Sink<SendMessage> for Conn {
+    type Error = ConnSendError;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match *self {
+            Self::Relay { ref mut conn } => Pin::new(conn).poll_ready(cx).map_err(Into::into),
+            Self::Ws { ref mut conn, .. } => Pin::new(conn)
+                .poll_ready(cx)
+                .map_err(tung_wasm_to_io_err)
+                .map_err(Into::into),
         }
     }
 
-    async fn server_handshake(&mut self) -> Result<()> {
-        debug!("server_handshake: started");
-        let client_info = ClientInfo {
-            version: PROTOCOL_VERSION,
-        };
-        debug!("server_handshake: sending client_key: {:?}", &client_info);
-        crate::protos::relay::send_client_key(&mut self.writer, &self.secret_key, &client_info)
-            .await?;
-
-        debug!("server_handshake: done");
-        Ok(())
+    fn start_send(mut self: Pin<&mut Self>, item: SendMessage) -> Result<(), Self::Error> {
+        if let SendMessage::SendPacket(_, bytes) = &item {
+            if bytes.len() > MAX_PACKET_SIZE {
+                return Err(ConnSendError::Protocol("Packet exceeds MAX_PACKET_SIZE"));
+            }
+        }
+        let frame = Frame::from(item);
+        match *self {
+            Self::Relay { ref mut conn } => Pin::new(conn).start_send(frame).map_err(Into::into),
+            Self::Ws { ref mut conn, .. } => Pin::new(conn)
+                .start_send(tokio_tungstenite_wasm::Message::binary(
+                    frame.encode_for_ws_msg(),
+                ))
+                .map_err(tung_wasm_to_io_err)
+                .map_err(Into::into),
+        }
     }
 
-    pub async fn build(mut self) -> Result<(Conn, ConnReceiver)> {
-        // exchange information with the server
-        self.server_handshake().await?;
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match *self {
+            Self::Relay { ref mut conn } => Pin::new(conn).poll_flush(cx).map_err(Into::into),
+            Self::Ws { ref mut conn, .. } => Pin::new(conn)
+                .poll_flush(cx)
+                .map_err(tung_wasm_to_io_err)
+                .map_err(Into::into),
+        }
+    }
 
-        // create task to handle writing to the server
-        let (writer_sender, writer_recv) = mpsc::channel(PER_CLIENT_SEND_QUEUE_DEPTH);
-        let writer_task = tokio::task::spawn(
-            ConnWriterTasks {
-                writer: self.writer,
-                recv_msgs: writer_recv,
-            }
-            .run()
-            .instrument(info_span!("conn.writer")),
-        );
-
-        let (reader_sender, reader_recv) = mpsc::channel(PER_CLIENT_READ_QUEUE_DEPTH);
-        let reader_task = tokio::task::spawn({
-            let writer_sender = writer_sender.clone();
-            async move {
-                loop {
-                    let frame = tokio::time::timeout(CLIENT_RECV_TIMEOUT, self.reader.next()).await;
-                    let res = match frame {
-                        Ok(Some(Ok(frame))) => process_incoming_frame(frame),
-                        Ok(Some(Err(err))) => {
-                            // Error processing incoming messages
-                            Err(err)
-                        }
-                        Ok(None) => {
-                            // EOF
-                            Err(anyhow::anyhow!("EOF: reader stream ended"))
-                        }
-                        Err(err) => {
-                            // Timeout
-                            Err(err.into())
-                        }
-                    };
-                    if res.is_err() {
-                        // shutdown
-                        writer_sender.send(ConnWriterMessage::Shutdown).await.ok();
-                        break;
-                    }
-                    if reader_sender.send(res).await.is_err() {
-                        // shutdown, as the reader is gone
-                        writer_sender.send(ConnWriterMessage::Shutdown).await.ok();
-                        break;
-                    }
-                }
-            }
-            .instrument(info_span!("conn.reader"))
-        });
-
-        let conn = Conn {
-            inner: Arc::new(ConnTasks {
-                local_addr: self.local_addr,
-                writer_channel: writer_sender,
-                writer_task: AbortOnDropHandle::new(writer_task),
-                reader_task: AbortOnDropHandle::new(reader_task),
-            }),
-        };
-
-        let conn_receiver = ConnReceiver {
-            reader_channel: reader_recv,
-        };
-
-        Ok((conn, conn_receiver))
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match *self {
+            Self::Relay { ref mut conn } => Pin::new(conn).poll_close(cx).map_err(Into::into),
+            Self::Ws { ref mut conn, .. } => Pin::new(conn)
+                .poll_close(cx)
+                .map_err(tung_wasm_to_io_err)
+                .map_err(Into::into),
+        }
     }
 }
 
+/// The messages received from a framed relay stream.
+///
+/// This is a type-validated version of the `Frame`s on the `RelayCodec`.
 #[derive(derive_more::Debug, Clone)]
-/// The type of message received by the [`Conn`] from a relay server.
 pub enum ReceivedMessage {
     /// Represents an incoming packet.
     ReceivedPacket {
@@ -487,23 +298,67 @@ pub enum ReceivedMessage {
     },
 }
 
-pub(crate) async fn send_packet<S: Sink<Frame, Error = std::io::Error> + Unpin>(
-    mut writer: S,
-    dst: NodeId,
-    packet: Bytes,
-) -> Result<()> {
-    ensure!(
-        packet.len() <= MAX_PACKET_SIZE,
-        "packet too big: {}",
-        packet.len()
-    );
+impl TryFrom<Frame> for ReceivedMessage {
+    type Error = anyhow::Error;
 
-    let frame = Frame::SendPacket {
-        dst_key: dst,
-        packet,
-    };
-    writer.send(frame).await?;
-    writer.flush().await?;
+    fn try_from(frame: Frame) -> std::result::Result<Self, Self::Error> {
+        match frame {
+            Frame::KeepAlive => {
+                // A one-way keep-alive message that doesn't require an ack.
+                // This predated FrameType::Ping/FrameType::Pong.
+                Ok(ReceivedMessage::KeepAlive)
+            }
+            Frame::NodeGone { node_id } => Ok(ReceivedMessage::NodeGone(node_id)),
+            Frame::RecvPacket { src_key, content } => {
+                let packet = ReceivedMessage::ReceivedPacket {
+                    remote_node_id: src_key,
+                    data: content,
+                };
+                Ok(packet)
+            }
+            Frame::Ping { data } => Ok(ReceivedMessage::Ping(data)),
+            Frame::Pong { data } => Ok(ReceivedMessage::Pong(data)),
+            Frame::Health { problem } => {
+                let problem = std::str::from_utf8(&problem)?.to_owned();
+                let problem = Some(problem);
+                Ok(ReceivedMessage::Health { problem })
+            }
+            Frame::Restarting {
+                reconnect_in,
+                try_for,
+            } => {
+                let reconnect_in = Duration::from_millis(reconnect_in as u64);
+                let try_for = Duration::from_millis(try_for as u64);
+                Ok(ReceivedMessage::ServerRestarting {
+                    reconnect_in,
+                    try_for,
+                })
+            }
+            _ => bail!("unexpected packet: {:?}", frame.typ()),
+        }
+    }
+}
 
-    Ok(())
+/// Messages we can send to a relay server.
+#[derive(Debug)]
+pub enum SendMessage {
+    /// Send a packet of data to the [`NodeId`].
+    SendPacket(NodeId, Bytes),
+    /// Mark or unmark the connected relay as the home relay.
+    NotePreferred(bool),
+    /// Sends a ping message to the connected relay server.
+    Ping([u8; 8]),
+    /// Sends a pong message to the connected relay server.
+    Pong([u8; 8]),
+}
+
+impl From<SendMessage> for Frame {
+    fn from(source: SendMessage) -> Self {
+        match source {
+            SendMessage::SendPacket(dst_key, packet) => Frame::SendPacket { dst_key, packet },
+            SendMessage::NotePreferred(preferred) => Frame::NotePreferred { preferred },
+            SendMessage::Ping(data) => Frame::Ping { data },
+            SendMessage::Pong(data) => Frame::Pong { data },
+        }
+    }
 }

--- a/iroh-relay/src/client/streams.rs
+++ b/iroh-relay/src/client/streams.rs
@@ -15,19 +15,14 @@ use tokio::{
 
 use super::util;
 
-pub enum MaybeTlsStreamReader {
-    Raw(util::Chain<std::io::Cursor<Bytes>, tokio::io::ReadHalf<ProxyStream>>),
-    Tls(
-        util::Chain<
-            std::io::Cursor<Bytes>,
-            tokio::io::ReadHalf<tokio_rustls::client::TlsStream<ProxyStream>>,
-        >,
-    ),
+pub enum MaybeTlsStreamChained {
+    Raw(util::Chain<std::io::Cursor<Bytes>, ProxyStream>),
+    Tls(util::Chain<std::io::Cursor<Bytes>, tokio_rustls::client::TlsStream<ProxyStream>>),
     #[cfg(all(test, feature = "server"))]
-    Mem(tokio::io::ReadHalf<tokio::io::DuplexStream>),
+    Mem(tokio::io::DuplexStream),
 }
 
-impl AsyncRead for MaybeTlsStreamReader {
+impl AsyncRead for MaybeTlsStreamChained {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -42,22 +37,15 @@ impl AsyncRead for MaybeTlsStreamReader {
     }
 }
 
-pub enum MaybeTlsStreamWriter {
-    Raw(tokio::io::WriteHalf<ProxyStream>),
-    Tls(tokio::io::WriteHalf<tokio_rustls::client::TlsStream<ProxyStream>>),
-    #[cfg(all(test, feature = "server"))]
-    Mem(tokio::io::WriteHalf<tokio::io::DuplexStream>),
-}
-
-impl AsyncWrite for MaybeTlsStreamWriter {
+impl AsyncWrite for MaybeTlsStreamChained {
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
         match &mut *self {
-            Self::Raw(stream) => Pin::new(stream).poll_write(cx, buf),
-            Self::Tls(stream) => Pin::new(stream).poll_write(cx, buf),
+            Self::Raw(stream) => Pin::new(stream.get_mut().1).poll_write(cx, buf),
+            Self::Tls(stream) => Pin::new(stream.get_mut().1).poll_write(cx, buf),
             #[cfg(all(test, feature = "server"))]
             Self::Mem(stream) => Pin::new(stream).poll_write(cx, buf),
         }
@@ -68,8 +56,8 @@ impl AsyncWrite for MaybeTlsStreamWriter {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
         match &mut *self {
-            Self::Raw(stream) => Pin::new(stream).poll_flush(cx),
-            Self::Tls(stream) => Pin::new(stream).poll_flush(cx),
+            Self::Raw(stream) => Pin::new(stream.get_mut().1).poll_flush(cx),
+            Self::Tls(stream) => Pin::new(stream.get_mut().1).poll_flush(cx),
             #[cfg(all(test, feature = "server"))]
             Self::Mem(stream) => Pin::new(stream).poll_flush(cx),
         }
@@ -80,8 +68,8 @@ impl AsyncWrite for MaybeTlsStreamWriter {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
         match &mut *self {
-            Self::Raw(stream) => Pin::new(stream).poll_shutdown(cx),
-            Self::Tls(stream) => Pin::new(stream).poll_shutdown(cx),
+            Self::Raw(stream) => Pin::new(stream.get_mut().1).poll_shutdown(cx),
+            Self::Tls(stream) => Pin::new(stream.get_mut().1).poll_shutdown(cx),
             #[cfg(all(test, feature = "server"))]
             Self::Mem(stream) => Pin::new(stream).poll_shutdown(cx),
         }
@@ -93,41 +81,31 @@ impl AsyncWrite for MaybeTlsStreamWriter {
         bufs: &[std::io::IoSlice<'_>],
     ) -> Poll<Result<usize, std::io::Error>> {
         match &mut *self {
-            Self::Raw(stream) => Pin::new(stream).poll_write_vectored(cx, bufs),
-            Self::Tls(stream) => Pin::new(stream).poll_write_vectored(cx, bufs),
+            Self::Raw(stream) => Pin::new(stream.get_mut().1).poll_write_vectored(cx, bufs),
+            Self::Tls(stream) => Pin::new(stream.get_mut().1).poll_write_vectored(cx, bufs),
             #[cfg(all(test, feature = "server"))]
             Self::Mem(stream) => Pin::new(stream).poll_write_vectored(cx, bufs),
         }
     }
 }
 
-pub fn downcast_upgrade(
-    upgraded: Upgraded,
-) -> Result<(MaybeTlsStreamReader, MaybeTlsStreamWriter)> {
+pub fn downcast_upgrade(upgraded: Upgraded) -> Result<MaybeTlsStreamChained> {
     match upgraded.downcast::<TokioIo<ProxyStream>>() {
         Ok(Parts { read_buf, io, .. }) => {
-            let inner = io.into_inner();
-            let (reader, writer) = tokio::io::split(inner);
+            let conn = io.into_inner();
             // Prepend data to the reader to avoid data loss
-            let reader = util::chain(std::io::Cursor::new(read_buf), reader);
-            Ok((
-                MaybeTlsStreamReader::Raw(reader),
-                MaybeTlsStreamWriter::Raw(writer),
-            ))
+            let conn = util::chain(std::io::Cursor::new(read_buf), conn);
+            Ok(MaybeTlsStreamChained::Raw(conn))
         }
         Err(upgraded) => {
             if let Ok(Parts { read_buf, io, .. }) =
                 upgraded.downcast::<TokioIo<tokio_rustls::client::TlsStream<ProxyStream>>>()
             {
-                let inner = io.into_inner();
-                let (reader, writer) = tokio::io::split(inner);
-                // Prepend data to the reader to avoid data loss
-                let reader = util::chain(std::io::Cursor::new(read_buf), reader);
+                let conn = io.into_inner();
 
-                return Ok((
-                    MaybeTlsStreamReader::Tls(reader),
-                    MaybeTlsStreamWriter::Tls(writer),
-                ));
+                // Prepend data to the reader to avoid data loss
+                let conn = util::chain(std::io::Cursor::new(read_buf), conn);
+                return Ok(MaybeTlsStreamChained::Tls(conn));
             }
 
             bail!(
@@ -137,6 +115,7 @@ pub fn downcast_upgrade(
     }
 }
 
+#[derive(Debug)]
 pub enum ProxyStream {
     Raw(TcpStream),
     Proxied(util::Chain<std::io::Cursor<Bytes>, MaybeTlsStream>),
@@ -214,6 +193,7 @@ impl ProxyStream {
     }
 }
 
+#[derive(Debug)]
 pub enum MaybeTlsStream {
     Raw(TcpStream),
     Tls(tokio_rustls::client::TlsStream<TcpStream>),

--- a/iroh-relay/src/defaults.rs
+++ b/iroh-relay/src/defaults.rs
@@ -34,18 +34,8 @@ pub(crate) mod timeouts {
     /// Timeout used by the relay client while connecting to the relay server,
     /// using `TcpStream::connect`
     pub(crate) const DIAL_NODE_TIMEOUT: Duration = Duration::from_millis(1500);
-    /// Timeout for expecting a pong from the relay server
-    pub(crate) const PING_TIMEOUT: Duration = Duration::from_secs(5);
-    /// Timeout for the entire relay connection, which includes dns, dialing
-    /// the server, upgrading the connection, and completing the handshake
-    pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
     /// Timeout for our async dns resolver
     pub(crate) const DNS_TIMEOUT: Duration = Duration::from_secs(1);
-
-    /// Maximum time the client will wait to receive on the connection, since
-    /// the last message. Longer than this time and the client will consider
-    /// the connection dead.
-    pub(crate) const CLIENT_RECV_TIMEOUT: Duration = Duration::from_secs(120);
 
     /// Maximum time the server will attempt to get a successful write to the connection.
     #[cfg(feature = "server")]

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -47,11 +47,4 @@ mod dns;
 
 pub use protos::relay::MAX_PACKET_SIZE;
 
-pub use self::{
-    client::{
-        conn::{Conn as RelayConn, ReceivedMessage},
-        Client as HttpClient, ClientBuilder as HttpClientBuilder, ClientError as HttpClientError,
-        ClientReceiver as HttpClientReceiver,
-    },
-    relay_map::{RelayMap, RelayNode, RelayQuicConfig},
-};
+pub use self::relay_map::{RelayMap, RelayNode, RelayQuicConfig};

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -12,6 +12,7 @@
 //!  * clients sends `FrameType::SendPacket`
 //!  * server then sends `FrameType::RecvPacket` to recipient
 
+#[cfg(feature = "server")]
 use std::time::Duration;
 
 use anyhow::{bail, ensure};
@@ -25,7 +26,7 @@ use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::KeyCache;
+use crate::{client::conn::ConnSendError, KeyCache};
 
 /// The maximum size of a packet sent over relay.
 /// (This only includes the data bytes visible to magicsock, not
@@ -46,8 +47,8 @@ pub(crate) const KEEP_ALIVE: Duration = Duration::from_secs(60);
 #[cfg(feature = "server")]
 pub(crate) const SERVER_CHANNEL_SIZE: usize = 1024 * 100;
 /// The number of packets buffered for sending per client
+#[cfg(feature = "server")]
 pub(crate) const PER_CLIENT_SEND_QUEUE_DEPTH: usize = 512; //32;
-pub(crate) const PER_CLIENT_READ_QUEUE_DEPTH: usize = 512;
 
 /// ProtocolVersion is bumped whenever there's a wire-incompatible change.
 ///  - version 1 (zero on wire): consistent box headers, in use by employee dev nodes a bit
@@ -130,6 +131,7 @@ pub(crate) struct ClientInfo {
 /// Ignores the timeout if `None`
 ///
 /// Does not flush.
+#[cfg(feature = "server")]
 pub(crate) async fn write_frame<S: Sink<Frame, Error = std::io::Error> + Unpin>(
     mut writer: S,
     frame: Frame,
@@ -148,7 +150,7 @@ pub(crate) async fn write_frame<S: Sink<Frame, Error = std::io::Error> + Unpin>(
 /// and the client's [`ClientInfo`], sealed using the server's [`PublicKey`].
 ///
 /// Flushes after writing.
-pub(crate) async fn send_client_key<S: Sink<Frame, Error = std::io::Error> + Unpin>(
+pub(crate) async fn send_client_key<S: Sink<Frame, Error = ConnSendError> + Unpin>(
     mut writer: S,
     client_secret_key: &SecretKey,
     client_info: &ClientInfo,
@@ -614,7 +616,8 @@ mod tests {
     async fn test_send_recv_client_key() -> anyhow::Result<()> {
         let (reader, writer) = tokio::io::duplex(1024);
         let mut reader = FramedRead::new(reader, RelayCodec::test());
-        let mut writer = FramedWrite::new(writer, RelayCodec::test());
+        let mut writer =
+            FramedWrite::new(writer, RelayCodec::test()).sink_map_err(ConnSendError::from);
 
         let client_key = SecretKey::generate(rand::thread_rng());
         let client_info = ClientInfo {

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -246,7 +246,7 @@ mod tests {
         (
             ClientConnConfig {
                 node_id: key,
-                stream: RelayedStream::Derp(Framed::new(
+                stream: RelayedStream::Relay(Framed::new(
                     MaybeTlsStream::Test(io),
                     RelayCodec::test(),
                 )),

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -61,7 +61,7 @@ pub struct Metrics {
     /// Number of accepted websocket connections
     pub websocket_accepts: Counter,
     /// Number of accepted 'iroh derp http' connection upgrades
-    pub derp_accepts: Counter,
+    pub relay_accepts: Counter,
     // TODO: enable when we can have multiple connections for one node id
     // pub duplicate_client_keys: Counter,
     // pub duplicate_client_conns: Counter,
@@ -112,7 +112,7 @@ impl Default for Metrics {
             unique_client_keys: Counter::new("Number of unique client keys per day."),
 
             websocket_accepts: Counter::new("Number of accepted websocket connections"),
-            derp_accepts: Counter::new("Number of accepted 'iroh derp http' connection upgrades"),
+            relay_accepts: Counter::new("Number of accepted 'iroh derp http' connection upgrades"),
             // TODO: enable when we can have multiple connections for one node id
             // pub duplicate_client_keys: Counter::new("Number of duplicate client keys."),
             // pub duplicate_client_conns: Counter::new("Number of duplicate client connections."),
@@ -128,7 +128,7 @@ impl Metric for Metrics {
     }
 }
 
-/// StunMetrics tracked for the DERPER
+/// StunMetrics tracked for the relay server
 #[derive(Debug, Clone, Iterable)]
 pub struct StunMetrics {
     /*

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -20,7 +20,7 @@ aead = { version = "0.5.2", features = ["bytes"] }
 anyhow = { version = "1" }
 concurrent-queue = "2.5"
 axum = { version = "0.7", optional = true }
-backoff = "0.4.0"
+backoff = { version = "0.4.0", features = ["futures", "tokio"]}
 base64 = "0.22.1"
 bytes = "1.7"
 crypto_box = { version = "0.9.1", features = ["serde", "chacha20"] }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1622,8 +1622,8 @@ mod tests {
                     let eps = ep.bound_sockets();
                     info!(me = %ep.node_id().fmt_short(), ipv4=%eps.0, ipv6=?eps.1, "server listening on");
                     for i in 0..n_clients {
-                        let now = Instant::now();
-                        println!("[server] round {}", i + 1);
+                        let round_start = Instant::now();
+                        info!("[server] round {i}");
                         let incoming = ep.accept().await.unwrap();
                         let conn = incoming.await.unwrap();
                         let peer_id = get_remote_node_id(&conn).unwrap();
@@ -1638,7 +1638,7 @@ mod tests {
                         send.stopped().await.unwrap();
                         recv.read_to_end(0).await.unwrap();
                         info!(%i, peer = %peer_id.fmt_short(), "finished");
-                        println!("[server] round {} done in {:?}", i + 1, now.elapsed());
+                        info!("[server] round {i} done in {:?}", round_start.elapsed());
                     }
                 }
                 .instrument(error_span!("server")),
@@ -1650,8 +1650,8 @@ mod tests {
         });
 
         for i in 0..n_clients {
-            let now = Instant::now();
-            println!("[client] round {}", i + 1);
+            let round_start = Instant::now();
+            info!("[client] round {}", i);
             let relay_map = relay_map.clone();
             let client_secret_key = SecretKey::generate(&mut rng);
             let relay_url = relay_url.clone();
@@ -1688,7 +1688,7 @@ mod tests {
             }
             .instrument(error_span!("client", %i))
             .await;
-            println!("[client] round {} done in {:?}", i + 1, now.elapsed());
+            info!("[client] round {i} done in {:?}", round_start.elapsed());
         }
 
         server.await.unwrap();

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1818,7 +1818,7 @@ struct RelayDatagramRecvQueue {
 }
 
 impl RelayDatagramRecvQueue {
-    /// Creates a new, empty queue with a fixed size bound of 128 items.
+    /// Creates a new, empty queue with a fixed size bound of 512 items.
     fn new() -> Self {
         Self {
             queue: ConcurrentQueue::bounded(512),

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1731,6 +1731,16 @@ enum DiscoBoxError {
 ///
 /// These includes the waker coordination required to support [`AsyncUdpSocket::try_send`]
 /// and [`quinn::UdpPoller::poll_writable`].
+///
+/// Note that this implementation has several bugs in them, but they have existed for rather
+/// a while:
+///
+/// - There can be multiple senders, which all have to be woken if they were blocked.  But
+///   only the last sender to install the waker is unblocked.
+///
+/// - poll_writable may return blocking when it doesn't need to.  Leaving the sender stuck
+///   until another recv is called (which hopefully would happen soon given that the channel
+///   is probably still rather full, but still).
 fn relay_datagram_sender() -> (
     RelayDatagramSendChannelSender,
     RelayDatagramSendChannelReceiver,

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1821,7 +1821,7 @@ impl RelayDatagramRecvQueue {
     /// Creates a new, empty queue with a fixed size bound of 128 items.
     fn new() -> Self {
         Self {
-            queue: ConcurrentQueue::bounded(128),
+            queue: ConcurrentQueue::bounded(512),
             waker: AtomicWaker::new(),
         }
     }

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -31,13 +31,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 use url::Url;
 
+use super::RelayDatagramSendChannelReceiver;
 use crate::{
     dns::DnsResolver,
     magicsock::{MagicSock, Metrics as MagicsockMetrics, RelayContents, RelayDatagramRecvQueue},
     util::MaybeFuture,
 };
-
-use super::RelayDatagramSendChannelReceiver;
 
 /// How long a non-home relay connection needs to be idle (last written to) before we close it.
 const RELAY_INACTIVE_CLEANUP_TIME: Duration = Duration::from_secs(60);

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -410,7 +410,7 @@ impl ActiveRelayActor {
                 .await?;
         }
 
-        loop {
+        let res = loop {
             if let Some(data) = state.pong_pending.take() {
                 let fut = client_sink.send(SendMessage::Pong(data));
                 self.run_sending(fut, &mut state, &mut client_stream)
@@ -517,7 +517,11 @@ impl ActiveRelayActor {
                     break Ok(());
                 }
             }
+        };
+        if res.is_ok() {
+            client_sink.close().await?;
         }
+        res
     }
 
     fn handle_relay_msg(&mut self, msg: ReceivedMessage, state: &mut ConnectedRelayState) {

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -444,6 +444,7 @@ impl ActiveRelayActor {
                     };
                     match msg {
                         ActiveRelayMessage::SetHomeRelay(is_preferred) => {
+                            self.is_home_relay = is_preferred;
                             let fut = client_sink.send(SendMessage::NotePreferred(is_preferred));
                             self.run_sending(fut, &mut state, &mut client_stream).await?;
                         }

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -438,7 +438,6 @@ impl RelayActor {
     pub(super) fn new(
         msock: Arc<MagicSock>,
         relay_datagram_recv_queue: Arc<RelayDatagramRecvQueue>,
-        // relay_datagram_send_queue: RelayDatagramsQueue,
     ) -> Self {
         let cancel_token = CancellationToken::new();
         Self {

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -9,27 +9,33 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     future::Future,
     net::IpAddr,
+    pin::{pin, Pin},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
 };
 
-use anyhow::Context;
-use backoff::backoff::Backoff;
+use anyhow::{anyhow, Result};
+use backoff::exponential::{ExponentialBackoff, ExponentialBackoffBuilder};
 use bytes::{Bytes, BytesMut};
 use futures_buffered::FuturesUnorderedBounded;
 use futures_lite::StreamExt;
+use futures_util::{future, SinkExt};
 use iroh_base::{NodeId, PublicKey, RelayUrl, SecretKey};
 use iroh_metrics::{inc, inc_by};
-use iroh_relay::{self as relay, client::ClientError, ReceivedMessage, MAX_PACKET_SIZE};
+use iroh_relay::{
+    self as relay,
+    client::{Client, ReceivedMessage, SendMessage},
+    MAX_PACKET_SIZE,
+};
 use tokio::{
     sync::{mpsc, oneshot},
     task::JoinSet,
-    time::{self, Duration, Instant},
+    time::{Duration, Instant, MissedTickBehavior},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, info_span, trace, warn, Instrument};
+use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
 use url::Url;
 
 use super::RelayDatagramSendChannelReceiver;
@@ -45,38 +51,91 @@ const RELAY_INACTIVE_CLEANUP_TIME: Duration = Duration::from_secs(60);
 /// Maximum size a datagram payload is allowed to be.
 const MAX_PAYLOAD_SIZE: usize = MAX_PACKET_SIZE - PublicKey::LENGTH;
 
+/// Maximum time for a relay server to respond to a relay protocol ping.
+const PING_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Number of datagrams which can be sent to the relay server in one batch.
+///
+/// This means while this batch is sending to the server no other relay protocol frames can
+/// be sent to the server, e.g. no Ping frames or so.  While the maximum packet size is
+/// rather large, each item can typically be expected to up to 1500 or the max GSO size.
+const SEND_DATAGRAM_BATCH_SIZE: usize = 20;
+
+/// Timeout for establishing the relay connection.
+///
+/// This includes DNS, dialing the server, upgrading the connection, and completing the
+/// handshake.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Time after which the [`ActiveRelayActor`] will drop undeliverable datagrams.
+///
+/// When the [`ActiveRelayActor`] is not connected it can not deliver datagrams.  However it
+/// will still receive datagrams to send from the [`RelayActor`].  If connecting takes
+/// longer than this timeout datagrams will be dropped.
+const UNDELIVERABLE_DATAGRAM_TIMEOUT: Duration = Duration::from_millis(400);
+
 /// An actor which handles the connection to a single relay server.
 ///
 /// It is responsible for maintaining the connection to the relay server and handling all
 /// communication with it.
+///
+/// The actor shuts down itself on inactivity: inactivity is determined when no more
+/// datagrams are being received to send.
+///
+/// This actor has 3 main states it can be in, each has it's dedicated run loop:
+///
+/// - Dialing the relay server.
+///
+///   This will continuously dial the server until connected, using exponential backoff if
+///   it can not connect.  See [`ActiveRelayActor::run_dialing`].
+///
+/// - Connected to the relay server.
+///
+///   This state allows receiving from the relay server, though sending is idle in this
+///   state.  See [`ActiveRelayActor::run_connected`].
+///
+/// - Sending to the relay server.
+///
+///   This is a sub-state of `connected` so the actor can still be receiving from the relay
+///   server at this time.  However it is actively sending data to the server so can not
+///   consume any further items from inboxes which will result in sending more data to the
+///   server until the actor goes back to the `connected` state.
+///
+/// All these are driven from the top-level [`ActiveRelayActor::run`] loop.
 #[derive(Debug)]
 struct ActiveRelayActor {
+    // The inboxes and channels this actor communicates over.
+    /// Inbox for messages which should be handled without any blocking.
+    fast_inbox: mpsc::Receiver<ActiveRelayFastMessage>,
+    /// Inbox for messages which involve sending to the relay server.
+    inbox: mpsc::Receiver<ActiveRelayMessage>,
     /// Queue to send received relay datagrams on.
     relay_datagrams_recv: Arc<RelayDatagramRecvQueue>,
     /// Channel on which we receive packets to send to the relay.
     relay_datagrams_send: mpsc::Receiver<RelaySendItem>,
+
+    // Other actor state.
+    /// The relay server for this actor.
     url: RelayUrl,
-    /// Whether or not this is the home relay connection.
-    is_home_relay: bool,
-    /// Configuration to establish connections to a relay server.
-    relay_connection_opts: RelayConnectionOptions,
-    relay_client: relay::client::Client,
-    relay_client_receiver: relay::client::ClientReceiver,
-    /// The set of remote nodes we know are present on this relay server.
+    /// Builder which can repeatedly build a relay client.
+    relay_client_builder: relay::client::ClientBuilder,
+    /// Whether or not this is the home relay server.
     ///
-    /// If we receive messages from a remote node via, this server it is added to this set.
-    /// If the server notifies us this node is gone, it is removed from this set.
-    node_present: BTreeSet<NodeId>,
-    backoff: backoff::exponential::ExponentialBackoff<backoff::SystemClock>,
-    last_packet_time: Option<Instant>,
-    last_packet_src: Option<NodeId>,
+    /// The home relay server needs to maintain it's connection to the relay server, even if
+    /// the relay actor is otherwise idle.
+    is_home_relay: bool,
+    /// When this expires the actor has been idle and should shut down.
+    ///
+    /// Unless it is managing the home relay connection.  Inactivity is only tracked on the
+    /// last datagram sent to the relay, received datagrams will trigger QUIC ACKs which is
+    /// sufficient to keep active connections open.
+    inactive_timeout: Pin<Box<tokio::time::Sleep>>,
+    /// Token indicating the [`ActiveRelayActor`] should stop.
+    stop_token: CancellationToken,
 }
 
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 enum ActiveRelayMessage {
-    /// Returns whether or not this relay can reach the NodeId.
-    HasNodeRoute(NodeId, oneshot::Sender<bool>),
     /// Triggers a connection check to the relay server.
     ///
     /// Sometimes it is known the local network interfaces have changed in which case it
@@ -88,18 +147,33 @@ enum ActiveRelayMessage {
     CheckConnection(Vec<IpAddr>),
     /// Sets this relay as the home relay, or not.
     SetHomeRelay(bool),
-    Shutdown,
     #[cfg(test)]
     GetLocalAddr(oneshot::Sender<Option<SocketAddr>>),
+    #[cfg(test)]
+    PingServer(oneshot::Sender<()>),
+}
+
+/// Messages for the [`ActiveRelayActor`] which should never block.
+///
+/// Most messages in the [`ActiveRelayMessage`] enum trigger sending to the relay server,
+/// which can be blocking.  So the actor may not always be processing that inbox.  Messages
+/// here are processed immediately.
+#[derive(Debug)]
+enum ActiveRelayFastMessage {
+    /// Returns whether or not this relay can reach the NodeId.
+    HasNodeRoute(NodeId, oneshot::Sender<bool>),
 }
 
 /// Configuration needed to start an [`ActiveRelayActor`].
 #[derive(Debug)]
 struct ActiveRelayActorOptions {
     url: RelayUrl,
+    fast_inbox: mpsc::Receiver<ActiveRelayFastMessage>,
+    inbox: mpsc::Receiver<ActiveRelayMessage>,
     relay_datagrams_send: mpsc::Receiver<RelaySendItem>,
     relay_datagrams_recv: Arc<RelayDatagramRecvQueue>,
     connection_opts: RelayConnectionOptions,
+    stop_token: CancellationToken,
 }
 
 /// Configuration needed to create a connection to a relay server.
@@ -117,35 +191,31 @@ impl ActiveRelayActor {
     fn new(opts: ActiveRelayActorOptions) -> Self {
         let ActiveRelayActorOptions {
             url,
+            fast_inbox,
+            inbox,
             relay_datagrams_send,
             relay_datagrams_recv,
             connection_opts,
+            stop_token,
         } = opts;
-        let (relay_client, relay_client_receiver) =
-            Self::create_relay_client(url.clone(), connection_opts.clone());
-
+        let relay_client_builder = Self::create_relay_builder(url.clone(), connection_opts);
         ActiveRelayActor {
+            fast_inbox,
+            inbox,
             relay_datagrams_recv,
             relay_datagrams_send,
             url,
+            relay_client_builder,
             is_home_relay: false,
-            node_present: BTreeSet::new(),
-            backoff: backoff::exponential::ExponentialBackoffBuilder::new()
-                .with_initial_interval(Duration::from_millis(10))
-                .with_max_interval(Duration::from_secs(5))
-                .build(),
-            last_packet_time: None,
-            last_packet_src: None,
-            relay_connection_opts: connection_opts,
-            relay_client,
-            relay_client_receiver,
+            inactive_timeout: Box::pin(tokio::time::sleep(RELAY_INACTIVE_CLEANUP_TIME)),
+            stop_token,
         }
     }
 
-    fn create_relay_client(
+    fn create_relay_builder(
         url: RelayUrl,
         opts: RelayConnectionOptions,
-    ) -> (relay::client::Client, relay::client::ClientReceiver) {
+    ) -> relay::client::ClientBuilder {
         let RelayConnectionOptions {
             secret_key,
             dns_resolver,
@@ -154,269 +224,435 @@ impl ActiveRelayActor {
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_cert_verify,
         } = opts;
-        let mut builder = relay::client::ClientBuilder::new(url)
+        let mut builder = relay::client::ClientBuilder::new(url, secret_key, dns_resolver)
             .address_family_selector(move || prefer_ipv6.load(Ordering::Relaxed));
         if let Some(proxy_url) = proxy_url {
             builder = builder.proxy_url(proxy_url);
         }
         #[cfg(any(test, feature = "test-utils"))]
         let builder = builder.insecure_skip_cert_verify(insecure_skip_cert_verify);
-        builder.build(secret_key, dns_resolver)
+        builder
     }
 
-    async fn run(mut self, mut inbox: mpsc::Receiver<ActiveRelayMessage>) -> anyhow::Result<()> {
+    /// The main actor run loop.
+    ///
+    /// Primarily switches between the dialing and connected states.
+    async fn run(mut self) -> anyhow::Result<()> {
         inc!(MagicsockMetrics, num_relay_conns_added);
-        debug!("initial dial {}", self.url);
-        self.relay_client
-            .connect()
-            .await
-            .context("initial connection")?;
-
-        // When this future has an inner, it is a future which is currently sending
-        // something to the relay server.  Nothing else can be sent to the relay server at
-        // the same time.
-        let mut relay_send_fut = std::pin::pin!(MaybeFuture::none());
-
-        // If inactive for one tick the actor should exit.  Inactivity is only tracked on
-        // the last datagrams sent to the relay, received datagrams will trigger ACKs which
-        // is sufficient to keep active connections open.
-        let mut inactive_timeout = tokio::time::interval(RELAY_INACTIVE_CLEANUP_TIME);
-        inactive_timeout.reset(); // skip immediate tick
 
         loop {
-            // If a read error occurred on the connection it might have been lost.  But we
-            // need this connection to stay alive so we can receive more messages sent by
-            // peers via the relay even if we don't start sending again first.
-            if !self.relay_client.is_connected().await? {
-                debug!("relay re-connecting");
-                self.relay_client.connect().await.context("keepalive")?;
-            }
-            tokio::select! {
-                msg = inbox.recv() => {
-                    let Some(msg) = msg else {
-                        debug!("all clients closed");
-                        break;
-                    };
-                    if self.handle_actor_msg(msg).await {
-                        break;
-                    }
-                }
-                // Only poll relay_send_fut if it is sending to the relay.
-                _ = &mut relay_send_fut, if relay_send_fut.is_some() => {
-                    relay_send_fut.as_mut().set_none();
-                }
-                // Only poll for new datagrams if relay_send_fut is not busy.
-                Some(item) = self.relay_datagrams_send.recv(), if relay_send_fut.is_none() => {
-                    debug_assert_eq!(item.url, self.url);
-                    let fut = Self::send_relay(self.relay_client.clone(), item);
-                    relay_send_fut.as_mut().set_future(fut);
-                    inactive_timeout.reset();
-
-                }
-                msg = self.relay_client_receiver.recv() => {
-                    trace!("tick: relay_client_receiver");
-                    if let Some(msg) = msg {
-                        if self.handle_relay_msg(msg).await == ReadResult::Break {
-                            // fatal error
-                            break;
-                        }
-                    }
-                }
-                _ = inactive_timeout.tick() => {
-                    debug!("Inactive for {RELAY_INACTIVE_CLEANUP_TIME:?}, exiting");
-                    break;
+            let Some(client) = self.run_dialing().instrument(info_span!("dialing")).await else {
+                break;
+            };
+            match self
+                .run_connected(client)
+                .instrument(info_span!("connected"))
+                .await
+            {
+                Ok(_) => break,
+                Err(err) => {
+                    debug!("Connection to relay server lost: {err:#}");
+                    continue;
                 }
             }
         }
         debug!("exiting");
-        self.relay_client.close().await?;
         inc!(MagicsockMetrics, num_relay_conns_removed);
         Ok(())
     }
 
-    async fn handle_actor_msg(&mut self, msg: ActiveRelayMessage) -> bool {
-        trace!("tick: inbox: {:?}", msg);
-        match msg {
-            ActiveRelayMessage::SetHomeRelay(is_preferred) => {
-                self.is_home_relay = is_preferred;
-                self.relay_client.note_preferred(is_preferred).await;
-            }
-            ActiveRelayMessage::HasNodeRoute(peer, r) => {
-                let has_peer = self.node_present.contains(&peer);
-                r.send(has_peer).ok();
-            }
-            ActiveRelayMessage::CheckConnection(local_ips) => {
-                self.handle_check_connection(local_ips).await;
-            }
-            ActiveRelayMessage::Shutdown => {
-                debug!("shutdown");
-                return true;
-            }
-            #[cfg(test)]
-            ActiveRelayMessage::GetLocalAddr(sender) => {
-                let addr = self.relay_client.local_addr().await;
-                sender.send(addr).ok();
-            }
-        }
-        false
+    fn reset_inactive_timeout(&mut self) {
+        self.inactive_timeout
+            .as_mut()
+            .reset(Instant::now() + RELAY_INACTIVE_CLEANUP_TIME);
     }
 
-    /// Checks if the current relay connection is fine or needs reconnecting.
+    /// Actor loop when connecting to the relay server.
     ///
-    /// If the local IP address of the current relay connection is in `local_ips` then this
-    /// pings the relay, recreating the connection on ping failure.  Otherwise it always
-    /// recreates the connection.
-    async fn handle_check_connection(&mut self, local_ips: Vec<IpAddr>) {
-        match self.relay_client.local_addr().await {
-            Some(local_addr) if local_ips.contains(&local_addr.ip()) => {
-                match self.relay_client.ping().await {
-                    Ok(latency) => debug!(?latency, "Still connected."),
-                    Err(err) => {
-                        debug!(?err, "Ping failed, reconnecting.");
-                        self.reconnect().await;
+    /// Returns `None` if the actor needs to shut down.  Returns `Some(client)` when the
+    /// connection is established.
+    async fn run_dialing(&mut self) -> Option<iroh_relay::client::Client> {
+        debug!("Actor loop: connecting to relay.");
+
+        // We regularly flush the relay_datagrams_send queue so it is not full of stale
+        // packets while reconnecting.  Those datagrams are dropped and the QUIC congestion
+        // controller will have to handle this (DISCO packets do not yet have retry).  This
+        // is not an ideal mechanism, an alternative approach would be to use
+        // e.g. ConcurrentQueue with force_push, though now you might still send very stale
+        // packets when eventually connected.  So perhaps this is a reasonable compromise.
+        let mut send_datagram_flush = tokio::time::interval(UNDELIVERABLE_DATAGRAM_TIMEOUT);
+        send_datagram_flush.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        send_datagram_flush.reset(); // Skip the immediate interval
+
+        let mut dialing_fut = self.dial_relay();
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.stop_token.cancelled() => {
+                    debug!("Shutdown.");
+                    break None;
+                }
+                msg = self.fast_inbox.recv() => {
+                    let Some(msg) = msg else {
+                        warn!("Fast inbox closed, shutdown.");
+                        break None;
+                    };
+                    match msg {
+                        ActiveRelayFastMessage::HasNodeRoute(_peer, sender) => {
+                            sender.send(false).ok();
+                        }
                     }
                 }
-            }
-            Some(_local_addr) => {
-                debug!("Local IP no longer valid, reconnecting");
-                self.reconnect().await;
-            }
-            None => {
-                debug!("No local address for this relay connection, reconnecting.");
-                self.reconnect().await;
+                res = &mut dialing_fut => {
+                    match res {
+                        Ok(client) => {
+                            break Some(client);
+                        }
+                        Err(err) => {
+                            warn!("Client failed to connect: {err:#}");
+                            dialing_fut = self.dial_relay();
+                        }
+                    }
+                }
+                msg = self.inbox.recv() => {
+                    let Some(msg) = msg else {
+                        debug!("Inbox closed, shutdown.");
+                        break None;
+                    };
+                    match msg {
+                        ActiveRelayMessage::SetHomeRelay(is_preferred) => {
+                            self.is_home_relay = is_preferred;
+                        }
+                        ActiveRelayMessage::CheckConnection(_local_ips) => {}
+                        #[cfg(test)]
+                        ActiveRelayMessage::GetLocalAddr(sender) => {
+                            sender.send(None).ok();
+                        }
+                        #[cfg(test)]
+                        ActiveRelayMessage::PingServer(sender) => {
+                            drop(sender);
+                        }
+                    }
+                }
+                _ = send_datagram_flush.tick() => {
+                    self.reset_inactive_timeout();
+                    let mut logged = false;
+                    while self.relay_datagrams_send.try_recv().is_ok() {
+                        if !logged {
+                            debug!(?UNDELIVERABLE_DATAGRAM_TIMEOUT, "Dropping datagrams to send.");
+                            logged = true;
+                        }
+                    }
+                }
+                _ = &mut self.inactive_timeout, if !self.is_home_relay => {
+                    debug!(?RELAY_INACTIVE_CLEANUP_TIME, "Inactive, exiting.");
+                    break None;
+                }
             }
         }
     }
 
-    async fn reconnect(&mut self) {
-        let (client, client_receiver) =
-            Self::create_relay_client(self.url.clone(), self.relay_connection_opts.clone());
-        self.relay_client = client;
-        self.relay_client_receiver = client_receiver;
+    /// Returns a future which will complete once connected to the relay server.
+    ///
+    /// The future only completes once the connection is established and retries
+    /// connections.  It currently does not ever return `Err` as the retries continue
+    /// forever.
+    fn dial_relay(&self) -> Pin<Box<dyn Future<Output = Result<Client>> + Send>> {
+        let backoff: ExponentialBackoff<backoff::SystemClock> = ExponentialBackoffBuilder::new()
+            .with_initial_interval(Duration::from_millis(10))
+            .with_max_interval(Duration::from_secs(5))
+            .build();
+        let connect_fn = {
+            let client_builder = self.relay_client_builder.clone();
+            move || {
+                let client_builder = client_builder.clone();
+                async move {
+                    match tokio::time::timeout(CONNECT_TIMEOUT, client_builder.connect()).await {
+                        Ok(Ok(client)) => Ok(client),
+                        Ok(Err(err)) => {
+                            warn!("Relay connection failed: {err:#}");
+                            Err(err.into())
+                        }
+                        Err(_) => {
+                            warn!(?CONNECT_TIMEOUT, "Timeout connecting to relay");
+                            Err(anyhow!("Timeout").into())
+                        }
+                    }
+                }
+            }
+        };
+        let retry_fut = backoff::future::retry(backoff, connect_fn);
+        Box::pin(retry_fut)
+    }
+
+    /// Runs the actor loop when connected to a relay server.
+    ///
+    /// Returns `Ok` if the actor needs to shut down.  `Err` is returned if the connection
+    /// to the relay server is lost.
+    async fn run_connected(&mut self, client: iroh_relay::client::Client) -> Result<()> {
+        debug!("Actor loop: connected to relay");
+
+        let (mut client_stream, mut client_sink) = client.split();
+
+        let mut state = ConnectedRelayState {
+            ping_tracker: PingTracker::new(),
+            nodes_present: BTreeSet::new(),
+            last_packet_src: None,
+            pong_pending: None,
+            #[cfg(test)]
+            test_pong: None,
+        };
+        let mut send_datagrams_buf = Vec::with_capacity(SEND_DATAGRAM_BATCH_SIZE);
+
         if self.is_home_relay {
-            self.relay_client.note_preferred(true).await;
+            let fut = client_sink.send(SendMessage::NotePreferred(true));
+            self.run_sending(fut, &mut state, &mut client_stream)
+                .await?;
         }
-    }
 
-    async fn send_relay(relay_client: relay::client::Client, item: RelaySendItem) {
-        // When Quinn sends a GSO Transmit magicsock::split_packets will make us receive
-        // more than one packet to send in a single call.  We join all packets back together
-        // and prefix them with a u16 packet size.  They then get sent as a single DISCO
-        // frame.  However this might still be multiple packets when otherwise the maximum
-        // packet size for the relay protocol would be exceeded.
-        for packet in PacketizeIter::<_, MAX_PAYLOAD_SIZE>::new(item.remote_node, item.datagrams) {
-            let len = packet.len();
-            match relay_client.send(packet.node_id, packet.payload).await {
-                Ok(_) => inc_by!(MagicsockMetrics, send_relay, len as _),
-                Err(err) => {
-                    warn!("send failed: {err:#}");
-                    inc!(MagicsockMetrics, send_relay_error);
-                }
+        loop {
+            if let Some(data) = state.pong_pending.take() {
+                let fut = client_sink.send(SendMessage::Pong(data));
+                self.run_sending(fut, &mut state, &mut client_stream)
+                    .await?;
             }
-        }
-    }
-
-    async fn handle_relay_msg(&mut self, msg: Result<ReceivedMessage, ClientError>) -> ReadResult {
-        match msg {
-            Err(err) => {
-                warn!("recv error {:?}", err);
-
-                // Forget that all these peers have routes.
-                self.node_present.clear();
-
-                if matches!(
-                    err,
-                    relay::client::ClientError::Closed | relay::client::ClientError::IPDisabled
-                ) {
-                    // drop client
-                    return ReadResult::Break;
+            tokio::select! {
+                biased;
+                _ = self.stop_token.cancelled() => {
+                    debug!("Shutdown.");
+                    break Ok(());
                 }
-
-                // If our relay connection broke, it might be because our network
-                // conditions changed. Start that check.
-                // TODO:
-                // self.re_stun("relay-recv-error").await;
-
-                // Back off a bit before reconnecting.
-                match self.backoff.next_backoff() {
-                    Some(t) => {
-                        debug!("backoff sleep: {}ms", t.as_millis());
-                        time::sleep(t).await;
-                        ReadResult::Continue
+                msg = self.fast_inbox.recv() => {
+                    let Some(msg) = msg else {
+                        warn!("Fast inbox closed, shutdown.");
+                        break Ok(());
+                    };
+                    match msg {
+                        ActiveRelayFastMessage::HasNodeRoute(peer, sender) => {
+                            let has_peer = state.nodes_present.contains(&peer);
+                            sender.send(has_peer).ok();
+                        }
                     }
-                    None => ReadResult::Break,
+                }
+                _ = state.ping_tracker.timeout() => {
+                    break Err(anyhow!("Ping timeout"));
+                }
+                msg = self.inbox.recv() => {
+                    let Some(msg) = msg else {
+                        warn!("Inbox closed, shutdown.");
+                        break Ok(());
+                    };
+                    match msg {
+                        ActiveRelayMessage::SetHomeRelay(is_preferred) => {
+                            let fut = client_sink.send(SendMessage::NotePreferred(is_preferred));
+                            self.run_sending(fut, &mut state, &mut client_stream).await?;
+                        }
+                        ActiveRelayMessage::CheckConnection(local_ips) => {
+                            match client_stream.local_addr() {
+                                Some(addr) if local_ips.contains(&addr.ip()) => {
+                                    let data = state.ping_tracker.new_ping();
+                                    let fut = client_sink.send(SendMessage::Ping(data));
+                                    self.run_sending(fut, &mut state, &mut client_stream).await?;
+                                }
+                                Some(_) => break Err(anyhow!("Local IP no longer valid")),
+                                None => break Err(anyhow!("No local addr, reconnecting")),
+                            }
+                        }
+                        #[cfg(test)]
+                        ActiveRelayMessage::GetLocalAddr(sender) => {
+                            let addr = client_stream.local_addr();
+                            sender.send(addr).ok();
+                        }
+                        #[cfg(test)]
+                        ActiveRelayMessage::PingServer(sender) => {
+                            let data = rand::random();
+                            state.test_pong = Some((data, sender));
+                            let fut = client_sink.send(SendMessage::Ping(data));
+                            self.run_sending(fut, &mut state, &mut client_stream).await?;
+                        }
+                    }
+                }
+                count = self.relay_datagrams_send.recv_many(
+                    &mut send_datagrams_buf,
+                    SEND_DATAGRAM_BATCH_SIZE,
+                ) => {
+                    if count == 0 {
+                        warn!("Datagram inbox closed, shutdown");
+                        break Ok(());
+                    };
+                    self.reset_inactive_timeout();
+                    // TODO: This allocation is *very* unfortunate.  But so is the
+                    // allocation *inside* of PacketizeIter...
+                    let dgrams = std::mem::replace(
+                        &mut send_datagrams_buf,
+                        Vec::with_capacity(SEND_DATAGRAM_BATCH_SIZE),
+                    );
+                    let packet_iter = dgrams.into_iter().flat_map(|datagrams| {
+                        PacketizeIter::<_, MAX_PAYLOAD_SIZE>::new(
+                            datagrams.remote_node,
+                            datagrams.datagrams.clone(),
+                        )
+                        .map(|p| {
+                            inc_by!(MagicsockMetrics, send_relay, p.payload.len() as _);
+                            SendMessage::SendPacket(p.node_id, p.payload)
+                        })
+                        .map(Ok)
+                    });
+                    let mut packet_stream = futures_util::stream::iter(packet_iter);
+                    let fut = client_sink.send_all(&mut packet_stream);
+                    self.run_sending(fut, &mut state, &mut client_stream).await?;
+                }
+                msg = client_stream.next() => {
+                    let Some(msg) = msg else {
+                        break Err(anyhow!("Client stream finished"));
+                    };
+                    match msg {
+                        Ok(msg) => self.handle_relay_msg(msg, &mut state),
+                        Err(err) => break Err(anyhow!("Client stream read error: {err:#}")),
+                    }
+                }
+                _ = &mut self.inactive_timeout, if !self.is_home_relay => {
+                    debug!("Inactive for {RELAY_INACTIVE_CLEANUP_TIME:?}, exiting.");
+                    break Ok(());
                 }
             }
-            Ok(msg) => {
-                // reset
-                self.backoff.reset();
-                let now = Instant::now();
-                if self
-                    .last_packet_time
+        }
+    }
+
+    fn handle_relay_msg(&mut self, msg: ReceivedMessage, state: &mut ConnectedRelayState) {
+        match msg {
+            ReceivedMessage::ReceivedPacket {
+                remote_node_id,
+                data,
+            } => {
+                trace!(len = %data.len(), "received msg");
+                // If this is a new sender, register a route for this peer.
+                if state
+                    .last_packet_src
                     .as_ref()
-                    .map(|t| t.elapsed() > Duration::from_secs(5))
+                    .map(|p| *p != remote_node_id)
                     .unwrap_or(true)
                 {
-                    self.last_packet_time = Some(now);
+                    // Avoid map lookup with high throughput single peer.
+                    state.last_packet_src = Some(remote_node_id);
+                    state.nodes_present.insert(remote_node_id);
                 }
-
-                match msg {
-                    ReceivedMessage::ReceivedPacket {
-                        remote_node_id,
-                        data,
-                    } => {
-                        trace!(len=%data.len(), "received msg");
-                        // If this is a new sender we hadn't seen before, remember it and
-                        // register a route for this peer.
-                        if self
-                            .last_packet_src
-                            .as_ref()
-                            .map(|p| *p != remote_node_id)
-                            .unwrap_or(true)
-                        {
-                            // avoid map lookup w/ high throughput single peer
-                            self.last_packet_src = Some(remote_node_id);
-                            self.node_present.insert(remote_node_id);
+                for datagram in PacketSplitIter::new(self.url.clone(), remote_node_id, data) {
+                    let Ok(datagram) = datagram else {
+                        warn!("Invalid packet split");
+                        break;
+                    };
+                    if let Err(err) = self.relay_datagrams_recv.try_send(datagram) {
+                        warn!("Dropping received relay packet: {err:#}");
+                    }
+                }
+            }
+            ReceivedMessage::NodeGone(node_id) => {
+                state.nodes_present.remove(&node_id);
+            }
+            ReceivedMessage::Ping(data) => state.pong_pending = Some(data),
+            ReceivedMessage::Pong(data) => {
+                #[cfg(test)]
+                {
+                    if let Some((expected_data, sender)) = state.test_pong.take() {
+                        if data == expected_data {
+                            sender.send(()).ok();
+                        } else {
+                            state.test_pong = Some((expected_data, sender));
                         }
+                    }
+                }
+                state.ping_tracker.pong_received(data)
+            }
+            ReceivedMessage::KeepAlive
+            | ReceivedMessage::Health { .. }
+            | ReceivedMessage::ServerRestarting { .. } => trace!("Ignoring {msg:?}"),
+        }
+    }
 
-                        for datagram in PacketSplitIter::new(self.url.clone(), remote_node_id, data)
-                        {
-                            let Ok(datagram) = datagram else {
-                                error!("Invalid packet split");
-                                break;
-                            };
-                            if let Err(err) = self.relay_datagrams_recv.try_send(datagram) {
-                                warn!("dropping received relay packet: {err:#}");
-                            }
+    /// Run the actor main loop while sending to the relay server.
+    ///
+    /// While sending the actor should not read any inboxes which will give it more things
+    /// to send to the relay server.
+    ///
+    /// # Returns
+    ///
+    /// On `Err` the relay connection should be disconnected.  An `Ok` return means either
+    /// the actor should shut down, consult the [`ActiveRelayActor::stop_token`] and
+    /// [`ActiveRelayActor::inactive_timeout`] for this, or the send was successful.
+    #[instrument(name = "tx", skip_all)]
+    async fn run_sending<T, E: Into<anyhow::Error>>(
+        &mut self,
+        sending_fut: impl Future<Output = Result<T, E>>,
+        state: &mut ConnectedRelayState,
+        client_stream: &mut iroh_relay::client::ClientStream,
+    ) -> Result<()> {
+        let mut sending_fut = pin!(sending_fut);
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.stop_token.cancelled() => {
+                    break Ok(());
+                }
+                msg = self.fast_inbox.recv() => {
+                    let Some(msg) = msg else {
+                        warn!("Fast inbox closed, shutdown.");
+                        break Ok(());
+                    };
+                    match msg {
+                        ActiveRelayFastMessage::HasNodeRoute(peer, sender) => {
+                            let has_peer = state.nodes_present.contains(&peer);
+                            sender.send(has_peer).ok();
                         }
-
-                        ReadResult::Continue
                     }
-                    ReceivedMessage::Ping(data) => {
-                        // Best effort reply to the ping.
-                        let dc = self.relay_client.clone();
-                        // TODO: Unbounded tasks/channel
-                        tokio::task::spawn(async move {
-                            if let Err(err) = dc.send_pong(data).await {
-                                warn!("pong error: {:?}", err);
-                            }
-                        });
-                        ReadResult::Continue
+                }
+                res = &mut sending_fut => {
+                    match res {
+                        Ok(_) => break Ok(()),
+                        Err(err) => break Err(err.into()),
                     }
-                    ReceivedMessage::Health { .. } => ReadResult::Continue,
-                    ReceivedMessage::NodeGone(key) => {
-                        self.node_present.remove(&key);
-                        ReadResult::Continue
+                }
+                _ = state.ping_tracker.timeout() => {
+                    break Err(anyhow!("Ping timeout"));
+                }
+                // No need to read the inbox or datagrams to send.
+                msg = client_stream.next() => {
+                    let Some(msg) = msg else {
+                        break Err(anyhow!("Client stream finished"));
+                    };
+                    match msg {
+                        Ok(msg) => self.handle_relay_msg(msg, state),
+                        Err(err) => break Err(anyhow!("Client stream read error: {err:#}")),
                     }
-                    other => {
-                        trace!("ignoring: {:?}", other);
-                        // Ignore.
-                        ReadResult::Continue
-                    }
+                }
+                _ = &mut self.inactive_timeout, if !self.is_home_relay => {
+                    debug!("Inactive for {RELAY_INACTIVE_CLEANUP_TIME:?}, exiting.");
+                    break Ok(());
                 }
             }
         }
     }
+}
+
+/// Shared state when the [`ActiveRelayActor`] is connected to a relay server.
+///
+/// Common state between [`ActiveRelayActor::run_connected`] and
+/// [`ActiveRelayActor::run_sending`].
+#[derive(Debug)]
+struct ConnectedRelayState {
+    /// Tracks pings we have sent, awaits pong replies.
+    ping_tracker: PingTracker,
+    /// Nodes which are reachable via this relay server.
+    nodes_present: BTreeSet<NodeId>,
+    /// The [`NodeId`] from whom we received the last packet.
+    ///
+    /// This is to avoid a slower lookup in the [`ConnectedRelayState::nodes_present`] map
+    /// when we are only communicating to a single remote node.
+    last_packet_src: Option<NodeId>,
+    /// A pong we need to send ASAP.
+    pong_pending: Option<[u8; 8]>,
+    #[cfg(test)]
+    test_pong: Option<([u8; 8], oneshot::Sender<()>)>,
 }
 
 pub(super) enum RelayActorMessage {
@@ -518,7 +754,9 @@ impl RelayActor {
                     }
                 }
                 // Only poll this future if it is in use.
-                _ = &mut datagram_send_fut, if datagram_send_fut.is_some() => {}
+                _ = &mut datagram_send_fut, if datagram_send_fut.is_some() => {
+                    datagram_send_fut.as_mut().set_none();
+                }
             }
         }
 
@@ -612,8 +850,8 @@ impl RelayActor {
             let check_futs = self.active_relays.iter().map(|(url, handle)| async move {
                 let (tx, rx) = oneshot::channel();
                 handle
-                    .inbox_addr
-                    .send(ActiveRelayMessage::HasNodeRoute(*remote_node, tx))
+                    .fast_inbox_addr
+                    .send(ActiveRelayFastMessage::HasNodeRoute(*remote_node, tx))
                     .await
                     .ok();
                 match rx.await {
@@ -667,25 +905,30 @@ impl RelayActor {
 
         // TODO: Replace 64 with PER_CLIENT_SEND_QUEUE_DEPTH once that's unused
         let (send_datagram_tx, send_datagram_rx) = mpsc::channel(64);
+        let (fast_inbox_tx, fast_inbox_rx) = mpsc::channel(32);
         let (inbox_tx, inbox_rx) = mpsc::channel(64);
         let span = info_span!("active-relay", %url);
         let opts = ActiveRelayActorOptions {
             url,
+            fast_inbox: fast_inbox_rx,
+            inbox: inbox_rx,
             relay_datagrams_send: send_datagram_rx,
             relay_datagrams_recv: self.relay_datagram_recv_queue.clone(),
             connection_opts,
+            stop_token: self.cancel_token.child_token(),
         };
         let actor = ActiveRelayActor::new(opts);
         self.active_relay_tasks.spawn(
             async move {
                 // TODO: Make the actor itself infallible.
-                if let Err(err) = actor.run(inbox_rx).await {
+                if let Err(err) = actor.run().await {
                     warn!("actor error: {err:#}");
                 }
             }
             .instrument(span),
         );
         let handle = ActiveRelayHandle {
+            fast_inbox_addr: fast_inbox_tx,
             inbox_addr: inbox_tx,
             datagrams_send_queue: send_datagram_tx,
         };
@@ -724,16 +967,7 @@ impl RelayActor {
 
     /// Stops all [`ActiveRelayActor`]s and awaits for them to finish.
     async fn close_all_active_relays(&mut self) {
-        let send_futs = self.active_relays.iter().map(|(url, handle)| async move {
-            debug!(%url, "Shutting down ActiveRelayActor");
-            handle
-                .inbox_addr
-                .send(ActiveRelayMessage::Shutdown)
-                .await
-                .ok();
-        });
-        futures_buffered::join_all(send_futs).await;
-
+        self.cancel_token.cancel();
         let tasks = std::mem::take(&mut self.active_relay_tasks);
         tasks.join_all().await;
 
@@ -764,6 +998,7 @@ impl RelayActor {
 /// Handle to one [`ActiveRelayActor`].
 #[derive(Debug, Clone)]
 struct ActiveRelayHandle {
+    fast_inbox_addr: mpsc::Sender<ActiveRelayFastMessage>,
     inbox_addr: mpsc::Sender<ActiveRelayMessage>,
     datagrams_send_queue: mpsc::Sender<RelaySendItem>,
 }
@@ -780,12 +1015,6 @@ struct RelaySendPacket {
     payload: Bytes,
 }
 
-impl RelaySendPacket {
-    fn len(&self) -> usize {
-        self.payload.len()
-    }
-}
-
 /// A single datagram received from a relay server.
 ///
 /// This could be either a QUIC or DISCO packet.
@@ -794,12 +1023,6 @@ pub(super) struct RelayRecvDatagram {
     pub(super) url: RelayUrl,
     pub(super) src: NodeId,
     pub(super) buf: Bytes,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub(super) enum ReadResult {
-    Break,
-    Continue,
 }
 
 /// Combines datagrams into a single DISCO frame of at most MAX_PACKET_SIZE.
@@ -910,8 +1133,65 @@ impl Iterator for PacketSplitIter {
     }
 }
 
+/// Tracks pings on a single relay connection.
+///
+/// Only the last ping needs is useful, any previously sent ping is forgotten and ignored.
+#[derive(Debug)]
+struct PingTracker {
+    inner: Option<PingInner>,
+}
+
+#[derive(Debug)]
+struct PingInner {
+    data: [u8; 8],
+    deadline: Instant,
+}
+
+impl PingTracker {
+    fn new() -> Self {
+        Self { inner: None }
+    }
+
+    /// Starts a new ping.
+    fn new_ping(&mut self) -> [u8; 8] {
+        let ping_data = rand::random();
+        debug!(data = ?ping_data, "Sending ping to relay server.");
+        self.inner = Some(PingInner {
+            data: ping_data,
+            deadline: Instant::now() + PING_TIMEOUT,
+        });
+        ping_data
+    }
+
+    /// Updates the ping tracker with a received pong.
+    ///
+    /// Only the pong of the most recent ping will do anything.  There is no harm feeding
+    /// any pong however.
+    fn pong_received(&mut self, data: [u8; 8]) {
+        if self.inner.as_ref().map(|inner| inner.data) == Some(data) {
+            debug!(?data, "Pong received from relay server");
+            self.inner = None;
+        }
+    }
+
+    /// Cancel-safe waiting for a ping timeout.
+    ///
+    /// Unless the most recent sent ping times out, this will never return.
+    async fn timeout(&mut self) {
+        match self.inner {
+            Some(PingInner { deadline, data }) => {
+                tokio::time::sleep_until(deadline).await;
+                debug!(?data, "Ping timeout.");
+                self.inner = None;
+            }
+            None => future::pending().await,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use anyhow::Context;
     use futures_lite::future;
     use iroh_base::SecretKey;
     use smallvec::smallvec;
@@ -953,15 +1233,21 @@ mod tests {
     }
 
     /// Starts a new [`ActiveRelayActor`].
+    #[allow(clippy::too_many_arguments)]
     fn start_active_relay_actor(
         secret_key: SecretKey,
+        stop_token: CancellationToken,
         url: RelayUrl,
+        fast_inbox_rx: mpsc::Receiver<ActiveRelayFastMessage>,
         inbox_rx: mpsc::Receiver<ActiveRelayMessage>,
         relay_datagrams_send: mpsc::Receiver<RelaySendItem>,
         relay_datagrams_recv: Arc<RelayDatagramRecvQueue>,
+        span: tracing::Span,
     ) -> AbortOnDropHandle<anyhow::Result<()>> {
         let opts = ActiveRelayActorOptions {
             url,
+            fast_inbox: fast_inbox_rx,
+            inbox: inbox_rx,
             relay_datagrams_send,
             relay_datagrams_recv,
             connection_opts: RelayConnectionOptions {
@@ -971,14 +1257,9 @@ mod tests {
                 prefer_ipv6: Arc::new(AtomicBool::new(true)),
                 insecure_skip_cert_verify: true,
             },
+            stop_token,
         };
-        let task = tokio::spawn(
-            async move {
-                let actor = ActiveRelayActor::new(opts);
-                actor.run(inbox_rx).await
-            }
-            .instrument(info_span!("actor-under-test")),
-        );
+        let task = tokio::spawn(ActiveRelayActor::new(opts).run().instrument(span));
         AbortOnDropHandle::new(task)
     }
 
@@ -991,13 +1272,18 @@ mod tests {
         let secret_key = SecretKey::from_bytes(&[8u8; 32]);
         let recv_datagram_queue = Arc::new(RelayDatagramRecvQueue::new());
         let (send_datagram_tx, send_datagram_rx) = mpsc::channel(16);
+        let (fast_inbox_tx, fast_inbox_rx) = mpsc::channel(8);
         let (inbox_tx, inbox_rx) = mpsc::channel(16);
+        let cancel_token = CancellationToken::new();
         let actor_task = start_active_relay_actor(
             secret_key.clone(),
+            cancel_token.clone(),
             relay_url.clone(),
+            fast_inbox_rx,
             inbox_rx,
             send_datagram_rx,
             recv_datagram_queue.clone(),
+            info_span!("echo-node"),
         );
         let echo_task = tokio::spawn({
             let relay_url = relay_url.clone();
@@ -1020,7 +1306,9 @@ mod tests {
         });
         let echo_task = AbortOnDropHandle::new(echo_task);
         let supervisor_task = tokio::spawn(async move {
-            // move the inbox_tx here so it is not dropped, as this stops the actor.
+            let _guard = cancel_token.drop_guard();
+            // move the inboxes here so it is not dropped, as this stops the actor.
+            let _fast_inbox_tx = fast_inbox_tx;
             let _inbox_tx = inbox_tx;
             tokio::select! {
                 biased;
@@ -1032,6 +1320,42 @@ mod tests {
         (secret_key.public(), supervisor_task)
     }
 
+    /// Sends a message to the echo node, receives the response.
+    ///
+    /// This takes care of retry and timeout.  Because we don't know when both the
+    /// node-under-test and the echo node will be ready and datagrams aren't queued to send
+    /// forever, we have to retry a few times.
+    async fn send_recv_echo(
+        item: RelaySendItem,
+        tx: &mpsc::Sender<RelaySendItem>,
+        rx: &Arc<RelayDatagramRecvQueue>,
+    ) -> Result<()> {
+        assert!(item.datagrams.len() == 1);
+        tokio::time::timeout(Duration::from_secs(10), async move {
+            loop {
+                let res = tokio::time::timeout(UNDELIVERABLE_DATAGRAM_TIMEOUT, async {
+                    tx.send(item.clone()).await?;
+                    let RelayRecvDatagram {
+                        url: _,
+                        src: _,
+                        buf,
+                    } = future::poll_fn(|cx| rx.poll_recv(cx)).await?;
+
+                    assert_eq!(buf.as_ref(), item.datagrams[0]);
+
+                    Ok::<_, anyhow::Error>(())
+                })
+                .await;
+                if res.is_ok() {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("overall timeout exceeded");
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_active_relay_reconnect() -> TestResult {
         let _guard = iroh_test::logging::setup();
@@ -1041,13 +1365,18 @@ mod tests {
         let secret_key = SecretKey::from_bytes(&[1u8; 32]);
         let datagram_recv_queue = Arc::new(RelayDatagramRecvQueue::new());
         let (send_datagram_tx, send_datagram_rx) = mpsc::channel(16);
+        let (_fast_inbox_tx, fast_inbox_rx) = mpsc::channel(8);
         let (inbox_tx, inbox_rx) = mpsc::channel(16);
+        let cancel_token = CancellationToken::new();
         let task = start_active_relay_actor(
             secret_key,
+            cancel_token.clone(),
             relay_url.clone(),
+            fast_inbox_rx,
             inbox_rx,
             send_datagram_rx,
             datagram_recv_queue.clone(),
+            info_span!("actor-under-test"),
         );
 
         // Send a datagram to our echo node.
@@ -1057,15 +1386,12 @@ mod tests {
             url: relay_url.clone(),
             datagrams: smallvec![Bytes::from_static(b"hello")],
         };
-        send_datagram_tx.send(hello_send_item.clone()).await?;
-
-        // Check we get it back
-        let RelayRecvDatagram {
-            url: _,
-            src: _,
-            buf,
-        } = future::poll_fn(|cx| datagram_recv_queue.poll_recv(cx)).await?;
-        assert_eq!(buf.as_ref(), b"hello");
+        send_recv_echo(
+            hello_send_item.clone(),
+            &send_datagram_tx,
+            &datagram_recv_queue,
+        )
+        .await?;
 
         // Now ask to check the connection, triggering a ping but no reconnect.
         let (tx, rx) = oneshot::channel();
@@ -1084,9 +1410,12 @@ mod tests {
 
         // Echo should still work.
         info!("second echo");
-        send_datagram_tx.send(hello_send_item.clone()).await?;
-        let recv = future::poll_fn(|cx| datagram_recv_queue.poll_recv(cx)).await?;
-        assert_eq!(recv.buf.as_ref(), b"hello");
+        send_recv_echo(
+            hello_send_item.clone(),
+            &send_datagram_tx,
+            &datagram_recv_queue,
+        )
+        .await?;
 
         // Now ask to check the connection, this will reconnect without pinging because we
         // do not supply any "valid" local IP addresses.
@@ -1100,12 +1429,15 @@ mod tests {
 
         // Echo should still work.
         info!("third echo");
-        send_datagram_tx.send(hello_send_item).await?;
-        let recv = future::poll_fn(|cx| datagram_recv_queue.poll_recv(cx)).await?;
-        assert_eq!(recv.buf.as_ref(), b"hello");
+        send_recv_echo(
+            hello_send_item.clone(),
+            &send_datagram_tx,
+            &datagram_recv_queue,
+        )
+        .await?;
 
         // Shut down the actor.
-        inbox_tx.send(ActiveRelayMessage::Shutdown).await?;
+        cancel_token.cancel();
         task.await??;
 
         Ok(())
@@ -1117,25 +1449,37 @@ mod tests {
         let (_relay_map, relay_url, _server) = test_utils::run_relay_server().await?;
 
         let secret_key = SecretKey::from_bytes(&[1u8; 32]);
-        let node_id = secret_key.public();
         let datagram_recv_queue = Arc::new(RelayDatagramRecvQueue::new());
         let (_send_datagram_tx, send_datagram_rx) = mpsc::channel(16);
+        let (_fast_inbox_tx, fast_inbox_rx) = mpsc::channel(8);
         let (inbox_tx, inbox_rx) = mpsc::channel(16);
+        let cancel_token = CancellationToken::new();
         let mut task = start_active_relay_actor(
             secret_key,
+            cancel_token.clone(),
             relay_url,
+            fast_inbox_rx,
             inbox_rx,
             send_datagram_rx,
             datagram_recv_queue.clone(),
+            info_span!("actor-under-test"),
         );
 
-        // Give the task some time to run.  If it responds to HasNodeRoute it is running.
-        let (tx, rx) = oneshot::channel();
-        inbox_tx
-            .send(ActiveRelayMessage::HasNodeRoute(node_id, tx))
-            .await
-            .ok();
-        rx.await?;
+        // Wait until the actor is connected to the relay server.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let (tx, rx) = oneshot::channel();
+                inbox_tx.send(ActiveRelayMessage::PingServer(tx)).await.ok();
+                if tokio::time::timeout(Duration::from_millis(200), rx)
+                    .await
+                    .map(|resp| resp.is_ok())
+                    .unwrap_or_default()
+                {
+                    break;
+                }
+            }
+        })
+        .await?;
 
         // We now have an idling ActiveRelayActor.  If we advance time just a little it
         // should stay alive.
@@ -1157,12 +1501,43 @@ mod tests {
         tokio::time::advance(RELAY_INACTIVE_CLEANUP_TIME).await;
         tokio::time::resume();
         assert!(
-            tokio::time::timeout(Duration::from_millis(100), task)
+            tokio::time::timeout(Duration::from_secs(1), task)
                 .await
                 .is_ok(),
             "actor task still running"
         );
 
+        cancel_token.cancel();
+
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ping_tracker() {
+        tokio::time::pause();
+        let mut tracker = PingTracker::new();
+
+        let ping0 = tracker.new_ping();
+
+        let res = tokio::time::timeout(Duration::from_secs(1), tracker.timeout()).await;
+        assert!(res.is_err(), "no ping timeout has elapsed yet");
+
+        tracker.pong_received(ping0);
+        let res = tokio::time::timeout(Duration::from_secs(10), tracker.timeout()).await;
+        assert!(res.is_err(), "ping completed before timeout");
+
+        let _ping1 = tracker.new_ping();
+
+        let res = tokio::time::timeout(Duration::from_secs(10), tracker.timeout()).await;
+        assert!(res.is_ok(), "ping timeout should have happened");
+
+        let _ping2 = tracker.new_ping();
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let res = tokio::time::timeout(Duration::from_millis(1), tracker.timeout()).await;
+        assert!(res.is_ok(), "ping timeout happened in the past");
+
+        let res = tokio::time::timeout(Duration::from_secs(10), tracker.timeout()).await;
+        assert!(res.is_err(), "ping timeout should only happen once");
     }
 }

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -29,7 +29,7 @@ impl<T> MaybeFuture<T> {
         Self::default()
     }
 
-    /// Clears the value
+    /// Sets the future to None again.
     pub(crate) fn set_none(mut self: Pin<&mut Self>) {
         self.as_mut().project_replace(Self::None);
     }


### PR DESCRIPTION
## Description

Experiments with splitting the `ActiveRelayActor` a bit more.  Inspired by https://github.com/n0-computer/iroh/pull/3062#discussion_r1901728617

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions


This doesn't work yet because there's a nasty `Send` issue and I'm not determined enough to fix this yet.  But it's a nice place to discuss the architecture a bit.

What **is** nice from this is that the methods on `ConnectedRelay` become, well, methods rather than taking this `&mut state` so that part feels more natural.

What would be nice to achieve on top of this is force the `run_sending` state into the type system as well since currently calling that is rather by convention.  That would be the thing that would make this approach really appealing.

----

A totally different approach is to split the actual actor in 3 again:
- The current actor which manages:
- A send-only actor
- A receive-only-actor.

The main benefit I would hope to achieve is that the concurrency of the send/receive is easier.  In the current version keeping receive going while sending is a bit awkward.  What it does not simplify is the state change between dialing and connected that the current actor has to juggle.

The main cost is that there would be another channel between the `ActiveRelayActor` and the sending sub-actor.  The nice thing about this is that the `ActiveRelayActor` can work with permits, which could be super nice!  The hard thing is deciding on the sizing of this channel.  But maybe a single-item channel wouldn't be so bad.

I do believe this version is worth exploring more, despite the fact it introduces two more actors again (but one one more queue on the send side already discussed).  But also I'm keenly aware I'm time-limited and the current version is not bad.


## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
