### PR TITLE
examples(iroh): allow to configure the receive window in the transfer example

### DIFF
--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -561,12 +561,20 @@ impl EndpointArgs {
         // stream-level receive window. The distinction between connection-level and stream-level
         // doesn't matter here because we don't have concurrent data-intensive streams
         // in the transfer protocol.
-        if let Some(size) = self.receive_window {
-            cfg = cfg.stream_receive_window((size as u32).into());
+        // We also set the send_window to 8 * stream_receive_window. This is the same as what
+        // the noq default does.
+        let rwnd = if let Some(size) = self.receive_window {
+            Some(size as u32)
         } else if let Some(expected_rtt) = self.receive_window_rtt {
             const MAX_STREAM_BANDWIDTH: u32 = 12500 * 1000; // bytes/s
-            let stream_rwnd = MAX_STREAM_BANDWIDTH / 1000 * expected_rtt;
-            cfg = cfg.stream_receive_window(stream_rwnd.into());
+            let size = MAX_STREAM_BANDWIDTH / 1000 * expected_rtt;
+            Some(size)
+        } else {
+            None
+        };
+        if let Some(size) = rwnd {
+            cfg = cfg.stream_receive_window(size.into());
+            cfg = cfg.send_window(size as u64 * 8);
         }
 
         #[cfg(feature = "qlog")]

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -331,17 +331,15 @@ struct EndpointArgs {
     /// Increasing this value gives higher throughput at high latencies, at the cost of
     /// more memory usage.
     ///
-    /// The default is 1.25 MB, which gives a max throughput of 12.5 MB/s at 100ms RTT.
+    /// The receive window is usually calculated as the product of desired throughput
+    /// and expected maximum roundtrip latency (RTT), i.e. for a throughput of 100 MBit/s
+    /// and a RTT of 200ms, you would set the receive window to (100 Mbit/s / 8) * 0.2s = 2.5M.
+    ///
+    /// The default is 1.25 MB, which gives a max throughput of 100 MBit/s at 100ms RTT.
     ///
     /// Accepts values like "5M", "2000K", etc.
     #[clap(long, value_parser = parse_byte_size, conflicts_with = "receive_window_rtt")]
-    receive_window: Option<u64>,
-    /// Receive window size derived from expected RTT in milliseconds.
-    ///
-    /// Calculates the receive window size for an expected RTT
-    /// and a desired max throughput of 12.5 MB/s.
-    #[clap(long, conflicts_with = "receive_window")]
-    receive_window_rtt: Option<u32>,
+    receive_window: Option<u32>,
 }
 
 #[derive(Subcommand, Debug, derive_more::Display)]
@@ -556,25 +554,17 @@ impl EndpointArgs {
 
         // Adjust the receive window, if configured.
         // By default noq and iroh set the connection-level receive window to VarInt::MAX, and
-        // the stream receive window to 1.25MB (for a throughput of 12.5 MB/s at 100ms latency).
+        // the stream receive window to 1.25 MB (for a throughput of 100 MBit/s at 100ms latency).
         // We leave the connection-level receive window at the default and adjust the
         // stream-level receive window. The distinction between connection-level and stream-level
         // doesn't matter here because we don't have concurrent data-intensive streams
         // in the transfer protocol.
-        // We also set the send_window to 8 * stream_receive_window. This is the same as what
-        // the noq default does.
-        let rwnd = if let Some(size) = self.receive_window {
-            Some(size as u32)
-        } else if let Some(expected_rtt) = self.receive_window_rtt {
-            const MAX_STREAM_BANDWIDTH: u32 = 12500 * 1000; // bytes/s
-            let size = MAX_STREAM_BANDWIDTH / 1000 * expected_rtt;
-            Some(size)
-        } else {
-            None
-        };
-        if let Some(size) = rwnd {
+        // We also set the send_window to 2 * stream_receive_window. By default, noq sets this
+        // to 8 * 1.25MB. The transfer protocol doesn't use concurrent data streams, so 2 times
+        // our receive window is enough.
+        if let Some(size) = self.receive_window {
             cfg = cfg.stream_receive_window(size.into());
-            cfg = cfg.send_window(size as u64 * 8);
+            cfg = cfg.send_window(size as u64 * 2);
         }
 
         #[cfg(feature = "qlog")]

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -38,8 +38,6 @@ use data_encoding::HEXLOWER;
 use derive_more::{Display, From};
 use indicatif::HumanBytes;
 use ipnet::{Ipv4Net, Ipv6Net};
-#[cfg(feature = "qlog")]
-use iroh::endpoint::QuicTransportConfig;
 use iroh::{
     Endpoint, EndpointAddr, EndpointId, RelayMap, RelayMode, RelayUrl, SecretKey, TransportAddr,
     Watcher,
@@ -50,8 +48,8 @@ use iroh::{
     },
     dns::{DnsResolver, N0_DNS_ENDPOINT_ORIGIN_PROD, N0_DNS_ENDPOINT_ORIGIN_STAGING},
     endpoint::{
-        BindOpts, Connection, ConnectionError, PathId, PathWatcher, RecvStream, SendStream, VarInt,
-        WriteError, presets,
+        BindOpts, Connection, ConnectionError, PathId, PathWatcher, QuicTransportConfig,
+        RecvStream, SendStream, VarInt, WriteError, presets,
     },
 };
 use n0_error::{Result, StackResultExt, StdResultExt, anyerr, ensure_any};
@@ -327,6 +325,23 @@ struct EndpointArgs {
     /// Disable all default bind addresses.
     #[clap(long)]
     no_default_bind: bool,
+    /// Receive window size.
+    ///
+    /// This controls the maximum amount of data that may be inflight for any stream in the connection.
+    /// Increasing this value gives higher throughput at high latencies, at the cost of
+    /// more memory usage.
+    ///
+    /// The default is 1.25 MB, which gives a max throughput of 12.5 MB/s at 100ms RTT.
+    ///
+    /// Accepts values like "5M", "2000K", etc.
+    #[clap(long, value_parser = parse_byte_size, conflicts_with = "receive_window_rtt")]
+    receive_window: Option<u64>,
+    /// Receive window size derived from expected RTT in milliseconds.
+    ///
+    /// Calculates the receive window size for an expected RTT
+    /// and a desired max throughput of 12.5 MB/s.
+    #[clap(long, conflicts_with = "receive_window")]
+    receive_window_rtt: Option<u32>,
 }
 
 #[derive(Subcommand, Debug, derive_more::Display)]
@@ -536,21 +551,34 @@ impl EndpointArgs {
             builder = builder
                 .bind_addr_with_opts(addr, BindOpts::default().set_prefix_len(prefix_len))?;
         }
+
+        let mut cfg = QuicTransportConfig::builder();
+
+        // Adjust the receive window, if configured.
+        // By default noq and iroh set the connection-level receive window to VarInt::MAX, and
+        // the stream receive window to 1.25MB (for a throughput of 12.5 MB/s at 100ms latency).
+        // We leave the connection-level receive window at the default and adjust the
+        // stream-level receive window. The distinction between connection-level and stream-level
+        // doesn't matter here because we don't have concurrent data-intensive streams
+        // in the transfer protocol.
+        if let Some(size) = self.receive_window {
+            cfg = cfg.stream_receive_window((size as u32).into());
+        } else if let Some(expected_rtt) = self.receive_window_rtt {
+            const MAX_STREAM_BANDWIDTH: u32 = 12500 * 1000; // bytes/s
+            let stream_rwnd = MAX_STREAM_BANDWIDTH / 1000 * expected_rtt;
+            cfg = cfg.stream_receive_window(stream_rwnd.into());
+        }
+
         #[cfg(feature = "qlog")]
-        {
-            let cfg = match (std::env::var("QLOGDIR").ok(), log) {
-                (Some(dir), _) => QuicTransportConfig::builder()
-                    .qlog_from_path(dir, "transfer")
-                    .build(),
-                (_, Some(log)) if log.qlog => QuicTransportConfig::builder()
-                    .qlog_from_path(&log.dir, "")
-                    .build(),
-                _ => Default::default(),
-            };
-            builder = builder.transport_config(cfg)
+        match (std::env::var("QLOGDIR").ok(), log) {
+            (Some(dir), _) => cfg = cfg.qlog_from_path(dir, "transfer"),
+            (_, Some(log)) if log.qlog => cfg = cfg.qlog_from_path(&log.dir, ""),
+            _ => {}
         }
         #[cfg(not(feature = "qlog"))]
         let _ = log;
+
+        builder = builder.transport_config(cfg.build());
 
         let endpoint = builder.alpns(vec![TRANSFER_ALPN.to_vec()]).bind().await?;
 

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -338,7 +338,7 @@ struct EndpointArgs {
     /// The default is 1.25 MB, which gives a max throughput of 100 MBit/s at 100ms RTT.
     ///
     /// Accepts values like "5M", "2000K", etc.
-    #[clap(long, value_parser = parse_byte_size, conflicts_with = "receive_window_rtt")]
+    #[clap(long, value_parser = parse_byte_size)]
     receive_window: Option<u32>,
 }
 


### PR DESCRIPTION
## Description

This allows to configure the receive window in the transfer example. It comes with docs that explain the tradeoffs and how to calculate a good value.

For a relay-only transfer (with `--relay-only`) and the relay pinned to use1 (~100ms one-way latency from my laptop, so 400ms RTT between two endpoints on my laptop), increasing this from the default to 5MB (i.e. `--receive-window 5M`or `--receive-window-rtt 400`) lets the transfer throughput go from ~600 KB/s to ~1.8 MB/s.

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.