### PR TITLE
refactor(transfer example): Remove `SelectedPath::Mixed` as an impossible state

### DIFF
--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -893,9 +893,6 @@ fn watch_conn_type(
                     rtt: path.rtt(),
                 });
                 previous = Some(path.clone());
-            } else if !paths.is_empty() {
-                print(SelectedPath::Mixed { count: paths.len() });
-                previous = None;
             } else {
                 output.emit(SelectedPath::None);
                 previous = None;
@@ -1060,9 +1057,6 @@ struct ConnectionTypeChanged {
 #[derive(Serialize, Debug, Clone)]
 #[serde(tag = "status")]
 enum SelectedPath {
-    Mixed {
-        count: usize,
-    },
     Selected {
         #[serde(skip)]
         id: PathId,
@@ -1076,9 +1070,6 @@ enum SelectedPath {
 impl fmt::Display for SelectedPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            Self::Mixed { count } => {
-                write!(f, "mixed ({count} paths)")
-            }
             Self::Selected { addr, rtt, id } => {
                 write!(f, "{addr:?} [id:{id}] (RTT: {})", fmt_duration(*rtt))
             }


### PR DESCRIPTION
## Description

There should never be a situation where multiple paths are selected, that's impossible from the way `RemoteStateActor` works.

This updates the example so that `SelectedPath::Mixed` is removed.
