### PR TITLE
chore: bump some spans up to warn, to ensure they are logged

### DIFF
--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -21,7 +21,7 @@ use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls_acme::AcmeAcceptor;
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-use tracing::{Instrument, debug, debug_span, error, info, info_span, trace, warn};
+use tracing::{Instrument, debug, error, info, info_span, trace, warn, warn_span};
 
 use super::{AccessConfig, SpawnError, clients::Clients, streams::InvalidBucketConfig};
 use crate::{
@@ -539,7 +539,7 @@ impl RelayService {
                     Err(err) => warn!("upgrade error: {err:#}"),
                 }
             }
-            .instrument(debug_span!("handler"))
+            .instrument(warn_span!("handler"))
         });
 
         // Now return a 101 Response saying we agree to the upgrade to the

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -395,7 +395,7 @@ impl Client {
         enough_relays: usize,
         do_full: bool,
     ) -> Vec<ProbeReport> {
-        use tracing::{Instrument, info_span};
+        use tracing::{Instrument, warn_span};
 
         debug!("spawning QAD probes");
 
@@ -450,7 +450,7 @@ impl Client {
                             PROBES_TIMEOUT,
                             run_probe_v4(ip_mapped_addrs, relay_node, quic_client, dns_resolver),
                         ))
-                        .instrument(info_span!("QAD-IPv4", %relay_url)),
+                        .instrument(warn_span!("QAD-IPv4", %relay_url)),
                 );
             }
 
@@ -468,7 +468,7 @@ impl Client {
                             PROBES_TIMEOUT,
                             run_probe_v6(ip_mapped_addrs, relay_node, quic_client, dns_resolver),
                         ))
-                        .instrument(info_span!("QAD-IPv6", %relay_url)),
+                        .instrument(warn_span!("QAD-IPv6", %relay_url)),
                 );
             }
         }

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -42,7 +42,7 @@ use rand::seq::IteratorRandom;
 use snafu::{IntoError, OptionExt, ResultExt, Snafu};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, debug_span, error, info_span, trace, warn};
+use tracing::{Instrument, debug, error, trace, warn, warn_span};
 use url::Host;
 
 #[cfg(wasm_browser)]
@@ -134,7 +134,7 @@ impl Client {
             insecure_skip_relay_cert_verify,
             if_state,
         };
-        let task = task::spawn(actor.run().instrument(info_span!("reportgen.actor")));
+        let task = task::spawn(actor.run().instrument(warn_span!("reportgen-actor")));
         (
             Self {
                 _drop_guard: AbortOnDropHandle::new(task),
@@ -316,7 +316,7 @@ impl Actor {
                     };
                     ProbeFinished::CaptivePortal(res)
                 }
-                .instrument(debug_span!("captive-portal")),
+                .instrument(warn_span!("captive-portal")),
             );
         }
         token
@@ -389,11 +389,11 @@ impl Actor {
                         };
                         ProbeFinished::Regular(res)
                     }
-                    .instrument(debug_span!(
+                    .instrument(warn_span!(
                         "run-probe",
                         ?proto,
                         ?delay,
-                        ?relay_node
+                        ?relay_node,
                     )),
                 );
             }


### PR DESCRIPTION
## Description

We were missing this information in some logs

## Breaking Changes

None

## Notes & open questions

Unclear if we should normalize differently, but this fixes the concrete issue for now.