### PR TITLE
fix(iroh): Only clear `last_call_me_maybe` when the best addr became invalid

### DIFF
--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -1025,10 +1025,12 @@ impl NodeState {
                 }
             }
         }
-        // Clear trust on our best_addr if it is not included in the updated set.  Also
-        // clear the last call-me-maybe send time so we will send one again.
-        self.udp_paths.update_to_best_addr(now);
-        self.last_call_me_maybe = None;
+        // Clear trust on our best_addr if it is not included in the updated set.
+        let changed = self.udp_paths.update_to_best_addr(now);
+        if changed {
+            // Clear the last call-me-maybe send time so we will send one again.
+            self.last_call_me_maybe = None;
+        }
         debug!(
             paths = %summarize_node_paths(&self.udp_paths.paths),
             "updated endpoint paths from call-me-maybe",


### PR DESCRIPTION
## Description

Fixes a bug introduced in #3400

We used to only reset `last_call_me_maybe` to `None` when the best address was cleared. The above PR accidentally changed that to always reset.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.