### PR TITLE
fix(iroh-bench): Gracefully close the quinn benchmark

### DIFF
--- a/iroh/bench/src/lib.rs
+++ b/iroh/bench/src/lib.rs
@@ -91,6 +91,7 @@ impl EndpointSelector {
             #[cfg(not(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd")))]
             EndpointSelector::Quinn(endpoint) => {
                 endpoint.close(0u32.into(), b"");
+                endpoint.wait_idle().await;
             }
         }
     }


### PR DESCRIPTION
## Description

Adds a call to `quinn::Endpoint::wait_idle` as the equivalent to `iroh::Endpoint::close`.

This fixes the quinn benchmark not timing out, but closing gracefully instead for me.
(Before, running `cargo run -p iroh-bench -- quinn` would take 18s to finish due to quinn waiting for a probe timeout, after this, this bench runs in 2s for me.)


## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.