### PR TITLE
feat: Make fmt_short return an impl Display so we can avoid an allocation.

### DIFF
--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -134,12 +134,20 @@ impl PublicKey {
 
     /// Convert to a hex string limited to the first 5 bytes for a friendly string
     /// representation of the key.
-    pub fn fmt_short(&self) -> String {
-        data_encoding::HEXLOWER.encode(&self.as_bytes()[..5])
+    pub fn fmt_short(&self) -> impl Display + 'static {
+        PublicKeyShort(*self)
     }
 
     /// The length of an ed25519 `PublicKey`, in bytes.
     pub const LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
+}
+
+struct PublicKeyShort(PublicKey);
+
+impl Display for PublicKeyShort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        data_encoding::HEXLOWER.encode_write(&self.0.as_bytes()[..5], f)
+    }
 }
 
 impl TryFrom<&[u8]> for PublicKey {

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -135,7 +135,11 @@ impl PublicKey {
     /// Convert to a hex string limited to the first 5 bytes for a friendly string
     /// representation of the key.
     pub fn fmt_short(&self) -> impl Display + 'static {
-        PublicKeyShort(self.0.as_bytes()[0..5].try_into().unwrap())
+        PublicKeyShort(
+            self.0.as_bytes()[0..5]
+                .try_into()
+                .expect("slice with incorrect length"),
+        )
     }
 
     /// The length of an ed25519 `PublicKey`, in bytes.

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -135,18 +135,18 @@ impl PublicKey {
     /// Convert to a hex string limited to the first 5 bytes for a friendly string
     /// representation of the key.
     pub fn fmt_short(&self) -> impl Display + 'static {
-        PublicKeyShort(*self)
+        PublicKeyShort(self.0.as_bytes()[0..5].try_into().unwrap())
     }
 
     /// The length of an ed25519 `PublicKey`, in bytes.
     pub const LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
 }
 
-struct PublicKeyShort(PublicKey);
+struct PublicKeyShort([u8; 5]);
 
 impl Display for PublicKeyShort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        data_encoding::HEXLOWER.encode_write(&self.0.as_bytes()[..5], f)
+        data_encoding::HEXLOWER.encode_write(&self.0, f)
     }
 }
 

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -697,7 +697,7 @@ impl Inner {
         };
         trace!("accept: create client");
         let node_id = client_conn_builder.node_id;
-        trace!(node_id = node_id.fmt_short(), "create client");
+        trace!(node_id = %node_id.fmt_short(), "create client");
 
         // build and register client, starting up read & write loops for the client
         // connection

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -3086,7 +3086,7 @@ mod tests {
         // test openmetrics encoding with labeled subregistries per endpoint
         fn register_endpoint(registry: &mut Registry, endpoint: &Endpoint) {
             let id = endpoint.node_id().fmt_short();
-            let sub_registry = registry.sub_registry_with_label("id", id);
+            let sub_registry = registry.sub_registry_with_label("id", id.to_string());
             sub_registry.register_all(endpoint.metrics());
         }
         let mut registry = Registry::default();

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -388,7 +388,7 @@ impl MagicSock {
         let mut pruned: usize = 0;
         for my_addr in self.direct_addrs.sockaddrs() {
             if addr.direct_addresses.remove(&my_addr) {
-                warn!( node_id=addr.node_id.fmt_short(), %my_addr, %source, "not adding our addr for node");
+                warn!( node_id=%addr.node_id.fmt_short(), %my_addr, %source, "not adding our addr for node");
                 pruned += 1;
             }
         }
@@ -804,7 +804,7 @@ impl MagicSock {
                         event!(
                             target: "iroh::_events::call-me-maybe::recv",
                             Level::DEBUG,
-                            remote_node = sender.fmt_short(),
+                            remote_node = %sender.fmt_short(),
                             via = ?url,
                             their_addrs = ?cm.my_numbers,
                         );
@@ -3082,7 +3082,7 @@ mod tests {
     /// connections using [`ALPN`].
     ///
     /// Use [`magicsock_connect`] to establish connections.
-    #[instrument(name = "ep", skip_all, fields(me = secret_key.public().fmt_short()))]
+    #[instrument(name = "ep", skip_all, fields(me = %secret_key.public().fmt_short()))]
     async fn magicsock_ep(secret_key: SecretKey) -> Result<Handle> {
         let quic_server_config = tls::TlsConfig::new(secret_key.clone(), DEFAULT_MAX_TLS_TICKETS)
             .make_server_config(vec![ALPN.to_vec()], true);
@@ -3112,7 +3112,7 @@ mod tests {
     /// Connects from `ep` returned by [`magicsock_ep`] to the `node_id`.
     ///
     /// Uses [`ALPN`], `node_id`, must match `addr`.
-    #[instrument(name = "connect", skip_all, fields(me = ep_secret_key.public().fmt_short()))]
+    #[instrument(name = "connect", skip_all, fields(me = %ep_secret_key.public().fmt_short()))]
     async fn magicsock_connect(
         ep: &quinn::Endpoint,
         ep_secret_key: SecretKey,
@@ -3138,7 +3138,7 @@ mod tests {
     /// This version allows customising the transport config.
     ///
     /// Uses [`ALPN`], `node_id`, must match `addr`.
-    #[instrument(name = "connect", skip_all, fields(me = ep_secret_key.public().fmt_short()))]
+    #[instrument(name = "connect", skip_all, fields(me = %ep_secret_key.public().fmt_short()))]
     async fn magicsock_connect_with_transport_config(
         ep: &quinn::Endpoint,
         ep_secret_key: SecretKey,
@@ -3291,7 +3291,7 @@ mod tests {
                     error!("{err:#}");
                 }
             }
-            .instrument(info_span!("ep2.accept", me = node_id_2.fmt_short()))
+            .instrument(info_span!("ep2.accept", me = %node_id_2.fmt_short()))
         });
         let _accept_task = AbortOnDropHandle::new(accept_task);
 

--- a/iroh/src/magicsock/transports/relay/actor.rs
+++ b/iroh/src/magicsock/transports/relay/actor.rs
@@ -1313,7 +1313,7 @@ mod tests {
                             src,
                             datagrams,
                         } = recv;
-                        info!(from = src.fmt_short(), "Received datagram");
+                        info!(from = %src.fmt_short(), "Received datagram");
                         let send = RelaySendItem {
                             remote_node: src,
                             url: relay_url.clone(),


### PR DESCRIPTION
## Description

Currently, fmt_short allocates a String. It is used quite a few times in trace! statements. This makes it not allocate.

Not sure if it is worth it.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
