### PR TITLE
feat(iroh): more precise information about incoming connections

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -70,8 +70,8 @@ pub use self::quic::{QlogConfig, QlogFactory, QlogFileFactory};
 pub use self::{
     connection::{
         Accept, Accepting, AlpnError, AuthenticationError, Connecting, ConnectingError, Connection,
-        ConnectionInfo, ConnectionState, HandshakeCompleted, Incoming, IncomingZeroRtt,
-        IncomingZeroRttConnection, OutgoingZeroRtt, OutgoingZeroRttConnection,
+        ConnectionInfo, ConnectionState, HandshakeCompleted, Incoming, IncomingAddress,
+        IncomingZeroRtt, IncomingZeroRttConnection, OutgoingZeroRtt, OutgoingZeroRttConnection,
         RemoteEndpointIdError, RetryError, ZeroRttStatus,
     },
     quic::{

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1461,6 +1461,12 @@ impl Endpoint {
 
     // # Remaining private methods
 
+    /// Translates a raw [`SocketAddr`] (which may be a synthetic mapped address) into
+    /// a transport address.
+    pub(crate) fn to_transport_addr(&self, addr: SocketAddr) -> crate::socket::transports::Addr {
+        self.inner.to_transport_addr(addr)
+    }
+
     #[cfg(test)]
     pub(crate) fn inner(&self) -> Result<Arc<EndpointInner>, EndpointError> {
         if self.is_closed() {

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -11,9 +11,7 @@
 //!
 //! [module docs]: crate
 
-#[cfg(not(wasm_browser))]
-use std::net::SocketAddr;
-use std::{pin::Pin, sync::Arc};
+use std::{net::SocketAddr, pin::Pin, sync::Arc};
 
 use iroh_base::{EndpointAddr, EndpointId, RelayUrl, SecretKey, TransportAddr};
 use iroh_relay::{RelayConfig, RelayMap};

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -70,7 +70,7 @@ pub use self::quic::{QlogConfig, QlogFactory, QlogFileFactory};
 pub use self::{
     connection::{
         Accept, Accepting, AlpnError, AuthenticationError, Connecting, ConnectingError, Connection,
-        ConnectionInfo, ConnectionState, HandshakeCompleted, Incoming, IncomingAddress,
+        ConnectionInfo, ConnectionState, HandshakeCompleted, Incoming, IncomingAddr,
         IncomingZeroRtt, IncomingZeroRttConnection, OutgoingZeroRtt, OutgoingZeroRttConnection,
         RemoteEndpointIdError, RetryError, ZeroRttStatus,
     },

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -178,7 +178,7 @@ impl Incoming {
     }
 
     /// Returns the remote address of this incoming connection.
-    pub fn remote_address(&self) -> IncomingAddr {
+    pub fn remote_addr(&self) -> IncomingAddr {
         self.ep
             .sock
             .to_transport_addr(self.inner.remote_address())
@@ -188,8 +188,8 @@ impl Incoming {
     /// Whether the socket address that is initiating this connection has been validated.
     ///
     /// This means that the sender of the initial packet has proved that they can receive
-    /// traffic sent to `self.remote_address()`.
-    pub fn remote_address_validated(&self) -> bool {
+    /// traffic sent to `self.remote_addr()`.
+    pub fn remote_addr_validated(&self) -> bool {
         self.inner.remote_address_validated()
     }
 }

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -189,7 +189,15 @@ impl Incoming {
     /// This means that the sender of the initial packet has proved that they can receive
     /// traffic sent to `self.remote_address()`.
     pub fn remote_address_validated(&self) -> bool {
-        self.inner.remote_address_validated()
+        let addr = self.inner.remote_address();
+        match addr.ip() {
+            IpAddr::V6(ip)
+                if crate::socket::mapped_addrs::RelayMappedAddr::try_from(ip).is_ok() =>
+            {
+                true
+            }
+            _ => self.inner.remote_address_validated(),
+        }
     }
 }
 

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -68,6 +68,15 @@ pub enum IncomingAddr {
     },
 }
 
+impl From<IncomingAddr> for iroh_base::TransportAddr {
+    fn from(addr: IncomingAddr) -> Self {
+        match addr {
+            IncomingAddr::Ip(addr) => Self::Ip(addr),
+            IncomingAddr::Relay { url, .. } => Self::Relay(url),
+        }
+    }
+}
+
 impl From<crate::socket::transports::Addr> for IncomingAddr {
     fn from(addr: crate::socket::transports::Addr) -> Self {
         match addr {

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -54,7 +54,7 @@ use crate::{
 ///
 /// When the incoming connection is a direct connection, this is a SocketAddr.
 /// When it is a relay connection, we know both the relay URL and the endpoint ID.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IncomingAddr {
     /// A direct connection from an IP address.
@@ -189,7 +189,7 @@ impl Incoming {
     /// Returns the remote address of this incoming connection.
     pub fn remote_addr(&self) -> IncomingAddr {
         self.ep
-            .sock
+            .inner
             .to_transport_addr(self.inner.remote_address())
             .into()
     }
@@ -615,9 +615,9 @@ impl Accepting {
     }
 
     /// Returns the remote address of this connection.
-    pub fn remote_address(&self) -> IncomingAddr {
+    pub fn remote_addr(&self) -> IncomingAddr {
         self.ep
-            .sock
+            .inner
             .to_transport_addr(self.inner.remote_address())
             .into()
     }

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -55,6 +55,7 @@ use crate::{
 /// When the incoming connection is a direct connection, this is a SocketAddr.
 /// When it is a relay connection, we know both the relay URL and the endpoint ID.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum IncomingAddr {
     /// A direct connection from an IP address.
     Ip(SocketAddr),
@@ -189,15 +190,7 @@ impl Incoming {
     /// This means that the sender of the initial packet has proved that they can receive
     /// traffic sent to `self.remote_address()`.
     pub fn remote_address_validated(&self) -> bool {
-        let addr = self.inner.remote_address();
-        match addr.ip() {
-            IpAddr::V6(ip)
-                if crate::socket::mapped_addrs::RelayMappedAddr::try_from(ip).is_ok() =>
-            {
-                true
-            }
-            _ => self.inner.remote_address_validated(),
-        }
+        self.inner.remote_address_validated()
     }
 }
 

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -55,7 +55,7 @@ use crate::{
 /// When the incoming connection is a direct connection, this is a SocketAddr.
 /// When it is a relay connection, we know both the relay URL and the endpoint ID.
 #[derive(Debug, Clone)]
-pub enum IncomingAddress {
+pub enum IncomingAddr {
     /// A direct connection from an IP address.
     Ip(SocketAddr),
     /// A connection via a relay.
@@ -67,7 +67,7 @@ pub enum IncomingAddress {
     },
 }
 
-impl From<crate::socket::transports::Addr> for IncomingAddress {
+impl From<crate::socket::transports::Addr> for IncomingAddr {
     fn from(addr: crate::socket::transports::Addr) -> Self {
         match addr {
             crate::socket::transports::Addr::Ip(addr) => Self::Ip(addr),
@@ -177,7 +177,7 @@ impl Incoming {
     }
 
     /// Returns the remote address of this incoming connection.
-    pub fn remote_address(&self) -> IncomingAddress {
+    pub fn remote_address(&self) -> IncomingAddr {
         self.ep
             .sock
             .to_transport_addr(self.inner.remote_address())
@@ -605,7 +605,7 @@ impl Accepting {
     }
 
     /// Returns the remote address of this connection.
-    pub fn remote_address(&self) -> IncomingAddress {
+    pub fn remote_address(&self) -> IncomingAddr {
         self.ep
             .sock
             .to_transport_addr(self.inner.remote_address())

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -189,7 +189,6 @@ impl Incoming {
     /// Returns the remote address of this incoming connection.
     pub fn remote_addr(&self) -> IncomingAddr {
         self.ep
-            .inner
             .to_transport_addr(self.inner.remote_address())
             .into()
     }
@@ -617,7 +616,6 @@ impl Accepting {
     /// Returns the remote address of this connection.
     pub fn remote_addr(&self) -> IncomingAddr {
         self.ep
-            .inner
             .to_transport_addr(self.inner.remote_address())
             .into()
     }

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -447,6 +447,18 @@ impl Socket {
         &self.dns_resolver
     }
 
+    /// Translates a raw [`SocketAddr`] (which may be a synthetic mapped address) into
+    /// a [`transports::Addr`].
+    ///
+    /// For regular IP addresses this returns `Addr::Ip`. For synthetic relay-mapped
+    /// IPv6 addresses this performs a reverse lookup and returns `Addr::Relay`.
+    pub(crate) fn to_transport_addr(&self, addr: SocketAddr) -> transports::Addr {
+        self.mapped_addrs
+            .relay_addrs
+            .to_transport_addr(addr)
+            .unwrap_or(transports::Addr::Ip(addr))
+    }
+
     /// Reference to the internal Address Lookup
     pub(crate) fn address_lookup(&self) -> &address_lookup::ConcurrentAddressLookup {
         &self.address_lookup

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -452,6 +452,12 @@ impl Socket {
     ///
     /// For regular IP addresses this returns `Addr::Ip`. For synthetic relay-mapped
     /// IPv6 addresses this performs a reverse lookup and returns `Addr::Relay`.
+    ///
+    /// This lookup only makes sense for a remote address of the
+    /// underlying QUIC connection.
+    ///
+    /// If you call this with a mapped address for which no mapping exists,
+    /// it will return the address as an `Addr::Ip`.
     pub(crate) fn to_transport_addr(&self, addr: SocketAddr) -> transports::Addr {
         self.mapped_addrs
             .relay_addrs


### PR DESCRIPTION
## Description

Provide more precise information about incoming connections. Instead of exposing the synthetic IPV6 addr for relay connections, we translate it to a special enum IncomingAddr that has all available info for a rate limiter or access control component to make a decision.

Implements https://github.com/n0-computer/iroh/issues/3948

## Breaking Changes

endpoint::Incoming::remote_address renamed to remote_addr, and returns IncomingAddr.
endpoint::Incoming::remote_address_validated renamed to remote_addr_validated.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
