### PR TITLE
fix: force reqwest to always use rustls backend

### DIFF
--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -237,7 +237,10 @@ impl From<AccessConfig> for iroh_relay::server::AccessConfig {
                 }))
             }
             AccessConfig::Http(mut config) => {
-                let client = reqwest::Client::default();
+                let client = reqwest::Client::builder()
+                    .use_rustls_tls()
+                    .build()
+                    .expect("request client builder");
                 // Allow to set bearer token via environment variable as well.
                 if let Ok(token) = std::env::var(ENV_HTTP_BEARER_TOKEN) {
                     config.bearer_token = Some(token);

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -856,7 +856,8 @@ mod tests {
         let server = spawn_local_relay().await.unwrap();
         let url = format!("http://{}", server.http_addr().unwrap());
 
-        let response = reqwest::get(&url).await.unwrap();
+        let client = reqwest::Client::builder().use_rustls_tls().build().unwrap();
+        let response = client.get(&url).send().await.unwrap();
         assert_eq!(response.status(), 200);
         let body = response.text().await.unwrap();
         assert!(body.contains("iroh.computer"));
@@ -869,7 +870,7 @@ mod tests {
         let url = format!("http://{}/generate_204", server.http_addr().unwrap());
         let challenge = "123az__.";
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder().use_rustls_tls().build().unwrap();
         let response = client
             .get(&url)
             .header(NO_CONTENT_CHALLENGE_HEADER, challenge)

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -527,7 +527,10 @@ impl PkarrRelayClient {
     /// Creates a new client.
     pub fn new(pkarr_relay_url: Url) -> Self {
         Self {
-            http_client: reqwest::Client::new(),
+            http_client: reqwest::Client::builder()
+                .use_rustls_tls()
+                .build()
+                .expect("reqwest client builder"),
             pkarr_relay_url,
         }
     }
@@ -536,6 +539,7 @@ impl PkarrRelayClient {
     #[cfg(not(wasm_browser))]
     pub fn with_dns_resolver(pkarr_relay_url: Url, dns_resolver: crate::dns::DnsResolver) -> Self {
         let http_client = reqwest::Client::builder()
+            .use_rustls_tls()
             .dns_resolver(Arc::new(dns_resolver))
             .build()
             .expect("failed to create request client");

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -574,7 +574,9 @@ async fn check_captive_portal(
         }
     };
 
-    let mut builder = reqwest::ClientBuilder::new().redirect(reqwest::redirect::Policy::none());
+    let mut builder = reqwest::Client::builder()
+        .use_rustls_tls()
+        .redirect(reqwest::redirect::Policy::none());
 
     if let Some(Host::Domain(domain)) = url.host() {
         // Use our own resolver rather than getaddrinfo
@@ -776,7 +778,7 @@ async fn run_https_probe(
     // This should also use same connection establishment as relay client itself, which
     // needs to be more configurable so users can do more crazy things:
     // https://github.com/n0-computer/iroh/issues/2901
-    let mut builder = reqwest::ClientBuilder::new();
+    let mut builder = reqwest::Client::builder().use_rustls_tls();
 
     #[cfg(not(wasm_browser))]
     {


### PR DESCRIPTION
## Description

This changes all uses of `reqwest` in iroh to use `ClientBuilder::use_rustls_tls()` to force using the rustls TLS backend, even if the `default-tls` feature got enabled through feature unification (we don't enable it in iroh directly). 

Reasoning:

We have reports of HTTPS net report probes failing. They *do* fail under the following circumstances:

- `reqwest` uses the native-tls backend (which is platform dependent, and is openssl on linux) whenever the `default-tls` feature is enabled. it is on by default. if both `rustls-tls` and `default-tls` features are enabled, the native-tls backend wins.
- in iroh, we use `reqwest` with `default-features = false, features = ["rustls-tls"]`, so without other deps changing features, the rustls backend is used
- the rustls backend apparently cleans up the domain name, removing a final dot if present, before comparing it to the certificate's hostname
- openssl apparently does not do that, so if the passed-in hostname has a final dot, but the certificate has not, an SSL verification error is thrown
- now, if *any* other crate in a binary's deps enables the `default-tls` feature for reqwest, due to feature unification iroh now by default also uses the native tls backend and not rustls anymore

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
