### PR TITLE
WIP Have relay actor remove itself from clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
  "webpki-roots",
 ]
 

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -86,6 +86,7 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
 url = { version = "2.5", features = ["serde"] }
+uuid = { version = "1.11", features = ["v4"] }
 webpki = { package = "rustls-webpki", version = "0.102" }
 webpki-roots = "0.26"
 data-encoding = "2.6.0"


### PR DESCRIPTION
## Description

Still WIP.

It seems to me that if a relay client actor errors almost anywhere ([for example when reading from the connection to the client](https://github.com/n0-computer/iroh/blob/c650ea83dae8e25165c9eb9b502d58113c7febc5/iroh-relay/src/server/client.rs#L219), which happens all the time) then that `Client` never gets removed from the `Clients` unless someone else tries sending a message to that node.

The `ConnectionId` thing is a pattern I've found useful for handling connection replacements. When the new connection gets put into the `Clients` list and then the old one gets shutdown, if we didn't check the connection id then the old connection would remove the new one from the list.

Also I haven't tested these changes at all, just interested in getting thoughts on them

## Breaking Changes

None?

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
