### PR TITLE
fix: stop polling transports when the magicsock is closing

### DIFF
--- a/iroh/src/magicsock/transports.rs
+++ b/iroh/src/magicsock/transports.rs
@@ -78,7 +78,7 @@ impl Transports {
         msock: &MagicSock,
     ) -> Poll<io::Result<usize>> {
         debug_assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
-        if msock.is_closed() {
+        if msock.is_closing() {
             return Poll::Pending;
         }
 


### PR DESCRIPTION
## Description

Since we merged #3601 we sometimes get ugly (but harmless) error log messages when the endpoint is shutting down:
```
2025-11-06T11:28:26.721826Z ERROR ep-client:client: iroh::magicsock::transports::relay: relay_recv_channel closed
2025-11-06T11:28:26.721884Z ERROR ep-client:client: iroh_quinn::endpoint: I/O error: connection closed
```
This fixes it: We already have a check in the transports to return `Pending` without polling the actual transports once `Magicsock::is_closed` is `true`. This PR changes it to instead check `Magicsock::is_closing`. The latter is set **after** `Endpoint::wait_idle` completed, but before cancelling the actor and transport tasks. Whereas `is_closed` is set *after* the actor and transport tasks are fully shutdown. When `Endpoint::wait_idle` completes, we do not expect the quinn endpoint to do anything meaningful, so it is fine to stop polling the transports at this time, and thus not get errors from the transports into quinn if they fail (because they are shutting down).

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
