### PR TITLE
refactor!: streamline discovery and node info types

### DIFF
--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -1,6 +1,10 @@
 use anyhow::Result;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use iroh::{discovery::pkarr::PkarrRelayClient, dns::node_info::NodeInfo, SecretKey};
+use iroh::{
+    discovery::{pkarr::PkarrRelayClient, NodeData},
+    dns::node_info::NodeInfo,
+    RelayUrl, SecretKey,
+};
 use iroh_dns_server::{config::Config, server::Server, ZoneStore};
 use rand_chacha::rand_core::SeedableRng;
 use tokio::runtime::Runtime;
@@ -29,9 +33,10 @@ fn benchmark_dns_server(c: &mut Criterion) {
                     let node_id = secret_key.public();
 
                     let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");
-                    let relay_url = Some("http://localhost:8080".parse().unwrap());
                     let pkarr = PkarrRelayClient::new(pkarr_relay);
-                    let node_info = NodeInfo::new(node_id, relay_url, Default::default());
+                    let relay_url: RelayUrl = "http://localhost:8080".parse().unwrap();
+                    let node_data = NodeData::default().with_relay_url(relay_url);
+                    let node_info = NodeInfo::new(node_id, node_data);
                     let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30).unwrap();
 
                     let start = std::time::Instant::now();

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use iroh::{discovery::pkarr::PkarrRelayClient, dns::node_info::NodeInfo, RelayUrl, SecretKey};
+use iroh::{discovery::pkarr::PkarrRelayClient, dns::node_info::NodeInfo, SecretKey};
 use iroh_dns_server::{config::Config, server::Server, ZoneStore};
 use rand_chacha::rand_core::SeedableRng;
 use tokio::runtime::Runtime;
@@ -30,7 +30,7 @@ fn benchmark_dns_server(c: &mut Criterion) {
 
                     let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");
                     let pkarr = PkarrRelayClient::new(pkarr_relay);
-                    let relay_url: RelayUrl = "http://localhost:8080".parse().unwrap();
+                    let relay_url = "http://localhost:8080".parse().unwrap();
                     let node_info = NodeInfo::new(node_id).with_relay_url(Some(relay_url));
                     let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30).unwrap();
 

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -1,10 +1,6 @@
 use anyhow::Result;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use iroh::{
-    discovery::{pkarr::PkarrRelayClient, NodeData},
-    dns::node_info::NodeInfo,
-    RelayUrl, SecretKey,
-};
+use iroh::{discovery::pkarr::PkarrRelayClient, dns::node_info::NodeInfo, RelayUrl, SecretKey};
 use iroh_dns_server::{config::Config, server::Server, ZoneStore};
 use rand_chacha::rand_core::SeedableRng;
 use tokio::runtime::Runtime;
@@ -35,8 +31,7 @@ fn benchmark_dns_server(c: &mut Criterion) {
                     let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");
                     let pkarr = PkarrRelayClient::new(pkarr_relay);
                     let relay_url: RelayUrl = "http://localhost:8080".parse().unwrap();
-                    let node_data = NodeData::default().with_relay_url(relay_url);
-                    let node_info = NodeInfo::new(node_id, node_data);
+                    let node_info = NodeInfo::new(node_id).with_relay_url(Some(relay_url));
                     let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30).unwrap();
 
                     let start = std::time::Instant::now();

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -6,6 +6,7 @@ use iroh::{
     discovery::{
         dns::{N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING},
         pkarr::{PkarrRelayClient, N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING},
+        NodeData,
     },
     dns::node_info::{NodeIdExt, NodeInfo, IROH_TXT_NAME},
     NodeId, SecretKey,
@@ -77,7 +78,8 @@ async fn main() -> Result<()> {
     println!("publish to {pkarr_relay} ...");
 
     let pkarr = PkarrRelayClient::new(pkarr_relay);
-    let node_info = NodeInfo::new(node_id, Some(args.relay_url), Default::default());
+    let data = NodeData::default().with_relay_url(args.relay_url);
+    let node_info = NodeInfo::new(node_id, data);
     let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
     pkarr.publish(&signed_packet).await?;
 

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -6,7 +6,6 @@ use iroh::{
     discovery::{
         dns::{N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING},
         pkarr::{PkarrRelayClient, N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING},
-        NodeData,
     },
     dns::node_info::{NodeIdExt, NodeInfo, IROH_TXT_NAME},
     NodeId, SecretKey,
@@ -78,8 +77,7 @@ async fn main() -> Result<()> {
     println!("publish to {pkarr_relay} ...");
 
     let pkarr = PkarrRelayClient::new(pkarr_relay);
-    let data = NodeData::default().with_relay_url(args.relay_url);
-    let node_info = NodeInfo::new(node_id, data);
+    let node_info = NodeInfo::new(node_id).with_relay_url(Some(args.relay_url.into()));
     let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
     pkarr.publish(&signed_packet).await?;
 

--- a/iroh-dns-server/examples/resolve.rs
+++ b/iroh-dns-server/examples/resolve.rs
@@ -51,10 +51,10 @@ async fn main() -> anyhow::Result<()> {
         Command::Domain { domain } => resolver.lookup_node_by_domain_name(&domain).await?,
     };
     println!("resolved node {}", resolved.node_id);
-    if let Some(url) = resolved.relay_url {
+    if let Some(url) = resolved.relay_url() {
         println!("    relay={url}")
     }
-    for addr in resolved.direct_addresses {
+    for addr in resolved.direct_addresses() {
         println!("    addr={addr}")
     }
     Ok(())

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -23,7 +23,7 @@ mod tests {
 
     use anyhow::Result;
     use iroh::{
-        discovery::pkarr::PkarrRelayClient,
+        discovery::{pkarr::PkarrRelayClient, NodeData},
         dns::{node_info::NodeInfo, DnsResolver},
         SecretKey,
     };
@@ -170,9 +170,10 @@ mod tests {
 
         let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
-        let relay_url: Url = "https://relay.example.".parse()?;
         let pkarr = PkarrRelayClient::new(pkarr_relay);
-        let node_info = NodeInfo::new(node_id, Some(relay_url.clone()), Default::default());
+        let relay_url: Url = "https://relay.example.".parse()?;
+        let node_data = NodeData::default().with_relay_url(relay_url.clone());
+        let node_info = NodeInfo::new(node_id, node_data);
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
 
         pkarr.publish(&signed_packet).await?;
@@ -235,7 +236,8 @@ mod tests {
         let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
         let relay_url: Url = "https://relay.example.".parse()?;
-        let node_info = NodeInfo::new(node_id, Some(relay_url.clone()), Default::default());
+        let node_data = NodeData::default().with_relay_url(relay_url.clone());
+        let node_info = NodeInfo::new(node_id, node_data);
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
 
         // publish the signed packet to our DHT
@@ -269,7 +271,8 @@ mod tests {
         let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
         let relay_url: Url = "https://relay.example.".parse()?;
-        let node_info = NodeInfo::new(node_id, Some(relay_url.clone()), Default::default());
+        let node_data = NodeData::default().with_relay_url(relay_url.clone());
+        let node_info = NodeInfo::new(node_id, node_data);
         node_info.to_pkarr_signed_packet(&secret_key, 30)
     }
 }

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -23,14 +23,13 @@ mod tests {
 
     use anyhow::Result;
     use iroh::{
-        discovery::{pkarr::PkarrRelayClient, NodeData},
+        discovery::pkarr::PkarrRelayClient,
         dns::{node_info::NodeInfo, DnsResolver},
         RelayUrl, SecretKey,
     };
     use pkarr::{PkarrClient, SignedPacket};
     use testresult::TestResult;
     use tracing_test::traced_test;
-    use url::Url;
 
     use crate::{
         config::BootstrapOption,
@@ -172,8 +171,7 @@ mod tests {
         let node_id = secret_key.public();
         let pkarr = PkarrRelayClient::new(pkarr_relay);
         let relay_url: RelayUrl = "https://relay.example.".parse()?;
-        let node_data = NodeData::default().with_relay_url(relay_url.clone());
-        let node_info = NodeInfo::new(node_id, node_data);
+        let node_info = NodeInfo::new(node_id).with_relay_url(Some(relay_url.clone()));
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
 
         pkarr.publish(&signed_packet).await?;
@@ -236,8 +234,7 @@ mod tests {
         let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
         let relay_url: RelayUrl = "https://relay.example.".parse()?;
-        let node_data = NodeData::default().with_relay_url(relay_url.clone());
-        let node_info = NodeInfo::new(node_id, node_data);
+        let node_info = NodeInfo::new(node_id).with_relay_url(Some(relay_url.clone()));
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
 
         // publish the signed packet to our DHT
@@ -270,9 +267,8 @@ mod tests {
     fn random_signed_packet() -> Result<SignedPacket> {
         let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
-        let relay_url: Url = "https://relay.example.".parse()?;
-        let node_data = NodeData::default().with_relay_url(relay_url.clone());
-        let node_info = NodeInfo::new(node_id, node_data);
+        let relay_url: RelayUrl = "https://relay.example.".parse()?;
+        let node_info = NodeInfo::new(node_id).with_relay_url(Some(relay_url.clone()));
         node_info.to_pkarr_signed_packet(&secret_key, 30)
     }
 }

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -25,7 +25,7 @@ mod tests {
     use iroh::{
         discovery::{pkarr::PkarrRelayClient, NodeData},
         dns::{node_info::NodeInfo, DnsResolver},
-        SecretKey,
+        RelayUrl, SecretKey,
     };
     use pkarr::{PkarrClient, SignedPacket};
     use testresult::TestResult;
@@ -171,7 +171,7 @@ mod tests {
         let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
         let pkarr = PkarrRelayClient::new(pkarr_relay);
-        let relay_url: Url = "https://relay.example.".parse()?;
+        let relay_url: RelayUrl = "https://relay.example.".parse()?;
         let node_data = NodeData::default().with_relay_url(relay_url.clone());
         let node_info = NodeInfo::new(node_id, node_data);
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
@@ -182,7 +182,7 @@ mod tests {
         let res = resolver.lookup_node_by_id(&node_id, origin).await?;
 
         assert_eq!(res.node_id, node_id);
-        assert_eq!(res.relay_url.map(Url::from), Some(relay_url));
+        assert_eq!(res.relay_url(), Some(&relay_url));
 
         server.shutdown().await?;
         Ok(())
@@ -235,7 +235,7 @@ mod tests {
         // create a signed packet
         let secret_key = SecretKey::generate(rand::thread_rng());
         let node_id = secret_key.public();
-        let relay_url: Url = "https://relay.example.".parse()?;
+        let relay_url: RelayUrl = "https://relay.example.".parse()?;
         let node_data = NodeData::default().with_relay_url(relay_url.clone());
         let node_info = NodeInfo::new(node_id, node_data);
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
@@ -254,7 +254,7 @@ mod tests {
         let res = resolver.lookup_node_by_id(&node_id, origin).await?;
 
         assert_eq!(res.node_id, node_id);
-        assert_eq!(res.relay_url.map(Url::from), Some(relay_url));
+        assert_eq!(res.relay_url(), Some(&relay_url));
 
         server.shutdown().await?;
         for mut node in testnet.nodes {

--- a/iroh-relay/src/dns/node_info.rs
+++ b/iroh-relay/src/dns/node_info.rs
@@ -108,8 +108,8 @@ impl NodeData {
     }
 
     /// Sets the direct addresses and returns the updated node data.
-    pub fn with_direct_addrs(mut self, direct_addrs: BTreeSet<SocketAddr>) -> Self {
-        self.direct_addresses = direct_addrs;
+    pub fn with_direct_addresses(mut self, direct_addresses: BTreeSet<SocketAddr>) -> Self {
+        self.direct_addresses = direct_addresses;
         self
     }
 
@@ -199,7 +199,7 @@ impl From<NodeAddr> for NodeInfo {
     fn from(addr: NodeAddr) -> Self {
         Self::new(addr.node_id)
             .with_relay_url(addr.relay_url)
-            .with_direct_addrs(addr.direct_addresses)
+            .with_direct_addresses(addr.direct_addresses)
     }
 }
 
@@ -221,8 +221,8 @@ impl NodeInfo {
     }
 
     /// Sets the direct addresses and returns the updated node info.
-    pub fn with_direct_addrs(mut self, direct_addrs: BTreeSet<SocketAddr>) -> Self {
-        self.data = self.data.with_direct_addrs(direct_addrs);
+    pub fn with_direct_addresses(mut self, direct_addresses: BTreeSet<SocketAddr>) -> Self {
+        self.data = self.data.with_direct_addresses(direct_addresses);
         self
     }
 
@@ -641,7 +641,7 @@ mod tests {
             "1992d53c02cdc04566e5c0edb1ce83305cd550297953a047a445ea3264b54b18",
         )?)
         .with_relay_url(Some("https://euw1-1.relay.iroh.network./".parse()?))
-        .with_direct_addrs(BTreeSet::from([
+        .with_direct_addresses(BTreeSet::from([
             "192.168.96.145:60165".parse()?,
             "213.208.157.87:60165".parse()?,
         ]));

--- a/iroh-relay/src/dns/node_info.rs
+++ b/iroh-relay/src/dns/node_info.rs
@@ -78,11 +78,12 @@ impl NodeIdExt for NodeId {
     }
 }
 
-/// The information that can be published about a node in discovery services.
+/// Data about a node that may be published to and resolved from discovery services.
 ///
 /// This includes an optional [`RelayUrl`] and a set of direct addresses.
 ///
-/// The struct is non-exhaustive, more fields may be added in the future.
+/// This struct does not include the node's [`NodeId`], only the data *about* a certain
+/// node. See [`NodeInfo`] for a struct that contains a [`NodeId`] with associated [`NodeData`].
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct NodeData {
     /// URL of the home relay of this node.
@@ -147,7 +148,9 @@ impl From<NodeAddr> for NodeData {
     }
 }
 
-/// Information about the iroh node contained in an [`IROH_TXT_NAME`] TXT resource record.
+/// Information about a node that may be published to and resolved from discovery services.
+///
+/// This struct couples a [`NodeId`] with its associated [`NodeData`].
 #[derive(derive_more::Debug, Clone, Eq, PartialEq)]
 pub struct NodeInfo {
     /// The [`NodeId`].

--- a/iroh-relay/src/dns/node_info.rs
+++ b/iroh-relay/src/dns/node_info.rs
@@ -79,6 +79,11 @@ impl NodeIdExt for NodeId {
 }
 
 /// The information that can be published about a node in discovery services.
+///
+/// This includes an optional [`RelayUrl`] and a set of direct addresses.
+///
+/// The fields are not public, but there are setter and getter functions for all fields
+/// contained in the struct.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct NodeData {
     relay_url: Option<RelayUrl>,

--- a/iroh-relay/src/dns/node_info.rs
+++ b/iroh-relay/src/dns/node_info.rs
@@ -85,9 +85,12 @@ impl NodeIdExt for NodeId {
 /// The fields are not public, but there are setter and getter functions for all fields
 /// contained in the struct.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct NodeData {
-    relay_url: Option<RelayUrl>,
-    direct_addresses: BTreeSet<SocketAddr>,
+    /// URL of the home relay of this node.
+    pub relay_url: Option<RelayUrl>,
+    /// Direct addresses where this node can be reached.
+    pub direct_addresses: BTreeSet<SocketAddr>,
 }
 
 impl NodeData {
@@ -109,16 +112,6 @@ impl NodeData {
     pub fn with_direct_addrs(mut self, direct_addrs: BTreeSet<SocketAddr>) -> Self {
         self.direct_addresses = direct_addrs;
         self
-    }
-
-    /// Returns the relay URL.
-    pub fn relay_url(&self) -> Option<&RelayUrl> {
-        self.relay_url.as_ref()
-    }
-
-    /// Returns the direct addresses.
-    pub fn direct_addrs(&self) -> &BTreeSet<SocketAddr> {
-        &self.direct_addresses
     }
 
     /// Removes all direct addresses.

--- a/iroh-relay/src/dns/node_info.rs
+++ b/iroh-relay/src/dns/node_info.rs
@@ -86,7 +86,7 @@ pub struct NodeData {
 }
 
 impl NodeData {
-    /// Creates a new [`DiscoveryData`] with a relay URL and a set of direct addresses.
+    /// Creates a new [`NodeData`] with a relay URL and a set of direct addresses.
     pub fn new(relay_url: Option<RelayUrl>, direct_addresses: BTreeSet<SocketAddr>) -> Self {
         Self {
             relay_url,

--- a/iroh-relay/src/dns/node_info.rs
+++ b/iroh-relay/src/dns/node_info.rs
@@ -130,7 +130,7 @@ impl NodeData {
 
     /// Adds direct addresses to the node data.
     pub fn add_direct_addresses(&mut self, addrs: impl IntoIterator<Item = SocketAddr>) {
-        self.direct_addresses.extend(addrs.into_iter())
+        self.direct_addresses.extend(addrs)
     }
 
     /// Sets the relay URL of the node data.

--- a/iroh-relay/src/dns/node_info.rs
+++ b/iroh-relay/src/dns/node_info.rs
@@ -153,7 +153,7 @@ impl From<NodeAddr> for NodeData {
 /// This struct couples a [`NodeId`] with its associated [`NodeData`].
 #[derive(derive_more::Debug, Clone, Eq, PartialEq)]
 pub struct NodeInfo {
-    /// The [`NodeId`].
+    /// The [`NodeId`] of the node this is about.
     pub node_id: NodeId,
     /// The information published about the node.
     pub data: NodeData,
@@ -227,7 +227,7 @@ impl NodeInfo {
     }
 
     /// Converts into a [`NodeAddr`] by cloning the needed fields.
-    pub fn node_addr(&self) -> NodeAddr {
+    pub fn to_node_addr(&self) -> NodeAddr {
         NodeAddr {
             node_id: self.node_id,
             relay_url: self.data.relay_url.clone(),

--- a/iroh-relay/src/dns/node_info.rs
+++ b/iroh-relay/src/dns/node_info.rs
@@ -211,6 +211,18 @@ impl NodeInfo {
         Self { node_id, data }
     }
 
+    /// Sets the relay URL and returns the updated node info.
+    pub fn with_relay_url(mut self, relay_url: impl Into<RelayUrl>) -> Self {
+        self.data = self.data.with_relay_url(relay_url);
+        self
+    }
+
+    /// Sets the direct addresses and returns the updated node info.
+    pub fn with_direct_addrs(mut self, direct_addrs: BTreeSet<SocketAddr>) -> Self {
+        self.data = self.data.with_direct_addrs(direct_addrs);
+        self
+    }
+
     /// Converts into a [`NodeAddr`] by cloning the needed fields.
     pub fn node_addr(&self) -> NodeAddr {
         NodeAddr {

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -196,8 +196,8 @@ impl<T: Discovery> Discovery for Arc<T> {}
 
 /// The results returned from [`Discovery::resolve`].
 ///
-/// This struct derefs to [`NodeData`], which that you can access the methods
-/// of [`NodeData`] directly from [`DiscoveryItem`].
+/// This struct derefs to [`NodeData`], so you can access the methods from [`NodeData`]
+/// directly from [`DiscoveryItem`].
 #[derive(Debug, Clone)]
 pub struct DiscoveryItem {
     /// The node info for the node, as discovered by the the discovery service.

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -217,13 +217,6 @@ pub struct DiscoveryItem {
     last_updated: Option<u64>,
 }
 
-impl std::ops::Deref for DiscoveryItem {
-    type Target = NodeData;
-    fn deref(&self) -> &Self::Target {
-        &self.node_info.data
-    }
-}
-
 impl DiscoveryItem {
     /// Creates a new [`DiscoveryItem`] from a [`NodeInfo`].
     pub fn new(node_info: NodeInfo, provenance: &'static str, last_updated: Option<u64>) -> Self {
@@ -246,12 +239,13 @@ impl DiscoveryItem {
 
     /// Returns the provenance of this discovery item.
     ///
-    /// The provenance is a static string to identify the discovery source.
+    /// The provenance is a static string which identifies the discovery service that produced
+    /// this discovery item.
     pub fn provenance(&self) -> &'static str {
         self.provenance
     }
 
-    /// Returns the optional timestamp when this node address info was last updated.
+    /// Returns the optional timestamp when this node info was last updated.
     ///
     /// The value is microseconds since the unix epoch.
     pub fn last_updated(&self) -> Option<u64> {
@@ -266,6 +260,19 @@ impl DiscoveryItem {
     /// Converts into a [`NodeAddr`] without cloning.
     pub fn into_node_addr(self) -> NodeAddr {
         self.node_info.into_node_addr()
+    }
+}
+
+impl std::ops::Deref for DiscoveryItem {
+    type Target = NodeData;
+    fn deref(&self) -> &Self::Target {
+        &self.node_info.data
+    }
+}
+
+impl From<DiscoveryItem> for NodeInfo {
+    fn from(item: DiscoveryItem) -> Self {
+        item.node_info
     }
 }
 

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -260,7 +260,7 @@ impl DiscoveryItem {
 
     /// Converts into a [`NodeAddr`] by cloning the needed fields.
     pub fn to_node_addr(&self) -> NodeAddr {
-        self.node_info.node_addr()
+        self.node_info.to_node_addr()
     }
 
     /// Converts into a [`NodeAddr`] without cloning.
@@ -883,7 +883,7 @@ mod test_dns_pkarr {
             direct_addresses: Default::default(),
         };
 
-        assert_eq!(resolved.node_addr(), expected);
+        assert_eq!(resolved.to_node_addr(), expected);
         Ok(())
     }
 

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -223,6 +223,21 @@ impl DiscoveryItem {
             last_updated,
         }
     }
+
+    /// Creates a new [`DiscoveryItem`] from a [`NodeData`].
+    pub fn from_node_data(
+        node_id: NodeId,
+        node_data: NodeData,
+        provenance: &'static str,
+        last_updated: Option<u64>,
+    ) -> Self {
+        let node_addr = node_data.into_node_addr(node_id);
+        Self {
+            node_addr,
+            provenance,
+            last_updated,
+        }
+    }
 }
 
 /// A discovery service that combines multiple discovery sources.
@@ -537,12 +552,7 @@ mod tests {
             };
             let stream = match addr_info {
                 Some((data, ts)) => {
-                    let node_addr = data.into_node_addr(node_id);
-                    let item = DiscoveryItem {
-                        node_addr,
-                        provenance: "test-disco",
-                        last_updated: Some(ts),
-                    };
+                    let item = DiscoveryItem::from_node_data(node_id, data, "test-disco", Some(ts));
                     let delay = self.delay;
                     let fut = async move {
                         time::sleep(delay).await;

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -194,7 +194,11 @@ pub trait Discovery: std::fmt::Debug + Send + Sync {
 
 impl<T: Discovery> Discovery for Arc<T> {}
 
-/// The results returned from [`Discovery::resolve`].
+/// Node discovery results from [`Discovery`] services.
+///
+/// This is the item in the streams returned from [`Discovery::resolve`] and
+/// [`Discovery::subscribe`]. It contains the [`NodeData`] about the discovered node,
+/// and some additional metadata about the discovery.
 ///
 /// This struct derefs to [`NodeData`], so you can access the methods from [`NodeData`]
 /// directly from [`DiscoveryItem`].

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -135,7 +135,7 @@ pub mod static_provider;
 /// looked up by other nodes.
 ///
 /// The published addressing information can include both a [`RelayUrl`] and/or direct
-/// addresses.
+/// addresses. See [`NodeData`] for details.
 ///
 /// To allow for discovery, the [`super::Endpoint`] will call `publish` whenever
 /// discovery information changes. If a discovery mechanism requires a periodic
@@ -143,7 +143,7 @@ pub mod static_provider;
 ///
 /// [`RelayUrl`]: crate::RelayUrl
 pub trait Discovery: std::fmt::Debug + Send + Sync {
-    /// Publishes the given [`RelayUrl`] and direct addreesses to the discovery mechanism.
+    /// Publishes the given [`NodeData`] to the discovery mechanism.
     ///
     /// This is fire and forget, since the [`Endpoint`] can not wait for successful
     /// publishing. If publishing is async, the implementation should start it's own task.

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -879,7 +879,7 @@ mod test_dns_pkarr {
         let publisher = PkarrPublisher::new(secret_key, dns_pkarr_server.pkarr_url.clone());
         let data = NodeData::new(relay_url.clone(), Default::default());
         // does not block, update happens in background task
-        publisher.update_addr_info(&data);
+        publisher.update_node_data(&data);
         // wait until our shared state received the update from pkarr publishing
         dns_pkarr_server.on_node(&node_id, PUBLISH_TIMEOUT).await?;
         let resolved = resolver.lookup_node_by_id(&node_id, &origin).await?;

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -583,8 +583,11 @@ mod tests {
             };
             let stream = match addr_info {
                 Some((data, ts)) => {
-                    let item =
-                        DiscoveryItem::new(NodeInfo::new(node_id, data), "test-disco", Some(ts));
+                    let item = DiscoveryItem::new(
+                        NodeInfo::from_parts(node_id, data),
+                        "test-disco",
+                        Some(ts),
+                    );
                     let delay = self.delay;
                     let fut = async move {
                         time::sleep(delay).await;
@@ -838,13 +841,8 @@ mod test_dns_pkarr {
         let (nameserver, _dns_drop_guard) = run_dns_server(state.clone()).await?;
 
         let secret_key = SecretKey::generate(rand::thread_rng());
-        let node_info = NodeInfo::new(
-            secret_key.public(),
-            NodeData::new(
-                Some("https://relay.example".parse().unwrap()),
-                Default::default(),
-            ),
-        );
+        let node_info = NodeInfo::new(secret_key.public())
+            .with_relay_url(Some("https://relay.example".parse().unwrap()));
         let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
         state.upsert(signed_packet)?;
 

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -248,7 +248,7 @@ impl DiscoveryItem {
     ///
     /// The provenance is a static string to identify the discovery source.
     pub fn provenance(&self) -> &'static str {
-        &self.provenance
+        self.provenance
     }
 
     /// Returns the optional timestamp when this node address info was last updated.
@@ -853,7 +853,7 @@ mod test_dns_pkarr {
             .lookup_node_by_id(&node_info.node_id, &origin)
             .await?;
 
-        assert_eq!(resolved, node_info.into());
+        assert_eq!(resolved, node_info);
 
         Ok(())
     }

--- a/iroh/src/discovery/dns.rs
+++ b/iroh/src/discovery/dns.rs
@@ -67,14 +67,10 @@ impl Discovery for DnsDiscovery {
         let resolver = ep.dns_resolver().clone();
         let origin_domain = self.origin_domain.clone();
         let fut = async move {
-            let node_addr = resolver
+            let node_info = resolver
                 .lookup_node_by_id_staggered(&node_id, &origin_domain, DNS_STAGGERING_MS)
                 .await?;
-            Ok(DiscoveryItem {
-                node_addr,
-                provenance: "dns",
-                last_updated: None,
-            })
+            Ok(DiscoveryItem::new(node_info, "dns", None))
         };
         let stream = n0_future::stream::once_future(fut);
         Some(Box::pin(stream))

--- a/iroh/src/discovery/local_swarm_discovery.rs
+++ b/iroh/src/discovery/local_swarm_discovery.rs
@@ -348,7 +348,7 @@ fn peer_to_discovery_item(peer: &Peer, node_id: &NodeId) -> DiscoveryItem {
         .iter()
         .map(|(ip, port)| SocketAddr::new(*ip, *port))
         .collect();
-    let node_info = NodeInfo::new(*node_id).with_direct_addrs(direct_addresses);
+    let node_info = NodeInfo::new(*node_id).with_direct_addresses(direct_addresses);
     DiscoveryItem::new(node_info, NAME, None)
 }
 

--- a/iroh/src/discovery/local_swarm_discovery.rs
+++ b/iroh/src/discovery/local_swarm_discovery.rs
@@ -348,8 +348,7 @@ fn peer_to_discovery_item(peer: &Peer, node_id: &NodeId) -> DiscoveryItem {
         .iter()
         .map(|(ip, port)| SocketAddr::new(*ip, *port))
         .collect();
-    let node_data = NodeData::new(None, direct_addresses);
-    let node_info = NodeInfo::new(*node_id, node_data);
+    let node_info = NodeInfo::new(*node_id).with_direct_addrs(direct_addresses);
     DiscoveryItem::new(node_info, NAME, None)
 }
 

--- a/iroh/src/discovery/local_swarm_discovery.rs
+++ b/iroh/src/discovery/local_swarm_discovery.rs
@@ -48,7 +48,7 @@ use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{debug, error, info_span, trace, warn, Instrument};
 
 use crate::{
-    discovery::{Discovery, DiscoveryData, DiscoveryItem},
+    discovery::{Discovery, DiscoveryItem, NodeData},
     watchable::Watchable,
     Endpoint,
 };
@@ -376,7 +376,7 @@ impl Discovery for LocalSwarmDiscovery {
         Some(Box::pin(stream.flatten_stream()))
     }
 
-    fn publish(&self, data: &DiscoveryData) {
+    fn publish(&self, data: &NodeData) {
         self.local_addrs
             .set(Some((
                 data.relay_url().cloned(),
@@ -418,7 +418,7 @@ mod tests {
             let (node_id_b, discovery_b) = make_discoverer()?;
 
             // make addr info for discoverer b
-            let addr_info = DiscoveryData::new(None, BTreeSet::from(["0.0.0.0:11111".parse()?]));
+            let addr_info = NodeData::new(None, BTreeSet::from(["0.0.0.0:11111".parse()?]));
 
             // pass in endpoint, this is never used
             let ep = crate::endpoint::Builder::default().bind().await?;
@@ -452,7 +452,7 @@ mod tests {
             let mut discoverers = vec![];
 
             let (_, discovery) = make_discoverer()?;
-            let addr_info = DiscoveryData::new(None, BTreeSet::from(["0.0.0.0:11111".parse()?]));
+            let addr_info = NodeData::new(None, BTreeSet::from(["0.0.0.0:11111".parse()?]));
 
             for _ in 0..num_nodes {
                 let (node_id, discovery) = make_discoverer()?;

--- a/iroh/src/discovery/local_swarm_discovery.rs
+++ b/iroh/src/discovery/local_swarm_discovery.rs
@@ -379,8 +379,8 @@ impl Discovery for LocalSwarmDiscovery {
     fn publish(&self, data: &NodeData) {
         self.local_addrs
             .set(Some((
-                data.relay_url().cloned(),
-                data.direct_addrs().clone(),
+                data.relay_url.clone(),
+                data.direct_addresses.clone(),
             )))
             .ok();
     }
@@ -436,10 +436,16 @@ mod tests {
             let s2_res = tokio::time::timeout(Duration::from_secs(5), s2.next())
                 .await?
                 .unwrap()?;
-            assert_eq!(s1_res.node_addr.relay_url.as_ref(), addr_info.relay_url());
-            assert_eq!(&s1_res.node_addr.direct_addresses, addr_info.direct_addrs());
-            assert_eq!(s2_res.node_addr.relay_url.as_ref(), addr_info.relay_url());
-            assert_eq!(&s2_res.node_addr.direct_addresses, addr_info.direct_addrs());
+            assert_eq!(s1_res.node_addr.relay_url, addr_info.relay_url);
+            assert_eq!(
+                s1_res.node_addr.direct_addresses,
+                addr_info.direct_addresses
+            );
+            assert_eq!(s2_res.node_addr.relay_url, addr_info.relay_url);
+            assert_eq!(
+                s2_res.node_addr.direct_addresses,
+                addr_info.direct_addresses
+            );
 
             Ok(())
         }

--- a/iroh/src/discovery/local_swarm_discovery.rs
+++ b/iroh/src/discovery/local_swarm_discovery.rs
@@ -48,12 +48,10 @@ use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{debug, error, info_span, trace, warn, Instrument};
 
 use crate::{
-    discovery::{Discovery, DiscoveryItem},
+    discovery::{Discovery, DiscoveryData, DiscoveryItem},
     watchable::Watchable,
     Endpoint,
 };
-
-use super::DiscoveryData;
 
 /// The n0 local swarm node discovery name
 const N0_LOCAL_SWARM: &str = "iroh.local.swarm";

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -199,7 +199,7 @@ impl PkarrPublisher {
             // If relay url is set: only publish relay url, and no direct addrs.
             data.clear_direct_addresses();
         }
-        let info = NodeInfo::new(self.node_id, data);
+        let info = NodeInfo::from_parts(self.node_id, data);
         self.watchable.set(Some(info)).ok();
     }
 }

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -54,11 +54,11 @@ use n0_future::{
     time::{self, Duration, Instant},
 };
 use pkarr::SignedPacket;
-use tracing::{debug, error_span, info, warn, Instrument};
+use tracing::{debug, error_span, warn, Instrument};
 use url::Url;
 
 use crate::{
-    discovery::{Discovery, DiscoveryData, DiscoveryItem},
+    discovery::{Discovery, DiscoveryItem, NodeData},
     dns::node_info::NodeInfo,
     endpoint::force_staging_infra,
     watchable::{Disconnected, Watchable, Watcher},
@@ -193,21 +193,19 @@ impl PkarrPublisher {
     /// Publishes the addressing information about this node to a pkarr relay.
     ///
     /// This is a nonblocking function, the actual update is performed in the background.
-    pub fn update_addr_info(&self, data: &DiscoveryData) {
-        let (relay_url, direct_addresses) = if let Some(relay_url) = data.relay_url() {
-            // Only publish relay url, and no direct addrs
-            let url = relay_url.clone();
-            (Some(url.into()), Default::default())
-        } else {
-            (None, data.direct_addrs().clone())
-        };
-        let info = NodeInfo::new(self.node_id, relay_url, direct_addresses);
+    pub fn update_addr_info(&self, data: &NodeData) {
+        let mut data = data.clone();
+        if data.relay_url().is_some() {
+            // If relay url is set: only publish relay url, and no direct addrs.
+            data.clear_direct_addresses();
+        }
+        let info = NodeInfo::new(self.node_id, data);
         self.watchable.set(Some(info)).ok();
     }
 }
 
 impl Discovery for PkarrPublisher {
-    fn publish(&self, data: &DiscoveryData) {
+    fn publish(&self, data: &NodeData) {
         self.update_addr_info(data);
     }
 }
@@ -266,11 +264,8 @@ impl PublisherService {
     }
 
     async fn publish_current(&self, info: NodeInfo) -> Result<()> {
-        info!(
-            relay_url = ?info
-                .relay_url
-                .as_ref()
-                .map(|s| s.as_str()),
+        debug!(
+            data = ?info.data,
             pkarr_relay = %self.pkarr_client.pkarr_relay_url,
             "Publish node info to pkarr"
         );
@@ -332,11 +327,7 @@ impl Discovery for PkarrResolver {
         let fut = async move {
             let signed_packet = pkarr_client.resolve(node_id).await?;
             let info = NodeInfo::from_pkarr_signed_packet(&signed_packet)?;
-            let item = DiscoveryItem {
-                node_addr: info.into(),
-                provenance: "pkarr",
-                last_updated: None,
-            };
+            let item = DiscoveryItem::from_node_info(info, "pkarr", None);
             Ok(item)
         };
         let stream = n0_future::stream::once_future(fut);

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -195,7 +195,7 @@ impl PkarrPublisher {
     /// This is a nonblocking function, the actual update is performed in the background.
     pub fn update_addr_info(&self, data: &NodeData) {
         let mut data = data.clone();
-        if data.relay_url.is_some() {
+        if data.relay_url().is_some() {
             // If relay url is set: only publish relay url, and no direct addrs.
             data.clear_direct_addresses();
         }
@@ -327,7 +327,7 @@ impl Discovery for PkarrResolver {
         let fut = async move {
             let signed_packet = pkarr_client.resolve(node_id).await?;
             let info = NodeInfo::from_pkarr_signed_packet(&signed_packet)?;
-            let item = DiscoveryItem::from_node_info(info, "pkarr", None);
+            let item = DiscoveryItem::new(info, "pkarr", None);
             Ok(item)
         };
         let stream = n0_future::stream::once_future(fut);

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -58,14 +58,12 @@ use tracing::{debug, error_span, info, warn, Instrument};
 use url::Url;
 
 use crate::{
-    discovery::{Discovery, DiscoveryItem},
+    discovery::{Discovery, DiscoveryData, DiscoveryItem},
     dns::node_info::NodeInfo,
     endpoint::force_staging_infra,
     watchable::{Disconnected, Watchable, Watcher},
     Endpoint,
 };
-
-use super::DiscoveryData;
 
 #[cfg(feature = "discovery-pkarr-dht")]
 pub mod dht;

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -195,7 +195,7 @@ impl PkarrPublisher {
     /// This is a nonblocking function, the actual update is performed in the background.
     pub fn update_addr_info(&self, data: &NodeData) {
         let mut data = data.clone();
-        if data.relay_url().is_some() {
+        if data.relay_url.is_some() {
             // If relay url is set: only publish relay url, and no direct addrs.
             data.clear_direct_addresses();
         }

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -193,7 +193,7 @@ impl PkarrPublisher {
     /// Publishes the addressing information about this node to a pkarr relay.
     ///
     /// This is a nonblocking function, the actual update is performed in the background.
-    pub fn update_addr_info(&self, data: &NodeData) {
+    pub fn update_node_data(&self, data: &NodeData) {
         let mut data = data.clone();
         if data.relay_url().is_some() {
             // If relay url is set: only publish relay url, and no direct addrs.
@@ -206,7 +206,7 @@ impl PkarrPublisher {
 
 impl Discovery for PkarrPublisher {
     fn publish(&self, data: &NodeData) {
-        self.update_addr_info(data);
+        self.update_node_data(data);
     }
 }
 

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -343,11 +343,10 @@ impl Discovery for DhtDiscovery {
             return;
         };
         tracing::debug!("publishing {data:?}");
-        let mut data = data.clone();
+        let mut info = NodeInfo::from_parts(keypair.public(), data.clone());
         if !self.0.include_direct_addresses {
-            data.clear_direct_addresses();
+            info.clear_direct_addresses();
         }
-        let info = NodeInfo::new(keypair.public(), data);
         let Ok(signed_packet) = info.to_pkarr_signed_packet(keypair, self.0.ttl) else {
             tracing::warn!("failed to create signed packet");
             return;
@@ -417,7 +416,7 @@ mod tests {
             .build()?;
         let relay_url: RelayUrl = Url::parse("https://example.com")?.into();
 
-        let data = NodeData::default().with_relay_url(relay_url.clone());
+        let data = NodeData::default().with_relay_url(Some(relay_url.clone()));
         discovery.publish(&data);
 
         // publish is fire and forget, so we have no way to wait until it is done.

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -137,7 +137,7 @@ impl StaticProvider {
         let NodeInfo { node_id, data } = node_info.into();
         let mut guard = self.nodes.write().expect("poisoned");
         let previous = guard.insert(node_id, StoredNodeInfo { data, last_updated });
-        previous.map(|x| NodeInfo::new(node_id, x.data).into_node_addr())
+        previous.map(|x| NodeInfo::from_parts(node_id, x.data).into_node_addr())
     }
 
     /// Augments node addressing information for the given node ID.
@@ -168,7 +168,7 @@ impl StaticProvider {
     pub fn get_node_info(&self, node_id: NodeId) -> Option<NodeInfo> {
         let guard = self.nodes.read().expect("poisoned");
         let info = guard.get(&node_id)?;
-        Some(NodeInfo::new(node_id, info.data.clone()))
+        Some(NodeInfo::from_parts(node_id, info.data.clone()))
     }
 
     /// Removes all node addressing information for the given node ID.
@@ -177,7 +177,7 @@ impl StaticProvider {
     pub fn remove_node_info(&self, node_id: NodeId) -> Option<NodeInfo> {
         let mut guard = self.nodes.write().expect("poisoned");
         let info = guard.remove(&node_id)?;
-        Some(NodeInfo::new(node_id, info.data))
+        Some(NodeInfo::from_parts(node_id, info.data))
     }
 }
 
@@ -199,7 +199,7 @@ impl Discovery for StaticProvider {
                     .expect("time drift")
                     .as_micros() as u64;
                 let item = DiscoveryItem::new(
-                    NodeInfo::new(node_id, node_info.data.clone()),
+                    NodeInfo::from_parts(node_id, node_info.data.clone()),
                     Self::PROVENANCE,
                     Some(last_updated),
                 );

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -22,7 +22,7 @@ use n0_future::{
     time::SystemTime,
 };
 
-use super::{Discovery, DiscoveryItem};
+use super::{Discovery, DiscoveryData, DiscoveryItem};
 
 /// A static node discovery to manually add node addressing information.
 ///
@@ -202,7 +202,7 @@ impl StaticProvider {
 }
 
 impl Discovery for StaticProvider {
-    fn publish(&self, _url: Option<&RelayUrl>, _addrs: &BTreeSet<SocketAddr>) {}
+    fn publish(&self, _data: &DiscoveryData) {}
 
     fn resolve(
         &self,

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -22,7 +22,7 @@ use n0_future::{
     time::SystemTime,
 };
 
-use super::{Discovery, DiscoveryData, DiscoveryItem};
+use super::{Discovery, DiscoveryItem, NodeData};
 
 /// A static node discovery to manually add node addressing information.
 ///
@@ -202,7 +202,7 @@ impl StaticProvider {
 }
 
 impl Discovery for StaticProvider {
-    fn publish(&self, _data: &DiscoveryData) {}
+    fn publish(&self, _data: &NodeData) {}
 
     fn resolve(
         &self,

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -154,7 +154,7 @@ impl StaticProvider {
                 let existing = entry.get_mut();
                 existing
                     .data
-                    .add_direct_addresses(data.direct_addresses().iter().map(|x| *x));
+                    .add_direct_addresses(data.direct_addresses().iter().copied());
                 existing.data.set_relay_url(data.relay_url().cloned());
                 existing.last_updated = last_updated;
             }

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2326,12 +2326,14 @@ impl Actor {
                 // forever like we do with the other branches that yield `Option`s
                 Some(discovery_item) = discovery_events.next() => {
                     trace!("tick: discovery event, address discovered: {discovery_item:?}");
+                    let provenance = discovery_item.provenance();
+                    let node_addr = discovery_item.into_node_addr();
                     if let Err(e) = self.msock.add_node_addr(
-                        discovery_item.node_addr.clone(),
+                        node_addr.clone(),
                         Source::Discovery {
-                            name: discovery_item.provenance.into()
+                            name: provenance.to_string()
                         }) {
-                        warn!(?discovery_item.node_addr, "unable to add discovered node address to the node map: {e:?}");
+                        warn!(?node_addr, "unable to add discovered node address to the node map: {e:?}");
                     }
                 }
             }

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -69,7 +69,7 @@ use crate::endpoint::PathSelection;
 use crate::{
     defaults::timeouts::NET_REPORT_TIMEOUT,
     disco::{self, CallMeMaybe, SendAddr},
-    discovery::{Discovery, DiscoveryData, DiscoveryItem},
+    discovery::{Discovery, DiscoveryItem, NodeData},
     dns::DnsResolver,
     key::{public_ed_box, secret_ed_box, DecryptionError, SharedSecret},
     watchable::{Watchable, Watcher},
@@ -1481,7 +1481,7 @@ impl MagicSock {
         if let Some(ref discovery) = self.discovery {
             let relay_url = self.my_relay();
             let direct_addrs = self.direct_addrs.sockaddrs();
-            let data = DiscoveryData::new(relay_url, direct_addrs);
+            let data = NodeData::new(relay_url, direct_addrs);
             discovery.publish(&data);
         }
     }

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -69,7 +69,7 @@ use crate::endpoint::PathSelection;
 use crate::{
     defaults::timeouts::NET_REPORT_TIMEOUT,
     disco::{self, CallMeMaybe, SendAddr},
-    discovery::{Discovery, DiscoveryItem},
+    discovery::{Discovery, DiscoveryData, DiscoveryItem},
     dns::DnsResolver,
     key::{public_ed_box, secret_ed_box, DecryptionError, SharedSecret},
     watchable::{Watchable, Watcher},
@@ -1479,7 +1479,10 @@ impl MagicSock {
     /// Called whenever our addresses or home relay node changes.
     fn publish_my_addr(&self) {
         if let Some(ref discovery) = self.discovery {
-            discovery.publish(self.my_relay().as_ref(), &self.direct_addrs.sockaddrs());
+            let relay_url = self.my_relay();
+            let direct_addrs = self.direct_addrs.sockaddrs();
+            let data = DiscoveryData::new(relay_url, direct_addrs);
+            discovery.publish(&data);
         }
     }
 }


### PR DESCRIPTION
## Description

Adds a `NodeData` struct that contains the information about a node that can be published in discovery services. This struct is both used in `iroh_relay::dns::NodeInfo` and in `iroh::discovery::Discovery`. Also, `iroh::discovery::DiscoveryItem` has no public fields anymore and uses `NodeInfo` internally to again reduce duplication. With these changes, the fields published about a node in discovery now are only defined in a single place.

This PR also serves these prupsoes:
* We want to add some "user defined data" to discovery (see #3176). This would add a third argument to `Discovery::publish`; with this PR instead we can just add it as an optional field to `NodeData`.
* It makes it possible to potentially add data to discovery after 1.0. The fields of `NodeData` are private, so we can add fields, and setter/getter methods, without this being a semver-breaking change.

A few other places are changed for consistency: `StaticProvider` now works with `NodeInfo` instead of `NodeAddr` (`NodeInfo` can be easily converted into `NodeAddr`). `DnsProvider::lookup_node_by_id` etc. now return `NodeInfo` instead of `NodeAddr`. A few method names are adjusted for consistency. `NodeInfo` is constructed in a builder-style fashion instead of passing all fields to `new`.

## Breaking Changes

* `iroh::discovery::Discovery::publish` now takes `data: &NodeData` as its single argument. `iroh::discovery::NodeData` is a re-export of `iroh_relay::dns::node_info::NodeData`, and contains relay URL and direct addresses. See docs for `NodeData` for details.
* `iroh::discovery::DiscoveryItem` no longer has any public fields. There are now getters for the contained data, and constructors for createing a `DiscoveryItem` from a `NodeInfo`.
* `iroh_relay::dns::node_info::NodeInfo` is changed.
    * `NodeInfo::new` now has a single `NodeId` argument. Use `NodeInfo::with_direct_addresses` and `NodeInfo::with_relay_url` to set addresses and relay URL. Alternatively, use `NodeInfo::from_parts` and pass a `NodeData` struct.
    *  `NodeInfo` now has two public fields `node_id: NodeId` and `data: NodeData`, and setter and getter methods for the relay URL and direct addresses.
* ` iroh::discovery::pkarr::PkarrPublisher::update_addr_info` now takes a `NodeData` argument

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
