### PR TITLE
feat(iroh-relay): Make `Endpoint::close` faster by aborting QAD connections faster

### DIFF
--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -375,8 +375,8 @@ mod tests {
     }
 
     /// Makes sure that, even though the RTT was set to some fairly low value,
-    /// we *do* try to connect longer than the probe timeout (1s), as long as
-    /// we haven't closed the connection.
+    /// we *do* try to connect for longer than what the time out would be after closing
+    /// the connection, when we *don't* close the connection.
     ///
     /// In this case we don't simulate it via synthetically high RTT, but by dropping
     /// all packets on the server-side for 2 seconds.


### PR DESCRIPTION
## Description

We reduce the RTT estimate for QAD connections. This means we don't wait as long for close frame acknowledgements when we abort these connection attempts.

Sooo no more 3s `Endpoint::close` time due to QAD probes never closing properly because they're sent into a black hole somewhere in the network path.

## Notes & open questions

The 111ms is arbitrarily chosen to give us a 1s probe timeout. Let me know if I'm missing something important here.

Keep in mind this doesn't prevent us from connecting if the *actual* RTT is longer. The test ensures that.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
