### PR TITLE
refactor: use qlog_from_env in iroh bench

### DIFF
--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -1,13 +1,9 @@
-#[cfg(feature = "qlog")]
-use std::sync::Arc;
 use std::{
     net::SocketAddr,
     time::{Duration, Instant},
 };
 
 use bytes::Bytes;
-#[cfg(feature = "qlog")]
-use iroh::endpoint::QlogFileFactory;
 use iroh::{
     Endpoint, EndpointAddr, RelayMode, RelayUrl,
     endpoint::{Connection, ConnectionError, QuicTransportConfig, RecvStream, SendStream},
@@ -138,9 +134,7 @@ pub fn transport_config(max_streams: usize, initial_mtu: u16) -> QuicTransportCo
     config.ack_frequency_config(Some(acks));
 
     #[cfg(feature = "qlog")]
-    config.qlog_factory(Arc::new(
-        QlogFileFactory::from_env().with_prefix("bench-iroh"),
-    ));
+    config.qlog_from_env("bench-iroh");
 
     config
 }

--- a/iroh/bench/src/quinn.rs
+++ b/iroh/bench/src/quinn.rs
@@ -5,8 +5,6 @@ use std::{
 };
 
 use bytes::Bytes;
-#[cfg(feature = "qlog")]
-use iroh::endpoint::QlogFileFactory;
 use n0_error::{Result, StdResultExt};
 use quinn::{
     Connection, Endpoint, RecvStream, SendStream, TransportConfig, crypto::rustls::QuicClientConfig,
@@ -119,9 +117,7 @@ pub fn transport_config(max_streams: usize, initial_mtu: u16) -> TransportConfig
     config.ack_frequency_config(Some(acks));
 
     #[cfg(feature = "qlog")]
-    config.qlog_factory(Arc::new(
-        QlogFileFactory::from_env().with_prefix("bench-quinn"),
-    ));
+    config.qlog_from_env("bench-iroh");
 
     config
 }


### PR DESCRIPTION
## Description

small change to use the simpler `TransportConfig::qlog_from_env` instead of manually constructing a `QlogFileFactory`.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
