### PR TITLE
tests(iroh-net-report): Do not ping hosts on the internet

### DIFF
--- a/iroh-net-report/src/ping.rs
+++ b/iroh-net-report/src/ping.rs
@@ -128,35 +128,6 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    #[ignore] // Doesn't work in CI
-    #[traced_test]
-    async fn test_ping_google() -> Result<()> {
-        // Public DNS addrs from google based on
-        // https://developers.google.com/speed/public-dns/docs/using
-
-        let pinger = Pinger::new();
-
-        // IPv4
-        let dur = pinger.send("8.8.8.8".parse()?, &[1u8; 8]).await?;
-        assert!(!dur.is_zero());
-
-        // IPv6
-        match pinger
-            .send("2001:4860:4860:0:0:0:0:8888".parse()?, &[1u8; 8])
-            .await
-        {
-            Ok(dur) => {
-                assert!(!dur.is_zero());
-            }
-            Err(err) => {
-                tracing::error!("IPv6 is not available: {:?}", err);
-            }
-        }
-
-        Ok(())
-    }
-
     // See net_report::reportgen::tests::test_icmp_probe_eu_relay for permissions to ping.
     #[tokio::test]
     #[traced_test]


### PR DESCRIPTION
## description

No matter what we do, pinging hosts on the internet is flaky, packets
do get lost.  We only care that we manage to send and receive pings
correctly, which we fully do by pinging localhost.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.