### PR TITLE
feat(iroh): Allow connecting with "fallback" ALPNs

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -253,7 +253,7 @@ impl Builder {
     /// Sets the [ALPN] protocols that this endpoint will accept on incoming connections.
     ///
     /// Not setting this will still allow creating connections, but to accept incoming
-    /// connections the [ALPN] must be set.
+    /// connections at least one [ALPN] must be set.
     ///
     /// [ALPN]: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation
     pub fn alpns(mut self, alpn_protocols: Vec<Vec<u8>>) -> Self {
@@ -1282,7 +1282,23 @@ impl ConnectOptions {
         self
     }
 
-    /// TODO
+    /// Sets more [ALPN] identifiers that should be signaled as supported on connection.
+    ///
+    /// This allows connecting to servers that may only support older versions of your
+    /// protocol. In this case, you would add the older [ALPN] identifiers with this
+    /// function.
+    ///
+    /// You'll know the final negotiated [ALPN] identifier once your connection was
+    /// established using [`Connection::alpn`], or even slightly earlier in the
+    /// handshake by using [`Connecting::alpn`].
+    ///
+    /// The [ALPN] identifier order on the connect side doesn't matter, since it's the
+    /// accept side that determines the protocol.
+    ///
+    /// For setting the supported [ALPN] identifiers on the accept side, see the endpoint
+    /// builder's [`Builder::alpns`] function.
+    ///
+    /// [ALPN]: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation
     pub fn with_additional_alpns(mut self, alpns: Vec<Vec<u8>>) -> Self {
         self.additional_alpns = alpns;
         self

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -752,7 +752,8 @@ impl Endpoint {
             "Attempting connection..."
         );
         let client_config = {
-            let alpn_protocols = vec![alpn.to_vec()];
+            let mut alpn_protocols = vec![alpn.to_vec()];
+            alpn_protocols.extend(options.additional_alpns);
             let quic_client_config = self.static_config.tls_auth.make_client_config(
                 &self.static_config.secret_key,
                 node_id,
@@ -1263,6 +1264,7 @@ impl Endpoint {
 #[derive(Default, Debug, Clone)]
 pub struct ConnectOptions {
     transport_config: Option<Arc<TransportConfig>>,
+    additional_alpns: Vec<Vec<u8>>,
 }
 
 impl ConnectOptions {
@@ -1277,6 +1279,12 @@ impl ConnectOptions {
     /// Sets the QUIC transport config options for this connection.
     pub fn with_transport_config(mut self, transport_config: Arc<TransportConfig>) -> Self {
         self.transport_config = Some(transport_config);
+        self
+    }
+
+    /// TODO
+    pub fn with_additional_alpns(mut self, alpns: Vec<Vec<u8>>) -> Self {
+        self.additional_alpns = alpns;
         self
     }
 }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1282,7 +1282,8 @@ impl ConnectOptions {
         self
     }
 
-    /// Sets more [ALPN] identifiers that should be signaled as supported on connection.
+    /// Sets [ALPN] identifiers that should be signaled as supported on connection, *in
+    /// addition* to the main [ALPN] identifier used in [`Endpoint::connect_with_opts`].
     ///
     /// This allows connecting to servers that may only support older versions of your
     /// protocol. In this case, you would add the older [ALPN] identifiers with this
@@ -1290,7 +1291,9 @@ impl ConnectOptions {
     ///
     /// You'll know the final negotiated [ALPN] identifier once your connection was
     /// established using [`Connection::alpn`], or even slightly earlier in the
-    /// handshake by using [`Connecting::alpn`].
+    /// handshake by using [`Connecting::alpn`], and the negotiated [ALPN] identifier
+    /// may be any of the [ALPN] identifiers in this list or the main [ALPN] used in
+    /// [`Endpoint::connect_with_opts`].
     ///
     /// The [ALPN] identifier order on the connect side doesn't matter, since it's the
     /// accept side that determines the protocol.

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1291,9 +1291,9 @@ impl ConnectOptions {
     ///
     /// You'll know the final negotiated [ALPN] identifier once your connection was
     /// established using [`Connection::alpn`], or even slightly earlier in the
-    /// handshake by using [`Connecting::alpn`], and the negotiated [ALPN] identifier
-    /// may be any of the [ALPN] identifiers in this list or the main [ALPN] used in
-    /// [`Endpoint::connect_with_opts`].
+    /// handshake by using [`Connecting::alpn`].
+    /// The negotiated [ALPN] identifier may be any of the [ALPN] identifiers in this
+    /// list or the main [ALPN] used in [`Endpoint::connect_with_opts`].
     ///
     /// The [ALPN] identifier order on the connect side doesn't matter, since it's the
     /// accept side that determines the protocol.


### PR DESCRIPTION
## Description

Allows connecting with multiple ALPNs so you can actually take advantage of ALPN also on the connecting side to support connections with older accept sides.

## Notes & open questions

This only implements this via the `ConnectOptions`, which I think is fair? I generally like the pattern of `connect` -> `connect_with_opts`, and I don't think this is worth changing `connect` for.

Closes #2949 

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
