### PR TITLE
refactor(iroh)!: remove Endpoint::latency

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -945,13 +945,6 @@ impl Endpoint {
     //
     // Partially they return things passed into the builder.
 
-    /// Returns the currently lowest latency for this endpoint.
-    ///
-    /// Will return `None` if we do not have any address information for the given `endpoint_id`.
-    pub async fn latency(&self, endpoint_id: EndpointId) -> Option<Duration> {
-        self.msock.latency(endpoint_id).await
-    }
-
     /// Returns the DNS resolver used in this [`Endpoint`].
     ///
     /// See [`Builder::dns_resolver`].

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -391,18 +391,6 @@ impl MagicSock {
         })
     }
 
-    // TODO: Build better info to expose to the user about remote nodes.  We probably want
-    // to expose this as part of path information instead.
-    pub(crate) async fn latency(&self, eid: EndpointId) -> Option<Duration> {
-        let remote_state = self.remote_map.remote_state_actor(eid);
-        let (tx, rx) = oneshot::channel();
-        remote_state
-            .send(RemoteStateMessage::Latency(tx))
-            .await
-            .ok();
-        rx.await.unwrap_or_default()
-    }
-
     /// Stores a new set of direct addresses.
     ///
     /// If the direct addresses have changed from the previous set, they are published to


### PR DESCRIPTION
## Description

Based on #3593 

This was always just a placeholder, and can now be collected using `EndpointHooks`.

## Breaking Changes

- remove `Endpoint::latency`

