### PR TITLE
chore: switch from `backoff` to `backon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,16 +331,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
 dependencies = [
- "futures-core",
- "getrandom 0.2.15",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
+ "fastrand",
+ "gloo-timers 0.3.0",
+ "tokio",
 ]
 
 [[package]]
@@ -1421,7 +1419,7 @@ dependencies = [
  "gloo-net",
  "gloo-render",
  "gloo-storage",
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "gloo-utils",
  "gloo-worker",
 ]
@@ -1539,6 +1537,18 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
 dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2224,7 +2234,7 @@ dependencies = [
  "anyhow",
  "atomic-waker",
  "axum",
- "backoff",
+ "backon",
  "bytes",
  "cfg_aliases",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,9 +4003,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "ed9b823fa29b721a59671b41d6b06e66b29e0628e207e8b1c3ceeda701ec928d"
 dependencies = [
  "cc",
  "cfg-if",

--- a/deny.toml
+++ b/deny.toml
@@ -21,4 +21,5 @@ allow = [
 ignore = [
   "RUSTSEC-2024-0384", # unmaintained, no upgrade available
   "RUSTSEC-2024-0436", # paste
+  "RUSTSEC-2025-0014", # humantime
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -19,5 +19,6 @@ allow = [
 
 [advisories]
 ignore = [
-    "RUSTSEC-2024-0384", # unmaintained, no upgrade available
+  "RUSTSEC-2024-0384", # unmaintained, no upgrade available
+  "RUSTSEC-2024-0436", # paste
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -21,5 +21,4 @@ allow = [
 ignore = [
   "RUSTSEC-2024-0384", # unmaintained, no upgrade available
   "RUSTSEC-2024-0436", # paste
-  "RUSTSEC-2025-0014", # humantime
 ]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -25,7 +25,7 @@ aead = { version = "0.5.2", features = ["bytes"] }
 anyhow = { version = "1" }
 atomic-waker = "1.1.2"
 concurrent-queue = "2.5"
-backoff = { version = "0.4.0", features = ["futures"] }
+backon = { version = "1.4" }
 bytes = "1.7"
 crypto_box = { version = "0.9.1", features = ["serde", "chacha20"] }
 data-encoding = "2.2"

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -429,7 +429,7 @@ impl ActiveRelayActor {
             }
         };
 
-        // We implement our own `Sleeper` here, so that we can use the `backoff`
+        // We implement our own `Sleeper` here, so that we can use the `backon`
         // crate with our own implementation of `time::sleep` (from `n0_future`)
         // that works in browsers.
         struct Sleeper;

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -38,7 +38,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use backoff::exponential::{ExponentialBackoff, ExponentialBackoffBuilder};
+use backon::{BackoffBuilder, ExponentialBuilder, Retryable};
 use bytes::{Bytes, BytesMut};
 use iroh_base::{NodeId, PublicKey, RelayUrl, SecretKey};
 use iroh_metrics::{inc, inc_by};
@@ -404,9 +404,10 @@ impl ActiveRelayActor {
     /// connections.  It currently does not ever return `Err` as the retries continue
     /// forever.
     fn dial_relay(&self) -> BoxFuture<Result<Client>> {
-        let backoff: ExponentialBackoff<backoff::SystemClock> = ExponentialBackoffBuilder::new()
-            .with_initial_interval(Duration::from_millis(10))
-            .with_max_interval(Duration::from_secs(5))
+        let backoff = ExponentialBuilder::new()
+            .with_min_delay(Duration::from_millis(10))
+            .with_max_delay(Duration::from_secs(5))
+            .without_max_times()
             .build();
         let connect_fn = {
             let client_builder = self.relay_client_builder.clone();
@@ -433,7 +434,7 @@ impl ActiveRelayActor {
         // that works in browsers.
         struct Sleeper;
 
-        impl backoff::future::Sleeper for Sleeper {
+        impl backon::Sleeper for Sleeper {
             type Sleep = time::Sleep;
 
             fn sleep(&self, dur: Duration) -> Self::Sleep {
@@ -441,17 +442,7 @@ impl ActiveRelayActor {
             }
         }
 
-        // Because we're using a lower-level backoff API, we need to provide a
-        // backoff::Notify implementation. By default backoff has one that
-        // doesn't do anything, but it doesn't expose that API. So we implement
-        // it here ourselves.
-        struct NoopNotify;
-
-        impl<E> backoff::Notify<E> for NoopNotify {
-            fn notify(&mut self, _: E, _: Duration) {}
-        }
-
-        let retry_fut = backoff::future::Retry::new(Sleeper, backoff, NoopNotify, connect_fn);
+        let retry_fut = connect_fn.retry(backoff).sleep(Sleeper);
         Box::pin(retry_fut)
     }
 

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -418,11 +418,11 @@ impl ActiveRelayActor {
                         Ok(Ok(client)) => Ok(client),
                         Ok(Err(err)) => {
                             warn!("Relay connection failed: {err:#}");
-                            Err(err.into())
+                            Err(err)
                         }
                         Err(_) => {
                             warn!(?CONNECT_TIMEOUT, "Timeout connecting to relay");
-                            Err(anyhow!("Timeout").into())
+                            Err(anyhow!("Timeout"))
                         }
                     }
                 }


### PR DESCRIPTION
## Description

`backoff` is no longer maintained, upgrade path in cargo-deny indicates switching to `backon`.

## Notes & open questions

There are some options in `backon` for using sleepers in the retry that are Wasm compatible: https://docs.rs/backon/1.4.0/backon/#sleep

I'm curious if we should be taking advantage.

Further questions:
~how do I resolve the `paste` cargo-deny issue?~
I don't: added `paste` and `humantime` advisories to the "allow" list

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
