### PR TITLE
refactor: try to use 'static to denote impls that don't reference argument lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,8 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.6.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=main#c3476f3ad4d6a59c3d777a66c3273ef9a4084002"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0445cbbb4d6d1afe22f4d1c14da2a2eb598a98b83650f15f988050bceefea5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3473,8 +3474,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portmapper"
-version = "0.6.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=main#c3476f3ad4d6a59c3d777a66c3273ef9a4084002"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abceb40595a7a1b65242013b497d031000c1c0e58505d4c5f7834951fd3800d4"
 dependencies = [
  "base64",
  "bytes",
@@ -5636,7 +5638,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.6.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=deps-update#1ad2a1620b42547766225978e5d9bc27eb4dcda0"
+source = "git+https://github.com/n0-computer/net-tools?branch=main#c3476f3ad4d6a59c3d777a66c3273ef9a4084002"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3474,7 +3474,7 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 [[package]]
 name = "portmapper"
 version = "0.6.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=deps-update#1ad2a1620b42547766225978e5d9bc27eb4dcda0"
+source = "git+https://github.com/n0-computer/net-tools?branch=main#c3476f3ad4d6a59c3d777a66c3273ef9a4084002"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.6.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=deps-update#fe688dccbbe22face271559e06fc46bcad507b72"
+source = "git+https://github.com/n0-computer/net-tools?branch=deps-update#1ad2a1620b42547766225978e5d9bc27eb4dcda0"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3474,7 +3474,7 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 [[package]]
 name = "portmapper"
 version = "0.6.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=deps-update#fe688dccbbe22face271559e06fc46bcad507b72"
+source = "git+https://github.com/n0-computer/net-tools?branch=deps-update#1ad2a1620b42547766225978e5d9bc27eb4dcda0"
 dependencies = [
  "base64",
  "bytes",
@@ -5636,7 +5636,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
@@ -44,15 +44,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -93,9 +93,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -108,36 +108,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -186,7 +186,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -198,7 +198,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -222,7 +222,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -331,7 +331,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
+checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
 dependencies = [
  "fastrand",
  "gloo-timers 0.3.0",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bincode"
@@ -447,9 +447,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -474,9 +474,9 @@ checksum = "387e80962b798815a2b5c4bcfdb6bf626fa922ffe9f74e373103b858738e9f31"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -498,9 +498,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -513,9 +513,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -609,27 +609,30 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "color-backtrace"
@@ -644,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -689,9 +692,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cordyceps"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0392f465ceba1713d30708f61c160ebf4dc1cf86bb166039d16b11ad4f3b5b6"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
 dependencies = [
  "loom",
  "tracing",
@@ -709,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -734,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -825,9 +828,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -874,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "373b7c5dbd637569a2cca66e8d66b8c446a1e7bf064ea321d265d7b3dfe7c97e"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -898,7 +901,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -955,7 +958,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -973,7 +976,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -984,7 +996,19 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -1040,7 +1064,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1082,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1128,27 +1152,27 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "enumflags2"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1168,12 +1192,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1190,9 +1214,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "flume"
@@ -1238,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
 dependencies = [
  "autocfg",
  "tokio",
@@ -1328,7 +1352,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1369,15 +1393,16 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
@@ -1400,15 +1425,15 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1619,7 +1644,7 @@ dependencies = [
  "futures-sink",
  "futures-timer",
  "futures-util",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
@@ -1633,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1677,9 +1702,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1718,9 +1743,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1832,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "hmac-sha256"
-version = "1.1.8"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8575493d277c9092b988c780c94737fb9fd8651a1001e16bee3eccfc1baedb"
+checksum = "ad6880c8d4a9ebf39c6e8b77007ce223f646a4d21ce29d99f70cb16420545425"
 
 [[package]]
 name = "hostname-validator"
@@ -1938,11 +1963,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http 1.3.1",
  "hyper",
  "hyper-util",
@@ -1951,24 +1975,28 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1986,7 +2014,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -2000,21 +2028,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2024,30 +2053,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -2055,65 +2064,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -2129,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2160,12 +2156,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -2204,12 +2200,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -2221,6 +2228,16 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
  "serde",
 ]
 
@@ -2238,11 +2255,11 @@ dependencies = [
  "crypto_box",
  "data-encoding",
  "der",
- "derive_more",
+ "derive_more 1.0.0",
  "ed25519-dalek",
  "futures-buffered",
  "futures-util",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "hickory-resolver",
  "http 1.3.1",
  "igd-next",
@@ -2258,7 +2275,7 @@ dependencies = [
  "n0-snafu",
  "n0-watcher",
  "nested_enum_utils",
- "netdev",
+ "netdev 0.31.0",
  "netwatch",
  "parse-size",
  "pin-project",
@@ -2303,7 +2320,7 @@ version = "0.90.0"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
- "derive_more",
+ "derive_more 1.0.0",
  "ed25519-dalek",
  "n0-snafu",
  "nested_enum_utils",
@@ -2351,7 +2368,7 @@ dependencies = [
  "clap",
  "criterion",
  "data-encoding",
- "derive_more",
+ "derive_more 1.0.0",
  "dirs-next",
  "governor",
  "hickory-resolver",
@@ -2420,7 +2437,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2436,7 +2453,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2473,7 +2490,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2489,8 +2506,8 @@ dependencies = [
  "crypto_box",
  "dashmap",
  "data-encoding",
- "derive_more",
- "getrandom 0.3.2",
+ "derive_more 1.0.0",
+ "getrandom 0.3.3",
  "governor",
  "hickory-proto",
  "hickory-resolver",
@@ -2617,17 +2634,17 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
 ]
 
@@ -2645,9 +2662,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
@@ -2657,9 +2674,9 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2690,8 +2707,14 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mainline"
@@ -2738,9 +2761,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -2766,22 +2789,22 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2810,7 +2833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb0e5d99e681ab3c938842b96fcb41bf8a7bb4bfdb11ccbd653a7e83e06c794"
 dependencies = [
  "cfg_aliases",
- "derive_more",
+ "derive_more 1.0.0",
  "futures-buffered",
  "futures-lite",
  "futures-util",
@@ -2843,7 +2866,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f216d4ebc5fcf9548244803cbb93f488a2ae160feba3706cd17040d69cf7a368"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "n0-future",
  "snafu",
 ]
@@ -2878,6 +2901,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "netdev"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862209dce034f82a44c95ce2b5183730d616f2a68746b9c1959aa2572e77c0a1"
+dependencies = [
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-route 0.22.0",
+ "netlink-sys",
+ "once_cell",
+ "system-configuration",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,12 +2944,27 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.23.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0800eae8638a299eaa67476e1c6b6692922273e0f7939fd188fc861c837b9cd2"
+checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
 dependencies = [
  "anyhow",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d83370a96813d7c977f8b63054f1162df6e5784f1c598d689236564fb5a6f2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.1",
  "byteorder",
  "libc",
  "log",
@@ -2959,35 +3014,34 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a829a830199b14989f9bccce6136ab928ab48336ab1f8b9002495dbbbb2edbe"
+source = "git+https://github.com/n0-computer/net-tools?branch=deps-update#fe688dccbbe22face271559e06fc46bcad507b72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
- "derive_more",
+ "derive_more 2.0.1",
  "iroh-quinn-udp",
  "js-sys",
  "libc",
  "n0-future",
  "n0-watcher",
  "nested_enum_utils",
- "netdev",
+ "netdev 0.36.0",
  "netlink-packet-core",
- "netlink-packet-route 0.23.0",
+ "netlink-packet-route 0.24.0",
  "netlink-proto",
  "netlink-sys",
  "pin-project-lite",
  "serde",
  "snafu",
- "socket2",
+ "socket2 0.6.0",
  "time",
  "tokio",
  "tokio-util",
  "tracing",
  "web-sys",
- "windows 0.59.0",
- "windows-result 0.3.2",
+ "windows",
+ "windows-result",
  "wmi",
 ]
 
@@ -3086,23 +3140,24 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3149,6 +3204,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,9 +3241,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3190,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3240,9 +3301,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -3251,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3261,24 +3322,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -3310,7 +3370,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3327,9 +3387,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32222ae3d617bf92414db29085f8a959a4515effce916e038e9399a335a0d6d"
+checksum = "41a50f65a2b97031863fbdff2f085ba832360b4bef3106d1fcff9ab5bf4063fe"
 dependencies = [
  "async-compat",
  "base32",
@@ -3413,7 +3473,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3450,19 +3510,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portmapper"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d82975dc029c00d566f4e0f61f567d31f0297a290cb5416b5580dd8b4b54ade"
+source = "git+https://github.com/n0-computer/net-tools?branch=deps-update#fe688dccbbe22face271559e06fc46bcad507b72"
 dependencies = [
  "base64",
  "bytes",
- "derive_more",
+ "derive_more 2.0.1",
  "futures-lite",
  "futures-util",
  "hyper-util",
@@ -3472,11 +3531,11 @@ dependencies = [
  "nested_enum_utils",
  "netwatch",
  "num_enum",
- "rand 0.8.5",
+ "rand 0.9.1",
  "serde",
  "smallvec",
  "snafu",
- "socket2",
+ "socket2 0.6.0",
  "time",
  "tokio",
  "tokio-util",
@@ -3487,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -3501,13 +3560,22 @@ dependencies = [
 
 [[package]]
 name = "postcard-derive"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0239fa9c1d225d4b7eb69925c25c5e082307a141e470573fbbe3a817ce6a7a37"
+checksum = "68f049d94cb6dda6938cc8a531d2898e7c08d71c6de63d8e67123cca6cdde2cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -3522,7 +3590,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3599,17 +3667,17 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -3619,15 +3687,15 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
 dependencies = [
  "crossbeam-utils",
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -3640,9 +3708,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3651,7 +3719,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -3660,12 +3728,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "lru-slab",
  "rand 0.9.1",
  "ring",
  "rustc-hash",
@@ -3680,14 +3749,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3713,9 +3782,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -3773,16 +3842,16 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3791,7 +3860,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3838,11 +3907,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3925,9 +3994,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64",
  "bytes",
@@ -3939,16 +4008,12 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3958,21 +4023,21 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.11",
- "windows-registry",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7c8f7f733062b66dc1c63f9db168ac0b97a9210e247fa90fdc9ad08f51b302"
+checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "ring"
@@ -3990,9 +4055,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -4024,7 +4089,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4033,9 +4098,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "log",
  "once_cell",
@@ -4118,7 +4183,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4141,9 +4206,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.2"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4152,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"
@@ -4219,8 +4284,8 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.10.0",
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4301,7 +4366,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4328,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -4439,23 +4504,20 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol_str"
@@ -4482,7 +4544,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4493,6 +4555,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4555,7 +4627,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4583,7 +4655,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4626,7 +4698,7 @@ dependencies = [
  "parking_lot",
  "pnet_packet",
  "rand 0.9.1",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -4641,7 +4713,7 @@ dependencies = [
  "acto",
  "hickory-proto",
  "rand 0.9.1",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4660,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4686,7 +4758,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4695,7 +4767,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4718,12 +4790,12 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4764,7 +4836,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4775,17 +4847,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -4824,9 +4895,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4859,18 +4930,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -4883,7 +4956,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4947,7 +5020,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "pin-project-lite",
  "tokio",
 ]
@@ -4962,7 +5035,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "http 1.3.1",
  "httparse",
  "rand 0.9.1",
@@ -4976,9 +5049,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -4988,18 +5061,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
@@ -5011,9 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -5033,15 +5106,18 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
+ "futures-util",
  "http 1.3.1",
  "http-body",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5089,20 +5165,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5177,7 +5253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5239,9 +5315,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -5278,12 +5354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5297,11 +5367,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5346,9 +5418,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -5381,7 +5453,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -5416,7 +5488,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5451,7 +5523,7 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5493,14 +5565,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.0",
+ "webpki-root-certs 1.0.1",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
+checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5511,14 +5583,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5562,83 +5634,48 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
-dependencies = [
- "windows-core 0.59.0",
- "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface 0.59.1",
- "windows-result 0.3.2",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
  "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-collections"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "windows-core",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.59.0"
+name = "windows-core"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5649,18 +5686,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5671,68 +5697,39 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result 0.3.2",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-result"
+name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -5771,6 +5768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -5821,9 +5827,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -5833,6 +5839,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6017,9 +6032,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -6040,41 +6055,35 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
 name = "wmi"
-version = "0.14.5"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7787dacdd8e71cbc104658aade4009300777f9b5fda6a75f19145fedb8a18e71"
+checksum = "3d3de777dce4cbcdc661d5d18e78ce4b46a37adc2bb7c0078a556c7f07bcce2f"
 dependencies = [
  "chrono",
  "futures",
  "log",
  "serde",
  "thiserror 2.0.12",
- "windows 0.59.0",
- "windows-core 0.59.0",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "ws_stream_wasm"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
 dependencies = [
  "async_io_stream",
  "futures",
@@ -6083,7 +6092,7 @@ dependencies = [
  "pharos",
  "rustc_version",
  "send_wrapper",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6108,9 +6117,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "xmltree"
@@ -6138,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6150,13 +6159,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -6168,42 +6177,22 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
-dependencies = [
- "zerocopy-derive 0.8.25",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6223,7 +6212,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -6234,10 +6223,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6246,11 +6246,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,12 +441,6 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -663,15 +657,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2166,15 +2160,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "tokio",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2205,7 +2199,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -2255,7 +2249,7 @@ dependencies = [
  "crypto_box",
  "data-encoding",
  "der",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "ed25519-dalek",
  "futures-buffered",
  "futures-util",
@@ -2275,7 +2269,7 @@ dependencies = [
  "n0-snafu",
  "n0-watcher",
  "nested_enum_utils",
- "netdev 0.31.0",
+ "netdev",
  "netwatch",
  "parse-size",
  "pin-project",
@@ -2295,7 +2289,7 @@ dependencies = [
  "smallvec",
  "snafu",
  "spki",
- "strum",
+ "strum 0.27.1",
  "stun-rs",
  "surge-ping",
  "swarm-discovery",
@@ -2320,7 +2314,7 @@ version = "0.90.0"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "ed25519-dalek",
  "n0-snafu",
  "nested_enum_utils",
@@ -2349,7 +2343,7 @@ dependencies = [
  "n0-snafu",
  "n0-watcher",
  "rand 0.8.5",
- "rcgen",
+ "rcgen 0.14.2",
  "rustls",
  "tokio",
  "tracing",
@@ -2368,7 +2362,7 @@ dependencies = [
  "clap",
  "criterion",
  "data-encoding",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "dirs-next",
  "governor",
  "hickory-resolver",
@@ -2384,7 +2378,7 @@ dependencies = [
  "pkarr",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rcgen",
+ "rcgen 0.13.2",
  "redb",
  "regex",
  "rustls",
@@ -2392,7 +2386,7 @@ dependencies = [
  "serde",
  "snafu",
  "struct_iterable",
- "strum",
+ "strum 0.26.3",
  "tokio",
  "tokio-rustls",
  "tokio-rustls-acme",
@@ -2506,7 +2500,7 @@ dependencies = [
  "crypto_box",
  "dashmap",
  "data-encoding",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "getrandom 0.3.3",
  "governor",
  "hickory-proto",
@@ -2530,7 +2524,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rcgen",
+ "rcgen 0.14.2",
  "regex",
  "reloadable-state",
  "reqwest",
@@ -2545,7 +2539,7 @@ dependencies = [
  "sha1",
  "simdutf8",
  "snafu",
- "strum",
+ "strum 0.27.1",
  "time",
  "tokio",
  "tokio-rustls",
@@ -2644,7 +2638,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "libc",
 ]
 
@@ -2885,23 +2879,6 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f901362e84cd407be6f8cd9d3a46bccf09136b095792785401ea7d283c79b91d"
-dependencies = [
- "dlopen2",
- "ipnet",
- "libc",
- "netlink-packet-core",
- "netlink-packet-route 0.17.1",
- "netlink-sys",
- "once_cell",
- "system-configuration",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "netdev"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862209dce034f82a44c95ce2b5183730d616f2a68746b9c1959aa2572e77c0a1"
@@ -2930,26 +2907,12 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
- "libc",
- "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-route"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
 dependencies = [
  "anyhow",
- "bitflags 2.9.1",
+ "bitflags",
  "byteorder",
  "libc",
  "log",
@@ -2964,7 +2927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d83370a96813d7c977f8b63054f1162df6e5784f1c598d689236564fb5a6f2"
 dependencies = [
  "anyhow",
- "bitflags 2.9.1",
+ "bitflags",
  "byteorder",
  "libc",
  "log",
@@ -3026,7 +2989,7 @@ dependencies = [
  "n0-future",
  "n0-watcher",
  "nested_enum_utils",
- "netdev 0.36.0",
+ "netdev",
  "netlink-packet-core",
  "netlink-packet-route 0.24.0",
  "netlink-proto",
@@ -3168,12 +3131,6 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -3673,7 +3630,7 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.1",
+ "bitflags",
  "lazy_static",
  "num-traits",
  "rand 0.9.1",
@@ -3860,7 +3817,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3897,6 +3854,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49bc8ffa8a832eb1d7c8000337f8b0d2f4f2f5ec3cf4ddc26f125e3ad2451824"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redb"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3911,7 +3881,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -4089,7 +4059,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4284,7 +4254,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4393,9 +4363,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -4504,7 +4474,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -4642,7 +4612,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -4650,6 +4629,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4767,7 +4759,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4984,7 +4976,7 @@ dependencies = [
  "num-bigint",
  "pem",
  "proc-macro2",
- "rcgen",
+ "rcgen 0.13.2",
  "reqwest",
  "ring",
  "rustls",
@@ -5049,14 +5041,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -5064,6 +5059,12 @@ name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
 dependencies = [
  "serde",
 ]
@@ -5075,18 +5076,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
+ "toml_datetime 0.6.11",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_parser"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -5110,7 +5117,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -5324,6 +5331,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "universal-hash"
@@ -6055,7 +6068,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+
+[patch.crates-io]
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "deps-update" }
+netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "deps-update" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,5 @@ unused-async = "warn"
 
 
 [patch.crates-io]
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "deps-update" }
-netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "deps-update" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
+netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,3 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
-
-
-[patch.crates-io]
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
-netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "main" }

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh-base"
 version = "0.90.0"
-edition = "2021"
+edition = "2024"
 readme = "README.md"
 description = "base type and utilities for Iroh"
 license = "MIT OR Apache-2.0"

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 curve25519-dalek = { version = "4.1.3", features = ["serde", "rand_core", "zeroize"], optional = true }
 data-encoding = { version = "2.3.3", optional = true }
 ed25519-dalek = { version = "2.1.1", features = ["serde", "rand_core", "zeroize"], optional = true }
-derive_more = { version = "1.0.0", features = ["display"], optional = true }
+derive_more = { version = "2.0.1", features = ["display"], optional = true }
 url = { version = "2.5.3", features = ["serde"], optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"], optional = true }
 rand_core = { version = "0.6.4", optional = true }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh-dns-server"
 version = "0.90.0"
-edition = "2021"
+edition = "2024"
 description = "A pkarr relay and DNS server"
 license = "MIT OR Apache-2.0"
 authors = ["Frando <franz@n0.computer>", "n0 team"]

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -16,7 +16,7 @@ axum-server = { version = "0.7", features = ["tls-rustls-no-provider"] }
 base64-url = "3.0"
 bytes = "1.7"
 clap = { version = "4.5.1", features = ["derive"] }
-derive_more = { version = "1.0.0", features = [
+derive_more = { version = "2.0.1", features = [
     "debug",
     "display",
     "into",
@@ -50,7 +50,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
 tokio-rustls-acme = { version = "0.7.1", features = ["axum"] }
 tokio-stream = "0.1.14"
 tokio-util = "0.7"
-toml = "0.8.10"
+toml = "0.9.2"
 tower-http = { version = "0.6.1", features = ["cors", "trace"] }
 tower_governor = "0.7"
 tracing = "0.1"

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use iroh::{discovery::pkarr::PkarrRelayClient, node_info::NodeInfo, SecretKey};
-use iroh_dns_server::{config::Config, metrics::Metrics, server::Server, ZoneStore};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use iroh::{SecretKey, discovery::pkarr::PkarrRelayClient, node_info::NodeInfo};
+use iroh_dns_server::{ZoneStore, config::Config, metrics::Metrics, server::Server};
 use n0_snafu::Result;
 use rand_chacha::rand_core::SeedableRng;
 use tokio::runtime::Runtime;

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -2,13 +2,13 @@ use std::{net::SocketAddr, str::FromStr};
 
 use clap::{Parser, ValueEnum};
 use iroh::{
-    discovery::{
-        dns::{N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING},
-        pkarr::{PkarrRelayClient, N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING},
-        UserData,
-    },
-    node_info::{NodeIdExt, NodeInfo, IROH_TXT_NAME},
     NodeId, SecretKey,
+    discovery::{
+        UserData,
+        dns::{N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING},
+        pkarr::{N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING, PkarrRelayClient},
+    },
+    node_info::{IROH_TXT_NAME, NodeIdExt, NodeInfo},
 };
 use n0_snafu::{Result, ResultExt};
 use url::Url;

--- a/iroh-dns-server/examples/resolve.rs
+++ b/iroh-dns-server/examples/resolve.rs
@@ -1,8 +1,8 @@
 use clap::{Parser, ValueEnum};
 use iroh::{
+    NodeId,
     discovery::dns::{N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING},
     dns::DnsResolver,
-    NodeId,
 };
 use n0_snafu::{Result, ResultExt};
 

--- a/iroh-dns-server/src/dns.rs
+++ b/iroh-dns-server/src/dns.rs
@@ -16,8 +16,8 @@ use hickory_server::{
         self,
         op::ResponseCode,
         rr::{
-            rdata::{self},
             LowerName, Name, RData, Record, RecordSet, RecordType, RrKey,
+            rdata::{self},
         },
         serialize::{binary::BinEncoder, txt::RDataParser},
         xfer::Protocol,
@@ -25,7 +25,7 @@ use hickory_server::{
     server::{Request, RequestHandler, ResponseHandler, ResponseInfo},
     store::in_memory::InMemoryAuthority,
 };
-use n0_snafu::{format_err, Result, ResultExt};
+use n0_snafu::{Result, ResultExt, format_err};
 use serde::{Deserialize, Serialize};
 use tokio::{
     net::{TcpListener, UdpSocket},

--- a/iroh-dns-server/src/dns/node_authority.rs
+++ b/iroh-dns-server/src/dns/node_authority.rs
@@ -19,7 +19,7 @@ use tracing::{debug, trace};
 
 use crate::{
     store::ZoneStore,
-    util::{record_set_append_origin, PublicKeyBytes},
+    util::{PublicKeyBytes, record_set_append_origin},
 };
 
 #[derive(derive_more::Debug)]

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -6,13 +6,13 @@ use std::{
 };
 
 use axum::{
+    Router,
     extract::{ConnectInfo, Request, State},
     handler::Handler,
     http::Method,
     middleware::{self, Next},
     response::IntoResponse,
     routing::get,
-    Router,
 };
 use n0_snafu::{Result, ResultExt};
 use serde::{Deserialize, Serialize};
@@ -22,7 +22,7 @@ use tower_http::{
     cors::{self, CorsLayer},
     trace::TraceLayer,
 };
-use tracing::{info, span, warn, Level};
+use tracing::{Level, info, span, warn};
 
 mod doh;
 mod error;

--- a/iroh-dns-server/src/http/doh.rs
+++ b/iroh-dns-server/src/http/doh.rs
@@ -4,17 +4,17 @@
 // https://github.com/fission-codes/fission-server/blob/main/fission-server/src/routes/doh.rs
 
 use axum::{
+    Json,
     extract::State,
     response::{IntoResponse, Response},
-    Json,
 };
 use hickory_server::proto::{
     serialize::binary::BinDecodable,
     {self},
 };
 use http::{
-    header::{CACHE_CONTROL, CONTENT_TYPE},
     HeaderValue, StatusCode,
+    header::{CACHE_CONTROL, CONTENT_TYPE},
 };
 use n0_snafu::ResultExt;
 

--- a/iroh-dns-server/src/http/doh/extract.rs
+++ b/iroh-dns-server/src/http/doh/extract.rs
@@ -25,7 +25,7 @@ use hickory_server::{
     },
     server::Request as DNSRequest,
 };
-use http::{header, request::Parts, HeaderValue, StatusCode};
+use http::{HeaderValue, StatusCode, header, request::Parts};
 use serde::Deserialize;
 use tracing::info;
 

--- a/iroh-dns-server/src/http/error.rs
+++ b/iroh-dns-server/src/http/error.rs
@@ -1,8 +1,8 @@
 use axum::{
+    Json,
     extract::rejection::{ExtensionRejection, QueryRejection},
     http::StatusCode,
     response::IntoResponse,
-    Json,
 };
 use serde::{Deserialize, Serialize};
 
@@ -78,7 +78,7 @@ impl From<ExtensionRejection> for AppError {
 /// We could have used http_serde, but it encodes the status code as a NUMBER.
 pub mod serde_status_code {
     use http::StatusCode;
-    use serde::{de::Unexpected, Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Unexpected};
 
     /// Serialize [StatusCode]s.
     pub fn serialize<S: Serializer>(status: &StatusCode, ser: S) -> Result<S::Ok, S::Error> {

--- a/iroh-dns-server/src/http/pkarr.rs
+++ b/iroh-dns-server/src/http/pkarr.rs
@@ -3,7 +3,7 @@ use axum::{
     response::IntoResponse,
 };
 use bytes::Bytes;
-use http::{header, StatusCode};
+use http::{StatusCode, header};
 use tracing::info;
 
 use super::error::AppError;

--- a/iroh-dns-server/src/http/rate_limiting.rs
+++ b/iroh-dns-server/src/http/rate_limiting.rs
@@ -3,9 +3,9 @@ use std::{sync::Arc, time::Duration};
 use governor::{clock::QuantaInstant, middleware::NoOpMiddleware};
 use serde::{Deserialize, Serialize};
 use tower_governor::{
+    GovernorLayer,
     governor::GovernorConfigBuilder,
     key_extractor::{PeerIpKeyExtractor, SmartIpKeyExtractor},
-    GovernorLayer,
 };
 
 /// Config for http server rate limit.
@@ -71,10 +71,12 @@ pub fn create(
     // The governor needs a background task for garbage collection (to clear expired records)
     let gc_interval = Duration::from_secs(60);
     let governor_limiter = governor_conf.limiter().clone();
-    std::thread::spawn(move || loop {
-        std::thread::sleep(gc_interval);
-        tracing::debug!("rate limiting storage size: {}", governor_limiter.len());
-        governor_limiter.retain_recent();
+    std::thread::spawn(move || {
+        loop {
+            std::thread::sleep(gc_interval);
+            tracing::debug!("rate limiting storage size: {}", governor_limiter.len());
+            governor_limiter.retain_recent();
+        }
     });
 
     Some(GovernorLayer {

--- a/iroh-dns-server/src/http/tls.rs
+++ b/iroh-dns-server/src/http/tls.rs
@@ -9,14 +9,14 @@ use axum_server::{
     accept::Accept,
     tls_rustls::{RustlsAcceptor, RustlsConfig},
 };
-use n0_future::{future::Boxed as BoxFuture, FutureExt};
+use n0_future::{FutureExt, future::Boxed as BoxFuture};
 use n0_snafu::{Result, ResultExt};
 use serde::{Deserialize, Serialize};
 use snafu::whatever;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_rustls_acme::{axum::AxumAcceptor, caches::DirCache, AcmeConfig};
+use tokio_rustls_acme::{AcmeConfig, axum::AxumAcceptor, caches::DirCache};
 use tokio_stream::StreamExt;
-use tracing::{debug, error, info_span, Instrument};
+use tracing::{Instrument, debug, error, info_span};
 
 /// The mode how SSL certificates should be created.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, strum::Display)]

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -22,19 +22,19 @@ mod tests {
     };
 
     use iroh::{
-        discovery::pkarr::PkarrRelayClient, dns::DnsResolver, node_info::NodeInfo, RelayUrl,
-        SecretKey,
+        RelayUrl, SecretKey, discovery::pkarr::PkarrRelayClient, dns::DnsResolver,
+        node_info::NodeInfo,
     };
     use n0_snafu::{Result, ResultExt};
     use pkarr::{SignedPacket, Timestamp};
     use tracing_test::traced_test;
 
     use crate::{
+        ZoneStore,
         config::BootstrapOption,
         server::Server,
         store::{PacketSource, ZoneStoreOptions},
         util::PublicKeyBytes,
-        ZoneStore,
     };
 
     const DNS_TIMEOUT: Duration = Duration::from_secs(1);

--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -14,7 +14,7 @@ use self::signed_packets::SignedPacketStore;
 use crate::{
     config::BootstrapOption,
     metrics::Metrics,
-    util::{signed_packet_to_hickory_records_without_origin, PublicKeyBytes},
+    util::{PublicKeyBytes, signed_packet_to_hickory_records_without_origin},
 };
 
 mod signed_packets;

--- a/iroh-dns-server/src/store/signed_packets.rs
+++ b/iroh-dns-server/src/store/signed_packets.rs
@@ -151,7 +151,7 @@ impl Actor {
                             Message::Upsert { packet, res } => {
                                 let key = PublicKeyBytes::from_signed_packet(&packet);
                                 trace!("upsert {}", key);
-                                let replaced = if let Some(existing) = get_packet(&tables.signed_packets, &key)? {
+                                let replaced = match get_packet(&tables.signed_packets, &key)? { Some(existing) => {
                                     if existing.more_recent_than(&packet) {
                                         res.send(false).ok();
                                         continue;
@@ -160,9 +160,9 @@ impl Actor {
                                         tables.update_time.remove(&existing.timestamp().to_bytes(), key.as_bytes()).e()?;
                                         true
                                     }
-                                } else {
+                                } _ => {
                                     false
-                                };
+                                }};
                                 let value = packet.serialize();
                                 tables.signed_packets
                                     .insert(key.as_bytes(), &value[..]).e()?;
@@ -177,14 +177,14 @@ impl Actor {
                             }
                             Message::Remove { key, res } => {
                                 trace!("remove {}", key);
-                                let updated = if let Some(row) = tables.signed_packets.remove(key.as_bytes()).e()? {
+                                let updated = match tables.signed_packets.remove(key.as_bytes()).e()? { Some(row) => {
                                     let packet = SignedPacket::deserialize(row.value()).e()?;
                                     tables.update_time.remove(&packet.timestamp().to_bytes(), key.as_bytes()).e()?;
                                     self.metrics.store_packets_removed.inc();
                                     true
-                                } else {
+                                } _ => {
                                     false
-                                };
+                                }};
                                 res.send(updated).ok();
                             }
                             Message::Snapshot { res } => {
@@ -193,7 +193,7 @@ impl Actor {
                             }
                             Message::CheckExpired { key, time } => {
                                 trace!("check expired {} at {}", key, fmt_time(time));
-                                if let Some(packet) = get_packet(&tables.signed_packets, &key)? {
+                                match get_packet(&tables.signed_packets, &key)? { Some(packet) => {
                                     let expired = Timestamp::now() - expiry_us;
                                     if packet.timestamp() < expired {
                                         tables.update_time.remove(&time.to_bytes(), key.as_bytes()).e()?;
@@ -204,10 +204,10 @@ impl Actor {
                                         debug!("packet {key} is no longer expired, removing obsolete expiry entry");
                                         tables.update_time.remove(&time.to_bytes(), key.as_bytes()).e()?;
                                     }
-                                } else {
+                                } _ => {
                                     debug!("expired packet {key} not found, remove from expiry table");
                                     tables.update_time.remove(&time.to_bytes(), key.as_bytes()).e()?;
-                                }
+                                }}
                             }
                         }
                     }

--- a/iroh-dns-server/src/store/signed_packets.rs
+++ b/iroh-dns-server/src/store/signed_packets.rs
@@ -6,10 +6,10 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use n0_snafu::{format_err, Result, ResultExt};
+use n0_snafu::{Result, ResultExt, format_err};
 use pkarr::{SignedPacket, Timestamp};
 use redb::{
-    backends::InMemoryBackend, Database, MultimapTableDefinition, ReadableTable, TableDefinition,
+    Database, MultimapTableDefinition, ReadableTable, TableDefinition, backends::InMemoryBackend,
 };
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
@@ -365,7 +365,9 @@ fn get_packet(
             buf.extend(data);
             match SignedPacket::deserialize(&buf) {
                 Ok(packet) => Ok(Some(packet)),
-                Err(err2) => Err(format_err!("Failed to decode as pkarr v3: {err:#}. Also failed to decode as pkarr v2: {err2:#}"))
+                Err(err2) => Err(format_err!(
+                    "Failed to decode as pkarr v3: {err:#}. Also failed to decode as pkarr v2: {err2:#}"
+                )),
             }
         }
     }

--- a/iroh-dns-server/src/util.rs
+++ b/iroh-dns-server/src/util.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 use std::{
-    collections::{btree_map, BTreeMap},
+    collections::{BTreeMap, btree_map},
     str::FromStr,
     sync::Arc,
 };
@@ -8,8 +8,8 @@ use std::{
 use hickory_server::proto::{
     op::Message,
     rr::{
-        domain::{IntoLabel, Label},
         Name, Record, RecordSet, RecordType, RrKey,
+        domain::{IntoLabel, Label},
     },
     serialize::binary::BinDecodable,
 };

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 bytes = "1.7"
-derive_more = { version = "1.0.0", features = [
+derive_more = { version = "2.0.1", features = [
     "debug",
     "display",
     "from",
@@ -50,7 +50,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 ] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { version = "1", features = ["derive", "rc"] }
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 tokio = { version = "1", features = [
     "io-util",
     "macros",
@@ -81,7 +81,7 @@ dashmap = { version = "6.1.0", optional = true }
 ahash = { version = "0.8.11", optional = true } # minimal version fix
 governor = { version = "0.8.0", optional = true }
 hickory-proto = { version = "0.25.1", default-features = false, optional = true }
-rcgen = { version = "0.13", optional = true }
+rcgen = { version = "0.14", optional = true }
 regex = { version = "1.7.1", optional = true }
 reloadable-state = { version = "0.1", optional = true }
 rustls-cert-reloadable-resolver = { version = "0.7.1", optional = true }
@@ -91,7 +91,7 @@ time = { version = "0.3.37", optional = true }
 tokio-rustls-acme = { version = "0.7.1", optional = true }
 tokio-websockets = { version = "0.12", features = ["rustls-bring-your-own-connector", "ring", "getrandom", "rand", "server"], optional = true } # server-side websocket implementation
 simdutf8 = { version = "0.1.5", optional = true } # minimal version fix
-toml = { version = "0.8", optional = true }
+toml = { version = "0.9", optional = true }
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh-relay"
 version = "0.90.0"
-edition = "2021"
+edition = "2024"
 readme = "README.md"
 description = "Iroh's relay server and client"
 license = "MIT OR Apache-2.0"

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -12,20 +12,21 @@ use std::{
 use conn::Conn;
 use iroh_base::{RelayUrl, SecretKey};
 use n0_future::{
-    split::{split, SplitSink, SplitStream},
-    time, Sink, Stream,
+    Sink, Stream,
+    split::{SplitSink, SplitStream, split},
+    time,
 };
 use nested_enum_utils::common_fields;
 use snafu::{Backtrace, Snafu};
 #[cfg(any(test, feature = "test-utils"))]
 use tracing::warn;
-use tracing::{debug, event, trace, Level};
+use tracing::{Level, debug, event, trace};
 use url::Url;
 
 pub use self::conn::{ReceivedMessage, RecvError, SendError, SendMessage};
 #[cfg(not(wasm_browser))]
 use crate::dns::{DnsError, DnsResolver};
-use crate::{http::RELAY_PATH, protos::relay::SendError as SendRelayError, KeyCache};
+use crate::{KeyCache, http::RELAY_PATH, protos::relay::SendError as SendRelayError};
 
 pub(crate) mod conn;
 #[cfg(not(wasm_browser))]

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -6,12 +6,12 @@ use std::{
     io,
     pin::Pin,
     str::Utf8Error,
-    task::{ready, Context, Poll},
+    task::{Context, Poll, ready},
 };
 
 use bytes::Bytes;
 use iroh_base::{NodeId, SecretKey};
-use n0_future::{time::Duration, Sink, Stream};
+use n0_future::{Sink, Stream, time::Duration};
 use nested_enum_utils::common_fields;
 use snafu::{Backtrace, ResultExt, Snafu};
 use tracing::{debug, warn};
@@ -20,11 +20,11 @@ use super::KeyCache;
 #[cfg(not(wasm_browser))]
 use crate::client::streams::{MaybeTlsStream, ProxyStream};
 use crate::{
-    protos::relay::{
-        ClientInfo, Frame, RecvError as RecvRelayError, SendError as SendRelayError,
-        PROTOCOL_VERSION,
-    },
     MAX_PACKET_SIZE,
+    protos::relay::{
+        ClientInfo, Frame, PROTOCOL_VERSION, RecvError as RecvRelayError,
+        SendError as SendRelayError,
+    },
 };
 
 /// Error for sending messages to the relay server.

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -9,7 +9,7 @@
 use bytes::Bytes;
 use data_encoding::BASE64URL;
 use http_body_util::Empty;
-use hyper::{upgrade::Parts, Request};
+use hyper::{Request, upgrade::Parts};
 use n0_future::{task, time};
 use rustls::client::Resumption;
 use snafu::{OptionExt, ResultExt};

--- a/iroh-relay/src/client/util.rs
+++ b/iroh-relay/src/client/util.rs
@@ -5,7 +5,7 @@
 use std::{
     fmt, io,
     pin::Pin,
-    task::{ready, Context, Poll},
+    task::{Context, Poll, ready},
 };
 
 use pin_project::pin_project;

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -15,7 +15,7 @@ use http::StatusCode;
 use iroh_base::NodeId;
 use iroh_relay::{
     defaults::{
-        DEFAULT_HTTPS_PORT, DEFAULT_HTTP_PORT, DEFAULT_METRICS_PORT, DEFAULT_RELAY_QUIC_PORT,
+        DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT, DEFAULT_METRICS_PORT, DEFAULT_RELAY_QUIC_PORT,
     },
     server::{self as relay, ClientRateLimit, QuicConfig},
 };
@@ -23,9 +23,9 @@ use n0_future::FutureExt;
 use n0_snafu::{Error, Result, ResultExt};
 use serde::{Deserialize, Serialize};
 use snafu::whatever;
-use tokio_rustls_acme::{caches::DirCache, AcmeConfig};
+use tokio_rustls_acme::{AcmeConfig, caches::DirCache};
 use tracing::{debug, warn};
-use tracing_subscriber::{prelude::*, EnvFilter};
+use tracing_subscriber::{EnvFilter, prelude::*};
 use url::Url;
 
 /// The default `http_bind_port` when using `--dev`.
@@ -597,7 +597,7 @@ async fn maybe_load_tls(
         #[cfg(feature = "server")]
         CertMode::Reloading => {
             use rustls_cert_file_reader::FileReader;
-            use rustls_cert_reloadable_resolver::{key_provider::Dyn, CertifiedKeyLoader};
+            use rustls_cert_reloadable_resolver::{CertifiedKeyLoader, key_provider::Dyn};
             use webpki_types::{CertificateDer, PrivateKeyDer};
 
             let cert_path = tls.cert_path();
@@ -656,7 +656,9 @@ async fn build_relay_config(cfg: Config) -> Result<relay::ServerConfig<std::io::
                 bind_addr: tls.quic_bind_addr,
             });
         } else {
-            whatever!("Must have a valid TLS configuration to enable a QUIC server for QUIC address discovery")
+            whatever!(
+                "Must have a valid TLS configuration to enable a QUIC server for QUIC address discovery"
+            )
         }
     };
     let limits = match cfg.limits {

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -41,7 +41,7 @@ use std::{
 };
 
 #[cfg(not(wasm_browser))]
-use hickory_resolver::{proto::ProtoError, Name};
+use hickory_resolver::{Name, proto::ProtoError};
 use iroh_base::{NodeAddr, NodeId, RelayUrl, SecretKey, SignatureError};
 use nested_enum_utils::common_fields;
 use snafu::{Backtrace, ResultExt, Snafu};
@@ -740,15 +740,15 @@ mod tests {
     use std::{collections::BTreeSet, str::FromStr, sync::Arc};
 
     use hickory_resolver::{
+        Name,
         lookup::Lookup,
         proto::{
             op::Query,
             rr::{
-                rdata::{A, TXT},
                 RData, Record, RecordType,
+                rdata::{A, TXT},
             },
         },
-        Name,
     };
     use iroh_base::{NodeId, SecretKey};
     use n0_snafu::{Result, ResultExt};
@@ -825,7 +825,7 @@ mod tests {
                 .context("name")?,
                 30,
                 RData::TXT(TXT::new(vec![
-                    "relay=https://euw1-1.relay.iroh.network./".to_string()
+                    "relay=https://euw1-1.relay.iroh.network./".to_string(),
                 ])),
             ),
             // Test a record with a completely different name
@@ -833,14 +833,14 @@ mod tests {
                 Name::from_utf8("dns.iroh.link.").context("name")?,
                 30,
                 RData::TXT(TXT::new(vec![
-                    "relay=https://euw1-1.relay.iroh.network./".to_string()
+                    "relay=https://euw1-1.relay.iroh.network./".to_string(),
                 ])),
             ),
             Record::from_rdata(
                 name.clone(),
                 30,
                 RData::TXT(TXT::new(vec![
-                    "relay=https://euw1-1.relay.iroh.network./".to_string()
+                    "relay=https://euw1-1.relay.iroh.network./".to_string(),
                 ])),
             ),
         ];

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -18,7 +18,7 @@ use bytes::{BufMut, Bytes};
 use iroh_base::{PublicKey, SecretKey, Signature, SignatureError};
 #[cfg(feature = "server")]
 use n0_future::time::Duration;
-use n0_future::{time, Sink, SinkExt};
+use n0_future::{Sink, SinkExt, time};
 #[cfg(any(test, feature = "server"))]
 use n0_future::{Stream, StreamExt};
 use nested_enum_utils::common_fields;
@@ -26,7 +26,7 @@ use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 use snafu::{Backtrace, Snafu};
 
-use crate::{client::conn::SendError as ConnSendError, KeyCache};
+use crate::{KeyCache, client::conn::SendError as ConnSendError};
 
 /// The maximum size of a packet sent over relay.
 /// (This only includes the data bytes visible to magicsock, not

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -472,7 +472,7 @@ mod tests {
         // Create a QAD server with a self-signed cert, all manually.
         let cert =
             rcgen::generate_simple_self_signed(vec!["localhost".into()]).context("self signed")?;
-        let key = PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+        let key = PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der());
         let mut server_crypto = rustls::ServerConfig::builder()
             .with_no_client_auth()
             .with_single_cert(vec![cert.cert.into()], key.into())

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -4,7 +4,7 @@ use std::{net::SocketAddr, sync::Arc};
 
 use n0_future::time::Duration;
 use nested_enum_utils::common_fields;
-use quinn::{crypto::rustls::QuicClientConfig, VarInt};
+use quinn::{VarInt, crypto::rustls::QuicClientConfig};
 use snafu::{Backtrace, Snafu};
 use tokio::sync::watch;
 
@@ -18,13 +18,13 @@ pub const QUIC_ADDR_DISC_CLOSE_REASON: &[u8] = b"finished";
 #[cfg(feature = "server")]
 pub(crate) mod server {
     use quinn::{
-        crypto::rustls::{NoInitialCipherSuite, QuicServerConfig},
         ApplicationClose, ConnectionError,
+        crypto::rustls::{NoInitialCipherSuite, QuicServerConfig},
     };
     use snafu::ResultExt;
     use tokio::task::JoinSet;
     use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-    use tracing::{debug, info, info_span, Instrument};
+    use tracing::{Instrument, debug, info, info_span};
 
     use super::*;
     pub use crate::server::QuicConfig;
@@ -364,7 +364,7 @@ mod tests {
     };
     use n0_snafu::{Error, Result, ResultExt};
     use quinn::crypto::rustls::QuicServerConfig;
-    use tracing::{debug, info, info_span, Instrument};
+    use tracing::{Instrument, debug, info, info_span};
     use tracing_test::traced_test;
     use webpki_types::PrivatePkcs8KeyDer;
 

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -19,14 +19,14 @@ use std::{fmt, future::Future, net::SocketAddr, num::NonZeroU32, pin::Pin, sync:
 
 use derive_more::Debug;
 use http::{
-    header::InvalidHeaderValue, response::Builder as ResponseBuilder, HeaderMap, Method, Request,
-    Response, StatusCode,
+    HeaderMap, Method, Request, Response, StatusCode, header::InvalidHeaderValue,
+    response::Builder as ResponseBuilder,
 };
 use hyper::body::Incoming;
 use iroh_base::NodeId;
 #[cfg(feature = "test-utils")]
 use iroh_base::RelayUrl;
-use n0_future::{future::Boxed, StreamExt};
+use n0_future::{StreamExt, future::Boxed};
 use nested_enum_utils::common_fields;
 use snafu::{Backtrace, ResultExt, Snafu};
 use tokio::{
@@ -34,7 +34,7 @@ use tokio::{
     task::{JoinError, JoinSet},
 };
 use tokio_util::task::AbortOnDropHandle;
-use tracing::{debug, error, info, info_span, instrument, Instrument};
+use tracing::{Instrument, debug, error, info, info_span, instrument};
 
 use crate::{
     defaults::DEFAULT_KEY_CACHE_CAPACITY,
@@ -53,7 +53,7 @@ pub mod testing;
 
 pub use self::{
     metrics::{Metrics, RelayMetrics},
-    resolver::{ReloadingResolver, DEFAULT_CERT_RELOAD_INTERVAL},
+    resolver::{DEFAULT_CERT_RELOAD_INTERVAL, ReloadingResolver},
 };
 
 const NO_CONTENT_CHALLENGE_HEADER: &str = "X-Tailscale-Challenge";
@@ -759,11 +759,11 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{
-        Access, AccessConfig, RelayConfig, Server, ServerConfig, SpawnError,
-        NO_CONTENT_CHALLENGE_HEADER, NO_CONTENT_RESPONSE_HEADER,
+        Access, AccessConfig, NO_CONTENT_CHALLENGE_HEADER, NO_CONTENT_RESPONSE_HEADER, RelayConfig,
+        Server, ServerConfig, SpawnError,
     };
     use crate::{
-        client::{conn::ReceivedMessage, ClientBuilder, SendMessage},
+        client::{ClientBuilder, SendMessage, conn::ReceivedMessage},
         dns::DnsResolver,
     };
 

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -14,19 +14,19 @@ use tokio::{
     time::MissedTickBehavior,
 };
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-use tracing::{debug, trace, warn, Instrument};
+use tracing::{Instrument, debug, trace, warn};
 
 use crate::{
+    PingTracker,
     protos::{
         disco,
-        relay::{write_frame, Frame, SendError as SendRelayError, PING_INTERVAL},
+        relay::{Frame, PING_INTERVAL, SendError as SendRelayError, write_frame},
     },
     server::{
         clients::Clients,
         metrics::Metrics,
         streams::{RelayedStream, StreamError},
     },
-    PingTracker,
 };
 
 /// A request to write a dataframe to a Client
@@ -560,7 +560,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::protos::relay::{recv_frame, FrameType};
+    use crate::protos::relay::{FrameType, recv_frame};
 
     #[tokio::test]
     #[traced_test]

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -4,8 +4,8 @@
 use std::{
     collections::HashSet,
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     },
 };
 
@@ -73,8 +73,7 @@ impl Clients {
     pub(super) fn unregister(&self, connection_id: u64, node_id: NodeId) {
         trace!(
             node_id = node_id.fmt_short(),
-            connection_id,
-            "unregistering client"
+            connection_id, "unregistering client"
         );
 
         if let Some((_, client)) = self
@@ -198,7 +197,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        protos::relay::{recv_frame, Frame, FrameType},
+        protos::relay::{Frame, FrameType, recv_frame},
         server::streams::RelayedStream,
     };
 

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -518,10 +518,13 @@ impl RelayService {
                     async move {
                         match hyper::upgrade::on(&mut req).await {
                             Ok(upgraded) => {
-                                if let Err(err) = this.0.relay_connection_handler(upgraded).await {
-                                    warn!("error accepting upgraded connection: {err:#}",);
-                                } else {
-                                    debug!("upgraded connection completed");
+                                match this.0.relay_connection_handler(upgraded).await {
+                                    Err(err) => {
+                                        warn!("error accepting upgraded connection: {err:#}",);
+                                    }
+                                    _ => {
+                                        debug!("upgraded connection completed");
+                                    }
                                 };
                             }
                             Err(err) => warn!("upgrade error: {err:#}"),

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -6,39 +6,39 @@ use bytes::Bytes;
 use derive_more::Debug;
 use http::{header::CONNECTION, response::Builder as ResponseBuilder};
 use hyper::{
+    HeaderMap, Method, Request, Response, StatusCode,
     body::Incoming,
     header::{HeaderValue, SEC_WEBSOCKET_ACCEPT, UPGRADE},
     service::Service,
     upgrade::Upgraded,
-    HeaderMap, Method, Request, Response, StatusCode,
 };
 use iroh_base::PublicKey;
-use n0_future::{time::Elapsed, FutureExt, SinkExt};
+use n0_future::{FutureExt, SinkExt, time::Elapsed};
 use nested_enum_utils::common_fields;
 use snafu::{Backtrace, ResultExt, Snafu};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls_acme::AcmeAcceptor;
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-use tracing::{debug, debug_span, error, info, info_span, trace, warn, Instrument};
+use tracing::{Instrument, debug, debug_span, error, info, info_span, trace, warn};
 
 use super::{
+    AccessConfig, SpawnError,
     clients::Clients,
     streams::{InvalidBucketConfig, StreamError},
-    AccessConfig, SpawnError,
 };
 use crate::{
-    defaults::{timeouts::SERVER_WRITE_TIMEOUT, DEFAULT_KEY_CACHE_CAPACITY},
+    KeyCache,
+    defaults::{DEFAULT_KEY_CACHE_CAPACITY, timeouts::SERVER_WRITE_TIMEOUT},
     http::{RELAY_PATH, SUPPORTED_WEBSOCKET_VERSION, WEBSOCKET_UPGRADE_PROTOCOL},
     protos::relay::{
-        recv_client_key, Frame, MAX_FRAME_SIZE, PER_CLIENT_SEND_QUEUE_DEPTH, PROTOCOL_VERSION,
+        Frame, MAX_FRAME_SIZE, PER_CLIENT_SEND_QUEUE_DEPTH, PROTOCOL_VERSION, recv_client_key,
     },
     server::{
+        BindTcpListenerSnafu, ClientRateLimit, NoLocalAddrSnafu,
         client::Config,
         metrics::Metrics,
         streams::{MaybeTlsStream, RateLimited, RelayedStream},
-        BindTcpListenerSnafu, ClientRateLimit, NoLocalAddrSnafu,
     },
-    KeyCache,
 };
 
 type BytesBody = http_body_util::Full<hyper::body::Bytes>;
@@ -860,8 +860,8 @@ mod tests {
     use super::*;
     use crate::{
         client::{
-            conn::{Conn, ReceivedMessage, SendMessage},
             Client, ClientBuilder, ConnectError,
+            conn::{Conn, ReceivedMessage, SendMessage},
         },
         dns::DnsResolver,
     };

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -871,7 +871,8 @@ mod tests {
 
         let cert = rcgen::generate_simple_self_signed(subject_alt_names).unwrap();
         let rustls_certificate = cert.cert.der().clone();
-        let rustls_key = rustls::pki_types::PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+        let rustls_key =
+            rustls::pki_types::PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der());
         let config = rustls::ServerConfig::builder_with_provider(Arc::new(
             rustls::crypto::ring::default_provider(),
         ))

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -173,10 +173,10 @@ impl AsyncRead for MaybeTlsStream {
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
         match &mut *self {
-            MaybeTlsStream::Plain(ref mut s) => Pin::new(s).poll_read(cx, buf),
-            MaybeTlsStream::Tls(ref mut s) => Pin::new(s).poll_read(cx, buf),
+            MaybeTlsStream::Plain(s) => Pin::new(s).poll_read(cx, buf),
+            MaybeTlsStream::Tls(s) => Pin::new(s).poll_read(cx, buf),
             #[cfg(test)]
-            MaybeTlsStream::Test(ref mut s) => Pin::new(s).poll_read(cx, buf),
+            MaybeTlsStream::Test(s) => Pin::new(s).poll_read(cx, buf),
         }
     }
 }
@@ -187,10 +187,10 @@ impl AsyncWrite for MaybeTlsStream {
         cx: &mut Context<'_>,
     ) -> Poll<std::result::Result<(), std::io::Error>> {
         match &mut *self {
-            MaybeTlsStream::Plain(ref mut s) => Pin::new(s).poll_flush(cx),
-            MaybeTlsStream::Tls(ref mut s) => Pin::new(s).poll_flush(cx),
+            MaybeTlsStream::Plain(s) => Pin::new(s).poll_flush(cx),
+            MaybeTlsStream::Tls(s) => Pin::new(s).poll_flush(cx),
             #[cfg(test)]
-            MaybeTlsStream::Test(ref mut s) => Pin::new(s).poll_flush(cx),
+            MaybeTlsStream::Test(s) => Pin::new(s).poll_flush(cx),
         }
     }
 
@@ -199,10 +199,10 @@ impl AsyncWrite for MaybeTlsStream {
         cx: &mut Context<'_>,
     ) -> Poll<std::result::Result<(), std::io::Error>> {
         match &mut *self {
-            MaybeTlsStream::Plain(ref mut s) => Pin::new(s).poll_shutdown(cx),
-            MaybeTlsStream::Tls(ref mut s) => Pin::new(s).poll_shutdown(cx),
+            MaybeTlsStream::Plain(s) => Pin::new(s).poll_shutdown(cx),
+            MaybeTlsStream::Tls(s) => Pin::new(s).poll_shutdown(cx),
             #[cfg(test)]
-            MaybeTlsStream::Test(ref mut s) => Pin::new(s).poll_shutdown(cx),
+            MaybeTlsStream::Test(s) => Pin::new(s).poll_shutdown(cx),
         }
     }
 
@@ -212,10 +212,10 @@ impl AsyncWrite for MaybeTlsStream {
         buf: &[u8],
     ) -> Poll<std::result::Result<usize, std::io::Error>> {
         match &mut *self {
-            MaybeTlsStream::Plain(ref mut s) => Pin::new(s).poll_write(cx, buf),
-            MaybeTlsStream::Tls(ref mut s) => Pin::new(s).poll_write(cx, buf),
+            MaybeTlsStream::Plain(s) => Pin::new(s).poll_write(cx, buf),
+            MaybeTlsStream::Tls(s) => Pin::new(s).poll_write(cx, buf),
             #[cfg(test)]
-            MaybeTlsStream::Test(ref mut s) => Pin::new(s).poll_write(cx, buf),
+            MaybeTlsStream::Test(s) => Pin::new(s).poll_write(cx, buf),
         }
     }
 
@@ -225,10 +225,10 @@ impl AsyncWrite for MaybeTlsStream {
         bufs: &[std::io::IoSlice<'_>],
     ) -> Poll<std::result::Result<usize, std::io::Error>> {
         match &mut *self {
-            MaybeTlsStream::Plain(ref mut s) => Pin::new(s).poll_write_vectored(cx, bufs),
-            MaybeTlsStream::Tls(ref mut s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            MaybeTlsStream::Plain(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            MaybeTlsStream::Tls(s) => Pin::new(s).poll_write_vectored(cx, bufs),
             #[cfg(test)]
-            MaybeTlsStream::Test(ref mut s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            MaybeTlsStream::Test(s) => Pin::new(s).poll_write_vectored(cx, bufs),
         }
     }
 }

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use n0_future::{ready, time, FutureExt, Sink, Stream};
+use n0_future::{FutureExt, Sink, Stream, ready, time};
 use snafu::{Backtrace, Snafu};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_websockets::WebSocketStream;
@@ -14,8 +14,8 @@ use tracing::instrument;
 
 use super::{ClientRateLimit, Metrics};
 use crate::{
-    protos::relay::{Frame, RecvError},
     KeyCache,
+    protos::relay::{Frame, RecvError},
 };
 
 /// A Stream and Sink for [`Frame`]s connected to a single relay client.
@@ -463,7 +463,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::Bucket;
-    use crate::server::{streams::RateLimited, Metrics};
+    use crate::server::{Metrics, streams::RateLimited};
 
     #[tokio::test(start_paused = true)]
     #[traced_test]

--- a/iroh-relay/src/server/testing.rs
+++ b/iroh-relay/src/server/testing.rs
@@ -17,7 +17,7 @@ pub fn self_signed_tls_certs_and_config() -> (
     ])
     .expect("valid");
     let rustls_cert = cert.cert.der();
-    let private_key = rustls::pki_types::PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+    let private_key = rustls::pki_types::PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der());
     let private_key = rustls::pki_types::PrivateKeyDer::from(private_key);
     let certs = vec![rustls_cert.clone()];
     let server_config = rustls::ServerConfig::builder_with_provider(std::sync::Arc::new(

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -43,7 +43,7 @@ n0-future = "0.1.2"
 n0-snafu = "0.2.1"
 n0-watcher = "0.2"
 nested_enum_utils = "0.2.1"
-netwatch = { version = "0.6" }
+netwatch = { version = "0.7" }
 pin-project = "1"
 pkarr = { version = "3.7", default-features = false, features = [
     "relays",
@@ -108,7 +108,7 @@ parse-size = { version = "=1.0.0", optional = true, features = ['std'] } # pinne
 hickory-resolver = "0.25.1"
 igd-next = { version = "0.16", features = ["aio_tokio"] }
 netdev = { version = "0.36.0" }
-portmapper = { version = "0.6.1", default-features = false }
+portmapper = { version = "0.7", default-features = false }
 quinn = { package = "iroh-quinn", version = "0.14.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -27,7 +27,7 @@ bytes = "1.7"
 crypto_box = { version = "0.9.1", features = ["serde", "chacha20"] }
 data-encoding = "2.2"
 der = { version = "0.7", features = ["alloc", "derive"] }
-derive_more = { version = "1.0.0", features = [
+derive_more = { version = "2.0.1", features = [
     "debug",
     "display",
     "from",
@@ -61,7 +61,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 smallvec = "1.11.1"
 snafu = { version = "0.8.5", features = ["rust_1_81"] }
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 stun-rs = "0.1.11"
 tokio = { version = "1.44.1", features = [
     "io-util",
@@ -99,7 +99,7 @@ clap = { version = "4", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
-indicatif = { version = "0.17", features = ["tokio"], optional = true }
+indicatif = { version = "0.18", features = ["tokio"], optional = true }
 parse-size = { version = "=1.0.0", optional = true, features = ['std'] } # pinned version to avoid bumping msrv to 1.81
 
 
@@ -107,7 +107,7 @@ parse-size = { version = "=1.0.0", optional = true, features = ['std'] } # pinne
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 hickory-resolver = "0.25.1"
 igd-next = { version = "0.16", features = ["aio_tokio"] }
-netdev = { version = "0.31.0" }
+netdev = { version = "0.36.0" }
 portmapper = { version = "0.6.1", default-features = false }
 quinn = { package = "iroh-quinn", version = "0.14.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh"
 version = "0.90.0"
-edition = "2021"
+edition = "2024"
 readme = "README.md"
 description = "p2p quic connections dialed by public key"
 license = "MIT OR Apache-2.0"

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh-bench"
 version = "0.90.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -15,7 +15,7 @@ n0-snafu = "0.2.0"
 n0-watcher = "0.2"
 quinn = { package = "iroh-quinn", version = "0.14" }
 rand = "0.8"
-rcgen = "0.13"
+rcgen = "0.14"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "sync"] }

--- a/iroh/bench/src/bin/bulk.rs
+++ b/iroh/bench/src/bin/bulk.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use clap::Parser;
 #[cfg(not(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd")))]
 use iroh_bench::quinn;
-use iroh_bench::{configure_tracing_subscriber, iroh, rt, s2n, Commands, Opt};
+use iroh_bench::{Commands, Opt, configure_tracing_subscriber, iroh, rt, s2n};
 use iroh_metrics::{MetricValue, MetricsGroup};
 use n0_snafu::Result;
 

--- a/iroh/bench/src/bin/bulk.rs
+++ b/iroh/bench/src/bin/bulk.rs
@@ -110,7 +110,7 @@ pub fn run_quinn(opt: Opt) -> Result<()> {
     let server_span = tracing::error_span!("server");
     let runtime = rt();
     let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-    let key = PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+    let key = PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der());
     let cert = CertificateDer::from(cert.cert);
 
     let (server_addr, endpoint) = {

--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -5,15 +5,15 @@ use std::{
 
 use bytes::Bytes;
 use iroh::{
-    endpoint::{Connection, ConnectionError, RecvStream, SendStream, TransportConfig},
     Endpoint, NodeAddr, RelayMode, RelayUrl,
+    endpoint::{Connection, ConnectionError, RecvStream, SendStream, TransportConfig},
 };
 use n0_snafu::{Result, ResultExt};
 use n0_watcher::Watcher as _;
 use tracing::{trace, warn};
 
 use crate::{
-    client_handler, stats::TransferResult, ClientStats, ConnectionSelector, EndpointSelector, Opt,
+    ClientStats, ConnectionSelector, EndpointSelector, Opt, client_handler, stats::TransferResult,
 };
 
 pub const ALPN: &[u8] = b"n0/iroh-bench/0";

--- a/iroh/bench/src/quinn.rs
+++ b/iroh/bench/src/quinn.rs
@@ -7,16 +7,16 @@ use std::{
 use bytes::Bytes;
 use n0_snafu::{Result, ResultExt};
 use quinn::{
-    crypto::rustls::QuicClientConfig, Connection, Endpoint, RecvStream, SendStream, TransportConfig,
+    Connection, Endpoint, RecvStream, SendStream, TransportConfig, crypto::rustls::QuicClientConfig,
 };
 use rustls::{
-    pki_types::{CertificateDer, PrivateKeyDer},
     RootCertStore,
+    pki_types::{CertificateDer, PrivateKeyDer},
 };
 use tracing::{trace, warn};
 
 use crate::{
-    client_handler, stats::TransferResult, ClientStats, ConnectionSelector, EndpointSelector, Opt,
+    ClientStats, ConnectionSelector, EndpointSelector, Opt, client_handler, stats::TransferResult,
 };
 
 pub const ALPN: &[u8] = b"n0/quinn-bench/0";

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -3,11 +3,11 @@ use std::{env, future::Future, str::FromStr, time::Instant};
 use clap::Parser;
 use data_encoding::HEXLOWER;
 use iroh::{
-    endpoint::{Connecting, Connection},
     SecretKey,
+    endpoint::{Connecting, Connection},
 };
 use iroh_base::ticket::NodeTicket;
-use n0_future::{future, StreamExt};
+use n0_future::{StreamExt, future};
 use n0_snafu::ResultExt;
 use n0_watcher::Watcher;
 use rand::thread_rng;

--- a/iroh/examples/echo.rs
+++ b/iroh/examples/echo.rs
@@ -7,9 +7,9 @@
 //!     cargo run --example echo --features=examples
 
 use iroh::{
+    Endpoint, NodeAddr,
     endpoint::Connection,
     protocol::{AcceptError, ProtocolHandler, Router},
-    Endpoint, NodeAddr,
 };
 use n0_snafu::{Result, ResultExt};
 use n0_watcher::Watcher as _;

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -5,7 +5,7 @@
 //!     $ cargo run --example listen
 use std::time::Duration;
 
-use iroh::{endpoint::ConnectionError, Endpoint, RelayMode, SecretKey};
+use iroh::{Endpoint, RelayMode, SecretKey, endpoint::ConnectionError};
 use n0_snafu::ResultExt;
 use n0_watcher::Watcher as _;
 use tracing::{debug, info, warn};

--- a/iroh/examples/locally-discovered-nodes.rs
+++ b/iroh/examples/locally-discovered-nodes.rs
@@ -5,7 +5,7 @@
 //! This is an async, non-determinate process, so the number of NodeIDs discovered each time may be different. If you have other iroh endpoints or iroh nodes with [`MdnsDiscovery`] enabled, it may discover those nodes as well.
 use std::time::Duration;
 
-use iroh::{node_info::UserData, Endpoint, NodeId};
+use iroh::{Endpoint, NodeId, node_info::UserData};
 use n0_future::StreamExt;
 use n0_snafu::Result;
 use tokio::task::JoinSet;

--- a/iroh/examples/search.rs
+++ b/iroh/examples/search.rs
@@ -33,13 +33,13 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use clap::Parser;
 use iroh::{
+    Endpoint, NodeId,
     endpoint::Connection,
     protocol::{AcceptError, ProtocolHandler, Router},
-    Endpoint, NodeId,
 };
 use n0_snafu::{Result, ResultExt};
 use tokio::sync::Mutex;
-use tracing_subscriber::{prelude::*, EnvFilter};
+use tracing_subscriber::{EnvFilter, prelude::*};
 
 #[derive(Debug, Parser)]
 pub struct Cli {

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -8,13 +8,13 @@ use clap::{Parser, Subcommand};
 use data_encoding::HEXLOWER;
 use indicatif::HumanBytes;
 use iroh::{
+    Endpoint, NodeAddr, NodeId, RelayMap, RelayMode, RelayUrl, SecretKey,
     discovery::{
         dns::DnsDiscovery,
-        pkarr::{PkarrPublisher, N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING},
+        pkarr::{N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING, PkarrPublisher},
     },
     dns::{DnsResolver, N0_DNS_NODE_ORIGIN_PROD, N0_DNS_NODE_ORIGIN_STAGING},
     endpoint::ConnectionError,
-    Endpoint, NodeAddr, NodeId, RelayMap, RelayMode, RelayUrl, SecretKey,
 };
 use iroh_base::ticket::NodeTicket;
 use n0_future::task::AbortOnDropHandle;

--- a/iroh/src/disco.rs
+++ b/iroh/src/disco.rs
@@ -27,7 +27,7 @@ use data_encoding::HEXLOWER;
 use iroh_base::{PublicKey, RelayUrl};
 use nested_enum_utils::common_fields;
 use serde::{Deserialize, Serialize};
-use snafu::{ensure, Snafu};
+use snafu::{Snafu, ensure};
 use url::Url;
 
 use crate::magicsock::transports;
@@ -433,7 +433,7 @@ mod tests {
     use iroh_base::SecretKey;
 
     use super::*;
-    use crate::key::{public_ed_box, secret_ed_box, SharedSecret};
+    use crate::key::{SharedSecret, public_ed_box, secret_ed_box};
 
     #[test]
     fn test_to_from_bytes() {
@@ -447,16 +447,22 @@ mod tests {
                 name: "ping_with_nodekey_src",
                 m: Message::Ping(Ping {
                     tx_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into(),
-                    node_key: PublicKey::try_from(&[
-                        190, 243, 65, 104, 37, 102, 175, 75, 243, 22, 69, 200, 167, 107, 24, 63, 216, 140, 120, 43, 4, 112, 16, 62, 117, 155, 45, 215, 72, 175, 40, 189][..]).unwrap(),
+                    node_key: PublicKey::try_from(
+                        &[
+                            190, 243, 65, 104, 37, 102, 175, 75, 243, 22, 69, 200, 167, 107, 24,
+                            63, 216, 140, 120, 43, 4, 112, 16, 62, 117, 155, 45, 215, 72, 175, 40,
+                            189,
+                        ][..],
+                    )
+                    .unwrap(),
                 }),
                 want: "01 00 01 02 03 04 05 06 07 08 09 0a 0b 0c be f3 41 68 25 66 af 4b f3 16 45 c8 a7 6b 18 3f d8 8c 78 2b 04 70 10 3e 75 9b 2d d7 48 af 28 bd",
             },
             Test {
                 name: "pong",
-                m: Message::Pong(Pong{
+                m: Message::Pong(Pong {
                     tx_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into(),
-                    ping_observed_addr:  SendAddr::Udp("2.3.4.5:1234".parse().unwrap()),
+                    ping_observed_addr: SendAddr::Udp("2.3.4.5:1234".parse().unwrap()),
                 }),
                 want: "02 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 00 00 00 00 00 00 00 00 00 00 ff ff 02 03 04 05 d2 04",
             },
@@ -470,7 +476,9 @@ mod tests {
             },
             Test {
                 name: "call_me_maybe",
-                m: Message::CallMeMaybe(CallMeMaybe { my_numbers: Vec::new() }),
+                m: Message::CallMeMaybe(CallMeMaybe {
+                    my_numbers: Vec::new(),
+                }),
                 want: "03 00",
             },
             Test {

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -699,7 +699,7 @@ impl DiscoverySubscribers {
         }
     }
 
-    pub(crate) fn subscribe(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> {
+    pub(crate) fn subscribe(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> + use<> {
         use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
         let recv = self.inner.subscribe();
         BroadcastStream::new(recv).map_err(|BroadcastStreamRecvError::Lagged(n)| Lagged { val: n })

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -699,7 +699,7 @@ impl DiscoverySubscribers {
         }
     }
 
-    pub(crate) fn subscribe(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> + use<> {
+    pub(crate) fn subscribe(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> + 'static {
         use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
         let recv = self.inner.subscribe();
         BroadcastStream::new(recv).map_err(|BroadcastStreamRecvError::Lagged(n)| Lagged { val: n })

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -61,8 +61,8 @@
 //!
 //! ```no_run
 //! use iroh::{
-//!     discovery::{dns::DnsDiscovery, pkarr::PkarrPublisher},
 //!     Endpoint, SecretKey,
+//!     discovery::{dns::DnsDiscovery, pkarr::PkarrPublisher},
 //! };
 //!
 //! # async fn wrapper() -> n0_snafu::Result<()> {
@@ -113,16 +113,16 @@ use std::sync::Arc;
 
 use iroh_base::{NodeAddr, NodeId};
 use n0_future::{
+    Stream, TryStreamExt,
     boxed::BoxStream,
     stream::StreamExt,
     task::{self, AbortOnDropHandle},
     time::{self, Duration},
-    Stream, TryStreamExt,
 };
 use nested_enum_utils::common_fields;
-use snafu::{ensure, IntoError, Snafu};
+use snafu::{IntoError, Snafu, ensure};
 use tokio::sync::oneshot;
-use tracing::{debug, error_span, warn, Instrument};
+use tracing::{Instrument, debug, error_span, warn};
 
 #[cfg(not(wasm_browser))]
 use crate::dns::DnsResolver;
@@ -700,7 +700,7 @@ impl DiscoverySubscribers {
     }
 
     pub(crate) fn subscribe(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> + use<> {
-        use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+        use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
         let recv = self.inner.subscribe();
         BroadcastStream::new(recv).map_err(|BroadcastStreamRecvError::Lagged(n)| Lagged { val: n })
     }
@@ -730,7 +730,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::{endpoint::ConnectOptions, Endpoint, RelayMode};
+    use crate::{Endpoint, RelayMode, endpoint::ConnectOptions};
 
     type InfoStore = HashMap<NodeId, (NodeData, u64)>;
 
@@ -1091,20 +1091,20 @@ mod tests {
 #[cfg(test)]
 mod test_dns_pkarr {
     use iroh_base::{NodeAddr, SecretKey};
-    use iroh_relay::{node_info::UserData, RelayMap};
+    use iroh_relay::{RelayMap, node_info::UserData};
     use n0_future::time::Duration;
     use n0_snafu::{Error, Result, ResultExt};
     use tokio_util::task::AbortOnDropHandle;
     use tracing_test::traced_test;
 
     use crate::{
-        discovery::{pkarr::PkarrPublisher, NodeData},
+        Endpoint, RelayMode,
+        discovery::{NodeData, pkarr::PkarrPublisher},
         dns::DnsResolver,
         node_info::NodeInfo,
         test_utils::{
-            dns_server::run_dns_server, pkarr_dns_state::State, run_relay_server, DnsPkarrServer,
+            DnsPkarrServer, dns_server::run_dns_server, pkarr_dns_state::State, run_relay_server,
         },
-        Endpoint, RelayMode,
     };
 
     const PUBLISH_TIMEOUT: Duration = Duration::from_secs(10);

--- a/iroh/src/discovery/mdns.rs
+++ b/iroh/src/discovery/mdns.rs
@@ -33,9 +33,9 @@
 use std::{
     collections::{BTreeSet, HashMap},
     net::{IpAddr, SocketAddr},
+    str::FromStr,
 };
 
-use derive_more::FromStr;
 use iroh_base::{NodeId, PublicKey};
 use n0_future::{
     boxed::BoxStream,

--- a/iroh/src/discovery/mdns.rs
+++ b/iroh/src/discovery/mdns.rs
@@ -45,7 +45,7 @@ use n0_future::{
 use n0_watcher::{Watchable, Watcher as _};
 use swarm_discovery::{Discoverer, DropGuard, IpClass, Peer};
 use tokio::sync::mpsc::{self, error::TrySendError};
-use tracing::{debug, error, info_span, trace, warn, Instrument};
+use tracing::{Instrument, debug, error, info_span, trace, warn};
 
 use super::{DiscoveryContext, DiscoveryError, IntoDiscovery, IntoDiscoveryError};
 use crate::discovery::{Discovery, DiscoveryItem, NodeData, NodeInfo};

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -55,11 +55,11 @@ use n0_future::{
 };
 use n0_watcher::{Disconnected, Watchable, Watcher as _};
 use pkarr::{
-    errors::{PublicKeyError, SignedPacketVerifyError},
     SignedPacket,
+    errors::{PublicKeyError, SignedPacketVerifyError},
 };
 use snafu::{ResultExt, Snafu};
-use tracing::{debug, error_span, warn, Instrument};
+use tracing::{Instrument, debug, error_span, warn};
 use url::Url;
 
 use super::{DiscoveryContext, DiscoveryError, IntoDiscovery, IntoDiscoveryError};

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -353,24 +353,27 @@ impl PublisherService {
                 break; // disconnected
             };
             if let Some(info) = info {
-                if let Err(err) = self.publish_current(info).await {
-                    failed_attempts += 1;
-                    // Retry after increasing timeout
-                    let retry_after = Duration::from_secs(failed_attempts);
-                    republish.as_mut().reset(Instant::now() + retry_after);
-                    warn!(
-                        err = %format!("{err:#}"),
-                        url = %self.pkarr_client.pkarr_relay_url ,
-                        ?retry_after,
-                        %failed_attempts,
-                        "Failed to publish to pkarr",
-                    );
-                } else {
-                    failed_attempts = 0;
-                    // Republish after fixed interval
-                    republish
-                        .as_mut()
-                        .reset(Instant::now() + self.republish_interval);
+                match self.publish_current(info).await {
+                    Err(err) => {
+                        failed_attempts += 1;
+                        // Retry after increasing timeout
+                        let retry_after = Duration::from_secs(failed_attempts);
+                        republish.as_mut().reset(Instant::now() + retry_after);
+                        warn!(
+                            err = %format!("{err:#}"),
+                            url = %self.pkarr_client.pkarr_relay_url ,
+                            ?retry_after,
+                            %failed_attempts,
+                            "Failed to publish to pkarr",
+                        );
+                    }
+                    _ => {
+                        failed_attempts = 0;
+                        // Republish after fixed interval
+                        republish
+                            .as_mut()
+                            .reset(Instant::now() + self.republish_interval);
+                    }
                 }
             }
             // Wait until either the retry/republish timeout is reached, or the node info changed.

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -19,9 +19,9 @@ use url::Url;
 
 use crate::{
     discovery::{
-        pkarr::{DEFAULT_PKARR_TTL, N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING},
         Discovery, DiscoveryContext, DiscoveryError, DiscoveryItem, IntoDiscovery,
         IntoDiscoveryError, NodeData,
+        pkarr::{DEFAULT_PKARR_TTL, N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING},
     },
     node_info::NodeInfo,
 };

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -11,7 +11,7 @@
 //! [`NodeTicket`]: https://docs.rs/iroh-base/latest/iroh_base/ticket/struct.NodeTicket
 
 use std::{
-    collections::{btree_map::Entry, BTreeMap},
+    collections::{BTreeMap, btree_map::Entry},
     sync::{Arc, RwLock},
 };
 
@@ -37,7 +37,7 @@ use super::{Discovery, DiscoveryError, DiscoveryItem, NodeData, NodeInfo};
 /// # Examples
 ///
 /// ```rust
-/// use iroh::{discovery::static_provider::StaticProvider, Endpoint, NodeAddr};
+/// use iroh::{Endpoint, NodeAddr, discovery::static_provider::StaticProvider};
 /// use iroh_base::SecretKey;
 ///
 /// # #[tokio::main]
@@ -53,13 +53,11 @@ use super::{Discovery, DiscoveryError, DiscoveryItem, NodeData, NodeInfo};
 /// // Sometime later add a RelayUrl for a fake NodeId.
 /// let node_id = SecretKey::from_bytes(&[0u8; 32]).public(); // Do not use fake secret keys!
 /// // You can pass either `NodeInfo` or `NodeAddr` to `add_node_info`.
-/// discovery.add_node_info(
-///     NodeAddr {
-///         node_id,
-///         relay_url: Some("https://example.com".parse()?),
-///         direct_addresses: Default::default(),
-///     },
-/// );
+/// discovery.add_node_info(NodeAddr {
+///     node_id,
+///     relay_url: Some("https://example.com".parse()?),
+///     direct_addresses: Default::default(),
+/// });
 ///
 /// # Ok(())
 /// # }
@@ -99,7 +97,7 @@ impl StaticProvider {
     /// ```rust
     /// use std::{net::SocketAddr, str::FromStr};
     ///
-    /// use iroh::{discovery::static_provider::StaticProvider, Endpoint, NodeAddr};
+    /// use iroh::{Endpoint, NodeAddr, discovery::static_provider::StaticProvider};
     ///
     /// # fn get_addrs() -> Vec<NodeAddr> {
     /// #     Vec::new()

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -21,14 +21,14 @@ use std::{
     task::Poll,
 };
 
-use ed25519_dalek::{pkcs8::DecodePublicKey, VerifyingKey};
+use ed25519_dalek::{VerifyingKey, pkcs8::DecodePublicKey};
 use iroh_base::{NodeAddr, NodeId, RelayUrl, SecretKey};
 use iroh_relay::RelayMap;
-use n0_future::{time::Duration, Stream};
+use n0_future::{Stream, time::Duration};
 use n0_watcher::Watcher;
 use nested_enum_utils::common_fields;
 use pin_project::pin_project;
-use snafu::{ensure, ResultExt, Snafu};
+use snafu::{ResultExt, Snafu, ensure};
 use tracing::{debug, instrument, trace, warn};
 use url::Url;
 
@@ -38,9 +38,9 @@ use crate::discovery::pkarr::PkarrResolver;
 use crate::{discovery::dns::DnsDiscovery, dns::DnsResolver};
 use crate::{
     discovery::{
-        pkarr::PkarrPublisher, ConcurrentDiscovery, Discovery, DiscoveryContext, DiscoveryError,
-        DiscoveryItem, DiscoverySubscribers, DiscoveryTask, DynIntoDiscovery, IntoDiscovery,
-        IntoDiscoveryError, Lagged, UserData,
+        ConcurrentDiscovery, Discovery, DiscoveryContext, DiscoveryError, DiscoveryItem,
+        DiscoverySubscribers, DiscoveryTask, DynIntoDiscovery, IntoDiscovery, IntoDiscoveryError,
+        Lagged, UserData, pkarr::PkarrPublisher,
     },
     magicsock::{self, Handle, NodeIdMappedAddr, OwnAddressSnafu},
     metrics::EndpointMetrics,
@@ -59,12 +59,12 @@ pub use quinn::{
     WeakConnectionHandle, WriteError,
 };
 pub use quinn_proto::{
+    FrameStats, PathStats, TransportError, TransportErrorCode, UdpStats, Written,
     congestion::{Controller, ControllerFactory},
     crypto::{
         AeadKey, CryptoError, ExportKeyingMaterialError, HandshakeTokenKey,
         ServerConfig as CryptoServerConfig, UnsupportedVersion,
     },
-    FrameStats, PathStats, TransportError, TransportErrorCode, UdpStats, Written,
 };
 
 use self::rtt_actor::RttMessage;
@@ -2250,19 +2250,19 @@ mod tests {
     };
 
     use iroh_base::{NodeAddr, NodeId, SecretKey};
-    use n0_future::{task::AbortOnDropHandle, StreamExt};
+    use n0_future::{StreamExt, task::AbortOnDropHandle};
     use n0_snafu::{Error, Result, ResultExt};
     use n0_watcher::Watcher;
     use quinn::ConnectionError;
     use rand::SeedableRng;
-    use tracing::{error_span, info, info_span, Instrument};
+    use tracing::{Instrument, error_span, info, info_span};
     use tracing_test::traced_test;
 
     use super::Endpoint;
     use crate::{
+        RelayMode,
         endpoint::{ConnectOptions, Connection, ConnectionType, RemoteInfo},
         test_utils::{run_relay_server, run_relay_server_with},
-        RelayMode,
     };
 
     const TEST_ALPN: &[u8] = b"n0/iroh/test";

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -908,7 +908,7 @@ impl Endpoint {
     /// # }
     /// ```
     #[cfg(not(wasm_browser))]
-    pub fn node_addr(&self) -> impl n0_watcher::Watcher<Value = Option<NodeAddr>> {
+    pub fn node_addr(&self) -> impl n0_watcher::Watcher<Value = Option<NodeAddr>> + use<> {
         let watch_addrs = self.direct_addresses();
         let watch_relay = self.home_relay();
         let node_id = self.node_id();
@@ -973,7 +973,7 @@ impl Endpoint {
     /// let _relay_url = mep.home_relay().initialized().await.unwrap();
     /// # });
     /// ```
-    pub fn home_relay(&self) -> impl n0_watcher::Watcher<Value = Vec<RelayUrl>> {
+    pub fn home_relay(&self) -> impl n0_watcher::Watcher<Value = Vec<RelayUrl>> + use<> {
         self.msock.home_relay()
     }
 
@@ -1043,7 +1043,7 @@ impl Endpoint {
     /// # });
     /// ```
     #[doc(hidden)]
-    pub fn net_report(&self) -> impl Watcher<Value = Option<Report>> {
+    pub fn net_report(&self) -> impl Watcher<Value = Option<Report>> + use<> {
         self.msock.net_report()
     }
 
@@ -1086,7 +1086,7 @@ impl Endpoint {
     /// connection was ever made or is even possible.
     ///
     /// See also [`Endpoint::remote_info`] to only retrieve information about a single node.
-    pub fn remote_info_iter(&self) -> impl Iterator<Item = RemoteInfo> {
+    pub fn remote_info_iter(&self) -> impl Iterator<Item = RemoteInfo> + use<> {
         self.msock.list_remote_infos().into_iter()
     }
 
@@ -1114,7 +1114,7 @@ impl Endpoint {
     ///
     /// [`MdnsDiscovery`]: crate::discovery::mdns::MdnsDiscovery
     /// [`StaticProvider`]: crate::discovery::static_provider::StaticProvider
-    pub fn discovery_stream(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> {
+    pub fn discovery_stream(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> + use<> {
         self.msock.discovery_subscribers().subscribe()
     }
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -973,7 +973,7 @@ impl Endpoint {
     /// let _relay_url = mep.home_relay().initialized().await.unwrap();
     /// # });
     /// ```
-    pub fn home_relay(&self) -> impl n0_watcher::Watcher<Value = Vec<RelayUrl>> + use<> {
+    pub fn home_relay(&self) -> impl n0_watcher::Watcher<Value = Vec<RelayUrl>> + 'static {
         self.msock.home_relay()
     }
 
@@ -1043,7 +1043,7 @@ impl Endpoint {
     /// # });
     /// ```
     #[doc(hidden)]
-    pub fn net_report(&self) -> impl Watcher<Value = Option<Report>> + use<> {
+    pub fn net_report(&self) -> impl Watcher<Value = Option<Report>> + 'static {
         self.msock.net_report()
     }
 
@@ -1086,7 +1086,7 @@ impl Endpoint {
     /// connection was ever made or is even possible.
     ///
     /// See also [`Endpoint::remote_info`] to only retrieve information about a single node.
-    pub fn remote_info_iter(&self) -> impl Iterator<Item = RemoteInfo> + use<> {
+    pub fn remote_info_iter(&self) -> impl Iterator<Item = RemoteInfo> + 'static {
         self.msock.list_remote_infos().into_iter()
     }
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -908,7 +908,7 @@ impl Endpoint {
     /// # }
     /// ```
     #[cfg(not(wasm_browser))]
-    pub fn node_addr(&self) -> impl n0_watcher::Watcher<Value = Option<NodeAddr>> + use<> {
+    pub fn node_addr(&self) -> impl n0_watcher::Watcher<Value = Option<NodeAddr>> + 'static {
         let watch_addrs = self.direct_addresses();
         let watch_relay = self.home_relay();
         let node_id = self.node_id();
@@ -1114,7 +1114,7 @@ impl Endpoint {
     ///
     /// [`MdnsDiscovery`]: crate::discovery::mdns::MdnsDiscovery
     /// [`StaticProvider`]: crate::discovery::static_provider::StaticProvider
-    pub fn discovery_stream(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> + use<> {
+    pub fn discovery_stream(&self) -> impl Stream<Item = Result<DiscoveryItem, Lagged>> + 'static {
         self.msock.discovery_subscribers().subscribe()
     }
 

--- a/iroh/src/endpoint/rtt_actor.rs
+++ b/iroh/src/endpoint/rtt_actor.rs
@@ -4,11 +4,11 @@ use std::{pin::Pin, sync::Arc, task::Poll};
 
 use iroh_base::NodeId;
 use n0_future::{
-    task::{self, AbortOnDropHandle},
     MergeUnbounded, Stream, StreamExt,
+    task::{self, AbortOnDropHandle},
 };
 use tokio::sync::mpsc;
-use tracing::{debug, info_span, Instrument};
+use tracing::{Instrument, debug, info_span};
 
 use crate::{magicsock::ConnectionType, metrics::MagicsockMetrics};
 

--- a/iroh/src/key.rs
+++ b/iroh/src/key.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use aead::Buffer;
 use nested_enum_utils::common_fields;
-use snafu::{ensure, ResultExt, Snafu};
+use snafu::{ResultExt, Snafu, ensure};
 
 pub(crate) const NONCE_LEN: usize = 24;
 

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -274,7 +274,7 @@ pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{
     KeyParsingError, NodeAddr, NodeId, PublicKey, RelayUrl, RelayUrlParseError, SecretKey,
 };
-pub use iroh_relay::{node_info, RelayMap, RelayNode};
+pub use iroh_relay::{RelayMap, RelayNode, node_info};
 pub use n0_watcher::Watcher;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -280,7 +280,7 @@ impl MagicSock {
         &self.ip_bind_addrs
     }
 
-    fn ip_local_addrs(&self) -> impl Iterator<Item = SocketAddr> {
+    fn ip_local_addrs(&self) -> impl Iterator<Item = SocketAddr> + use<> {
         self.local_addr()
             .into_iter()
             .filter_map(|addr| addr.into_socket_addr())
@@ -336,7 +336,7 @@ impl MagicSock {
     ///
     /// [`Watcher`]: n0_watcher::Watcher
     /// [`Watcher::initialized`]: n0_watcher::Watcher::initialized
-    pub(crate) fn net_report(&self) -> impl Watcher<Value = Option<Report>> {
+    pub(crate) fn net_report(&self) -> impl Watcher<Value = Option<Report>> + use<> {
         self.net_report
             .watch()
             .map(|(r, _)| r)
@@ -347,7 +347,7 @@ impl MagicSock {
     ///
     /// Note that this can be used to wait for the initial home relay to be known using
     /// [`Watcher::initialized`].
-    pub(crate) fn home_relay(&self) -> impl Watcher<Value = Vec<RelayUrl>> {
+    pub(crate) fn home_relay(&self) -> impl Watcher<Value = Vec<RelayUrl>> + use<> {
         let res = self.local_addrs_watch.clone().map(|addrs| {
             addrs
                 .into_iter()

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -280,7 +280,7 @@ impl MagicSock {
         &self.ip_bind_addrs
     }
 
-    fn ip_local_addrs(&self) -> impl Iterator<Item = SocketAddr> + use<> {
+    fn ip_local_addrs(&self) -> impl Iterator<Item = SocketAddr> + 'static {
         self.local_addr()
             .into_iter()
             .filter_map(|addr| addr.into_socket_addr())
@@ -336,7 +336,7 @@ impl MagicSock {
     ///
     /// [`Watcher`]: n0_watcher::Watcher
     /// [`Watcher::initialized`]: n0_watcher::Watcher::initialized
-    pub(crate) fn net_report(&self) -> impl Watcher<Value = Option<Report>> + use<> {
+    pub(crate) fn net_report(&self) -> impl Watcher<Value = Option<Report>> + 'static {
         self.net_report
             .watch()
             .map(|(r, _)| r)
@@ -347,7 +347,7 @@ impl MagicSock {
     ///
     /// Note that this can be used to wait for the initial home relay to be known using
     /// [`Watcher::initialized`].
-    pub(crate) fn home_relay(&self) -> impl Watcher<Value = Vec<RelayUrl>> + use<> {
+    pub(crate) fn home_relay(&self) -> impl Watcher<Value = Vec<RelayUrl>> + 'static {
         let res = self.local_addrs_watch.clone().map(|addrs| {
             addrs
                 .into_iter()

--- a/iroh/src/magicsock/node_map.rs
+++ b/iroh/src/magicsock/node_map.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, hash_map::Entry},
     hash::Hash,
     net::{IpAddr, SocketAddr},
     sync::Mutex,
@@ -15,7 +15,7 @@ use self::{
     best_addr::ClearReason,
     node_state::{NodeState, Options, PingHandled},
 };
-use super::{metrics::Metrics, transports, ActorMessage, NodeIdMappedAddr};
+use super::{ActorMessage, NodeIdMappedAddr, metrics::Metrics, transports};
 use crate::disco::{CallMeMaybe, Pong, SendAddr};
 #[cfg(any(test, feature = "test-utils"))]
 use crate::endpoint::PathSelection;

--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{btree_map::Entry, BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, btree_map::Entry},
     hash::Hash,
     net::{IpAddr, SocketAddr},
 };
@@ -13,19 +13,19 @@ use n0_future::{
 use n0_watcher::Watchable;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
-use tracing::{debug, event, info, instrument, trace, warn, Level};
+use tracing::{Level, debug, event, info, instrument, trace, warn};
 
 use super::{
-    best_addr::{self, ClearReason, Source as BestAddrSource},
-    path_state::{summarize_node_paths, PathState},
-    udp_paths::{NodeUdpPaths, UdpSendAddr},
     IpPort, Source,
+    best_addr::{self, ClearReason, Source as BestAddrSource},
+    path_state::{PathState, summarize_node_paths},
+    udp_paths::{NodeUdpPaths, UdpSendAddr},
 };
 #[cfg(any(test, feature = "test-utils"))]
 use crate::endpoint::PathSelection;
 use crate::{
     disco::{self, SendAddr},
-    magicsock::{ActorMessage, MagicsockMetrics, NodeIdMappedAddr, HEARTBEAT_INTERVAL},
+    magicsock::{ActorMessage, HEARTBEAT_INTERVAL, MagicsockMetrics, NodeIdMappedAddr},
 };
 
 /// Number of addresses that are not active that we keep around per node.

--- a/iroh/src/magicsock/node_map/path_state.rs
+++ b/iroh/src/magicsock/node_map/path_state.rs
@@ -7,11 +7,11 @@ use std::{
 
 use iroh_base::NodeId;
 use n0_future::time::{Duration, Instant};
-use tracing::{debug, event, Level};
+use tracing::{Level, debug, event};
 
 use super::{
-    node_state::{ControlMsg, PongReply, SESSION_ACTIVE_TIMEOUT},
     IpPort, PingRole, Source,
+    node_state::{ControlMsg, PongReply, SESSION_ACTIVE_TIMEOUT},
 };
 use crate::{disco::SendAddr, magicsock::HEARTBEAT_INTERVAL};
 

--- a/iroh/src/magicsock/node_map/udp_paths.rs
+++ b/iroh/src/magicsock/node_map/udp_paths.rs
@@ -12,10 +12,10 @@ use rand::seq::IteratorRandom;
 use tracing::warn;
 
 use super::{
+    IpPort,
     best_addr::{self, BestAddr},
     node_state::PongReply,
     path_state::PathState,
-    IpPort,
 };
 use crate::disco::SendAddr;
 

--- a/iroh/src/magicsock/transports.rs
+++ b/iroh/src/magicsock/transports.rs
@@ -2,7 +2,7 @@ use std::{
     io::{self, IoSliceMut},
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
     pin::Pin,
-    sync::{atomic::AtomicUsize, Arc},
+    sync::{Arc, atomic::AtomicUsize},
     task::{Context, Poll},
 };
 

--- a/iroh/src/magicsock/transports.rs
+++ b/iroh/src/magicsock/transports.rs
@@ -2,7 +2,7 @@ use std::{
     io::{self, IoSliceMut},
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
     pin::Pin,
-    sync::{atomic::AtomicUsize, Arc},
+    sync::{Arc, atomic::AtomicUsize},
     task::{Context, Poll},
 };
 
@@ -420,7 +420,7 @@ impl UdpSender {
         match destination {
             #[cfg(wasm_browser)]
             Addr::Ip(..) => {
-                return Poll::Ready(Err(io::Error::other("IP is unsupported in browser")))
+                return Poll::Ready(Err(io::Error::other("IP is unsupported in browser")));
             }
             #[cfg(not(wasm_browser))]
             Addr::Ip(addr) => {

--- a/iroh/src/magicsock/transports.rs
+++ b/iroh/src/magicsock/transports.rs
@@ -2,7 +2,7 @@ use std::{
     io::{self, IoSliceMut},
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
     pin::Pin,
-    sync::{Arc, atomic::AtomicUsize},
+    sync::{atomic::AtomicUsize, Arc},
     task::{Context, Poll},
 };
 

--- a/iroh/src/magicsock/transports/relay.rs
+++ b/iroh/src/magicsock/transports/relay.rs
@@ -13,7 +13,7 @@ use n0_watcher::{Watchable, Watcher as _};
 use smallvec::SmallVec;
 use tokio::sync::mpsc;
 use tokio_util::sync::PollSender;
-use tracing::{error, info_span, trace, warn, Instrument};
+use tracing::{Instrument, error, info_span, trace, warn};
 
 use super::{Addr, Transmit};
 use crate::magicsock::RelayContents;

--- a/iroh/src/magicsock/transports/relay/actor.rs
+++ b/iroh/src/magicsock/transports/relay/actor.rs
@@ -30,10 +30,10 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     future::Future,
     net::IpAddr,
-    pin::{pin, Pin},
+    pin::{Pin, pin},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
@@ -41,14 +41,13 @@ use backon::{Backoff, BackoffBuilder, ExponentialBuilder};
 use bytes::{Bytes, BytesMut};
 use iroh_base::{NodeId, PublicKey, RelayUrl, SecretKey};
 use iroh_relay::{
-    self as relay,
+    self as relay, MAX_PACKET_SIZE, PingTracker,
     client::{Client, ConnectError, ReceivedMessage, RecvError, SendError, SendMessage},
-    PingTracker, MAX_PACKET_SIZE,
 };
 use n0_future::{
+    FuturesUnorderedBounded, SinkExt, StreamExt,
     task::JoinSet,
     time::{self, Duration, Instant, MissedTickBehavior},
-    FuturesUnorderedBounded, SinkExt, StreamExt,
 };
 use n0_watcher::Watchable;
 use nested_enum_utils::common_fields;
@@ -56,7 +55,7 @@ use netwatch::interfaces;
 use snafu::{IntoError, ResultExt, Snafu};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, event, info, info_span, instrument, trace, warn, Instrument, Level};
+use tracing::{Instrument, Level, debug, error, event, info, info_span, instrument, trace, warn};
 use url::Url;
 
 #[cfg(not(wasm_browser))]
@@ -1368,7 +1367,7 @@ impl Iterator for PacketSplitIter {
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::{atomic::AtomicBool, Arc},
+        sync::{Arc, atomic::AtomicBool},
         time::Duration,
     };
 
@@ -1379,13 +1378,13 @@ mod tests {
     use smallvec::smallvec;
     use tokio::sync::{mpsc, oneshot};
     use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-    use tracing::{info, info_span, Instrument};
+    use tracing::{Instrument, info, info_span};
     use tracing_test::traced_test;
 
     use super::{
         ActiveRelayActor, ActiveRelayActorOptions, ActiveRelayMessage, ActiveRelayPrioMessage,
-        PacketizeIter, RelayConnectionOptions, RelayRecvDatagram, RelaySendItem, MAX_PACKET_SIZE,
-        RELAY_INACTIVE_CLEANUP_TIME, UNDELIVERABLE_DATAGRAM_TIMEOUT,
+        MAX_PACKET_SIZE, PacketizeIter, RELAY_INACTIVE_CLEANUP_TIME, RelayConnectionOptions,
+        RelayRecvDatagram, RelaySendItem, UNDELIVERABLE_DATAGRAM_TIMEOUT,
     };
     use crate::{dns::DnsResolver, test_utils};
 

--- a/iroh/src/magicsock/transports/relay/actor.rs
+++ b/iroh/src/magicsock/transports/relay/actor.rs
@@ -499,7 +499,7 @@ impl ActiveRelayActor {
     /// connections.  It currently does not ever return `Err` as the retries continue
     /// forever.
     // This is using `impl Future` to return a future without a reference to self.
-    fn dial_relay(&self) -> impl Future<Output = Result<Client, DialError>> + use<> {
+    fn dial_relay(&self) -> impl Future<Output = Result<Client, DialError>> + 'static {
         let client_builder = self.relay_client_builder.clone();
         async move {
             match time::timeout(CONNECT_TIMEOUT, client_builder.connect()).await {
@@ -983,7 +983,7 @@ impl RelayActor {
     async fn try_send_datagram(
         &mut self,
         item: RelaySendItem,
-    ) -> Option<impl Future<Output = ()> + use<>> {
+    ) -> Option<impl Future<Output = ()> + 'static> {
         let url = item.url.clone();
         let handle = self
             .active_relay_handle_for_node(&item.url, &item.remote_node)
@@ -1218,7 +1218,7 @@ impl RelayActor {
         });
     }
 
-    fn active_relay_sorted(&self) -> impl Iterator<Item = RelayUrl> + use<> {
+    fn active_relay_sorted(&self) -> impl Iterator<Item = RelayUrl> + 'static {
         let mut ids: Vec<_> = self.active_relays.keys().cloned().collect();
         ids.sort();
 

--- a/iroh/src/magicsock/transports/relay/actor.rs
+++ b/iroh/src/magicsock/transports/relay/actor.rs
@@ -500,7 +500,7 @@ impl ActiveRelayActor {
     /// connections.  It currently does not ever return `Err` as the retries continue
     /// forever.
     // This is using `impl Future` to return a future without a reference to self.
-    fn dial_relay(&self) -> impl Future<Output = Result<Client, DialError>> {
+    fn dial_relay(&self) -> impl Future<Output = Result<Client, DialError>> + use<> {
         let client_builder = self.relay_client_builder.clone();
         async move {
             match time::timeout(CONNECT_TIMEOUT, client_builder.connect()).await {
@@ -981,7 +981,10 @@ impl RelayActor {
     /// If the datagram can not be sent immediately, because the destination channel is
     /// full, a future is returned that will complete once the datagrams have been sent to
     /// the [`ActiveRelayActor`].
-    async fn try_send_datagram(&mut self, item: RelaySendItem) -> Option<impl Future<Output = ()>> {
+    async fn try_send_datagram(
+        &mut self,
+        item: RelaySendItem,
+    ) -> Option<impl Future<Output = ()> + use<>> {
         let url = item.url.clone();
         let handle = self
             .active_relay_handle_for_node(&item.url, &item.remote_node)
@@ -1216,7 +1219,7 @@ impl RelayActor {
         });
     }
 
-    fn active_relay_sorted(&self) -> impl Iterator<Item = RelayUrl> {
+    fn active_relay_sorted(&self) -> impl Iterator<Item = RelayUrl> + use<> {
         let mut ids: Vec<_> = self.active_relays.keys().cloned().collect();
         ids.sort();
 

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -20,21 +20,21 @@ use std::{
 use defaults::timeouts::PROBES_TIMEOUT;
 use iroh_base::RelayUrl;
 #[cfg(not(wasm_browser))]
+use iroh_relay::RelayNode;
+#[cfg(not(wasm_browser))]
 use iroh_relay::dns::DnsResolver;
 #[cfg(not(wasm_browser))]
 use iroh_relay::quic::QuicClient;
-#[cfg(not(wasm_browser))]
-use iroh_relay::RelayNode;
 use iroh_relay::{
-    quic::{QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON},
     RelayMap,
+    quic::{QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON},
 };
 #[cfg(not(wasm_browser))]
 use n0_future::task;
 use n0_future::{
+    StreamExt,
     task::AbortOnDropHandle,
     time::{self, Duration, Instant},
-    StreamExt,
 };
 use n0_watcher::{Watchable, Watcher};
 use tokio::task::JoinSet;
@@ -395,7 +395,7 @@ impl Client {
         enough_relays: usize,
         do_full: bool,
     ) -> Vec<ProbeReport> {
-        use tracing::{info_span, Instrument};
+        use tracing::{Instrument, info_span};
 
         debug!("spawning QAD probes");
 
@@ -812,7 +812,7 @@ async fn run_probe_v6(
 mod test_utils {
     //! Creates a relay server against which to perform tests
 
-    use iroh_relay::{server, RelayNode, RelayQuicConfig};
+    use iroh_relay::{RelayNode, RelayQuicConfig, server};
 
     pub(crate) async fn relay() -> (server::Server, RelayNode) {
         let server = server::Server::spawn(server::testing::server_config())

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -160,7 +160,7 @@ impl QadConns {
         reports
     }
 
-    fn watch_v4(&self) -> impl n0_future::Stream<Item = Option<QadProbeReport>> + Unpin {
+    fn watch_v4(&self) -> impl n0_future::Stream<Item = Option<QadProbeReport>> + Unpin + use<> {
         let watcher = self.v4.as_ref().map(|(_url, conn)| conn.observer.watch());
 
         if let Some(watcher) = watcher {
@@ -170,7 +170,7 @@ impl QadConns {
         }
     }
 
-    fn watch_v6(&self) -> impl n0_future::Stream<Item = Option<QadProbeReport>> + Unpin {
+    fn watch_v6(&self) -> impl n0_future::Stream<Item = Option<QadProbeReport>> + Unpin + use<> {
         let watcher = self.v6.as_ref().map(|(_url, conn)| conn.observer.watch());
         if let Some(watcher) = watcher {
             watcher.stream_updates_only().boxed()

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -160,7 +160,7 @@ impl QadConns {
         reports
     }
 
-    fn watch_v4(&self) -> impl n0_future::Stream<Item = Option<QadProbeReport>> + Unpin + use<> {
+    fn watch_v4(&self) -> impl n0_future::Stream<Item = Option<QadProbeReport>> + Unpin + 'static {
         let watcher = self.v4.as_ref().map(|(_url, conn)| conn.observer.watch());
 
         if let Some(watcher) = watcher {
@@ -170,7 +170,7 @@ impl QadConns {
         }
     }
 
-    fn watch_v6(&self) -> impl n0_future::Stream<Item = Option<QadProbeReport>> + Unpin + use<> {
+    fn watch_v6(&self) -> impl n0_future::Stream<Item = Option<QadProbeReport>> + Unpin + 'static {
         let watcher = self.v6.as_ref().map(|(_url, conn)| conn.observer.watch());
         if let Some(watcher) = watcher {
             watcher.stream_updates_only().boxed()

--- a/iroh/src/net_report/ip_mapped_addrs.rs
+++ b/iroh/src/net_report/ip_mapped_addrs.rs
@@ -2,8 +2,8 @@ use std::{
     collections::BTreeMap,
     net::{IpAddr, Ipv6Addr, SocketAddr},
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     },
 };
 

--- a/iroh/src/net_report/options.rs
+++ b/iroh/src/net_report/options.rs
@@ -6,7 +6,7 @@ pub use imp::Options;
 mod imp {
     use std::collections::BTreeSet;
 
-    use crate::net_report::{probes::Probe, QuicConfig};
+    use crate::net_report::{QuicConfig, probes::Probe};
 
     /// Options for running probes
     ///

--- a/iroh/src/net_report/report.rs
+++ b/iroh/src/net_report/report.rs
@@ -8,7 +8,7 @@ use std::{
 use iroh_base::RelayUrl;
 use tracing::warn;
 
-use super::{probes::Probe, ProbeReport};
+use super::{ProbeReport, probes::Probe};
 
 /// A net_report report.
 #[derive(Default, Debug, PartialEq, Eq, Clone)]

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -25,7 +25,7 @@ use std::{
 
 use http::StatusCode;
 use iroh_base::RelayUrl;
-use iroh_relay::{defaults::DEFAULT_RELAY_QUIC_PORT, http::RELAY_PROBE_PATH, RelayMap, RelayNode};
+use iroh_relay::{RelayMap, RelayNode, defaults::DEFAULT_RELAY_QUIC_PORT, http::RELAY_PROBE_PATH};
 #[cfg(not(wasm_browser))]
 use iroh_relay::{
     dns::{DnsError, DnsResolver, StaggeredError},
@@ -34,25 +34,25 @@ use iroh_relay::{
 #[cfg(wasm_browser)]
 use n0_future::future::Pending;
 use n0_future::{
+    StreamExt as _,
     task::{self, AbortOnDropHandle, JoinSet},
     time::{self, Duration, Instant},
-    StreamExt as _,
 };
 use rand::seq::IteratorRandom;
 use snafu::{IntoError, OptionExt, ResultExt, Snafu};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, debug_span, error, info_span, trace, warn, Instrument};
+use tracing::{Instrument, debug, debug_span, error, info_span, trace, warn};
 use url::Host;
 
 #[cfg(wasm_browser)]
 use super::portmapper; // We stub the library
+use super::{
+    Report,
+    probes::{Probe, ProbePlan},
+};
 #[cfg(not(wasm_browser))]
 use super::{defaults::timeouts::DNS_TIMEOUT, ip_mapped_addrs::IpMappedAddresses};
-use super::{
-    probes::{Probe, ProbePlan},
-    Report,
-};
 #[cfg(not(wasm_browser))]
 use crate::discovery::dns::DNS_STAGGERING_MS;
 use crate::net_report::defaults::timeouts::{

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -46,11 +46,11 @@ use n0_future::{
 };
 use snafu::{Backtrace, Snafu};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info_span, trace, warn, Instrument};
+use tracing::{Instrument, error, info_span, trace, warn};
 
 use crate::{
-    endpoint::{Connecting, Connection, RemoteNodeIdError},
     Endpoint,
+    endpoint::{Connecting, Connection, RemoteNodeIdError},
 };
 
 /// The built router.
@@ -573,7 +573,7 @@ mod tests {
     use quinn::ApplicationClose;
 
     use super::*;
-    use crate::{endpoint::ConnectionError, RelayMode};
+    use crate::{RelayMode, endpoint::ConnectionError};
 
     #[tokio::test]
     async fn test_shutdown() -> Result {

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -483,7 +483,7 @@ pub(crate) mod pkarr_dns_state {
         node_info: &NodeInfo,
         origin: &str,
         ttl: u32,
-    ) -> impl Iterator<Item = hickory_resolver::proto::rr::Record> + 'static {
+    ) -> impl Iterator<Item = hickory_resolver::proto::rr::Record> + 'static + use<> {
         let txt_strings = node_info.to_txt_strings();
         let records = to_hickory_records(txt_strings, node_info.node_id, origin, ttl);
         records.collect::<Vec<_>>().into_iter()

--- a/iroh/src/tls/resolver.rs
+++ b/iroh/src/tls/resolver.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use ed25519_dalek::pkcs8::{spki::der::pem::LineEnding, EncodePrivateKey};
+use ed25519_dalek::pkcs8::{EncodePrivateKey, spki::der::pem::LineEnding};
 use iroh_base::SecretKey;
 use nested_enum_utils::common_fields;
 use snafu::Snafu;
-use webpki_types::{pem::PemObject, CertificateDer, PrivatePkcs8KeyDer};
+use webpki_types::{CertificateDer, PrivatePkcs8KeyDer, pem::PemObject};
 
 #[derive(Debug)]
 pub(super) struct AlwaysResolvesCert {

--- a/iroh/src/tls/verifier.rs
+++ b/iroh/src/tls/verifier.rs
@@ -6,12 +6,12 @@
 use ed25519_dalek::pkcs8::EncodePublicKey;
 use iroh_base::PublicKey;
 use rustls::{
-    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
-    crypto::{verify_tls13_signature_with_raw_key, WebPkiSupportedAlgorithms},
-    pki_types::CertificateDer as Certificate,
-    server::danger::{ClientCertVerified, ClientCertVerifier},
     CertificateError, DigitallySignedStruct, DistinguishedName, SignatureScheme,
     SupportedProtocolVersion,
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::{WebPkiSupportedAlgorithms, verify_tls13_signature_with_raw_key},
+    pki_types::CertificateDer as Certificate,
+    server::danger::{ClientCertVerified, ClientCertVerifier},
 };
 use webpki::ring as webpki_algs;
 use webpki_types::SubjectPublicKeyInfoDer;

--- a/iroh/tests/integration.rs
+++ b/iroh/tests/integration.rs
@@ -10,18 +10,17 @@
 //! In the past we've hit relay rate-limits from all the tests in our CI, but I expect
 //! we won't hit these with only this integration test.
 use iroh::{
-    discovery::{pkarr::PkarrResolver, Discovery},
     Endpoint,
+    discovery::{Discovery, pkarr::PkarrResolver},
 };
 use n0_future::{
-    task,
+    StreamExt, task,
     time::{self, Duration},
-    StreamExt,
 };
 use n0_snafu::{Result, ResultExt};
 #[cfg(not(wasm_browser))]
 use tokio::test;
-use tracing::{info_span, Instrument};
+use tracing::{Instrument, info_span};
 #[cfg(wasm_browser)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 


### PR DESCRIPTION
## Description

Try to use 'static instead of the new and somewhat weird use<> syntax to express that a function return argument does not reference any of the lifetimes of the function arguments or &self.

## Breaking Changes

'static seems to be subtly different than use<> even though I don't really understand the difference.

## Notes & open questions

I find 'static more clear to express that the result does not capture any lifetimes... YMMV.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
