### PR TITLE
refactor: update to latest iroh-metrics branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2972,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#640166ea310788a1fabca4ea99fc8cb0c6ae70f4"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#dae8cea85713f36a3880c40893c17ccb3f712af0"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3469,7 +3469,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#640166ea310788a1fabca4ea99fc8cb0c6ae70f4"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#dae8cea85713f36a3880c40893c17ccb3f712af0"
 dependencies = [
  "base64",
  "bytes",
@@ -5563,7 +5563,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,6 +2266,7 @@ dependencies = [
  "pin-project",
  "pkarr",
  "portmapper",
+ "postcard",
  "pretty_assertions",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -2972,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#dae8cea85713f36a3880c40893c17ccb3f712af0"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3469,7 +3470,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#dae8cea85713f36a3880c40893c17ccb3f712af0"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,12 +1038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,14 +2392,13 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d64b607e49f67fa42b3e780109cad0fa1fdb476b4a78d4cf8443499bbc1ad0a"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
 dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
  "iroh-metrics-derive",
- "prometheus-client",
+ "itoa",
  "reqwest",
  "serde",
  "thiserror 2.0.11",
@@ -2416,8 +2409,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa484b5f192006b1cc39261712d65baf87342fc72a4acc1560355d1dc410d9"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2980,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ef897c745d78dbd19429bdf6131f91c9563c2c1a"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#640166ea310788a1fabca4ea99fc8cb0c6ae70f4"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3477,7 +3469,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ef897c745d78dbd19429bdf6131f91c9563c2c1a"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#640166ea310788a1fabca4ea99fc8cb0c6ae70f4"
 dependencies = [
  "base64",
  "bytes",
@@ -3487,7 +3479,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2)",
  "num_enum",
  "rand 0.8.5",
  "serde",
@@ -3611,29 +3603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -5594,7 +5563,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2402,7 +2402,7 @@ dependencies = [
  "itoa",
  "reqwest",
  "serde",
- "thiserror 2.0.11",
+ "snafu",
  "tokio",
  "tracing",
 ]
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ff9840322c1c57dc87010f2909f174c5bb8944b3"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3470,7 +3470,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ff9840322c1c57dc87010f2909f174c5bb8944b3"
 dependencies = [
  "base64",
  "bytes",
@@ -3480,7 +3480,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2)",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
  "num_enum",
  "rand 0.8.5",
  "serde",
@@ -4504,6 +4504,27 @@ name = "smol_str"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+
+[[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "socket2"

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -28,7 +28,7 @@ governor = "0.6.3" #needs new release of tower_governor for 0.7.0
 hickory-server = { version = "0.25.1", features = ["https-ring"] }
 http = "1.0.0"
 humantime-serde = "1.1.1"
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", features = ["service"] }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main", features = ["service"] }
 lru = "0.12.3"
 n0-future = "0.1.2"
 pkarr = { version = "2.3.1", features = [ "async", "relay", "dht"], default-features = false }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -28,7 +28,7 @@ governor = "0.6.3" #needs new release of tower_governor for 0.7.0
 hickory-server = { version = "0.25.1", features = ["https-ring"] }
 http = "1.0.0"
 humantime-serde = "1.1.1"
-iroh-metrics = { version = "0.33.0", features = ["metrics", "service"] }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", features = ["service"] }
 lru = "0.12.3"
 n0-future = "0.1.2"
 pkarr = { version = "2.3.1", features = [ "async", "relay", "dht"], default-features = false }

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -3,7 +3,7 @@
 use iroh_metrics::{Counter, MetricsGroup};
 
 /// Metrics for iroh-dns-server
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "dns_server")]
 pub struct Metrics {
     /// Number of pkarr relay puts that updated the state

--- a/iroh-dns-server/src/server.rs
+++ b/iroh-dns-server/src/server.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use iroh_metrics::{service::start_metrics_server, MetricsGroup};
+use iroh_metrics::service::start_metrics_server;
 use tracing::info;
 
 use crate::{
@@ -62,8 +62,8 @@ impl Server {
         let metrics_task = tokio::task::spawn(async move {
             if let Some(addr) = metrics_addr {
                 let mut registry = iroh_metrics::Registry::default();
-                metrics.register(&mut registry);
-                start_metrics_server(addr, std::sync::Arc::new(registry)).await?;
+                registry.register(metrics);
+                start_metrics_server(addr, Arc::new(registry)).await?;
             }
             Ok(())
         });

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -33,7 +33,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 iroh-base = { version = "0.34.1", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
-iroh-metrics = { version = "0.33", default-features = false }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", default-features = false }
 n0-future = "0.1.2"
 num_enum = "0.7"
 pin-project = "1"

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -33,7 +33,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 iroh-base = { version = "0.34.1", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", default-features = false }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main", default-features = false }
 n0-future = "0.1.2"
 num_enum = "0.7"
 pin-project = "1"

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -27,7 +27,6 @@ use hyper::body::Incoming;
 use iroh_base::NodeId;
 #[cfg(feature = "test-utils")]
 use iroh_base::RelayUrl;
-use iroh_metrics::MetricsGroupSet;
 use metrics::RelayMetrics;
 use n0_future::{future::Boxed, StreamExt};
 use tokio::{
@@ -288,7 +287,7 @@ impl Server {
         if let Some(addr) = config.metrics_addr {
             debug!("Starting metrics server");
             let mut registry = iroh_metrics::Registry::default();
-            metrics.register(&mut registry);
+            registry.register_all(&metrics);
             tasks.spawn(
                 async move {
                     iroh_metrics::service::start_metrics_server(addr, Arc::new(registry)).await?;

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use iroh_metrics::{Counter, MetricsGroup, MetricsGroupSet};
 
 /// Metrics tracked for the relay server
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "relayserver")]
 pub struct Metrics {
     /*
@@ -85,7 +85,7 @@ pub struct Metrics {
 }
 
 /// StunMetrics tracked for the relay server
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "stun")]
 pub struct StunMetrics {
     /// Number of STUN requests made to the server.
@@ -100,22 +100,9 @@ pub struct StunMetrics {
     pub failures: Counter,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, MetricsGroupSet)]
+#[metrics(name = "relay")]
 pub struct RelayMetrics {
     pub stun: Arc<StunMetrics>,
     pub server: Arc<Metrics>,
-}
-
-impl MetricsGroupSet for RelayMetrics {
-    fn name(&self) -> &'static str {
-        "relay"
-    }
-
-    fn groups(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
-        [
-            &*self.stun as &dyn MetricsGroup,
-            &*self.server as &dyn MetricsGroup,
-        ]
-        .into_iter()
-    }
 }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -128,6 +128,7 @@ time = { version = "0.3", features = ["wasm-bindgen"] }
 
 # target-common test/dev dependencies
 [dev-dependencies]
+postcard = { version = "1.1.1", features = ["use-std"] }
 testresult = "0.4.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -81,7 +81,7 @@ x509-parser = "0.16"
 z32 = "1.0.3"
 
 # metrics
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", default-features = false }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main", default-features = false }
 
 # local-swarm-discovery
 swarm-discovery = { version = "0.3.1", optional = true }
@@ -104,7 +104,7 @@ hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 # portmapper = { version = "0.4.1", default-features = false }
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics2" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -81,7 +81,7 @@ x509-parser = "0.16"
 z32 = "1.0.3"
 
 # metrics
-iroh-metrics = { version = "0.33", default-features = false }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset", default-features = false }
 
 # local-swarm-discovery
 swarm-discovery = { version = "0.3.1", optional = true }
@@ -104,7 +104,7 @@ hickory-resolver = "0.25.1"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
 # portmapper = { version = "0.4.1", default-features = false }
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "Frando/metrics2" }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.22"
 bytes = "1.7"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh = { path = ".." }
-iroh-metrics = "0.33"
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset" }
 n0-future = "0.1.1"
 quinn = { package = "iroh-quinn", version = "0.13" }
 rand = "0.8"

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.22"
 bytes = "1.7"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh = { path = ".." }
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main" }
 n0-future = "0.1.1"
 quinn = { package = "iroh-quinn", version = "0.13" }
 rand = "0.8"

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2902,8 +2902,8 @@ mod tests {
 
         // test openmetrics encoding with labeled subregistries per endpoint
         fn register_endpoint(registry: &mut Registry, endpoint: &Endpoint) {
-            let id = endpoint.node_id().fmt_short().into();
-            let sub_registry = registry.sub_registry_with_label(("id".into(), id));
+            let id = endpoint.node_id().fmt_short();
+            let sub_registry = registry.sub_registry_with_label("id", id);
             endpoint.metrics().register(sub_registry);
         }
         let mut registry = Registry::default();

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1199,7 +1199,10 @@ impl Endpoint {
     ///
     /// // Wait for the metrics server to bind, then fetch the metrics via HTTP.
     /// tokio::time::sleep(Duration::from_millis(500));
-    /// let res = reqwest::get("http://localhost:9100/metrics").await?.text().await?;
+    /// let res = reqwest::get("http://localhost:9100/metrics")
+    ///     .await?
+    ///     .text()
+    ///     .await?;
     ///
     /// assert!(res.contains(r#"TYPE magicsock_recv_datagrams counter"#));
     /// assert!(res.contains(r#"magicsock_recv_datagrams_total 0"#));

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2092,7 +2092,7 @@ mod tests {
 
     use std::time::Instant;
 
-    use iroh_metrics::{service::MetricsSource, MetricsGroupSet};
+    use iroh_metrics::MetricsSource;
     use iroh_relay::http::Protocol;
     use n0_future::StreamExt;
     use rand::SeedableRng;
@@ -2904,12 +2904,12 @@ mod tests {
         fn register_endpoint(registry: &mut Registry, endpoint: &Endpoint) {
             let id = endpoint.node_id().fmt_short();
             let sub_registry = registry.sub_registry_with_label("id", id);
-            endpoint.metrics().register(sub_registry);
+            sub_registry.register_all(endpoint.metrics());
         }
         let mut registry = Registry::default();
         register_endpoint(&mut registry, &client);
         register_endpoint(&mut registry, &server);
-        let s = registry.encode_openmetrics()?;
+        let s = registry.encode_openmetrics_to_string()?;
         assert!(s.contains(r#"magicsock_nodes_contacted_directly_total{id="3b6a27bcce"} 1"#));
         assert!(s.contains(r#"magicsock_nodes_contacted_directly_total{id="8a88e3dd74"} 1"#));
 

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -3,7 +3,7 @@ use iroh_metrics::{Counter, MetricsGroup};
 /// Enum of metrics for the module
 // TODO(frando): Add description doc strings for each metric.
 #[allow(missing_docs)]
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[non_exhaustive]
 #[metrics(name = "magicsock")]
 pub struct Metrics {

--- a/iroh/src/magicsock/metrics.rs
+++ b/iroh/src/magicsock/metrics.rs
@@ -1,9 +1,10 @@
 use iroh_metrics::{Counter, MetricsGroup};
+use serde::{Deserialize, Serialize};
 
 /// Enum of metrics for the module
 // TODO(frando): Add description doc strings for each metric.
 #[allow(missing_docs)]
-#[derive(Debug, Default, MetricsGroup)]
+#[derive(Debug, Default, Serialize, Deserialize, MetricsGroup)]
 #[non_exhaustive]
 #[metrics(name = "magicsock")]
 pub struct Metrics {

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Co-locating all of the iroh metrics structs
 use std::sync::Arc;
 
-use iroh_metrics::{MetricsGroup, MetricsGroupSet};
+use iroh_metrics::MetricsGroupSet;
 #[cfg(feature = "test-utils")]
 pub use iroh_relay::server::Metrics as RelayMetrics;
 #[cfg(not(wasm_browser))]
@@ -12,7 +12,8 @@ pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as N
 /// Metrics collected by an [`crate::endpoint::Endpoint`].
 ///
 /// See [`crate::endpoint::Endpoint::metrics`] for details.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, MetricsGroupSet)]
+#[metrics(name = "endpoint")]
 #[non_exhaustive]
 pub struct EndpointMetrics {
     /// Metrics collected by the endpoint's socket.
@@ -22,26 +23,4 @@ pub struct EndpointMetrics {
     /// Metrics collected by the portmapper service.
     #[cfg(not(wasm_browser))]
     pub portmapper: Arc<PortmapMetrics>,
-}
-
-impl MetricsGroupSet for EndpointMetrics {
-    fn groups(&self) -> impl Iterator<Item = &dyn MetricsGroup> {
-        #[cfg(not(wasm_browser))]
-        return [
-            &*self.magicsock as &dyn MetricsGroup,
-            &*self.net_report as &dyn MetricsGroup,
-            &*self.portmapper as &dyn MetricsGroup,
-        ]
-        .into_iter();
-        #[cfg(wasm_browser)]
-        return [
-            &*self.magicsock as &dyn MetricsGroup,
-            &*self.net_report as &dyn MetricsGroup,
-        ]
-        .into_iter();
-    }
-
-    fn name(&self) -> &'static str {
-        "endpoint"
-    }
 }

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -6,13 +6,14 @@ use iroh_metrics::MetricsGroupSet;
 pub use iroh_relay::server::Metrics as RelayMetrics;
 #[cfg(not(wasm_browser))]
 pub use portmapper::Metrics as PortmapMetrics;
+use serde::{Deserialize, Serialize};
 
 pub use crate::{magicsock::Metrics as MagicsockMetrics, net_report::Metrics as NetReportMetrics};
 
 /// Metrics collected by an [`crate::endpoint::Endpoint`].
 ///
 /// See [`crate::endpoint::Endpoint::metrics`] for details.
-#[derive(Default, Debug, Clone, MetricsGroupSet)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, MetricsGroupSet)]
 #[metrics(name = "endpoint")]
 #[non_exhaustive]
 pub struct EndpointMetrics {
@@ -23,4 +24,19 @@ pub struct EndpointMetrics {
     /// Metrics collected by the portmapper service.
     #[cfg(not(wasm_browser))]
     pub portmapper: Arc<PortmapMetrics>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EndpointMetrics;
+    #[test]
+    fn test_serde() {
+        let metrics = EndpointMetrics::default();
+        metrics.magicsock.actor_link_change.inc();
+        metrics.net_report.reports.inc_by(10);
+        let encoded = postcard::to_stdvec(&metrics).unwrap();
+        let decoded: EndpointMetrics = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded.magicsock.actor_link_change.get(), 1);
+        assert_eq!(decoded.net_report.reports.get(), 10);
+    }
 }

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -1,7 +1,7 @@
 use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "net_report")]
 #[non_exhaustive]
 pub struct Metrics {

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -1,7 +1,8 @@
 use iroh_metrics::{Counter, MetricsGroup};
+use serde::{Deserialize, Serialize};
 
 /// Enum of metrics for the module
-#[derive(Debug, Default, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup, Serialize, Deserialize)]
 #[metrics(name = "net_report")]
 #[non_exhaustive]
 pub struct Metrics {


### PR DESCRIPTION
## Description

Updates #3262 to the latest changes in iroh-metrics (see PRs below)

Depends on #3262
Depends on https://github.com/n0-computer/net-tools/pull/23
Depends on https://github.com/n0-computer/iroh-metrics/pull/22
Depends on https://github.com/n0-computer/iroh-metrics/pull/23

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [x] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
        - https://github.com/n0-computer/iroh-gossip/pull/62
    - [x] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
       - https://github.com/n0-computer/iroh-blobs/pull/85
 