### PR TITLE
feat(iroh)!: Remove access to local and remote IP addresses

### DIFF
--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -71,9 +71,8 @@ async fn main() -> anyhow::Result<()> {
         let conn = connecting.await?;
         let node_id = conn.remote_node_id()?;
         info!(
-            "new (unreliable) connection from {node_id} with ALPN {} (coming from {})",
+            "new (unreliable) connection from {node_id} with ALPN {}",
             String::from_utf8_lossy(&alpn),
-            conn.remote_address()
         );
         // spawn a task to handle reading and writing off of the connection
         tokio::spawn(async move {

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -72,9 +72,8 @@ async fn main() -> anyhow::Result<()> {
         let conn = connecting.await?;
         let node_id = conn.remote_node_id()?;
         info!(
-            "new connection from {node_id} with ALPN {} (coming from {})",
+            "new connection from {node_id} with ALPN {}",
             String::from_utf8_lossy(&alpn),
-            conn.remote_address()
         );
 
         // spawn a task to handle reading and writing off of the connection

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -181,9 +181,8 @@ async fn provide(
         let conn = connecting.await?;
         let node_id = conn.remote_node_id()?;
         info!(
-            "new connection from {node_id} with ALPN {} (coming from {})",
+            "new connection from {node_id} with ALPN {}",
             String::from_utf8_lossy(TRANSFER_ALPN),
-            conn.remote_address()
         );
 
         // spawn a task to handle reading and writing off of the connection

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1282,16 +1282,6 @@ impl Connecting {
         self.inner.handshake_data().await
     }
 
-    /// The local IP address which was used when the peer established the connection.
-    pub fn local_ip(&self) -> Option<IpAddr> {
-        self.inner.local_ip()
-    }
-
-    /// The peer's UDP address.
-    pub fn remote_address(&self) -> SocketAddr {
-        self.inner.remote_address()
-    }
-
     /// Extracts the ALPN protocol from the peer's handshake data.
     // Note, we could totally provide this method to be on a Connection as well.  But we'd
     // need to wrap Connection too.
@@ -1497,28 +1487,6 @@ impl Connection {
     #[inline]
     pub fn datagram_send_buffer_space(&self) -> usize {
         self.inner.datagram_send_buffer_space()
-    }
-
-    /// The peer's UDP address.
-    ///
-    /// If [`ServerConfig::migration`] is `true`, clients may change addresses at will,
-    /// e.g. when switching to a cellular internet connection.
-    #[inline]
-    pub fn remote_address(&self) -> SocketAddr {
-        self.inner.remote_address()
-    }
-
-    /// The local IP address which was used when the peer established the connection.
-    ///
-    /// This can be different from the address the endpoint is bound to, in case the
-    /// endpoint is bound to a wildcard address like `0.0.0.0` or `::`.
-    ///
-    /// This will return `None` for clients, or when the platform does not expose this
-    /// information. See [`quinn::udp::RecvMeta::dst_ip`] for a list of supported
-    /// platforms.
-    #[inline]
-    pub fn local_ip(&self) -> Option<IpAddr> {
-        self.inner.local_ip()
     }
 
     /// Current best estimate of this connection's latency (round-trip-time).


### PR DESCRIPTION
## Description

The Connecting and Connection structs exposed IP addresses, these are
probably the NodeIdMappedAddresses rather than real ones.  We address
based on NodeId, so let's remove this stuff.

## Breaking Changes

### iroh

- `Connecting::local_ip` is removed.
- `Connecting::remote_address` is removed.
- `Connection::local_ip` is removed.
- `Connection::remote_address` is removed.

## Notes & open questions

I didn't think long about this.  Getting this PR out so someone else
can think carefully about this.  :)

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.