### PR TITLE
feat: Customization for endpoint TLS configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773628058,
+        "narHash": "sha256-hpXH0z3K9xv0fHaje136KY872VT2T5uwxtezlAskQgY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f8573b9c935cfaa162dd62cc9e75ae2db86f85df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773716879,
+        "narHash": "sha256-vXCTasEzzTTd0ZGEuyle20H2hjRom66JeNr7i2ktHD0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "1a9ddeb45c5751b800331363703641b84d1f41f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "Development environment for iroh";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        rustStable = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" "clippy" "rustfmt" ];
+        };
+
+        rustNightly = pkgs.rust-bin.nightly.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" "clippy" "rustfmt" ];
+        };
+
+        commonInputs = with pkgs; [
+          pkg-config
+          llvmPackages.clang
+          llvmPackages.bintools
+          cargo-nextest
+          cargo-deny
+          cargo-make
+        ];
+      in
+      {
+        devShells = {
+          default = pkgs.mkShell {
+            buildInputs = [ rustStable ] ++ commonInputs;
+
+            RUST_BACKTRACE = "1";
+          };
+
+          nightly = pkgs.mkShell {
+            buildInputs = [ rustNightly ] ++ commonInputs;
+
+            RUST_BACKTRACE = "1";
+          };
+        };
+      }
+    );
+}

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -47,7 +47,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
 ] }
 rustc-hash = "2"
-rustls = { version = "0.23.33", default-features = false, features = ["ring"] }
+rustls = { version = "0.23.37", default-features = false, features = ["ring"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 smallvec = "1.11.1"
 strum = { version = "0.28", features = ["derive"] }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -193,6 +193,8 @@ impl Builder {
             ca_roots_config: None,
             #[cfg(not(wasm_browser))]
             dns_resolver: None,
+            tls_config_params: None,
+            remote_id_strategy: Box::new(RawEd25519Id {}),
             max_tls_tickets: DEFAULT_MAX_TLS_TICKETS,
             transports,
             hooks: Default::default(),

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -51,23 +51,25 @@ use crate::dns::DnsResolver;
 #[cfg(feature = "unstable-custom-transports")]
 use crate::endpoint::transports::CustomTransport;
 use crate::{
-    NetReport,
+    IdFromQuinnConn, NetReport,
     address_lookup::{
         AddrFilter, AddressLookupBuilder, ConcurrentAddressLookup, DynAddressLookupBuilder,
         Error as AddressLookupError, UserData,
     },
-    endpoint::presets::Preset,
+    endpoint::{id::RawEd25519Id, presets::Preset},
     metrics::EndpointMetrics,
     socket::{
         self, EndpointInner, RemoteStateActorStoppedError, StaticConfig, mapped_addrs::MappedAddr,
     },
-    tls::{self, DEFAULT_MAX_TLS_TICKETS},
+    tls::{self, DEFAULT_MAX_TLS_TICKETS, EndpointTlsConfigParams},
 };
 
 #[cfg(not(wasm_browser))]
 mod bind;
 mod connection;
 pub(crate) mod hooks;
+/// Endpoint identity extraction from QUIC connections.
+pub mod id;
 pub mod presets;
 pub(crate) mod quic;
 
@@ -125,6 +127,8 @@ pub struct Builder {
     #[cfg(not(wasm_browser))]
     dns_resolver: Option<DnsResolver>,
     transports: Vec<TransportConfig>,
+    tls_config_params: Option<EndpointTlsConfigParams>,
+    remote_id_strategy: Box<dyn IdFromQuinnConn>,
     max_tls_tickets: usize,
     hooks: EndpointHooksList,
     transport_bias: socket::transports::TransportBiasMap,
@@ -209,9 +213,15 @@ impl Builder {
         let span = info_span!("endpoint", id = %secret_key.public().fmt_short());
         let _guard = span.enter();
 
+        let tls_config: tls::TlsConfig = match self.tls_config_params {
+            Some(cfg) => tls::TlsConfig::new(secret_key.clone(), cfg),
+            None => tls::TlsConfig::new_default(secret_key.clone(), self.max_tls_tickets),
+        };
+
         let static_config = StaticConfig {
             transport_config: self.transport_config.clone(),
-            tls_config: tls::TlsConfig::new(secret_key.clone(), self.max_tls_tickets),
+            remote_id_strategy: self.remote_id_strategy,
+            tls_config,
             keylog: self.keylog,
         };
         let server_config = static_config.create_server_config(self.alpn_protocols);
@@ -666,6 +676,29 @@ impl Builder {
     /// filename will result in this file being used to log the TLS pre-master keys.
     pub fn keylog(mut self, keylog: bool) -> Self {
         self.keylog = keylog;
+        self
+    }
+
+    /// Set the endpoint TLS config parameters.
+    ///
+    /// Set this to customize endpoint TLS configuration if you need advanced
+    /// control over authentication and authorization.
+    ///
+    /// Default is designed to interoperate with Iroh's pubkey ID. Do NOT
+    /// modify this unless you understand the risks associated with customizing
+    /// authentication and authorization logic at the TLS layer.
+    pub fn tls_config_params(mut self, cfg: EndpointTlsConfigParams) -> Self {
+        self.tls_config_params = Some(cfg);
+        self
+    }
+
+    /// Set the strategy used to identify a remote endpoint using a quic connection.
+    ///
+    /// By default, this will extract an Ed25519 key from the remote peer's
+    /// certificate. Use this configuration option in conjunction with the
+    /// tls_config_params option to customize the quic handshake.
+    pub fn remote_id_strategy(mut self, strategy: Box<dyn IdFromQuinnConn>) -> Self {
+        self.remote_id_strategy = strategy;
         self
     }
 
@@ -1591,6 +1624,10 @@ impl Endpoint {
             return Err(e!(EndpointError::Closed));
         }
         Ok(self.inner.clone())
+    }
+
+    pub(crate) fn remote_id_strategy(&self) -> &dyn IdFromQuinnConn {
+        &*self.inner.static_config.remote_id_strategy
     }
 }
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -51,7 +51,7 @@ use crate::dns::DnsResolver;
 #[cfg(feature = "unstable-custom-transports")]
 use crate::endpoint::transports::CustomTransport;
 use crate::{
-    IdFromQuinnConn, NetReport,
+    IdFromQuicConn, NetReport,
     address_lookup::{
         AddrFilter, AddressLookupBuilder, ConcurrentAddressLookup, DynAddressLookupBuilder,
         Error as AddressLookupError, UserData,
@@ -128,7 +128,7 @@ pub struct Builder {
     dns_resolver: Option<DnsResolver>,
     transports: Vec<TransportConfig>,
     tls_config_params: Option<EndpointTlsConfigParams>,
-    remote_id_strategy: Box<dyn IdFromQuinnConn>,
+    remote_id_strategy: Box<dyn IdFromQuicConn>,
     max_tls_tickets: usize,
     hooks: EndpointHooksList,
     transport_bias: socket::transports::TransportBiasMap,
@@ -697,7 +697,7 @@ impl Builder {
     /// By default, this will extract an Ed25519 key from the remote peer's
     /// certificate. Use this configuration option in conjunction with the
     /// tls_config_params option to customize the quic handshake.
-    pub fn remote_id_strategy(mut self, strategy: Box<dyn IdFromQuinnConn>) -> Self {
+    pub fn remote_id_strategy(mut self, strategy: Box<dyn IdFromQuicConn>) -> Self {
         self.remote_id_strategy = strategy;
         self
     }
@@ -1626,7 +1626,7 @@ impl Endpoint {
         Ok(self.inner.clone())
     }
 
-    pub(crate) fn remote_id_strategy(&self) -> &dyn IdFromQuinnConn {
+    pub(crate) fn remote_id_strategy(&self) -> &dyn IdFromQuicConn {
         &*self.inner.static_config.remote_id_strategy
     }
 }

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -25,7 +25,6 @@ use std::{
     task::Poll,
 };
 
-use ed25519_dalek::{VerifyingKey, pkcs8::DecodePublicKey};
 use futures_util::{FutureExt, future::Shared};
 use iroh_base::{EndpointId, RelayUrl};
 use n0_error::{e, stack_error};
@@ -38,6 +37,7 @@ use crate::{
     Endpoint,
     endpoint::{
         AfterHandshakeOutcome,
+        id::IdFromQuinnConn,
         quic::{
             AcceptBi, AcceptUni, ConnectionError, ConnectionStats, Controller,
             ExportKeyingMaterialError, OpenBi, OpenUni, PathId, ReadDatagram, SendDatagram,
@@ -306,7 +306,7 @@ fn conn_from_noq_conn(
     impl Future<Output = Result<Connection, ConnectingError>> + Send + 'static,
     ConnectingError,
 > {
-    let info = match static_info_from_conn(&conn) {
+    let info = match static_info_from_conn(ep, &conn) {
         Ok(val) => val,
         Err(auth_err) => {
             // If the authentication error raced with a connection error, the connection
@@ -353,50 +353,13 @@ fn conn_from_noq_conn(
     })
 }
 
-fn static_info_from_conn(conn: &noq::Connection) -> Result<StaticInfo, AuthenticationError> {
-    let endpoint_id = remote_id_from_noq_conn(conn)?;
+fn static_info_from_conn(
+    ep: &Endpoint,
+    conn: &noq::Connection,
+) -> Result<StaticInfo, AuthenticationError> {
+    let endpoint_id = ep.remote_id_strategy().remote_id_from_quinn_conn(conn)?;
     let alpn = alpn_from_noq_conn(conn).ok_or_else(|| e!(AuthenticationError::NoAlpn))?;
     Ok(StaticInfo { endpoint_id, alpn })
-}
-
-/// Returns the [`EndpointId`] from the peer's TLS certificate.
-///
-/// The [`PublicKey`] of an endpoint is also known as an [`EndpointId`].  This [`PublicKey`] is
-/// included in the TLS certificate presented during the handshake when connecting.
-/// This function allows you to get the [`EndpointId`] of the remote endpoint of this
-/// connection.
-///
-/// [`PublicKey`]: iroh_base::PublicKey
-fn remote_id_from_noq_conn(conn: &noq::Connection) -> Result<EndpointId, RemoteEndpointIdError> {
-    let data = conn.peer_identity();
-    match data {
-        None => {
-            warn!("no peer certificate found");
-            Err(RemoteEndpointIdError::new())
-        }
-        Some(data) => match data.downcast::<Vec<rustls::pki_types::CertificateDer>>() {
-            Ok(certs) => {
-                if certs.len() != 1 {
-                    warn!(
-                        "expected a single peer certificate, but {} found",
-                        certs.len()
-                    );
-                    return Err(RemoteEndpointIdError::new());
-                }
-
-                let peer_id = EndpointId::from_verifying_key(
-                    VerifyingKey::from_public_key_der(&certs[0])
-                        .map_err(|_| RemoteEndpointIdError::new())?,
-                );
-
-                Ok(peer_id)
-            }
-            Err(err) => {
-                warn!("invalid peer certificate: {:?}", err);
-                Err(RemoteEndpointIdError::new())
-            }
-        },
-    }
 }
 
 /// An outgoing connection in progress.
@@ -1150,7 +1113,7 @@ impl Connection<IncomingZeroRtt> {
     ///
     /// [`PublicKey`]: iroh_base::PublicKey
     pub fn remote_id(&self) -> Result<EndpointId, RemoteEndpointIdError> {
-        remote_id_from_noq_conn(&self.inner)
+        crate::endpoint::id::RawEd25519Id.remote_id_from_quinn_conn(&self.inner)
     }
 }
 
@@ -1192,7 +1155,7 @@ impl Connection<OutgoingZeroRtt> {
     ///
     /// [`PublicKey`]: iroh_base::PublicKey
     pub fn remote_id(&self) -> Result<EndpointId, RemoteEndpointIdError> {
-        remote_id_from_noq_conn(&self.inner)
+        crate::endpoint::id::RawEd25519Id.remote_id_from_quinn_conn(&self.inner)
     }
 }
 

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -37,7 +37,7 @@ use crate::{
     Endpoint,
     endpoint::{
         AfterHandshakeOutcome,
-        id::IdFromQuinnConn,
+        id::IdFromQuicConn,
         quic::{
             AcceptBi, AcceptUni, ConnectionError, ConnectionStats, Controller,
             ExportKeyingMaterialError, OpenBi, OpenUni, PathId, ReadDatagram, SendDatagram,

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -31,7 +31,7 @@ use n0_error::{e, stack_error};
 use n0_future::{TryFutureExt, future::Boxed as BoxFuture, time::Duration};
 use noq::WeakConnectionHandle;
 use pin_project::pin_project;
-use tracing::{event, warn};
+use tracing::event;
 
 use crate::{
     Endpoint,

--- a/iroh/src/endpoint/id.rs
+++ b/iroh/src/endpoint/id.rs
@@ -14,7 +14,7 @@ use crate::endpoint::RemoteEndpointIdError;
 ///
 /// See [`RawEd25519Id`] for the default implementation used by standard iroh
 /// endpoints.
-pub trait IdFromQuinnConn: std::fmt::Debug + Send + Sync {
+pub trait IdFromQuicConn: std::fmt::Debug + Send + Sync {
     /// Extract the remote peer's [`EndpointId`] from an established QUIC
     /// connection.
     ///
@@ -27,7 +27,7 @@ pub trait IdFromQuinnConn: std::fmt::Debug + Send + Sync {
     ) -> Result<EndpointId, RemoteEndpointIdError>;
 }
 
-/// Default [`IdFromQuinnConn`] implementation for standard iroh endpoints.
+/// Default [`IdFromQuicConn`] implementation for standard iroh endpoints.
 ///
 /// Expects exactly one certificate entry containing a DER-encoded Ed25519
 /// SPKI (SubjectPublicKeyInfo, per RFC 7250 raw public keys) and converts
@@ -35,7 +35,7 @@ pub trait IdFromQuinnConn: std::fmt::Debug + Send + Sync {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct RawEd25519Id;
 
-impl IdFromQuinnConn for RawEd25519Id {
+impl IdFromQuicConn for RawEd25519Id {
     fn remote_id_from_quinn_conn(
         &self,
         conn: &noq::Connection,

--- a/iroh/src/endpoint/id.rs
+++ b/iroh/src/endpoint/id.rs
@@ -1,0 +1,76 @@
+use ed25519_dalek::{VerifyingKey, pkcs8::DecodePublicKey};
+use iroh_base::EndpointId;
+use tracing::warn;
+
+use crate::endpoint::RemoteEndpointIdError;
+
+/// Strategy for extracting a remote [`EndpointId`] from a QUIC connection.
+///
+/// After a TLS handshake completes, the peer's identity must be derived from
+/// the certificate(s) presented during the handshake.  Implementations of this
+/// trait define *how* that derivation works, allowing different TLS
+/// configurations (e.g. raw public keys vs. X.509 certificates) to plug in
+/// their own logic.
+///
+/// See [`RawEd25519Id`] for the default implementation used by standard iroh
+/// endpoints.
+pub trait IdFromQuinnConn: std::fmt::Debug + Send + Sync {
+    /// Extract the remote peer's [`EndpointId`] from an established QUIC
+    /// connection.
+    ///
+    /// Called after the TLS handshake succeeds.  The implementation should
+    /// inspect [`quinn::Connection::peer_identity`] to obtain the peer's
+    /// certificate chain and derive a stable 32-byte identifier from it.
+    fn remote_id_from_quinn_conn(
+        &self,
+        conn: &noq::Connection,
+    ) -> Result<EndpointId, RemoteEndpointIdError>;
+}
+
+/// Default [`IdFromQuinnConn`] implementation for standard iroh endpoints.
+///
+/// Expects exactly one certificate entry containing a DER-encoded Ed25519
+/// SPKI (SubjectPublicKeyInfo, per RFC 7250 raw public keys) and converts
+/// it directly into an [`EndpointId`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RawEd25519Id;
+
+impl IdFromQuinnConn for RawEd25519Id {
+    fn remote_id_from_quinn_conn(
+        &self,
+        conn: &noq::Connection,
+    ) -> Result<EndpointId, RemoteEndpointIdError> {
+        let data = conn.peer_identity();
+
+        match data {
+            None => {
+                warn!("no peer certificate found");
+                Err(RemoteEndpointIdError::new())
+            }
+
+            Some(data) => match data.downcast::<Vec<rustls::pki_types::CertificateDer>>() {
+                Ok(certs) => {
+                    if certs.len() != 1 {
+                        warn!(
+                            "expected a single peer certificate, but {} found",
+                            certs.len()
+                        );
+                        return Err(RemoteEndpointIdError::new());
+                    }
+
+                    let peer_id = EndpointId::from_verifying_key(
+                        VerifyingKey::from_public_key_der(&certs[0])
+                            .map_err(|_| RemoteEndpointIdError::new())?,
+                    );
+
+                    Ok(peer_id)
+                }
+
+                Err(err) => {
+                    warn!("invalid peer certificate: {:?}", err);
+                    Err(RemoteEndpointIdError::new())
+                }
+            },
+        }
+    }
+}

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -267,7 +267,7 @@ pub mod metrics;
 mod net_report;
 pub mod protocol;
 
-pub use endpoint::id::IdFromQuinnConn;
+pub use endpoint::id::IdFromQuicConn;
 pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{
     EndpointAddr, EndpointId, KeyParsingError, PublicKey, RelayUrl, RelayUrlParseError, SecretKey,

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -267,6 +267,7 @@ pub mod metrics;
 mod net_report;
 pub mod protocol;
 
+pub use endpoint::id::IdFromQuinnConn;
 pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{
     EndpointAddr, EndpointId, KeyParsingError, PublicKey, RelayUrl, RelayUrlParseError, SecretKey,
@@ -277,6 +278,7 @@ pub use iroh_relay::dns;
 pub use iroh_relay::{RelayConfig, RelayMap, endpoint_info};
 pub use n0_watcher::Watcher;
 pub use net_report::{Report as NetReport, TIMEOUT as NET_REPORT_TIMEOUT};
+pub use tls::EndpointTlsConfigParams;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -58,6 +58,7 @@ use crate::dns::DnsResolver;
 #[cfg(not(wasm_browser))]
 use crate::net_report::QuicConfig;
 use crate::{
+    IdFromQuinnConn,
     address_lookup::{self, AddressLookup, EndpointData, Error as AddressLookupError, UserData},
     defaults::timeouts::NET_REPORT_TIMEOUT,
     endpoint::{hooks::EndpointHooksList, quic::QuicTransportConfig},
@@ -190,6 +191,7 @@ impl Drop for EndpointInner {
 #[derive(Debug)]
 pub(crate) struct StaticConfig {
     pub(crate) tls_config: tls::TlsConfig,
+    pub(crate) remote_id_strategy: Box<dyn IdFromQuinnConn>,
     pub(crate) transport_config: QuicTransportConfig,
     pub(crate) keylog: bool,
 }
@@ -1743,12 +1745,12 @@ mod tests {
         Endpoint, SecretKey,
         address_lookup::memory::MemoryLookup,
         dns::DnsResolver,
-        endpoint::QuicTransportConfig,
+        endpoint::{QuicTransportConfig, id::RawEd25519Id},
         socket::{
             EndpointInner, StaticConfig, TransportConfig,
             mapped_addrs::{EndpointIdMappedAddr, MappedAddr},
         },
-        tls::{self, DEFAULT_MAX_TLS_TICKETS},
+        tls,
     };
 
     const ALPN: &[u8] = b"n0/test/1";
@@ -1756,7 +1758,7 @@ mod tests {
     fn default_options<R: CryptoRng + ?Sized>(rng: &mut R) -> Options {
         let secret_key = SecretKey::generate(rng);
         let static_config = StaticConfig {
-            tls_config: tls::TlsConfig::new(secret_key.clone(), DEFAULT_MAX_TLS_TICKETS),
+            tls_config: tls::TlsConfig::new_default(secret_key.clone()),
             transport_config: QuicTransportConfig::default(),
             keylog: false,
         };
@@ -2154,7 +2156,8 @@ mod tests {
     #[instrument(name = "ep", skip_all, fields(me = %secret_key.public().fmt_short()))]
     async fn socket_ep(secret_key: SecretKey) -> Result<EndpointInner> {
         let static_config = StaticConfig {
-            tls_config: tls::TlsConfig::new(secret_key.clone(), DEFAULT_MAX_TLS_TICKETS),
+            tls_config: tls::TlsConfig::new_default(secret_key.clone()),
+            remote_id_strategy: Box::new(RawEd25519Id),
             transport_config: QuicTransportConfig::default(),
             keylog: true,
         };
@@ -2223,8 +2226,7 @@ mod tests {
     ) -> Result<noq::Connection> {
         let alpns = vec![ALPN.to_vec()];
         let quic_client_config =
-            tls::TlsConfig::new(ep_secret_key.clone(), DEFAULT_MAX_TLS_TICKETS)
-                .make_client_config(alpns, true);
+            tls::TlsConfig::new_default(ep_secret_key.clone()).make_client_config(alpns, true);
         let mut client_config = noq::ClientConfig::new(Arc::new(quic_client_config));
         client_config.transport_config(transport_config);
         let connect = ep

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1750,7 +1750,7 @@ mod tests {
             EndpointInner, StaticConfig, TransportConfig,
             mapped_addrs::{EndpointIdMappedAddr, MappedAddr},
         },
-        tls,
+        tls::{self, DEFAULT_MAX_TLS_TICKETS},
     };
 
     const ALPN: &[u8] = b"n0/test/1";
@@ -1758,7 +1758,8 @@ mod tests {
     fn default_options<R: CryptoRng + ?Sized>(rng: &mut R) -> Options {
         let secret_key = SecretKey::generate(rng);
         let static_config = StaticConfig {
-            tls_config: tls::TlsConfig::new_default(secret_key.clone()),
+            remote_id_strategy: Box::new(RawEd25519Id {}),
+            tls_config: tls::TlsConfig::new_default(secret_key.clone(), DEFAULT_MAX_TLS_TICKETS),
             transport_config: QuicTransportConfig::default(),
             keylog: false,
         };
@@ -2156,7 +2157,7 @@ mod tests {
     #[instrument(name = "ep", skip_all, fields(me = %secret_key.public().fmt_short()))]
     async fn socket_ep(secret_key: SecretKey) -> Result<EndpointInner> {
         let static_config = StaticConfig {
-            tls_config: tls::TlsConfig::new_default(secret_key.clone()),
+            tls_config: tls::TlsConfig::new_default(secret_key.clone(), DEFAULT_MAX_TLS_TICKETS),
             remote_id_strategy: Box::new(RawEd25519Id),
             transport_config: QuicTransportConfig::default(),
             keylog: true,
@@ -2226,7 +2227,8 @@ mod tests {
     ) -> Result<noq::Connection> {
         let alpns = vec![ALPN.to_vec()];
         let quic_client_config =
-            tls::TlsConfig::new_default(ep_secret_key.clone()).make_client_config(alpns, true);
+            tls::TlsConfig::new_default(ep_secret_key.clone(), DEFAULT_MAX_TLS_TICKETS)
+                .make_client_config(alpns, true);
         let mut client_config = noq::ClientConfig::new(Arc::new(quic_client_config));
         client_config.transport_config(transport_config);
         let connect = ep

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -58,7 +58,7 @@ use crate::dns::DnsResolver;
 #[cfg(not(wasm_browser))]
 use crate::net_report::QuicConfig;
 use crate::{
-    IdFromQuinnConn,
+    IdFromQuicConn,
     address_lookup::{self, AddressLookup, EndpointData, Error as AddressLookupError, UserData},
     defaults::timeouts::NET_REPORT_TIMEOUT,
     endpoint::{hooks::EndpointHooksList, quic::QuicTransportConfig},
@@ -191,7 +191,7 @@ impl Drop for EndpointInner {
 #[derive(Debug)]
 pub(crate) struct StaticConfig {
     pub(crate) tls_config: tls::TlsConfig,
-    pub(crate) remote_id_strategy: Box<dyn IdFromQuinnConn>,
+    pub(crate) remote_id_strategy: Box<dyn IdFromQuicConn>,
     pub(crate) transport_config: QuicTransportConfig,
     pub(crate) keylog: bool,
 }

--- a/iroh/src/tls.rs
+++ b/iroh/src/tls.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use iroh_base::SecretKey;
 use noq::crypto::rustls::{QuicClientConfig, QuicServerConfig};
+use rustls::crypto::CryptoProvider;
 use tracing::warn;
 
 use self::resolver::ResolveRawPublicKeyCert;
@@ -29,6 +30,34 @@ pub use iroh_relay::tls::{CaRootsConfig, default_provider};
 /// I think 150KB is an acceptable default upper limit for such a cache.
 pub(crate) const DEFAULT_MAX_TLS_TICKETS: usize = 8 * 32;
 
+/// Parameters for constructing a [`TlsConfig`].
+///
+/// This bundles the TLS components that can be customized when building an
+/// endpoint: certificate resolvers, certificate verifiers, session storage,
+/// and ticket cache sizing. A default set of parameters is used by
+/// [`TlsConfig::new_default`]; pass a custom instance to [`TlsConfig::new`]
+/// to override individual components.
+#[derive(Debug)]
+pub struct EndpointTlsConfigParams {
+    /// Resolver that provides the client certificate during TLS handshakes.
+    pub client_cert_resolver: Arc<dyn rustls::client::ResolvesClientCert>,
+
+    /// Resolver that provides the server certificate during TLS handshakes.
+    pub server_cert_resolver: Arc<dyn rustls::server::ResolvesServerCert>,
+
+    /// Verifier used to validate server certificates presented by peers.
+    pub server_verifier: Arc<dyn rustls::client::danger::ServerCertVerifier>,
+
+    /// Verifier used to validate client certificates presented by peers.
+    pub client_verifier: Arc<dyn rustls::server::danger::ClientCertVerifier>,
+
+    /// Storage backend for TLS client session data (tickets, etc.).
+    pub session_store: Arc<dyn rustls::client::ClientSessionStore>,
+
+    /// Crypto provider used for all TLS crypto operations
+    pub crypto_provider: Arc<CryptoProvider>,
+}
+
 /// Configuration for TLS.
 ///
 /// The main point of this struct is to keep state that should be kept the same
@@ -39,23 +68,47 @@ pub(crate) const DEFAULT_MAX_TLS_TICKETS: usize = 8 * 32;
 #[derive(Debug)]
 pub(crate) struct TlsConfig {
     pub(crate) secret_key: SecretKey,
-    cert_resolver: Arc<ResolveRawPublicKeyCert>,
-    server_verifier: Arc<verifier::ServerCertificateVerifier>,
-    client_verifier: Arc<verifier::ClientCertificateVerifier>,
+    client_cert_resolver: Arc<dyn rustls::client::ResolvesClientCert>,
+    server_cert_resolver: Arc<dyn rustls::server::ResolvesServerCert>,
+    server_verifier: Arc<dyn rustls::client::danger::ServerCertVerifier>,
+    client_verifier: Arc<dyn rustls::server::danger::ClientCertVerifier>,
     session_store: Arc<dyn rustls::client::ClientSessionStore>,
+    crypto_provider: Arc<CryptoProvider>,
 }
 
 impl TlsConfig {
-    pub(crate) fn new(secret_key: SecretKey, max_tls_tickets: usize) -> Self {
+    pub(crate) fn new(
+        secret_key: SecretKey,
+        endpoint_tls_config_params: EndpointTlsConfigParams,
+    ) -> Self {
         Self {
-            cert_resolver: Arc::new(ResolveRawPublicKeyCert::new(&secret_key)),
+            secret_key,
+            client_cert_resolver: endpoint_tls_config_params.client_cert_resolver,
+            server_cert_resolver: endpoint_tls_config_params.server_cert_resolver,
+            server_verifier: endpoint_tls_config_params.server_verifier,
+            client_verifier: endpoint_tls_config_params.client_verifier,
+            session_store: endpoint_tls_config_params.session_store,
+            crypto_provider: endpoint_tls_config_params.crypto_provider,
+        }
+    }
+
+    pub(crate) fn new_default(secret_key: SecretKey, max_tls_tickets: usize) -> Self {
+        let cert_resolver = Arc::new(
+            ResolveRawPublicKeyCert::new(&secret_key).expect("Client cert key DER is valid; qed"),
+        );
+
+        let session_store = rustls::client::ClientSessionMemoryCache::new(max_tls_tickets);
+
+        let endpoint_tls_config_params = EndpointTlsConfigParams {
+            client_cert_resolver: cert_resolver.clone(),
+            server_cert_resolver: cert_resolver,
             server_verifier: Arc::new(verifier::ServerCertificateVerifier),
             client_verifier: Arc::new(verifier::ClientCertificateVerifier),
-            session_store: Arc::new(rustls::client::ClientSessionMemoryCache::new(
-                max_tls_tickets,
-            )),
-            secret_key,
-        }
+            session_store: Arc::new(session_store),
+            crypto_provider: Arc::new(rustls::crypto::ring::default_provider()),
+        };
+
+        Self::new(secret_key, endpoint_tls_config_params)
     }
 
     /// Create a TLS client configuration.
@@ -68,12 +121,12 @@ impl TlsConfig {
         alpn_protocols: Vec<Vec<u8>>,
         keylog: bool,
     ) -> QuicClientConfig {
-        let mut crypto = rustls::ClientConfig::builder_with_provider(default_provider())
+        let mut crypto = rustls::ClientConfig::builder_with_provider(self.crypto_provider.clone())
             .with_protocol_versions(verifier::PROTOCOL_VERSIONS)
             .expect("version supported by ring")
             .dangerous()
             .with_custom_certificate_verifier(self.server_verifier.clone())
-            .with_client_cert_resolver(self.cert_resolver.clone());
+            .with_client_cert_resolver(self.client_cert_resolver.clone());
         crypto.alpn_protocols = alpn_protocols;
 
         // TODO: enable/disable 0-RTT/storing tickets
@@ -100,13 +153,11 @@ impl TlsConfig {
         alpn_protocols: Vec<Vec<u8>>,
         keylog: bool,
     ) -> QuicServerConfig {
-        let mut crypto = rustls::ServerConfig::builder_with_provider(Arc::new(
-            rustls::crypto::ring::default_provider(),
-        ))
-        .with_protocol_versions(verifier::PROTOCOL_VERSIONS)
-        .expect("fixed config")
-        .with_client_cert_verifier(self.client_verifier.clone())
-        .with_cert_resolver(self.cert_resolver.clone());
+        let mut crypto = rustls::ServerConfig::builder_with_provider(self.crypto_provider.clone())
+            .with_protocol_versions(verifier::PROTOCOL_VERSIONS)
+            .expect("fixed config")
+            .with_client_cert_verifier(self.client_verifier.clone())
+            .with_cert_resolver(self.server_cert_resolver.clone());
         crypto.alpn_protocols = alpn_protocols;
         if keylog {
             warn!("enabling SSLKEYLOGFILE for TLS pre-master keys");

--- a/iroh/src/tls.rs
+++ b/iroh/src/tls.rs
@@ -93,9 +93,7 @@ impl TlsConfig {
     }
 
     pub(crate) fn new_default(secret_key: SecretKey, max_tls_tickets: usize) -> Self {
-        let cert_resolver = Arc::new(
-            ResolveRawPublicKeyCert::new(&secret_key).expect("Client cert key DER is valid; qed"),
-        );
+        let cert_resolver = Arc::new(ResolveRawPublicKeyCert::new(&secret_key));
 
         let session_store = rustls::client::ClientSessionMemoryCache::new(max_tls_tickets);
 


### PR DESCRIPTION
## Description

Enable customization of endpoint TLS configuration for QUIC connections

## Breaking Changes

There are no breaking changes, endpoints will be configured identically, and no change have been made to the endpoint setup process

## Notes & open questions

This PR significantly improves connecting configuration customization, without changing the current user experience in any material way

## Change checklist
<!-- Remove any that are not relevant. -->
- [X] Self-review.
