### PR TITLE
fix(iroh): Clear `EndpointStateActor::selected_path` once the last connection closes

### DIFF
--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -248,6 +248,10 @@ impl EndpointStateActor {
                 }
                 Some(conn_id) = self.connections_close.next(), if !self.connections_close.is_empty() => {
                     self.connections.remove(&conn_id);
+                    if self.connections.is_empty() {
+                        trace!("last connection closed - clearing selected_path");
+                        self.selected_path.set(None).ok();
+                    }
                 }
                 _ = self.local_addrs.updated() => {
                     trace!("local addrs updated, triggering holepunching");


### PR DESCRIPTION
## Description

Addresses #3602 for multipath.

This implements the first bullet point from @flub's suggestion in the above issue: We clear the `selected_path` once the last known connection to an endpoint closes.

This means that a new connection attempt after that will instead send to all addresses again, and avoids the case where we send on e.g. the old port from a previous restart of the endpoint we're connecting to.

This turns the `test_0rtt_after_server_restart` test green.

## Notes & open questions

I *think* this will still fail if we have an "open" connection to the server that's in the process of timing out and we open a new connection to the restarted server while that's happening. I'm not sure though.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
