### PR TITLE
feat!: transport generic EndpointAddr

### DIFF
--- a/iroh-base/src/endpoint_addr.rs
+++ b/iroh-base/src/endpoint_addr.rs
@@ -55,7 +55,7 @@ pub enum TransportAddr {
 }
 
 impl EndpointAddr {
-    /// Creates a new [`EndpointAddr`] with no `relay_url` and no `direct_addresses`.
+    /// Creates a new [`EndpointAddr`] with no addresses.
     pub fn new(id: PublicKey) -> Self {
         EndpointAddr {
             id,
@@ -69,11 +69,8 @@ impl EndpointAddr {
         self
     }
 
-    /// Adds the given direct addresses.
-    pub fn with_direct_addresses(
-        mut self,
-        addresses: impl IntoIterator<Item = SocketAddr>,
-    ) -> Self {
+    /// Adds the given IP addresses.
+    pub fn with_ip_addresses(mut self, addresses: impl IntoIterator<Item = SocketAddr>) -> Self {
         for addr in addresses.into_iter() {
             self.addrs.insert(TransportAddr::Ip(addr));
         }
@@ -93,7 +90,7 @@ impl EndpointAddr {
         self.addrs.is_empty()
     }
 
-    /// Returns the direct addresses of this peer.
+    /// Returns the IP addresses of this peer.
     pub fn ip_addresses(&self) -> impl Iterator<Item = &SocketAddr> {
         self.addrs.iter().filter_map(|addr| match addr {
             TransportAddr::Ip(addr) => Some(addr),
@@ -112,12 +109,12 @@ impl EndpointAddr {
 
 impl From<(PublicKey, Option<RelayUrl>, &[SocketAddr])> for EndpointAddr {
     fn from(value: (PublicKey, Option<RelayUrl>, &[SocketAddr])) -> Self {
-        let (id, relay_url, direct_addresses_iter) = value;
+        let (id, relay_url, ip_addrs_iter) = value;
         let mut addrs = BTreeSet::new();
         if let Some(url) = relay_url {
             addrs.insert(TransportAddr::Relay(url));
         }
-        for addr in direct_addresses_iter {
+        for addr in ip_addrs_iter {
             addrs.insert(TransportAddr::Ip(*addr));
         }
         EndpointAddr { id, addrs }

--- a/iroh-base/src/endpoint_addr.rs
+++ b/iroh-base/src/endpoint_addr.rs
@@ -48,10 +48,10 @@ pub struct EndpointAddr {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum TransportAddr {
-    /// IP based addresses
-    Ip(SocketAddr),
     /// Relays
     Relay(RelayUrl),
+    /// IP based addresses
+    Ip(SocketAddr),
 }
 
 impl EndpointAddr {
@@ -134,10 +134,10 @@ mod tests {
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[non_exhaustive]
     enum NewAddrType {
-        /// IP based addresses
-        Ip(SocketAddr),
         /// Relays
         Relay(RelayUrl),
+        /// IP based addresses
+        Ip(SocketAddr),
         /// New addr type for testing
         Cool(u16),
     }

--- a/iroh-base/src/endpoint_addr.rs
+++ b/iroh-base/src/endpoint_addr.rs
@@ -94,7 +94,7 @@ impl EndpointAddr {
     }
 
     /// Returns the direct addresses of this peer.
-    pub fn direct_addresses(&self) -> impl Iterator<Item = &SocketAddr> {
+    pub fn ip_addresses(&self) -> impl Iterator<Item = &SocketAddr> {
         self.addrs.iter().filter_map(|addr| match addr {
             AddrType::Ip(addr) => Some(addr),
             _ => None,
@@ -102,14 +102,11 @@ impl EndpointAddr {
     }
 
     /// Returns the relay url of this peer.
-    pub fn relay_url(&self) -> Option<&RelayUrl> {
-        self.addrs
-            .iter()
-            .filter_map(|addr| match addr {
-                AddrType::Relay(url) => Some(url),
-                _ => None,
-            })
-            .next()
+    pub fn relay_urls(&self) -> impl Iterator<Item = &RelayUrl> {
+        self.addrs.iter().filter_map(|addr| match addr {
+            AddrType::Relay(url) => Some(url),
+            _ => None,
+        })
     }
 }
 

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -15,7 +15,7 @@ mod key;
 mod relay_url;
 
 #[cfg(feature = "key")]
-pub use self::endpoint_addr::{AddrType, EndpointAddr};
+pub use self::endpoint_addr::{EndpointAddr, TransportAddr};
 #[cfg(feature = "key")]
 pub use self::key::{EndpointId, KeyParsingError, PublicKey, SecretKey, Signature, SignatureError};
 #[cfg(feature = "relay")]

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -4,8 +4,8 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
 // TODO: move to own crate
-#[cfg(feature = "ticket")]
-pub mod ticket;
+//#[cfg(feature = "ticket")]
+// b mod ticket;
 
 #[cfg(feature = "key")]
 mod endpoint_addr;
@@ -15,7 +15,7 @@ mod key;
 mod relay_url;
 
 #[cfg(feature = "key")]
-pub use self::endpoint_addr::EndpointAddr;
+pub use self::endpoint_addr::{AddrType, EndpointAddr};
 #[cfg(feature = "key")]
 pub use self::key::{EndpointId, KeyParsingError, PublicKey, SecretKey, Signature, SignatureError};
 #[cfg(feature = "relay")]

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -3,9 +3,8 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
-// TODO: move to own crate
-//#[cfg(feature = "ticket")]
-// b mod ticket;
+#[cfg(feature = "ticket")]
+pub mod ticket;
 
 #[cfg(feature = "key")]
 mod endpoint_addr;

--- a/iroh-base/src/ticket.rs
+++ b/iroh-base/src/ticket.rs
@@ -3,13 +3,13 @@
 //! ticket would contain the hash of the data as well as information about how to reach the
 //! provider.
 
-use std::{collections::BTreeSet, net::SocketAddr};
+use std::collections::BTreeSet;
 
 use nested_enum_utils::common_fields;
 use serde::{Deserialize, Serialize};
 use snafu::{Backtrace, Snafu};
 
-use crate::{key::EndpointId, relay_url::RelayUrl};
+use crate::{TransportAddr, key::EndpointId};
 
 mod endpoint;
 
@@ -103,13 +103,12 @@ impl ParseError {
 }
 
 #[derive(Serialize, Deserialize)]
-struct Variant0NodeAddr {
-    node_id: EndpointId,
-    info: Variant0AddrInfo,
+struct Variant1EndpointAddr {
+    id: EndpointId,
+    info: Variant1AddrInfo,
 }
 
 #[derive(Serialize, Deserialize)]
-struct Variant0AddrInfo {
-    relay_url: Option<RelayUrl>,
-    direct_addresses: BTreeSet<SocketAddr>,
+struct Variant1AddrInfo {
+    addrs: BTreeSet<TransportAddr>,
 }

--- a/iroh-base/src/ticket/endpoint.rs
+++ b/iroh-base/src/ticket/endpoint.rs
@@ -36,7 +36,7 @@ pub struct EndpointTicket {
 /// Wire format for [`EndpointTicket`].
 #[derive(Serialize, Deserialize)]
 enum TicketWireFormat {
-    Variant0(Variant1EndpointTicket),
+    Variant1(Variant1EndpointTicket),
 }
 
 // Legacy
@@ -49,7 +49,7 @@ impl Ticket for EndpointTicket {
     const KIND: &'static str = "endpoint";
 
     fn to_bytes(&self) -> Vec<u8> {
-        let data = TicketWireFormat::Variant0(Variant1EndpointTicket {
+        let data = TicketWireFormat::Variant1(Variant1EndpointTicket {
             addr: Variant1EndpointAddr {
                 id: self.addr.id,
                 info: Variant1AddrInfo {
@@ -62,7 +62,7 @@ impl Ticket for EndpointTicket {
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, ParseError> {
         let res: TicketWireFormat = postcard::from_bytes(bytes)?;
-        let TicketWireFormat::Variant0(Variant1EndpointTicket { addr }) = res;
+        let TicketWireFormat::Variant1(Variant1EndpointTicket { addr }) = res;
         Ok(Self {
             addr: EndpointAddr {
                 id: addr.id,

--- a/iroh-base/src/ticket/endpoint.rs
+++ b/iroh-base/src/ticket/endpoint.rs
@@ -52,7 +52,7 @@ impl Ticket for EndpointTicket {
     fn to_bytes(&self) -> Vec<u8> {
         let data = TicketWireFormat::Variant0(Variant0NodeTicket {
             node: Variant0NodeAddr {
-                node_id: self.node.endpoint_id,
+                node_id: self.node.id,
                 info: Variant0AddrInfo {
                     relay_url: self.node.relay_url.clone(),
                     direct_addresses: self.node.direct_addresses.clone(),

--- a/iroh-base/src/ticket/endpoint.rs
+++ b/iroh-base/src/ticket/endpoint.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use super::{Variant0AddrInfo, Variant0NodeAddr};
+use super::{Variant1AddrInfo, Variant1EndpointAddr};
 use crate::{
     endpoint_addr::EndpointAddr,
     ticket::{self, ParseError, Ticket},
@@ -14,8 +14,7 @@ use crate::{
 ///
 /// Contains
 /// - The [`EndpointId`] of the endpoint to connect to (a 32-byte ed25519 public key).
-/// - If used, the ['RelayUrl`] of on which the endpoint can be reached.
-/// - Any *direct addresses* on which the endpoint might be reachable.
+/// - Any known [`TransportAddr`]s on which the endpoint can be reached.
 ///
 /// This allows establishing a connection to the endpoint in most circumstances where it is
 /// possible to do so.
@@ -27,35 +26,34 @@ use crate::{
 /// [`EndpointId`]: crate::key::EndpointId
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
-/// ['RelayUrl`]: crate::relay_url::RelayUrl
+/// [`TransportAddr`]: crate::TransportAddr
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
 #[display("{}", Ticket::serialize(self))]
 pub struct EndpointTicket {
-    node: EndpointAddr,
+    addr: EndpointAddr,
 }
 
 /// Wire format for [`EndpointTicket`].
 #[derive(Serialize, Deserialize)]
 enum TicketWireFormat {
-    Variant0(Variant0NodeTicket),
+    Variant0(Variant1EndpointTicket),
 }
 
 // Legacy
 #[derive(Serialize, Deserialize)]
-struct Variant0NodeTicket {
-    node: Variant0NodeAddr,
+struct Variant1EndpointTicket {
+    addr: Variant1EndpointAddr,
 }
 
 impl Ticket for EndpointTicket {
-    const KIND: &'static str = "node";
+    const KIND: &'static str = "endpoint";
 
     fn to_bytes(&self) -> Vec<u8> {
-        let data = TicketWireFormat::Variant0(Variant0NodeTicket {
-            node: Variant0NodeAddr {
-                node_id: self.node.id,
-                info: Variant0AddrInfo {
-                    relay_url: self.node.relay_url.clone(),
-                    direct_addresses: self.node.direct_addresses.clone(),
+        let data = TicketWireFormat::Variant0(Variant1EndpointTicket {
+            addr: Variant1EndpointAddr {
+                id: self.addr.id,
+                info: Variant1AddrInfo {
+                    addrs: self.addr.addrs.clone(),
                 },
             },
         });
@@ -64,12 +62,11 @@ impl Ticket for EndpointTicket {
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, ParseError> {
         let res: TicketWireFormat = postcard::from_bytes(bytes)?;
-        let TicketWireFormat::Variant0(Variant0NodeTicket { node }) = res;
+        let TicketWireFormat::Variant0(Variant1EndpointTicket { addr }) = res;
         Ok(Self {
-            node: EndpointAddr {
-                endpoint_id: node.node_id,
-                relay_url: node.info.relay_url,
-                direct_addresses: node.info.direct_addresses,
+            addr: EndpointAddr {
+                id: addr.id,
+                addrs: addr.info.addrs,
             },
         })
     }
@@ -85,27 +82,27 @@ impl FromStr for EndpointTicket {
 
 impl EndpointTicket {
     /// Creates a new ticket.
-    pub fn new(node: EndpointAddr) -> Self {
-        Self { node }
+    pub fn new(addr: EndpointAddr) -> Self {
+        Self { addr }
     }
 
     /// The [`EndpointAddr`] of the provider for this ticket.
     pub fn endpoint_addr(&self) -> &EndpointAddr {
-        &self.node
+        &self.addr
     }
 }
 
 impl From<EndpointAddr> for EndpointTicket {
     /// Creates a ticket from given addressing info.
     fn from(addr: EndpointAddr) -> Self {
-        Self { node: addr }
+        Self { addr }
     }
 }
 
 impl From<EndpointTicket> for EndpointAddr {
     /// Returns the addressing info from given ticket.
     fn from(ticket: EndpointTicket) -> Self {
-        ticket.node
+        ticket.addr
     }
 }
 
@@ -114,8 +111,8 @@ impl Serialize for EndpointTicket {
         if serializer.is_human_readable() {
             serializer.serialize_str(&self.to_string())
         } else {
-            let EndpointTicket { node } = self;
-            (node).serialize(serializer)
+            let EndpointTicket { addr } = self;
+            (addr).serialize(serializer)
         }
     }
 }
@@ -140,15 +137,17 @@ mod tests {
     use rand::SeedableRng;
 
     use super::*;
-    use crate::key::{PublicKey, SecretKey};
+    use crate::{
+        TransportAddr,
+        key::{PublicKey, SecretKey},
+    };
 
     fn make_ticket() -> EndpointTicket {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
         let peer = SecretKey::generate(&mut rng).public();
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
-        let relay_url = None;
         EndpointTicket {
-            node: EndpointAddr::from_parts(peer, relay_url, [addr]),
+            addr: EndpointAddr::from_parts(peer, [TransportAddr::Ip(addr)]),
         }
     }
 
@@ -175,17 +174,19 @@ mod tests {
                 .unwrap();
 
         let ticket = EndpointTicket {
-            node: EndpointAddr::from_parts(
+            addr: EndpointAddr::from_parts(
                 endpoint_id,
-                Some("http://derp.me./".parse().unwrap()),
-                ["127.0.0.1:1024".parse().unwrap()],
+                [
+                    TransportAddr::Relay("http://derp.me./".parse().unwrap()),
+                    TransportAddr::Ip("127.0.0.1:1024".parse().unwrap()),
+                ],
             ),
         };
         let base32 = data_encoding::BASE32_NOPAD
             .decode(
                 ticket
                     .to_string()
-                    .strip_prefix("node")
+                    .strip_prefix("endpoint")
                     .unwrap()
                     .to_ascii_uppercase()
                     .as_bytes(),
@@ -194,20 +195,34 @@ mod tests {
         let expected = [
             // variant
             "00",
-            // node id, 32 bytes, see above
+            // endpoint id, 32 bytes, see above
             "ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6",
-            // relay url present
-            "01",
-            // relay url, 16 bytes, see above
+            // two addrs
+            "02",
+            // TransportAddr: Relay
+            "00",
+            // 16 bytes
             "10",
+            // RelayUrl
             "687474703a2f2f646572702e6d652e2f",
-            // one direct address
+            // TransportAddr: IP
             "01",
-            // ipv4
+            // IPv4
             "00",
             // address, see above
             "7f0000018008",
         ];
+
+        // 00ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6
+        // 02
+        // 00
+        // 10
+        // 687474703a2f2f646572702e6d652e2f
+        // 01
+        // 00
+        // 7f0000018008
+        dbg!(&expected);
+        dbg!(HEXLOWER.encode(&base32));
         let expected = HEXLOWER.decode(expected.concat().as_bytes()).unwrap();
         assert_eq!(base32, expected);
     }

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
     let pkarr = PkarrRelayClient::new(pkarr_relay_url);
     let endpoint_info = EndpointInfo::new(endpoint_id)
         .with_relay_url(relay_url.map(Into::into))
-        .with_direct_addresses(args.addr.into_iter().collect())
+        .with_ip_addresses(args.addr.into_iter().collect())
         .with_user_data(args.user_data);
     let signed_packet = endpoint_info.to_pkarr_signed_packet(&secret_key, 30)?;
     tracing::debug!("signed packet: {signed_packet:?}");

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
     let pkarr = PkarrRelayClient::new(pkarr_relay_url);
     let endpoint_info = EndpointInfo::new(endpoint_id)
         .with_relay_url(relay_url.map(Into::into))
-        .with_ip_addresses(args.addr.into_iter().collect())
+        .with_ip_addrs(args.addr.into_iter().collect())
         .with_user_data(args.user_data);
     let signed_packet = endpoint_info.to_pkarr_signed_packet(&secret_key, 30)?;
     tracing::debug!("signed packet: {signed_packet:?}");

--- a/iroh-dns-server/examples/resolve.rs
+++ b/iroh-dns-server/examples/resolve.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
         Command::Domain { domain } => resolver.lookup_endpoint_by_domain_name(&domain).await?,
     };
     println!("resolved endpoint {}", resolved.endpoint_id);
-    if let Some(url) = resolved.relay_url() {
+    for url in resolved.relay_urls() {
         println!("    relay={url}")
     }
     for addr in resolved.ip_addresses() {

--- a/iroh-dns-server/examples/resolve.rs
+++ b/iroh-dns-server/examples/resolve.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
     for url in resolved.relay_urls() {
         println!("    relay={url}")
     }
-    for addr in resolved.ip_addresses() {
+    for addr in resolved.ip_addrs() {
         println!("    addr={addr}")
     }
     if let Some(user_data) = resolved.user_data() {

--- a/iroh-dns-server/examples/resolve.rs
+++ b/iroh-dns-server/examples/resolve.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
     if let Some(url) = resolved.relay_url() {
         println!("    relay={url}")
     }
-    for addr in resolved.direct_addresses() {
+    for addr in resolved.ip_addresses() {
         println!("    addr={addr}")
     }
     if let Some(user_data) = resolved.user_data() {

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
         let res = resolver.lookup_endpoint_by_id(&endpoint_id, origin).await?;
 
         assert_eq!(res.endpoint_id, endpoint_id);
-        assert_eq!(res.relay_url(), Some(&relay_url));
+        assert_eq!(res.relay_urls().next(), Some(&relay_url));
 
         server.shutdown().await?;
         Ok(())
@@ -257,7 +257,7 @@ mod tests {
         let res = resolver.lookup_endpoint_by_id(&endpoint_id, origin).await?;
 
         assert_eq!(res.endpoint_id, endpoint_id);
-        assert_eq!(res.relay_url(), Some(&relay_url));
+        assert_eq!(res.relay_urls().next(), Some(&relay_url));
 
         server.shutdown().await?;
         Ok(())

--- a/iroh-relay/src/endpoint_info.rs
+++ b/iroh-relay/src/endpoint_info.rs
@@ -206,6 +206,11 @@ impl EndpointData {
     pub fn set_user_data(&mut self, user_data: Option<UserData>) {
         self.user_data = user_data;
     }
+
+    /// Returns the full list of all known addresses
+    pub fn addrs(&self) -> impl Iterator<Item = &AddrType> {
+        self.addrs.iter()
+    }
 }
 
 impl From<EndpointAddr> for EndpointData {
@@ -333,7 +338,7 @@ impl From<EndpointInfo> for EndpointAddr {
 impl From<EndpointAddr> for EndpointInfo {
     fn from(addr: EndpointAddr) -> Self {
         let mut info = Self::new(addr.id);
-        info.add_addrs(addr.addrs.into_iter());
+        info.add_addrs(addr.addrs);
         info
     }
 }

--- a/iroh-relay/src/endpoint_info.rs
+++ b/iroh-relay/src/endpoint_info.rs
@@ -150,7 +150,7 @@ impl EndpointData {
     }
 
     /// Sets the direct addresses and returns the updated endpoint data.
-    pub fn with_ip_addresses(mut self, addresses: BTreeSet<SocketAddr>) -> Self {
+    pub fn with_ip_addrs(mut self, addresses: BTreeSet<SocketAddr>) -> Self {
         for addr in addresses.into_iter() {
             self.addrs.insert(TransportAddr::Ip(addr));
         }
@@ -177,7 +177,7 @@ impl EndpointData {
     }
 
     /// Returns the direct addresses of the endpoint.
-    pub fn ip_addresses(&self) -> impl Iterator<Item = &SocketAddr> {
+    pub fn ip_addrs(&self) -> impl Iterator<Item = &SocketAddr> {
         self.addrs.iter().filter_map(|addr| match addr {
             TransportAddr::Ip(addr) => Some(addr),
             _ => None,
@@ -185,7 +185,7 @@ impl EndpointData {
     }
 
     /// Removes all direct addresses from the endpoint data.
-    pub fn clear_ip_addresses(&mut self) {
+    pub fn clear_ip_addrs(&mut self) {
         self.addrs
             .retain(|addr| !matches!(addr, TransportAddr::Ip(_)));
     }
@@ -366,9 +366,9 @@ impl EndpointInfo {
         self
     }
 
-    /// Sets the direct addresses and returns the updated endpoint info.
-    pub fn with_ip_addresses(mut self, addrs: BTreeSet<SocketAddr>) -> Self {
-        self.data = self.data.with_ip_addresses(addrs);
+    /// Sets the IP based addresses and returns the updated endpoint info.
+    pub fn with_ip_addrs(mut self, addrs: BTreeSet<SocketAddr>) -> Self {
+        self.data = self.data.with_ip_addrs(addrs);
         self
     }
 
@@ -785,7 +785,7 @@ mod tests {
             "1992d53c02cdc04566e5c0edb1ce83305cd550297953a047a445ea3264b54b18",
         )?)
         .with_relay_url(Some("https://euw1-1.relay.iroh.network./".parse()?))
-        .with_ip_addresses(BTreeSet::from([
+        .with_ip_addrs(BTreeSet::from([
             "192.168.96.145:60165".parse().unwrap(),
             "213.208.157.87:60165".parse().unwrap(),
         ]));

--- a/iroh-relay/src/endpoint_info.rs
+++ b/iroh-relay/src/endpoint_info.rs
@@ -150,7 +150,7 @@ impl EndpointData {
     }
 
     /// Sets the direct addresses and returns the updated endpoint data.
-    pub fn with_direct_addresses(mut self, addresses: BTreeSet<SocketAddr>) -> Self {
+    pub fn with_ip_addresses(mut self, addresses: BTreeSet<SocketAddr>) -> Self {
         for addr in addresses.into_iter() {
             self.addrs.insert(AddrType::Ip(addr));
         }
@@ -164,14 +164,11 @@ impl EndpointData {
     }
 
     /// Returns the relay URL of the endpoint.
-    pub fn relay_url(&self) -> Option<&RelayUrl> {
-        self.addrs
-            .iter()
-            .filter_map(|addr| match addr {
-                AddrType::Relay(url) => Some(url),
-                _ => None,
-            })
-            .next()
+    pub fn relay_urls(&self) -> impl Iterator<Item = &RelayUrl> {
+        self.addrs.iter().filter_map(|addr| match addr {
+            AddrType::Relay(url) => Some(url),
+            _ => None,
+        })
     }
 
     /// Returns the optional user-defined data of the endpoint.
@@ -180,7 +177,7 @@ impl EndpointData {
     }
 
     /// Returns the direct addresses of the endpoint.
-    pub fn direct_addresses(&self) -> impl Iterator<Item = &SocketAddr> {
+    pub fn ip_addresses(&self) -> impl Iterator<Item = &SocketAddr> {
         self.addrs.iter().filter_map(|addr| match addr {
             AddrType::Ip(addr) => Some(addr),
             _ => None,
@@ -360,7 +357,7 @@ impl EndpointInfo {
 
     /// Sets the direct addresses and returns the updated endpoint info.
     pub fn with_direct_addresses(mut self, direct_addresses: BTreeSet<SocketAddr>) -> Self {
-        self.data = self.data.with_direct_addresses(direct_addresses);
+        self.data = self.data.with_ip_addresses(direct_addresses);
         self
     }
 

--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -54,7 +54,7 @@ pub fn server_endpoint(
 
         let addr = ep.bound_sockets();
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr[0].port());
-        let mut addr = EndpointAddr::new(ep.id()).with_direct_addresses([addr]);
+        let mut addr = EndpointAddr::new(ep.id()).with_ip_addresses([addr]);
         if let Some(relay_url) = relay_url {
             addr = addr.with_relay_url(relay_url.clone());
         }

--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -54,7 +54,7 @@ pub fn server_endpoint(
 
         let addr = ep.bound_sockets();
         let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), addr[0].port());
-        let mut addr = EndpointAddr::new(ep.id()).with_ip_addresses([addr]);
+        let mut addr = EndpointAddr::new(ep.id()).with_ip_addr(addr);
         if let Some(relay_url) = relay_url {
             addr = addr.with_relay_url(relay_url.clone());
         }

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -144,12 +144,12 @@ async fn accept(_args: Args) -> n0_snafu::Result<()> {
         let Some(addr) = addrs.next().await else {
             snafu::whatever!("Address stream closed");
         };
-        if !addr.ip_addresses.is_empty() {
+        if !addr.ip_addresses().count() == 0 {
             break addr;
         }
     };
     println!("Listening on: {addr:?}");
-    println!("Endpoint ID: {:?}", addr.endpoint_id);
+    println!("Endpoint ID: {:?}", addr.id);
     println!("Ticket: {}", EndpointTicket::from(addr));
 
     let accept = async move {

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -144,7 +144,7 @@ async fn accept(_args: Args) -> n0_snafu::Result<()> {
         let Some(addr) = addrs.next().await else {
             snafu::whatever!("Address stream closed");
         };
-        if !addr.direct_addresses.is_empty() {
+        if !addr.ip_addresses.is_empty() {
             break addr;
         }
     };

--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -144,7 +144,7 @@ async fn accept(_args: Args) -> n0_snafu::Result<()> {
         let Some(addr) = addrs.next().await else {
             snafu::whatever!("Address stream closed");
         };
-        if !addr.ip_addresses().count() == 0 {
+        if !addr.ip_addrs().count() == 0 {
             break addr;
         }
     };

--- a/iroh/examples/connect-unreliable.rs
+++ b/iroh/examples/connect-unreliable.rs
@@ -9,6 +9,7 @@ use std::net::SocketAddr;
 
 use clap::Parser;
 use iroh::{Endpoint, EndpointAddr, RelayMode, RelayUrl, SecretKey};
+use iroh_base::AddrType;
 use n0_snafu::ResultExt;
 use tracing::info;
 
@@ -55,19 +56,25 @@ async fn main() -> n0_snafu::Result<()> {
     endpoint.online().await;
 
     let endpoint_addr = endpoint.addr();
-    let me = endpoint_addr.endpoint_id;
+    let me = endpoint_addr.id;
     println!("endpoint id: {me}");
     println!("endpoint listening addresses:");
     endpoint_addr
-        .ip_addresses
-        .iter()
+        .ip_addresses()
         .for_each(|addr| println!("\t{addr}"));
     let relay_url = endpoint_addr
-        .relay_url
+        .relay_urls()
+        .next()
         .expect("Should have a relay URL, assuming a default endpoint setup.");
     println!("endpoint relay server url: {relay_url}\n");
     // Build a `EndpointAddr` from the endpoint_id, relay url, and UDP addresses.
-    let addr = EndpointAddr::from_parts(args.endpoint_id, Some(args.relay_url), args.addrs);
+    let addrs = args
+        .addrs
+        .into_iter()
+        .map(AddrType::Ip)
+        .chain(std::iter::once(AddrType::Relay(args.relay_url)));
+
+    let addr = EndpointAddr::from_parts(args.endpoint_id, addrs);
 
     // Attempt to connect, over the given ALPN.
     // Returns a QUIC connection.

--- a/iroh/examples/connect-unreliable.rs
+++ b/iroh/examples/connect-unreliable.rs
@@ -60,7 +60,7 @@ async fn main() -> n0_snafu::Result<()> {
     println!("endpoint id: {me}");
     println!("endpoint listening addresses:");
     endpoint_addr
-        .ip_addresses()
+        .ip_addrs()
         .for_each(|addr| println!("\t{addr}"));
     let relay_url = endpoint_addr
         .relay_urls()

--- a/iroh/examples/connect-unreliable.rs
+++ b/iroh/examples/connect-unreliable.rs
@@ -59,7 +59,7 @@ async fn main() -> n0_snafu::Result<()> {
     println!("endpoint id: {me}");
     println!("endpoint listening addresses:");
     endpoint_addr
-        .direct_addresses
+        .ip_addresses
         .iter()
         .for_each(|addr| println!("\t{addr}"));
     let relay_url = endpoint_addr

--- a/iroh/examples/connect-unreliable.rs
+++ b/iroh/examples/connect-unreliable.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddr;
 
 use clap::Parser;
 use iroh::{Endpoint, EndpointAddr, RelayMode, RelayUrl, SecretKey};
-use iroh_base::AddrType;
+use iroh_base::TransportAddr;
 use n0_snafu::ResultExt;
 use tracing::info;
 
@@ -71,8 +71,8 @@ async fn main() -> n0_snafu::Result<()> {
     let addrs = args
         .addrs
         .into_iter()
-        .map(AddrType::Ip)
-        .chain(std::iter::once(AddrType::Relay(args.relay_url)));
+        .map(TransportAddr::Ip)
+        .chain(std::iter::once(TransportAddr::Relay(args.relay_url)));
 
     let addr = EndpointAddr::from_parts(args.endpoint_id, addrs);
 

--- a/iroh/examples/connect.rs
+++ b/iroh/examples/connect.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
     let me = endpoint.id();
     println!("endpoint id: {me}");
     println!("endpoint listening addresses:");
-    for addr in endpoint_addr.ip_addresses() {
+    for addr in endpoint_addr.ip_addrs() {
         println!("\t{addr}")
     }
 

--- a/iroh/examples/connect.rs
+++ b/iroh/examples/connect.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
     let me = endpoint.id();
     println!("endpoint id: {me}");
     println!("endpoint listening addresses:");
-    for addr in endpoint_addr.direct_addresses() {
+    for addr in endpoint_addr.ip_addresses() {
         println!("\t{addr}")
     }
 

--- a/iroh/examples/connect.rs
+++ b/iroh/examples/connect.rs
@@ -8,7 +8,7 @@
 use std::net::SocketAddr;
 
 use clap::Parser;
-use iroh::{AddrType, Endpoint, EndpointAddr, RelayMode, RelayUrl, SecretKey};
+use iroh::{Endpoint, EndpointAddr, RelayMode, RelayUrl, SecretKey, TransportAddr};
 use n0_snafu::{Result, ResultExt};
 use tracing::info;
 
@@ -71,8 +71,8 @@ async fn main() -> Result<()> {
     let addrs = args
         .addrs
         .into_iter()
-        .map(AddrType::Ip)
-        .chain(std::iter::once(AddrType::Relay(args.relay_url)));
+        .map(TransportAddr::Ip)
+        .chain(std::iter::once(TransportAddr::Relay(args.relay_url)));
     let addr = EndpointAddr::from_parts(args.endpoint_id, addrs);
 
     // Attempt to connect, over the given ALPN.

--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -41,8 +41,7 @@ async fn main() -> Result<()> {
 
     let endpoint_addr = endpoint.addr();
     let local_addrs = endpoint_addr
-        .ip_addresses
-        .into_iter()
+        .ip_addresses()
         .map(|addr| {
             let addr = addr.to_string();
             println!("\t{addr}");
@@ -51,7 +50,8 @@ async fn main() -> Result<()> {
         .collect::<Vec<_>>()
         .join(" ");
     let relay_url = endpoint_addr
-        .relay_url
+        .relay_urls()
+        .next()
         .expect("Should have a relay URL, assuming a default endpoint setup.");
     println!("endpoint relay server url: {relay_url}");
     println!("\nin a separate terminal run:");

--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
 
     let endpoint_addr = endpoint.addr();
     let local_addrs = endpoint_addr
-        .ip_addresses()
+        .ip_addrs()
         .map(|addr| {
             let addr = addr.to_string();
             println!("\t{addr}");

--- a/iroh/examples/listen-unreliable.rs
+++ b/iroh/examples/listen-unreliable.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
 
     let endpoint_addr = endpoint.addr();
     let local_addrs = endpoint_addr
-        .direct_addresses
+        .ip_addresses
         .into_iter()
         .map(|addr| {
             let addr = addr.to_string();

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -43,7 +43,7 @@ async fn main() -> n0_snafu::Result<()> {
     let endpoint_addr = endpoint.addr();
 
     let local_addrs = endpoint_addr
-        .direct_addresses
+        .ip_addresses
         .iter()
         .map(|addr| {
             let addr = addr.to_string();

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -43,8 +43,7 @@ async fn main() -> n0_snafu::Result<()> {
     let endpoint_addr = endpoint.addr();
 
     let local_addrs = endpoint_addr
-        .ip_addresses
-        .iter()
+        .ip_addresses()
         .map(|addr| {
             let addr = addr.to_string();
             println!("\t{addr}");
@@ -52,7 +51,7 @@ async fn main() -> n0_snafu::Result<()> {
         })
         .collect::<Vec<_>>()
         .join(" ");
-    let relay_url = endpoint_addr.relay_url.expect("missing relay");
+    let relay_url = endpoint_addr.relay_urls().next().expect("missing relay");
     println!("endpoint relay server url: {relay_url}");
     println!("\nin a separate terminal run:");
 

--- a/iroh/examples/listen.rs
+++ b/iroh/examples/listen.rs
@@ -43,7 +43,7 @@ async fn main() -> n0_snafu::Result<()> {
     let endpoint_addr = endpoint.addr();
 
     let local_addrs = endpoint_addr
-        .ip_addresses()
+        .ip_addrs()
         .map(|addr| {
             let addr = addr.to_string();
             println!("\t{addr}");

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -392,7 +392,7 @@ async fn provide(endpoint: Endpoint, size: u64) -> Result<()> {
 async fn fetch(endpoint: Endpoint, ticket: &str) -> Result<()> {
     let me = endpoint.id().fmt_short();
     let ticket: EndpointTicket = ticket.parse()?;
-    let remote_endpoint_id = ticket.endpoint_addr().endpoint_id;
+    let remote_endpoint_id = ticket.endpoint_addr().id;
     let start = Instant::now();
 
     // Attempt to connect, over the given ALPN.

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 use data_encoding::HEXLOWER;
 use indicatif::HumanBytes;
 use iroh::{
-    Endpoint, EndpointAddr, EndpointId, RelayMap, RelayMode, RelayUrl, SecretKey,
+    AddrType, Endpoint, EndpointAddr, EndpointId, RelayMap, RelayMode, RelayUrl, SecretKey,
     discovery::{
         dns::DnsDiscovery,
         pkarr::{N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING, PkarrPublisher},
@@ -288,11 +288,11 @@ impl EndpointArgs {
         let endpoint_addr = endpoint.addr();
 
         println!("Our direct addresses:");
-        for addr in &endpoint_addr.ip_addresses {
+        for addr in endpoint_addr.ip_addresses() {
             println!("\t{addr}");
         }
 
-        if let Some(url) = endpoint_addr.relay_url {
+        if let Some(url) = endpoint_addr.relay_urls().next() {
             println!("Our home relay server:\t{url}");
         } else {
             println!("No home relay server found");
@@ -311,7 +311,9 @@ async fn provide(endpoint: Endpoint, size: u64) -> Result<()> {
     println!("Ticket with our home relay and direct addresses:\n{ticket}\n",);
 
     let mut endpoint_addr = endpoint.addr();
-    endpoint_addr.ip_addresses = Default::default();
+    endpoint_addr
+        .addrs
+        .retain(|addr| !matches!(addr, AddrType::Ip(_)));
     let ticket = EndpointTicket::new(endpoint_addr);
     println!("Ticket with our home relay but no direct addresses:\n{ticket}\n",);
 

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -288,7 +288,7 @@ impl EndpointArgs {
         let endpoint_addr = endpoint.addr();
 
         println!("Our direct addresses:");
-        for addr in &endpoint_addr.direct_addresses {
+        for addr in &endpoint_addr.ip_addresses {
             println!("\t{addr}");
         }
 
@@ -311,7 +311,7 @@ async fn provide(endpoint: Endpoint, size: u64) -> Result<()> {
     println!("Ticket with our home relay and direct addresses:\n{ticket}\n",);
 
     let mut endpoint_addr = endpoint.addr();
-    endpoint_addr.direct_addresses = Default::default();
+    endpoint_addr.ip_addresses = Default::default();
     let ticket = EndpointTicket::new(endpoint_addr);
     println!("Ticket with our home relay but no direct addresses:\n{ticket}\n",);
 

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 use data_encoding::HEXLOWER;
 use indicatif::HumanBytes;
 use iroh::{
-    AddrType, Endpoint, EndpointAddr, EndpointId, RelayMap, RelayMode, RelayUrl, SecretKey,
+    Endpoint, EndpointAddr, EndpointId, RelayMap, RelayMode, RelayUrl, SecretKey, TransportAddr,
     discovery::{
         dns::DnsDiscovery,
         pkarr::{N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING, PkarrPublisher},
@@ -313,7 +313,7 @@ async fn provide(endpoint: Endpoint, size: u64) -> Result<()> {
     let mut endpoint_addr = endpoint.addr();
     endpoint_addr
         .addrs
-        .retain(|addr| !matches!(addr, AddrType::Ip(_)));
+        .retain(|addr| !matches!(addr, TransportAddr::Ip(_)));
     let ticket = EndpointTicket::new(endpoint_addr);
     println!("Ticket with our home relay but no direct addresses:\n{ticket}\n",);
 

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -288,7 +288,7 @@ impl EndpointArgs {
         let endpoint_addr = endpoint.addr();
 
         println!("Our direct addresses:");
-        for addr in endpoint_addr.ip_addresses() {
+        for addr in endpoint_addr.ip_addrs() {
             println!("\t{addr}");
         }
 

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -637,7 +637,7 @@ mod tests {
         time::SystemTime,
     };
 
-    use iroh_base::{AddrType, EndpointAddr, SecretKey};
+    use iroh_base::{EndpointAddr, SecretKey, TransportAddr};
     use n0_snafu::{Error, Result, ResultExt};
     use quinn::{IdleTimeout, TransportConfig};
     use rand::{CryptoRng, Rng, SeedableRng};
@@ -707,7 +707,7 @@ mod tests {
                 let port: u16 = rand::rng().random_range(10_000..20_000);
                 // "240.0.0.0/4" is reserved and unreachable
                 let addr: SocketAddr = format!("240.0.0.1:{port}").parse().unwrap();
-                let data = EndpointData::new([AddrType::Ip(addr)]);
+                let data = EndpointData::new([TransportAddr::Ip(addr)]);
                 Some((data, ts))
             } else {
                 self.shared
@@ -890,7 +890,7 @@ mod tests {
 
         let ep1_wrong_addr = EndpointAddr {
             id: ep1.id(),
-            addrs: [AddrType::Ip("240.0.0.1:1000".parse().unwrap())]
+            addrs: [TransportAddr::Ip("240.0.0.1:1000".parse().unwrap())]
                 .into_iter()
                 .collect(),
         };
@@ -956,7 +956,7 @@ mod tests {
 /// publish to. The DNS and pkarr servers share their state.
 #[cfg(test)]
 mod test_dns_pkarr {
-    use iroh_base::{AddrType, EndpointAddr, SecretKey};
+    use iroh_base::{EndpointAddr, SecretKey, TransportAddr};
     use iroh_relay::{RelayMap, endpoint_info::UserData};
     use n0_future::time::Duration;
     use n0_snafu::{Error, Result, ResultExt};
@@ -1017,7 +1017,9 @@ mod test_dns_pkarr {
         let secret_key = SecretKey::generate(&mut rng);
         let endpoint_id = secret_key.public();
 
-        let relay_url = Some(AddrType::Relay("https://relay.example".parse().unwrap()));
+        let relay_url = Some(TransportAddr::Relay(
+            "https://relay.example".parse().unwrap(),
+        ));
 
         let resolver = DnsResolver::with_nameserver(dns_pkarr_server.nameserver);
         let publisher =

--- a/iroh/src/discovery/mdns.rs
+++ b/iroh/src/discovery/mdns.rs
@@ -279,7 +279,7 @@ impl MdnsDiscovery {
                         tracing::trace!(?data, "MdnsDiscovery address changed");
                         discovery.remove_all();
                         let addrs =
-                            MdnsDiscovery::socketaddrs_to_addrs(data.direct_addresses());
+                            MdnsDiscovery::socketaddrs_to_addrs(data.ip_addresses());
                         for addr in addrs {
                             discovery.add(addr.0, addr.1)
                         }

--- a/iroh/src/discovery/mdns.rs
+++ b/iroh/src/discovery/mdns.rs
@@ -279,7 +279,7 @@ impl MdnsDiscovery {
                         tracing::trace!(?data, "MdnsDiscovery address changed");
                         discovery.remove_all();
                         let addrs =
-                            MdnsDiscovery::socketaddrs_to_addrs(data.ip_addresses());
+                            MdnsDiscovery::socketaddrs_to_addrs(data.ip_addrs());
                         for addr in addrs {
                             discovery.add(addr.0, addr.1)
                         }
@@ -508,7 +508,7 @@ fn peer_to_discovery_item(peer: &Peer, endpoint_id: &EndpointId) -> DiscoveryIte
         None
     };
     let endpoint_info = EndpointInfo::new(*endpoint_id)
-        .with_ip_addresses(ip_addrs)
+        .with_ip_addrs(ip_addrs)
         .with_user_data(user_data);
     DiscoveryItem::new(endpoint_info, NAME, None)
 }

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -315,7 +315,7 @@ impl PkarrPublisher {
     /// This is a nonblocking function, the actual update is performed in the background.
     pub fn update_endpoint_data(&self, data: &EndpointData) {
         let mut data = data.clone();
-        if data.relay_url().is_some() {
+        if data.relay_urls().next().is_some() {
             // If relay url is set: only publish relay url, and no direct addrs.
             data.clear_direct_addresses();
         }

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -317,7 +317,7 @@ impl PkarrPublisher {
         let mut data = data.clone();
         if data.relay_urls().next().is_some() {
             // If relay url is set: only publish relay url, and no  addrs.
-            data.clear_ip_addresses();
+            data.clear_ip_addrs();
         }
         let info = EndpointInfo::from_parts(self.endpoint_id, data);
         self.watchable.set(Some(info)).ok();

--- a/iroh/src/discovery/pkarr.rs
+++ b/iroh/src/discovery/pkarr.rs
@@ -316,8 +316,8 @@ impl PkarrPublisher {
     pub fn update_endpoint_data(&self, data: &EndpointData) {
         let mut data = data.clone();
         if data.relay_urls().next().is_some() {
-            // If relay url is set: only publish relay url, and no direct addrs.
-            data.clear_direct_addresses();
+            // If relay url is set: only publish relay url, and no  addrs.
+            data.clear_ip_addresses();
         }
         let info = EndpointInfo::from_parts(self.endpoint_id, data);
         self.watchable.set(Some(info)).ok();

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -292,14 +292,14 @@ impl Discovery for DhtDiscovery {
             tracing::debug!("no keypair set, not publishing");
             return;
         };
-        if data.relay_url().is_none() && data.ip_addresses().is_empty() {
+        if !data.has_addrs() {
             tracing::debug!("no relay url or direct addresses in endpoint data, not publishing");
             return;
         }
         tracing::debug!("publishing {data:?}");
         let mut info = EndpointInfo::from_parts(keypair.public(), data.clone());
         if !self.0.include_direct_addresses {
-            info.clear_direct_addresses();
+            info.clear_ip_addresses();
         }
         let Ok(signed_packet) = info.to_pkarr_signed_packet(keypair, self.0.ttl) else {
             tracing::warn!("failed to create signed packet");
@@ -369,7 +369,7 @@ mod tests {
                     .collect::<Vec<_>>()
                     .await;
                 for item in items.into_iter().flatten() {
-                    if let Some(url) = item.relay_url() {
+                    for url in item.relay_urls() {
                         found_relay_urls.insert(url.clone());
                     }
                 }

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -299,7 +299,7 @@ impl Discovery for DhtDiscovery {
         tracing::debug!("publishing {data:?}");
         let mut info = EndpointInfo::from_parts(keypair.public(), data.clone());
         if !self.0.include_direct_addresses {
-            info.clear_ip_addresses();
+            info.clear_ip_addrs();
         }
         let Ok(signed_packet) = info.to_pkarr_signed_packet(keypair, self.0.ttl) else {
             tracing::warn!("failed to create signed packet");

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -292,7 +292,7 @@ impl Discovery for DhtDiscovery {
             tracing::debug!("no keypair set, not publishing");
             return;
         };
-        if data.relay_url().is_none() && data.direct_addresses().is_empty() {
+        if data.relay_url().is_none() && data.ip_addresses().is_empty() {
             tracing::debug!("no relay url or direct addresses in endpoint data, not publishing");
             return;
         }

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -50,11 +50,11 @@ use super::{Discovery, DiscoveryError, DiscoveryItem, EndpointData, EndpointInfo
 ///     .bind()
 ///     .await?;
 ///
-/// // Sometime later add a RelayUrl for a fake EndpointId.
-/// let endpoint_id = SecretKey::from_bytes(&[0u8; 32]).public(); // Do not use fake secret keys!
+/// // Sometime later add a RelayUrl for our endpoint.
+/// let id = SecretKey::generate(&mut rand::rng()).public();
 /// // You can pass either `EndpointInfo` or `EndpointAddr` to `add_endpoint_info`.
 /// discovery.add_endpoint_info(EndpointAddr {
-///     endpoint_id,
+///     id,
 ///     addrs: [TransportAddr::Relay("https://example.com".parse()?)]
 ///         .into_iter()
 ///         .collect(),

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -231,7 +231,7 @@ impl Discovery for StaticProvider {
 
 #[cfg(test)]
 mod tests {
-    use iroh_base::{AddrType, EndpointAddr, SecretKey};
+    use iroh_base::{EndpointAddr, SecretKey, TransportAddr};
     use n0_snafu::{Result, ResultExt};
 
     use super::*;
@@ -249,7 +249,7 @@ mod tests {
         let key = SecretKey::from_bytes(&[0u8; 32]);
         let addr = EndpointAddr {
             id: key.public(),
-            addrs: [AddrType::Relay("https://example.com".parse()?)]
+            addrs: [TransportAddr::Relay("https://example.com".parse()?)]
                 .into_iter()
                 .collect(),
         };
@@ -281,7 +281,7 @@ mod tests {
         let key = SecretKey::from_bytes(&[0u8; 32]);
         let addr = EndpointAddr {
             id: key.public(),
-            addrs: [AddrType::Relay("https://example.com".parse()?)]
+            addrs: [TransportAddr::Relay("https://example.com".parse()?)]
                 .into_iter()
                 .collect(),
         };

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -176,8 +176,10 @@ impl StaticProvider {
                 let existing = entry.get_mut();
                 existing
                     .data
-                    .add_direct_addresses(data.direct_addresses().iter().copied());
-                existing.data.set_relay_url(data.relay_url().cloned());
+                    .add_direct_addresses(data.ip_addresses().copied());
+                existing
+                    .data
+                    .set_relay_url(data.relay_urls().next().cloned());
                 existing.data.set_user_data(data.user_data().cloned());
                 existing.last_updated = last_updated;
             }

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -37,7 +37,7 @@ use super::{Discovery, DiscoveryError, DiscoveryItem, EndpointData, EndpointInfo
 /// # Examples
 ///
 /// ```rust
-/// use iroh::{Endpoint, EndpointAddr, discovery::static_provider::StaticProvider};
+/// use iroh::{Endpoint, EndpointAddr, TransportAddr, discovery::static_provider::StaticProvider};
 /// use iroh_base::SecretKey;
 ///
 /// # #[tokio::main]
@@ -55,8 +55,9 @@ use super::{Discovery, DiscoveryError, DiscoveryItem, EndpointData, EndpointInfo
 /// // You can pass either `EndpointInfo` or `EndpointAddr` to `add_endpoint_info`.
 /// discovery.add_endpoint_info(EndpointAddr {
 ///     endpoint_id,
-///     relay_url: Some("https://example.com".parse()?),
-///     direct_addresses: Default::default(),
+///     addrs: [TransportAddr::Relay("https://example.com".parse()?)]
+///         .into_iter()
+///         .collect(),
 /// });
 ///
 /// # Ok(())

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -698,7 +698,7 @@ impl Endpoint {
             self.add_endpoint_addr(endpoint_addr.clone(), Source::App)?;
         }
         let endpoint_id = endpoint_addr.id;
-        let ip_addresses: Vec<_> = endpoint_addr.ip_addresses().cloned().collect();
+        let ip_addresses: Vec<_> = endpoint_addr.ip_addrs().cloned().collect();
         let relay_url = endpoint_addr.relay_urls().next().cloned();
 
         // Get the mapped IPv6 address from the magic socket. Quinn will connect to this
@@ -870,7 +870,7 @@ impl Endpoint {
     /// [`RelayUrl`]: crate::RelayUrl
     #[cfg(not(wasm_browser))]
     pub fn watch_addr(&self) -> impl n0_watcher::Watcher<Value = EndpointAddr> + use<> {
-        let watch_addrs = self.msock.ip_addresses();
+        let watch_addrs = self.msock.ip_addrs();
         let watch_relay = self.msock.home_relay();
         let endpoint_id = self.id();
 
@@ -2723,7 +2723,7 @@ mod tests {
             .bind()
             .await?;
 
-        assert!(ep.addr().ip_addresses().count() > 0);
+        assert!(ep.addr().ip_addrs().count() > 0);
 
         Ok(())
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -877,7 +877,7 @@ impl Endpoint {
         watch_addrs
             .or(watch_relay)
             .map(move |(addrs, relays)| {
-                use iroh_base::AddrType;
+                use iroh_base::TransportAddr;
 
                 debug_assert!(!addrs.is_empty(), "direct addresses must never be empty");
 
@@ -885,8 +885,8 @@ impl Endpoint {
                     endpoint_id,
                     relays
                         .into_iter()
-                        .map(AddrType::Relay)
-                        .chain(addrs.into_iter().map(|x| AddrType::Ip(x.addr))),
+                        .map(TransportAddr::Relay)
+                        .chain(addrs.into_iter().map(|x| TransportAddr::Ip(x.addr))),
                 )
             })
             .expect("watchable is alive - cannot be disconnected yet")
@@ -2135,7 +2135,7 @@ fn is_cgi() -> bool {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use iroh_base::{AddrType, EndpointAddr, EndpointId, SecretKey};
+    use iroh_base::{EndpointAddr, EndpointId, SecretKey, TransportAddr};
     use n0_future::{BufferedStreamExt, StreamExt, stream, task::AbortOnDropHandle};
     use n0_snafu::{Error, Result, ResultExt};
     use n0_watcher::Watcher;
@@ -2460,7 +2460,8 @@ mod tests {
         println!("round1: {:?}", addr);
 
         // remove direct addrs to force relay usage
-        addr.addrs.retain(|addr| !matches!(addr, AddrType::Ip(_)));
+        addr.addrs
+            .retain(|addr| !matches!(addr, TransportAddr::Ip(_)));
 
         let conn = client.connect(addr, TEST_ALPN).await?;
         let (mut send, mut recv) = conn.open_bi().await.e()?;
@@ -2509,7 +2510,8 @@ mod tests {
         assert_eq!(addr.relay_urls().next(), Some(&new_relay_url));
 
         // remove direct addrs to force relay usage
-        addr.addrs.retain(|addr| !matches!(addr, AddrType::Ip(_)));
+        addr.addrs
+            .retain(|addr| !matches!(addr, TransportAddr::Ip(_)));
 
         let conn = client.connect(addr, TEST_ALPN).await?;
         let (mut send, mut recv) = conn.open_bi().await.e()?;

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -857,8 +857,8 @@ impl Endpoint {
     /// that initial call to [`Endpoint::online`], to understand if your
     /// endpoint is no longer able to be connected to by endpoints outside
     /// of the private or local network, watch for changes in it's [`EndpointAddr`].
-    /// If the `relay_url` is `None` or if there are no `direct_addresses` in
-    /// the [`EndpointAddr`], you may not be dialable by other endpoints on the internet.
+    /// If there are no `addrs`in the [`EndpointAddr`], you may not be dialable by other endpoints
+    /// on the internet.
     ///
     ///
     /// The `EndpointAddr` will change as:
@@ -870,7 +870,7 @@ impl Endpoint {
     /// [`RelayUrl`]: crate::RelayUrl
     #[cfg(not(wasm_browser))]
     pub fn watch_addr(&self) -> impl n0_watcher::Watcher<Value = EndpointAddr> + use<> {
-        let watch_addrs = self.msock.direct_addresses();
+        let watch_addrs = self.msock.ip_addresses();
         let watch_relay = self.msock.home_relay();
         let endpoint_id = self.id();
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use ed25519_dalek::{VerifyingKey, pkcs8::DecodePublicKey};
-use iroh_base::{EndpointAddr, EndpointId, RelayUrl, SecretKey};
+use iroh_base::{EndpointAddr, EndpointId, RelayUrl, SecretKey, TransportAddr};
 use iroh_relay::{RelayConfig, RelayMap};
 use n0_future::time::Duration;
 use n0_watcher::Watcher;
@@ -877,8 +877,6 @@ impl Endpoint {
         watch_addrs
             .or(watch_relay)
             .map(move |(addrs, relays)| {
-                use iroh_base::TransportAddr;
-
                 debug_assert!(!addrs.is_empty(), "direct addresses must never be empty");
 
                 EndpointAddr::from_parts(
@@ -906,7 +904,7 @@ impl Endpoint {
         let endpoint_id = self.id();
         watch_relay
             .map(move |mut relays| {
-                EndpointAddr::from_parts(endpoint_id, relays.pop(), std::iter::empty())
+                EndpointAddr::from_parts(endpoint_id, relays.into_iter().map(TransportAddr::Relay))
             })
             .expect("watchable is alive - cannot be disconnected yet")
     }

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -272,8 +272,8 @@ pub mod protocol;
 
 pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{
-    EndpointAddr, EndpointId, KeyParsingError, PublicKey, RelayUrl, RelayUrlParseError, SecretKey,
-    Signature, SignatureError,
+    AddrType, EndpointAddr, EndpointId, KeyParsingError, PublicKey, RelayUrl, RelayUrlParseError,
+    SecretKey, Signature, SignatureError,
 };
 pub use iroh_relay::{RelayConfig, RelayMap, endpoint_info};
 pub use n0_watcher::Watcher;

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -272,8 +272,8 @@ pub mod protocol;
 
 pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{
-    AddrType, EndpointAddr, EndpointId, KeyParsingError, PublicKey, RelayUrl, RelayUrlParseError,
-    SecretKey, Signature, SignatureError,
+    EndpointAddr, EndpointId, KeyParsingError, PublicKey, RelayUrl, RelayUrlParseError, SecretKey,
+    Signature, SignatureError, TransportAddr,
 };
 pub use iroh_relay::{RelayConfig, RelayMap, endpoint_info};
 pub use n0_watcher::Watcher;

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -30,7 +30,7 @@ use std::{
 
 use bytes::Bytes;
 use data_encoding::HEXLOWER;
-use iroh_base::{EndpointAddr, EndpointId, PublicKey, RelayUrl, SecretKey};
+use iroh_base::{AddrType, EndpointAddr, EndpointId, PublicKey, RelayUrl, SecretKey};
 use iroh_relay::{RelayConfig, RelayMap};
 use n0_future::{
     task::{self, AbortOnDropHandle},
@@ -410,7 +410,7 @@ impl MagicSock {
     ) -> Result<(), AddEndpointAddrError> {
         let mut pruned: usize = 0;
         for my_addr in self.direct_addrs.sockaddrs() {
-            if addr.ip_addresses.remove(&my_addr) {
+            if addr.addrs.remove(&AddrType::Ip(my_addr)) {
                 warn!( endpoint_id=%addr.id.fmt_short(), %my_addr, %source, "not adding our addr for endpoint");
                 pruned += 1;
             }
@@ -435,7 +435,7 @@ impl MagicSock {
         let updated = self.direct_addrs.update(addrs);
         if updated {
             self.endpoint_map
-                .on_direct_addr_discovered(self.direct_addrs.sockaddrs());
+                .on_direct_addr_discovered(self.direct_addrs.sockaddrs().collect());
             self.publish_my_addr();
         }
     }
@@ -1157,19 +1157,22 @@ impl MagicSock {
     /// Called whenever our addresses or home relay endpoint changes.
     fn publish_my_addr(&self) {
         let relay_url = self.my_relay();
-        let direct_addrs = self.direct_addrs.sockaddrs();
+        let mut addrs: BTreeSet<_> = self.direct_addrs.sockaddrs().map(AddrType::Ip).collect();
 
         let user_data = self
             .discovery_user_data
             .read()
             .expect("lock poisened")
             .clone();
-        if relay_url.is_none() && direct_addrs.is_empty() && user_data.is_none() {
+        if relay_url.is_none() && addrs.is_empty() && user_data.is_none() {
             // do not bother publishing if we don't have any information
             return;
         }
+        if let Some(url) = relay_url {
+            addrs.insert(AddrType::Relay(url));
+        }
 
-        let data = EndpointData::new(relay_url, direct_addrs).with_user_data(user_data);
+        let data = EndpointData::new(addrs).with_user_data(user_data);
         self.discovery.publish(&data);
     }
 }
@@ -2351,8 +2354,8 @@ impl DiscoveredDirectAddrs {
         updated
     }
 
-    fn sockaddrs(&self) -> BTreeSet<SocketAddr> {
-        self.addrs.get().into_iter().map(|da| da.addr).collect()
+    fn sockaddrs(&self) -> impl Iterator<Item = SocketAddr> {
+        self.addrs.get().into_iter().map(|da| da.addr)
     }
 
     /// Whether the direct addr information is considered "fresh".
@@ -2539,7 +2542,7 @@ mod tests {
     use std::{collections::BTreeSet, net::SocketAddr, sync::Arc, time::Duration};
 
     use data_encoding::HEXLOWER;
-    use iroh_base::{EndpointAddr, EndpointId, PublicKey};
+    use iroh_base::{AddrType, EndpointAddr, EndpointId, PublicKey};
     use n0_future::{StreamExt, time};
     use n0_snafu::{Result, ResultExt};
     use n0_watcher::Watcher;
@@ -2669,9 +2672,8 @@ mod tests {
                 }
 
                 let addr = EndpointAddr {
-                    endpoint_id: me.public(),
-                    relay_url: None,
-                    direct_addresses: new_addrs.clone(),
+                    id: me.public(),
+                    addrs: new_addrs.iter().copied().map(AddrType::Ip).collect(),
                 };
                 m.endpoint.magic_sock().add_test_addr(addr);
             }
@@ -3230,15 +3232,15 @@ mod tests {
         });
         let _accept_task = AbortOnDropHandle::new(accept_task);
 
+        let addrs = msock_2
+            .direct_addresses()
+            .get()
+            .into_iter()
+            .map(|x| AddrType::Ip(x.addr))
+            .collect();
         let endpoint_addr_2 = EndpointAddr {
-            endpoint_id: endpoint_id_2,
-            relay_url: None,
-            direct_addresses: msock_2
-                .direct_addresses()
-                .get()
-                .into_iter()
-                .map(|x| x.addr)
-                .collect(),
+            id: endpoint_id_2,
+            addrs,
         };
         msock_1
             .add_endpoint_addr(
@@ -3308,9 +3310,8 @@ mod tests {
         // Add an empty entry in the EndpointMap of ep_1
         msock_1.endpoint_map.add_endpoint_addr(
             EndpointAddr {
-                endpoint_id: endpoint_id_2,
-                relay_url: None,
-                direct_addresses: Default::default(),
+                id: endpoint_id_2,
+                addrs: Default::default(),
             },
             Source::NamedApp {
                 name: "test".into(),
@@ -3344,16 +3345,16 @@ mod tests {
         info!("first connect timed out as expected");
 
         // Provide correct addressing information
+        let addrs = msock_2
+            .direct_addresses()
+            .get()
+            .into_iter()
+            .map(|x| AddrType::Ip(x.addr))
+            .collect();
         msock_1.endpoint_map.add_endpoint_addr(
             EndpointAddr {
-                endpoint_id: endpoint_id_2,
-                relay_url: None,
-                direct_addresses: msock_2
-                    .direct_addresses()
-                    .get()
-                    .into_iter()
-                    .map(|x| x.addr)
-                    .collect(),
+                id: endpoint_id_2,
+                addrs,
             },
             Source::NamedApp {
                 name: "test".into(),
@@ -3395,11 +3396,8 @@ mod tests {
         assert_eq!(stack.endpoint.magic_sock().endpoint_map.endpoint_count(), 0);
 
         // Empty
-        let empty_addr = EndpointAddr {
-            endpoint_id: SecretKey::generate(&mut rng).public(),
-            relay_url: None,
-            direct_addresses: Default::default(),
-        };
+        let empty_addr = EndpointAddr::new(SecretKey::generate(&mut rng).public());
+
         let err = stack
             .endpoint
             .magic_sock()
@@ -3413,9 +3411,10 @@ mod tests {
 
         // relay url only
         let addr = EndpointAddr {
-            endpoint_id: SecretKey::generate(&mut rng).public(),
-            relay_url: Some("http://my-relay.com".parse().unwrap()),
-            direct_addresses: Default::default(),
+            id: SecretKey::generate(&mut rng).public(),
+            addrs: [AddrType::Relay("http://my-relay.com".parse().unwrap())]
+                .into_iter()
+                .collect(),
         };
         stack
             .endpoint
@@ -3425,9 +3424,10 @@ mod tests {
 
         // addrs only
         let addr = EndpointAddr {
-            endpoint_id: SecretKey::generate(&mut rng).public(),
-            relay_url: None,
-            direct_addresses: ["127.0.0.1:1234".parse().unwrap()].into_iter().collect(),
+            id: SecretKey::generate(&mut rng).public(),
+            addrs: [AddrType::Ip("127.0.0.1:1234".parse().unwrap())]
+                .into_iter()
+                .collect(),
         };
         stack
             .endpoint
@@ -3437,9 +3437,13 @@ mod tests {
 
         // both
         let addr = EndpointAddr {
-            endpoint_id: SecretKey::generate(&mut rng).public(),
-            relay_url: Some("http://my-relay.com".parse().unwrap()),
-            direct_addresses: ["127.0.0.1:1234".parse().unwrap()].into_iter().collect(),
+            id: SecretKey::generate(&mut rng).public(),
+            addrs: [
+                AddrType::Relay("http://my-relay.com".parse().unwrap()),
+                AddrType::Ip("127.0.0.1:1234".parse().unwrap()),
+            ]
+            .into_iter()
+            .collect(),
         };
         stack
             .endpoint

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -329,7 +329,7 @@ impl MagicSock {
     ///
     /// [`Watcher`]: n0_watcher::Watcher
     /// [`Watcher::initialized`]: n0_watcher::Watcher::initialized
-    pub(crate) fn ip_addresses(&self) -> n0_watcher::Direct<BTreeSet<DirectAddr>> {
+    pub(crate) fn ip_addrs(&self) -> n0_watcher::Direct<BTreeSet<DirectAddr>> {
         self.direct_addrs.addrs.watch()
     }
 
@@ -2693,8 +2693,8 @@ mod tests {
                 let me = m.endpoint.id().fmt_short();
                 let mut stream = m.endpoint.watch_addr().stream();
                 while let Some(addr) = stream.next().await {
-                    info!(%me, "conn{} endpoints update: {:?}", my_idx + 1, addr.ip_addresses().collect::<Vec<_>>());
-                    update_direct_addrs(&stacks, my_idx, addr.ip_addresses().copied().collect());
+                    info!(%me, "conn{} endpoints update: {:?}", my_idx + 1, addr.ip_addrs().collect::<Vec<_>>());
+                    update_direct_addrs(&stacks, my_idx, addr.ip_addrs().copied().collect());
                 }
             });
         }
@@ -3080,12 +3080,12 @@ mod tests {
         let ms = Handle::new(default_options(&mut rng)).await.unwrap();
 
         // See if we can get endpoints.
-        let eps0 = ms.ip_addresses().get();
+        let eps0 = ms.ip_addrs().get();
         println!("{eps0:?}");
         assert!(!eps0.is_empty());
 
         // Getting the endpoints again immediately should give the same results.
-        let eps1 = ms.ip_addresses().get();
+        let eps1 = ms.ip_addrs().get();
         println!("{eps1:?}");
         assert_eq!(eps0, eps1);
     }
@@ -3237,7 +3237,7 @@ mod tests {
         let _accept_task = AbortOnDropHandle::new(accept_task);
 
         let addrs = msock_2
-            .ip_addresses()
+            .ip_addrs()
             .get()
             .into_iter()
             .map(|x| TransportAddr::Ip(x.addr))
@@ -3350,7 +3350,7 @@ mod tests {
 
         // Provide correct addressing information
         let addrs = msock_2
-            .ip_addresses()
+            .ip_addrs()
             .get()
             .into_iter()
             .map(|x| TransportAddr::Ip(x.addr))

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -410,8 +410,8 @@ impl MagicSock {
     ) -> Result<(), AddEndpointAddrError> {
         let mut pruned: usize = 0;
         for my_addr in self.direct_addrs.sockaddrs() {
-            if addr.direct_addresses.remove(&my_addr) {
-                warn!( endpoint_id=%addr.endpoint_id.fmt_short(), %my_addr, %source, "not adding our addr for endpoint");
+            if addr.ip_addresses.remove(&my_addr) {
+                warn!( endpoint_id=%addr.id.fmt_short(), %my_addr, %source, "not adding our addr for endpoint");
                 pruned += 1;
             }
         }
@@ -2687,8 +2687,8 @@ mod tests {
                 let me = m.endpoint.id().fmt_short();
                 let mut stream = m.endpoint.watch_addr().stream();
                 while let Some(addr) = stream.next().await {
-                    info!(%me, "conn{} endpoints update: {:?}", my_idx + 1, addr.direct_addresses);
-                    update_direct_addrs(&stacks, my_idx, addr.direct_addresses);
+                    info!(%me, "conn{} endpoints update: {:?}", my_idx + 1, addr.ip_addresses().collect::<Vec<_>>());
+                    update_direct_addrs(&stacks, my_idx, addr.ip_addresses().copied().collect());
                 }
             });
         }

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -329,7 +329,7 @@ impl MagicSock {
     ///
     /// [`Watcher`]: n0_watcher::Watcher
     /// [`Watcher::initialized`]: n0_watcher::Watcher::initialized
-    pub(crate) fn direct_addresses(&self) -> n0_watcher::Direct<BTreeSet<DirectAddr>> {
+    pub(crate) fn ip_addresses(&self) -> n0_watcher::Direct<BTreeSet<DirectAddr>> {
         self.direct_addrs.addrs.watch()
     }
 
@@ -3080,12 +3080,12 @@ mod tests {
         let ms = Handle::new(default_options(&mut rng)).await.unwrap();
 
         // See if we can get endpoints.
-        let eps0 = ms.direct_addresses().get();
+        let eps0 = ms.ip_addresses().get();
         println!("{eps0:?}");
         assert!(!eps0.is_empty());
 
         // Getting the endpoints again immediately should give the same results.
-        let eps1 = ms.direct_addresses().get();
+        let eps1 = ms.ip_addresses().get();
         println!("{eps1:?}");
         assert_eq!(eps0, eps1);
     }
@@ -3237,7 +3237,7 @@ mod tests {
         let _accept_task = AbortOnDropHandle::new(accept_task);
 
         let addrs = msock_2
-            .direct_addresses()
+            .ip_addresses()
             .get()
             .into_iter()
             .map(|x| TransportAddr::Ip(x.addr))
@@ -3350,7 +3350,7 @@ mod tests {
 
         // Provide correct addressing information
         let addrs = msock_2
-            .direct_addresses()
+            .ip_addresses()
             .get()
             .into_iter()
             .map(|x| TransportAddr::Ip(x.addr))

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -390,8 +390,8 @@ impl EndpointMapInner {
                 path_selection,
             });
         endpoint_state.update_from_endpoint_addr(
-            endpoint_addr.relay_url.as_ref(),
-            &endpoint_addr.ip_addresses,
+            endpoint_addr.relay_urls().next(),
+            endpoint_addr.ip_addresses().copied(),
             source0,
             have_ipv6,
             metrics,

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -367,7 +367,7 @@ impl EndpointMapInner {
     }
 
     /// Add the contact information for an endpoint.
-    #[instrument(skip_all, fields(endpoint = %endpoint_addr.endpoint_id.fmt_short()))]
+    #[instrument(skip_all, fields(endpoint = %endpoint_addr.id.fmt_short()))]
     fn add_endpoint_addr(
         &mut self,
         endpoint_addr: EndpointAddr,
@@ -376,8 +376,8 @@ impl EndpointMapInner {
         metrics: &Metrics,
     ) {
         let source0 = source.clone();
-        let endpoint_id = endpoint_addr.endpoint_id;
-        let relay_url = endpoint_addr.relay_url.clone();
+        let endpoint_id = endpoint_addr.id;
+        let relay_url = endpoint_addr.relay_urls().next().cloned();
         #[cfg(any(test, feature = "test-utils"))]
         let path_selection = self.path_selection;
         let endpoint_state =
@@ -391,13 +391,13 @@ impl EndpointMapInner {
             });
         endpoint_state.update_from_endpoint_addr(
             endpoint_addr.relay_url.as_ref(),
-            &endpoint_addr.direct_addresses,
+            &endpoint_addr.ip_addresses,
             source0,
             have_ipv6,
             metrics,
         );
         let id = endpoint_state.id();
-        for addr in endpoint_addr.direct_addresses() {
+        for addr in endpoint_addr.ip_addresses() {
             self.set_endpoint_state_for_ip_port(*addr, id);
         }
     }

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -391,13 +391,13 @@ impl EndpointMapInner {
             });
         endpoint_state.update_from_endpoint_addr(
             endpoint_addr.relay_urls().next(),
-            endpoint_addr.ip_addresses().copied(),
+            endpoint_addr.ip_addrs().copied(),
             source0,
             have_ipv6,
             metrics,
         );
         let id = endpoint_state.id();
-        for addr in endpoint_addr.ip_addresses() {
+        for addr in endpoint_addr.ip_addrs() {
             self.set_endpoint_state_for_ip_port(*addr, id);
         }
     }
@@ -419,7 +419,7 @@ impl EndpointMapInner {
             if let Entry::Occupied(mut entry) = self.by_id.entry(id) {
                 let endpoint = entry.get_mut();
                 endpoint.remove_direct_addr(&ipp, now, why);
-                if endpoint.ip_addresses().count() == 0 {
+                if endpoint.ip_addrs().count() == 0 {
                     let endpoint_id = endpoint.public_key();
                     let mapped_addr = endpoint.quic_mapped_addr();
                     self.by_endpoint_key.remove(endpoint_id);
@@ -707,7 +707,7 @@ impl EndpointMapInner {
                 continue;
             };
 
-            for ip_port in ep.ip_addresses() {
+            for ip_port in ep.ip_addrs() {
                 self.by_ip_port.remove(&ip_port);
             }
 
@@ -757,7 +757,7 @@ impl IpPort {
 mod tests {
     use std::net::Ipv4Addr;
 
-    use iroh_base::SecretKey;
+    use iroh_base::{SecretKey, TransportAddr};
     use rand::SeedableRng;
     use tracing_test::traced_test;
 
@@ -792,14 +792,13 @@ mod tests {
         let relay_x: RelayUrl = "https://my-relay-1.com".parse().unwrap();
         let relay_y: RelayUrl = "https://my-relay-2.com".parse().unwrap();
 
-        let direct_addresses_a = [addr(4000), addr(4001)];
-        let direct_addresses_c = [addr(5000)];
+        let ip_addresses_a = [TransportAddr::Ip(addr(4000)), TransportAddr::Ip(addr(4001))];
+        let ip_addresses_c = [TransportAddr::Ip(addr(5000))];
 
-        let endpoint_addr_a = EndpointAddr::new(endpoint_a)
-            .with_relay_url(relay_x)
-            .with_ip_addresses(direct_addresses_a);
+        let addrs_a = std::iter::once(TransportAddr::Relay(relay_x)).chain(ip_addresses_a);
+        let endpoint_addr_a = EndpointAddr::new(endpoint_a).with_addrs(addrs_a);
         let endpoint_addr_b = EndpointAddr::new(endpoint_b).with_relay_url(relay_y);
-        let endpoint_addr_c = EndpointAddr::new(endpoint_c).with_ip_addresses(direct_addresses_c);
+        let endpoint_addr_c = EndpointAddr::new(endpoint_c).with_addrs(ip_addresses_c);
         let endpoint_addr_d = EndpointAddr::new(endpoint_d);
 
         endpoint_map.add_test_addr(endpoint_addr_a);
@@ -877,7 +876,7 @@ mod tests {
         info!("Adding active addresses");
         for i in 0..MAX_INACTIVE_DIRECT_ADDRESSES {
             let addr = SocketAddr::new(LOCALHOST, 5000 + i as u16);
-            let endpoint_addr = EndpointAddr::new(public_key).with_ip_addresses([addr]);
+            let endpoint_addr = EndpointAddr::new(public_key).with_ip_addr(addr);
             // add address
             endpoint_map.add_test_addr(endpoint_addr);
             // make it active
@@ -887,7 +886,7 @@ mod tests {
         info!("Adding offline/inactive addresses");
         for i in 0..MAX_INACTIVE_DIRECT_ADDRESSES * 2 {
             let addr = SocketAddr::new(LOCALHOST, 6000 + i as u16);
-            let endpoint_addr = EndpointAddr::new(public_key).with_ip_addresses([addr]);
+            let endpoint_addr = EndpointAddr::new(public_key).with_ip_addr(addr);
             endpoint_map.add_test_addr(endpoint_addr);
         }
 
@@ -909,14 +908,14 @@ mod tests {
         // Half the offline addresses should have been pruned.  All the active and alive
         // addresses should have been kept.
         assert_eq!(
-            endpoint.ip_addresses().count(),
+            endpoint.ip_addrs().count(),
             MAX_INACTIVE_DIRECT_ADDRESSES * 3
         );
 
         // We should have both offline and alive addresses which are not active.
         assert_eq!(
             endpoint
-                .ip_address_states()
+                .ip_addr_states()
                 .filter(|(_addr, state)| !state.is_active())
                 .count(),
             MAX_INACTIVE_DIRECT_ADDRESSES * 2
@@ -931,7 +930,7 @@ mod tests {
         // add one active endpoint and more than MAX_INACTIVE_ENDPOINTS inactive endpoints
         let active_endpoint = SecretKey::generate(&mut rng).public();
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 167);
-        endpoint_map.add_test_addr(EndpointAddr::new(active_endpoint).with_ip_addresses([addr]));
+        endpoint_map.add_test_addr(EndpointAddr::new(active_endpoint).with_ip_addr(addr));
         endpoint_map
             .inner
             .lock()

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -1206,12 +1206,12 @@ impl EndpointState {
     }
 
     /// Get the IP addresses for this endpoint.
-    pub(super) fn ip_addresses(&self) -> impl Iterator<Item = IpPort> + '_ {
+    pub(super) fn ip_addrs(&self) -> impl Iterator<Item = IpPort> + '_ {
         self.udp_paths.paths().keys().copied()
     }
 
     #[cfg(test)]
-    pub(super) fn ip_address_states(&self) -> impl Iterator<Item = (&IpPort, &PathState)> + '_ {
+    pub(super) fn ip_addr_states(&self) -> impl Iterator<Item = (&IpPort, &PathState)> + '_ {
         self.udp_paths.paths().iter()
     }
 

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -1205,13 +1205,13 @@ impl EndpointState {
         (udp_addr, relay_url, ping_msgs)
     }
 
-    /// Get the direct addresses for this endpoint.
-    pub(super) fn direct_addresses(&self) -> impl Iterator<Item = IpPort> + '_ {
+    /// Get the IP addresses for this endpoint.
+    pub(super) fn ip_addresses(&self) -> impl Iterator<Item = IpPort> + '_ {
         self.udp_paths.paths().keys().copied()
     }
 
     #[cfg(test)]
-    pub(super) fn direct_address_states(&self) -> impl Iterator<Item = (&IpPort, &PathState)> + '_ {
+    pub(super) fn ip_address_states(&self) -> impl Iterator<Item = (&IpPort, &PathState)> + '_ {
         self.udp_paths.paths().iter()
     }
 

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use data_encoding::HEXLOWER;
-use iroh_base::{AddrType, EndpointAddr, EndpointId, PublicKey, RelayUrl};
+use iroh_base::{EndpointAddr, EndpointId, PublicKey, RelayUrl, TransportAddr};
 use n0_future::{
     task::{self, AbortOnDropHandle},
     time::{self, Duration, Instant},
@@ -1225,11 +1225,11 @@ impl From<RemoteInfo> for EndpointAddr {
         let mut addrs = info
             .addrs
             .into_iter()
-            .map(|info| AddrType::Ip(info.addr))
+            .map(|info| TransportAddr::Ip(info.addr))
             .collect::<BTreeSet<_>>();
 
         if let Some(url) = info.relay_url {
-            addrs.insert(AddrType::Relay(url.into()));
+            addrs.insert(TransportAddr::Relay(url.into()));
         }
 
         EndpointAddr {

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use data_encoding::HEXLOWER;
-use iroh_base::{EndpointAddr, EndpointId, PublicKey, RelayUrl};
+use iroh_base::{AddrType, EndpointAddr, EndpointId, PublicKey, RelayUrl};
 use n0_future::{
     task::{self, AbortOnDropHandle},
     time::{self, Duration, Instant},
@@ -1220,16 +1220,19 @@ impl EndpointState {
 
 impl From<RemoteInfo> for EndpointAddr {
     fn from(info: RemoteInfo) -> Self {
-        let direct_addresses = info
+        let mut addrs = info
             .addrs
             .into_iter()
-            .map(|info| info.addr)
+            .map(|info| AddrType::Ip(info.addr))
             .collect::<BTreeSet<_>>();
 
+        if let Some(url) = info.relay_url {
+            addrs.insert(AddrType::Relay(url.into()));
+        }
+
         EndpointAddr {
-            endpoint_id: info.endpoint_id,
-            relay_url: info.relay_url.map(Into::into),
-            direct_addresses,
+            id: info.endpoint_id,
+            addrs,
         }
     }
 }

--- a/iroh/tests/integration.rs
+++ b/iroh/tests/integration.rs
@@ -103,7 +103,7 @@ async fn simple_endpoint_id_based_connection_transfer() -> Result {
                     tracing::info!("no items on stream when resolving, looping");
                     continue;
                 };
-                if item.relay_url().is_some() {
+                if item.relay_urls().next().is_some() {
                     tracing::info!("home relay found");
                     break;
                 }


### PR DESCRIPTION
## Description

This marks the first public step towards generic transports. For now there are two types of `TransportAddr`s, `Relay` and `Ip` which, replace the previous explicit fields in `EndpointAddr` of `relay_url` and `direct_addrs`.

Closes https://github.com/n0-computer/iroh/issues/3417

## Breaking Changes

- `direct_addresses` are now called `ip_addresses`
- `EndpointAddr` type is completely changed
-  APIs with `addresse(s)` are now normalized to `addr(s)` to be consistent in the code base
