### PR TITLE
refactor: Implement per path max_transmit_segments in iroh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,8 +2153,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a207ea77da14b683e8d454088795b6ac38e5d5cf26ded6868b9d80392cf8c1"
+source = "git+https://github.com/n0-computer/quinn?branch=max-transmit-per-path#01a7654ddebbc032d43717d175fff3c113ed1303"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2174,8 +2173,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn-proto"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f66e567aa8b052c5632b8fc902fbb503891eda705553494ccddf3505257be40"
+source = "git+https://github.com/n0-computer/quinn?branch=max-transmit-per-path#01a7654ddebbc032d43717d175fff3c113ed1303"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2215,8 +2213,7 @@ dependencies = [
 [[package]]
 name = "iroh-quinn-udp"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f981dadd5a072a9e0efcd24bdcc388e570073f7e51b33505ceb1ef4668c80c86"
+source = "git+https://github.com/n0-computer/quinn?branch=max-transmit-per-path#01a7654ddebbc032d43717d175fff3c113ed1303"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2742,8 +2739,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454b8c0759b2097581f25ed5180b4a1d14c324fde6d0734932a288e044d06232"
+source = "git+https://github.com/n0-computer/net-tools?branch=per-path-max-transmit-segments#eb153084abc32a3068376cce310fd81684423ebd"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,9 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+iroh-quinn = { git = "https://github.com/n0-computer/quinn", branch = "max-transmit-per-path" }
+iroh-quinn-proto = { git = "https://github.com/n0-computer/quinn", branch = "max-transmit-per-path" }
+iroh-quinn-udp = { git = "https://github.com/n0-computer/quinn", branch = "max-transmit-per-path" }
+netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "per-path-max-transmit-segments" }

--- a/iroh/src/socket/transports/ip.rs
+++ b/iroh/src/socket/transports/ip.rs
@@ -222,8 +222,8 @@ impl IpTransport {
         self.local_addr.watch()
     }
 
-    pub(super) fn max_transmit_segments(&self) -> NonZeroUsize {
-        self.socket.max_gso_segments()
+    pub(super) fn max_transmit_segments(&self, destination: &SocketAddr) -> NonZeroUsize {
+        self.socket.max_gso_segments(destination)
     }
 
     pub(super) fn max_receive_segments(&self) -> NonZeroUsize {


### PR DESCRIPTION
## Description

This updates iroh to the changes in https://github.com/n0-computer/quinn/pull/380, see https://github.com/n0-computer/quinn/issues/379 for why we might need this.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
