### PR TITLE
deps: bump tokio to 1.44.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4876,9 +4876,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
## Description

We have a cargo-deny warning on main due to this tokio rustsec advisory: https://rustsec.org/advisories/RUSTSEC-2025-0023

Fix is to bump tokio, which this PR does.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review