### PR TITLE
feat(iroh): implement Discovery for Arc'ed Discovery types

### DIFF
--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -447,7 +447,6 @@ mod tests {
 
     use iroh_base::SecretKey;
     use rand::Rng;
-    use testresult::TestResult;
     use tokio_util::task::AbortOnDropHandle;
 
     use super::*;

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -111,7 +111,7 @@
     doc = "[`LocalSwarmDiscovery`]: local_swarm_discovery::LocalSwarmDiscovery"
 )]
 
-use std::{collections::BTreeSet, net::SocketAddr, time::Duration};
+use std::{collections::BTreeSet, net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, ensure, Result};
 use futures_lite::stream::{Boxed as BoxStream, StreamExt};
@@ -193,6 +193,8 @@ pub trait Discovery: std::fmt::Debug + Send + Sync {
         None
     }
 }
+
+impl<T: Discovery> Discovery for Arc<T> {}
 
 /// The results returned from [`Discovery::resolve`].
 #[derive(Debug, Clone)]
@@ -445,6 +447,7 @@ mod tests {
 
     use iroh_base::SecretKey;
     use rand::Rng;
+    use testresult::TestResult;
     use tokio_util::task::AbortOnDropHandle;
 
     use super::*;
@@ -724,6 +727,21 @@ mod tests {
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("time drift")
             .as_micros() as u64
+    }
+
+    #[tokio::test]
+    async fn test_arc_discovery() -> TestResult {
+        let discovery = Arc::new(EmptyDiscovery);
+
+        let _ep = Endpoint::builder()
+            .add_discovery({
+                let discovery = discovery.clone();
+                move |_| Some(discovery)
+            })
+            .bind()
+            .await?;
+
+        Ok(())
     }
 }
 

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -728,21 +728,6 @@ mod tests {
             .expect("time drift")
             .as_micros() as u64
     }
-
-    #[tokio::test]
-    async fn test_arc_discovery() -> TestResult {
-        let discovery = Arc::new(EmptyDiscovery);
-
-        let _ep = Endpoint::builder()
-            .add_discovery({
-                let discovery = discovery.clone();
-                move |_| Some(discovery)
-            })
-            .bind()
-            .await?;
-
-        Ok(())
-    }
 }
 
 /// This module contains end-to-end tests for DNS node discovery.


### PR DESCRIPTION
## Description

Nothing in the trait stops it from working for discovery structs which
are Arc'ed.  Not all discovery types are in control of the users so
this is helpful.

I stumbled upon this because StaticProvider is not Clone.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.