### PR TITLE
refactor(iroh): remove stun-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,12 +499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bounded-integer"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102dbef1187b1893e6dfe05a774e79fd52265f49f214f6879c8ff49f52c8188b"
-
-[[package]]
 name = "btparse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,7 +1148,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.6",
- "subtle",
 ]
 
 [[package]]
@@ -1246,7 +1239,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.9.3",
  "serde",
- "sha2 0.11.0-rc.2",
+ "sha2",
  "signature",
  "subtle",
  "zeroize",
@@ -1289,26 +1282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,12 +1305,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.1",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -1976,37 +1943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-sha1"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b05da5b9e5d4720bfb691eebb2b9d42da3570745da71eac8a1f5bb7e59aab88"
-dependencies = [
- "hmac",
- "sha1",
-]
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6880c8d4a9ebf39c6e8b77007ce223f646a4d21ce29d99f70cb16420545425"
-
-[[package]]
-name = "hostname-validator"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,7 +2405,6 @@ dependencies = [
  "smallvec",
  "snafu",
  "strum",
- "stun-rs",
  "surge-ping",
  "swarm-discovery",
  "time",
@@ -2924,12 +2859,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3460,49 +3389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
-dependencies = [
- "pest",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3764,40 +3650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precis-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2e7b31f132e0c6f8682cfb7bf4a5340dbe925b7986618d0826a56dfe0c8e56"
-dependencies = [
- "precis-tools",
- "ucd-parse",
- "unicode-normalization",
-]
-
-[[package]]
-name = "precis-profiles"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e2768890a47af73a032af9f0cedbddce3c9d06cf8de201d5b8f2436ded7674"
-dependencies = [
- "lazy_static",
- "precis-core",
- "precis-tools",
- "unicode-normalization",
-]
-
-[[package]]
-name = "precis-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc1eb2d5887ac7bfd2c0b745764db89edb84b856e4214e204ef48ef96d10c4a"
-dependencies = [
- "lazy_static",
- "regex",
- "ucd-parse",
-]
-
-[[package]]
 name = "prefix-trie"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3938,16 +3790,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "quoted-string-parser"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc75379cdb451d001f1cb667a9f74e8b355e9df84cc5193513cbe62b96fc5e9"
-dependencies = [
- "pest",
- "pest_derive",
 ]
 
 [[package]]
@@ -4130,12 +3972,6 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-lite"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f41321c63ef1c92fd763bfe054d2668f7f225a5c29f0105903dc2fc04ba30"
 
 [[package]]
 name = "regex-syntax"
@@ -4651,17 +4487,6 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
@@ -4870,30 +4695,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "stun-rs"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb921f10397d5669e1af6455e9e2d367bf1f9cebcd6b1dd1dc50e19f6a9ac2ac"
-dependencies = [
- "base64",
- "bounded-integer",
- "byteorder",
- "crc",
- "enumflags2",
- "fallible-iterator",
- "hmac-sha1",
- "hmac-sha256",
- "hostname-validator",
- "lazy_static",
- "md5",
- "paste",
- "precis-core",
- "precis-profiles",
- "quoted-string-parser",
- "rand 0.9.2",
 ]
 
 [[package]]
@@ -5534,21 +5335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "ucd-parse"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06ff81122fcbf4df4c1660b15f7e3336058e7aec14437c9f85c6b31a0f279b9"
-dependencies = [
- "regex-lite",
-]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5559,15 +5345,6 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-width"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -60,7 +60,6 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 smallvec = "1.11.1"
 snafu = { version = "0.8.5", features = ["rust_1_81"] }
 strum = { version = "0.27", features = ["derive"] }
-stun-rs = "0.1.11"
 tokio = { version = "1.44.1", features = [
     "io-util",
     "macros",

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1809,7 +1809,7 @@ impl AsyncUdpSocket for MagicUdpSocket {
 
 #[derive(Debug)]
 enum ActorMessage {
-    EndpointPingExpired(usize, stun_rs::TransactionId),
+    EndpointPingExpired(usize, crate::disco::TransactionId),
     NetworkChange,
     ScheduleDirectAddrUpdate(UpdateReason, Option<(EndpointId, RelayUrl)>),
     RelayMapChange,

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -68,7 +68,7 @@ use crate::endpoint::PathSelection;
 use crate::net_report::{IpMappedAddr, QuicConfig};
 use crate::{
     defaults::timeouts::NET_REPORT_TIMEOUT,
-    disco::{self, SendAddr},
+    disco::{self, SendAddr, TransactionId},
     discovery::{
         ConcurrentDiscovery, Discovery, DiscoveryContext, DynIntoDiscovery, EndpointData,
         IntoDiscoveryError, UserData,
@@ -1809,7 +1809,7 @@ impl AsyncUdpSocket for MagicUdpSocket {
 
 #[derive(Debug)]
 enum ActorMessage {
-    EndpointPingExpired(usize, crate::disco::TransactionId),
+    EndpointPingExpired(usize, TransactionId),
     NetworkChange,
     ScheduleDirectAddrUpdate(UpdateReason, Option<(EndpointId, RelayUrl)>),
     RelayMapChange,

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -183,7 +183,7 @@ impl EndpointMap {
         &self,
         id: usize,
         dst: SendAddr,
-        tx_id: crate::disco::TransactionId,
+        tx_id: TransactionId,
         purpose: DiscoPingPurpose,
         msg_sender: tokio::sync::mpsc::Sender<ActorMessage>,
     ) {
@@ -197,12 +197,7 @@ impl EndpointMap {
         }
     }
 
-    pub(super) fn notify_ping_timeout(
-        &self,
-        id: usize,
-        tx_id: crate::disco::TransactionId,
-        metrics: &Metrics,
-    ) {
+    pub(super) fn notify_ping_timeout(&self, id: usize, tx_id: TransactionId, metrics: &Metrics) {
         if let Some(ep) = self
             .inner
             .lock()
@@ -903,7 +898,7 @@ mod tests {
         info!("Adding alive addresses");
         for i in 0..MAX_INACTIVE_DIRECT_ADDRESSES {
             let addr = SendAddr::Udp(SocketAddr::new(LOCALHOST, 7000 + i as u16));
-            let txid = crate::disco::TransactionId::from([i as u8; 12]);
+            let txid = TransactionId::from([i as u8; 12]);
             // Note that this already invokes .prune_direct_addresses() because these are
             // new UDP paths.
             endpoint.handle_ping(addr, txid);

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -9,7 +9,7 @@ use std::{
 use iroh_base::{EndpointAddr, EndpointId, PublicKey, RelayUrl};
 use n0_future::time::Instant;
 use serde::{Deserialize, Serialize};
-use stun_rs::TransactionId;
+use crate::disco::TransactionId;
 use tracing::{debug, info, instrument, trace, warn};
 
 use self::endpoint_state::{EndpointState, Options, PingHandled};
@@ -184,7 +184,7 @@ impl EndpointMap {
         &self,
         id: usize,
         dst: SendAddr,
-        tx_id: stun_rs::TransactionId,
+        tx_id: crate::disco::TransactionId,
         purpose: DiscoPingPurpose,
         msg_sender: tokio::sync::mpsc::Sender<ActorMessage>,
     ) {
@@ -201,7 +201,7 @@ impl EndpointMap {
     pub(super) fn notify_ping_timeout(
         &self,
         id: usize,
-        tx_id: stun_rs::TransactionId,
+        tx_id: crate::disco::TransactionId,
         metrics: &Metrics,
     ) {
         if let Some(ep) = self
@@ -904,7 +904,7 @@ mod tests {
         info!("Adding alive addresses");
         for i in 0..MAX_INACTIVE_DIRECT_ADDRESSES {
             let addr = SendAddr::Udp(SocketAddr::new(LOCALHOST, 7000 + i as u16));
-            let txid = stun_rs::TransactionId::from([i as u8; 12]);
+            let txid = crate::disco::TransactionId::from([i as u8; 12]);
             // Note that this already invokes .prune_direct_addresses() because these are
             // new UDP paths.
             endpoint.handle_ping(addr, txid);

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -9,12 +9,11 @@ use std::{
 use iroh_base::{EndpointAddr, EndpointId, PublicKey, RelayUrl};
 use n0_future::time::Instant;
 use serde::{Deserialize, Serialize};
-use crate::disco::TransactionId;
 use tracing::{debug, info, instrument, trace, warn};
 
 use self::endpoint_state::{EndpointState, Options, PingHandled};
 use super::{ActorMessage, EndpointIdMappedAddr, metrics::Metrics, transports};
-use crate::disco::{CallMeMaybe, Pong, SendAddr};
+use crate::disco::{CallMeMaybe, Pong, SendAddr, TransactionId};
 #[cfg(any(test, feature = "test-utils"))]
 use crate::endpoint::PathSelection;
 

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -24,7 +24,7 @@ use super::{
 #[cfg(any(test, feature = "test-utils"))]
 use crate::endpoint::PathSelection;
 use crate::{
-    disco::{self, SendAddr},
+    disco::{self, SendAddr, TransactionId},
     magicsock::{
         ActorMessage, EndpointIdMappedAddr, HEARTBEAT_INTERVAL, MagicsockMetrics,
         endpoint_map::path_validity::PathValidity,
@@ -69,7 +69,7 @@ pub(in crate::magicsock) struct SendPing {
     pub id: usize,
     pub dst: SendAddr,
     pub dst_endpoint: EndpointId,
-    pub tx_id: crate::disco::TransactionId,
+    pub tx_id: TransactionId,
     pub purpose: DiscoPingPurpose,
 }
 
@@ -116,7 +116,7 @@ pub(super) struct EndpointState {
     /// The fallback/bootstrap path, if non-zero (non-zero for well-behaved clients).
     relay_url: Option<(RelayUrl, PathState)>,
     udp_paths: EndpointUdpPaths,
-    sent_pings: HashMap<crate::disco::TransactionId, SentPing>,
+    sent_pings: HashMap<TransactionId, SentPing>,
     /// Last time this endpoint was used.
     ///
     /// An endpoint is marked as in use when sending datagrams to them, or when having received
@@ -448,7 +448,7 @@ impl EndpointState {
     #[instrument("disco", skip_all, fields(endpoint = %self.endpoint_id.fmt_short()))]
     pub(super) fn ping_timeout(
         &mut self,
-        txid: crate::disco::TransactionId,
+        txid: TransactionId,
         now: Instant,
         metrics: &MagicsockMetrics,
     ) {
@@ -502,7 +502,7 @@ impl EndpointState {
             return None; // Similar to `RelayOnly` mode, we don't send UDP pings for hole-punching.
         }
 
-        let tx_id = crate::disco::TransactionId::default();
+        let tx_id = TransactionId::default();
         trace!(tx = %HEXLOWER.encode(&tx_id), %dst, ?purpose,
                dst = %self.endpoint_id.fmt_short(), "start ping");
         event!(
@@ -526,7 +526,7 @@ impl EndpointState {
     pub(super) fn ping_sent(
         &mut self,
         to: SendAddr,
-        tx_id: crate::disco::TransactionId,
+        tx_id: TransactionId,
         purpose: DiscoPingPurpose,
         sender: mpsc::Sender<ActorMessage>,
     ) {
@@ -739,11 +739,7 @@ impl EndpointState {
     ///
     /// This is called once we've already verified that we got a valid discovery message
     /// from `self` via ep.
-    pub(super) fn handle_ping(
-        &mut self,
-        path: SendAddr,
-        tx_id: crate::disco::TransactionId,
-    ) -> PingHandled {
+    pub(super) fn handle_ping(&mut self, path: SendAddr, tx_id: TransactionId) -> PingHandled {
         let now = Instant::now();
 
         let role = match path {

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -69,7 +69,7 @@ pub(in crate::magicsock) struct SendPing {
     pub id: usize,
     pub dst: SendAddr,
     pub dst_endpoint: EndpointId,
-    pub tx_id: stun_rs::TransactionId,
+    pub tx_id: crate::disco::TransactionId,
     pub purpose: DiscoPingPurpose,
 }
 
@@ -116,7 +116,7 @@ pub(super) struct EndpointState {
     /// The fallback/bootstrap path, if non-zero (non-zero for well-behaved clients).
     relay_url: Option<(RelayUrl, PathState)>,
     udp_paths: EndpointUdpPaths,
-    sent_pings: HashMap<stun_rs::TransactionId, SentPing>,
+    sent_pings: HashMap<crate::disco::TransactionId, SentPing>,
     /// Last time this endpoint was used.
     ///
     /// An endpoint is marked as in use when sending datagrams to them, or when having received
@@ -448,7 +448,7 @@ impl EndpointState {
     #[instrument("disco", skip_all, fields(endpoint = %self.endpoint_id.fmt_short()))]
     pub(super) fn ping_timeout(
         &mut self,
-        txid: stun_rs::TransactionId,
+        txid: crate::disco::TransactionId,
         now: Instant,
         metrics: &MagicsockMetrics,
     ) {
@@ -502,7 +502,7 @@ impl EndpointState {
             return None; // Similar to `RelayOnly` mode, we don't send UDP pings for hole-punching.
         }
 
-        let tx_id = stun_rs::TransactionId::default();
+        let tx_id = crate::disco::TransactionId::default();
         trace!(tx = %HEXLOWER.encode(&tx_id), %dst, ?purpose,
                dst = %self.endpoint_id.fmt_short(), "start ping");
         event!(
@@ -526,7 +526,7 @@ impl EndpointState {
     pub(super) fn ping_sent(
         &mut self,
         to: SendAddr,
-        tx_id: stun_rs::TransactionId,
+        tx_id: crate::disco::TransactionId,
         purpose: DiscoPingPurpose,
         sender: mpsc::Sender<ActorMessage>,
     ) {
@@ -742,7 +742,7 @@ impl EndpointState {
     pub(super) fn handle_ping(
         &mut self,
         path: SendAddr,
-        tx_id: stun_rs::TransactionId,
+        tx_id: crate::disco::TransactionId,
     ) -> PingHandled {
         let now = Instant::now();
 

--- a/iroh/src/magicsock/endpoint_map/path_state.rs
+++ b/iroh/src/magicsock/endpoint_map/path_state.rs
@@ -41,7 +41,7 @@ pub(super) struct PathState {
     /// If non-zero, means that this was an endpoint that we learned about at runtime (from an
     /// incoming ping). If so, we keep the time updated and use it to discard old candidates.
     // NOTE: tx_id Originally added in tailscale due to <https://github.com/tailscale/tailscale/issues/7078>.
-    last_got_ping: Option<(Instant, stun_rs::TransactionId)>,
+    last_got_ping: Option<(Instant, crate::disco::TransactionId)>,
 
     /// The time this endpoint was last advertised via a call-me-maybe DISCO message.
     pub(super) call_me_maybe_time: Option<Instant>,
@@ -108,7 +108,7 @@ impl PathState {
     pub(super) fn with_ping(
         endpoint_id: EndpointId,
         path: SendAddr,
-        tx_id: stun_rs::TransactionId,
+        tx_id: crate::disco::TransactionId,
         source: Source,
         now: Instant,
     ) -> Self {
@@ -247,7 +247,7 @@ impl PathState {
         }
     }
 
-    pub(super) fn handle_ping(&mut self, tx_id: stun_rs::TransactionId, now: Instant) -> PingRole {
+    pub(super) fn handle_ping(&mut self, tx_id: crate::disco::TransactionId, now: Instant) -> PingRole {
         if Some(&tx_id) == self.last_got_ping.as_ref().map(|(_t, tx_id)| tx_id) {
             PingRole::Duplicate
         } else {

--- a/iroh/src/magicsock/endpoint_map/path_state.rs
+++ b/iroh/src/magicsock/endpoint_map/path_state.rs
@@ -11,7 +11,7 @@ use super::{
     endpoint_state::{ControlMsg, PongReply, SESSION_ACTIVE_TIMEOUT},
 };
 use crate::{
-    disco::SendAddr,
+    disco::{SendAddr, TransactionId},
     magicsock::{
         HEARTBEAT_INTERVAL, Metrics as MagicsockMetrics,
         endpoint_map::path_validity::{self, PathValidity},
@@ -41,7 +41,7 @@ pub(super) struct PathState {
     /// If non-zero, means that this was an endpoint that we learned about at runtime (from an
     /// incoming ping). If so, we keep the time updated and use it to discard old candidates.
     // NOTE: tx_id Originally added in tailscale due to <https://github.com/tailscale/tailscale/issues/7078>.
-    last_got_ping: Option<(Instant, crate::disco::TransactionId)>,
+    last_got_ping: Option<(Instant, TransactionId)>,
 
     /// The time this endpoint was last advertised via a call-me-maybe DISCO message.
     pub(super) call_me_maybe_time: Option<Instant>,
@@ -108,7 +108,7 @@ impl PathState {
     pub(super) fn with_ping(
         endpoint_id: EndpointId,
         path: SendAddr,
-        tx_id: crate::disco::TransactionId,
+        tx_id: TransactionId,
         source: Source,
         now: Instant,
     ) -> Self {
@@ -247,11 +247,7 @@ impl PathState {
         }
     }
 
-    pub(super) fn handle_ping(
-        &mut self,
-        tx_id: crate::disco::TransactionId,
-        now: Instant,
-    ) -> PingRole {
+    pub(super) fn handle_ping(&mut self, tx_id: TransactionId, now: Instant) -> PingRole {
         if Some(&tx_id) == self.last_got_ping.as_ref().map(|(_t, tx_id)| tx_id) {
             PingRole::Duplicate
         } else {

--- a/iroh/src/magicsock/endpoint_map/path_state.rs
+++ b/iroh/src/magicsock/endpoint_map/path_state.rs
@@ -247,7 +247,11 @@ impl PathState {
         }
     }
 
-    pub(super) fn handle_ping(&mut self, tx_id: crate::disco::TransactionId, now: Instant) -> PingRole {
+    pub(super) fn handle_ping(
+        &mut self,
+        tx_id: crate::disco::TransactionId,
+        now: Instant,
+    ) -> PingRole {
         if Some(&tx_id) == self.last_got_ping.as_ref().map(|(_t, tx_id)| tx_id) {
             PingRole::Duplicate
         } else {


### PR DESCRIPTION
## Description

`iroh` has `stun-rs` in its dependencies for a single type, `TransactionId`. `stun-rs` is causing some duplicate dependencies, so this removes stun_rs from the deps and instead inlines the single type we are using from it.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
