### PR TITLE
chore(iroh)!: change default relays to new "canary" relays

### DIFF
--- a/iroh/src/defaults.rs
+++ b/iroh/src/defaults.rs
@@ -23,11 +23,11 @@ pub mod prod {
     use super::*;
 
     /// Hostname of the default NA relay.
-    pub const NA_RELAY_HOSTNAME: &str = "use1-1.relay.iroh.network.";
+    pub const NA_RELAY_HOSTNAME: &str = "use1-1.relay.n0.iroh-canary.iroh.link.";
     /// Hostname of the default EU relay.
-    pub const EU_RELAY_HOSTNAME: &str = "euw1-1.relay.iroh.network.";
+    pub const EU_RELAY_HOSTNAME: &str = "euc1-1.relay.n0.iroh-canary.iroh.link.";
     /// Hostname of the default Asia-Pacific relay.
-    pub const AP_RELAY_HOSTNAME: &str = "aps1-1.relay.iroh.network.";
+    pub const AP_RELAY_HOSTNAME: &str = "aps1-1.relay.n0.iroh-canary.iroh.link.";
 
     /// Get the default [`RelayMap`].
     pub fn default_relay_map() -> RelayMap {
@@ -86,9 +86,11 @@ pub mod staging {
     use super::*;
 
     /// Hostname of the default NA relay.
-    pub const NA_RELAY_HOSTNAME: &str = "staging-use1-1.relay.iroh.network.";
+    // TODO(ramfox): for `0.91` release, make sure we have canary staging relays
+    pub const NA_RELAY_HOSTNAME: &str = "use1-1.relay.n0.iroh-canary.iroh.link.";
     /// Hostname of the default EU relay.
-    pub const EU_RELAY_HOSTNAME: &str = "staging-euw1-1.relay.iroh.network.";
+    // TODO(ramfox): for `0.91` release, make sure we have canary staging relays
+    pub const EU_RELAY_HOSTNAME: &str = "euc1-1.relay.n0.iroh-canary.iroh.link.";
 
     /// Get the default [`RelayMap`].
     pub fn default_relay_map() -> RelayMap {


### PR DESCRIPTION
## Description

Now that we are on our final push to `1.0`, we are not going to be limiting ourselves to make network-level breaking changes. Because we know some users need network stability, they won't be upgrading until the `1.0` is released. So, we will need to maintain two sets of relays, one that stays on `0.35`, for the folks who won't be upgrading until `1.0`, and our new `0.9X` relays (which we will call our "canary" relays).

This PR points our staging and prod default relays to the new canary relays.

By our next release, we will also have separate staging canary relays, and so those values will change again.

## Breaking Changes

The default prod and staging relays are now different:

    - NA (prod & staging):  "use1-1.relay.n0.iroh-canary.iroh.link.";
    - EU (prod & staging): "euc1-1.relay.n0.iroh-canary.iroh.link.";
    - AP (prod): "aps1-1.relay.n0.iroh-canary.iroh.link.";

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.