### PR TITLE
docs: grammar nitpick

### DIFF
--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -154,8 +154,8 @@
 //! ## Node Discovery
 //!
 //! The need to know the [`RelayUrl`] *or* some direct addresses in addition to the
-//! [`NodeId`] to connect to an iroh node can be an obstacle.  To address this the
-//! [`endpoint::Builder`] allows to configure a [`discovery`] service.
+//! [`NodeId`] to connect to an iroh node can be an obstacle.  To address this, the
+//! [`endpoint::Builder`] allows you to configure a [`discovery`] service.
 //!
 //! The [`DnsDiscovery`] service is a discovery service which will publish the [`RelayUrl`]
 //! and direct addresses to a service publishing those as DNS records.  To connect it looks


### PR DESCRIPTION
## Description

Really small grammar check, no breaking issues I'm aware of. "allows to" isn't a phrase that is technically correct.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
"To address this, the thing allows for the configuration of a discovery service." could work too, but I prefer using "you" in instructions to make things just the littlest bit less abstract.

## Change checklist
<!-- Remove any that are not relevant. -->
- [X] Self-review.