### PR TITLE
docs(iroh-relay): README.md: config.toml must use [tls] instead of [tlsconfig]

### DIFF
--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -49,7 +49,7 @@ The easiest get that is to generate self-signed certificates using `rcgen`
 
 Next, add the certificate paths to your iroh-relay config, here is an example of a config.toml file that will enable quic address discovery.
 ```toml
-[tlsconfig]
+[tls]
 cert_mode = "Manual"
 manual_cert_path = "/path/to/certs/cert.pem"
 manual_key_path = "/path/to/certs/cert.key.pem"


### PR DESCRIPTION
## Description

config.toml must use [tls] instead of [tlsconfig]

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
