### PR TITLE
fix(iroh): Ensure the selected holepunched path is set to `PathStatus::Available`

### DIFF
--- a/iroh/src/magicsock/remote_map/remote_state.rs
+++ b/iroh/src/magicsock/remote_map/remote_state.rs
@@ -716,6 +716,15 @@ impl RemoteStateActor {
                 Some(path_id) => {
                     trace!(?conn_id, ?path_id, "opening new path");
                     conn_state.add_path(open_addr.clone(), path_id);
+                    // We still need to ensure that the path status is set correctly,
+                    // in case the path was opened by QNT, which opens all IP paths
+                    // using PATH_STATUS_BACKUP. We need to switch the selected path
+                    // to use PATH_STATUS_AVAILABLE though!
+                    if let Some(path) = conn.path(path_id) {
+                        if let Err(e) = path.set_status(path_status) {
+                            warn!(?e, ?open_addr, ?path_status, "Setting path status failed");
+                        }
+                    }
                 }
                 None => {
                     let ret = now_or_never(fut);


### PR DESCRIPTION
## Description

This should fix a possible bug that works like this:
- Connection is opened using a MixedMappedAddr, and the relay wins, so we end up with only a single relay addr.
- The client side initiates holepunching.
- The client side's quinn opens a bunch of paths. For that it uses `open_path_ensure` inside quinn with `PathStatus::Backup` (This is good! I initially wanted to fix that, but ever since QNT this is already fixed!)
- Once the first IP path holepunches, the RemoteStateActor on the client side will see the path open. It'll `select_path` and call `open_path_ensure` on all connections it has with the best path's remote addr and `PathStatus::Available`.
- However, because QNT already opened a path there, `open_path_ensure` doesn't do anything, thus doesn't switch the path to available. We're now stuck with only backup paths, so **keep sending on the relay**.


## Notes & open questions

Someone please tell me how to best test/verify this. Perhaps I should log all the known paths and their statuses on the connection? Or something like that?

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.