### PR TITLE
tests: make sure the mainline DHT testnet is bootstrapped before using it

### DIFF
--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -221,16 +221,18 @@ mod tests {
     async fn integration_mainline() -> Result<()> {
         // run a mainline testnet
         let testnet = pkarr::mainline::Testnet::new(5)?;
-        let bootstrapped: Vec<bool> = FuturesUnordered::from_iter(
-            testnet
-                .nodes
-                .iter()
-                .cloned()
-                .map(|node| async move { node.as_async().bootstrapped().await }),
-        )
-        .collect()
-        .await;
-        assert!(bootstrapped.into_iter().any(|x| x), "testnet bootstrapped");
+        assert!(
+            FuturesUnordered::from_iter(
+                testnet
+                    .nodes
+                    .iter()
+                    .cloned()
+                    .map(|node| async move { node.as_async().bootstrapped().await }),
+            )
+            .any(|x| x)
+            .await,
+            "testnet bootstrapped"
+        );
 
         let bootstrap = testnet.bootstrap.clone();
         // spawn our server with mainline support

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -321,7 +321,6 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    #[ignore = "flaky"]
     #[traced_test]
     async fn dht_discovery_smoke() -> TestResult {
         let ep = crate::Endpoint::builder().bind().await?;

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -326,7 +326,7 @@ mod tests {
     async fn dht_discovery_smoke() -> TestResult {
         let ep = crate::Endpoint::builder().bind().await?;
         let secret = ep.secret_key().clone();
-        let testnet = pkarr::mainline::Testnet::new(2)?;
+        let testnet = pkarr::mainline::Testnet::new(3)?;
         assert!(
             FuturesUnordered::from_iter(
                 testnet

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -327,16 +327,18 @@ mod tests {
         let ep = crate::Endpoint::builder().bind().await?;
         let secret = ep.secret_key().clone();
         let testnet = pkarr::mainline::Testnet::new(2)?;
-        let bootstrapped: Vec<bool> = FuturesUnordered::from_iter(
-            testnet
-                .nodes
-                .iter()
-                .cloned()
-                .map(|node| async move { node.as_async().bootstrapped().await }),
-        )
-        .collect()
-        .await;
-        assert!(bootstrapped.into_iter().any(|x| x), "testnet bootstrapped");
+        assert!(
+            FuturesUnordered::from_iter(
+                testnet
+                    .nodes
+                    .iter()
+                    .cloned()
+                    .map(|node| async move { node.as_async().bootstrapped().await }),
+            )
+            .any(|x| x)
+            .await,
+            "testnet bootstrapped"
+        );
 
         let client = pkarr::Client::builder()
             .dht(|builder| builder.bootstrap(&testnet.bootstrap))


### PR DESCRIPTION
## Description

This makes sure that the `mainline` DHT testnet is bootstrapped before we start to use it. Should avoid flakes like [this one](https://github.com/n0-computer/iroh/actions/runs/14213182767/job/39824005798).

Based on #3186

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
