### PR TITLE
feat(metrics): add cache metrics to dns-server

### DIFF
--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Metrics support for the server
 
-use iroh_metrics::{Counter, MetricsGroup};
+use iroh_metrics::{Counter, Gauge, MetricsGroup};
 
 /// Metrics for iroh-dns-server
 #[derive(Debug, Default, MetricsGroup)]
@@ -38,4 +38,8 @@ pub struct Metrics {
     pub store_packets_updated: Counter,
     /// Number of expired packets
     pub store_packets_expired: Counter,
+    /// Current number of zones in the main cache
+    pub cache_zones: Gauge,
+    /// Current number of zones in the DHT cache
+    pub cache_zones_dht: Gauge,
 }

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Metrics exposed by the server.
 
-use iroh_metrics::{Counter, MetricsGroup};
+use iroh_metrics::{Counter, Gauge, MetricsGroup};
 
 /// Counters exposed by iroh-dns-server.
 #[derive(Debug, Default, MetricsGroup)]
@@ -39,4 +39,8 @@ pub struct Metrics {
     pub store_packets_updated: Counter,
     /// Number of signed packets removed by the eviction task.
     pub store_packets_expired: Counter,
+    /// Current number of zones in the main cache
+    pub cache_zones: Gauge,
+    /// Current number of zones in the DHT cache
+    pub cache_zones_dht: Gauge,
 }

--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -85,7 +85,7 @@ impl ZoneStore {
 
     /// Create a new zone store.
     fn new(store: SignedPacketStore, metrics: Arc<Metrics>) -> Self {
-        let zone_cache = ZoneCache::new(DEFAULT_CACHE_CAPACITY);
+        let zone_cache = ZoneCache::new(DEFAULT_CACHE_CAPACITY, metrics.clone());
         Self {
             store: Arc::new(store),
             cache: Arc::new(Mutex::new(zone_cache)),
@@ -103,22 +103,25 @@ impl ZoneStore {
         record_type: RecordType,
     ) -> Result<Option<Arc<RecordSet>>> {
         trace!("store resolve");
-        if let Some(rset) = self.cache.lock().await.resolve(pubkey, name, record_type) {
-            debug!(
-                len = rset.records_without_rrsigs().count(),
-                "resolved from cache"
-            );
-            return Ok(Some(rset));
+
+        // Check cache first (short lock scope)
+        {
+            let mut cache = self.cache.lock().await;
+            if let Some(rset) = cache.resolve(pubkey, name, record_type) {
+                debug!(
+                    len = rset.records_without_rrsigs().count(),
+                    "resolved from cache"
+                );
+                return Ok(Some(rset));
+            }
         }
 
+        // Check persistent store
         if let Some(packet) = self.store.get(pubkey).await? {
             trace!(packet_timestamp = ?packet.timestamp(), "store hit");
-            return match self
-                .cache
-                .lock()
-                .await
-                .insert_and_resolve(&packet, name, record_type)
-            {
+            let mut cache = self.cache.lock().await;
+            let result = cache.insert_and_resolve(&packet, name, record_type);
+            return match result {
                 Ok(Some(rset)) => {
                     debug!(
                         len = rset.records_without_rrsigs().count(),
@@ -212,13 +215,19 @@ struct ZoneCache {
     /// so we don't cache stale entries indefinitely.
     #[debug("dht_cache")]
     dht_cache: TtlCache<PublicKeyBytes, CachedZone>,
+    #[debug("metrics")]
+    metrics: Arc<Metrics>,
 }
 
 impl ZoneCache {
-    fn new(cap: usize) -> Self {
+    fn new(cap: usize, metrics: Arc<Metrics>) -> Self {
         let cache = LruCache::new(NonZeroUsize::new(cap).expect("capacity must be larger than 0"));
         let dht_cache = TtlCache::new(cap);
-        Self { cache, dht_cache }
+        Self {
+            cache,
+            dht_cache,
+            metrics,
+        }
     }
 
     fn resolve(
@@ -260,6 +269,9 @@ impl ZoneCache {
         let zone = CachedZone::from_signed_packet(signed_packet).anyerr()?;
         let res = zone.resolve(name, record_type);
         self.dht_cache.insert(pubkey, zone, DHT_CACHE_TTL);
+        self.metrics
+            .cache_zones_dht
+            .set(self.dht_cache.iter().count() as i64);
         Ok(res)
     }
 
@@ -278,6 +290,7 @@ impl ZoneCache {
                 pubkey,
                 CachedZone::from_signed_packet(signed_packet).anyerr()?,
             );
+            self.metrics.cache_zones.set(self.cache.len() as i64);
             trace!("inserted into cache");
             Ok(())
         }
@@ -286,6 +299,10 @@ impl ZoneCache {
     fn remove(&mut self, pubkey: &PublicKeyBytes) {
         self.cache.pop(pubkey);
         self.dht_cache.remove(pubkey);
+        self.metrics.cache_zones.set(self.cache.len() as i64);
+        self.metrics
+            .cache_zones_dht
+            .set(self.dht_cache.iter().count() as i64);
     }
 }
 

--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -85,7 +85,7 @@ impl ZoneStore {
 
     /// Create a new zone store.
     pub fn new(store: SignedPacketStore, metrics: Arc<Metrics>) -> Self {
-        let zone_cache = ZoneCache::new(DEFAULT_CACHE_CAPACITY);
+        let zone_cache = ZoneCache::new(DEFAULT_CACHE_CAPACITY, metrics.clone());
         Self {
             store: Arc::new(store),
             cache: Arc::new(Mutex::new(zone_cache)),
@@ -103,22 +103,25 @@ impl ZoneStore {
         record_type: RecordType,
     ) -> Result<Option<Arc<RecordSet>>> {
         trace!("store resolve");
-        if let Some(rset) = self.cache.lock().await.resolve(pubkey, name, record_type) {
-            debug!(
-                len = rset.records_without_rrsigs().count(),
-                "resolved from cache"
-            );
-            return Ok(Some(rset));
+
+        // Check cache first (short lock scope)
+        {
+            let mut cache = self.cache.lock().await;
+            if let Some(rset) = cache.resolve(pubkey, name, record_type) {
+                debug!(
+                    len = rset.records_without_rrsigs().count(),
+                    "resolved from cache"
+                );
+                return Ok(Some(rset));
+            }
         }
 
+        // Check persistent store
         if let Some(packet) = self.store.get(pubkey).await? {
             trace!(packet_timestamp = ?packet.timestamp(), "store hit");
-            return match self
-                .cache
-                .lock()
-                .await
-                .insert_and_resolve(&packet, name, record_type)
-            {
+            let mut cache = self.cache.lock().await;
+            let result = cache.insert_and_resolve(&packet, name, record_type);
+            return match result {
                 Ok(Some(rset)) => {
                     debug!(
                         len = rset.records_without_rrsigs().count(),
@@ -137,20 +140,15 @@ impl ZoneStore {
             };
         };
 
+        // DHT fallback (lock not held during network call)
         if let Some(pkarr) = self.pkarr.as_ref() {
             let key = pkarr::PublicKey::try_from(pubkey.as_bytes()).expect("valid public key");
-            // use the more expensive `resolve_most_recent` here.
-            //
-            // it will be cached for some time.
             debug!("DHT resolve {}", key.to_z32());
             let packet_opt = pkarr.resolve(&key).await;
             if let Some(packet) = packet_opt {
                 debug!("DHT resolve successful {:?}", packet);
-                return self
-                    .cache
-                    .lock()
-                    .await
-                    .insert_and_resolve_dht(&packet, name, record_type);
+                let mut cache = self.cache.lock().await;
+                return cache.insert_and_resolve_dht(&packet, name, record_type);
             } else {
                 debug!("DHT resolve failed");
             }
@@ -192,13 +190,19 @@ struct ZoneCache {
     /// so we don't cache stale entries indefinitely.
     #[debug("dht_cache")]
     dht_cache: TtlCache<PublicKeyBytes, CachedZone>,
+    #[debug("metrics")]
+    metrics: Arc<Metrics>,
 }
 
 impl ZoneCache {
-    fn new(cap: usize) -> Self {
+    fn new(cap: usize, metrics: Arc<Metrics>) -> Self {
         let cache = LruCache::new(NonZeroUsize::new(cap).expect("capacity must be larger than 0"));
         let dht_cache = TtlCache::new(cap);
-        Self { cache, dht_cache }
+        Self {
+            cache,
+            dht_cache,
+            metrics,
+        }
     }
 
     fn resolve(
@@ -240,6 +244,9 @@ impl ZoneCache {
         let zone = CachedZone::from_signed_packet(signed_packet).anyerr()?;
         let res = zone.resolve(name, record_type);
         self.dht_cache.insert(pubkey, zone, DHT_CACHE_TTL);
+        self.metrics
+            .cache_zones_dht
+            .set(self.dht_cache.iter().count() as i64);
         Ok(res)
     }
 
@@ -258,6 +265,7 @@ impl ZoneCache {
                 pubkey,
                 CachedZone::from_signed_packet(signed_packet).anyerr()?,
             );
+            self.metrics.cache_zones.set(self.cache.len() as i64);
             trace!("inserted into cache");
             Ok(())
         }
@@ -266,6 +274,10 @@ impl ZoneCache {
     fn remove(&mut self, pubkey: &PublicKeyBytes) {
         self.cache.pop(pubkey);
         self.dht_cache.remove(pubkey);
+        self.metrics.cache_zones.set(self.cache.len() as i64);
+        self.metrics
+            .cache_zones_dht
+            .set(self.dht_cache.iter().count() as i64);
     }
 }
 


### PR DESCRIPTION
## Description

Two simple gauges to just have basic info about the cache sizes at runtime.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
