### PR TITLE
feat: Make getting the remote node id infallible

### DIFF
--- a/iroh/examples/dht_discovery.rs
+++ b/iroh/examples/dht_discovery.rs
@@ -87,7 +87,7 @@ async fn chat_server(args: Args) -> n0_snafu::Result<()> {
         };
         tokio::spawn(async move {
             let connection = connecting.await.e()?;
-            let remote_node_id = connection.remote_node_id()?;
+            let remote_node_id = connection.remote_node_id();
             println!("got connection from {remote_node_id}");
             // just leave the tasks hanging. this is just an example.
             let (mut writer, mut reader) = connection.accept_bi().await.e()?;

--- a/iroh/examples/echo-no-router.rs
+++ b/iroh/examples/echo-no-router.rs
@@ -89,7 +89,7 @@ async fn start_accept_side() -> Result<Endpoint> {
                     let connection = incoming.await.e()?;
 
                     // We can get the remote's node id from the connection.
-                    let node_id = connection.remote_node_id()?;
+                    let node_id = connection.remote_node_id();
                     println!("accepted connection from {node_id}");
 
                     // Our protocol is a simple request-response protocol, so we expect the

--- a/iroh/examples/echo.rs
+++ b/iroh/examples/echo.rs
@@ -85,7 +85,7 @@ impl ProtocolHandler for Echo {
     /// the connection lasts.
     async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
         // We can get the remote's node id from the connection.
-        let node_id = connection.remote_node_id()?;
+        let node_id = connection.remote_node_id();
         println!("accepted connection from {node_id}");
 
         // Our protocol is a simple request-response protocol, so we expect the

--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
         };
         let alpn = connecting.alpn().await?;
         let conn = connecting.await.e()?;
-        let node_id = conn.remote_node_id()?;
+        let node_id = conn.remote_node_id();
         info!(
             "new (unreliable) connection from {node_id} with ALPN {}",
             String::from_utf8_lossy(&alpn),

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -71,7 +71,7 @@ async fn main() -> n0_snafu::Result<()> {
         };
         let alpn = connecting.alpn().await?;
         let conn = connecting.await.e()?;
-        let node_id = conn.remote_node_id()?;
+        let node_id = conn.remote_node_id();
         info!(
             "new connection from {node_id} with ALPN {}",
             String::from_utf8_lossy(&alpn),

--- a/iroh/examples/search.rs
+++ b/iroh/examples/search.rs
@@ -128,7 +128,7 @@ impl ProtocolHandler for BlobSearch {
     /// the connection lasts.
     async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
         // We can get the remote's node id from the connection.
-        let node_id = connection.remote_node_id()?;
+        let node_id = connection.remote_node_id();
         println!("accepted connection from {node_id}");
 
         // Our protocol is a simple request-response protocol, so we expect the

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -303,7 +303,7 @@ async fn provide(endpoint: Endpoint, size: u64) -> Result<()> {
         let endpoint_clone = endpoint.clone();
         tokio::spawn(async move {
             let conn = connecting.await.e()?;
-            let node_id = conn.remote_node_id()?;
+            let node_id = conn.remote_node_id();
             info!(
                 "new connection from {node_id} with ALPN {}",
                 String::from_utf8_lossy(TRANSFER_ALPN),

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2066,21 +2066,19 @@ impl Connection {
             Some(data) => match data.downcast::<Vec<rustls::pki_types::CertificateDer>>() {
                 Ok(certs) => {
                     if certs.len() != 1 {
-                        warn!(
+                        panic!(
                             "expected a single peer certificate, but {} found",
                             certs.len()
                         );
-                        return Err(RemoteNodeIdSnafu.build());
                     }
 
-                    let peer_id = VerifyingKey::from_public_key_der(&certs[0])
-                        .map_err(|_| RemoteNodeIdSnafu.build())?
-                        .into();
-                    Ok(peer_id)
+                    let Ok(peer_id) = VerifyingKey::from_public_key_der(&certs[0]) else {
+                        panic!("invalid peer certificate");
+                    };
+                    Ok(peer_id.into())
                 }
                 Err(err) => {
-                    warn!("invalid peer certificate: {:?}", err);
-                    Err(RemoteNodeIdSnafu.build())
+                    panic!("invalid peer certificate: {:?}", err);
                 }
             },
         }

--- a/iroh/tests/integration.rs
+++ b/iroh/tests/integration.rs
@@ -54,7 +54,7 @@ async fn simple_node_id_based_connection_transfer() -> Result {
         async move {
             while let Some(incoming) = server.accept().await {
                 let conn = incoming.await.e()?;
-                let node_id = conn.remote_node_id()?;
+                let node_id = conn.remote_node_id();
                 tracing::info!(node_id = %node_id.fmt_short(), "Accepted connection");
 
                 let (mut send, mut recv) = conn.accept_bi().await.e()?;


### PR DESCRIPTION
## Description

Implements https://github.com/n0-computer/iroh/issues/3123

## Breaking Changes

- iroh::endpoint::Connection::remote_node_id returns just NodeId
- iroh::endpoint::RemoteNodeIdError is removed

## Notes & open questions

Note (from discord): "feel free to do the unwrap thing right now in a small PR to make it infallible even.  why not.  we can leave the issue open for the better solution"

We are going to refactor the internals later to make this more obviously infallible.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
