### PR TITLE
feat(iroh-base)!: reduce external types in the iroh-base API for keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,6 +2507,7 @@ dependencies = [
  "serde_test",
  "snafu",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -6596,6 +6597,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,6 +2508,7 @@ dependencies = [
  "snafu",
  "url",
  "zeroize",
+ "zeroize_derive",
 ]
 
 [[package]]

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -27,6 +27,7 @@ snafu = { version = "0.8.5", features = ["rust_1_81"], optional = true }
 n0-snafu = "0.2.2"
 nested_enum_utils = "0.2.0"
 zeroize = { version = "1.8.2", optional = true, features = ["derive"] }
+zeroize_derive = { version = "1.4.2", optional = true } # needed for minimal versions
 
 [dev-dependencies]
 postcard = { version = "1", features = ["use-std"] }
@@ -49,6 +50,7 @@ key = [
   "dep:data-encoding",
   "dep:rand_core",
   "dep:zeroize",
+  "dep:zeroize_derive",
   "relay",
 ]
 relay = [

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 snafu = { version = "0.8.5", features = ["rust_1_81"], optional = true }
 n0-snafu = "0.2.2"
 nested_enum_utils = "0.2.0"
+zeroize = { version = "1.8", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 postcard = { version = "1", features = ["use-std"] }
@@ -47,6 +48,7 @@ key = [
   "dep:snafu",
   "dep:data-encoding",
   "dep:rand_core",
+  "dep:zeroize",
   "relay",
 ]
 relay = [

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 snafu = { version = "0.8.5", features = ["rust_1_81"], optional = true }
 n0-snafu = "0.2.2"
 nested_enum_utils = "0.2.0"
-zeroize = { version = "1.8", optional = true, features = ["derive"] }
+zeroize = { version = "1.8.2", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 postcard = { version = "1", features = ["use-std"] }

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -175,7 +175,6 @@ impl AsRef<[u8]> for PublicKey {
     }
 }
 
-// TODO: remove once this is not needed anymore in iroh
 #[doc(hidden)]
 impl From<VerifyingKey> for PublicKey {
     fn from(verifying_key: VerifyingKey) -> Self {
@@ -184,7 +183,6 @@ impl From<VerifyingKey> for PublicKey {
     }
 }
 
-// TODO: remove once this is not needed anymore in iroh
 #[doc(hidden)]
 impl From<&PublicKey> for VerifyingKey {
     fn from(value: &PublicKey) -> Self {
@@ -192,7 +190,6 @@ impl From<&PublicKey> for VerifyingKey {
     }
 }
 
-// TODO: remove once this is not needed anymore in iroh
 #[doc(hidden)]
 impl From<PublicKey> for VerifyingKey {
     fn from(value: PublicKey) -> Self {

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -146,6 +146,12 @@ impl PublicKey {
     pub fn as_verifying_key(&self) -> VerifyingKey {
         VerifyingKey::from_bytes(self.0.as_bytes()).expect("already verified")
     }
+
+    /// Needed for internal conversions, not part of the stable API.
+    #[doc(hidden)]
+    pub fn from_verifying_key(key: VerifyingKey) -> Self {
+        Self(CompressedEdwardsY(key.to_bytes()))
+    }
 }
 
 struct PublicKeyShort([u8; 5]);

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -40,7 +40,7 @@ use std::{
     str::{FromStr, Utf8Error},
 };
 
-use iroh_base::{NodeAddr, NodeId, RelayUrl, SecretKey, SignatureError};
+use iroh_base::{KeyParsingError, NodeAddr, NodeId, RelayUrl, SecretKey};
 use nested_enum_utils::common_fields;
 use snafu::{Backtrace, ResultExt, Snafu};
 use url::Url;
@@ -81,7 +81,10 @@ pub enum DecodingError {
     #[snafu(display("length must be 32 bytes, but got {len} byte(s)"))]
     InvalidLength { len: usize },
     #[snafu(display("node id is not a valid public key"))]
-    InvalidSignature { source: SignatureError },
+    InvalidKey {
+        #[snafu(source(from(KeyParsingError, Box::new)))]
+        source: Box<KeyParsingError>,
+    },
 }
 
 /// Extension methods for [`NodeId`] to encode to and decode from [`z32`],
@@ -108,7 +111,7 @@ impl NodeIdExt for NodeId {
         let bytes: &[u8; 32] = &bytes
             .try_into()
             .map_err(|_| InvalidLengthSnafu { len: s.len() }.build())?;
-        let node_id = NodeId::from_bytes(bytes).context(InvalidSignatureSnafu)?;
+        let node_id = NodeId::from_bytes(bytes).context(InvalidKeySnafu)?;
         Ok(node_id)
     }
 }

--- a/iroh-relay/src/node_info.rs
+++ b/iroh-relay/src/node_info.rs
@@ -564,7 +564,7 @@ impl<T: FromStr + Display + Hash + Ord> TxtAttrs<T> {
         };
         let pubkey = packet.public_key();
         let pubkey_z32 = pubkey.to_z32();
-        let node_id = NodeId::from(*pubkey.verifying_key());
+        let node_id = NodeId::from_bytes(&pubkey.verifying_key().to_bytes()).expect("valid key");
         let zone = dns::Name::new(&pubkey_z32).expect("z32 encoding is valid");
         let txt_data = packet
             .all_resource_records()

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -10,7 +10,7 @@
 use std::num::NonZeroU16;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use iroh_base::{NodeId, SignatureError};
+use iroh_base::{KeyParsingError, NodeId};
 use n0_future::time::Duration;
 use nested_enum_utils::common_fields;
 use snafu::{Backtrace, ResultExt, Snafu};
@@ -59,7 +59,7 @@ pub enum Error {
     #[snafu(transparent)]
     FrameTypeError { source: FrameTypeError },
     #[snafu(display("Invalid public key"))]
-    InvalidPublicKey { source: SignatureError },
+    InvalidPublicKey { source: KeyParsingError },
     #[snafu(display("Invalid frame encoding"))]
     InvalidFrame {},
     #[snafu(display("Invalid frame type: {frame_type:?}"))]
@@ -216,7 +216,7 @@ impl Datagrams {
         + self.contents.len()
     }
 
-    #[allow(clippy::len_zero)]
+    #[allow(clippy::len_zero, clippy::result_large_err)]
     fn from_bytes(mut bytes: Bytes, is_batch: bool) -> Result<Self, Error> {
         if is_batch {
             // 1 bytes ECN, 2 bytes segment size

--- a/iroh/src/disco.rs
+++ b/iroh/src/disco.rs
@@ -521,8 +521,8 @@ mod tests {
             node_key: sender_key.public(),
         });
 
-        let sender_secret = secret_ed_box(sender_key.as_ref());
-        let shared = SharedSecret::new(&sender_secret, &public_ed_box(&recv_key.public().into()));
+        let sender_secret = secret_ed_box(&sender_key);
+        let shared = SharedSecret::new(&sender_secret, &public_ed_box(&recv_key.public()));
         let mut seal = msg.as_bytes();
         shared.seal(&mut seal);
 
@@ -535,9 +535,8 @@ mod tests {
         assert_eq!(raw_key, sender_key.public());
         assert_eq!(seal_back, seal);
 
-        let recv_secret = secret_ed_box(recv_key.as_ref());
-        let shared_recv =
-            SharedSecret::new(&recv_secret, &public_ed_box(&sender_key.public().into()));
+        let recv_secret = secret_ed_box(&recv_key);
+        let shared_recv = SharedSecret::new(&recv_secret, &public_ed_box(&sender_key.public()));
         let mut open_seal = seal_back.to_vec();
         shared_recv
             .open(&mut open_seal)

--- a/iroh/src/disco.rs
+++ b/iroh/src/disco.rs
@@ -521,8 +521,8 @@ mod tests {
             node_key: sender_key.public(),
         });
 
-        let sender_secret = secret_ed_box(sender_key.secret());
-        let shared = SharedSecret::new(&sender_secret, &public_ed_box(&recv_key.public().public()));
+        let sender_secret = secret_ed_box(sender_key.as_ref());
+        let shared = SharedSecret::new(&sender_secret, &public_ed_box(&recv_key.public().into()));
         let mut seal = msg.as_bytes();
         shared.seal(&mut seal);
 
@@ -535,9 +535,9 @@ mod tests {
         assert_eq!(raw_key, sender_key.public());
         assert_eq!(seal_back, seal);
 
-        let recv_secret = secret_ed_box(recv_key.secret());
+        let recv_secret = secret_ed_box(recv_key.as_ref());
         let shared_recv =
-            SharedSecret::new(&recv_secret, &public_ed_box(&sender_key.public().public()));
+            SharedSecret::new(&recv_secret, &public_ed_box(&sender_key.public().into()));
         let mut open_seal = seal_back.to_vec();
         shared_recv
             .open(&mut open_seal)

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1986,9 +1986,12 @@ impl Connection {
                         return Err(RemoteNodeIdSnafu.build());
                     }
 
-                    let peer_id = VerifyingKey::from_public_key_der(&certs[0])
-                        .map_err(|_| RemoteNodeIdSnafu.build())?
-                        .into();
+                    let peer_id = NodeId::from_bytes(
+                        VerifyingKey::from_public_key_der(&certs[0])
+                            .map_err(|_| RemoteNodeIdSnafu.build())?
+                            .as_bytes(),
+                    )
+                    .expect("valid key");
                     Ok(peer_id)
                 }
                 Err(err) => {

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1986,12 +1986,11 @@ impl Connection {
                         return Err(RemoteNodeIdSnafu.build());
                     }
 
-                    let peer_id = NodeId::from_bytes(
+                    let peer_id = NodeId::from_verifying_key(
                         VerifyingKey::from_public_key_der(&certs[0])
-                            .map_err(|_| RemoteNodeIdSnafu.build())?
-                            .as_bytes(),
-                    )
-                    .expect("valid key");
+                            .map_err(|_| RemoteNodeIdSnafu.build())?,
+                    );
+
                     Ok(peer_id)
                 }
                 Err(err) => {

--- a/iroh/src/key.rs
+++ b/iroh/src/key.rs
@@ -86,8 +86,8 @@ mod tests {
     use super::*;
 
     fn shared(this: &iroh_base::SecretKey, other: &iroh_base::PublicKey) -> SharedSecret {
-        let secret_key = secret_ed_box(this.secret());
-        let public_key = public_ed_box(&other.public());
+        let secret_key = secret_ed_box(this.as_ref());
+        let public_key = public_ed_box(&other.into());
 
         SharedSecret::new(&secret_key, &public_key)
     }
@@ -134,8 +134,8 @@ mod tests {
     fn test_same_public_key_api() {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
         let key = iroh_base::SecretKey::generate(&mut rng);
-        let public_key1: crypto_box::PublicKey = public_ed_box(&key.public().public());
-        let public_key2: crypto_box::PublicKey = secret_ed_box(key.secret()).public_key();
+        let public_key1: crypto_box::PublicKey = public_ed_box(&key.public().into());
+        let public_key2: crypto_box::PublicKey = secret_ed_box(key.as_ref()).public_key();
 
         assert_eq!(public_key1, public_key2);
     }

--- a/iroh/src/key.rs
+++ b/iroh/src/key.rs
@@ -12,12 +12,12 @@ pub(crate) const NONCE_LEN: usize = 24;
 const AEAD_DATA: &[u8] = &[];
 
 pub(super) fn public_ed_box(key: &PublicKey) -> crypto_box::PublicKey {
-    let key = ed25519_dalek::VerifyingKey::from_bytes(key.as_bytes()).expect("valid key");
+    let key = key.as_verifying_key();
     crypto_box::PublicKey::from(key.to_montgomery())
 }
 
 pub(super) fn secret_ed_box(key: &SecretKey) -> crypto_box::SecretKey {
-    let key = ed25519_dalek::SigningKey::from_bytes(&key.to_bytes());
+    let key = key.as_signing_key();
     crypto_box::SecretKey::from(key.to_scalar())
 }
 

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -273,6 +273,7 @@ pub mod protocol;
 pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{
     KeyParsingError, NodeAddr, NodeId, PublicKey, RelayUrl, RelayUrlParseError, SecretKey,
+    Signature, SignatureError,
 };
 pub use iroh_relay::{RelayMap, RelayNode, node_info};
 pub use n0_watcher::Watcher;

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1408,7 +1408,7 @@ impl Handle {
         });
         let relay_transports = vec![relay_transport];
 
-        let secret_encryption_key = secret_ed_box(secret_key.as_ref());
+        let secret_encryption_key = secret_ed_box(&secret_key);
         #[cfg(not(wasm_browser))]
         let ipv6 = ip_transports.iter().any(|t| t.bind_addr().is_ipv6());
 
@@ -1687,7 +1687,7 @@ impl DiscoState {
     {
         let mut inner = self.secrets.lock().expect("poisoned");
         let x = inner.entry(node_id).or_insert_with(|| {
-            let public_key = public_ed_box(&node_id.into());
+            let public_key = public_ed_box(&node_id);
             SharedSecret::new(&self.secret_encryption_key, &public_key)
         });
         cb(x)

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1408,7 +1408,7 @@ impl Handle {
         });
         let relay_transports = vec![relay_transport];
 
-        let secret_encryption_key = secret_ed_box(secret_key.secret());
+        let secret_encryption_key = secret_ed_box(secret_key.as_ref());
         #[cfg(not(wasm_browser))]
         let ipv6 = ip_transports.iter().any(|t| t.bind_addr().is_ipv6());
 
@@ -1687,7 +1687,7 @@ impl DiscoState {
     {
         let mut inner = self.secrets.lock().expect("poisoned");
         let x = inner.entry(node_id).or_insert_with(|| {
-            let public_key = public_ed_box(&node_id.public());
+            let public_key = public_ed_box(&node_id.into());
             SharedSecret::new(&self.secret_encryption_key, &public_key)
         });
         cb(x)

--- a/iroh/src/tls/resolver.rs
+++ b/iroh/src/tls/resolver.rs
@@ -29,7 +29,7 @@ impl AlwaysResolvesCert {
     pub(super) fn new(secret_key: &SecretKey) -> Result<Self, CreateConfigError> {
         // Directly use the key
         let client_private_key = secret_key
-            .secret()
+            .as_ref()
             .to_pkcs8_pem(LineEnding::default())
             .expect("key is valid");
 

--- a/iroh/src/tls/resolver.rs
+++ b/iroh/src/tls/resolver.rs
@@ -29,7 +29,7 @@ impl AlwaysResolvesCert {
     pub(super) fn new(secret_key: &SecretKey) -> Result<Self, CreateConfigError> {
         // Directly use the key
         let client_private_key = secret_key
-            .as_ref()
+            .as_signing_key()
             .to_pkcs8_pem(LineEnding::default())
             .expect("key is valid");
 

--- a/iroh/src/tls/verifier.rs
+++ b/iroh/src/tls/verifier.rs
@@ -54,8 +54,7 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms
 pub(super) struct ServerCertificateVerifier;
 
 fn public_key_to_spki(remote_peer_id: &PublicKey) -> SubjectPublicKeyInfoDer<'static> {
-    let der_key = remote_peer_id
-        .public()
+    let der_key = ed25519_dalek::VerifyingKey::from(remote_peer_id)
         .to_public_key_der()
         .expect("valid key");
     SubjectPublicKeyInfoDer::from(der_key.into_vec())

--- a/iroh/src/tls/verifier.rs
+++ b/iroh/src/tls/verifier.rs
@@ -54,7 +54,8 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms
 pub(super) struct ServerCertificateVerifier;
 
 fn public_key_to_spki(remote_peer_id: &PublicKey) -> SubjectPublicKeyInfoDer<'static> {
-    let der_key = ed25519_dalek::VerifyingKey::from(remote_peer_id)
+    let der_key = remote_peer_id
+        .as_verifying_key()
         .to_public_key_der()
         .expect("valid key");
     SubjectPublicKeyInfoDer::from(der_key.into_vec())


### PR DESCRIPTION
## Description

In preparation of stabilizing our APIs, this removes `ed25519_dalek` types from the public API of `iroh-base`, except for a few conversions, which are `doc(hidden)` to clearly mark them as not stable.

Ref #3177

## Breaking Changes

-  added `iroh_base::Signature` which replaces `ed25519_dalek::Signature` in the public API of `iroh_base`
- `iroh_base` error types have changed
- removed `Into` and `From` conversions for `PublicKey` - `ed25519_dalek::VerifyingKey`
- removed `Into` and `From` conversions for `SecretKey` - `ed25519_dalek::SigningKey`

