### PR TITLE
use macro to DRY the snafu error enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2492,7 +2492,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2521,6 +2521,7 @@ dependencies = [
  "lru",
  "n0-future",
  "n0-snafu",
+ "nested_enum_utils",
  "num_enum",
  "pin-project",
  "pkarr",
@@ -2876,6 +2877,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "nested_enum_utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9130744b54f1dee2499dcfe7c3704985740bb42bd0e1b7c292b2cc2b15ffc6a2"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3725,7 +3738,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4101,7 +4114,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4799,7 +4812,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5635,7 +5648,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -94,6 +94,7 @@ toml = { version = "0.8", optional = true }
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
+nested_enum_utils = "0.2.0"
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -15,6 +15,7 @@ use n0_future::{
     split::{split, SplitSink, SplitStream},
     time, Sink, Stream,
 };
+use nested_enum_utils::common_fields;
 use snafu::{Backtrace, Snafu};
 #[cfg(any(test, feature = "test-utils"))]
 use tracing::warn;
@@ -38,86 +39,39 @@ mod tls;
 mod util;
 
 /// Connection errors
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: n0_snafu::SpanTrace,
+})]
 #[allow(missing_docs)]
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 #[snafu(visibility(pub(crate)))]
 pub enum ConnectError {
     #[snafu(display("Invalid URL for websocket: {url}"))]
-    InvalidWebsocketUrl {
-        url: Url,
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    InvalidWebsocketUrl { url: Url },
     #[snafu(display("Invalid relay URL: {url}"))]
-    InvalidRelayUrl {
-        url: Url,
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    InvalidRelayUrl { url: Url },
     #[snafu(transparent)]
-    Websocket {
-        source: tokio_websockets::Error,
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    Websocket { source: tokio_websockets::Error },
     #[snafu(transparent)]
-    Handshake {
-        source: HandshakeError,
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    Handshake { source: HandshakeError },
     #[snafu(transparent)]
-    Dial {
-        source: DialError,
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    Dial { source: DialError },
     #[snafu(display("Unexpected status during upgrade: {code}"))]
-    UnexpectedUpgradeStatus {
-        code: hyper::StatusCode,
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    UnexpectedUpgradeStatus { code: hyper::StatusCode },
     #[snafu(display("Failed to upgrade response"))]
-    Upgrade {
-        source: hyper::Error,
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    Upgrade { source: hyper::Error },
     #[snafu(display("Invalid TLS servername"))]
-    InvalidTlsServername {
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    InvalidTlsServername {},
     #[snafu(display("No local address available"))]
-    NoLocalAddr {
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    NoLocalAddr {},
     #[snafu(display("tls connection failed"))]
-    Tls {
-        source: std::io::Error,
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    Tls { source: std::io::Error },
     #[cfg(wasm_browser)]
     #[snafu(display("The relay protocol is not available in browsers"))]
-    RelayProtoNotAvailable {
-        backtrace: Option<Backtrace>,
-        #[snafu(implicit)]
-        span_trace: n0_snafu::SpanTrace,
-    },
+    RelayProtoNotAvailable {},
 }
 
 /// Dialing errors


### PR DESCRIPTION
## Description

Use a new macro from nested-enum-utils to DRY the strum error enums. One example.

## Breaking Changes

Adds a dependency.

## Notes & open questions

Should we reexport common_fields from n0_snafu?

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
