### PR TITLE
refactor(iroh)!: finish removal of add_node_addr from public api

### DIFF
--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -632,7 +632,10 @@ impl DiscoveryTask {
                         continue;
                     }
                     debug!(%provenance, addr = ?node_addr, "new address found");
-                    ep.add_node_addr_with_source(node_addr, provenance).ok();
+                    let source = crate::magicsock::Source::Discovery {
+                        name: provenance.to_string(),
+                    };
+                    ep.add_node_addr(node_addr, source).ok();
 
                     if let Some(tx) = on_first_tx.take() {
                         tx.send(Ok(())).ok();


### PR DESCRIPTION
## Description

* Removes `Endpoint::add_node_addr_with_source`
* Changes visibility of `Endpoint::add_node_addr` from private to `pub(crate)` and add a `source` argument, and uses it in discovery instead of the now-removed `add_node_addr_with_source`
* Refactors a few tests to not use `Endpoint::add_node_addr`  anymore

The *only*  remaining uses of `Endpoint::add_node_addr`  are now in `Endpoint::connect` (when passing a NodeAddr) and in the task processing discovery results. Yay!

## Breaking Changes

* `iroh::Endpoint::add_node_addr_with_source` is removed. Use a discovery service instead.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
