### PR TITLE
test(iroh): Fix `test_two_devices_setup_teardown` hanging

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -2058,10 +2058,8 @@ mod tests {
         let ep2_addr_stream = ep2.watch_addr().stream();
         let mut addr_stream = MergeBounded::from_iter([ep1_addr_stream, ep2_addr_stream]);
         let task = tokio::spawn(async move {
-            loop {
-                while let Some(addr) = addr_stream.next().await {
-                    discovery.add_endpoint_info(addr);
-                }
+            while let Some(addr) = addr_stream.next().await {
+                discovery.add_endpoint_info(addr);
             }
         });
 


### PR DESCRIPTION
## Description

Avoid potentially busy looping in a tokio task.
I think this blocking leads to tokio not being able to close the runtime properly.

