### PR TITLE
feat: add AcceptError::from_boxed

### DIFF
--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -132,6 +132,7 @@ impl AcceptError {
     }
 
     /// Creates a new user error from an arbitrary boxed error.
+    #[track_caller]
     pub fn from_boxed(value: Box<dyn std::error::Error + Send + Sync>) -> Self {
         e!(AcceptError::User {
             source: AnyError::from_std_box(value)

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -123,10 +123,18 @@ pub enum AcceptError {
 
 impl AcceptError {
     /// Creates a new user error from an arbitrary error type.
+    // TODO(Frando): Rename to `from_std`
     #[track_caller]
     pub fn from_err<T: std::error::Error + Send + Sync + 'static>(value: T) -> Self {
         e!(AcceptError::User {
             source: AnyError::from_std(value)
+        })
+    }
+
+    /// Creates a new user error from an arbitrary boxed error.
+    pub fn from_boxed(value: Box<dyn std::error::Error + Send + Sync>) -> Self {
+        e!(AcceptError::User {
+            source: AnyError::from_std_box(value)
         })
     }
 }


### PR DESCRIPTION
## Description

This allows to do `AcceptError::from_boxed(anyhow_err.into_boxed_dyn_error())`

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
