### PR TITLE
ci: enable dependabot for crates and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: docker
+    schedule:
+      interval: weekly


### PR DESCRIPTION
I would like to try this for a bit

Closes #3416 