### PR TITLE
fix(iroh-relay): Fix proptests, make `Datagrams::segment_size` be an `Option<NonZeroU16>`

### DIFF
--- a/iroh-relay/proptest-regressions/protos/relay.txt
+++ b/iroh-relay/proptest-regressions/protos/relay.txt
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc 9295f5287162dfb180e5826e563c2cea08b477b803ef412ff8351eb5c3eb45ef # shrinks to frame = KeepAlive
 cc 753aabcf8ae2b4e4a52f451d58339aab85a4b61108afdf4b9600f97b3a33bf42 # shrinks to frame = Health { problem: None }
+cc 2b45ae945ff922d4c3dfbad31a5e57c535c0ee2739906272f21ed77f8b862528 # shrinks to frame = Datagrams { remote_node_id: PublicKey(3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29), datagrams: Datagrams { ecn: None, segment_size: Some(0), .. } }

--- a/iroh/src/magicsock/transports/relay.rs
+++ b/iroh/src/magicsock/transports/relay.rs
@@ -1,5 +1,6 @@
 use std::{
     io,
+    num::NonZeroU16,
     task::{Context, Poll},
 };
 
@@ -104,7 +105,7 @@ impl RelayTransport {
             meta_out.stride = dm
                 .datagrams
                 .segment_size
-                .map_or(dm.datagrams.contents.len(), |s| s as usize);
+                .map_or(dm.datagrams.contents.len(), |s| u16::from(s) as usize);
             meta_out.ecn = None;
             meta_out.dst_ip = None; // TODO: insert the relay url for this relay
 
@@ -314,7 +315,10 @@ fn datagrams_from_transmit(transmit: &Transmit<'_>) -> Datagrams {
             quinn_udp::EcnCodepoint::Ect1 => quinn_proto::EcnCodepoint::Ect1,
             quinn_udp::EcnCodepoint::Ce => quinn_proto::EcnCodepoint::Ce,
         }),
-        segment_size: transmit.segment_size.map(|ss| ss as u16),
+        segment_size: transmit
+            .segment_size
+            .map(|ss| ss as u16)
+            .and_then(NonZeroU16::new),
         contents: Bytes::copy_from_slice(transmit.contents),
     }
 }


### PR DESCRIPTION
## Description

The proptests were failing in some rare case where `Datagrams::segment_size` was generated as `Some(0)`. (For some reason we haven't hit that before?).

I added the failing case hash to the proptest regressions file and fixed the problem.

I also changed `Datagrams::segment_size` to be an `Option<NonZeroU16>` instead of `Option<u16>`, which checks this invariant on the type level now.

## Breaking Changes

- `Datagrams::segment_size` is now an `Option<NonZeroU16>` instead of `Option<u16>`.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
