### PR TITLE
refactor: Prefer EndpointAddr::from_parts over EndpointAddr { ... }

### DIFF
--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -909,12 +909,10 @@ mod tests {
         let (ep2, _guard2) =
             new_endpoint(&mut rng, |ep| disco_shared.create_discovery(ep.id())).await;
 
-        let ep1_wrong_addr = EndpointAddr {
-            id: ep1.id(),
-            addrs: [TransportAddr::Ip("240.0.0.1:1000".parse().unwrap())]
-                .into_iter()
-                .collect(),
-        };
+        let ep1_wrong_addr = EndpointAddr::from_parts(
+            ep1.id(),
+            [TransportAddr::Ip("240.0.0.1:1000".parse().unwrap())],
+        );
         let _conn = ep2.connect(ep1_wrong_addr, TEST_ALPN).await?;
         Ok(())
     }
@@ -1059,10 +1057,7 @@ mod test_dns_pkarr {
             .await?;
         println!("resolved {resolved:?}");
 
-        let expected_addr = EndpointAddr {
-            id: endpoint_id,
-            addrs: relay_url.into_iter().collect(),
-        };
+        let expected_addr = EndpointAddr::from_parts(endpoint_id, relay_url);
 
         assert_eq!(resolved.to_endpoint_addr(), expected_addr);
         assert_eq!(resolved.user_data(), Some(&user_data));

--- a/iroh/src/discovery/static_provider.rs
+++ b/iroh/src/discovery/static_provider.rs
@@ -248,12 +248,10 @@ mod tests {
             .await?;
 
         let key = SecretKey::from_bytes(&[0u8; 32]);
-        let addr = EndpointAddr {
-            id: key.public(),
-            addrs: [TransportAddr::Relay("https://example.com".parse()?)]
-                .into_iter()
-                .collect(),
-        };
+        let addr = EndpointAddr::from_parts(
+            key.public(),
+            [TransportAddr::Relay("https://example.com".parse()?)],
+        );
         let user_data = Some("foobar".parse().unwrap());
         let endpoint_info = EndpointInfo::from(addr.clone()).with_user_data(user_data.clone());
         discovery.add_endpoint_info(endpoint_info.clone());
@@ -280,12 +278,10 @@ mod tests {
     async fn test_provenance() -> Result {
         let discovery = StaticProvider::with_provenance("foo");
         let key = SecretKey::from_bytes(&[0u8; 32]);
-        let addr = EndpointAddr {
-            id: key.public(),
-            addrs: [TransportAddr::Relay("https://example.com".parse()?)]
-                .into_iter()
-                .collect(),
-        };
+        let addr = EndpointAddr::from_parts(
+            key.public(),
+            [TransportAddr::Relay("https://example.com".parse()?)],
+        );
         discovery.add_endpoint_info(addr);
         let mut stream = discovery.resolve(key.public()).unwrap();
         let item = stream.next().await.unwrap()?;

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2651,10 +2651,10 @@ mod tests {
                     continue;
                 }
 
-                let addr = EndpointAddr {
-                    id: me.public(),
-                    addrs: new_addrs.iter().copied().map(TransportAddr::Ip).collect(),
-                };
+                let addr = EndpointAddr::from_parts(
+                    me.public(),
+                    new_addrs.iter().copied().map(TransportAddr::Ip),
+                );
                 m.endpoint.magic_sock().add_test_addr(addr);
             }
         }
@@ -3216,12 +3216,8 @@ mod tests {
             .ip_addrs()
             .get()
             .into_iter()
-            .map(|x| TransportAddr::Ip(x.addr))
-            .collect();
-        let endpoint_addr_2 = EndpointAddr {
-            id: endpoint_id_2,
-            addrs,
-        };
+            .map(|x| TransportAddr::Ip(x.addr));
+        let endpoint_addr_2 = EndpointAddr::from_parts(endpoint_id_2, addrs);
         msock_1
             .add_endpoint_addr(
                 endpoint_addr_2,
@@ -3292,10 +3288,7 @@ mod tests {
 
         // Add an empty entry in the EndpointMap of ep_1
         msock_1.endpoint_map.add_endpoint_addr(
-            EndpointAddr {
-                id: endpoint_id_2,
-                addrs: Default::default(),
-            },
+            EndpointAddr::from_parts(endpoint_id_2, []),
             Source::NamedApp {
                 name: "test".into(),
             },
@@ -3332,13 +3325,9 @@ mod tests {
             .ip_addrs()
             .get()
             .into_iter()
-            .map(|x| TransportAddr::Ip(x.addr))
-            .collect();
+            .map(|x| TransportAddr::Ip(x.addr));
         msock_1.endpoint_map.add_endpoint_addr(
-            EndpointAddr {
-                id: endpoint_id_2,
-                addrs,
-            },
+            EndpointAddr::from_parts(endpoint_id_2, addrs),
             Source::NamedApp {
                 name: "test".into(),
             },
@@ -3393,12 +3382,10 @@ mod tests {
         );
 
         // relay url only
-        let addr = EndpointAddr {
-            id: SecretKey::generate(&mut rng).public(),
-            addrs: [TransportAddr::Relay("http://my-relay.com".parse().unwrap())]
-                .into_iter()
-                .collect(),
-        };
+        let addr = EndpointAddr::from_parts(
+            SecretKey::generate(&mut rng).public(),
+            [TransportAddr::Relay("http://my-relay.com".parse().unwrap())],
+        );
         stack
             .endpoint
             .magic_sock()
@@ -3406,12 +3393,10 @@ mod tests {
         assert_eq!(stack.endpoint.magic_sock().endpoint_map.endpoint_count(), 1);
 
         // addrs only
-        let addr = EndpointAddr {
-            id: SecretKey::generate(&mut rng).public(),
-            addrs: [TransportAddr::Ip("127.0.0.1:1234".parse().unwrap())]
-                .into_iter()
-                .collect(),
-        };
+        let addr = EndpointAddr::from_parts(
+            SecretKey::generate(&mut rng).public(),
+            [TransportAddr::Ip("127.0.0.1:1234".parse().unwrap())],
+        );
         stack
             .endpoint
             .magic_sock()
@@ -3419,15 +3404,13 @@ mod tests {
         assert_eq!(stack.endpoint.magic_sock().endpoint_map.endpoint_count(), 2);
 
         // both
-        let addr = EndpointAddr {
-            id: SecretKey::generate(&mut rng).public(),
-            addrs: [
+        let addr = EndpointAddr::from_parts(
+            SecretKey::generate(&mut rng).public(),
+            [
                 TransportAddr::Relay("http://my-relay.com".parse().unwrap()),
                 TransportAddr::Ip("127.0.0.1:1234".parse().unwrap()),
-            ]
-            .into_iter()
-            .collect(),
-        };
+            ],
+        );
         stack
             .endpoint
             .magic_sock()

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -1232,10 +1232,7 @@ impl From<RemoteInfo> for EndpointAddr {
             addrs.insert(TransportAddr::Relay(url.into()));
         }
 
-        EndpointAddr {
-            id: info.endpoint_id,
-            addrs,
-        }
+        EndpointAddr::from_parts(info.endpoint_id, addrs)
     }
 }
 


### PR DESCRIPTION
## Description

This would make the diff smaller if we decide to go with generic endpoint ids. See https://github.com/n0-computer/iroh/pull/3653 . And I also think it is nicer in any case.

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
