### PR TITLE
  Upgrade rand ecosystem (rand, rand_chacha, rand_core) to 0.10 and

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -435,14 +435,14 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
 ]
@@ -507,6 +507,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "chrono"
@@ -704,6 +715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,16 +847,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.1"
+version = "5.0.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "rand_core",
+ "rand_core 0.10.0",
  "rustc_version",
  "serde",
  "subtle",
@@ -1046,9 +1066,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.10"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa94b64bfc6549e6e4b5a3216f22593224174083da7a90db47e951c4fb31725"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -1138,13 +1158,13 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.1"
+version = "3.0.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad207ed88a133091f83224265eac21109930db09bedcad05d5252f2af2de20a1"
+checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.10.0",
  "serde",
  "sha2",
  "signature",
@@ -1232,7 +1252,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand",
+ "rand 0.9.2",
  "siphasher",
 ]
 
@@ -1493,6 +1513,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1536,7 +1557,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.9.2",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1656,7 +1677,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustls",
  "serde",
@@ -1681,7 +1702,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.9.2",
  "resolv-conf",
  "rustls",
  "serde",
@@ -2012,7 +2033,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.9.2",
  "tokio",
  "url",
  "xmltree",
@@ -2125,8 +2146,8 @@ dependencies = [
  "portmapper",
  "postcard",
  "pretty_assertions",
- "rand",
- "rand_chacha",
+ "rand 0.10.0",
+ "rand_chacha 0.10.0",
  "reqwest",
  "rustc-hash",
  "rustls",
@@ -2163,9 +2184,9 @@ dependencies = [
  "n0-error",
  "postcard",
  "proptest",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.10.0",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -2187,7 +2208,7 @@ dependencies = [
  "n0-error",
  "n0-future",
  "noq",
- "rand",
+ "rand 0.10.0",
  "rcgen",
  "rustls",
  "tokio",
@@ -2222,8 +2243,8 @@ dependencies = [
  "n0-future",
  "n0-tracing-test",
  "pkarr",
- "rand",
- "rand_chacha",
+ "rand 0.10.0",
+ "rand_chacha 0.10.0",
  "rcgen",
  "redb",
  "regex",
@@ -2314,8 +2335,8 @@ dependencies = [
  "pkarr",
  "postcard",
  "proptest",
- "rand",
- "rand_chacha",
+ "rand 0.10.0",
+ "rand_chacha 0.10.0",
  "rcgen",
  "reloadable-state",
  "reqwest",
@@ -2849,7 +2870,7 @@ dependencies = [
  "identity-hash",
  "lru-slab",
  "n0-qlog",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3270,7 +3291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3302,7 +3323,7 @@ dependencies = [
  "n0-error",
  "netwatch",
  "num_enum",
- "rand",
+ "rand 0.9.2",
  "serde",
  "smallvec",
  "socket2 0.6.3",
@@ -3421,8 +3442,8 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -3489,7 +3510,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3542,8 +3563,19 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3553,7 +3585,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3566,12 +3608,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4134,12 +4182,12 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c777f0a122a53fddb0beb6e706771197000b8eb5c9f42b5b850f450ef48c788"
+checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4151,12 +4199,12 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4401,7 +4449,7 @@ checksum = "1a5ab62937edac8b23fa40e55a358ea1924245b17fc1eb20d14929c8f11be98d"
 dependencies = [
  "acto",
  "hickory-proto",
- "rand",
+ "rand 0.9.2",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -4682,7 +4730,7 @@ dependencies = [
  "getrandom 0.3.4",
  "http",
  "httparse",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustls-pki-types",
  "simdutf8",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -15,16 +15,16 @@ rust-version = "1.89"
 workspace = true
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.1", features = ["serde", "rand_core", "zeroize"], optional = true }
+curve25519-dalek = { version = "=5.0.0-pre.6", features = ["serde", "rand_core", "zeroize"], optional = true }
 data-encoding = { version = "2.3.3", optional = true }
 # Pin digest to version compatible with curve25519-dalek 5.0.0-pre.1.
-digest = { version = "=0.11.0-rc.10", optional = true }
+digest = { version = "0.11", optional = true }
 # Pin sha2 to fix version incompatibility
-sha2 = { version = "=0.11.0-rc.2", optional = true }
-ed25519-dalek = { version = "=3.0.0-pre.1", features = ["serde", "rand_core", "zeroize"], optional = true }
+sha2 = { version = "=0.11.0-rc.5", optional = true }
+ed25519-dalek = { version = "=3.0.0-pre.6", features = ["serde", "rand_core", "zeroize"], optional = true }
 derive_more = { version = "2.0.1", features = ["debug", "display"], optional = true }
-url = { version = "2.5.3", features = ["serde"], optional = true }
-rand_core = { version = "0.9.3", optional = true }
+url = { version = "2.5.4", features = ["serde"], optional = true }
+rand_core = { version = "0.10.0", optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
 n0-error = "0.1"
 zeroize = { version = "1.8.2", optional = true, features = ["derive"] }
@@ -33,8 +33,8 @@ zeroize_derive = { version = "1.4.2", optional = true } # needed for minimal ver
 [dev-dependencies]
 postcard = { version = "1", features = ["use-std"] }
 proptest = "1.0.0"
-rand = "0.9.2"
-rand_chacha = "0.9"
+rand = "0.10.0"
+rand_chacha = "0.10.0"
 serde_json = "1"
 serde_test = "1"
 

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -55,7 +55,7 @@ tower_governor = { version = "0.8", default-features = false, features = ["axum"
 tracing = "0.1"
 tracing-subscriber = "0.3.18"
 ttl_cache = "0.5.1"
-url = "2.5.3"
+url = "2.5.4"
 z32 = "1.1.1"
 
 [dev-dependencies]
@@ -65,8 +65,8 @@ hickory-resolver = "0.25.0"
 iroh = { path = "../iroh" }
 n0-tracing-test = "0.3"
 pkarr = { version = "5", features = ["relays", "dht"], default-features = false }
-rand = "0.9.2"
-rand_chacha = "0.9"
+rand = "0.10.0"
+rand_chacha = "0.10.0"
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls", "http2"
 ] }

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -48,7 +48,7 @@ postcard = { version = "1", default-features = false, features = [
 ] }
 noq = { version = "0.17.0", default-features = false, features = ["rustls-ring"] }
 noq-proto = "0.16.0"
-rand = "0.9.2"
+rand = "0.10.0"
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
@@ -69,7 +69,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
 ] }
 tokio-util = { version = "0.7", features = ["io-util", "io", "codec", "rt"] }
 tracing = "0.1"
-url = { version = "2.5.3", features = ["serde"] }
+url = { version = "2.5.4", features = ["serde"] }
 webpki-roots = "1.0.3"
 webpki_types = { package = "rustls-pki-types", version = "1.12" }
 z32 = "1.0.3"
@@ -86,7 +86,7 @@ time = { version = "0.3.37", optional = true }
 tokio-rustls-acme = { version = "0.9", optional = true }
 tokio-websockets = { version = "0.12", features = ["rustls-bring-your-own-connector", "ring", "getrandom", "rand", "server"], optional = true } # server-side websocket implementation
 simdutf8 = { version = "0.1.5", optional = true } # minimal version fix
-sha1 = { version = "0.11.0-rc.2", optional = true }
+sha1 = { version = "0.11.0-rc.5", optional = true }
 toml = { version = "1.0", optional = true }
 serde_json = { version = "1", optional = true }
 tracing-subscriber = { version = "0.3", features = [
@@ -115,7 +115,7 @@ getrandom = { version = "0.3.2", features = ["wasm_js"] }
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
 proptest = "1.2.0"
-rand_chacha = "0.9"
+rand_chacha = "0.10.0"
 tokio = { version = "1", features = [
     "io-util",
     "sync",

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 use iroh_base::EndpointId;
 use n0_error::{e, stack_error};
 use n0_future::{SinkExt, StreamExt};
-use rand::Rng;
+use rand::RngExt as _;
 use time::{Date, OffsetDateTime};
 use tokio::{
     sync::mpsc::{self, error::TrySendError},

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -25,7 +25,7 @@ backon = { version = "1.4" }
 bytes = "1.11"
 data-encoding = "2.2"
 derive_more = { version = "2.0.1", features = ["debug", "display", "from", "try_into", "deref", "from_str", "into_iterator"] }
-ed25519-dalek = { version = "3.0.0-pre.1", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
+ed25519-dalek = { version = "3.0.0-pre.6", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
 http = "1"
 ipnet = "2"
 iroh-base = { version = "0.97.0", default-features = false, features = ["key", "relay"], path = "../iroh-base" }
@@ -41,7 +41,7 @@ pkarr = { version = "5", default-features = false }
 noq = { version = "0.17.0", default-features = false, features = ["rustls-ring"] }
 noq-proto = "0.16"
 noq-udp = "0.9"
-rand = "0.9.2"
+rand = "0.10.0"
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "stream",
@@ -104,14 +104,14 @@ getrandom = { version = "0.3.2", features = ["wasm_js"] }
 console_error_panic_hook = "0.1"
 postcard = { version = "1.1.1", features = ["use-std"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-rand_chacha = "0.9"
+rand_chacha = "0.10.0"
 chrono = "0.4.43"
 
 # *non*-wasm-in-browser test/dev dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 axum = { version = "0.8" }
 pretty_assertions = "1.4"
-rand_chacha = "0.9"
+rand_chacha = "0.10.0"
 tokio = { version = "1", features = [
     "io-util",
     "sync",

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -13,7 +13,7 @@ iroh-metrics = { version = "0.38", optional = true }
 n0-future = "0.3"
 n0-error = "0.1"
 noq = "0.17.0"
-rand = "0.9.2"
+rand = "0.10.0"
 rcgen = "0.14"
 rustls = { version = "0.23.33", default-features = false, features = ["ring"] }
 clap = { version = "4", features = ["derive"] }

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -596,7 +596,7 @@ mod tests {
     use n0_error::{AnyError, Result, StackResultExt};
     use n0_future::{StreamExt, time};
     use n0_tracing_test::traced_test;
-    use rand::{CryptoRng, Rng, SeedableRng};
+    use rand::{CryptoRng, RngExt as _, SeedableRng};
     use tokio_util::task::AbortOnDropHandle;
 
     use super::*;

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2776,8 +2776,8 @@ mod tests {
     }
 
     #[cfg(feature = "metrics")]
-    #[tokio::test]
     #[traced_test]
+    #[tokio::test]
     async fn metrics_smoke() -> Result {
         use iroh_metrics::Registry;
 

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -38,7 +38,7 @@ use n0_watcher::{self, Watchable, Watcher};
 use netwatch::ip::LocalAddresses;
 use netwatch::netmon;
 use noq::WeakConnectionHandle;
-use rand::Rng;
+use rand::RngExt as _;
 use tokio::sync::{
     Mutex as AsyncMutex,
     mpsc::{self},
@@ -1734,7 +1734,7 @@ mod tests {
     use n0_future::{MergeBounded, StreamExt, time};
     use n0_tracing_test::traced_test;
     use n0_watcher::Watcher;
-    use rand::{CryptoRng, Rng, RngCore, SeedableRng};
+    use rand::{CryptoRng, Rng, RngExt as _, SeedableRng};
     use tokio_util::task::AbortOnDropHandle;
     use tracing::{Instrument, error, info, info_span, instrument};
 


### PR DESCRIPTION
## Description

bump ed25519-dalek/curve25519-dalek to latest pre-releases. Unpin
digest to stable 0.11. Adapt call sites to rand 0.10 API changes
(Rng -> RngExt).
