### PR TITLE
fix: better tracing spans

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -728,7 +728,7 @@ impl Endpoint {
     ///    establishing and maintaining direct connections.  Carefully test settings you use and
     ///    consider this currently as still rather experimental.
     #[instrument(name = "connect", skip_all, fields(
-        me = self.node_id().fmt_short(),
+        me = %self.node_id().fmt_short(),
         remote = tracing::field::Empty,
         alpn = String::from_utf8_lossy(alpn).to_string(),
     ))]
@@ -739,7 +739,10 @@ impl Endpoint {
         options: ConnectOptions,
     ) -> Result<Connecting, ConnectWithOptsError> {
         let node_addr: NodeAddr = node_addr.into();
-        tracing::Span::current().record("remote", node_addr.node_id.fmt_short());
+        tracing::Span::current().record(
+            "remote",
+            tracing::field::display(node_addr.node_id.fmt_short()),
+        );
 
         // Connecting to ourselves is not supported.
         ensure!(node_addr.node_id != self.node_id(), SelfConnectSnafu);

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1184,24 +1184,27 @@ impl DirectAddrUpdateState {
         let msock = self.msock.clone();
 
         let run_done = self.run_done.clone();
-        task::spawn(async move {
-            let fut = time::timeout(
-                NET_REPORT_TIMEOUT,
-                net_reporter.get_report(if_state, why.is_major()),
-            );
-            match fut.await {
-                Ok(report) => {
-                    msock.net_report.set((Some(report), why)).ok();
+        task::spawn(
+            async move {
+                let fut = time::timeout(
+                    NET_REPORT_TIMEOUT,
+                    net_reporter.get_report(if_state, why.is_major()),
+                );
+                match fut.await {
+                    Ok(report) => {
+                        msock.net_report.set((Some(report), why)).ok();
+                    }
+                    Err(time::Elapsed { .. }) => {
+                        warn!("net_report report timed out");
+                    }
                 }
-                Err(time::Elapsed { .. }) => {
-                    warn!("net_report report timed out");
-                }
-            }
 
-            // mark run as finished
-            debug!("direct addr update done ({:?})", why);
-            run_done.send(()).await.ok();
-        });
+                // mark run as finished
+                debug!("direct addr update done ({:?})", why);
+                run_done.send(()).await.ok();
+            }
+            .instrument(tracing::Span::current()),
+        );
     }
 }
 


### PR DESCRIPTION
## Description

This adds tracing spans to tasks we spawn where we didn't do this so far.

I also added alpn and remote fields to the router tasks for connections, to match what we do for outgoing connections.

Additionally, this improves the display of remote node ids and ALPNs by using tracing's display formatter, to omit the  quotes.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
