### PR TITLE
feat(Connecting): add remote_node_id method to Connecting

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1510,6 +1510,11 @@ impl Connecting {
             Err(_) => bail!("unknown handshake type"),
         }
     }
+
+    /// The remote_node_id, this should always be available after a successfull call to ['Connecting::handshake_data'] or ['Connecting::alpn']
+    pub fn remote_node_id(&self) -> Option<NodeId> {
+        self.remote_node_id
+    }
 }
 
 impl Future for Connecting {


### PR DESCRIPTION
## Description

add remote_node_id method to Connecting to read remote id before Connecting is turned into a Connection, which can be useful if one wants to create a Router or drop connections that are not in a predetermined list of allowed nodes. 

## Breaking Changes

None



