### PR TITLE
feat(iroh): add tracing events for connections

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -26,7 +26,7 @@ use n0_error::{e, ensure, stack_error};
 use n0_watcher::Watcher;
 use pin_project::pin_project;
 use tokio_util::sync::WaitForCancellationFutureOwned;
-use tracing::{Instrument, Span, debug, info_span, instrument, warn};
+use tracing::{Instrument, Span, debug, event, info_span, instrument, warn};
 use url::Url;
 
 /// Types for defining custom transports
@@ -980,6 +980,13 @@ impl Endpoint {
 
         // Connecting to ourselves is not supported.
         ensure!(endpoint_id != self.id(), ConnectWithOptsError::SelfConnect);
+
+        event!(
+            target: "iroh::_events::conn::connecting",
+            tracing::Level::DEBUG,
+            remote_id = %endpoint_id.fmt_short(),
+            alpn = %String::from_utf8_lossy(alpn),
+        );
 
         debug!(
             relay_url = ?endpoint_addr.relay_urls().next().cloned(),

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -32,7 +32,7 @@ use n0_error::{e, stack_error};
 use n0_future::{TryFutureExt, future::Boxed as BoxFuture, time::Duration};
 use noq::WeakConnectionHandle;
 use pin_project::pin_project;
-use tracing::warn;
+use tracing::{event, warn};
 
 use crate::{
     Endpoint,
@@ -110,10 +110,18 @@ impl Future for Accept<'_> {
         match this.inner.poll(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(None) => Poll::Ready(None),
-            Poll::Ready(Some(inner)) => Poll::Ready(Some(Incoming {
-                inner,
-                ep: this.ep.clone(),
-            })),
+            Poll::Ready(Some(inner)) => {
+                let incoming = Incoming {
+                    inner,
+                    ep: this.ep.clone(),
+                };
+                event!(
+                    target: "iroh::_events::conn::incoming",
+                    tracing::Level::DEBUG,
+                    remote_addr = ?incoming.remote_addr(),
+                );
+                Poll::Ready(Some(incoming))
+            }
         }
     }
 }
@@ -310,6 +318,15 @@ fn conn_from_noq_conn(
             }
         }
     };
+
+    event!(
+        target: "iroh::_events::conn::connected",
+        tracing::Level::DEBUG,
+        conn_id = conn.stable_id(),
+        side = ?conn.side(),
+        remote_id = %info.endpoint_id.fmt_short(),
+        alpn = %String::from_utf8_lossy(&info.alpn),
+    );
 
     // Register this connection with the socket.
     let fut = ep

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -15,7 +15,7 @@ use n0_future::{
     time::{self, Duration, Instant},
 };
 use n0_watcher::{Watchable, Watcher};
-use noq::WeakConnectionHandle;
+use noq::{ConnectionError, WeakConnectionHandle};
 use noq_proto::{PathError, PathEvent, PathId, n0_nat_traversal};
 use rustc_hash::FxHashMap;
 use sync_wrapper::SyncStream;
@@ -308,8 +308,8 @@ impl RemoteStateActor {
                     trace!(?id, ?evt, "remote addrs updated, triggering holepunching");
                     self.trigger_holepunching();
                 }
-                Some(conn_id) = self.connections_close.next(), if !self.connections_close.is_empty() => {
-                    self.handle_connection_close(conn_id);
+                Some((conn_id, reason)) = self.connections_close.next(), if !self.connections_close.is_empty() => {
+                    self.handle_connection_close(conn_id, reason);
                 }
                 res = self.local_direct_addrs.updated() => {
                     if let Err(n0_watcher::Disconnected) = res {
@@ -568,7 +568,14 @@ impl RemoteStateActor {
             self.trigger_holepunching();
         }
     }
-    fn handle_connection_close(&mut self, conn_id: ConnId) {
+    fn handle_connection_close(&mut self, conn_id: ConnId, reason: ConnectionError) {
+        event!(
+            target: "iroh::_events::conn::closed",
+            Level::DEBUG,
+            %conn_id,
+            remote_id = %self.endpoint_id.fmt_short(),
+            ?reason,
+        );
         if self.connections.remove(&conn_id).is_some() {
             self.metrics.num_conns_closed.inc();
         }
@@ -1331,11 +1338,11 @@ impl OnClosed {
 }
 
 impl Future for OnClosed {
-    type Output = ConnId;
+    type Output = (ConnId, ConnectionError);
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let (_close_reason, _stats) = std::task::ready!(Pin::new(&mut self.inner).poll(cx));
-        Poll::Ready(self.conn_id)
+        let (close_reason, _stats) = std::task::ready!(Pin::new(&mut self.inner).poll(cx));
+        Poll::Ready((self.conn_id, close_reason))
     }
 }
 

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -568,6 +568,7 @@ impl RemoteStateActor {
             self.trigger_holepunching();
         }
     }
+
     fn handle_connection_close(&mut self, conn_id: ConnId, reason: ConnectionError) {
         event!(
             target: "iroh::_events::conn::closed",


### PR DESCRIPTION
## Description

This adds `iroh::_event::conn` events for incoming and outgoing connections. We already have path events, but no connection events, so this makes our event system more complete, and gives good context when reading `iroh::_events`.