### PR TITLE
deps: switch from tracing-test to n0-tracing-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1920,7 +1920,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2180,6 +2180,7 @@ dependencies = [
  "iroh-relay",
  "n0-error",
  "n0-future",
+ "n0-tracing-test",
  "n0-watcher",
  "netdev",
  "netwatch",
@@ -2211,7 +2212,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-subscriber-wasm",
- "tracing-test",
  "url",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -2286,6 +2286,7 @@ dependencies = [
  "lru 0.16.2",
  "n0-error",
  "n0-future",
+ "n0-tracing-test",
  "pkarr",
  "rand",
  "rand_chacha",
@@ -2308,7 +2309,6 @@ dependencies = [
  "tower_governor",
  "tracing",
  "tracing-subscriber",
- "tracing-test",
  "ttl_cache",
  "url",
  "vergen-gitcl",
@@ -2359,7 +2359,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -2400,9 +2400,9 @@ source = "git+https://github.com/n0-computer/quinn?branch=main#4dcb3a7f05d1b3eb5
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2430,6 +2430,7 @@ dependencies = [
  "lru 0.16.2",
  "n0-error",
  "n0-future",
+ "n0-tracing-test",
  "num_enum",
  "pin-project",
  "pkarr",
@@ -2460,7 +2461,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "tracing-test",
  "url",
  "vergen-gitcl",
  "webpki-roots",
@@ -2778,6 +2778,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "n0-tracing-test"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "274dc19cfda091561b364e4f61b39aa959ade203232f9794884f1911022e8e59"
+dependencies = [
+ "n0-tracing-test-macro",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "n0-tracing-test-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab691281e87f2453a860e76dde99157f4464df18cb7cb3eb9c3847161ccc4ce1"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "n0-watcher"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,7 +2951,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3390,7 +3411,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3427,9 +3448,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3698,7 +3719,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3820,7 +3841,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4395,7 +4416,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4820,27 +4841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-test"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
-dependencies = [
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5208,7 +5208,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -66,7 +66,7 @@ hickory-resolver = "0.25.0"
 iroh = { path = "../iroh" }
 rand = "0.9.2"
 rand_chacha = "0.9"
-tracing-test = { package = "n0-tracing-test", version = "0.3" }
+n0-tracing-test = "0.3"
 
 [[bench]]
 name = "write"

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -66,7 +66,7 @@ hickory-resolver = "0.25.0"
 iroh = { path = "../iroh" }
 rand = "0.9.2"
 rand_chacha = "0.9"
-tracing-test = "0.2.5"
+tracing-test = { package = "n0-tracing-test", version = "0.3" }
 
 [[bench]]
 name = "write"

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -26,9 +26,9 @@ mod tests {
         endpoint_info::EndpointInfo,
     };
     use n0_error::{Result, StdResultExt};
+    use n0_tracing_test::traced_test;
     use pkarr::{SignedPacket, Timestamp};
     use rand::{CryptoRng, SeedableRng};
-    use tracing_test::traced_test;
 
     use crate::{
         ZoneStore,

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -130,7 +130,7 @@ tokio = { version = "1", features = [
 ] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = "1"
-tracing-test = { package = "n0-tracing-test", version = "0.3" }
+n0-tracing-test = "0.3"
 
 [build-dependencies]
 cfg_aliases = "0.2.1"

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -130,7 +130,7 @@ tokio = { version = "1", features = [
 ] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = "1"
-tracing-test = "0.2.5"
+tracing-test = { package = "n0-tracing-test", version = "0.3" }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -778,7 +778,7 @@ fn add_jitter(delay: &u64) -> Duration {
 pub(crate) mod tests {
     use std::sync::atomic::AtomicUsize;
 
-    use tracing_test::traced_test;
+    use n0_tracing_test::traced_test;
 
     use super::*;
 

--- a/iroh-relay/src/protos/handshake.rs
+++ b/iroh-relay/src/protos/handshake.rs
@@ -534,10 +534,10 @@ mod tests {
     use iroh_base::{PublicKey, SecretKey};
     use n0_error::{Result, StackResultExt, StdResultExt};
     use n0_future::{Sink, SinkExt, Stream, TryStreamExt};
+    use n0_tracing_test::traced_test;
     use rand::SeedableRng;
     use tokio_util::codec::{Framed, LengthDelimitedCodec};
     use tracing::{Instrument, info_span};
-    use tracing_test::traced_test;
 
     use super::{
         ClientAuth, KeyMaterialClientAuth, Mechanism, ServerChallenge, ServerConfirmsAuth,

--- a/iroh-relay/src/quic.rs
+++ b/iroh-relay/src/quic.rs
@@ -364,9 +364,9 @@ mod tests {
         task::AbortOnDropHandle,
         time::{self, Instant},
     };
+    use n0_tracing_test::traced_test;
     use quinn::crypto::rustls::QuicServerConfig;
     use tracing::{Instrument, debug, info, info_span};
-    use tracing_test::traced_test;
     use webpki_types::PrivatePkcs8KeyDer;
 
     use super::*;

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -784,9 +784,9 @@ mod tests {
     use iroh_base::{EndpointId, RelayUrl, SecretKey};
     use n0_error::Result;
     use n0_future::{FutureExt, SinkExt, StreamExt};
+    use n0_tracing_test::traced_test;
     use rand::SeedableRng;
     use tracing::{info, instrument};
-    use tracing_test::traced_test;
 
     use super::{
         Access, AccessConfig, NO_CONTENT_CHALLENGE_HEADER, NO_CONTENT_RESPONSE_HEADER, RelayConfig,

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -481,9 +481,9 @@ mod tests {
     use iroh_base::SecretKey;
     use n0_error::{Result, StdResultExt, bail_any};
     use n0_future::Stream;
+    use n0_tracing_test::traced_test;
     use rand::SeedableRng;
     use tracing::info;
-    use tracing_test::traced_test;
 
     use super::*;
     use crate::{client::conn::Conn, protos::common::FrameType};

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -850,10 +850,10 @@ mod tests {
     use iroh_base::{PublicKey, SecretKey};
     use n0_error::{Result, StdResultExt, bail_any};
     use n0_future::{SinkExt, StreamExt};
+    use n0_tracing_test::traced_test;
     use rand::SeedableRng;
     use reqwest::Url;
     use tracing::info;
-    use tracing_test::traced_test;
 
     use super::*;
     use crate::{

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -488,8 +488,8 @@ mod tests {
 
     use n0_error::{Result, StdResultExt};
     use n0_future::time;
+    use n0_tracing_test::traced_test;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tracing_test::traced_test;
 
     use super::Bucket;
     use crate::server::{Metrics, streams::RateLimited};

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -127,7 +127,7 @@ tokio = { version = "1", features = [
 ] }
 serde_json = "1"
 iroh-relay = { path = "../iroh-relay", default-features = false, features = ["test-utils", "server"] }
-tracing-test = { package = "n0-tracing-test", version = "0.3" }
+n0-tracing-test = "0.3"
 # tracing-test = { git = "https://github.com/Frando/tracing-test", branch = "feat/color-and-filter-on-cli", features = ["pretty-log-printing"] }
 clap = { version = "4", features = ["derive"] }
 tracing-subscriber = { version = "0.3", features = [

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -128,7 +128,6 @@ tokio = { version = "1", features = [
 serde_json = "1"
 iroh-relay = { path = "../iroh-relay", default-features = false, features = ["test-utils", "server"] }
 n0-tracing-test = "0.3"
-# tracing-test = { git = "https://github.com/Frando/tracing-test", branch = "feat/color-and-filter-on-cli", features = ["pretty-log-printing"] }
 clap = { version = "4", features = ["derive"] }
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -127,7 +127,7 @@ tokio = { version = "1", features = [
 ] }
 serde_json = "1"
 iroh-relay = { path = "../iroh-relay", default-features = false, features = ["test-utils", "server"] }
-tracing-test = "0.2.5"
+tracing-test = { package = "n0-tracing-test", version = "0.3" }
 # tracing-test = { git = "https://github.com/Frando/tracing-test", branch = "feat/color-and-filter-on-cli", features = ["pretty-log-printing"] }
 clap = { version = "4", features = ["derive"] }
 tracing-subscriber = { version = "0.3", features = [

--- a/iroh/src/discovery.rs
+++ b/iroh/src/discovery.rs
@@ -502,9 +502,9 @@ mod tests {
     use iroh_base::{EndpointAddr, SecretKey, TransportAddr};
     use n0_error::{AnyError as Error, Result, StackResultExt};
     use n0_future::{StreamExt, time};
+    use n0_tracing_test::traced_test;
     use rand::{CryptoRng, Rng, SeedableRng};
     use tokio_util::task::AbortOnDropHandle;
-    use tracing_test::traced_test;
 
     use super::*;
     use crate::{
@@ -823,9 +823,9 @@ mod test_dns_pkarr {
     use iroh_relay::{RelayMap, endpoint_info::UserData};
     use n0_error::{AnyError as Error, Result, StackResultExt};
     use n0_future::time::Duration;
+    use n0_tracing_test::traced_test;
     use rand::{CryptoRng, SeedableRng};
     use tokio_util::task::AbortOnDropHandle;
-    use tracing_test::traced_test;
 
     use crate::{
         Endpoint, RelayMode,

--- a/iroh/src/discovery/mdns.rs
+++ b/iroh/src/discovery/mdns.rs
@@ -548,8 +548,8 @@ mod tests {
         use iroh_base::{SecretKey, TransportAddr};
         use n0_error::{AnyError as Error, Result, StdResultExt, bail_any};
         use n0_future::StreamExt;
+        use n0_tracing_test::traced_test;
         use rand::{CryptoRng, SeedableRng};
-        use tracing_test::traced_test;
 
         use super::super::*;
         use crate::discovery::UserData;

--- a/iroh/src/discovery/pkarr/dht.rs
+++ b/iroh/src/discovery/pkarr/dht.rs
@@ -334,7 +334,7 @@ mod tests {
 
     use iroh_base::RelayUrl;
     use n0_error::{Result, StdResultExt};
-    use tracing_test::traced_test;
+    use n0_tracing_test::traced_test;
 
     use super::*;
 

--- a/iroh/src/dns.rs
+++ b/iroh/src/dns.rs
@@ -15,7 +15,7 @@ pub use iroh_relay::dns::{
 pub(crate) mod tests {
     use std::time::Duration;
 
-    use tracing_test::traced_test;
+    use n0_tracing_test::traced_test;
 
     use super::DnsResolver;
     use crate::defaults::staging::NA_EAST_RELAY_HOSTNAME;

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1311,12 +1311,12 @@ mod tests {
     use iroh_base::{EndpointAddr, EndpointId, SecretKey, TransportAddr};
     use n0_error::{AnyError as Error, Result, StdResultExt};
     use n0_future::{BufferedStreamExt, StreamExt, stream, time};
+    use n0_tracing_test::traced_test;
     use n0_watcher::Watcher;
     use quinn::ConnectionError;
     use rand::SeedableRng;
     use tokio::sync::oneshot;
     use tracing::{Instrument, debug_span, info, info_span, instrument};
-    use tracing_test::traced_test;
 
     use super::Endpoint;
     use crate::{

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -1139,10 +1139,10 @@ mod tests {
     use iroh_base::{EndpointAddr, SecretKey};
     use n0_error::{Result, StackResultExt, StdResultExt};
     use n0_future::StreamExt;
+    use n0_tracing_test::traced_test;
     use n0_watcher::Watcher;
     use rand::SeedableRng;
     use tracing::{Instrument, error_span, info, info_span, trace_span};
-    use tracing_test::traced_test;
 
     use super::Endpoint;
     use crate::{

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1540,12 +1540,12 @@ mod tests {
     use iroh_base::{EndpointAddr, EndpointId, TransportAddr};
     use n0_error::{Result, StackResultExt, StdResultExt};
     use n0_future::{MergeBounded, StreamExt, time};
+    use n0_tracing_test::traced_test;
     use n0_watcher::Watcher;
     use quinn::ServerConfig;
     use rand::{CryptoRng, Rng, RngCore, SeedableRng};
     use tokio_util::task::AbortOnDropHandle;
     use tracing::{Instrument, error, info, info_span, instrument};
-    use tracing_test::traced_test;
 
     use super::Options;
     use crate::{

--- a/iroh/src/magicsock/transports/relay/actor.rs
+++ b/iroh/src/magicsock/transports/relay/actor.rs
@@ -1218,10 +1218,10 @@ mod tests {
     use iroh_base::{EndpointId, RelayUrl, SecretKey};
     use iroh_relay::{PingTracker, protos::relay::Datagrams};
     use n0_error::{AnyError as Error, Result, StackResultExt, StdResultExt};
+    use n0_tracing_test::traced_test;
     use tokio::sync::{mpsc, oneshot};
     use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
     use tracing::{Instrument, info, info_span};
-    use tracing_test::traced_test;
 
     use super::{
         ActiveRelayActor, ActiveRelayActorOptions, ActiveRelayMessage, ActiveRelayPrioMessage,

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -987,8 +987,8 @@ mod tests {
     use iroh_base::RelayUrl;
     use iroh_relay::dns::DnsResolver;
     use n0_error::{Result, StdResultExt};
+    use n0_tracing_test::traced_test;
     use tokio_util::sync::CancellationToken;
-    use tracing_test::traced_test;
 
     use super::*;
     use crate::net_report::probes::Probe;

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -875,7 +875,7 @@ mod tests {
 
     use iroh_relay::dns::DnsResolver;
     use n0_error::{Result, StdResultExt};
-    use tracing_test::traced_test;
+    use n0_tracing_test::traced_test;
 
     use super::{super::test_utils, *};
 


### PR DESCRIPTION
## Description

Switches from [`tracing-test`](https://github.com/dbrgn/tracing-test/) to our new fork [`n0-tracing-test`](https://github.com/n0-computer/n0-tracing-test). Reason for the fork is that we really want the [colored log output in the terminal](https://github.com/dbrgn/tracing-test/pull/51) which remained unmerged at upstream for many months.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
