### PR TITLE
fix(ci): install cmake and nasm for aws-lc-sys on Windows

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -221,6 +221,13 @@ jobs:
         with:
           release: false
 
+      - name: Install aws-lc-sys build dependencies
+        shell: powershell
+        run: |
+          choco install cmake nasm -y
+          echo "C:\Program Files\CMake\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Program Files\NASM" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: build tests
         run: |
           cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
@@ -308,6 +315,13 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           release: false
+
+      - name: Install aws-lc-sys build dependencies
+        shell: powershell
+        run: |
+          choco install cmake nasm -y
+          echo "C:\Program Files\CMake\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Program Files\NASM" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: cargo check
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -224,7 +224,12 @@ jobs:
       - name: Install aws-lc-sys build dependencies
         shell: powershell
         run: |
-          choco install cmake nasm -y
+          $chocoPath = "$Env:ProgramData\chocolatey\bin\choco.exe"
+          if (!(Test-Path $chocoPath)) {
+            $chocoPath = "$Env:SystemDrive\ProgramData\chocolatey\bin\choco.exe"
+          }
+          & $chocoPath install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          & $chocoPath install nasm -y
           echo "C:\Program Files\CMake\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\Program Files\NASM" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
@@ -319,7 +324,12 @@ jobs:
       - name: Install aws-lc-sys build dependencies
         shell: powershell
         run: |
-          choco install cmake nasm -y
+          $chocoPath = "$Env:ProgramData\chocolatey\bin\choco.exe"
+          if (!(Test-Path $chocoPath)) {
+            $chocoPath = "$Env:SystemDrive\ProgramData\chocolatey\bin\choco.exe"
+          }
+          & $chocoPath install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          & $chocoPath install nasm -y
           echo "C:\Program Files\CMake\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\Program Files\NASM" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 


### PR DESCRIPTION
## Description

aws-lc-sys requires cmake and NASM to build on Windows MSVC targets.
This adds a choco install step to both Windows CI jobs and ensure the installed binaries are on PATH.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
