### PR TITLE
refactor!: move examples deps to non-wasm dev deps

### DIFF
--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -91,14 +91,6 @@ futures-util = "0.3"
 # test_utils
 axum = { version = "0.8", optional = true }
 
-# Examples
-clap = { version = "4", features = ["derive"], optional = true }
-tracing-subscriber = { version = "0.3", features = [
-    "env-filter",
-], optional = true }
-indicatif = { version = "0.18", features = ["tokio"], optional = true }
-parse-size = { version = "=1.0.0", optional = true, features = ['std'] } # pinned version to avoid bumping msrv to 1.81
-
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 hickory-resolver = "0.25.1"
@@ -137,7 +129,6 @@ rand_chacha = "0.9"
 # *non*-wasm-in-browser test/dev dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 axum = { version = "0.8" }
-clap = { version = "4", features = ["derive"] }
 pretty_assertions = "1.4"
 rand_chacha = "0.9"
 tokio = { version = "1", features = [
@@ -153,6 +144,13 @@ tokio = { version = "1", features = [
 serde_json = "1"
 iroh-relay = { path = "../iroh-relay", default-features = false, features = ["test-utils", "server"] }
 tracing-test = "0.2.5"
+clap = { version = "4", features = ["derive"] }
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter",
+] }
+indicatif = { version = "0.18", features = ["tokio"] }
+parse-size = { version = "=1.0.0", features = ['std'] } # pinned version to avoid bumping msrv to 1.81
+iroh-base = { version = "0.92.0", default-features = false, features = ["key", "relay", "ticket"], path = "../iroh-base" }
 
 # wasm-in-browser test/dev dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
@@ -168,13 +166,6 @@ metrics = ["iroh-metrics/metrics", "iroh-relay/metrics", "portmapper/metrics"]
 test-utils = ["iroh-relay/test-utils", "iroh-relay/server", "dep:axum"]
 discovery-local-network = ["dep:swarm-discovery"]
 discovery-pkarr-dht = ["pkarr/dht"]
-examples = [
-  "dep:clap",
-  "dep:tracing-subscriber",
-  "dep:indicatif",
-  "dep:parse-size",
-  "iroh-base/ticket"
-]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -186,19 +177,19 @@ path = "tests/integration.rs"
 
 [[example]]
 name = "listen"
-required-features = ["examples"]
+required-features = []
 
 [[example]]
 name = "connect"
-required-features = ["examples"]
+required-features = []
 
 [[example]]
 name = "listen-unreliable"
-required-features = ["examples"]
+required-features = []
 
 [[example]]
 name = "connect-unreliable"
-required-features = ["examples"]
+required-features = []
 
 [[example]]
 name = "dht_discovery"
@@ -210,20 +201,20 @@ required-features = ["discovery-local-network"]
 
 [[example]]
 name = "search"
-required-features = ["examples"]
+required-features = []
 
 [[example]]
 name = "echo"
-required-features = ["examples"]
+required-features = []
 
 [[example]]
 name = "echo-no-router"
-required-features = ["examples"]
+required-features = []
 
 [[example]]
 name = "transfer"
-required-features = ["examples"]
+required-features = []
 
 [[example]]
 name = "0rtt"
-required-features = ["examples"]
+required-features = []


### PR DESCRIPTION

## Description

Move examples deps to non-wasm dev deps

This makes it possible to run most examples without the --features examples feature flag.

## Breaking Changes

Feature `examples` was removed

## Notes & open questions

Q: Should we do the same for the remaining examples? Can we?

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
