### PR TITLE
feat(iroh): watch discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4672,6 +4672,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -83,7 +83,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
     "logging",
     "ring",
 ] }
-tokio-stream = { version = "0.1.15" }
+tokio-stream = { version = "0.1.15", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["io-util", "io", "codec", "rt"] }
 tracing = "0.1"
 url = { version = "2.5", features = ["serde"] }

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -475,9 +475,19 @@ mod tests {
 
     type InfoStore = HashMap<NodeId, (Option<RelayUrl>, BTreeSet<SocketAddr>, u64)>;
 
-    #[derive(Debug, Clone, Default)]
+    #[derive(Debug, Clone)]
     struct TestDiscoveryShared {
         nodes: Arc<Mutex<InfoStore>>,
+        watchers: tokio::sync::broadcast::Sender<DiscoveryItem>,
+    }
+
+    impl Default for TestDiscoveryShared {
+        fn default() -> Self {
+            Self {
+                nodes: Default::default(),
+                watchers: tokio::sync::broadcast::Sender::new(1024),
+            }
+        }
     }
 
     impl TestDiscoveryShared {
@@ -499,6 +509,10 @@ mod tests {
                 resolve_wrong: true,
                 delay: Duration::from_millis(100),
             }
+        }
+
+        pub fn send_passive(&self, item: DiscoveryItem) {
+            self.watchers.send(item).ok();
         }
     }
 
@@ -565,6 +579,13 @@ mod tests {
                 None => n0_future::stream::empty().boxed(),
             };
             Some(stream)
+        }
+
+        fn subscribe(&self) -> Option<BoxStream<DiscoveryItem>> {
+            let recv = self.shared.watchers.subscribe();
+            let stream =
+                tokio_stream::wrappers::BroadcastStream::new(recv).filter_map(|item| item.ok());
+            Some(Box::pin(stream))
         }
     }
 
@@ -713,6 +734,52 @@ mod tests {
             direct_addresses: BTreeSet::from(["240.0.0.1:1000".parse().unwrap()]),
         };
         let _conn = ep2.connect(ep1_wrong_addr, TEST_ALPN).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn endpoint_discovery_watch() -> anyhow::Result<()> {
+        let disco_shared = TestDiscoveryShared::default();
+        let (ep1, _guard1) = {
+            let secret = SecretKey::generate(rand::thread_rng());
+            let disco = disco_shared.create_discovery(secret.public());
+            new_endpoint(secret, disco).await
+        };
+        let (ep2, _guard2) = {
+            let secret = SecretKey::generate(rand::thread_rng());
+            let disco = disco_shared.create_discovery(secret.public());
+            new_endpoint(secret, disco).await
+        };
+
+        let stream = ep1.watch_discovery();
+
+        // wait for ep2 node addr to be updated and connect from ep1 -> discovery via resolve
+        ep2.node_addr().await?;
+        let _ = ep1.connect(ep2.node_id(), TEST_ALPN).await?;
+
+        // inject item into discovery via subscribe
+        let passive_addr = SecretKey::generate(rand::thread_rng()).public();
+        let passive_item = DiscoveryItem {
+            node_addr: NodeAddr::from(passive_addr),
+            provenance: "test-disco-passive",
+            last_updated: None,
+        };
+        disco_shared.send_passive(passive_item.clone());
+
+        let discovered = stream.take(2).collect::<Vec<_>>().await;
+        assert_eq!(discovered.len(), 2);
+        let discovered_active = discovered
+            .iter()
+            .find(|x| x.provenance == "test-disco")
+            .unwrap();
+        assert_eq!(discovered_active.node_addr.node_id, ep2.node_id());
+        let discovered_passive = discovered
+            .iter()
+            .find(|x| x.provenance == "test-disco-passive")
+            .unwrap();
+        assert_eq!(discovered_passive.node_addr, passive_item.node_addr);
+
         Ok(())
     }
 

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -112,6 +112,7 @@ use n0_future::{
     stream::{Boxed as BoxStream, StreamExt},
     task::{self, AbortOnDropHandle},
     time::{self, Duration},
+    Stream, TryStreamExt,
 };
 use tokio::sync::oneshot;
 use tracing::{debug, error_span, warn, Instrument};
@@ -434,6 +435,18 @@ impl Drop for DiscoveryTask {
     }
 }
 
+/// Error returned when a discovery watch stream lagged too far behind.
+///
+/// The stream returned from [`Endpoint::watch_discovery`] yields this error
+/// if the loop in which the stream is processed cannot keep up with the emitted
+/// discovery events. Attempting to read the next item from the channel afterwards
+/// will return the oldest discovery event that is still retained.
+///
+/// Includes the number of skipped messages.
+#[derive(Debug, thiserror::Error)]
+#[error("channel lagged by {0}")]
+pub struct Lagged(u64);
+
 #[derive(Clone, Debug)]
 pub(super) struct DiscoverySubscribers {
     inner: tokio::sync::broadcast::Sender<DiscoveryItem>,
@@ -441,15 +454,26 @@ pub(super) struct DiscoverySubscribers {
 
 impl DiscoverySubscribers {
     pub(crate) fn new() -> Self {
+        // TODO: Make capacity configurable from the endpoint builder?
+        // This is the maximum number of [`DiscoveryItem`]s held by the channel if
+        // subscribers are stalled.
+        const CAPACITY: usize = 128;
         Self {
-            inner: tokio::sync::broadcast::Sender::new(1024),
+            inner: tokio::sync::broadcast::Sender::new(CAPACITY),
         }
     }
-    pub(crate) fn subscribe(&self) -> tokio::sync::broadcast::Receiver<DiscoveryItem> {
-        self.inner.subscribe()
+
+    pub(crate) fn subscribe(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> {
+        let recv = self.inner.subscribe();
+        tokio_stream::wrappers::BroadcastStream::new(recv).map_err(|err| {
+            let tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n) = err;
+            Lagged(n)
+        })
     }
 
     pub(crate) fn send(&self, item: DiscoveryItem) {
+        // `broadcast::Sender::send` returns an error if the channel has no subscribers,
+        // which we don't care about.
         self.inner.send(item).ok();
     }
 }
@@ -752,7 +776,7 @@ mod tests {
             new_endpoint(secret, disco).await
         };
 
-        let stream = ep1.watch_discovery();
+        let stream = ep1.discovery_stream();
 
         // wait for ep2 node addr to be updated and connect from ep1 -> discovery via resolve
         ep2.node_addr().await?;
@@ -771,11 +795,13 @@ mod tests {
         assert_eq!(discovered.len(), 2);
         let discovered_active = discovered
             .iter()
+            .map(|item| item.as_ref().expect("unexpected lag"))
             .find(|x| x.provenance == "test-disco")
             .unwrap();
         assert_eq!(discovered_active.node_addr.node_id, ep2.node_id());
         let discovered_passive = discovered
             .iter()
+            .map(|item| item.as_ref().expect("unexpected lag"))
             .find(|x| x.provenance == "test-disco-passive")
             .unwrap();
         assert_eq!(discovered_passive.node_addr, passive_item.node_addr);

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -776,35 +776,36 @@ mod tests {
             new_endpoint(secret, disco).await
         };
 
-        let stream = ep1.discovery_stream();
+        let mut stream = ep1.discovery_stream();
 
         // wait for ep2 node addr to be updated and connect from ep1 -> discovery via resolve
         ep2.node_addr().await?;
         let _ = ep1.connect(ep2.node_id(), TEST_ALPN).await?;
 
-        // inject item into discovery via subscribe
-        let passive_addr = SecretKey::generate(rand::thread_rng()).public();
+        let item = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("timeout")
+            .expect("stream closed")
+            .expect("stream lagged");
+        assert_eq!(item.node_addr.node_id, ep2.node_id());
+        assert_eq!(item.provenance, "test-disco");
+
+        // inject item into discovery passively
+        let passive_node_id = SecretKey::generate(rand::thread_rng()).public();
         let passive_item = DiscoveryItem {
-            node_addr: NodeAddr::from(passive_addr),
+            node_addr: NodeAddr::from(passive_node_id),
             provenance: "test-disco-passive",
             last_updated: None,
         };
         disco_shared.send_passive(passive_item.clone());
 
-        let discovered = stream.take(2).collect::<Vec<_>>().await;
-        assert_eq!(discovered.len(), 2);
-        let discovered_active = discovered
-            .iter()
-            .map(|item| item.as_ref().expect("unexpected lag"))
-            .find(|x| x.provenance == "test-disco")
-            .unwrap();
-        assert_eq!(discovered_active.node_addr.node_id, ep2.node_id());
-        let discovered_passive = discovered
-            .iter()
-            .map(|item| item.as_ref().expect("unexpected lag"))
-            .find(|x| x.provenance == "test-disco-passive")
-            .unwrap();
-        assert_eq!(discovered_passive.node_addr, passive_item.node_addr);
+        let item = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("timeout")
+            .expect("stream closed")
+            .expect("stream lagged");
+        assert_eq!(item.node_addr.node_id, passive_node_id);
+        assert_eq!(item.provenance, "test-disco-passive");
 
         Ok(())
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -920,14 +920,27 @@ impl Endpoint {
         self.msock.list_remote_infos().into_iter()
     }
 
-    /// Returns a stream that yields information for all nodes discovered by this endpoint.
+    /// Returns a stream of all remote nodes discovered through the endpoint's discovery services.
     ///
     /// Whenever a node is discovered via the endpoint's discovery service, the corresponding
-    /// [`DiscoveryItem`] is yielded from the stream returned from this function. If the stream
-    /// is not processed fast enough, [`Lagged`] may be yielded, indicating that items were missed.
+    /// [`DiscoveryItem`] is yielded from this stream. This includes nodes discovered actively
+    /// through [`Discovery::resolve`], which is invoked automatically when calling
+    /// [`Endpoint::connect`] for a [`NodeId`] unknown to the endpoint. It also includes
+    /// nodes that the endpoint discovers passively from discovery services that implement
+    /// [`Discovery::subscribe`], which e.g. [`LocalSwarmDiscovery`] does.
     ///
-    /// This yields both nodes discovered actively when attempting to connect and [`Discovery::resolve`]
-    /// is invoked, and nodes discovered passively from the endpoint's subscription to [`Discovery::subscribe`].
+    /// The stream does not yield information about nodes that are added manually to the endpoint's
+    /// addressbook by calling [`Endpoint::add_node_addr`] or by supplying a full [`NodeAddr`] to
+    /// [`Endpoint::connect`]. It also does not yield information about nodes that we only
+    /// know about because they connected to us.
+    ///
+    /// The stream should be processed in a loop. If the stream is not processed fast enough,
+    /// [`Lagged`] may be yielded, indicating that items were missed.
+    ///
+    /// See also [`Endpoint::remote_info_iter`], which returns an iterator over all remotes
+    /// the endpoint knows about at a specific point in time.
+    ///
+    /// [`LocalSwarmDiscovery`]: crate::discovery::local_swarm_discovery::LocalSwarmDiscovery
     pub fn discovery_stream(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> {
         self.msock.discovery_subscribers().subscribe()
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -31,7 +31,8 @@ use url::Url;
 
 use crate::{
     discovery::{
-        dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery, DiscoveryTask,
+        dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery, DiscoveryItem,
+        DiscoverySubscribers, DiscoveryTask,
     },
     dns::DnsResolver,
     magicsock::{self, Handle, NodeIdMappedAddr},
@@ -919,6 +920,13 @@ impl Endpoint {
         self.msock.list_remote_infos().into_iter()
     }
 
+    /// Returns a stream that yield all items from node discovery, both active and passive.
+    pub fn watch_discovery(&self) -> impl n0_future::Stream<Item = DiscoveryItem> {
+        use n0_future::StreamExt;
+        let recv = self.msock.discovery_subscribers.subscribe();
+        tokio_stream::wrappers::BroadcastStream::new(recv).filter_map(|item| item.ok())
+    }
+
     // # Methods for less common getters.
     //
     // Partially they return things passed into the builder.
@@ -1077,6 +1085,10 @@ impl Endpoint {
                 }
             }
         }
+    }
+
+    pub(crate) fn discovery_subscribers(&self) -> &DiscoverySubscribers {
+        &self.msock.discovery_subscribers
     }
 
     #[cfg(test)]

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -24,7 +24,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use iroh_base::{NodeAddr, NodeId, RelayUrl, SecretKey};
 use iroh_relay::RelayMap;
-use n0_future::time::Duration;
+use n0_future::{time::Duration, Stream};
 use pin_project::pin_project;
 use tracing::{debug, instrument, trace, warn};
 use url::Url;
@@ -32,7 +32,7 @@ use url::Url;
 use crate::{
     discovery::{
         dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery, DiscoveryItem,
-        DiscoverySubscribers, DiscoveryTask,
+        DiscoverySubscribers, DiscoveryTask, Lagged,
     },
     dns::DnsResolver,
     magicsock::{self, Handle, NodeIdMappedAddr},
@@ -920,11 +920,16 @@ impl Endpoint {
         self.msock.list_remote_infos().into_iter()
     }
 
-    /// Returns a stream that yield all items from node discovery, both active and passive.
-    pub fn watch_discovery(&self) -> impl n0_future::Stream<Item = DiscoveryItem> {
-        use n0_future::StreamExt;
-        let recv = self.msock.discovery_subscribers.subscribe();
-        tokio_stream::wrappers::BroadcastStream::new(recv).filter_map(|item| item.ok())
+    /// Returns a stream that yields information for all nodes discovered by this endpoint.
+    ///
+    /// Whenever a node is discovered via the endpoint's discovery service, the corresponding
+    /// [`DiscoveryItem`] is yielded from the stream returned from this function. If the stream
+    /// is not processed fast enough, [`Lagged`] may be yielded, indicating that items were missed.
+    ///
+    /// This yields both nodes discovered actively when attempting to connect and [`Discovery::resolve`]
+    /// is invoked, and nodes discovered passively from the endpoint's subscription to [`Discovery::subscribe`].
+    pub fn discovery_stream(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> {
+        self.msock.discovery_subscribers().subscribe()
     }
 
     // # Methods for less common getters.
@@ -1087,8 +1092,9 @@ impl Endpoint {
         }
     }
 
+    /// Returns a reference to the subscribers channel for discovery events.
     pub(crate) fn discovery_subscribers(&self) -> &DiscoverySubscribers {
-        &self.msock.discovery_subscribers
+        self.msock.discovery_subscribers()
     }
 
     #[cfg(test)]

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -278,7 +278,8 @@ pub(crate) struct MagicSock {
     #[cfg(any(test, feature = "test-utils"))]
     insecure_skip_relay_cert_verify: bool,
 
-    pub(crate) discovery_subscribers: DiscoverySubscribers,
+    /// Broadcast channel for listening to discovery updates.
+    discovery_subscribers: DiscoverySubscribers,
 }
 
 impl MagicSock {
@@ -434,6 +435,11 @@ impl MagicSock {
             .send(ActorMessage::NetworkChange)
             .await
             .ok();
+    }
+
+    /// Returns a reference to the subscribers channel for discovery events.
+    pub(crate) fn discovery_subscribers(&self) -> &DiscoverySubscribers {
+        &self.discovery_subscribers
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Description

Implements a subscription stream to watch all items retrieved through discovery services. the stream includes both nodes discovered actively (through `Discovery::resolve`, which is invoked when `Endpoint::connect` is called for nodes we don't have addressing info), and nodes discovered passively (through `Discovery::subscribe`, which is only implemented for the local swarm discovery).

Uses `tokio::sync:.broadcast` internally (but without exposing this in the public API) which fits well here I think: if a consumer is too slow in processing the stream, it will miss events but can still continue.

Currently the capacity of the broadcast channel is hardcoded to 128. We could also expose this as a setting on the endpoint builder, not sure if there is a default that fits everything.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
