### PR TITLE
test(iroh): Make `test_relay_datagram_queue` less timing dependent

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -4096,7 +4096,7 @@ mod tests {
         tasks.spawn({
             let queue = queue.clone();
             async move {
-                let mut expected_msgs: BTreeSet<usize> = (0..capacity).into_iter().collect();
+                let mut expected_msgs: BTreeSet<usize> = (0..capacity).collect();
                 while !expected_msgs.is_empty() {
                     let datagram = futures_lite::future::poll_fn(|cx| {
                         queue.poll_recv(cx).map(|result| result.unwrap())
@@ -4131,7 +4131,10 @@ mod tests {
         }
 
         // We expect all of this work to be done in 10 seconds max.
-        if let Err(_) = tokio::time::timeout(Duration::from_secs(10), tasks.join_all()).await {
+        if tokio::time::timeout(Duration::from_secs(10), tasks.join_all())
+            .await
+            .is_err()
+        {
             panic!("Timeout - not all messages between 0 and {capacity} received.");
         }
     }


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
I've seen `test_relay_datagram_queue` fail on windows recently: https://github.com/n0-computer/iroh/actions/runs/12669553316/job/35307313406

Given that
- when the test failed, it took 720ms,
- when the test succeeded, it took 150ms and 320ms,
- we've got a 100ms timeout on one of the futures, and
- the tokio scheduler (I think) doesn't optimize for average job time,

I'm not convinced there's a race condition.

So, instead I'm rewriting the test to be less timing-dependent. And less confusing as well *and* have better logging.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
