### PR TITLE
chore(iroh): Add `echo-no-router.rs` example

### DIFF
--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -210,5 +210,9 @@ name = "echo"
 required-features = ["examples"]
 
 [[example]]
+name = "echo-no-router"
+required-features = ["examples"]
+
+[[example]]
 name = "transfer"
 required-features = ["examples"]


### PR DESCRIPTION
## Description

Adds an example showing how to implement a basic protocol without using a `Router`.
As a bonus, one can compare what `echo.rs` and `echo-no-router.rs` are doing to see the difference.

## Notes & open questions

I think this is slightly useful, but YMMV. I don't think it's a lot of work to maintain though.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
