### PR TITLE
feat!: Add a `Resolver` trait to abstract over DNS resolvers

### DIFF
--- a/iroh-dns-server/examples/resolve.rs
+++ b/iroh-dns-server/examples/resolve.rs
@@ -54,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
         DnsResolver::with_nameserver(addr)
     } else {
         match args.env {
-            Env::Staging | Env::Prod => DnsResolver::new(),
+            Env::Staging | Env::Prod => DnsResolver::default(),
             Env::Dev => {
                 DnsResolver::with_nameserver(DEV_DNS_SERVER.parse().expect("valid address"))
             }

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -116,25 +116,25 @@ mod tests {
         // resolve root record
         let name = Name::from_utf8(format!("{pubkey}."))?;
         let res = resolver.lookup_txt(name, DNS_TIMEOUT).await?;
-        let records = res.into_iter().map(|t| t.to_string()).collect::<Vec<_>>();
+        let records = res.map(|t| t.to_string()).collect::<Vec<_>>();
         assert_eq!(records, vec!["hi0".to_string()]);
 
         // resolve level one record
         let name = Name::from_utf8(format!("_hello.{pubkey}."))?;
         let res = resolver.lookup_txt(name, DNS_TIMEOUT).await?;
-        let records = res.into_iter().map(|t| t.to_string()).collect::<Vec<_>>();
+        let records = res.map(|t| t.to_string()).collect::<Vec<_>>();
         assert_eq!(records, vec!["hi1".to_string()]);
 
         // resolve level two record
         let name = Name::from_utf8(format!("_hello.world.{pubkey}."))?;
         let res = resolver.lookup_txt(name, DNS_TIMEOUT).await?;
-        let records = res.into_iter().map(|t| t.to_string()).collect::<Vec<_>>();
+        let records = res.map(|t| t.to_string()).collect::<Vec<_>>();
         assert_eq!(records, vec!["hi2".to_string()]);
 
         // resolve multiple records for same name
         let name = Name::from_utf8(format!("multiple.{pubkey}."))?;
         let res = resolver.lookup_txt(name, DNS_TIMEOUT).await?;
-        let records = res.into_iter().map(|t| t.to_string()).collect::<Vec<_>>();
+        let records = res.map(|t| t.to_string()).collect::<Vec<_>>();
         assert_eq!(records, vec!["hi3".to_string(), "hi4".to_string()]);
 
         // resolve A record

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -141,7 +141,7 @@ impl DnsResolver {
         timeout: Duration,
     ) -> Result<impl Iterator<Item = IpAddr>> {
         let addrs = time::timeout(timeout, self.0.lookup_ipv4(host.to_string())).await??;
-        Ok(addrs.map(|ip| IpAddr::V4(ip)))
+        Ok(addrs.map(IpAddr::V4))
     }
 
     /// Performs an IPv6 lookup with a timeout.
@@ -151,7 +151,7 @@ impl DnsResolver {
         timeout: Duration,
     ) -> Result<impl Iterator<Item = IpAddr>> {
         let addrs = time::timeout(timeout, self.0.lookup_ipv6(host.to_string())).await??;
-        Ok(addrs.map(|ip| IpAddr::V6(ip)))
+        Ok(addrs.map(IpAddr::V6))
     }
 
     /// Resolves IPv4 and IPv6 in parallel with a timeout.

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -358,7 +358,7 @@ impl Resolver for TokioResolver {
 ///
 /// [`TxtRecord`] implements [`fmt::Display`], so you can call [`ToString::to_string`] to
 /// convert the record data into a string. This will parse each character string with
-/// [`String::from_utf8_lossy`] and then concatenate all strings without a seperator.
+/// [`String::from_utf8_lossy`] and then concatenate all strings without a separator.
 ///
 /// If you want to process each character string individually, use [`Self::iter`].
 ///

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -41,12 +41,8 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-#[cfg(not(wasm_browser))]
 use iroh_base::{NodeAddr, NodeId, RelayUrl, SecretKey};
-#[cfg(not(wasm_browser))]
 use url::Url;
-
-#[cfg(not(wasm_browser))]
 
 /// The DNS name for the iroh TXT record.
 pub const IROH_TXT_NAME: &str = "_iroh";
@@ -560,7 +556,7 @@ pub(crate) fn ensure_iroh_txt_label(name: String) -> String {
     if parts.next() == Some(IROH_TXT_NAME) {
         name
     } else {
-        [IROH_TXT_NAME, ".", &name].join(".")
+        format!("{}.{}", IROH_TXT_NAME, name)
     }
 }
 

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -340,14 +340,14 @@ impl NodeInfo {
         self.into()
     }
 
-    #[cfg(not(wasm_browser))]
     /// Parses a [`NodeInfo`] from a TXT records lookup.
-    pub fn from_txt_lookup(
+    #[cfg(not(wasm_browser))]
+    pub(crate) fn from_txt_lookup(
         name: String,
         lookup: impl Iterator<Item = crate::dns::TxtRecord>,
     ) -> Result<Self> {
         let attrs = TxtAttrs::from_txt_lookup(name, lookup)?;
-        Ok(attrs.into())
+        Ok(Self::from(attrs))
     }
 
     /// Parses a [`NodeInfo`] from a [`pkarr::SignedPacket`].

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -344,7 +344,7 @@ impl NodeInfo {
     #[cfg(not(wasm_browser))]
     pub(crate) fn from_txt_lookup(
         name: String,
-        lookup: impl Iterator<Item = crate::dns::TxtRecord>,
+        lookup: impl Iterator<Item = crate::dns::TxtRecordData>,
     ) -> Result<Self> {
         let attrs = TxtAttrs::from_txt_lookup(name, lookup)?;
         Ok(Self::from(attrs))
@@ -513,7 +513,7 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
     #[cfg(not(wasm_browser))]
     pub(crate) fn from_txt_lookup(
         name: String,
-        lookup: impl Iterator<Item = crate::dns::TxtRecord>,
+        lookup: impl Iterator<Item = crate::dns::TxtRecordData>,
     ) -> Result<Self> {
         let queried_node_id = node_id_from_txt_name(&name)
             .ok_or_else(|| anyhow!("invalid DNS answer: not a query for _iroh.z32encodedpubkey"))?;
@@ -584,7 +584,7 @@ mod tests {
     use testresult::TestResult;
 
     use super::{NodeData, NodeIdExt, NodeInfo};
-    use crate::dns::TxtRecord;
+    use crate::dns::TxtRecordData;
 
     #[test]
     fn txt_attr_roundtrip() {
@@ -677,7 +677,7 @@ mod tests {
         let lookup = hickory_resolver::lookup::TxtLookup::from(lookup);
         let lookup = lookup
             .into_iter()
-            .map(|txt| TxtRecord::from_iter(txt.iter().cloned()));
+            .map(|txt| TxtRecordData::from_iter(txt.iter().cloned()));
 
         let node_info = NodeInfo::from_txt_lookup(name.to_string(), lookup)?;
 

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -869,7 +869,7 @@ mod tests {
     }
 
     fn dns_resolver() -> DnsResolver {
-        DnsResolver::new()
+        DnsResolver::default()
     }
 
     #[tokio::test]

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -840,8 +840,8 @@ mod tests {
 
     async fn create_test_client(key: SecretKey, server_url: Url) -> Result<(PublicKey, Client)> {
         let public_key = key.public();
-        let client =
-            ClientBuilder::new(server_url, key, DnsResolver::new()).insecure_skip_cert_verify(true);
+        let client = ClientBuilder::new(server_url, key, DnsResolver::default())
+            .insecure_skip_cert_verify(true);
         let client = client.connect().await?;
 
         Ok((public_key, client))

--- a/iroh/src/dns.rs
+++ b/iroh/src/dns.rs
@@ -7,7 +7,9 @@
 //! See the [`node_info`](crate::node_info) module documentation for details on how
 //! iroh node records are structured.
 
-pub use iroh_relay::dns::{DnsResolver, N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING};
+pub use iroh_relay::dns::{
+    DnsResolver, Resolver, N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING,
+};
 
 #[cfg(test)]
 pub(crate) mod tests {
@@ -24,7 +26,7 @@ pub(crate) mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_dns_lookup_ipv4_ipv6() {
-        let resolver = DnsResolver::new();
+        let resolver = DnsResolver::default();
         let res: Vec<_> = resolver
             .lookup_ipv4_ipv6_staggered(NA_RELAY_HOSTNAME, TIMEOUT, STAGGERING_DELAYS)
             .await

--- a/iroh/src/dns.rs
+++ b/iroh/src/dns.rs
@@ -7,9 +7,7 @@
 //! See the [`node_info`](crate::node_info) module documentation for details on how
 //! iroh node records are structured.
 
-pub use iroh_relay::dns::{
-    DnsResolver, Resolver, N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING,
-};
+pub use iroh_relay::dns::*;
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1991,7 +1991,7 @@ impl Connection {
     /// [`Connecting::handshake_data()`] succeeds. See that method's documentations for
     /// details on the returned value.
     ///
-    /// [`Connection::handshake_data()`]: crate::Connecting::handshake_data
+    /// [`Connection::handshake_data()`]: crate::endpoint::Connecting::handshake_data
     #[inline]
     pub fn handshake_data(&self) -> Option<Box<dyn Any>> {
         self.inner.handshake_data()

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -3455,7 +3455,6 @@ mod tests {
     use super::*;
     use crate::{
         defaults::staging::{self, EU_RELAY_HOSTNAME},
-        dns::DnsResolver,
         tls,
         watcher::Watcher as _,
         Endpoint, RelayMode,
@@ -3477,7 +3476,7 @@ mod tests {
                 node_map: None,
                 discovery: None,
                 proxy_url: None,
-                dns_resolver: DnsResolver::new(),
+                dns_resolver: DnsResolver::default(),
                 server_config,
                 #[cfg(any(test, feature = "test-utils"))]
                 insecure_skip_relay_cert_verify: false,
@@ -4080,7 +4079,7 @@ mod tests {
         let mut server_config = ServerConfig::with_crypto(Arc::new(quic_server_config));
         server_config.transport_config(Arc::new(quinn::TransportConfig::default()));
 
-        let dns_resolver = DnsResolver::new();
+        let dns_resolver = DnsResolver::default();
         let opts = Options {
             addr_v4: None,
             addr_v6: None,

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -1288,7 +1288,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::{dns::DnsResolver, test_utils};
+    use crate::test_utils;
 
     #[test]
     fn test_packetize_iter() {
@@ -1341,7 +1341,7 @@ mod tests {
             relay_datagrams_recv,
             connection_opts: RelayConnectionOptions {
                 secret_key,
-                dns_resolver: DnsResolver::new(),
+                dns_resolver: DnsResolver::default(),
                 proxy_url: None,
                 prefer_ipv6: Arc::new(AtomicBool::new(true)),
                 insecure_skip_cert_verify: true,

--- a/iroh/src/net_report/dns.rs
+++ b/iroh/src/net_report/dns.rs
@@ -7,6 +7,6 @@ pub(crate) mod tests {
 
     /// Get a DNS resolver suitable for testing.
     pub fn resolver() -> DnsResolver {
-        DnsResolver::new()
+        DnsResolver::default()
     }
 }


### PR DESCRIPTION
## Description

This adds a `Resolver` trait to abstract over DNS resolution. It contains methods to resolve IPv4 or IPv6 addresses, and TXT records. Because the trait needs to be dyn-compatible for our usage (we don't want to have a generic for the DNS resolver on the Endpoint), all methods return boxed futures that contain boxed iterators. 

The `DnsResolver` struct is changed to contain an `Arc<dyn Resolver>` instead of being hardcoded to `hickory_resolver::TokioResolver`. Iroh ships an implementation of `Resolver` for `hickory_resolver::TokioResolver`, but does not have any hickory types in the public API anymore. 

Users can implement the `Resolver` trait on whatever struct to use a completely custom DNS resolver.

## Breaking Changes

Changes in `iroh_relay::dns` (reexported from `iroh::dns`):
* `DnsResolver::new` now takes an `impl Resolver`. To create a default resolver, use `DnsResolver::default` or the equivalent `DnsResolver::new_with_system_defaults`
*  `DnsResolver::lookup_txt` now returns `impl Iterator<Item = TxtRecord>`
* `TxtLookup` and `TXT` are removed.

Changes in `iroh_relay::node_info` (reexported from `iroh::discovery`):
* `NodeInfo::from_txt_lookup` now takes `name: String, lookup: impl Iterator<Item = crate::dns::TxtRecord>`


## Notes & open questions

We could now put the implementation of `Resolver` for `hickory_resolver::TokioResolver` behind a (default) feature flag to not have to hard-depend on a specific version of hickory_resolver anymore during iroh 1.0 - I think? Or maybe we'd still have to newtype it. Will need to think about this some more.




<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
