### PR TITLE
docs(iroh-relay): Remove incorrect help text about default config file creation (#3258)

### DIFF
--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -47,9 +47,6 @@ struct Cli {
     #[clap(long, default_value_t = false)]
     dev: bool,
     /// Path to the configuration file.
-    ///
-    /// If provided and no configuration file exists the default configuration will be
-    /// written to the file.
     #[clap(long, short)]
     config_path: Option<PathBuf>,
 }


### PR DESCRIPTION
## Description

Fixes incorrect help text in `iroh-relay` that claimed default configuration would be automatically written to file when a config path is provided but no file exists. This behavior is not implemented, so the misleading documentation line has been removed.

**Changes:**

- Removed one line from help text: "If provided and no configuration file exists the default configuration will be written to the file."

## Breaking Changes

None.

## Notes & open questions

This is my first contribution to an open source project! I chose this very small documentation fix to get a first glance at the codebase and get familiar with the contribution process. I'm really excited about the iroh project and look forward to contributing more as my understanding of it grows.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.