### PR TITLE
test(iroh): Fix `test_active_relay_inactive` test being flaky

### DIFF
--- a/iroh/src/magicsock/transports/relay/actor.rs
+++ b/iroh/src/magicsock/transports/relay/actor.rs
@@ -1515,6 +1515,10 @@ mod tests {
         tokio::time::pause();
         tokio::time::advance(RELAY_INACTIVE_CLEANUP_TIME).await;
         tokio::time::resume();
+
+        // We resume time for these timeouts, as there's actual I/O happening,
+        // for example closing the TCP stream, so we actually need the tokio
+        // runtime to idle a bit while the kernel is doing its thing.
         assert!(
             tokio::time::timeout(Duration::from_secs(1), task)
                 .await


### PR DESCRIPTION
## Description

This reverts a change from this PR: https://github.com/n0-computer/iroh/pull/3384

I originally thought I could make this test more reliable by pausing the tokio time across the `tokio::time::timeout` calls, but it turns out that actually makes the test *more* flaky:
- When time is paused, the timeout will immediately fire once the tokio runtime has no more CPU work to do.
- It's possible that there's no CPU work to do anymore, while there's something else that is actually still doing work, e.g. networking.
- Before the `ActiveRelayActor` finishes its `run_connected` loop, it will call `client_sink.close().await`, which will do actual I/O. When the tokio runtime is paused at that moment, it'll immediately trigger the test's timeout.

## Notes & open questions

I couldn't reproduce this problem even across a couple thousand runs of the test locally. I'm not super confident that this fixes things, but I've analyzed the logs and this seems to be the most likely thing that's happening to me.

Closes #3613 

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
