### PR TITLE
deps: Remove process and signal tokio features

### DIFF
--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -104,8 +104,6 @@ tokio = { version = "1", features = [
     "net",
     "fs",
     "io-std",
-    "signal",
-    "process",
 ] }
 tokio-websockets = { version = "0.12", features = ["rustls-bring-your-own-connector", "ring", "getrandom", "rand", "client"] }
 
@@ -142,6 +140,7 @@ default = ["metrics"]
 platform-verifier = ["dep:rustls-platform-verifier"]
 server = [
     "metrics",
+    "tokio/signal",
     "dep:clap",
     "dep:dashmap",
     "dep:ahash",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -90,8 +90,6 @@ tokio = { version = "1", features = [
     "net",
     "fs",
     "io-std",
-    "signal",
-    "process",
 ] }
 
 # wasm-in-browser dependencies


### PR DESCRIPTION
## Description

They are not needed except for the binary, and especially signal pulls in some stuff that causes trouble on some weird platforms.

## Breaking Changes

None? I mean strictly speaking we could break a build since we now have fewer tokio features. But is that considered breaking?

## Notes & open questions

Note: this is fallout from my (successful) attempt to get iroh to run on an ESP32.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
