### PR TITLE
feat(iroh): proper span for endpoints

### DIFF
--- a/iroh/examples/echo.rs
+++ b/iroh/examples/echo.rs
@@ -21,6 +21,7 @@ const ALPN: &[u8] = b"iroh-example/echo/0";
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
     let router = start_accept_side().await?;
 
     // wait for the endpoint to be online

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -26,7 +26,7 @@ use n0_watcher::Watcher;
 use netdev::ipnet::{Ipv4Net, Ipv6Net};
 use pin_project::pin_project;
 use tokio_util::sync::WaitForCancellationFutureOwned;
-use tracing::{debug, instrument, trace, warn};
+use tracing::{Instrument, Span, debug, info_span, instrument, warn};
 use url::Url;
 
 use self::hooks::EndpointHooksList;
@@ -190,6 +190,9 @@ impl Builder {
             .secret_key
             .unwrap_or_else(move || SecretKey::generate(&mut rng));
 
+        let span = info_span!("endpoint", id = %secret_key.public().fmt_short());
+        let _guard = span.enter();
+
         let static_config = StaticConfig {
             transport_config: self.transport_config.clone(),
             tls_config: tls::TlsConfig::new(secret_key.clone(), self.max_tls_tickets),
@@ -222,9 +225,14 @@ impl Builder {
             static_config,
         };
 
-        let inner = socket::Socket::spawn(sock_opts).await?;
-        trace!("created socket");
-        debug!(version = env!("CARGO_PKG_VERSION"), "iroh Endpoint created");
+        let inner = socket::EndpointInner::bind(sock_opts)
+            .instrument(Span::current())
+            .await?;
+        debug!(
+            id = %inner.static_config.tls_config.secret_key.public(),
+            iroh_version = %env!("CARGO_PKG_VERSION"),
+            "iroh endpoint created"
+        );
 
         let ep = Endpoint {
             inner: Arc::new(inner),
@@ -860,7 +868,7 @@ impl Endpoint {
     #[instrument(name = "connect", skip_all, fields(
         me = %self.id().fmt_short(),
         remote = tracing::field::Empty,
-        alpn = String::from_utf8_lossy(alpn).to_string(),
+        alpn = %String::from_utf8_lossy(alpn).to_string(),
     ))]
     pub async fn connect_with_opts(
         &self,
@@ -871,21 +879,22 @@ impl Endpoint {
         if self.is_closed() {
             return Err(e!(ConnectWithOptsError::EndpointClosed));
         }
+
         let endpoint_addr: EndpointAddr = endpoint_addr.into();
+        let endpoint_id = endpoint_addr.id;
+
+        Span::current().record("remote", tracing::field::display(endpoint_id.fmt_short()));
+
         if let BeforeConnectOutcome::Reject =
             self.inner.hooks.before_connect(&endpoint_addr, alpn).await
         {
             return Err(e!(ConnectWithOptsError::LocallyRejected));
         }
-        let endpoint_id = endpoint_addr.id;
-
-        tracing::Span::current().record("remote", tracing::field::display(endpoint_id.fmt_short()));
 
         // Connecting to ourselves is not supported.
         ensure!(endpoint_id != self.id(), ConnectWithOptsError::SelfConnect);
 
-        trace!(
-            dst_endpoint_id = %endpoint_id.fmt_short(),
+        debug!(
             relay_url = ?endpoint_addr.relay_urls().next().cloned(),
             ip_addresses = ?endpoint_addr.ip_addrs().cloned().collect::<Vec<_>>(),
             "connecting",

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -231,7 +231,7 @@ impl Builder {
         debug!(
             id = %inner.static_config.tls_config.secret_key.public(),
             iroh_version = %env!("CARGO_PKG_VERSION"),
-            "iroh endpoint created"
+            "iroh endpoint bound"
         );
 
         let ep = Endpoint {

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -3342,7 +3342,8 @@ mod tests {
         // so we resort to log assertions.
         // TODO(Frando): Replace once we add a proper API for this.
         let expected_log_line = format!(
-            "ep2:relay-actor:active-relay{{url={relay_url}}}:connected: iroh::_events::relay::connected"
+            "ep2:endpoint{{id={}}}:relay-actor:active-relay{{url={relay_url}}}:connected: iroh::_events::relay::connected",
+            ep2.id().fmt_short()
         );
         tokio::time::timeout(Duration::from_secs(5), async {
             while !logs_contain(&expected_log_line) {

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -402,8 +402,8 @@ impl Client {
         self.add_report_history_and_set_preferred_relay(&mut report);
         debug!(
             ?report,
-            "generated report in {:02}ms",
-            now.elapsed().as_millis()
+            duration = ?now.elapsed(),
+            "net_report generated",
         );
 
         report
@@ -474,7 +474,7 @@ impl Client {
         let relays = self.relay_map.relays::<Vec<_>>();
         for relay in relays.into_iter().take(MAX_RELAYS) {
             if if_state.have_v4 && needs_v4_probe {
-                debug!(?relay.url, "v4 QAD probe");
+                trace!(?relay.url, "v4 QAD probe starting");
                 let relay = relay.clone();
                 let dns_resolver = self.socket_state.dns_resolver.clone();
                 let quic_client = quic_client.clone();
@@ -491,7 +491,7 @@ impl Client {
                 );
             }
             if if_state.have_v6 && needs_v6_probe {
-                debug!(?relay.url, "v6 QAD probe");
+                trace!(?relay.url, "v6 QAD probe starting");
                 let relay = relay.clone();
                 let dns_resolver = self.socket_state.dns_resolver.clone();
                 let quic_client = quic_client.clone();

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -409,7 +409,7 @@ impl Actor {
                         "run-probe",
                         ?proto,
                         ?delay,
-                        ?relay,
+                        relay=%relay.url,
                     )),
                 );
             }
@@ -511,7 +511,7 @@ impl Probe {
         }
         debug!("starting probe");
 
-        match self {
+        let report = match self {
             Probe::Https => {
                 match run_https_probe(
                     #[cfg(not(wasm_browser))]
@@ -528,7 +528,9 @@ impl Probe {
             }
             #[cfg(not(wasm_browser))]
             Probe::QadIpv4 | Probe::QadIpv6 => unreachable!("must not be used"),
-        }
+        };
+        debug!(?report, "probe finished");
+        report
     }
 }
 

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -249,7 +249,7 @@ impl Actor {
 
                         // If all probes are done & we have_udp cancel captive
                         if num_probes == 0 {
-                            debug!("all regular probes done");
+                            trace!("all regular probes done");
                             debug_assert!(probes.len() <= 1, "{} probes", probes.len());
 
                             if have_udp {
@@ -509,7 +509,7 @@ impl Probe {
             trace!("delaying probe");
             time::sleep(delay).await;
         }
-        debug!("starting probe");
+        trace!("starting probe");
 
         let report = match self {
             Probe::Https => {
@@ -579,7 +579,7 @@ async fn check_captive_portal(
         None => {
             let urls: Vec<_> = dm.urls();
             if urls.is_empty() {
-                debug!("No suitable relay for captive portal check");
+                trace!("No suitable relay for captive portal check");
                 return Ok(false);
             }
 
@@ -630,7 +630,7 @@ async fn check_captive_portal(
         .map(|s| s.to_str().unwrap_or_default())
         == Some(&expected_response);
 
-    debug!(
+    trace!(
         "check_captive_portal url={} status_code={} valid_response={}",
         res.url(),
         res.status(),

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -45,7 +45,7 @@ use tokio::sync::{
     oneshot,
 };
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
-use tracing::{Instrument, Level, debug, event, info_span, instrument, trace, warn};
+use tracing::{Instrument, Level, Span, debug, event, info_span, instrument, trace, warn};
 use transports::{LocalAddrsWatch, Transport, TransportConfig};
 use url::Url;
 
@@ -264,6 +264,8 @@ impl ShutdownState {
 /// It is usually only necessary to use a single [`Socket`] instance in an application, it
 /// means any QUIC endpoints on top will be sharing as much information about endpoints as
 /// possible.
+///
+/// To create a [`Socket`] use [`EndpointInner::new`], there's no direct constructor.
 #[derive(Debug)]
 pub(crate) struct Socket {
     /// Channels for sending time-crucial messages to `RemoteStateActors`.
@@ -307,14 +309,11 @@ pub(crate) struct Socket {
     /// Metrics
     pub(crate) metrics: EndpointMetrics,
     pub(crate) hooks: EndpointHooksList,
+    /// Tracing span for this endpoint.
+    pub(crate) span: Span,
 }
 
 impl Socket {
-    /// Creates a [`Socket`] listening.
-    pub(crate) async fn spawn(opts: Options) -> Result<EndpointInner, BindError> {
-        EndpointInner::new(opts).await
-    }
-
     /// Returns the relay endpoint we are connected to, that has the best latency.
     ///
     /// If `None`, then we are not connected to any relay endpoints.
@@ -755,8 +754,13 @@ pub enum BindError {
 }
 
 impl EndpointInner {
-    /// Creates a [`Socket`].
-    async fn new(opts: Options) -> Result<Self, BindError> {
+    /// Creates a [`EndpointInner`].
+    pub(crate) async fn bind(opts: Options) -> Result<Self, BindError> {
+        // Use the current span as the main span for all tasks spawned in this endpoint.
+        // `EndpointInner::bind` is not public and only called from `crate::endpoint::Builder::bind`,
+        // which instruments the call with a span created for this purpose.
+        let span = tracing::Span::current();
+
         let Options {
             secret_key,
             transports: transport_configs,
@@ -857,11 +861,11 @@ impl EndpointInner {
 
         let remote_map = {
             RemoteMap::new(
-                secret_key.public(),
                 metrics.socket.clone(),
                 direct_addrs.addrs.watch(),
                 address_lookup.clone(),
                 shutdown_token.child_token(),
+                span.clone(),
             )
         };
 
@@ -884,6 +888,7 @@ impl EndpointInner {
             ip_bind_addrs: transports.ip_bind_addrs(),
             tls_config: tls_config.clone(),
             hooks,
+            span: span.clone(),
         });
 
         let mut endpoint_config = quinn::EndpointConfig::default();
@@ -974,7 +979,7 @@ impl EndpointInner {
                     shutdown_token.child_token(),
                     local_addrs_watch,
                 )
-                .instrument(info_span!("actor")),
+                .instrument(info_span!(parent: span, "actor")),
         );
 
         let actor_task = Mutex::new(Some(AbortOnDropHandle::new(actor_task)));
@@ -1001,7 +1006,7 @@ impl EndpointInner {
     /// after this call.
     ///
     /// [`Poll::Pending`]: std::task::Poll::Pending
-    #[instrument(skip_all)]
+    #[instrument(skip_all, parent = self.sock.span.clone())]
     pub(crate) async fn close(&self) {
         if self.sock.is_closed() || self.sock.is_closing() {
             return;
@@ -1751,7 +1756,7 @@ mod tests {
         dns::DnsResolver,
         endpoint::QuicTransportConfig,
         socket::{
-            EndpointInner, Socket, StaticConfig, TransportConfig,
+            EndpointInner, StaticConfig, TransportConfig,
             mapped_addrs::{EndpointIdMappedAddr, MappedAddr},
         },
         tls::{self, DEFAULT_MAX_TLS_TICKETS},
@@ -2134,7 +2139,9 @@ mod tests {
     #[traced_test]
     async fn test_direct_addresses() {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
-        let sock = EndpointInner::new(default_options(&mut rng)).await.unwrap();
+        let sock = EndpointInner::bind(default_options(&mut rng))
+            .await
+            .unwrap();
 
         // See if we can get endpoints.
         let eps0 = sock.ip_addrs().get();
@@ -2180,7 +2187,7 @@ mod tests {
             hooks: Default::default(),
             static_config,
         };
-        let sock = Socket::spawn(opts).await?;
+        let sock = EndpointInner::bind(opts).await?;
         Ok(sock)
     }
 

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -11,7 +11,7 @@ use n0_future::task::JoinSet;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error};
+use tracing::{Span, debug, error};
 
 pub(crate) use self::remote_state::PathWatchable;
 use self::remote_state::RemoteStateActor;
@@ -76,8 +76,6 @@ struct Tasks {
     //
     // State required for spawning new actors.
     //
-    /// The endpoint ID of the local endpoint.
-    local_endpoint_id: EndpointId,
     metrics: Arc<SocketMetrics>,
     /// The "direct" addresses known for our local endpoint
     local_direct_addrs: n0_watcher::Direct<BTreeSet<DirectAddr>>,
@@ -94,28 +92,30 @@ struct Tasks {
     tasks: JoinSet<(EndpointId, Vec<RemoteStateMessage>)>,
     /// The waker that notifies `poll_cleanup` when the join set is populated with another task.
     poll_cleanup_waker: Option<Waker>,
+    /// The tracing span for this endpoint, to be used as parent span for `RemoteStateActor` tasks.
+    span: Span,
 }
 
 impl RemoteMap {
     /// Creates a new [`RemoteMap`].
     pub(super) fn new(
-        local_endpoint_id: EndpointId,
         metrics: Arc<SocketMetrics>,
         local_direct_addrs: n0_watcher::Direct<BTreeSet<DirectAddr>>,
         address_lookup: address_lookup::ConcurrentAddressLookup,
         shutdown_token: CancellationToken,
+        span: Span,
     ) -> Self {
         Self {
             mapped_addrs: Default::default(),
             senders: Default::default(),
             tasks: Tasks {
-                local_endpoint_id,
                 metrics,
                 local_direct_addrs,
                 address_lookup,
                 shutdown_token,
                 tasks: Default::default(),
                 poll_cleanup_waker: None,
+                span,
             },
         }
     }
@@ -263,13 +263,17 @@ impl Tasks {
         mapped_addrs.endpoint_addrs.get(&eid);
         let sender = RemoteStateActor::new(
             eid,
-            self.local_endpoint_id,
             self.local_direct_addrs.clone(),
             mapped_addrs.relay_addrs.clone(),
             self.metrics.clone(),
             self.address_lookup.clone(),
         )
-        .start(initial_msgs, &mut self.tasks, self.shutdown_token.clone());
+        .start(
+            initial_msgs,
+            &mut self.tasks,
+            self.shutdown_token.clone(),
+            self.span.clone(),
+        );
         if let Some(waker) = self.poll_cleanup_waker.take() {
             // Notify something waiting for changes to tasks when there's a new task.
             waker.wake();

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -499,7 +499,7 @@ impl RemoteStateActor {
                     remote = %self.endpoint_id.fmt_short(),
                     ?path_remote,
                     ?path_status,
-                    ?conn_id,
+                    %conn_id,
                     path_id = %PathId::ZERO,
                     ?res,
                 );
@@ -823,7 +823,7 @@ impl RemoteStateActor {
                     remote = %self.endpoint_id.fmt_short(),
                     ?open_addr,
                     ?path_status,
-                    ?conn_id,
+                    %conn_id,
                     %path_id,
                     ?res,
                 );
@@ -835,7 +835,7 @@ impl RemoteStateActor {
             let fut = conn.open_path_ensure(quic_addr, path_status);
             match fut.path_id() {
                 Some(path_id) => {
-                    trace!(?conn_id, %path_id, ?path_status, "opening new path");
+                    trace!(%conn_id, %path_id, ?path_status, "opening new path");
                     // Just like in the PATH_STATUS comment above, we need to make sure that the
                     // path status is set correctly, even if the path already existed.
                     if let Some(path) = conn.path(path_id) {
@@ -846,7 +846,7 @@ impl RemoteStateActor {
                             remote = %self.endpoint_id.fmt_short(),
                             ?open_addr,
                             ?path_status,
-                            ?conn_id,
+                            %conn_id,
                             %path_id,
                             ?res,
                         );
@@ -907,7 +907,7 @@ impl RemoteStateActor {
                         Level::DEBUG,
                         remote = %self.endpoint_id.fmt_short(),
                         ?path_remote,
-                        ?conn_id,
+                        %conn_id,
                         %path_id,
                     );
                     conn_state.add_open_path(path_remote.clone(), path_id, &self.metrics);
@@ -931,7 +931,7 @@ impl RemoteStateActor {
                     Level::DEBUG,
                     remote = %self.endpoint_id.fmt_short(),
                     ?path_remote,
-                    ?conn_id,
+                    %conn_id,
                     path_id = ?id,
                 );
 
@@ -944,11 +944,11 @@ impl RemoteStateActor {
                         continue;
                     };
                     if let Some(path) = conn.path(*path_id) {
-                        trace!(?path_remote, ?conn_id, %path_id, "closing path");
+                        trace!(?path_remote, %conn_id, %path_id, "closing path");
                         if let Err(err) = path.close() {
                             trace!(
                                 ?path_remote,
-                                ?conn_id,
+                                %conn_id,
                                 %path_id,
                                 "path close failed: {err:#}"
                             );
@@ -1076,7 +1076,7 @@ impl RemoteStateActor {
                     .filter(|conn| conn.side().is_client())
                     .and_then(|conn| conn.path(*path_id))
                 {
-                    trace!(?path_remote, ?conn_id, %path_id, "closing direct path");
+                    trace!(?path_remote, %conn_id, %path_id, "closing direct path");
                     match path.close() {
                         Err(quinn_proto::ClosePathError::MultipathNotNegotiated) => {
                             error!("multipath not negotiated");
@@ -1269,7 +1269,8 @@ struct HolepunchAttempt {
 ///
 /// The wrapped value is the [`quinn::Connection::stable_id`] value, and is thus only valid
 /// for active connections.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::Display)]
+#[display("{_0}")]
 struct ConnId(usize);
 
 /// State about one connection.

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -22,7 +22,7 @@ use sync_wrapper::SyncStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, Level, debug, error, event, info_span, instrument, trace, warn};
+use tracing::{Instrument, Level, Span, debug, error, event, info_span, instrument, trace, warn};
 
 use self::path_state::RemotePathState;
 pub(crate) use self::path_watcher::PathWatchable;
@@ -130,8 +130,6 @@ type AddressLookupStream = Either<
 pub(super) struct RemoteStateActor {
     /// The endpoint ID of the remote endpoint.
     endpoint_id: EndpointId,
-    /// The endpoint ID of the local endpoint.
-    local_endpoint_id: EndpointId,
 
     // Hooks into the rest of the Socket.
     //
@@ -195,7 +193,6 @@ impl RemoteStateActor {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         endpoint_id: EndpointId,
-        local_endpoint_id: EndpointId,
         local_direct_addrs: n0_watcher::Direct<BTreeSet<DirectAddr>>,
         relay_mapped_addrs: AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
         metrics: Arc<SocketMetrics>,
@@ -203,7 +200,6 @@ impl RemoteStateActor {
     ) -> Self {
         Self {
             endpoint_id,
-            local_endpoint_id,
             metrics: metrics.clone(),
             local_direct_addrs,
             relay_mapped_addrs,
@@ -227,9 +223,9 @@ impl RemoteStateActor {
         initial_msgs: Vec<RemoteStateMessage>,
         tasks: &mut JoinSet<(EndpointId, Vec<RemoteStateMessage>)>,
         shutdown_token: CancellationToken,
+        parent_span: Span,
     ) -> mpsc::Sender<RemoteStateMessage> {
         let (tx, rx) = mpsc::channel(16);
-        let me = self.local_endpoint_id;
         let endpoint_id = self.endpoint_id;
 
         // Ideally we'd use the endpoint span as parent.  We'd have to plug that span into
@@ -240,9 +236,8 @@ impl RemoteStateActor {
         tasks.spawn(
             self.run(initial_msgs, rx, shutdown_token)
                 .instrument(info_span!(
-                    parent: None,
+                    parent: parent_span,
                     "RemoteStateActor",
-                    me = %me.fmt_short(),
                     remote = %endpoint_id.fmt_short(),
                 )),
         );

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -431,7 +431,7 @@ pub(crate) struct Transmit<'a> {
 }
 
 impl<'a> Transmit<'a> {
-    pub(crate) fn datagram_count(&self) -> usize {
+    fn datagram_count(&self) -> usize {
         match self.segment_size {
             None => 1,
             Some(size) => self.contents.len().div_ceil(size),

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -430,6 +430,15 @@ pub(crate) struct Transmit<'a> {
     pub(crate) segment_size: Option<usize>,
 }
 
+impl<'a> Transmit<'a> {
+    pub(crate) fn datagram_count(&self) -> usize {
+        match self.segment_size {
+            None => 1,
+            Some(size) => self.contents.len().div_ceil(size),
+        }
+    }
+}
+
 /// An outgoing packet that can be sent across channels.
 #[derive(Debug, Clone)]
 pub(crate) struct OwnedTransmit {
@@ -827,9 +836,17 @@ impl quinn::UdpSender for Sender {
             .sender
             .poll_send(cx, &transport_addr, quinn_transmit.src_ip, &transmit)
         {
-            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Ready(Ok(())) => {
+                trace!(
+                    dst = ?transport_addr,
+                    len = transmit.contents.len(),
+                    datagram_count = transmit.datagram_count(),
+                    "sent transmit"
+                );
+                Poll::Ready(Ok(()))
+            }
             Poll::Ready(Err(ref err)) => {
-                warn!(?transport_addr, "dropped transmit: {err:#}");
+                warn!(dst=?transport_addr, "dropped transmit: {err:#}");
                 Poll::Ready(Ok(()))
             }
             Poll::Pending => {
@@ -837,7 +854,7 @@ impl quinn::UdpSender for Sender {
                 // different transport.  Instead we let Quinn handle this as a lost
                 // datagram.
                 // TODO: Revisit this: we might want to do something better.
-                trace!(?transport_addr, "transport pending, dropped transmit");
+                trace!(dst=?transport_addr, "transport pending, dropped transmit");
                 Poll::Ready(Ok(()))
             }
         }


### PR DESCRIPTION
## Description

* Adds a `endpoint{id=id_short}` info-level span when binding the endpoint
* Use this span as parent span for RemoteStateActor tasks and the main socket actor
* Alter a few logging statements here and there that stood out while taking a good look at debug logs for the echo example. There's still more work here of course.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
