### PR TITLE
refactor(multipath): Make registering connections with the magicsock async

### DIFF
--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -29,7 +29,7 @@ use ed25519_dalek::{VerifyingKey, pkcs8::DecodePublicKey};
 use futures_util::{FutureExt, future::Shared};
 use iroh_base::EndpointId;
 use n0_error::{e, stack_error};
-use n0_future::{TryFutureExt, boxed::BoxFuture, time::Duration};
+use n0_future::{TryFutureExt, future::Boxed as BoxFuture, time::Duration};
 use n0_watcher::Watcher;
 use pin_project::pin_project;
 use quinn::{

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -211,21 +211,21 @@ pub enum AuthenticationError {
         #[error(std_err)]
         source: ConnectionError,
     },
-    #[error("endpoint state actor stopped")]
-    EndpointStateActorStopped,
+    #[error("internal consistency error: EndpointStateActor stopped")]
+    InternalConsistencyError,
 }
 
 impl From<EndpointStateActorStoppedError> for AuthenticationError {
     #[track_caller]
     fn from(_value: EndpointStateActorStoppedError) -> Self {
-        e!(Self::EndpointStateActorStopped)
+        e!(Self::InternalConsistencyError)
     }
 }
 
 impl From<EndpointStateActorStoppedError> for ConnectingError {
     #[track_caller]
     fn from(_value: EndpointStateActorStoppedError) -> Self {
-        e!(AuthenticationError::EndpointStateActorStopped).into()
+        e!(AuthenticationError::InternalConsistencyError).into()
     }
 }
 

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -43,7 +43,7 @@ use crate::{
     discovery::DiscoveryTask,
     magicsock::{
         EndpointStateActorStoppedError,
-        endpoint_map::{PathInfoList, PathsWatchable},
+        endpoint_map::{PathInfoList, PathsWatcher},
     },
 };
 
@@ -1202,7 +1202,7 @@ pub struct Connection {
     inner: quinn::Connection,
     remote_id: EndpointId,
     alpn: Vec<u8>,
-    paths: PathsWatchable,
+    paths: PathsWatcher,
 }
 
 #[allow(missing_docs)]
@@ -1452,7 +1452,7 @@ impl Connection {
     /// [`PathInfo::is_selected`]: crate::magicsock::PathInfo::is_selected
     /// [`PathInfo`]: crate::magicsock::PathInfo
     pub fn paths(&self) -> impl Watcher<Value = PathInfoList> {
-        self.paths.watch(self.inner.weak_handle())
+        self.paths.clone()
     }
 
     /// Derives keying material from this connection's TLS session secrets.

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -43,7 +43,7 @@ use crate::{
     discovery::DiscoveryTask,
     magicsock::{
         EndpointStateActorStoppedError,
-        endpoint_map::{PathInfoList, PathsWatcher},
+        endpoint_map::{PathInfoList, PathsWatchable},
     },
 };
 
@@ -1213,7 +1213,7 @@ pub struct Connection {
     inner: quinn::Connection,
     remote_id: EndpointId,
     alpn: Vec<u8>,
-    paths: PathsWatcher,
+    paths: PathsWatchable,
 }
 
 #[allow(missing_docs)]
@@ -1463,7 +1463,7 @@ impl Connection {
     /// [`PathInfo::is_selected`]: crate::magicsock::PathInfo::is_selected
     /// [`PathInfo`]: crate::magicsock::PathInfo
     pub fn paths(&self) -> impl Watcher<Value = PathInfoList> {
-        self.paths.clone()
+        self.paths.watch(self.inner.weak_handle())
     }
 
     /// Derives keying material from this connection's TLS session secrets.

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -275,8 +275,7 @@ impl MagicSock {
     /// The actor is responsible for holepunching and opening additional paths to this
     /// connection.
     ///
-    /// Returns a future that resolves to [`PathsWatcher`], which is a [`Watcher`] over the
-    /// transmission paths for this connection.
+    /// Returns a future that resolves to [`PathsWatchable`].
     ///
     /// The returned future is `'static`, so it can be stored without being liftetime-bound to `&self`.
     pub(crate) fn register_connection(

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -270,7 +270,7 @@ impl MagicSock {
         self.local_addrs_watch.clone().get()
     }
 
-    /// Registers the connection in the [`EndpointStateActor`].
+    /// Registers the connection in the `EndpointStateActor`.
     ///
     /// The actor is responsible for holepunching and opening additional paths to this
     /// connection.
@@ -279,8 +279,6 @@ impl MagicSock {
     /// transmission paths for this connection.
     ///
     /// The returned future is `'static`, so it can be stored without being liftetime-bound to `&self`.
-    ///
-    /// [`EndpointStateActor`]: self::endpoint_map::EndpointStateActor
     pub(crate) fn register_connection(
         &self,
         remote: EndpointId,

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -39,7 +39,6 @@ use netwatch::netmon;
 #[cfg(not(wasm_browser))]
 use netwatch::{UdpSocket, ip::LocalAddresses};
 use quinn::ServerConfig;
-use quinn_proto::PathId;
 use rand::Rng;
 use tokio::sync::{Mutex as AsyncMutex, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
@@ -65,7 +64,7 @@ use crate::{
     disco::{self, SendAddr},
     discovery::{ConcurrentDiscovery, Discovery, EndpointData, UserData},
     key::{DecryptionError, SharedSecret, public_ed_box, secret_ed_box},
-    magicsock::endpoint_map::{PathAddrList, PathsWatchable},
+    magicsock::endpoint_map::PathsWatchable,
     metrics::EndpointMetrics,
     net_report::{self, IfStateDetails, Report},
 };
@@ -104,6 +103,10 @@ pub(crate) const PATH_MAX_IDLE_TIMEOUT: Duration = Duration::from_millis(6500);
 ///
 /// Pretty arbitrary and high right now.
 pub(crate) const MAX_MULTIPATH_PATHS: u32 = 16;
+
+#[stack_error(derive)]
+#[error("endpoint state actor stopped")]
+pub(crate) struct EndpointStateActorStoppedError;
 
 /// Contains options for `MagicSock::listen`.
 #[derive(derive_more::Debug)]
@@ -270,48 +273,20 @@ impl MagicSock {
     ///
     /// The actor is responsible for holepunching and opening additional paths to this
     /// connection.
-    pub(crate) fn register_connection(
+    pub(crate) async fn register_connection(
         &self,
         remote: EndpointId,
         conn: &quinn::Connection,
-    ) -> PathsWatchable {
-        // Init the open paths watchable.
-        let mut open_paths: PathAddrList = Default::default();
-        if let Some(path0) = conn.path(PathId::ZERO) {
-            // This all is supposed to be infallible, but anyway.
-            if let Ok(remote) = path0.remote_address() {
-                if let Some(remote) = self.endpoint_map.transport_addr_from_mapped(remote) {
-                    open_paths.push((remote.clone(), PathId::ZERO));
-                }
-            }
-        }
-        let open_paths = n0_watcher::Watchable::new(open_paths);
-
-        // TODO: Spawning tasks like this is obviously bad.  But it is solvable:
-        //   - This is only called from inside Connection::new.
-        //   - Connection::new is called from:
-        //     - impl Future for IncomingFuture
-        //     - impl Future for Connecting
-        //     - Connecting::into_0rtt()
-        //
-        // The first two can keep returning Pending until this message is also sent.  It'll
-        // require storing the pinned future but it'll work.
-        //
-        // The last one is trickier.  But we can make that function async.  Or more likely
-        // we'll end up changing Connecting::into_0rtt() to return a ZrttConnection.  Then
-        // have a ZrttConnection::into_connection() function which can be async and actually
-        // send this.  Before the handshake has completed we don't have anything useful to
-        // do with this connection inside of the EndpointStateActor anyway.
+    ) -> Result<PathsWatchable, EndpointStateActorStoppedError> {
         let weak_handle = conn.weak_handle();
-        let (sender, selected_path) = self
-            .endpoint_map
-            .endpoint_state_actor_with_selected_path(remote);
-        let msg = EndpointStateMessage::AddConnection(weak_handle, open_paths.clone());
-
-        task::spawn(async move {
-            sender.send(msg).await.ok();
-        });
-        PathsWatchable::new(open_paths, selected_path)
+        let (tx, rx) = oneshot::channel();
+        let sender = self.endpoint_map.endpoint_state_actor(remote);
+        let msg = EndpointStateMessage::AddConnection(weak_handle, tx);
+        sender
+            .send(msg)
+            .await
+            .map_err(|_| EndpointStateActorStoppedError)?;
+        rx.await.map_err(|_| EndpointStateActorStoppedError)
     }
 
     #[cfg(not(wasm_browser))]

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -64,7 +64,7 @@ use crate::{
     disco::{self, SendAddr},
     discovery::{ConcurrentDiscovery, Discovery, EndpointData, UserData},
     key::{DecryptionError, SharedSecret, public_ed_box, secret_ed_box},
-    magicsock::endpoint_map::PathsWatcher,
+    magicsock::endpoint_map::PathsWatchable,
     metrics::EndpointMetrics,
     net_report::{self, IfStateDetails, Report},
 };
@@ -283,7 +283,7 @@ impl MagicSock {
         &self,
         remote: EndpointId,
         conn: WeakConnectionHandle,
-    ) -> impl Future<Output = Result<PathsWatcher, EndpointStateActorStoppedError>> + Send + 'static
+    ) -> impl Future<Output = Result<PathsWatchable, EndpointStateActorStoppedError>> + Send + 'static
     {
         let (tx, rx) = oneshot::channel();
         let sender = self.endpoint_map.endpoint_state_actor(remote);

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -64,7 +64,7 @@ use crate::{
     disco::{self, SendAddr},
     discovery::{ConcurrentDiscovery, Discovery, EndpointData, UserData},
     key::{DecryptionError, SharedSecret, public_ed_box, secret_ed_box},
-    magicsock::endpoint_map::PathsWatchable,
+    magicsock::endpoint_map::PathsWatcher,
     metrics::EndpointMetrics,
     net_report::{self, IfStateDetails, Report},
 };
@@ -277,7 +277,7 @@ impl MagicSock {
         &self,
         remote: EndpointId,
         conn: WeakConnectionHandle,
-    ) -> impl Future<Output = Result<PathsWatchable, EndpointStateActorStoppedError>> + Send + 'static
+    ) -> impl Future<Output = Result<PathsWatcher, EndpointStateActorStoppedError>> + Send + 'static
     {
         let (tx, rx) = oneshot::channel();
         let sender = self.endpoint_map.endpoint_state_actor(remote);

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -25,7 +25,7 @@ mod endpoint_state;
 mod path_state;
 
 pub(super) use endpoint_state::EndpointStateMessage;
-pub(crate) use endpoint_state::PathsWatcher;
+pub(crate) use endpoint_state::PathsWatchable;
 pub use endpoint_state::{ConnectionType, PathInfo, PathInfoList};
 use endpoint_state::{EndpointStateActor, EndpointStateHandle};
 

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -25,7 +25,7 @@ mod endpoint_state;
 mod path_state;
 
 pub(super) use endpoint_state::EndpointStateMessage;
-pub(crate) use endpoint_state::PathsWatchable;
+pub(crate) use endpoint_state::PathsWatcher;
 pub use endpoint_state::{ConnectionType, PathInfo, PathInfoList};
 use endpoint_state::{EndpointStateActor, EndpointStateHandle};
 

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -331,10 +331,9 @@ impl EndpointStateActor {
     async fn handle_msg_add_connection(
         &mut self,
         handle: WeakConnectionHandle,
-        tx: oneshot::Sender<PathsWatcher>,
+        tx: oneshot::Sender<PathsWatchable>,
     ) {
         let pub_open_paths = Watchable::default();
-
         if let Some(conn) = handle.upgrade() {
             // Remove any conflicting stable_ids from the local state.
             let conn_id = ConnId(conn.stable_id());
@@ -394,12 +393,11 @@ impl EndpointStateActor {
             }
             self.trigger_holepunching().await;
         }
-
-        // Create a watcher over the open path and the selected path and pass it back
-        // to the Connection.
-        let paths_watcher =
-            paths_watcher(handle, pub_open_paths.watch(), self.selected_path.watch());
-        tx.send(paths_watcher).ok();
+        tx.send(PathsWatchable {
+            open_paths: pub_open_paths,
+            selected_path: self.selected_path.clone(),
+        })
+        .ok();
     }
 
     /// Handles [`EndpointStateMessage::AddEndpointAddr`].
@@ -998,7 +996,7 @@ pub(crate) enum EndpointStateMessage {
     /// needed, any new paths discovered via holepunching will be added.  And closed paths
     /// will be removed etc.
     #[debug("AddConnection(..)")]
-    AddConnection(WeakConnectionHandle, oneshot::Sender<PathsWatcher>),
+    AddConnection(WeakConnectionHandle, oneshot::Sender<PathsWatchable>),
     /// Adds a [`EndpointAddr`] with locations where the endpoint might be reachable.
     AddEndpointAddr(EndpointAddr, Source),
     /// Process a received DISCO CallMeMaybe message.
@@ -1145,30 +1143,30 @@ impl ConnectionState {
     }
 }
 
-/// Watcher over [`PathInfoList`].
-pub(crate) type PathsWatcher = n0_watcher::Map<
-    (
-        n0_watcher::Direct<PathAddrList>,
-        n0_watcher::Direct<Option<transports::Addr>>,
-    ),
-    PathInfoList,
->;
-
-/// Combines the open_paths and selected_path watchers into a watcher over [`PathInfoList`].
+/// Watchables for the open paths and selected transmission path in a connection.
 ///
-/// Takes a [`WeakConnectionHandle`] which is used to populate the stats in [`PathInfo`] when the list updates.
-fn paths_watcher(
-    conn_handle: WeakConnectionHandle,
-    open_paths_watcher: n0_watcher::Direct<PathAddrList>,
-    selected_path_watcher: n0_watcher::Direct<Option<transports::Addr>>,
-) -> PathsWatcher {
-    open_paths_watcher
-        .or(selected_path_watcher)
-        .map(move |(open_paths, selected_path)| {
+/// This is stored in the [`Connection`], and the watchables are set from within the endpoint state actor.
+///
+/// [`Connection`]: crate::endpoint::Connection
+#[derive(Debug, Default, Clone)]
+pub(crate) struct PathsWatchable {
+    /// Watchable for the open paths (in this connection).
+    open_paths: Watchable<PathAddrList>,
+    /// Watchable for the selected transmission path (global for this remote endpoint).
+    selected_path: Watchable<Option<transports::Addr>>,
+}
+
+impl PathsWatchable {
+    pub(crate) fn watch(
+        &self,
+        conn_handle: WeakConnectionHandle,
+    ) -> impl Watcher<Value = PathInfoList> {
+        let joined_watcher = (self.open_paths.watch(), self.selected_path.watch());
+        joined_watcher.map(move |(open_paths, selected_path)| {
+            let selected_path: Option<TransportAddr> = selected_path.map(Into::into);
             let Some(conn) = conn_handle.upgrade() else {
                 return PathInfoList(Default::default());
             };
-            let selected_path = selected_path.map(TransportAddr::from);
             let list = open_paths
                 .into_iter()
                 .flat_map(move |(remote, path_id)| {
@@ -1177,6 +1175,7 @@ fn paths_watcher(
                 .collect();
             PathInfoList(list)
         })
+    }
 }
 
 /// List of [`PathInfo`] for the network paths of a [`Connection`].
@@ -1211,10 +1210,10 @@ impl PathInfoList {
 #[derive(derive_more::Debug, Clone)]
 pub struct PathInfo {
     path_id: PathId,
-    remote: TransportAddr,
     #[debug(skip)]
     handle: WeakConnectionHandle,
     stats: PathStats,
+    remote: TransportAddr,
     is_selected: bool,
 }
 
@@ -1223,7 +1222,6 @@ impl PartialEq for PathInfo {
         self.path_id == other.path_id
             && self.remote == other.remote
             && self.is_selected == other.is_selected
-            && self.stats == other.stats
     }
 }
 


### PR DESCRIPTION
## Description

Currently, `Magicsock::register_connection` is a sync function, but needs to send over an async channel to notify the endpoint state actor about the new connection. It currently employs a hack to achieve that: it spawns a tokio task for sending the message. 

This PR cleans this up by making `regsiter_connection` return a future, and awaits this future at the various sites where we go from quinn::Connection to iroh Connection. Luckily, all these call sites already are in async contexts.

* When going from `Connecting` or `Accepting` to `Connection`, we await the registration after having the `quinn::Connecting` completes. The future is stored in an option instead of using a state enum as you would usually, because we need unconditional access to the `quinn::Connecting` in the functions on  `Connecting`/`Accepting`.
* For the `(Incoming|Outgoing)ZeroRttConnection`, we store a future that first awaits the handshake and then registers the connection. So we need only a single future here.

With `register_connection` being async, we can also clean up some of the not-so-nice things introduced in #3622: Because we now have an async function, we can let the endpoint state actor return a reply. This makes it much more straightforward because we can have the endpoint state actor initialize a watcher for the paths and return it instead of having to do a weird dance with parts of the state being initialized or stored outside of the endpoint state actor to satisfy the sync function constraints. This is much nicer now IMO.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

This adds a boxed future into the process of going from a  `Connecting` to a `Connection`. If we really wanted, we could use a manually implemented future instead. However, I don't think one boxed future *per connection*  is an issue, so I'd prefer to leave it like this (implementing a manual future for `tokio::mpsc::Sender::send` is cumbersome).

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
