### PR TITLE
example: Example for 0rtt that can also serve as a benchmark

### DIFF
--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -224,3 +224,7 @@ required-features = ["examples"]
 [[example]]
 name = "transfer"
 required-features = ["examples"]
+
+[[example]]
+name = "0rtt"
+required-features = ["examples"]

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -1,7 +1,4 @@
-use std::{
-    future::Future,
-    time::{Duration, Instant},
-};
+use std::{future::Future, time::Instant};
 
 use clap::Parser;
 use iroh::{
@@ -89,10 +86,11 @@ async fn connect(args: Args) -> anyhow::Result<()> {
         } else {
             pingpong_0rtt(connecting, i).await?
         };
-        tokio::spawn(async move {
-            tokio::time::sleep(connection.rtt() * 2).await;
-            connection.close(0u8.into(), b"done");
-        });
+        // tokio::spawn(async move {
+        //     tokio::time::sleep(connection.rtt() * 2).await;
+        //     connection.close(0u8.into(), b"done");
+        // });
+        connection.close(0u8.into(), b"done");
         let elapsed = t0.elapsed();
         debug!("round {}: {} us", i, elapsed.as_micros());
     }

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -86,11 +86,13 @@ async fn connect(args: Args) -> anyhow::Result<()> {
         } else {
             pingpong_0rtt(connecting, i).await?
         };
-        // tokio::spawn(async move {
-        //     tokio::time::sleep(connection.rtt() * 2).await;
-        //     connection.close(0u8.into(), b"done");
-        // });
-        connection.close(0u8.into(), b"done");
+        tokio::spawn(async move {
+            // wait for some time for the handshake to complete and the server
+            // to send a NewSessionTicket. This is less than ideal, but we
+            // don't have a better way to wait for the handshake to complete.
+            tokio::time::sleep(connection.rtt() * 2).await;
+            connection.close(0u8.into(), b"done");
+        });
         let elapsed = t0.elapsed();
         debug!("round {}: {} us", i, elapsed.as_micros());
     }

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -86,14 +86,13 @@ async fn connect(args: Args) -> anyhow::Result<()> {
         } else {
             pingpong_0rtt(connecting, i).await?
         };
-        // tokio::spawn(async move {
-        //     // wait for some time for the handshake to complete and the server
-        //     // to send a NewSessionTicket. This is less than ideal, but we
-        //     // don't have a better way to wait for the handshake to complete.
-        //     tokio::time::sleep(connection.rtt() * 2).await;
-        //     connection.close(0u8.into(), b"done");
-        // });
-        connection.close(0u8.into(), b"done");
+        tokio::spawn(async move {
+            // wait for some time for the handshake to complete and the server
+            // to send a NewSessionTicket. This is less than ideal, but we
+            // don't have a better way to wait for the handshake to complete.
+            tokio::time::sleep(connection.rtt() * 2).await;
+            connection.close(0u8.into(), b"");
+        });
         let elapsed = t0.elapsed();
         debug!("round {}: {} us", i, elapsed.as_micros());
     }

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -1,0 +1,113 @@
+use std::time::Instant;
+
+use clap::Parser;
+use iroh::{endpoint::Connection, watcher::Watcher};
+use iroh_base::ticket::NodeTicket;
+use tracing::{info, trace};
+
+const PINGPONG_ALPN: &[u8] = b"0rtt-pingpong";
+
+#[derive(Parser)]
+struct Args {
+    /// The node id to connect to. If not set, the program will start a server.
+    node: Option<NodeTicket>,
+    /// Number of rounds to run.
+    #[clap(long, default_value = "100")]
+    rounds: u64,
+    /// Run without 0-RTT for comparison.
+    #[clap(long)]
+    disable_0rtt: bool,
+}
+
+async fn pingpong(connection: &Connection, x: u64) -> anyhow::Result<()> {
+    let t0 = Instant::now();
+    let (mut send, mut recv) = connection.open_bi().await?;
+    let data = x.to_be_bytes();
+    send.write_all(&data).await?;
+    send.finish()?;
+    let echo = recv.read_to_end(8).await?;
+    anyhow::ensure!(echo == data);
+    let elapsed = t0.elapsed();
+    info!("pingpong round {}: {}us", x, elapsed.as_micros());
+    Ok(())
+}
+
+async fn connect(args: Args) -> anyhow::Result<()> {
+    let node_addr = args.node.unwrap().node_addr().clone();
+    let endpoint = iroh::Endpoint::builder().bind().await?;
+    let t0 = Instant::now();
+    for i in 0..args.rounds {
+        let connecting = endpoint
+            .connect_with_opts(node_addr.clone(), PINGPONG_ALPN, Default::default())
+            .await?;
+        if args.disable_0rtt {
+            let connection = connecting.await?;
+            trace!("connecting without 0-RTT");
+            pingpong(&connection, i).await?;
+            connection.close(0u32.into(), b"done");
+        } else {
+            let (connection, accepted) = match connecting.into_0rtt() {
+                Ok(res) => {
+                    trace!("0-RTT possible from our side");
+                    res
+                }
+                Err(connecting) => {
+                    trace!("0-RTT not possible from our side");
+                    let connection = connecting.await?;
+                    pingpong(&connection, i).await?;
+                    continue;
+                }
+            };
+            pingpong(&connection, i).await?;
+            if !accepted.await {
+                trace!("0-RTT not accepted, trying again without 0-RTT");
+                pingpong(&connection, i).await?;
+            }
+            connection.close(0u32.into(), b"done");
+        }
+    }
+    let elapsed = t0.elapsed();
+    info!("total time: {}us", elapsed.as_micros());
+    info!(
+        "time per round: {}us",
+        elapsed.as_micros() / (args.rounds as u128)
+    );
+    Ok(())
+}
+
+async fn accept(_args: Args) -> anyhow::Result<()> {
+    let endpoint = iroh::Endpoint::builder()
+        .alpns(vec![PINGPONG_ALPN.to_vec()])
+        .bind()
+        .await?;
+    let addr = endpoint.node_addr().initialized().await?;
+    println!("Listening on: {:?}", addr);
+    println!("Node ID: {:?}", addr.node_id);
+    println!("Ticket: {}", NodeTicket::from(addr));
+    while let Some(incoming) = endpoint.accept().await {
+        tokio::spawn(async move {
+            let conn = incoming.accept()?.await?;
+            let (mut send, mut recv) = conn.accept_bi().await?;
+            trace!("recv.is_0rtt: {}", recv.is_0rtt());
+            let data = recv.read_to_end(8).await?;
+            trace!("recv: {}", data.len());
+            send.write_all(&data).await?;
+            send.finish()?;
+            conn.closed().await;
+            anyhow::Ok(())
+        });
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+    if args.node.is_some() {
+        connect(args).await?;
+    } else {
+        accept(args).await?;
+    };
+    Ok(())
+}

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -58,7 +58,10 @@ async fn connect(args: Args) -> anyhow::Result<()> {
                     continue;
                 }
             };
-            pingpong(&connection, i).await?;
+            if pingpong(&connection, i).await.is_ok() {
+                // 0-RTT worked, we don't need to wait for accept to complete
+                continue;
+            }
             if !accepted.await {
                 trace!("0-RTT not accepted, trying again without 0-RTT");
                 pingpong(&connection, i).await?;

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -10,7 +10,7 @@ use iroh::{
 use iroh_base::ticket::NodeTicket;
 use n0_future::{future, StreamExt};
 use rand::thread_rng;
-use tracing::{debug, info, trace};
+use tracing::{info, trace};
 
 const PINGPONG_ALPN: &[u8] = b"0rtt-pingpong";
 
@@ -117,11 +117,11 @@ async fn connect(args: Args) -> anyhow::Result<()> {
             connection.close(0u8.into(), b"");
         });
         let elapsed = t0.elapsed();
-        debug!("round {}: {} us", i, elapsed.as_micros());
+        println!("round {}: {} us", i, elapsed.as_micros());
     }
     let elapsed = t0.elapsed();
-    info!("total time: {} us", elapsed.as_micros());
-    info!(
+    println!("total time: {} us", elapsed.as_micros());
+    println!(
         "time per round: {} us",
         elapsed.as_micros() / (args.rounds as u128)
     );

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use clap::Parser;
 use iroh::{endpoint::Connection, watcher::Watcher};
 use iroh_base::ticket::NodeTicket;
-use tracing::{info, trace};
+use tracing::{debug, info, trace};
 
 const PINGPONG_ALPN: &[u8] = b"0rtt-pingpong";
 
@@ -28,7 +28,7 @@ async fn pingpong(connection: &Connection, x: u64) -> anyhow::Result<()> {
     let echo = recv.read_to_end(8).await?;
     anyhow::ensure!(echo == data);
     let elapsed = t0.elapsed();
-    info!("pingpong round {}: {}us", x, elapsed.as_micros());
+    debug!("pingpong round {}: {} us", x, elapsed.as_micros());
     Ok(())
 }
 
@@ -70,9 +70,9 @@ async fn connect(args: Args) -> anyhow::Result<()> {
         }
     }
     let elapsed = t0.elapsed();
-    info!("total time: {}us", elapsed.as_micros());
+    info!("total time: {} us", elapsed.as_micros());
     info!(
-        "time per round: {}us",
+        "time per round: {} us",
         elapsed.as_micros() / (args.rounds as u128)
     );
     Ok(())

--- a/iroh/src/tls.rs
+++ b/iroh/src/tls.rs
@@ -124,7 +124,6 @@ impl TlsConfig {
         .expect("fixed config")
         .with_client_cert_verifier(self.client_verifier.clone())
         .with_cert_resolver(self.cert_resolver.clone());
-        crypto.send_tls13_tickets = 4;
         crypto.alpn_protocols = alpn_protocols;
         if keylog {
             warn!("enabling SSLKEYLOGFILE for TLS pre-master keys");

--- a/iroh/src/tls.rs
+++ b/iroh/src/tls.rs
@@ -124,6 +124,7 @@ impl TlsConfig {
         .expect("fixed config")
         .with_client_cert_verifier(self.client_verifier.clone())
         .with_cert_resolver(self.cert_resolver.clone());
+        crypto.send_tls13_tickets = 4;
         crypto.alpn_protocols = alpn_protocols;
         if keylog {
             warn!("enabling SSLKEYLOGFILE for TLS pre-master keys");
@@ -133,7 +134,6 @@ impl TlsConfig {
         // must be u32::MAX or 0 (the default). Any other value panics with QUIC
         // This is specified in RFC 9001: https://www.rfc-editor.org/rfc/rfc9001#section-4.6.1
         crypto.max_early_data_size = u32::MAX;
-
         crypto
             .try_into()
             .expect("expected to have a TLS1.3-compatible crypto provider set (hardcoded)")


### PR DESCRIPTION
## Description

A simple 0rtt ping protocol client and server.

## Breaking Changes

None

## Notes & open questions

Note: we need a way to wait for a TLS session ticket. A fixed delay is quite crude.
Note: it would be nice to be able to configure how many NewSessionTicket messages get emitted