### PR TITLE
chore: Remove checkboxes from PR templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,9 @@
 
 ## Change checklist
 
-- [ ] Self-review.
-- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
-- [ ] Tests if relevant.
-- [ ] All breaking changes documented.
+Please make sure to consider all of these:
+
+- Self-review.
+- Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text).
+- Tests.
+- Document breaking changes.


### PR DESCRIPTION
## Description

A significant number of our own PRs don't bother with the checkboxes.
This makes the checkboxes themselves have low value, the number of
completed tasks in the PR list has no bearing on the state of PRs.

It also makes it hard to enforce (I've tried!) and does not give us
anything to ask from external contributors either.

I'm also often torn what to do with non-applicable items, I've tried
all of:
- Remove them.  Weird.
- Strike them out, not so weird, but so much effort.
- Tick off even if not-applicable (my current approach), also weird.

So instead of bothering the humans I'm adapting to their behaviour.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

An alternative I could live with would be enforce this by machines:
Have a required CI check that needs the checkboxes ticked off so that
you can not merge a PR while ignoring this.  Maybe with some more
guidance on what to do if not applicable.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.