### PR TITLE
feat!: metrics refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#04b9c4fca09b15856d00da4640cfa3d882f3c750"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#b7f521f03734e890725a8b2c6a70055ef97cee0b"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2967,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#92e9c70819dc2c27f0d832289efdcfa92aee4b11"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#4c953aef8bab936c891224215ac3e1aaedb00942"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3464,7 +3464,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#92e9c70819dc2c27f0d832289efdcfa92aee4b11"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#4c953aef8bab936c891224215ac3e1aaedb00942"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,8 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#a1a6e1090892bde5c2d2c115afd03a409f12f6a3"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d64b607e49f67fa42b3e780109cad0fa1fdb476b4a78d4cf8443499bbc1ad0a"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2415,7 +2416,8 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#a1a6e1090892bde5c2d2c115afd03a409f12f6a3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa484b5f192006b1cc39261712d65baf87342fc72a4acc1560355d1dc410d9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2978,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#731a154aa91ccdae75f1337a9ce5888d4ae484be"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#7012b8e65c352e1ce2c9f15aaa614fa193704e4f"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3475,7 +3477,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#731a154aa91ccdae75f1337a9ce5888d4ae484be"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#7012b8e65c352e1ce2c9f15aaa614fa193704e4f"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2972,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#640166ea310788a1fabca4ea99fc8cb0c6ae70f4"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#dae8cea85713f36a3880c40893c17ccb3f712af0"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3469,7 +3469,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#640166ea310788a1fabca4ea99fc8cb0c6ae70f4"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#dae8cea85713f36a3880c40893c17ccb3f712af0"
 dependencies = [
  "base64",
  "bytes",
@@ -5563,7 +5563,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#edca9ebc27d6ef7ba10a99b340356e8ff1c197f5"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#04b9c4fca09b15856d00da4640cfa3d882f3c750"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -4000,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#c04c68d3624e32f8bb682442db63cf467b1a938c"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#92e9c70819dc2c27f0d832289efdcfa92aee4b11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3464,7 +3464,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#c04c68d3624e32f8bb682442db63cf467b1a938c"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#92e9c70819dc2c27f0d832289efdcfa92aee4b11"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,7 +2273,7 @@ dependencies = [
  "iroh-relay",
  "n0-future",
  "netdev",
- "netwatch 0.4.0",
+ "netwatch 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-size",
  "pin-project",
  "pkarr",
@@ -2404,6 +2404,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/metric-sets#7edb7839128f79089e113e76ae045ce3a3370427"
 dependencies = [
  "erased_set",
  "http-body-util",
@@ -2939,24 +2940,22 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64da82edf903649e6cb6a77b5a6f7fe01387d8865065d411d139018510880302"
+checksum = "0b7879c2cfdf30d92f2be89efa3169b3d78107e3ab7f7b9a37157782569314e1"
 dependencies = [
- "anyhow",
  "atomic-waker",
  "bytes",
+ "cfg_aliases",
  "derive_more",
- "futures-lite",
- "futures-sink",
- "futures-util",
  "iroh-quinn-udp",
+ "js-sys",
  "libc",
+ "n0-future",
  "netdev",
  "netlink-packet-core",
  "netlink-packet-route 0.19.0",
  "netlink-sys",
- "once_cell",
  "rtnetlink 0.13.1",
  "rtnetlink 0.14.1",
  "serde",
@@ -2966,15 +2965,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "windows 0.58.0",
+ "web-sys",
+ "windows 0.59.0",
+ "windows-result 0.3.0",
  "wmi",
 ]
 
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7879c2cfdf30d92f2be89efa3169b3d78107e3ab7f7b9a37157782569314e1"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#1c0a3904bd26841d46ce61c82be2eeea3866ccbd"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3470,9 +3470,8 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "portmapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b715da165f399be093fecb2ca774b00713a3b32f6b27e0752fbf255e3be622af"
+version = "0.4.1"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#1c0a3904bd26841d46ce61c82be2eeea3866ccbd"
 dependencies = [
  "base64",
  "bytes",
@@ -3482,7 +3481,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.3.0",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
  "num_enum",
  "rand 0.8.5",
  "serde",
@@ -6272,7 +6271,3 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
-
-[[patch.unused]]
-name = "portmapper"
-version = "0.4.1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#a1a6e1090892bde5c2d2c115afd03a409f12f6a3"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2415,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#a1a6e1090892bde5c2d2c115afd03a409f12f6a3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#56845af49f5d8a2b7ea52f64ca2945679e66fd33"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#731a154aa91ccdae75f1337a9ce5888d4ae484be"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3475,7 +3475,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#56845af49f5d8a2b7ea52f64ca2945679e66fd33"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#731a154aa91ccdae75f1337a9ce5888d4ae484be"
 dependencies = [
  "base64",
  "bytes",
@@ -3485,7 +3485,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2)",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
  "num_enum",
  "rand 0.8.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,6 +2266,7 @@ dependencies = [
  "pin-project",
  "pkarr",
  "portmapper",
+ "postcard",
  "pretty_assertions",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -2972,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#dae8cea85713f36a3880c40893c17ccb3f712af0"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3469,7 +3470,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#dae8cea85713f36a3880c40893c17ccb3f712af0"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,12 +1038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,14 +2392,13 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d64b607e49f67fa42b3e780109cad0fa1fdb476b4a78d4cf8443499bbc1ad0a"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
 dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
  "iroh-metrics-derive",
- "prometheus-client",
+ "itoa",
  "reqwest",
  "serde",
  "thiserror 2.0.11",
@@ -2416,8 +2409,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa484b5f192006b1cc39261712d65baf87342fc72a4acc1560355d1dc410d9"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2980,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ef897c745d78dbd19429bdf6131f91c9563c2c1a"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#640166ea310788a1fabca4ea99fc8cb0c6ae70f4"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3477,7 +3469,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ef897c745d78dbd19429bdf6131f91c9563c2c1a"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#640166ea310788a1fabca4ea99fc8cb0c6ae70f4"
 dependencies = [
  "base64",
  "bytes",
@@ -3487,7 +3479,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2)",
  "num_enum",
  "rand 0.8.5",
  "serde",
@@ -3611,29 +3603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -5594,7 +5563,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,14 +1232,15 @@ dependencies = [
 
 [[package]]
 name = "futures-buffered"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34acda8ae8b63fbe0b2195c998b180cff89a8212fb2622a78b572a9f1c6f7684"
+checksum = "fe940397c8b744b9c2c974791c2c08bca2c3242ce0290393249e98f215a00472"
 dependencies = [
  "cordyceps",
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
+ "spin",
 ]
 
 [[package]]
@@ -1950,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1960,6 +1961,7 @@ dependencies = [
  "http 1.2.0",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2131,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.15.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
+checksum = "d06464e726471718db9ad3fefc020529fabcde03313a0fc3967510e2db5add12"
 dependencies = [
  "async-trait",
  "attohttpc",
@@ -2144,7 +2146,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.8.5",
+ "rand 0.9.0",
  "tokio",
  "url",
  "xmltree",
@@ -2249,7 +2251,7 @@ dependencies = [
  "iroh-relay",
  "n0-future",
  "netdev",
- "netwatch 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netwatch",
  "parse-size",
  "pin-project",
  "pkarr",
@@ -2599,9 +2601,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libredox"
@@ -2812,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "n0-future"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399e11dc3b0e8d9d65b27170d22f5d779d52d9bed888db70d7e0c2c7ce3dfc52"
+checksum = "7bb0e5d99e681ab3c938842b96fcb41bf8a7bb4bfdb11ccbd653a7e83e06c794"
 dependencies = [
  "cfg_aliases",
  "derive_more",
@@ -2829,6 +2831,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "nested_enum_utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fa9161ed44d30e9702fe42bd78693bceac0fed02f647da749f36109023d3a3"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2875,11 +2889,12 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.19.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+checksum = "0800eae8638a299eaa67476e1c6b6692922273e0f7939fd188fc861c837b9cd2"
 dependencies = [
  "anyhow",
+ "bitflags 2.8.0",
  "byteorder",
  "libc",
  "log",
@@ -2928,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7879c2cfdf30d92f2be89efa3169b3d78107e3ab7f7b9a37157782569314e1"
+checksum = "67eeaa5f7505c93c5a9b35ba84fd21fb8aa3f24678c76acfe8716af7862fb07a"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2940,15 +2955,15 @@ dependencies = [
  "js-sys",
  "libc",
  "n0-future",
+ "nested_enum_utils",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.19.0",
+ "netlink-packet-route 0.23.0",
+ "netlink-proto",
  "netlink-sys",
- "rtnetlink 0.13.1",
- "rtnetlink 0.14.1",
  "serde",
+ "snafu",
  "socket2",
- "thiserror 2.0.11",
  "time",
  "tokio",
  "tokio-util",
@@ -2957,60 +2972,6 @@ dependencies = [
  "windows 0.59.0",
  "windows-result 0.3.0",
  "wmi",
-]
-
-[[package]]
-name = "netwatch"
-version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#54f4557ee760b0fb4c3a25f1b5596592aca55194"
-dependencies = [
- "atomic-waker",
- "bytes",
- "cfg_aliases",
- "derive_more",
- "iroh-quinn-udp",
- "js-sys",
- "libc",
- "n0-future",
- "netdev",
- "netlink-packet-core",
- "netlink-packet-route 0.19.0",
- "netlink-sys",
- "rtnetlink 0.13.1",
- "rtnetlink 0.14.1",
- "serde",
- "socket2",
- "thiserror 2.0.11",
- "time",
- "tokio",
- "tokio-util",
- "tracing",
- "web-sys",
- "windows 0.59.0",
- "windows-result 0.3.0",
- "wmi",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.8.0",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -3478,27 +3439,31 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "portmapper"
-version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#54f4557ee760b0fb4c3a25f1b5596592aca55194"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6db66007eac4a0ec8331d0d20c734bd64f6445d64bbaf0d0a27fea7a054e36"
 dependencies = [
  "base64",
  "bytes",
  "derive_more",
  "futures-lite",
  "futures-util",
+ "hyper-util",
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
+ "nested_enum_utils",
+ "netwatch",
  "num_enum",
  "rand 0.8.5",
  "serde",
  "smallvec",
+ "snafu",
  "socket2",
- "thiserror 2.0.11",
  "time",
  "tokio",
  "tokio-util",
+ "tower-layer",
  "tracing",
  "url",
 ]
@@ -4005,42 +3970,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rtnetlink"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-packet-route 0.17.1",
- "netlink-packet-utils",
- "netlink-proto",
- "netlink-sys",
- "nix 0.26.4",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "rtnetlink"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-packet-route 0.19.0",
- "netlink-packet-utils",
- "netlink-proto",
- "netlink-sys",
- "nix 0.27.1",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4537,9 +4466,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4987,15 +4916,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "pin-project-lite",
  "tokio",
 ]
@@ -5579,7 +5508,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#357d542d2fde20f26d35ec3c56eb860fb9b6f304"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2415,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#357d542d2fde20f26d35ec3c56eb860fb9b6f304"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#2f2ba0975b5e880b98a3102324f13710433069e8"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#56845af49f5d8a2b7ea52f64ca2945679e66fd33"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3475,7 +3475,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#2f2ba0975b5e880b98a3102324f13710433069e8"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#56845af49f5d8a2b7ea52f64ca2945679e66fd33"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#83b0335857dcfe379ffbf4e854851f209ddeeb6c"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#edca9ebc27d6ef7ba10a99b340356e8ff1c197f5"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5581,7 +5581,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2402,7 +2402,7 @@ dependencies = [
  "itoa",
  "reqwest",
  "serde",
- "thiserror 2.0.11",
+ "snafu",
  "tokio",
  "tracing",
 ]
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ff9840322c1c57dc87010f2909f174c5bb8944b3"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3470,7 +3470,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ff9840322c1c57dc87010f2909f174c5bb8944b3"
 dependencies = [
  "base64",
  "bytes",
@@ -3480,7 +3480,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2)",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
  "num_enum",
  "rand 0.8.5",
  "serde",
@@ -4504,6 +4504,27 @@ name = "smol_str"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+
+[[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,12 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "erased_set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a02a5d186d7bf1cb21f1f95e1a9cfa5c1f2dcd803a47aad454423ceec13525c5"
-
-[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,9 +2398,8 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/metric-sets#7edb7839128f79089e113e76ae045ce3a3370427"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#83b0335857dcfe379ffbf4e854851f209ddeeb6c"
 dependencies = [
- "erased_set",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2974,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#1c0a3904bd26841d46ce61c82be2eeea3866ccbd"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#c04c68d3624e32f8bb682442db63cf467b1a938c"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3471,7 +3464,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#1c0a3904bd26841d46ce61c82be2eeea3866ccbd"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#c04c68d3624e32f8bb682442db63cf467b1a938c"
 dependencies = [
  "base64",
  "bytes",
@@ -5588,7 +5581,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,8 +2404,6 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f7cd1ffe3b152a5f4f4c1880e01e07d96001f20e02cc143cb7842987c616b3"
 dependencies = [
  "erased_set",
  "http-body-util",
@@ -6274,3 +6272,7 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
+
+[[patch.unused]]
+name = "portmapper"
+version = "0.4.1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#7012b8e65c352e1ce2c9f15aaa614fa193704e4f"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ef897c745d78dbd19429bdf6131f91c9563c2c1a"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3477,7 +3477,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#7012b8e65c352e1ce2c9f15aaa614fa193704e4f"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ef897c745d78dbd19429bdf6131f91c9563c2c1a"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5581,7 +5581,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,18 +2398,29 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#b7f521f03734e890725a8b2c6a70055ef97cee0b"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#357d542d2fde20f26d35ec3c56eb860fb9b6f304"
 dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "iroh-metrics-derive",
  "prometheus-client",
  "reqwest",
  "serde",
- "struct_iterable",
  "thiserror 2.0.11",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "0.1.0"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#357d542d2fde20f26d35ec3c56eb860fb9b6f304"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2967,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#4c953aef8bab936c891224215ac3e1aaedb00942"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#2f2ba0975b5e880b98a3102324f13710433069e8"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3464,7 +3475,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#4c953aef8bab936c891224215ac3e1aaedb00942"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#2f2ba0975b5e880b98a3102324f13710433069e8"
 dependencies = [
  "base64",
  "bytes",
@@ -3474,7 +3485,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2)",
  "num_enum",
  "rand 0.8.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,8 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.33.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70466f14caff7420a14373676947e25e2917af6a5b1bec45825beb2bf1eb6a7"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2409,8 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d12f5c45c4ed2436302a4e03cad9a0ad34b2962ad0c5791e1019c0ee30eeb09"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2973,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ff9840322c1c57dc87010f2909f174c5bb8944b3"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#54f4557ee760b0fb4c3a25f1b5596592aca55194"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3470,7 +3472,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ff9840322c1c57dc87010f2909f174c5bb8944b3"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#54f4557ee760b0fb4c3a25f1b5596592aca55194"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,3 @@ unused-async = "warn"
 
 [patch.crates-io]
 iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 unused-async = "warn"
 
 [patch.crates-io]
-iroh-metrics = { path = "../iroh-metrics" }
-portmapper = { path = "../net-tools/portmapper" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/metric-sets" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 unused-async = "warn"
 
 [patch.crates-io]
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 unused-async = "warn"
 
 [patch.crates-io]
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/metric-sets" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }
 portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,3 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
-
-[patch.crates-io]
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+iroh-metrics = { path = "../iroh-metrics" }
+portmapper = { path = "../net-tools/portmapper" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 unused-async = "warn"
 
 [patch.crates-io]
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor2" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -28,7 +28,7 @@ governor = "0.6.3" #needs new release of tower_governor for 0.7.0
 hickory-server = { version = "0.25.1", features = ["https-ring"] }
 http = "1.0.0"
 humantime-serde = "1.1.1"
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", features = ["service"] }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main", features = ["service"] }
 lru = "0.12.3"
 n0-future = "0.1.2"
 pkarr = { version = "2.3.1", features = [ "async", "relay", "dht"], default-features = false }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -28,7 +28,7 @@ governor = "0.6.3" #needs new release of tower_governor for 0.7.0
 hickory-server = { version = "0.25.1", features = ["https-ring"] }
 http = "1.0.0"
 humantime-serde = "1.1.1"
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main", features = ["service"] }
+iroh-metrics = { version = "0.34", features = ["service"] }
 lru = "0.12.3"
 n0-future = "0.1.2"
 pkarr = { version = "2.3.1", features = [ "async", "relay", "dht"], default-features = false }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -28,7 +28,7 @@ governor = "0.6.3" #needs new release of tower_governor for 0.7.0
 hickory-server = { version = "0.25.1", features = ["https-ring"] }
 http = "1.0.0"
 humantime-serde = "1.1.1"
-iroh-metrics = { version = "0.33.0", features = ["metrics", "service"] }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", features = ["service"] }
 lru = "0.12.3"
 n0-future = "0.1.2"
 pkarr = { version = "2.3.1", features = [ "async", "relay", "dht"], default-features = false }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -28,7 +28,7 @@ governor = "0.6.3" #needs new release of tower_governor for 0.7.0
 hickory-server = { version = "0.25.1", features = ["https-ring"] }
 http = "1.0.0"
 humantime-serde = "1.1.1"
-iroh-metrics = { version = "0.32.0", features = ["metrics", "service"] }
+iroh-metrics = { version = "0.33.0", features = ["metrics", "service"] }
 lru = "0.12.3"
 n0-future = "0.1.2"
 pkarr = { version = "2.3.1", features = [ "async", "relay", "dht"], default-features = false }

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -1,15 +1,22 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use iroh::{discovery::pkarr::PkarrRelayClient, node_info::NodeInfo, SecretKey};
-use iroh_dns_server::{config::Config, server::Server, ZoneStore};
+use iroh_dns_server::{config::Config, metrics::Metrics, server::Server, ZoneStore};
 use rand_chacha::rand_core::SeedableRng;
 use tokio::runtime::Runtime;
 
 const LOCALHOST_PKARR: &str = "http://localhost:8080/pkarr";
 
 async fn start_dns_server(config: Config) -> Result<Server> {
-    let store = ZoneStore::persistent(Config::signed_packet_store_path()?, Default::default())?;
-    Server::spawn(config, store).await
+    let metrics = Arc::new(Metrics::default());
+    let store = ZoneStore::persistent(
+        Config::signed_packet_store_path()?,
+        Default::default(),
+        metrics.clone(),
+    )?;
+    Server::spawn(config, store, metrics).await
 }
 
 fn benchmark_dns_server(c: &mut Criterion) {

--- a/iroh-dns-server/src/dns.rs
+++ b/iroh-dns-server/src/dns.rs
@@ -26,7 +26,6 @@ use hickory_server::{
     server::{Request, RequestHandler, ResponseHandler, ResponseInfo},
     store::in_memory::InMemoryAuthority,
 };
-use iroh_metrics::inc;
 use serde::{Deserialize, Serialize};
 use tokio::{
     net::{TcpListener, UdpSocket},
@@ -122,12 +121,13 @@ impl DnsServer {
 pub struct DnsHandler {
     #[debug("Catalog")]
     catalog: Arc<Catalog>,
+    metrics: Arc<Metrics>,
 }
 
 impl DnsHandler {
     /// Create a DNS server given some settings, a connection to the DB for DID-by-username lookups
     /// and the server DID to serve under `_did.<origin>`.
-    pub fn new(zone_store: ZoneStore, config: &DnsConfig) -> Result<Self> {
+    pub fn new(zone_store: ZoneStore, config: &DnsConfig, metrics: Arc<Metrics>) -> Result<Self> {
         let origins = config
             .origins
             .iter()
@@ -149,6 +149,7 @@ impl DnsHandler {
 
         Ok(Self {
             catalog: Arc::new(catalog),
+            metrics,
         })
     }
 
@@ -168,10 +169,14 @@ impl RequestHandler for DnsHandler {
         request: &Request,
         response_handle: R,
     ) -> ResponseInfo {
-        inc!(Metrics, dns_requests);
+        self.metrics.dns_requests.inc();
         match request.protocol() {
-            Protocol::Udp => inc!(Metrics, dns_requests_udp),
-            Protocol::Https => inc!(Metrics, dns_requests_https),
+            Protocol::Udp => {
+                self.metrics.dns_requests_udp.inc();
+            }
+            Protocol::Https => {
+                self.metrics.dns_requests_https.inc();
+            }
             _ => {}
         }
         debug!(protocol=%request.protocol(), queries=?request.queries(), "incoming DNS request");
@@ -179,12 +184,12 @@ impl RequestHandler for DnsHandler {
         let res = self.catalog.handle_request(request, response_handle).await;
         match &res.response_code() {
             ResponseCode::NoError => match res.answer_count() {
-                0 => inc!(Metrics, dns_lookup_notfound),
-                _ => inc!(Metrics, dns_lookup_success),
+                0 => self.metrics.dns_lookup_notfound.inc(),
+                _ => self.metrics.dns_lookup_success.inc(),
             },
-            ResponseCode::NXDomain => inc!(Metrics, dns_lookup_notfound),
-            _ => inc!(Metrics, dns_lookup_error),
-        }
+            ResponseCode::NXDomain => self.metrics.dns_lookup_notfound.inc(),
+            _ => self.metrics.dns_lookup_error.inc(),
+        };
         res
     }
 }

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::{bail, Context, Result};
 use axum::{
-    extract::{ConnectInfo, Request},
+    extract::{ConnectInfo, Request, State},
     handler::Handler,
     http::Method,
     middleware::{self, Next},
@@ -15,7 +15,6 @@ use axum::{
     routing::get,
     Router,
 };
-use iroh_metrics::{inc, inc_by};
 use serde::{Deserialize, Serialize};
 use tokio::{net::TcpListener, task::JoinSet};
 use tower_http::{
@@ -31,7 +30,7 @@ mod rate_limiting;
 mod tls;
 
 pub use self::{rate_limiting::RateLimitConfig, tls::CertMode};
-use crate::{config::Config, metrics::Metrics, state::AppState};
+use crate::{config::Config, state::AppState};
 
 /// Config for the HTTP server
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -227,13 +226,13 @@ pub(crate) fn create_app(state: AppState, rate_limit_config: &RateLimitConfig) -
         )
         .route("/healthcheck", get(|| async { "OK" }))
         .route("/", get(|| async { "Hi!" }))
-        .with_state(state);
+        .with_state(state.clone());
 
     // configure app
     router
         .layer(cors)
         .layer(trace)
-        .route_layer(middleware::from_fn(metrics_middleware))
+        .route_layer(middleware::from_fn_with_state(state, metrics_middleware))
 }
 
 /// Record request metrics.
@@ -244,17 +243,24 @@ pub(crate) fn create_app(state: AppState, rate_limit_config: &RateLimitConfig) -
 //
 // See also
 // https://github.com/tokio-rs/axum/blob/main/examples/prometheus-metrics/src/main.rs#L114
-async fn metrics_middleware(req: Request, next: Next) -> impl IntoResponse {
+async fn metrics_middleware(
+    State(state): State<AppState>,
+    req: Request,
+    next: Next,
+) -> impl IntoResponse {
     let start = Instant::now();
     let response = next.run(req).await;
     let latency = start.elapsed().as_millis();
     let status = response.status();
-    inc_by!(Metrics, http_requests_duration_ms, latency as u64);
-    inc!(Metrics, http_requests);
+    state
+        .metrics
+        .http_requests_duration_ms
+        .inc_by(latency as u64);
+    state.metrics.http_requests.inc();
     if status.is_success() {
-        inc!(Metrics, http_requests_success);
+        state.metrics.http_requests_success.inc();
     } else {
-        inc!(Metrics, http_requests_error);
+        state.metrics.http_requests_error.inc();
     }
     response
 }

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -194,7 +194,7 @@ mod tests {
             max_batch_time: Duration::from_millis(100),
             ..Default::default()
         };
-        let store = ZoneStore::in_memory(options)?;
+        let store = ZoneStore::in_memory(options, Default::default())?;
 
         // create a signed packet
         let signed_packet = random_signed_packet()?;

--- a/iroh-dns-server/src/main.rs
+++ b/iroh-dns-server/src/main.rs
@@ -2,9 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-use iroh_dns_server::{
-    config::Config, metrics::init_metrics, server::run_with_config_until_ctrl_c,
-};
+use iroh_dns_server::{config::Config, server::run_with_config_until_ctrl_c};
 use tracing::debug;
 
 #[derive(Parser, Debug)]
@@ -27,6 +25,5 @@ async fn main() -> Result<()> {
         Config::default()
     };
 
-    init_metrics();
     run_with_config_until_ctrl_c(config).await
 }

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Metrics support for the server
 
-use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
+use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
 
 /// Metrics for iroh-dns-server
 #[derive(Debug, Clone, Iterable)]
@@ -49,7 +49,7 @@ impl Default for Metrics {
     }
 }
 
-impl Metric for Metrics {
+impl MetricsGroup for Metrics {
     fn name(&self) -> &'static str {
         "dns_server"
     }

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -3,7 +3,7 @@
 use iroh_metrics::{Counter, MetricsGroup};
 
 /// Metrics for iroh-dns-server
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "dns_server")]
 pub struct Metrics {
     /// Number of pkarr relay puts that updated the state

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -1,7 +1,6 @@
 //! Metrics support for the server
 
-use iroh_metrics::core::{Core, Counter, Metric, MetricExt};
-use struct_iterable::Iterable;
+use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
 
 /// Metrics for iroh-dns-server
 #[derive(Debug, Clone, Iterable)]
@@ -54,11 +53,4 @@ impl Metric for Metrics {
     fn name(&self) -> &'static str {
         "dns_server"
     }
-}
-
-/// Init the metrics collection core.
-pub fn init_metrics() {
-    Core::init(|reg, metrics| {
-        metrics.insert(Metrics::new(reg));
-    });
 }

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Metrics support for the server
 
-use iroh_metrics::core::{Core, Counter, Metric};
+use iroh_metrics::core::{Core, Counter, Metric, MetricExt};
 use struct_iterable::Iterable;
 
 /// Metrics for iroh-dns-server
@@ -51,7 +51,7 @@ impl Default for Metrics {
 }
 
 impl Metric for Metrics {
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         "dns_server"
     }
 }

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -1,56 +1,41 @@
 //! Metrics support for the server
 
-use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
+use iroh_metrics::{Counter, MetricsGroup};
 
 /// Metrics for iroh-dns-server
-#[derive(Debug, Clone, Iterable)]
-#[allow(missing_docs)]
+#[derive(Debug, Clone, MetricsGroup)]
+#[metrics(name = "dns_server")]
 pub struct Metrics {
+    /// Number of pkarr relay puts that updated the state
     pub pkarr_publish_update: Counter,
+    /// Number of pkarr relay puts that did not update the state
     pub pkarr_publish_noop: Counter,
+    /// DNS requests (total)
     pub dns_requests: Counter,
+    /// DNS requests via UDP
     pub dns_requests_udp: Counter,
+    /// DNS requests via HTTPS (DoH)
     pub dns_requests_https: Counter,
+    /// DNS lookup responses with at least one answer
     pub dns_lookup_success: Counter,
+    /// DNS lookup responses with no answers
     pub dns_lookup_notfound: Counter,
+    /// DNS lookup responses which failed
     pub dns_lookup_error: Counter,
+    /// Number of HTTP requests
     pub http_requests: Counter,
+    /// Number of HTTP requests with a 2xx status code
     pub http_requests_success: Counter,
+    /// Number of HTTP requests with a non-2xx status code
     pub http_requests_error: Counter,
+    /// Total duration of all HTTP requests
     pub http_requests_duration_ms: Counter,
+    /// Signed packets inserted into the store
     pub store_packets_inserted: Counter,
+    /// Signed packets removed from the store
     pub store_packets_removed: Counter,
+    /// Number of updates to existing packets
     pub store_packets_updated: Counter,
+    /// Number of expired packets
     pub store_packets_expired: Counter,
-}
-
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            pkarr_publish_update: Counter::new("Number of pkarr relay puts that updated the state"),
-            pkarr_publish_noop: Counter::new(
-                "Number of pkarr relay puts that did not update the state",
-            ),
-            dns_requests: Counter::new("DNS requests (total)"),
-            dns_requests_udp: Counter::new("DNS requests via UDP"),
-            dns_requests_https: Counter::new("DNS requests via HTTPS (DoH)"),
-            dns_lookup_success: Counter::new("DNS lookup responses with at least one answer"),
-            dns_lookup_notfound: Counter::new("DNS lookup responses with no answers"),
-            dns_lookup_error: Counter::new("DNS lookup responses which failed"),
-            http_requests: Counter::new("Number of HTTP requests"),
-            http_requests_success: Counter::new("Number of HTTP requests with a 2xx status code"),
-            http_requests_error: Counter::new("Number of HTTP requests with a non-2xx status code"),
-            http_requests_duration_ms: Counter::new("Total duration of all HTTP requests"),
-            store_packets_inserted: Counter::new("Signed packets inserted into the store"),
-            store_packets_removed: Counter::new("Signed packets removed from the store"),
-            store_packets_updated: Counter::new("Number of updates to existing packets"),
-            store_packets_expired: Counter::new("Number of expired packets"),
-        }
-    }
-}
-
-impl MetricsGroup for Metrics {
-    fn name(&self) -> &'static str {
-        "dns_server"
-    }
 }

--- a/iroh-dns-server/src/server.rs
+++ b/iroh-dns-server/src/server.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use iroh_metrics::{service::start_metrics_server, Metric};
+use iroh_metrics::{service::start_metrics_server, MetricsGroup};
 use tracing::info;
 
 use crate::{

--- a/iroh-dns-server/src/server.rs
+++ b/iroh-dns-server/src/server.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use iroh_metrics::{service::start_metrics_server, MetricsGroup};
+use iroh_metrics::service::start_metrics_server;
 use tracing::info;
 
 use crate::{
@@ -62,8 +62,8 @@ impl Server {
         let metrics_task = tokio::task::spawn(async move {
             if let Some(addr) = metrics_addr {
                 let mut registry = iroh_metrics::Registry::default();
-                metrics.register(&mut registry);
-                start_metrics_server(addr, std::sync::Arc::new(registry)).await?;
+                registry.register(metrics);
+                start_metrics_server(addr, Arc::new(registry)).await?;
             }
             Ok(())
         });

--- a/iroh-dns-server/src/state.rs
+++ b/iroh-dns-server/src/state.rs
@@ -1,6 +1,8 @@
 //! Shared state and store for the iroh-dns-server
 
-use crate::{dns::DnsHandler, store::ZoneStore};
+use std::sync::Arc;
+
+use crate::{dns::DnsHandler, metrics::Metrics, store::ZoneStore};
 
 /// The shared app state.
 #[derive(Clone)]
@@ -9,4 +11,6 @@ pub struct AppState {
     pub store: ZoneStore,
     /// Handler for DNS requests
     pub dns_handler: DnsHandler,
+    /// Metrics collector.
+    pub metrics: Arc<Metrics>,
 }

--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -4,7 +4,6 @@ use std::{collections::BTreeMap, num::NonZeroUsize, path::Path, sync::Arc, time:
 
 use anyhow::Result;
 use hickory_server::proto::rr::{Name, RecordSet, RecordType, RrKey};
-use iroh_metrics::inc;
 use lru::LruCache;
 use pkarr::{mainline::dht::DhtSettings, PkarrClient, SignedPacket};
 use tokio::sync::Mutex;
@@ -41,19 +40,24 @@ pub struct ZoneStore {
     cache: Arc<Mutex<ZoneCache>>,
     store: Arc<SignedPacketStore>,
     pkarr: Option<Arc<PkarrClient>>,
+    metrics: Arc<Metrics>,
 }
 
 impl ZoneStore {
     /// Create a persistent store
-    pub fn persistent(path: impl AsRef<Path>, options: ZoneStoreOptions) -> Result<Self> {
-        let packet_store = SignedPacketStore::persistent(path, options)?;
-        Ok(Self::new(packet_store))
+    pub fn persistent(
+        path: impl AsRef<Path>,
+        options: ZoneStoreOptions,
+        metrics: Arc<Metrics>,
+    ) -> Result<Self> {
+        let packet_store = SignedPacketStore::persistent(path, options, metrics.clone())?;
+        Ok(Self::new(packet_store, metrics))
     }
 
     /// Create an in-memory store.
-    pub fn in_memory(options: ZoneStoreOptions) -> Result<Self> {
-        let packet_store = SignedPacketStore::in_memory(options)?;
-        Ok(Self::new(packet_store))
+    pub fn in_memory(options: ZoneStoreOptions, metrics: Arc<Metrics>) -> Result<Self> {
+        let packet_store = SignedPacketStore::in_memory(options, metrics.clone())?;
+        Ok(Self::new(packet_store, metrics))
     }
 
     /// Configure a pkarr client for resolution of packets from the bittorrent mainline DHT.
@@ -80,12 +84,13 @@ impl ZoneStore {
     }
 
     /// Create a new zone store.
-    pub fn new(store: SignedPacketStore) -> Self {
+    pub fn new(store: SignedPacketStore, metrics: Arc<Metrics>) -> Self {
         let zone_cache = ZoneCache::new(DEFAULT_CACHE_CAPACITY);
         Self {
             store: Arc::new(store),
             cache: Arc::new(Mutex::new(zone_cache)),
             pkarr: None,
+            metrics,
         }
     }
 
@@ -147,11 +152,11 @@ impl ZoneStore {
     pub async fn insert(&self, signed_packet: SignedPacket, _source: PacketSource) -> Result<bool> {
         let pubkey = PublicKeyBytes::from_signed_packet(&signed_packet);
         if self.store.upsert(signed_packet).await? {
-            inc!(Metrics, pkarr_publish_update);
+            self.metrics.pkarr_publish_update.inc();
             self.cache.lock().await.remove(&pubkey);
             Ok(true)
         } else {
-            inc!(Metrics, pkarr_publish_noop);
+            self.metrics.pkarr_publish_noop.inc();
             Ok(false)
         }
     }

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -33,7 +33,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 iroh-base = { version = "0.34.1", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
-iroh-metrics = { version = "0.33", default-features = false }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", default-features = false }
 n0-future = "0.1.2"
 num_enum = "0.7"
 pin-project = "1"

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -139,6 +139,7 @@ cfg_aliases = { version = "0.2" }
 [features]
 default = ["metrics"]
 server = [
+    "metrics",
     "dep:clap",
     "dep:dashmap",
     "dep:governor",

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -33,7 +33,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 iroh-base = { version = "0.34.1", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main", default-features = false }
+iroh-metrics = { version = "0.34", default-features = false }
 n0-future = "0.1.2"
 num_enum = "0.7"
 pin-project = "1"

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -33,7 +33,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 iroh-base = { version = "0.34.1", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
-iroh-metrics = { version = "0.32", default-features = false }
+iroh-metrics = { version = "0.33", default-features = false }
 n0-future = "0.1.2"
 num_enum = "0.7"
 pin-project = "1"

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -33,7 +33,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 iroh-base = { version = "0.34.1", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", default-features = false }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main", default-features = false }
 n0-future = "0.1.2"
 num_enum = "0.7"
 pin-project = "1"

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -724,54 +724,6 @@ async fn build_relay_config(cfg: Config) -> Result<relay::ServerConfig<std::io::
     })
 }
 
-mod metrics {
-    use iroh_metrics::{
-        core::{Counter, Metric},
-        struct_iterable::Iterable,
-    };
-
-    /// StunMetrics tracked for the relay server
-    #[allow(missing_docs)]
-    #[derive(Debug, Clone, Iterable)]
-    pub struct StunMetrics {
-        /*
-         * Metrics about STUN requests over ipv6
-         */
-        /// Number of stun requests made
-        pub requests: Counter,
-        /// Number of successful requests over ipv4
-        pub ipv4_success: Counter,
-        /// Number of successful requests over ipv6
-        pub ipv6_success: Counter,
-
-        /// Number of bad requests, either non-stun packets or incorrect binding request
-        pub bad_requests: Counter,
-        /// Number of failures
-        pub failures: Counter,
-    }
-
-    impl Default for StunMetrics {
-        fn default() -> Self {
-            Self {
-                /*
-                 * Metrics about STUN requests
-                 */
-                requests: Counter::new("Number of STUN requests made to the server."),
-                ipv4_success: Counter::new("Number of successful ipv4 STUN requests served."),
-                ipv6_success: Counter::new("Number of successful ipv6 STUN requests served."),
-                bad_requests: Counter::new("Number of bad requests made to the STUN endpoint."),
-                failures: Counter::new("Number of STUN requests that end in failure."),
-            }
-        }
-    }
-
-    impl Metric for StunMetrics {
-        fn name() -> &'static str {
-            "stun"
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroU32;

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -27,7 +27,6 @@ use hyper::body::Incoming;
 use iroh_base::NodeId;
 #[cfg(feature = "test-utils")]
 use iroh_base::RelayUrl;
-use iroh_metrics::MetricsGroupSet;
 use metrics::RelayMetrics;
 use n0_future::{future::Boxed, StreamExt};
 use tokio::{
@@ -288,7 +287,7 @@ impl Server {
         if let Some(addr) = config.metrics_addr {
             debug!("Starting metrics server");
             let mut registry = iroh_metrics::Registry::default();
-            metrics.register(&mut registry);
+            registry.register_all(&metrics);
             tasks.spawn(
                 async move {
                     iroh_metrics::service::start_metrics_server(addr, Arc::new(registry)).await?;

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -283,7 +283,7 @@ impl Server {
         #[cfg(feature = "metrics")]
         if let Some(addr) = config.metrics_addr {
             debug!("Starting metrics server");
-            use iroh_metrics::core::Metric;
+            use iroh_metrics::core::MetricExt;
 
             iroh_metrics::core::Core::init(|reg, metrics| {
                 metrics.insert(metrics::Metrics::new(reg));

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -27,7 +27,6 @@ use hyper::body::Incoming;
 use iroh_base::NodeId;
 #[cfg(feature = "test-utils")]
 use iroh_base::RelayUrl;
-use metrics::RelayMetrics;
 use n0_future::{future::Boxed, StreamExt};
 use tokio::{
     net::{TcpListener, UdpSocket},
@@ -53,7 +52,7 @@ pub(crate) mod streams;
 pub mod testing;
 
 pub use self::{
-    metrics::{Metrics, StunMetrics},
+    metrics::{Metrics, RelayMetrics, StunMetrics},
     resolver::{ReloadingResolver, DEFAULT_CERT_RELOAD_INTERVAL},
 };
 

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -351,15 +351,15 @@ impl Server {
                 let key_cache_capacity = relay_config
                     .key_cache_capacity
                     .unwrap_or(DEFAULT_KEY_CACHE_CAPACITY);
-                let mut builder =
-                    http_server::ServerBuilder::new(relay_bind_addr, metrics.server.clone())
-                        .headers(headers)
-                        .key_cache_capacity(key_cache_capacity)
-                        .access(relay_config.access)
-                        .request_handler(Method::GET, "/", Box::new(root_handler))
-                        .request_handler(Method::GET, "/index.html", Box::new(root_handler))
-                        .request_handler(Method::GET, RELAY_PROBE_PATH, Box::new(probe_handler))
-                        .request_handler(Method::GET, "/robots.txt", Box::new(robots_handler));
+                let mut builder = http_server::ServerBuilder::new(relay_bind_addr)
+                    .metrics(metrics.server.clone())
+                    .headers(headers)
+                    .key_cache_capacity(key_cache_capacity)
+                    .access(relay_config.access)
+                    .request_handler(Method::GET, "/", Box::new(root_handler))
+                    .request_handler(Method::GET, "/index.html", Box::new(root_handler))
+                    .request_handler(Method::GET, RELAY_PROBE_PATH, Box::new(probe_handler))
+                    .request_handler(Method::GET, "/robots.txt", Box::new(robots_handler));
                 if let Some(cfg) = relay_config.limits.client_rx {
                     builder = builder.client_rx_ratelimit(cfg);
                 }

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -13,7 +13,6 @@ use anyhow::{bail, Result};
 use bytes::Bytes;
 use dashmap::DashMap;
 use iroh_base::NodeId;
-use iroh_metrics::inc;
 use tokio::sync::mpsc::error::TrySendError;
 use tracing::{debug, trace};
 
@@ -45,12 +44,12 @@ impl Clients {
     }
 
     /// Builds the client handler and starts the read & write loops for the connection.
-    pub async fn register(&self, client_config: Config) {
+    pub async fn register(&self, client_config: Config, metrics: Arc<Metrics>) {
         let node_id = client_config.node_id;
         let connection_id = self.get_connection_id();
         trace!(remote_node = node_id.fmt_short(), "registering client");
 
-        let client = Client::new(client_config, connection_id, self);
+        let client = Client::new(client_config, connection_id, self, metrics);
         if let Some(old_client) = self.0.clients.insert(node_id, client) {
             debug!(
                 remote_node = node_id.fmt_short(),
@@ -104,10 +103,16 @@ impl Clients {
     }
 
     /// Attempt to send a packet to client with [`NodeId`] `dst`.
-    pub(super) fn send_packet(&self, dst: NodeId, data: Bytes, src: NodeId) -> Result<()> {
+    pub(super) fn send_packet(
+        &self,
+        dst: NodeId,
+        data: Bytes,
+        src: NodeId,
+        metrics: &Metrics,
+    ) -> Result<()> {
         let Some(client) = self.0.clients.get(&dst) else {
             debug!(dst = dst.fmt_short(), "no connected client, dropped packet");
-            inc!(Metrics, send_packets_dropped);
+            metrics.send_packets_dropped.inc();
             return Ok(());
         };
         match client.try_send_packet(src, data) {
@@ -135,13 +140,19 @@ impl Clients {
     }
 
     /// Attempt to send a disco packet to client with [`NodeId`] `dst`.
-    pub(super) fn send_disco_packet(&self, dst: NodeId, data: Bytes, src: NodeId) -> Result<()> {
+    pub(super) fn send_disco_packet(
+        &self,
+        dst: NodeId,
+        data: Bytes,
+        src: NodeId,
+        metrics: &Metrics,
+    ) -> Result<()> {
         let Some(client) = self.0.clients.get(&dst) else {
             debug!(
                 dst = dst.fmt_short(),
                 "no connected client, dropped disco packet"
             );
-            inc!(Metrics, disco_packets_dropped);
+            metrics.disco_packets_dropped.inc();
             return Ok(());
         };
         match client.try_send_disco_packet(src, data) {
@@ -209,11 +220,12 @@ mod tests {
         let (builder_a, mut a_rw) = test_client_builder(a_key);
 
         let clients = Clients::default();
-        clients.register(builder_a).await;
+        let metrics = Arc::new(Metrics::default());
+        clients.register(builder_a, metrics.clone()).await;
 
         // send packet
         let data = b"hello world!";
-        clients.send_packet(a_key, Bytes::from(&data[..]), b_key)?;
+        clients.send_packet(a_key, Bytes::from(&data[..]), b_key, &metrics)?;
         let frame = recv_frame(FrameType::RecvPacket, &mut a_rw).await?;
         assert_eq!(
             frame,
@@ -224,7 +236,7 @@ mod tests {
         );
 
         // send disco packet
-        clients.send_disco_packet(a_key, Bytes::from(&data[..]), b_key)?;
+        clients.send_disco_packet(a_key, Bytes::from(&data[..]), b_key, &metrics)?;
         let frame = recv_frame(FrameType::RecvPacket, &mut a_rw).await?;
         assert_eq!(
             frame,

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -178,10 +178,11 @@ impl MetricsGroupSet for RelayMetrics {
         "relay"
     }
 
-    fn iter(&self) -> impl IntoIterator<Item = &dyn MetricsGroup> {
+    fn iter(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
         [
             &*self.stun as &dyn MetricsGroup,
             &*self.server as &dyn MetricsGroup,
         ]
+        .into_iter()
     }
 }

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -123,7 +123,7 @@ impl Default for Metrics {
 }
 
 impl Metric for Metrics {
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         "relayserver"
     }
 }
@@ -163,7 +163,7 @@ impl Default for StunMetrics {
 }
 
 impl Metric for StunMetrics {
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         "stun"
     }
 }

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -1,4 +1,6 @@
-use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
+use std::sync::Arc;
+
+use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup, MetricsGroupSet};
 
 /// Metrics tracked for the relay server
 #[derive(Debug, Clone, Iterable)]
@@ -119,7 +121,7 @@ impl Default for Metrics {
     }
 }
 
-impl Metric for Metrics {
+impl MetricsGroup for Metrics {
     fn name(&self) -> &'static str {
         "relayserver"
     }
@@ -159,8 +161,27 @@ impl Default for StunMetrics {
     }
 }
 
-impl Metric for StunMetrics {
+impl MetricsGroup for StunMetrics {
     fn name(&self) -> &'static str {
         "stun"
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RelayMetrics {
+    pub stun: Arc<StunMetrics>,
+    pub server: Arc<Metrics>,
+}
+
+impl MetricsGroupSet for RelayMetrics {
+    fn name(&self) -> &'static str {
+        "relay"
+    }
+
+    fn iter(&self) -> impl IntoIterator<Item = &dyn MetricsGroup> {
+        [
+            &*self.stun as &dyn MetricsGroup,
+            &*self.server as &dyn MetricsGroup,
+        ]
     }
 }

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -128,44 +128,21 @@ impl MetricsGroup for Metrics {
 }
 
 /// StunMetrics tracked for the relay server
-#[derive(Debug, Clone, Iterable)]
+#[derive(Debug, Clone, MetricsGroup)]
+#[metrics_group(name = "stun")]
 pub struct StunMetrics {
-    /*
-     * Metrics about STUN requests
-     */
-    /// Number of stun requests made
+    /// Number of STUN requests made to the server.
     pub requests: Counter,
-    /// Number of successful requests over ipv4
+    /// Number of successful ipv4 STUN requests served.
     pub ipv4_success: Counter,
-    /// Number of successful requests over ipv6
+    /// Number of successful ipv6 STUN requests served.
     pub ipv6_success: Counter,
-
-    /// Number of bad requests, either non-stun packets or incorrect binding request
+    /// Number of bad requests made to the STUN endpoint.
     pub bad_requests: Counter,
-    /// Number of failures
+    /// Number of STUN requests that end in failure.
     pub failures: Counter,
 }
 
-impl Default for StunMetrics {
-    fn default() -> Self {
-        Self {
-            /*
-             * Metrics about STUN requests
-             */
-            requests: Counter::new("Number of STUN requests made to the server."),
-            ipv4_success: Counter::new("Number of successful ipv4 STUN requests served."),
-            ipv6_success: Counter::new("Number of successful ipv6 STUN requests served."),
-            bad_requests: Counter::new("Number of bad requests made to the STUN endpoint."),
-            failures: Counter::new("Number of STUN requests that end in failure."),
-        }
-    }
-}
-
-impl MetricsGroup for StunMetrics {
-    fn name(&self) -> &'static str {
-        "stun"
-    }
-}
 
 #[derive(Debug, Default, Clone)]
 pub struct RelayMetrics {
@@ -178,7 +155,7 @@ impl MetricsGroupSet for RelayMetrics {
         "relay"
     }
 
-    fn iter(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
+    fn groups(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
         [
             &*self.stun as &dyn MetricsGroup,
             &*self.server as &dyn MetricsGroup,

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -10,54 +10,50 @@ pub struct Metrics {
      * Metrics about packets
      */
     /// Bytes sent from a `FrameType::SendPacket`
-    #[metrics(description = "Number of bytes sent.")]
+    #[metrics(help = "Number of bytes sent.")]
     pub bytes_sent: Counter,
     /// Bytes received from a `FrameType::SendPacket`
-    #[metrics(description = "Number of bytes received.")]
+    #[metrics(help = "Number of bytes received.")]
     pub bytes_recv: Counter,
 
     /// `FrameType::SendPacket` sent, that are not disco messages
-    #[metrics(description = "Number of 'send' packets relayed.")]
+    #[metrics(help = "Number of 'send' packets relayed.")]
     pub send_packets_sent: Counter,
     /// `FrameType::SendPacket` received, that are not disco messages
-    #[metrics(description = "Number of 'send' packets received.")]
+    #[metrics(help = "Number of 'send' packets received.")]
     pub send_packets_recv: Counter,
     /// `FrameType::SendPacket` dropped, that are not disco messages
-    #[metrics(description = "Number of 'send' packets dropped.")]
+    #[metrics(help = "Number of 'send' packets dropped.")]
     pub send_packets_dropped: Counter,
 
     /// `FrameType::SendPacket` sent that are disco messages
-    #[metrics(description = "Number of disco packets sent.")]
+    #[metrics(help = "Number of disco packets sent.")]
     pub disco_packets_sent: Counter,
     /// `FrameType::SendPacket` received that are disco messages
-    #[metrics(description = "Number of disco packets received.")]
+    #[metrics(help = "Number of disco packets received.")]
     pub disco_packets_recv: Counter,
     /// `FrameType::SendPacket` dropped that are disco messages
-    #[metrics(description = "Number of disco packets dropped.")]
+    #[metrics(help = "Number of disco packets dropped.")]
     pub disco_packets_dropped: Counter,
 
     /// Packets of other `FrameType`s sent
-    #[metrics(
-        description = "Number of packets sent that were not disco packets or 'send' packets"
-    )]
+    #[metrics(help = "Number of packets sent that were not disco packets or 'send' packets")]
     pub other_packets_sent: Counter,
     /// Packets of other `FrameType`s received
-    #[metrics(
-        description = "Number of packets received that were not disco packets or 'send' packets"
-    )]
+    #[metrics(help = "Number of packets received that were not disco packets or 'send' packets")]
     pub other_packets_recv: Counter,
     /// Packets of other `FrameType`s dropped
-    #[metrics(description = "Number of times a non-disco, non-send packet was dropped.")]
+    #[metrics(help = "Number of times a non-disco, non-send packet was dropped.")]
     pub other_packets_dropped: Counter,
 
     /// Number of `FrameType::Ping`s received
-    #[metrics(description = "Number of times the server has received a Ping from a client.")]
+    #[metrics(help = "Number of times the server has received a Ping from a client.")]
     pub got_ping: Counter,
     /// Number of `FrameType::Pong`s sent
-    #[metrics(description = "Number of times the server has sent a Pong to a client.")]
+    #[metrics(help = "Number of times the server has sent a Pong to a client.")]
     pub sent_pong: Counter,
     /// Number of `FrameType::Unknown` received
-    #[metrics(description = "Number of unknown frames sent to this server.")]
+    #[metrics(help = "Number of unknown frames sent to this server.")]
     pub unknown_frames: Counter,
 
     /// Number of frames received from client connection which have been rate-limited.
@@ -71,7 +67,7 @@ pub struct Metrics {
     /// Number of times this server has accepted a connection.
     pub accepts: Counter,
     /// Number of connections we have removed because of an error
-    #[metrics(description = "Number of clients that have then disconnected.")]
+    #[metrics(help = "Number of clients that have then disconnected.")]
     pub disconnects: Counter,
 
     /// Number of unique client keys per day

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -73,7 +73,7 @@ pub struct Metrics {
     /// Number of unique client keys per day
     pub unique_client_keys: Counter,
 
-    /// Number of accepted websocket connections.
+    /// Number of accepted websocket connections
     pub websocket_accepts: Counter,
     /// Number of accepted 'iroh derp http' connection upgrades
     pub relay_accepts: Counter,
@@ -84,7 +84,7 @@ pub struct Metrics {
     // pub average_queue_duration:
 }
 
-/// StunMetrics tracked for the relay server
+/// Metrics tracked for the STUN server.
 #[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "stun")]
 pub struct StunMetrics {
@@ -100,9 +100,12 @@ pub struct StunMetrics {
     pub failures: Counter,
 }
 
+/// All metrics tracked in the relay server.
 #[derive(Debug, Default, Clone, MetricsGroupSet)]
 #[metrics(name = "relay")]
 pub struct RelayMetrics {
+    /// Metrics tracked for the STUN server.
     pub stun: Arc<StunMetrics>,
+    /// Metrics tracked for the relay server.
     pub server: Arc<Metrics>,
 }

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use iroh_metrics::{Counter, MetricsGroup, MetricsGroupSet};
 
 /// Metrics tracked for the relay server
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "relayserver")]
 pub struct Metrics {
     /*
@@ -85,7 +85,7 @@ pub struct Metrics {
 }
 
 /// StunMetrics tracked for the relay server
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "stun")]
 pub struct StunMetrics {
     /// Number of STUN requests made to the server.
@@ -100,22 +100,9 @@ pub struct StunMetrics {
     pub failures: Counter,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, MetricsGroupSet)]
+#[metrics(name = "relay")]
 pub struct RelayMetrics {
     pub stun: Arc<StunMetrics>,
     pub server: Arc<Metrics>,
-}
-
-impl MetricsGroupSet for RelayMetrics {
-    fn name(&self) -> &'static str {
-        "relay"
-    }
-
-    fn groups(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
-        [
-            &*self.stun as &dyn MetricsGroup,
-            &*self.server as &dyn MetricsGroup,
-        ]
-        .into_iter()
-    }
 }

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -1,7 +1,4 @@
-use iroh_metrics::{
-    core::{Counter, Metric},
-    struct_iterable::Iterable,
-};
+use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
 
 /// Metrics tracked for the relay server
 #[derive(Debug, Clone, Iterable)]

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -1,44 +1,63 @@
 use std::sync::Arc;
 
-use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup, MetricsGroupSet};
+use iroh_metrics::{Counter, MetricsGroup, MetricsGroupSet};
 
 /// Metrics tracked for the relay server
-#[derive(Debug, Clone, Iterable)]
+#[derive(Debug, Clone, MetricsGroup)]
+#[metrics(name = "relayserver")]
 pub struct Metrics {
     /*
      * Metrics about packets
      */
     /// Bytes sent from a `FrameType::SendPacket`
+    #[metrics(description = "Number of bytes sent.")]
     pub bytes_sent: Counter,
     /// Bytes received from a `FrameType::SendPacket`
+    #[metrics(description = "Number of bytes received.")]
     pub bytes_recv: Counter,
 
     /// `FrameType::SendPacket` sent, that are not disco messages
+    #[metrics(description = "Number of 'send' packets relayed.")]
     pub send_packets_sent: Counter,
     /// `FrameType::SendPacket` received, that are not disco messages
+    #[metrics(description = "Number of 'send' packets received.")]
     pub send_packets_recv: Counter,
     /// `FrameType::SendPacket` dropped, that are not disco messages
+    #[metrics(description = "Number of 'send' packets dropped.")]
     pub send_packets_dropped: Counter,
 
     /// `FrameType::SendPacket` sent that are disco messages
+    #[metrics(description = "Number of disco packets sent.")]
     pub disco_packets_sent: Counter,
     /// `FrameType::SendPacket` received that are disco messages
+    #[metrics(description = "Number of disco packets received.")]
     pub disco_packets_recv: Counter,
     /// `FrameType::SendPacket` dropped that are disco messages
+    #[metrics(description = "Number of disco packets dropped.")]
     pub disco_packets_dropped: Counter,
 
     /// Packets of other `FrameType`s sent
+    #[metrics(
+        description = "Number of packets sent that were not disco packets or 'send' packets"
+    )]
     pub other_packets_sent: Counter,
     /// Packets of other `FrameType`s received
+    #[metrics(
+        description = "Number of packets received that were not disco packets or 'send' packets"
+    )]
     pub other_packets_recv: Counter,
     /// Packets of other `FrameType`s dropped
+    #[metrics(description = "Number of times a non-disco, non-send packet was dropped.")]
     pub other_packets_dropped: Counter,
 
     /// Number of `FrameType::Ping`s received
+    #[metrics(description = "Number of times the server has received a Ping from a client.")]
     pub got_ping: Counter,
     /// Number of `FrameType::Pong`s sent
+    #[metrics(description = "Number of times the server has sent a Pong to a client.")]
     pub sent_pong: Counter,
     /// Number of `FrameType::Unknown` received
+    #[metrics(description = "Number of unknown frames sent to this server.")]
     pub unknown_frames: Counter,
 
     /// Number of frames received from client connection which have been rate-limited.
@@ -49,15 +68,16 @@ pub struct Metrics {
     /*
      * Metrics about peers
      */
-    /// Number of connections we have accepted
+    /// Number of times this server has accepted a connection.
     pub accepts: Counter,
     /// Number of connections we have removed because of an error
+    #[metrics(description = "Number of clients that have then disconnected.")]
     pub disconnects: Counter,
 
     /// Number of unique client keys per day
     pub unique_client_keys: Counter,
 
-    /// Number of accepted websocket connections
+    /// Number of accepted websocket connections.
     pub websocket_accepts: Counter,
     /// Number of accepted 'iroh derp http' connection upgrades
     pub relay_accepts: Counter,
@@ -68,68 +88,9 @@ pub struct Metrics {
     // pub average_queue_duration:
 }
 
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            /*
-             * Metrics about packets
-             */
-            send_packets_sent: Counter::new("Number of 'send' packets relayed."),
-            bytes_sent: Counter::new("Number of bytes sent."),
-            send_packets_recv: Counter::new("Number of 'send' packets received."),
-            bytes_recv: Counter::new("Number of bytes received."),
-            send_packets_dropped: Counter::new("Number of 'send' packets dropped."),
-            disco_packets_sent: Counter::new("Number of disco packets sent."),
-            disco_packets_recv: Counter::new("Number of disco packets received."),
-            disco_packets_dropped: Counter::new("Number of disco packets dropped."),
-
-            other_packets_sent: Counter::new(
-                "Number of packets sent that were not disco packets or 'send' packets",
-            ),
-            other_packets_recv: Counter::new(
-                "Number of packets received that were not disco packets or 'send' packets",
-            ),
-            other_packets_dropped: Counter::new(
-                "Number of times a non-disco, non-'send; packet was dropped.",
-            ),
-            got_ping: Counter::new("Number of times the server has received a Ping from a client."),
-            sent_pong: Counter::new("Number of times the server has sent a Pong to a client."),
-            unknown_frames: Counter::new("Number of unknown frames sent to this server."),
-            frames_rx_ratelimited_total: Counter::new(
-                "Number of frames received from client connection which have been rate-limited.",
-            ),
-            conns_rx_ratelimited_total: Counter::new(
-                "Number of client connections which have had any frames rate-limited.",
-            ),
-
-            /*
-             * Metrics about peers
-             */
-            accepts: Counter::new("Number of times this server has accepted a connection."),
-            disconnects: Counter::new("Number of clients that have then disconnected."),
-
-            unique_client_keys: Counter::new("Number of unique client keys per day."),
-
-            websocket_accepts: Counter::new("Number of accepted websocket connections"),
-            relay_accepts: Counter::new("Number of accepted 'iroh derp http' connection upgrades"),
-            // TODO: enable when we can have multiple connections for one node id
-            // pub duplicate_client_keys: Counter::new("Number of duplicate client keys."),
-            // pub duplicate_client_conns: Counter::new("Number of duplicate client connections."),
-            // TODO: only important stat that we cannot track right now
-            // pub average_queue_duration:
-        }
-    }
-}
-
-impl MetricsGroup for Metrics {
-    fn name(&self) -> &'static str {
-        "relayserver"
-    }
-}
-
 /// StunMetrics tracked for the relay server
 #[derive(Debug, Clone, MetricsGroup)]
-#[metrics_group(name = "stun")]
+#[metrics(name = "stun")]
 pub struct StunMetrics {
     /// Number of STUN requests made to the server.
     pub requests: Counter,
@@ -142,7 +103,6 @@ pub struct StunMetrics {
     /// Number of STUN requests that end in failure.
     pub failures: Counter,
 }
-
 
 #[derive(Debug, Default, Clone)]
 pub struct RelayMetrics {

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -43,7 +43,7 @@ http = "1"
 iroh-base = { version = "0.34.1", default-features = false, features = ["key", "relay"], path = "../iroh-base" }
 iroh-relay = { version = "0.34", path = "../iroh-relay", default-features = false }
 n0-future = "0.1.2"
-netwatch = { version = "0.4" }
+netwatch = { version = "0.5" }
 pin-project = "1"
 pkarr = { version = "3.7", default-features = false, features = [
     "relays",
@@ -100,10 +100,9 @@ parse-size = { version = "=1.0.0", optional = true } # pinned version to avoid b
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 hickory-resolver = "0.25.1"
-igd-next = { version = "0.15.1", features = ["aio_tokio"] }
+igd-next = { version = "0.16", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
-# portmapper = { version = "0.4.1", default-features = false }
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }
+portmapper = { version = "0.5.0", default-features = false }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -104,7 +104,7 @@ hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 # portmapper = { version = "0.4.1", default-features = false }
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics2" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -128,6 +128,7 @@ time = { version = "0.3", features = ["wasm-bindgen"] }
 
 # target-common test/dev dependencies
 [dev-dependencies]
+postcard = { version = "1.1.1", features = ["use-std"] }
 testresult = "0.4.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -81,7 +81,7 @@ x509-parser = "0.16"
 z32 = "1.0.3"
 
 # metrics
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", default-features = false }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main", default-features = false }
 
 # local-swarm-discovery
 swarm-discovery = { version = "0.3.1", optional = true }
@@ -104,7 +104,7 @@ hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 # portmapper = { version = "0.4.1", default-features = false }
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics2" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -81,7 +81,7 @@ x509-parser = "0.16"
 z32 = "1.0.3"
 
 # metrics
-iroh-metrics = { version = "0.33", default-features = false }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", default-features = false }
 
 # local-swarm-discovery
 swarm-discovery = { version = "0.3.1", optional = true }
@@ -104,7 +104,7 @@ hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 # portmapper = { version = "0.4.1", default-features = false }
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics2" }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -103,7 +103,8 @@ parse-size = { version = "=1.0.0", optional = true } # pinned version to avoid b
 hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
-portmapper = { version = "0.4.1", default-features = false }
+# portmapper = { version = "0.4.1", default-features = false }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -81,7 +81,7 @@ x509-parser = "0.16"
 z32 = "1.0.3"
 
 # metrics
-iroh-metrics = { version = "0.32", default-features = false }
+iroh-metrics = { version = "0.33", default-features = false }
 
 # local-swarm-discovery
 swarm-discovery = { version = "0.3.1", optional = true }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -81,7 +81,7 @@ x509-parser = "0.16"
 z32 = "1.0.3"
 
 # metrics
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main", default-features = false }
+iroh-metrics = { version = "0.34", default-features = false }
 
 # local-swarm-discovery
 swarm-discovery = { version = "0.3.1", optional = true }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -103,7 +103,7 @@ parse-size = { version = "=1.0.0", optional = true } # pinned version to avoid b
 hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
-portmapper = { version = "0.4", default-features = false }
+portmapper = { version = "0.4.1", default-features = false }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -104,7 +104,7 @@ hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 # portmapper = { version = "0.4.1", default-features = false }
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics2" }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.22"
 bytes = "1.7"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh = { path = ".." }
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main" }
+iroh-metrics = "0.34"
 n0-future = "0.1.1"
 quinn = { package = "iroh-quinn", version = "0.13" }
 rand = "0.8"

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.22"
 bytes = "1.7"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh = { path = ".." }
-iroh-metrics = "0.33"
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset" }
 n0-future = "0.1.1"
 quinn = { package = "iroh-quinn", version = "0.13" }
 rand = "0.8"

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.22"
 bytes = "1.7"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh = { path = ".." }
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main" }
 n0-future = "0.1.1"
 quinn = { package = "iroh-quinn", version = "0.13" }
 rand = "0.8"

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.22"
 bytes = "1.7"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh = { path = ".." }
-iroh-metrics = "0.32"
+iroh-metrics = "0.33"
 n0-future = "0.1.1"
 quinn = { package = "iroh-quinn", version = "0.13" }
 rand = "0.8"

--- a/iroh/bench/src/bin/bulk.rs
+++ b/iroh/bench/src/bin/bulk.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 #[cfg(not(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd")))]
 use iroh_bench::quinn;
 use iroh_bench::{configure_tracing_subscriber, iroh, rt, s2n, Commands, Opt};
+use iroh_metrics::core::MetricExt;
 
 fn main() {
     let cmd = Commands::parse();
@@ -34,7 +35,6 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
     if opt.metrics {
         // enable recording metrics
         iroh_metrics::core::Core::try_init(|reg, metrics| {
-            use iroh_metrics::core::Metric;
             metrics.insert(::iroh::metrics::MagicsockMetrics::new(reg));
             metrics.insert(::iroh::metrics::NetReportMetrics::new(reg));
             metrics.insert(::iroh::metrics::PortmapMetrics::new(reg));

--- a/iroh/bench/src/bin/bulk.rs
+++ b/iroh/bench/src/bin/bulk.rs
@@ -88,8 +88,8 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
     if opt.metrics {
         // print metrics
         println!("\nMetrics:");
-        collect_and_print("MagicsockMetrics", &endpoint_metrics.magicsock);
-        collect_and_print("NetReportMetrics", &endpoint_metrics.net_report);
+        collect_and_print("MagicsockMetrics", &*endpoint_metrics.magicsock);
+        collect_and_print("NetReportMetrics", &*endpoint_metrics.net_report);
         collect_and_print("PortmapMetrics", &*endpoint_metrics.portmapper);
         #[cfg(feature = "local-relay")]
         if let Some(relay_server) = relay_server.as_ref() {

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2833,14 +2833,14 @@ mod tests {
         assert_eq!(m.magicsock.connection_became_direct.get(), 1);
         assert_eq!(m.magicsock.connection_handshake_success.get(), 1);
         assert_eq!(m.magicsock.nodes_contacted_directly.get(), 1);
-        assert_eq!(m.magicsock.recv_datagrams.get(), 6);
+        assert!(m.magicsock.recv_datagrams.get() > 0);
 
         let m = server.metrics();
         assert_eq!(m.magicsock.num_direct_conns_added.get(), 1);
         assert_eq!(m.magicsock.connection_became_direct.get(), 1);
         assert_eq!(m.magicsock.nodes_contacted_directly.get(), 1);
         assert_eq!(m.magicsock.connection_handshake_success.get(), 1);
-        assert_eq!(m.magicsock.recv_datagrams.get(), 6);
+        assert!(m.magicsock.recv_datagrams.get() > 0);
 
         Ok(())
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2902,8 +2902,8 @@ mod tests {
 
         // test openmetrics encoding with labeled subregistries per endpoint
         fn register_endpoint(registry: &mut Registry, endpoint: &Endpoint) {
-            let id = endpoint.node_id().fmt_short().into();
-            let sub_registry = registry.sub_registry_with_label(("id".into(), id));
+            let id = endpoint.node_id().fmt_short();
+            let sub_registry = registry.sub_registry_with_label("id", id);
             endpoint.metrics().register(sub_registry);
         }
         let mut registry = Registry::default();

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1199,7 +1199,10 @@ impl Endpoint {
     ///
     /// // Wait for the metrics server to bind, then fetch the metrics via HTTP.
     /// tokio::time::sleep(Duration::from_millis(500));
-    /// let res = reqwest::get("http://localhost:9100/metrics").await?.text().await?;
+    /// let res = reqwest::get("http://localhost:9100/metrics")
+    ///     .await?
+    ///     .text()
+    ///     .await?;
     ///
     /// assert!(res.contains(r#"TYPE magicsock_recv_datagrams counter"#));
     /// assert!(res.contains(r#"magicsock_recv_datagrams_total 0"#));

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1126,8 +1126,8 @@ impl Endpoint {
     /// # }
     /// ```
     ///
-    /// [`EndpointMetrics`] implements [`iroh_metrics::MetricsGroupSet`], and each field
-    /// implements [`iroh_metrics::MetricsGroup`]. These trait provides various methods to iterate
+    /// [`EndpointMetrics`] implements [`MetricsGroupSet`], and each field
+    /// implements [`MetricsGroup`]. These trait provides various methods to iterate
     /// the groups in the set, and over the individual metrics in each group, without having
     /// to access each field manually. With these methods, it is straightforward to collect
     /// all metrics into a map or push their values to some other metrics collector.
@@ -1163,6 +1163,9 @@ impl Endpoint {
     ///
     /// [`prometheus_client`]: https://docs.rs/prometheus-client/latest/prometheus_client/index.html
     /// [`Registry`]: https://docs.rs/prometheus-client/latest/prometheus_client/registry/struct.Registry.html
+    /// [`EndpointMetrics::register`]: iroh_metrics::MetricsGroupSet::register
+    /// [`MetricsGroup`]: iroh_metrics::MetricsGroup
+    /// [`MetricsGroupSet`]: iroh_metrics::MetricsGroupSet
     #[cfg(feature = "metrics")]
     pub fn metrics(&self) -> &EndpointMetrics {
         &self.msock.metrics

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1125,7 +1125,7 @@ impl Endpoint {
     /// ```
     ///
     /// [`EndpointMetrics`] implements [`MetricsGroupSet`], and each field
-    /// implements [`MetricsGroup`]. These trait provides methods to iterate over
+    /// implements [`MetricsGroup`]. These traits provide methods to iterate over
     /// the groups in the set, and over the individual metrics in each group, without having
     /// to access each field manually. With these methods, it is straightforward to collect
     /// all metrics into a map or push their values to a metrics collector.

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2092,7 +2092,7 @@ mod tests {
 
     use std::time::Instant;
 
-    use iroh_metrics::{service::MetricsSource, MetricsGroupSet};
+    use iroh_metrics::MetricsSource;
     use iroh_relay::http::Protocol;
     use n0_future::StreamExt;
     use rand::SeedableRng;
@@ -2904,12 +2904,12 @@ mod tests {
         fn register_endpoint(registry: &mut Registry, endpoint: &Endpoint) {
             let id = endpoint.node_id().fmt_short();
             let sub_registry = registry.sub_registry_with_label("id", id);
-            endpoint.metrics().register(sub_registry);
+            sub_registry.register_all(endpoint.metrics());
         }
         let mut registry = Registry::default();
         register_endpoint(&mut registry, &client);
         register_endpoint(&mut registry, &server);
-        let s = registry.encode_openmetrics()?;
+        let s = registry.encode_openmetrics_to_string()?;
         assert!(s.contains(r#"magicsock_nodes_contacted_directly_total{id="3b6a27bcce"} 1"#));
         assert!(s.contains(r#"magicsock_nodes_contacted_directly_total{id="8a88e3dd74"} 1"#));
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1135,18 +1135,16 @@ impl Endpoint {
     /// For example, the following snippet collects all metrics into a map:
     /// ```rust
     /// # use std::collections::BTreeMap;
-    /// # use iroh_metrics::{MetricsGroup, MetricValue, MetricsGroupSet};
+    /// # use iroh_metrics::{Metric, MetricsGroup, MetricValue, MetricsGroupSet};
     /// # use iroh::endpoint::Endpoint;
     /// # async fn wrapper() -> testresult::TestResult {
     /// let endpoint = Endpoint::builder().bind().await?;
     /// let metrics: BTreeMap<String, MetricValue> = endpoint
     ///     .metrics()
     ///     .iter()
-    ///     .flat_map(|group| {
-    ///         group.values().map(|item| {
-    ///             let name = [group.name(), item.name].join(":");
-    ///             (name, item.value)
-    ///         })
+    ///     .map(|(group, metric)| {
+    ///         let name = [group, metric.name()].join(":");
+    ///         (name, metric.value())
     ///     })
     ///     .collect();
     ///

--- a/iroh/src/endpoint/rtt_actor.rs
+++ b/iroh/src/endpoint/rtt_actor.rs
@@ -1,6 +1,6 @@
 //! Actor which coordinates the congestion controller for the magic socket
 
-use std::{pin::Pin, task::Poll};
+use std::{pin::Pin, sync::Arc, task::Poll};
 
 use iroh_base::NodeId;
 use n0_future::{
@@ -20,7 +20,7 @@ pub(super) struct RttHandle {
 }
 
 impl RttHandle {
-    pub(super) fn new(metrics: MagicsockMetrics) -> Self {
+    pub(super) fn new(metrics: Arc<MagicsockMetrics>) -> Self {
         let mut actor = RttActor {
             connection_events: Default::default(),
             metrics,
@@ -62,7 +62,7 @@ struct RttActor {
     /// Stream of connection type changes.
     #[debug("MergeUnbounded<WatcherStream<ConnectionType>>")]
     connection_events: MergeUnbounded<MappedStream>,
-    metrics: MagicsockMetrics,
+    metrics: Arc<MagicsockMetrics>,
 }
 
 #[derive(Debug)]

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -473,10 +473,6 @@ impl MagicSock {
             .magicsock
             .send_data
             .inc_by(transmit.contents.len() as _);
-        self.metrics
-            .magicsock
-            .send_data
-            .inc_by(transmit.contents.len() as _);
 
         if self.is_closed() {
             self.metrics

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -74,7 +74,7 @@ use crate::{
     disco::{self, CallMeMaybe, SendAddr},
     discovery::{Discovery, DiscoveryItem, DiscoverySubscribers, NodeData, UserData},
     key::{public_ed_box, secret_ed_box, DecryptionError, SharedSecret},
-    metrics::{EndpointMetrics, PortmapMetrics},
+    metrics::EndpointMetrics,
     net_report::{self, IpMappedAddresses},
     watchable::{Watchable, Watcher},
 };
@@ -2361,7 +2361,7 @@ impl ActorSocketState {
     fn bind(
         addr_v4: Option<SocketAddrV4>,
         addr_v6: Option<SocketAddrV6>,
-        metrics: PortmapMetrics,
+        metrics: portmapper::Metrics,
     ) -> Result<Self> {
         let port_mapper = portmapper::Client::with_metrics(Default::default(), metrics);
         let (v4, v6) = Self::bind_sockets(addr_v4, addr_v6)?;

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2361,7 +2361,7 @@ impl ActorSocketState {
     fn bind(
         addr_v4: Option<SocketAddrV4>,
         addr_v6: Option<SocketAddrV6>,
-        metrics: portmapper::Metrics,
+        metrics: Arc<portmapper::Metrics>,
     ) -> Result<Self> {
         let port_mapper = portmapper::Client::with_metrics(Default::default(), metrics);
         let (v4, v6) = Self::bind_sockets(addr_v4, addr_v6)?;

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -1,7 +1,4 @@
-use iroh_metrics::{
-    core::{Counter, Metric},
-    struct_iterable::Iterable,
-};
+use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
 
 /// Enum of metrics for the module
 #[allow(missing_docs)]

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -3,7 +3,7 @@ use iroh_metrics::{Counter, MetricsGroup};
 /// Enum of metrics for the module
 // TODO(frando): Add description doc strings for each metric.
 #[allow(missing_docs)]
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[non_exhaustive]
 #[metrics(name = "magicsock")]
 pub struct Metrics {

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -1,9 +1,11 @@
-use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
+use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
+// TODO(frando): Add description doc strings for each metric.
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Iterable)]
+#[derive(Debug, Clone, MetricsGroup)]
 #[non_exhaustive]
+#[metrics(name = "magicsock")]
 pub struct Metrics {
     pub re_stun_calls: Counter,
     pub update_direct_addrs: Counter,
@@ -76,82 +78,4 @@ pub struct Metrics {
     pub connection_handshake_success: Counter,
     /// Number of connections with a successful handshake that became direct.
     pub connection_became_direct: Counter,
-}
-
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            num_relay_conns_added: Counter::new("num_relay_conns added"),
-            num_relay_conns_removed: Counter::new("num_relay_conns removed"),
-
-            re_stun_calls: Counter::new("restun_calls"),
-            update_direct_addrs: Counter::new("update_endpoints"),
-
-            // Sends (data or disco)
-            send_ipv4: Counter::new("send_ipv4"),
-            send_ipv6: Counter::new("send_ipv6"),
-            send_relay: Counter::new("send_relay"),
-            send_relay_error: Counter::new("send_relay_error"),
-
-            // Data packets (non-disco)
-            send_data: Counter::new("send_data"),
-            send_data_network_down: Counter::new("send_data_network_down"),
-            recv_data_relay: Counter::new("recv_data_relay"),
-            recv_data_ipv4: Counter::new("recv_data_ipv4"),
-            recv_data_ipv6: Counter::new("recv_data_ipv6"),
-            recv_datagrams: Counter::new("recv_datagrams"),
-            recv_gro_datagrams: Counter::new("recv_gro_packets"),
-
-            // Disco packets
-            send_disco_udp: Counter::new("disco_send_udp"),
-            send_disco_relay: Counter::new("disco_send_relay"),
-            sent_disco_udp: Counter::new("disco_sent_udp"),
-            sent_disco_relay: Counter::new("disco_sent_relay"),
-            sent_disco_ping: Counter::new("disco_sent_ping"),
-            sent_disco_pong: Counter::new("disco_sent_pong"),
-            sent_disco_call_me_maybe: Counter::new("disco_sent_callmemaybe"),
-            recv_disco_bad_key: Counter::new("disco_recv_bad_key"),
-            recv_disco_bad_parse: Counter::new("disco_recv_bad_parse"),
-
-            recv_disco_udp: Counter::new("disco_recv_udp"),
-            recv_disco_relay: Counter::new("disco_recv_relay"),
-            recv_disco_ping: Counter::new("disco_recv_ping"),
-            recv_disco_pong: Counter::new("disco_recv_pong"),
-            recv_disco_call_me_maybe: Counter::new("disco_recv_callmemaybe"),
-            recv_disco_call_me_maybe_bad_disco: Counter::new("disco_recv_callmemaybe_bad_disco"),
-
-            // How many times our relay home node DI has changed from non-zero to a different non-zero.
-            relay_home_change: Counter::new("relay_home_change"),
-
-            num_direct_conns_added: Counter::new(
-                "number of direct connections to a peer we have added",
-            ),
-            num_direct_conns_removed: Counter::new(
-                "number of direct connections to a peer we have removed",
-            ),
-
-            actor_tick_main: Counter::new("actor_tick_main"),
-            actor_tick_msg: Counter::new("actor_tick_msg"),
-            actor_tick_re_stun: Counter::new("actor_tick_re_stun"),
-            actor_tick_portmap_changed: Counter::new("actor_tick_portmap_changed"),
-            actor_tick_direct_addr_heartbeat: Counter::new("actor_tick_direct_addr_heartbeat"),
-            actor_tick_direct_addr_update_receiver: Counter::new(
-                "actor_tick_direct_addr_update_receiver",
-            ),
-            actor_link_change: Counter::new("actor_link_change"),
-            actor_tick_other: Counter::new("actor_tick_other"),
-
-            nodes_contacted: Counter::new("nodes_contacted"),
-            nodes_contacted_directly: Counter::new("nodes_contacted_directly"),
-
-            connection_handshake_success: Counter::new("connection_handshake_success"),
-            connection_became_direct: Counter::new("connection_became_direct"),
-        }
-    }
-}
-
-impl MetricsGroup for Metrics {
-    fn name(&self) -> &'static str {
-        "magicsock"
-    }
 }

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -1,4 +1,4 @@
-use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
+use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
 
 /// Enum of metrics for the module
 #[allow(missing_docs)]
@@ -150,7 +150,7 @@ impl Default for Metrics {
     }
 }
 
-impl Metric for Metrics {
+impl MetricsGroup for Metrics {
     fn name(&self) -> &'static str {
         "magicsock"
     }

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -154,7 +154,7 @@ impl Default for Metrics {
 }
 
 impl Metric for Metrics {
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         "magicsock"
     }
 }

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -1,9 +1,10 @@
 use iroh_metrics::{Counter, MetricsGroup};
+use serde::{Deserialize, Serialize};
 
 /// Enum of metrics for the module
 // TODO(frando): Add description doc strings for each metric.
 #[allow(missing_docs)]
-#[derive(Debug, Default, MetricsGroup)]
+#[derive(Debug, Default, Serialize, Deserialize, MetricsGroup)]
 #[non_exhaustive]
 #[metrics(name = "magicsock")]
 pub struct Metrics {

--- a/iroh/src/magicsock/node_map.rs
+++ b/iroh/src/magicsock/node_map.rs
@@ -127,7 +127,7 @@ impl NodeMap {
     #[cfg(not(any(test, feature = "test-utils")))]
     /// Create a new [`NodeMap`] from a list of [`NodeAddr`]s.
     pub(super) fn load_from_vec(nodes: Vec<NodeAddr>, metrics: &Metrics) -> Self {
-        Self::from_inner(NodeMapInner::load_from_vec(nodes))
+        Self::from_inner(NodeMapInner::load_from_vec(nodes, metrics))
     }
 
     #[cfg(any(test, feature = "test-utils"))]
@@ -337,7 +337,7 @@ impl NodeMapInner {
     fn load_from_vec(nodes: Vec<NodeAddr>, metrics: &Metrics) -> Self {
         let mut me = Self::default();
         for node_addr in nodes {
-            me.add_node_addr(node_addr, Source::Saved);
+            me.add_node_addr(node_addr, Source::Saved, metrics);
         }
         me
     }

--- a/iroh/src/magicsock/node_map.rs
+++ b/iroh/src/magicsock/node_map.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use iroh_base::{NodeAddr, NodeId, PublicKey, RelayUrl};
-use iroh_metrics::inc;
 use n0_future::time::Instant;
 use serde::{Deserialize, Serialize};
 use stun_rs::TransactionId;
@@ -16,9 +15,7 @@ use self::{
     best_addr::ClearReason,
     node_state::{NodeState, Options, PingHandled},
 };
-use super::{
-    metrics::Metrics as MagicsockMetrics, ActorMessage, DiscoMessageSource, NodeIdMappedAddr,
-};
+use super::{metrics::Metrics, ActorMessage, DiscoMessageSource, NodeIdMappedAddr};
 #[cfg(any(test, feature = "test-utils"))]
 use crate::endpoint::PathSelection;
 use crate::{
@@ -55,7 +52,7 @@ const MAX_INACTIVE_NODES: usize = 30;
 ///   These come and go as the node moves around on the internet
 ///
 /// An index of nodeInfos by node key, NodeIdMappedAddr, and discovered ip:port endpoints.
-#[derive(Default, Debug)]
+#[derive(Debug, Default)]
 pub(super) struct NodeMap {
     inner: Mutex<NodeMapInner>,
 }
@@ -129,14 +126,18 @@ pub enum Source {
 impl NodeMap {
     #[cfg(not(any(test, feature = "test-utils")))]
     /// Create a new [`NodeMap`] from a list of [`NodeAddr`]s.
-    pub(super) fn load_from_vec(nodes: Vec<NodeAddr>) -> Self {
+    pub(super) fn load_from_vec(nodes: Vec<NodeAddr>, metrics: &Metrics) -> Self {
         Self::from_inner(NodeMapInner::load_from_vec(nodes))
     }
 
     #[cfg(any(test, feature = "test-utils"))]
     /// Create a new [`NodeMap`] from a list of [`NodeAddr`]s.
-    pub(super) fn load_from_vec(nodes: Vec<NodeAddr>, path_selection: PathSelection) -> Self {
-        Self::from_inner(NodeMapInner::load_from_vec(nodes, path_selection))
+    pub(super) fn load_from_vec(
+        nodes: Vec<NodeAddr>,
+        path_selection: PathSelection,
+        metrics: &Metrics,
+    ) -> Self {
+        Self::from_inner(NodeMapInner::load_from_vec(nodes, path_selection, metrics))
     }
 
     fn from_inner(inner: NodeMapInner) -> Self {
@@ -146,11 +147,11 @@ impl NodeMap {
     }
 
     /// Add the contact information for a node.
-    pub(super) fn add_node_addr(&self, node_addr: NodeAddr, source: Source) {
+    pub(super) fn add_node_addr(&self, node_addr: NodeAddr, source: Source, metrics: &Metrics) {
         self.inner
             .lock()
             .expect("poisoned")
-            .add_node_addr(node_addr, source)
+            .add_node_addr(node_addr, source, metrics)
     }
 
     /// Number of nodes currently listed.
@@ -239,11 +240,12 @@ impl NodeMap {
         &self,
         sender: PublicKey,
         cm: CallMeMaybe,
+        metrics: &Metrics,
     ) -> Vec<PingAction> {
         self.inner
             .lock()
             .expect("poisoned")
-            .handle_call_me_maybe(sender, cm)
+            .handle_call_me_maybe(sender, cm, metrics)
     }
 
     #[allow(clippy::type_complexity)]
@@ -251,6 +253,7 @@ impl NodeMap {
         &self,
         addr: NodeIdMappedAddr,
         have_ipv6: bool,
+        metrics: &Metrics,
     ) -> Option<(
         PublicKey,
         Option<SocketAddr>,
@@ -261,7 +264,7 @@ impl NodeMap {
         let ep = inner.get_mut(NodeStateKey::NodeIdMappedAddr(addr))?;
         let public_key = *ep.public_key();
         trace!(dest = %addr, node_id = %public_key.fmt_short(), "dst mapped to NodeId");
-        let (udp_addr, relay_url, msgs) = ep.get_send_addrs(have_ipv6);
+        let (udp_addr, relay_url, msgs) = ep.get_send_addrs(have_ipv6, metrics);
         Some((public_key, udp_addr, relay_url, msgs))
     }
 
@@ -331,7 +334,7 @@ impl NodeMap {
 impl NodeMapInner {
     #[cfg(not(any(test, feature = "test-utils")))]
     /// Create a new [`NodeMap`] from a list of [`NodeAddr`]s.
-    fn load_from_vec(nodes: Vec<NodeAddr>) -> Self {
+    fn load_from_vec(nodes: Vec<NodeAddr>, metrics: &Metrics) -> Self {
         let mut me = Self::default();
         for node_addr in nodes {
             me.add_node_addr(node_addr, Source::Saved);
@@ -341,20 +344,24 @@ impl NodeMapInner {
 
     #[cfg(any(test, feature = "test-utils"))]
     /// Create a new [`NodeMap`] from a list of [`NodeAddr`]s.
-    fn load_from_vec(nodes: Vec<NodeAddr>, path_selection: PathSelection) -> Self {
+    fn load_from_vec(
+        nodes: Vec<NodeAddr>,
+        path_selection: PathSelection,
+        metrics: &Metrics,
+    ) -> Self {
         let mut me = Self {
             path_selection,
             ..Default::default()
         };
         for node_addr in nodes {
-            me.add_node_addr(node_addr, Source::Saved);
+            me.add_node_addr(node_addr, Source::Saved, metrics);
         }
         me
     }
 
     /// Add the contact information for a node.
     #[instrument(skip_all, fields(node = %node_addr.node_id.fmt_short()))]
-    fn add_node_addr(&mut self, node_addr: NodeAddr, source: Source) {
+    fn add_node_addr(&mut self, node_addr: NodeAddr, source: Source, metrics: &Metrics) {
         let source0 = source.clone();
         let node_id = node_addr.node_id;
         let relay_url = node_addr.relay_url.clone();
@@ -372,6 +379,7 @@ impl NodeMapInner {
             node_addr.relay_url.as_ref(),
             &node_addr.direct_addresses,
             source0,
+            metrics,
         );
         let id = node_state.id();
         for addr in node_addr.direct_addresses() {
@@ -517,7 +525,12 @@ impl NodeMapInner {
     }
 
     #[must_use = "actions must be handled"]
-    fn handle_call_me_maybe(&mut self, sender: NodeId, cm: CallMeMaybe) -> Vec<PingAction> {
+    fn handle_call_me_maybe(
+        &mut self,
+        sender: NodeId,
+        cm: CallMeMaybe,
+        metrics: &Metrics,
+    ) -> Vec<PingAction> {
         let ns_id = NodeStateKey::NodeId(sender);
         if let Some(id) = self.get_id(ns_id.clone()) {
             for number in &cm.my_numbers {
@@ -527,8 +540,8 @@ impl NodeMapInner {
         }
         match self.get_mut(ns_id) {
             None => {
-                inc!(MagicsockMetrics, recv_disco_call_me_maybe_bad_disco);
                 debug!("received call-me-maybe: ignore, node is unknown");
+                metrics.recv_disco_call_me_maybe_bad_disco.inc();
                 vec![]
             }
             Some(ns) => {
@@ -712,6 +725,7 @@ mod tests {
                 Source::NamedApp {
                     name: "test".into(),
                 },
+                &Default::default(),
             )
         }
     }
@@ -757,7 +771,8 @@ mod tests {
                 Some(addr)
             })
             .collect();
-        let loaded_node_map = NodeMap::load_from_vec(addrs.clone(), PathSelection::default());
+        let loaded_node_map =
+            NodeMap::load_from_vec(addrs.clone(), PathSelection::default(), &Default::default());
 
         let mut loaded: Vec<NodeAddr> = loaded_node_map
             .list_remote_infos(Instant::now())

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -41,7 +41,6 @@ use anyhow::{anyhow, Context, Result};
 use backon::{Backoff, BackoffBuilder, ExponentialBuilder};
 use bytes::{Bytes, BytesMut};
 use iroh_base::{NodeId, PublicKey, RelayUrl, SecretKey};
-use iroh_metrics::{inc, inc_by};
 use iroh_relay::{
     self as relay,
     client::{Client, ReceivedMessage, SendMessage},
@@ -157,6 +156,7 @@ struct ActiveRelayActor {
     inactive_timeout: Pin<Box<time::Sleep>>,
     /// Token indicating the [`ActiveRelayActor`] should stop.
     stop_token: CancellationToken,
+    metrics: MagicsockMetrics,
 }
 
 #[derive(Debug)]
@@ -199,6 +199,7 @@ struct ActiveRelayActorOptions {
     relay_datagrams_recv: Arc<RelayDatagramRecvQueue>,
     connection_opts: RelayConnectionOptions,
     stop_token: CancellationToken,
+    metrics: MagicsockMetrics,
 }
 
 /// Configuration needed to create a connection to a relay server.
@@ -235,6 +236,7 @@ impl ActiveRelayActor {
             relay_datagrams_recv,
             connection_opts,
             stop_token,
+            metrics,
         } = opts;
         let relay_client_builder = Self::create_relay_builder(url.clone(), connection_opts);
         ActiveRelayActor {
@@ -247,6 +249,7 @@ impl ActiveRelayActor {
             is_home_relay: false,
             inactive_timeout: Box::pin(time::sleep(RELAY_INACTIVE_CLEANUP_TIME)),
             stop_token,
+            metrics,
         }
     }
 
@@ -285,7 +288,9 @@ impl ActiveRelayActor {
     ///
     /// Primarily switches between the dialing and connected states.
     async fn run(mut self) -> Result<()> {
-        inc!(MagicsockMetrics, num_relay_conns_added);
+        // TODO(frando): decide what this metric means, it's either wrong here or in node_state.rs.
+        // From the existing description, it is wrong here.
+        // self.metrics.num_relay_conns_added.inc();
 
         let mut backoff = Self::build_backoff();
 
@@ -307,7 +312,9 @@ impl ActiveRelayActor {
             }
         }
         debug!("exiting");
-        inc!(MagicsockMetrics, num_relay_conns_removed);
+        // TODO(frando): decide what this metric means, it's either wrong here or in node_state.rs.
+        // From the existing description, it is wrong here.
+        // self.metrics.num_relay_conns_removed.inc();
         Ok(())
     }
 
@@ -573,18 +580,22 @@ impl ActiveRelayActor {
                         &mut send_datagrams_buf,
                         Vec::with_capacity(SEND_DATAGRAM_BATCH_SIZE),
                     );
+                    // TODO(frando): can we avoid the clone here?
+                    let metrics = self.metrics.clone();
                     let packet_iter = dgrams.into_iter().flat_map(|datagrams| {
                         PacketizeIter::<_, MAX_PAYLOAD_SIZE>::new(
                             datagrams.remote_node,
                             datagrams.datagrams.clone(),
                         )
                         .map(|p| {
-                            inc_by!(MagicsockMetrics, send_relay, p.payload.len() as _);
-                            SendMessage::SendPacket(p.node_id, p.payload)
+                            Ok(SendMessage::SendPacket(p.node_id, p.payload))
                         })
-                        .map(Ok)
                     });
-                    let mut packet_stream = n0_future::stream::iter(packet_iter);
+                    let mut packet_stream = n0_future::stream::iter(packet_iter).inspect(|m| {
+                        if let Ok(SendMessage::SendPacket(_node_id, payload)) = m {
+                            metrics.send_relay.inc_by(payload.len() as _);
+                        }
+                    });
                     let fut = client_sink.send_all(&mut packet_stream);
                     self.run_sending(fut, &mut state, &mut client_stream).await?;
                 }
@@ -1047,6 +1058,7 @@ impl RelayActor {
             relay_datagrams_recv: self.relay_datagram_recv_queue.clone(),
             connection_opts,
             stop_token: self.cancel_token.child_token(),
+            metrics: self.msock.metrics.magicsock.clone(),
         };
         let actor = ActiveRelayActor::new(opts);
         self.active_relay_tasks.spawn(
@@ -1336,6 +1348,7 @@ mod tests {
                 protocol: iroh_relay::http::Protocol::default(),
             },
             stop_token,
+            metrics: Default::default(),
         };
         let task = tokio::spawn(ActiveRelayActor::new(opts).run().instrument(span));
         AbortOnDropHandle::new(task)

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -156,7 +156,7 @@ struct ActiveRelayActor {
     inactive_timeout: Pin<Box<time::Sleep>>,
     /// Token indicating the [`ActiveRelayActor`] should stop.
     stop_token: CancellationToken,
-    metrics: MagicsockMetrics,
+    metrics: Arc<MagicsockMetrics>,
 }
 
 #[derive(Debug)]
@@ -199,7 +199,7 @@ struct ActiveRelayActorOptions {
     relay_datagrams_recv: Arc<RelayDatagramRecvQueue>,
     connection_opts: RelayConnectionOptions,
     stop_token: CancellationToken,
-    metrics: MagicsockMetrics,
+    metrics: Arc<MagicsockMetrics>,
 }
 
 /// Configuration needed to create a connection to a relay server.

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -15,9 +15,9 @@ pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as N
 #[derive(Default, Debug, Clone)]
 pub struct EndpointMetrics {
     /// Metrics collected by the endpoint's socket.
-    pub magicsock: MagicsockMetrics,
+    pub magicsock: Arc<MagicsockMetrics>,
     /// Metrics collected by net reports.
-    pub net_report: NetReportMetrics,
+    pub net_report: Arc<NetReportMetrics>,
     /// Metrics collected by the portmapper service.
     #[cfg(not(wasm_browser))]
     pub portmapper: Arc<PortmapMetrics>,
@@ -27,14 +27,14 @@ impl MetricsGroupSet for EndpointMetrics {
     fn iter(&self) -> impl IntoIterator<Item = &dyn MetricsGroup> {
         #[cfg(not(wasm_browser))]
         return [
-            &self.magicsock as &dyn MetricsGroup,
-            &self.net_report as &dyn MetricsGroup,
+            &*self.magicsock as &dyn MetricsGroup,
+            &*self.net_report as &dyn MetricsGroup,
             &*self.portmapper as &dyn MetricsGroup,
         ];
         #[cfg(wasm_browser)]
         return [
-            &self.magicsock as &dyn MetricsGroup,
-            &self.net_report as &dyn MetricsGroup,
+            &*self.magicsock as &dyn MetricsGroup,
+            &*self.net_report as &dyn MetricsGroup,
         ];
     }
 

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -26,7 +26,7 @@ pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as N
 /// # }
 /// ```
 ///
-/// [`EndpointMetrics] implements [`MetricsGroupSet`], and all fields of this struct implement
+/// [`EndpointMetrics`] implements [`MetricsGroupSet`], and all fields of this struct implement
 /// implement [`iroh_metrics::MetricsGroup`]. These trait provides various methods to iterate
 /// the groups in the set, and over the individual metrics in each group, without having
 /// to access each field manually. With these methods, it is straightforward to collect
@@ -55,13 +55,14 @@ pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as N
 /// # }
 /// ```
 ///
-/// The metrics can also be used with the types from the `prometheus_client` crate.
+/// The metrics can also be used with the types from the [`prometheus_client`] crate.
 /// With [`EndpointMetrics::register`], you can register all metrics onto a onto a
-/// [`prometheus_client::Registry`]. [`iroh_metrics`] provides functions to easily start
-/// services to serve the metrics with a HTTP server, dump them to a file, or push them
-/// to a Prometheus gateway. See the `service` module in `iroh_metrics` for details.
+/// [`Registry`]. [`iroh_metrics`] provides functions to easily start services
+/// to serve the metrics with a HTTP server, dump them to a file, or push them
+/// to a Prometheus gateway. See the `service` module in [`iroh_metrics`] for details.
 ///
-/// [`prometheus_client::Registry`]: https://docs.rs/prometheus-client/latest/prometheus_client/registry/struct.Registry.html
+/// [`prometheus_client`]: https://docs.rs/prometheus-client/latest/prometheus_client/index.html
+/// [`Registry`]: https://docs.rs/prometheus-client/latest/prometheus_client/registry/struct.Registry.html
 #[derive(Default, Debug, Clone)]
 pub struct EndpointMetrics {
     /// Metrics collected by the endpoint's socket.

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Co-locating all of the iroh metrics structs
-use iroh_metrics::core::Metric;
+use std::sync::Arc;
+
+use iroh_metrics::Metric;
 #[cfg(feature = "test-utils")]
 pub use iroh_relay::server::Metrics as RelayMetrics;
 #[cfg(not(wasm_browser))]
@@ -18,16 +20,16 @@ pub struct EndpointMetrics {
     pub net_report: NetReportMetrics,
     /// Metrics collected by the portmapper service.
     #[cfg(not(wasm_browser))]
-    pub portmapper: PortmapMetrics,
+    pub portmapper: Arc<PortmapMetrics>,
 }
 
-impl iroh_metrics::core::MetricSet for EndpointMetrics {
+impl iroh_metrics::MetricSet for EndpointMetrics {
     fn iter(&self) -> impl IntoIterator<Item = &dyn Metric> {
         #[cfg(not(wasm_browser))]
         return [
             &self.magicsock as &dyn Metric,
             &self.net_report as &dyn Metric,
-            &self.portmapper as &dyn Metric,
+            &*self.portmapper as &dyn Metric,
         ];
         #[cfg(wasm_browser)]
         return [

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -14,17 +14,24 @@ pub struct EndpointMetrics {
     pub magicsock: MagicsockMetrics,
     ///
     pub net_report: NetReportMetrics,
-    // TODO(frando): add portmap metrics
-    // #[cfg(not(wasm_browser))]
-    // portmap: PortmapMetrics
+    ///
+    #[cfg(not(wasm_browser))]
+    pub portmapper: PortmapMetrics,
 }
 
 impl iroh_metrics::core::MetricSet for EndpointMetrics {
     fn iter<'a>(&'a self) -> impl IntoIterator<Item = &'a dyn Metric> {
-        [
+        #[cfg(not(wasm_browser))]
+        return [
             &self.magicsock as &dyn Metric,
             &self.net_report as &dyn Metric,
-        ]
+            &self.portmapper as &dyn Metric,
+        ];
+        #[cfg(wasm_browser)]
+        return [
+            &self.magicsock as &dyn Metric,
+            &self.net_report as &dyn Metric,
+        ];
     }
 
     fn name(&self) -> &'static str {

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Co-locating all of the iroh metrics structs
 use std::sync::Arc;
 
-use iroh_metrics::{MetricsGroup, MetricsGroupSet};
+use iroh_metrics::MetricsGroupSet;
 #[cfg(feature = "test-utils")]
 pub use iroh_relay::server::Metrics as RelayMetrics;
 #[cfg(not(wasm_browser))]
@@ -12,7 +12,8 @@ pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as N
 /// Metrics collected by an [`crate::endpoint::Endpoint`].
 ///
 /// See [`crate::endpoint::Endpoint::metrics`] for details.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, MetricsGroupSet)]
+#[metrics(name = "endpoint")]
 #[non_exhaustive]
 pub struct EndpointMetrics {
     /// Metrics collected by the endpoint's socket.
@@ -22,26 +23,4 @@ pub struct EndpointMetrics {
     /// Metrics collected by the portmapper service.
     #[cfg(not(wasm_browser))]
     pub portmapper: Arc<PortmapMetrics>,
-}
-
-impl MetricsGroupSet for EndpointMetrics {
-    fn groups(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
-        #[cfg(not(wasm_browser))]
-        return [
-            &*self.magicsock as &dyn MetricsGroup,
-            &*self.net_report as &dyn MetricsGroup,
-            &*self.portmapper as &dyn MetricsGroup,
-        ]
-        .into_iter();
-        #[cfg(wasm_browser)]
-        return [
-            &*self.magicsock as &dyn MetricsGroup,
-            &*self.net_report as &dyn MetricsGroup,
-        ]
-        .into_iter();
-    }
-
-    fn name(&self) -> &'static str {
-        "endpoint"
-    }
 }

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -31,20 +31,3 @@ impl iroh_metrics::core::MetricSet for EndpointMetrics {
         "endpoint"
     }
 }
-
-/// Increments the given counter or gauge by 1.
-macro_rules! inc {
-    ($msock:expr, $f:ident) => {
-        $msock.metrics.magicsock.$f.inc()
-    };
-}
-
-/// Increments the given counter or gauge by `n`.
-macro_rules! inc_by {
-    ($msock:ident, $f:ident, $n:expr) => {
-        $msock.metrics.magicsock.$f.inc_by($n)
-    };
-}
-
-pub(crate) use inc;
-pub(crate) use inc_by;

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -6,13 +6,14 @@ use iroh_metrics::MetricsGroupSet;
 pub use iroh_relay::server::Metrics as RelayMetrics;
 #[cfg(not(wasm_browser))]
 pub use portmapper::Metrics as PortmapMetrics;
+use serde::{Deserialize, Serialize};
 
 pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as NetReportMetrics};
 
 /// Metrics collected by an [`crate::endpoint::Endpoint`].
 ///
 /// See [`crate::endpoint::Endpoint::metrics`] for details.
-#[derive(Default, Debug, Clone, MetricsGroupSet)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, MetricsGroupSet)]
 #[metrics(name = "endpoint")]
 #[non_exhaustive]
 pub struct EndpointMetrics {
@@ -23,4 +24,19 @@ pub struct EndpointMetrics {
     /// Metrics collected by the portmapper service.
     #[cfg(not(wasm_browser))]
     pub portmapper: Arc<PortmapMetrics>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EndpointMetrics;
+    #[test]
+    fn test_serde() {
+        let metrics = EndpointMetrics::default();
+        metrics.magicsock.actor_link_change.inc();
+        metrics.net_report.reports.inc_by(10);
+        let encoded = postcard::to_stdvec(&metrics).unwrap();
+        let decoded: EndpointMetrics = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded.magicsock.actor_link_change.get(), 1);
+        assert_eq!(decoded.net_report.reports.get(), 10);
+    }
 }

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -12,6 +12,56 @@ pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as N
 /// Metrics collected by an [`crate::endpoint::Endpoint`].
 ///
 /// The metrics for an endpoint can be accessed via [`crate::endpoint::Endpoint::metrics`].
+/// You can access individual metrics directly by using the public fields.
+/// ```rust
+/// # use std::collections::BTreeMap;
+/// # use iroh_metrics::{MetricsGroup, MetricValue, MetricsGroupSet};
+/// # use iroh::endpoint::Endpoint;
+/// # async fn wrapper() -> testresult::TestResult {
+/// let endpoint = Endpoint::builder().bind().await?;
+/// let metrics = endpoint.metrics();
+///
+/// assert_eq!(metrics.magicsock.recv_datagrams.get(), 0);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`EndpointMetrics] implements [`MetricsGroupSet`], and all fields of this struct implement
+/// implement [`iroh_metrics::MetricsGroup`]. These trait provides various methods to iterate
+/// the groups in the set, and over the individual metrics in each group, without having
+/// to access each field manually. With these methods, it is straightforward to collect
+/// all metrics into a map or push their values to some other metrics collector.
+///
+/// For example, the following snippet collects all metrics into a map:
+/// ```rust
+/// # use std::collections::BTreeMap;
+/// # use iroh_metrics::{MetricsGroup, MetricValue, MetricsGroupSet};
+/// # use iroh::endpoint::Endpoint;
+/// # async fn wrapper() -> testresult::TestResult {
+/// let endpoint = Endpoint::builder().bind().await?;
+/// let metrics: BTreeMap<String, MetricValue> = endpoint
+///     .metrics()
+///     .iter()
+///     .flat_map(|group| {
+///         group.values().map(|item| {
+///             let name = [group.name(), item.name].join(":");
+///             (name, item.value)
+///         })
+///     })
+///     .collect();
+///
+/// assert_eq!(metrics["magicsock:recv_datagrams"], MetricValue::Counter(0));
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The metrics can also be used with the types from the `prometheus_client` crate.
+/// With [`EndpointMetrics::register`], you can register all metrics onto a onto a
+/// [`prometheus_client::Registry`]. [`iroh_metrics`] provides functions to easily start
+/// services to serve the metrics with a HTTP server, dump them to a file, or push them
+/// to a Prometheus gateway. See the `service` module in `iroh_metrics` for details.
+///
+/// [`prometheus_client::Registry`]: https://docs.rs/prometheus-client/latest/prometheus_client/registry/struct.Registry.html
 #[derive(Default, Debug, Clone)]
 pub struct EndpointMetrics {
     /// Metrics collected by the endpoint's socket.
@@ -24,18 +74,20 @@ pub struct EndpointMetrics {
 }
 
 impl MetricsGroupSet for EndpointMetrics {
-    fn iter(&self) -> impl IntoIterator<Item = &dyn MetricsGroup> {
+    fn iter(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
         #[cfg(not(wasm_browser))]
         return [
             &*self.magicsock as &dyn MetricsGroup,
             &*self.net_report as &dyn MetricsGroup,
             &*self.portmapper as &dyn MetricsGroup,
-        ];
+        ]
+        .into_iter();
         #[cfg(wasm_browser)]
         return [
             &*self.magicsock as &dyn MetricsGroup,
             &*self.net_report as &dyn MetricsGroup,
-        ];
+        ]
+        .into_iter();
     }
 
     fn name(&self) -> &'static str {

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -13,6 +13,7 @@ pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as N
 ///
 /// See [`crate::endpoint::Endpoint::metrics`] for details.
 #[derive(Default, Debug, Clone)]
+#[non_exhaustive]
 pub struct EndpointMetrics {
     /// Metrics collected by the endpoint's socket.
     pub magicsock: Arc<MagicsockMetrics>,

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -7,20 +7,22 @@ pub use portmapper::Metrics as PortmapMetrics;
 
 pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as NetReportMetrics};
 
+/// Metrics collected by an [`crate::endpoint::Endpoint`].
 ///
+/// The metrics for an endpoint can be accessed via [`crate::endpoint::Endpoint::metrics`].
 #[derive(Default, Debug, Clone)]
 pub struct EndpointMetrics {
-    ///
+    /// Metrics collected by the endpoint's socket.
     pub magicsock: MagicsockMetrics,
-    ///
+    /// Metrics collected by net reports.
     pub net_report: NetReportMetrics,
-    ///
+    /// Metrics collected by the portmapper service.
     #[cfg(not(wasm_browser))]
     pub portmapper: PortmapMetrics,
 }
 
 impl iroh_metrics::core::MetricSet for EndpointMetrics {
-    fn iter<'a>(&'a self) -> impl IntoIterator<Item = &'a dyn Metric> {
+    fn iter(&self) -> impl IntoIterator<Item = &dyn Metric> {
         #[cfg(not(wasm_browser))]
         return [
             &self.magicsock as &dyn Metric,

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -1,7 +1,50 @@
 //! Co-locating all of the iroh metrics structs
+use iroh_metrics::core::Metric;
 #[cfg(feature = "test-utils")]
 pub use iroh_relay::server::Metrics as RelayMetrics;
 #[cfg(not(wasm_browser))]
 pub use portmapper::Metrics as PortmapMetrics;
 
 pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as NetReportMetrics};
+
+///
+#[derive(Default, Debug, Clone)]
+pub struct EndpointMetrics {
+    ///
+    pub magicsock: MagicsockMetrics,
+    ///
+    pub net_report: NetReportMetrics,
+    // TODO(frando): add portmap metrics
+    // #[cfg(not(wasm_browser))]
+    // portmap: PortmapMetrics
+}
+
+impl iroh_metrics::core::MetricSet for EndpointMetrics {
+    fn iter<'a>(&'a self) -> impl IntoIterator<Item = &'a dyn Metric> {
+        [
+            &self.magicsock as &dyn Metric,
+            &self.net_report as &dyn Metric,
+        ]
+    }
+
+    fn name(&self) -> &'static str {
+        "endpoint"
+    }
+}
+
+/// Increments the given counter or gauge by 1.
+macro_rules! inc {
+    ($msock:expr, $f:ident) => {
+        $msock.metrics.magicsock.$f.inc()
+    };
+}
+
+/// Increments the given counter or gauge by `n`.
+macro_rules! inc_by {
+    ($msock:ident, $f:ident, $n:expr) => {
+        $msock.metrics.magicsock.$f.inc_by($n)
+    };
+}
+
+pub(crate) use inc;
+pub(crate) use inc_by;

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -11,58 +11,7 @@ pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as N
 
 /// Metrics collected by an [`crate::endpoint::Endpoint`].
 ///
-/// The metrics for an endpoint can be accessed via [`crate::endpoint::Endpoint::metrics`].
-/// You can access individual metrics directly by using the public fields.
-/// ```rust
-/// # use std::collections::BTreeMap;
-/// # use iroh_metrics::{MetricsGroup, MetricValue, MetricsGroupSet};
-/// # use iroh::endpoint::Endpoint;
-/// # async fn wrapper() -> testresult::TestResult {
-/// let endpoint = Endpoint::builder().bind().await?;
-/// let metrics = endpoint.metrics();
-///
-/// assert_eq!(metrics.magicsock.recv_datagrams.get(), 0);
-/// # Ok(())
-/// # }
-/// ```
-///
-/// [`EndpointMetrics`] implements [`MetricsGroupSet`], and all fields of this struct implement
-/// implement [`iroh_metrics::MetricsGroup`]. These trait provides various methods to iterate
-/// the groups in the set, and over the individual metrics in each group, without having
-/// to access each field manually. With these methods, it is straightforward to collect
-/// all metrics into a map or push their values to some other metrics collector.
-///
-/// For example, the following snippet collects all metrics into a map:
-/// ```rust
-/// # use std::collections::BTreeMap;
-/// # use iroh_metrics::{MetricsGroup, MetricValue, MetricsGroupSet};
-/// # use iroh::endpoint::Endpoint;
-/// # async fn wrapper() -> testresult::TestResult {
-/// let endpoint = Endpoint::builder().bind().await?;
-/// let metrics: BTreeMap<String, MetricValue> = endpoint
-///     .metrics()
-///     .iter()
-///     .flat_map(|group| {
-///         group.values().map(|item| {
-///             let name = [group.name(), item.name].join(":");
-///             (name, item.value)
-///         })
-///     })
-///     .collect();
-///
-/// assert_eq!(metrics["magicsock:recv_datagrams"], MetricValue::Counter(0));
-/// # Ok(())
-/// # }
-/// ```
-///
-/// The metrics can also be used with the types from the [`prometheus_client`] crate.
-/// With [`EndpointMetrics::register`], you can register all metrics onto a onto a
-/// [`Registry`]. [`iroh_metrics`] provides functions to easily start services
-/// to serve the metrics with a HTTP server, dump them to a file, or push them
-/// to a Prometheus gateway. See the `service` module in [`iroh_metrics`] for details.
-///
-/// [`prometheus_client`]: https://docs.rs/prometheus-client/latest/prometheus_client/index.html
-/// [`Registry`]: https://docs.rs/prometheus-client/latest/prometheus_client/registry/struct.Registry.html
+/// See [`crate::endpoint::Endpoint::metrics`] for details.
 #[derive(Default, Debug, Clone)]
 pub struct EndpointMetrics {
     /// Metrics collected by the endpoint's socket.

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -24,7 +24,7 @@ pub struct EndpointMetrics {
 }
 
 impl MetricsGroupSet for EndpointMetrics {
-    fn iter(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
+    fn groups(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
         #[cfg(not(wasm_browser))]
         return [
             &*self.magicsock as &dyn MetricsGroup,

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Co-locating all of the iroh metrics structs
 use std::sync::Arc;
 
-use iroh_metrics::Metric;
+use iroh_metrics::{MetricsGroup, MetricsGroupSet};
 #[cfg(feature = "test-utils")]
 pub use iroh_relay::server::Metrics as RelayMetrics;
 #[cfg(not(wasm_browser))]
@@ -23,18 +23,18 @@ pub struct EndpointMetrics {
     pub portmapper: Arc<PortmapMetrics>,
 }
 
-impl iroh_metrics::MetricSet for EndpointMetrics {
-    fn iter(&self) -> impl IntoIterator<Item = &dyn Metric> {
+impl MetricsGroupSet for EndpointMetrics {
+    fn iter(&self) -> impl IntoIterator<Item = &dyn MetricsGroup> {
         #[cfg(not(wasm_browser))]
         return [
-            &self.magicsock as &dyn Metric,
-            &self.net_report as &dyn Metric,
-            &*self.portmapper as &dyn Metric,
+            &self.magicsock as &dyn MetricsGroup,
+            &self.net_report as &dyn MetricsGroup,
+            &*self.portmapper as &dyn MetricsGroup,
         ];
         #[cfg(wasm_browser)]
         return [
-            &self.magicsock as &dyn Metric,
-            &self.net_report as &dyn Metric,
+            &self.magicsock as &dyn MetricsGroup,
+            &self.net_report as &dyn MetricsGroup,
         ];
     }
 

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -20,8 +20,6 @@ use std::{
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use iroh_base::RelayUrl;
-#[cfg(feature = "metrics")]
-use iroh_metrics::inc;
 #[cfg(not(wasm_browser))]
 use iroh_relay::dns::DnsResolver;
 use iroh_relay::{protos::stun, RelayMap};
@@ -249,6 +247,7 @@ impl Client {
         #[cfg(not(wasm_browser))] port_mapper: Option<portmapper::Client>,
         #[cfg(not(wasm_browser))] dns_resolver: DnsResolver,
         #[cfg(not(wasm_browser))] ip_mapped_addrs: Option<IpMappedAddresses>,
+        metrics: Metrics,
     ) -> Result<Self> {
         let mut actor = Actor::new(
             #[cfg(not(wasm_browser))]
@@ -257,6 +256,7 @@ impl Client {
             dns_resolver,
             #[cfg(not(wasm_browser))]
             ip_mapped_addrs,
+            metrics,
         )?;
         let addr = actor.addr();
         let task = task::spawn(
@@ -404,6 +404,7 @@ pub(crate) enum Message {
 #[derive(Debug, Clone)]
 pub struct Addr {
     sender: mpsc::Sender<Message>,
+    metrics: Metrics,
 }
 
 impl Addr {
@@ -425,8 +426,7 @@ impl Addr {
             payload,
             from_addr: src,
         }) {
-            #[cfg(feature = "metrics")]
-            inc!(Metrics, stun_packets_dropped);
+            self.metrics.stun_packets_dropped.inc();
             warn!("dropping stun packet from {}", src);
         }
     }
@@ -480,6 +480,7 @@ struct Actor {
     /// The [`IpMappedAddresses`] that allows you to do QAD in iroh
     #[cfg(not(wasm_browser))]
     ip_mapped_addrs: Option<IpMappedAddresses>,
+    metrics: Metrics,
 }
 
 impl Actor {
@@ -491,6 +492,7 @@ impl Actor {
         #[cfg(not(wasm_browser))] port_mapper: Option<portmapper::Client>,
         #[cfg(not(wasm_browser))] dns_resolver: DnsResolver,
         #[cfg(not(wasm_browser))] ip_mapped_addrs: Option<IpMappedAddresses>,
+        metrics: Metrics,
     ) -> Result<Self> {
         // TODO: consider an instrumented flume channel so we have metrics.
         let (sender, receiver) = mpsc::channel(32);
@@ -506,6 +508,7 @@ impl Actor {
             dns_resolver,
             #[cfg(not(wasm_browser))]
             ip_mapped_addrs,
+            metrics,
         })
     }
 
@@ -513,6 +516,7 @@ impl Actor {
     fn addr(&self) -> Addr {
         Addr {
             sender: self.sender.clone(),
+            metrics: self.metrics.clone(),
         }
     }
 
@@ -596,17 +600,16 @@ impl Actor {
             self.reports.last = None; // causes ProbePlan::new below to do a full (initial) plan
             self.reports.next_full = false;
             self.reports.last_full = now;
-            #[cfg(feature = "metrics")]
-            inc!(Metrics, reports_full);
+            self.metrics.reports_full.inc();
         }
-        #[cfg(feature = "metrics")]
-        inc!(Metrics, reports);
+        self.metrics.reports.inc();
 
         let actor = reportgen::Client::new(
             self.addr(),
             self.reports.last.clone(),
             relay_map,
             protocols,
+            self.metrics.clone(),
             #[cfg(not(wasm_browser))]
             socket_state,
         );
@@ -645,10 +648,10 @@ impl Actor {
         #[cfg(feature = "metrics")]
         match &src {
             SocketAddr::V4(_) => {
-                inc!(Metrics, stun_packets_recv_ipv4);
+                self.metrics.stun_packets_recv_ipv4.inc();
             }
             SocketAddr::V6(_) => {
-                inc!(Metrics, stun_packets_recv_ipv6);
+                self.metrics.stun_packets_recv_ipv6.inc();
             }
         }
 
@@ -1064,7 +1067,7 @@ mod tests {
             stun_utils::serve("127.0.0.1".parse().unwrap()).await?;
 
         let resolver = dns::tests::resolver();
-        let mut client = Client::new(None, resolver.clone(), None)?;
+        let mut client = Client::new(None, resolver.clone(), None, Default::default())?;
         let dm = stun_utils::relay_map_of([stun_addr].into_iter());
 
         // Note that the ProbePlan will change with each iteration.
@@ -1111,7 +1114,7 @@ mod tests {
 
         // Now create a client and generate a report.
         let resolver = dns::tests::resolver();
-        let mut client = Client::new(None, resolver.clone(), None)?;
+        let mut client = Client::new(None, resolver.clone(), None, Default::default())?;
 
         let r = client.get_report_all(dm, None, None, None).await?;
         let mut r: Report = (*r).clone();
@@ -1314,7 +1317,7 @@ mod tests {
         let resolver = dns::tests::resolver();
         for mut tt in tests {
             println!("test: {}", tt.name);
-            let mut actor = Actor::new(None, resolver.clone(), None).unwrap();
+            let mut actor = Actor::new(None, resolver.clone(), None, Default::default()).unwrap();
             for s in &mut tt.steps {
                 // trigger the timer
                 tokio::time::advance(Duration::from_secs(s.after)).await;
@@ -1349,7 +1352,7 @@ mod tests {
         dbg!(&dm);
 
         let resolver = dns::tests::resolver().clone();
-        let mut client = Client::new(None, resolver, None)?;
+        let mut client = Client::new(None, resolver, None, Default::default())?;
 
         // Set up an external socket to send STUN requests from, this will be discovered as
         // our public socket address by STUN.  We send back any packets received on this

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -247,7 +247,7 @@ impl Client {
         #[cfg(not(wasm_browser))] port_mapper: Option<portmapper::Client>,
         #[cfg(not(wasm_browser))] dns_resolver: DnsResolver,
         #[cfg(not(wasm_browser))] ip_mapped_addrs: Option<IpMappedAddresses>,
-        metrics: Metrics,
+        metrics: Arc<Metrics>,
     ) -> Result<Self> {
         let mut actor = Actor::new(
             #[cfg(not(wasm_browser))]
@@ -404,7 +404,7 @@ pub(crate) enum Message {
 #[derive(Debug, Clone)]
 pub struct Addr {
     sender: mpsc::Sender<Message>,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
 }
 
 impl Addr {
@@ -480,7 +480,7 @@ struct Actor {
     /// The [`IpMappedAddresses`] that allows you to do QAD in iroh
     #[cfg(not(wasm_browser))]
     ip_mapped_addrs: Option<IpMappedAddresses>,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
 }
 
 impl Actor {
@@ -492,7 +492,7 @@ impl Actor {
         #[cfg(not(wasm_browser))] port_mapper: Option<portmapper::Client>,
         #[cfg(not(wasm_browser))] dns_resolver: DnsResolver,
         #[cfg(not(wasm_browser))] ip_mapped_addrs: Option<IpMappedAddresses>,
-        metrics: Metrics,
+        metrics: Arc<Metrics>,
     ) -> Result<Self> {
         // TODO: consider an instrumented flume channel so we have metrics.
         let (sender, receiver) = mpsc::channel(32);

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -1,7 +1,4 @@
-use iroh_metrics::{
-    core::{Counter, Metric},
-    struct_iterable::Iterable,
-};
+use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
 
 /// Enum of metrics for the module
 #[allow(missing_docs)]

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -1,9 +1,9 @@
 use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
-#[allow(missing_docs)]
 #[derive(Debug, Clone, MetricsGroup)]
 #[metrics(name = "net_report")]
+#[non_exhaustive]
 pub struct Metrics {
     /// Incoming STUN packets dropped due to a full receiving queue.
     pub stun_packets_dropped: Counter,

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -35,7 +35,7 @@ impl Default for Metrics {
 }
 
 impl Metric for Metrics {
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         "net_report"
     }
 }

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -1,7 +1,7 @@
 use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "net_report")]
 #[non_exhaustive]
 pub struct Metrics {

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -1,7 +1,8 @@
 use iroh_metrics::{Counter, MetricsGroup};
+use serde::{Deserialize, Serialize};
 
 /// Enum of metrics for the module
-#[derive(Debug, Default, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup, Serialize, Deserialize)]
 #[metrics(name = "net_report")]
 #[non_exhaustive]
 pub struct Metrics {

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -1,38 +1,22 @@
-use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
+use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Iterable)]
+#[derive(Debug, Clone, MetricsGroup)]
+#[metrics(name = "net_report")]
 pub struct Metrics {
+    /// Incoming STUN packets dropped due to a full receiving queue.
     pub stun_packets_dropped: Counter,
+    /// Number of IPv4 STUN packets sent.
     pub stun_packets_sent_ipv4: Counter,
+    /// Number of IPv6 STUN packets sent.
     pub stun_packets_sent_ipv6: Counter,
+    /// Number of IPv4 STUN packets received.
     pub stun_packets_recv_ipv4: Counter,
+    /// Number of IPv6 STUN packets received.
     pub stun_packets_recv_ipv6: Counter,
+    /// Number of reports executed by net_report, including full reports.
     pub reports: Counter,
+    /// Number of full reports executed by net_report
     pub reports_full: Counter,
-}
-
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            stun_packets_dropped: Counter::new(
-                "Incoming STUN packets dropped due to a full receiving queue.",
-            ),
-            stun_packets_sent_ipv4: Counter::new("Number of IPv4 STUN packets sent"),
-            stun_packets_sent_ipv6: Counter::new("Number of IPv6 STUN packets sent"),
-            stun_packets_recv_ipv4: Counter::new("Number of IPv4 STUN packets received"),
-            stun_packets_recv_ipv6: Counter::new("Number of IPv6 STUN packets received"),
-            reports: Counter::new(
-                "Number of reports executed by net_report, including full reports",
-            ),
-            reports_full: Counter::new("Number of full reports executed by net_report"),
-        }
-    }
-}
-
-impl MetricsGroup for Metrics {
-    fn name(&self) -> &'static str {
-        "net_report"
-    }
 }

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -1,4 +1,4 @@
-use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
+use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
 
 /// Enum of metrics for the module
 #[allow(missing_docs)]
@@ -31,7 +31,7 @@ impl Default for Metrics {
     }
 }
 
-impl Metric for Metrics {
+impl MetricsGroup for Metrics {
     fn name(&self) -> &'static str {
         "net_report"
     }

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -112,7 +112,7 @@ impl Client {
         last_report: Option<Arc<Report>>,
         relay_map: RelayMap,
         protocols: BTreeSet<ProbeProto>,
-        metrics: Metrics,
+        metrics: Arc<Metrics>,
         #[cfg(not(wasm_browser))] socket_state: SocketState,
     ) -> Self {
         let (msg_tx, msg_rx) = mpsc::channel(32);
@@ -213,7 +213,7 @@ struct Actor {
     /// The hairpin actor.
     #[cfg(not(wasm_browser))]
     hairpin_actor: hairpin::Client,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
 }
 
 impl Actor {
@@ -755,7 +755,7 @@ async fn run_probe(
     relay_node: Arc<RelayNode>,
     probe: Probe,
     net_report: net_report::Addr,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
     #[cfg(not(wasm_browser))] pinger: Pinger,
     #[cfg(not(wasm_browser))] socket_state: SocketState,
 ) -> Result<ProbeReport, ProbeError> {

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -27,8 +27,6 @@ use std::{
 
 use anyhow::{anyhow, bail, Context as _, Result};
 use iroh_base::RelayUrl;
-#[cfg(feature = "metrics")]
-use iroh_metrics::inc;
 #[cfg(not(wasm_browser))]
 use iroh_relay::dns::DnsResolver;
 use iroh_relay::{
@@ -116,6 +114,7 @@ impl Client {
         last_report: Option<Arc<Report>>,
         relay_map: RelayMap,
         protocols: BTreeSet<ProbeProto>,
+        metrics: Metrics,
         #[cfg(not(wasm_browser))] socket_state: SocketState,
     ) -> Self {
         let (msg_tx, msg_rx) = mpsc::channel(32);
@@ -135,6 +134,7 @@ impl Client {
             socket_state,
             #[cfg(not(wasm_browser))]
             hairpin_actor: hairpin::Client::new(net_report, addr),
+            metrics,
         };
         let task =
             task::spawn(async move { actor.run().await }.instrument(info_span!("reportgen.actor")));
@@ -215,6 +215,7 @@ struct Actor {
     /// The hairpin actor.
     #[cfg(not(wasm_browser))]
     hairpin_actor: hairpin::Client,
+    metrics: Metrics,
 }
 
 impl Actor {
@@ -615,12 +616,14 @@ impl Actor {
                 #[cfg(not(wasm_browser))]
                 let socket_state = self.socket_state.clone();
 
+                let metrics = self.metrics.clone();
                 set.spawn(
                     run_probe(
                         reportstate,
                         relay_node,
                         probe.clone(),
                         net_report,
+                        metrics,
                         #[cfg(not(wasm_browser))]
                         pinger,
                         #[cfg(not(wasm_browser))]
@@ -754,6 +757,7 @@ async fn run_probe(
     relay_node: Arc<RelayNode>,
     probe: Probe,
     net_report: net_report::Addr,
+    metrics: Metrics,
     #[cfg(not(wasm_browser))] pinger: Pinger,
     #[cfg(not(wasm_browser))] socket_state: SocketState,
 ) -> Result<ProbeReport, ProbeError> {
@@ -806,7 +810,7 @@ async fn run_probe(
             };
             match maybe_sock {
                 Some(sock) => {
-                    result = run_stun_probe(sock, relay_addr, net_report, probe).await?;
+                    result = run_stun_probe(sock, relay_addr, net_report, probe, &metrics).await?;
                 }
                 None => {
                     return Err(ProbeError::AbortSet(
@@ -885,6 +889,7 @@ async fn run_stun_probe(
     relay_addr: SocketAddr,
     net_report: net_report::Addr,
     probe: Probe,
+    metrics: &Metrics,
 ) -> Result<ProbeReport, ProbeError> {
     match probe.proto() {
         ProbeProto::StunIpv4 => debug_assert!(relay_addr.is_ipv4()),
@@ -920,12 +925,10 @@ async fn run_stun_probe(
 
             if matches!(probe, Probe::StunIpv4 { .. }) {
                 result.ipv4_can_send = true;
-                #[cfg(feature = "metrics")]
-                inc!(Metrics, stun_packets_sent_ipv4);
+                metrics.stun_packets_sent_ipv4.inc();
             } else {
                 result.ipv6_can_send = true;
-                #[cfg(feature = "metrics")]
-                inc!(Metrics, stun_packets_sent_ipv6);
+                metrics.stun_packets_sent_ipv6.inc();
             }
             let (delay, addr) = stun_rx
                 .await

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -51,7 +51,6 @@ use url::Host;
 
 #[cfg(wasm_browser)]
 use crate::net_report::portmapper; // We stub the library
-#[cfg(feature = "metrics")]
 use crate::net_report::Metrics;
 use crate::net_report::{self, Report};
 #[cfg(not(wasm_browser))]

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -51,8 +51,7 @@ use url::Host;
 
 #[cfg(wasm_browser)]
 use crate::net_report::portmapper; // We stub the library
-use crate::net_report::Metrics;
-use crate::net_report::{self, Report};
+use crate::net_report::{self, Metrics, Report};
 #[cfg(not(wasm_browser))]
 use crate::net_report::{
     defaults::timeouts::DNS_TIMEOUT,

--- a/iroh/src/net_report/reportgen/hairpin.rs
+++ b/iroh/src/net_report/reportgen/hairpin.rs
@@ -206,6 +206,7 @@ mod tests {
         let (net_report_tx, mut net_report_rx) = mpsc::channel(32);
         let net_report_addr = net_report::Addr {
             sender: net_report_tx,
+            metrics: Default::default(),
         };
         let (reportstate_tx, mut reportstate_rx) = mpsc::channel(32);
         let reportstate_addr = reportgen::Addr {
@@ -282,6 +283,7 @@ mod tests {
         let (net_report_tx, _net_report_rx) = mpsc::channel(32);
         let net_report_addr = net_report::Addr {
             sender: net_report_tx,
+            metrics: Default::default(),
         };
         let (reportstate_tx, _reportstate_rx) = mpsc::channel(32);
         let reportstate_addr = reportgen::Addr {


### PR DESCRIPTION
## Description

Depends on https://github.com/n0-computer/net-tools/pull/20

Until now, we were using a superglobal static `iroh_metrics::core::Core` struct to collect metrics into. This allowed us to use macros to track metrics from anywhere in the codebase. However, this also made it impossible to collect metrics *per endpoint*, which is what you want usually as soon as you have more than one endpoint in your app.

This PR builds on n0-computer/iroh-metrics#15, n0-computer/iroh-metrics#22, and n0-computer/iroh-metrics#23. It removes the global metrics collection from all crates in the iroh repository. Instead, we now create and pass metrics collector structs to all places where we need to collect metrics.

This PR disables the `static_core` feature from iroh-metrics, which means the macros for superglobal metrics collection are not available anymore. This is good, because otherwise we could easily miss metrics not tracked onto the proper metrics collector.

This PR also updates iroh-dns-server and iroh-relay to use manual metrics collection.

While this means that we have to pass our metrics structs to more places, it also makes metrics collection more visible, and we can now also split the metrics structs further easily if we want to separate concerns more.

This PR should not change anything apart from metrics collection. Most places are straightforward conversions from the macros to methods on the metrics collectors. At a few places, logic was changed slightly to move metrics collection a layer up to save a few clones.

## Breaking Changes

* All metrics structs (`iroh::metrics::{MagicsockMetrics, PortmapMetrics, NetReportMetrics}`) now implement `MetricsGroup` from the new version `0.34` of `iroh-metrics` and no longer implement traits from `iroh-metrics@0.32`. 
* Metrics are no longer registered onto the static superglobal `Core`. `iroh` does not use `static_core` feature of `iroh-metrics`. Metrics are now exposed from the subsystems that track them, see e.g. `Endpoint::metrics`. 

Several methods now take a `Metrics` argument. You can always pass `Default::default` if you don't want to unify metrics tracking with other sections.

#### `iroh`

* `iroh::metrics::{MagicsockMetrics, NetReportMetrics, PortmapMetrics}` all are now marked `non_exhaustive`, and implement `iroh_metrics::MetricsGroup` from `iroh-metrics@0.34`  and no longer implement `iroh_metrics::Metric` from `iroh-metrics@0.32`. They also no longer implement `Clone` (put them into an `Arc` for cloning instead).

* `iroh::net_report::Client::new` now takes `iroh::net_report::metrics::Metrics` as forth argument

#### `iroh-dns-server`
*  `iroh_dns_server::server::Server::spawn` now takes `Metrics` as third argument
*  `iroh_dns_server::ZoneStore::persistent` now takes  `Metrics` as third argument
*  `iroh_dns_server::ZoneStore::in_memory` now takes  `Metrics` as third argument
*  `iroh_dns_server::ZoneStore::new` now takes  `Metrics` as third argument
* `iroh_dns_server::state::AppState` now has a public `metrics: Metrics` field
*  `iroh_dns_server::dns::DnsHandler::new` now takes  `Metrics` as third argument
* function `iroh_dns_server::metrics::init_metrics` is removed

#### `iroh-relay`

* `iroh_relay::metrics::{StunMetrics, Metrics}` all are now marked `non_exhaustive`, and implement `iroh_metrics::MetricsGroup` from `iroh-metrics@0.34`  and no longer implement `iroh_metrics::Metric` from `iroh-metrics@0.32`. They also no longer implement `Clone` (put them into an `Arc` for cloning instead).

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
  - [x] List all breaking changes in the above "Breaking Changes" section.
  - [x] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves.
    - [x] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
      - https://github.com/n0-computer/iroh-gossip/pull/58
    - [x] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
      - https://github.com/n0-computer/iroh-blobs/pull/85
    - [x] [`iroh-docs`](https://github.com/n0-computer/iroh-docs)
      - https://github.com/n0-computer/iroh-docs/pull/41
