### PR TITLE
feat(iroh): Allow protocols to gracefully shutdown connections

### DIFF
--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -122,10 +122,17 @@ pub trait ProtocolHandler: Send + Sync + std::fmt::Debug + 'static {
 
     /// Handle an incoming connection.
     ///
-    /// This runs on a freshly spawned tokio task so this can be long-running.
+    /// This runs on a freshly spawned tokio task so the returned future can be long-running.
+    ///
+    /// When [`Router::shutdown`] is called, no further connections will be accepted, and
+    /// the futures returned by [`Self::accept`] will be aborted after the future returned
+    /// from [`ProtocolHandler::shutdown`] completes.
     fn accept(&self, connection: Connection) -> BoxFuture<Result<()>>;
 
-    /// Called when the node shuts down.
+    /// Called when the router shuts down.
+    ///
+    /// This is called from [`Router::shutdown`]. The returned future is awaited before
+    /// the router closes the endpoint.
     fn shutdown(&self) -> BoxFuture<()> {
         Box::pin(async move {})
     }

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -434,7 +434,7 @@ mod tests {
     use testresult::TestResult;
 
     use super::*;
-    use crate::{endpoint::ConnectionError, watcher::Watcher};
+    use crate::{endpoint::ConnectionError, watcher::Watcher, RelayMode};
 
     #[tokio::test]
     async fn test_shutdown() -> Result<()> {
@@ -528,13 +528,19 @@ mod tests {
             }
         }
 
-        let endpoint = Endpoint::builder().bind().await?;
+        let endpoint = Endpoint::builder()
+            .relay_mode(RelayMode::Disabled)
+            .bind()
+            .await?;
         let router = Router::builder(endpoint)
             .accept(TEST_ALPN, TestProtocol::default())
             .spawn();
         let addr = router.endpoint().node_addr().initialized().await?;
 
-        let endpoint2 = Endpoint::builder().bind().await?;
+        let endpoint2 = Endpoint::builder()
+            .relay_mode(RelayMode::Disabled)
+            .bind()
+            .await?;
         let conn = endpoint2.connect(addr, TEST_ALPN).await?;
 
         router.shutdown().await?;


### PR DESCRIPTION
## Description

Currently, when `Router::shutdown` is called, we shutdown the endpoint and await the futures returned from `ProtocolHandler::shutdown` concurrently. This means that `ProtocolHandler::shutdown` cannot actually gracefully close their connections, because `Endpoint::close` is already called at the same time, which closes all connections immediately with an error code `0`.

This PR changes the shutdown order such that `ProtocolHandler::shutdown` is called and awaited first, and `Endpoint::close` afterwards.

I also added a test that fails without this change and passes now.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
