### PR TITLE
refactor: Adapt to new UnorderedRecvStream in iroh-quinn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn"
 version = "0.14.0"
-source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#67df91c6670cc48ff2043563e4da388541b4e20b"
+source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#8dfdc04e138a310e95489f714bc05d0d38a44379"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2296,9 +2296,10 @@ dependencies = [
 [[package]]
 name = "iroh-quinn-proto"
 version = "0.13.0"
-source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#67df91c6670cc48ff2043563e4da388541b4e20b"
+source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#8dfdc04e138a310e95489f714bc05d0d38a44379"
 dependencies = [
  "bytes",
+ "derive_more 2.1.0",
  "fastbloom",
  "getrandom 0.3.4",
  "identity-hash",
@@ -2321,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn-udp"
 version = "0.6.0"
-source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#67df91c6670cc48ff2043563e4da388541b4e20b"
+source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#8dfdc04e138a310e95489f714bc05d0d38a44379"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn"
 version = "0.14.0"
-source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#8dfdc04e138a310e95489f714bc05d0d38a44379"
+source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#4f9d519ef4a299b5b36629b2a8f41b8888f41b8d"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn-proto"
 version = "0.13.0"
-source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#8dfdc04e138a310e95489f714bc05d0d38a44379"
+source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#4f9d519ef4a299b5b36629b2a8f41b8888f41b8d"
 dependencies = [
  "bytes",
  "derive_more 2.1.0",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn-udp"
 version = "0.6.0"
-source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#8dfdc04e138a310e95489f714bc05d0d38a44379"
+source = "git+https://github.com/n0-computer/quinn?branch=main-iroh#4f9d519ef4a299b5b36629b2a8f41b8888f41b8d"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/iroh/bench/src/quinn.rs
+++ b/iroh/bench/src/quinn.rs
@@ -123,7 +123,7 @@ pub fn transport_config(max_streams: usize, initial_mtu: u16) -> TransportConfig
 }
 
 async fn drain_stream(
-    stream: &mut RecvStream,
+    mut stream: RecvStream,
     read_unordered: bool,
 ) -> Result<(usize, Duration, u64)> {
     let mut read = 0;
@@ -135,7 +135,8 @@ async fn drain_stream(
     let mut num_chunks: u64 = 0;
 
     if read_unordered {
-        while let Some(chunk) = stream.read_chunk(usize::MAX, false).await.anyerr()? {
+        let mut stream = stream.into_unordered();
+        while let Some(chunk) = stream.read_chunk(usize::MAX).await.anyerr()? {
             if first_byte {
                 ttfb = download_start.elapsed();
                 first_byte = false;
@@ -207,7 +208,7 @@ pub async fn handle_client_stream(
 ) -> Result<(TransferResult, TransferResult)> {
     let start = Instant::now();
 
-    let (mut send_stream, mut recv_stream) = connection
+    let (mut send_stream, recv_stream) = connection
         .open_bi()
         .await
         .std_context("failed to open stream")?;
@@ -217,7 +218,7 @@ pub async fn handle_client_stream(
     let upload_result = TransferResult::new(start.elapsed(), upload_size, Duration::default(), 0);
 
     let start = Instant::now();
-    let (size, ttfb, num_chunks) = drain_stream(&mut recv_stream, read_unordered).await?;
+    let (size, ttfb, num_chunks) = drain_stream(recv_stream, read_unordered).await?;
     let download_result = TransferResult::new(start.elapsed(), size as u64, ttfb, num_chunks);
 
     Ok((upload_result, download_result))
@@ -243,7 +244,7 @@ pub async fn server(endpoint: Endpoint, opt: Opt) -> Result<()> {
 
         server_tasks.push(tokio::spawn(async move {
             loop {
-                let (mut send_stream, mut recv_stream) = match connection.accept_bi().await {
+                let (mut send_stream, recv_stream) = match connection.accept_bi().await {
                     Err(::quinn::ConnectionError::ApplicationClosed(_)) => break,
                     Err(e) => {
                         eprintln!("accepting stream failed: {e:?}");
@@ -254,7 +255,7 @@ pub async fn server(endpoint: Endpoint, opt: Opt) -> Result<()> {
                 trace!("stream established");
 
                 tokio::spawn(async move {
-                    drain_stream(&mut recv_stream, opt.read_unordered).await?;
+                    drain_stream(recv_stream, opt.read_unordered).await?;
                     send_data_on_stream(&mut send_stream, opt.download_size).await?;
                     n0_error::Ok(())
                 });

--- a/iroh/tests/integration.rs
+++ b/iroh/tests/integration.rs
@@ -67,7 +67,7 @@ async fn simple_endpoint_id_based_connection_transfer() -> Result {
 
                 let (mut send, mut recv) = conn.accept_bi().await.anyerr()?;
                 let mut bytes_sent = 0;
-                while let Some(chunk) = recv.read_chunk(10_000, true).await.anyerr()? {
+                while let Some(chunk) = recv.read_chunk(10_000).await.anyerr()? {
                     bytes_sent += chunk.bytes.len();
                     send.write_chunk(chunk.bytes).await.anyerr()?;
                 }


### PR DESCRIPTION
## Description

Adapt to changes made to iroh-quinn in https://github.com/n0-computer/quinn/pull/257

## Breaking Changes

endpoint::RecvStream::read_chunk: ordering: bool removed.

To read unordered chunks, you now have to create an UnorderedRecvStream. read_chunk on RecvStream is always ordered.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
