### PR TITLE
fix: when we get a udp packet from a socket addr, and we have no `best_addr`already set, choose that socketaddr as the `best_addr`

### DIFF
--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -1064,8 +1064,7 @@ impl NodeState {
         state.last_payload_msg = Some(now);
         self.last_used = Some(now);
         self.udp_paths
-            .best_addr
-            .reconfirm_if_used(addr.into(), BestAddrSource::Udp, now);
+            .reconfirm_or_assign_best_addr(addr.into(), BestAddrSource::Udp, now);
     }
 
     pub(super) fn receive_relay(&mut self, url: &RelayUrl, src: NodeId, now: Instant) {


### PR DESCRIPTION
## Description

If there is no best addr assigned, but we do get UDP traffic back from our "chosen candidate" socketaddr, we would ignore the UDP traffic and not promote the "chosen candidate" to the "best addr" until we receive a pong with a latency.

It's possible we would like to instead behave in the way laid out in this PR: if we get back UDP traffic for this `NodeId` on the "chosen candidate", we upgrade that candidate to "best addr". The only weird thing in this set up is that we don't have a proper latency for this addr. I just put 500ms

## Notes & open questions

Is this correct? Do we want to do this? Is 500ms for a dummy latency appropriate?
