### PR TITLE
tests(iroh): fix doctests for bind_addr to use port 0

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -267,8 +267,8 @@ impl Builder {
     /// # use iroh::Endpoint;
     /// let endpoint = Endpoint::builder()
     ///     .clear_ip_transports()
-    ///     .bind_addr("127.0.0.1:1234")?
-    ///     .bind_addr("[::1]:1235")?
+    ///     .bind_addr("127.0.0.1:0")?
+    ///     .bind_addr("[::1]:0")?
     ///     .bind()
     ///     .await?;
     /// # Ok(()) }
@@ -340,8 +340,8 @@ impl Builder {
     /// # use iroh::{Endpoint, endpoint::BindOpts};
     /// let endpoint = Endpoint::builder()
     ///     .clear_ip_transports()
-    ///     .bind_addr_with_opts("127.0.0.1:1234", BindOpts::default().set_prefix_len(24))?
-    ///     .bind_addr_with_opts("[::1]:1235", BindOpts::default().set_prefix_len(48))?
+    ///     .bind_addr_with_opts("127.0.0.1:0", BindOpts::default().set_prefix_len(24))?
+    ///     .bind_addr_with_opts("[::1]:0", BindOpts::default().set_prefix_len(48))?
     ///     .bind()
     ///     .await?;
     /// # Ok(()) }


### PR DESCRIPTION
## Description

The doctests for `endpoint::Builder::bind_addr` are flaky because they set the same ports in two tests and thus when run in parallel may fail.
See e.g. here https://github.com/n0-computer/iroh/actions/runs/20848834716/job/59898808126?pr=3837#step:7:664

This changes them to use port 0


## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
