### PR TITLE
refactor: use Connection::on_closed in endpoint state actor

### DIFF
--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -1308,7 +1308,8 @@ fn now_or_never<T, F: Future<Output = T>>(fut: F) -> Option<T> {
 
 /// Future that resolves to the `conn_id` once a connection is closed.
 ///
-/// This uses [`Connection::on_closed`], which does not keep the connection alive while awaiting the future.
+/// This uses [`quinn::Connection::on_closed`], which does not keep the connection alive
+/// while awaiting the future.
 struct OnClosed {
     conn_id: ConnId,
     inner: quinn::OnClosed,


### PR DESCRIPTION
## Description

In the endpoint state actor, this uses the `Connection::on_closed` future added in https://github.com/n0-computer/quinn/pull/153 to remove connections once they are closed instead of relying on manual cleanup.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
