### PR TITLE
fix(docs): Just a typo in the documentation for mdns discovery

### DIFF
--- a/iroh/src/address_lookup/mdns.rs
+++ b/iroh/src/address_lookup/mdns.rs
@@ -175,7 +175,7 @@ impl MdnsAddressLookupBuilder {
     /// `7rutqynuzu65fcdgoerbt4uoh3p62wuto2mp56x3uvhitqzssxga._irohv1._udp.local`
     ///
     /// Any custom service name will take the form, for example:
-    /// `7rutqynuzu65fcdgoerbt4uoh3p62wuto2mp56x3uvhitqzssxga._{service_name}.upd.local`
+    /// `7rutqynuzu65fcdgoerbt4uoh3p62wuto2mp56x3uvhitqzssxga._{service_name}._udp.local`
     pub fn service_name(mut self, service_name: impl Into<String>) -> Self {
         self.service_name = service_name.into();
         self


### PR DESCRIPTION
## Description

Update docs for mdnsbuilder's servicename method to fix a typo

## Breaking Changes

None

## Notes & open questions

None

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.