### PR TITLE
chore(iroh-relay): Fix cargo check warning

### DIFF
--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -131,7 +131,7 @@ impl MaybeTlsStreamBuilder {
         }
     }
 
-    fn tls_servername(&self) -> Option<rustls::pki_types::ServerName> {
+    fn tls_servername(&self) -> Option<rustls::pki_types::ServerName<'_>> {
         let host_str = self.url.host_str()?;
         let servername = rustls::pki_types::ServerName::try_from(host_str).ok()?;
         Some(servername)


### PR DESCRIPTION
## Description

This should fix [the `minimal-crates` failure](https://github.com/n0-computer/iroh/actions/runs/15528521924/job/43712497899) that we run with the flaky test suite regularly.

![image](https://github.com/user-attachments/assets/a657d0b1-1332-439d-aa92-261a8026e6fb)

## Change checklist
<!-- Remove any that are not relevant. -->
- [X] Self-review.
