### PR TITLE
fix: `Endpoint::node_addr` completes with direct addrs or relay ready

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2317,6 +2317,8 @@ mod tests {
         let ep1_nodeid = ep1.node_id();
         let ep2_nodeid = ep2.node_id();
 
+        // wait for the direct addresses to be initialized.
+        ep1.direct_addresses().initialized().await.unwrap();
         let ep1_nodeaddr = ep1.node_addr().await.unwrap();
         tracing::info!(
             "node id 1 {ep1_nodeid}, relay URL {:?}",


### PR DESCRIPTION
## Description

Currently, `Endpoint::node_addr` waits for the endpoint's direct addresses to be initialized, and then returns. This is an issue for iroh in the browser, because there we never have direct addresses.

This PR changes the behavior of `Endpoint::node_addr` so that it completes once either the direct addresses or the home relay URL are initialized.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
