### PR TITLE
feat(example): Improve path stat printing in transfer example

### DIFF
--- a/iroh/src/magicsock/remote_map/remote_state.rs
+++ b/iroh/src/magicsock/remote_map/remote_state.rs
@@ -1550,13 +1550,6 @@ impl PathInfo {
     pub fn rtt(&self) -> Duration {
         self.stats().rtt
     }
-
-    /// The path ID the underlying network library uses to identify this path.
-    ///
-    /// This is a QUIC multipath path ID. It uniquely identifies this path on both sides of the connection.
-    pub fn path_id(&self) -> PathId {
-        self.path_id
-    }
 }
 
 /// Poll a future once, like n0_future::future::poll_once but sync.


### PR DESCRIPTION
## Description

- Improve path stat printing in the transfer example.

Before:
```
Path stats:
  Relay(RelayUrl("https://127.0.0.1:43765/")): RTT 73.884361ms, 11 packets sent
  Ip([3fff:172:20:20::1]:47128): RTT 1.255437ms, 1 packets sent
```
(also missing a bunch of stats from closed paths)

Now:
```
Path stats:
  Relay(RelayUrl("https://staging-euw1-1.relay.iroh.network./")): RTT 31.046345ms, tx=42738 rx=12
  Ip(176.199.209.244:26617): RTT 25.767613ms, tx=212 rx=17189
  Ip([2a02:8071:d85:19c0::232c]:52316): RTT 264.134µs, tx=13 rx=691477
  Ip(172.18.0.1:45901): RTT 280.83µs, tx=6 rx=16759
  Ip([3fff:172:20:20::1]:52316): RTT 274.261µs, tx=6 rx=7516
  Ip(192.168.0.99:45901): RTT 280.83µs, tx=6 rx=8550
  Ip(172.17.0.1:45901): RTT 2.591812ms, tx=3 rx=2
  Ip([2a02:8071:d85:19c0:c2fb:b929:b323:b940]:52316): RTT 2.607457ms, tx=3 rx=1
  Ip([2a02:8071:d85:19c0:aecd:32d7:7c59:81a2]:52316): RTT 2.607457ms, tx=3 rx=1
  Ip(172.20.20.1:45901): RTT 2.62841ms, tx=3 rx=1
```

## Notes & open questions

There's also something else that's ... weird at least. When the connection is dropped, and we call `PathInfo::stats`, we get back the "fallback" value `self.stats`, but that's only set initially and never updated. So this will look like the stats at the end are suddenly drastically decreasing.

---

The transfer example now has two "side tasks": one for watching the path stats and one for watching the connection type.
I think I'd rather have them split than putting both of these tasks into one? Not sure if everyone might agree.
