### PR TITLE
refactor(iroh-relay,iroh): Slightly clean up staggered DNS errors

### DIFF
--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -31,6 +31,7 @@ use iroh_base::RelayUrl;
 use iroh_relay::dns::{DnsError, DnsResolver};
 use iroh_relay::{
     defaults::{DEFAULT_RELAY_QUIC_PORT, DEFAULT_STUN_PORT},
+    dns::StaggeredError,
     http::RELAY_PROBE_PATH,
     protos::stun,
     RelayMap, RelayNode,
@@ -1129,6 +1130,8 @@ async fn run_quic_probe(
 enum CaptivePortalError {
     #[snafu(transparent)]
     DnsLookup { source: DnsError },
+    #[snafu(transparent)]
+    StaggeredDnsLookup { source: StaggeredError<DnsError> },
     #[snafu(display("Creating HTTP client failed"))]
     CreateReqwestClient { source: reqwest::Error },
     #[snafu(display("HTTP request failed"))]
@@ -1260,7 +1263,7 @@ pub enum GetRelayAddrError {
     #[snafu(display("No suitable relay address found"))]
     NoAddrFound,
     #[snafu(display("DNS lookup failed"))]
-    DnsLookup { source: DnsError },
+    DnsLookup { source: StaggeredError<DnsError> },
     #[snafu(display("Relay node is not suitable for non-STUN probes"))]
     UnsupportedRelayNode,
     #[snafu(display("HTTPS probes are not implemented"))]
@@ -1418,7 +1421,7 @@ enum MeasureHttpsLatencyError {
     InvalidUrl { source: url::ParseError },
     #[cfg(not(wasm_browser))]
     #[snafu(transparent)]
-    DnsLookup { source: DnsError },
+    DnsLookup { source: StaggeredError<DnsError> },
     #[cfg(not(wasm_browser))]
     #[snafu(display("Invalid certificate"))]
     InvalidCertificate { source: reqwest::Error },


### PR DESCRIPTION
## Description

Instead of having two `StaggeredError` variants, let's just have one generic one.

## Breaking Changes

? see notes

## Notes & open questions

We haven't cut a release since we've introduced the error types. So I guess any changes to the error types aren't breaking changes *yet*?

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
