### PR TITLE
chore(iroh,iroh-relay): Bump iroh-metrics version to 0.35, bump portmapper to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,7 +1965,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2238,7 +2238,7 @@ dependencies = [
  "iroh-relay",
  "n0-future",
  "netdev",
- "netwatch",
+ "netwatch 0.5.0",
  "parse-size",
  "pin-project",
  "pkarr",
@@ -2371,15 +2371,16 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70466f14caff7420a14373676947e25e2917af6a5b1bec45825beb2bf1eb6a7"
+checksum = "c8922c169f1b84d39d325c02ef1bbe1419d4de6e35f0403462b3c7e60cc19634"
 dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
  "iroh-metrics-derive",
  "itoa",
+ "postcard",
  "reqwest",
  "serde",
  "snafu",
@@ -2807,6 +2808,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "n0-watcher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f216d4ebc5fcf9548244803cbb93f488a2ae160feba3706cd17040d69cf7a368"
+dependencies = [
+ "derive_more",
+ "n0-future",
+ "snafu",
+]
+
+[[package]]
 name = "nested_enum_utils"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,7 +2955,42 @@ dependencies = [
  "tracing",
  "web-sys",
  "windows 0.59.0",
- "windows-result 0.3.2",
+ "windows-result 0.3.4",
+ "wmi",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a829a830199b14989f9bccce6136ab928ab48336ab1f8b9002495dbbbb2edbe"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "iroh-quinn-udp",
+ "js-sys",
+ "libc",
+ "n0-future",
+ "n0-watcher",
+ "nested_enum_utils",
+ "netdev",
+ "netlink-packet-core",
+ "netlink-packet-route 0.23.0",
+ "netlink-proto",
+ "netlink-sys",
+ "pin-project-lite",
+ "serde",
+ "snafu",
+ "socket2",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows 0.59.0",
+ "windows-result 0.3.4",
  "wmi",
 ]
 
@@ -3412,9 +3459,9 @@ checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "portmapper"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6db66007eac4a0ec8331d0d20c734bd64f6445d64bbaf0d0a27fea7a054e36"
+checksum = "2d82975dc029c00d566f4e0f61f567d31f0297a290cb5416b5580dd8b4b54ade"
 dependencies = [
  "base64",
  "bytes",
@@ -3426,7 +3473,7 @@ dependencies = [
  "iroh-metrics",
  "libc",
  "nested_enum_utils",
- "netwatch",
+ "netwatch 0.6.0",
  "num_enum",
  "rand 0.8.5",
  "serde",
@@ -4431,18 +4478,18 @@ checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
 
 [[package]]
 name = "snafu"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5553,22 +5600,22 @@ checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
  "windows-implement 0.59.0",
  "windows-interface 0.59.1",
- "windows-result 0.3.2",
+ "windows-result 0.3.4",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
  "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -5628,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
@@ -5638,7 +5685,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.3.2",
+ "windows-result 0.3.4",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
@@ -5654,9 +5701,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -5682,9 +5729,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -29,7 +29,7 @@ hickory-server = { version = "0.25.1", features = ["https-ring"] }
 http = "1.0.0"
 humantime = "2.2.0"
 humantime-serde = "1.1.1"
-iroh-metrics = { version = "0.34", features = ["service"] }
+iroh-metrics = { version = "0.35", features = ["service"] }
 lru = "0.12.3"
 n0-future = "0.1.2"
 pkarr = { version = "3.7", features = ["relays", "dht"], default-features = false }

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -33,7 +33,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = "0.1.1"
 iroh-base = { version = "0.35.0", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
-iroh-metrics = { version = "0.34", default-features = false }
+iroh-metrics = { version = "0.35", default-features = false }
 n0-future = "0.1.2"
 num_enum = "0.7"
 pin-project = "1"

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -127,7 +127,7 @@ impl MaybeTlsStreamBuilder {
         }
     }
 
-    fn tls_servername(&self) -> Option<rustls::pki_types::ServerName> {
+    fn tls_servername(&self) -> Option<rustls::pki_types::ServerName<'_>> {
         self.url
             .host_str()
             .and_then(|s| rustls::pki_types::ServerName::try_from(s).ok())

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -86,7 +86,7 @@ futures-buffered = "0.2.11"
 spki = { version = "0.7.3", features = ["std"] }
 
 # metrics
-iroh-metrics = { version = "0.34", default-features = false }
+iroh-metrics = { version = "0.35", default-features = false }
 
 # local-swarm-discovery
 swarm-discovery = { version = "0.3.1", optional = true }
@@ -108,7 +108,7 @@ parse-size = { version = "=1.0.0", optional = true } # pinned version to avoid b
 hickory-resolver = "0.25.1"
 igd-next = { version = "0.16", features = ["aio_tokio"] }
 netdev = { version = "0.31.0" }
-portmapper = { version = "0.5.0", default-features = false }
+portmapper = { version = "0.6.1", default-features = false }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.22"
 bytes = "1.7"
 hdrhistogram = { version = "7.2", default-features = false }
 iroh = { path = ".." }
-iroh-metrics = "0.34"
+iroh-metrics = "0.35"
 n0-future = "0.1.1"
 quinn = { package = "iroh-quinn", version = "0.13" }
 rand = "0.8"

--- a/iroh/src/magicsock/node_map/best_addr.rs
+++ b/iroh/src/magicsock/node_map/best_addr.rs
@@ -180,7 +180,7 @@ impl BestAddr {
         self.0 = Some(inner);
     }
 
-    pub fn state(&self, now: Instant) -> State {
+    pub fn state(&self, now: Instant) -> State<'_> {
         match &self.0 {
             None => State::Empty,
             Some(state) => match state.trust_until {

--- a/iroh/src/tls/certificate.rs
+++ b/iroh/src/tls/certificate.rs
@@ -121,7 +121,7 @@ pub(crate) struct VerificationError(#[from] pub(crate) webpki::Error);
 /// Internal function that only parses but does not verify the certificate.
 ///
 /// Useful for testing but unsuitable for production.
-fn parse_unverified(der_input: &[u8]) -> Result<P2pCertificate, webpki::Error> {
+fn parse_unverified(der_input: &[u8]) -> Result<P2pCertificate<'_>, webpki::Error> {
     let x509 = X509Certificate::from_der(der_input)
         .map(|(_rest_input, x509)| x509)
         .map_err(|_| webpki::Error::BadDer)?;

--- a/iroh/src/watchable.rs
+++ b/iroh/src/watchable.rs
@@ -131,7 +131,7 @@ impl<T: Clone + Eq> Watcher<T> {
     /// # Cancel Safety
     ///
     /// The returned future is cancel-safe.
-    pub fn updated(&mut self) -> WatchNextFut<T> {
+    pub fn updated(&mut self) -> WatchNextFut<'_, T> {
         WatchNextFut { watcher: self }
     }
 
@@ -180,7 +180,7 @@ impl<T: Clone + Eq> Watcher<Option<T>> {
     ///
     /// This is a utility for the common case of storing an [`Option`] inside a
     /// [`Watchable`].
-    pub fn initialized(&mut self) -> WatchInitializedFut<T> {
+    pub fn initialized(&mut self) -> WatchInitializedFut<'_, T> {
         self.epoch = PRE_INITIAL_EPOCH;
         WatchInitializedFut { watcher: self }
     }


### PR DESCRIPTION
## Description

Bumping these versions so that we can use iroh-metrics version 0.35 in iroh-n0des.

This ends up working end-to-end.

## Breaking Changes

- `EndpointMetrics` now doesn't implement iroh-metrics v0.34's `MetricsGroupSet`, but iroh-metrics v0.35 instead.

## Notes & open questions

The breaking change prevents this from being released as 0.35.1...

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
