### PR TITLE
feat(iroh)!: Make retrieving NodeID and ALPN infallible

### DIFF
--- a/iroh/examples/dht_discovery.rs
+++ b/iroh/examples/dht_discovery.rs
@@ -88,7 +88,7 @@ async fn chat_server(args: Args) -> anyhow::Result<()> {
         };
         tokio::spawn(async move {
             let connection = connecting.await?;
-            let remote_node_id = connection.remote_node_id()?;
+            let remote_node_id = connection.remote_node_id();
             println!("got connection from {}", remote_node_id);
             // just leave the tasks hanging. this is just an example.
             let (mut writer, mut reader) = connection.accept_bi().await?;

--- a/iroh/examples/echo.rs
+++ b/iroh/examples/echo.rs
@@ -77,7 +77,7 @@ impl ProtocolHandler for Echo {
             // Wait for the connection to be fully established.
             let connection = connecting.await?;
             // We can get the remote's node id from the connection.
-            let node_id = connection.remote_node_id()?;
+            let node_id = connection.remote_node_id();
             println!("accepted connection from {node_id}");
 
             // Our protocol is a simple request-response protocol, so we expect the

--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
     // accept incoming connections, returns a normal QUIC connection
 
     while let Some(incoming) = endpoint.accept().await {
-        let mut connecting = match incoming.accept() {
+        let connecting = match incoming.accept() {
             Ok(connecting) => connecting,
             Err(err) => {
                 warn!("incoming connection failed: {err:#}");
@@ -67,9 +67,9 @@ async fn main() -> anyhow::Result<()> {
                 continue;
             }
         };
-        let alpn = connecting.alpn().await?;
         let conn = connecting.await?;
-        let node_id = conn.remote_node_id()?;
+        let alpn = conn.alpn();
+        let node_id = conn.remote_node_id();
         info!(
             "new (unreliable) connection from {node_id} with ALPN {} (coming from {})",
             String::from_utf8_lossy(&alpn),

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
     );
     // accept incoming connections, returns a normal QUIC connection
     while let Some(incoming) = endpoint.accept().await {
-        let mut connecting = match incoming.accept() {
+        let connecting = match incoming.accept() {
             Ok(connecting) => connecting,
             Err(err) => {
                 warn!("incoming connection failed: {err:#}");
@@ -68,9 +68,9 @@ async fn main() -> anyhow::Result<()> {
                 continue;
             }
         };
-        let alpn = connecting.alpn().await?;
         let conn = connecting.await?;
-        let node_id = conn.remote_node_id()?;
+        let alpn = conn.alpn();
+        let node_id = conn.remote_node_id();
         info!(
             "new connection from {node_id} with ALPN {} (coming from {})",
             String::from_utf8_lossy(&alpn),

--- a/iroh/examples/search.rs
+++ b/iroh/examples/search.rs
@@ -134,7 +134,7 @@ impl ProtocolHandler for BlobSearch {
             // Wait for the connection to be fully established.
             let connection = connecting.await?;
             // We can get the remote's node id from the connection.
-            let node_id = connection.remote_node_id()?;
+            let node_id = connection.remote_node_id();
             println!("accepted connection from {node_id}");
 
             // Our protocol is a simple request-response protocol, so we expect the

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -179,7 +179,7 @@ async fn provide(
             }
         };
         let conn = connecting.await?;
-        let node_id = conn.remote_node_id()?;
+        let node_id = conn.remote_node_id();
         info!(
             "new connection from {node_id} with ALPN {} (coming from {})",
             String::from_utf8_lossy(TRANSFER_ALPN),


### PR DESCRIPTION
## Description

Our crypto setup makese some guarantees here.  But we do need to be
careful not to unwrap something that can be triggered by a modified or
custom remote.

## Breaking Changes

TODO

### iroh

- Removes `Connecting::handshake_data`.
- Removes `Connection::handshake_data`.
- Removes `Connection::peer_identity`.
- Error type for `Connecting::alpn` changed to ConnectionError.
- `Connection::alpn` is now infallible.
- `Connection::remote_node_id` is now infallible.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.