### PR TITLE
refactor: remove Endpoint::path_selection

### DIFF
--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -34,11 +34,9 @@ pub fn server_endpoint(
         #[cfg(feature = "local-relay")]
         {
             builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some());
-            let path_selection = match opt.only_relay {
-                true => iroh::endpoint::PathSelection::RelayOnly,
-                false => iroh::endpoint::PathSelection::default(),
-            };
-            builder = builder.path_selection(path_selection);
+            if opt.only_relay {
+                builder = builder.clear_ip_transports();
+            }
         }
         let ep = builder
             .alpns(vec![ALPN.to_vec()])
@@ -95,11 +93,9 @@ pub async fn connect_client(
     #[cfg(feature = "local-relay")]
     {
         builder = builder.insecure_skip_relay_cert_verify(relay_url.is_some());
-        let path_selection = match opt.only_relay {
-            true => iroh::endpoint::PathSelection::RelayOnly,
-            false => iroh::endpoint::PathSelection::default(),
-        };
-        builder = builder.path_selection(path_selection);
+        if opt.only_relay {
+            builder = builder.clear_ip_transports();
+        }
     }
     let endpoint = builder
         .alpns(vec![ALPN.to_vec()])

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -242,16 +242,7 @@ impl EndpointArgs {
         }
 
         if self.relay_only {
-            #[cfg(feature = "test-utils")]
-            {
-                builder = builder.path_selection(iroh::endpoint::PathSelection::RelayOnly)
-            }
-            #[cfg(not(feature = "test-utils"))]
-            {
-                n0_error::bail_any!(
-                    "Must have the `discovery-local-network` enabled when using the `--mdns` flag"
-                );
-            }
+            builder = builder.clear_ip_transports();
         }
 
         if let Some(host) = self.dns_server {
@@ -280,7 +271,7 @@ impl EndpointArgs {
             #[cfg(not(feature = "discovery-local-network"))]
             {
                 n0_error::bail_any!(
-                    "Must have the `test-utils` feature enabled when using the `--relay-only` flag"
+                    "Must have the `discovery-local-network` enabled when using the `--mdns` flag"
                 );
             }
         }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -81,18 +81,6 @@ pub use crate::magicsock::transports::TransportConfig;
 /// is still no connection the configured [`crate::discovery::Discovery`] will be used however.
 const DISCOVERY_WAIT_PERIOD: Duration = Duration::from_millis(500);
 
-/// Defines the mode of path selection for all traffic flowing through
-/// the endpoint.
-#[cfg(any(test, feature = "test-utils"))]
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
-pub enum PathSelection {
-    /// Uses all available paths
-    #[default]
-    All,
-    /// Forces all traffic to go exclusively through relays
-    RelayOnly,
-}
-
 /// Builder for [`Endpoint`].
 ///
 /// By default the endpoint will generate a new random [`SecretKey`], which will result in a
@@ -113,8 +101,6 @@ pub struct Builder {
     #[cfg(any(test, feature = "test-utils"))]
     insecure_skip_relay_cert_verify: bool,
     transports: Vec<TransportConfig>,
-    #[cfg(any(test, feature = "test-utils"))]
-    path_selection: PathSelection,
     max_tls_tickets: usize,
 }
 
@@ -176,8 +162,6 @@ impl Builder {
             dns_resolver: None,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
-            #[cfg(any(test, feature = "test-utils"))]
-            path_selection: PathSelection::default(),
             max_tls_tickets: DEFAULT_MAX_TLS_TICKETS,
             transports,
         }
@@ -224,8 +208,6 @@ impl Builder {
             server_config,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
-            // #[cfg(any(test, feature = "test-utils"))]
-            // path_selection: self.path_selection,
             metrics,
         };
 
@@ -468,14 +450,6 @@ impl Builder {
     #[cfg(any(test, feature = "test-utils"))]
     pub fn insecure_skip_relay_cert_verify(mut self, skip_verify: bool) -> Self {
         self.insecure_skip_relay_cert_verify = skip_verify;
-        self
-    }
-
-    /// This implies we only use the relay to communicate
-    /// and do not attempt to do any hole punching.
-    #[cfg(any(test, feature = "test-utils"))]
-    pub fn path_selection(mut self, path_selection: PathSelection) -> Self {
-        self.path_selection = path_selection;
         self
     }
 

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -53,8 +53,6 @@ use self::{
 };
 #[cfg(not(wasm_browser))]
 use crate::dns::DnsResolver;
-// #[cfg(any(test, feature = "test-utils"))]
-// use crate::endpoint::PathSelection;
 #[cfg(not(wasm_browser))]
 use crate::net_report::QuicConfig;
 use crate::{
@@ -136,10 +134,6 @@ pub(crate) struct Options {
     /// May only be used in tests.
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) insecure_skip_relay_cert_verify: bool,
-
-    // /// Configuration for what path selection to use
-    // #[cfg(any(test, feature = "test-utils"))]
-    // pub(crate) path_selection: PathSelection,
     pub(crate) metrics: EndpointMetrics,
 }
 
@@ -936,8 +930,6 @@ impl Handle {
             server_config,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify,
-            // #[cfg(any(test, feature = "test-utils"))]
-            // path_selection,
             metrics,
         } = opts;
 
@@ -1026,8 +1018,6 @@ impl Handle {
         let endpoint_map = {
             EndpointMap::new(
                 secret_key.public(),
-                // #[cfg(any(test, feature = "test-utils"))]
-                // path_selection,
                 metrics.magicsock.clone(),
                 direct_addrs.addrs.watch(),
                 disco.clone(),
@@ -1856,12 +1846,9 @@ mod tests {
 
     use super::{EndpointIdMappedAddr, Options, endpoint_map::Source, mapped_addrs::MappedAddr};
     use crate::{
-        Endpoint,
-        RelayMode,
-        SecretKey,
+        Endpoint, RelayMode, SecretKey,
         discovery::static_provider::StaticProvider,
         dns::DnsResolver,
-        // endpoint::PathSelection,
         magicsock::{Handle, MagicSock, TransportConfig},
         tls::{self, DEFAULT_MAX_TLS_TICKETS},
     };
@@ -1883,7 +1870,6 @@ mod tests {
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_relay_cert_verify: false,
             #[cfg(any(test, feature = "test-utils"))]
-            // path_selection: PathSelection::default(),
             discovery_user_data: None,
             metrics: Default::default(),
         }
@@ -2319,7 +2305,6 @@ mod tests {
             proxy_url: None,
             server_config,
             insecure_skip_relay_cert_verify: false,
-            // path_selection: PathSelection::default(),
             metrics: Default::default(),
         };
         let msock = MagicSock::spawn(opts).await?;

--- a/iroh/src/magicsock/endpoint_map.rs
+++ b/iroh/src/magicsock/endpoint_map.rs
@@ -12,8 +12,6 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::warn;
 
-// #[cfg(any(test, feature = "test-utils"))]
-// use crate::endpoint::PathSelection;
 pub(super) use self::endpoint_state::EndpointStateMessage;
 pub(crate) use self::endpoint_state::PathsWatcher;
 use self::endpoint_state::{EndpointStateActor, EndpointStateHandle};
@@ -69,8 +67,6 @@ impl EndpointMap {
     /// Creates a new [`EndpointMap`].
     pub(super) fn new(
         local_endpoint_id: EndpointId,
-        // TODO:
-        // #[cfg(any(test, feature = "test-utils"))] path_selection: PathSelection,
         metrics: Arc<MagicsockMetrics>,
 
         local_addrs: n0_watcher::Direct<BTreeSet<DirectAddr>>,

--- a/iroh/src/magicsock/endpoint_map/endpoint_state.rs
+++ b/iroh/src/magicsock/endpoint_map/endpoint_state.rs
@@ -35,10 +35,6 @@ use crate::{
     util::MaybeFuture,
 };
 
-// TODO: Use this
-// #[cfg(any(test, feature = "test-utils"))]
-// use crate::endpoint::PathSelection;
-
 mod guarded_channel;
 
 // TODO: use this


### PR DESCRIPTION
## Description

Remove the test-only `Endpoint::path_selection` API and instead use `Endpoint::clear_ip_transports` for `PathSelection::RelayOnly `, now that this public API was added in https://github.com/n0-computer/iroh/pull/3651.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
