### PR TITLE
feat: add a DNS resolver trait

### DIFF
--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -378,12 +378,12 @@ impl NodeInfo {
     }
 
     #[cfg(not(wasm_browser))]
-    /// Parses a [`NodeInfo`] from a TXT records lookup.
-    pub(crate) fn from_txt_lookup(
-        name: String,
+    /// Parses a [`NodeInfo`] from DNS TXT lookup.
+    pub fn from_txt_lookup(
+        domain_name: String,
         lookup: impl Iterator<Item = crate::dns::TxtRecordData>,
     ) -> Result<Self, ParseError> {
-        let attrs = TxtAttrs::from_txt_lookup(name, lookup)?;
+        let attrs = TxtAttrs::from_txt_lookup(domain_name, lookup)?;
         Ok(Self::from(attrs))
     }
 

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -651,9 +651,8 @@ mod tests {
     use iroh_base::{NodeId, SecretKey};
     use n0_snafu::{Result, ResultExt};
 
-    use crate::dns::TxtRecordData;
-
     use super::{NodeData, NodeIdExt, NodeInfo};
+    use crate::dns::TxtRecordData;
 
     #[test]
     fn txt_attr_roundtrip() {

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -40,20 +40,10 @@ use std::{
     str::{FromStr, Utf8Error},
 };
 
-#[cfg(not(wasm_browser))]
-use hickory_resolver::{Name, proto::ProtoError};
 use iroh_base::{NodeAddr, NodeId, RelayUrl, SecretKey, SignatureError};
 use nested_enum_utils::common_fields;
 use snafu::{Backtrace, ResultExt, Snafu};
-#[cfg(not(wasm_browser))]
-use tracing::warn;
 use url::Url;
-
-#[cfg(not(wasm_browser))]
-use crate::{
-    defaults::timeouts::DNS_TIMEOUT,
-    dns::{DnsError, DnsResolver},
-};
 
 /// The DNS name for the iroh TXT record.
 pub const IROH_TXT_NAME: &str = "_iroh";
@@ -389,9 +379,12 @@ impl NodeInfo {
 
     #[cfg(not(wasm_browser))]
     /// Parses a [`NodeInfo`] from a TXT records lookup.
-    pub fn from_txt_lookup(lookup: crate::dns::TxtLookup) -> Result<Self, ParseError> {
-        let attrs = TxtAttrs::from_txt_lookup(lookup)?;
-        Ok(attrs.into())
+    pub(crate) fn from_txt_lookup(
+        name: String,
+        lookup: impl Iterator<Item = crate::dns::TxtRecordData>,
+    ) -> Result<Self, ParseError> {
+        let attrs = TxtAttrs::from_txt_lookup(name, lookup)?;
+        Ok(Self::from(attrs))
     }
 
     /// Parses a [`NodeInfo`] from a [`pkarr::SignedPacket`].
@@ -415,32 +408,6 @@ impl NodeInfo {
     pub fn to_txt_strings(&self) -> Vec<String> {
         self.to_attrs().to_txt_strings().collect()
     }
-}
-
-#[cfg(not(wasm_browser))]
-#[common_fields({
-    backtrace: Option<Backtrace>,
-    #[snafu(implicit)]
-    span_trace: n0_snafu::SpanTrace,
-})]
-#[allow(missing_docs)]
-#[derive(Debug, Snafu)]
-#[non_exhaustive]
-#[snafu(visibility(pub(crate)))]
-pub enum LookupError {
-    #[snafu(display("Malformed txt from lookup"))]
-    ParseError {
-        #[snafu(source(from(ParseError, Box::new)))]
-        source: Box<ParseError>,
-    },
-    #[snafu(display("Failed to resolve TXT record"))]
-    LookupFailed {
-        #[snafu(source(from(DnsError, Box::new)))]
-        source: Box<DnsError>,
-    },
-    #[cfg(not(wasm_browser))]
-    #[snafu(display("Name is not a valid TXT label"))]
-    InvalidLabel { source: ProtoError },
 }
 
 #[common_fields({
@@ -489,23 +456,17 @@ impl std::ops::DerefMut for NodeInfo {
 /// [`IROH_TXT_NAME`] and the second label to be a z32 encoded [`NodeId`]. Ignores
 /// subsequent labels.
 #[cfg(not(wasm_browser))]
-fn node_id_from_hickory_name(
-    name: &hickory_resolver::proto::rr::Name,
-) -> Result<NodeId, ParseError> {
-    if name.num_labels() < 2 {
-        return Err(NumLabelsSnafu {
-            num_labels: name.num_labels(),
-        }
-        .build());
+fn node_id_from_txt_name(name: &str) -> Result<NodeId, ParseError> {
+    let num_labels = name.split(".").count();
+    if num_labels < 2 {
+        return Err(NumLabelsSnafu { num_labels }.build());
     }
-    let mut labels = name.iter();
-    let label =
-        std::str::from_utf8(labels.next().expect("num_labels checked")).context(Utf8Snafu)?;
+    let mut labels = name.split(".");
+    let label = labels.next().expect("checked above");
     if label != IROH_TXT_NAME {
         return Err(NotAnIrohRecordSnafu { label }.build());
     }
-    let label =
-        std::str::from_utf8(labels.next().expect("num_labels checked")).context(Utf8Snafu)?;
+    let label = labels.next().expect("checked above");
     let node_id = NodeId::from_z32(label)?;
     Ok(node_id)
 }
@@ -580,38 +541,6 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
         Ok(Self { attrs, node_id })
     }
 
-    #[cfg(not(wasm_browser))]
-    async fn lookup(resolver: &DnsResolver, name: Name) -> Result<Self, LookupError> {
-        let name = ensure_iroh_txt_label(name)?;
-        let lookup = resolver
-            .lookup_txt(name, DNS_TIMEOUT)
-            .await
-            .context(LookupFailedSnafu)?;
-        let attrs = Self::from_txt_lookup(lookup).context(ParseSnafu)?;
-        Ok(attrs)
-    }
-
-    /// Looks up attributes by [`NodeId`] and origin domain.
-    #[cfg(not(wasm_browser))]
-    pub(crate) async fn lookup_by_id(
-        resolver: &DnsResolver,
-        node_id: &NodeId,
-        origin: &str,
-    ) -> Result<Self, LookupError> {
-        let name = node_domain(node_id, origin)?;
-        TxtAttrs::lookup(resolver, name).await
-    }
-
-    /// Looks up attributes by DNS name.
-    #[cfg(not(wasm_browser))]
-    pub(crate) async fn lookup_by_name(
-        resolver: &DnsResolver,
-        name: &str,
-    ) -> Result<Self, LookupError> {
-        let name = Name::from_str(name).context(InvalidLabelSnafu)?;
-        TxtAttrs::lookup(resolver, name).await
-    }
-
     /// Returns the parsed attributes.
     pub(crate) fn attrs(&self) -> &BTreeMap<T, Vec<String>> {
         &self.attrs
@@ -650,43 +579,13 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
 
     /// Parses a TXT records lookup.
     #[cfg(not(wasm_browser))]
-    pub(crate) fn from_txt_lookup(lookup: crate::dns::TxtLookup) -> Result<Self, ParseError> {
-        let queried_node_id = node_id_from_hickory_name(lookup.0.query().name())?;
+    pub(crate) fn from_txt_lookup(
+        name: String,
+        lookup: impl Iterator<Item = crate::dns::TxtRecordData>,
+    ) -> Result<Self, ParseError> {
+        let queried_node_id = node_id_from_txt_name(&name)?;
 
-        let strings = lookup.0.as_lookup().record_iter().filter_map(|record| {
-            match node_id_from_hickory_name(record.name()) {
-                // Filter out only TXT record answers that match the node_id we searched for.
-                Ok(n) if n == queried_node_id => match record.data().as_txt() {
-                    Some(txt) => Some(txt.to_string()),
-                    None => {
-                        warn!(
-                            ?queried_node_id,
-                            data = ?record.data(),
-                            "unexpected record type for DNS discovery query"
-                        );
-                        None
-                    }
-                },
-                Ok(answered_node_id) => {
-                    warn!(
-                        ?queried_node_id,
-                        ?answered_node_id,
-                        "unexpected node ID answered for DNS query"
-                    );
-                    None
-                }
-                Err(e) => {
-                    warn!(
-                        ?queried_node_id,
-                        name = ?record.name(),
-                        err = ?e,
-                        "unexpected answer record name for DNS query"
-                    );
-                    None
-                }
-            }
-        });
-
+        let strings = lookup.map(|record| record.to_string());
         Self::from_strings(queried_node_id, strings)
     }
 
@@ -720,19 +619,18 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
 }
 
 #[cfg(not(wasm_browser))]
-fn ensure_iroh_txt_label(name: Name) -> Result<Name, LookupError> {
-    if name.iter().next() == Some(IROH_TXT_NAME.as_bytes()) {
-        Ok(name)
+pub(crate) fn ensure_iroh_txt_label(name: String) -> String {
+    let mut parts = name.split(".");
+    if parts.next() == Some(IROH_TXT_NAME) {
+        name
     } else {
-        Name::parse(IROH_TXT_NAME, Some(&name)).context(InvalidLabelSnafu)
+        format!("{}.{}", IROH_TXT_NAME, name)
     }
 }
 
 #[cfg(not(wasm_browser))]
-fn node_domain(node_id: &NodeId, origin: &str) -> Result<Name, LookupError> {
-    let domain = format!("{}.{origin}", NodeId::to_z32(node_id));
-    let domain = Name::from_str(&domain).context(InvalidLabelSnafu)?;
-    Ok(domain)
+pub(crate) fn node_domain(node_id: &NodeId, origin: &str) -> String {
+    format!("{}.{}", NodeId::to_z32(node_id), origin)
 }
 
 #[cfg(test)]
@@ -752,6 +650,8 @@ mod tests {
     };
     use iroh_base::{NodeId, SecretKey};
     use n0_snafu::{Result, ResultExt};
+
+    use crate::dns::TxtRecordData;
 
     use super::{NodeData, NodeIdExt, NodeInfo};
 
@@ -846,8 +746,11 @@ mod tests {
         ];
         let lookup = Lookup::new_with_max_ttl(query, Arc::new(records));
         let lookup = hickory_resolver::lookup::TxtLookup::from(lookup);
+        let lookup = lookup
+            .into_iter()
+            .map(|txt| TxtRecordData::from_iter(txt.iter().cloned()));
 
-        let node_info = NodeInfo::from_txt_lookup(lookup.into())?;
+        let node_info = NodeInfo::from_txt_lookup(name.to_string(), lookup)?;
 
         let expected_node_info = NodeInfo::new(NodeId::from_str(
             "1992d53c02cdc04566e5c0edb1ce83305cd550297953a047a445ea3264b54b18",


### PR DESCRIPTION
## Description

Replaces #2116 
Fixes #3468

This adds a `Resolver` trait to abstract over DNS resolution. It contains methods to resolve IPv4 or IPv6 addresses, and TXT records. Because the trait needs to be dyn-compatible for our usage (we don't want to have a generic for the DNS resolver on the Endpoint), all methods return boxed futures that contain boxed iterators. 

To not pay the cost of boxing when using the default hickory-based resolver, the iroh `DnsResolver` internally contains an enum which is either the default resolver or the boxed custom resolver.

Users can implement the `Resolver` trait on whatever struct to use a completely custom DNS resolver.

## Breaking Changes

Changes in `iroh_relay::dns` (reexported from `iroh::dns`):
*  `DnsResolver::lookup_txt` now returns `impl Iterator<Item = TxtRecord>`
* `TxtLookup` and `TXT` are removed.

Changes in `iroh_relay::node_info` (reexported from `iroh::discovery`):
* `NodeInfo::from_txt_lookup` now takes `domain_name: String, lookup: impl Iterator<Item = crate::dns::TxtRecordData>`

Moved items:
* `iroh_relay::node_info::LookupError` was moved to `iroh_relay::dns::LookupError`

## Notes & open questions

We likely want to still add a builder for our DnsResolver to allow setting a few more of the common options on the hickory resolver. But with this, people that want to use some completely custom way of resolving DNS records can do so.


<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
