### PR TITLE
tests: Fix ip_wins_over_custom flakiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3998,9 +3998,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -503,7 +503,7 @@ mod tests {
         let t2 = network.create_transport(s2.public())?;
 
         // Strong RTT advantage for custom transport
-        let custom_bias = TransportBias::primary().with_rtt_advantage(Duration::from_millis(100));
+        let custom_bias = TransportBias::primary().with_rtt_advantage(Duration::from_secs(1));
         let config = EndpointConfig::default()
             .with_ip()
             .with_custom_bias(custom_bias);
@@ -542,8 +542,7 @@ mod tests {
         let t2 = network.create_transport(s2.public())?;
 
         // Strong RTT disadvantage for custom transport
-        let custom_bias =
-            TransportBias::primary().with_rtt_disadvantage(Duration::from_millis(100));
+        let custom_bias = TransportBias::primary().with_rtt_disadvantage(Duration::from_secs(1));
         let config = EndpointConfig::default()
             .with_ip()
             .with_custom_bias(custom_bias);

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -318,6 +318,7 @@ mod tests {
 
     use iroh_relay::RelayMap;
     use n0_error::{Result, StdResultExt};
+    use n0_tracing_test::traced_test;
     use n0_watcher::Watcher;
 
     use super::*;
@@ -455,6 +456,7 @@ mod tests {
 
     /// Test custom transport only - no IP, no relay, dial by custom address.
     #[tokio::test]
+    #[traced_test]
     async fn test_custom_transport_only() -> Result<()> {
         let network = TestNetwork::new();
         let s1 = SecretKey::generate(&mut rand::rng());
@@ -491,6 +493,7 @@ mod tests {
 
     /// Test that custom transport is selected over IP when given an RTT advantage.
     #[tokio::test]
+    #[traced_test]
     async fn test_custom_transport_wins_over_ip() -> Result<()> {
         let network = TestNetwork::new();
         let s1 = SecretKey::generate(&mut rand::rng());
@@ -529,6 +532,7 @@ mod tests {
 
     /// Test that IP is selected over custom transport when custom has an RTT disadvantage.
     #[tokio::test]
+    #[traced_test]
     async fn test_ip_wins_over_custom() -> Result<()> {
         let network = TestNetwork::new();
         let s1 = SecretKey::generate(&mut rand::rng());
@@ -572,6 +576,7 @@ mod tests {
     /// both relay and custom addresses to verify the custom transport (primary) wins
     /// over the relay (backup).
     #[tokio::test]
+    #[traced_test]
     async fn test_custom_transport_wins_over_relay() -> Result<()> {
         let (relay_map, _relay_url, _guard) = run_relay_server().await?;
         let network = TestNetwork::new();

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -503,7 +503,7 @@ mod tests {
         let t2 = network.create_transport(s2.public())?;
 
         // Strong RTT advantage for custom transport
-        let custom_bias = TransportBias::primary().with_rtt_advantage(Duration::from_secs(1));
+        let custom_bias = TransportBias::primary().with_rtt_advantage(Duration::from_secs(10));
         let config = EndpointConfig::default()
             .with_ip()
             .with_custom_bias(custom_bias);
@@ -542,7 +542,7 @@ mod tests {
         let t2 = network.create_transport(s2.public())?;
 
         // Strong RTT disadvantage for custom transport
-        let custom_bias = TransportBias::primary().with_rtt_disadvantage(Duration::from_secs(1));
+        let custom_bias = TransportBias::primary().with_rtt_disadvantage(Duration::from_secs(10));
         let config = EndpointConfig::default()
             .with_ip()
             .with_custom_bias(custom_bias);


### PR DESCRIPTION
## Description

Increase the bias so we can't accidentally get a wrong selection because IP transport is super slow.

## Breaking Changes

None

## Notes & open questions

Should I make this a minute?

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
