### PR TITLE
Fix the roundtrip test

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1620,7 +1620,6 @@ mod tests {
 
         let stats = conn.stats();
         info!("stats: {:#?}", stats);
-        // TODO: ensure panics in this function are reported ok
         if matches!(loss, ExpectedLoss::AlmostNone) {
             for info in conn.paths().get().iter() {
                 assert!(
@@ -1631,10 +1630,10 @@ mod tests {
             }
         }
 
-        info!("close");
-        conn.close(0u32.into(), b"done");
-        info!("wait idle");
+        conn.closed().await;
+        info!("closed");
         ep.endpoint().wait_idle().await;
+        info!("idle");
 
         Ok(())
     }
@@ -1685,10 +1684,10 @@ mod tests {
             }
         }
 
-        info!("close");
         conn.close(0u32.into(), b"done");
-        info!("wait idle");
+        info!("closed");
         ep.endpoint().wait_idle().await;
+        info!("idle");
         Ok(())
     }
 
@@ -1709,26 +1708,26 @@ mod tests {
         let recv_endpoint_id = receiver.id();
         info!("\nroundtrip: {send_endpoint_id:#} -> {recv_endpoint_id:#}");
 
-        let receiver_task = tokio::spawn(echo_receiver(receiver, loss));
+        let receiver_task = AbortOnDropHandle::new(tokio::spawn(echo_receiver(receiver, loss)));
         let sender_res = echo_sender(sender, recv_endpoint_id, payload, loss).await;
         let sender_is_err = match sender_res {
             Ok(()) => false,
             Err(err) => {
-                eprintln!("[sender] Error:\n{err:#?}");
+                error!("[sender] Error:\n{err:#?}");
                 true
             }
         };
         let receiver_is_err = match receiver_task.await {
             Ok(Ok(())) => false,
             Ok(Err(err)) => {
-                eprintln!("[receiver] Error:\n{err:#?}");
+                error!("[receiver] Error:\n{err:#?}");
                 true
             }
             Err(joinerr) => {
                 if joinerr.is_panic() {
                     std::panic::resume_unwind(joinerr.into_panic());
                 } else {
-                    eprintln!("[receiver] Error:\n{joinerr:#?}");
+                    error!("[receiver] Error:\n{joinerr:#?}");
                 }
                 true
             }
@@ -1802,6 +1801,7 @@ mod tests {
             rng.fill_bytes(&mut data);
             run_roundtrip(m1.clone(), m2.clone(), &data, ExpectedLoss::AlmostNone).await;
             run_roundtrip(m2.clone(), m1.clone(), &data, ExpectedLoss::AlmostNone).await;
+            info!("\n-- round {i} finished");
         }
 
         Ok(())


### PR DESCRIPTION
## Description

Since the server was actively closing the connection it is possible
that the client would not have read the response yet by the time the
connection is closed.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)

<!-- Message of single commit: -->