### PR TITLE
fix(iroh-base)!: remove display impl for SecretKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,6 +2351,7 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
+ "data-encoding",
  "derive_more",
  "dirs-next",
  "governor",

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -229,17 +229,6 @@ impl Debug for SecretKey {
     }
 }
 
-impl Display for SecretKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // TODO: revivew for security
-        write!(
-            f,
-            "{}",
-            data_encoding::HEXLOWER.encode(self.secret.as_bytes())
-        )
-    }
-}
-
 impl FromStr for SecretKey {
     type Err = KeyParsingError;
 
@@ -394,10 +383,12 @@ mod tests {
     }
 
     #[test]
-    fn test_display_from_str() {
+    fn test_from_str() {
         let key = SecretKey::generate(&mut rand::thread_rng());
         assert_eq!(
-            SecretKey::from_str(&key.to_string()).unwrap().to_bytes(),
+            SecretKey::from_str(&HEXLOWER.encode(&key.to_bytes()))
+                .unwrap()
+                .to_bytes(),
             key.to_bytes()
         );
 

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -61,6 +61,7 @@ z32 = "1.1.1"
 
 [dev-dependencies]
 criterion = "0.5.1"
+data-encoding = "2.3.3"
 hickory-resolver = "0.25.0"
 iroh = { path = "../iroh" }
 rand = "0.8"

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -65,7 +65,10 @@ async fn main() -> Result<()> {
         Err(_) => {
             let s = SecretKey::generate(rand::rngs::OsRng);
             println!("Generated a new node secret. To reuse, set");
-            println!("\tIROH_SECRET={s}\n");
+            println!(
+                "\tIROH_SECRET={}",
+                data_encoding::HEXLOWER.encode(&s.to_bytes())
+            );
             s
         }
     };

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -1,6 +1,7 @@
 use std::{env, future::Future, str::FromStr, time::Instant};
 
 use clap::Parser;
+use data_encoding::HEXLOWER;
 use iroh::{
     endpoint::{Connecting, Connection},
     SecretKey,
@@ -35,7 +36,10 @@ pub fn get_or_generate_secret_key() -> n0_snafu::Result<SecretKey> {
     } else {
         // Generate a new random key
         let secret_key = SecretKey::generate(&mut thread_rng());
-        println!("Generated new secret key: {}", secret_key);
+        println!(
+            "Generated new secret key: {}",
+            HEXLOWER.encode(&secret_key.to_bytes())
+        );
         println!("To reuse this key, set the IROH_SECRET environment variable to this value");
         Ok(secret_key)
     }

--- a/iroh/examples/connect-unreliable.rs
+++ b/iroh/examples/connect-unreliable.rs
@@ -35,7 +35,7 @@ async fn main() -> n0_snafu::Result<()> {
     println!("\nconnect (unreliable) example!\n");
     let args = Cli::parse();
     let secret_key = SecretKey::generate(rand::rngs::OsRng);
-    println!("secret key: {secret_key}");
+    println!("public key: {}", secret_key.public());
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay protocol and relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.
     let endpoint = Endpoint::builder()

--- a/iroh/examples/connect.rs
+++ b/iroh/examples/connect.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     println!("\nconnect example!\n");
     let args = Cli::parse();
     let secret_key = SecretKey::generate(rand::rngs::OsRng);
-    println!("secret key: {secret_key}");
+    println!("public key: {}", secret_key.public());
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay protocol and relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.
     let endpoint = Endpoint::builder()

--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     println!("\nlisten (unreliable) example!\n");
     let secret_key = SecretKey::generate(rand::rngs::OsRng);
-    println!("secret key: {secret_key}");
+    println!("public key: {}", secret_key.public());
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.
     let endpoint = Endpoint::builder()

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -18,7 +18,7 @@ async fn main() -> n0_snafu::Result<()> {
     tracing_subscriber::fmt::init();
     println!("\nlisten example!\n");
     let secret_key = SecretKey::generate(rand::rngs::OsRng);
-    println!("secret key: {secret_key}");
+    println!("public key: {}", secret_key.public());
 
     // Build a `Endpoint`, which uses PublicKeys as node identifiers, uses QUIC for directly connecting to other nodes, and uses the relay protocol and relay servers to holepunch direct connections between nodes when there are NATs or firewalls preventing direct connections. If no direct connection can be made, packets are relayed over the relay servers.
     let endpoint = Endpoint::builder()

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -5,6 +5,7 @@ use std::{
 
 use bytes::Bytes;
 use clap::{Parser, Subcommand};
+use data_encoding::HEXLOWER;
 use indicatif::HumanBytes;
 use iroh::{
     discovery::{
@@ -184,7 +185,7 @@ impl EndpointArgs {
             Err(_) => {
                 let s = SecretKey::generate(rand::rngs::OsRng);
                 println!("Generated a new node secret. To reuse, set");
-                println!("\tIROH_SECRET={s}");
+                println!("\tIROH_SECRET={}", HEXLOWER.encode(&s.to_bytes()));
                 s
             }
         };


### PR DESCRIPTION
## Description

Closes #3363

## Breaking Changes

- `Display` implementation was removed for `SecretKey`, use `.to_bytes()` and encode as hex to get the previous bytes explicitly

