### PR TITLE
chore(ci): colocate sims into iroh repo

### DIFF
--- a/.github/sims/integration/iroh.json
+++ b/.github/sims/integration/iroh.json
@@ -1,0 +1,142 @@
+{
+    "name": "intg_iroh",
+    "cases": [
+        {
+            "name": "1_to_1",
+            "description": "",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=10 --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "1_to_3",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 3,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=10 --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_2",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=10 --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_4",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 4,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=10 --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/integration/iroh_full.json
+++ b/.github/sims/integration/iroh_full.json
@@ -1,0 +1,200 @@
+{
+    "name": "intg_iroh_full",
+    "cases": [
+        {
+            "name": "1_to_1",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "2_d",
+                    "count": 1,
+                    "cmd": "./bins/iroh-dns-server --config ./data/dns.test.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_3",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "2_d",
+                    "count": 1,
+                    "cmd": "./bins/iroh-dns-server --config ./data/dns.test.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 3,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_1ro",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "2_d",
+                    "count": 1,
+                    "cmd": "./bins/iroh-dns-server --config ./data/dns.test.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_1x3",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "2_d",
+                    "count": 1,
+                    "cmd": "./bins/iroh-dns-server --config ./data/dns.test.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/n_runs.sh 3 ./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short"
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/integration/relay.json
+++ b/.github/sims/integration/relay.json
@@ -1,0 +1,50 @@
+{
+    "name": "intg_iroh_relay",
+    "cases": [
+        {
+            "name": "1_to_1",
+            "description": "",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=20 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/integration/relay_only.json
+++ b/.github/sims/integration/relay_only.json
@@ -1,0 +1,83 @@
+{
+    "name": "intg_iroh_relay_only",
+    "cases": [
+        {
+            "name": "1_to_1",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_3",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 3,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/iroh/iroh.json
+++ b/.github/sims/iroh/iroh.json
@@ -1,0 +1,237 @@
+{
+    "name": "iroh",
+    "cases": [
+        {
+            "name": "1_to_1",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 20,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_3",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 20,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 3,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_5",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 20,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 5,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 20,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_2",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 20,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_4",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 20,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 4,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_6",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 20,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 6,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 20,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/iroh/iroh_10gb.json
+++ b/.github/sims/iroh/iroh_10gb.json
@@ -1,0 +1,237 @@
+{
+    "name": "iroh_cust_10gb",
+    "cases": [
+        {
+            "name": "1_to_1",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=10G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_3",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 3,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=10G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_5",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 5,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=10G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=10G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_2",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=10G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_4",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 4,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=10G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_6",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 6,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=10G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=10G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/iroh/iroh_200ms.json
+++ b/.github/sims/iroh/iroh_200ms.json
@@ -1,0 +1,277 @@
+{
+    "name": "iroh_latency_200ms",
+    "cases": [
+        {
+            "name": "1_to_1",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 200,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "1_to_3",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 3,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 200,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "1_to_5",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 5,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 200,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "1_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 200,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_2",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 200,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_4",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 4,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 200,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_6",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 6,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 200,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 200,
+                        "bw": 100000
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/iroh/iroh_20ms.json
+++ b/.github/sims/iroh/iroh_20ms.json
@@ -1,0 +1,277 @@
+{
+    "name": "iroh_latency_20ms",
+    "cases": [
+        {
+            "name": "1_to_1",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 20,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "1_to_3",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 3,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 20,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "1_to_5",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 5,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 20,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "1_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 20,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_2",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 20,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_4",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 4,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 20,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_6",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 6,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 20,
+                        "bw": 100000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "2_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "link": {
+                        "loss": 0,
+                        "latency": 20,
+                        "bw": 100000
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/iroh/iroh_relay_only.json
+++ b/.github/sims/iroh/iroh_relay_only.json
@@ -1,0 +1,317 @@
+{
+    "name": "iroh_relay_only",
+    "cases": [
+        {
+            "name": "1_to_1",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_3",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 3,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_5",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 5,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "1_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_2",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_4",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 4,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_6",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 6,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        },
+        {
+            "name": "2_to_10",
+            "description": "",
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 2,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 10,
+                    "cmd": "./bins/iroh-transfer --output json fetch --size=1G --env dev --relay-only --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json"
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/paused/adverse.json
+++ b/.github/sims/paused/adverse.json
@@ -1,0 +1,305 @@
+{
+    "name": "adverse_iroh",
+    "cases": [
+        {
+            "name": "direct_throttled",
+            "description": "Direct transfer with 4Mbit/s throttle",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=30 --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    },
+                    "link": {
+                        "bw": 4,
+                        "latency": 200,
+                        "loss": 0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "direct_lossy",
+            "description": "Direct transfer with 1% packet loss",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=30 --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    },
+                    "link": {
+                        "loss": 1,
+                        "bw": 8,
+                        "latency": 200
+                    }
+                }
+            ]
+        },
+        {
+            "name": "relay_dns_throttled",
+            "description": "Relay+DNS transfer with 4Mbit/s throttle",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "2_d",
+                    "count": 1,
+                    "cmd": "./bins/iroh-dns-server --config ./data/dns.test.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=30 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    },
+                    "link": {
+                        "bw": 4,
+                        "latency": 200,
+                        "loss": 0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "relay_dns_lossy",
+            "description": "Relay+DNS transfer with 1% packet loss",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "2_d",
+                    "count": 1,
+                    "cmd": "./bins/iroh-dns-server --config ./data/dns.test.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=30 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --pkarr-relay-url=\"http://10.0.0.2:8080/pkarr\" --dns-origin-domain=\"10.0.0.2:5300\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    },
+                    "link": {
+                        "loss": 1,
+                        "bw": 8,
+                        "latency": 200
+                    }
+                }
+            ]
+        },
+        {
+            "name": "nat_both_throttled",
+            "description": "Both nodes behind NAT with 4Mbit/s throttle",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "nat",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=30 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "nat",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    },
+                    "link": {
+                        "bw": 4,
+                        "latency": 200,
+                        "loss": 0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "nat_both_lossy",
+            "description": "Both nodes behind NAT with 1% packet loss",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "nat",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=30 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "nat",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    },
+                    "link": {
+                        "loss": 1,
+                        "bw": 8,
+                        "latency": 200
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/paused/interface_switch.json
+++ b/.github/sims/paused/interface_switch.json
@@ -1,0 +1,165 @@
+{
+    "name": "interface_switch_iroh",
+    "cases": [
+        {
+            "name": "route_switch_mid_transfer",
+            "description": "Multi-homed host switches route from NAT1 to NAT2 mid-transfer",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "nat",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=15 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "multi_nat",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    },
+                    "link": {
+                        "bw": 10,
+                        "latency": 50,
+                        "loss": 0
+                    },
+                    "actions": [
+                        {"delay": 5, "action": "switch_route", "from": 0, "to": 1}
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "interface_down_up",
+            "description": "Interface goes down mid-transfer then comes back up",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "nat",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=15 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "nat",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    },
+                    "link": {
+                        "bw": 10,
+                        "latency": 50,
+                        "loss": 0
+                    },
+                    "actions": [
+                        {"delay": 5, "action": "link_down", "interface": 0},
+                        {"delay": 10, "action": "link_up", "interface": 0}
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "route_switch_both_multi_nat",
+            "description": "Both provider and consumer are multi-homed, consumer switches mid-transfer",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "multi_nat",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=15 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "multi_nat",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    },
+                    "link": {
+                        "bw": 10,
+                        "latency": 50,
+                        "loss": 0
+                    },
+                    "actions": [
+                        {"delay": 5, "action": "switch_route", "from": 0, "to": 1}
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/.github/sims/paused/relay_nat.json
+++ b/.github/sims/paused/relay_nat.json
@@ -1,0 +1,140 @@
+{
+    "name": "intg_iroh_relay_nat",
+    "cases": [
+        {
+            "name": "1_to_1_NAT_provide",
+            "description": "",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "nat",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=20 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "public",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "1_to_1_NAT_get",
+            "description": "",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "public",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=20 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "nat",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "1_to_1_NAT_both",
+            "description": "",
+            "visualize": true,
+            "nodes": [
+                {
+                    "name": "1_r",
+                    "count": 1,
+                    "cmd": "./bins/iroh-relay --dev --config-path ./data/relay.cfg",
+                    "type": "public",
+                    "wait": 2,
+                    "connect": {
+                        "strategy": "none"
+                    }
+                },
+                {
+                    "name": "i_srv",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json provide --env dev --relay-url=\"http://10.0.0.1:3340\"",
+                    "type": "nat",
+                    "wait": 10,
+                    "connect": {
+                        "strategy": "none"
+                    },
+                    "param_parser": "iroh_endpoint_json"
+                },
+                {
+                    "name": "i_get",
+                    "count": 1,
+                    "cmd": "./bins/iroh-transfer --output json fetch --duration=20 --env dev --relay-url=\"http://10.0.0.1:3340\" --remote-relay-url=\"http://10.0.0.1:3340\" --remote-direct-address=\"%s\" %s",
+                    "type": "nat",
+                    "connect": {
+                        "strategy": "params_with_parsed_addrs",
+                        "node": "i_srv"
+                    },
+                    "process": "short",
+                    "parser": "iroh_json",
+                    "integration": "magic_iroh_client_json",
+                    "integration_require": {
+                        "transfer_success": "true",
+                        "final_conn_direct": "true"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -132,6 +132,12 @@ jobs:
         ./setup.sh
         ./cleanup.sh || true
 
+    - name: Copy sim configs
+      run: |
+        cp -r .github/sims/iroh/ ../chuck/netsim/sims/iroh/
+        cp -r .github/sims/integration/ ../chuck/netsim/sims/integration/
+        cp -r .github/sims/paused/ ../chuck/netsim/sims/paused/
+
     - name: Copy binaries to right location
       run: |
         cp target/${{inputs.build_profile}}/examples/* ../chuck/netsim/bins/


### PR DESCRIPTION
## Description

We've done this in the quinn repo already. This should make life easier to both fiddle with sims while working but also to easily sync up changes when needed instead of having to sync merges across repos. Netsim itself changes less frequently and also is a lot more decoupled and tolerant of moving independently this way.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
