### PR TITLE
fix: allow hp to continue after interface change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2122,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5828152c482cf9d95f3039848ac2be5e6e47c41dbf3695a453e6c02739c50d2c"
+checksum = "c946095f060e6e59b9ff30cc26c75cdb758e7fb0cde8312c89e2144654989fcb"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2142,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e12bd0763fd16062f5cc5e8db15dd52d26e75a8af4c7fb57ccee3589b344b8"
+checksum = "cab063c2bfd6c3d5a33a913d4fdb5252f140db29ec67c704f20f3da7e8f92dbf"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn"
 version = "0.15.0"
-source = "git+https://github.com/n0-computer/quinn?branch=main#aa6c3735cee6d3074d5421a97b5e48332de8e7b3"
+source = "git+https://github.com/n0-computer/quinn?branch=main#d7e98af8cf261987450cc78a8b8747eca2745dc0"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2164,7 +2164,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn-proto"
 version = "0.14.0"
-source = "git+https://github.com/n0-computer/quinn?branch=main#aa6c3735cee6d3074d5421a97b5e48332de8e7b3"
+source = "git+https://github.com/n0-computer/quinn?branch=main#d7e98af8cf261987450cc78a8b8747eca2745dc0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2202,11 +2202,11 @@ dependencies = [
 [[package]]
 name = "iroh-quinn-udp"
 version = "0.7.0"
-source = "git+https://github.com/n0-computer/quinn?branch=main#aa6c3735cee6d3074d5421a97b5e48332de8e7b3"
+source = "git+https://github.com/n0-computer/quinn?branch=main#d7e98af8cf261987450cc78a8b8747eca2745dc0"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3312,7 +3312,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3349,7 +3349,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5089,7 +5089,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,7 +1155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1735,7 +1735,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2164,7 +2164,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -2206,9 +2206,9 @@ source = "git+https://github.com/n0-computer/quinn?branch=main#aa6c3735cee6d3074
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2692,8 +2692,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970729c08dbe7987d698f996c6b4945cbfdcdd6ee627df6de51d5469cec13b99"
+source = "git+https://github.com/n0-computer/net-tools?branch=quinn-latest#31b6c5442f7763b8d15ea4e49875e7b66464df45"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2768,7 +2767,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3313,7 +3312,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3350,9 +3349,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3622,7 +3621,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3735,7 +3734,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.5",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4289,7 +4288,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ unused-async = "warn"
 iroh-quinn = { git = "https://github.com/n0-computer/quinn", branch = "main" }
 iroh-quinn-udp = { git = "https://github.com/n0-computer/quinn", branch = "main" }
 iroh-quinn-proto = { git = "https://github.com/n0-computer/quinn", branch = "main" }
+netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "quinn-latest" }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1987,6 +1987,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[traced_test]
     async fn test_holepunch_recovery_after_network_change() -> Result {
+        
         // Test that holepunching re-triggers after a network interface change.
         // This verifies that direct paths recover when the same IPs re-appear.
         let (relay_map, _relay_url, _relay_server_guard) = run_relay_server().await?;

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1984,6 +1984,130 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    #[traced_test]
+    async fn test_holepunch_recovery_after_network_change() -> Result {
+        // Test that holepunching re-triggers after a network interface change.
+        // This verifies that direct paths recover when the same IPs re-appear.
+        let (relay_map, _relay_url, _relay_server_guard) = run_relay_server().await?;
+        let (node_addr_tx, node_addr_rx) = oneshot::channel();
+
+        #[instrument(name = "client", skip_all)]
+        async fn connect(
+            relay_map: RelayMap,
+            node_addr_rx: oneshot::Receiver<EndpointAddr>,
+        ) -> Result<(u64, u64)> {
+            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42u64);
+            let secret = SecretKey::generate(&mut rng);
+            let ep = Endpoint::builder()
+                .secret_key(secret)
+                .alpns(vec![TEST_ALPN.to_vec()])
+                .insecure_skip_relay_cert_verify(true)
+                .relay_mode(RelayMode::Custom(relay_map))
+                .bind()
+                .await?;
+
+            info!(me = %ep.id().fmt_short(), "client starting");
+            let dst = node_addr_rx.await.anyerr()?;
+
+            info!(me = %ep.id().fmt_short(), "client connecting");
+            let conn = ep.connect(dst, TEST_ALPN).await?;
+
+            // PHASE 1: Wait for initial direct path via holepunch
+            let mut paths = conn.paths().stream();
+            info!("Waiting for initial direct connection");
+            while let Some(infos) = paths.next().await {
+                info!(?infos, "new PathInfos");
+                if infos.iter().any(|info| info.is_ip()) {
+                    break;
+                }
+            }
+            info!("Have initial direct connection");
+
+            #[cfg(feature = "metrics")]
+            let hp_before = ep.metrics().socket.holepunch_attempts.get();
+            #[cfg(not(feature = "metrics"))]
+            let hp_before = 0u64;
+
+            // PHASE 2: Trigger network change (simulates interface down/up)
+            info!("Triggering network change");
+            ep.socket().force_network_change(true).await;
+
+            // Give time for paths to potentially drop and recover
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            // PHASE 3: Wait for direct path recovery
+            info!("Waiting for direct path recovery");
+            let recovery_timeout = tokio::time::timeout(Duration::from_secs(5), async {
+                let mut paths = conn.paths().stream();
+                while let Some(infos) = paths.next().await {
+                    info!(?infos, "recovery PathInfos");
+                    if infos.iter().any(|info| info.is_ip()) {
+                        return true;
+                    }
+                }
+                false
+            })
+            .await;
+
+            let recovered = recovery_timeout.unwrap_or(false);
+            info!(recovered, "direct path recovery result");
+
+            #[cfg(feature = "metrics")]
+            let hp_after = ep.metrics().socket.holepunch_attempts.get();
+            #[cfg(not(feature = "metrics"))]
+            let hp_after = 0u64;
+
+            conn.close(0u32.into(), b"done");
+            Ok((hp_before, hp_after))
+        }
+
+        #[instrument(name = "server", skip_all)]
+        async fn accept(
+            relay_map: RelayMap,
+            node_addr_tx: oneshot::Sender<EndpointAddr>,
+        ) -> Result {
+            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(43u64);
+            let secret = SecretKey::generate(&mut rng);
+            let ep = Endpoint::builder()
+                .secret_key(secret)
+                .alpns(vec![TEST_ALPN.to_vec()])
+                .insecure_skip_relay_cert_verify(true)
+                .relay_mode(RelayMode::Custom(relay_map))
+                .bind()
+                .await?;
+            ep.online().await;
+
+            // Provide only relay address to force holepunching
+            let mut node_addr = ep.addr();
+            node_addr.addrs.retain(|addr| addr.is_relay());
+            node_addr_tx.send(node_addr).unwrap();
+
+            info!(me = %ep.id().fmt_short(), "server starting");
+            let conn = ep.accept().await.anyerr()?.await.anyerr()?;
+
+            // Keep connection alive until client closes
+            let _ = conn.closed().await;
+            info!("server connection closed");
+            Ok(())
+        }
+
+        let server_task = tokio::spawn(accept(relay_map.clone(), node_addr_tx));
+        let client_task = tokio::spawn(connect(relay_map, node_addr_rx));
+
+        let (hp_before, hp_after) = client_task.await.anyerr()??;
+        server_task.await.anyerr()??;
+
+        // Verify holepunch was re-triggered after network change
+        #[cfg(feature = "metrics")]
+        assert!(
+            hp_after > hp_before,
+            "holepunch should re-trigger after network change: before={hp_before}, after={hp_after}"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     #[traced_test]
     async fn endpoint_two_relay_only_no_ip() -> Result {

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -998,7 +998,7 @@ impl Handle {
     }
 
     #[cfg(test)]
-    async fn force_network_change(&self, is_major: bool) {
+    pub(crate) async fn force_network_change(&self, is_major: bool) {
         self.actor_sender
             .send(ActorMessage::ForceNetworkChange(is_major))
             .await

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1275,6 +1275,13 @@ impl Actor {
 
             #[cfg(not(wasm_browser))]
             self.sock.dns_resolver.reset().await;
+
+            // Immediately update direct_addrs with local netmon addresses.
+            // This ensures holepunching uses fresh addresses before net_report completes,
+            // which is important because QAD probes can timeout during interface transitions.
+            #[cfg(not(wasm_browser))]
+            self.update_direct_addresses(None);
+
             self.re_stun(UpdateReason::LinkChangeMajor);
         } else {
             self.re_stun(UpdateReason::LinkChangeMinor);


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
