### PR TITLE
feat(iroh): add `Endpoint::closed` and document watcher behavior

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -23,6 +23,7 @@ use n0_error::{e, ensure, stack_error};
 use n0_watcher::Watcher;
 #[cfg(not(wasm_browser))]
 use netdev::ipnet::{Ipv4Net, Ipv6Net};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, instrument, trace, warn};
 use url::Url;
 
@@ -984,12 +985,16 @@ impl Endpoint {
     /// If there are no `addrs`in the [`EndpointAddr`], you may not be dialable by other endpoints
     /// on the internet.
     ///
-    ///
     /// The `EndpointAddr` will change as:
     /// - network conditions change
     /// - the endpoint connects to a relay server
     /// - the endpoint changes its preferred relay server
     /// - more addresses are discovered for this endpoint
+    ///
+    /// The returned watcher only becomes disconnected once the last clone of the [`Endpoint`]
+    /// is dropped. Closing the endpoint does not disconnect the watcher. Thus, a stream created
+    /// via [`Watcher::stream`] only terminates once the endpoint stops. If you want to stop a
+    /// task once the endpoint stops combine with [`Self::closed`].
     ///
     /// [`RelayUrl`]: crate::RelayUrl
     #[cfg(not(wasm_browser))]
@@ -1014,6 +1019,11 @@ impl Endpoint {
     /// When compiled to Wasm, this function returns a watcher that initializes
     /// with an [`EndpointAddr`] that only contains a relay URL, but no direct addresses,
     /// as there are no APIs for directly using sockets in browsers.
+    ///
+    /// The returned watcher only becomes disconnected once the last clone of the [`Endpoint`]
+    /// is dropped. Closing the endpoint does not disconnect the watcher. Thus, a stream created
+    /// via [`Watcher::stream`] only terminates once the endpoint stops. If you want to stop a
+    /// task once the endpoint stops combine with [`Self::closed`].
     #[cfg(wasm_browser)]
     pub fn watch_addr(&self) -> impl n0_watcher::Watcher<Value = EndpointAddr> + use<> {
         // In browsers, there will never be any direct addresses, so we wait
@@ -1090,6 +1100,11 @@ impl Endpoint {
     /// with [`Some`] value yet.  Once the net-report has been successfully
     /// run, the [`Watcher`] will always return [`Some`] report immediately, which
     /// is the most recently run `net-report`.
+    ///
+    /// The returned watcher only becomes disconnected once the last clone of the [`Endpoint`]
+    /// is dropped. Closing the endpoint does not disconnect the watcher. Thus, a stream created
+    /// via [`Watcher::stream`] only terminates once the endpoint stops. If you want to stop a
+    /// task once the endpoint stops combine with [`Self::closed`].
     ///
     /// # Examples
     ///
@@ -1383,6 +1398,13 @@ impl Endpoint {
         self.inner.is_closed()
     }
 
+    /// Returns a [`CancellationToken`] that is cancelled once the endpoint is shutting down.
+    ///
+    /// Cancelling the [`CancellationToken`] has no effect. Use [`Endpoint::close`] to close the endpoint.
+    pub fn closed(&self) -> CancellationToken {
+        self.inner.closed()
+    }
+
     /// Create a [`ServerConfigBuilder`] for this endpoint that includes the given alpns.
     ///
     /// Use the [`ServerConfigBuilder`] to customize the [`ServerConfig`] connection configuration
@@ -1578,7 +1600,9 @@ mod tests {
     use iroh_base::{EndpointAddr, EndpointId, RelayUrl, SecretKey, TransportAddr};
     use iroh_relay::endpoint_info::UserData;
     use n0_error::{AnyError as Error, Result, StdResultExt};
-    use n0_future::{BufferedStreamExt, StreamExt, stream, task::AbortOnDropHandle, time};
+    use n0_future::{
+        BufferedStreamExt, StreamExt, future::now_or_never, stream, task::AbortOnDropHandle, time,
+    };
     use n0_tracing_test::traced_test;
     use n0_watcher::Watcher;
     use rand::SeedableRng;
@@ -3130,10 +3154,14 @@ mod tests {
         // ensure methods behave in the expected way
         info!("Creating endpoint");
         let ep = Endpoint::builder().bind().await?;
+        let closed = ep.closed();
         info!("Closing endpoint");
         let now = Instant::now();
         ep.close().await;
         info!("Endpoint closed in {:?}", now.elapsed());
+
+        // Assert that the `closed` cancellation token is now cancelled
+        assert_eq!(now_or_never(closed.cancelled()), Some(()));
 
         info!("Set ALPNS fails silently");
         ep.set_alpns(vec![b"test".into()]);
@@ -3171,25 +3199,13 @@ mod tests {
         // this should work
         info!("Addr: {:?}", ep.addr());
 
-        // this should not hang
-        // TODO(Frando): This now suddenly hangs again, not sure where the interaction with the
-        // removal of the lock around the quinn::Endpoint comes from
-        // let mut addrs = ep.watch_addr().stream();
-        // while let Some(addr) = addrs.next().await {
-        //     info!("Addrs stream: {addr:?}");
-        // }
+        // create watchers to verify they terminate after the endpoint is dropped.
+        let mut addrs = ep.watch_addr().stream();
+        let mut net_reports = ep.net_report().stream();
 
         // returns None
-        info!("here");
         let net_report = ep.last_net_report();
         info!("last Net report {net_report:?}");
-
-        // this currently hangs
-        // TODO(ramfox): why?
-        // let mut net_reports = ep.net_report().stream();
-        // while let Some(net_report) = net_reports.next().await {
-        //     info!("Net report stream: {net_report:?}");
-        // }
 
         // this should work
         let sockets = ep.bound_sockets();
@@ -3213,6 +3229,18 @@ mod tests {
         ep.set_user_data_for_address_lookup(Some(
             UserData::try_from("TEST".to_string()).expect("valid string"),
         ));
+        drop(ep);
+        // now that the endpoint is dropped, all watchers should terminate.
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while let Some(addr) = addrs.next().await {
+                info!("Addrs stream: {addr:?}");
+            }
+            while let Some(net_report) = net_reports.next().await {
+                info!("Net report stream: {net_report:?}");
+            }
+        })
+        .await
+        .expect("watchers not closed");
 
         info!("Done!");
         Ok(())

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -314,6 +314,10 @@ impl Socket {
         self.shutdown.is_closing()
     }
 
+    pub(crate) fn closed(&self) -> CancellationToken {
+        self.shutdown.at_close_start.child_token()
+    }
+
     /// Get the cached version of addresses.
     pub(crate) fn local_addr(&self) -> Vec<transports::Addr> {
         self.local_addrs_watch.clone().get()


### PR DESCRIPTION
## Description

Based on #3941 which is based on #3879

* Add `Endpoint::closed`, which returns a `CancellationToken` that is cancelled once the endpoint is closing
* Document watcher behavior with regards to closing the endpoint
* Fix test

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

* Instead of returning a `CancellationToken` we could make this an `async fn`, however to me it looks quite useful to get a `CancellationToken` and be able to use `tokio::spawn(endpoint_closed.run_until_cancelled_owned(async move { .. })))`
* The cancellation token is cancelled when `Endpoint::close` *starts*, not when it *ends*. I wasn't sure what expected behavior is here. I opted for start because this guarantees that the endpoint is fully usable until then.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
