### PR TITLE
refactor(iroh)!: simplify discovery errors

### DIFF
--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -143,8 +143,8 @@ pub mod static_provider;
 pub enum DiscoveryError {
     #[snafu(display("No discovery service configured"))]
     NoServiceConfigured {},
-    #[snafu(display("Discovery produced no results"))]
-    NoResults {},
+    #[snafu(display("Discovery produced no results for {}", node_id.fmt_short()))]
+    NoResults { node_id: NodeId },
     #[snafu(display("Service '{provenance}' error"))]
     User {
         provenance: &'static str,
@@ -478,7 +478,7 @@ impl DiscoveryTask {
         let discovery = ep.discovery().ok_or(NoServiceConfiguredSnafu.build())?;
         let stream = discovery
             .resolve(ep.clone(), node_id)
-            .ok_or(NoResultsSnafu {}.build())?;
+            .ok_or(NoResultsSnafu { node_id }.build())?;
         Ok(stream)
     }
 
@@ -545,7 +545,7 @@ impl DiscoveryTask {
             }
         }
         if let Some(tx) = on_first_tx.take() {
-            tx.send(Err(NoResultsSnafu {}.build())).ok();
+            tx.send(Err(NoResultsSnafu { node_id }.build())).ok();
         }
     }
 }

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -47,7 +47,7 @@
 use std::sync::Arc;
 
 use iroh_base::{NodeId, RelayUrl, SecretKey};
-use iroh_relay::node_info::NodeInfo;
+use iroh_relay::node_info::{EncodingError, NodeInfo};
 use n0_future::{
     boxed::BoxStream,
     task::{self, AbortOnDropHandle},
@@ -63,7 +63,7 @@ use url::Url;
 
 use super::DiscoveryError;
 use crate::{
-    discovery::{Discovery, DiscoveryItem, NodeData, ParsePacketSnafu, SignedPacketSnafu},
+    discovery::{Discovery, DiscoveryItem, NodeData},
     endpoint::force_staging_infra,
     watcher::{self, Disconnected, Watchable, Watcher as _},
     Endpoint,
@@ -88,6 +88,8 @@ pub enum PkarrError {
     HttpRequest { status: reqwest::StatusCode },
     #[snafu(display("Http payload error"))]
     HttpPayload { source: reqwest::Error },
+    #[snafu(display("EncodingError"))]
+    Encoding { source: EncodingError },
 }
 
 impl From<PkarrError> for DiscoveryError {
@@ -291,7 +293,7 @@ impl PublisherService {
         }
     }
 
-    async fn publish_current(&self, info: NodeInfo) -> Result<(), DiscoveryError> {
+    async fn publish_current(&self, info: NodeInfo) -> Result<(), PkarrError> {
         debug!(
             data = ?info.data,
             pkarr_relay = %self.pkarr_client.pkarr_relay_url,
@@ -299,7 +301,7 @@ impl PublisherService {
         );
         let signed_packet = info
             .to_pkarr_signed_packet(&self.secret_key, self.ttl)
-            .context(SignedPacketSnafu)?;
+            .context(EncodingSnafu)?;
         self.pkarr_client.publish(&signed_packet).await?;
         Ok(())
     }
@@ -360,8 +362,8 @@ impl Discovery for PkarrResolver {
         let pkarr_client = self.pkarr_client.clone();
         let fut = async move {
             let signed_packet = pkarr_client.resolve(node_id).await?;
-            let info =
-                NodeInfo::from_pkarr_signed_packet(&signed_packet).context(ParsePacketSnafu)?;
+            let info = NodeInfo::from_pkarr_signed_packet(&signed_packet)
+                .map_err(|err| DiscoveryError::from_err("pkarr", err))?;
             let item = DiscoveryItem::new(info, "pkarr", None);
             Ok(item)
         };
@@ -426,7 +428,7 @@ impl PkarrRelayClient {
     }
 
     /// Publishes a [`SignedPacket`].
-    pub async fn publish(&self, signed_packet: &SignedPacket) -> Result<(), DiscoveryError> {
+    pub async fn publish(&self, signed_packet: &SignedPacket) -> Result<(), PkarrError> {
         let mut url = self.pkarr_relay_url.clone();
         url.path_segments_mut()
             .map_err(|_| {

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -451,8 +451,7 @@ impl PkarrRelayClient {
             return Err(HttpRequestSnafu {
                 status: response.status(),
             }
-            .build()
-            .into());
+            .build());
         }
 
         Ok(())


### PR DESCRIPTION
## Description

A couple of variants where only used internally, and the the `NodeId` variant had the same semantics as `NoResults`, so they can be merged.

## Breaking Changes

- Some variants of the `iroh::discovery::DiscoveryError` have been changed

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
