### PR TITLE
feat(iroh)!: allow dynamic changing of the `RelayMap` of an endpoint

### DIFF
--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -440,7 +440,8 @@ impl Client {
         let mut v6_buf = JoinSet::new();
         let cancel_v6 = CancellationToken::new();
 
-        for relay_node in self.relay_map.nodes().take(MAX_RELAYS) {
+        let nodes = self.relay_map.nodes::<Vec<_>>();
+        for relay_node in nodes.into_iter().take(MAX_RELAYS) {
             if if_state.have_v4 && needs_v4_probe {
                 debug!(?relay_node.url, "v4 QAD probe");
                 let ip_mapped_addrs = self.socket_state.ip_mapped_addrs.clone();

--- a/iroh/src/net_report/probes.rs
+++ b/iroh/src/net_report/probes.rs
@@ -101,7 +101,7 @@ impl ProbePlan {
     pub(super) fn initial(relay_map: &RelayMap, protocols: &BTreeSet<Probe>) -> Self {
         let mut plan = Self::default();
 
-        for relay_node in relay_map.nodes() {
+        for relay_node in relay_map.nodes::<Vec<_>>() {
             let mut https_probes = ProbeSet::new(Probe::Https);
 
             for attempt in 0u32..3 {
@@ -194,8 +194,8 @@ mod tests {
     #[tokio::test]
     async fn test_initial_probeplan() {
         let (_servers, relay_map) = test_utils::relay_map(2).await;
-        let relay_node_1 = relay_map.nodes().next().unwrap();
-        let relay_node_2 = relay_map.nodes().nth(1).unwrap();
+        let relay_node_1 = &relay_map.nodes::<Vec<_>>()[0];
+        let relay_node_2 = &relay_map.nodes::<Vec<_>>()[1];
         let plan = ProbePlan::initial(&relay_map, &default_protocols());
 
         let expected_plan: ProbePlan = [
@@ -234,8 +234,8 @@ mod tests {
     #[tokio::test]
     async fn test_initial_probeplan_some_protocols() {
         let (_servers, relay_map) = test_utils::relay_map(2).await;
-        let relay_node_1 = relay_map.nodes().next().unwrap();
-        let relay_node_2 = relay_map.nodes().nth(1).unwrap();
+        let relay_node_1 = &relay_map.nodes::<Vec<_>>()[0];
+        let relay_node_2 = &relay_map.nodes::<Vec<_>>()[1];
         let plan = ProbePlan::initial(&relay_map, &BTreeSet::from([Probe::Https]));
 
         let expected_plan: ProbePlan = [

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -566,7 +566,7 @@ async fn check_captive_portal(
     let url = match preferred_relay {
         Some(url) => url,
         None => {
-            let urls: Vec<_> = dm.nodes().map(|n| n.url.clone()).collect();
+            let urls: Vec<_> = dm.urls();
             if urls.is_empty() {
                 debug!("No suitable relay node for captive portal check");
                 return Ok(false);


### PR DESCRIPTION
## Description

Closes #3471

## Breaking Changes

- added
  - `iroh::Endpoint::insert_relay`
  - `iroh::Endpoint::remove_relay`
  - `iroh::Endpoint::RelayMap::insert`
  - `iroh::Endpoint::RelayMap::remove`
- changed 
  - `iroh_relay::RelayMap::urls` 
  - `iroh_relay::RelayMap::nodes`
  - `iroh_relay::RelayMap::get_node`


## Notes & open questions

- Are the changes to the API of `RelayMap` acceptable?
- Is this enough? 

