### PR TITLE
refactor: Make `Endpoint::node_addr` sync and infallible, and add `Endpoint::node_addr_initialized`

### DIFF
--- a/iroh/examples/connect-unreliable.rs
+++ b/iroh/examples/connect-unreliable.rs
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
         .bind()
         .await?;
 
-    let node_addr = endpoint.node_addr().await?;
+    let node_addr = endpoint.node_addr();
     let me = node_addr.node_id;
     println!("node id: {me}");
     println!("node listening addresses:");

--- a/iroh/examples/echo.rs
+++ b/iroh/examples/echo.rs
@@ -23,7 +23,7 @@ const ALPN: &[u8] = b"iroh-example/echo/0";
 #[tokio::main]
 async fn main() -> Result<()> {
     let router = accept_side().await?;
-    let node_addr = router.endpoint().node_addr().await?;
+    let node_addr = router.endpoint().node_addr();
 
     connect_side(node_addr).await?;
 

--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
     println!("node id: {me}");
     println!("node listening addresses:");
 
-    let node_addr = endpoint.node_addr().await?;
+    let node_addr = endpoint.node_addr();
     let local_addrs = node_addr
         .direct_addresses
         .into_iter()

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
     println!("node id: {me}");
     println!("node listening addresses:");
 
-    let node_addr = endpoint.node_addr().await?;
+    let node_addr = endpoint.node_addr();
     let local_addrs = node_addr
         .direct_addresses
         .into_iter()

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -646,7 +646,7 @@ mod tests {
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
         // wait for our address to be updated and thus published at least once
-        ep1.node_addr().await?;
+        ep1.node_addr_initialized().await;
         let _conn = ep2.connect(ep1_addr, TEST_ALPN).await?;
         Ok(())
     }
@@ -672,7 +672,7 @@ mod tests {
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
         // wait for out address to be updated and thus published at least once
-        ep1.node_addr().await.context("waiting for NodeAddr")?;
+        ep1.node_addr_initialized().await;
         let _conn = ep2
             .connect(ep1_addr, TEST_ALPN)
             .await
@@ -704,7 +704,7 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         // wait for out address to be updated and thus published at least once
-        ep1.node_addr().await?;
+        ep1.node_addr_initialized().await;
         let _conn = ep2.connect(ep1.node_id(), TEST_ALPN).await?;
         Ok(())
     }
@@ -726,7 +726,7 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         // wait for out address to be updated and thus published at least once
-        ep1.node_addr().await?;
+        ep1.node_addr();
 
         // 10x faster test via a 3s idle timeout instead of the 30s default
         let mut config = TransportConfig::default();
@@ -759,7 +759,7 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         // wait for out address to be updated and thus published at least once
-        ep1.node_addr().await?;
+        ep1.node_addr();
         let ep1_wrong_addr = NodeAddr {
             node_id: ep1.node_id(),
             relay_url: None,

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2317,6 +2317,8 @@ mod tests {
         let ep1_nodeid = ep1.node_id();
         let ep2_nodeid = ep2.node_id();
 
+        // wait for the direct addresses to be initialized.
+        ep1.direct_addresses().initialized().await.unwrap();
         let ep1_nodeaddr = ep1.node_addr().await.unwrap();
         tracing::info!(
             "node id 1 {ep1_nodeid}, relay URL {:?}",

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -3505,7 +3505,7 @@ mod tests {
         println!("first conn!");
         let conn = m1
             .endpoint
-            .connect(m2.endpoint.node_addr().await?, ALPN)
+            .connect(m2.endpoint.node_addr(), ALPN)
             .await?;
         println!("Closing first conn");
         conn.close(0u32.into(), b"bye lolz");


### PR DESCRIPTION
## Description

This makes `Endpoint::node_addr` a synchronous, infallible function that always returns the current state of the endpoint's node address. Right after binding that node address might be empty, because neither the home relay nor our direct addresses are yet determined.

Therefore, we add a `async fn node_addr_initialized(&self)` that waits for either the home relay or the direct addresses to be initialized.

Alternative to #3190 

## Breaking Changes

* `Endpoint::node_addr` now is sync and infallible. If you want to wait for the address to be initialized, await `Endpoint::node_addr_initialized` before.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
