### PR TITLE
feat: add must_use attributes to Router::spawn

### DIFF
--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -416,7 +416,7 @@ impl RouterBuilder {
     }
 
     /// Spawns an accept loop and returns a handle to it encapsulated as the [`Router`].
-    #[must_use = "The router shuts down when dropped"]
+    #[must_use = "Router aborts when dropped, use Router::shutdown to shut the router down cleanly"]
     pub fn spawn(self) -> Router {
         // Update the endpoint with our alpns.
         let alpns = self

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -416,6 +416,7 @@ impl RouterBuilder {
     }
 
     /// Spawns an accept loop and returns a handle to it encapsulated as the [`Router`].
+    #[must_use = "The router shuts down when dropped"]
     pub fn spawn(self) -> Router {
         // Update the endpoint with our alpns.
         let alpns = self


### PR DESCRIPTION
## Description

A router is stopped when dropped, so let's add a `must_use` attribute to its `spawn` function. This quite easily prevents a common footgun people run into.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
