### PR TITLE
fix: remove final dot in relay urls when doing https requests

### DIFF
--- a/iroh-base/src/relay_url.rs
+++ b/iroh-base/src/relay_url.rs
@@ -38,6 +38,44 @@ impl From<Url> for RelayUrl {
     }
 }
 
+impl RelayUrl {
+    /// Returns the URL while removing the final dot in the relay URL's domain name.
+    ///
+    /// By default, we add a final dot to relay URLs to make sure that DNS resolution always
+    /// considers them as top-level domains without appending a search suffix. When using
+    /// the URL for TLS hostname verification, usually a domain name without a final
+    /// dot is expected. So when using the URL in the context of HTTPS or TLS, use
+    /// this function to get the URL without the final dot.
+    pub fn without_final_dot(&self) -> Url {
+        let mut url = self.0.deref().clone();
+        if let Some(domain) = url.domain() {
+            if domain.ends_with('.') {
+                let domain_without_dot = domain[..(domain.len() - 1)].to_string();
+                url.set_host(Some(&domain_without_dot)).ok();
+            }
+        }
+        url
+    }
+
+    /// Return the string representation of the host (domain or IP address) for this URL, if any.
+    ///
+    /// If the host is a domain, and the domain ends with a final dot, the final dot is removed.
+    ///
+    /// See [`Self::without_final_dot`] for details on when you might want to use this.
+    pub fn host_str_without_final_dot(&self) -> Option<&str> {
+        if let Some(domain) = self.0.domain() {
+            if domain.ends_with('.') {
+                let domain_without_dot = &domain[..(domain.len() - 1)];
+                Some(domain_without_dot)
+            } else {
+                Some(domain)
+            }
+        } else {
+            self.0.host_str()
+        }
+    }
+}
+
 /// Can occur when parsing a string into a [`RelayUrl`].
 #[derive(Debug, Snafu)]
 #[snafu(display("Failed to parse"))]

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -694,7 +694,10 @@ async fn run_probe_v4(
         reportgen::maybe_to_mapped_addr(ip_mapped_addrs.as_ref(), relay_addr_orig.into());
 
     debug!(?relay_addr_orig, ?relay_addr, "relay addr v4");
-    let host = relay_node.url.host_str().context("missing host url")?;
+    let host = relay_node
+        .url
+        .host_str_without_final_dot()
+        .context("missing host url")?;
     let conn = quic_client.create_conn(relay_addr, host).await?;
     let mut receiver = conn.observed_external_addr();
 
@@ -761,7 +764,10 @@ async fn run_probe_v6(
         reportgen::maybe_to_mapped_addr(ip_mapped_addrs.as_ref(), relay_addr_orig.into());
 
     debug!(?relay_addr_orig, ?relay_addr, "relay addr v6");
-    let host = relay_node.url.host_str().context("missing host url")?;
+    let host = relay_node
+        .url
+        .host_str_without_final_dot()
+        .context("missing host url")?;
     let conn = quic_client.create_conn(relay_addr, host).await?;
     let mut receiver = conn.observed_external_addr();
 

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -598,7 +598,7 @@ async fn check_captive_portal(
     // length is limited; see is_challenge_char in bin/iroh-relay for more
     // details.
 
-    let host_name = url.host_str().unwrap_or_default();
+    let host_name = url.host_str_without_final_dot().unwrap_or_default();
     let challenge = format!("ts_{host_name}");
     let portal_url = format!("http://{host_name}/generate_204");
     let res = client
@@ -771,7 +771,6 @@ async fn run_https_probe(
     #[cfg(any(test, feature = "test-utils"))] insecure_skip_relay_cert_verify: bool,
 ) -> Result<HttpsProbeReport, MeasureHttpsLatencyError> {
     trace!("HTTPS probe start");
-    let url = relay_node.join(RELAY_PROBE_PATH)?;
 
     // This should also use same connection establishment as relay client itself, which
     // needs to be more configurable so users can do more crazy things:
@@ -784,7 +783,7 @@ async fn run_https_probe(
     }
 
     #[cfg(not(wasm_browser))]
-    if let Some(Host::Domain(domain)) = url.host() {
+    if let Some(Host::Domain(domain)) = relay_node.host() {
         // Use our own resolver rather than getaddrinfo
         //
         // Be careful, a non-zero port will override the port in the URI.
@@ -809,6 +808,7 @@ async fn run_https_probe(
         .context(measure_https_latency_error::CreateReqwestClientSnafu)?;
 
     let start = Instant::now();
+    let url = relay_node.without_final_dot().join(RELAY_PROBE_PATH)?;
     let response = client
         .request(reqwest::Method::GET, url)
         .send()


### PR DESCRIPTION
## Description

We append a final dot to all relay URL domains, to make sure that during DNS resolution the domain is treated as absolute, and no search suffix is appended. However, in the context of TLS name verification it is more correct to *not* have a final dot, so that the URL's hostname matches the name in the certificate. It seems this is not an issue with rustls, but when using openssl this is an issue (which we had reports for, but those are also fixed by #3486).

This PR adds methods to get the relay URL or hostname without the final dot, and uses those in the context of HTTPS requests.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Should check if there's more uses of those URLs. Likely we want to do the same when actually *connecting* to the relay? But didn't yet find the perfect spot for that.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
