### PR TITLE
refactor: cleaning up unnecessary logs

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1787,13 +1787,10 @@ impl Handle {
     /// indefinitely after this call.
     #[instrument(skip_all, fields(me = %self.msock.me))]
     pub(crate) async fn close(&self) {
-        tracing::warn!("msock - closing connections");
+        trace!("magicsock closing...");
         // Initiate closing all connections, and refuse future connections.
-        tracing::warn!("msock - endpoint close");
         self.endpoint.close(0u16.into(), b"");
-        tracing::warn!("msock - wait idle");
         self.endpoint.wait_idle().await;
-        tracing::warn!("msock - endpoint done");
 
         if self.msock.is_closed() {
             return;
@@ -1801,7 +1798,6 @@ impl Handle {
         self.msock.closing.store(true, Ordering::Relaxed);
         // If this fails, then there's no receiver listening for shutdown messages,
         // so nothing to shut down anyways.
-        tracing::warn!("msock - send actor shutdown message");
         self.msock
             .actor_sender
             .send(ActorMessage::Shutdown)
@@ -1826,13 +1822,8 @@ impl Handle {
             // shutdown all tasks
             warn!("aborting remaining {}/3 tasks", tasks.len());
             tasks.shutdown().await;
-        } else {
-            warn!("tasks did not shut cleanly");
-            // shutdown all tasks
-            warn!("aborting remaining {}/3 tasks", tasks.len());
-            tasks.shutdown().await;
         }
-        warn!("msock - finished closing");
+        trace!("magicsock closed");
     }
 }
 


### PR DESCRIPTION
## Description

Cleaning up logs that were only useful when debugging the endpoint closing delay.

## Change checklist

- [x] Self-review.
