### PR TITLE
feat(iroh-net-report): Support wasm32 building & running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,11 +169,20 @@ jobs:
       - name: wasm32 build (iroh-relay)
         run: cargo build --target wasm32-unknown-unknown -p iroh-relay --no-default-features
 
+      - name: wasm32 build (iroh-net-report)
+        run: cargo build --target wasm32-unknown-unknown -p iroh-net-report --no-default-features
+
       # If the Wasm file contains any 'import "env"' declarations, then
       # some non-Wasm-compatible code made it into the final code.
       - name: Ensure no 'import "env"' in iroh-relay Wasm
         run: |
           ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/iroh_relay.wasm | grep 'import "env"'
+
+      # If the Wasm file contains any 'import "env"' declarations, then
+      # some non-Wasm-compatible code made it into the final code.
+      - name: Ensure no 'import "env"' in iroh-net-report Wasm
+        run: |
+          ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/iroh_net_report.wasm | grep 'import "env"'
       
 
   check_semver:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,7 +2206,9 @@ version = "0.32.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "cfg_aliases",
  "derive_more",
+ "futures-lite",
  "hickory-resolver",
  "iroh-base",
  "iroh-metrics",
@@ -3698,11 +3700,13 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "windows-registry",
@@ -5190,6 +5194,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["networking"]
 # Sadly this also needs to be updated in .github/workflows/ci.yml
 rust-version = "1.81"
 
+[lib]
+crate-type = ["lib", "cdylib"] # cdylib is needed for Wasm support
+
 [lints]
 workspace = true
 

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -21,7 +21,7 @@ bytes = "1.7"
 derive_more = { version = "1.0.0", features = ["display"] }
 iroh-base = { version = "0.32.0", path = "../iroh-base", default-features = false, features = ["relay"] }
 iroh-metrics = { version = "0.31", default-features = false }
-iroh-relay = { version = "0.32", path = "../iroh-relay" }
+iroh-relay = { version = "0.32", default-features = false, path = "../iroh-relay" }
 n0-future = "0.1.2"
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false }
 rand = "0.8"

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -19,30 +19,38 @@ workspace = true
 anyhow = "1"
 bytes = "1.7"
 derive_more = { version = "1.0.0", features = ["display"] }
-hickory-resolver = "=0.25.0-alpha.4"
 iroh-base = { version = "0.32.0", path = "../iroh-base", default-features = false, features = ["relay"] }
 iroh-metrics = { version = "0.31", default-features = false }
 iroh-relay = { version = "0.32", path = "../iroh-relay" }
 n0-future = "0.1.2"
-netwatch = { version = "0.3" }
-portmapper = { version = "0.3", default-features = false }
-quinn = { package = "iroh-quinn", version = "0.13.0" }
+quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false }
 rand = "0.8"
-reqwest = { version = "0.12", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 rustls = { version = "0.23", default-features = false }
-surge-ping = "0.8.0"
 thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["sync", "time", "macros", "rt"] }
 tokio-util = { version = "0.7.12", default-features = false }
 tracing = "0.1"
 url = { version = "2.4" }
 
+# non-wasm-in-browser dependencies
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+hickory-resolver = "=0.25.0-alpha.4"
+netwatch = { version = "0.3" }
+portmapper = { version = "0.3", default-features = false }
+surge-ping = "0.8.0"
+
 [dev-dependencies]
+futures-lite = "2.3"
 iroh-relay = { path = "../iroh-relay", features = ["test-utils", "server"] }
 pretty_assertions = "1.4"
+quinn = { package = "iroh-quinn", version = "0.13.0" }
 testresult = "0.4.0"
 tokio = { version = "1", default-features = false, features = ["test-util"] }
 tracing-test = "0.2.5"
+
+[build-dependencies]
+cfg_aliases = { version = "0.2" }
 
 [features]
 default = ["metrics"]

--- a/iroh-net-report/build.rs
+++ b/iroh-net-report/build.rs
@@ -1,0 +1,9 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    // Setup cfg aliases
+    cfg_aliases! {
+        // Convenience aliases
+        wasm_browser: { all(target_family = "wasm", target_os = "unknown") },
+    }
+}

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
+#![cfg_attr(wasm_browser, allow(unused))]
 
 use std::{
     collections::{BTreeMap, HashMap},

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, HashMap},
     fmt::{self, Debug},
     net::{SocketAddr, SocketAddrV4, SocketAddrV6},
     sync::Arc,
@@ -43,6 +43,8 @@ mod metrics;
 mod ping;
 mod reportgen;
 
+mod options;
+
 /// We "vendor" what we need of the library in browsers for simplicity.
 ///
 /// We could consider making `portmapper` compile to wasm in the future,
@@ -65,7 +67,7 @@ pub mod portmapper {
 #[cfg(not(wasm_browser))]
 pub use ip_mapped_addrs::{IpMappedAddr, IpMappedAddrError, IpMappedAddresses, MAPPED_ADDR_PORT};
 pub use metrics::Metrics;
-use reportgen::ProbeProto;
+pub use options::Options;
 pub use reportgen::QuicConfig;
 #[cfg(not(wasm_browser))]
 use reportgen::SocketState;
@@ -235,186 +237,6 @@ impl Default for Reports {
             last: Default::default(),
             last_full: Instant::now(),
         }
-    }
-}
-
-/// Options for running probes
-///
-/// By default, will run icmp over IPv4, icmp over IPv6, and Https probes.
-///
-/// Use [`Options::stun_v4`], [`Options::stun_v6`], and [`Options::quic_config`]
-/// to enable STUN over IPv4, STUN over IPv6, and QUIC address discovery.
-#[cfg(not(wasm_browser))]
-#[derive(Debug, Clone)]
-pub struct Options {
-    /// Socket to send IPv4 STUN probes from.
-    ///
-    /// Responses are never read from this socket, they must be passed in via internal
-    /// messaging since, when used internally in iroh, the socket is also used to receive
-    /// other packets from in the magicsocket (`MagicSock`).
-    ///
-    /// If not provided, STUN probes will not be sent over IPv4.
-    stun_sock_v4: Option<Arc<UdpSocket>>,
-    /// Socket to send IPv6 STUN probes from.
-    ///
-    /// Responses are never read from this socket, they must be passed in via internal
-    /// messaging since, when used internally in iroh, the socket is also used to receive
-    /// other packets from in the magicsocket (`MagicSock`).
-    ///
-    /// If not provided, STUN probes will not be sent over IPv6.
-    stun_sock_v6: Option<Arc<UdpSocket>>,
-    /// The configuration needed to launch QUIC address discovery probes.
-    ///
-    /// If not provided, will not run QUIC address discovery.
-    quic_config: Option<QuicConfig>,
-    /// Enable icmp_v4 probes
-    ///
-    /// On by default
-    icmp_v4: bool,
-    /// Enable icmp_v6 probes
-    ///
-    /// On by default
-    icmp_v6: bool,
-    /// Enable https probes
-    ///
-    /// On by default
-    https: bool,
-}
-
-#[cfg(not(wasm_browser))]
-impl Default for Options {
-    fn default() -> Self {
-        Self {
-            stun_sock_v4: None,
-            stun_sock_v6: None,
-            quic_config: None,
-            icmp_v4: true,
-            icmp_v6: true,
-            https: true,
-        }
-    }
-}
-
-#[cfg(not(wasm_browser))]
-impl Options {
-    /// Create an [`Options`] that disables all probes
-    pub fn disabled() -> Self {
-        Self {
-            stun_sock_v4: None,
-            stun_sock_v6: None,
-            quic_config: None,
-            icmp_v4: false,
-            icmp_v6: false,
-            https: false,
-        }
-    }
-
-    /// Set the ipv4 stun socket and enable ipv4 stun probes
-    pub fn stun_v4(mut self, sock: Option<Arc<UdpSocket>>) -> Self {
-        self.stun_sock_v4 = sock;
-        self
-    }
-
-    /// Set the ipv6 stun socket and enable ipv6 stun probes
-    pub fn stun_v6(mut self, sock: Option<Arc<UdpSocket>>) -> Self {
-        self.stun_sock_v6 = sock;
-        self
-    }
-
-    /// Enable quic probes
-    pub fn quic_config(mut self, quic_config: Option<QuicConfig>) -> Self {
-        self.quic_config = quic_config;
-        self
-    }
-
-    /// Enable or disable icmp_v4 probe
-    pub fn icmp_v4(mut self, enable: bool) -> Self {
-        self.icmp_v4 = enable;
-        self
-    }
-
-    /// Enable or disable icmp_v6 probe
-    pub fn icmp_v6(mut self, enable: bool) -> Self {
-        self.icmp_v6 = enable;
-        self
-    }
-
-    /// Enable or disable https probe
-    pub fn https(mut self, enable: bool) -> Self {
-        self.https = enable;
-        self
-    }
-
-    /// Turn the options into set of valid protocols
-    fn to_protocols(&self) -> BTreeSet<ProbeProto> {
-        let mut protocols = BTreeSet::new();
-        if self.stun_sock_v4.is_some() {
-            protocols.insert(ProbeProto::StunIpv4);
-        }
-        if self.stun_sock_v6.is_some() {
-            protocols.insert(ProbeProto::StunIpv6);
-        }
-        if let Some(ref quic) = self.quic_config {
-            if quic.ipv4 {
-                protocols.insert(ProbeProto::QuicIpv4);
-            }
-            if quic.ipv6 {
-                protocols.insert(ProbeProto::QuicIpv6);
-            }
-        }
-        if self.icmp_v4 {
-            protocols.insert(ProbeProto::IcmpV4);
-        }
-        if self.icmp_v6 {
-            protocols.insert(ProbeProto::IcmpV6);
-        }
-        if self.https {
-            protocols.insert(ProbeProto::Https);
-        }
-        protocols
-    }
-}
-
-/// Options for running probes (in browsers).
-///
-/// Only HTTPS probes are supported in browsers.
-/// These are run by default.
-#[cfg(wasm_browser)]
-#[derive(Debug, Clone)]
-pub struct Options {
-    /// Enable https probes
-    ///
-    /// On by default
-    https: bool,
-}
-
-#[cfg(wasm_browser)]
-impl Default for Options {
-    fn default() -> Self {
-        Self { https: true }
-    }
-}
-
-#[cfg(wasm_browser)]
-impl Options {
-    /// Create an [`Options`] that disables all probes
-    pub fn disabled() -> Self {
-        Self { https: false }
-    }
-
-    /// Enable or disable https probe
-    pub fn https(mut self, enable: bool) -> Self {
-        self.https = enable;
-        self
-    }
-
-    /// Turn the options into set of valid protocols
-    fn to_protocols(&self) -> BTreeSet<ProbeProto> {
-        let mut protocols = BTreeSet::new();
-        if self.https {
-            protocols.insert(ProbeProto::Https);
-        }
-        protocols
     }
 }
 

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -949,6 +949,12 @@ pub fn os_has_ipv6() -> bool {
     UdpSocket::bind_local_v6(0).is_ok()
 }
 
+/// Always returns false in browsers
+#[cfg(wasm_browser)]
+pub fn os_has_ipv6() -> bool {
+    false
+}
+
 #[cfg(any(test, feature = "stun-utils"))]
 pub(crate) mod stun_utils {
     use anyhow::Context as _;

--- a/iroh-net-report/src/options.rs
+++ b/iroh-net-report/src/options.rs
@@ -1,0 +1,191 @@
+pub use imp::Options;
+
+#[cfg(not(wasm_browser))]
+mod imp {
+    use std::{collections::BTreeSet, sync::Arc};
+
+    use netwatch::UdpSocket;
+
+    use crate::{reportgen::ProbeProto, QuicConfig};
+
+    /// Options for running probes
+    ///
+    /// By default, will run icmp over IPv4, icmp over IPv6, and Https probes.
+    ///
+    /// Use [`Options::stun_v4`], [`Options::stun_v6`], and [`Options::quic_config`]
+    /// to enable STUN over IPv4, STUN over IPv6, and QUIC address discovery.
+    #[derive(Debug, Clone)]
+    pub struct Options {
+        /// Socket to send IPv4 STUN probes from.
+        ///
+        /// Responses are never read from this socket, they must be passed in via internal
+        /// messaging since, when used internally in iroh, the socket is also used to receive
+        /// other packets from in the magicsocket (`MagicSock`).
+        ///
+        /// If not provided, STUN probes will not be sent over IPv4.
+        pub(crate) stun_sock_v4: Option<Arc<UdpSocket>>,
+        /// Socket to send IPv6 STUN probes from.
+        ///
+        /// Responses are never read from this socket, they must be passed in via internal
+        /// messaging since, when used internally in iroh, the socket is also used to receive
+        /// other packets from in the magicsocket (`MagicSock`).
+        ///
+        /// If not provided, STUN probes will not be sent over IPv6.
+        pub(crate) stun_sock_v6: Option<Arc<UdpSocket>>,
+        /// The configuration needed to launch QUIC address discovery probes.
+        ///
+        /// If not provided, will not run QUIC address discovery.
+        pub(crate) quic_config: Option<QuicConfig>,
+        /// Enable icmp_v4 probes
+        ///
+        /// On by default
+        pub(crate) icmp_v4: bool,
+        /// Enable icmp_v6 probes
+        ///
+        /// On by default
+        pub(crate) icmp_v6: bool,
+        /// Enable https probes
+        ///
+        /// On by default
+        pub(crate) https: bool,
+    }
+
+    impl Default for Options {
+        fn default() -> Self {
+            Self {
+                stun_sock_v4: None,
+                stun_sock_v6: None,
+                quic_config: None,
+                icmp_v4: true,
+                icmp_v6: true,
+                https: true,
+            }
+        }
+    }
+
+    impl Options {
+        /// Create an [`Options`] that disables all probes
+        pub fn disabled() -> Self {
+            Self {
+                stun_sock_v4: None,
+                stun_sock_v6: None,
+                quic_config: None,
+                icmp_v4: false,
+                icmp_v6: false,
+                https: false,
+            }
+        }
+
+        /// Set the ipv4 stun socket and enable ipv4 stun probes
+        pub fn stun_v4(mut self, sock: Option<Arc<UdpSocket>>) -> Self {
+            self.stun_sock_v4 = sock;
+            self
+        }
+
+        /// Set the ipv6 stun socket and enable ipv6 stun probes
+        pub fn stun_v6(mut self, sock: Option<Arc<UdpSocket>>) -> Self {
+            self.stun_sock_v6 = sock;
+            self
+        }
+
+        /// Enable quic probes
+        pub fn quic_config(mut self, quic_config: Option<QuicConfig>) -> Self {
+            self.quic_config = quic_config;
+            self
+        }
+
+        /// Enable or disable icmp_v4 probe
+        pub fn icmp_v4(mut self, enable: bool) -> Self {
+            self.icmp_v4 = enable;
+            self
+        }
+
+        /// Enable or disable icmp_v6 probe
+        pub fn icmp_v6(mut self, enable: bool) -> Self {
+            self.icmp_v6 = enable;
+            self
+        }
+
+        /// Enable or disable https probe
+        pub fn https(mut self, enable: bool) -> Self {
+            self.https = enable;
+            self
+        }
+
+        /// Turn the options into set of valid protocols
+        pub(crate) fn to_protocols(&self) -> BTreeSet<ProbeProto> {
+            let mut protocols = BTreeSet::new();
+            if self.stun_sock_v4.is_some() {
+                protocols.insert(ProbeProto::StunIpv4);
+            }
+            if self.stun_sock_v6.is_some() {
+                protocols.insert(ProbeProto::StunIpv6);
+            }
+            if let Some(ref quic) = self.quic_config {
+                if quic.ipv4 {
+                    protocols.insert(ProbeProto::QuicIpv4);
+                }
+                if quic.ipv6 {
+                    protocols.insert(ProbeProto::QuicIpv6);
+                }
+            }
+            if self.icmp_v4 {
+                protocols.insert(ProbeProto::IcmpV4);
+            }
+            if self.icmp_v6 {
+                protocols.insert(ProbeProto::IcmpV6);
+            }
+            if self.https {
+                protocols.insert(ProbeProto::Https);
+            }
+            protocols
+        }
+    }
+}
+
+#[cfg(wasm_browser)]
+mod imp {
+    use std::collections::BTreeSet;
+
+    use crate::reportgen::ProbeProto;
+
+    /// Options for running probes (in browsers).
+    ///
+    /// Only HTTPS probes are supported in browsers.
+    /// These are run by default.
+    #[derive(Debug, Clone)]
+    pub struct Options {
+        /// Enable https probes
+        ///
+        /// On by default
+        pub(crate) https: bool,
+    }
+
+    impl Default for Options {
+        fn default() -> Self {
+            Self { https: true }
+        }
+    }
+
+    impl Options {
+        /// Create an [`Options`] that disables all probes
+        pub fn disabled() -> Self {
+            Self { https: false }
+        }
+
+        /// Enable or disable https probe
+        pub fn https(mut self, enable: bool) -> Self {
+            self.https = enable;
+            self
+        }
+
+        /// Turn the options into set of valid protocols
+        pub(crate) fn to_protocols(&self) -> BTreeSet<ProbeProto> {
+            let mut protocols = BTreeSet::new();
+            if self.https {
+                protocols.insert(ProbeProto::Https);
+            }
+            protocols
+        }
+    }
+}

--- a/iroh-net-report/src/options.rs
+++ b/iroh-net-report/src/options.rs
@@ -1,3 +1,5 @@
+//! Options for creating a report gen client.
+
 pub use imp::Options;
 
 #[cfg(not(wasm_browser))]

--- a/iroh-net-report/src/ping.rs
+++ b/iroh-net-report/src/ping.rs
@@ -4,10 +4,10 @@ use std::{
     fmt::Debug,
     net::IpAddr,
     sync::{Arc, Mutex},
-    time::Duration,
 };
 
 use anyhow::{Context, Result};
+use n0_future::time::Duration;
 use surge_ping::{Client, Config, IcmpPacket, PingIdentifier, PingSequence, ICMP};
 use tracing::debug;
 

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -86,6 +86,9 @@ pub(super) struct Client {
     _drop_guard: AbortOnDropHandle<()>,
 }
 
+/// Any state that depends on sockets being available in the current environment.
+///
+/// Factored out so it can be disabled easily in browsers.
 #[cfg(not(wasm_browser))]
 #[derive(Debug, Clone)]
 pub(crate) struct SocketState {
@@ -208,6 +211,7 @@ struct Actor {
     protocols: BTreeSet<ProbeProto>,
     /// Optional [`IpMappedAddresses`] used to enable QAD in iroh
 
+    /// Any socket-related state that doesn't exist/work in browsers
     #[cfg(not(wasm_browser))]
     socket_state: SocketState,
     /// The hairpin actor.

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -29,9 +29,10 @@ use anyhow::{anyhow, bail, Context as _, Result};
 use iroh_base::RelayUrl;
 #[cfg(feature = "metrics")]
 use iroh_metrics::inc;
+#[cfg(not(wasm_browser))]
+use iroh_relay::dns::DnsResolver;
 use iroh_relay::{
     defaults::{DEFAULT_RELAY_QUIC_PORT, DEFAULT_STUN_PORT},
-    dns::DnsResolver,
     http::RELAY_PROBE_PATH,
     protos::stun,
     RelayMap, RelayNode,
@@ -39,7 +40,9 @@ use iroh_relay::{
 use n0_future::{
     task::{self, AbortOnDropHandle, JoinSet},
     time::{self, Duration, Instant},
+    StreamExt as _,
 };
+#[cfg(not(wasm_browser))]
 use netwatch::{interfaces, UdpSocket};
 use rand::seq::IteratorRandom;
 use tokio::sync::{mpsc, oneshot};
@@ -48,15 +51,16 @@ use url::Host;
 
 #[cfg(feature = "metrics")]
 use crate::Metrics;
+use crate::{self as net_report, Report};
+#[cfg(not(wasm_browser))]
 use crate::{
-    self as net_report,
     defaults::timeouts::DNS_TIMEOUT,
     dns::DNS_STAGGERING_MS,
     ip_mapped_addrs::IpMappedAddresses,
     ping::{PingError, Pinger},
-    Report,
 };
 
+#[cfg(not(wasm_browser))]
 mod hairpin;
 mod probes;
 
@@ -87,14 +91,14 @@ impl Client {
     pub(super) fn new(
         net_report: net_report::Addr,
         last_report: Option<Arc<Report>>,
-        port_mapper: Option<portmapper::Client>,
+        #[cfg(not(wasm_browser))] port_mapper: Option<portmapper::Client>,
         relay_map: RelayMap,
-        stun_sock4: Option<Arc<UdpSocket>>,
-        stun_sock6: Option<Arc<UdpSocket>>,
-        quic_config: Option<QuicConfig>,
-        dns_resolver: DnsResolver,
+        #[cfg(not(wasm_browser))] stun_sock4: Option<Arc<UdpSocket>>,
+        #[cfg(not(wasm_browser))] stun_sock6: Option<Arc<UdpSocket>>,
+        #[cfg(not(wasm_browser))] quic_config: Option<QuicConfig>,
+        #[cfg(not(wasm_browser))] dns_resolver: DnsResolver,
         protocols: BTreeSet<ProbeProto>,
-        ip_mapped_addrs: Option<IpMappedAddresses>,
+        #[cfg(not(wasm_browser))] ip_mapped_addrs: Option<IpMappedAddresses>,
     ) -> Self {
         let (msg_tx, msg_rx) = mpsc::channel(32);
         let addr = Addr {
@@ -105,16 +109,23 @@ impl Client {
             msg_rx,
             net_report: net_report.clone(),
             last_report,
+            #[cfg(not(wasm_browser))]
             port_mapper,
             relay_map,
+            #[cfg(not(wasm_browser))]
             stun_sock4,
+            #[cfg(not(wasm_browser))]
             stun_sock6,
+            #[cfg(not(wasm_browser))]
             quic_config,
             report: Report::default(),
+            #[cfg(not(wasm_browser))]
             hairpin_actor: hairpin::Client::new(net_report, addr),
             outstanding_tasks: OutstandingTasks::default(),
+            #[cfg(not(wasm_browser))]
             dns_resolver,
             protocols,
+            #[cfg(not(wasm_browser))]
             ip_mapped_addrs,
         };
         let task =
@@ -177,31 +188,38 @@ struct Actor {
     /// The previous report, if it exists.
     last_report: Option<Arc<Report>>,
     /// The portmapper client, if there is one.
+    #[cfg(not(wasm_browser))]
     port_mapper: Option<portmapper::Client>,
     /// The relay configuration.
     relay_map: RelayMap,
     /// Socket to send IPv4 STUN requests from.
+    #[cfg(not(wasm_browser))]
     stun_sock4: Option<Arc<UdpSocket>>,
     /// Socket so send IPv6 STUN requests from.
+    #[cfg(not(wasm_browser))]
     stun_sock6: Option<Arc<UdpSocket>>,
     /// QUIC configuration to do QUIC address Discovery
+    #[cfg(not(wasm_browser))]
     quic_config: Option<QuicConfig>,
 
     // Internal state.
     /// The report being built.
     report: Report,
     /// The hairpin actor.
+    #[cfg(not(wasm_browser))]
     hairpin_actor: hairpin::Client,
     /// Which tasks the [`Actor`] is still waiting on.
     ///
     /// This is essentially the summary of all the work the [`Actor`] is doing.
     outstanding_tasks: OutstandingTasks,
     /// The DNS resolver to use for probes that need to resolve DNS records.
+    #[cfg(not(wasm_browser))]
     dns_resolver: DnsResolver,
     /// Protocols we should attempt to create probes for, if we have the correct
     /// configuration for that protocol.
     protocols: BTreeSet<ProbeProto>,
     /// Optional [`IpMappedAddresses`] used to enable QAD in iroh
+    #[cfg(not(wasm_browser))]
     ip_mapped_addrs: Option<IpMappedAddresses>,
 }
 
@@ -237,15 +255,25 @@ impl Actor {
     ///   - Updates the report, cancels unneeded futures.
     /// - Sends the report to the net_report actor.
     async fn run_inner(&mut self) -> Result<()> {
-        debug!(
-            port_mapper = %self.port_mapper.is_some(),
-            "reportstate actor starting",
-        );
+        #[cfg(not(wasm_browser))]
+        let port_mapper = self.port_mapper.is_some();
+        #[cfg(wasm_browser)]
+        let port_mapper = false;
+        debug!(%port_mapper, "reportstate actor starting");
 
-        self.report.os_has_ipv6 = super::os_has_ipv6();
+        #[cfg(not(wasm_browser))]
+        {
+            self.report.os_has_ipv6 = super::os_has_ipv6();
+        }
 
+        #[cfg(not(wasm_browser))]
         let mut port_mapping = self.prepare_portmapper_task();
+        #[cfg(wasm_browser)]
+        let mut port_mapping = n0_future::future::pending();
+        #[cfg(not(wasm_browser))]
         let mut captive_task = self.prepare_captive_portal_task();
+        #[cfg(wasm_browser)]
+        let mut captive_task = n0_future::future::pending();
         let mut probes = self.spawn_probes_task().await?;
 
         let total_timer = time::sleep(OVERALL_REPORT_TIMEOUT);
@@ -278,10 +306,14 @@ impl Actor {
 
                 // Drive the portmapper.
                 pm = &mut port_mapping, if self.outstanding_tasks.port_mapper => {
-                    debug!(report=?pm, "tick: portmapper probe report");
-                    self.report.portmap_probe = pm;
-                    port_mapping.inner = None;
-                    self.outstanding_tasks.port_mapper = false;
+                    // This future is completely disabled in wasm.
+                    #[cfg(not(wasm_browser))]
+                    {
+                        debug!(report=?pm, "tick: portmapper probe report");
+                        self.report.portmap_probe = pm;
+                        port_mapping.inner = None;
+                        self.outstanding_tasks.port_mapper = false;
+                    }
                 }
 
                 // Check for probes finishing.
@@ -302,10 +334,14 @@ impl Actor {
 
                 // Drive the captive task.
                 found = &mut captive_task, if self.outstanding_tasks.captive_task => {
-                    trace!("tick: captive portal task done");
-                    self.report.captive_portal = found;
-                    captive_task.inner = None;
-                    self.outstanding_tasks.captive_task = false;
+                    // This future is completely disabled in wasm.
+                    #[cfg(not(wasm_browser))]
+                    {
+                        trace!("tick: captive portal task done");
+                        self.report.captive_portal = found;
+                        captive_task.inner = None;
+                        self.outstanding_tasks.captive_task = false;
+                    }
                 }
 
                 // Handle actor messages.
@@ -364,6 +400,7 @@ impl Actor {
         update_report(&mut self.report, probe_report);
 
         // When we discover the first IPv4 address we want to start the hairpin actor.
+        #[cfg(not(wasm_browser))]
         if let Some(ref addr) = self.report.global_v4 {
             if !self.hairpin_actor.has_started() {
                 self.hairpin_actor.start_check(*addr);
@@ -412,6 +449,7 @@ impl Actor {
         }
 
         // If the probe is for IPv6 and we don't yet have an IPv6 report, that would help.
+        #[cfg(not(wasm_browser))]
         if probe.proto() == ProbeProto::StunIpv6 && self.report.relay_v6_latency.is_empty() {
             return true;
         }
@@ -422,6 +460,7 @@ impl Actor {
         // talking to. If we don't yet have two results yet
         // (`mapping_varies_by_dest_ip` is blank), then another IPv4 probe
         // would be good.
+        #[cfg(not(wasm_browser))]
         if probe.proto() == ProbeProto::StunIpv4 && self.report.mapping_varies_by_dest_ip.is_none()
         {
             return true;
@@ -448,6 +487,7 @@ impl Actor {
     /// Creates the future which will perform the portmapper task.
     ///
     /// The returned future will run the portmapper, if enabled, resolving to it's result.
+    #[cfg(not(wasm_browser))]
     fn prepare_portmapper_task(
         &mut self,
     ) -> MaybeFuture<Pin<Box<impl Future<Output = Option<portmapper::ProbeOutput>>>>> {
@@ -472,6 +512,7 @@ impl Actor {
     }
 
     /// Creates the future which will perform the captive portal check.
+    #[cfg(not(wasm_browser))]
     fn prepare_captive_portal_task(
         &mut self,
     ) -> MaybeFuture<Pin<Box<impl Future<Output = Option<bool>>>>> {
@@ -543,19 +584,31 @@ impl Actor {
     ///   - Once there are [`ProbeReport`]s from enough nodes, all remaining probes are
     ///     aborted.  That is, the main actor loop stops polling them.
     async fn spawn_probes_task(&mut self) -> Result<JoinSet<Result<ProbeReport>>> {
+        #[cfg(not(wasm_browser))]
         let if_state = interfaces::State::new().await;
+        #[cfg(not(wasm_browser))]
         debug!(%if_state, "Local interfaces");
         let plan = match self.last_report {
-            Some(ref report) => {
-                ProbePlan::with_last_report(&self.relay_map, &if_state, report, &self.protocols)
-            }
-            None => ProbePlan::initial(&self.relay_map, &if_state, &self.protocols),
+            Some(ref report) => ProbePlan::with_last_report(
+                &self.relay_map,
+                #[cfg(not(wasm_browser))]
+                &if_state,
+                report,
+                &self.protocols,
+            ),
+            None => ProbePlan::initial(
+                &self.relay_map,
+                #[cfg(not(wasm_browser))]
+                &if_state,
+                &self.protocols,
+            ),
         };
         trace!(%plan, "probe plan");
 
         // The pinger is created here so that any sockets that might be bound for it are
         // shared between the probes that use it.  It binds sockets lazily, so we can always
         // create it.
+        #[cfg(not(wasm_browser))]
         let pinger = Pinger::new();
 
         // A collection of futures running probe sets.
@@ -564,27 +617,39 @@ impl Actor {
             let mut set = JoinSet::default();
             for probe in probe_set {
                 let reportstate = self.addr();
+                #[cfg(not(wasm_browser))]
                 let stun_sock4 = self.stun_sock4.clone();
+                #[cfg(not(wasm_browser))]
                 let stun_sock6 = self.stun_sock6.clone();
+                #[cfg(not(wasm_browser))]
                 let quic_config = self.quic_config.clone();
                 let relay_node = probe.node().clone();
                 let probe = probe.clone();
                 let net_report = self.net_report.clone();
+                #[cfg(not(wasm_browser))]
                 let pinger = pinger.clone();
+                #[cfg(not(wasm_browser))]
                 let dns_resolver = self.dns_resolver.clone();
+                #[cfg(not(wasm_browser))]
                 let ip_mapped_addrs = self.ip_mapped_addrs.clone();
 
                 set.spawn(
                     run_probe(
                         reportstate,
+                        #[cfg(not(wasm_browser))]
                         stun_sock4,
+                        #[cfg(not(wasm_browser))]
                         stun_sock6,
+                        #[cfg(not(wasm_browser))]
                         quic_config,
                         relay_node,
                         probe.clone(),
                         net_report,
+                        #[cfg(not(wasm_browser))]
                         pinger,
+                        #[cfg(not(wasm_browser))]
                         dns_resolver,
+                        #[cfg(not(wasm_browser))]
                         ip_mapped_addrs,
                     )
                     .instrument(debug_span!("run_probe", %probe)),
@@ -713,15 +778,15 @@ pub struct QuicConfig {
 #[allow(clippy::too_many_arguments)]
 async fn run_probe(
     reportstate: Addr,
-    stun_sock4: Option<Arc<UdpSocket>>,
-    stun_sock6: Option<Arc<UdpSocket>>,
-    quic_config: Option<QuicConfig>,
+    #[cfg(not(wasm_browser))] stun_sock4: Option<Arc<UdpSocket>>,
+    #[cfg(not(wasm_browser))] stun_sock6: Option<Arc<UdpSocket>>,
+    #[cfg(not(wasm_browser))] quic_config: Option<QuicConfig>,
     relay_node: Arc<RelayNode>,
     probe: Probe,
     net_report: net_report::Addr,
-    pinger: Pinger,
-    dns_resolver: DnsResolver,
-    ip_mapped_addrs: Option<IpMappedAddresses>,
+    #[cfg(not(wasm_browser))] pinger: Pinger,
+    #[cfg(not(wasm_browser))] dns_resolver: DnsResolver,
+    #[cfg(not(wasm_browser))] ip_mapped_addrs: Option<IpMappedAddresses>,
 ) -> Result<ProbeReport, ProbeError> {
     if !probe.delay().is_zero() {
         trace!("delaying probe");
@@ -755,6 +820,7 @@ async fn run_probe(
         ));
     }
 
+    #[cfg(not(wasm_browser))]
     let relay_addr = get_relay_addr(&dns_resolver, &relay_node, probe.proto())
         .await
         .context("no relay node addr")
@@ -762,6 +828,7 @@ async fn run_probe(
 
     let mut result = ProbeReport::new(probe.clone());
     match probe {
+        #[cfg(not(wasm_browser))]
         Probe::StunIpv4 { .. } | Probe::StunIpv6 { .. } => {
             let maybe_sock = if matches!(probe, Probe::StunIpv4 { .. }) {
                 stun_sock4.as_ref()
@@ -780,13 +847,22 @@ async fn run_probe(
                 }
             }
         }
+        #[cfg(not(wasm_browser))]
         Probe::IcmpV4 { .. } | Probe::IcmpV6 { .. } => {
             result = run_icmp_probe(probe, relay_addr, pinger).await?
         }
         Probe::Https { ref node, .. } => {
             debug!("sending probe HTTPS");
-            match measure_https_latency(&dns_resolver, node, None).await {
+            match measure_https_latency(
+                #[cfg(not(wasm_browser))]
+                &dns_resolver,
+                node,
+                None,
+            )
+            .await
+            {
                 Ok((latency, ip)) => {
+                    debug!(?latency, "latency");
                     result.latency = Some(latency);
                     // We set these IPv4 and IPv6 but they're not really used
                     // and we don't necessarily set them both. If UDP is blocked
@@ -804,6 +880,7 @@ async fn run_probe(
             }
         }
 
+        #[cfg(not(wasm_browser))]
         Probe::QuicIpv4 { ref node, .. } | Probe::QuicIpv6 { ref node, .. } => {
             debug!("sending QUIC address discovery probe");
             let url = node.url.clone();
@@ -827,6 +904,7 @@ async fn run_probe(
 }
 
 /// Run a STUN IPv4 or IPv6 probe.
+#[cfg(not(wasm_browser))]
 async fn run_stun_probe(
     sock: &Arc<UdpSocket>,
     relay_addr: SocketAddr,
@@ -909,6 +987,7 @@ async fn run_stun_probe(
     }
 }
 
+#[cfg(not(wasm_browser))]
 fn maybe_to_mapped_addr(
     ip_mapped_addrs: Option<IpMappedAddresses>,
     addr: SocketAddr,
@@ -920,6 +999,7 @@ fn maybe_to_mapped_addr(
 }
 
 /// Run a QUIC address discovery probe.
+#[cfg(not(wasm_browser))]
 async fn run_quic_probe(
     quic_config: QuicConfig,
     url: RelayUrl,
@@ -964,6 +1044,7 @@ async fn run_quic_probe(
 /// return a "204 No Content" response and checking if that's what we get.
 ///
 /// The boolean return is whether we think we have a captive portal.
+#[cfg(not(wasm_browser))]
 async fn check_captive_portal(
     dns_resolver: &DnsResolver,
     dm: &RelayMap,
@@ -997,6 +1078,7 @@ async fn check_captive_portal(
     };
 
     let mut builder = reqwest::ClientBuilder::new().redirect(reqwest::redirect::Policy::none());
+
     if let Some(Host::Domain(domain)) = url.host() {
         // Use our own resolver rather than getaddrinfo
         //
@@ -1047,6 +1129,7 @@ async fn check_captive_portal(
 /// Returns the proper port based on the protocol of the probe.
 fn get_port(relay_node: &RelayNode, proto: &ProbeProto) -> Result<u16> {
     match proto {
+        #[cfg(not(wasm_browser))]
         ProbeProto::QuicIpv4 | ProbeProto::QuicIpv6 => {
             if let Some(ref quic) = relay_node.quic {
                 if quic.port == 0 {
@@ -1078,6 +1161,7 @@ fn get_port(relay_node: &RelayNode, proto: &ProbeProto) -> Result<u16> {
 /// assume that we are running this net report with `iroh`, and need to provide mapped
 /// addresses to the probe in order for it to function in the specialize iroh-quinn
 /// endpoint that expects mapped addresses.
+#[cfg(not(wasm_browser))]
 async fn get_relay_addr(
     dns_resolver: &DnsResolver,
     relay_node: &RelayNode,
@@ -1163,6 +1247,7 @@ async fn relay_lookup_ipv6_staggered(
 ///
 /// The `pinger` is passed in so the ping sockets are only bound once
 /// for the probe set.
+#[cfg(not(wasm_browser))]
 async fn run_icmp_probe(
     probe: Probe,
     relay_addr: SocketAddr,
@@ -1183,6 +1268,7 @@ async fn run_icmp_probe(
                 anyhow!("Failed to create pinger ({err:#}), aborting probeset"),
                 probe.clone(),
             ),
+            #[cfg(not(wasm_browser))]
             PingError::Ping(err) => ProbeError::Error(err.into(), probe.clone()),
         })?;
     debug!(dst = %relay_addr, len = DATA.len(), ?latency, "ICMP ping done");
@@ -1207,7 +1293,7 @@ async fn run_icmp_probe(
 /// use of self-signed certificates for servers.  Currently this is used for testing.
 #[allow(clippy::unused_async)]
 async fn measure_https_latency(
-    dns_resolver: &DnsResolver,
+    #[cfg(not(wasm_browser))] dns_resolver: &DnsResolver,
     node: &RelayNode,
     certs: Option<Vec<rustls::pki_types::CertificateDer<'static>>>,
 ) -> Result<(Duration, IpAddr)> {
@@ -1216,7 +1302,14 @@ async fn measure_https_latency(
     // This should also use same connection establishment as relay client itself, which
     // needs to be more configurable so users can do more crazy things:
     // https://github.com/n0-computer/iroh/issues/2901
-    let mut builder = reqwest::ClientBuilder::new().redirect(reqwest::redirect::Policy::none());
+    let mut builder = reqwest::ClientBuilder::new();
+
+    #[cfg(not(wasm_browser))]
+    {
+        builder = builder.redirect(reqwest::redirect::Policy::none());
+    }
+
+    #[cfg(not(wasm_browser))]
     if let Some(Host::Domain(domain)) = url.host() {
         // Use our own resolver rather than getaddrinfo
         //
@@ -1232,6 +1325,8 @@ async fn measure_https_latency(
             .collect();
         builder = builder.resolve_to_addrs(domain, &addrs);
     }
+
+    #[cfg(not(wasm_browser))]
     if let Some(certs) = certs {
         for cert in certs {
             let cert = reqwest::Certificate::from_der(&cert)?;
@@ -1241,24 +1336,30 @@ async fn measure_https_latency(
     let client = builder.build()?;
 
     let start = Instant::now();
-    let mut response = client.request(reqwest::Method::GET, url).send().await?;
+    let response = client.request(reqwest::Method::GET, url).send().await?;
     let latency = start.elapsed();
     if response.status().is_success() {
+        // Only `None` if a different hyper HttpConnector in the request.
+        #[cfg(not(wasm_browser))]
+        let remote_ip = response
+            .remote_addr()
+            .context("missing HttpInfo from HttpConnector")?
+            .ip();
+        #[cfg(wasm_browser)]
+        let remote_ip = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
+
         // Drain the response body to be nice to the server, up to a limit.
         const MAX_BODY_SIZE: usize = 8 << 10; // 8 KiB
         let mut body_size = 0;
-        while let Some(chunk) = response.chunk().await? {
+        let mut stream = response.bytes_stream();
+        // ignore failing frames
+        while let Some(Ok(chunk)) = stream.next().await {
             body_size += chunk.len();
             if body_size >= MAX_BODY_SIZE {
                 break;
             }
         }
 
-        // Only `None` if a different hyper HttpConnector in the request.
-        let remote_ip = response
-            .remote_addr()
-            .context("missing HttpInfo from HttpConnector")?
-            .ip();
         Ok((latency, remote_ip))
     } else {
         Err(anyhow!(
@@ -1276,6 +1377,7 @@ fn update_report(report: &mut Report, probe_report: ProbeReport) {
             .relay_latency
             .update_relay(relay_node.url.clone(), latency);
 
+        #[cfg(not(wasm_browser))]
         if matches!(
             probe_report.probe.proto(),
             ProbeProto::StunIpv4

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -107,7 +107,6 @@ pub(crate) struct SocketState {
 }
 
 impl Client {
-    #[allow(clippy::too_many_arguments)]
     /// Creates a new actor generating a single report.
     ///
     /// The actor starts running immediately and only generates a single report, after which
@@ -751,7 +750,6 @@ pub struct QuicConfig {
 /// Executes a particular [`Probe`], including using a delayed start if needed.
 ///
 /// If *stun_sock4* and *stun_sock6* are `None` the STUN probes are disabled.
-#[allow(clippy::too_many_arguments)]
 async fn run_probe(
     reportstate: Addr,
     relay_node: Arc<RelayNode>,

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -257,10 +257,7 @@ impl Actor {
         let port_mapper = false;
         debug!(%port_mapper, "reportstate actor starting");
 
-        #[cfg(not(wasm_browser))]
-        {
-            self.report.os_has_ipv6 = super::os_has_ipv6();
-        }
+        self.report.os_has_ipv6 = super::os_has_ipv6();
 
         let mut port_mapping = self.prepare_portmapper_task();
         let mut captive_task = self.prepare_captive_portal_task();

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -208,7 +208,6 @@ struct Actor {
     /// Protocols we should attempt to create probes for, if we have the correct
     /// configuration for that protocol.
     protocols: BTreeSet<ProbeProto>,
-    /// Optional [`IpMappedAddresses`] used to enable QAD in iroh
 
     /// Any socket-related state that doesn't exist/work in browsers
     #[cfg(not(wasm_browser))]

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/n0-computer/iroh"
 keywords = ["networking", "holepunching", "p2p"]
 rust-version = "1.81"
 
+[lib]
+crate-type = ["lib", "cdylib"] # cdylib is needed for Wasm support
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
## Description

This makes iroh-net-report compile to Wasm. We make sure it's likely to work by grepping the generated Wasm file for "env" imports (which would make it not work in browsers).
Mostly this will disable functionality in iroh-net-report for the browser target - specifically, it disables STUN, QAD, ICMP and all other probes besides HTTPS to relays.
I've experimentally verified this code works with an integration test, it's really hard to come up with a good strategy for automating this testing due to requiring running cross-languages.
I'd like to do that as a follow-up once #3145 is merged.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
