### PR TITLE
refactor(iroh, iroh-net-report)!: Make ports more private

### DIFF
--- a/iroh-net-report/src/ip_mapped_addrs.rs
+++ b/iroh-net-report/src/ip_mapped_addrs.rs
@@ -7,9 +7,6 @@ use std::{
     },
 };
 
-/// The dummy port used for all mapped addresses
-pub const MAPPED_ADDR_PORT: u16 = 12345;
-
 /// Can occur when converting a [`SocketAddr`] to an [`IpMappedAddr`]
 #[derive(Debug, thiserror::Error)]
 #[error("Failed to convert")]
@@ -32,6 +29,9 @@ impl IpMappedAddr {
     /// The Subnet ID used in our Unique Local Addresses.
     const ADDR_SUBNET: [u8; 2] = [0, 1];
 
+    /// The dummy port used for all mapped addresses.
+    const MAPPED_ADDR_PORT: u16 = 12345;
+
     /// Generates a globally unique fake UDP address.
     ///
     /// This generates a new IPv6 address in the Unique Local Address range (RFC 4193)
@@ -48,9 +48,15 @@ impl IpMappedAddr {
         Self(Ipv6Addr::from(addr))
     }
 
-    /// Return a [`SocketAddr`] from the [`IpMappedAddr`].
-    pub fn socket_addr(&self) -> SocketAddr {
-        SocketAddr::new(IpAddr::from(self.0), MAPPED_ADDR_PORT)
+    /// Returns a consistent [`SocketAddr`] for the [`IpMappedAddr`].
+    ///
+    /// This does not have a routable IP address.
+    ///
+    /// This uses a made-up, but fixed port number.  The [IpMappedAddresses`] map this is
+    /// made for creates a unique [`IpMappedAddr`] for each IP+port and thus does not use
+    /// the port to map back to the original [`SocketAddr`].
+    pub fn private_socket_addr(&self) -> SocketAddr {
+        SocketAddr::new(IpAddr::from(self.0), Self::MAPPED_ADDR_PORT)
     }
 }
 

--- a/iroh-net-report/src/lib.rs
+++ b/iroh-net-report/src/lib.rs
@@ -66,7 +66,7 @@ pub mod portmapper {
 }
 
 #[cfg(not(wasm_browser))]
-pub use ip_mapped_addrs::{IpMappedAddr, IpMappedAddrError, IpMappedAddresses, MAPPED_ADDR_PORT};
+pub use ip_mapped_addrs::{IpMappedAddr, IpMappedAddrError, IpMappedAddresses};
 pub use metrics::Metrics;
 pub use options::Options;
 pub use reportgen::QuicConfig;

--- a/iroh-net-report/src/reportgen.rs
+++ b/iroh-net-report/src/reportgen.rs
@@ -968,7 +968,7 @@ fn maybe_to_mapped_addr(
     addr: SocketAddr,
 ) -> SocketAddr {
     if let Some(ip_mapped_addrs) = ip_mapped_addrs.as_ref() {
-        return ip_mapped_addrs.get_or_register(addr).socket_addr();
+        return ip_mapped_addrs.get_or_register(addr).private_socket_addr();
     }
     addr
 }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -754,7 +754,7 @@ impl Endpoint {
         let server_name = &format!("{}.iroh.invalid", BASE32_DNSSEC.encode(node_id.as_bytes()));
         let connect = self.msock.endpoint().connect_with(
             client_config,
-            mapped_addr.socket_addr(),
+            mapped_addr.private_socket_addr(),
             server_name,
         )?;
 


### PR DESCRIPTION
## Description

I find this whole port business of these mapped addresses very
confusing.  This attempts to document them better, make it clearer
that these SocketAddrs are made up and are not routable.

## Breaking Changes

### iroh-net-report

- `MAPPED_ADDR_PORT` is removed.
- `IpMappedAddr::socket_addr` -> `IpMappedAddr::private_socket_addr`

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.
  - [x] List all breaking changes in the above "Breaking Changes" section.