### PR TITLE
feat(iroh)!: add `MdnsDiscoveryBuilder::service_name` method

### DIFF
--- a/iroh/src/discovery/mdns.rs
+++ b/iroh/src/discovery/mdns.rs
@@ -153,11 +153,11 @@ impl MdnsDiscoveryBuilder {
     /// Sets a custom service name.
     ///
     /// The default is `irohv1`, which will show up on a record in the
-    /// following form:
-    /// `NODE_ID._irohv1._upd.local`
+    /// following form, for example:
+    /// `7rutqynuzu65fcdgoerbt4uoh3p62wuto2mp56x3uvhitqzssxga._irohv1._udp.local`
     ///
-    /// Any custom service name will take the form:
-    /// `NODE_ID._{service_name}.upd.local`
+    /// Any custom service name will take the form, for example:
+    /// `7rutqynuzu65fcdgoerbt4uoh3p62wuto2mp56x3uvhitqzssxga._{service_name}.upd.local`
     pub fn service_name(mut self, service_name: impl Into<String>) -> Self {
         self.service_name = service_name.into();
         self


### PR DESCRIPTION
## Description
Changes the default service name to `irohv1` as well as changing the provenance name to simply `mdns`.

Adds an `MdnsDiscoveryBuilder::service_name` method to allow users to use their own service name for their mDNS records.

This commit also narrows down the options to create an `MdnsDiscovery` service. Now you must use `MdnsDiscovery::builder` to create an `MdnsDiscoveryBuilder`, then use the `build()` method to create the `MdnsDiscovery` service.


## Breaking Changes

  - `MdnsDiscovery::new` is now private
  - `MdnsDiscoveryBuilder::new` is now private
      - Use `MdnsDiscovery::builder()` to create an `MdnsDiscoveryBuilder`
  - Default service name changed from `iroh.local.swarm` to `irohv1`
  - Provenance field name in `DiscoveryItem` changed from `local.swarm.discovery` to `mdns`

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
  - [x] List all breaking changes in the above "Breaking Changes" section.
