### PR TITLE
chore: add additional todos in the "change checklist"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 - [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
 - [ ] Tests if relevant.
 - [ ] All breaking changes documented.
-  - [ ] Document or create PRs for how these changes will effect downstream dependencies. The major ones are:
+  - [ ] Open an issue or PR on any affected downstream dependency repos. The major ones are:
     - [ ] `quic-rpc`
     - [ ] `iroh-gossip`
     - [ ] `iroh-blobs`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,3 +16,9 @@
 - [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
 - [ ] Tests if relevant.
 - [ ] All breaking changes documented.
+  - [ ] Document or create PRs for how these changes will effect downstream dependencies. The major ones are:
+    - [ ] `quic-rpc`
+    - [ ] `iroh-gossip`
+    - [ ] `iroh-blobs`
+    - [ ] `dumbpipe`
+    - [ ] `sendme`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
 - [ ] Tests if relevant.
 - [ ] All breaking changes documented.
   - [ ] List all breaking changes in the above "Breaking Changes" section.
-  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. The major ones are:
+  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
     - [ ] `quic-rpc`
     - [ ] `iroh-gossip`
     - [ ] `iroh-blobs`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,8 +18,8 @@
 - [ ] All breaking changes documented.
   - [ ] List all breaking changes in the above "Breaking Changes" section.
   - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
-    - [ ] `quic-rpc`
-    - [ ] `iroh-gossip`
-    - [ ] `iroh-blobs`
-    - [ ] `dumbpipe`
-    - [ ] `sendme`
+    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
+    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
+    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
+    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
+    - [ ] [`sendme`](https://github.com/n0-computer/sendme)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 <!-- Any notes, remarks or open questions you have to make about the PR. -->
 
 ## Change checklist
-
+<!-- Remove any that are not relevant. -->
 - [ ] Self-review.
 - [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
 - [ ] Tests if relevant.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,8 @@
 - [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
 - [ ] Tests if relevant.
 - [ ] All breaking changes documented.
-  - [ ] Open an issue or PR on any affected downstream dependency repos. The major ones are:
+  - [ ] List all breaking changes in the above "Breaking Changes" section.
+  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. The major ones are:
     - [ ] `quic-rpc`
     - [ ] `iroh-gossip`
     - [ ] `iroh-blobs`


### PR DESCRIPTION
## Description

In order to be better prepared for releases, we are trying to "front load" more work on understanding the effects of breaking changes in our downstream dependencies. Part of this is to remind folks to take a look at the downstream dependencies when they make a breaking change, and file an issue (or they have capacity), open a PR on how to deal with those breaking changes in that dependency.

The PR template looks like this now:

## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] `quic-rpc`
    - [ ] `iroh-gossip`
    - [ ] `iroh-blobs`
    - [ ] `dumbpipe`
    - [ ] `sendme`