### PR TITLE
feat(iroh-relay): Convert all client-side errors to snafu

### DIFF
--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -52,7 +52,6 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { version = "1", features = ["derive", "rc"] }
 strum = { version = "0.26", features = ["derive"] }
 stun-rs = "0.1.5"
-thiserror = "2"
 tokio = { version = "1", features = [
     "io-util",
     "macros",
@@ -88,6 +87,7 @@ rustls-cert-reloadable-resolver = { version = "0.7.1", optional = true }
 rustls-cert-file-reader = { version = "0.4.1", optional = true }
 rustls-pemfile = { version = "2.1", optional = true }
 time = { version = "0.3.37", optional = true }
+thiserror = { version = "2", optional = true }
 tokio-rustls-acme = { version = "0.7.1", optional = true }
 tokio-websockets = { version = "0.11.3", features = ["rustls-bring-your-own-connector", "ring", "getrandom", "rand", "server"], optional = true } # server-side websocket implementation
 toml = { version = "0.8", optional = true }
@@ -154,6 +154,7 @@ server = [
     "dep:rustls-cert-reloadable-resolver",
     "dep:rustls-pemfile",
     "dep:time",
+    "dep:thiserror",
     "dep:tokio-rustls-acme",
     "dep:tokio-websockets",
     "dep:toml",

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -54,7 +54,12 @@ pub enum ConnectError {
     #[snafu(display("Invalid relay URL: {url}"))]
     InvalidRelayUrl { url: Url },
     #[snafu(transparent)]
-    Websocket { source: tokio_websockets::Error },
+    Websocket {
+        #[cfg(not(wasm_browser))]
+        source: tokio_websockets::Error,
+        #[cfg(wasm_browser)]
+        source: ws_stream_wasm::WsErr,
+    },
     #[snafu(transparent)]
     Handshake { source: crate::protos::relay::Error },
     #[snafu(transparent)]

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -233,7 +233,7 @@ impl ClientBuilder {
                 (conn, Some(local_addr))
             }
             #[cfg(wasm_browser)]
-            Protocol::Relay => return Err(ConnectError::RelayProtoNotAvailable),
+            Protocol::Relay => return Err(RelayProtoNotAvailableSnafu.build()),
         };
 
         event!(

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -22,7 +22,7 @@ use tracing::warn;
 use tracing::{debug, event, trace, Level};
 use url::Url;
 
-pub use self::conn::{ConnSendError, HandshakeError, ReceivedMessage, RecvError, SendMessage};
+pub use self::conn::{ReceivedMessage, RecvError, SendError, SendMessage};
 #[cfg(not(wasm_browser))]
 use crate::dns::{DnsResolver, Error as DnsError};
 use crate::{
@@ -56,7 +56,7 @@ pub enum ConnectError {
     #[snafu(transparent)]
     Websocket { source: tokio_websockets::Error },
     #[snafu(transparent)]
-    Handshake { source: HandshakeError },
+    Handshake { source: crate::protos::relay::Error },
     #[snafu(transparent)]
     Dial { source: DialError },
     #[snafu(display("Unexpected status during upgrade: {code}"))]
@@ -75,30 +75,36 @@ pub enum ConnectError {
 }
 
 /// Dialing errors
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: n0_snafu::SpanTrace,
+})]
 #[allow(missing_docs)]
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Snafu)]
 #[non_exhaustive]
+#[snafu(visibility(pub(crate)))]
 pub enum DialError {
-    #[error("Invliad target port")]
-    InvalidTargetPort,
-    #[error(transparent)]
+    #[snafu(display("Invliad target port"))]
+    InvalidTargetPort {},
+    #[snafu(transparent)]
     #[cfg(not(wasm_browser))]
-    Dns(#[from] DnsError),
-    #[error("Timeout")]
-    Timeout(#[from] time::Elapsed),
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-    #[error("Invalid URL {0}")]
-    InvalidUrl(Url),
-    #[error("Failed proxy connection: {0}")]
-    ProxyConnectInvalidStatus(hyper::StatusCode),
-    #[error("Invalid Proxy URL {0}")]
-    ProxyInvalidUrl(Url),
-    #[error("failed to establish proxy connection")]
-    ProxyConnect(#[source] hyper::Error),
-    #[error("Invalid proxy TLS servername")]
-    ProxyInvalidTlsServername,
-    #[error("Invliad proxy target port")]
+    Dns { source: DnsError },
+    #[snafu(transparent)]
+    Timeout { source: time::Elapsed },
+    #[snafu(transparent)]
+    Io { source: std::io::Error },
+    #[snafu(display("Invalid URL: {url}"))]
+    InvalidUrl { url: Url },
+    #[snafu(display("Failed proxy connection: {status}"))]
+    ProxyConnectInvalidStatus { status: hyper::StatusCode },
+    #[snafu(display("Invalid Proxy URL {proxy_url}"))]
+    ProxyInvalidUrl { proxy_url: Url },
+    #[snafu(display("failed to establish proxy connection"))]
+    ProxyConnect { source: hyper::Error },
+    #[snafu(display("Invalid proxy TLS servername: {proxy_hostname}"))]
+    ProxyInvalidTlsServername { proxy_hostname: String },
+    #[snafu(display("Invalid proxy target port"))]
     ProxyInvalidTargetPort,
 }
 
@@ -294,7 +300,7 @@ impl Stream for Client {
 }
 
 impl Sink<SendMessage> for Client {
-    type Error = ConnSendError;
+    type Error = SendError;
 
     fn poll_ready(
         mut self: Pin<&mut Self>,
@@ -329,7 +335,7 @@ pub struct ClientSink {
 }
 
 impl Sink<SendMessage> for ClientSink {
-    type Error = ConnSendError;
+    type Error = SendError;
 
     fn poll_ready(
         mut self: Pin<&mut Self>,

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -318,9 +318,8 @@ impl Sink<SendMessage> for Conn {
 
     fn start_send(mut self: Pin<&mut Self>, item: SendMessage) -> Result<(), Self::Error> {
         if let SendMessage::SendPacket(_, bytes) = &item {
-            if bytes.len() > MAX_PACKET_SIZE {
-                return Err(ExceedsMaxPacketSizeSnafu { size: bytes.len() }.build());
-            }
+            let size = bytes.len();
+            snafu::ensure!(size <= MAX_PACKET_SIZE, ExceedsMaxPacketSizeSnafu { size });
         }
         let frame = Frame::from(item);
         match *self {

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -67,7 +67,12 @@ pub enum RecvError {
     #[snafu(transparent)]
     Protocol { source: crate::protos::relay::Error },
     #[snafu(transparent)]
-    Websocket { source: tokio_websockets::Error },
+    Websocket {
+        #[cfg(not(wasm_browser))]
+        source: tokio_websockets::Error,
+        #[cfg(wasm_browser)]
+        source: ws_stream_wasm::WsErr,
+    },
     #[snafu(display("invalid protocol message encoding"))]
     InvalidProtocolMessageEncoding { source: Utf8Error },
     #[snafu(display("Unexpected frame received: {frame_type}"))]

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -436,7 +436,7 @@ impl TryFrom<Frame> for ReceivedMessage {
             Frame::Pong { data } => Ok(ReceivedMessage::Pong(data)),
             Frame::Health { problem } => {
                 let problem = std::str::from_utf8(&problem)
-                    .context(InvalidProtocolMessageEncodingSnafu {})?
+                    .context(InvalidProtocolMessageEncodingSnafu)?
                     .to_owned();
                 let problem = Some(problem);
                 Ok(ReceivedMessage::Health { problem })

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -177,7 +177,7 @@ impl DnsResolver {
         prefer_ipv6: bool,
         timeout: Duration,
     ) -> Result<IpAddr, Error> {
-        let host = url.host().context(MissingHostSnafu {})?;
+        let host = url.host().context(MissingHostSnafu)?;
         match host {
             url::Host::Domain(domain) => {
                 // Need to do a DNS lookup
@@ -198,9 +198,9 @@ impl DnsResolver {
                     (Ok(mut v4), Ok(mut v6)) => (v4.next(), v6.next()),
                 };
                 if prefer_ipv6 {
-                    v6.or(v4).context(NoResponseSnafu {})
+                    v6.or(v4).context(NoResponseSnafu)
                 } else {
-                    v4.or(v6).context(NoResponseSnafu {})
+                    v4.or(v6).context(NoResponseSnafu)
                 }
             }
             url::Host::Ipv4(ip) => Ok(IpAddr::V4(ip)),
@@ -459,7 +459,7 @@ pub(crate) mod tests {
             let r_pos = DONE_CALL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             async move {
                 tracing::info!(r_pos, "call");
-                CALL_RESULTS[r_pos].map_err(|_| InvalidResponseSnafu {}.build())
+                CALL_RESULTS[r_pos].map_err(|_| InvalidResponseSnafu.build())
             }
         };
 

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -43,6 +43,8 @@ use std::{
 #[cfg(not(wasm_browser))]
 use hickory_resolver::{proto::ProtoError, Name};
 use iroh_base::{NodeAddr, NodeId, RelayUrl, SecretKey, SignatureError};
+use nested_enum_utils::common_fields;
+use snafu::{Backtrace, ResultExt, Snafu};
 #[cfg(not(wasm_browser))]
 use tracing::warn;
 use url::Url;
@@ -56,24 +58,31 @@ use crate::{
 /// The DNS name for the iroh TXT record.
 pub const IROH_TXT_NAME: &str = "_iroh";
 
-#[derive(Debug, thiserror::Error)]
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: n0_snafu::SpanTrace,
+})]
 #[allow(missing_docs)]
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+#[snafu(visibility(pub(crate)))]
 pub enum Error {
-    #[error("node id was not encoded in valid z32")]
-    InvalidEncodingZ32(#[from] z32::Z32Error),
-    #[error("length must be 32 bytes")]
-    InvalidLength,
-    #[error("node id is not a valid public key")]
-    InvalidSignature(#[from] SignatureError),
-    #[error("name is not a valid TXT label")]
-    InvalidLabel(#[from] ProtoError),
-    #[error("failed to resolve TXT record")]
-    LookupFailed(#[from] DnsError),
-    #[error(transparent)]
-    Pkarr(#[from] pkarr::Error),
-    #[error("invalid TXT entry")]
-    InvalidTxtEntry(#[source] pkarr::dns::SimpleDnsError),
-    #[error("no calls succeeded: [{}]", errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(""))]
+    #[snafu(display("node id was not encoded in valid z32"))]
+    InvalidEncodingZ32 { source: z32::Z32Error },
+    #[snafu(display("length must be 32 bytes, but got {len} byte(s)"))]
+    InvalidLength { len: usize },
+    #[snafu(display("node id is not a valid public key"))]
+    InvalidSignature { source: SignatureError },
+    #[snafu(display("name is not a valid TXT label"))]
+    InvalidLabel { source: ProtoError },
+    #[snafu(display("failed to resolve TXT record"))]
+    LookupFailed { source: DnsError },
+    #[snafu(transparent)]
+    Pkarr { source: pkarr::Error },
+    #[snafu(display("invalid TXT entry"))]
+    InvalidTxtEntry { source: pkarr::dns::SimpleDnsError },
+    #[snafu(display("no calls succeeded: [{}]", errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("")))]
     Staggered { errors: Vec<Error> },
 }
 
@@ -97,9 +106,11 @@ impl NodeIdExt for NodeId {
     }
 
     fn from_z32(s: &str) -> Result<NodeId, Error> {
-        let bytes = z32::decode(s.as_bytes())?;
-        let bytes: &[u8; 32] = &bytes.try_into().map_err(|_| Error::InvalidLength)?;
-        let node_id = NodeId::from_bytes(bytes)?;
+        let bytes = z32::decode(s.as_bytes()).context(InvalidEncodingZ32Snafu {})?;
+        let bytes: &[u8; 32] = &bytes
+            .try_into()
+            .map_err(|_| InvalidLengthSnafu { len: s.len() }.build())?;
+        let node_id = NodeId::from_bytes(bytes).context(InvalidSignatureSnafu {})?;
         Ok(node_id)
     }
 }
@@ -217,16 +228,21 @@ impl UserData {
 }
 
 /// Error returned when an input value is too long for [`UserData`].
-#[derive(Debug, thiserror::Error)]
-#[error("User-defined data exceeds max length")]
-pub struct MaxLengthExceededError;
+#[allow(missing_docs)]
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub struct MaxLengthExceededError {
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: n0_snafu::SpanTrace,
+}
 
 impl TryFrom<String> for UserData {
     type Error = MaxLengthExceededError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         if value.len() > Self::MAX_LENGTH {
-            Err(MaxLengthExceededError)
+            Err(MaxLengthExceededSnafu {}.build())
         } else {
             Ok(Self(value))
         }
@@ -238,7 +254,7 @@ impl FromStr for UserData {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         if s.len() > Self::MAX_LENGTH {
-            Err(MaxLengthExceededError)
+            Err(MaxLengthExceededSnafu {}.build())
         } else {
             Ok(Self(s.to_string()))
         }
@@ -508,7 +524,10 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
     #[cfg(not(wasm_browser))]
     async fn lookup(resolver: &DnsResolver, name: Name) -> Result<Self, Error> {
         let name = ensure_iroh_txt_label(name)?;
-        let lookup = resolver.lookup_txt(name, DNS_TIMEOUT).await?;
+        let lookup = resolver
+            .lookup_txt(name, DNS_TIMEOUT)
+            .await
+            .context(LookupFailedSnafu {})?;
         let attrs = Self::from_txt_lookup(lookup)?;
         Ok(attrs)
     }
@@ -527,7 +546,7 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
     /// Looks up attributes by DNS name.
     #[cfg(not(wasm_browser))]
     pub(crate) async fn lookup_by_name(resolver: &DnsResolver, name: &str) -> Result<Self, Error> {
-        let name = Name::from_str(name)?;
+        let name = Name::from_str(name).context(InvalidLabelSnafu {})?;
         TxtAttrs::lookup(resolver, name).await
     }
 
@@ -567,8 +586,12 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
     /// Parses a TXT records lookup.
     #[cfg(not(wasm_browser))]
     pub(crate) fn from_txt_lookup(lookup: crate::dns::TxtLookup) -> Result<Self, Error> {
+        use snafu::OptionExt;
+
+        // TODO(matheus23): Errors here are extremely weird and need cleanup
         let queried_node_id = node_id_from_hickory_name(lookup.0.query().name())
-            .ok_or_else(|| DnsError::InvalidResponse)?;
+            .context(crate::dns::InvalidResponseSnafu {})
+            .context(LookupFailedSnafu {})?;
 
         let strings = lookup.0.as_lookup().record_iter().filter_map(|record| {
             match node_id_from_hickory_name(record.name()) {
@@ -635,7 +658,7 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
         let mut packet = dns::Packet::new_reply(0);
         for s in self.to_txt_strings() {
             let mut txt = rdata::TXT::new();
-            txt.add_string(&s).map_err(Error::InvalidTxtEntry)?;
+            txt.add_string(&s).context(InvalidTxtEntrySnafu {})?;
             let rdata = rdata::RData::TXT(txt.into_owned());
             packet.answers.push(dns::ResourceRecord::new(
                 name.clone(),
@@ -649,18 +672,18 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
 }
 
 #[cfg(not(wasm_browser))]
-fn ensure_iroh_txt_label(name: Name) -> Result<Name, ProtoError> {
+fn ensure_iroh_txt_label(name: Name) -> Result<Name, Error> {
     if name.iter().next() == Some(IROH_TXT_NAME.as_bytes()) {
         Ok(name)
     } else {
-        Name::parse(IROH_TXT_NAME, Some(&name))
+        Name::parse(IROH_TXT_NAME, Some(&name)).context(InvalidLabelSnafu {})
     }
 }
 
 #[cfg(not(wasm_browser))]
 fn node_domain(node_id: &NodeId, origin: &str) -> Result<Name, Error> {
     let domain = format!("{}.{}", NodeId::to_z32(node_id), origin);
-    let domain = Name::from_str(&domain)?;
+    let domain = Name::from_str(&domain).context(InvalidLabelSnafu {})?;
     Ok(domain)
 }
 

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -241,11 +241,8 @@ impl TryFrom<String> for UserData {
     type Error = MaxLengthExceededError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        if value.len() > Self::MAX_LENGTH {
-            Err(MaxLengthExceededSnafu {}.build())
-        } else {
-            Ok(Self(value))
-        }
+        snafu::ensure!(value.len() <= Self::MAX_LENGTH, MaxLengthExceededSnafu {});
+        Ok(Self(value))
     }
 }
 
@@ -253,11 +250,8 @@ impl FromStr for UserData {
     type Err = MaxLengthExceededError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        if s.len() > Self::MAX_LENGTH {
-            Err(MaxLengthExceededSnafu {}.build())
-        } else {
-            Ok(Self(s.to_string()))
-        }
+        snafu::ensure!(s.len() <= Self::MAX_LENGTH, MaxLengthExceededSnafu {});
+        Ok(Self(s.to_string()))
     }
 }
 

--- a/iroh-relay/src/protos/stun.rs
+++ b/iroh-relay/src/protos/stun.rs
@@ -90,13 +90,11 @@ pub fn parse_binding_request(b: &[u8]) -> Result<TransactionId, Error> {
         .with_validation() // ensure fingerprint is validated
         .build();
     let decoder = MessageDecoderBuilder::default().with_context(ctx).build();
-    let (msg, _) = decoder
-        .decode(b)
-        .map_err(|_| InvalidMessageSnafu {}.build())?;
+    let (msg, _) = decoder.decode(b).map_err(|_| InvalidMessageSnafu.build())?;
 
     let tx = *msg.transaction_id();
     if msg.method() != methods::BINDING {
-        return Err(NotBindingSnafu {}.build());
+        return Err(NotBindingSnafu.build());
     }
 
     // TODO: Tailscale sets the software to tailscale, we should check if we want to do this too.
@@ -107,7 +105,7 @@ pub fn parse_binding_request(b: &[u8]) -> Result<TransactionId, Error> {
         .map(|attr| !attr.is_fingerprint())
         .unwrap_or_default()
     {
-        return Err(NoFingerprintSnafu {}.build());
+        return Err(NoFingerprintSnafu.build());
     }
 
     Ok(tx)
@@ -117,13 +115,11 @@ pub fn parse_binding_request(b: &[u8]) -> Result<TransactionId, Error> {
 /// The IP address is extracted from the XOR-MAPPED-ADDRESS attribute.
 pub fn parse_response(b: &[u8]) -> Result<(TransactionId, SocketAddr), Error> {
     let decoder = MessageDecoder::default();
-    let (msg, _) = decoder
-        .decode(b)
-        .map_err(|_| InvalidMessageSnafu {}.build())?;
+    let (msg, _) = decoder.decode(b).map_err(|_| InvalidMessageSnafu.build())?;
 
     let tx = *msg.transaction_id();
     if msg.class() != MessageClass::SuccessResponse {
-        return Err(NotSuccessResponseSnafu {}.build());
+        return Err(NotSuccessResponseSnafu.build());
     }
 
     // Read through the attributes.
@@ -158,7 +154,7 @@ pub fn parse_response(b: &[u8]) -> Result<(TransactionId, SocketAddr), Error> {
         return Ok((tx, addr));
     }
 
-    Err(MalformedAttrsSnafu {}.build())
+    Err(MalformedAttrsSnafu.build())
 }
 
 #[cfg(test)]

--- a/iroh-relay/src/protos/stun.rs
+++ b/iroh-relay/src/protos/stun.rs
@@ -2,6 +2,8 @@
 
 use std::net::SocketAddr;
 
+use nested_enum_utils::common_fields;
+use snafu::{Backtrace, Snafu};
 use stun_rs::{
     attributes::stun::{Fingerprint, XorMappedAddress},
     DecoderContextBuilder, MessageDecoderBuilder, MessageEncoderBuilder, StunMessageBuilder,
@@ -12,26 +14,34 @@ pub use stun_rs::{
 };
 
 /// Errors that can occur when handling a STUN packet.
-#[derive(Debug, thiserror::Error)]
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: n0_snafu::SpanTrace,
+})]
+#[allow(missing_docs)]
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+#[snafu(visibility(pub(crate)))]
 pub enum Error {
     /// The STUN message could not be parsed or is otherwise invalid.
-    #[error("invalid message")]
-    InvalidMessage,
+    #[snafu(display("invalid message"))]
+    InvalidMessage {},
     /// STUN request is not a binding request when it should be.
-    #[error("not binding")]
-    NotBinding,
+    #[snafu(display("not binding"))]
+    NotBinding {},
     /// STUN packet is not a response when it should be.
-    #[error("not success response")]
-    NotSuccessResponse,
+    #[snafu(display("not success response"))]
+    NotSuccessResponse {},
     /// STUN response has malformed attributes.
-    #[error("malformed attributes")]
-    MalformedAttrs,
+    #[snafu(display("malformed attributes"))]
+    MalformedAttrs {},
     /// STUN request didn't end in fingerprint.
-    #[error("no fingerprint")]
-    NoFingerprint,
+    #[snafu(display("no fingerprint"))]
+    NoFingerprint {},
     /// STUN request had bogus fingerprint.
-    #[error("invalid fingerprint")]
-    InvalidFingerprint,
+    #[snafu(display("invalid fingerprint"))]
+    InvalidFingerprint {},
 }
 
 /// Generates a binding request STUN packet.
@@ -80,11 +90,13 @@ pub fn parse_binding_request(b: &[u8]) -> Result<TransactionId, Error> {
         .with_validation() // ensure fingerprint is validated
         .build();
     let decoder = MessageDecoderBuilder::default().with_context(ctx).build();
-    let (msg, _) = decoder.decode(b).map_err(|_| Error::InvalidMessage)?;
+    let (msg, _) = decoder
+        .decode(b)
+        .map_err(|_| InvalidMessageSnafu {}.build())?;
 
     let tx = *msg.transaction_id();
     if msg.method() != methods::BINDING {
-        return Err(Error::NotBinding);
+        return Err(NotBindingSnafu {}.build());
     }
 
     // TODO: Tailscale sets the software to tailscale, we should check if we want to do this too.
@@ -95,7 +107,7 @@ pub fn parse_binding_request(b: &[u8]) -> Result<TransactionId, Error> {
         .map(|attr| !attr.is_fingerprint())
         .unwrap_or_default()
     {
-        return Err(Error::NoFingerprint);
+        return Err(NoFingerprintSnafu {}.build());
     }
 
     Ok(tx)
@@ -105,11 +117,13 @@ pub fn parse_binding_request(b: &[u8]) -> Result<TransactionId, Error> {
 /// The IP address is extracted from the XOR-MAPPED-ADDRESS attribute.
 pub fn parse_response(b: &[u8]) -> Result<(TransactionId, SocketAddr), Error> {
     let decoder = MessageDecoder::default();
-    let (msg, _) = decoder.decode(b).map_err(|_| Error::InvalidMessage)?;
+    let (msg, _) = decoder
+        .decode(b)
+        .map_err(|_| InvalidMessageSnafu {}.build())?;
 
     let tx = *msg.transaction_id();
     if msg.class() != MessageClass::SuccessResponse {
-        return Err(Error::NotSuccessResponse);
+        return Err(NotSuccessResponseSnafu {}.build());
     }
 
     // Read through the attributes.
@@ -144,7 +158,7 @@ pub fn parse_response(b: &[u8]) -> Result<(TransactionId, SocketAddr), Error> {
         return Ok((tx, addr));
     }
 
-    Err(Error::MalformedAttrs)
+    Err(MalformedAttrsSnafu {}.build())
 }
 
 #[cfg(test)]

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -399,7 +399,7 @@ mod tests {
 
         println!("Closed in {time:?}");
         assert!(Duration::from_millis(900) < time);
-        assert!(time < Duration::from_millis(1100));
+        assert!(time < Duration::from_millis(1500)); // give it some lee-way. Apparently github actions ubuntu runners can be slow?
 
         Ok(())
     }

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -3,10 +3,12 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use n0_future::time::Duration;
+use nested_enum_utils::common_fields;
 use quinn::{
     crypto::rustls::{NoInitialCipherSuite, QuicClientConfig},
     VarInt,
 };
+use snafu::{Backtrace, Snafu};
 use tokio::sync::watch;
 
 /// ALPN for our quic addr discovery
@@ -196,17 +198,24 @@ pub(crate) mod server {
 }
 
 /// Quic client related errors.
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: n0_snafu::SpanTrace,
+})]
 #[allow(missing_docs)]
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+#[snafu(visibility(pub(crate)))]
 pub enum Error {
-    #[error(transparent)]
-    Connect(#[from] quinn::ConnectError),
-    #[error(transparent)]
-    Connection(#[from] quinn::ConnectionError),
-    #[error(transparent)]
-    WatchRecv(#[from] watch::error::RecvError),
-    #[error(transparent)]
-    NoIntitialCipherSuite(#[from] NoInitialCipherSuite),
+    #[snafu(transparent)]
+    Connect { source: quinn::ConnectError },
+    #[snafu(transparent)]
+    Connection { source: quinn::ConnectionError },
+    #[snafu(transparent)]
+    WatchRecv { source: watch::error::RecvError },
+    #[snafu(transparent)]
+    NoIntitialCipherSuite { source: NoInitialCipherSuite },
 }
 
 /// Handles the client side of QUIC address discovery.

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -43,7 +43,7 @@ use iroh_base::{NodeId, PublicKey, RelayUrl, SecretKey};
 use iroh_metrics::{inc, inc_by};
 use iroh_relay::{
     self as relay,
-    client::{Client, ConnSendError, ConnectError, ReceivedMessage, RecvError, SendMessage},
+    client::{Client, ConnectError, ReceivedMessage, RecvError, SendError, SendMessage},
     PingTracker, MAX_PACKET_SIZE,
 };
 use n0_future::{
@@ -253,7 +253,7 @@ enum RunError {
     #[snafu(display("Client stream read failed"))]
     ClientStreamRead { source: RecvError },
     #[snafu(transparent)]
-    Send { source: ConnSendError },
+    Send { source: SendError },
 }
 
 #[allow(missing_docs)]

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -252,8 +252,8 @@ enum RunError {
     StreamClosedServer {},
     #[snafu(display("Client stream read failed"))]
     ClientStreamRead { source: RecvError },
-    #[snafu(transparent)]
-    Send { source: SendError },
+    #[snafu(display("Client stream write failed"))]
+    ClientStreamWrite { source: SendError },
 }
 
 #[allow(missing_docs)]
@@ -518,7 +518,8 @@ impl ActiveRelayActor {
             home_relay = self.is_home_relay,
         );
 
-        let (mut client_stream, mut client_sink) = client.split();
+        let (mut client_stream, client_sink) = client.split();
+        let mut client_sink = client_sink.sink_map_err(|e| ClientStreamWriteSnafu.into_error(e));
 
         let mut state = ConnectedRelayState {
             ping_tracker: PingTracker::default(),
@@ -730,9 +731,9 @@ impl ActiveRelayActor {
     /// the actor should shut down, consult the [`ActiveRelayActor::stop_token`] and
     /// [`ActiveRelayActor::inactive_timeout`] for this, or the send was successful.
     #[instrument(name = "tx", skip_all)]
-    async fn run_sending<T, E: Into<RunError>>(
+    async fn run_sending<T>(
         &mut self,
-        sending_fut: impl Future<Output = Result<T, E>>,
+        sending_fut: impl Future<Output = Result<T, RunError>>,
         state: &mut ConnectedRelayState,
         client_stream: &mut iroh_relay::client::ClientStream,
     ) -> Result<(), RelayConnectionError> {


### PR DESCRIPTION
## Description

- Converts more relay client side errors to snafu
- Removes thiserror dependency, unless server feature is enabled
- Completely removed `HandshakeError` and simply pass through the `relay::protos::Error`

## Breaking Changes

Yes, the error types.

Renamed `ConnSendError` to `SendError`, to align with `RecvError`.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
