### PR TITLE
chore(ci): add custom RUST_LOG support for netsim

### DIFF
--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: boolean
         default: false
+      rust_log:
+        description: "Custom RUST_LOG value (e.g. 'iroh=debug,iroh_quinn=trace'). If empty, defaults to warn."
+        required: false
+        type: string
+        default: ""
 
 env:
   RUST_BACKTRACE: 1
@@ -58,3 +63,4 @@ jobs:
       publish_metrics: false
       build_profile: "optimized-release"
       report_table: ${{inputs.report_table}}
+      rust_log: ${{inputs.rust_log}}

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -14,10 +14,11 @@ on:
         required: true
         type: string
         default: "main"
-      debug_logs:
+      rust_log:
+        description: "Custom RUST_LOG value (e.g. 'iroh=debug,iroh_quinn=trace'). If empty, defaults to warn."
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ""
       build_profile:
         required: false
         type: string
@@ -55,10 +56,11 @@ on:
         required: true
         type: string
         default: "main"
-      debug_logs:
+      rust_log:
+        description: "Custom RUST_LOG value (e.g. 'iroh=debug,iroh_quinn=trace'). If empty, defaults to warn."
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ""
       build_profile:
         required: false
         type: string
@@ -147,8 +149,13 @@ jobs:
         cd ../chuck/netsim
         # split sim_paths by comma
         IFS=',' read -ra sim_paths <<< "${{ inputs.sim_paths }}"
+        rust_log="${{ inputs.rust_log }}"
         for sim_path in "${sim_paths[@]}"; do
-          sudo python3 main.py ${{ inputs.debug_logs && '--debug' || ''}} --max-workers=${{ inputs.max_workers }} ${{ inputs.skip && format('--skip={0}', inputs.skip) || ''}} --integration $sim_path
+          if [[ -n "${rust_log}" ]]; then
+            sudo RUST_LOG="${rust_log}" python3 main.py --max-workers=${{ inputs.max_workers }} ${{ inputs.skip && format('--skip={0}', inputs.skip) || ''}} --integration $sim_path
+          else
+            sudo python3 main.py --max-workers=${{ inputs.max_workers }} ${{ inputs.skip && format('--skip={0}', inputs.skip) || ''}} --integration $sim_path
+          fi
         done
 
     - name: Generate report


### PR DESCRIPTION
## Description

removes the basic debug flag in favor of passing a custom `RUST_LOG`

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
