### PR TITLE
feat: Add the timeout duration to the relay dial error

### DIFF
--- a/iroh/src/magicsock/transports/relay/actor.rs
+++ b/iroh/src/magicsock/transports/relay/actor.rs
@@ -258,7 +258,7 @@ enum RunError {
 })]
 #[derive(Debug, Snafu)]
 enum DialError {
-    #[snafu(display("timeout (>{timeout:?}) trying to establish a connection "))]
+    #[snafu(display("timeout (>{timeout:?}) trying to establish a connection"))]
     Timeout { timeout: Duration },
     #[snafu(display("unable to connect"))]
     Connect {


### PR DESCRIPTION
## Description

This adds the timeout used to the error.  This error ends up being logged, knowing the actual timeout exceeded is kind of useful.

## Breaking Changes

None

## Notes & open questions

My first attempt at using snafu.  Hopefully this is about right.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
