### PR TITLE
refactor: add Side re-export

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -61,7 +61,7 @@ pub use self::{
         CryptoError, CryptoServerConfig, ExportKeyingMaterialError, FrameStats, HandshakeTokenKey,
         IdleTimeout, MtuDiscoveryConfig, OpenBi, OpenUni, PathStats, QuicTransportConfig,
         ReadDatagram, ReadError, ReadExactError, ReadToEndError, RecvStream, ResetError,
-        RetryError, SendDatagramError, SendStream, ServerConfig, StoppedError, StreamId,
+        RetryError, SendDatagramError, SendStream, ServerConfig, Side, StoppedError, StreamId,
         TransportError, TransportErrorCode, UdpStats, UnsupportedVersion, VarInt,
         VarIntBoundsExceeded, WeakConnectionHandle, WriteError, Written,
     },

--- a/iroh/src/endpoint/quic.rs
+++ b/iroh/src/endpoint/quic.rs
@@ -13,7 +13,7 @@ pub use quinn::{
     AcceptBi, AcceptUni, AckFrequencyConfig, ApplicationClose, Chunk, ClosedStream,
     ConnectionClose, ConnectionError, ConnectionStats, MtuDiscoveryConfig, OpenBi, OpenUni,
     PathStats, ReadDatagram, ReadError, ReadExactError, ReadToEndError, RecvStream, ResetError,
-    RetryError, SendDatagramError, SendStream, ServerConfig, StoppedError, StreamId, VarInt,
+    RetryError, SendDatagramError, SendStream, ServerConfig, Side, StoppedError, StreamId, VarInt,
     VarIntBoundsExceeded, WeakConnectionHandle, WriteError,
 };
 pub use quinn_proto::{


### PR DESCRIPTION
## Description

Adds a missing re-export for `quinn::Side` 

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
