### PR TITLE
chore(iroh): Don't depend on unused `rustls-platform-verifier` dependency

### DIFF
--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -104,7 +104,7 @@ hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 portmapper = { version = "0.4", default-features = false }
-quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["platform-verifier", "runtime-tokio", "rustls-ring"] }
+quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",
     "macros",


### PR DESCRIPTION
## Description

We used to depend on `rustls-platform-verifier` through `quinn` via its `platform-verifier` feature.
We don't actually use that feature (it only provides `ClientConfig::with_platform_verifier()` as a fn, but we don't use it).

# Notes

There's no changes to `Cargo.lock`, because we still pull in rustls-platform-verifier as a dev-dependency.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
