### PR TITLE
refactor(iroh): Factor out socket-related state & construction into `magicsock::SocketState` and `ActorSocketState`

### DIFF
--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -37,7 +37,6 @@ use tracing::{debug, error, info_span, trace, warn, Instrument};
 mod defaults;
 #[cfg(not(wasm_browser))]
 mod dns;
-#[cfg(not(wasm_browser))]
 mod ip_mapped_addrs;
 mod metrics;
 #[cfg(not(wasm_browser))]
@@ -65,7 +64,6 @@ pub mod portmapper {
     }
 }
 
-#[cfg(not(wasm_browser))]
 pub use ip_mapped_addrs::{IpMappedAddr, IpMappedAddrError, IpMappedAddresses, MAPPED_ADDR_PORT};
 pub use metrics::Metrics;
 pub use options::Options;

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -3095,7 +3095,7 @@ fn bind_with_fallback(mut addr: SocketAddr) -> anyhow::Result<UdpSocket> {
 
     // Otherwise, try binding with port 0
     addr.set_port(0);
-    Ok(UdpSocket::bind_full(addr).context("failed to bind on fallback port")?)
+    UdpSocket::bind_full(addr).context("failed to bind on fallback port")
 }
 
 /// The discovered direct addresses of this [`MagicSock`].

--- a/iroh/src/magicsock/udp_conn.rs
+++ b/iroh/src/magicsock/udp_conn.rs
@@ -7,40 +7,28 @@ use std::{
     task::{Context, Poll},
 };
 
-use anyhow::{bail, Context as _};
 use netwatch::UdpSocket;
 use quinn::AsyncUdpSocket;
 use quinn_udp::Transmit;
-use tracing::debug;
 
-/// A UDP socket implementing Quinn's [`AsyncUdpSocket`].
+/// Wrapper struct to implement Quinn's [`AsyncUdpSocket`] for [`UdpSocket`].
 #[derive(Debug, Clone)]
-pub struct UdpConn {
-    io: Arc<UdpSocket>,
+pub(super) struct UdpConn {
+    inner: Arc<UdpSocket>,
 }
 
 impl UdpConn {
-    pub(super) fn as_socket(&self) -> Arc<UdpSocket> {
-        self.io.clone()
+    pub(super) fn wrap(inner: Arc<UdpSocket>) -> Self {
+        Self { inner }
     }
 
     pub(super) fn as_socket_ref(&self) -> &UdpSocket {
-        &self.io
-    }
-
-    pub(super) fn bind(addr: SocketAddr) -> anyhow::Result<Self> {
-        let sock = bind(addr)?;
-
-        Ok(Self { io: Arc::new(sock) })
-    }
-
-    pub fn port(&self) -> u16 {
-        self.local_addr().map(|p| p.port()).unwrap_or_default()
+        &self.inner
     }
 
     pub(super) fn create_io_poller(&self) -> Pin<Box<dyn quinn::UdpPoller>> {
         Box::pin(IoPoller {
-            io: self.io.clone(),
+            io: self.inner.clone(),
         })
     }
 }
@@ -51,7 +39,7 @@ impl AsyncUdpSocket for UdpConn {
     }
 
     fn try_send(&self, transmit: &Transmit<'_>) -> io::Result<()> {
-        self.io.try_send_quinn(transmit)
+        self.inner.try_send_quinn(transmit)
     }
 
     fn poll_recv(
@@ -60,61 +48,24 @@ impl AsyncUdpSocket for UdpConn {
         bufs: &mut [io::IoSliceMut<'_>],
         meta: &mut [quinn_udp::RecvMeta],
     ) -> Poll<io::Result<usize>> {
-        self.io.poll_recv_quinn(cx, bufs, meta)
+        self.inner.poll_recv_quinn(cx, bufs, meta)
     }
 
     fn local_addr(&self) -> io::Result<SocketAddr> {
-        self.io.local_addr()
+        self.inner.local_addr()
     }
 
     fn may_fragment(&self) -> bool {
-        self.io.may_fragment()
+        self.inner.may_fragment()
     }
 
     fn max_transmit_segments(&self) -> usize {
-        self.io.max_gso_segments()
+        self.inner.max_gso_segments()
     }
 
     fn max_receive_segments(&self) -> usize {
-        self.io.gro_segments()
+        self.inner.gro_segments()
     }
-}
-
-fn bind(mut addr: SocketAddr) -> anyhow::Result<UdpSocket> {
-    debug!(%addr, "binding");
-
-    // Build a list of preferred ports.
-    // - Best is the port that the user requested.
-    // - Second best is the port that is currently in use.
-    // - If those fail, fall back to 0.
-
-    let mut ports = Vec::new();
-    if addr.port() != 0 {
-        ports.push(addr.port());
-    }
-    // Backup port
-    ports.push(0);
-    // Remove duplicates. (All duplicates are consecutive.)
-    ports.dedup();
-    debug!(?ports, "candidate ports");
-
-    for port in &ports {
-        addr.set_port(*port);
-        match UdpSocket::bind_full(addr) {
-            Ok(pconn) => {
-                let local_addr = pconn.local_addr().context("UDP socket not bound")?;
-                debug!(%addr, %local_addr, "successfully bound");
-                return Ok(pconn);
-            }
-            Err(err) => {
-                debug!(%addr, "failed to bind: {err:#}");
-                continue;
-            }
-        }
-    }
-
-    // Failed to bind, including on port 0 (!).
-    bail!("failed to bind any ports on {:?} (tried {:?})", addr, ports);
 }
 
 /// Poller for when the socket is writable.
@@ -177,10 +128,16 @@ mod tests {
     }
 
     async fn rebinding_conn_send_recv(network: IpFamily) -> Result<()> {
-        let m1 = UdpConn::bind(SocketAddr::new(network.unspecified_addr(), 0))?;
+        let m1 = UdpConn::wrap(Arc::new(UdpSocket::bind_full(SocketAddr::new(
+            network.unspecified_addr(),
+            0,
+        ))?));
         let (m1, _m1_key) = wrap_socket(m1)?;
 
-        let m2 = UdpConn::bind(SocketAddr::new(network.unspecified_addr(), 0))?;
+        let m2 = UdpConn::wrap(Arc::new(UdpSocket::bind_full(SocketAddr::new(
+            network.unspecified_addr(),
+            0,
+        ))?));
         let (m2, _m2_key) = wrap_socket(m2)?;
 
         let m1_addr = SocketAddr::new(network.local_addr(), m1.local_addr()?.port());


### PR DESCRIPTION
## Description

This factors out the socket & related state from `MagicSock` into a `SocketState` struct, as well as from the `Actor` struct into an `ActorSocketState` struct.

This helps reduce line noise in the `magicsock::Handle::with_name` function related to all the `#[cfg(not(wasm_browser))]`. 

In order to do this I needed to slightly modify how `UdpConn` is used.
We now work *more* with `Arc<UdpSocket>` rather than `UdpConn`, and treat `UdpConn` only as a wrapper to allow us to implement `quinn::AsyncUdpSocket` for `Arc<UdpSocket>`.
I've also moved the socket binding logic from `udp_conn.rs` to `magicsock.rs` and cleaned it up.

The main difference between `SocketState` and `ActorSocketState` is that the former stores `UdpConn` and the latter stores `Arc<UdpSocket>`, as the former uses its sockets only to implement methods from `AsyncUdpSocket` for `MagicSock`, whereas the latter uses it for a bunch of things, including sending disco messages and port mapping.

Finally, I also went ahead and renamed any `pconn4` and `pconn6` names to say `socket`, `socket.v4` or `socket.v6`, as I find that would make more sense.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
