### PR TITLE
refactor(iroh)!: bind addrs with prefix len 0 are default routes

### DIFF
--- a/iroh/src/endpoint/bind.rs
+++ b/iroh/src/endpoint/bind.rs
@@ -37,7 +37,7 @@ pub struct BindOpts {
     /// this subnet has a gateway router to route such packets.
     ///
     /// See [`Self::prefix_len`] for details of how such routing works.
-    is_default_route: bool,
+    is_default_route: Option<bool>,
 }
 
 impl Default for BindOpts {
@@ -45,7 +45,7 @@ impl Default for BindOpts {
         Self {
             prefix_len: 0,
             is_required: true,
-            is_default_route: false,
+            is_default_route: None,
         }
     }
 }
@@ -101,16 +101,23 @@ impl BindOpts {
     ///
     /// See [`Self::set_prefix_len`] for details on how this routing works.
     ///
-    /// Defaults to `false`. If the prefix length is set to `0` (the default) then this
-    /// will be set to `true` implicitly.
+    /// If not set explicitly, then [`Self::is_default_route`] will return `true`
+    /// if the prefix length is set to `0` (the default) and `false` otherwise.
     pub fn set_is_default_route(mut self, is_default_route: bool) -> Self {
-        self.is_default_route = is_default_route;
+        self.is_default_route = Some(is_default_route);
         self
     }
 
-    /// Returns the current value set by [`Self::set_is_default_route`].
+    /// Returns whether this is a default route.
+    ///
+    /// If [`Self::set_is_default_route`] has been called then that value is returned.
+    /// Otherwise, returns `true` if the [`prefix_len`][`Self::prefix_len] is `0` and
+    /// `false` otherwise.
     pub fn is_default_route(&self) -> bool {
-        self.is_default_route
+        match self.is_default_route {
+            Some(is_default) => is_default,
+            None => self.prefix_len() == 0,
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Changes `bind_addr_with_opts` such that when binding addresses with a prefix length of 0, they are marked as default routes and thus replace the preconfigured unspecified address for the address family.

This means that now `bind_addr` *replaces* the preconfigured unspecified bind for that family, which is arguably what users expect.

Also changes `BindOpts::is_default_route` to be an `Option<bool>` internally. This allows to explicitly set `is_default_route(false)` even with a prefix_len of 0.

## Breaking Changes

* `endpoint::Builder::bind_addr()` now replaces the preconfigured unspecified bind addr for the address family. Previously, a new socket would be added in addition to the preconfigured wildcard ones.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
