### PR TITLE
refactor(iroh): Re-batch datagrams inside `RelayTransport` instead of the `ActiveRelayActor`

### DIFF
--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -161,14 +161,14 @@ impl Datagrams {
     /// the batch with at most `num_segments` and leaving only the rest in `self`.
     ///
     /// Calling this on a datagram batch that only contains a single datagram (`segment_size == None`)
-    /// will result in returning essentially `Some(self.clone())`, while making `self` empty afterwards.
+    /// will result in returning essentially a clone of `self`, while making `self` empty afterwards.
     ///
     /// Calling this on a datagram batch with e.g. 15 datagrams with `num_segments == 10` will
-    /// result in returning `Some(datagram_batch)` where that `datagram_batch` contains the first
-    /// 10 datagrams and `self` contains the remaining 5 datagrams.
+    /// result in returning a datagram batch taht contains the first 10 datagrams and leave `self`
+    /// containing the remaining 5 datagrams.
     ///
-    /// Calling this on a datagram batch that doesn't contain `num_segments` datagrams, but less
-    /// will result in making `self` empty and returning essentially a clone of `self`.
+    /// Calling this on a datagram batch with less than `num_segments` datagrams will result in
+    /// making `self` empty and returning essentially a clone of `self`.
     pub fn take_segments(&mut self, num_segments: usize) -> Datagrams {
         let Some(segment_size) = self.segment_size else {
             let contents = std::mem::take(&mut self.contents);

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -187,6 +187,12 @@ impl Datagrams {
 
         let is_datagram_batch = num_segments > 1 && usize_segment_size < contents.len();
 
+        // If this left our batch with only one more datagram, then remove the segment size
+        // to uphold the invariant that single-datagram batches don't have a segment size set.
+        if self.contents.len() <= usize_segment_size {
+            self.segment_size = None;
+        }
+
         Datagrams {
             ecn: self.ecn,
             segment_size: is_datagram_batch.then_some(segment_size),

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -164,7 +164,7 @@ impl Datagrams {
     /// will result in returning essentially a clone of `self`, while making `self` empty afterwards.
     ///
     /// Calling this on a datagram batch with e.g. 15 datagrams with `num_segments == 10` will
-    /// result in returning a datagram batch taht contains the first 10 datagrams and leave `self`
+    /// result in returning a datagram batch that contains the first 10 datagrams and leave `self`
     /// containing the remaining 5 datagrams.
     ///
     /// Calling this on a datagram batch with less than `num_segments` datagrams will result in

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -23,7 +23,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc, Mutex, RwLock,
-        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     task::{Context, Poll},
 };
@@ -1269,7 +1269,6 @@ impl Handle {
 
         let my_relay = Watchable::new(None);
         let ipv6_reported = Arc::new(AtomicBool::new(ipv6_reported));
-        let max_receive_segments = Arc::new(AtomicUsize::new(1));
 
         let relay_transport = RelayTransport::new(RelayActorConfig {
             my_relay: my_relay.clone(),
@@ -1278,7 +1277,6 @@ impl Handle {
             dns_resolver: dns_resolver.clone(),
             proxy_url: proxy_url.clone(),
             ipv6_reported: ipv6_reported.clone(),
-            max_receive_segments: max_receive_segments.clone(),
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify,
             metrics: metrics.magicsock.clone(),
@@ -1290,9 +1288,9 @@ impl Handle {
         let ipv6 = ip_transports.iter().any(|t| t.bind_addr().is_ipv6());
 
         #[cfg(not(wasm_browser))]
-        let transports = Transports::new(ip_transports, relay_transports, max_receive_segments);
+        let transports = Transports::new(ip_transports, relay_transports);
         #[cfg(wasm_browser)]
-        let transports = Transports::new(relay_transports, max_receive_segments);
+        let transports = Transports::new(relay_transports);
 
         let (disco, disco_receiver) = DiscoState::new(secret_encryption_key);
 

--- a/iroh/src/magicsock/transports/relay.rs
+++ b/iroh/src/magicsock/transports/relay.rs
@@ -104,16 +104,19 @@ impl RelayTransport {
             };
 
             // This *tries* to make the datagrams fit into our buffer by re-batching them.
-            let num_segments =
-                buf_out.len() / dm.datagrams.segment_size.map_or(0, u16::from) as usize;
+            let num_segments = dm
+                .datagrams
+                .segment_size
+                .map_or(1, |ss| buf_out.len() / u16::from(ss) as usize);
             let datagrams = dm.datagrams.take_segments(num_segments);
+            let empty_after = dm.datagrams.contents.is_empty();
             let dm = RelayRecvDatagram {
                 datagrams,
                 src: dm.src,
                 url: dm.url.clone(),
             };
             // take_segments can leave `self.pending_item` empty, in that case we clear it
-            if dm.datagrams.contents.is_empty() {
+            if empty_after {
                 self.pending_item = None;
             }
 

--- a/iroh/src/magicsock/transports/relay/actor.rs
+++ b/iroh/src/magicsock/transports/relay/actor.rs
@@ -33,7 +33,7 @@ use std::{
     pin::{Pin, pin},
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
 };
 
@@ -149,8 +149,6 @@ struct ActiveRelayActor {
     /// last datagram sent to the relay, received datagrams will trigger QUIC ACKs which is
     /// sufficient to keep active connections open.
     inactive_timeout: Pin<Box<time::Sleep>>,
-    /// The last known value for the magic socket's `AsyncUdpSocket::max_receive_segments`.
-    max_receive_segments: Arc<AtomicUsize>,
     /// Token indicating the [`ActiveRelayActor`] should stop.
     stop_token: CancellationToken,
     metrics: Arc<MagicsockMetrics>,
@@ -195,7 +193,6 @@ struct ActiveRelayActorOptions {
     relay_datagrams_send: mpsc::Receiver<RelaySendItem>,
     relay_datagrams_recv: mpsc::Sender<RelayRecvDatagram>,
     connection_opts: RelayConnectionOptions,
-    max_receive_segments: Arc<AtomicUsize>,
     stop_token: CancellationToken,
     metrics: Arc<MagicsockMetrics>,
 }
@@ -279,7 +276,6 @@ impl ActiveRelayActor {
             relay_datagrams_send,
             relay_datagrams_recv,
             connection_opts,
-            max_receive_segments,
             stop_token,
             metrics,
         } = opts;
@@ -293,7 +289,6 @@ impl ActiveRelayActor {
             relay_client_builder,
             is_home_relay: false,
             inactive_timeout: Box::pin(time::sleep(RELAY_INACTIVE_CLEANUP_TIME)),
-            max_receive_segments,
             stop_token,
             metrics,
         }
@@ -684,27 +679,12 @@ impl ActiveRelayActor {
                     state.nodes_present.insert(remote_node_id);
                 }
 
-                let max_segments = self
-                    .max_receive_segments
-                    .load(std::sync::atomic::Ordering::Relaxed);
-                // We might receive a datagram batch that's bigger than our magic socket's
-                // `AsyncUdpSocket::max_receive_segments`, if the other endpoint behind the relay
-                // has a higher `AsyncUdpSocket::max_transmit_segments` than we do.
-                // This happens e.g. when a linux machine (max transmit segments is usually 64)
-                // talks to a windows machine or a macos machine (max transmit segments is usually 1).
-                let re_batched = DatagramReBatcher {
-                    max_segments,
+                if let Err(err) = self.relay_datagrams_recv.try_send(RelayRecvDatagram {
+                    url: self.url.clone(),
+                    src: remote_node_id,
                     datagrams,
-                };
-                for datagrams in re_batched {
-                    if let Err(err) = self.relay_datagrams_recv.try_send(RelayRecvDatagram {
-                        url: self.url.clone(),
-                        src: remote_node_id,
-                        datagrams,
-                    }) {
-                        warn!("Dropping received relay packet: {err:#}");
-                        break; // No need to hot-loop in that case.
-                    }
+                }) {
+                    warn!("Dropping received relay packet: {err:#}");
                 }
             }
             RelayToClientMsg::NodeGone(node_id) => {
@@ -880,8 +860,6 @@ pub struct Config {
     pub proxy_url: Option<Url>,
     /// If the last net_report report, reports IPv6 to be available.
     pub ipv6_reported: Arc<AtomicBool>,
-    /// The last known return value of the magic socket's `AsyncUdpSocket::max_receive_segments` value
-    pub max_receive_segments: Arc<AtomicUsize>,
     #[cfg(any(test, feature = "test-utils"))]
     pub insecure_skip_relay_cert_verify: bool,
     pub metrics: Arc<MagicsockMetrics>,
@@ -1137,7 +1115,6 @@ impl RelayActor {
             relay_datagrams_send: send_datagram_rx,
             relay_datagrams_recv: self.relay_datagram_recv_queue.clone(),
             connection_opts,
-            max_receive_segments: self.config.max_receive_segments.clone(),
             stop_token: self.cancel_token.child_token(),
             metrics: self.config.metrics.clone(),
         };
@@ -1249,34 +1226,13 @@ pub(crate) struct RelayRecvDatagram {
     pub(crate) datagrams: Datagrams,
 }
 
-/// Turns a datagrams batch into multiple datagram batches of maximum `max_segments` size.
-///
-/// If the given datagram isn't batched, it just returns that datagram once.
-struct DatagramReBatcher {
-    max_segments: usize,
-    datagrams: Datagrams,
-}
-
-impl Iterator for DatagramReBatcher {
-    type Item = Datagrams;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.datagrams.take_segments(self.max_segments)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
-        num::NonZeroU16,
-        sync::{
-            Arc,
-            atomic::{AtomicBool, AtomicUsize},
-        },
+        sync::{Arc, atomic::AtomicBool},
         time::Duration,
     };
 
-    use bytes::Bytes;
     use iroh_base::{NodeId, RelayUrl, SecretKey};
     use iroh_relay::{PingTracker, protos::relay::Datagrams};
     use n0_snafu::{Error, Result, ResultExt};
@@ -1290,9 +1246,7 @@ mod tests {
         RELAY_INACTIVE_CLEANUP_TIME, RelayConnectionOptions, RelayRecvDatagram, RelaySendItem,
         UNDELIVERABLE_DATAGRAM_TIMEOUT,
     };
-    use crate::{
-        dns::DnsResolver, magicsock::transports::relay::actor::DatagramReBatcher, test_utils,
-    };
+    use crate::{dns::DnsResolver, test_utils};
 
     /// Starts a new [`ActiveRelayActor`].
     #[allow(clippy::too_many_arguments)]
@@ -1319,7 +1273,6 @@ mod tests {
                 prefer_ipv6: Arc::new(AtomicBool::new(true)),
                 insecure_skip_cert_verify: true,
             },
-            max_receive_segments: Arc::new(AtomicUsize::new(1)),
             stop_token,
             metrics: Default::default(),
         };
@@ -1617,40 +1570,5 @@ mod tests {
 
         let res = tokio::time::timeout(Duration::from_secs(10), tracker.timeout()).await;
         assert!(res.is_err(), "ping timeout should only happen once");
-    }
-
-    fn run_datagram_re_batcher(max_segments: usize, expected_lengths: Vec<usize>) {
-        let contents = Bytes::from_static(
-            b"Hello world! There's lots of stuff to talk about when you need a big buffer.",
-        );
-        let datagrams = Datagrams {
-            contents: contents.clone(),
-            ecn: None,
-            segment_size: NonZeroU16::new(10),
-        };
-
-        let re_batched_lengths = DatagramReBatcher {
-            datagrams,
-            max_segments,
-        }
-        .map(|d| d.contents.len())
-        .collect::<Vec<_>>();
-
-        assert_eq!(expected_lengths, re_batched_lengths);
-    }
-
-    #[test]
-    fn test_datagram_re_batcher_small_batches() {
-        run_datagram_re_batcher(3, vec![30, 30, 16]);
-    }
-
-    #[test]
-    fn test_datagram_re_batcher_batch_full() {
-        run_datagram_re_batcher(10, vec![76]);
-    }
-
-    #[test]
-    fn test_datagram_re_batcher_unbatch() {
-        run_datagram_re_batcher(1, vec![10, 10, 10, 10, 10, 10, 10, 6]);
     }
 }


### PR DESCRIPTION
## Description

This does the re-batching inside `RelayTransport` by storing a `pending_item: Option<RelayRecvDatagram>`.
When we `poll_recv`, we first try to use that pending item instead of polling a new one.

Once we've got a pending item, we try to split off as much from it as can possibly fit into our receive buffer and handle that.

## Breaking Changes

- `iroh_relay::protos::relay::Datagrams::take_segments` now return `Datagrams` instead of `Option<Datagrams>`, not distinguishing the case where `Datagrams` might be empty.

## Notes

Probably needs some test.
I'd love to test two `RelayTransport`s talking to each other with different `max_transmit_segments`/`max_receive_segments`, but I'm not sure I can make such a test setup happen easily.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
