### PR TITLE
ci(dependabot): skip patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       day: "thursday"
       time: "08:00"
       timezone: "America/New_York"
+    ignore:
+      - dependency-name: "*"
+      - update-types: ["version-update:semver-patch"]
   - package-ecosystem: docker
     directory: docker
     schedule:


### PR DESCRIPTION
## Description

dig: "I usually skip minor changes e.g. 1.3.1 -> 1.3.2"

Let's automate that. Or try at least.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] yolo test in CI