### PR TITLE
feat(iroh): publish and resolve user-defined data in discovery

### DIFF
--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{net::SocketAddr, str::FromStr};
 
 use anyhow::{bail, Result};
 use clap::{Parser, ValueEnum};
@@ -6,6 +6,7 @@ use iroh::{
     discovery::{
         dns::{N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING},
         pkarr::{PkarrRelayClient, N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING},
+        UserData,
     },
     dns::node_info::{NodeIdExt, NodeInfo, IROH_TXT_NAME},
     NodeId, SecretKey,
@@ -39,7 +40,14 @@ struct Cli {
     #[clap(long, conflicts_with = "env")]
     pkarr_relay: Option<Url>,
     /// Home relay server to publish for this node
-    relay_url: Url,
+    #[clap(short, long)]
+    relay_url: Option<Url>,
+    /// Direct addresses to publish for this node
+    #[clap(short, long)]
+    addr: Vec<SocketAddr>,
+    /// User data to publish for this node
+    #[clap(short, long)]
+    user_data: Option<UserData>,
     /// Create a new node secret if IROH_SECRET is unset. Only for development / debugging.
     #[clap(short, long)]
     create: bool,
@@ -72,12 +80,23 @@ async fn main() -> Result<()> {
     };
 
     println!("announce {node_id}:");
-    println!("    relay={}", args.relay_url);
+    if let Some(relay_url) = &args.relay_url {
+        println!("    relay={relay_url}");
+    }
+    for addr in &args.addr {
+        println!("    addr={addr}");
+    }
+    if let Some(user_data) = &args.user_data {
+        println!("    user-data={user_data}");
+    }
     println!();
     println!("publish to {pkarr_relay} ...");
 
     let pkarr = PkarrRelayClient::new(pkarr_relay);
-    let node_info = NodeInfo::new(node_id).with_relay_url(Some(args.relay_url.into()));
+    let node_info = NodeInfo::new(node_id)
+        .with_relay_url(args.relay_url.map(Into::into))
+        .with_direct_addresses(args.addr.into_iter().collect())
+        .with_user_data(args.user_data);
     let signed_packet = node_info.to_pkarr_signed_packet(&secret_key, 30)?;
     pkarr.publish(&signed_packet).await?;
 

--- a/iroh-dns-server/examples/resolve.rs
+++ b/iroh-dns-server/examples/resolve.rs
@@ -57,5 +57,8 @@ async fn main() -> anyhow::Result<()> {
     for addr in resolved.direct_addresses() {
         println!("    addr={addr}")
     }
+    if let Some(user_data) = resolved.user_data() {
+        println!("    user-data={user_data}")
+    }
     Ok(())
 }

--- a/iroh-relay/src/dns/node_info.rs
+++ b/iroh-relay/src/dns/node_info.rs
@@ -34,7 +34,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fmt::Display,
+    fmt::{self, Display},
     hash::Hash,
     net::SocketAddr,
     str::FromStr,
@@ -80,7 +80,9 @@ impl NodeIdExt for NodeId {
 
 /// Data about a node that may be published to and resolved from discovery services.
 ///
-/// This includes an optional [`RelayUrl`] and a set of direct addresses.
+/// This includes an optional [`RelayUrl`], a set of direct addresses, and the optional
+/// [`UserData`], a string that can be set by applications and is not parsed or used by iroh
+/// itself.
 ///
 /// This struct does not include the node's [`NodeId`], only the data *about* a certain
 /// node. See [`NodeInfo`] for a struct that contains a [`NodeId`] with associated [`NodeData`].
@@ -90,6 +92,8 @@ pub struct NodeData {
     relay_url: Option<RelayUrl>,
     /// Direct addresses where this node can be reached.
     direct_addresses: BTreeSet<SocketAddr>,
+    /// Optional user-defined [`UserData`] for this node.
+    user_data: Option<UserData>,
 }
 
 impl NodeData {
@@ -98,6 +102,7 @@ impl NodeData {
         Self {
             relay_url,
             direct_addresses,
+            user_data: None,
         }
     }
 
@@ -113,9 +118,20 @@ impl NodeData {
         self
     }
 
+    /// Sets the user-defined data and returns the updated node data.
+    pub fn with_user_data(mut self, user_data: Option<UserData>) -> Self {
+        self.user_data = user_data;
+        self
+    }
+
     /// Returns the relay URL of the node.
     pub fn relay_url(&self) -> Option<&RelayUrl> {
         self.relay_url.as_ref()
+    }
+
+    /// Returns the optional user-defined data of the node.
+    pub fn user_data(&self) -> Option<&UserData> {
+        self.user_data.as_ref()
     }
 
     /// Returns the direct addresses of the node.
@@ -137,6 +153,11 @@ impl NodeData {
     pub fn set_relay_url(&mut self, relay_url: Option<RelayUrl>) {
         self.relay_url = relay_url
     }
+
+    /// Sets the user-defined data of the node data.
+    pub fn set_user_data(&mut self, user_data: Option<UserData>) {
+        self.user_data = user_data;
+    }
 }
 
 impl From<NodeAddr> for NodeData {
@@ -144,7 +165,69 @@ impl From<NodeAddr> for NodeData {
         Self {
             relay_url: node_addr.relay_url,
             direct_addresses: node_addr.direct_addresses,
+            user_data: None,
         }
+    }
+}
+
+// User-defined data that can be published and resolved through node discovery.
+///
+/// Under the hood this is a UTF-8 String is no longer than [`UserData::MAX_LENGTH`] bytes.
+///
+/// Iroh does not keep track of or examine the user-defined data.
+///
+/// `UserData` implements [`FromStr`] and [`TryFrom<String>`], so you can
+/// convert `&str` and `String` into `UserData` easily.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct UserData(String);
+
+impl UserData {
+    /// The max byte length allowed for user-defined data.
+    ///
+    /// In DNS discovery services, the user-defined data is stored in a TXT record character string,
+    /// which has a max length of 255 bytes. We need to subtract the `user-data=` prefix,
+    /// which leaves 245 bytes for the actual user-defined data.
+    pub const MAX_LENGTH: usize = 245;
+}
+
+/// Error returned when an input value is too long for [`UserData`].
+#[derive(Debug, thiserror::Error)]
+#[error("User-defined data exceeds max length")]
+pub struct MaxLengthExceededError;
+
+impl TryFrom<String> for UserData {
+    type Error = MaxLengthExceededError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.len() > Self::MAX_LENGTH {
+            Err(MaxLengthExceededError)
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+impl FromStr for UserData {
+    type Err = MaxLengthExceededError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        if s.len() > Self::MAX_LENGTH {
+            Err(MaxLengthExceededError)
+        } else {
+            Ok(Self(s.to_string()))
+        }
+    }
+}
+
+impl fmt::Display for UserData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for UserData {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 
@@ -181,9 +264,16 @@ impl From<&TxtAttrs<IrohAttr>> for NodeInfo {
             .flatten()
             .filter_map(|s| SocketAddr::from_str(s).ok())
             .collect();
+        let user_data = attrs
+            .get(&IrohAttr::UserData)
+            .into_iter()
+            .flatten()
+            .next()
+            .and_then(|s| UserData::from_str(s).ok());
         let data = NodeData {
             relay_url: relay_url.map(Into::into),
             direct_addresses,
+            user_data,
         };
         Self { node_id, data }
     }
@@ -223,6 +313,12 @@ impl NodeInfo {
     /// Sets the direct addresses and returns the updated node info.
     pub fn with_direct_addresses(mut self, direct_addresses: BTreeSet<SocketAddr>) -> Self {
         self.data = self.data.with_direct_addresses(direct_addresses);
+        self
+    }
+
+    /// Sets the user-defined data and returns the updated node info.
+    pub fn with_user_data(mut self, user_data: Option<UserData>) -> Self {
+        self.data = self.data.with_user_data(user_data);
         self
     }
 
@@ -321,6 +417,8 @@ pub(super) enum IrohAttr {
     Relay,
     /// Direct address.
     Addr,
+    /// User-defined data
+    UserData,
 }
 
 /// Attributes parsed from [`IROH_TXT_NAME`] TXT records.
@@ -342,6 +440,9 @@ impl From<&NodeInfo> for TxtAttrs<IrohAttr> {
         }
         for addr in &info.data.direct_addresses {
             attrs.push((IrohAttr::Addr, addr.to_string()));
+        }
+        if let Some(user_data) = &info.data.user_data {
+            attrs.push((IrohAttr::UserData, user_data.to_string()));
         }
         Self::from_parts(info.node_id, attrs.into_iter())
     }
@@ -552,7 +653,8 @@ mod tests {
         let node_data = NodeData::new(
             Some("https://example.com".parse().unwrap()),
             ["127.0.0.1:1234".parse().unwrap()].into_iter().collect(),
-        );
+        )
+        .with_user_data(Some("foobar".parse().unwrap()));
         let node_id = "vpnk377obfvzlipnsfbqba7ywkkenc4xlpmovt5tsfujoa75zqia"
             .parse()
             .unwrap();
@@ -569,7 +671,8 @@ mod tests {
         let node_data = NodeData::new(
             Some("https://example.com".parse().unwrap()),
             ["127.0.0.1:1234".parse().unwrap()].into_iter().collect(),
-        );
+        )
+        .with_user_data(Some("foobar".parse().unwrap()));
         let expected = NodeInfo::from_parts(secret_key.public(), node_data);
         let packet = expected.to_pkarr_signed_packet(&secret_key, 30).unwrap();
         let actual = NodeInfo::from_pkarr_signed_packet(&packet).unwrap();

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -109,7 +109,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, ensure, Result};
 use iroh_base::{NodeAddr, NodeId};
-pub use iroh_relay::dns::node_info::{NodeData, NodeInfo};
+pub use iroh_relay::dns::node_info::{NodeData, NodeInfo, UserData};
 use n0_future::{
     stream::{Boxed as BoxStream, StreamExt},
     task::{self, AbortOnDropHandle},
@@ -832,7 +832,7 @@ mod tests {
 mod test_dns_pkarr {
     use anyhow::Result;
     use iroh_base::{NodeAddr, SecretKey};
-    use iroh_relay::RelayMap;
+    use iroh_relay::{dns::node_info::UserData, RelayMap};
     use n0_future::time::Duration;
     use tokio_util::task::AbortOnDropHandle;
     use tracing_test::traced_test;
@@ -885,20 +885,24 @@ mod test_dns_pkarr {
 
         let resolver = DnsResolver::with_nameserver(dns_pkarr_server.nameserver);
         let publisher = PkarrPublisher::new(secret_key, dns_pkarr_server.pkarr_url.clone());
-        let data = NodeData::new(relay_url.clone(), Default::default());
+        let user_data: UserData = "foobar".parse().unwrap();
+        let data = NodeData::new(relay_url.clone(), Default::default())
+            .with_user_data(Some(user_data.clone()));
         // does not block, update happens in background task
         publisher.update_node_data(&data);
         // wait until our shared state received the update from pkarr publishing
         dns_pkarr_server.on_node(&node_id, PUBLISH_TIMEOUT).await?;
         let resolved = resolver.lookup_node_by_id(&node_id, &origin).await?;
+        println!("resolved {resolved:?}");
 
-        let expected = NodeAddr {
+        let expected_addr = NodeAddr {
             node_id,
             relay_url,
             direct_addresses: Default::default(),
         };
 
-        assert_eq!(resolved.to_node_addr(), expected);
+        assert_eq!(resolved.to_node_addr(), expected_addr);
+        assert_eq!(resolved.user_data(), Some(&user_data));
         Ok(())
     }
 

--- a/iroh/src/discovery/local_swarm_discovery.rs
+++ b/iroh/src/discovery/local_swarm_discovery.rs
@@ -63,6 +63,8 @@ const N0_LOCAL_SWARM: &str = "iroh.local.swarm";
 /// Used in the [`crate::endpoint::Source::Discovery`] enum variant as the `name`.
 pub const NAME: &str = "local.swarm.discovery";
 
+const USER_DATA_ATTRIBUTE: &str = "user-data";
+
 /// How long we will wait before we stop sending discovery items
 const DISCOVERY_DURATION: Duration = Duration::from_secs(10);
 
@@ -170,6 +172,11 @@ impl LocalSwarmDiscovery {
                             LocalSwarmDiscovery::socketaddrs_to_addrs(data.direct_addresses());
                         for addr in addrs {
                             discovery.add(addr.0, addr.1)
+                        }
+                        if let Some(user_data) = data.user_data() {
+                            if let Err(err) = discovery.set_txt_attribute(USER_DATA_ATTRIBUTE.to_string(), Some(user_data.to_string())) {
+                                warn!("Failed to set the user-defined data in local swarm discovery: {err:?}");
+                            }
                         }
                         continue;
                     }
@@ -348,7 +355,16 @@ fn peer_to_discovery_item(peer: &Peer, node_id: &NodeId) -> DiscoveryItem {
         .iter()
         .map(|(ip, port)| SocketAddr::new(*ip, *port))
         .collect();
-    let node_info = NodeInfo::new(*node_id).with_direct_addresses(direct_addresses);
+    // Get the user-defined data from the resolved peer info. We expect an attribute with a value
+    // that parses as `UserData`. Otherwise, omit.
+    let user_data = if let Some(Some(user_data)) = peer.txt_attribute(USER_DATA_ATTRIBUTE) {
+        user_data.parse().ok()
+    } else {
+        None
+    };
+    let node_info = NodeInfo::new(*node_id)
+        .with_direct_addresses(direct_addresses)
+        .with_user_data(user_data);
     DiscoveryItem::new(node_info, NAME, None)
 }
 
@@ -397,6 +413,7 @@ mod tests {
         use tracing_test::traced_test;
 
         use super::super::*;
+        use crate::discovery::UserData;
 
         #[tokio::test]
         #[traced_test]
@@ -405,7 +422,10 @@ mod tests {
             let (node_id_b, discovery_b) = make_discoverer()?;
 
             // make addr info for discoverer b
-            let addr_info = NodeData::new(None, BTreeSet::from(["0.0.0.0:11111".parse()?]));
+            let user_data: UserData = "foobar".parse()?;
+            let node_data = NodeData::new(None, BTreeSet::from(["0.0.0.0:11111".parse()?]))
+                .with_user_data(Some(user_data.clone()));
+            println!("info {node_data:?}");
 
             // pass in endpoint, this is never used
             let ep = crate::endpoint::Builder::default().bind().await?;
@@ -416,15 +436,15 @@ mod tests {
 
             tracing::debug!(?node_id_b, "Discovering node id b");
             // publish discovery_b's address
-            discovery_b.publish(&addr_info);
+            discovery_b.publish(&node_data);
             let s1_res = tokio::time::timeout(Duration::from_secs(5), s1.next())
                 .await?
                 .unwrap()?;
             let s2_res = tokio::time::timeout(Duration::from_secs(5), s2.next())
                 .await?
                 .unwrap()?;
-            assert_eq!(s1_res.node_info().data, addr_info);
-            assert_eq!(s2_res.node_info().data, addr_info);
+            assert_eq!(s1_res.node_info().data, node_data);
+            assert_eq!(s2_res.node_info().data, node_data);
 
             Ok(())
         }
@@ -437,12 +457,14 @@ mod tests {
             let mut discoverers = vec![];
 
             let (_, discovery) = make_discoverer()?;
-            let addr_info = NodeData::new(None, BTreeSet::from(["0.0.0.0:11111".parse()?]));
+            let node_data = NodeData::new(None, BTreeSet::from(["0.0.0.0:11111".parse()?]));
 
-            for _ in 0..num_nodes {
+            for i in 0..num_nodes {
                 let (node_id, discovery) = make_discoverer()?;
-                node_ids.insert(node_id);
-                discovery.publish(&addr_info);
+                let user_data: UserData = format!("node{i}").parse()?;
+                let node_data = node_data.clone().with_user_data(Some(user_data.clone()));
+                node_ids.insert((node_id, Some(user_data)));
+                discovery.publish(&node_data);
                 discoverers.push(discovery);
             }
 
@@ -452,8 +474,8 @@ mod tests {
                 let mut got_ids = BTreeSet::new();
                 while got_ids.len() != num_nodes {
                     if let Some(item) = events.next().await {
-                        if node_ids.contains(&item.node_id()) {
-                            got_ids.insert(item.node_id());
+                        if node_ids.contains(&(item.node_id(), item.user_data().cloned())) {
+                            got_ids.insert((item.node_id(), item.user_data().cloned()));
                         }
                     } else {
                         anyhow::bail!(

--- a/iroh/src/discovery/local_swarm_discovery.rs
+++ b/iroh/src/discovery/local_swarm_discovery.rs
@@ -63,6 +63,8 @@ const N0_LOCAL_SWARM: &str = "iroh.local.swarm";
 /// Used in the [`crate::endpoint::Source::Discovery`] enum variant as the `name`.
 pub const NAME: &str = "local.swarm.discovery";
 
+/// The key of the attribute under which the `UserData` is stored in
+/// the TXT record supported by swarm-discovery.
 const USER_DATA_ATTRIBUTE: &str = "user-data";
 
 /// How long we will wait before we stop sending discovery items
@@ -358,7 +360,13 @@ fn peer_to_discovery_item(peer: &Peer, node_id: &NodeId) -> DiscoveryItem {
     // Get the user-defined data from the resolved peer info. We expect an attribute with a value
     // that parses as `UserData`. Otherwise, omit.
     let user_data = if let Some(Some(user_data)) = peer.txt_attribute(USER_DATA_ATTRIBUTE) {
-        user_data.parse().ok()
+        match user_data.parse() {
+            Err(err) => {
+                debug!("failed to parse user data from TXT attribute: {err}");
+                None
+            }
+            Ok(data) => Some(data),
+        }
     } else {
         None
     };

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -159,6 +159,7 @@ impl StaticProvider {
                     .data
                     .add_direct_addresses(data.direct_addresses().iter().copied());
                 existing.data.set_relay_url(data.relay_url().cloned());
+                existing.data.set_user_data(data.user_data().cloned());
                 existing.last_updated = last_updated;
             }
             Entry::Vacant(entry) => {
@@ -240,12 +241,14 @@ mod tests {
             relay_url: Some("https://example.com".parse()?),
             direct_addresses: Default::default(),
         };
-        let node_info = NodeInfo::from(addr.clone());
+        let user_data = Some("foobar".parse().unwrap());
+        let node_info = NodeInfo::from(addr.clone()).with_user_data(user_data.clone());
         discovery.add_node_info(node_info.clone());
 
         let back = discovery.get_node_info(key.public()).context("no addr")?;
 
         assert_eq!(back, node_info);
+        assert_eq!(back.user_data(), user_data.as_ref());
         assert_eq!(back.into_node_addr(), addr);
 
         let removed = discovery

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -382,7 +382,7 @@ impl Builder {
         self
     }
 
-    /// Sets the user-defined data to be published in discovery services with this node's addresses.
+    /// Sets the initial user-defined data to be published in discovery services for this node.
     ///
     /// When using discovery services, this string of [`UserData`] will be published together
     /// with the node's addresses and relay URL. When other nodes discover this node,
@@ -1034,9 +1034,13 @@ impl Endpoint {
 
     // # Methods to update internal state.
 
-    /// Sets the user-defined data to be published in discovery services with this node's addresses.
+    /// Sets the initial user-defined data to be published in discovery services for this node.
     ///
-    /// See [`Builder::user_data_for_discovery`] for details.
+    /// If the user-defined data passed to this function is different to the previous one,
+    /// the endpoint will republish its node info to the configured discovery services.
+    ///
+    /// See also [`Builder::user_data_for_discovery`] for setting an initial value when
+    /// building the endpoint.
     pub fn set_user_data_for_discovery(&self, user_data: Option<UserData>) {
         self.msock.set_user_data_for_discovery(user_data);
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -32,7 +32,7 @@ use url::Url;
 
 use crate::{
     discovery::{
-        dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery,
+        dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery, DiscoveryItem,
         DiscoverySubscribers, DiscoveryTask, Lagged, UserData,
     },
     dns::DnsResolver,

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -33,6 +33,7 @@ use url::Url;
 use crate::{
     discovery::{
         dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery, DiscoveryTask,
+        UserData,
     },
     dns::DnsResolver,
     magicsock::{self, Handle, NodeIdMappedAddr},
@@ -110,6 +111,7 @@ pub struct Builder {
     keylog: bool,
     #[debug(skip)]
     discovery: Vec<DiscoveryBuilder>,
+    discovery_user_data: Option<UserData>,
     proxy_url: Option<Url>,
     /// List of known nodes. See [`Builder::known_nodes`].
     node_map: Option<Vec<NodeAddr>>,
@@ -133,6 +135,7 @@ impl Default for Builder {
             transport_config,
             keylog: Default::default(),
             discovery: Default::default(),
+            discovery_user_data: Default::default(),
             proxy_url: None,
             node_map: None,
             dns_resolver: None,
@@ -183,6 +186,7 @@ impl Builder {
             relay_map,
             node_map: self.node_map,
             discovery,
+            discovery_user_data: self.discovery_user_data,
             proxy_url: self.proxy_url,
             dns_resolver,
             server_config,
@@ -375,6 +379,19 @@ impl Builder {
                 .map(|x| Box::new(x) as _)
                 .ok()
         }));
+        self
+    }
+
+    /// Sets the user-defined data to be published in discovery services with this node's addresses.
+    ///
+    /// When using discovery services, this string of [`UserData`] will be published together
+    /// with the node's addresses and relay URL. When other nodes discover this node,
+    /// they retrieve the [`UserData`] in addition to the addressing info.
+    ///
+    /// Iroh itself does not interpret the user-defined data in any way, it is purely left
+    /// for applications to parse and use.
+    pub fn user_data_for_discovery(mut self, user_data: UserData) -> Self {
+        self.discovery_user_data = Some(user_data);
         self
     }
 
@@ -1013,6 +1030,15 @@ impl Endpoint {
     /// the network change itself, there is no harm in calling this function.
     pub async fn network_change(&self) {
         self.msock.network_change().await;
+    }
+
+    // # Methods to update internal state.
+
+    /// Sets the user-defined data to be published in discovery services with this node's addresses.
+    ///
+    /// See [`Builder::user_data_for_discovery`] for details.
+    pub fn set_user_data_for_discovery(&self, user_data: Option<UserData>) {
+        self.msock.set_user_data_for_discovery(user_data);
     }
 
     // # Methods for terminating the endpoint.

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -33,7 +33,7 @@ use url::Url;
 use crate::{
     discovery::{
         dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery,
-        DiscoverySubscribers, DiscoveryTask, DiscoveryTask, Lagged, UserData,
+        DiscoverySubscribers, DiscoveryTask, Lagged, UserData,
     },
     dns::DnsResolver,
     magicsock::{self, Handle, NodeIdMappedAddr},

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -69,7 +69,7 @@ use crate::endpoint::PathSelection;
 use crate::{
     defaults::timeouts::NET_REPORT_TIMEOUT,
     disco::{self, CallMeMaybe, SendAddr},
-    discovery::{Discovery, DiscoveryItem, NodeData},
+    discovery::{Discovery, DiscoveryItem, NodeData, UserData},
     dns::DnsResolver,
     key::{public_ed_box, secret_ed_box, DecryptionError, SharedSecret},
     watchable::{Watchable, Watcher},
@@ -117,6 +117,9 @@ pub(crate) struct Options {
     /// Optional node discovery mechanism.
     pub(crate) discovery: Option<Box<dyn Discovery>>,
 
+    /// Optional user-defined discovery data.
+    pub(crate) discovery_user_data: Option<UserData>,
+
     /// A DNS resolver to use for resolving relay URLs.
     ///
     /// You can use [`crate::dns::DnsResolver::new`] for a resolver
@@ -152,6 +155,7 @@ impl Default for Options {
             relay_map: RelayMap::empty(),
             node_map: None,
             discovery: None,
+            discovery_user_data: None,
             proxy_url: None,
             dns_resolver: DnsResolver::new(),
             server_config,
@@ -261,6 +265,9 @@ pub(crate) struct MagicSock {
 
     /// Optional discovery service
     discovery: Option<Box<dyn Discovery>>,
+
+    /// Optional user-defined discover data.
+    discovery_user_data: RwLock<Option<UserData>>,
 
     /// Our discovered direct addresses.
     direct_addrs: DiscoveredDirectAddrs,
@@ -424,6 +431,16 @@ impl MagicSock {
     /// Reference to optional discovery service
     pub(crate) fn discovery(&self) -> Option<&dyn Discovery> {
         self.discovery.as_ref().map(Box::as_ref)
+    }
+
+    /// Updates the user-defined discovery data for this node.
+    pub(crate) fn set_user_data_for_discovery(&self, user_data: Option<UserData>) {
+        let mut guard = self.discovery_user_data.write().expect("lock poisened");
+        if *guard != user_data {
+            *guard = user_data;
+            drop(guard);
+            self.publish_my_addr();
+        }
     }
 
     /// Call to notify the system of potential network changes.
@@ -1481,7 +1498,12 @@ impl MagicSock {
         if let Some(ref discovery) = self.discovery {
             let relay_url = self.my_relay();
             let direct_addrs = self.direct_addrs.sockaddrs();
-            let data = NodeData::new(relay_url, direct_addrs);
+            let user_data = self
+                .discovery_user_data
+                .read()
+                .expect("lock poisened")
+                .clone();
+            let data = NodeData::new(relay_url, direct_addrs).with_user_data(user_data);
             discovery.publish(&data);
         }
     }
@@ -1624,6 +1646,7 @@ impl Handle {
             relay_map,
             node_map,
             discovery,
+            discovery_user_data,
             dns_resolver,
             proxy_url,
             server_config,
@@ -1697,6 +1720,7 @@ impl Handle {
             ip_mapped_addrs,
             udp_disco_sender,
             discovery,
+            discovery_user_data: RwLock::new(discovery_user_data),
             direct_addrs: Default::default(),
             pending_call_me_maybes: Default::default(),
             direct_addr_update_state: DirectAddrUpdateState::new(),
@@ -4054,6 +4078,7 @@ mod tests {
             relay_map: RelayMap::empty(),
             node_map: None,
             discovery: None,
+            discovery_user_data: None,
             dns_resolver,
             proxy_url: None,
             server_config,


### PR DESCRIPTION
## Description

**Based on #3175**

Adds support for publishing and resolving a string of user-defined data through Iroh's discovery services.

This gives applications a way to add additional information to the records published and resolved through discovery, in addition to the addressing information (relay URL and direct addresses). Iroh itself does not parse or use this user-defined data string in any way.

All existing discovery services are updated to support the user data. All DNS-based discovery services encode the user-defined data in a TXT record, in the same way as the DNS/pkarr services already encode the relay URL and direct addresses. Therefore, the length of the `user-data=<user-data>` string is limited to 255 bytes, which is the max length for a single character string in DNS messages. Thus, the length of the actual user-defined data string is limited to 245 bytes (255 minux `user-data=`). This limit is enforced when constructing a `UserData` (which is just a wrapper around a `String` otherwise).

The local swarm discovery uses `swarm-discovery` under the hood, for which I added support for TXT records in https://github.com/rkuhn/swarm-discovery/pull/12. This was released as `swarm-discovery@0.3.0-alpha.2`.


## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Note that currently the `DiscoveryItem` which contains the user-defined data is only accessible when directly calling the methods on the `Discovery` trait. For discoveries initiated by the endpoint, both active from `Endpoint::connect` and passive from the magicsock's subscription to `Discovery::subscribe`, the `DiscoveryItem`s are currently not exposed in any way, thus there's no way for an app to access the user data of nodes discovered by the endpoint. However, with #3181, there will be a way to watch for all `DiscoveryItem`s found by the endpoint.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
