### PR TITLE
refactor(iroh): Remove CancellationToken from Endpoint

### DIFF
--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -248,9 +248,8 @@ impl RouterBuilder {
         let mut join_set = JoinSet::new();
         let endpoint = self.endpoint.clone();
 
-        // We use a child token of the endpoint, to ensure that this is shutdown
-        // when the endpoint is shutdown, but that we can shutdown ourselves independently.
-        let cancel = endpoint.cancel_token().child_token();
+        // Our own shutdown works with a cancellation token.
+        let cancel = CancellationToken::new();
         let cancel_token = cancel.clone();
 
         let run_loop_fut = async move {
@@ -289,7 +288,7 @@ impl RouterBuilder {
                     // handle incoming p2p connections.
                     incoming = endpoint.accept() => {
                         let Some(incoming) = incoming else {
-                            break;
+                            break; // Endpoint is closed.
                         };
 
                         let protocols = protocols.clone();


### PR DESCRIPTION
## Description

The internal CancellationToke was used to know by other parts of the
code when the endpoint is shut down.  But those bits of code already
have mechanisms to do so.  This bit of API makes is a bit of extra
complexity that is not needed.

## Breaking Changes

None, this is internal.

## Notes & open questions

Closes #3096.
Closes #3098 (replaces).

Maybe not directly but now there's an example of how to write an
accept loop without having to rely on the CancellationToken.


## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.