### PR TITLE
chore: make clippy 1.87 happy

### DIFF
--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -57,7 +57,7 @@ impl From<tokio_websockets::Error> for ConnSendError {
     fn from(err: tokio_websockets::Error) -> Self {
         let io_err = match err {
             tokio_websockets::Error::Io(io_err) => io_err,
-            _ => std::io::Error::new(std::io::ErrorKind::Other, err.to_string()),
+            _ => std::io::Error::other(err.to_string()),
         };
         Self::Io(io_err)
     }

--- a/iroh-relay/src/client/streams.rs
+++ b/iroh-relay/src/client/streams.rs
@@ -15,6 +15,7 @@ use tokio::{
 
 use super::util;
 
+#[allow(clippy::large_enum_variant)]
 pub enum MaybeTlsStreamChained {
     Raw(util::Chain<std::io::Cursor<Bytes>, ProxyStream>),
     Tls(util::Chain<std::io::Cursor<Bytes>, tokio_rustls::client::TlsStream<ProxyStream>>),
@@ -112,6 +113,7 @@ pub fn downcast_upgrade(upgraded: Upgraded) -> Result<MaybeTlsStreamChained> {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum ProxyStream {
     Raw(TcpStream),
     Proxied(util::Chain<std::io::Cursor<Bytes>, MaybeTlsStream<TcpStream>>),
@@ -190,6 +192,7 @@ impl ProxyStream {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum MaybeTlsStream<IO> {
     Raw(IO),
     Tls(tokio_rustls::client::TlsStream<IO>),

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -28,7 +28,7 @@ pub(crate) enum RelayedStream {
 fn ws_to_io_err(e: tokio_websockets::Error) -> std::io::Error {
     match e {
         tokio_websockets::Error::Io(io_err) => io_err,
-        _ => std::io::Error::new(std::io::ErrorKind::Other, e.to_string()),
+        _ => std::io::Error::other(e.to_string()),
     }
 }
 
@@ -105,6 +105,7 @@ impl Stream for RelayedStream {
 ///
 /// Allows choosing whether or not the underlying [`tokio::net::TcpStream`] is served over Tls
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum MaybeTlsStream {
     /// A plain non-Tls [`tokio::net::TcpStream`]
     Plain(tokio::net::TcpStream),

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1569,6 +1569,7 @@ impl Incoming {
     /// This requires the client to retry with address validation.
     ///
     /// Errors if `remote_address_validated()` is true.
+    #[allow(clippy::result_large_err)]
     pub fn retry(self) -> Result<(), RetryError> {
         self.inner.retry()
     }
@@ -1698,6 +1699,7 @@ impl Connecting {
     ///
     /// You can use [`RecvStream::is_0rtt`] to check whether a stream has been opened in 0-RTT
     /// and thus whether parts of the stream are operating under this reduced security level.
+    #[allow(clippy::result_large_err)]
     pub fn into_0rtt(self) -> Result<(Connection, ZeroRttAccepted), Self> {
         match self.inner.into_0rtt() {
             Ok((inner, zrtt_accepted)) => {

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -774,7 +774,7 @@ impl MagicSock {
                 .sockets
                 .v6
                 .as_ref()
-                .ok_or(io::Error::new(io::ErrorKind::Other, "no IPv6 connection"))?,
+                .ok_or(io::Error::other("no IPv6 connection"))?,
         };
         Ok(sock)
     }
@@ -1388,7 +1388,7 @@ impl MagicSock {
             }
             SendAddr::Relay(ref url) => {
                 if !self.send_disco_message_relay(url, dst_key, msg) {
-                    return Err(io::Error::new(io::ErrorKind::Other, "Relay channel full"));
+                    return Err(io::Error::other("Relay channel full"));
                 }
             }
         }

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -366,6 +366,7 @@ pub(crate) struct Inflight {
 
 /// Messages to send to the [`Actor`].
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Message {
     /// Run a net_report.
     ///


### PR DESCRIPTION
## Description

The newly released Rust 1.87 apparently makes some clippy lints for large enum or error variants tick earlier than before, and some other lints got stronger too.
See any recent PR run, e.g. https://github.com/n0-computer/iroh/actions/runs/15063556139/job/42343263605?pr=3309

This adds the fixes as applied by `clippy --fix`, and adds `allow`s for the large variants. Not sure if we actually would want to care about these large variants?

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
