### PR TITLE
feat(iroh): Allow customising the TransportConfig for connections

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -380,6 +380,9 @@ impl Builder {
     /// internet applications. Applications protocols which forbid remotely-initiated
     /// streams should set `max_concurrent_bidi_streams` and `max_concurrent_uni_streams` to
     /// zero.
+    ///
+    /// Please be aware that changing some settings may have adverse effects on establishing
+    /// and maintaining direct connections.
     pub fn transport_config(mut self, transport_config: quinn::TransportConfig) -> Self {
         self.transport_config = transport_config;
         self
@@ -608,9 +611,9 @@ impl Endpoint {
     /// Like [`Endpoint::connect`], but allows providing a custom for the connection.  See
     /// the docs of [`Endpoint::connect`] for details.
     ///
-    /// Please be aware that changing these settings may have adverse effects on
-    /// establishing and maintaining direct connections.  Carefully test settings you use
-    /// and consider this currently as still rather experimental.
+    /// Please be aware that changing some settings may have adverse effects on establishing
+    /// and maintaining direct connections.  Carefully test settings you use and consider
+    /// this currently as still rather experimental.
     pub async fn connect_with(
         &self,
         node_addr: impl Into<NodeAddr>,


### PR DESCRIPTION
## Description

Previously the TransportConfig was hardcoded for the
client (client/server in QUIC terminology: client initiates the
connection, server accepts the connection).  This rendered some
customisations on the server-side, as supported by the Builder,
impossible since the client would negotiate different limits.

Specifically the QUIC keep-alives were at a 1s or faster interval
while the connection timeout was at 30s or less.

This adds a new API marked as experimental which allows customising
the transport config for clients.

Secondly it also respects any custom TransportConfig set in the
Builder for clients as well as servers.  This is not a behaviour
change since the parameters set by default are now moved to the
Builder and due to how these are negotiated it does not matter that
the server will now also have the same values set by default.

Closes #2872.

## Breaking Changes

### iroh

If Builder::transport_config is used it will now also affect initiated
connections, while before it only affected the accepted connections.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.