### PR TITLE
fix: increase DNS timeout and address lookup stagger intervals

### DIFF
--- a/iroh-relay/src/defaults.rs
+++ b/iroh-relay/src/defaults.rs
@@ -30,8 +30,11 @@ pub mod timeouts {
     /// Timeout used by the relay client while connecting to the relay server,
     /// using `TcpStream::connect`
     pub(crate) const DIAL_ENDPOINT_TIMEOUT: Duration = Duration::from_millis(1500);
-    /// Timeout for our async dns resolver
-    pub(crate) const DNS_TIMEOUT: Duration = Duration::from_secs(1);
+
+    /// Default timeout for DNS queries issued by [`DnsResolver`].
+    ///
+    /// [`DnsResolver`]: crate::dns::DnsResolver
+    pub(crate) const DNS_TIMEOUT: Duration = Duration::from_secs(3);
 
     /// Maximum time the server will attempt to get a successful write to the connection.
     #[cfg(feature = "server")]

--- a/iroh-relay/src/defaults.rs
+++ b/iroh-relay/src/defaults.rs
@@ -34,7 +34,7 @@ pub mod timeouts {
     /// Default timeout for DNS queries issued by [`DnsResolver`].
     ///
     /// [`DnsResolver`]: crate::dns::DnsResolver
-    pub(crate) const DNS_TIMEOUT: Duration = Duration::from_secs(3);
+    pub const DNS_TIMEOUT: Duration = Duration::from_secs(3);
 
     /// Maximum time the server will attempt to get a successful write to the connection.
     #[cfg(feature = "server")]

--- a/iroh-relay/src/defaults.rs
+++ b/iroh-relay/src/defaults.rs
@@ -34,7 +34,7 @@ pub mod timeouts {
     /// Default timeout for DNS queries issued by [`DnsResolver`].
     ///
     /// [`DnsResolver`]: crate::dns::DnsResolver
-    pub const DNS_TIMEOUT: Duration = Duration::from_secs(3);
+    pub(crate) const DNS_TIMEOUT: Duration = Duration::from_secs(3);
 
     /// Maximum time the server will attempt to get a successful write to the connection.
     #[cfg(feature = "server")]

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -36,9 +36,9 @@ use crate::{
 };
 
 /// The n0 address lookup DNS origin, for production.
-pub const N0_DNS_ENDPOINT_ORIGIN_PROD: &str = "dns.iroh.link";
+pub const N0_DNS_ENDPOINT_ORIGIN_PROD: &str = "dns.iroh.link.";
 /// The n0 address lookup DNS origin, for testing.
-pub const N0_DNS_ENDPOINT_ORIGIN_STAGING: &str = "staging-dns.iroh.link";
+pub const N0_DNS_ENDPOINT_ORIGIN_STAGING: &str = "staging-dns.iroh.link.";
 
 /// Percent of total delay to jitter. 20 means +/- 20% of delay.
 const MAX_JITTER_PERCENT: u64 = 20;
@@ -583,6 +583,7 @@ impl HickoryResolver {
 
         // see [`DnsResolver::lookup_ipv4_ipv6`] for info on why we avoid `LookupIpStrategy::Ipv4AndIpv6`
         options.ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv4thenIpv6;
+        options.negative_max_ttl = Some(Duration::ZERO);
 
         let mut hickory_builder =
             TokioResolver::builder_with_config(config, TokioConnectionProvider::default());

--- a/iroh/src/address_lookup/dns.rs
+++ b/iroh/src/address_lookup/dns.rs
@@ -4,6 +4,7 @@ use iroh_base::EndpointId;
 use iroh_relay::dns::DnsResolver;
 pub use iroh_relay::dns::{N0_DNS_ENDPOINT_ORIGIN_PROD, N0_DNS_ENDPOINT_ORIGIN_STAGING};
 use n0_future::boxed::BoxStream;
+use tracing::{Instrument, debug, debug_span, trace};
 
 use crate::{
     Endpoint,
@@ -14,7 +15,13 @@ use crate::{
     endpoint::force_staging_infra,
 };
 
-pub(crate) const DNS_STAGGERING_MS: &[u64] = &[200, 300];
+/// Delays after which additional DNS lookup calls are issued.
+///
+/// Each query has its own timeout, which is 3s (see [`DNS_TIMEOUT`]).
+/// This means that a lookup will finally abort after 6 seconds.
+///
+/// [`DNS_TIMEOUT`]: iroh_relay::defaults::timeouts::DNS_TIMEOUT
+pub(crate) const DNS_STAGGERING_MS: &[u64] = &[200, 300, 600, 1000, 2000, 3000];
 
 /// DNS endpoint discovery
 ///
@@ -114,13 +121,18 @@ impl AddressLookup for DnsAddressLookup {
     ) -> Option<BoxStream<Result<AddressLookupItem, AddressLookupError>>> {
         let resolver = self.dns_resolver.clone();
         let origin_domain = self.origin_domain.clone();
+        let span = debug_span!("DnsAddressLookup", id=%endpoint_id.fmt_short(), %origin_domain);
         let fut = async move {
+            trace!("starting DNS lookup");
             let endpoint_info = resolver
                 .lookup_endpoint_by_id_staggered(&endpoint_id, &origin_domain, DNS_STAGGERING_MS)
                 .await
+                .inspect_err(|err| debug!("DNS lookup failed: {err:#}"))
                 .map_err(|e| AddressLookupError::from_err_any("dns", e))?;
+            debug!(info=?endpoint_info, "DNS lookup success");
             Ok(AddressLookupItem::new(endpoint_info, "dns", None))
-        };
+        }
+        .instrument(span);
         let stream = n0_future::stream::once_future(fut);
         Some(Box::pin(stream))
     }

--- a/iroh/src/address_lookup/dns.rs
+++ b/iroh/src/address_lookup/dns.rs
@@ -17,10 +17,8 @@ use crate::{
 
 /// Delays after which additional DNS lookup calls are issued.
 ///
-/// Each query has its own timeout, which is 3s (see [`DNS_TIMEOUT`]).
-/// This means that a lookup will finally abort after 6 seconds.
-///
-/// [`DNS_TIMEOUT`]: iroh_relay::defaults::timeouts::DNS_TIMEOUT
+/// Each query has its own timeout of 3s. This means that a lookup will finally
+/// abort after 6 seconds.
 pub(crate) const DNS_STAGGERING_MS: &[u64] = &[200, 300, 600, 1000, 2000, 3000];
 
 /// DNS endpoint discovery
@@ -121,7 +119,8 @@ impl AddressLookup for DnsAddressLookup {
     ) -> Option<BoxStream<Result<AddressLookupItem, AddressLookupError>>> {
         let resolver = self.dns_resolver.clone();
         let origin_domain = self.origin_domain.clone();
-        let span = debug_span!("DnsAddressLookup", id=%endpoint_id.fmt_short(), %origin_domain);
+        let span =
+            debug_span!("DnsAddressLookup", lookup_id=%endpoint_id.fmt_short(), %origin_domain);
         let fut = async move {
             trace!("starting DNS lookup");
             let endpoint_info = resolver

--- a/iroh/src/address_lookup/pkarr.rs
+++ b/iroh/src/address_lookup/pkarr.rs
@@ -71,7 +71,7 @@ use pkarr::{
     SignedPacket,
     errors::{PublicKeyError, SignedPacketVerifyError},
 };
-use tracing::{Instrument, debug, error_span, warn};
+use tracing::{Instrument, debug, error_span, trace, warn};
 use url::Url;
 
 #[cfg(not(wasm_browser))]
@@ -390,7 +390,7 @@ impl PublisherService {
                             "Failed to publish to pkarr",
                         );
                     }
-                    _ => {
+                    Ok(()) => {
                         failed_attempts = 0;
                         // Republish after fixed interval
                         republish
@@ -414,12 +414,17 @@ impl PublisherService {
         debug!(
             data = ?info.data,
             pkarr_relay = %self.pkarr_client.pkarr_relay_url,
-            "Publish endpoint info to pkarr"
+            "Publishing endpoint info to pkarr"
         );
         let signed_packet = info
             .to_pkarr_signed_packet(&self.secret_key, self.ttl)
             .map_err(|err| e!(PkarrError::Encoding, err))?;
         self.pkarr_client.publish(&signed_packet).await?;
+        trace!(
+            data = ?info.data,
+            pkarr_relay = %self.pkarr_client.pkarr_relay_url,
+            "Published endpoint info to pkarr"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

* Increases DNS_TIMEOUT from 1s to 3s
* When looking up endpoint info via DnsAddressLookup, add more staggered calls up to 3s to not give up as quick as before
* Don't ever cache negative responses in our DNS resolver
* Slightly improve logging about DnsAddressLookup so we can debug more issues better.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
