### PR TITLE
refactor(multipath): Store `Watcher`, not `Watchable` on `Connection`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2378,7 +2378,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2739,8 +2739,7 @@ dependencies = [
 [[package]]
 name = "n0-watcher"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38acf13c1ddafc60eb7316d52213467f8ccb70b6f02b65e7d97f7799b1f50be4"
+source = "git+https://github.com/n0-computer/n0-watcher?branch=Frando%2Flazy-direct#334044203e4b2a616570fe67e15773f949dc7a2f"
 dependencies = [
  "derive_more 2.0.1",
  "n0-error",
@@ -2889,7 +2888,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3397,7 +3396,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3666,7 +3665,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3768,7 +3767,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3789,7 +3788,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4352,7 +4351,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5124,7 +5123,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ unused-async = "warn"
 iroh-quinn = { git = "https://github.com/n0-computer/quinn", branch = "main-iroh" }
 iroh-quinn-proto = { git = "https://github.com/n0-computer/quinn", branch = "main-iroh" }
 iroh-quinn-udp = { git = "https://github.com/n0-computer/quinn", branch = "main-iroh" }
+n0-watcher = { git = "https://github.com/n0-computer/n0-watcher", branch = "Frando/lazy-direct" }
 
 # iroh-quinn = { path = "../iroh-quinn/quinn" }
 # iroh-quinn-proto = { path = "../iroh-quinn/quinn-proto" }

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -43,7 +43,7 @@ use crate::{
     discovery::DiscoveryTask,
     magicsock::{
         EndpointStateActorStoppedError,
-        endpoint_map::{PathInfoList, PathsWatcher},
+        endpoint_map::{PathInfoIter, PathsWatcher},
     },
 };
 
@@ -1462,8 +1462,8 @@ impl Connection {
     ///
     /// [`PathInfo::is_selected`]: crate::magicsock::PathInfo::is_selected
     /// [`PathInfo`]: crate::magicsock::PathInfo
-    pub fn paths(&self) -> impl Watcher<Value = PathInfoList> {
-        self.paths.clone()
+    pub fn paths(&self) -> impl Watcher<Value = PathInfoIter> {
+        self.paths.watch(self.inner.weak_handle())
     }
 
     /// Derives keying material from this connection's TLS session secrets.

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1985,7 +1985,7 @@ mod tests {
         info!("stats: {:#?}", stats);
         // TODO: ensure panics in this function are reported ok
         if matches!(loss, ExpectedLoss::AlmostNone) {
-            for info in conn.paths().get().iter() {
+            for info in conn.paths().get() {
                 assert!(
                     info.stats().lost_packets < 10,
                     "[receiver] path {:?} should not loose many packets",

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -26,7 +26,7 @@ mod path_state;
 
 pub(super) use endpoint_state::EndpointStateMessage;
 pub(crate) use endpoint_state::PathsWatcher;
-pub use endpoint_state::{ConnectionType, PathInfo, PathInfoList};
+pub use endpoint_state::{ConnectionType, PathInfo, PathInfoIter};
 use endpoint_state::{EndpointStateActor, EndpointStateHandle};
 
 // TODO: use this

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -79,7 +79,7 @@ type PathEvents = MergeUnbounded<
 >;
 
 /// List of addrs and path ids for open paths in a connection.
-pub(crate) type PathAddrList = SmallVec<[(TransportAddr, PathId); 4]>;
+pub(crate) type PathAddrList = SmallVec<[(TransportAddr, PathId); 2]>;
 
 /// The state we need to know about a single remote endpoint.
 ///
@@ -397,8 +397,10 @@ impl EndpointStateActor {
 
         // Create a watcher over the open path and the selected path and pass it back
         // to the Connection.
-        let paths_watcher =
-            paths_watcher(handle, pub_open_paths.watch(), self.selected_path.watch());
+        let paths_watcher = PathsWatcher {
+            open_paths: pub_open_paths.weak_watcher(),
+            selected_path: self.selected_path.weak_watcher(),
+        };
         tx.send(paths_watcher).ok();
     }
 
@@ -1145,63 +1147,90 @@ impl ConnectionState {
     }
 }
 
-/// Watcher over [`PathInfoList`].
-pub(crate) type PathsWatcher = n0_watcher::Map<
-    (
-        n0_watcher::Direct<PathAddrList>,
-        n0_watcher::Direct<Option<transports::Addr>>,
-    ),
-    PathInfoList,
->;
+/// Watchers for the open paths and selected path of a connection.
+#[derive(Debug, Clone)]
+pub(crate) struct PathsWatcher {
+    open_paths: n0_watcher::WeakWatcher<PathAddrList>,
+    selected_path: n0_watcher::WeakWatcher<Option<transports::Addr>>,
+}
 
-/// Combines the open_paths and selected_path watchers into a watcher over [`PathInfoList`].
-///
-/// Takes a [`WeakConnectionHandle`] which is used to populate the stats in [`PathInfo`] when the list updates.
-fn paths_watcher(
-    conn_handle: WeakConnectionHandle,
-    open_paths_watcher: n0_watcher::Direct<PathAddrList>,
-    selected_path_watcher: n0_watcher::Direct<Option<transports::Addr>>,
-) -> PathsWatcher {
-    open_paths_watcher
-        .or(selected_path_watcher)
-        .map(move |(open_paths, selected_path)| {
-            let Some(conn) = conn_handle.upgrade() else {
-                return PathInfoList(Default::default());
-            };
-            let selected_path = selected_path.map(TransportAddr::from);
-            let list = open_paths
-                .into_iter()
-                .flat_map(move |(remote, path_id)| {
-                    PathInfo::new(path_id, &conn, remote, selected_path.as_ref())
-                })
-                .collect();
-            PathInfoList(list)
-        })
+impl PathsWatcher {
+    pub(crate) fn watch(
+        &self,
+        conn_handle: WeakConnectionHandle,
+    ) -> impl Watcher<Value = PathInfoIter> {
+        self.open_paths
+            .upgrade_lazy()
+            .or(self.selected_path.upgrade_lazy())
+            .map(move |(open_paths, selected_path)| {
+                let selected_path = selected_path.map(TransportAddr::from);
+                PathInfoIter {
+                    conn_handle: conn_handle.clone(),
+                    selected_path,
+                    open_paths,
+                    iter_pos: 0,
+                }
+            })
+    }
 }
 
 /// List of [`PathInfo`] for the network paths of a [`Connection`].
 ///
-/// This struct implements [`IntoIterator`].
+/// This struct implements [`Iterator`].
 ///
 /// [`Connection`]: crate::endpoint::Connection
-#[derive(derive_more::Debug, derive_more::IntoIterator, Eq, PartialEq, Clone)]
-#[debug("{_0:?}")]
-pub struct PathInfoList(SmallVec<[PathInfo; 4]>);
+#[derive(derive_more::Debug, Clone)]
+pub struct PathInfoIter {
+    open_paths: PathAddrList,
+    selected_path: Option<TransportAddr>,
+    #[debug(skip)]
+    conn_handle: WeakConnectionHandle,
+    iter_pos: usize,
+}
 
-impl PathInfoList {
-    /// Returns an iterator over the path infos.
-    pub fn iter(&self) -> impl Iterator<Item = &PathInfo> {
-        self.0.iter()
+impl PartialEq for PathInfoIter {
+    fn eq(&self, other: &Self) -> bool {
+        self.open_paths == other.open_paths && self.selected_path == other.selected_path
+    }
+}
+
+impl Eq for PathInfoIter {}
+
+impl Iterator for PathInfoIter {
+    type Item = PathInfo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (remote, path_id) = self.open_paths.get(self.iter_pos)?;
+        let stats = self
+            .conn_handle
+            .upgrade()
+            .and_then(|conn| conn.path_stats(*path_id))?;
+        let is_selected = Some(remote) == self.selected_path.as_ref();
+        self.iter_pos += 1;
+        Some(PathInfo {
+            is_selected,
+            remote: remote.clone(),
+            stats,
+        })
     }
 
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.open_paths.len() - self.iter_pos;
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for PathInfoIter {}
+
+impl PathInfoIter {
     /// Returns `true` if the list is empty.
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.len() == 0
     }
 
     /// Returns the number of paths.
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.open_paths.len()
     }
 }
 
@@ -1210,18 +1239,14 @@ impl PathInfoList {
 /// [`Connection`]: crate::endpoint::Connection
 #[derive(derive_more::Debug, Clone)]
 pub struct PathInfo {
-    path_id: PathId,
     remote: TransportAddr,
-    #[debug(skip)]
-    handle: WeakConnectionHandle,
-    stats: PathStats,
     is_selected: bool,
+    stats: PathStats,
 }
 
 impl PartialEq for PathInfo {
     fn eq(&self, other: &Self) -> bool {
-        self.path_id == other.path_id
-            && self.remote == other.remote
+        self.remote == other.remote
             && self.is_selected == other.is_selected
             && self.stats == other.stats
     }
@@ -1230,22 +1255,6 @@ impl PartialEq for PathInfo {
 impl Eq for PathInfo {}
 
 impl PathInfo {
-    fn new(
-        path_id: PathId,
-        conn: &quinn::Connection,
-        remote: TransportAddr,
-        selected_path: Option<&TransportAddr>,
-    ) -> Option<Self> {
-        let stats = conn.path_stats(path_id)?;
-        Some(Self {
-            path_id,
-            handle: conn.weak_handle(),
-            is_selected: Some(&remote) == selected_path,
-            remote,
-            stats,
-        })
-    }
-
     /// The remote transport address used by this network path.
     pub fn remote_addr(&self) -> &TransportAddr {
         &self.remote
@@ -1269,11 +1278,8 @@ impl PathInfo {
     }
 
     /// Returns stats for this transmission path.
-    pub fn stats(&self) -> PathStats {
-        self.handle
-            .upgrade()
-            .and_then(|conn| conn.path_stats(self.path_id))
-            .unwrap_or(self.stats)
+    pub fn stats(&self) -> &PathStats {
+        &self.stats
     }
 
     /// Current best estimate of this paths's latency (round-trip-time)


### PR DESCRIPTION
## Description

Currently the `Connection` stores a `Watchable` for the open and selected paths. This means, though, that a watcher stream for the open paths will only close once the last connection is dropped, not once the connection is closed. That is bad API and will lead to confusion.

In an initial version, I swapped the Watchables for a `n0_watcher::Map<(Direct, Direct)>` but this increases the size of the `Connection` struct from ~80 to ~700 bytes, because it would store both the two unmapped values and the mapped final value inline. It is also completely unneeded, because we'd clone out the watcher anyways on `Connection::watch`  and `get` or `stream` on the watcher would refetch the value.

Instead, this now uses https://github.com/n0-computer/n0-watcher/pull/31 to only store a weak pointer to the watchable's shared state without keeping it alive, and then creates the PathInfos on demand from that. The `stats` are now fetched while iterating, so if you're e.g. only checking the number of paths, the stats won't be fetched at all. 

We fetch the paths through upgrading the handle in the `next` method, so that we can return `None` if the connection was dropped in the meantime (the alternative would be a fallible `PathInfo::stats` method)

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
