### PR TITLE
fix(iroh-base): Remove unused `getrandom` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,7 +2295,6 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
- "getrandom 0.2.15",
  "postcard",
  "proptest",
  "rand 0.8.5",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -25,9 +25,6 @@ rand_core = { version = "0.6.4", optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
 thiserror = { version = "2", optional = true }
 
-# wasm
-getrandom = { version = "0.2", default-features = false, optional = true }
-
 [dev-dependencies]
 postcard = { version = "1", features = ["use-std"] }
 proptest = "1.0.0"
@@ -44,13 +41,11 @@ key = [
   "dep:ed25519-dalek",
   "dep:url",
   "dep:derive_more",
-  "dep:getrandom",
   "dep:thiserror",
   "dep:data-encoding",
   "dep:rand_core",
   "relay",
 ]
-wasm = ["getrandom?/js"]
 relay = [
   "dep:url",
   "dep:derive_more",


### PR DESCRIPTION
## Description

Removes `getrandom` from `iroh-base`'s dependencies. It's unused.

## Notes & open questions

Will this remove a feature flag called `getrandom` and thus be a breaking change? Not sure.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
