### PR TITLE
cargo: add aarch64-linux-gnu-gcc linker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
 [target.wasm32-unknown-unknown]
 runner = "wasm-bindgen-test-runner"
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
Fixes https://github.com/n0-computer/iroh/issues/3439

How... is this not the default? Other platforms cross-compile just fine. Other Rust C code cross-compiles just fine. Cargo bug? IDK. Anyway.