### PR TITLE
fix: fix dht publishing at startup

### DIFF
--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -258,12 +258,17 @@ impl DhtDiscovery {
     /// Periodically publishes the node address to the DHT and/or relay.
     async fn publish_loop(self, keypair: SecretKey, signed_packet: SignedPacket) {
         let this = self;
-        let public_key = pkarr::PublicKey::try_from(keypair.public().as_bytes())
-            .expect("valid public key");
+        let public_key =
+            pkarr::PublicKey::try_from(keypair.public().as_bytes()).expect("valid public key");
         let z32 = public_key.to_z32();
         loop {
             // If the task gets aborted while doing this lookup, we have not published yet.
-            let prev_timestamp = this.0.pkarr.resolve_most_recent(&public_key).await.map(|p| p.timestamp());
+            let prev_timestamp = this
+                .0
+                .pkarr
+                .resolve_most_recent(&public_key)
+                .await
+                .map(|p| p.timestamp());
             let res = this.0.pkarr.publish(&signed_packet, prev_timestamp).await;
             match res {
                 Ok(()) => {


### PR DESCRIPTION
## Description

Before, you would publish two times in very close succession, which caused an error during the second publish. pkarr will notice if you try to publish while the previous publish is still ongoing, and abort.

## Breaking Changes

fn discovery::pkarr::dht::Builder::initial_publish_delay is removed, since this does not exist anymore.

## Notes & open questions

Note: I think the whole dht publishing code would benefit from some cleanup since a few things have changed. But this is just a minimal fix to get things to work again.

fixes https://github.com/n0-computer/iroh/issues/3395