### PR TITLE
feat: upgrade redb to v3 compatible format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,7 +2516,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2596,7 +2596,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3759,7 +3759,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3912,9 +3912,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.4.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0a72cd7140de9fc3e318823b883abf819c20d478ec89ce880466dc2ef263c6"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
 dependencies = [
  "libc",
 ]
@@ -4092,7 +4092,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4194,7 +4194,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4819,7 +4819,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5666,7 +5666,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -34,7 +34,7 @@ n0-future = "0.1.2"
 n0-snafu = "0.2.2"
 pkarr = { version = "3.7", features = ["relays", "dht"], default-features = false }
 rcgen = "0.13"
-redb = "=2.4.0" # 2.5.0 has MSRV 1.85
+redb = "2.6.3"
 regex = "1.10.3"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 rustls-pemfile = { version = "2.1" }

--- a/iroh-dns-server/src/store/signed_packets.rs
+++ b/iroh-dns-server/src/store/signed_packets.rs
@@ -272,9 +272,14 @@ impl SignedPacketStore {
                 )
             })?;
         }
-        let db = Database::builder()
+        let mut db = Database::builder()
             .create(path)
             .context("failed to open packet database")?;
+        match db.upgrade() {
+            Ok(true) => info!("Database was upgraded to redb v3 compatible format"),
+            Ok(false) => {}
+            Err(err) => warn!("Database upgrade to redb v3 compatible format failed: {err:#}"),
+        }
         Self::open(db, options, metrics)
     }
 


### PR DESCRIPTION
## Description

We are using redb in iroh-dns-server. The recently released redb v3 has incompatible changes to the database format. The recommended upgrade procedure is to upgrade the database with `Database::upgrade` on redb v2.6+. The upgrade has to be done on redb v2, not v3. See https://github.com/cberner/redb/blob/master/CHANGELOG.md#removes-support-for-file-format-v2.

This updates redb to 2.6 and performs the upgrade when opening the database. Calling upgrade on an already upgraded database is a no-op.

With this merged in the next release, we can then update redb to v3 in the version after.


## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
