### PR TITLE
chore(iroh-relay): Make QAD test non-flaky by using tokio's paused time

### DIFF
--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -276,7 +276,7 @@ impl QuicClient {
         // we're sacrificing initial throughput, which is fine for
         // QAD, which doesn't require us to have good initial throughput.
         // It also implies a 999ms probe timeout, which means that
-        // if the packet gets lots (e.g. because we're probing ipv6, but
+        // if the packet gets lost (e.g. because we're probing ipv6, but
         // ipv6 packets always get lost in our network configuration) we
         // time out *closing the connection* after only 999ms.
         // Even if the round trip time is bigger than 999ms, this doesn't


### PR DESCRIPTION
## Description

Use `tokio`'s paused time to make the QAD test non-flaky. We've experienced occasional slowdowns recently every now and then, causing our timeout test to get out of the "acceptable" range.
Instead, this test now pauses the time, and will assert that the time that we sleep before considering the datagrams lost forever to be *exactly* 999ms.

## Notes & open questions

Doesn't "real world" test the code, but honestly, this is testing that a timeout is set fairly low, so I think this should be acceptable?

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.