### PR TITLE
feat(iroh): re-export `n0_watcher::Watcher` trait

### DIFF
--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -275,7 +275,6 @@ pub use iroh_base::{
     KeyParsingError, NodeAddr, NodeId, PublicKey, RelayUrl, RelayUrlParseError, SecretKey,
 };
 pub use iroh_relay::{http::Protocol as RelayProtocol, node_info, RelayMap, RelayNode};
-
 pub use n0_watcher::Watcher;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -276,5 +276,7 @@ pub use iroh_base::{
 };
 pub use iroh_relay::{http::Protocol as RelayProtocol, node_info, RelayMap, RelayNode};
 
+pub use n0_watcher::Watcher;
+
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;


### PR DESCRIPTION
## Description

Re-export the `n0_watcher::Watcher` so it is easier for our users to use heavily relied on methods like `Endpoint::node_addr`.

This becomes especially painful when you are working on any protocols using iroh.

## Notes & open questions

Should this be exported from a different module? `iroh::endpoint::Watcher`?


## Change checklist
- [x] Self-review.
