### PR TITLE
refactor!(iroh): Make `discovery-pkarr-dht` feature non-default

### DIFF
--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -133,7 +133,7 @@ testresult = "0.4.0"
 iroh-relay = { path = "../iroh-relay", default-features = false, features = ["test-utils", "server"] }
 
 [features]
-default = ["metrics", "discovery-pkarr-dht"]
+default = ["metrics"]
 metrics = ["iroh-metrics/metrics", "iroh-relay/metrics", "net-report/metrics", "portmapper/metrics"]
 test-utils = ["iroh-relay/test-utils", "iroh-relay/server", "dep:axum"]
 discovery-local-network = ["dep:swarm-discovery"]


### PR DESCRIPTION
## Description

What it says on the tin.

Reasoning:
- We mostly advertise using `Endpoint::discovery_n0`, and none of our examples use `Endpoint::discovery_dht`.
- For the default case we stop depending on `mainline` needlessly (we can disable the `pkarr/dht` feature).

## Breaking Changes

- The `discovery-pkarr-dht` feature became non-default (moved from opt-out to opt-in).

## Change checklist

- [x] Self-review.
- [x] All breaking changes documented.
