### PR TITLE
fix(iroh-relay): Fix the number of active relay connections

### DIFF
--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -210,6 +210,10 @@ struct Actor {
 
 impl Actor {
     async fn run(mut self, done: CancellationToken) {
+        // Note the accept and disconnects metrics must be in a pair.  Technically the
+        // connection is accepted long before this in the HTTP server, but it is clearer to
+        // handle the metric here.
+        inc!(Metrics, accepts);
         match self.run_inner(done).await {
             Err(e) => {
                 warn!("actor errored {e:#?}, exiting");
@@ -220,6 +224,7 @@ impl Actor {
         }
 
         self.clients.unregister(self.connection_id, self.node_id);
+        inc!(Metrics, disconnects);
     }
 
     async fn run_inner(&mut self, done: CancellationToken) -> Result<()> {

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -551,7 +551,6 @@ impl Inner {
             rate_limit: self.rate_limit,
         };
         trace!("accept: create client");
-        inc!(Metrics, accepts);
         let node_id = client_conn_builder.node_id;
         trace!(node_id = node_id.fmt_short(), "create client");
 


### PR DESCRIPTION
## Description

The disconnects metric was accidentally removed and this has been
giving us wrong numbers since forever and it is so painful yet so easy
to fix.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.