### PR TITLE
feat(iroh-relay)!: use concret errors for the client part of iroh-relay

### DIFF
--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use curve25519_dalek::edwards::CompressedEdwardsY;
-pub use ed25519_dalek::Signature;
-use ed25519_dalek::{SignatureError, SigningKey, VerifyingKey};
+pub use ed25519_dalek::{Signature, SignatureError};
+use ed25519_dalek::{SigningKey, VerifyingKey};
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -15,7 +15,7 @@ mod node_addr;
 mod relay_url;
 
 #[cfg(feature = "key")]
-pub use self::key::{KeyParsingError, NodeId, PublicKey, SecretKey, Signature};
+pub use self::key::{KeyParsingError, NodeId, PublicKey, SecretKey, Signature, SignatureError};
 #[cfg(feature = "key")]
 pub use self::node_addr::NodeAddr;
 #[cfg(feature = "relay")]

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -977,7 +977,7 @@ mod test_utils {
             servers.push(relay_server);
             nodes.push(node);
         }
-        let map = crate::RelayMap::from_nodes(nodes).expect("unuque urls");
+        let map = crate::RelayMap::from_nodes(nodes);
         (servers, map)
     }
 }
@@ -1049,7 +1049,7 @@ mod tests {
                     quic: None,
                 }
             });
-            RelayMap::from_nodes(nodes).expect("generated invalid nodes")
+            RelayMap::from_nodes(nodes)
         }
 
         /// Sets up a simple STUN server binding to `0.0.0.0:0`.

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -921,11 +921,11 @@ async fn run_quic_probe(
         }
     };
     let quic_client = iroh_relay::quic::QuicClient::new(quic_config.ep, quic_config.client_config)
-        .map_err(|e| ProbeError::Error(e, probe.clone()))?;
+        .map_err(|e| ProbeError::Error(e.into(), probe.clone()))?;
     let (addr, latency) = quic_client
         .get_addr_and_latency(relay_addr, host)
         .await
-        .map_err(|e| ProbeError::Error(e, probe.clone()))?;
+        .map_err(|e| ProbeError::Error(e.into(), probe.clone()))?;
     let mut result = ProbeReport::new(probe.clone());
     if matches!(probe, Probe::QuicIpv4 { .. }) {
         result.ipv4_can_send = true;

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.81"
 workspace = true
 
 [dependencies]
-anyhow = { version = "1" }
 bytes = "1.7"
 derive_more = { version = "1.0.0", features = [
     "debug",
@@ -67,6 +66,7 @@ data-encoding = "2.6.0"
 lru = "0.12"
 
 # server feature
+anyhow = { version = "1", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 dashmap = { version = "6.1.0", optional = true }
 governor = { version = "0.7.0", optional = true }
@@ -125,6 +125,7 @@ cfg_aliases = { version = "0.2" }
 [features]
 default = ["metrics"]
 server = [
+    "dep:anyhow",
     "dep:clap",
     "dep:dashmap",
     "dep:governor",

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -17,7 +17,7 @@ use tokio_tungstenite_wasm::WebSocketStream;
 use tokio_util::codec::Framed;
 use tracing::debug;
 
-use super::KeyCache;
+use super::{Error, KeyCache};
 use crate::protos::relay::{ClientInfo, Frame, MAX_PACKET_SIZE, PROTOCOL_VERSION};
 #[cfg(not(wasm_browser))]
 use crate::{client::streams::MaybeTlsStreamChained, protos::relay::RelayCodec};
@@ -74,7 +74,7 @@ impl Conn {
         conn: WebSocketStream,
         key_cache: KeyCache,
         secret_key: &SecretKey,
-    ) -> Result<Self> {
+    ) -> Result<Self, Error> {
         let mut conn = Self::Ws { conn, key_cache };
 
         // exchange information with the server
@@ -89,7 +89,7 @@ impl Conn {
         conn: MaybeTlsStreamChained,
         key_cache: KeyCache,
         secret_key: &SecretKey,
-    ) -> Result<Self> {
+    ) -> Result<Self, Error> {
         let conn = Framed::new(conn, RelayCodec::new(key_cache));
 
         let mut conn = Self::Relay { conn };
@@ -102,7 +102,7 @@ impl Conn {
 }
 
 /// Sends the server handshake message.
-async fn server_handshake(writer: &mut Conn, secret_key: &SecretKey) -> Result<()> {
+async fn server_handshake(writer: &mut Conn, secret_key: &SecretKey) -> Result<(), Error> {
     debug!("server_handshake: started");
     let client_info = ClientInfo {
         version: PROTOCOL_VERSION,

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -12,7 +12,6 @@
 //!  * clients sends `FrameType::SendPacket`
 //!  * server then sends `FrameType::RecvPacket` to recipient
 
-use anyhow::{bail, ensure};
 use bytes::{BufMut, Bytes};
 use iroh_base::{PublicKey, SecretKey, Signature, SignatureError};
 #[cfg(feature = "server")]
@@ -74,7 +73,7 @@ const NOT_PREFERRED: u8 = 0u8;
 /// length of the remaining frame (not including the initial 5 bytes)
 #[derive(Debug, PartialEq, Eq, num_enum::IntoPrimitive, num_enum::FromPrimitive, Clone, Copy)]
 #[repr(u8)]
-pub(crate) enum FrameType {
+pub enum FrameType {
     /// magic + 32b pub key + 24B nonce + bytes
     ClientInfo = 2,
     /// 32B dest pub key + packet bytes
@@ -110,6 +109,7 @@ pub(crate) enum FrameType {
     ///
     /// Handled on the `[relay::Client]`, but currently never sent on the `[relay::Server]`
     Restarting = 15,
+    /// Unknown frame type
     #[num_enum(default)]
     Unknown = 255,
 }
@@ -126,6 +126,8 @@ pub(crate) struct ClientInfo {
     pub(crate) version: usize,
 }
 
+/// Protocol related errors.
+#[allow(missing_docs)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
@@ -139,7 +141,15 @@ pub enum Error {
     #[error(transparent)]
     InvalidSignature(#[from] SignatureError),
     #[error(transparent)]
-    Other(#[from] anyhow::Error),
+    ConnSend(#[from] ConnSendError),
+    #[error("Too few bytes")]
+    TooSmall,
+    #[error("Frame is too large, has {0} bytes")]
+    FrameTooLarge(usize),
+    #[error("Invalid frame encoding")]
+    InvalidFrame,
+    #[error("Invalid frame type: {0}")]
+    InvalidFrameType(FrameType),
 }
 
 /// Writes complete frame, errors if it is unable to write within the given `timeout`.
@@ -187,9 +197,12 @@ pub(crate) async fn send_client_key<S: Sink<Frame, Error = ConnSendError> + Unpi
 /// Reads the `FrameType::ClientInfo` frame from the client (its proof of identity)
 /// upon it's initial connection.
 #[cfg(any(test, feature = "server"))]
-pub(crate) async fn recv_client_key<S: Stream<Item = anyhow::Result<Frame>> + Unpin>(
+pub(crate) async fn recv_client_key<E, S: Stream<Item = Result<Frame, E>> + Unpin>(
     stream: S,
-) -> Result<(PublicKey, ClientInfo), Error> {
+) -> Result<(PublicKey, ClientInfo), E>
+where
+    E: From<Error>,
+{
     // the client is untrusted at this point, limit the input size even smaller than our usual
     // maximum frame size, and give a timeout
 
@@ -198,7 +211,8 @@ pub(crate) async fn recv_client_key<S: Stream<Item = anyhow::Result<Frame>> + Un
         std::time::Duration::from_secs(10),
         recv_frame(FrameType::ClientInfo, stream),
     )
-    .await??;
+    .await
+    .map_err(Error::from)??;
 
     if let Frame::ClientInfo {
         client_public_key,
@@ -206,12 +220,18 @@ pub(crate) async fn recv_client_key<S: Stream<Item = anyhow::Result<Frame>> + Un
         signature,
     } = buf
     {
-        client_public_key.verify(&message, &signature)?;
+        client_public_key
+            .verify(&message, &signature)
+            .map_err(Error::from)?;
 
-        let info: ClientInfo = postcard::from_bytes(&message)?;
+        let info: ClientInfo = postcard::from_bytes(&message).map_err(Error::from)?;
         Ok((client_public_key, info))
     } else {
-        Err(Error::UnexpectedFrame)
+        Err(Error::UnexpectedFrame {
+            got: buf.typ(),
+            expected: FrameType::ClientInfo,
+        }
+        .into())
     }
 }
 
@@ -326,9 +346,9 @@ impl Frame {
     /// Tries to decode a frame received over websockets.
     ///
     /// Specifically, bytes received from a binary websocket message frame.
-    pub(crate) fn decode_from_ws_msg(vec: Vec<u8>, cache: &KeyCache) -> anyhow::Result<Self> {
+    pub(crate) fn decode_from_ws_msg(vec: Vec<u8>, cache: &KeyCache) -> Result<Self, Error> {
         if vec.is_empty() {
-            bail!("error parsing relay::codec::Frame: too few bytes (0)");
+            return Err(Error::TooSmall);
         }
         let bytes = Bytes::from(vec);
         let typ = FrameType::from(bytes[0]);
@@ -397,18 +417,15 @@ impl Frame {
         }
     }
 
-    fn from_bytes(frame_type: FrameType, content: Bytes, cache: &KeyCache) -> anyhow::Result<Self> {
+    fn from_bytes(frame_type: FrameType, content: Bytes, cache: &KeyCache) -> Result<Self, Error> {
         let res = match frame_type {
             FrameType::ClientInfo => {
-                ensure!(
-                    content.len() >= PublicKey::LENGTH + Signature::BYTE_SIZE + MAGIC.len(),
-                    "invalid client info frame length: {}",
-                    content.len()
-                );
-                ensure!(
-                    &content[..MAGIC.len()] == MAGIC.as_bytes(),
-                    "invalid client info frame magic"
-                );
+                if content.len() < PublicKey::LENGTH + Signature::BYTE_SIZE + MAGIC.len() {
+                    return Err(Error::InvalidFrame);
+                }
+                if &content[..MAGIC.len()] != MAGIC.as_bytes() {
+                    return Err(Error::InvalidFrame);
+                }
 
                 let start = MAGIC.len();
                 let client_public_key =
@@ -425,84 +442,88 @@ impl Frame {
                 }
             }
             FrameType::SendPacket => {
-                ensure!(
-                    content.len() >= PublicKey::LENGTH,
-                    "invalid send packet frame length: {}",
-                    content.len()
-                );
+                if content.len() < PublicKey::LENGTH {
+                    return Err(Error::InvalidFrame);
+                }
                 let packet_len = content.len() - PublicKey::LENGTH;
-                ensure!(
-                    packet_len <= MAX_PACKET_SIZE,
-                    "data packet longer ({packet_len}) than max of {MAX_PACKET_SIZE}"
-                );
+                if packet_len > MAX_PACKET_SIZE {
+                    return Err(Error::FrameTooLarge(packet_len));
+                }
+
                 let dst_key = cache.key_from_slice(&content[..PublicKey::LENGTH])?;
                 let packet = content.slice(PublicKey::LENGTH..);
                 Self::SendPacket { dst_key, packet }
             }
             FrameType::RecvPacket => {
-                ensure!(
-                    content.len() >= PublicKey::LENGTH,
-                    "invalid recv packet frame length: {}",
-                    content.len()
-                );
+                if content.len() < PublicKey::LENGTH {
+                    return Err(Error::InvalidFrame);
+                }
+
                 let packet_len = content.len() - PublicKey::LENGTH;
-                ensure!(
-                    packet_len <= MAX_PACKET_SIZE,
-                    "data packet longer ({packet_len}) than max of {MAX_PACKET_SIZE}"
-                );
+                if packet_len > MAX_PACKET_SIZE {
+                    return Err(Error::FrameTooLarge(packet_len));
+                }
+
                 let src_key = cache.key_from_slice(&content[..PublicKey::LENGTH])?;
                 let content = content.slice(PublicKey::LENGTH..);
                 Self::RecvPacket { src_key, content }
             }
             FrameType::KeepAlive => {
-                anyhow::ensure!(content.is_empty(), "invalid keep alive frame length");
+                if !content.is_empty() {
+                    return Err(Error::InvalidFrame);
+                }
                 Self::KeepAlive
             }
             FrameType::NotePreferred => {
-                anyhow::ensure!(content.len() == 1, "invalid note preferred frame length");
+                if content.len() != 1 {
+                    return Err(Error::InvalidFrame);
+                }
                 let preferred = match content[0] {
                     PREFERRED => true,
                     NOT_PREFERRED => false,
-                    _ => anyhow::bail!("invalid note preferred frame content"),
+                    _ => return Err(Error::InvalidFrame),
                 };
                 Self::NotePreferred { preferred }
             }
             FrameType::PeerGone => {
-                anyhow::ensure!(
-                    content.len() == PublicKey::LENGTH,
-                    "invalid peer gone frame length"
-                );
+                if content.len() != PublicKey::LENGTH {
+                    return Err(Error::InvalidFrame);
+                }
                 let peer = cache.key_from_slice(&content[..32])?;
                 Self::NodeGone { node_id: peer }
             }
             FrameType::Ping => {
-                anyhow::ensure!(content.len() == 8, "invalid ping frame length");
+                if content.len() != 8 {
+                    return Err(Error::InvalidFrame);
+                }
                 let mut data = [0u8; 8];
                 data.copy_from_slice(&content[..8]);
                 Self::Ping { data }
             }
             FrameType::Pong => {
-                anyhow::ensure!(content.len() == 8, "invalid pong frame length");
+                if content.len() != 8 {
+                    return Err(Error::InvalidFrame);
+                }
                 let mut data = [0u8; 8];
                 data.copy_from_slice(&content[..8]);
                 Self::Pong { data }
             }
             FrameType::Health => Self::Health { problem: content },
             FrameType::Restarting => {
-                ensure!(
-                    content.len() == 4 + 4,
-                    "invalid restarting frame length: {}",
-                    content.len()
-                );
-                let reconnect_in = u32::from_be_bytes(content[..4].try_into()?);
-                let try_for = u32::from_be_bytes(content[4..].try_into()?);
+                if content.len() != 4 + 4 {
+                    return Err(Error::InvalidFrame);
+                }
+                let reconnect_in =
+                    u32::from_be_bytes(content[..4].try_into().map_err(|_| Error::InvalidFrame)?);
+                let try_for =
+                    u32::from_be_bytes(content[4..].try_into().map_err(|_| Error::InvalidFrame)?);
                 Self::Restarting {
                     reconnect_in,
                     try_for,
                 }
             }
             _ => {
-                anyhow::bail!("invalid frame type: {:?}", frame_type);
+                return Err(Error::InvalidFrameType(frame_type));
             }
         };
         Ok(res)
@@ -526,7 +547,7 @@ mod framing {
 
     impl Decoder for RelayCodec {
         type Item = Frame;
-        type Error = anyhow::Error;
+        type Error = Error;
 
         fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
             // Need at least 5 bytes
@@ -548,7 +569,7 @@ mod framing {
             };
 
             if frame_len > MAX_FRAME_SIZE {
-                anyhow::bail!("Frame of length {} is too large.", frame_len);
+                return Err(Error::FrameTooLarge(frame_len));
             }
 
             if src.len() < HEADER_LEN + frame_len {
@@ -595,38 +616,43 @@ mod framing {
 /// Receives the next frame and matches the frame type. If the correct type is found returns the content,
 /// otherwise an error.
 #[cfg(any(test, feature = "server"))]
-pub(crate) async fn recv_frame<S: Stream<Item = anyhow::Result<Frame>> + Unpin>(
+pub(crate) async fn recv_frame<E, S: Stream<Item = Result<Frame, E>> + Unpin>(
     frame_type: FrameType,
     mut stream: S,
-) -> Result<Frame, Error> {
+) -> Result<Frame, E>
+where
+    Error: Into<E>,
+{
     match stream.next().await {
         Some(Ok(frame)) => {
             if frame_type != frame.typ() {
                 return Err(Error::UnexpectedFrame {
                     got: frame.typ(),
                     expected: frame_type,
-                });
+                }
+                .into());
             }
             Ok(frame)
         }
-        Some(Err(err)) => Err(err.into()),
-        None => Err(std::io::Error::new(
+        Some(Err(err)) => Err(err),
+        None => Err(Error::from(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "expected frame".to_string(),
-        )
+        ))
         .into()),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use testresult::TestResult;
     use tokio_util::codec::{FramedRead, FramedWrite};
 
     use super::*;
 
     #[tokio::test]
     #[cfg(feature = "server")]
-    async fn test_basic_read_write() -> anyhow::Result<()> {
+    async fn test_basic_read_write() -> TestResult {
         let (reader, writer) = tokio::io::duplex(1024);
         let mut reader = FramedRead::new(reader, RelayCodec::test());
         let mut writer = FramedWrite::new(writer, RelayCodec::test());
@@ -646,7 +672,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_send_recv_client_key() -> anyhow::Result<()> {
+    async fn test_send_recv_client_key() -> TestResult {
         let (reader, writer) = tokio::io::duplex(1024);
         let mut reader = FramedRead::new(reader, RelayCodec::test());
         let mut writer =
@@ -665,7 +691,7 @@ mod tests {
     }
 
     #[test]
-    fn test_frame_snapshot() -> anyhow::Result<()> {
+    fn test_frame_snapshot() -> TestResult {
         let client_key = SecretKey::from_bytes(&[42u8; 32]);
         let client_info = ClientInfo {
             version: PROTOCOL_VERSION,

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -850,7 +850,8 @@ mod tests {
             else {
                 continue;
             };
-            return res.context("stream finished")?;
+            let res = res.context("stream finished")??;
+            return Ok(res);
         }
         panic!("failed to send and recv message");
     }

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -287,7 +287,8 @@ impl Actor {
     ///
     /// Errors if the send does not happen within the `timeout` duration
     async fn write_frame(&mut self, frame: Frame) -> Result<()> {
-        write_frame(&mut self.stream, frame, Some(self.timeout)).await
+        write_frame(&mut self.stream, frame, Some(self.timeout)).await?;
+        Ok(())
     }
 
     /// Writes contents to the client in a `RECV_PACKET` frame.
@@ -334,11 +335,14 @@ impl Actor {
     }
 
     /// Handles frame read results.
-    async fn handle_frame(&mut self, maybe_frame: Option<Result<Frame>>) -> Result<()> {
+    async fn handle_frame(
+        &mut self,
+        maybe_frame: Option<Result<Frame, super::streams::Error>>,
+    ) -> Result<()> {
         trace!(?maybe_frame, "handle incoming frame");
         let frame = match maybe_frame {
             Some(frame) => frame?,
-            None => anyhow::bail!("stream terminated"),
+            None => bail!("stream terminated"),
         };
 
         match frame {
@@ -400,7 +404,7 @@ enum State {
         /// Future which will complete when the item can be yielded.
         delay: Pin<Box<dyn Future<Output = ()> + Send + Sync>>,
         /// Item to yield when the `delay` future completes.
-        item: anyhow::Result<Frame>,
+        item: Result<Frame, super::streams::Error>,
     },
     Ready,
 }
@@ -438,7 +442,7 @@ impl RateLimitedRelayedStream {
 }
 
 impl Stream for RateLimitedRelayedStream {
-    type Item = anyhow::Result<Frame>;
+    type Item = Result<Frame, super::streams::Error>;
 
     #[instrument(name = "rate_limited_relayed_stream", skip_all)]
     fn poll_next(

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -567,7 +567,7 @@ mod tests {
     };
 
     #[tokio::test]
-    async fn test_client_actor_basic() -> Result<()> {
+    async fn test_client_actor_basic() -> TestResult {
         let _logging = iroh_test::logging::setup();
 
         let (send_queue_s, send_queue_r) = mpsc::channel(10);

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -700,7 +700,6 @@ impl std::ops::DerefMut for Handlers {
 mod tests {
     use std::sync::Arc;
 
-    use anyhow::Result;
     use bytes::Bytes;
     use iroh_base::{PublicKey, SecretKey};
     use n0_future::{SinkExt, StreamExt};
@@ -759,7 +758,7 @@ mod tests {
             if let std::net::IpAddr::V4(ipv4_addr) = addr.ip() {
                 ipv4_addr
             } else {
-                anyhow::bail!("cannot get ipv4 addr from socket addr {addr:?}");
+                bail!("cannot get ipv4 addr from socket addr {addr:?}");
             }
         };
         info!("addr: {addr}:{port}");
@@ -820,7 +819,9 @@ mod tests {
         Ok((public_key, client))
     }
 
-    fn process_msg(msg: Option<Result<ReceivedMessage>>) -> Option<(PublicKey, Bytes)> {
+    fn process_msg(
+        msg: Option<Result<ReceivedMessage, crate::client::Error>>,
+    ) -> Option<(PublicKey, Bytes)> {
         match msg {
             Some(Err(e)) => {
                 info!("client `recv` error {e}");
@@ -869,7 +870,7 @@ mod tests {
             if let std::net::IpAddr::V4(ipv4_addr) = addr.ip() {
                 ipv4_addr
             } else {
-                anyhow::bail!("cannot get ipv4 addr from socket addr {addr:?}");
+                bail!("cannot get ipv4 addr from socket addr {addr:?}");
             }
         };
         info!("Relay listening on: {addr}:{port}");
@@ -979,7 +980,7 @@ mod tests {
                 assert_eq!(&msg[..], data);
             }
             msg => {
-                anyhow::bail!("expected ReceivedPacket msg, got {msg:?}");
+                bail!("expected ReceivedPacket msg, got {msg:?}");
             }
         }
 
@@ -997,7 +998,7 @@ mod tests {
                 assert_eq!(&msg[..], data);
             }
             msg => {
-                anyhow::bail!("expected ReceivedPacket msg, got {msg:?}");
+                bail!("expected ReceivedPacket msg, got {msg:?}");
             }
         }
 
@@ -1072,7 +1073,7 @@ mod tests {
                 assert_eq!(&msg[..], data);
             }
             msg => {
-                anyhow::bail!("expected ReceivedPacket msg, got {msg:?}");
+                bail!("expected ReceivedPacket msg, got {msg:?}");
             }
         }
 
@@ -1090,7 +1091,7 @@ mod tests {
                 assert_eq!(&msg[..], data);
             }
             msg => {
-                anyhow::bail!("expected ReceivedPacket msg, got {msg:?}");
+                bail!("expected ReceivedPacket msg, got {msg:?}");
             }
         }
 
@@ -1120,7 +1121,7 @@ mod tests {
                 assert_eq!(&msg[..], data);
             }
             msg => {
-                anyhow::bail!("expected ReceivedPacket msg, got {msg:?}");
+                bail!("expected ReceivedPacket msg, got {msg:?}");
             }
         }
 
@@ -1138,7 +1139,7 @@ mod tests {
                 assert_eq!(&msg[..], data);
             }
             msg => {
-                anyhow::bail!("expected ReceivedPacket msg, got {msg:?}");
+                bail!("expected ReceivedPacket msg, got {msg:?}");
             }
         }
 

--- a/iroh/src/defaults.rs
+++ b/iroh/src/defaults.rs
@@ -41,7 +41,6 @@ pub mod prod {
             default_eu_relay_node(),
             default_ap_relay_node(),
         ])
-        .expect("default nodes invalid")
     }
 
     /// Get the default [`RelayNode`] for NA.
@@ -105,7 +104,6 @@ pub mod staging {
     /// Get the default [`RelayMap`].
     pub fn default_relay_map() -> RelayMap {
         RelayMap::from_nodes([default_na_relay_node(), default_eu_relay_node()])
-            .expect("default nodes invalid")
     }
 
     /// Get the default [`RelayNode`] for NA.

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -407,7 +407,7 @@ impl ActiveRelayActor {
                         Ok(Ok(client)) => Ok(client),
                         Ok(Err(err)) => {
                             warn!("Relay connection failed: {err:#}");
-                            Err(err.into())
+                            Err(anyhow::Error::from(err).into())
                         }
                         Err(_) => {
                             warn!(?CONNECT_TIMEOUT, "Timeout connecting to relay");

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -106,7 +106,7 @@ pub async fn run_relay_server_with(
         stun_only: false,
         stun_port: server.stun_addr().map_or(DEFAULT_STUN_PORT, |s| s.port()),
         quic,
-    }])?;
+    }]);
     Ok((m, url, server))
 }
 


### PR DESCRIPTION
## Description

Another step towards https://github.com/n0-computer/iroh/issues/2741

## Breaking Changes

- `RelayMap::from_nodes` does not return an error anymore
- errors in client apis of `iroh_relay` are not `anyhow::Error` but rather concrete error types

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
