### PR TITLE
refactor: reuse the cleanup future between loop iterations

### DIFF
--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -1099,6 +1099,9 @@ impl Actor {
         // ensure we are doing an initial publish of our addresses
         self.msock.publish_my_addr();
 
+        let remote_map_cleanup_fut = cleanup_remote_map(self.msock.clone());
+        tokio::pin!(remote_map_cleanup_fut);
+
         while !shutdown_token.is_cancelled() {
             self.msock.metrics.magicsock.actor_tick_main.inc();
             #[cfg(not(wasm_browser))]
@@ -1205,8 +1208,9 @@ impl Actor {
                     self.msock.metrics.magicsock.actor_link_change.inc();
                     self.handle_network_change(is_major).await;
                 }
-                eid = poll_fn(|cx| self.msock.remote_map.poll_cleanup(cx)) => {
+                eid = &mut remote_map_cleanup_fut => {
                     trace!(%eid, "cleaned up RemoteStateActor");
+                    remote_map_cleanup_fut.set(cleanup_remote_map(self.msock.clone()));
                 }
                 else => {
                     trace!("tick: else");
@@ -1417,6 +1421,13 @@ impl Actor {
         #[cfg(not(wasm_browser))]
         self.update_direct_addresses(report.as_ref());
     }
+}
+
+/// Potentially removes terminated `RemoteStateActor`s from the remote map.
+///
+/// Takes msock by value not by reference so that this returns a static future.
+async fn cleanup_remote_map(msock: Arc<MagicSock>) -> EndpointId {
+    poll_fn(|cx| msock.remote_map.poll_cleanup(cx)).await
 }
 
 fn new_re_stun_timer(initial_delay: bool) -> time::Interval {


### PR DESCRIPTION
## Description

Another try at reusing the cleanup future between loop iterations in #3681

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
