### PR TITLE
fix(iroh): `AsyncUdpSocket` backpressure when connection type is *not* mixed

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -551,6 +551,7 @@ impl MagicSock {
 
                 if udp_pending && relay_pending && has_path {
                     // Handle backpressure.
+                    inc!(MagicsockMetrics, send_pending);
                     Err(io::Error::new(io::ErrorKind::WouldBlock, "pending"))
                 } else {
                     if relay_sent || udp_sent {

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -535,15 +535,21 @@ impl MagicSock {
                     }
                 }
 
-                let udp_pending = udp_error
-                    .as_ref()
-                    .map(|err| err.kind() == io::ErrorKind::WouldBlock)
-                    .unwrap_or_default();
-                let relay_pending = relay_error
-                    .as_ref()
-                    .map(|err| err.kind() == io::ErrorKind::WouldBlock)
-                    .unwrap_or_default();
-                if udp_pending && relay_pending {
+                let udp_pending = udp_addr.is_some()
+                    && udp_error
+                        .as_ref()
+                        .map(|err| err.kind() == io::ErrorKind::WouldBlock)
+                        .unwrap_or_default();
+
+                let relay_pending = relay_url.is_some()
+                    && relay_error
+                        .as_ref()
+                        .map(|err| err.kind() == io::ErrorKind::WouldBlock)
+                        .unwrap_or_default();
+
+                let has_path = udp_addr.is_some() || relay_url.is_some();
+
+                if udp_pending && relay_pending && has_path {
                     // Handle backpressure.
                     Err(io::Error::new(io::ErrorKind::WouldBlock, "pending"))
                 } else {

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -535,21 +535,21 @@ impl MagicSock {
                     }
                 }
 
-                let udp_pending = udp_addr.is_some()
-                    && udp_error
-                        .as_ref()
-                        .map(|err| err.kind() == io::ErrorKind::WouldBlock)
-                        .unwrap_or_default();
+                let udp_pending = udp_error
+                    .as_ref()
+                    .map(|err| err.kind() == io::ErrorKind::WouldBlock)
+                    .unwrap_or_default();
 
-                let relay_pending = relay_url.is_some()
-                    && relay_error
-                        .as_ref()
-                        .map(|err| err.kind() == io::ErrorKind::WouldBlock)
-                        .unwrap_or_default();
+                let relay_pending = relay_error
+                    .as_ref()
+                    .map(|err| err.kind() == io::ErrorKind::WouldBlock)
+                    .unwrap_or_default();
 
-                let has_path = udp_addr.is_some() || relay_url.is_some();
+                let udp_path = udp_addr.is_some();
+                let relay_path = relay_url.is_some();
+                let has_path = udp_path || relay_path;
 
-                if udp_pending && relay_pending && has_path {
+                if (udp_pending || !udp_path) && (relay_pending || !relay_path) && has_path {
                     // Handle backpressure.
                     inc!(MagicsockMetrics, send_pending);
                     Err(io::Error::new(io::ErrorKind::WouldBlock, "pending"))

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -20,7 +20,7 @@ pub struct Metrics {
     // Data packets (non-disco)
     pub send_data: Counter,
     pub send_data_network_down: Counter,
-    pub send_pending: Counter,
+    pub send_would_block: Counter,
     pub recv_data_relay: Counter,
     pub recv_data_ipv4: Counter,
     pub recv_data_ipv6: Counter,
@@ -100,7 +100,7 @@ impl Default for Metrics {
             // Data packets (non-disco)
             send_data: Counter::new("send_data"),
             send_data_network_down: Counter::new("send_data_network_down"),
-            send_pending: Counter::new("send_data"),
+            send_would_block: Counter::new("send_data"),
             recv_data_relay: Counter::new("recv_data_relay"),
             recv_data_ipv4: Counter::new("recv_data_ipv4"),
             recv_data_ipv6: Counter::new("recv_data_ipv6"),

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -20,6 +20,7 @@ pub struct Metrics {
     // Data packets (non-disco)
     pub send_data: Counter,
     pub send_data_network_down: Counter,
+    pub send_pending: Counter,
     pub recv_data_relay: Counter,
     pub recv_data_ipv4: Counter,
     pub recv_data_ipv6: Counter,
@@ -99,6 +100,7 @@ impl Default for Metrics {
             // Data packets (non-disco)
             send_data: Counter::new("send_data"),
             send_data_network_down: Counter::new("send_data_network_down"),
+            send_pending: Counter::new("send_data"),
             recv_data_relay: Counter::new("recv_data_relay"),
             recv_data_ipv4: Counter::new("recv_data_ipv4"),
             recv_data_ipv6: Counter::new("recv_data_ipv6"),


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
With the previous logic, when `relay_url` is `None`, then `relay_pending` is `false`.
The same is true with `udp_addr` and `udp_pending`.
However, we only ever report `WouldBlock` if `udp_pending` *and* `relay_pending`.
So this means we only ever report `WouldBlock` if `relay_url` isn't `None` and `udp_addr` isn't `None`, so when we're in mixed connection mode.
Because in e.g. direct connection mode, `relay_url` is `None`, thus `relay_pending` is `false` and we never return `Err(WouldBlock)`.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
~~I'm curious about netsim numbers.~~ No changes

Maybe this should have a test. EDIT: Hm this is really hard to test. I can't find a way to 'induce' `WouldBlock` in the relay and/or socket without fairly invasive changes that would allow replacing the socket & relay implementations.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~ Very hard to test this.
- [x] All breaking changes documented.
