### PR TITLE
fix(iroh): Return error if disco send via relay fails

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1214,7 +1214,9 @@ impl MagicSock {
                 self.try_send_disco_message_udp(addr, dst_key, &msg)?;
             }
             SendAddr::Relay(ref url) => {
-                self.send_disco_message_relay(url, dst_key, msg);
+                if !self.send_disco_message_relay(url, dst_key, msg) {
+                    return Err(io::Error::new(io::ErrorKind::Other, "Relay channel full"));
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
## Description

The signature of this function expects an error if the send fails, but
the relay part did not do this.  The impact of this is that you might
silently drop a packet, which makes debugging a bit harder.  Returning
an error should propagate this correctly and the failures will be
noticed and logged.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.