### PR TITLE
feat(iroh)!: introduce `online` method

### DIFF
--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -5,7 +5,7 @@ use std::{
 
 use bytes::Bytes;
 use iroh::{
-    Endpoint, NodeAddr, RelayMode, RelayUrl, Watcher as _,
+    Endpoint, NodeAddr, RelayMode, RelayUrl,
     endpoint::{Connection, ConnectionError, RecvStream, SendStream, TransportConfig},
 };
 use n0_snafu::{Result, ResultExt};
@@ -49,7 +49,7 @@ pub fn server_endpoint(
             .unwrap();
 
         if relay_url.is_some() {
-            ep.home_relay().initialized().await;
+            ep.online().await;
         }
 
         let addr = ep.bound_sockets();
@@ -110,7 +110,7 @@ pub async fn connect_client(
         .unwrap();
 
     if relay_url.is_some() {
-        endpoint.home_relay().initialized().await;
+        endpoint.online().await;
     }
 
     // TODO: We don't support passing client transport config currently

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -140,7 +140,7 @@ async fn accept(_args: Args) -> n0_snafu::Result<()> {
         .relay_mode(iroh::RelayMode::Disabled)
         .bind()
         .await?;
-    let mut addrs = endpoint.node_addr().stream();
+    let mut addrs = endpoint.watch_node_addr().stream();
     let addr = loop {
         let Some(addr) = addrs.next().await else {
             snafu::whatever!("Address stream closed");

--- a/iroh/examples/connect-unreliable.rs
+++ b/iroh/examples/connect-unreliable.rs
@@ -10,7 +10,6 @@ use std::net::SocketAddr;
 use clap::Parser;
 use iroh::{Endpoint, NodeAddr, RelayMode, RelayUrl, SecretKey};
 use n0_snafu::ResultExt;
-use n0_watcher::Watcher as _;
 use tracing::info;
 
 // An example ALPN that we are using to communicate over the `Endpoint`
@@ -52,7 +51,10 @@ async fn main() -> n0_snafu::Result<()> {
         .bind()
         .await?;
 
-    let node_addr = endpoint.node_addr().initialized().await;
+    // wait for the node to be online
+    endpoint.online().await;
+
+    let node_addr = endpoint.node_addr();
     let me = node_addr.node_id;
     println!("node id: {me}");
     println!("node listening addresses:");

--- a/iroh/examples/connect.rs
+++ b/iroh/examples/connect.rs
@@ -10,7 +10,6 @@ use std::net::SocketAddr;
 use clap::Parser;
 use iroh::{Endpoint, NodeAddr, RelayMode, RelayUrl, SecretKey};
 use n0_snafu::{Result, ResultExt};
-use n0_watcher::Watcher as _;
 use tracing::info;
 
 // An example ALPN that we are using to communicate over the `Endpoint`
@@ -52,19 +51,20 @@ async fn main() -> Result<()> {
         .bind()
         .await?;
 
+    // wait for the node to be online
+    endpoint.online().await;
+
+    let node_addr = endpoint.node_addr();
     let me = endpoint.node_id();
     println!("node id: {me}");
     println!("node listening addresses:");
-    for local_endpoint in endpoint.direct_addresses().initialized().await {
-        println!("\t{}", local_endpoint.addr)
+    for addr in node_addr.direct_addresses() {
+        println!("\t{addr}")
     }
 
-    let relay_url = endpoint
-        .home_relay()
-        .get()
-        .first()
-        .cloned()
-        .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
+    let relay_url = node_addr
+        .relay_url
+        .expect("should be connected to a relay server");
     println!("node relay server url: {relay_url}\n");
     // Build a `NodeAddr` from the node_id, relay url, and UDP addresses.
     let addr = NodeAddr::from_parts(args.node_id, Some(args.relay_url), args.addrs);

--- a/iroh/examples/echo-no-router.rs
+++ b/iroh/examples/echo-no-router.rs
@@ -9,7 +9,6 @@
 
 use iroh::{Endpoint, NodeAddr};
 use n0_snafu::{Error, Result, ResultExt};
-use n0_watcher::Watcher as _;
 
 /// Each protocol is identified by its ALPN string.
 ///
@@ -20,9 +19,11 @@ const ALPN: &[u8] = b"iroh-example/echo/0";
 #[tokio::main]
 async fn main() -> Result<()> {
     let endpoint = start_accept_side().await?;
-    let node_addr = endpoint.node_addr().initialized().await;
 
-    connect_side(node_addr).await?;
+    // wait for the node to be online
+    endpoint.online().await;
+
+    connect_side(endpoint.node_addr()).await?;
 
     // This makes sure the endpoint is closed properly and connections close gracefully
     // and will indirectly close the tasks spawned by `start_accept_side`.

--- a/iroh/examples/echo.rs
+++ b/iroh/examples/echo.rs
@@ -12,7 +12,6 @@ use iroh::{
     protocol::{AcceptError, ProtocolHandler, Router},
 };
 use n0_snafu::{Result, ResultExt};
-use n0_watcher::Watcher as _;
 
 /// Each protocol is identified by its ALPN string.
 ///
@@ -23,9 +22,11 @@ const ALPN: &[u8] = b"iroh-example/echo/0";
 #[tokio::main]
 async fn main() -> Result<()> {
     let router = start_accept_side().await?;
-    let node_addr = router.endpoint().node_addr().initialized().await;
 
-    connect_side(node_addr).await?;
+    // wait for the node to be online
+    router.endpoint().online().await;
+
+    connect_side(router.endpoint().node_addr()).await?;
 
     // This makes sure the endpoint in the router is closed properly and connections close gracefully
     router.shutdown().await.e()?;

--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -5,7 +5,6 @@
 //!     $ cargo run --example listen-unreliable
 use iroh::{Endpoint, RelayMode, SecretKey};
 use n0_snafu::{Error, Result, ResultExt};
-use n0_watcher::Watcher as _;
 use tracing::{info, warn};
 
 // An example ALPN that we are using to communicate over the `Endpoint`
@@ -37,7 +36,10 @@ async fn main() -> Result<()> {
     println!("node id: {me}");
     println!("node listening addresses:");
 
-    let node_addr = endpoint.node_addr().initialized().await;
+    // wait for the node to be online
+    endpoint.online().await;
+
+    let node_addr = endpoint.node_addr();
     let local_addrs = node_addr
         .direct_addresses
         .into_iter()

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -273,26 +273,22 @@ impl EndpointArgs {
         let node_id = endpoint.node_id();
         println!("Our node id:\n\t{node_id}");
 
-        let eps = endpoint.direct_addresses().initialized().await;
+        let node_addr = endpoint.watch_node_addr().initialized().await;
+
         println!("Our direct addresses:");
-        for local_endpoint in eps {
-            println!("\t{} (type: {:?})", local_endpoint.addr, local_endpoint.typ)
+        for addr in &node_addr.direct_addresses {
+            println!("\t{}", addr);
         }
 
-        if self.relay_only {
-            let relay_url = endpoint.home_relay().initialized().await;
-            println!("Our home relay server:\t{relay_url}");
-        } else if !self.no_relay {
-            let relay_url = tokio::time::timeout(Duration::from_secs(2), async {
-                endpoint.home_relay().initialized().await
-            })
-            .await
-            .ok();
-            if let Some(url) = relay_url {
-                println!("Our home relay server:\t{url}");
-            } else {
-                println!("No home relay server found");
-            }
+        if !self.no_relay {
+            tokio::time::timeout(Duration::from_secs(2), endpoint.online())
+                .await
+                .ok();
+        }
+        if let Some(url) = node_addr.relay_url {
+            println!("Our home relay server:\t{url}");
+        } else {
+            println!("No home relay server found");
         }
 
         println!();
@@ -303,11 +299,14 @@ impl EndpointArgs {
 async fn provide(endpoint: Endpoint, size: u64) -> Result<()> {
     let node_id = endpoint.node_id();
 
-    let node_addr = endpoint.node_addr().initialized().await;
+    // wait for the node to be online
+    endpoint.online().await;
+
+    let node_addr = endpoint.node_addr();
     let ticket = NodeTicket::new(node_addr);
     println!("Ticket with our home relay and direct addresses:\n{ticket}\n",);
 
-    let mut node_addr = endpoint.node_addr().initialized().await;
+    let mut node_addr = endpoint.node_addr();
     node_addr.direct_addresses = Default::default();
     let ticket = NodeTicket::new(node_addr);
     println!("Ticket with our home relay but no direct addresses:\n{ticket}\n",);

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -884,7 +884,7 @@ mod tests {
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
         // wait for our address to be updated and thus published at least once
-        ep1.node_addr().initialized().await;
+        ep1.watch_node_addr().initialized().await;
         let _conn = ep2.connect(ep1_addr, TEST_ALPN).await?;
         Ok(())
     }
@@ -910,7 +910,7 @@ mod tests {
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
         // wait for out address to be updated and thus published at least once
-        ep1.node_addr().initialized().await;
+        ep1.watch_node_addr().initialized().await;
         let _conn = ep2
             .connect(ep1_addr, TEST_ALPN)
             .await
@@ -942,7 +942,7 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         // wait for out address to be updated and thus published at least once
-        ep1.node_addr().initialized().await;
+        ep1.watch_node_addr().initialized().await;
         let _conn = ep2.connect(ep1.node_id(), TEST_ALPN).await?;
         Ok(())
     }
@@ -964,7 +964,7 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         // wait for out address to be updated and thus published at least once
-        ep1.node_addr().initialized().await;
+        ep1.watch_node_addr().initialized().await;
 
         // 10x faster test via a 3s idle timeout instead of the 30s default
         let mut config = TransportConfig::default();
@@ -997,7 +997,7 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         // wait for out address to be updated and thus published at least once
-        ep1.node_addr().initialized().await;
+        ep1.watch_node_addr().initialized().await;
         let ep1_wrong_addr = NodeAddr {
             node_id: ep1.node_id(),
             relay_url: None,
@@ -1025,7 +1025,7 @@ mod tests {
         let mut stream = ep1.discovery_stream();
 
         // wait for ep2 node addr to be updated and connect from ep1 -> discovery via resolve
-        ep2.node_addr().initialized().await;
+        ep2.watch_node_addr().initialized().await;
         let _ = ep1.connect(ep2.node_id(), TEST_ALPN).await?;
 
         let DiscoveryEvent::Discovered(item) =

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -13,7 +13,6 @@
 
 use std::{
     any::Any,
-    collections::BTreeSet,
     future::{Future, IntoFuture},
     net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6},
     pin::Pin,
@@ -22,7 +21,7 @@ use std::{
 };
 
 use ed25519_dalek::{VerifyingKey, pkcs8::DecodePublicKey};
-use iroh_base::{NodeAddr, NodeId, RelayUrl, SecretKey};
+use iroh_base::{NodeAddr, NodeId, SecretKey};
 use iroh_relay::RelayMap;
 use n0_future::{Stream, time::Duration};
 use n0_watcher::Watcher;
@@ -903,6 +902,26 @@ impl Endpoint {
         self.static_config.tls_config.secret_key.public()
     }
 
+    /// Returns the current [`NodeAddr`].
+    pub fn node_addr(&self) -> NodeAddr {
+        let node_id = self.node_id();
+        let relay_url = self.msock.home_relay().get().first().cloned();
+        let direct_addresses = self
+            .msock
+            .direct_addresses()
+            .get()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|addr| addr.addr)
+            .collect();
+
+        NodeAddr {
+            node_id,
+            relay_url,
+            direct_addresses,
+        }
+    }
+
     /// Returns a [`Watcher`] for the current [`NodeAddr`] for this endpoint.
     ///
     /// The observed [`NodeAddr`] will have the current [`RelayUrl`] and direct addresses
@@ -918,15 +937,15 @@ impl Endpoint {
     ///     .alpns(vec![b"my-alpn".to_vec()])
     ///     .bind()
     ///     .await?;
-    /// let node_addr = endpoint.node_addr().initialized().await;
+    /// let node_addr = endpoint.watch_node_addr().initialized().await;
     /// # let _ = node_addr;
     /// # Ok(())
     /// # }
     /// ```
     #[cfg(not(wasm_browser))]
-    pub fn node_addr(&self) -> impl n0_watcher::Watcher<Value = Option<NodeAddr>> + use<> {
-        let watch_addrs = self.direct_addresses();
-        let watch_relay = self.home_relay();
+    pub fn watch_node_addr(&self) -> impl n0_watcher::Watcher<Value = Option<NodeAddr>> + use<> {
+        let watch_addrs = self.msock.direct_addresses();
+        let watch_relay = self.msock.home_relay();
         let node_id = self.node_id();
 
         watch_addrs
@@ -950,7 +969,7 @@ impl Endpoint {
     /// with a [`NodeAddr`] that only contains a relay URL, but no direct addresses,
     /// as there are no APIs for directly using sockets in browsers.
     #[cfg(wasm_browser)]
-    pub fn node_addr(&self) -> impl n0_watcher::Watcher<Value = Option<NodeAddr>> + use<> {
+    pub fn watch_node_addr(&self) -> impl n0_watcher::Watcher<Value = Option<NodeAddr>> + use<> {
         // In browsers, there will never be any direct addresses, so we wait
         // for the home relay instead. This makes the `NodeAddr` have *some* way
         // of connecting to us.
@@ -965,69 +984,16 @@ impl Endpoint {
             .expect("watchable is alive - cannot be disconnected yet")
     }
 
-    /// Returns a [`Watcher`] for the [`RelayUrl`] of the Relay server used as home relay.
+    /// Waits for the node to be considered online.
     ///
-    /// Every endpoint has a home Relay server which it chooses as the server with the
-    /// lowest latency out of the configured servers provided by [`Builder::relay_mode`].
-    /// This is the server other iroh nodes can use to reliably establish a connection
-    /// to this node.
+    /// This currently means at least one relay server was connected,
+    /// and at least one local IP address is available.
     ///
-    /// The watcher stores `None` if we are not connected to any Relay server.
-    ///
-    /// Note that this will store `None` right after the [`Endpoint`] is created since it takes
-    /// some time to connect to find and connect to the home relay server.
-    ///
-    /// # Examples
-    ///
-    /// To wait for a home relay connection to be established, use [`Watcher::initialized`]:
-    /// ```no_run
-    /// use iroh::{Endpoint, Watcher};
-    ///
-    /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    /// # rt.block_on(async move {
-    /// let mep = Endpoint::builder().bind().await.unwrap();
-    /// let _relay_url = mep.home_relay().initialized().await;
-    /// # });
-    /// ```
-    pub fn home_relay(&self) -> impl n0_watcher::Watcher<Value = Vec<RelayUrl>> + use<> {
-        self.msock.home_relay()
-    }
-
-    /// Returns a [`Watcher`] for the direct addresses of this [`Endpoint`].
-    ///
-    /// The direct addresses of the [`Endpoint`] are those that could be used by other
-    /// iroh nodes to establish direct connectivity, depending on the network
-    /// situation. The yielded lists of direct addresses contain both the locally-bound
-    /// addresses and the [`Endpoint`]'s publicly reachable addresses discovered through
-    /// mechanisms such as [QAD] and port mapping.  Hence usually only a subset of these
-    /// will be applicable to a certain remote iroh node.
-    ///
-    /// The [`Endpoint`] continuously monitors the direct addresses for changes as its own
-    /// location in the network might change.  Whenever changes are detected this stream
-    /// will yield a new list of direct addresses.
-    ///
-    /// When issuing the first call to this method the first direct address discovery might
-    /// still be underway, in this case the [`Watcher`] might not be initialized with [`Some`]
-    /// value yet.  Once the first set of local direct addresses are discovered the [`Watcher`]
-    /// will always return [`Some`] set of direct addresses immediately, which are the most
-    /// recently discovered direct addresses.
-    ///
-    /// # Examples
-    ///
-    /// To get the first set of direct addresses use [`Watcher::initialized`]:
-    /// ```no_run
-    /// use iroh::{Endpoint, Watcher as _};
-    ///
-    /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    /// # rt.block_on(async move {
-    /// let ep = Endpoint::builder().bind().await.unwrap();
-    /// let _addrs = ep.direct_addresses().initialized().await;
-    /// # });
-    /// ```
-    ///
-    /// [QAD]: https://www.ietf.org/archive/id/draft-ietf-quic-address-discovery-00.html
-    pub fn direct_addresses(&self) -> n0_watcher::Direct<Option<BTreeSet<DirectAddr>>> {
-        self.msock.direct_addresses()
+    /// This has no timeout, so if that is needed, you need to wrap it in a timeout.
+    pub async fn online(&self) {
+        let mut watch1 = self.msock.home_relay();
+        let mut watch2 = self.msock.direct_addresses();
+        tokio::join!(watch1.initialized(), watch2.initialized());
     }
 
     /// Returns a [`Watcher`] for any net-reports run from this [`Endpoint`].
@@ -2293,7 +2259,7 @@ mod tests {
             .bind()
             .await
             .unwrap();
-        let my_addr = ep.node_addr().initialized().await;
+        let my_addr = ep.watch_node_addr().initialized().await;
         let res = ep.connect(my_addr.clone(), TEST_ALPN).await;
         assert!(res.is_err());
         let err = res.err().unwrap();
@@ -2322,7 +2288,7 @@ mod tests {
             .bind()
             .await?;
         // Wait for the endpoint to be reachable via relay
-        ep.home_relay().initialized().await;
+        ep.online().await;
 
         let server = tokio::spawn(
             async move {
@@ -2476,7 +2442,8 @@ mod tests {
             .bind()
             .await?;
         // Also make sure the server has a working relay connection
-        ep.home_relay().initialized().await;
+
+        ep.online().await;
 
         info!(time = ?test_start.elapsed(), "test setup done");
 
@@ -2596,7 +2563,7 @@ mod tests {
             }
         });
 
-        let addr = server.node_addr().initialized().await;
+        let addr = server.watch_node_addr().initialized().await;
         let conn = client.connect(addr, TEST_ALPN).await?;
         let (mut send, mut recv) = conn.open_bi().await.e()?;
         send.write_all(b"Hello, world!").await.e()?;
@@ -2628,8 +2595,8 @@ mod tests {
 
         let ep2 = ep2.bind().await?;
 
-        let ep1_nodeaddr = ep1.node_addr().initialized().await;
-        let ep2_nodeaddr = ep2.node_addr().initialized().await;
+        let ep1_nodeaddr = ep1.watch_node_addr().initialized().await;
+        let ep2_nodeaddr = ep2.watch_node_addr().initialized().await;
         ep1.add_node_addr(ep2_nodeaddr.clone())?;
         ep2.add_node_addr(ep1_nodeaddr.clone())?;
         let ep1_nodeid = ep1.node_id();
@@ -2754,7 +2721,7 @@ mod tests {
         let ep1_nodeid = ep1.node_id();
         let ep2_nodeid = ep2.node_id();
 
-        let ep1_nodeaddr = ep1.node_addr().initialized().await;
+        let ep1_nodeaddr = ep1.watch_node_addr().initialized().await;
         tracing::info!(
             "node id 1 {ep1_nodeid}, relay URL {:?}",
             ep1_nodeaddr.relay_url()
@@ -2804,9 +2771,15 @@ mod tests {
             .bind()
             .await?;
 
-        tokio::time::timeout(Duration::from_secs(10), ep.direct_addresses().initialized())
-            .await
-            .e()?;
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            ep.watch_node_addr()
+                .map(|addr| addr.map(|addr| addr.direct_addresses))
+                .unwrap()
+                .initialized(),
+        )
+        .await
+        .e()?;
         Ok(())
     }
 
@@ -2916,9 +2889,10 @@ mod tests {
         )
         .await?;
 
-        connect_client_0rtt_expect_err(&client, server.node_addr().initialized().await).await?;
+        connect_client_0rtt_expect_err(&client, server.watch_node_addr().initialized().await)
+            .await?;
         // The second 0rtt attempt should work
-        connect_client_0rtt_expect_ok(&client, server.node_addr().initialized().await, true)
+        connect_client_0rtt_expect_ok(&client, server.watch_node_addr().initialized().await, true)
             .await?;
 
         client.close().await;
@@ -2943,7 +2917,8 @@ mod tests {
         )
         .await?;
 
-        connect_client_0rtt_expect_err(&client, server.node_addr().initialized().await).await?;
+        connect_client_0rtt_expect_err(&client, server.watch_node_addr().initialized().await)
+            .await?;
 
         // connecting with another endpoint should not interfere with our
         // TLS session ticket cache for the first endpoint:
@@ -2952,10 +2927,11 @@ mod tests {
             info_span!("another"),
         )
         .await?;
-        connect_client_0rtt_expect_err(&client, another.node_addr().initialized().await).await?;
+        connect_client_0rtt_expect_err(&client, another.watch_node_addr().initialized().await)
+            .await?;
         another.close().await;
 
-        connect_client_0rtt_expect_ok(&client, server.node_addr().initialized().await, true)
+        connect_client_0rtt_expect_ok(&client, server.watch_node_addr().initialized().await, true)
             .await?;
 
         client.close().await;
@@ -2975,8 +2951,9 @@ mod tests {
         let server_key = SecretKey::generate(rand::thread_rng());
         let server = spawn_0rtt_server(server_key.clone(), info_span!("server-initial")).await?;
 
-        connect_client_0rtt_expect_err(&client, server.node_addr().initialized().await).await?;
-        connect_client_0rtt_expect_ok(&client, server.node_addr().initialized().await, true)
+        connect_client_0rtt_expect_err(&client, server.watch_node_addr().initialized().await)
+            .await?;
+        connect_client_0rtt_expect_ok(&client, server.watch_node_addr().initialized().await, true)
             .await?;
 
         server.close().await;
@@ -2986,7 +2963,7 @@ mod tests {
         // we expect the client to *believe* it can 0-RTT connect to the server (hence expect_ok),
         // but the server will reject the early data because it discarded necessary state
         // to decrypt it when restarting.
-        connect_client_0rtt_expect_ok(&client, server.node_addr().initialized().await, false)
+        connect_client_0rtt_expect_ok(&client, server.watch_node_addr().initialized().await, false)
             .await?;
 
         client.close().await;
@@ -3003,7 +2980,7 @@ mod tests {
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
             .await?;
-        let server_addr = server.node_addr().initialized().await;
+        let server_addr = server.watch_node_addr().initialized().await;
         let server_task = tokio::spawn(async move {
             let incoming = server.accept().await.e()?;
             let conn = incoming.await.e()?;
@@ -3053,7 +3030,7 @@ mod tests {
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
             .await?;
-        let server_addr = server.node_addr().initialized().await;
+        let server_addr = server.watch_node_addr().initialized().await;
         let server_task = tokio::task::spawn(async move {
             let conn = server.accept().await.e()?.accept().e()?.await.e()?;
             let mut uni = conn.accept_uni().await.e()?;
@@ -3114,7 +3091,7 @@ mod tests {
             .alpns(accept_alpns)
             .bind()
             .await?;
-        let server_addr = server.node_addr().initialized().await;
+        let server_addr = server.watch_node_addr().initialized().await;
         let server_task = tokio::spawn({
             let server = server.clone();
             async move {
@@ -3238,7 +3215,7 @@ mod tests {
                 .bind()
                 .await
                 .e()?;
-            let addr = endpoint.node_addr().initialized().await;
+            let addr = endpoint.watch_node_addr().initialized().await;
             let router = Router::builder(endpoint).accept(NOOP_ALPN, Noop).spawn();
             Ok((router, addr))
         }
@@ -3267,7 +3244,7 @@ mod tests {
         // wait for the endpoint to be initialized. This should not be needed,
         // but we don't want to measure endpoint init time but connection time
         // from a fully initialized endpoint.
-        endpoint.node_addr().initialized().await;
+        endpoint.watch_node_addr().initialized().await;
         let t0 = Instant::now();
         for id in &ids {
             let conn = endpoint.connect(*id, NOOP_ALPN).await?;

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2528,7 +2528,7 @@ impl Display for DirectAddrType {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, sync::Arc, time::Duration};
+    use std::{collections::BTreeSet, net::SocketAddr, sync::Arc, time::Duration};
 
     use data_encoding::HEXLOWER;
     use iroh_base::{NodeAddr, NodeId, PublicKey};
@@ -2546,7 +2546,7 @@ mod tests {
     use crate::{
         Endpoint, RelayMap, RelayMode, SecretKey,
         dns::DnsResolver,
-        endpoint::{DirectAddr, PathSelection, Source},
+        endpoint::{PathSelection, Source},
         magicsock::{Handle, MagicSock, node_map},
         tls::{self, DEFAULT_MAX_TLS_TICKETS},
     };
@@ -2657,7 +2657,7 @@ mod tests {
         fn update_direct_addrs(
             stacks: &[MagicStack],
             my_idx: usize,
-            new_addrs: BTreeSet<DirectAddr>,
+            new_addrs: BTreeSet<SocketAddr>,
         ) {
             let me = &stacks[my_idx];
             for (i, m) in stacks.iter().enumerate() {
@@ -2668,7 +2668,7 @@ mod tests {
                 let addr = NodeAddr {
                     node_id: me.public(),
                     relay_url: None,
-                    direct_addresses: new_addrs.iter().map(|ep| ep.addr).collect(),
+                    direct_addresses: new_addrs.clone(),
                 };
                 m.endpoint.magic_sock().add_test_addr(addr);
             }
@@ -2682,10 +2682,10 @@ mod tests {
             let stacks = stacks.clone();
             tasks.spawn(async move {
                 let me = m.endpoint.node_id().fmt_short();
-                let mut stream = m.endpoint.direct_addresses().stream().filter_map(|i| i);
-                while let Some(new_eps) = stream.next().await {
-                    info!(%me, "conn{} endpoints update: {:?}", my_idx + 1, new_eps);
-                    update_direct_addrs(&stacks, my_idx, new_eps);
+                let mut stream = m.endpoint.watch_node_addr().stream().filter_map(|i| i);
+                while let Some(addr) = stream.next().await {
+                    info!(%me, "conn{} endpoints update: {:?}", my_idx + 1, addr.direct_addresses);
+                    update_direct_addrs(&stacks, my_idx, addr.direct_addresses);
                 }
             });
         }
@@ -2918,7 +2918,7 @@ mod tests {
         println!("first conn!");
         let conn = m1
             .endpoint
-            .connect(m2.endpoint.node_addr().initialized().await, ALPN)
+            .connect(m2.endpoint.watch_node_addr().initialized().await, ALPN)
             .await?;
         println!("Closing first conn");
         conn.close(0u32.into(), b"bye lolz");

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -629,7 +629,7 @@ mod tests {
         let proto = AccessLimit::new(Echo, |_node_id| false);
         let r1 = Router::builder(e1.clone()).accept(ECHO_ALPN, proto).spawn();
 
-        let addr1 = r1.endpoint().node_addr().initialized().await;
+        let addr1 = r1.endpoint().watch_node_addr().initialized().await;
         dbg!(&addr1);
         let e2 = Endpoint::builder()
             .relay_mode(RelayMode::Disabled)
@@ -682,7 +682,7 @@ mod tests {
             .accept(TEST_ALPN, TestProtocol::default())
             .spawn();
         eprintln!("waiting for node addr");
-        let addr = router.endpoint().node_addr().initialized().await;
+        let addr = router.endpoint().watch_node_addr().initialized().await;
 
         eprintln!("creating ep2");
         let endpoint2 = Endpoint::builder()


### PR DESCRIPTION
## Description

A new attempt to start improving the address and boot up situation.

There is a new `online` method, which simply waits for the `NodeAddr` to be filled, usage is easiest to see by looking at how the examples have changed.

## Breaking Changes

- removed
  -  `iroh::Endpoint::direct_addresses`
  - `iroh::Endpoint::home_relay`
- changed
  - `iroh::Endpoint::node_addr` now returns synchronously the current addressing information
- added
  - `iroh::Endpoint::online`
  - `iroh::Endpoint::watch_node_addr` 


