### PR TITLE
fix(iroh): preserve ordering of IPs for nat traversal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,7 +3203,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "0.17.0"
-source = "git+https://github.com/n0-computer/noq?branch=fix-order-ips#8e0bd4e3b49c8b9ff8828c379e54ad64398cb0df"
+source = "git+https://github.com/n0-computer/noq?branch=fix-order-ips#21da20810dba118120be1bcb523d2023b520b6b9"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "0.16.0"
-source = "git+https://github.com/n0-computer/noq?branch=fix-order-ips#8e0bd4e3b49c8b9ff8828c379e54ad64398cb0df"
+source = "git+https://github.com/n0-computer/noq?branch=fix-order-ips#21da20810dba118120be1bcb523d2023b520b6b9"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "0.9.0"
-source = "git+https://github.com/n0-computer/noq?branch=fix-order-ips#8e0bd4e3b49c8b9ff8828c379e54ad64398cb0df"
+source = "git+https://github.com/n0-computer/noq?branch=fix-order-ips#21da20810dba118120be1bcb523d2023b520b6b9"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,7 +3203,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "0.17.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#44387fda1bccf2872e1961f3f44561ff07dcefae"
+source = "git+https://github.com/n0-computer/noq?branch=fix-order-ips#8e0bd4e3b49c8b9ff8828c379e54ad64398cb0df"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "0.16.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#44387fda1bccf2872e1961f3f44561ff07dcefae"
+source = "git+https://github.com/n0-computer/noq?branch=fix-order-ips#8e0bd4e3b49c8b9ff8828c379e54ad64398cb0df"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3234,6 +3234,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.4.2",
  "identity-hash",
+ "indexmap",
  "lru-slab",
  "n0-qlog",
  "rand 0.10.0",
@@ -3253,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "0.9.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#44387fda1bccf2872e1961f3f44561ff07dcefae"
+source = "git+https://github.com/n0-computer/noq?branch=fix-order-ips#8e0bd4e3b49c8b9ff8828c379e54ad64398cb0df"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,6 @@ unused-async = "warn"
 [patch.crates-io]
 portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
 netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
-noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
-noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
-noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }
+noq = { git = "https://github.com/n0-computer/noq", branch = "fix-order-ips" }
+noq-udp = { git = "https://github.com/n0-computer/noq", branch = "fix-order-ips" }
+noq-proto = { git = "https://github.com/n0-computer/noq", branch = "fix-order-ips" }

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1952,6 +1952,19 @@ pub enum DirectAddrType {
     Qad4LocalPort,
 }
 
+impl DirectAddrType {
+    /// Priority for NAT traversal probing. Lower = probed first.
+    pub(crate) fn priority(self) -> u8 {
+        match self {
+            Self::Portmapped => 0,
+            Self::Qad => 1,
+            Self::Qad4LocalPort => 2,
+            Self::Local => 3,
+            Self::Unknown => 4,
+        }
+    }
+}
+
 impl Display for DirectAddrType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -455,14 +455,11 @@ impl RemoteStateActor {
             ));
             self.connections_close.push(OnClosed::new(&conn));
 
-            // Add local addrs to the connection
-            let local_addrs = self
-                .local_direct_addrs
-                .get()
-                .iter()
-                .map(|d| d.addr)
-                .collect::<BTreeSet<_>>();
-            Self::update_qnt_candidates(&conn, &local_addrs);
+            // Add local addrs to the connection in priority order
+            let mut sorted: Vec<_> = self.local_direct_addrs.get().iter().cloned().collect();
+            sorted.sort_by_key(|da| da.typ.priority());
+            let sorted_addrs: Vec<SocketAddr> = sorted.iter().map(|da| da.addr).collect();
+            Self::update_qnt_candidates(&conn, &sorted_addrs);
 
             // Store the connection
             let conn_state = self
@@ -636,39 +633,40 @@ impl RemoteStateActor {
     /// Each connection needs to have the local direct addresses to use as QNT address
     /// candidates.
     fn update_local_direct_address(&mut self) {
-        let local_addrs = self
-            .local_direct_addrs
-            .get()
-            .iter()
-            .map(|d| d.addr)
-            .collect::<BTreeSet<_>>();
+        let direct_addrs = self.local_direct_addrs.get();
+        // Sort by priority: public/portmapped first, local last.
+        let mut sorted: Vec<_> = direct_addrs.iter().cloned().collect();
+        sorted.sort_by_key(|da| da.typ.priority());
+        let sorted_addrs: Vec<SocketAddr> = sorted.iter().map(|da| da.addr).collect();
 
         for conn in self.connections.values().filter_map(|s| s.handle.upgrade()) {
-            Self::update_qnt_candidates(&conn, &local_addrs);
+            Self::update_qnt_candidates(&conn, &sorted_addrs);
         }
-        // todo: trace
     }
 
-    /// Updates QNT's candidate addresses to be the current set of direct addresses.
+    /// Updates QNT's candidate addresses to match the given set.
     ///
-    /// `direct_addrs` must be a set of addresses extracted from the endpoint's current
-    /// [`DirectAddr`]s.
-    fn update_qnt_candidates(conn: &noq::Connection, direct_addrs: &BTreeSet<SocketAddr>) {
-        let noq_candidates = match conn.get_local_nat_traversal_addresses() {
+    /// Addresses are added in the order provided (priority order).
+    fn update_qnt_candidates(conn: &noq::Connection, direct_addrs: &[SocketAddr]) {
+        let noq_candidates: BTreeSet<SocketAddr> = match conn.get_local_nat_traversal_addresses() {
             Ok(addrs) => BTreeSet::from_iter(addrs),
             Err(err) => {
                 warn!("failed to get local nat candidates: {err:#}");
                 return;
             }
         };
-        for addr in direct_addrs.difference(&noq_candidates) {
-            if let Err(err) = conn.add_nat_traversal_address(*addr) {
-                warn!("failed adding local addr: {err:#}",);
-            }
-        }
-        for addr in noq_candidates.difference(direct_addrs) {
+        let desired: BTreeSet<SocketAddr> = direct_addrs.iter().copied().collect();
+        // Remove addresses no longer in our set
+        for addr in noq_candidates.difference(&desired) {
             if let Err(err) = conn.remove_nat_traversal_address(*addr) {
                 warn!("failed removing local addr: {err:#}");
+            }
+        }
+        for addr in direct_addrs {
+            if !noq_candidates.contains(addr)
+                && let Err(err) = conn.add_nat_traversal_address(*addr)
+            {
+                warn!("failed adding local addr: {err:#}");
             }
         }
         trace!(?direct_addrs, "updated local QNT addresses");

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -455,11 +455,13 @@ impl RemoteStateActor {
             ));
             self.connections_close.push(OnClosed::new(&conn));
 
-            // Add local addrs to the connection in priority order
-            let mut sorted: Vec<_> = self.local_direct_addrs.get().iter().cloned().collect();
-            sorted.sort_by_key(|da| da.typ.priority());
-            let sorted_addrs: Vec<SocketAddr> = sorted.iter().map(|da| da.addr).collect();
-            Self::update_qnt_candidates(&conn, &sorted_addrs);
+            let addrs: Vec<_> = self
+                .local_direct_addrs
+                .get()
+                .iter()
+                .map(|da| (da.addr, da.typ.priority()))
+                .collect();
+            Self::update_qnt_candidates(&conn, &addrs);
 
             // Store the connection
             let conn_state = self
@@ -633,43 +635,40 @@ impl RemoteStateActor {
     /// Each connection needs to have the local direct addresses to use as QNT address
     /// candidates.
     fn update_local_direct_address(&mut self) {
-        let direct_addrs = self.local_direct_addrs.get();
-        // Sort by priority: public/portmapped first, local last.
-        let mut sorted: Vec<_> = direct_addrs.iter().cloned().collect();
-        sorted.sort_by_key(|da| da.typ.priority());
-        let sorted_addrs: Vec<SocketAddr> = sorted.iter().map(|da| da.addr).collect();
-
+        let addrs: Vec<_> = self
+            .local_direct_addrs
+            .get()
+            .iter()
+            .map(|da| (da.addr, da.typ.priority()))
+            .collect();
         for conn in self.connections.values().filter_map(|s| s.handle.upgrade()) {
-            Self::update_qnt_candidates(&conn, &sorted_addrs);
+            Self::update_qnt_candidates(&conn, &addrs);
         }
     }
 
-    /// Updates QNT's candidate addresses to match the given set.
-    ///
-    /// Addresses are added in the order provided (priority order).
-    fn update_qnt_candidates(conn: &noq::Connection, direct_addrs: &[SocketAddr]) {
-        let noq_candidates: BTreeSet<SocketAddr> = match conn.get_local_nat_traversal_addresses() {
-            Ok(addrs) => BTreeSet::from_iter(addrs),
+    /// Replaces QNT's candidate addresses with the given set and priorities.
+    fn update_qnt_candidates(conn: &noq::Connection, addrs: &[(SocketAddr, u8)]) {
+        let noq_candidates = match conn.get_local_nat_traversal_addresses() {
+            Ok(addrs) => addrs,
             Err(err) => {
                 warn!("failed to get local nat candidates: {err:#}");
                 return;
             }
         };
-        let desired: BTreeSet<SocketAddr> = direct_addrs.iter().copied().collect();
-        // Remove addresses no longer in our set
-        for addr in noq_candidates.difference(&desired) {
-            if let Err(err) = conn.remove_nat_traversal_address(*addr) {
+        let desired: BTreeSet<SocketAddr> = addrs.iter().map(|(a, _)| *a).collect();
+        for addr in noq_candidates {
+            if !desired.contains(&addr)
+                && let Err(err) = conn.remove_nat_traversal_address(addr)
+            {
                 warn!("failed removing local addr: {err:#}");
             }
         }
-        for addr in direct_addrs {
-            if !noq_candidates.contains(addr)
-                && let Err(err) = conn.add_nat_traversal_address(*addr)
-            {
+        for (addr, priority) in addrs {
+            if let Err(err) = conn.add_nat_traversal_address(*addr, *priority) {
                 warn!("failed adding local addr: {err:#}");
             }
         }
-        trace!(?direct_addrs, "updated local QNT addresses");
+        trace!(?addrs, "updated local QNT addresses");
     }
 
     /// Triggers holepunching to the remote endpoint.

--- a/iroh/tests/patchbay.rs
+++ b/iroh/tests/patchbay.rs
@@ -35,7 +35,9 @@ use patchbay::{IpSupport, LinkCondition, LinkDirection, LinkLimits, Nat, RouterP
 use testdir::testdir;
 use tracing::info;
 
-use self::util::{Pair, PathWatcherExt, lab_with_relay, ping_accept, ping_open};
+use self::util::{
+    Pair, PathWatcherExt, add_unreachable_addrs, lab_with_relay, ping_accept, ping_open,
+};
 
 #[path = "patchbay/util.rs"]
 mod util;
@@ -78,6 +80,43 @@ async fn holepunch_simple() -> Result {
                 .wait_ip(timeout)
                 .await
                 .context("holepunch to direct")?;
+            info!("connection became direct");
+            Ok(())
+        })
+        .run()
+        .await?;
+    guard.ok();
+    Ok(())
+}
+
+/// Holepunching succeeds despite many unreachable local addresses (Docker, VPN, etc).
+#[tokio::test]
+#[traced_test]
+async fn holepunch_many_addrs() -> Result {
+    let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
+    let nat1 = lab.add_router("nat1").nat(Nat::Home).build().await?;
+    let nat2 = lab.add_router("nat2").nat(Nat::Home).build().await?;
+    let server = lab.add_device("server").uplink(nat1.id()).build().await?;
+    let client = lab.add_device("client").uplink(nat2.id()).build().await?;
+
+    // Add unreachable veth interfaces on the client.
+    // iroh discovers these as Local candidates and advertises them via REACH_OUT.
+    // The server's noq must probe through these to find the real address.
+    add_unreachable_addrs(&client, 8)?;
+
+    let timeout = Duration::from_secs(15);
+    Pair::new(relay_map)
+        .server(server, async |_dev, _ep, conn| {
+            conn.closed().await;
+            Ok(())
+        })
+        .client(client, async move |_dev, _ep, conn| {
+            let mut paths = conn.paths();
+            assert!(paths.selected().is_relay(), "connection started relayed");
+            paths
+                .wait_ip(timeout)
+                .await
+                .context("holepunch to direct with many addrs")?;
             info!("connection became direct");
             Ok(())
         })

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, path::PathBuf, sync::Arc, time::Duration};
+use std::{future::Future, path::PathBuf, process::Command, sync::Arc, time::Duration};
 
 use iroh::{
     Endpoint, EndpointAddr, RelayMap, RelayMode, Watcher,
@@ -449,4 +449,32 @@ mod relay {
 
         Ok((relay_map, server))
     }
+}
+
+/// Adds `count` veth interfaces with unreachable IPs in the `10.200.x.x/24` range.
+pub fn add_unreachable_addrs(device: &Device, count: u8) -> Result {
+    for i in 0..count {
+        let veth = format!("veth{i}");
+        let peer = format!("vpeer{i}");
+        let ip = format!("10.{}.{}.1/24", 200 + i, i);
+        let mut cmd = Command::new("ip");
+        cmd.args(["link", "add", &veth, "type", "veth", "peer", "name", &peer]);
+        device
+            .spawn_command_sync(cmd)?
+            .wait()
+            .context("ip link add veth")?;
+        let mut cmd = Command::new("ip");
+        cmd.args(["addr", "add", &ip, "dev", &veth]);
+        device
+            .spawn_command_sync(cmd)?
+            .wait()
+            .context("ip addr add")?;
+        let mut cmd = Command::new("ip");
+        cmd.args(["link", "set", &veth, "up"]);
+        device
+            .spawn_command_sync(cmd)?
+            .wait()
+            .context("ip link set up")?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
Depends on https://github.com/n0-computer/noq/pull/571