### PR TITLE
fix(iroh): Allow gracefully closing connections

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1023,13 +1023,10 @@ impl Endpoint {
     /// of `0` and an empty reason.  Though it is best practice to close those
     /// explicitly before with a custom error code and reason.
     ///
-    /// This will not wait for the [`quinn::Endpoint`] to drain connections.
-    ///
-    /// To ensure no data is lost, design protocols so that the last *sender*
-    /// of data in the protocol calls [`Connection::closed`], and `await`s until
-    /// it receives a "close" message from the *receiver*. Once the *receiver*
-    /// gets the last data in the protocol, it should call [`Connection::close`]
-    /// to inform the *sender* that all data has been received.
+    /// It will then make a best effort to wait for all close notifications to be
+    /// acknowledged by the peers, re-transmitting them if needed. This ensures the
+    /// peers are aware of the closed connections instead of having to wait for a timeout
+    /// on the connection. Once all connections are closed or timed out, the magic socket is closed.
     ///
     /// Be aware however that the underlying UDP sockets are only closed
     /// on [`Drop`], bearing in mind the [`Endpoint`] is only dropped once all the clones
@@ -1542,16 +1539,21 @@ impl Connection {
     ///
     /// # Gracefully closing a connection
     ///
-    /// Only the peer last **receiving** application data can be certain that all data is
-    /// delivered.
+    /// Only the peer last receiving application data can be certain that all data is
+    /// delivered. The only reliable action it can then take is to close the connection,
+    /// potentially with a custom error code. The delivery of the final CONNECTION_CLOSE
+    /// frame is very likely if both endpoints stay online long enough, calling
+    /// [`Endpoint::close`] will wait to provide sufficient time. Otherwise, the remote peer
+    /// will time out the connection, provided that the idle timeout is not disabled.
     ///
-    /// To communicate to the last **sender** of the application data that all the data was received, we recommend designing protocols that follow this pattern:
+    /// The sending side can not guarantee all stream data is delivered to the remote
+    /// application. It only knows the data is delivered to the QUIC stack of the remote
+    /// endpoint. Once the local side sends a CONNECTION_CLOSE frame in response to calling
+    /// [`close`] the remote endpoint may drop any data it received but is as yet
+    /// undelivered to the application, including data that was acknowledged as received to
+    /// the local endpoint.
     ///
-    /// 1) The **sender** sends the last data. It then calls [`Connection::closed`]. This will wait until it receives a CONNECTION_CLOSE frame from the other side.
-    /// 2) The **receiver** receives the last data. It then calls [`Connection::close`] and provides an error_code and/or reason.
-    /// 3) The **sender** checks that the error_code is the expected error code.
-    ///
-    /// If the `close`/`closed` dance is not done, or is interrupted at any point, the connection will eventually time out, provided that the idle timeout is not disabled.
+    /// [`close`]: Connection::close
     #[inline]
     pub fn close(&self, error_code: VarInt, reason: &[u8]) {
         self.inner.close(error_code, reason)


### PR DESCRIPTION
## Description

This adds a test case that checks that we can call `Connection::close` and actually receive the close code on the other side, indicating we've gracefully closed the connection.
Even though in the test we call `Endpoint::close` and wait for that, with current iroh 0.32, we don't receive the close frame. The only way I can see to make it work with iroh's 0.32 API, is to choose some time to sleep before calling `Endpoint::close`.

I've also attached a revert of #3165 which fixes the test, as that makes `Endpoint::close` wait for the close frames to be acknowledged again (by calling `quinn::Endpoint::wait_idle`).

## Notes & open questions

There might be other ways to fix this, I welcome feedback on that. I do believe this is the right way to fix it, though.

Given that the `Endpoint::wait_idle` call has been introduced and removed *twice* already, we should finally make a choice on whether it belongs in there or not, and then add sufficient code comments to make sure whoever looks at it next is fully informed.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
