### PR TITLE
fix(iroh): ensure passing a crpyto provider to rustls clients

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2609,9 +2609,13 @@ impl Actor {
         // create a client config for the endpoint to use for QUIC address discovery
         let root_store =
             rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-        let client_config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
+        let client_config = rustls::client::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .expect("ring supports these")
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
         let quic_config = Some(QuicConfig {
             ep: self.qad_endpoint.clone(),
             client_config,


### PR DESCRIPTION
## Description

This will result in a panic otherwise, if no default crypto provider is setup for rustls.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
