### PR TITLE
feat(iroh)!: make ProtocolHandler use async functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,18 +97,16 @@ let router = Router::builder(endpoint)
 struct Echo;
 
 impl ProtocolHandler for Echo {
-    fn accept(&self, connection: Connection) -> BoxedFuture<Result<()>> {
-        Box::pin(async move {
-            let (mut send, mut recv) = connection.accept_bi().await?;
+    async fn accept(&self, connection: Connection) -> Result<()> {
+        let (mut send, mut recv) = connection.accept_bi().await?;
 
-            // Echo any bytes received back directly.
-            let bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
+        // Echo any bytes received back directly.
+        let bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
 
-            send.finish()?;
-            connection.closed().await;
+        send.finish()?;
+        connection.closed().await;
 
-            Ok(())
-        })
+        Ok(())
     }
 }
 ```

--- a/iroh/examples/echo.rs
+++ b/iroh/examples/echo.rs
@@ -13,7 +13,6 @@ use iroh::{
     watcher::Watcher as _,
     Endpoint, NodeAddr,
 };
-use n0_future::boxed::BoxFuture;
 
 /// Each protocol is identified by its ALPN string.
 ///
@@ -84,31 +83,28 @@ impl ProtocolHandler for Echo {
     ///
     /// The returned future runs on a newly spawned tokio task, so it can run as long as
     /// the connection lasts.
-    fn accept(&self, connection: Connection) -> BoxFuture<Result<()>> {
-        // We have to return a boxed future from the handler.
-        Box::pin(async move {
-            // We can get the remote's node id from the connection.
-            let node_id = connection.remote_node_id()?;
-            println!("accepted connection from {node_id}");
+    async fn accept(&self, connection: Connection) -> Result<()> {
+        // We can get the remote's node id from the connection.
+        let node_id = connection.remote_node_id()?;
+        println!("accepted connection from {node_id}");
 
-            // Our protocol is a simple request-response protocol, so we expect the
-            // connecting peer to open a single bi-directional stream.
-            let (mut send, mut recv) = connection.accept_bi().await?;
+        // Our protocol is a simple request-response protocol, so we expect the
+        // connecting peer to open a single bi-directional stream.
+        let (mut send, mut recv) = connection.accept_bi().await?;
 
-            // Echo any bytes received back directly.
-            // This will keep copying until the sender signals the end of data on the stream.
-            let bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
-            println!("Copied over {bytes_sent} byte(s)");
+        // Echo any bytes received back directly.
+        // This will keep copying until the sender signals the end of data on the stream.
+        let bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
+        println!("Copied over {bytes_sent} byte(s)");
 
-            // By calling `finish` on the send stream we signal that we will not send anything
-            // further, which makes the receive stream on the other end terminate.
-            send.finish()?;
+        // By calling `finish` on the send stream we signal that we will not send anything
+        // further, which makes the receive stream on the other end terminate.
+        send.finish()?;
 
-            // Wait until the remote closes the connection, which it does once it
-            // received the response.
-            connection.closed().await;
+        // Wait until the remote closes the connection, which it does once it
+        // received the response.
+        connection.closed().await;
 
-            Ok(())
-        })
+        Ok(())
     }
 }

--- a/iroh/examples/search.rs
+++ b/iroh/examples/search.rs
@@ -38,7 +38,6 @@ use iroh::{
     protocol::{ProtocolHandler, Router},
     Endpoint, NodeId,
 };
-use n0_future::boxed::BoxFuture;
 use tokio::sync::Mutex;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
@@ -127,40 +126,36 @@ impl ProtocolHandler for BlobSearch {
     ///
     /// The returned future runs on a newly spawned tokio task, so it can run as long as
     /// the connection lasts.
-    fn accept(&self, connection: Connection) -> BoxFuture<Result<()>> {
-        let this = self.clone();
-        // We have to return a boxed future from the handler.
-        Box::pin(async move {
-            // We can get the remote's node id from the connection.
-            let node_id = connection.remote_node_id()?;
-            println!("accepted connection from {node_id}");
+    async fn accept(&self, connection: Connection) -> Result<()> {
+        // We can get the remote's node id from the connection.
+        let node_id = connection.remote_node_id()?;
+        println!("accepted connection from {node_id}");
 
-            // Our protocol is a simple request-response protocol, so we expect the
-            // connecting peer to open a single bi-directional stream.
-            let (mut send, mut recv) = connection.accept_bi().await?;
+        // Our protocol is a simple request-response protocol, so we expect the
+        // connecting peer to open a single bi-directional stream.
+        let (mut send, mut recv) = connection.accept_bi().await?;
 
-            // We read the query from the receive stream, while enforcing a max query length.
-            let query_bytes = recv.read_to_end(64).await?;
+        // We read the query from the receive stream, while enforcing a max query length.
+        let query_bytes = recv.read_to_end(64).await?;
 
-            // Now, we can perform the actual query on our local database.
-            let query = String::from_utf8(query_bytes)?;
-            let num_matches = this.query_local(&query).await;
+        // Now, we can perform the actual query on our local database.
+        let query = String::from_utf8(query_bytes)?;
+        let num_matches = self.query_local(&query).await;
 
-            // We want to return a list of hashes. We do the simplest thing possible, and just send
-            // one hash after the other. Because the hashes have a fixed size of 32 bytes, this is
-            // very easy to parse on the other end.
-            send.write_all(&num_matches.to_le_bytes()).await?;
+        // We want to return a list of hashes. We do the simplest thing possible, and just send
+        // one hash after the other. Because the hashes have a fixed size of 32 bytes, this is
+        // very easy to parse on the other end.
+        send.write_all(&num_matches.to_le_bytes()).await?;
 
-            // By calling `finish` on the send stream we signal that we will not send anything
-            // further, which makes the receive stream on the other end terminate.
-            send.finish()?;
+        // By calling `finish` on the send stream we signal that we will not send anything
+        // further, which makes the receive stream on the other end terminate.
+        send.finish()?;
 
-            // Wait until the remote closes the connection, which it does once it
-            // received the response.
-            connection.closed().await;
+        // Wait until the remote closes the connection, which it does once it
+        // received the response.
+        connection.closed().await;
 
-            Ok(())
-        })
+        Ok(())
     }
 }
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1991,7 +1991,7 @@ impl Connection {
     /// [`Connecting::handshake_data()`] succeeds. See that method's documentations for
     /// details on the returned value.
     ///
-    /// [`Connection::handshake_data()`]: crate::Connecting::handshake_data
+    /// [`Connection::handshake_data()`]: crate::endpoint::Connecting::handshake_data
     #[inline]
     pub fn handshake_data(&self) -> Option<Box<dyn Any>> {
         self.inner.handshake_data()

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -4,7 +4,6 @@
 //!
 //! ```no_run
 //! # use anyhow::Result;
-//! # use futures_lite::future::Boxed as BoxedFuture;
 //! # use iroh::{endpoint::Connection, protocol::{ProtocolHandler, Router}, Endpoint, NodeAddr};
 //! #
 //! # async fn test_compile() -> Result<()> {
@@ -21,27 +20,24 @@
 //! struct Echo;
 //!
 //! impl ProtocolHandler for Echo {
-//!     fn accept(&self, connection: Connection) -> BoxedFuture<Result<()>> {
-//!         Box::pin(async move {
-//!             let (mut send, mut recv) = connection.accept_bi().await?;
+//!     async fn accept(&self, connection: Connection) -> Result<()> {
+//!         let (mut send, mut recv) = connection.accept_bi().await?;
 //!
-//!             // Echo any bytes received back directly.
-//!             let bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
+//!         // Echo any bytes received back directly.
+//!         let bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
 //!
-//!             send.finish()?;
-//!             connection.closed().await;
+//!         send.finish()?;
+//!         connection.closed().await;
 //!
-//!             Ok(())
-//!         })
+//!         Ok(())
 //!     }
 //! }
 //! ```
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, future::Future, pin::Pin, sync::Arc};
 
 use anyhow::Result;
 use iroh_base::NodeId;
 use n0_future::{
-    boxed::BoxFuture,
     join_all,
     task::{self, AbortOnDropHandle, JoinSet},
 };
@@ -109,75 +105,135 @@ pub struct RouterBuilder {
 /// Implement this trait on a struct that should handle incoming connections.
 /// The protocol handler must then be registered on the node for an ALPN protocol with
 /// [`crate::protocol::RouterBuilder::accept`].
+///
+/// See the [module documentation](crate::protocol) for an example.
 pub trait ProtocolHandler: Send + Sync + std::fmt::Debug + 'static {
     /// Optional interception point to handle the `Connecting` state.
     ///
+    /// Can be implemented as `async fn on_connecting(&self, connecting: Connecting) -> Result<Connection>`.
+    ///
     /// This enables accepting 0-RTT data from clients, among other things.
-    fn on_connecting(&self, connecting: Connecting) -> BoxFuture<Result<Connection>> {
+    fn on_connecting(
+        &self,
+        connecting: Connecting,
+    ) -> impl Future<Output = Result<Connection>> + Send {
+        async move {
+            let conn = connecting.await?;
+            Ok(conn)
+        }
+    }
+
+    /// Handle an incoming connection.
+    ///
+    /// Can be implemented as `async fn accept(&self, connection: Connection) -> Result<Connection>`.
+    ///
+    /// The returned future runs on a freshly spawned tokio task so it can be long-running.
+    ///
+    /// When [`Router::shutdown`] is called, no further connections will be accepted, and
+    /// the futures returned by [`Self::accept`] will be aborted after the future returned
+    /// from [`ProtocolHandler::shutdown`] completes.
+    fn accept(&self, connection: Connection) -> impl Future<Output = Result<()>> + Send;
+
+    /// Called when the router shuts down.
+    ///
+    /// Can be implemented as `async fn shutdown(&self)`.
+    ///
+    /// This is called from [`Router::shutdown`]. The returned future is awaited before
+    /// the router closes the endpoint.
+    fn shutdown(&self) -> impl Future<Output = ()> + Send {
+        async move {}
+    }
+}
+
+impl<T: ProtocolHandler> ProtocolHandler for Arc<T> {
+    async fn on_connecting(&self, conn: Connecting) -> Result<Connection> {
+        self.as_ref().on_connecting(conn).await
+    }
+
+    async fn accept(&self, conn: Connection) -> Result<()> {
+        self.as_ref().accept(conn).await
+    }
+
+    async fn shutdown(&self) {
+        self.as_ref().shutdown().await
+    }
+}
+
+impl<T: ProtocolHandler> ProtocolHandler for Box<T> {
+    async fn on_connecting(&self, conn: Connecting) -> Result<Connection> {
+        self.as_ref().on_connecting(conn).await
+    }
+
+    async fn accept(&self, conn: Connection) -> Result<()> {
+        self.as_ref().accept(conn).await
+    }
+
+    async fn shutdown(&self) {
+        self.as_ref().shutdown().await
+    }
+}
+
+/// A dyn-compatible version of [`ProtocolHandler`] that returns boxed futures.
+///
+/// We are not using [`n0_future::boxed::BoxFuture] because we don't need a `'static` bound
+/// on these futures.
+pub(crate) trait DynProtocolHandler: Send + Sync + std::fmt::Debug + 'static {
+    /// See [`ProtocolHandler::on_connecting`].
+    fn on_connecting(
+        &self,
+        connecting: Connecting,
+    ) -> Pin<Box<dyn Future<Output = Result<Connection>> + Send + '_>> {
         Box::pin(async move {
             let conn = connecting.await?;
             Ok(conn)
         })
     }
 
-    /// Handle an incoming connection.
-    ///
-    /// This runs on a freshly spawned tokio task so the returned future can be long-running.
-    ///
-    /// When [`Router::shutdown`] is called, no further connections will be accepted, and
-    /// the futures returned by [`Self::accept`] will be aborted after the future returned
-    /// from [`ProtocolHandler::shutdown`] completes.
-    fn accept(&self, connection: Connection) -> BoxFuture<Result<()>>;
+    /// See [`ProtocolHandler::accept`].
+    fn accept(
+        &self,
+        connection: Connection,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
 
-    /// Called when the router shuts down.
-    ///
-    /// This is called from [`Router::shutdown`]. The returned future is awaited before
-    /// the router closes the endpoint.
-    fn shutdown(&self) -> BoxFuture<()> {
+    /// See [`ProtocolHandler::shutdown`].
+    fn shutdown(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {})
     }
 }
 
-impl<T: ProtocolHandler> ProtocolHandler for Arc<T> {
-    fn on_connecting(&self, conn: Connecting) -> BoxFuture<Result<Connection>> {
-        self.as_ref().on_connecting(conn)
+impl<P: ProtocolHandler> DynProtocolHandler for P {
+    fn accept(
+        &self,
+        connection: Connection,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(<Self as ProtocolHandler>::accept(self, connection))
     }
 
-    fn accept(&self, conn: Connection) -> BoxFuture<Result<()>> {
-        self.as_ref().accept(conn)
+    fn on_connecting(
+        &self,
+        connecting: Connecting,
+    ) -> Pin<Box<dyn Future<Output = Result<Connection>> + Send + '_>> {
+        Box::pin(<Self as ProtocolHandler>::on_connecting(self, connecting))
     }
 
-    fn shutdown(&self) -> BoxFuture<()> {
-        self.as_ref().shutdown()
-    }
-}
-
-impl<T: ProtocolHandler> ProtocolHandler for Box<T> {
-    fn on_connecting(&self, conn: Connecting) -> BoxFuture<Result<Connection>> {
-        self.as_ref().on_connecting(conn)
-    }
-
-    fn accept(&self, conn: Connection) -> BoxFuture<Result<()>> {
-        self.as_ref().accept(conn)
-    }
-
-    fn shutdown(&self) -> BoxFuture<()> {
-        self.as_ref().shutdown()
+    fn shutdown(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(<Self as ProtocolHandler>::shutdown(self))
     }
 }
 
 /// A typed map of protocol handlers, mapping them from ALPNs.
 #[derive(Debug, Default)]
-pub(crate) struct ProtocolMap(BTreeMap<Vec<u8>, Box<dyn ProtocolHandler>>);
+pub(crate) struct ProtocolMap(BTreeMap<Vec<u8>, Box<dyn DynProtocolHandler>>);
 
 impl ProtocolMap {
     /// Returns the registered protocol handler for an ALPN as a [`Arc<dyn ProtocolHandler>`].
-    pub(crate) fn get(&self, alpn: &[u8]) -> Option<&dyn ProtocolHandler> {
+    pub(crate) fn get(&self, alpn: &[u8]) -> Option<&dyn DynProtocolHandler> {
         self.0.get(alpn).map(|p| &**p)
     }
 
     /// Inserts a protocol handler.
-    pub(crate) fn insert(&mut self, alpn: Vec<u8>, handler: Box<dyn ProtocolHandler>) {
+    pub(crate) fn insert(&mut self, alpn: Vec<u8>, handler: impl ProtocolHandler) {
+        let handler = Box::new(handler);
         self.0.insert(alpn, handler);
     }
 
@@ -248,8 +304,7 @@ impl RouterBuilder {
 
     /// Configures the router to accept the [`ProtocolHandler`] when receiving a connection
     /// with this `alpn`.
-    pub fn accept<T: ProtocolHandler>(mut self, alpn: impl AsRef<[u8]>, handler: T) -> Self {
-        let handler = Box::new(handler);
+    pub fn accept(mut self, alpn: impl AsRef<[u8]>, handler: impl ProtocolHandler) -> Self {
         self.protocols.insert(alpn.as_ref().to_vec(), handler);
         self
     }
@@ -416,25 +471,22 @@ impl<P: ProtocolHandler + Clone> AccessLimit<P> {
 }
 
 impl<P: ProtocolHandler + Clone> ProtocolHandler for AccessLimit<P> {
-    fn on_connecting(&self, conn: Connecting) -> BoxFuture<Result<Connection>> {
+    fn on_connecting(&self, conn: Connecting) -> impl Future<Output = Result<Connection>> + Send {
         self.proto.on_connecting(conn)
     }
 
-    fn accept(&self, conn: Connection) -> BoxFuture<Result<()>> {
-        let this = self.clone();
-        Box::pin(async move {
-            let remote = conn.remote_node_id()?;
-            let is_allowed = (this.limiter)(remote);
-            if !is_allowed {
-                conn.close(0u32.into(), b"not allowed");
-                anyhow::bail!("not allowed");
-            }
-            this.proto.accept(conn).await?;
-            Ok(())
-        })
+    async fn accept(&self, conn: Connection) -> Result<()> {
+        let remote = conn.remote_node_id()?;
+        let is_allowed = (self.limiter)(remote);
+        if !is_allowed {
+            conn.close(0u32.into(), b"not allowed");
+            anyhow::bail!("not allowed");
+        }
+        self.proto.accept(conn).await?;
+        Ok(())
     }
 
-    fn shutdown(&self) -> BoxFuture<()> {
+    fn shutdown(&self) -> impl Future<Output = ()> + Send {
         self.proto.shutdown()
     }
 }
@@ -472,19 +524,17 @@ mod tests {
     const ECHO_ALPN: &[u8] = b"/iroh/echo/1";
 
     impl ProtocolHandler for Echo {
-        fn accept(&self, connection: Connection) -> BoxFuture<Result<()>> {
+        async fn accept(&self, connection: Connection) -> Result<()> {
             println!("accepting echo");
-            Box::pin(async move {
-                let (mut send, mut recv) = connection.accept_bi().await?;
+            let (mut send, mut recv) = connection.accept_bi().await?;
 
-                // Echo any bytes received back directly.
-                let _bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
+            // Echo any bytes received back directly.
+            let _bytes_sent = tokio::io::copy(&mut recv, &mut send).await?;
 
-                send.finish()?;
-                connection.closed().await;
+            send.finish()?;
+            connection.closed().await;
 
-                Ok(())
-            })
+            Ok(())
         }
     }
     #[tokio::test]
@@ -521,23 +571,17 @@ mod tests {
         const TEST_ALPN: &[u8] = b"/iroh/test/1";
 
         impl ProtocolHandler for TestProtocol {
-            fn accept(&self, connection: Connection) -> BoxFuture<Result<()>> {
-                let this = self.clone();
-                Box::pin(async move {
-                    this.connections.lock().expect("poisoned").push(connection);
-                    Ok(())
-                })
+            async fn accept(&self, connection: Connection) -> Result<()> {
+                self.connections.lock().expect("poisoned").push(connection);
+                Ok(())
             }
 
-            fn shutdown(&self) -> BoxFuture<()> {
-                let this = self.clone();
-                Box::pin(async move {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    let mut connections = this.connections.lock().expect("poisoned");
-                    for conn in connections.drain(..) {
-                        conn.close(42u32.into(), b"shutdown");
-                    }
-                })
+            async fn shutdown(&self) {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                let mut connections = self.connections.lock().expect("poisoned");
+                for conn in connections.drain(..) {
+                    conn.close(42u32.into(), b"shutdown");
+                }
             }
         }
 


### PR DESCRIPTION
## Description

This changes the `ProtocolHandler` trait so that the functions return `impl Future` instead of `BoxFuture`, which means implementors can simply implement the trait with `async fn`. We don't even need a `'static` bound on these futures, so you can use `&self` freely without cloning and moving.

Internally, we still box the futures return by `accept`, `on_connecting` and `shutdown`. So performance wise this change should not have any effects. But the boxing is hidden from the user and implementing the trait now feels a lot more normal and simpler.

## Breaking Changes

* `iroh::protocol::ProtocolHandler` methods now return `impl Future` instead of `BoxFuture`. You can simply remove the `Box::pin(async move {})` from the implementations and instead implement the methods as `async fn`. See the updated documentation for the `iroh::protocol` module for an example.
* `iroh::protocol::ProtocolHandler` is no longer dyn-compatible. If you need a dyn-compatible version, you need to build your own dyn-compatible wrapper trait. See the (non-public) `DynProtocolHandler` in `iroh::protocol` as an example.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
  - [x] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
