### PR TITLE
fix(example): always close the endpoint

### DIFF
--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -744,8 +744,9 @@ async fn fetch(
         duration: start.elapsed(),
     });
 
-    // stats are collected by the paths watcher. this just works around our miserable api to
-    // give us a reliable way to tell us when the stats will stop changing or something.
+    // Stats are collected by the paths watcher, so we do not look at the stats returned by
+    // this call. It is however the only API we currently have to tell us when the
+    // connection is drained and the stats will no longer change.
     conn_info.closed().await;
     output.emit(PathStats::from_watcher(watcher));
 


### PR DESCRIPTION
## Description

Even if there's an error we want to gracefully close the endpoint.

I also added some extra logging.

## Breaking Changes

n/a

## Notes & open questions

Look, this is the code we're making everyone write now.

I appreciate this is just a quick fix, I did not check out the full structure of the example and try to organise it as nicely as possible. So this probably increases technical debt of this example a bit more.

## Change checklist

- [x] Self-review.