### PR TITLE
feat(iroh)!: make direct_addresses always be initialised

### DIFF
--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -144,10 +144,8 @@ async fn accept(_args: Args) -> n0_snafu::Result<()> {
         let Some(addr) = addrs.next().await else {
             snafu::whatever!("Address stream closed");
         };
-        if let Some(addr) = addr {
-            if !addr.direct_addresses.is_empty() {
-                break addr;
-            }
+        if !addr.direct_addresses.is_empty() {
+            break addr;
         }
     };
     println!("Listening on: {addr:?}");

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -273,7 +273,7 @@ impl EndpointArgs {
         let node_id = endpoint.node_id();
         println!("Our node id:\n\t{node_id}");
 
-        let node_addr = endpoint.watch_node_addr().initialized().await;
+        let node_addr = endpoint.node_addr();
 
         println!("Our direct addresses:");
         for addr in &node_addr.direct_addresses {

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -641,7 +641,6 @@ mod tests {
 
     use iroh_base::{NodeAddr, SecretKey};
     use n0_snafu::{Error, Result, ResultExt};
-    use n0_watcher::Watcher as _;
     use quinn::{IdleTimeout, TransportConfig};
     use rand::{Rng, SeedableRng};
     use tokio_util::task::AbortOnDropHandle;
@@ -770,8 +769,6 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
-        // wait for our address to be updated and thus published at least once
-        ep1.watch_node_addr().initialized().await;
         let _conn = ep2.connect(ep1_addr, TEST_ALPN).await?;
         Ok(())
     }
@@ -796,8 +793,6 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
-        // wait for our address to be updated and thus published at least once
-        ep1.watch_node_addr().initialized().await;
         let _conn = ep2.connect(ep1_addr, TEST_ALPN).await?;
         Ok(())
     }
@@ -823,8 +818,7 @@ mod tests {
             new_endpoint(secret, disco).await
         };
         let ep1_addr = NodeAddr::new(ep1.node_id());
-        // wait for out address to be updated and thus published at least once
-        ep1.watch_node_addr().initialized().await;
+
         let _conn = ep2
             .connect(ep1_addr, TEST_ALPN)
             .await
@@ -856,8 +850,7 @@ mod tests {
             disco.add(disco3);
             new_endpoint(secret, disco).await
         };
-        // wait for out address to be updated and thus published at least once
-        ep1.watch_node_addr().initialized().await;
+
         let _conn = ep2.connect(ep1.node_id(), TEST_ALPN).await?;
         Ok(())
     }
@@ -880,8 +873,6 @@ mod tests {
             let disco = ConcurrentDiscovery::from_services(vec![Box::new(disco1)]);
             new_endpoint(secret, disco).await
         };
-        // wait for out address to be updated and thus published at least once
-        ep1.watch_node_addr().initialized().await;
 
         // 10x faster test via a 3s idle timeout instead of the 30s default
         let mut config = TransportConfig::default();
@@ -915,8 +906,7 @@ mod tests {
             let disco = disco_shared.create_discovery(secret.public());
             new_endpoint(secret, disco).await
         };
-        // wait for out address to be updated and thus published at least once
-        ep1.watch_node_addr().initialized().await;
+
         let ep1_wrong_addr = NodeAddr {
             node_id: ep1.node_id(),
             relay_url: None,

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -875,24 +875,17 @@ impl Endpoint {
     }
 
     /// Returns the current [`NodeAddr`].
+    /// As long as the endpoint was able to binde to a network interfaces, some
+    /// local addresses will be available.
     ///
-    /// If this is called right after the [`Endpoint`] has been created, there is
-    /// a good chance these fields will be empty.
-    ///
+    /// The state of other fields depends on the state of networking and connectivity.
     /// Use the [`Endpoint::online`] method to ensure that the endpoint is considered
-    /// "online" (has contacted a  relay server and has at least one local addresses)
-    /// before calling this method, if you want to ensure that the `NodeAddr` will
-    /// contain enough information to allow this endpoint to be dialable by
-    /// a remote endpoint.
+    /// "online" (has contacted a relay server) before calling this method, if you want
+    /// to ensure that the `NodeAddr` will contain enough information to allow this endpoint
+    /// to be dialable by a remote endpoint over the internet.
     ///
-    /// Or, use the [`Endpoint::watch_node_addr`] method to get updates when the
-    /// `NodeAddr` changes.
-    ///
-    /// The `NodeAddr` will change as:
-    /// - network conditions change
-    /// - the endpoint connects to a relay server
-    /// - the endpoint changes its preferred relay server
-    /// - more addresses are discovered for this endpoint
+    /// You can use the [`Endpoint::watch_node_addr`] method to get updates when the `NodeAddr`
+    /// changes.
     pub fn node_addr(&self) -> NodeAddr {
         self.watch_node_addr().get()
     }
@@ -922,6 +915,13 @@ impl Endpoint {
     /// of the private or local network, watch for changes in it's [`NodeAddr`].
     /// If the `relay_url` is `None` or if there are no `direct_addresses` in
     /// the [`NodeAddr`], you may not be dialable by other endpoints on the internet.
+    ///
+    ///
+    /// The `NodeAddr` will change as:
+    /// - network conditions change
+    /// - the endpoint connects to a relay server
+    /// - the endpoint changes its preferred relay server
+    /// - more addresses are discovered for this endpoint
     ///
     /// [`RelayUrl`]: crate::RelayUrl
     #[cfg(not(wasm_browser))]

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -946,18 +946,14 @@ impl Endpoint {
     /// with a [`NodeAddr`] that only contains a relay URL, but no direct addresses,
     /// as there are no APIs for directly using sockets in browsers.
     #[cfg(wasm_browser)]
-    pub fn watch_node_addr(&self) -> impl n0_watcher::Watcher<Value = Option<NodeAddr>> + use<> {
+    pub fn watch_node_addr(&self) -> impl n0_watcher::Watcher<Value = NodeAddr> + use<> {
         // In browsers, there will never be any direct addresses, so we wait
         // for the home relay instead. This makes the `NodeAddr` have *some* way
         // of connecting to us.
         let watch_relay = self.msock.home_relay();
         let node_id = self.node_id();
         watch_relay
-            .map(move |mut relays| {
-                relays.pop().map(|relay_url| {
-                    NodeAddr::from_parts(node_id, Some(relay_url), std::iter::empty())
-                })
-            })
+            .map(move |mut relays| NodeAddr::from_parts(node_id, relays.pop(), std::iter::empty()))
             .expect("watchable is alive - cannot be disconnected yet")
     }
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -970,24 +970,6 @@ impl Endpoint {
     /// To understand if the endpoint has gone back "offline",
     /// you must use the [`Endpoint::watch_node_addr`] method, to
     /// get information on the current relay and direct address information.
-    #[cfg(not(wasm_browser))]
-    pub async fn online(&self) {
-        self.msock.home_relay().initialized().await;
-    }
-
-    /// A convenience method that waits for the endpoint to be considered "online".
-    ///
-    /// This currently means at least one relay server was connected.
-    /// Event if no relays are configured, this will still wait for a relay connection.
-    ///
-    /// Once this has been resolved once, this will always immediately resolve.
-    ///
-    /// This has no timeout, so if that is needed, you need to wrap it in a timeout.
-    ///
-    /// To understand if the endpoint has gone back "offline",
-    /// you must use the [`Endpoint::watch_node_addr`] method, to
-    /// get information on the current relay and direct address information.
-    #[cfg(wasm_browser)]
     pub async fn online(&self) {
         self.msock.home_relay().initialized().await;
     }

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -478,6 +478,7 @@ impl MagicSock {
         }
     }
 
+    #[cfg(not(wasm_browser))]
     fn collect_local_addresses(
         &self,
         netmon_watcher: &mut n0_watcher::Direct<netmon::State>,

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -312,7 +312,7 @@ impl MagicSock {
     ///
     /// [`Watcher`]: n0_watcher::Watcher
     /// [`Watcher::initialized`]: n0_watcher::Watcher::initialized
-    pub(crate) fn direct_addresses(&self) -> n0_watcher::Direct<Option<BTreeSet<DirectAddr>>> {
+    pub(crate) fn direct_addresses(&self) -> n0_watcher::Direct<BTreeSet<DirectAddr>> {
         self.direct_addrs.addrs.watch()
     }
 
@@ -475,6 +475,69 @@ impl MagicSock {
         match ipv4_addr {
             Some(addr) => Ok(addr),
             None => Err(io::Error::other("no valid socket available")),
+        }
+    }
+
+    fn collect_local_addresses(
+        &self,
+        netmon_watcher: &mut n0_watcher::Direct<netmon::State>,
+        addrs: &mut BTreeMap<SocketAddr, DirectAddrType>,
+    ) {
+        let local_addrs: Vec<(SocketAddr, SocketAddr)> = self
+            .ip_bind_addrs()
+            .iter()
+            .copied()
+            .zip(self.ip_local_addrs())
+            .collect();
+
+        let has_ipv4_unspecified = local_addrs.iter().find_map(|(_, a)| {
+            if a.is_ipv4() && a.ip().is_unspecified() {
+                Some(a.port())
+            } else {
+                None
+            }
+        });
+        let has_ipv6_unspecified = local_addrs.iter().find_map(|(_, a)| {
+            if a.is_ipv6() && a.ip().is_unspecified() {
+                Some(a.port())
+            } else {
+                None
+            }
+        });
+
+        // If a socket is bound to the unspecified address, create SocketAddrs for
+        // each local IP address by pairing it with the port the socket is bound on.
+        if local_addrs
+            .iter()
+            .any(|(_, local)| local.ip().is_unspecified())
+        {
+            let LocalAddresses {
+                regular: mut ips,
+                loopback,
+            } = netmon_watcher.get().local_addresses;
+            if ips.is_empty() && addrs.is_empty() {
+                // Include loopback addresses only if there are no other interfaces
+                // or public addresses, this allows testing offline.
+                ips = loopback;
+            }
+
+            for ip in ips {
+                let port_if_unspecified = match ip {
+                    IpAddr::V4(_) => has_ipv4_unspecified,
+                    IpAddr::V6(_) => has_ipv6_unspecified,
+                };
+                if let Some(port) = port_if_unspecified {
+                    let addr = SocketAddr::new(ip, port);
+                    addrs.entry(addr).or_insert(DirectAddrType::Local);
+                }
+            }
+        }
+
+        // If a socket is bound to a specific address, add it.
+        for (bound, local) in local_addrs {
+            if !bound.ip().is_unspecified() {
+                addrs.entry(local).or_insert(DirectAddrType::Local);
+            }
         }
     }
 
@@ -1429,7 +1492,7 @@ impl Handle {
             ip_mapped_addrs: ip_mapped_addrs.clone(),
             discovery,
             discovery_user_data: RwLock::new(discovery_user_data),
-            direct_addrs: Default::default(),
+            direct_addrs: DiscoveredDirectAddrs::default(),
             net_report: Watchable::new((None, UpdateReason::None)),
             #[cfg(not(wasm_browser))]
             dns_resolver: dns_resolver.clone(),
@@ -1514,7 +1577,9 @@ impl Handle {
         );
 
         let netmon_watcher = network_monitor.interface_state();
-        let actor = Actor {
+
+        #[cfg_attr(not(wasm_browser), allow(unused_mut))]
+        let mut actor = Actor {
             msg_receiver: actor_receiver,
             msock: msock.clone(),
             periodic_re_stun_timer: new_re_stun_timer(false),
@@ -1526,9 +1591,13 @@ impl Handle {
             pending_call_me_maybes: Default::default(),
             disco_receiver,
         };
+        // Initialize addresses
+        #[cfg(not(wasm_browser))]
+        actor.update_direct_addresses(None);
 
         let actor_token = CancellationToken::new();
         let token = actor_token.clone();
+
         let actor_task = task::spawn(
             actor
                 .run(token, local_addrs_watch, sender)
@@ -1853,10 +1922,6 @@ impl Actor {
         mut watcher: impl Watcher<Value = Vec<transports::Addr>> + Send + Sync,
         sender: UdpSender,
     ) {
-        // Initialize addresses
-        #[cfg(not(wasm_browser))]
-        self.update_direct_addresses(None);
-
         // Setup network monitoring
         let mut current_netmon_state = self.netmon_watcher.get();
 
@@ -2130,63 +2195,8 @@ impl Actor {
             }
         }
 
-        let local_addrs: Vec<(SocketAddr, SocketAddr)> = self
-            .msock
-            .ip_bind_addrs()
-            .iter()
-            .copied()
-            .zip(self.msock.ip_local_addrs())
-            .collect();
-
-        let has_ipv4_unspecified = local_addrs.iter().find_map(|(_, a)| {
-            if a.is_ipv4() && a.ip().is_unspecified() {
-                Some(a.port())
-            } else {
-                None
-            }
-        });
-        let has_ipv6_unspecified = local_addrs.iter().find_map(|(_, a)| {
-            if a.is_ipv6() && a.ip().is_unspecified() {
-                Some(a.port())
-            } else {
-                None
-            }
-        });
-
-        // If a socket is bound to the unspecified address, create SocketAddrs for
-        // each local IP address by pairing it with the port the socket is bound on.
-        if local_addrs
-            .iter()
-            .any(|(_, local)| local.ip().is_unspecified())
-        {
-            let LocalAddresses {
-                regular: mut ips,
-                loopback,
-            } = self.netmon_watcher.get().local_addresses;
-            if ips.is_empty() && addrs.is_empty() {
-                // Include loopback addresses only if there are no other interfaces
-                // or public addresses, this allows testing offline.
-                ips = loopback;
-            }
-
-            for ip in ips {
-                let port_if_unspecified = match ip {
-                    IpAddr::V4(_) => has_ipv4_unspecified,
-                    IpAddr::V6(_) => has_ipv6_unspecified,
-                };
-                if let Some(port) = port_if_unspecified {
-                    let addr = SocketAddr::new(ip, port);
-                    addrs.entry(addr).or_insert(DirectAddrType::Local);
-                }
-            }
-        }
-
-        // If a socket is bound to a specific address, add it.
-        for (bound, local) in local_addrs {
-            if !bound.ip().is_unspecified() {
-                addrs.entry(local).or_insert(DirectAddrType::Local);
-            }
-        }
+        self.msock
+            .collect_local_addresses(&mut self.netmon_watcher, &mut addrs);
 
         // Finally create and store store all these direct addresses and send any
         // queued call-me-maybe messages.
@@ -2290,10 +2300,10 @@ fn bind_with_fallback(mut addr: SocketAddr) -> io::Result<UdpSocket> {
 /// These are all the [`DirectAddr`]s that this [`MagicSock`] is aware of for itself.
 /// They include all locally bound ones as well as those discovered by other mechanisms like
 /// QAD.
-#[derive(derive_more::Debug, Default, Clone)]
+#[derive(derive_more::Debug, Clone, Default)]
 struct DiscoveredDirectAddrs {
     /// The last set of discovered direct addresses.
-    addrs: Watchable<Option<BTreeSet<DirectAddr>>>,
+    addrs: Watchable<BTreeSet<DirectAddr>>,
 
     /// The last time the direct addresses were updated, even if there was no change.
     ///
@@ -2305,7 +2315,7 @@ impl DiscoveredDirectAddrs {
     /// Updates the direct addresses, returns `true` if they changed, `false` if not.
     fn update(&self, addrs: BTreeSet<DirectAddr>) -> bool {
         *self.updated_at.write().expect("poisoned") = Some(Instant::now());
-        let updated = self.addrs.set(Some(addrs)).is_ok();
+        let updated = self.addrs.set(addrs).is_ok();
         if updated {
             event!(
                 target: "iroh::_events::direct_addrs",
@@ -2317,12 +2327,7 @@ impl DiscoveredDirectAddrs {
     }
 
     fn sockaddrs(&self) -> BTreeSet<SocketAddr> {
-        self.addrs
-            .get()
-            .unwrap_or_default()
-            .into_iter()
-            .map(|da| da.addr)
-            .collect()
+        self.addrs.get().into_iter().map(|da| da.addr).collect()
     }
 
     /// Whether the direct addr information is considered "fresh".
@@ -2348,13 +2353,7 @@ impl DiscoveredDirectAddrs {
     }
 
     fn to_call_me_maybe_message(&self) -> disco::CallMeMaybe {
-        let my_numbers = self
-            .addrs
-            .get()
-            .unwrap_or_default()
-            .into_iter()
-            .map(|da| da.addr)
-            .collect();
+        let my_numbers = self.addrs.get().into_iter().map(|da| da.addr).collect();
         disco::CallMeMaybe { my_numbers }
     }
 }
@@ -2663,7 +2662,7 @@ mod tests {
             let stacks = stacks.clone();
             tasks.spawn(async move {
                 let me = m.endpoint.node_id().fmt_short();
-                let mut stream = m.endpoint.watch_node_addr().stream().filter_map(|i| i);
+                let mut stream = m.endpoint.watch_node_addr().stream();
                 while let Some(addr) = stream.next().await {
                     info!(%me, "conn{} endpoints update: {:?}", my_idx + 1, addr.direct_addresses);
                     update_direct_addrs(&stacks, my_idx, addr.direct_addresses);
@@ -2899,10 +2898,7 @@ mod tests {
         }));
 
         println!("first conn!");
-        let conn = m1
-            .endpoint
-            .connect(m2.endpoint.watch_node_addr().initialized().await, ALPN)
-            .await?;
+        let conn = m1.endpoint.connect(m2.endpoint.node_addr(), ALPN).await?;
         println!("Closing first conn");
         conn.close(0u32.into(), b"bye lolz");
         conn.closed().await;
@@ -3055,12 +3051,12 @@ mod tests {
         let ms = Handle::new(default_options(&mut rng)).await.unwrap();
 
         // See if we can get endpoints.
-        let eps0 = ms.direct_addresses().initialized().await;
+        let eps0 = ms.direct_addresses().get();
         println!("{eps0:?}");
         assert!(!eps0.is_empty());
 
         // Getting the endpoints again immediately should give the same results.
-        let eps1 = ms.direct_addresses().initialized().await;
+        let eps1 = ms.direct_addresses().get();
         println!("{eps1:?}");
         assert_eq!(eps0, eps1);
     }
@@ -3217,8 +3213,7 @@ mod tests {
             relay_url: None,
             direct_addresses: msock_2
                 .direct_addresses()
-                .initialized()
-                .await
+                .get()
                 .into_iter()
                 .map(|x| x.addr)
                 .collect(),
@@ -3328,8 +3323,7 @@ mod tests {
                 relay_url: None,
                 direct_addresses: msock_2
                     .direct_addresses()
-                    .initialized()
-                    .await
+                    .get()
                     .into_iter()
                     .map(|x| x.addr)
                     .collect(),

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -575,7 +575,6 @@ mod tests {
     use std::{sync::Mutex, time::Duration};
 
     use n0_snafu::{Result, ResultExt};
-    use n0_watcher::Watcher;
     use quinn::ApplicationClose;
 
     use super::*;
@@ -629,7 +628,7 @@ mod tests {
         let proto = AccessLimit::new(Echo, |_node_id| false);
         let r1 = Router::builder(e1.clone()).accept(ECHO_ALPN, proto).spawn();
 
-        let addr1 = r1.endpoint().watch_node_addr().initialized().await;
+        let addr1 = r1.endpoint().node_addr();
         dbg!(&addr1);
         let e2 = Endpoint::builder()
             .relay_mode(RelayMode::Disabled)
@@ -682,7 +681,7 @@ mod tests {
             .accept(TEST_ALPN, TestProtocol::default())
             .spawn();
         eprintln!("waiting for node addr");
-        let addr = router.endpoint().watch_node_addr().initialized().await;
+        let addr = router.endpoint().node_addr();
 
         eprintln!("creating ep2");
         let endpoint2 = Endpoint::builder()


### PR DESCRIPTION
## Description

Turns out we just need to call the init early enough. 

Thanks to @flub for reminding me of this


## Breaking Changes

- changed
  - `iroh::Endpoint::watch_node_addr` now returns a watchable for `NodeAddr` not `Option<NodeAddr>`

## Notes & open questions

Currently this means that in wasm we have a different signature for `watch_node_addr()` because it can be empty, need some feedback on how to solve this
