### PR TITLE
chore(iroh-dns-server): Mark `integration_mainline` as flaky

### DIFF
--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -221,6 +221,7 @@ mod tests {
         panic!("store did not evict packet");
     }
 
+    #[ignore = "flaky"]
     #[tokio::test]
     #[traced_test]
     async fn integration_mainline() -> Result {


### PR DESCRIPTION
## Description

Failed here: https://github.com/n0-computer/iroh/actions/runs/18947088082/job/54101371310?pr=3587

Made an issue for this: https://github.com/n0-computer/iroh/issues/3590

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
