### PR TITLE
refactor(iroh): store quic config, instead of recreating

### DIFF
--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -217,7 +217,7 @@ impl Default for Reports {
 ///
 /// Use [`Options::stun_v4`], [`Options::stun_v6`], and [`Options::quic_config`]
 /// to enable STUN over IPv4, STUN over IPv6, and QUIC address discovery.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Options {
     /// Socket to send IPv4 STUN probes from.
     ///


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
