### PR TITLE
feat(iroh): add option to disable portmapping

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -104,6 +104,7 @@ pub struct Builder {
     transports: Vec<TransportConfig>,
     max_tls_tickets: usize,
     hooks: EndpointHooksList,
+    enable_portmapper: bool,
 }
 
 impl From<RelayMode> for Option<TransportConfig> {
@@ -169,6 +170,7 @@ impl Builder {
             max_tls_tickets: DEFAULT_MAX_TLS_TICKETS,
             transports,
             hooks: Default::default(),
+            enable_portmapper: true,
         }
     }
 
@@ -205,6 +207,7 @@ impl Builder {
             insecure_skip_relay_cert_verify: self.insecure_skip_relay_cert_verify,
             metrics,
             hooks: self.hooks,
+            enable_portmapper: self.enable_portmapper,
         };
 
         let msock = magicsock::MagicSock::spawn(msock_opts).await?;
@@ -624,6 +627,14 @@ impl Builder {
     /// See [`EndpointHooks`] for details on the possible interception points in the connection lifecycle.
     pub fn hooks(mut self, hooks: impl EndpointHooks + 'static) -> Self {
         self.hooks.push(hooks);
+        self
+    }
+
+    /// Disables portmapping (Upnp, etc).
+    ///
+    /// This is enabled by default.
+    pub fn disable_portmapper(mut self) -> Self {
+        self.enable_portmapper = false;
         self
     }
 }

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -140,6 +140,10 @@ pub(crate) struct Options {
     pub(crate) insecure_skip_relay_cert_verify: bool,
     pub(crate) metrics: EndpointMetrics,
     pub(crate) hooks: EndpointHooksList,
+    /// Enable portmapping. Upnp and friends.
+    ///
+    /// Defaults to `true`
+    pub(crate) enable_portmapper: bool,
 }
 
 /// Handle for [`MagicSock`].
@@ -583,7 +587,7 @@ struct DirectAddrUpdateState {
     want_update: Option<UpdateReason>,
     msock: Arc<MagicSock>,
     #[cfg(not(wasm_browser))]
-    port_mapper: portmapper::Client,
+    port_mapper: Option<portmapper::Client>,
     /// The prober that discovers local network conditions, including the closest relay relay and NAT mappings.
     net_reporter: Arc<AsyncMutex<net_report::Client>>,
     relay_map: RelayMap,
@@ -612,7 +616,7 @@ impl UpdateReason {
 impl DirectAddrUpdateState {
     fn new(
         msock: Arc<MagicSock>,
-        #[cfg(not(wasm_browser))] port_mapper: portmapper::Client,
+        #[cfg(not(wasm_browser))] port_mapper: Option<portmapper::Client>,
         net_reporter: Arc<AsyncMutex<net_report::Client>>,
         relay_map: RelayMap,
         run_done: mpsc::Sender<()>,
@@ -671,7 +675,7 @@ impl DirectAddrUpdateState {
             debug!("skipping net_report, socket is shutting down");
             // deactivate portmapper
             #[cfg(not(wasm_browser))]
-            self.port_mapper.deactivate();
+            self.port_mapper.as_ref().map(|p| p.deactivate());
             return;
         }
         if self.relay_map.is_empty() {
@@ -681,7 +685,7 @@ impl DirectAddrUpdateState {
         }
 
         #[cfg(not(wasm_browser))]
-        self.port_mapper.procure_mapping();
+        self.port_mapper.as_ref().map(|p| p.procure_mapping());
 
         debug!("requesting net_report report");
         let msock = self.msock.clone();
@@ -753,12 +757,14 @@ impl Handle {
             insecure_skip_relay_cert_verify,
             metrics,
             hooks,
+            enable_portmapper,
         } = opts;
 
         let discovery = ConcurrentDiscovery::default();
         #[cfg(not(wasm_browser))]
-        let port_mapper =
-            portmapper::Client::with_metrics(Default::default(), metrics.portmapper.clone());
+        let port_mapper = enable_portmapper.then(|| {
+            portmapper::Client::with_metrics(Default::default(), metrics.portmapper.clone())
+        });
 
         let relay_transport_configs: Vec<_> = transport_configs
             .iter()
@@ -820,7 +826,9 @@ impl Handle {
                 // NOTE: we can end up with a zero port if `netwatch::UdpSocket::socket_addr` fails
                 match v4_port.try_into() {
                     Ok(non_zero_port) => {
-                        port_mapper.update_local_port(non_zero_port);
+                        port_mapper
+                            .as_ref()
+                            .map(|p| p.update_local_port(non_zero_port));
                     }
                     Err(_zero_port) => debug!("Skipping port mapping with zero local port"),
                 }
@@ -1086,10 +1094,11 @@ impl Actor {
         let mut current_netmon_state = self.netmon_watcher.get();
 
         #[cfg(not(wasm_browser))]
-        let mut portmap_watcher = self
+        let portmap_watcher = self
             .direct_addr_update_state
             .port_mapper
-            .watch_external_address();
+            .as_ref()
+            .map(|p| p.watch_external_address());
 
         let mut receiver_closed = false;
         #[cfg_attr(wasm_browser, allow(unused_mut))]
@@ -1103,7 +1112,19 @@ impl Actor {
         while !shutdown_token.is_cancelled() {
             self.msock.metrics.magicsock.actor_tick_main.inc();
             #[cfg(not(wasm_browser))]
-            let portmap_watcher_changed = portmap_watcher.changed();
+            let portmap_watcher_changed = if let Some(ref p) = portmap_watcher {
+                Box::pin(p.changed())
+                    as std::pin::Pin<
+                        Box<
+                            dyn Future<Output = Result<(), tokio::sync::watch::error::RecvError>>
+                                + Send
+                                + Sync
+                                + 'static,
+                        >,
+                    >
+            } else {
+                Box::pin(n0_future::future::pending())
+            };
             #[cfg(wasm_browser)]
             let portmap_watcher_changed = n0_future::future::pending();
 
@@ -1182,9 +1203,11 @@ impl Actor {
 
                         trace!("tick: portmap changed");
                         self.msock.metrics.magicsock.actor_tick_portmap_changed.inc();
-                        let new_external_address = *portmap_watcher.borrow();
-                        debug!("external address updated: {new_external_address:?}");
-                        self.re_stun(UpdateReason::PortmapUpdated);
+                        if let Some(ref p) = portmap_watcher {
+                            let new_external_address = *p.borrow();
+                            debug!("external address updated: {new_external_address:?}");
+                            self.re_stun(UpdateReason::PortmapUpdated);
+                        }
                     }
                     #[cfg(wasm_browser)]
                     let _unused_in_browsers = change;
@@ -1275,7 +1298,8 @@ impl Actor {
         let portmap_watcher = self
             .direct_addr_update_state
             .port_mapper
-            .watch_external_address();
+            .as_ref()
+            .map(|p| p.watch_external_address());
 
         // We only want to have one DirectAddr for each SocketAddr we have.  So we store
         // this as a map of SocketAddr -> DirectAddrType.  At the end we will construct a
@@ -1283,7 +1307,7 @@ impl Actor {
         let mut addrs: BTreeMap<SocketAddr, DirectAddrType> = BTreeMap::new();
 
         // First add PortMapper provided addresses.
-        let maybe_port_mapped = *portmap_watcher.borrow();
+        let maybe_port_mapped = portmap_watcher.and_then(|p| *p.borrow());
         if let Some(portmap_ext) = maybe_port_mapped.map(SocketAddr::V4) {
             addrs
                 .entry(portmap_ext)
@@ -1579,6 +1603,7 @@ mod tests {
             discovery_user_data: None,
             metrics: Default::default(),
             hooks: Default::default(),
+            enable_portmapper: true,
         }
     }
 
@@ -1971,6 +1996,7 @@ mod tests {
             insecure_skip_relay_cert_verify: false,
             metrics: Default::default(),
             hooks: Default::default(),
+            enable_portmapper: true,
         };
         let msock = MagicSock::spawn(opts).await?;
         Ok(msock)


### PR DESCRIPTION
## Description

Adds an option to disable portmapping when creating an iroh endpoint.

Closes #3811

