### PR TITLE
fix(iroh-relay): Don't double-count connection accepts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,9 +4513,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -665,7 +665,6 @@ impl Inner {
         let io = RateLimited::from_cfg(self.rate_limit, io, self.metrics.clone())
             .context(RateLimitingMisconfiguredSnafu)?;
 
-        self.metrics.accepts.inc();
         // Create a server builder with default config
         let websocket = tokio_websockets::ServerBuilder::new()
             .limits(tokio_websockets::Limits::default().max_payload_len(Some(MAX_FRAME_SIZE)))

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -216,7 +216,7 @@ impl Builder {
                 }
                 if let Some(url) = &self.pkarr_relay {
                     builder
-                        .relays(&[url.clone()])
+                        .relays(std::slice::from_ref(url))
                         .map_err(|e| IntoDiscoveryError::from_err("pkarr", e))?;
                 }
                 builder


### PR DESCRIPTION
## Description

- Wrote a test checking that accepts == disconnects in relay metrics
- Fixed duplicate accept counts

Bug was originally introduced in #3384: We used to `metrics.relay_accepts.inc()` or `metrics.websocket_accepts.inc()` and I thought there should be a replacement for these calls, `metrics.accepts.inc()` (along with removing the above two).
Turns out the accepts are already tracked somewhere else, so I ended up counting them twice.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
