### PR TITLE
fix(iroh): Parse DNS answer with multiple records into a proper `NodeAddr`

### DIFF
--- a/iroh/src/dns/node_info.rs
+++ b/iroh/src/dns/node_info.rs
@@ -493,38 +493,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[test]
-    fn test_record_multiple_values() -> TestResult {
-        let name = Name::from_utf8(
-            "_iroh.dgjpkxyn3zyrk3zfads5duwdgbqpkwbjxfj4yt7rezidr3fijccy.dns.iroh.link.",
-        )?;
-        let test_records = [Record::from_rdata(
-            name,
-            30,
-            RData::TXT(TXT::new(vec![
-                "addr=192.168.96.145:60165".to_string(),
-                "addr=213.208.157.87:60165".to_string(),
-                "relay=https://euw1-1.relay.iroh.network./".to_string(),
-            ])),
-        )];
-
-        let node_info = NodeInfo::from_hickory_records(&test_records)?;
-
-        assert_eq!(
-            node_info,
-            NodeInfo {
-                node_id: NodeId::from_str(
-                    "1992d53c02cdc04566e5c0edb1ce83305cd550297953a047a445ea3264b54b18"
-                )?,
-                relay_url: Some("https://euw1-1.relay.iroh.network./".parse()?),
-                direct_addresses: BTreeSet::from([
-                    "192.168.96.145:60165".parse()?,
-                    "213.208.157.87:60165".parse()?,
-                ])
-            }
-        );
-
-        Ok(())
-    }
 }

--- a/iroh/src/dns/node_info.rs
+++ b/iroh/src/dns/node_info.rs
@@ -444,8 +444,14 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    /// There used to be a bug where uploading a NodeAddr with more than only exactly
+    /// one relay URL or one publicly reachable IP addr would prevent connection
+    /// establishment.
+    ///
+    /// The reason was that only the first address was parsed (e.g. 192.168.96.145 in
+    /// this example), which could be a local, unreachable address.
     #[test]
-    fn regression_record_parse_multiple_txt_entries() -> TestResult {
+    fn test_dns_answer_multiple_txt_records() -> TestResult {
         let name = Name::from_utf8(
             "_iroh.dgjpkxyn3zyrk3zfads5duwdgbqpkwbjxfj4yt7rezidr3fijccy.dns.iroh.link.",
         )?;
@@ -489,7 +495,7 @@ mod tests {
     }
 
     #[test]
-    fn regression_record_parse_bigger_txt_record() -> TestResult {
+    fn test_record_multiple_values() -> TestResult {
         let name = Name::from_utf8(
             "_iroh.dgjpkxyn3zyrk3zfads5duwdgbqpkwbjxfj4yt7rezidr3fijccy.dns.iroh.link.",
         )?;

--- a/iroh/src/dns/node_info.rs
+++ b/iroh/src/dns/node_info.rs
@@ -442,9 +442,8 @@ mod tests {
     use iroh_base::{NodeId, SecretKey};
     use testresult::TestResult;
 
-    use crate::dns::node_info::to_z32;
-
     use super::NodeInfo;
+    use crate::dns::node_info::to_z32;
 
     #[test]
     fn txt_attr_roundtrip() {
@@ -501,7 +500,7 @@ mod tests {
             Record::from_rdata(name.clone(), 30, RData::A(A::new(127, 0, 0, 1))),
             // Test a record with a mismatching name
             Record::from_rdata(
-                Name::from_utf8(&format!(
+                Name::from_utf8(format!(
                     "_iroh.{}.dns.iroh.link.",
                     to_z32(&NodeId::from_str(
                         // Another NodeId


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
Running `iroh-doctor` this morning with flub I wasn't able to connect. Flub was on iroh 0.30, I was on iroh main (commit c650ea83).
I noticed this in the logs:
```
2025-01-08T08:09:59.939435Z DEBUG connect{me=cabd2a9e0b alpn="n0/drderp/1"}:discovery{me=cabd2a9e0b node=1992d53c02}: hickory_proto::error: response: ; header 65474:RESPONSE:RD,RA:NoError:QUERY:3/0/0
; query
;; _iroh.dgjpkxyn3zyrk3zfads5duwdgbqpkwbjxfj4yt7rezidr3fijccy.dns.iroh.link. IN TXT
; answers 3
_iroh.dgjpkxyn3zyrk3zfads5duwdgbqpkwbjxfj4yt7rezidr3fijccy.dns.iroh.link. 30 IN TXT addr=192.168.96.145:60165
_iroh.dgjpkxyn3zyrk3zfads5duwdgbqpkwbjxfj4yt7rezidr3fijccy.dns.iroh.link. 30 IN TXT addr=213.208.157.87:60165
_iroh.dgjpkxyn3zyrk3zfads5duwdgbqpkwbjxfj4yt7rezidr3fijccy.dns.iroh.link. 30 IN TXT relay=https://euw1-1.relay.iroh.network./
; nameservers 0
; additionals 0

2025-01-08T08:09:59.939617Z DEBUG connect{me=cabd2a9e0b alpn="n0/drderp/1"}:discovery{me=cabd2a9e0b node=1992d53c02}: iroh::discovery: discovery: new address found provenance=dns addr=NodeAddr { node_id: PublicKey(1992d53c02cdc04566e5c0edb1ce83305cd550297953a047a445ea3264b54b18), relay_url: None, direct_addresses: {192.168.96.145:60165} }
[...]
2025-01-08T08:10:09.545100Z DEBUG ep{me=cabd2a9e0b}:magicsock:actor:stayin_alive{node=1992d53c02}: iroh::magicsock::node_map::node_state: can not send call-me-maybe, no relay URL
```

"no relay URL"? Even though the DNS record clearly contains one.

From the logs it showed that the `DiscoveryItem` didn't contain all information from the DNS answer.

This PR adds a test that initially failed - it only parsed the first TXT record out of the DNS answer, because of a call to `records.all`, which drained the iterator of all remaining items.

It also fixes this bug by avoiding a call to `.all`.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

None.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
I tried to avoid functional changes besides the bugfix. But, all of this parsing code makes me think of [Postel's Law / the robustness principle](https://en.wikipedia.org/wiki/Robustness_principle): Instead of erroring out when we see conflicting information - should we filter out non-matching answer records?
There seems to be some difference between `from_pkarr_signed_packet` and `from_hickory_records`: The former is very lenient in what it parses, the latter is very strict and opts to error out when something's amiss.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
