### PR TITLE
fix: update project_sync

### DIFF
--- a/.github/workflows/project_sync.yaml
+++ b/.github/workflows/project_sync.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  REPOS_LIST: "iroh tools n0.computer ops iroh.computer quic-rpc chuck abao bao-tree iroh-examples iroh.network tokio-rustls-acme iroh-ffi iroh-car iroh-io iroh-blake3 dumbpipe.dev dumbpipe sendme swarmie iroh-c-ffi willow-store quinn iroh-experiments willow-rs iroh-gossip iroh-doctor iroh-blobs iroh-docs iroh-s3 iroh-doctor-server iroh-willow iroh-metrics net-tools iroh-node-util workflows ips"
+  REPOS_LIST: "iroh tools n0.computer ops iroh.computer quic-rpc chuck abao bao-tree iroh-examples iroh.network tokio-rustls-acme iroh-ffi iroh-car iroh-io iroh-blake3 dumbpipe.dev dumbpipe sendme swarmie iroh-c-ffi willow-store quinn iroh-experiments willow-rs iroh-gossip iroh-doctor iroh-blobs iroh-docs iroh-doctor-server iroh-willow iroh-metrics net-tools iroh-node-util workflows ips iroh-roq"
 
 jobs:
   add-to-project:


### PR DESCRIPTION
## Description

Remove `iroh-s3` which is not tracked and add `iroh-roq`

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
