### PR TITLE
fix: `impl<T: Discovery> Discovery for Arc<T>`

### DIFF
--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -333,6 +333,7 @@ impl<T: Discovery> Discovery for Arc<T> {
     fn publish(&self, data: &NodeData) {
         self.as_ref().publish(data);
     }
+
     fn resolve(&self, node_id: NodeId) -> Option<BoxStream<Result<DiscoveryItem, DiscoveryError>>> {
         self.as_ref().resolve(node_id)
     }

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -357,7 +357,14 @@ pub trait Discovery: std::fmt::Debug + Send + Sync + 'static {
     }
 }
 
-impl<T: Discovery> Discovery for Arc<T> {}
+impl<T: Discovery> Discovery for Arc<T> {
+    fn publish(&self, data: &NodeData) {
+        self.as_ref().publish(data);
+    }
+    fn resolve(&self, node_id: NodeId) -> Option<BoxStream<Result<DiscoveryItem, DiscoveryError>>> {
+        self.as_ref().resolve(node_id)
+    }
+}
 
 /// An event emitted from [`Discovery`] services.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -889,6 +896,31 @@ mod tests {
         Ok(())
     }
 
+    /// This is a smoke test to ensure a discovery service can be
+    /// `Arc`-d, and discovery will still work
+    #[tokio::test]
+    #[traced_test]
+    async fn endpoint_discovery_simple_shared_with_arc() -> Result {
+        let disco_shared = TestDiscoveryShared::default();
+        let (ep1, _guard1) = {
+            let secret = SecretKey::generate(rand::thread_rng());
+            let disco = disco_shared.create_discovery(secret.public());
+            let disco = Arc::new(disco);
+            new_endpoint(secret, disco).await
+        };
+        let (ep2, _guard2) = {
+            let secret = SecretKey::generate(rand::thread_rng());
+            let disco = disco_shared.create_discovery(secret.public());
+            let disco = Arc::new(disco);
+            new_endpoint(secret, disco).await
+        };
+        let ep1_addr = NodeAddr::new(ep1.node_id());
+        // wait for our address to be updated and thus published at least once
+        ep1.node_addr().initialized().await;
+        let _conn = ep2.connect(ep1_addr, TEST_ALPN).await?;
+        Ok(())
+    }
+
     /// This test adds an empty discovery which provides no addresses.
     #[tokio::test]
     #[traced_test]
@@ -1068,7 +1100,7 @@ mod tests {
     ) -> (Endpoint, AbortOnDropHandle<Result<()>>) {
         let ep = Endpoint::builder()
             .secret_key(secret)
-            .discovery(disco)
+            .add_discovery(disco)
             .relay_mode(RelayMode::Disabled)
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()


### PR DESCRIPTION
## Description

Fixes the implementation of `Discovery` for an `Arc<impl Discovery>`

- Added a failing test illustrating that when we added an `Arc<Discovery>`, the endpoint was unable to actually discover anything
- Fixed the test by actually implementing the trait on an `Arc`

closes #3489 

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Tests if relevant.

