### PR TITLE
docs: Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ To ensure these connections are as fast as possible, we [continuously measure ir
 ### Built on [QUIC]
 
 Iroh uses [Quinn] to establish [QUIC] connections between nodes.
-This way you get authenticated encryption, concurrent streams with stream prioirities, a datagram transport and avoid head-of-line-blocking out of the box.
+This way you get authenticated encryption, concurrent streams with stream priorities, a datagram transport and avoid head-of-line-blocking out of the box.
 
 ## Compose Protocols
 
 Use pre-existing protocols built on iroh instead of writing your own:
-- [iroh-blobs] for [BLAKE3]-based content-addressed blob transfer scaling from kilobytes to terrabytes
+- [iroh-blobs] for [BLAKE3]-based content-addressed blob transfer scaling from kilobytes to terabytes
 - [iroh-gossip] for establishing publish-subscribe overlay networks that scale, requiring only resources that your average phone can handle
 - [iroh-docs] for an eventually-consistent key-value store of [iroh-blobs] blobs
 - [iroh-willow] for an (in-construction) implementation of the [willow protocol]


### PR DESCRIPTION
## Description

This PR fixes two trivial typos in the README file.

## Breaking Changes

None

## Notes & open questions

None

## Change checklist

- [ ] Self-review.
- [X] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
