### PR TITLE
refactor: use new derive macros from `iroh-metrics`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#357d542d2fde20f26d35ec3c56eb860fb9b6f304"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2415,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#357d542d2fde20f26d35ec3c56eb860fb9b6f304"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#2f2ba0975b5e880b98a3102324f13710433069e8"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#56845af49f5d8a2b7ea52f64ca2945679e66fd33"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3475,7 +3475,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#2f2ba0975b5e880b98a3102324f13710433069e8"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#56845af49f5d8a2b7ea52f64ca2945679e66fd33"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,18 +2398,29 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor#b7f521f03734e890725a8b2c6a70055ef97cee0b"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#357d542d2fde20f26d35ec3c56eb860fb9b6f304"
 dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "iroh-metrics-derive",
  "prometheus-client",
  "reqwest",
  "serde",
- "struct_iterable",
  "thiserror 2.0.11",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "0.1.0"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/refactor2#357d542d2fde20f26d35ec3c56eb860fb9b6f304"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2967,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#4c953aef8bab936c891224215ac3e1aaedb00942"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#2f2ba0975b5e880b98a3102324f13710433069e8"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3464,7 +3475,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#4c953aef8bab936c891224215ac3e1aaedb00942"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#2f2ba0975b5e880b98a3102324f13710433069e8"
 dependencies = [
  "base64",
  "bytes",
@@ -3474,7 +3485,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2)",
  "num_enum",
  "rand 0.8.5",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 unused-async = "warn"
 
 [patch.crates-io]
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor2" }

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -1,56 +1,41 @@
 //! Metrics support for the server
 
-use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
+use iroh_metrics::{Counter, MetricsGroup};
 
 /// Metrics for iroh-dns-server
-#[derive(Debug, Clone, Iterable)]
-#[allow(missing_docs)]
+#[derive(Debug, Clone, MetricsGroup)]
+#[metrics(name = "dns_server")]
 pub struct Metrics {
+    /// Number of pkarr relay puts that updated the state
     pub pkarr_publish_update: Counter,
+    /// Number of pkarr relay puts that did not update the state
     pub pkarr_publish_noop: Counter,
+    /// DNS requests (total)
     pub dns_requests: Counter,
+    /// DNS requests via UDP
     pub dns_requests_udp: Counter,
+    /// DNS requests via HTTPS (DoH)
     pub dns_requests_https: Counter,
+    /// DNS lookup responses with at least one answer
     pub dns_lookup_success: Counter,
+    /// DNS lookup responses with no answers
     pub dns_lookup_notfound: Counter,
+    /// DNS lookup responses which failed
     pub dns_lookup_error: Counter,
+    /// Number of HTTP requests
     pub http_requests: Counter,
+    /// Number of HTTP requests with a 2xx status code
     pub http_requests_success: Counter,
+    /// Number of HTTP requests with a non-2xx status code
     pub http_requests_error: Counter,
+    /// Total duration of all HTTP requests
     pub http_requests_duration_ms: Counter,
+    /// Signed packets inserted into the store
     pub store_packets_inserted: Counter,
+    /// Signed packets removed from the store
     pub store_packets_removed: Counter,
+    /// Number of updates to existing packets
     pub store_packets_updated: Counter,
+    /// Number of expired packets
     pub store_packets_expired: Counter,
-}
-
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            pkarr_publish_update: Counter::new("Number of pkarr relay puts that updated the state"),
-            pkarr_publish_noop: Counter::new(
-                "Number of pkarr relay puts that did not update the state",
-            ),
-            dns_requests: Counter::new("DNS requests (total)"),
-            dns_requests_udp: Counter::new("DNS requests via UDP"),
-            dns_requests_https: Counter::new("DNS requests via HTTPS (DoH)"),
-            dns_lookup_success: Counter::new("DNS lookup responses with at least one answer"),
-            dns_lookup_notfound: Counter::new("DNS lookup responses with no answers"),
-            dns_lookup_error: Counter::new("DNS lookup responses which failed"),
-            http_requests: Counter::new("Number of HTTP requests"),
-            http_requests_success: Counter::new("Number of HTTP requests with a 2xx status code"),
-            http_requests_error: Counter::new("Number of HTTP requests with a non-2xx status code"),
-            http_requests_duration_ms: Counter::new("Total duration of all HTTP requests"),
-            store_packets_inserted: Counter::new("Signed packets inserted into the store"),
-            store_packets_removed: Counter::new("Signed packets removed from the store"),
-            store_packets_updated: Counter::new("Number of updates to existing packets"),
-            store_packets_expired: Counter::new("Number of expired packets"),
-        }
-    }
-}
-
-impl MetricsGroup for Metrics {
-    fn name(&self) -> &'static str {
-        "dns_server"
-    }
 }

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -128,44 +128,21 @@ impl MetricsGroup for Metrics {
 }
 
 /// StunMetrics tracked for the relay server
-#[derive(Debug, Clone, Iterable)]
+#[derive(Debug, Clone, MetricsGroup)]
+#[metrics_group(name = "stun")]
 pub struct StunMetrics {
-    /*
-     * Metrics about STUN requests
-     */
-    /// Number of stun requests made
+    /// Number of STUN requests made to the server.
     pub requests: Counter,
-    /// Number of successful requests over ipv4
+    /// Number of successful ipv4 STUN requests served.
     pub ipv4_success: Counter,
-    /// Number of successful requests over ipv6
+    /// Number of successful ipv6 STUN requests served.
     pub ipv6_success: Counter,
-
-    /// Number of bad requests, either non-stun packets or incorrect binding request
+    /// Number of bad requests made to the STUN endpoint.
     pub bad_requests: Counter,
-    /// Number of failures
+    /// Number of STUN requests that end in failure.
     pub failures: Counter,
 }
 
-impl Default for StunMetrics {
-    fn default() -> Self {
-        Self {
-            /*
-             * Metrics about STUN requests
-             */
-            requests: Counter::new("Number of STUN requests made to the server."),
-            ipv4_success: Counter::new("Number of successful ipv4 STUN requests served."),
-            ipv6_success: Counter::new("Number of successful ipv6 STUN requests served."),
-            bad_requests: Counter::new("Number of bad requests made to the STUN endpoint."),
-            failures: Counter::new("Number of STUN requests that end in failure."),
-        }
-    }
-}
-
-impl MetricsGroup for StunMetrics {
-    fn name(&self) -> &'static str {
-        "stun"
-    }
-}
 
 #[derive(Debug, Default, Clone)]
 pub struct RelayMetrics {
@@ -178,7 +155,7 @@ impl MetricsGroupSet for RelayMetrics {
         "relay"
     }
 
-    fn iter(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
+    fn groups(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
         [
             &*self.stun as &dyn MetricsGroup,
             &*self.server as &dyn MetricsGroup,

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -10,54 +10,50 @@ pub struct Metrics {
      * Metrics about packets
      */
     /// Bytes sent from a `FrameType::SendPacket`
-    #[metrics(description = "Number of bytes sent.")]
+    #[metrics(help = "Number of bytes sent.")]
     pub bytes_sent: Counter,
     /// Bytes received from a `FrameType::SendPacket`
-    #[metrics(description = "Number of bytes received.")]
+    #[metrics(help = "Number of bytes received.")]
     pub bytes_recv: Counter,
 
     /// `FrameType::SendPacket` sent, that are not disco messages
-    #[metrics(description = "Number of 'send' packets relayed.")]
+    #[metrics(help = "Number of 'send' packets relayed.")]
     pub send_packets_sent: Counter,
     /// `FrameType::SendPacket` received, that are not disco messages
-    #[metrics(description = "Number of 'send' packets received.")]
+    #[metrics(help = "Number of 'send' packets received.")]
     pub send_packets_recv: Counter,
     /// `FrameType::SendPacket` dropped, that are not disco messages
-    #[metrics(description = "Number of 'send' packets dropped.")]
+    #[metrics(help = "Number of 'send' packets dropped.")]
     pub send_packets_dropped: Counter,
 
     /// `FrameType::SendPacket` sent that are disco messages
-    #[metrics(description = "Number of disco packets sent.")]
+    #[metrics(help = "Number of disco packets sent.")]
     pub disco_packets_sent: Counter,
     /// `FrameType::SendPacket` received that are disco messages
-    #[metrics(description = "Number of disco packets received.")]
+    #[metrics(help = "Number of disco packets received.")]
     pub disco_packets_recv: Counter,
     /// `FrameType::SendPacket` dropped that are disco messages
-    #[metrics(description = "Number of disco packets dropped.")]
+    #[metrics(help = "Number of disco packets dropped.")]
     pub disco_packets_dropped: Counter,
 
     /// Packets of other `FrameType`s sent
-    #[metrics(
-        description = "Number of packets sent that were not disco packets or 'send' packets"
-    )]
+    #[metrics(help = "Number of packets sent that were not disco packets or 'send' packets")]
     pub other_packets_sent: Counter,
     /// Packets of other `FrameType`s received
-    #[metrics(
-        description = "Number of packets received that were not disco packets or 'send' packets"
-    )]
+    #[metrics(help = "Number of packets received that were not disco packets or 'send' packets")]
     pub other_packets_recv: Counter,
     /// Packets of other `FrameType`s dropped
-    #[metrics(description = "Number of times a non-disco, non-send packet was dropped.")]
+    #[metrics(help = "Number of times a non-disco, non-send packet was dropped.")]
     pub other_packets_dropped: Counter,
 
     /// Number of `FrameType::Ping`s received
-    #[metrics(description = "Number of times the server has received a Ping from a client.")]
+    #[metrics(help = "Number of times the server has received a Ping from a client.")]
     pub got_ping: Counter,
     /// Number of `FrameType::Pong`s sent
-    #[metrics(description = "Number of times the server has sent a Pong to a client.")]
+    #[metrics(help = "Number of times the server has sent a Pong to a client.")]
     pub sent_pong: Counter,
     /// Number of `FrameType::Unknown` received
-    #[metrics(description = "Number of unknown frames sent to this server.")]
+    #[metrics(help = "Number of unknown frames sent to this server.")]
     pub unknown_frames: Counter,
 
     /// Number of frames received from client connection which have been rate-limited.
@@ -71,7 +67,7 @@ pub struct Metrics {
     /// Number of times this server has accepted a connection.
     pub accepts: Counter,
     /// Number of connections we have removed because of an error
-    #[metrics(description = "Number of clients that have then disconnected.")]
+    #[metrics(help = "Number of clients that have then disconnected.")]
     pub disconnects: Counter,
 
     /// Number of unique client keys per day

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -1,44 +1,63 @@
 use std::sync::Arc;
 
-use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup, MetricsGroupSet};
+use iroh_metrics::{Counter, MetricsGroup, MetricsGroupSet};
 
 /// Metrics tracked for the relay server
-#[derive(Debug, Clone, Iterable)]
+#[derive(Debug, Clone, MetricsGroup)]
+#[metrics(name = "relayserver")]
 pub struct Metrics {
     /*
      * Metrics about packets
      */
     /// Bytes sent from a `FrameType::SendPacket`
+    #[metrics(description = "Number of bytes sent.")]
     pub bytes_sent: Counter,
     /// Bytes received from a `FrameType::SendPacket`
+    #[metrics(description = "Number of bytes received.")]
     pub bytes_recv: Counter,
 
     /// `FrameType::SendPacket` sent, that are not disco messages
+    #[metrics(description = "Number of 'send' packets relayed.")]
     pub send_packets_sent: Counter,
     /// `FrameType::SendPacket` received, that are not disco messages
+    #[metrics(description = "Number of 'send' packets received.")]
     pub send_packets_recv: Counter,
     /// `FrameType::SendPacket` dropped, that are not disco messages
+    #[metrics(description = "Number of 'send' packets dropped.")]
     pub send_packets_dropped: Counter,
 
     /// `FrameType::SendPacket` sent that are disco messages
+    #[metrics(description = "Number of disco packets sent.")]
     pub disco_packets_sent: Counter,
     /// `FrameType::SendPacket` received that are disco messages
+    #[metrics(description = "Number of disco packets received.")]
     pub disco_packets_recv: Counter,
     /// `FrameType::SendPacket` dropped that are disco messages
+    #[metrics(description = "Number of disco packets dropped.")]
     pub disco_packets_dropped: Counter,
 
     /// Packets of other `FrameType`s sent
+    #[metrics(
+        description = "Number of packets sent that were not disco packets or 'send' packets"
+    )]
     pub other_packets_sent: Counter,
     /// Packets of other `FrameType`s received
+    #[metrics(
+        description = "Number of packets received that were not disco packets or 'send' packets"
+    )]
     pub other_packets_recv: Counter,
     /// Packets of other `FrameType`s dropped
+    #[metrics(description = "Number of times a non-disco, non-send packet was dropped.")]
     pub other_packets_dropped: Counter,
 
     /// Number of `FrameType::Ping`s received
+    #[metrics(description = "Number of times the server has received a Ping from a client.")]
     pub got_ping: Counter,
     /// Number of `FrameType::Pong`s sent
+    #[metrics(description = "Number of times the server has sent a Pong to a client.")]
     pub sent_pong: Counter,
     /// Number of `FrameType::Unknown` received
+    #[metrics(description = "Number of unknown frames sent to this server.")]
     pub unknown_frames: Counter,
 
     /// Number of frames received from client connection which have been rate-limited.
@@ -49,15 +68,16 @@ pub struct Metrics {
     /*
      * Metrics about peers
      */
-    /// Number of connections we have accepted
+    /// Number of times this server has accepted a connection.
     pub accepts: Counter,
     /// Number of connections we have removed because of an error
+    #[metrics(description = "Number of clients that have then disconnected.")]
     pub disconnects: Counter,
 
     /// Number of unique client keys per day
     pub unique_client_keys: Counter,
 
-    /// Number of accepted websocket connections
+    /// Number of accepted websocket connections.
     pub websocket_accepts: Counter,
     /// Number of accepted 'iroh derp http' connection upgrades
     pub relay_accepts: Counter,
@@ -68,68 +88,9 @@ pub struct Metrics {
     // pub average_queue_duration:
 }
 
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            /*
-             * Metrics about packets
-             */
-            send_packets_sent: Counter::new("Number of 'send' packets relayed."),
-            bytes_sent: Counter::new("Number of bytes sent."),
-            send_packets_recv: Counter::new("Number of 'send' packets received."),
-            bytes_recv: Counter::new("Number of bytes received."),
-            send_packets_dropped: Counter::new("Number of 'send' packets dropped."),
-            disco_packets_sent: Counter::new("Number of disco packets sent."),
-            disco_packets_recv: Counter::new("Number of disco packets received."),
-            disco_packets_dropped: Counter::new("Number of disco packets dropped."),
-
-            other_packets_sent: Counter::new(
-                "Number of packets sent that were not disco packets or 'send' packets",
-            ),
-            other_packets_recv: Counter::new(
-                "Number of packets received that were not disco packets or 'send' packets",
-            ),
-            other_packets_dropped: Counter::new(
-                "Number of times a non-disco, non-'send; packet was dropped.",
-            ),
-            got_ping: Counter::new("Number of times the server has received a Ping from a client."),
-            sent_pong: Counter::new("Number of times the server has sent a Pong to a client."),
-            unknown_frames: Counter::new("Number of unknown frames sent to this server."),
-            frames_rx_ratelimited_total: Counter::new(
-                "Number of frames received from client connection which have been rate-limited.",
-            ),
-            conns_rx_ratelimited_total: Counter::new(
-                "Number of client connections which have had any frames rate-limited.",
-            ),
-
-            /*
-             * Metrics about peers
-             */
-            accepts: Counter::new("Number of times this server has accepted a connection."),
-            disconnects: Counter::new("Number of clients that have then disconnected."),
-
-            unique_client_keys: Counter::new("Number of unique client keys per day."),
-
-            websocket_accepts: Counter::new("Number of accepted websocket connections"),
-            relay_accepts: Counter::new("Number of accepted 'iroh derp http' connection upgrades"),
-            // TODO: enable when we can have multiple connections for one node id
-            // pub duplicate_client_keys: Counter::new("Number of duplicate client keys."),
-            // pub duplicate_client_conns: Counter::new("Number of duplicate client connections."),
-            // TODO: only important stat that we cannot track right now
-            // pub average_queue_duration:
-        }
-    }
-}
-
-impl MetricsGroup for Metrics {
-    fn name(&self) -> &'static str {
-        "relayserver"
-    }
-}
-
 /// StunMetrics tracked for the relay server
 #[derive(Debug, Clone, MetricsGroup)]
-#[metrics_group(name = "stun")]
+#[metrics(name = "stun")]
 pub struct StunMetrics {
     /// Number of STUN requests made to the server.
     pub requests: Counter,
@@ -142,7 +103,6 @@ pub struct StunMetrics {
     /// Number of STUN requests that end in failure.
     pub failures: Counter,
 }
-
 
 #[derive(Debug, Default, Clone)]
 pub struct RelayMetrics {

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -104,7 +104,7 @@ hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 # portmapper = { version = "0.4.1", default-features = false }
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics2" }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1135,18 +1135,16 @@ impl Endpoint {
     /// For example, the following snippet collects all metrics into a map:
     /// ```rust
     /// # use std::collections::BTreeMap;
-    /// # use iroh_metrics::{MetricsGroup, MetricValue, MetricsGroupSet};
+    /// # use iroh_metrics::{Metric, MetricsGroup, MetricValue, MetricsGroupSet};
     /// # use iroh::endpoint::Endpoint;
     /// # async fn wrapper() -> testresult::TestResult {
     /// let endpoint = Endpoint::builder().bind().await?;
     /// let metrics: BTreeMap<String, MetricValue> = endpoint
     ///     .metrics()
     ///     .iter()
-    ///     .flat_map(|group| {
-    ///         group.values().map(|item| {
-    ///             let name = [group.name(), item.name].join(":");
-    ///             (name, item.value)
-    ///         })
+    ///     .map(|(group, metric)| {
+    ///         let name = [group, metric.name()].join(":");
+    ///         (name, metric.value())
     ///     })
     ///     .collect();
     ///

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -1,9 +1,11 @@
-use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
+use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
+// TODO(frando): Add description doc strings for each metric.
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Iterable)]
+#[derive(Debug, Clone, MetricsGroup)]
 #[non_exhaustive]
+#[metrics(name = "magicsock")]
 pub struct Metrics {
     pub re_stun_calls: Counter,
     pub update_direct_addrs: Counter,
@@ -76,82 +78,4 @@ pub struct Metrics {
     pub connection_handshake_success: Counter,
     /// Number of connections with a successful handshake that became direct.
     pub connection_became_direct: Counter,
-}
-
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            num_relay_conns_added: Counter::new("num_relay_conns added"),
-            num_relay_conns_removed: Counter::new("num_relay_conns removed"),
-
-            re_stun_calls: Counter::new("restun_calls"),
-            update_direct_addrs: Counter::new("update_endpoints"),
-
-            // Sends (data or disco)
-            send_ipv4: Counter::new("send_ipv4"),
-            send_ipv6: Counter::new("send_ipv6"),
-            send_relay: Counter::new("send_relay"),
-            send_relay_error: Counter::new("send_relay_error"),
-
-            // Data packets (non-disco)
-            send_data: Counter::new("send_data"),
-            send_data_network_down: Counter::new("send_data_network_down"),
-            recv_data_relay: Counter::new("recv_data_relay"),
-            recv_data_ipv4: Counter::new("recv_data_ipv4"),
-            recv_data_ipv6: Counter::new("recv_data_ipv6"),
-            recv_datagrams: Counter::new("recv_datagrams"),
-            recv_gro_datagrams: Counter::new("recv_gro_packets"),
-
-            // Disco packets
-            send_disco_udp: Counter::new("disco_send_udp"),
-            send_disco_relay: Counter::new("disco_send_relay"),
-            sent_disco_udp: Counter::new("disco_sent_udp"),
-            sent_disco_relay: Counter::new("disco_sent_relay"),
-            sent_disco_ping: Counter::new("disco_sent_ping"),
-            sent_disco_pong: Counter::new("disco_sent_pong"),
-            sent_disco_call_me_maybe: Counter::new("disco_sent_callmemaybe"),
-            recv_disco_bad_key: Counter::new("disco_recv_bad_key"),
-            recv_disco_bad_parse: Counter::new("disco_recv_bad_parse"),
-
-            recv_disco_udp: Counter::new("disco_recv_udp"),
-            recv_disco_relay: Counter::new("disco_recv_relay"),
-            recv_disco_ping: Counter::new("disco_recv_ping"),
-            recv_disco_pong: Counter::new("disco_recv_pong"),
-            recv_disco_call_me_maybe: Counter::new("disco_recv_callmemaybe"),
-            recv_disco_call_me_maybe_bad_disco: Counter::new("disco_recv_callmemaybe_bad_disco"),
-
-            // How many times our relay home node DI has changed from non-zero to a different non-zero.
-            relay_home_change: Counter::new("relay_home_change"),
-
-            num_direct_conns_added: Counter::new(
-                "number of direct connections to a peer we have added",
-            ),
-            num_direct_conns_removed: Counter::new(
-                "number of direct connections to a peer we have removed",
-            ),
-
-            actor_tick_main: Counter::new("actor_tick_main"),
-            actor_tick_msg: Counter::new("actor_tick_msg"),
-            actor_tick_re_stun: Counter::new("actor_tick_re_stun"),
-            actor_tick_portmap_changed: Counter::new("actor_tick_portmap_changed"),
-            actor_tick_direct_addr_heartbeat: Counter::new("actor_tick_direct_addr_heartbeat"),
-            actor_tick_direct_addr_update_receiver: Counter::new(
-                "actor_tick_direct_addr_update_receiver",
-            ),
-            actor_link_change: Counter::new("actor_link_change"),
-            actor_tick_other: Counter::new("actor_tick_other"),
-
-            nodes_contacted: Counter::new("nodes_contacted"),
-            nodes_contacted_directly: Counter::new("nodes_contacted_directly"),
-
-            connection_handshake_success: Counter::new("connection_handshake_success"),
-            connection_became_direct: Counter::new("connection_became_direct"),
-        }
-    }
-}
-
-impl MetricsGroup for Metrics {
-    fn name(&self) -> &'static str {
-        "magicsock"
-    }
 }

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -24,7 +24,7 @@ pub struct EndpointMetrics {
 }
 
 impl MetricsGroupSet for EndpointMetrics {
-    fn iter(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
+    fn groups(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
         #[cfg(not(wasm_browser))]
         return [
             &*self.magicsock as &dyn MetricsGroup,

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -1,38 +1,22 @@
-use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
+use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Iterable)]
+#[derive(Debug, Clone, MetricsGroup)]
+#[metrics(name = "net_report")]
 pub struct Metrics {
+    /// Incoming STUN packets dropped due to a full receiving queue.
     pub stun_packets_dropped: Counter,
+    /// Number of IPv4 STUN packets sent.
     pub stun_packets_sent_ipv4: Counter,
+    /// Number of IPv6 STUN packets sent.
     pub stun_packets_sent_ipv6: Counter,
+    /// Number of IPv4 STUN packets received.
     pub stun_packets_recv_ipv4: Counter,
+    /// Number of IPv6 STUN packets received.
     pub stun_packets_recv_ipv6: Counter,
+    /// Number of reports executed by net_report, including full reports.
     pub reports: Counter,
+    /// Number of full reports executed by net_report
     pub reports_full: Counter,
-}
-
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            stun_packets_dropped: Counter::new(
-                "Incoming STUN packets dropped due to a full receiving queue.",
-            ),
-            stun_packets_sent_ipv4: Counter::new("Number of IPv4 STUN packets sent"),
-            stun_packets_sent_ipv6: Counter::new("Number of IPv6 STUN packets sent"),
-            stun_packets_recv_ipv4: Counter::new("Number of IPv4 STUN packets received"),
-            stun_packets_recv_ipv6: Counter::new("Number of IPv6 STUN packets received"),
-            reports: Counter::new(
-                "Number of reports executed by net_report, including full reports",
-            ),
-            reports_full: Counter::new("Number of full reports executed by net_report"),
-        }
-    }
-}
-
-impl MetricsGroup for Metrics {
-    fn name(&self) -> &'static str {
-        "net_report"
-    }
 }


### PR DESCRIPTION
## Description

Based on #3262 
Depends on https://github.com/n0-computer/iroh-metrics/pull/18

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
