### PR TITLE
fix(iroh): Don't cause re-stuns all the time in browsers

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1913,11 +1913,16 @@ impl Handle {
             }
         })
         .await;
-        if shutdown_done.is_ok() {
-            warn!("tasks shutdown complete");
-            // shutdown all tasks
-            warn!("aborting remaining {}/3 tasks", tasks.len());
-            tasks.shutdown().await;
+        match shutdown_done {
+            Ok(_) => trace!("tasks finished in time, shutdown complete"),
+            Err(_elapsed) => {
+                // shutdown all tasks
+                warn!(
+                    "tasks didn't finish in time, aborting remaining {}/3 tasks",
+                    tasks.len()
+                );
+                tasks.shutdown().await;
+            }
         }
         trace!("magicsock closed");
     }

--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -387,6 +387,7 @@ impl NodeState {
     ///
     /// When a call-me-maybe message is sent we also need to send pings to all known paths
     /// of the endpoint.  The [`NodeState::send_call_me_maybe`] function takes care of this.
+    #[cfg(not(wasm_browser))]
     #[instrument("want_call_me_maybe", skip_all)]
     fn want_call_me_maybe(&self, now: &Instant) -> bool {
         trace!("full ping: wanted?");
@@ -416,6 +417,12 @@ impl NodeState {
                 }
             }
         }
+    }
+
+    #[cfg(wasm_browser)]
+    fn want_call_me_maybe(&self, _now: &Instant) -> bool {
+        trace!("full ping: skipped in browser");
+        false
     }
 
     /// Cleanup the expired ping for the passed in txid.


### PR DESCRIPTION
## Description

- Always return `false` in `want_call_me_maybe` in browsers, as we never actually want to send call me maybes, since there's no direct addresses we can put into these messages.
- Fix the shutdown logging in magicsock. Redundant warning were printed on graceful shutdown, and one was skipped in non-graceful shutdown.

## Notes & open questions

Closes #3232

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
