### PR TITLE
feat: Allow configuring the max number of TLS tickets

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -45,7 +45,7 @@ use crate::{
     magicsock::{self, Handle, NodeIdMappedAddr, OwnAddressSnafu},
     metrics::EndpointMetrics,
     net_report::Report,
-    tls,
+    tls::{self, DEFAULT_MAX_TLS_TICKETS},
 };
 
 mod rtt_actor;
@@ -118,6 +118,7 @@ pub struct Builder {
     addr_v6: Option<SocketAddrV6>,
     #[cfg(any(test, feature = "test-utils"))]
     path_selection: PathSelection,
+    max_tls_tickets: usize,
 }
 
 impl Default for Builder {
@@ -142,6 +143,7 @@ impl Default for Builder {
             addr_v6: None,
             #[cfg(any(test, feature = "test-utils"))]
             path_selection: PathSelection::default(),
+            max_tls_tickets: DEFAULT_MAX_TLS_TICKETS,
         }
     }
 }
@@ -160,7 +162,7 @@ impl Builder {
             .unwrap_or_else(|| SecretKey::generate(rand::rngs::OsRng));
         let static_config = StaticConfig {
             transport_config: Arc::new(self.transport_config),
-            tls_config: tls::TlsConfig::new(secret_key.clone()),
+            tls_config: tls::TlsConfig::new(secret_key.clone(), self.max_tls_tickets),
             keylog: self.keylog,
         };
         let server_config = static_config.create_server_config(self.alpn_protocols);
@@ -472,6 +474,15 @@ impl Builder {
     #[cfg(any(test, feature = "test-utils"))]
     pub fn path_selection(mut self, path_selection: PathSelection) -> Self {
         self.path_selection = path_selection;
+        self
+    }
+
+    /// Set the maximum number of TLS tickets to cache.
+    ///
+    /// Set this to a larger value if you want to do 0rtt connections to a large
+    /// number of clients.
+    pub fn max_tls_tickets(mut self, n: usize) -> Self {
+        self.max_tls_tickets = n;
         self
     }
 }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -481,6 +481,8 @@ impl Builder {
     ///
     /// Set this to a larger value if you want to do 0rtt connections to a large
     /// number of clients.
+    ///
+    /// The default is 256, taking about 150 KiB in memory.
     pub fn max_tls_tickets(mut self, n: usize) -> Self {
         self.max_tls_tickets = n;
         self

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2545,7 +2545,7 @@ mod tests {
         dns::DnsResolver,
         endpoint::{DirectAddr, PathSelection, Source},
         magicsock::{Handle, MagicSock, node_map},
-        tls,
+        tls::{self, DEFAULT_MAX_TLS_TICKETS},
     };
 
     const ALPN: &[u8] = b"n0/test/1";
@@ -2577,7 +2577,8 @@ mod tests {
     /// Generate a server config with no ALPNS and a default transport configuration
     fn make_default_server_config(secret_key: &SecretKey) -> ServerConfig {
         let quic_server_config =
-            crate::tls::TlsConfig::new(secret_key.clone()).make_server_config(vec![], false);
+            crate::tls::TlsConfig::new(secret_key.clone(), DEFAULT_MAX_TLS_TICKETS)
+                .make_server_config(vec![], false);
         let mut server_config = ServerConfig::with_crypto(Arc::new(quic_server_config));
         server_config.transport_config(Arc::new(quinn::TransportConfig::default()));
         server_config
@@ -3080,8 +3081,8 @@ mod tests {
     /// Use [`magicsock_connect`] to establish connections.
     #[instrument(name = "ep", skip_all, fields(me = secret_key.public().fmt_short()))]
     async fn magicsock_ep(secret_key: SecretKey) -> Result<Handle> {
-        let quic_server_config =
-            tls::TlsConfig::new(secret_key.clone()).make_server_config(vec![ALPN.to_vec()], true);
+        let quic_server_config = tls::TlsConfig::new(secret_key.clone(), DEFAULT_MAX_TLS_TICKETS)
+            .make_server_config(vec![ALPN.to_vec()], true);
         let mut server_config = ServerConfig::with_crypto(Arc::new(quic_server_config));
         server_config.transport_config(Arc::new(quinn::TransportConfig::default()));
 
@@ -3144,7 +3145,8 @@ mod tests {
     ) -> Result<quinn::Connection> {
         let alpns = vec![ALPN.to_vec()];
         let quic_client_config =
-            tls::TlsConfig::new(ep_secret_key.clone()).make_client_config(alpns, true);
+            tls::TlsConfig::new(ep_secret_key.clone(), DEFAULT_MAX_TLS_TICKETS)
+                .make_client_config(alpns, true);
         let mut client_config = quinn::ClientConfig::new(Arc::new(quic_client_config));
         client_config.transport_config(transport_config);
         let connect = ep

--- a/iroh/src/tls.rs
+++ b/iroh/src/tls.rs
@@ -25,7 +25,7 @@ mod verifier;
 /// So 8 * 32 * (200 + 387) = 150.272 bytes, assuming pointers to certificates
 /// are never aliased pointers (they're Arc'ed).
 /// I think 150KB is an acceptable default upper limit for such a cache.
-const MAX_TLS_TICKETS: usize = 8 * 32;
+pub(crate) const DEFAULT_MAX_TLS_TICKETS: usize = 8 * 32;
 
 /// Configuration for TLS.
 ///
@@ -44,7 +44,7 @@ pub(crate) struct TlsConfig {
 }
 
 impl TlsConfig {
-    pub(crate) fn new(secret_key: SecretKey) -> Self {
+    pub(crate) fn new(secret_key: SecretKey, max_tls_tickets: usize) -> Self {
         let cert_resolver = Arc::new(
             AlwaysResolvesCert::new(&secret_key).expect("Client cert key DER is valid; qed"),
         );
@@ -54,7 +54,7 @@ impl TlsConfig {
             server_verifier: Arc::new(verifier::ServerCertificateVerifier),
             client_verifier: Arc::new(verifier::ClientCertificateVerifier),
             session_store: Arc::new(rustls::client::ClientSessionMemoryCache::new(
-                MAX_TLS_TICKETS,
+                max_tls_tickets,
             )),
         }
     }


### PR DESCRIPTION
## Description

Allows increasing the max number of TLS tickets without having to patch iroh. This is needed if you want to do a large number of 0rtt connections to different clients.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Q: is this enough, or should we allow passing in an `Arc<dyn ClientSessionStore>`? The latter would mean exposing one more rustls type.

Note: this is mostly for playing around with it, not sure if we want to merge it as is. But then, it seems pretty straightforward. If we ever want the ability to provide an `Arc<dyn ClientSessionStore>` we can always make the `fn max_tls_tickets` just init an in-mem provider.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
