### PR TITLE
deps: Prefer portable_atomic over native AtomicU64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
  "pin-project",
  "pkarr",
  "pkcs8",
+ "portable-atomic",
  "portmapper",
  "postcard",
  "pretty_assertions",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -35,6 +35,7 @@ n0-watcher = "0.6"
 netwatch = { version = "0.14" }
 papaya = { version = "0.2.3", default-features = false }
 pin-project = "1"
+portable-atomic = "1"
 pkarr = { version = "5", default-features = false, features = ["relays"] }
 quinn = { package = "noq", version = "0.16.1", default-features = false, features = ["rustls-ring"] }
 quinn-proto = { package = "noq-proto", version = "0.15.1" }

--- a/iroh/src/runtime.rs
+++ b/iroh/src/runtime.rs
@@ -1,9 +1,7 @@
-use std::{
-    pin::Pin,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::pin::Pin;
 
 use iroh_base::EndpointId;
+use portable_atomic::{AtomicU64, Ordering};
 use tokio_util::sync::CancellationToken;
 #[cfg(not(wasm_browser))]
 use tokio_util::task::TaskTracker;

--- a/iroh/src/socket/mapped_addrs.rs
+++ b/iroh/src/socket/mapped_addrs.rs
@@ -8,14 +8,12 @@ use std::{
     fmt,
     hash::Hash,
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::Arc,
 };
 
 use iroh_base::{EndpointId, RelayUrl};
 use n0_error::{e, stack_error};
+use portable_atomic::{AtomicU64, Ordering};
 use rustc_hash::FxHashMap;
 use tracing::{error, trace};
 


### PR DESCRIPTION
## Description

On some 32 bit platforms there is no AtomicU64. Portable_atomic uses the underlying atomic on 64 bit platforms, so there is no perf overhead on those.

We already have portable_atomic in the deps, from moka and once_cell. So there is no additional dependency cost.

This is needed to get iroh to work on 32 bit platforms without native support for AtomicU64. 

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
