### PR TITLE
fix(iroh-relay): don't stop relay client actor if queues become full

### DIFF
--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -365,7 +365,9 @@ impl Actor {
         match frame {
             Frame::SendPacket { dst_key, packet } => {
                 let packet_len = packet.len();
-                self.handle_frame_send_packet(dst_key, packet)?;
+                if let Err(err) = self.handle_frame_send_packet(dst_key, packet) {
+                    warn!("failed to handle send packet frame: {err:#}");
+                }
                 self.metrics.bytes_recv.inc_by(packet_len as u64);
             }
             Frame::Ping { data } => {

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -389,7 +389,7 @@ impl Actor {
         Ok(())
     }
 
-    fn handle_frame_send_packet(&self, dst: NodeId, data: Bytes) -> Result<()> {
+    fn handle_frame_send_packet(&self, dst: NodeId, data: Bytes) -> Result<(), ForwardPacketError> {
         if disco::looks_like_disco_wrapper(&data) {
             self.metrics.disco_packets_recv.inc();
             self.clients
@@ -400,6 +400,31 @@ impl Actor {
                 .send_packet(dst, data, self.node_id, &self.metrics)?;
         }
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum PacketScope {
+    Disco,
+    Data,
+}
+
+#[derive(Debug)]
+pub(crate) enum SendError {
+    Full,
+    Closed,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("failed to forward {scope:?} packet: {reason:?}")]
+pub(crate) struct ForwardPacketError {
+    scope: PacketScope,
+    reason: SendError,
+}
+
+impl ForwardPacketError {
+    pub(crate) fn new(scope: PacketScope, reason: SendError) -> Self {
+        Self { scope, reason }
     }
 }
 

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -365,7 +365,9 @@ impl Actor {
         match frame {
             Frame::SendPacket { dst_key, packet } => {
                 let packet_len = packet.len();
-                if let Err(err) = self.handle_frame_send_packet(dst_key, packet) {
+                if let Err(err @ ForwardPacketError { .. }) =
+                    self.handle_frame_send_packet(dst_key, packet)
+                {
                     warn!("failed to handle send packet frame: {err:#}");
                 }
                 self.metrics.bytes_recv.inc_by(packet_len as u64);

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -126,7 +126,7 @@ impl Clients {
                     dst = dst.fmt_short(),
                     "client too busy to receive packet, dropping packet"
                 );
-                bail!("failed to send message: full");
+                bail!("failed to send packet message: full");
             }
             Err(TrySendError::Closed(_)) => {
                 debug!(
@@ -134,7 +134,7 @@ impl Clients {
                     "can no longer write to client, dropping message and pruning connection"
                 );
                 client.start_shutdown();
-                bail!("failed to send message: gone");
+                bail!("failed to send packet message: gone");
             }
         }
     }
@@ -166,7 +166,7 @@ impl Clients {
                     dst = dst.fmt_short(),
                     "client too busy to receive disco packet, dropping packet"
                 );
-                bail!("failed to send message: full");
+                bail!("failed to send disco message: full");
             }
             Err(TrySendError::Closed(_)) => {
                 debug!(
@@ -174,7 +174,7 @@ impl Clients {
                     "can no longer write to client, dropping disco message and pruning connection"
                 );
                 client.start_shutdown();
-                bail!("failed to send message: gone");
+                bail!("failed to send disco message: gone");
             }
         }
     }

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -129,10 +129,7 @@ impl Clients {
                     dst = dst.fmt_short(),
                     "client too busy to receive packet, dropping packet"
                 );
-                return Err(ForwardPacketError::new(
-                    PacketScope::Data,
-                    SendError::Closed,
-                ));
+                Err(ForwardPacketError::new(PacketScope::Data, SendError::Full))
             }
             Err(TrySendError::Closed(_)) => {
                 debug!(
@@ -140,10 +137,10 @@ impl Clients {
                     "can no longer write to client, dropping message and pruning connection"
                 );
                 client.start_shutdown();
-                return Err(ForwardPacketError::new(
+                Err(ForwardPacketError::new(
                     PacketScope::Data,
                     SendError::Closed,
-                ));
+                ))
             }
         }
     }
@@ -175,7 +172,7 @@ impl Clients {
                     dst = dst.fmt_short(),
                     "client too busy to receive disco packet, dropping packet"
                 );
-                return Err(ForwardPacketError::new(PacketScope::Disco, SendError::Full));
+                Err(ForwardPacketError::new(PacketScope::Disco, SendError::Full))
             }
             Err(TrySendError::Closed(_)) => {
                 debug!(
@@ -183,10 +180,10 @@ impl Clients {
                     "can no longer write to client, dropping disco message and pruning connection"
                 );
                 client.start_shutdown();
-                return Err(ForwardPacketError::new(
+                Err(ForwardPacketError::new(
                     PacketScope::Disco,
                     SendError::Closed,
-                ));
+                ))
             }
         }
     }


### PR DESCRIPTION
## Description

This is a fix to the iroh-relay server.

Current situation: If a client stream becomes full (because the client is not reading fast enough from the network), the internal queue where messages to that client are queued becomes full too. Now, when another client wants to send a message to the filled-up client, instead of skipping over the message we propagate the error such that the sending client's actor dies. This is bad, we should instead just drop the message.

This PR changes the behavior to log the failed forward (at WARN level) but does not stop the sending client's actor.

It also adds a test that fails without the change and passes with the change.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Tests if relevant.
