### PR TITLE
refactor: Remove special fast path for hickory resolver

### DIFF
--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -556,7 +556,6 @@ impl HickoryResolver {
         }
         Ok((config, options))
     }
-
 }
 
 impl Resolver for HickoryResolver {
@@ -582,8 +581,11 @@ impl Resolver for HickoryResolver {
         let resolver = self.resolver.clone();
         Box::pin(async move {
             let lookup = resolver.txt_lookup(host).await?;
-            let iter: BoxIter<TxtRecordData> =
-                Box::new(lookup.into_iter().map(|txt| TxtRecordData::from_iter(txt.iter().cloned())));
+            let iter: BoxIter<TxtRecordData> = Box::new(
+                lookup
+                    .into_iter()
+                    .map(|txt| TxtRecordData::from_iter(txt.iter().cloned())),
+            );
             Ok(iter)
         })
     }

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -200,8 +200,7 @@ impl Builder {
 
     /// Builds the DNS resolver.
     pub fn build(self) -> DnsResolver {
-        let resolver = HickoryResolver::new(self);
-        DnsResolver(DnsResolverInner::Hickory(Arc::new(RwLock::new(resolver))))
+        DnsResolver(Arc::new(RwLock::new(HickoryResolver::new(self))))
     }
 }
 
@@ -212,7 +211,7 @@ impl Builder {
 /// Alternatively, you can create a fully custom DNS resolver by implementing the [`Resolver`]
 /// trait and creating the resolver with [`Self::custom`].
 #[derive(Debug, Clone)]
-pub struct DnsResolver(DnsResolverInner);
+pub struct DnsResolver(Arc<RwLock<dyn Resolver>>);
 
 impl DnsResolver {
     /// Creates a new DNS resolver with sensible cross-platform defaults.
@@ -242,17 +241,17 @@ impl DnsResolver {
     /// implement the [`Resolver`] trait on a struct and implement DNS resolution
     /// however you see fit.
     pub fn custom(resolver: impl Resolver) -> Self {
-        Self(DnsResolverInner::Custom(Arc::new(RwLock::new(resolver))))
+        Self(Arc::new(RwLock::new(resolver)))
     }
 
     /// Removes all entries from the cache.
     pub async fn clear_cache(&self) {
-        self.0.clear_cache().await
+        self.0.read().await.clear_cache()
     }
 
     /// Recreates the inner resolver.
     pub async fn reset(&self) {
-        self.0.reset().await
+        self.0.write().await.reset()
     }
 
     /// Looks up a TXT record.
@@ -262,7 +261,8 @@ impl DnsResolver {
         timeout: Duration,
     ) -> Result<impl Iterator<Item = TxtRecordData>, DnsError> {
         let host = host.to_string();
-        let res = time::timeout(timeout, self.0.lookup_txt(host)).await??;
+        let fut = self.0.read().await.lookup_txt(host);
+        let res = time::timeout(timeout, fut).await??;
         Ok(res)
     }
 
@@ -273,7 +273,8 @@ impl DnsResolver {
         timeout: Duration,
     ) -> Result<impl Iterator<Item = IpAddr> + use<T>, DnsError> {
         let host = host.to_string();
-        let addrs = time::timeout(timeout, self.0.lookup_ipv4(host)).await??;
+        let fut = self.0.read().await.lookup_ipv4(host);
+        let addrs = time::timeout(timeout, fut).await??;
         Ok(addrs.into_iter().map(IpAddr::V4))
     }
 
@@ -284,7 +285,8 @@ impl DnsResolver {
         timeout: Duration,
     ) -> Result<impl Iterator<Item = IpAddr> + use<T>, DnsError> {
         let host = host.to_string();
-        let addrs = time::timeout(timeout, self.0.lookup_ipv6(host)).await??;
+        let fut = self.0.read().await.lookup_ipv6(host);
+        let addrs = time::timeout(timeout, fut).await??;
         Ok(addrs.into_iter().map(IpAddr::V6))
     }
 
@@ -490,62 +492,6 @@ impl reqwest::dns::Resolve for DnsResolver {
     }
 }
 
-/// Wrapper enum that contains either a hickory resolver or a custom resolver.
-///
-/// We do this to save the cost of boxing the futures and iterators when using
-/// default hickory resolver.
-#[derive(Debug, Clone)]
-enum DnsResolverInner {
-    Hickory(Arc<RwLock<HickoryResolver>>),
-    Custom(Arc<RwLock<dyn Resolver>>),
-}
-
-impl DnsResolverInner {
-    async fn lookup_ipv4(
-        &self,
-        host: String,
-    ) -> Result<impl Iterator<Item = Ipv4Addr> + use<>, DnsError> {
-        Ok(match self {
-            Self::Hickory(resolver) => Either::Left(resolver.read().await.lookup_ipv4(host).await?),
-            Self::Custom(resolver) => Either::Right(resolver.read().await.lookup_ipv4(host).await?),
-        })
-    }
-
-    async fn lookup_ipv6(
-        &self,
-        host: String,
-    ) -> Result<impl Iterator<Item = Ipv6Addr> + use<>, DnsError> {
-        Ok(match self {
-            Self::Hickory(resolver) => Either::Left(resolver.read().await.lookup_ipv6(host).await?),
-            Self::Custom(resolver) => Either::Right(resolver.read().await.lookup_ipv6(host).await?),
-        })
-    }
-
-    async fn lookup_txt(
-        &self,
-        host: String,
-    ) -> Result<impl Iterator<Item = TxtRecordData> + use<>, DnsError> {
-        Ok(match self {
-            Self::Hickory(resolver) => Either::Left(resolver.read().await.lookup_txt(host).await?),
-            Self::Custom(resolver) => Either::Right(resolver.read().await.lookup_txt(host).await?),
-        })
-    }
-
-    async fn clear_cache(&self) {
-        match self {
-            Self::Hickory(resolver) => resolver.read().await.clear_cache(),
-            Self::Custom(resolver) => resolver.read().await.clear_cache(),
-        }
-    }
-
-    async fn reset(&self) {
-        match self {
-            Self::Hickory(resolver) => resolver.write().await.reset(),
-            Self::Custom(resolver) => resolver.write().await.reset(),
-        }
-    }
-}
-
 #[derive(Debug)]
 struct HickoryResolver {
     resolver: TokioResolver,
@@ -611,45 +557,37 @@ impl HickoryResolver {
         Ok((config, options))
     }
 
-    async fn lookup_ipv4(
-        &self,
-        host: String,
-    ) -> Result<impl Iterator<Item = Ipv4Addr> + use<>, DnsError> {
-        Ok(self
-            .resolver
-            .ipv4_lookup(host)
-            .await?
-            .into_iter()
-            .map(Ipv4Addr::from))
+}
+
+impl Resolver for HickoryResolver {
+    fn lookup_ipv4(&self, host: String) -> BoxFuture<Result<BoxIter<Ipv4Addr>, DnsError>> {
+        let resolver = self.resolver.clone();
+        Box::pin(async move {
+            let lookup = resolver.ipv4_lookup(host).await?;
+            let iter: BoxIter<Ipv4Addr> = Box::new(lookup.into_iter().map(Ipv4Addr::from));
+            Ok(iter)
+        })
     }
 
-    /// Looks up an IPv6 address.
-    async fn lookup_ipv6(
-        &self,
-        host: String,
-    ) -> Result<impl Iterator<Item = Ipv6Addr> + use<>, DnsError> {
-        Ok(self
-            .resolver
-            .ipv6_lookup(host)
-            .await?
-            .into_iter()
-            .map(Ipv6Addr::from))
+    fn lookup_ipv6(&self, host: String) -> BoxFuture<Result<BoxIter<Ipv6Addr>, DnsError>> {
+        let resolver = self.resolver.clone();
+        Box::pin(async move {
+            let lookup = resolver.ipv6_lookup(host).await?;
+            let iter: BoxIter<Ipv6Addr> = Box::new(lookup.into_iter().map(Ipv6Addr::from));
+            Ok(iter)
+        })
     }
 
-    /// Looks up TXT records.
-    async fn lookup_txt(
-        &self,
-        host: String,
-    ) -> Result<impl Iterator<Item = TxtRecordData> + use<>, DnsError> {
-        Ok(self
-            .resolver
-            .txt_lookup(host)
-            .await?
-            .into_iter()
-            .map(|txt| TxtRecordData::from_iter(txt.iter().cloned())))
+    fn lookup_txt(&self, host: String) -> BoxFuture<Result<BoxIter<TxtRecordData>, DnsError>> {
+        let resolver = self.resolver.clone();
+        Box::pin(async move {
+            let lookup = resolver.txt_lookup(host).await?;
+            let iter: BoxIter<TxtRecordData> =
+                Box::new(lookup.into_iter().map(|txt| TxtRecordData::from_iter(txt.iter().cloned())));
+            Ok(iter)
+        })
     }
 
-    /// Clears the internal cache.
     fn clear_cache(&self) {
         self.resolver.clear_cache()
     }
@@ -698,23 +636,6 @@ impl FromIterator<Box<[u8]>> for TxtRecordData {
 impl From<Vec<Box<[u8]>>> for TxtRecordData {
     fn from(value: Vec<Box<[u8]>>) -> Self {
         Self(value.into_boxed_slice())
-    }
-}
-
-/// Helper enum to give a unified type to either of two iterators
-enum Either<A, B> {
-    Left(A),
-    Right(B),
-}
-
-impl<T, A: Iterator<Item = T>, B: Iterator<Item = T>> Iterator for Either<A, B> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Either::Left(iter) => iter.next(),
-            Either::Right(iter) => iter.next(),
-        }
     }
 }
 


### PR DESCRIPTION
## Description

Remove special fast path for hickory resolver

The downside is that we have 1 more box for each lookup_ipv6 or lookup_ipv4, but I doubt that it matters. These are network ops, maybe cache hits, but in any case much more heavyweight than a boxed future.

The upside is that hickory will be easier to feature gate later, which we need for embedded. And it's less code.

Rationale for this: hickory is really nasty on embedded. It requires giant (for embedded) stack sizes and also is a big dep. We need it for address_discovery_dns, but there is an alternative for that: just use pkarr for both put and get.

If we don't have a default dep on hickory we can implement a simple dns resolver that just uses getaddrinfo. It won't work for TXT records, but we don't need them for the core functionality of doing just plain A or AAAA requests to figure out relay ip addrs.

## Breaking Changes

None

## Notes & open questions

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
