### PR TITLE
fix: 0rtt flakes

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2698,8 +2698,18 @@ mod tests {
         tokio::spawn({
             let server = server.clone();
             async move {
+                tracing::trace!("Server accept loop started");
                 while let Some(incoming) = server.accept().await {
-                    let connecting = incoming.accept().e()?;
+                    tracing::trace!("Server received incoming connection");
+                    // Handle connection errors gracefully instead of exiting the task
+                    let connecting = match incoming.accept() {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::warn!("Failed to accept incoming connection: {e:?}");
+                            continue;
+                        }
+                    };
+
                     let conn = match connecting.into_0rtt() {
                         Ok((conn, _)) => {
                             info!("0rtt accepted");
@@ -2707,17 +2717,48 @@ mod tests {
                         }
                         Err(connecting) => {
                             info!("0rtt denied");
-                            connecting.await.e()?
+                            match connecting.await {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    tracing::warn!("Connection failed: {e:?}");
+                                    continue;
+                                }
+                            }
                         }
                     };
-                    let (mut send, mut recv) = conn.accept_bi().await.e()?;
-                    let data = recv.read_to_end(10_000_000).await.e()?;
-                    send.write_all(&data).await.e()?;
-                    send.finish().e()?;
+
+                    // Handle stream errors gracefully
+                    let (mut send, mut recv) = match conn.accept_bi().await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::warn!("Failed to accept bi stream: {e:?}");
+                            continue;
+                        }
+                    };
+
+                    let data = match recv.read_to_end(10_000_000).await {
+                        Ok(d) => d,
+                        Err(e) => {
+                            tracing::warn!("Failed to read data: {e:?}");
+                            continue;
+                        }
+                    };
+
+                    if let Err(e) = send.write_all(&data).await {
+                        tracing::warn!("Failed to write data: {e:?}");
+                        continue;
+                    }
+
+                    if let Err(e) = send.finish() {
+                        tracing::warn!("Failed to finish send: {e:?}");
+                        continue;
+                    }
 
                     // Stay alive until the other side closes the connection.
                     conn.closed().await;
+                    tracing::trace!("Connection closed, ready for next");
                 }
+                tracing::trace!("Server accept loop exiting");
                 Ok::<_, Error>(())
             }
             .instrument(log_span)
@@ -2749,6 +2790,7 @@ mod tests {
         server_addr: NodeAddr,
         expect_server_accepts: bool,
     ) -> Result {
+        tracing::trace!(?server_addr, "Client connecting with 0-RTT");
         let (conn, accepted_0rtt) = client
             .connect_with_opts(server_addr, TEST_ALPN, ConnectOptions::new())
             .await?
@@ -2756,12 +2798,15 @@ mod tests {
             .ok()
             .e()?;
 
+        tracing::trace!("Client established 0-RTT connection");
         // This is how we send data in 0-RTT:
         let (mut send, recv) = conn.open_bi().await.e()?;
         send.write_all(b"hello").await.e()?;
         send.finish().e()?;
+        tracing::trace!("Client sent 0-RTT data, waiting for server response");
         // When this resolves, we've gotten a response from the server about whether the 0-RTT data above was accepted:
         let accepted = accepted_0rtt.await;
+        tracing::trace!(?accepted, "Server responded to 0-RTT");
         assert_eq!(accepted, expect_server_accepts);
         let mut recv = if accepted {
             recv

--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -699,18 +699,6 @@ impl NodeState {
         }
 
         let mut access = self.udp_paths.access_mut(now);
-
-        // Invalidate paths that are not in the new address set.
-        // If the remote node sends us new addresses, old ones are likely stale (e.g., after restart).
-        // This forces immediate re-evaluation and prevents preferring "known bad" outdated paths
-        // over "unknown potentially good" new paths.
-        for (ip_port, path_state) in access.paths().iter_mut() {
-            if !new_addrs.contains(&(*ip_port).into()) && !path_state.validity.is_empty() {
-                debug!(path=?ip_port, "invalidating path not in new address set");
-                path_state.validity = PathValidity::empty();
-            }
-        }
-
         for &addr in new_addrs.iter() {
             access
                 .paths()

--- a/iroh/src/magicsock/node_map/node_state.rs
+++ b/iroh/src/magicsock/node_map/node_state.rs
@@ -699,6 +699,18 @@ impl NodeState {
         }
 
         let mut access = self.udp_paths.access_mut(now);
+
+        // Invalidate paths that are not in the new address set.
+        // If the remote node sends us new addresses, old ones are likely stale (e.g., after restart).
+        // This forces immediate re-evaluation and prevents preferring "known bad" outdated paths
+        // over "unknown potentially good" new paths.
+        for (ip_port, path_state) in access.paths().iter_mut() {
+            if !new_addrs.contains(&(*ip_port).into()) && !path_state.validity.is_empty() {
+                debug!(path=?ip_port, "invalidating path not in new address set");
+                path_state.validity = PathValidity::empty();
+            }
+        }
+
         for &addr in new_addrs.iter() {
             access
                 .paths()


### PR DESCRIPTION
## Description

So rough description of what was happening:
- the errors got swallowed but nuked the loop so it failed silently - fixed that
- the 0rtt tries connecting on the new port/addr but still prefers the old path so needs to wait out for the path invalidation to do it's job before it continues to work

Being slow enough made it sometimes pass. Locally now tests pass ~instantly vs 15 seconds or so after the fix to gracefully handle errors.

I'm unsure if this is safe at all, like handling path updates from other angles or partial updates etc.
If it turns out too risky, we can drop the path invalidation changes and just keep the graceful error handling. Tests will pass.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
