### PR TITLE
example: add qlog support to transfer example

### DIFF
--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -44,6 +44,9 @@ const DEV_DNS_SERVER: &str = "127.0.0.1:5300";
 ///
 /// --mdns needs the `discovery-local-network` feature
 ///
+/// To emit qlog files, enable the `qlog` feature and set the QLOGDIR
+/// environment variable to the path where qlog files should be written to.
+///
 /// To enable all features, run the example with --all-features:
 ///
 /// cargo run --release --example transfer --all-features -- ARGS
@@ -146,9 +149,12 @@ enum Commands {
     },
     /// Fetch data.
     Fetch {
+        /// Endpoint id of the remote to connect to.
         remote_id: EndpointId,
+        /// Optionally set a relay URL for the remote.
         #[clap(long)]
         remote_relay_url: Option<RelayUrl>,
+        /// Optionally set direct addresses for the remote.
         #[clap(long)]
         remote_direct_address: Vec<SocketAddr>,
         #[clap(flatten)]


### PR DESCRIPTION
## Description

usage:
`QLOGDIR=./qlog cargo run --examples transfer --release --features qlog`
or
`QLOGDIR=./qlog cargo run --examples transfer --release --all-features`

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
