### PR TITLE
docs: fix docs.rs docs generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-02-20
+          toolchain: nightly-2025-10-09
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2025-02-20
+        toolchain: nightly-2025-10-09
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.9
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ missing_debug_implementations = "warn"
 # feature in any dependencies, because some indirect dependencies
 # require a feature enabled when using `--cfg docsrs` which we can not
 # do.  To enable for a crate set `#![cfg_attr(iroh_docsrs,
-# feature(doc_auto_cfg))]` in the crate.
+# feature(doc_cfg))]` in the crate.
 # We also have our own `iroh_loom` cfg to enable tokio-rs/loom testing.
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_loom)"] }
 

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -1,5 +1,5 @@
 //! Base types and utilities for Iroh
-#![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 

--- a/iroh-base/src/ticket/node.rs
+++ b/iroh-base/src/ticket/node.rs
@@ -27,6 +27,7 @@ use crate::{
 /// [`NodeId`]: crate::key::NodeId
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
+/// ['RelayUrl`]: crate::relay_url::RelayUrl
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
 #[display("{}", Ticket::serialize(self))]
 pub struct NodeTicket {

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -26,7 +26,7 @@
 //!   QAD support and expose metrics.
 // Based on tailscale/derp/derp.go
 
-#![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -89,12 +89,12 @@ pub enum DecodingError {
 pub trait NodeIdExt {
     /// Encodes a [`NodeId`] in [`z-base-32`] encoding.
     ///
-    /// [z-base-32]: https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
+    /// [`z-base-32`]: https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
     fn to_z32(&self) -> String;
 
     /// Parses a [`NodeId`] from [`z-base-32`] encoding.
     ///
-    /// [z-base-32]: https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
+    /// [`z-base-32`]: https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
     fn from_z32(s: &str) -> Result<NodeId, DecodingError>;
 }
 

--- a/iroh/src/discovery/dns.rs
+++ b/iroh/src/discovery/dns.rs
@@ -32,7 +32,7 @@ pub(crate) const DNS_STAGGERING_MS: &[u64] = &[200, 300];
 /// The DNS resolver defaults to using the nameservers configured on the host system, but can be changed
 /// with [`crate::endpoint::Builder::dns_resolver`].
 ///
-/// [z-base-32]: https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
+/// [`z-base-32`]: https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
 /// [`Endpoint`]: crate::Endpoint
 #[derive(Debug)]
 pub struct DnsDiscovery {

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -250,7 +250,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(wasm_browser, allow(unused))]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
-#![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 
 mod disco;
 mod key;

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -5,7 +5,7 @@
 //! etc and reachability to the configured relays.
 // Based on <https://github.com/tailscale/tailscale/blob/main/net/netcheck/netcheck.go>
 
-#![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 #![cfg_attr(wasm_browser, allow(unused))]


### PR DESCRIPTION
## Description

Try to fix docs.rs docs generation

- fix some links
- replace doc_auto_cfg with doc_cfg as instructed by the failed docs.rs run

[INFO] [stderr] 253 | #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
[INFO] [stderr]     |                                  ^^^^^^^^^^^^ feature has been removed
[INFO] [stderr]     |
[INFO] [stderr]     = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
[INFO] [stderr]     = note: merged into `doc_cfg`

## Breaking Changes

None

## Notes & open questions

Not sure how to test this.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
