### PR TITLE
fix(iroh): Disable QAD if no IP transports are configured

### DIFF
--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -753,14 +753,15 @@ impl Handle {
         let (actor_sender, actor_receiver) = mpsc::channel(256);
 
         #[cfg(not(wasm_browser))]
-        let ipv6 = transports
+        let has_ipv6_transport = transports
             .ip_bind_addrs()
             .into_iter()
             .any(|addr| addr.is_ipv6());
 
-        let direct_addrs = DiscoveredDirectAddrs::default();
-
+        #[cfg(not(wasm_browser))]
         let has_ip_transports = !transports.ip_bind_addrs().is_empty();
+
+        let direct_addrs = DiscoveredDirectAddrs::default();
 
         let remote_map = {
             RemoteMap::new(
@@ -841,7 +842,7 @@ impl Handle {
                 ep: endpoint.clone(),
                 client_config,
                 ipv4: true,
-                ipv6,
+                ipv6: has_ipv6_transport,
             });
             net_report_config.quic_config(qad_config)
         };


### PR DESCRIPTION
## Description

When no IP transports are configured, QAD will always fail, because it uses an endpoint without ip transports and thus can't send anything. Therefore, this PR changes this such that when IP transports are disabled, no QAD config is created for the relay client, thus QAD probes will be skipped.
