### PR TITLE
fix(iroh)!: Correct the error structure

### DIFF
--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -605,11 +605,11 @@ impl OutgoingZeroRttConnection {
     /// the handshake will error and any data sent should be re-sent on a
     /// new stream.
     ///
-    /// This may fail with [`AuthenticationError::ConnectionError`], if there was
+    /// This may fail with [`ConnectingError::ConnectionError`], if there was
     /// some general failure with the connection, such as a network timeout since
     /// we initiated the connection.
     ///
-    /// This may fail with other [`AuthenticationError`]s, if the other side
+    /// This may fail with [`ConnectingError::HandshakeFailure`], if the other side
     /// doesn't use the right TLS authentication, which usually every iroh endpoint
     /// uses and requires.
     ///
@@ -915,11 +915,11 @@ pub struct IncomingZeroRttConnection {
 impl IncomingZeroRttConnection {
     /// Waits until the full handshake occurs and then returns a [`Connection`].
     ///
-    /// This may fail with [`AuthenticationError::ConnectionError`], if there was
+    /// This may fail with [`ConnectingError::ConnectionError`], if there was
     /// some general failure with the connection, such as a network timeout since
     /// we accepted the connection.
     ///
-    /// This may fail with other [`AuthenticationError`]s, if the other side
+    /// This may fail with [`ConnectingError::HandshakeFailure`], if the other side
     /// doesn't use the right TLS authentication, which usually every iroh endpoint
     /// uses and requires.
     ///


### PR DESCRIPTION
## Description

For some odd reason AuthenticationError was given a branch that had
quinn::ConnectionError inside it.  But logically the connection error
has nothing to do with authentication.  That should have been a red
flag.

AuthenticationError itself is almost always wrapped in
ConnectingError, which does correctly have a quinn::ConnectionError
branch.  And the few places where it was directly returned to the user
it arguably **should** have been wrapped in a ConnectingError.

The result of this is that before this fix you would get a very
confusing authentication error if the remote client closed the
connection right at the same time as the handshake completed for
it (yes, this is difficult to do at the right time, and it only
happens for the client since that completes the handshake one network
hop before the server).  But this was no authentication error, it is
simply a closed connection.  The new error structure captures this
correctly.

Similarly the InternalConsistencyError belongs on the ConnectingError.
Though that one should be impossible to produce since it's supposed to
be an invariant.

## Breaking Changes

- `AuthenticationError` loses the `ConnectionError` and
  `InternalConsistencyError` branches.  Both are on the
  `ConnectingError` instead.
- `OutgoingZeroRttConnection::handshake_completed` and
  `IncomingZeroRttConnection` now return a `ConnectingError` instead
  of `AuthenticationError`.

## Notes & open questions

While I've managed to trigger this error somewhat occasionally using a
program that races the closing with the completed handshake in a very
tight loop **before** applying this fix.  I'm completely failing to
trigger it since applying this fix, so I can admire the beautiful new
error reporting this fix should give.  It's a bit confusing.

**edit**: it **is** confusing.  But it is correct.  Because my flaky failure does always close the connection *after* it completes the handshake.  So ALPN and EndpointId are always available.  And then you yield a valid `Connection` when awaiting an `Incoming`, it just is already closed.

This fix could also be made against main.  I believe the same commit should be able to be cherry-picked and will probably apply fairly clean.  Do you think I should make it against main?

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] All breaking changes documented.
  - [x] List all breaking changes in the above "Breaking Changes" section.