### PR TITLE
docs(iroh): fix documentation on endpoint::Builder::empty

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -136,8 +136,7 @@ impl Builder {
         self
     }
 
-    /// Creates an empty builder, which means there are no relays
-    /// and no discovery services configured.
+    /// Creates an empty builder with no discovery services.
     pub fn empty(relay_mode: RelayMode) -> Self {
         let mut transport_config = quinn::TransportConfig::default();
         transport_config.keep_alive_interval(Some(Duration::from_secs(1)));


### PR DESCRIPTION
# Description

Fixes a small documentation error.
See also the discussion on discord: https://discord.com/channels/1161119546170687619/1161119546644627528/1433606524336476182

> No, the docs are wrong —from a previous iteration that did not take a relay mode as an argument.
> We want folks to be forced to choose a relay mode, there are too many footguns that can happen if you don't think about your specific use case.
