### PR TITLE
feat(iroh): add new protocols to router at runtime

### DIFF
--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -388,7 +388,7 @@ impl Router {
     ///
     /// If a protocol handler was already registered for `alpn`, the previous handler will be
     /// shutdown. Existing connections will not be aborted by the router, but some protocol
-    /// handlers may abort existing connnections in their [`Router::shutdown`] implementation.
+    /// handlers may abort existing connections in their [`Router::shutdown`] implementation.
     /// Consult the documentation of the protocol handler to see if that is the case.
     pub async fn accept(
         &self,
@@ -413,7 +413,7 @@ impl Router {
     ///
     /// If a protocol handler was registered for `alpn`, the handler will be
     /// shutdown. Existing connections will not be aborted by the router, but some protocol
-    /// handlers may abort existing connnections in their [`Router::shutdown`] implementation.
+    /// handlers may abort existing connections in their [`Router::shutdown`] implementation.
     /// Consult the documentation of the protocol handler to see if that is the case.
     ///
     /// Returns an error if the router has been shutdown or no protocol is registered for `alpn`.


### PR DESCRIPTION
## Description

This allows adding new protocols and removing protocols to an iroh `Router` after the router is built.
Also adds a timeout to shutdown for a protocol handler of 30s.

Also wrote a test for this.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
