### PR TITLE
feat: expose known remote addrs

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1060,7 +1060,7 @@ impl Endpoint {
     /// Returns addressing information about a recently used remote endpoint.
     ///
     /// The returned [`RemoteInfo`] contains a list of all transport addresses for the remote
-    /// that we know about.
+    /// that we know about. This is a snapshot in time and not a watcher.
     ///
     /// Returns `None` if the endpoint doesn't have information about the remote.
     /// When remote endpoints are no longer used, our endpoint will keep information around

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -51,7 +51,7 @@ use crate::discovery::pkarr::PkarrResolver;
 use crate::dns::DnsResolver;
 pub use crate::magicsock::{
     DirectAddr, DirectAddrType, PathInfo,
-    remote_map::{AddrUsage, PathInfoList, RemoteAddr, RemoteInfo, Source},
+    remote_map::{PathInfoList, RemoteInfo, Source, TransportAddrInfo, TransportAddrUsage},
     transports::TransportConfig,
 };
 use crate::{

--- a/iroh/src/magicsock/remote_map.rs
+++ b/iroh/src/magicsock/remote_map.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 
 pub(crate) use self::remote_state::PathsWatcher;
 pub(super) use self::remote_state::RemoteStateMessage;
-pub use self::remote_state::{PathInfo, PathInfoList};
+pub use self::remote_state::{AddrUsage, PathInfo, PathInfoList, RemoteAddr, RemoteInfo};
 use self::remote_state::{RemoteStateActor, RemoteStateHandle};
 use super::{
     DirectAddr, MagicsockMetrics,
@@ -116,6 +116,17 @@ impl RemoteMap {
                 sender
             }
         }
+    }
+
+    pub(super) fn remote_state_actor_if_exists(
+        &self,
+        eid: EndpointId,
+    ) -> Option<mpsc::Sender<RemoteStateMessage>> {
+        self.actor_handles
+            .lock()
+            .expect("poisoned")
+            .get(&eid)
+            .and_then(|handle| handle.sender.get())
     }
 
     /// Starts a new remote state actor and returns a handle and a sender.

--- a/iroh/src/magicsock/remote_map.rs
+++ b/iroh/src/magicsock/remote_map.rs
@@ -13,7 +13,9 @@ use tokio::sync::mpsc;
 
 pub(crate) use self::remote_state::PathsWatcher;
 pub(super) use self::remote_state::RemoteStateMessage;
-pub use self::remote_state::{AddrUsage, PathInfo, PathInfoList, RemoteAddr, RemoteInfo};
+pub use self::remote_state::{
+    PathInfo, PathInfoList, RemoteInfo, TransportAddrInfo, TransportAddrUsage,
+};
 use self::remote_state::{RemoteStateActor, RemoteStateHandle};
 use super::{
     DirectAddr, MagicsockMetrics,

--- a/iroh/src/magicsock/remote_map/remote_state.rs
+++ b/iroh/src/magicsock/remote_map/remote_state.rs
@@ -24,7 +24,7 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 use tracing::{Instrument, Level, debug, error, event, info_span, instrument, trace, warn};
 
-pub use self::remote_info::{AddrUsage, RemoteAddr, RemoteInfo};
+pub use self::remote_info::{RemoteInfo, TransportAddrInfo, TransportAddrUsage};
 use self::{
     guarded_channel::{GuardedReceiver, GuardedSender, guarded_channel},
     path_state::RemotePathState,

--- a/iroh/src/magicsock/remote_map/remote_state.rs
+++ b/iroh/src/magicsock/remote_map/remote_state.rs
@@ -24,6 +24,7 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 use tracing::{Instrument, Level, debug, error, event, info_span, instrument, trace, warn};
 
+pub use self::remote_info::{AddrUsage, RemoteAddr, RemoteInfo};
 use self::{
     guarded_channel::{GuardedReceiver, GuardedSender, guarded_channel},
     path_state::RemotePathState,
@@ -49,6 +50,7 @@ const HOLEPUNCH_ATTEMPTS_INTERVAL: Duration = Duration::from_secs(5);
 
 mod guarded_channel;
 mod path_state;
+mod remote_info;
 
 // TODO: use this
 // /// The latency at or under which we don't try to upgrade to a better path.
@@ -335,6 +337,14 @@ impl RemoteStateActor {
             }
             RemoteStateMessage::ResolveRemote(addrs, tx) => {
                 self.handle_msg_resolve_remote(addrs, tx);
+            }
+            RemoteStateMessage::RemoteInfo(tx) => {
+                let addrs = self.paths.to_remote_addrs();
+                let info = RemoteInfo {
+                    endpoint_id: self.endpoint_id,
+                    addrs,
+                };
+                tx.send(info).ok();
             }
         }
     }
@@ -1090,6 +1100,10 @@ pub(crate) enum RemoteStateMessage {
         BTreeSet<TransportAddr>,
         oneshot::Sender<Result<(), DiscoveryError>>,
     ),
+    /// Returns information about the remote.
+    ///
+    /// This currently only includes a list of all known transport addresses for the remote.
+    RemoteInfo(oneshot::Sender<RemoteInfo>),
 }
 
 /// A handle to a [`RemoteStateActor`].

--- a/iroh/src/magicsock/remote_map/remote_state/path_state.rs
+++ b/iroh/src/magicsock/remote_map/remote_state/path_state.rs
@@ -62,27 +62,25 @@ impl RemotePathState {
             metrics,
         }
     }
+
     pub(super) fn to_remote_addrs(&self) -> Vec<TransportAddrInfo> {
         self.paths
             .iter()
             .flat_map(|(addr, state)| {
                 let usage = match state.status {
                     PathStatus::Open => TransportAddrUsage::Active,
-                    PathStatus::Inactive(instant) => {
-                        TransportAddrUsage::Inactive { last_used: instant }
+                    PathStatus::Inactive(_) | PathStatus::Unusable | PathStatus::Unknown => {
+                        TransportAddrUsage::Inactive
                     }
-                    PathStatus::Unusable => TransportAddrUsage::Unusable,
-                    PathStatus::Unknown => TransportAddrUsage::Unknown,
                 };
-                let last_source = state.sources.iter().max_by(|a, b| a.1.cmp(b.1))?;
                 Some(TransportAddrInfo {
                     addr: addr.clone().into(),
                     usage,
-                    most_recent_source: last_source.0.clone(),
                 })
             })
             .collect()
     }
+
     /// Insert a new address of an open path into our list of paths.
     ///
     /// This will emit pending resolve requests and trigger pruning paths.

--- a/iroh/src/magicsock/remote_map/remote_state/path_state.rs
+++ b/iroh/src/magicsock/remote_map/remote_state/path_state.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use tokio::sync::oneshot;
 use tracing::trace;
 
-use super::Source;
+use super::{AddrUsage, RemoteAddr, Source};
 use crate::{discovery::DiscoveryError, magicsock::transports, metrics::MagicsockMetrics};
 
 /// Maximum number of IP paths we keep around per endpoint.
@@ -61,6 +61,25 @@ impl RemotePathState {
             pending_resolve_requests: Default::default(),
             metrics,
         }
+    }
+    pub(super) fn to_remote_addrs(&self) -> Vec<RemoteAddr> {
+        self.paths
+            .iter()
+            .flat_map(|(addr, state)| {
+                let usage = match state.status {
+                    PathStatus::Open => AddrUsage::Active,
+                    PathStatus::Inactive(instant) => AddrUsage::Inactive { last_used: instant },
+                    PathStatus::Unusable => AddrUsage::Unusable,
+                    PathStatus::Unknown => AddrUsage::Unknown,
+                };
+                let last_source = state.sources.iter().max_by(|a, b| a.1.cmp(b.1))?;
+                Some(RemoteAddr {
+                    addr: addr.clone().into(),
+                    usage,
+                    last_source: last_source.0.clone(),
+                })
+            })
+            .collect()
     }
     /// Insert a new address of an open path into our list of paths.
     ///

--- a/iroh/src/magicsock/remote_map/remote_state/remote_info.rs
+++ b/iroh/src/magicsock/remote_map/remote_state/remote_info.rs
@@ -32,7 +32,7 @@ impl RemoteInfo {
         self.addrs.into_iter()
     }
 
-    /// Returns a [`EndpointAddr`] that includes all addresses that are not [`AddrUsage::Unusable`].
+    /// Returns a [`EndpointAddr`] that includes all addresses that are not [`TransportAddrUsage::Unusable`].
     pub fn into_endpoint_addr(self) -> EndpointAddr {
         let addrs = self
             .addrs

--- a/iroh/src/magicsock/remote_map/remote_state/remote_info.rs
+++ b/iroh/src/magicsock/remote_map/remote_state/remote_info.rs
@@ -1,0 +1,90 @@
+use std::collections::BTreeSet;
+
+use iroh_base::{EndpointAddr, EndpointId, TransportAddr};
+use n0_future::time::Instant;
+
+use crate::endpoint::Source;
+
+/// Information about a remote endpoint.
+#[derive(Debug, Clone)]
+pub struct RemoteInfo {
+    pub(super) endpoint_id: EndpointId,
+    pub(super) addrs: Vec<RemoteAddr>,
+}
+
+impl RemoteInfo {
+    /// Returns the remote's endpoint id.
+    pub fn id(&self) -> EndpointId {
+        self.endpoint_id
+    }
+
+    /// Returns an iterator over known all addresses for this remote.
+    ///
+    /// Note that this may include outdated or unusable addresses.
+    pub fn addrs(&self) -> impl Iterator<Item = &RemoteAddr> {
+        self.addrs.iter()
+    }
+
+    /// Returns a [`EndpointAddr`] that includes all addresses that are not [`AddrUsage::Unusable`].
+    pub fn into_endpoint_addr(self) -> EndpointAddr {
+        let addrs = self
+            .addrs
+            .into_iter()
+            .filter(|a| !matches!(a.usage(), AddrUsage::Unusable))
+            .map(|a| a.addr);
+
+        EndpointAddr {
+            id: self.endpoint_id,
+            addrs: BTreeSet::from_iter(addrs),
+        }
+    }
+}
+
+/// Address of a remote with some metadata
+#[derive(Debug, Clone)]
+pub struct RemoteAddr {
+    pub(super) addr: TransportAddr,
+    pub(super) usage: AddrUsage,
+    pub(super) last_source: Source,
+}
+
+impl RemoteAddr {
+    /// Returns the [`TransportAddr`].
+    pub fn addr(&self) -> &TransportAddr {
+        &self.addr
+    }
+
+    /// Converts into [`TransportAddr`].
+    pub fn into_addr(self) -> TransportAddr {
+        self.addr
+    }
+
+    /// Returns information how this address is used.
+    pub fn usage(&self) -> AddrUsage {
+        self.usage
+    }
+
+    /// Returns the most recent source of this address.
+    ///
+    /// We may learn about new addresses from multiple sources. This returns the most recent source
+    /// that told us about this address.
+    pub fn last_source(&self) -> &Source {
+        &self.last_source
+    }
+}
+
+/// Information how a transport address is used.
+#[derive(Debug, Copy, Clone)]
+pub enum AddrUsage {
+    /// The address is in active use.
+    Active,
+    /// The address was used, but is not currently.
+    Inactive {
+        /// Instant when this address was last used.
+        last_used: Instant,
+    },
+    /// We tried to use this address, but failed.
+    Unusable,
+    /// We have not tried to use this address.
+    Unknown,
+}

--- a/iroh/src/magicsock/remote_map/remote_state/remote_info.rs
+++ b/iroh/src/magicsock/remote_map/remote_state/remote_info.rs
@@ -43,6 +43,8 @@ impl RemoteInfo {
     /// let addr = EndpointAddr::from_parts(info.id(), info.into_addrs().map(|addr| addr.into_addr()));
     /// # }
     /// ```
+    ///
+    /// [`EndpointAddr`]: crate::EndpointAddr
     pub fn into_addrs(self) -> impl Iterator<Item = TransportAddrInfo> {
         self.addrs.into_iter()
     }


### PR DESCRIPTION
## Description

Adds `Endpoint::remote_info` which returns `Option<RemoteInfo>`. The `RemoteInfo` exposes an iterator over all transport addrs for this remote that we know about. 

Fixes #3521

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

This basically copies the `RemotePathInfo` from the RemoteStateActor into a new struct `RemoteInfo`. So, this an async fn over the channel to the RemoteStateActor, and allocates. As this is a rather niche API, I think that's fine.

I wasn't entirely sure how much info we want to expose. Right now, the PR only includes the latest `Source` for the address, as I wasn't sure if we really want or need to expose the full list of sources.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
