### PR TITLE
Revert "docs(endpoint::Builder): clarify that clearing relay transport doesn't alter holepunching"

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -410,11 +410,6 @@ impl Builder {
     }
 
     /// Removes all relay based transports.
-    ///
-    /// This method only disables using relays to send data, and has no effect
-    /// on the endpoint using relays for connection establishment. To disable
-    /// both connection establishment and relays-as-transports, disable relays
-    /// entirely with [`RelayMode::Disabled`].
     pub fn clear_relay_transports(mut self) -> Self {
         self.transports
             .retain(|t| !matches!(t, TransportConfig::Relay { .. }));


### PR DESCRIPTION
Reverts n0-computer/iroh#3833

To holepunch you still need to have a QUIC connection to the peer via the relay transport. That same connection that carries application data. So this isn't true.