### PR TITLE
test(iroh-relay): add 300ms timeout to the `test_qad_client_closes_unresponsive_fast` test

### DIFF
--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -432,7 +432,7 @@ mod tests {
 
         println!("Closed in {time:?}");
         assert!(Duration::from_millis(900) < time);
-        assert!(time < Duration::from_millis(1500)); // give it some lee-way. Apparently github actions ubuntu runners can be slow?
+        assert!(time < Duration::from_millis(1800)); // give it some lee-way. Apparently github actions ubuntu runners can be slow?
 
         Ok(())
     }


### PR DESCRIPTION
## Description

The linux runner can sometimes be very slow. This test is currently flaky, but only in that it takes a few more milliseconds to complete. Added some time to the duration to remove the flaky-ness.

