### PR TITLE
chore(iroh-relay): Fix README.md instuctions to enable `server` feature

### DIFF
--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -58,7 +58,7 @@ manual_key_path = "/path/to/certs/cert.key.pem"
 ```
 
 Then run the server with the `--dev` flag, like you would when normally testing locally:
-`cargo run --bin iroh-relay -- --config-path=/path/to/config.toml --dev`
+`cargo run --features="server" --bin iroh-relay -- --config-path=/path/to/config.toml --dev`
 
 The relay server will run over http on port 3340, as it does using the `--dev` flag, but it will also run a QUIC server on port 7824.
 


### PR DESCRIPTION
## Description

add feature "server" while running iroh-relay via cargo run

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
  - [x] List all breaking changes in the above "Breaking Changes" section.
  - [x] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [x] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [x] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [x] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [x] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [x] [`sendme`](https://github.com/n0-computer/sendme)
