### PR TITLE
refactor: rename last two `local_endpoints` usages to `direct_addresses`

### DIFF
--- a/iroh/examples/connect.rs
+++ b/iroh/examples/connect.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
         .get()
         .first()
         .cloned()
-        .expect("should be connected to a relay server, try calling `endpoint.local_endpoints()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
+        .expect("should be connected to a relay server, try calling `endpoint.direct_addresses()` or `endpoint.connect()` first, to ensure the endpoint has actually attempted a connection before checking for the connected relay server");
     println!("node relay server url: {relay_url}\n");
     // Build a `NodeAddr` from the node_id, relay url, and UDP addresses.
     let addr = NodeAddr::from_parts(args.node_id, Some(args.relay_url), args.addrs);

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -3062,7 +3062,7 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn test_local_endpoints() {
+    async fn test_direct_addresses() {
         let ms = Handle::new(Default::default()).await.unwrap();
 
         // See if we can get endpoints.


### PR DESCRIPTION
## Description

Cleans up the last few changes from https://github.com/n0-computer/iroh/pull/2369

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.