### PR TITLE
fix(iroh-net-report): Only add QUIC ipv6 probes if we have an ipv6 interface

### DIFF
--- a/iroh-net-report/src/reportgen/probes.rs
+++ b/iroh-net-report/src/reportgen/probes.rs
@@ -265,13 +265,13 @@ impl ProbePlan {
                             node: relay_node.clone(),
                         })
                         .expect("adding StunIpv6 probe to a StunIpv6 probe set");
+                    quic_ipv6_probes
+                        .push(Probe::QuicIpv6 {
+                            delay,
+                            node: relay_node.clone(),
+                        })
+                        .expect("adding QuicIpv6 probe to a QuicAddrIpv6 probe set");
                 }
-                quic_ipv6_probes
-                    .push(Probe::QuicIpv6 {
-                        delay,
-                        node: relay_node.clone(),
-                    })
-                    .expect("adding QuicIpv6 probe to a QuicAddrIpv6 probe set");
             }
             plan.add_if_enabled(stun_ipv4_probes);
             plan.add_if_enabled(stun_ipv6_probes);


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
Just what it says on the tin. From pattern matching the rest of the code, this seems like what it should be.

## Change checklist

- [x] Self-review.
