### PR TITLE
feat(iroh-relay): send regular pings to check the connection

### DIFF
--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -38,6 +38,8 @@ pub mod quic;
 #[cfg(feature = "server")]
 pub mod server;
 
+mod ping_tracker;
+
 mod key_cache;
 mod relay_map;
 pub(crate) use key_cache::KeyCache;
@@ -47,4 +49,7 @@ mod dns;
 
 pub use protos::relay::MAX_PACKET_SIZE;
 
-pub use self::relay_map::{RelayMap, RelayNode, RelayQuicConfig};
+pub use self::{
+    ping_tracker::PingTracker,
+    relay_map::{RelayMap, RelayNode, RelayQuicConfig},
+};

--- a/iroh-relay/src/ping_tracker.rs
+++ b/iroh-relay/src/ping_tracker.rs
@@ -2,6 +2,9 @@ use std::time::{Duration, Instant};
 
 use tracing::debug;
 
+/// Maximum time for a ping response in the relay protocol.
+pub const PING_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Tracks pings on a single relay connection.
 ///
 /// Only the last ping needs is useful, any previously sent ping is forgotten and ignored.
@@ -17,6 +20,12 @@ struct PingInner {
     deadline: Instant,
 }
 
+impl Default for PingTracker {
+    fn default() -> Self {
+        Self::new(PING_TIMEOUT)
+    }
+}
+
 impl PingTracker {
     /// Creates a new ping tracker, setting the ping timeout for pings.
     pub fn new(default_timeout: Duration) -> Self {
@@ -24,6 +33,11 @@ impl PingTracker {
             inner: None,
             default_timeout,
         }
+    }
+
+    /// Returns the current timeout set for pings.
+    pub fn default_timeout(&self) -> Duration {
+        self.default_timeout
     }
 
     /// Starts a new ping.

--- a/iroh-relay/src/ping_tracker.rs
+++ b/iroh-relay/src/ping_tracker.rs
@@ -1,0 +1,64 @@
+use std::time::{Duration, Instant};
+
+use tracing::debug;
+
+/// Tracks pings on a single relay connection.
+///
+/// Only the last ping needs is useful, any previously sent ping is forgotten and ignored.
+#[derive(Debug)]
+pub struct PingTracker {
+    inner: Option<PingInner>,
+    default_timeout: Duration,
+}
+
+#[derive(Debug)]
+struct PingInner {
+    data: [u8; 8],
+    deadline: Instant,
+}
+
+impl PingTracker {
+    /// Creates a new ping tracker, setting the ping timeout for pings.
+    pub fn new(default_timeout: Duration) -> Self {
+        Self {
+            inner: None,
+            default_timeout,
+        }
+    }
+
+    /// Starts a new ping.
+    pub fn new_ping(&mut self) -> [u8; 8] {
+        let ping_data = rand::random();
+        debug!(data = ?ping_data, "Sending ping to relay server.");
+        self.inner = Some(PingInner {
+            data: ping_data,
+            deadline: Instant::now() + self.default_timeout,
+        });
+        ping_data
+    }
+
+    /// Updates the ping tracker with a received pong.
+    ///
+    /// Only the pong of the most recent ping will do anything.  There is no harm feeding
+    /// any pong however.
+    pub fn pong_received(&mut self, data: [u8; 8]) {
+        if self.inner.as_ref().map(|inner| inner.data) == Some(data) {
+            debug!(?data, "Pong received from relay server");
+            self.inner = None;
+        }
+    }
+
+    /// Cancel-safe waiting for a ping timeout.
+    ///
+    /// Unless the most recent sent ping times out, this will never return.
+    pub async fn timeout(&mut self) {
+        match self.inner {
+            Some(PingInner { deadline, data }) => {
+                tokio::time::sleep_until(deadline.into()).await;
+                debug!(?data, "Ping timeout.");
+                self.inner = None;
+            }
+            None => std::future::pending().await,
+        }
+    }
+}

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -41,8 +41,17 @@ const MAX_FRAME_SIZE: usize = 1024 * 1024;
 /// The Relay magic number, sent in the FrameType::ClientInfo frame upon initial connection.
 const MAGIC: &str = "RELAY🔑";
 
+/// Maximum time for a relay server to respond to a relay protocol ping.
 #[cfg(feature = "server")]
-pub(crate) const KEEP_ALIVE: Duration = Duration::from_secs(60);
+pub(crate) const PING_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Interval in which we ping the relay server to ensure the connection is alive.
+///
+/// The default QUIC max_idle_timeout is 30s, so setting that to half this time gives some
+/// chance of recovering.
+#[cfg(feature = "server")]
+pub(crate) const PING_INTERVAL: Duration = Duration::from_secs(15);
+
 /// The number of packets buffered for sending per client
 #[cfg(feature = "server")]
 pub(crate) const PER_CLIENT_SEND_QUEUE_DEPTH: usize = 512; //32;

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -41,10 +41,6 @@ const MAX_FRAME_SIZE: usize = 1024 * 1024;
 /// The Relay magic number, sent in the FrameType::ClientInfo frame upon initial connection.
 const MAGIC: &str = "RELAY🔑";
 
-/// Maximum time for a relay server to respond to a relay protocol ping.
-#[cfg(feature = "server")]
-pub(crate) const PING_TIMEOUT: Duration = Duration::from_secs(5);
-
 /// Interval in which we ping the relay server to ensure the connection is alive.
 ///
 /// The default QUIC max_idle_timeout is 30s, so setting that to half this time gives some

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, instrument, trace, warn, Instrument};
 use crate::{
     protos::{
         disco,
-        relay::{write_frame, Frame, PING_INTERVAL, PING_TIMEOUT},
+        relay::{write_frame, Frame, PING_INTERVAL},
     },
     server::{clients::Clients, metrics::Metrics, streams::RelayedStream, ClientRateLimit},
     PingTracker,
@@ -107,7 +107,7 @@ impl Client {
             node_id,
             connection_id,
             clients: clients.clone(),
-            ping_tracker: PingTracker::new(PING_TIMEOUT),
+            ping_tracker: PingTracker::default(),
         };
 
         // start io loop
@@ -592,7 +592,7 @@ mod tests {
             connection_id: 0,
             node_id,
             clients: clients.clone(),
-            ping_tracker: PingTracker::new(Duration::from_secs(5)),
+            ping_tracker: PingTracker::default(),
         };
 
         let done = CancellationToken::new();

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -250,6 +250,8 @@ impl Actor {
                 }
                 maybe_frame = self.stream.next() => {
                     self.handle_frame(maybe_frame).await.context("handle read")?;
+                    // reset the ping interval, we just received a message
+                    ping_interval.reset();
                 }
                 // First priority, disco packets
                 packet = self.disco_send_queue.recv() => {


### PR DESCRIPTION
## Description

Because of issues with TCP, we now send regular ping-pongs from client to server and vice versa.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
