### PR TITLE
chore(iroh): Update from alpha to release 0.25 hickory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,14 +1724,15 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.0-alpha.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d00147af6310f4392a31680db52a3ed45a2e0f68eb18e8c3fe5537ecc96d9e2"
+checksum = "6d844af74f7b799e41c78221be863bade11c430d46042c3b49ca8ae0c6d27287"
 dependencies = [
  "async-recursion",
  "async-trait",
  "bytes",
  "cfg-if",
+ "critical-section",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -1743,6 +1744,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand 0.9.0",
+ "ring",
  "rustls",
  "serde",
  "thiserror 2.0.11",
@@ -1755,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.0-alpha.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5762f69ebdbd4ddb2e975cd24690bf21fe6b2604039189c26acddbc427f12887"
+checksum = "a128410b38d6f931fcc6ca5c107a3b02cabd6c05967841269a4ad65d23c44331"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1779,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.25.0-alpha.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c8bea0a467929d4f0841977d181f9ca8c65779a6140c4c893e8b784362207f"
+checksum = "716f516285473ce476dfc996bac9a3c9ef2fee4f380ebec5980b12216fe4f547"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3181,6 +3183,10 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -3577,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4defc8f5ac7522968431b7592a34432215d80cceb1cf7e0c06287087bca4f046"
+checksum = "eb5f930995ba4986bd239ba8d8fded67cad82d1db329c4f316f312847cba16aa"
 dependencies = [
  "ipnet",
  "num-traits",
@@ -4679,8 +4685,7 @@ dependencies = [
 [[package]]
 name = "swarm-discovery"
 version = "0.3.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6406a372c38c426a841d2c1095204dfb259229e3ab8080b1c4102f8966bedfcd"
+source = "git+https://github.com/n0-computer/swarm-discovery.git?branch=matheus23/hickory-0.25#9ffa202a49963ca888ec0108f53af3566e3fb594"
 dependencies = [
  "acto",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,8 +4684,9 @@ dependencies = [
 
 [[package]]
 name = "swarm-discovery"
-version = "0.3.0-alpha.2"
-source = "git+https://github.com/n0-computer/swarm-discovery.git?branch=matheus23/hickory-0.25#9ffa202a49963ca888ec0108f53af3566e3fb594"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a95032b94c1dc318f55e0b130e3d2176cda022310a65c3df0092764ea69562"
 dependencies = [
  "acto",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+swarm-discovery = { git = "https://github.com/n0-computer/swarm-discovery.git", branch = "matheus23/hickory-0.25" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,3 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
-
-[patch.crates-io]
-swarm-discovery = { git = "https://github.com/n0-computer/swarm-discovery.git", branch = "matheus23/hickory-0.25" }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -25,7 +25,7 @@ derive_more = { version = "1.0.0", features = [
 ] }
 dirs-next = "2.0.0"
 governor = "0.6.3" #needs new release of tower_governor for 0.7.0
-hickory-server = { version = "0.25", features = ["https-ring"] }
+hickory-server = { version = "0.25.1", features = ["https-ring"] }
 http = "1.0.0"
 humantime-serde = "1.1.1"
 iroh-metrics = { version = "0.32.0", features = ["metrics", "service"] }
@@ -59,7 +59,7 @@ z32 = "1.1.1"
 
 [dev-dependencies]
 criterion = "0.5.1"
-hickory-resolver = "0.25"
+hickory-resolver = "0.25.0"
 iroh = { path = "../iroh" }
 pkarr = { version = "2.3.1", features = ["rand"] }
 rand = "0.8"

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -25,7 +25,7 @@ derive_more = { version = "1.0.0", features = [
 ] }
 dirs-next = "2.0.0"
 governor = "0.6.3" #needs new release of tower_governor for 0.7.0
-hickory-server = { version = "=0.25.0-alpha.5", features = ["dns-over-rustls", "dns-over-https-rustls"] }
+hickory-server = { version = "0.25", features = ["https-ring"] }
 http = "1.0.0"
 humantime-serde = "1.1.1"
 iroh-metrics = { version = "0.32.0", features = ["metrics", "service"] }
@@ -59,7 +59,7 @@ z32 = "1.1.1"
 
 [dev-dependencies]
 criterion = "0.5.1"
-hickory-resolver = "=0.25.0-alpha.5"
+hickory-resolver = "0.25"
 iroh = { path = "../iroh" }
 pkarr = { version = "2.3.1", features = ["rand"] }
 rand = "0.8"

--- a/iroh-dns-server/src/util.rs
+++ b/iroh-dns-server/src/util.rs
@@ -111,7 +111,7 @@ pub fn signed_packet_to_hickory_records_without_origin(
         if name.num_labels() < 1 {
             continue;
         }
-        let zone = name.iter().last().unwrap().into_label()?;
+        let zone = name.iter().next_back().unwrap().into_label()?;
         if zone != common_zone {
             continue;
         }

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -40,7 +40,7 @@ url = { version = "2.4" }
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = "0.25"
+hickory-resolver = "0.25.1"
 netwatch = { version = "0.4" }
 portmapper = { version = "0.4", default-features = false }
 surge-ping = "0.8.0"

--- a/iroh-net-report/Cargo.toml
+++ b/iroh-net-report/Cargo.toml
@@ -40,7 +40,7 @@ url = { version = "2.4" }
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = "=0.25.0-alpha.5"
+hickory-resolver = "0.25"
 netwatch = { version = "0.4" }
 portmapper = { version = "0.4", default-features = false }
 surge-ping = "0.8.0"

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -78,7 +78,7 @@ z32 = "1.0.3"
 clap = { version = "4", features = ["derive"], optional = true }
 dashmap = { version = "6.1.0", optional = true }
 governor = { version = "0.7.0", optional = true }
-hickory-proto = { version = "0.25", default-features = false, optional = true }
+hickory-proto = { version = "0.25.1", default-features = false, optional = true }
 rcgen = { version = "0.13", optional = true }
 regex = { version = "1.7.1", optional = true }
 reloadable-state = { version = "0.1", optional = true }
@@ -95,7 +95,7 @@ tracing-subscriber = { version = "0.3", features = [
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = { version = "0.25", features = ["tokio"] }
+hickory-resolver = { version = "0.25.1", features = ["tokio"] }
 tokio = { version = "1", features = [
     "io-util",
     "macros",

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -78,7 +78,7 @@ z32 = "1.0.3"
 clap = { version = "4", features = ["derive"], optional = true }
 dashmap = { version = "6.1.0", optional = true }
 governor = { version = "0.7.0", optional = true }
-hickory-proto = { version = "=0.25.0-alpha.5", default-features = false, optional = true }
+hickory-proto = { version = "0.25", default-features = false, optional = true }
 rcgen = { version = "0.13", optional = true }
 regex = { version = "1.7.1", optional = true }
 reloadable-state = { version = "0.1", optional = true }
@@ -95,7 +95,7 @@ tracing-subscriber = { version = "0.3", features = [
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = "=0.25.0-alpha.5"
+hickory-resolver = { version = "0.25", features = ["tokio"] }
 tokio = { version = "1", features = [
     "io-util",
     "macros",

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -322,7 +322,7 @@ impl Server {
             relay.tls.as_ref().and_then(|tls| match tls.cert {
                 CertConfig::LetsEncrypt { .. } => None,
                 CertConfig::Manual { ref certs, .. } => Some(certs.clone()),
-                CertConfig::Reloading { .. } => None,
+                CertConfig::Reloading => None,
             })
         });
 
@@ -384,7 +384,7 @@ impl Server {
                                     acceptor,
                                 })
                             }
-                            CertConfig::Manual { .. } | CertConfig::Reloading { .. } => {
+                            CertConfig::Manual { .. } | CertConfig::Reloading => {
                                 let server_config = Arc::new(tls_config.server_config);
                                 let acceptor =
                                     tokio_rustls::TlsAcceptor::from(server_config.clone());

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -100,7 +100,7 @@ parse-size = { version = "=1.0.0", optional = true } # pinned version to avoid b
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = { version = "=0.25.0-alpha.5" }
+hickory-resolver = "0.25"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 portmapper = { version = "0.4", default-features = false }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -100,7 +100,7 @@ parse-size = { version = "=1.0.0", optional = true } # pinned version to avoid b
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = "0.25"
+hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 portmapper = { version = "0.4", default-features = false }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -84,7 +84,7 @@ net-report = { package = "iroh-net-report", path = "../iroh-net-report", version
 iroh-metrics = { version = "0.32", default-features = false }
 
 # local-swarm-discovery
-swarm-discovery = { version = "0.3.0-alpha.2", optional = true }
+swarm-discovery = { version = "0.3.1", optional = true }
 futures-util = "0.3"
 
 # test_utils


### PR DESCRIPTION
## Description

Updates hickory from 0.25-alpha.5 to hickory 0.25.1.

## Notes & open questions

Depends on https://github.com/rkuhn/swarm-discovery/pull/15

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Checked `sendme`, `dumbpipe`, `iroh-gossip`, `iroh-blobs` and `iroh-docs` for `hickory` dependencies. None of them have it.