### PR TITLE
refactor!: move `IpMappedAddresses` to `DnsResolver`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,4 +21,5 @@ allow = [
 ignore = [
   "RUSTSEC-2024-0384", # unmaintained, no upgrade available
   "RUSTSEC-2024-0436", # paste
+  "RUSTSEC-2025-0014", # humantime
 ]

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -281,7 +281,7 @@ impl DnsResolver {
         stagger_call(f, delays_ms).await
     }
 
-    /// Look up a [`RelayNode`] and return an [`IpMappedAddr`].
+    /// Look up a [`RelayNode`] and return a [`SocketAddr`].
     ///
     /// Uses `[DnsResolver::lookup_ipv4_staggered]`.
     ///
@@ -319,7 +319,7 @@ impl DnsResolver {
         }
     }
 
-    /// Look up a [`RelayNode`] and return an [`IpMappedAddr`].
+    /// Look up a [`RelayNode`] and return an [`SocketAddr`].
     ///
     /// Uses `[DnsResolver::lookup_ipv6_staggered]`.
     ///

--- a/iroh-relay/src/ip_mapped_addrs.rs
+++ b/iroh-relay/src/ip_mapped_addrs.rs
@@ -1,3 +1,5 @@
+//! Defines the `IpMappedAddr`  and `IpMappedAddresses`, used in `iroh` to dial relay nodes during Quic Address Discovery.
+
 use std::{
     collections::BTreeMap,
     net::{IpAddr, Ipv6Addr, SocketAddr},
@@ -89,7 +91,7 @@ impl std::fmt::Display for IpMappedAddr {
 pub struct IpMappedAddresses(Arc<std::sync::Mutex<Inner>>);
 
 #[derive(Debug, Default)]
-pub struct Inner {
+struct Inner {
     by_mapped_addr: BTreeMap<IpMappedAddr, SocketAddr>,
     /// Because [`std::net::SocketAddrV6`] contains extra fields besides the IP
     /// address and port (ie, flow_info and scope_id), the a [`std::net::SocketAddrV6`]

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -46,11 +46,13 @@ pub(crate) use key_cache::KeyCache;
 
 #[cfg(not(wasm_browser))]
 pub mod dns;
+pub mod ip_mapped_addrs;
 pub mod node_info;
 
 pub use protos::relay::MAX_PACKET_SIZE;
 
 pub use self::{
+    ip_mapped_addrs::{IpMappedAddr, IpMappedAddrError, IpMappedAddresses},
     ping_tracker::PingTracker,
     relay_map::{RelayMap, RelayNode, RelayQuicConfig},
 };


### PR DESCRIPTION
## Description

In order to facilitate QUIC address discovery inside of `iroh`, we needed a way to map resolved URLs to an `IpMappedAddr`. Previously, we did that by passing in an optional `IpMappedAddresses` struct into the `iroh-net-report`.

Now that we have an `iroh` `DnsResolver`, we can do the mapping inside of `DnsResolver`, when we know we are resolving a URL that needs mapping.

`IpMappedAddr`, `IpMappedAddresses`, etc, have been moved from `iroh-net-report` to `iroh-relay` where the `DnsResolver` is defined.

`DnsResolver` has an optional `IpMappedAddresses` field.

Now, when `iroh-net-report` resolves a relay-url that we know will be used in QAD, we call the new `DnsResolver::lookup_relay_node_ipv4` and `DnsResolver::lookup_relay_node_ipv6`, and it will return the associated socket address for the `IpMappedAddr`.

## Breaking Changes

- `iroh-net-report`
   - changed
       - `iroh-net-report::Client::new` no longer contains the `mapped_addrs` parameter 

## Notes & open questions

Small PR, but questions around naming.

Should `DnsResolver::lookup_relay_node_ipvX` be more explicit? `DnsResolver::lookup_relay_node_ipvX_mapped`? Should it return a `IpMappedAddr` instead of a `SocketAddr` to be more explicit?

Not sure, from a user perspective, what the cleanest/least confusing API would be.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
  - [x] List all breaking changes in the above "Breaking Changes" section.
  - [x] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [x] [`iroh-doctor`](https://github.com/n0-computer/iroh-doctor)

