### PR TITLE
feat(iroh): make Endpoint::cancel_token public

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1008,7 +1008,7 @@ impl Endpoint {
     // # Remaining private methods
 
     /// Expose the internal [`CancellationToken`] to link shutdowns.
-    pub(crate) fn cancel_token(&self) -> &CancellationToken {
+    pub fn cancel_token(&self) -> &CancellationToken {
         &self.cancel_token
     }
 


### PR DESCRIPTION
It's used inside the Router to automatically shut down if the Endpoint is shut down, but this is a privilege uniquely granted to Router since it's part of Iroh proper.

End-user code with a custom accept loop is not able to see this cancel_token method, and thus is not able to automatically shut down should the Endpoint shut down.

To bring end-user accept loops into feature parity with Iroh's internals, this method must be `pub`.

Closes https://github.com/n0-computer/iroh/issues/3096