### PR TITLE
docs(iroh): Use `iroh::Watcher` reexport in docs

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -912,8 +912,7 @@ impl Endpoint {
     ///
     /// ```no_run
     /// # async fn wrapper() -> n0_snafu::Result {
-    /// use iroh::Endpoint;
-    /// use n0_watcher::Watcher;
+    /// use iroh::{Endpoint, Watcher};
     ///
     /// let endpoint = Endpoint::builder()
     ///     .alpns(vec![b"my-alpn".to_vec()])
@@ -982,9 +981,7 @@ impl Endpoint {
     ///
     /// To wait for a home relay connection to be established, use [`Watcher::initialized`]:
     /// ```no_run
-    /// use iroh::Endpoint;
-    /// use n0_future::StreamExt;
-    /// use n0_watcher::Watcher as _;
+    /// use iroh::{Endpoint, Watcher};
     ///
     /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
     /// # rt.block_on(async move {
@@ -1019,14 +1016,12 @@ impl Endpoint {
     ///
     /// To get the first set of direct addresses use [`Watcher::initialized`]:
     /// ```no_run
-    /// use iroh::Endpoint;
-    /// use n0_future::StreamExt;
-    /// use n0_watcher::Watcher as _;
+    /// use iroh::{Endpoint, Watcher as _};
     ///
     /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
     /// # rt.block_on(async move {
-    /// let mep = Endpoint::builder().bind().await.unwrap();
-    /// let _addrs = mep.direct_addresses().initialized().await.unwrap();
+    /// let ep = Endpoint::builder().bind().await.unwrap();
+    /// let _addrs = ep.direct_addresses().initialized().await.unwrap();
     /// # });
     /// ```
     ///
@@ -1055,9 +1050,7 @@ impl Endpoint {
     ///
     /// To get the first report use [`Watcher::initialized`]:
     /// ```no_run
-    /// use iroh::Endpoint;
-    /// use n0_future::StreamExt;
-    /// use n0_watcher::Watcher as _;
+    /// use iroh::{Endpoint, Watcher as _};
     ///
     /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
     /// # rt.block_on(async move {


### PR DESCRIPTION
## Description

Fixes the documentation examples to avoid `n0_watcher` imports in favor of just `iroh::Watcher`.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.