### PR TITLE
ref(iroh): Relay map extend

### DIFF
--- a/iroh-relay/src/relay_map.rs
+++ b/iroh-relay/src/relay_map.rs
@@ -112,11 +112,14 @@ impl RelayMap {
         self.relays.write().expect("poisoned").remove(url)
     }
 
-    /// Extends this `RelayMap` with another one.
-    pub fn extend(&self, other: &RelayMap) {
-        let mut a = self.relays.write().expect("poisoned");
-        let b = other.relays.read().expect("poisoned");
-        a.extend(b.iter().map(|(a, b)| (a.clone(), b.clone())));
+    /// Joins this `RelayMap` with another one into a new one
+    pub fn join(self, other: RelayMap) -> RelayMap {
+        {
+            let mut a = self.relays.write().expect("poisoned");
+            let b = other.relays.read().expect("poisoned");
+            a.extend(b.iter().map(|(a, b)| (a.clone(), b.clone())));
+        }
+        self
     }
 }
 


### PR DESCRIPTION
## Description

Following https://github.com/n0-computer/iroh/pull/3575 (which was inspired by me complaining on your discord that this was missing from the interface) and the discussion on your discord, I figured I would fancy a slightly different approach to that PR and the interfaces introduced in your PR there.

This is twofold:

* Replace the `RelayMap::extend` with an actual `impl Extend ror RelayMap` (that can easily be used with an existing `RelayMap` by calling `rm.relays::<Vec<_>>()` on it
* Rewrite the existing `RelayMap::extend` with an `RelayMap::join`. Reason here is that my usecase (that, again, inspired this to be added) is to build a `RelayMap` object with defaults + custom entries _before_ using them, so there's no need to update (`.extend()`ing) an existing `RelayMap` during runtime. This is still preserved via the `impl Extend` though.

Tell me what you think! CCing people from discord:

* CC @flub
* CC @dignifiedquire 

## Breaking Changes

- `RelayMap::extend` (unreleased) -> `RelayMap::join`