### PR TITLE
ci: update to mozilla-actions/sccache-action@v0.0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Setup Environment (PR)
         if: ${{ github.event_name == 'pull_request' }}
@@ -238,7 +238,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - uses: mozilla-actions/sccache-action@v0.0.7
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: taiki-e/install-action@cargo-make
       - run: cargo make format-check
 
@@ -256,7 +256,7 @@ jobs:
         with:
           toolchain: nightly-2024-11-30
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Docs
         run: cargo doc --workspace --all-features --no-deps --document-private-items
@@ -273,7 +273,7 @@ jobs:
         with:
           components: clippy
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       # TODO: We have a bunch of platform-dependent code so should
       #    probably run this job on the full platform matrix
@@ -300,7 +300,7 @@ jobs:
         with:
           toolchain: ${{ env.MSRV }}
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Check MSRV all features
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,7 @@ jobs:
       with:
         toolchain: nightly-2024-11-30
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Generate Docs
       run: cargo doc --workspace --all-features --no-deps

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -109,7 +109,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Build iroh
       run: |
@@ -142,7 +142,7 @@ jobs:
       shell: bash
       run: |
         echo "LAST_COMMIT_SHA=$(git rev-parse --short ${GITHUB_SHA})" >> ${GITHUB_ENV}
-  
+
     - name: Run tests
       id: run_tests
       continue-on-error: true
@@ -163,14 +163,14 @@ jobs:
         python3 reports_csv.py --prom --commit ${{ env.LAST_COMMIT_SHA }} > report_prom.txt
         python3 reports_csv.py --metro --commit ${{ env.LAST_COMMIT_SHA }} > report_metro.txt
         python3 reports_csv.py --metro --integration --commit ${{ env.LAST_COMMIT_SHA }} > report_metro_integration.txt
-    
+
     - name: Upload report
       if: always()
       run: |
         export AWS_ACCESS_KEY_ID=${{secrets.S3_ACCESS_KEY_ID}}
         export AWS_SECRET_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}
         export AWS_DEFAULT_REGION=us-west-2
-        
+
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
         unzip -q awscliv2.zip
         sudo ./aws/install --update
@@ -181,7 +181,7 @@ jobs:
         tar -cvzf report.tar.gz report_prom.txt report_table.txt report_metro.txt report_metro_integration.txt logs/ report/ viz/
         if [[ -n "${{ secrets.S3_BUCKET }}" ]]; then
           aws s3 cp ./report.tar.gz s3://${{secrets.S3_REPORT_BUCKET}}/$aws_fname --no-progress
-        fi        
+        fi
 
     - name: Move report
       if: always()
@@ -197,7 +197,7 @@ jobs:
         path: report.tar.gz
         retention-days: 3
         overwrite: true
-    
+
     - name: Fail Job if Tests Failed
       if: ${{ steps.run_tests.outcome == 'failure' }}
       run: |
@@ -222,10 +222,10 @@ jobs:
         body: |
           Netsim report & logs for this PR have been generated and is available at: [LOGS](${{steps.upload-report.outputs.artifact-url}})
           This report will remain available for 3 days.
-          
+
           Last updated for commit: ${{ env.LAST_COMMIT_SHA }}
         edit-mode: replace
-    
+
     - name: Generate report table
       if: ${{ inputs.pr_number != '' && inputs.report_table}}
       id: generate_report_table

--- a/.github/workflows/test_relay_server.yml
+++ b/.github/workflows/test_relay_server.yml
@@ -32,7 +32,7 @@ jobs:
         - name: Install rust stable
           uses: dtolnay/rust-toolchain@stable
         - name: Install sccache
-          uses: mozilla-actions/sccache-action@v0.0.7
+          uses: mozilla-actions/sccache-action@v0.0.9
 
         - name: build release
           run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
           tool: nextest@0.9.80
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Select features
         run: |
@@ -206,7 +206,7 @@ jobs:
           }
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: msys2/setup-msys2@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,9 +752,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
This is needed because of
https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts