### PR TITLE
refactor!: switch to iroh headers for captive portal checks

### DIFF
--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -603,7 +603,7 @@ async fn check_captive_portal(
     let portal_url = format!("http://{host_name}/generate_204");
     let res = client
         .request(reqwest::Method::GET, portal_url)
-        .header("X-Tailscale-Challenge", &challenge)
+        .header("X-Iroh-Challenge", &challenge)
         .send()
         .await
         .context(captive_portal_error::HttpRequestSnafu)?;
@@ -611,7 +611,7 @@ async fn check_captive_portal(
     let expected_response = format!("response {challenge}");
     let is_valid_response = res
         .headers()
-        .get("X-Tailscale-Response")
+        .get("X-Iroh-Response")
         .map(|s| s.to_str().unwrap_or_default())
         == Some(&expected_response);
 


### PR DESCRIPTION
## Description

Switches to use `X-Iroh` instead of `X-Tailscale` headers for the captive portal challenges.

Old headers are preserved on the `iroh-relay` side, until we do more breaking changes.

## Breaking Changes

The challenges for captive portals need to be sent to the latest version of `iroh-relay`

