### PR TITLE
refactor(iroh)!: improve BindError

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -28,7 +28,7 @@ use url::Url;
 
 use self::hooks::EndpointHooksList;
 pub use super::magicsock::{
-    DirectAddr, DirectAddrType, PathInfo,
+    BindError, DirectAddr, DirectAddrType, PathInfo,
     remote_map::{PathInfoList, RemoteInfo, Source, TransportAddrInfo, TransportAddrUsage},
 };
 #[cfg(wasm_browser)]
@@ -709,20 +709,6 @@ pub enum ConnectError {
     Connection {
         #[error(std_err)]
         source: ConnectionError,
-    },
-}
-
-#[allow(missing_docs)]
-#[stack_error(derive, add_meta, from_sources)]
-#[non_exhaustive]
-pub enum BindError {
-    #[error(transparent)]
-    MagicSpawn {
-        source: magicsock::CreateHandleError,
-    },
-    #[error(transparent)]
-    Discovery {
-        source: crate::discovery::IntoDiscoveryError,
     },
 }
 

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -724,7 +724,7 @@ impl DirectAddrUpdateState {
 #[non_exhaustive]
 pub enum BindError {
     #[error("Failed to bind sockets")]
-    BindSockets { source: io::Error },
+    Sockets { source: io::Error },
     #[error("Failed to create internal QUIC endpoint")]
     CreateQuicEndpoint { source: io::Error },
     #[error("Failed to create netmon monitor")]
@@ -806,7 +806,7 @@ impl Handle {
             &metrics,
             shutdown_token.child_token(),
         )
-        .map_err(|err| e!(BindError::BindSockets, err))?;
+        .map_err(|err| e!(BindError::Sockets, err))?;
 
         #[cfg(not(wasm_browser))]
         {

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -235,7 +235,7 @@ pub(crate) struct MagicSock {
 
 impl MagicSock {
     /// Creates a magic [`MagicSock`] listening.
-    pub(crate) async fn spawn(opts: Options) -> Result<Handle, CreateHandleError> {
+    pub(crate) async fn spawn(opts: Options) -> Result<Handle, BindError> {
         Handle::new(opts).await
     }
 
@@ -722,24 +722,25 @@ impl DirectAddrUpdateState {
 #[allow(missing_docs)]
 #[stack_error(derive, add_meta)]
 #[non_exhaustive]
-pub enum CreateHandleError {
-    #[error("Failed to create bind sockets")]
+pub enum BindError {
+    #[error("Failed to bind sockets")]
     BindSockets { source: io::Error },
-    #[error("Failed to create internal quinn endpoint")]
-    CreateQuinnEndpoint { source: io::Error },
-    #[error("Failed to create socket state")]
-    CreateSocketState { source: io::Error },
+    #[error("Failed to create internal QUIC endpoint")]
+    CreateQuicEndpoint { source: io::Error },
     #[error("Failed to create netmon monitor")]
     CreateNetmonMonitor { source: netmon::Error },
-    #[error("Failed to subscribe netmon monitor")]
-    SubscribeNetmonMonitor { source: netmon::Error },
     #[error("Invalid transport configuration")]
     InvalidTransportConfig,
+    #[error("Failed to create a discovery service")]
+    Discovery {
+        #[error(from)]
+        source: crate::discovery::IntoDiscoveryError,
+    },
 }
 
 impl Handle {
     /// Creates a magic [`MagicSock`].
-    async fn new(opts: Options) -> Result<Self, CreateHandleError> {
+    async fn new(opts: Options) -> Result<Self, BindError> {
         let Options {
             secret_key,
             transports: transport_configs,
@@ -766,7 +767,7 @@ impl Handle {
 
         // Currently we only support a single relay transport
         if relay_transport_configs.len() > 1 {
-            bail!(CreateHandleError::InvalidTransportConfig);
+            bail!(BindError::InvalidTransportConfig);
         }
         let relay_map = relay_transport_configs
             .iter()
@@ -805,7 +806,7 @@ impl Handle {
             &metrics,
             shutdown_token.child_token(),
         )
-        .map_err(|err| e!(CreateHandleError::BindSockets, err))?;
+        .map_err(|err| e!(BindError::BindSockets, err))?;
 
         #[cfg(not(wasm_browser))]
         {
@@ -886,11 +887,11 @@ impl Handle {
             #[cfg(wasm_browser)]
             Arc::new(crate::web_runtime::WebRuntime),
         )
-        .map_err(|err| e!(CreateHandleError::CreateQuinnEndpoint, err))?;
+        .map_err(|err| e!(BindError::CreateQuicEndpoint, err))?;
 
         let network_monitor = netmon::Monitor::new()
             .await
-            .map_err(|err| e!(CreateHandleError::CreateNetmonMonitor, err))?;
+            .map_err(|err| e!(BindError::CreateNetmonMonitor, err))?;
 
         let qad_endpoint = endpoint.clone();
 


### PR DESCRIPTION
## Description

Removes one layer of nesting from `iroh::endpoint::BindError` by adding the variant for failing to start a discovery service to the inner error. Thus removes the badly-named `MagicSpawn` variant and its inner `CreateHandleError` and making this all much friendlier to users.

Also removed a `SubscribeNetmonMonitor` variant that was entirely unused, and renames `CreateQuinnEndpoint` to `CreateQuicEndpoint`.

## Breaking Changes

* Changed: `iroh::endpoint::BindError` now directly includes the variants that were previously nested in its `MagicSpawn` variant and `iroh::endpoint::CreateHandleError`.
* Removed: `iroh::endpoint::CreateHandleError`

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
