### PR TITLE
fix(iroh): convert to canonical IP address in IpSender

### DIFF
--- a/iroh/src/magicsock/transports/ip.rs
+++ b/iroh/src/magicsock/transports/ip.rs
@@ -129,11 +129,16 @@ pub(super) struct IpSender {
 }
 
 impl IpSender {
-    pub(super) fn is_valid_send_addr(&self, addr: &SocketAddr) -> bool {
+    pub(super) fn is_valid_send_addr(&self, dst: &SocketAddr) -> bool {
+        // Our net-tools crate binds sockets to their specific family.  This means an IPv6
+        // socket can not sent to IPv4, on any platform.  So we need to convert and
+        // IPv4-mapped IPv6 address back to it's canonical IPv4 address.
+        let dst_ip = dst.ip().to_canonical();
+
         #[allow(clippy::match_like_matches_macro)]
-        match (self.bind_addr, addr) {
-            (SocketAddr::V4(_), SocketAddr::V4(..)) => true,
-            (SocketAddr::V6(_), SocketAddr::V6(..)) => true,
+        match (self.bind_addr.ip(), dst_ip) {
+            (IpAddr::V4(_), IpAddr::V4(_)) => true,
+            (IpAddr::V6(_), IpAddr::V6(_)) => true,
             _ => false,
         }
     }
@@ -149,7 +154,7 @@ impl IpSender {
         let res = self
             .sender
             .send(&quinn_udp::Transmit {
-                destination,
+                destination: Self::canonical_addr(destination),
                 ecn: transmit.ecn,
                 contents: transmit.contents,
                 segment_size: transmit.segment_size,
@@ -174,6 +179,16 @@ impl IpSender {
         }
     }
 
+    /// Creates a canonical socket address.
+    ///
+    /// We may be asked to send IPv4-mapped IPv6 addresses.  But our sockets are configured
+    /// to only send their actual family.  So we need to map those back to the canonical
+    /// addresses.
+    #[inline]
+    fn canonical_addr(addr: SocketAddr) -> SocketAddr {
+        SocketAddr::new(addr.ip().to_canonical(), addr.port())
+    }
+
     pub(super) fn poll_send(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context,
@@ -185,7 +200,7 @@ impl IpSender {
         let total_bytes = transmit.contents.len() as u64;
         let res = Pin::new(&mut self.sender).poll_send(
             &quinn_udp::Transmit {
-                destination,
+                destination: Self::canonical_addr(destination),
                 ecn: transmit.ecn,
                 contents: transmit.contents,
                 segment_size: transmit.segment_size,


### PR DESCRIPTION
## Description

Our AsyncUdpSocket is always an IPv6 socket, because we need to sent to our IPv6 ULAs for the mapped addresses.  This means Quinn will convert any IPv4 destination into an IPv4-mapped IPv6 address (::ffff:a.b.c.d).

But our sockets are bound to a specific family, so even if the OS supports and IPv6 socket that can handle IPv4 it will not accept those addresses.  So when we are using the destinations we need to convert back to the canonical addresses in the IPSender.


Based on https://github.com/n0-computer/iroh/commit/4eb0f07e34cccbb53e1842093d29c7b013ff4f5d

