### PR TITLE
feat: add methods to create variants of the `iroh-base::ticket::ParseError` enum.

### DIFF
--- a/iroh-base/src/ticket.rs
+++ b/iroh-base/src/ticket.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeSet, net::SocketAddr};
 
 use nested_enum_utils::common_fields;
 use serde::{Deserialize, Serialize};
-use snafu::{Backtrace, IntoError, Snafu};
+use snafu::{Backtrace, Snafu};
 
 use crate::{key::NodeId, relay_url::RelayUrl};
 
@@ -76,7 +76,7 @@ pub enum ParseError {
         expected: &'static str,
     },
     /// This looks like a ticket, but postcard deserialization failed.
-    #[snafu(display("deserialization failed"))]
+    #[snafu(transparent)]
     Postcard { source: postcard::Error },
     /// This looks like a ticket, but base32 decoding failed.
     #[snafu(transparent)]
@@ -99,12 +99,6 @@ impl ParseError {
     /// deserialized bytes failed.
     pub fn verification_failed(message: &'static str) -> Self {
         VerifySnafu { message }.build()
-    }
-}
-
-impl From<postcard::Error> for ParseError {
-    fn from(source: postcard::Error) -> Self {
-        PostcardSnafu.into_error(source)
     }
 }
 

--- a/iroh-base/src/ticket/node.rs
+++ b/iroh-base/src/ticket/node.rs
@@ -3,7 +3,6 @@
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-use snafu::ResultExt;
 
 use super::{Variant0AddrInfo, Variant0NodeAddr};
 use crate::{
@@ -63,7 +62,7 @@ impl Ticket for NodeTicket {
     }
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, ParseError> {
-        let res: TicketWireFormat = postcard::from_bytes(bytes).context(ticket::PostcardSnafu)?;
+        let res: TicketWireFormat = postcard::from_bytes(bytes)?;
         let TicketWireFormat::Variant0(Variant0NodeTicket { node }) = res;
         Ok(Self {
             node: NodeAddr {


### PR DESCRIPTION
## Description

Adds a `From` impl for `postcard::Error`, and adds `ParseError::verification_failed` and `ParseError::wrong_prefix` methods.

## Open Questions

Should we add a variant to `ParseError` for a more "open ended" error, like we do for `protocol::AcceptError`? Something like `ParseError::Custom`?

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
