### PR TITLE
fix(iroh): remove `quinn::Endpoint::wait_idle` from `iroh::Endpoint::close` process

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1789,9 +1789,9 @@ impl Handle {
     /// This will not wait for the [`quinn::Endpoint`] to drain connections.
     ///
     /// To ensure no data is lost, design protocols so that the last *sender*
-    /// of data in the protocol calls [`Connection::closed`], and `await`s until
+    /// of data in the protocol calls [`crate::endpoint::Connection::closed`], and `await`s until
     /// it receives a "close" message from the *receiver*. Once the *receiver*
-    /// gets the last data in the protocol, it should call [`Connection::close`]
+    /// gets the last data in the protocol, it should call [`crate::endpoint::Connection::close`]
     /// to inform the *sender* that all data has been received.
     #[instrument(skip_all, fields(me = %self.msock.me))]
     pub(crate) async fn close(&self) {

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1785,12 +1785,19 @@ impl Handle {
     /// Only the first close does anything. Any later closes return nil.
     /// Polling the socket ([`AsyncUdpSocket::poll_recv`]) will return [`Poll::Pending`]
     /// indefinitely after this call.
+    ///
+    /// This will not wait for the [`quinn::Endpoint`] to drain connections.
+    ///
+    /// To ensure no data is lost, design protocols so that the last *sender*
+    /// of data in the protocol calls [`Connection::closed`], and `await`s until
+    /// it receives a "close" message from the *receiver*. Once the *receiver*
+    /// gets the last data in the protocol, it should call [`Connection::close`]
+    /// to inform the *sender* that all data has been received.
     #[instrument(skip_all, fields(me = %self.msock.me))]
     pub(crate) async fn close(&self) {
         trace!("magicsock closing...");
         // Initiate closing all connections, and refuse future connections.
         self.endpoint.close(0u16.into(), b"");
-        self.endpoint.wait_idle().await;
 
         if self.msock.is_closed() {
             return;


### PR DESCRIPTION
## Description

`quinn::Endpoint::wait_idle` adds a minimum 3 second closing time to `iroh::Endpoint::close` if you have any connections that have not closed gracefully. 

While we *want* users to close connections gracefully, we should also not be forcing users to wait 3 seconds to close the `iroh::Endpoint` if a connection has "gone wrong" if they don't want to.

So instead, we are taking out `quinn::Endpoint::wait_idle` and adding more context for how to close a connection gracefully.

## Notes & open questions

Before 1.0 we will be re-visiting closing to make sure the APIs make sense.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
