### PR TITLE
feat(iroh): introduce endpoint presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Install it using `cargo add iroh`, then on the connecting side:
 ```rs
 const ALPN: &[u8] = b"iroh-example/echo/0";
 
-let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+let endpoint = Endpoint::bind().await?;
 
 // Open a connection to the accepting endpoint
 let conn = endpoint.connect(addr, ALPN).await?;
@@ -85,7 +85,7 @@ endpoint.close().await;
 
 And on the accepting side:
 ```rs
-let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+let endpoint = Endpoint::bind().await?;
 
 let router = Router::builder(endpoint)
     .accept(ALPN.to_vec(), Arc::new(Echo))

--- a/iroh/examples/echo-no-router.rs
+++ b/iroh/examples/echo-no-router.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
 }
 
 async fn connect_side(addr: EndpointAddr) -> Result<()> {
-    let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+    let endpoint = Endpoint::bind().await?;
 
     // Open a connection to the accepting endpoint
     let conn = endpoint.connect(addr, ALPN).await?;
@@ -68,7 +68,6 @@ async fn connect_side(addr: EndpointAddr) -> Result<()> {
 
 async fn start_accept_side() -> Result<Endpoint> {
     let endpoint = Endpoint::builder()
-        .discovery_n0()
         // The accept side needs to opt-in to the protocols it accepts,
         // as any connection attempts that can't be found with a matching ALPN
         // will be rejected.

--- a/iroh/examples/echo.rs
+++ b/iroh/examples/echo.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
 }
 
 async fn connect_side(addr: EndpointAddr) -> Result<()> {
-    let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+    let endpoint = Endpoint::bind().await?;
 
     // Open a connection to the accepting endpoint
     let conn = endpoint.connect(addr, ALPN).await?;
@@ -68,7 +68,7 @@ async fn connect_side(addr: EndpointAddr) -> Result<()> {
 }
 
 async fn start_accept_side() -> Result<Router> {
-    let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+    let endpoint = Endpoint::bind().await?;
 
     // Build our protocol handler and add our protocol, identified by its ALPN, and spawn the endpoint.
     let router = Router::builder(endpoint).accept(ALPN, Echo).spawn();

--- a/iroh/examples/locally-discovered-nodes.rs
+++ b/iroh/examples/locally-discovered-nodes.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     println!("Discovering Local Endpoints Example!");
 
-    let ep = Endpoint::builder().bind().await?;
+    let ep = Endpoint::bind().await?;
     let endpoint_id = ep.id();
 
     let mdns = MdnsDiscovery::builder().build(endpoint_id)?;
@@ -68,7 +68,8 @@ async fn main() -> Result<()> {
     for _ in 0..endpoint_count {
         let ud = user_data.clone();
         set.spawn(async move {
-            let ep = Endpoint::builder().discovery_local_network().bind().await?;
+            let ep = Endpoint::bind().await?;
+            ep.discovery().add(MdnsDiscovery::builder().build(ep.id())?);
             ep.set_user_data_for_discovery(Some(ud));
             tokio::time::sleep(Duration::from_secs(3)).await;
             ep.close().await;

--- a/iroh/examples/screening-connection.rs
+++ b/iroh/examples/screening-connection.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
 }
 
 async fn connect_side(addr: &EndpointAddr) -> Result<()> {
-    let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+    let endpoint = Endpoint::bind().await?;
 
     // Open a connection to the accepting endpoint
     let conn = endpoint.connect(addr.clone(), ALPN).await?;
@@ -79,7 +79,7 @@ async fn connect_side(addr: &EndpointAddr) -> Result<()> {
 }
 
 async fn start_accept_side() -> Result<Router> {
-    let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+    let endpoint = Endpoint::bind().await?;
 
     let echo = ScreenedEcho {
         conn_attempt_count: Arc::new(AtomicU64::new(0)),

--- a/iroh/examples/search.rs
+++ b/iroh/examples/search.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
     let args = Cli::parse();
 
     // Build an endpoint
-    let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+    let endpoint = Endpoint::bind().await?;
 
     // Build our protocol handler. The `builder` exposes access to various subsystems in the
     // iroh endpoint. In our case, we need a blobs client and the endpoint.

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -448,7 +448,7 @@ impl ConcurrentDiscovery {
         self.services.read().expect("poisoned").is_empty()
     }
 
-    /// How many services are configured?
+    /// Returns the number of services configured.
     pub fn len(&self) -> usize {
         self.services.read().expect("poisoned").len()
     }

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -62,12 +62,14 @@
 //! use iroh::{
 //!     Endpoint, SecretKey,
 //!     discovery::{dns::DnsDiscovery, pkarr::PkarrPublisher},
+//!     endpoint::RelayMode,
 //! };
 //!
 //! # async fn wrapper() -> n0_snafu::Result<()> {
 //! let ep = Endpoint::empty_builder()
 //!     .discovery(PkarrPublisher::n0_dns())
 //!     .discovery(DnsDiscovery::n0_dns())
+//!     .relay_mode(RelayMode::Default)
 //!     .bind()
 //!     .await?;
 //! # Ok(())
@@ -81,6 +83,7 @@
 //! # {
 //! # use iroh::{
 //! #    discovery::{dns::DnsDiscovery, pkarr::PkarrPublisher, mdns::MdnsDiscovery},
+//! #    endpoint::RelayMode,
 //! #    Endpoint, SecretKey,
 //! # };
 //! #
@@ -89,6 +92,7 @@
 //!     .discovery(PkarrPublisher::n0_dns())
 //!     .discovery(DnsDiscovery::n0_dns())
 //!     .discovery(MdnsDiscovery::builder())
+//!     .relay_mode(RelayMode::Default)
 //!     .bind()
 //!     .await?;
 //! # Ok(())

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -66,10 +66,9 @@
 //! };
 //!
 //! # async fn wrapper() -> n0_snafu::Result<()> {
-//! let ep = Endpoint::empty_builder()
+//! let ep = Endpoint::empty_builder(RelayMode::Default)
 //!     .discovery(PkarrPublisher::n0_dns())
 //!     .discovery(DnsDiscovery::n0_dns())
-//!     .relay_mode(RelayMode::Default)
 //!     .bind()
 //!     .await?;
 //! # Ok(())
@@ -88,11 +87,10 @@
 //! # };
 //! #
 //! # async fn wrapper() -> n0_snafu::Result<()> {
-//! let ep = Endpoint::empty_builder()
+//! let ep = Endpoint::empty_builder(RelayMode::Default)
 //!     .discovery(PkarrPublisher::n0_dns())
 //!     .discovery(DnsDiscovery::n0_dns())
 //!     .discovery(MdnsDiscovery::builder())
-//!     .relay_mode(RelayMode::Default)
 //!     .bind()
 //!     .await?;
 //! # Ok(())
@@ -916,9 +914,8 @@ mod tests {
     ) -> (Endpoint, AbortOnDropHandle<Result<()>>) {
         let secret = SecretKey::generate(rng);
 
-        let ep = Endpoint::empty_builder()
+        let ep = Endpoint::empty_builder(RelayMode::Disabled)
             .secret_key(secret)
-            .relay_mode(RelayMode::Disabled)
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
             .await
@@ -1080,8 +1077,7 @@ mod test_dns_pkarr {
         dns_pkarr_server: &DnsPkarrServer,
     ) -> Result<(Endpoint, AbortOnDropHandle<Result<()>>)> {
         let secret_key = SecretKey::generate(rng);
-        let ep = Endpoint::empty_builder()
-            .relay_mode(RelayMode::Custom(relay_map.clone()))
+        let ep = Endpoint::empty_builder(RelayMode::Custom(relay_map.clone()))
             .insecure_skip_relay_cert_verify(true)
             .secret_key(secret_key.clone())
             .alpns(vec![TEST_ALPN.to_vec()])

--- a/iroh/src/discovery/dns.rs
+++ b/iroh/src/discovery/dns.rs
@@ -5,8 +5,9 @@ use iroh_relay::dns::DnsResolver;
 pub use iroh_relay::dns::{N0_DNS_ENDPOINT_ORIGIN_PROD, N0_DNS_ENDPOINT_ORIGIN_STAGING};
 use n0_future::boxed::BoxStream;
 
-use super::{DiscoveryContext, DiscoveryError, IntoDiscovery, IntoDiscoveryError};
+use super::{DiscoveryError, IntoDiscovery, IntoDiscoveryError};
 use crate::{
+    Endpoint,
     discovery::{Discovery, DiscoveryItem},
     endpoint::force_staging_infra,
 };
@@ -93,12 +94,9 @@ impl DnsDiscovery {
 }
 
 impl IntoDiscovery for DnsDiscoveryBuilder {
-    fn into_discovery(
-        mut self,
-        context: &DiscoveryContext,
-    ) -> Result<impl Discovery, IntoDiscoveryError> {
+    fn into_discovery(mut self, endpoint: &Endpoint) -> Result<impl Discovery, IntoDiscoveryError> {
         if self.dns_resolver.is_none() {
-            self.dns_resolver = Some(context.dns_resolver().clone());
+            self.dns_resolver = Some(endpoint.dns_resolver().clone());
         }
         Ok(self.build())
     }

--- a/iroh/src/discovery/mdns.rs
+++ b/iroh/src/discovery/mdns.rs
@@ -9,7 +9,7 @@
 //! use std::time::Duration;
 //!
 //! use iroh::{
-//!     SecretKey,
+//!     RelayMode, SecretKey,
 //!     discovery::mdns::{DiscoveryEvent, MdnsDiscovery},
 //!     endpoint::{Endpoint, Source},
 //! };
@@ -18,7 +18,10 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let recent = Duration::from_secs(600); // 10 minutes in seconds
-//!     let endpoint = Endpoint::empty_builder().bind().await.unwrap();
+//!     let endpoint = Endpoint::empty_builder(RelayMode::Disabled)
+//!         .bind()
+//!         .await
+//!         .unwrap();
 //!
 //!     // Register the discovery services with the endpoint
 //!     let mdns = MdnsDiscovery::builder().build(endpoint.id()).unwrap();

--- a/iroh/src/discovery/mdns.rs
+++ b/iroh/src/discovery/mdns.rs
@@ -18,7 +18,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let recent = Duration::from_secs(600); // 10 minutes in seconds
-//!     let endpoint = Endpoint::builder().bind().await.unwrap();
+//!     let endpoint = Endpoint::bind().await.unwrap();
 //!
 //!     // Register the discovery services with the endpoint
 //!     let mdns = MdnsDiscovery::builder().build(endpoint.id()).unwrap();
@@ -57,8 +57,11 @@ use swarm_discovery::{Discoverer, DropGuard, IpClass, Peer};
 use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{Instrument, debug, error, info_span, trace, warn};
 
-use super::{DiscoveryContext, DiscoveryError, IntoDiscovery, IntoDiscoveryError};
-use crate::discovery::{Discovery, DiscoveryItem, EndpointData, EndpointInfo};
+use super::{DiscoveryError, IntoDiscovery, IntoDiscoveryError};
+use crate::{
+    Endpoint,
+    discovery::{Discovery, DiscoveryItem, EndpointData, EndpointInfo},
+};
 
 /// The n0 local service name
 const N0_SERVICE_NAME: &str = "irohv1";
@@ -195,11 +198,8 @@ impl Default for MdnsDiscoveryBuilder {
 }
 
 impl IntoDiscovery for MdnsDiscoveryBuilder {
-    fn into_discovery(
-        self,
-        context: &DiscoveryContext,
-    ) -> Result<impl Discovery, IntoDiscoveryError> {
-        self.build(context.endpoint_id())
+    fn into_discovery(self, endpoint: &Endpoint) -> Result<impl Discovery, IntoDiscoveryError> {
+        self.build(endpoint.id())
     }
 }
 

--- a/iroh/src/discovery/mdns.rs
+++ b/iroh/src/discovery/mdns.rs
@@ -18,7 +18,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let recent = Duration::from_secs(600); // 10 minutes in seconds
-//!     let endpoint = Endpoint::bind().await.unwrap();
+//!     let endpoint = Endpoint::empty_builder().bind().await.unwrap();
 //!
 //!     // Register the discovery services with the endpoint
 //!     let mdns = MdnsDiscovery::builder().build(endpoint.id()).unwrap();

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -337,14 +337,12 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::Endpoint;
 
     #[tokio::test]
     #[ignore = "flaky"]
     #[traced_test]
     async fn dht_discovery_smoke() -> Result {
-        let ep = Endpoint::bind().await?;
-        let secret = ep.secret_key().clone();
+        let secret = SecretKey::generate(&mut rand::rng());
         let testnet = pkarr::mainline::Testnet::new_async(3).await.e()?;
         let client = pkarr::Client::builder()
             .dht(|builder| builder.bootstrap(&testnet.bootstrap))

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -18,9 +18,9 @@ use pkarr::{Client as PkarrClient, SignedPacket};
 use url::Url;
 
 use crate::{
+    Endpoint,
     discovery::{
-        Discovery, DiscoveryContext, DiscoveryError, DiscoveryItem, EndpointData, IntoDiscovery,
-        IntoDiscoveryError,
+        Discovery, DiscoveryError, DiscoveryItem, EndpointData, IntoDiscovery, IntoDiscoveryError,
         pkarr::{DEFAULT_PKARR_TTL, N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING},
     },
     endpoint_info::EndpointInfo,
@@ -241,11 +241,8 @@ impl Builder {
 }
 
 impl IntoDiscovery for Builder {
-    fn into_discovery(
-        self,
-        context: &DiscoveryContext,
-    ) -> Result<impl Discovery, IntoDiscoveryError> {
-        self.secret_key(context.secret_key().clone()).build()
+    fn into_discovery(self, endpoint: &Endpoint) -> Result<impl Discovery, IntoDiscoveryError> {
+        self.secret_key(endpoint.secret_key().clone()).build()
     }
 }
 
@@ -346,7 +343,7 @@ mod tests {
     #[ignore = "flaky"]
     #[traced_test]
     async fn dht_discovery_smoke() -> Result {
-        let ep = Endpoint::builder().bind().await?;
+        let ep = Endpoint::bind().await?;
         let secret = ep.secret_key().clone();
         let testnet = pkarr::mainline::Testnet::new_async(3).await.e()?;
         let client = pkarr::Client::builder()

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -46,7 +46,7 @@ use super::{Discovery, DiscoveryError, DiscoveryItem, EndpointData, EndpointInfo
 /// let discovery = StaticProvider::new();
 ///
 /// let _ep = Endpoint::builder()
-///     .add_discovery(discovery.clone())
+///     .discovery(discovery.clone())
 ///     .bind()
 ///     .await?;
 ///
@@ -133,7 +133,7 @@ impl StaticProvider {
     /// // create a StaticProvider from the list of addrs.
     /// let discovery = StaticProvider::from_endpoint_info(addrs);
     /// // create an endpoint with the discovery
-    /// let endpoint = Endpoint::builder().add_discovery(discovery).bind().await?;
+    /// let endpoint = Endpoint::builder().discovery(discovery).bind().await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -245,7 +245,7 @@ mod tests {
         let discovery = StaticProvider::new();
 
         let _ep = Endpoint::builder()
-            .add_discovery(discovery.clone())
+            .discovery(discovery.clone())
             .bind()
             .await?;
 

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -238,13 +238,13 @@ mod tests {
     use n0_snafu::{Result, ResultExt};
 
     use super::*;
-    use crate::Endpoint;
+    use crate::{Endpoint, RelayMode};
 
     #[tokio::test]
     async fn test_basic() -> Result {
         let discovery = StaticProvider::new();
 
-        let _ep = Endpoint::empty_builder()
+        let _ep = Endpoint::empty_builder(RelayMode::Disabled)
             .discovery(discovery.clone())
             .bind()
             .await?;

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -244,7 +244,7 @@ mod tests {
     async fn test_basic() -> Result {
         let discovery = StaticProvider::new();
 
-        let _ep = Endpoint::builder()
+        let _ep = Endpoint::empty_builder()
             .discovery(discovery.clone())
             .bind()
             .await?;

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -34,18 +34,20 @@ use url::Url;
 #[cfg(wasm_browser)]
 use crate::discovery::pkarr::PkarrResolver;
 #[cfg(not(wasm_browser))]
-use crate::{discovery::dns::DnsDiscovery, dns::DnsResolver};
+use crate::dns::DnsResolver;
 use crate::{
     discovery::{
         ConcurrentDiscovery, DiscoveryError, DiscoveryTask, DynIntoDiscovery, IntoDiscovery,
-        UserData, pkarr::PkarrPublisher,
+        UserData,
     },
+    endpoint::presets::Preset,
     magicsock::{self, EndpointIdMappedAddr, Handle, OwnAddressSnafu},
     metrics::EndpointMetrics,
     net_report::Report,
     tls::{self, DEFAULT_MAX_TLS_TICKETS},
 };
 
+pub mod presets;
 mod rtt_actor;
 
 // Missing still: SendDatagram and ConnectionClose::frame_type's Type.
@@ -117,13 +119,31 @@ pub struct Builder {
     max_tls_tickets: usize,
 }
 
-impl Default for Builder {
-    fn default() -> Self {
+impl Builder {
+    // The ordering of public methods is reflected directly in the documentation.  This is
+    // roughly ordered by what is most commonly needed by users.
+
+    /// Creates a new [`Builder`] using the given [`Preset`].
+    ///
+    /// See [`presets`] for more.
+    pub fn new<P: Preset>(preset: P) -> Self {
+        Self::empty().preset(preset)
+    }
+
+    /// Applies the given [`Preset`].
+    pub fn preset<P: Preset>(mut self, preset: P) -> Self {
+        self = preset.apply(self);
+        self
+    }
+
+    /// Creates an empty builder, which means there are no relays
+    /// and no discovery services configured.
+    pub fn empty() -> Self {
         let mut transport_config = quinn::TransportConfig::default();
         transport_config.keep_alive_interval(Some(Duration::from_secs(1)));
         Self {
             secret_key: Default::default(),
-            relay_mode: default_relay_mode(),
+            relay_mode: RelayMode::Disabled,
             alpn_protocols: Default::default(),
             transport_config,
             keylog: Default::default(),
@@ -141,11 +161,6 @@ impl Default for Builder {
             max_tls_tickets: DEFAULT_MAX_TLS_TICKETS,
         }
     }
-}
-
-impl Builder {
-    // The ordering of public methods is reflected directly in the documentation.  This is
-    // roughly ordered by what is most commonly needed by users.
 
     // # The final constructor that everyone needs.
 
@@ -173,7 +188,6 @@ impl Builder {
             addr_v6: self.addr_v6,
             secret_key,
             relay_map,
-            discovery: self.discovery,
             discovery_user_data: self.discovery_user_data,
             proxy_url: self.proxy_url,
             #[cfg(not(wasm_browser))]
@@ -186,7 +200,24 @@ impl Builder {
             metrics,
         };
 
-        Endpoint::bind(static_config, msock_opts).await
+        let msock = magicsock::MagicSock::spawn(msock_opts).await?;
+        trace!("created magicsock");
+        debug!(version = env!("CARGO_PKG_VERSION"), "iroh Endpoint created");
+
+        let metrics = msock.metrics.magicsock.clone();
+        let ep = Endpoint {
+            msock,
+            rtt_actor: Arc::new(rtt_actor::RttHandle::new(metrics)),
+            static_config: Arc::new(static_config),
+        };
+
+        // Add discovery mechanisms
+        for create_service in self.discovery {
+            let service = create_service.into_discovery(&ep)?;
+            ep.discovery().add_boxed(service);
+        }
+
+        Ok(ep)
     }
 
     // # The very common methods everyone basically needs.
@@ -260,24 +291,13 @@ impl Builder {
     }
 
     /// Removes all discovery services from the builder.
-    pub fn clear_discovery(mut self) -> Self {
-        self.discovery.clear();
-        self
-    }
-
-    /// Optionally sets a discovery mechanism for this endpoint.
-    ///
-    /// If you want to combine multiple discovery services, you can use
-    /// [`Builder::add_discovery`] instead. This will internally create a
-    /// [`crate::discovery::ConcurrentDiscovery`].
     ///
     /// If no discovery service is set, connecting to an endpoint without providing its
     /// direct addresses or relay URLs will fail.
     ///
     /// See the documentation of the [`crate::discovery::Discovery`] trait for details.
-    pub fn discovery(mut self, discovery: impl IntoDiscovery) -> Self {
+    pub fn clear_discovery(mut self) -> Self {
         self.discovery.clear();
-        self.discovery.push(Box::new(discovery));
         self
     }
 
@@ -297,66 +317,12 @@ impl Builder {
     /// To clear all discovery services, use [`Builder::clear_discovery`].
     ///
     /// See the documentation of the [`crate::discovery::Discovery`] trait for details.
-    pub fn add_discovery(mut self, discovery: impl IntoDiscovery) -> Self {
+    pub fn discovery(mut self, discovery: impl IntoDiscovery) -> Self {
         self.discovery.push(Box::new(discovery));
         self
     }
 
-    /// Configures the endpoint to use the default n0 DNS discovery service.
-    ///
-    /// The default discovery service publishes to and resolves from the
-    /// n0.computer dns server `iroh.link`.
-    ///
-    /// This is equivalent to adding both a [`crate::discovery::pkarr::PkarrPublisher`]
-    /// and a [`crate::discovery::dns::DnsDiscovery`], both configured to use the
-    /// n0.computer dns server.
-    ///
-    /// This will by default use [`N0_DNS_PKARR_RELAY_PROD`].
-    /// When in tests, or when the `test-utils` feature is enabled, this will use the
-    /// [`N0_DNS_PKARR_RELAY_STAGING`].
-    ///
-    /// [`N0_DNS_PKARR_RELAY_PROD`]: crate::discovery::pkarr::N0_DNS_PKARR_RELAY_PROD
-    /// [`N0_DNS_PKARR_RELAY_STAGING`]: crate::discovery::pkarr::N0_DNS_PKARR_RELAY_STAGING
-    pub fn discovery_n0(mut self) -> Self {
-        self = self.add_discovery(PkarrPublisher::n0_dns());
-        // Resolve using HTTPS requests to our DNS server's /pkarr path in browsers
-        #[cfg(wasm_browser)]
-        {
-            self = self.add_discovery(PkarrResolver::n0_dns());
-        }
-        // Resolve using DNS queries outside browsers.
-        #[cfg(not(wasm_browser))]
-        {
-            self = self.add_discovery(DnsDiscovery::n0_dns());
-        }
-        self
-    }
-
-    #[cfg(feature = "discovery-pkarr-dht")]
-    /// Configures the endpoint to also use the mainline DHT with default settings.
-    ///
-    /// This is equivalent to adding a [`crate::discovery::pkarr::dht::DhtDiscovery`]
-    /// with default settings. Note that DhtDiscovery has various more advanced
-    /// configuration options. If you need any of those, you should manually
-    /// create a DhtDiscovery and add it with [`Builder::add_discovery`].
-    pub fn discovery_dht(mut self) -> Self {
-        self = self.add_discovery(crate::discovery::pkarr::dht::DhtDiscovery::builder());
-        self
-    }
-
-    #[cfg(feature = "discovery-local-network")]
-    /// Configures the endpoint to also use local network discovery.
-    ///
-    /// This is equivalent to adding a [`crate::discovery::mdns::MdnsDiscovery`]
-    /// with default settings. Note that MdnsDiscovery has various more advanced
-    /// configuration options. If you need any of those, you should manually
-    /// create a MdnsDiscovery and add it with [`Builder::add_discovery`].
-    pub fn discovery_local_network(mut self) -> Self {
-        self = self.add_discovery(crate::discovery::mdns::MdnsDiscovery::builder());
-        self
-    }
-
-    /// Sets the initial user-defined data to be published in discovery services for this endpoint.
+    /// Sets the initial user-defined data to be published in discovery services for this node.
     ///
     /// When using discovery services, this string of [`UserData`] will be published together
     /// with the endpoint's addresses and relay URL. When other endpoints discover this endpoint,
@@ -569,6 +535,10 @@ pub enum BindError {
     MagicSpawn {
         source: magicsock::CreateHandleError,
     },
+    #[snafu(transparent)]
+    Discovery {
+        source: crate::discovery::IntoDiscoveryError,
+    },
 }
 
 #[allow(missing_docs)]
@@ -597,30 +567,24 @@ impl Endpoint {
     // # Methods relating to construction.
 
     /// Returns the builder for an [`Endpoint`], with a production configuration.
+    ///
+    /// This uses the [`presets::N0`] as the configuration.
     pub fn builder() -> Builder {
-        Builder::default()
+        Builder::new(presets::N0)
     }
 
-    /// Creates a quinn endpoint backed by a magicsock.
+    /// Returns the builder for an [`Endpoint`], with an empty configuration.
     ///
-    /// This is for internal use, the public interface is the [`Builder`] obtained from
-    /// [Self::builder]. See the methods on the builder for documentation of the parameters.
-    #[instrument("ep", skip_all, fields(me = %static_config.tls_config.secret_key.public().fmt_short()))]
-    async fn bind(
-        static_config: StaticConfig,
-        msock_opts: magicsock::Options,
-    ) -> Result<Self, BindError> {
-        let msock = magicsock::MagicSock::spawn(msock_opts).await?;
-        trace!("created magicsock");
-        debug!(version = env!("CARGO_PKG_VERSION"), "iroh Endpoint created");
+    /// See [`Builder::empty`] for details.
+    pub fn empty_builder() -> Builder {
+        Builder::empty()
+    }
 
-        let metrics = msock.metrics.magicsock.clone();
-        let ep = Self {
-            msock,
-            rtt_actor: Arc::new(rtt_actor::RttHandle::new(metrics)),
-            static_config: Arc::new(static_config),
-        };
-        Ok(ep)
+    /// Constructs a default [`Endpoint`] and binds it immediately.
+    ///
+    /// Uses the [`presets::N0`] as configuration.
+    pub async fn bind() -> Result<Self, BindError> {
+        Self::builder().bind().await
     }
 
     /// Sets the list of accepted ALPN protocols.
@@ -987,7 +951,7 @@ impl Endpoint {
     ///
     /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
     /// # rt.block_on(async move {
-    /// let ep = Endpoint::builder().bind().await.unwrap();
+    /// let ep = Endpoint::bind().await.unwrap();
     /// let _report = ep.net_report().initialized().await;
     /// # });
     /// ```
@@ -1071,7 +1035,7 @@ impl Endpoint {
     /// # use std::collections::BTreeMap;
     /// # use iroh::endpoint::Endpoint;
     /// # async fn wrapper() -> n0_snafu::Result {
-    /// let endpoint = Endpoint::builder().bind().await?;
+    /// let endpoint = Endpoint::bind().await?;
     /// assert_eq!(endpoint.metrics().magicsock.recv_datagrams.get(), 0);
     /// # Ok(())
     /// # }
@@ -1089,7 +1053,7 @@ impl Endpoint {
     /// # use iroh_metrics::{Metric, MetricsGroup, MetricValue, MetricsGroupSet};
     /// # use iroh::endpoint::Endpoint;
     /// # async fn wrapper() -> n0_snafu::Result {
-    /// let endpoint = Endpoint::builder().bind().await?;
+    /// let endpoint = Endpoint::bind().await?;
     /// let metrics: BTreeMap<String, MetricValue> = endpoint
     ///     .metrics()
     ///     .iter()
@@ -1112,7 +1076,7 @@ impl Endpoint {
     /// # use iroh_metrics::{Registry, MetricsSource};
     /// # use iroh::endpoint::Endpoint;
     /// # async fn wrapper() -> n0_snafu::Result {
-    /// let endpoint = Endpoint::builder().bind().await?;
+    /// let endpoint = Endpoint::bind().await?;
     /// let mut registry = Registry::default();
     /// registry.register_all(endpoint.metrics());
     /// let s = registry.encode_openmetrics_to_string()?;
@@ -1149,7 +1113,7 @@ impl Endpoint {
     /// });
     ///
     /// // Spawn an endpoint and add the metrics to the registry.
-    /// let endpoint = Endpoint::builder().bind().await?;
+    /// let endpoint = Endpoint::bind().await?;
     /// registry.write().unwrap().register_all(endpoint.metrics());
     ///
     /// // Wait for the metrics server to bind, then fetch the metrics via HTTP.
@@ -2190,7 +2154,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_connect_self() -> Result {
-        let ep = Endpoint::builder()
+        let ep = Endpoint::empty_builder()
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
             .await
@@ -2212,7 +2176,7 @@ mod tests {
         let server_peer_id = server_secret_key.public();
 
         // Wait for the endpoint to be started to make sure it's up before clients try to connect
-        let ep = Endpoint::builder()
+        let ep = Endpoint::empty_builder()
             .secret_key(server_secret_key)
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map.clone()))
@@ -2252,7 +2216,7 @@ mod tests {
 
         let client = tokio::spawn(
             async move {
-                let ep = Endpoint::builder()
+                let ep = Endpoint::empty_builder()
                     .alpns(vec![TEST_ALPN.to_vec()])
                     .relay_mode(RelayMode::Custom(relay_map))
                     .insecure_skip_relay_cert_verify(true)
@@ -2312,7 +2276,7 @@ mod tests {
         let server_endpoint_id = server_secret_key.public();
 
         // Make sure the server is bound before having clients connect to it:
-        let ep = Endpoint::builder()
+        let ep = Endpoint::empty_builder()
             .insecure_skip_relay_cert_verify(true)
             .secret_key(server_secret_key)
             .alpns(vec![TEST_ALPN.to_vec()])
@@ -2361,7 +2325,7 @@ mod tests {
             let client_secret_key = SecretKey::generate(&mut rng);
             async {
                 info!("client binding");
-                let ep = Endpoint::builder()
+                let ep = Endpoint::empty_builder()
                     .alpns(vec![TEST_ALPN.to_vec()])
                     .insecure_skip_relay_cert_verify(true)
                     .relay_mode(RelayMode::Custom(relay_map.clone()))
@@ -2412,7 +2376,7 @@ mod tests {
     #[traced_test]
     async fn endpoint_send_relay() -> Result {
         let (relay_map, _relay_url, _guard) = run_relay_server().await?;
-        let client = Endpoint::builder()
+        let client = Endpoint::empty_builder()
             .insecure_skip_relay_cert_verify(true)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .bind()
@@ -2572,14 +2536,14 @@ mod tests {
     #[traced_test]
     async fn endpoint_bidi_send_recv() -> Result {
         let disco = StaticProvider::new();
-        let ep1 = Endpoint::builder()
+        let ep1 = Endpoint::empty_builder()
             .discovery(disco.clone())
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Disabled)
             .bind()
             .await?;
 
-        let ep2 = Endpoint::builder()
+        let ep2 = Endpoint::empty_builder()
             .discovery(disco.clone())
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Disabled)
@@ -2676,14 +2640,14 @@ mod tests {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
         let ep1_secret_key = SecretKey::generate(&mut rng);
         let ep2_secret_key = SecretKey::generate(&mut rng);
-        let ep1 = Endpoint::builder()
+        let ep1 = Endpoint::empty_builder()
             .secret_key(ep1_secret_key)
             .insecure_skip_relay_cert_verify(true)
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .bind()
             .await?;
-        let ep2 = Endpoint::builder()
+        let ep2 = Endpoint::empty_builder()
             .secret_key(ep2_secret_key)
             .insecure_skip_relay_cert_verify(true)
             .alpns(vec![TEST_ALPN.to_vec()])
@@ -2761,7 +2725,7 @@ mod tests {
     async fn test_direct_addresses_no_qad_relay() -> Result {
         let (relay_map, _, _guard) = run_relay_server_with(false).await.unwrap();
 
-        let ep = Endpoint::builder()
+        let ep = Endpoint::empty_builder()
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Custom(relay_map))
             .insecure_skip_relay_cert_verify(true)
@@ -2774,7 +2738,7 @@ mod tests {
     }
 
     async fn spawn_0rtt_server(secret_key: SecretKey, log_span: tracing::Span) -> Result<Endpoint> {
-        let server = Endpoint::builder()
+        let server = Endpoint::empty_builder()
             .secret_key(secret_key)
             .alpns(vec![TEST_ALPN.to_vec()])
             .relay_mode(RelayMode::Disabled)
@@ -2918,7 +2882,7 @@ mod tests {
     #[traced_test]
     async fn test_0rtt() -> Result {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
-        let client = Endpoint::builder()
+        let client = Endpoint::empty_builder()
             .relay_mode(RelayMode::Disabled)
             .bind()
             .await?;
@@ -2941,7 +2905,7 @@ mod tests {
     #[traced_test]
     async fn test_0rtt_non_consecutive() -> Result {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
-        let client = Endpoint::builder()
+        let client = Endpoint::empty_builder()
             .relay_mode(RelayMode::Disabled)
             .bind()
             .await?;
@@ -2969,7 +2933,7 @@ mod tests {
     #[traced_test]
     async fn test_0rtt_after_server_restart() -> Result {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
-        let client = Endpoint::builder()
+        let client = Endpoint::empty_builder()
             .relay_mode(RelayMode::Disabled)
             .bind()
             .await?;
@@ -2997,8 +2961,8 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn graceful_close() -> Result {
-        let client = Endpoint::builder().bind().await?;
-        let server = Endpoint::builder()
+        let client = Endpoint::bind().await?;
+        let server = Endpoint::empty_builder()
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
             .await?;
@@ -3040,13 +3004,13 @@ mod tests {
         use iroh_metrics::{MetricsSource, Registry};
 
         let secret_key = SecretKey::from_bytes(&[0u8; 32]);
-        let client = Endpoint::builder()
+        let client = Endpoint::empty_builder()
             .secret_key(secret_key)
             .relay_mode(RelayMode::Disabled)
             .bind()
             .await?;
         let secret_key = SecretKey::from_bytes(&[1u8; 32]);
-        let server = Endpoint::builder()
+        let server = Endpoint::empty_builder()
             .secret_key(secret_key)
             .relay_mode(RelayMode::Disabled)
             .alpns(vec![TEST_ALPN.to_vec()])
@@ -3104,11 +3068,11 @@ mod tests {
         primary_connect_alpn: &[u8],
         secondary_connect_alpns: Vec<Vec<u8>>,
     ) -> Result<Option<Vec<u8>>> {
-        let client = Endpoint::builder()
+        let client = Endpoint::empty_builder()
             .relay_mode(RelayMode::Disabled)
             .bind()
             .await?;
-        let server = Endpoint::builder()
+        let server = Endpoint::empty_builder()
             .relay_mode(RelayMode::Disabled)
             .alpns(accept_alpns)
             .bind()
@@ -3198,7 +3162,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn watch_net_report() -> Result {
-        let endpoint = Endpoint::builder()
+        let endpoint = Endpoint::empty_builder()
             .relay_mode(RelayMode::Staging)
             .bind()
             .await?;
@@ -3232,7 +3196,7 @@ mod tests {
         }
 
         async fn noop_server() -> Result<(Router, EndpointAddr)> {
-            let endpoint = Endpoint::builder()
+            let endpoint = Endpoint::empty_builder()
                 .relay_mode(RelayMode::Disabled)
                 .bind()
                 .await
@@ -3260,7 +3224,7 @@ mod tests {
             .map(|addr| addr.endpoint_id)
             .collect::<Vec<_>>();
         let discovery = StaticProvider::from_endpoint_info(addrs);
-        let endpoint = Endpoint::builder()
+        let endpoint = Endpoint::empty_builder()
             .relay_mode(RelayMode::Disabled)
             .discovery(discovery)
             .bind()

--- a/iroh/src/endpoint/presets.rs
+++ b/iroh/src/endpoint/presets.rs
@@ -4,9 +4,12 @@
 //!
 //! ```no_run
 //! # async fn wrapper() -> n0_snafu::Result {
-//! use iroh::{Endpoint, Watcher, endpoint::presets};
+//! use iroh::{Endpoint, RelayMode, Watcher, endpoint::presets};
 //!
-//! let endpoint = Endpoint::empty_builder().preset(presets::N0).bind().await?;
+//! let endpoint = Endpoint::empty_builder(RelayMode::Disabled)
+//!     .preset(presets::N0)
+//!     .bind()
+//!     .await?;
 //! # let _ = endpoint;
 //! # Ok(())
 //! # }

--- a/iroh/src/endpoint/presets.rs
+++ b/iroh/src/endpoint/presets.rs
@@ -1,0 +1,70 @@
+//! Presets allow configuring an endpoint quickly with a chosen set of defaults.
+//!
+//! # Example
+//!
+//! ```no_run
+//! # async fn wrapper() -> n0_snafu::Result {
+//! use iroh::{Endpoint, Watcher, endpoint::presets};
+//!
+//! let endpoint = Endpoint::empty_builder().preset(presets::N0).bind().await?;
+//! # let _ = endpoint;
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::{
+    discovery::pkarr::PkarrPublisher,
+    endpoint::{Builder, default_relay_mode},
+};
+
+/// Defines a preset
+pub trait Preset {
+    /// Applies the configuration to the passed in [`Builder`].
+    fn apply(self, builder: Builder) -> Builder;
+}
+
+/// Configures the endpoint to use the n0 defaults
+///
+/// Currently this consists of
+/// - the DNS discovery service.
+/// - the default relay servers provided by Number 0.
+///
+/// The default discovery service publishes to and resolves from the
+/// n0.computer dns server `iroh.link`.
+///
+/// This is equivalent to adding both a [`crate::discovery::pkarr::PkarrPublisher`]
+/// and a [`crate::discovery::dns::DnsDiscovery`], both configured to use the
+/// n0.computer dns server.
+///
+/// This will by default use [`N0_DNS_PKARR_RELAY_PROD`].
+/// When in tests, or when the `test-utils` feature is enabled, this will use the
+/// [`N0_DNS_PKARR_RELAY_STAGING`].
+///
+/// [`N0_DNS_PKARR_RELAY_PROD`]: crate::discovery::pkarr::N0_DNS_PKARR_RELAY_PROD
+/// [`N0_DNS_PKARR_RELAY_STAGING`]: crate::discovery::pkarr::N0_DNS_PKARR_RELAY_STAGING
+#[derive(Debug, Copy, Clone, Default)]
+pub struct N0;
+
+impl Preset for N0 {
+    fn apply(self, mut builder: Builder) -> Builder {
+        builder = builder.discovery(PkarrPublisher::n0_dns());
+        // Resolve using HTTPS requests to our DNS server's /pkarr path in browsers
+        #[cfg(wasm_browser)]
+        {
+            use crate::discovery::pkarr::PkarrResolver;
+
+            builder = builder.discovery(PkarrResolver::n0_dns());
+        }
+        // Resolve using DNS queries outside browsers.
+        #[cfg(not(wasm_browser))]
+        {
+            use crate::discovery::dns::DnsDiscovery;
+
+            builder = builder.discovery(DnsDiscovery::n0_dns());
+        }
+
+        builder = builder.relay_mode(default_relay_mode());
+
+        builder
+    }
+}

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -12,7 +12,7 @@
 //! # use n0_snafu::ResultExt;
 //! # async fn wrapper() -> n0_snafu::Result {
 //! let addr: EndpointAddr = todo!();
-//! let ep = Endpoint::builder().bind().await?;
+//! let ep = Endpoint::bind().await?;
 //! let conn = ep.connect(addr, b"my-alpn").await?;
 //! let mut send_stream = conn.open_uni().await.context("unable to open uni")?;
 //! send_stream
@@ -174,8 +174,8 @@
 //! use n0_snafu::{Result, ResultExt};
 //!
 //! async fn connect(addr: EndpointAddr) -> Result<()> {
-//!     // The Endpoint is the central object that manages an iroh endpoint.
-//!     let ep = Endpoint::builder().bind().await?;
+//!     // The Endpoint is the central object that manages an iroh node.
+//!     let ep = Endpoint::bind().await?;
 //!
 //!     // Establish a QUIC connection, open a bi-directional stream, exchange messages.
 //!     let conn = ep.connect(addr, b"hello-world").await?;

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2618,10 +2618,9 @@ mod tests {
             let mut transport_config = quinn::TransportConfig::default();
             transport_config.max_idle_timeout(Some(Duration::from_secs(10).try_into().unwrap()));
 
-            let endpoint = Endpoint::empty_builder()
+            let endpoint = Endpoint::empty_builder(relay_mode)
                 .secret_key(secret_key.clone())
                 .transport_config(transport_config)
-                .relay_mode(relay_mode)
                 .alpns(vec![ALPN.to_vec()])
                 .bind()
                 .await

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -581,11 +581,11 @@ mod tests {
     use quinn::ApplicationClose;
 
     use super::*;
-    use crate::{RelayMode, endpoint::ConnectionError};
+    use crate::endpoint::ConnectionError;
 
     #[tokio::test]
     async fn test_shutdown() -> Result {
-        let endpoint = Endpoint::bind().await?;
+        let endpoint = Endpoint::empty_builder().bind().await?;
         let router = Router::builder(endpoint.clone()).spawn();
 
         assert!(!router.is_shutdown());
@@ -623,20 +623,14 @@ mod tests {
     #[tokio::test]
     async fn test_limiter() -> Result {
         // tracing_subscriber::fmt::try_init().ok();
-        let e1 = Endpoint::builder()
-            .relay_mode(RelayMode::Disabled)
-            .bind()
-            .await?;
+        let e1 = Endpoint::empty_builder().bind().await?;
         // deny all access
         let proto = AccessLimit::new(Echo, |_endpoint_id| false);
         let r1 = Router::builder(e1.clone()).accept(ECHO_ALPN, proto).spawn();
 
         let addr1 = r1.endpoint().addr();
         dbg!(&addr1);
-        let e2 = Endpoint::builder()
-            .relay_mode(RelayMode::Disabled)
-            .bind()
-            .await?;
+        let e2 = Endpoint::empty_builder().bind().await?;
 
         println!("connecting");
         let conn = e2.connect(addr1, ECHO_ALPN).await?;
@@ -676,10 +670,7 @@ mod tests {
         }
 
         eprintln!("creating ep1");
-        let endpoint = Endpoint::builder()
-            .relay_mode(RelayMode::Disabled)
-            .bind()
-            .await?;
+        let endpoint = Endpoint::empty_builder().bind().await?;
         let router = Router::builder(endpoint)
             .accept(TEST_ALPN, TestProtocol::default())
             .spawn();
@@ -687,10 +678,7 @@ mod tests {
         let addr = router.endpoint().addr();
 
         eprintln!("creating ep2");
-        let endpoint2 = Endpoint::builder()
-            .relay_mode(RelayMode::Disabled)
-            .bind()
-            .await?;
+        let endpoint2 = Endpoint::empty_builder().bind().await?;
         eprintln!("connecting to {addr:?}");
         let conn = endpoint2.connect(addr, TEST_ALPN).await?;
 

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -581,11 +581,11 @@ mod tests {
     use quinn::ApplicationClose;
 
     use super::*;
-    use crate::endpoint::ConnectionError;
+    use crate::{RelayMode, endpoint::ConnectionError};
 
     #[tokio::test]
     async fn test_shutdown() -> Result {
-        let endpoint = Endpoint::empty_builder().bind().await?;
+        let endpoint = Endpoint::empty_builder(RelayMode::Disabled).bind().await?;
         let router = Router::builder(endpoint.clone()).spawn();
 
         assert!(!router.is_shutdown());
@@ -623,14 +623,14 @@ mod tests {
     #[tokio::test]
     async fn test_limiter() -> Result {
         // tracing_subscriber::fmt::try_init().ok();
-        let e1 = Endpoint::empty_builder().bind().await?;
+        let e1 = Endpoint::empty_builder(RelayMode::Disabled).bind().await?;
         // deny all access
         let proto = AccessLimit::new(Echo, |_endpoint_id| false);
         let r1 = Router::builder(e1.clone()).accept(ECHO_ALPN, proto).spawn();
 
         let addr1 = r1.endpoint().addr();
         dbg!(&addr1);
-        let e2 = Endpoint::empty_builder().bind().await?;
+        let e2 = Endpoint::empty_builder(RelayMode::Disabled).bind().await?;
 
         println!("connecting");
         let conn = e2.connect(addr1, ECHO_ALPN).await?;
@@ -670,7 +670,7 @@ mod tests {
         }
 
         eprintln!("creating ep1");
-        let endpoint = Endpoint::empty_builder().bind().await?;
+        let endpoint = Endpoint::empty_builder(RelayMode::Disabled).bind().await?;
         let router = Router::builder(endpoint)
             .accept(TEST_ALPN, TestProtocol::default())
             .spawn();
@@ -678,7 +678,7 @@ mod tests {
         let addr = router.endpoint().addr();
 
         eprintln!("creating ep2");
-        let endpoint2 = Endpoint::empty_builder().bind().await?;
+        let endpoint2 = Endpoint::empty_builder(RelayMode::Disabled).bind().await?;
         eprintln!("connecting to {addr:?}");
         let conn = endpoint2.connect(addr, TEST_ALPN).await?;
 

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -3,14 +3,17 @@
 //! ## Example
 //!
 //! ```no_run
-//! # use iroh::{endpoint::{Connection, BindError}, protocol::{AcceptError, ProtocolHandler, Router}, Endpoint, EndpointAddr};
+//! # use iroh::{
+//! #     endpoint::{Connection, BindError},
+//! #     protocol::{AcceptError, ProtocolHandler, Router},
+//! #     Endpoint,
+//! #     EndpointAddr
+//! # };
 //! #
 //! # async fn test_compile() -> Result<(), BindError> {
-//! let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+//! let endpoint = Endpoint::bind().await?;
 //!
-//! let router = Router::builder(endpoint)
-//!     .accept(b"/my/alpn", Echo)
-//!     .spawn();
+//! let router = Router::builder(endpoint).accept(b"/my/alpn", Echo).spawn();
 //! # Ok(())
 //! # }
 //!
@@ -71,7 +74,7 @@ use crate::{
 /// # use iroh::{endpoint::Connecting, protocol::{ProtocolHandler, Router}, Endpoint, EndpointAddr};
 /// #
 /// # async fn test_compile() -> n0_snafu::Result<()> {
-/// let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+/// let endpoint = Endpoint::bind().await?;
 ///
 /// let router = Router::builder(endpoint)
 ///     // .accept(&ALPN, <something>)
@@ -582,7 +585,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_shutdown() -> Result {
-        let endpoint = Endpoint::builder().bind().await?;
+        let endpoint = Endpoint::bind().await?;
         let router = Router::builder(endpoint.clone()).spawn();
 
         assert!(!router.is_shutdown());

--- a/iroh/tests/integration.rs
+++ b/iroh/tests/integration.rs
@@ -38,12 +38,10 @@ async fn simple_endpoint_id_based_connection_transfer() -> Result {
 
     let client = Endpoint::builder()
         .relay_mode(RelayMode::Staging)
-        .discovery_n0()
         .bind()
         .await?;
     let server = Endpoint::builder()
         .relay_mode(RelayMode::Staging)
-        .discovery_n0()
         .alpns(vec![ECHO_ALPN.to_vec()])
         .bind()
         .await?;


### PR DESCRIPTION
## Description

Closes #3470

## Breaking Changes

- removed
  - `iroh::endpoint::Builder::n0_discovery`
  - `iroh::endpoint::Builder::discovery_dht`
  - `iroh::endpoint::Builder::discovery_local_network`
  - `iroh::endpoint::Builder::discovery`
  - `iroh::discovery::DiscoveryContext`
  - `iroh::endpoint::Builder::default`
- added
  -  `iroh::Endpoint::bind` - this allows to immediately create an `Endpoint` with the defaults and binds it
  - `iroh::endpoint::Endpoint::empty_builder`
  - `iroh::endpoint::presets` - new module, defining a trait on how to preconfigure and `Endpoint`
  - `iroh::endpoint::Builder::new` - creates a new builder with the `N0` preset
  - `iroh::endpoint::Builder::preset`
  - `iroh::endpoint::Builder::empty` - creates a new builder, completely empty (no discovery, no relay map)
- changed
  - `iroh::'Endpoint::add_discovery` is now called just `discovery`
  - `iroh::discovery::IntoDiscovery` now takes an `Endpoint` instead of a `DiscoveryContext`




