### PR TITLE
chore: Pin digest to version compatible with curve25519-dalek 5.0.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,7 @@ dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "derive_more",
+ "digest",
  "ed25519-dalek",
  "n0-error",
  "postcard",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -17,6 +17,8 @@ workspace = true
 [dependencies]
 curve25519-dalek = { version = "=5.0.0-pre.1", features = ["serde", "rand_core", "zeroize"], optional = true }
 data-encoding = { version = "2.3.3", optional = true }
+# Pin digest to version compatible with curve25519-dalek 5.0.0-pre.1
+digest = { version = "<0.11.0-rc.11", optional = true }
 ed25519-dalek = { version = "=3.0.0-pre.1", features = ["serde", "rand_core", "zeroize"], optional = true }
 derive_more = { version = "2.0.1", features = ["display"], optional = true }
 url = { version = "2.5.3", features = ["serde"], optional = true }
@@ -39,6 +41,7 @@ serde_test = "1"
 default = ["relay"]
 key = [
   "dep:curve25519-dalek",
+  "dep:digest",
   "dep:ed25519-dalek",
   "dep:url",
   "dep:derive_more",


### PR DESCRIPTION
## Description

curve25519-dalek 5.0.0-pre.x for x>1 uses rand 0.10 rc, which we don't want.
But digest 0.11.0-rc.11 and later no longer work with curve25519-dalek 5.0.0-pre.1

## Breaking Changes

n/a

## Notes & open questions

none