### PR TITLE
fix(iroh)!: faster relay health check after network change

### DIFF
--- a/iroh-relay/src/ping_tracker.rs
+++ b/iroh-relay/src/ping_tracker.rs
@@ -46,9 +46,10 @@ impl PingTracker {
         self.default_timeout
     }
 
-    /// Starts a new ping.
+    /// Starts a new ping with an RTT-based timeout.
     pub fn new_ping(&mut self) -> [u8; 8] {
-        self.new_ping_with_timeout(self.default_timeout)
+        let timeout = self.ping_timeout();
+        self.new_ping_with_timeout(timeout)
     }
 
     /// Starts a new ping with a custom timeout.
@@ -79,11 +80,11 @@ impl PingTracker {
         }
     }
 
-    /// Returns an appropriate timeout for a health check ping.
+    /// Returns the timeout for the next ping.
     ///
     /// Uses 3x the last measured RTT (to account for jitter), falling back to
     /// the default timeout if no RTT has been measured yet.
-    pub fn health_check_timeout(&self) -> Duration {
+    pub fn ping_timeout(&self) -> Duration {
         self.last_rtt
             .map(|rtt| {
                 (rtt * 3)

--- a/iroh-relay/src/ping_tracker.rs
+++ b/iroh-relay/src/ping_tracker.rs
@@ -87,7 +87,7 @@ impl PingTracker {
     /// the default timeout if no RTT has been measured yet.
     pub fn health_check_timeout(&self) -> Duration {
         self.last_rtt
-            .map(|rtt| (rtt * 3).max(Duration::from_millis(500)))
+            .map(|rtt| (rtt * 3).max(Duration::from_millis(500)).min(self.default_timeout))
             .unwrap_or(self.default_timeout)
     }
 

--- a/iroh-relay/src/ping_tracker.rs
+++ b/iroh-relay/src/ping_tracker.rs
@@ -87,7 +87,11 @@ impl PingTracker {
     /// the default timeout if no RTT has been measured yet.
     pub fn health_check_timeout(&self) -> Duration {
         self.last_rtt
-            .map(|rtt| (rtt * 3).max(Duration::from_millis(500)).min(self.default_timeout))
+            .map(|rtt| {
+                (rtt * 3)
+                    .max(Duration::from_millis(500))
+                    .min(self.default_timeout)
+            })
             .unwrap_or(self.default_timeout)
     }
 

--- a/iroh-relay/src/ping_tracker.rs
+++ b/iroh-relay/src/ping_tracker.rs
@@ -4,6 +4,9 @@ use tracing::debug;
 /// Maximum time for a ping response in the relay protocol.
 pub const PING_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Minimum timeout for an RTT-based health check ping.
+const MIN_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_millis(500);
+
 /// Tracks pings on a single relay connection.
 ///
 /// Only the last ping needs is useful, any previously sent ping is forgotten and ignored.
@@ -84,7 +87,7 @@ impl PingTracker {
         self.last_rtt
             .map(|rtt| {
                 (rtt * 3)
-                    .max(Duration::from_millis(500))
+                    .max(MIN_HEALTH_CHECK_TIMEOUT)
                     .min(self.default_timeout)
             })
             .unwrap_or(self.default_timeout)

--- a/iroh-relay/src/ping_tracker.rs
+++ b/iroh-relay/src/ping_tracker.rs
@@ -11,12 +11,15 @@ pub const PING_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct PingTracker {
     inner: Option<PingInner>,
     default_timeout: Duration,
+    /// Last measured round-trip time to the relay server.
+    last_rtt: Option<Duration>,
 }
 
 #[derive(Debug)]
 struct PingInner {
     data: [u8; 8],
     deadline: Instant,
+    sent_at: Instant,
 }
 
 impl Default for PingTracker {
@@ -31,6 +34,7 @@ impl PingTracker {
         Self {
             inner: None,
             default_timeout,
+            last_rtt: None,
         }
     }
 
@@ -41,11 +45,18 @@ impl PingTracker {
 
     /// Starts a new ping.
     pub fn new_ping(&mut self) -> [u8; 8] {
+        self.new_ping_with_timeout(self.default_timeout)
+    }
+
+    /// Starts a new ping with a custom timeout.
+    pub fn new_ping_with_timeout(&mut self, timeout: Duration) -> [u8; 8] {
         let ping_data = rand::random();
+        let now = Instant::now();
         debug!(data = ?ping_data, "Sending ping to relay server.");
         self.inner = Some(PingInner {
             data: ping_data,
-            deadline: Instant::now() + self.default_timeout,
+            deadline: now + timeout,
+            sent_at: now,
         });
         ping_data
     }
@@ -55,10 +66,29 @@ impl PingTracker {
     /// Only the pong of the most recent ping will do anything.  There is no harm feeding
     /// any pong however.
     pub fn pong_received(&mut self, data: [u8; 8]) {
-        if self.inner.as_ref().map(|inner| inner.data) == Some(data) {
-            debug!(?data, "Pong received from relay server");
+        if let Some(inner) = &self.inner
+            && inner.data == data
+        {
+            let rtt = inner.sent_at.elapsed();
+            debug!(?data, ?rtt, "Pong received from relay server");
+            self.last_rtt = Some(rtt);
             self.inner = None;
         }
+    }
+
+    /// Returns the last measured RTT to the relay server, if any.
+    pub fn last_rtt(&self) -> Option<Duration> {
+        self.last_rtt
+    }
+
+    /// Returns an appropriate timeout for a health check ping.
+    ///
+    /// Uses 3x the last measured RTT (to account for jitter), falling back to
+    /// the default timeout if no RTT has been measured yet.
+    pub fn health_check_timeout(&self) -> Duration {
+        self.last_rtt
+            .map(|rtt| (rtt * 3).max(Duration::from_millis(500)))
+            .unwrap_or(self.default_timeout)
     }
 
     /// Cancel-safe waiting for a ping timeout.
@@ -66,7 +96,7 @@ impl PingTracker {
     /// Unless the most recent sent ping times out, this will never return.
     pub async fn timeout(&mut self) {
         match self.inner {
-            Some(PingInner { deadline, data }) => {
+            Some(PingInner { deadline, data, .. }) => {
                 time::sleep_until(deadline).await;
                 debug!(?data, "Ping timeout.");
                 self.inner = None;

--- a/iroh-relay/src/ping_tracker.rs
+++ b/iroh-relay/src/ping_tracker.rs
@@ -76,11 +76,6 @@ impl PingTracker {
         }
     }
 
-    /// Returns the last measured RTT to the relay server, if any.
-    pub fn last_rtt(&self) -> Option<Duration> {
-        self.last_rtt
-    }
-
     /// Returns an appropriate timeout for a health check ping.
     ///
     /// Uses 3x the last measured RTT (to account for jitter), falling back to

--- a/iroh-relay/src/ping_tracker.rs
+++ b/iroh-relay/src/ping_tracker.rs
@@ -13,7 +13,7 @@ const MIN_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_millis(500);
 #[derive(Debug)]
 pub struct PingTracker {
     inner: Option<PingInner>,
-    default_timeout: Duration,
+    max_timeout: Duration,
     /// Last measured round-trip time to the relay server.
     last_rtt: Option<Duration>,
 }
@@ -32,18 +32,18 @@ impl Default for PingTracker {
 }
 
 impl PingTracker {
-    /// Creates a new ping tracker, setting the ping timeout for pings.
-    pub fn new(default_timeout: Duration) -> Self {
+    /// Creates a new ping tracker with the given maximum ping timeout.
+    pub fn new(max_timeout: Duration) -> Self {
         Self {
             inner: None,
-            default_timeout,
+            max_timeout,
             last_rtt: None,
         }
     }
 
-    /// Returns the current timeout set for pings.
-    pub fn default_timeout(&self) -> Duration {
-        self.default_timeout
+    /// Returns the maximum ping timeout.
+    pub fn max_timeout(&self) -> Duration {
+        self.max_timeout
     }
 
     /// Starts a new ping with an RTT-based timeout.
@@ -86,12 +86,8 @@ impl PingTracker {
     /// the default timeout if no RTT has been measured yet.
     pub fn ping_timeout(&self) -> Duration {
         self.last_rtt
-            .map(|rtt| {
-                (rtt * 3)
-                    .max(MIN_HEALTH_CHECK_TIMEOUT)
-                    .min(self.default_timeout)
-            })
-            .unwrap_or(self.default_timeout)
+            .map(|rtt| (rtt * 3).clamp(MIN_HEALTH_CHECK_TIMEOUT, self.max_timeout))
+            .unwrap_or(self.max_timeout)
     }
 
     /// Cancel-safe waiting for a ping timeout.

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1546,6 +1546,7 @@ impl Actor {
             if let Err(err) = self.transports_network_change.rebind() {
                 warn!("failed to rebind transports: {err:?}");
             }
+            self.transports_network_change.check_relay_connection();
 
             #[cfg(not(wasm_browser))]
             self.sock.dns_resolver.reset().await;
@@ -1638,13 +1639,6 @@ impl Actor {
 
         self.endpoint.handle_network_change(Some(Arc::new(hint)));
         self.remote_map.on_network_change(is_major);
-
-        if is_major {
-            // Trigger immediate relay health check with RTT-based timeout.
-            // If the relay connection is alive, the ping succeeds quickly.
-            // If broken, detected faster than the default 5s ping timeout.
-            self.transports_network_change.check_relay_connection();
-        }
     }
 
     fn handle_relay_map_change(&mut self) {

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1638,6 +1638,13 @@ impl Actor {
 
         self.endpoint.handle_network_change(Some(Arc::new(hint)));
         self.remote_map.on_network_change(is_major);
+
+        if is_major {
+            // Trigger immediate relay health check with RTT-based timeout.
+            // If the relay connection is alive, the ping succeeds quickly.
+            // If broken, detected faster than the default 5s ping timeout.
+            self.transports_network_change.check_relay_connection();
+        }
     }
 
     fn handle_relay_map_change(&mut self) {

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -449,6 +449,15 @@ impl NetworkChangeSender {
         }
     }
 
+    /// Triggers an immediate relay connection health check after a network change.
+    ///
+    /// Uses RTT-based timeout for faster detection of broken connections.
+    pub(crate) fn check_relay_connection(&self) {
+        for relay in &self.relay {
+            relay.check_connection_after_network_change();
+        }
+    }
+
     /// Rebinds underlying connections, if necessary.
     pub(crate) fn rebind(&self) -> std::io::Result<()> {
         let mut res = Ok(());

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -212,6 +212,11 @@ impl RelayNetworkChangeSender {
         });
     }
 
+    /// Triggers an immediate health check on relay connections after a network change.
+    pub(super) fn check_connection_after_network_change(&self) {
+        self.send_relay_actor(RelayActorMessage::CheckConnectionAfterNetworkChange);
+    }
+
     pub(super) fn rebind(&self) -> io::Result<()> {
         self.send_relay_actor(RelayActorMessage::MaybeCloseRelaysOnRebind);
 

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -813,9 +813,7 @@ impl ConnectedRelayState {
 
 pub(super) enum RelayActorMessage {
     MaybeCloseRelaysOnRebind,
-    NetworkChange {
-        report: Report,
-    },
+    NetworkChange { report: Report },
     /// Trigger an immediate health check on all relay connections.
     ///
     /// Sent after a major network change to detect broken connections faster
@@ -1138,31 +1136,7 @@ impl RelayActor {
     ///
     /// Uses RTT-based timeout for faster detection of broken connections.
     async fn check_connection_after_network_change(&mut self) {
-        #[cfg(not(wasm_browser))]
-        let ifs = interfaces::State::new().await;
-        #[cfg(not(wasm_browser))]
-        let local_ips: Vec<_> = ifs
-            .interfaces
-            .values()
-            .flat_map(|netif| netif.addrs())
-            .map(|ipnet| ipnet.addr())
-            .collect();
-        #[cfg(wasm_browser)]
-        let local_ips = Vec::new();
-        let send_futs = self.active_relays.values().map(|handle| {
-            let local_ips = local_ips.clone();
-            async move {
-                handle
-                    .inbox_addr
-                    .send(ActiveRelayMessage::CheckConnection {
-                        local_ips,
-                        is_network_change: true,
-                    })
-                    .await
-                    .ok();
-            }
-        });
-        n0_future::join_all(send_futs).await;
+        self.send_check_connection(true).await;
     }
 
     /// Closes the relay connections not originating from a local IP address.
@@ -1171,6 +1145,13 @@ impl RelayActor {
     /// that's not known to be currently a local IP address should be closed.  All the other
     /// relay connections are pinged.
     async fn maybe_close_relays_on_rebind(&mut self) {
+        self.send_check_connection(false).await;
+        self.log_active_relay();
+    }
+
+    /// Sends a [`ActiveRelayMessage::CheckConnection`] to all active relays with current
+    /// local IPs.
+    async fn send_check_connection(&self, is_network_change: bool) {
         #[cfg(not(wasm_browser))]
         let ifs = interfaces::State::new().await;
         #[cfg(not(wasm_browser))]
@@ -1180,7 +1161,8 @@ impl RelayActor {
             .flat_map(|netif| netif.addrs())
             .map(|ipnet| ipnet.addr())
             .collect();
-        // In browsers, we don't have this information. This will do the right thing in the ActiveRelayActor, though.
+        // In browsers, we don't have this information. This will do the right thing
+        // in the ActiveRelayActor, though.
         #[cfg(wasm_browser)]
         let local_ips = Vec::new();
         let send_futs = self.active_relays.values().map(|handle| {
@@ -1190,14 +1172,13 @@ impl RelayActor {
                     .inbox_addr
                     .send(ActiveRelayMessage::CheckConnection {
                         local_ips,
-                        is_network_change: false,
+                        is_network_change,
                     })
                     .await
                     .ok();
             }
         });
         n0_future::join_all(send_futs).await;
-        self.log_active_relay();
     }
 
     /// Cleans up [`ActiveRelayActor`]s which have stopped running.

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -163,14 +163,7 @@ enum ActiveRelayMessage {
     /// socket with an IP address in this list the relay server will be pinged.  If the
     /// connection uses a local socket with an IP address not in this list the server will
     /// always re-connect.
-    ///
-    /// When `is_network_change` is true, uses a shorter RTT-based timeout for the health
-    /// check ping instead of the default 5s, to detect broken connections faster after
-    /// a network change.
-    CheckConnection {
-        local_ips: Vec<IpAddr>,
-        is_network_change: bool,
-    },
+    CheckConnection { local_ips: Vec<IpAddr> },
     /// Sets this relay as the home relay, or not.
     SetHomeRelay(bool),
     #[cfg(test)]
@@ -567,17 +560,10 @@ impl ActiveRelayActor {
                         ActiveRelayMessage::SetHomeRelay(is_home) => {
                             self.set_home_relay(is_home);
                         }
-                        ActiveRelayMessage::CheckConnection { local_ips, is_network_change } => {
+                        ActiveRelayMessage::CheckConnection { local_ips } => {
                             match client_stream.local_addr() {
                                 Some(addr) if local_ips.contains(&addr.ip()) => {
-                                    let data = if is_network_change {
-                                        // Use RTT-based timeout for faster detection
-                                        let timeout = state.ping_tracker.health_check_timeout();
-                                        debug!(?timeout, "health check ping after network change");
-                                        state.ping_tracker.new_ping_with_timeout(timeout)
-                                    } else {
-                                        state.ping_tracker.new_ping()
-                                    };
+                                    let data = state.ping_tracker.new_ping();
                                     let fut = client_sink.send(ClientToRelayMsg::Ping(data));
                                     self.run_sending(fut, &mut state, &mut client_stream).await?;
                                 }
@@ -1135,10 +1121,8 @@ impl RelayActor {
     }
 
     /// Triggers an immediate health check on all relay connections after a network change.
-    ///
-    /// Uses RTT-based timeout for faster detection of broken connections.
     async fn check_connection_after_network_change(&mut self) {
-        self.send_check_connection(true).await;
+        self.send_check_connection().await;
     }
 
     /// Closes the relay connections not originating from a local IP address.
@@ -1147,13 +1131,13 @@ impl RelayActor {
     /// that's not known to be currently a local IP address should be closed.  All the other
     /// relay connections are pinged.
     async fn maybe_close_relays_on_rebind(&mut self) {
-        self.send_check_connection(false).await;
+        self.send_check_connection().await;
         self.log_active_relay();
     }
 
     /// Sends a [`ActiveRelayMessage::CheckConnection`] to all active relays with current
     /// local IPs.
-    async fn send_check_connection(&self, is_network_change: bool) {
+    async fn send_check_connection(&self) {
         #[cfg(not(wasm_browser))]
         let ifs = interfaces::State::new().await;
         #[cfg(not(wasm_browser))]
@@ -1172,10 +1156,7 @@ impl RelayActor {
             async move {
                 handle
                     .inbox_addr
-                    .send(ActiveRelayMessage::CheckConnection {
-                        local_ips,
-                        is_network_change,
-                    })
+                    .send(ActiveRelayMessage::CheckConnection { local_ips })
                     .await
                     .ok();
             }
@@ -1451,7 +1432,6 @@ mod tests {
         inbox_tx
             .send(ActiveRelayMessage::CheckConnection {
                 local_ips: vec![local_addr.ip()],
-                is_network_change: false,
             })
             .await
             .std_context("send check connection message")?;
@@ -1480,7 +1460,6 @@ mod tests {
         inbox_tx
             .send(ActiveRelayMessage::CheckConnection {
                 local_ips: Vec::new(),
-                is_network_change: false,
             })
             .await
             .std_context("send check connection msg")?;

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -163,7 +163,14 @@ enum ActiveRelayMessage {
     /// socket with an IP address in this list the relay server will be pinged.  If the
     /// connection uses a local socket with an IP address not in this list the server will
     /// always re-connect.
-    CheckConnection(Vec<IpAddr>),
+    ///
+    /// When `is_network_change` is true, uses a shorter RTT-based timeout for the health
+    /// check ping instead of the default 5s, to detect broken connections faster after
+    /// a network change.
+    CheckConnection {
+        local_ips: Vec<IpAddr>,
+        is_network_change: bool,
+    },
     /// Sets this relay as the home relay, or not.
     SetHomeRelay(bool),
     #[cfg(test)]
@@ -434,7 +441,7 @@ impl ActiveRelayActor {
                         ActiveRelayMessage::SetHomeRelay(is_home) => {
                             self.set_home_relay(is_home);
                         }
-                        ActiveRelayMessage::CheckConnection(_local_ips) => {}
+                        ActiveRelayMessage::CheckConnection { .. } => {}
                         #[cfg(test)]
                         ActiveRelayMessage::GetLocalAddr(sender) => {
                             sender.send(None).ok();
@@ -560,10 +567,17 @@ impl ActiveRelayActor {
                         ActiveRelayMessage::SetHomeRelay(is_home) => {
                             self.set_home_relay(is_home);
                         }
-                        ActiveRelayMessage::CheckConnection(local_ips) => {
+                        ActiveRelayMessage::CheckConnection { local_ips, is_network_change } => {
                             match client_stream.local_addr() {
                                 Some(addr) if local_ips.contains(&addr.ip()) => {
-                                    let data = state.ping_tracker.new_ping();
+                                    let data = if is_network_change {
+                                        // Use RTT-based timeout for faster detection
+                                        let timeout = state.ping_tracker.health_check_timeout();
+                                        debug!(?timeout, "health check ping after network change");
+                                        state.ping_tracker.new_ping_with_timeout(timeout)
+                                    } else {
+                                        state.ping_tracker.new_ping()
+                                    };
                                     let fut = client_sink.send(ClientToRelayMsg::Ping(data));
                                     self.run_sending(fut, &mut state, &mut client_stream).await?;
                                 }
@@ -799,7 +813,14 @@ impl ConnectedRelayState {
 
 pub(super) enum RelayActorMessage {
     MaybeCloseRelaysOnRebind,
-    NetworkChange { report: Report },
+    NetworkChange {
+        report: Report,
+    },
+    /// Trigger an immediate health check on all relay connections.
+    ///
+    /// Sent after a major network change to detect broken connections faster
+    /// using RTT-based timeouts instead of the default 5s ping timeout.
+    CheckConnectionAfterNetworkChange,
 }
 
 #[derive(Debug, Clone)]
@@ -928,6 +949,9 @@ impl RelayActor {
             }
             RelayActorMessage::MaybeCloseRelaysOnRebind => {
                 self.maybe_close_relays_on_rebind().await;
+            }
+            RelayActorMessage::CheckConnectionAfterNetworkChange => {
+                self.check_connection_after_network_change().await;
             }
         }
     }
@@ -1110,6 +1134,37 @@ impl RelayActor {
         handle
     }
 
+    /// Triggers an immediate health check on all relay connections after a network change.
+    ///
+    /// Uses RTT-based timeout for faster detection of broken connections.
+    async fn check_connection_after_network_change(&mut self) {
+        #[cfg(not(wasm_browser))]
+        let ifs = interfaces::State::new().await;
+        #[cfg(not(wasm_browser))]
+        let local_ips: Vec<_> = ifs
+            .interfaces
+            .values()
+            .flat_map(|netif| netif.addrs())
+            .map(|ipnet| ipnet.addr())
+            .collect();
+        #[cfg(wasm_browser)]
+        let local_ips = Vec::new();
+        let send_futs = self.active_relays.values().map(|handle| {
+            let local_ips = local_ips.clone();
+            async move {
+                handle
+                    .inbox_addr
+                    .send(ActiveRelayMessage::CheckConnection {
+                        local_ips,
+                        is_network_change: true,
+                    })
+                    .await
+                    .ok();
+            }
+        });
+        n0_future::join_all(send_futs).await;
+    }
+
     /// Closes the relay connections not originating from a local IP address.
     ///
     /// Called in response to a rebind, any relay connection originating from an address
@@ -1133,7 +1188,10 @@ impl RelayActor {
             async move {
                 handle
                     .inbox_addr
-                    .send(ActiveRelayMessage::CheckConnection(local_ips))
+                    .send(ActiveRelayMessage::CheckConnection {
+                        local_ips,
+                        is_network_change: false,
+                    })
                     .await
                     .ok();
             }
@@ -1408,7 +1466,10 @@ mod tests {
             .context("no local addr")?;
         info!(?local_addr, "check connection with addr");
         inbox_tx
-            .send(ActiveRelayMessage::CheckConnection(vec![local_addr.ip()]))
+            .send(ActiveRelayMessage::CheckConnection {
+                local_ips: vec![local_addr.ip()],
+                is_network_change: false,
+            })
             .await
             .std_context("send check connection message")?;
 
@@ -1434,7 +1495,10 @@ mod tests {
         // do not supply any "valid" local IP addresses.
         info!("check connection");
         inbox_tx
-            .send(ActiveRelayMessage::CheckConnection(Vec::new()))
+            .send(ActiveRelayMessage::CheckConnection {
+                local_ips: Vec::new(),
+                is_network_change: false,
+            })
             .await
             .std_context("send check connection msg")?;
 

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -813,7 +813,9 @@ impl ConnectedRelayState {
 
 pub(super) enum RelayActorMessage {
     MaybeCloseRelaysOnRebind,
-    NetworkChange { report: Report },
+    NetworkChange {
+        report: Report,
+    },
     /// Trigger an immediate health check on all relay connections.
     ///
     /// Sent after a major network change to detect broken connections faster


### PR DESCRIPTION
## Description

After a major network change, send an immediate health check ping to the relay server using an RTT-based timeout (3x last RTT, minimum 500ms) instead of waiting for the next scheduled ping (up to 5s).

If the relay is healthy, the ping succeeds and nothing changes. If it's broken, this detects it ~4.5s faster than the normal ping timeout, triggering reconnection sooner.