### PR TITLE
tests(iroh): add patchbay test matrix for switching uplinks

### DIFF
--- a/iroh/tests/patchbay.rs
+++ b/iroh/tests/patchbay.rs
@@ -28,15 +28,17 @@
 
 use std::time::Duration;
 
-use iroh::{TransportAddr, endpoint::Side};
+use iroh::endpoint::Side;
 use n0_error::{Result, StackResultExt, StdResultExt};
 use n0_tracing_test::traced_test;
-use patchbay::{IpSupport, LinkCondition, LinkDirection, LinkLimits, Nat, RouterPreset, TestGuard};
+use patchbay::{LinkCondition, LinkDirection, LinkLimits, Nat, TestGuard};
 use testdir::testdir;
 use tracing::info;
 
 use self::util::{Pair, PathWatcherExt, lab_with_relay, ping_accept, ping_open};
 
+#[path = "patchbay/switch-uplink.rs"]
+mod switch_uplink;
 #[path = "patchbay/util.rs"]
 mod util;
 
@@ -79,168 +81,6 @@ async fn holepunch_simple() -> Result {
                 .await
                 .context("holepunch to direct")?;
             info!("connection became direct");
-            Ok(())
-        })
-        .run()
-        .await?;
-    guard.ok();
-    Ok(())
-}
-
-/// Switches the client's IPv4 uplink to a different NAT mid-connection.
-///
-/// The client starts behind `nat2`, holepunches a direct path, then replugs
-/// its interface to `nat3`. The server waits until a direct path with a new
-/// remote address is selected. We verify with a ping that the new path works.
-#[tokio::test]
-#[traced_test]
-async fn switch_uplink_v4() -> Result {
-    let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let nat1 = lab.add_router("nat1").nat(Nat::Home).build().await?;
-    let nat2 = lab.add_router("nat2").nat(Nat::Home).build().await?;
-    let nat3 = lab.add_router("nat3").nat(Nat::Home).build().await?;
-    let server = lab.add_device("server").uplink(nat1.id()).build().await?;
-    let client = lab.add_device("client").uplink(nat2.id()).build().await?;
-    let timeout = Duration::from_secs(10);
-    Pair::new(relay_map)
-        .server(server, async move |_dev, _ep, conn| {
-            let mut paths = conn.paths();
-            assert!(paths.selected().is_relay(), "connection started relayed");
-
-            // Wait until a first direct path is established.
-            let first = paths.wait_ip(timeout).await?;
-            info!(addr=?first.remote_addr(), "connection became direct, waiting for path change");
-
-            // Now wait until the direct path changes, which happens after the other endpoint
-            // changes its uplink. We check is_ip() explicitly to avoid triggering on a
-            // transient relay fallback during the network switch.
-            let second = paths
-                .wait_selected(timeout, |p| {
-                    p.is_ip() && p.remote_addr() != first.remote_addr()
-                })
-                .await
-                .context("did not switch paths")?;
-            info!(addr=?second.remote_addr(), "connection changed path, wait for ping");
-
-            ping_accept(&conn, timeout).await?;
-            info!("ping done");
-            conn.closed().await;
-            Ok(())
-        })
-        .client(client, async move |dev, _ep, conn| {
-            let mut paths = conn.paths();
-            assert!(paths.selected().is_relay(), "connection started relayed");
-
-            // Wait for conn to become direct.
-            paths
-                .wait_ip(timeout)
-                .await
-                .context("holepunch to direct")?;
-
-            // Wait a little more and then switch wifis.
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            info!("switch IP uplink");
-            dev.iface("eth0").unwrap().replug(nat3.id()).await?;
-
-            // We don't assert any path changes here, because the remote stays identical,
-            // and PathInfo does not contain info on local addrs. Instead, the remote
-            // only accepts our ping after the path changed.
-            info!("send ping");
-            ping_open(&conn, timeout)
-                .await
-                .context("failed at ping_open")?;
-            info!("ping done");
-            conn.close(0u32.into(), b"bye");
-            Ok(())
-        })
-        .run()
-        .await?;
-    guard.ok();
-    Ok(())
-}
-
-/// Switches the client's uplink from an IPv4 NAT to an IPv6-only ISP network.
-///
-/// Similar to [`switch_uplink_v4`], but the client replugs from a Home NAT
-/// to an IPv6-only ISP router. The server waits for the selected path to
-/// switch from an IPv4 to an IPv6 remote address.
-#[tokio::test]
-#[traced_test]
-async fn switch_uplink_v6() -> Result {
-    let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let public = lab
-        .add_router("public")
-        .preset(RouterPreset::Public)
-        .build()
-        .await?;
-    let home = lab
-        .add_router("nat2")
-        .preset(RouterPreset::Home)
-        .ip_support(IpSupport::V4Only)
-        .build()
-        .await?;
-    let mobile = lab
-        .add_router("nat3")
-        .preset(RouterPreset::IspV6)
-        .build()
-        .await?;
-    let server = lab.add_device("server").uplink(public.id()).build().await?;
-    let client = lab.add_device("client").uplink(home.id()).build().await?;
-    let timeout = Duration::from_secs(10);
-    Pair::new(relay_map)
-        .server(server, async move |_dev, _ep, conn| {
-            let mut paths = conn.paths();
-            assert!(paths.selected().is_relay(), "connection started relayed");
-
-            // Wait until a first direct path is established.
-            let first = paths
-                .wait_ip(timeout)
-                .await
-                .context("did not become direct")?;
-            info!(addr=?first.remote_addr(), "connection became direct, waiting for path change");
-
-            ping_accept(&conn, timeout).await.context("ping_accept 1")?;
-
-            // Now wait until the direct path switches to an IPv6 address, which happens
-            // after the other endpoint replugs to the v6-only ISP router.
-            let second = paths
-                .wait_selected(
-                    timeout,
-                    |p| matches!(p.remote_addr(), TransportAddr::Ip(addr) if addr.ip().is_ipv6()),
-                )
-                .await
-                .context("did not switch paths to v6")?;
-            info!(addr=?second.remote_addr(), "connection changed path, wait for ping");
-
-            ping_accept(&conn, timeout).await.context("ping_accept 2")?;
-            info!("ping done");
-            conn.closed().await;
-            Ok(())
-        })
-        .client(client, async move |dev, _ep, conn| {
-            let mut paths = conn.paths();
-            assert!(paths.selected().is_relay(), "connection started relayed");
-
-            // Wait for conn to become direct.
-            paths
-                .wait_ip(timeout)
-                .await
-                .context("holepunch to direct")?;
-
-            ping_open(&conn, timeout)
-                .await
-                .context("ping before switch")?;
-
-            info!("switch IP uplink to v6");
-            dev.iface("eth0").unwrap().replug(mobile.id()).await?;
-
-            // We don't assert any path changes here, because the remote stays identical,
-            // and PathInfo does not contain info on local addrs. Instead, the remote
-            // only accepts our ping after the path changed.
-            ping_open(&conn, timeout)
-                .await
-                .context("ping after v6 switch")?;
-            conn.close(0u32.into(), b"bye");
             Ok(())
         })
         .run()

--- a/iroh/tests/patchbay/switch-uplink.rs
+++ b/iroh/tests/patchbay/switch-uplink.rs
@@ -13,7 +13,7 @@
 
 use std::time::Duration;
 
-use iroh::{TransportAddr, endpoint::Side};
+use iroh::{TransportAddr, Watcher, endpoint::Side};
 use n0_error::{Result, StackResultExt};
 use n0_tracing_test::traced_test;
 use patchbay::{IpSupport, RouterPreset};
@@ -30,8 +30,8 @@ fn router_preset(ip: IpSupport) -> RouterPreset {
     }
 }
 
-fn path_switched(to: IpSupport, first: &TransportAddr, new: &TransportAddr) -> bool {
-    if new == first {
+fn path_switched(to: IpSupport, previous: &[TransportAddr], new: &TransportAddr) -> bool {
+    if previous.contains(new) {
         return false;
     }
     match to {
@@ -128,13 +128,18 @@ async fn run_switch_uplink(switching_side: Side, from: IpSupport, to: IpSupport)
         to: IpSupport,
     ) -> Result {
         let mut paths = conn.paths();
-        let first = paths.wait_ip(timeout).await.context("initial holepunch")?;
+        paths.wait_ip(timeout).await.context("initial holepunch")?;
         ping_open(&conn, timeout)
             .await
             .context("ping_open before switch")?;
+        let previous: Vec<TransportAddr> = paths
+            .get()
+            .iter()
+            .map(|p| p.remote_addr().clone())
+            .collect();
         paths
             .wait_selected(timeout, |p| {
-                path_switched(to, first.remote_addr(), p.remote_addr())
+                path_switched(to, &previous, p.remote_addr())
             })
             .await
             .context("path did not switch")?;

--- a/iroh/tests/patchbay/switch-uplink.rs
+++ b/iroh/tests/patchbay/switch-uplink.rs
@@ -138,9 +138,7 @@ async fn run_switch_uplink(switching_side: Side, from: IpSupport, to: IpSupport)
             .map(|p| p.remote_addr().clone())
             .collect();
         paths
-            .wait_selected(timeout, |p| {
-                path_switched(to, &previous, p.remote_addr())
-            })
+            .wait_selected(timeout, |p| path_switched(to, &previous, p.remote_addr()))
             .await
             .context("path did not switch")?;
         ping_open(&conn, timeout)

--- a/iroh/tests/patchbay/switch-uplink.rs
+++ b/iroh/tests/patchbay/switch-uplink.rs
@@ -22,45 +22,22 @@ use tracing::info;
 
 use crate::util::{Pair, PathWatcherExt, lab_with_relay, ping_accept, ping_open};
 
-/// Describes which IP family transition the switching side makes.
-///
-/// Each variant determines the router presets for the "from" and "to" routers.
-/// For example, [`V4ToV6`](Self::V4ToV6) starts the switcher behind a v4-only
-/// Home NAT and replugs to a v6-only ISP router.
-#[derive(Debug, Clone, Copy)]
-enum SwitchKind {
-    V4ToV4,
-    V4ToV6,
-    V6ToV4,
-    V6ToV6,
-    DualToDual,
+fn router_preset(ip: IpSupport) -> RouterPreset {
+    match ip {
+        IpSupport::V4Only => RouterPreset::Home,
+        IpSupport::V6Only => RouterPreset::IspV6,
+        IpSupport::DualStack => RouterPreset::Home,
+    }
 }
 
-impl SwitchKind {
-    /// Returns the `(preset, ip_support)` pairs for the "from" and "to" routers.
-    fn router_configs(self) -> ((RouterPreset, IpSupport), (RouterPreset, IpSupport)) {
-        use IpSupport::*;
-        use RouterPreset::*;
-        match self {
-            Self::V4ToV4 => ((Home, V4Only), (Home, V4Only)),
-            Self::V4ToV6 => ((Home, V4Only), (IspV6, V6Only)),
-            Self::V6ToV4 => ((IspV6, V6Only), (Home, V4Only)),
-            Self::V6ToV6 => ((IspV6, V6Only), (IspV6, V6Only)),
-            Self::DualToDual => ((Home, DualStack), (Home, DualStack)),
-        }
+fn path_switched(to: IpSupport, first: &TransportAddr, new: &TransportAddr) -> bool {
+    if new == first {
+        return false;
     }
-
-    /// Checks whether the selected path has changed as expected after the switch.
-    ///
-    /// For cross-family switches (v4-to-v6, v6-to-v4), we verify the new path
-    /// uses the target address family. For same-family switches, we verify the
-    /// remote address changed (different NAT, different public IP).
-    fn path_switched(self, first: &TransportAddr, new: &TransportAddr) -> bool {
-        match self {
-            Self::V4ToV6 => matches!(new, TransportAddr::Ip(a) if a.ip().is_ipv6()),
-            Self::V6ToV4 => matches!(new, TransportAddr::Ip(a) if a.ip().is_ipv4()),
-            _ => matches!(new, TransportAddr::Ip(_)) && new != first,
-        }
+    match to {
+        IpSupport::V4Only => matches!(new, TransportAddr::Ip(a) if a.ip().is_ipv4()),
+        IpSupport::V6Only => matches!(new, TransportAddr::Ip(a) if a.ip().is_ipv6()),
+        IpSupport::DualStack => matches!(new, TransportAddr::Ip(_)),
     }
 }
 
@@ -68,13 +45,13 @@ impl SwitchKind {
 ///
 /// The topology has three routers:
 /// - "observer": dual-stack Home NAT for the non-switching side
-/// - "from": the switching side's initial router (determined by `kind`)
-/// - "to": the router the switching side replugs to (determined by `kind`)
+/// - "from": the switching side's initial router (determined by `from`)
+/// - "to": the router the switching side replugs to (determined by `to`)
 ///
 /// After both sides holepunch and exchange a ping, the switching side replugs
 /// from "from" to "to". The observer waits for the selected path to change,
 /// then both sides exchange another ping to confirm the new path works.
-async fn run_switch_uplink(switching_side: Side, kind: SwitchKind) -> Result {
+async fn run_switch_uplink(switching_side: Side, from: IpSupport, to: IpSupport) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
     let timeout = Duration::from_secs(30);
 
@@ -86,18 +63,17 @@ async fn run_switch_uplink(switching_side: Side, kind: SwitchKind) -> Result {
         .await?
         .id();
 
-    let ((from_preset, from_ip), (to_preset, to_ip)) = kind.router_configs();
     let from_id = lab
         .add_router("from")
-        .preset(from_preset)
-        .ip_support(from_ip)
+        .preset(router_preset(from))
+        .ip_support(from)
         .build()
         .await?
         .id();
     let to_id = lab
         .add_router("to")
-        .preset(to_preset)
-        .ip_support(to_ip)
+        .preset(router_preset(to))
+        .ip_support(to)
         .build()
         .await?
         .id();
@@ -117,7 +93,7 @@ async fn run_switch_uplink(switching_side: Side, kind: SwitchKind) -> Result {
         .build()
         .await?;
 
-    info!(?switching_side, ?kind, "switch uplink test start");
+    info!(?switching_side, ?from, ?to, "switch uplink test start");
 
     /// The switching side: holepunches, pings, replugs to a new router, pings again.
     ///
@@ -152,7 +128,7 @@ async fn run_switch_uplink(switching_side: Side, kind: SwitchKind) -> Result {
     async fn do_observe(
         conn: iroh::endpoint::Connection,
         timeout: Duration,
-        kind: SwitchKind,
+        to: IpSupport,
     ) -> Result {
         let mut paths = conn.paths();
         let first = paths.wait_ip(timeout).await.context("initial holepunch")?;
@@ -161,7 +137,7 @@ async fn run_switch_uplink(switching_side: Side, kind: SwitchKind) -> Result {
             .context("ping_open before switch")?;
         paths
             .wait_selected(timeout, |p| {
-                kind.path_switched(first.remote_addr(), p.remote_addr())
+                path_switched(to, first.remote_addr(), p.remote_addr())
             })
             .await
             .context("path did not switch")?;
@@ -176,7 +152,7 @@ async fn run_switch_uplink(switching_side: Side, kind: SwitchKind) -> Result {
     let pair = match switching_side {
         Side::Client => pair
             .server(server, async move |_dev, _ep, conn| {
-                do_observe(conn, timeout, kind).await
+                do_observe(conn, timeout, to).await
             })
             .client(client, async move |dev, _ep, conn| {
                 do_switch(dev, conn, timeout, to_id).await
@@ -186,7 +162,7 @@ async fn run_switch_uplink(switching_side: Side, kind: SwitchKind) -> Result {
                 do_switch(dev, conn, timeout, to_id).await
             })
             .client(client, async move |_dev, _ep, conn| {
-                do_observe(conn, timeout, kind).await
+                do_observe(conn, timeout, to).await
             }),
     };
     pair.run().await?;
@@ -200,31 +176,55 @@ async fn run_switch_uplink(switching_side: Side, kind: SwitchKind) -> Result {
 #[tokio::test]
 #[traced_test]
 async fn switch_client_v4_to_v4() -> Result {
-    run_switch_uplink(Side::Client, SwitchKind::V4ToV4).await
+    run_switch_uplink(Side::Client, IpSupport::V4Only, IpSupport::V4Only).await
 }
 
 #[tokio::test]
 #[traced_test]
 async fn switch_client_v4_to_v6() -> Result {
-    run_switch_uplink(Side::Client, SwitchKind::V4ToV6).await
+    run_switch_uplink(Side::Client, IpSupport::V4Only, IpSupport::V6Only).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_client_v4_to_dual() -> Result {
+    run_switch_uplink(Side::Client, IpSupport::V4Only, IpSupport::DualStack).await
 }
 
 #[tokio::test]
 #[traced_test]
 async fn switch_client_v6_to_v4() -> Result {
-    run_switch_uplink(Side::Client, SwitchKind::V6ToV4).await
+    run_switch_uplink(Side::Client, IpSupport::V6Only, IpSupport::V4Only).await
 }
 
 #[tokio::test]
 #[traced_test]
 async fn switch_client_v6_to_v6() -> Result {
-    run_switch_uplink(Side::Client, SwitchKind::V6ToV6).await
+    run_switch_uplink(Side::Client, IpSupport::V6Only, IpSupport::V6Only).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_client_v6_to_dual() -> Result {
+    run_switch_uplink(Side::Client, IpSupport::V6Only, IpSupport::DualStack).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_client_dual_to_v4() -> Result {
+    run_switch_uplink(Side::Client, IpSupport::DualStack, IpSupport::V4Only).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_client_dual_to_v6() -> Result {
+    run_switch_uplink(Side::Client, IpSupport::DualStack, IpSupport::V6Only).await
 }
 
 #[tokio::test]
 #[traced_test]
 async fn switch_client_dual_to_dual() -> Result {
-    run_switch_uplink(Side::Client, SwitchKind::DualToDual).await
+    run_switch_uplink(Side::Client, IpSupport::DualStack, IpSupport::DualStack).await
 }
 
 // --- Server switches uplink ---
@@ -232,29 +232,53 @@ async fn switch_client_dual_to_dual() -> Result {
 #[tokio::test]
 #[traced_test]
 async fn switch_server_v4_to_v4() -> Result {
-    run_switch_uplink(Side::Server, SwitchKind::V4ToV4).await
+    run_switch_uplink(Side::Server, IpSupport::V4Only, IpSupport::V4Only).await
 }
 
 #[tokio::test]
 #[traced_test]
 async fn switch_server_v4_to_v6() -> Result {
-    run_switch_uplink(Side::Server, SwitchKind::V4ToV6).await
+    run_switch_uplink(Side::Server, IpSupport::V4Only, IpSupport::V6Only).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_server_v4_to_dual() -> Result {
+    run_switch_uplink(Side::Server, IpSupport::V4Only, IpSupport::DualStack).await
 }
 
 #[tokio::test]
 #[traced_test]
 async fn switch_server_v6_to_v4() -> Result {
-    run_switch_uplink(Side::Server, SwitchKind::V6ToV4).await
+    run_switch_uplink(Side::Server, IpSupport::V6Only, IpSupport::V4Only).await
 }
 
 #[tokio::test]
 #[traced_test]
 async fn switch_server_v6_to_v6() -> Result {
-    run_switch_uplink(Side::Server, SwitchKind::V6ToV6).await
+    run_switch_uplink(Side::Server, IpSupport::V6Only, IpSupport::V6Only).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_server_v6_to_dual() -> Result {
+    run_switch_uplink(Side::Server, IpSupport::V6Only, IpSupport::DualStack).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_server_dual_to_v4() -> Result {
+    run_switch_uplink(Side::Server, IpSupport::DualStack, IpSupport::V4Only).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_server_dual_to_v6() -> Result {
+    run_switch_uplink(Side::Server, IpSupport::DualStack, IpSupport::V6Only).await
 }
 
 #[tokio::test]
 #[traced_test]
 async fn switch_server_dual_to_dual() -> Result {
-    run_switch_uplink(Side::Server, SwitchKind::DualToDual).await
+    run_switch_uplink(Side::Server, IpSupport::DualStack, IpSupport::DualStack).await
 }

--- a/iroh/tests/patchbay/switch-uplink.rs
+++ b/iroh/tests/patchbay/switch-uplink.rs
@@ -1,0 +1,260 @@
+//! Uplink switch tests.
+//!
+//! Each test verifies that an iroh connection survives a network change on one
+//! side: the switching device replugs from one router to another, and we verify
+//! that a new direct path is established and data flows over it.
+//!
+//! We test every combination of:
+//! - which side switches (client or server)
+//! - which IP families are involved (v4, v6, dual-stack)
+//!
+//! The non-switching side is always behind a dual-stack Home NAT, so it is
+//! reachable on both address families regardless of what the switcher does.
+
+use std::time::Duration;
+
+use iroh::{TransportAddr, endpoint::Side};
+use n0_error::{Result, StackResultExt};
+use n0_tracing_test::traced_test;
+use patchbay::{IpSupport, RouterPreset};
+use testdir::testdir;
+use tracing::info;
+
+use crate::util::{Pair, PathWatcherExt, lab_with_relay, ping_accept, ping_open};
+
+/// Describes which IP family transition the switching side makes.
+///
+/// Each variant determines the router presets for the "from" and "to" routers.
+/// For example, [`V4ToV6`](Self::V4ToV6) starts the switcher behind a v4-only
+/// Home NAT and replugs to a v6-only ISP router.
+#[derive(Debug, Clone, Copy)]
+enum SwitchKind {
+    V4ToV4,
+    V4ToV6,
+    V6ToV4,
+    V6ToV6,
+    DualToDual,
+}
+
+impl SwitchKind {
+    /// Returns the `(preset, ip_support)` pairs for the "from" and "to" routers.
+    fn router_configs(self) -> ((RouterPreset, IpSupport), (RouterPreset, IpSupport)) {
+        use IpSupport::*;
+        use RouterPreset::*;
+        match self {
+            Self::V4ToV4 => ((Home, V4Only), (Home, V4Only)),
+            Self::V4ToV6 => ((Home, V4Only), (IspV6, V6Only)),
+            Self::V6ToV4 => ((IspV6, V6Only), (Home, V4Only)),
+            Self::V6ToV6 => ((IspV6, V6Only), (IspV6, V6Only)),
+            Self::DualToDual => ((Home, DualStack), (Home, DualStack)),
+        }
+    }
+
+    /// Checks whether the selected path has changed as expected after the switch.
+    ///
+    /// For cross-family switches (v4-to-v6, v6-to-v4), we verify the new path
+    /// uses the target address family. For same-family switches, we verify the
+    /// remote address changed (different NAT, different public IP).
+    fn path_switched(self, first: &TransportAddr, new: &TransportAddr) -> bool {
+        match self {
+            Self::V4ToV6 => matches!(new, TransportAddr::Ip(a) if a.ip().is_ipv6()),
+            Self::V6ToV4 => matches!(new, TransportAddr::Ip(a) if a.ip().is_ipv4()),
+            _ => matches!(new, TransportAddr::Ip(_)) && new != first,
+        }
+    }
+}
+
+/// Builds the lab topology and runs a single uplink switch test.
+///
+/// The topology has three routers:
+/// - "observer": dual-stack Home NAT for the non-switching side
+/// - "from": the switching side's initial router (determined by `kind`)
+/// - "to": the router the switching side replugs to (determined by `kind`)
+///
+/// After both sides holepunch and exchange a ping, the switching side replugs
+/// from "from" to "to". The observer waits for the selected path to change,
+/// then both sides exchange another ping to confirm the new path works.
+async fn run_switch_uplink(switching_side: Side, kind: SwitchKind) -> Result {
+    let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
+    let timeout = Duration::from_secs(30);
+
+    let observer_id = lab
+        .add_router("observer")
+        .preset(RouterPreset::Home)
+        .ip_support(IpSupport::DualStack)
+        .build()
+        .await?
+        .id();
+
+    let ((from_preset, from_ip), (to_preset, to_ip)) = kind.router_configs();
+    let from_id = lab
+        .add_router("from")
+        .preset(from_preset)
+        .ip_support(from_ip)
+        .build()
+        .await?
+        .id();
+    let to_id = lab
+        .add_router("to")
+        .preset(to_preset)
+        .ip_support(to_ip)
+        .build()
+        .await?
+        .id();
+
+    let (server_uplink, client_uplink) = match switching_side {
+        Side::Client => (observer_id, from_id),
+        Side::Server => (from_id, observer_id),
+    };
+    let server = lab
+        .add_device("server")
+        .uplink(server_uplink)
+        .build()
+        .await?;
+    let client = lab
+        .add_device("client")
+        .uplink(client_uplink)
+        .build()
+        .await?;
+
+    info!(?switching_side, ?kind, "switch uplink test start");
+
+    /// The switching side: holepunches, pings, replugs to a new router, pings again.
+    ///
+    /// Waits for the peer to close the connection after the second ping succeeds.
+    async fn do_switch(
+        dev: patchbay::Device,
+        conn: iroh::endpoint::Connection,
+        timeout: Duration,
+        to_id: patchbay::NodeId,
+    ) -> Result {
+        let mut paths = conn.paths();
+        paths.wait_ip(timeout).await.context("initial holepunch")?;
+        ping_accept(&conn, timeout)
+            .await
+            .context("ping_accept before switch")?;
+        // TODO(Frando): Without this sleep, some of the server-side tests fail.
+        // Exact reason not yet known, but things are very timing-sensitive atm.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        dev.iface("eth0").unwrap().replug(to_id).await?;
+        ping_accept(&conn, timeout)
+            .await
+            .context("ping_accept after switch")?;
+        conn.closed().await;
+        Ok(())
+    }
+
+    /// The observing side: holepunches, pings, waits for the path to change, pings again.
+    ///
+    /// After the switching side replugs, the observer sees the selected path change
+    /// to match the expected address family (or a new address for same-family switches).
+    /// Closes the connection after the second ping succeeds.
+    async fn do_observe(
+        conn: iroh::endpoint::Connection,
+        timeout: Duration,
+        kind: SwitchKind,
+    ) -> Result {
+        let mut paths = conn.paths();
+        let first = paths.wait_ip(timeout).await.context("initial holepunch")?;
+        ping_open(&conn, timeout)
+            .await
+            .context("ping_open before switch")?;
+        paths
+            .wait_selected(timeout, |p| {
+                kind.path_switched(first.remote_addr(), p.remote_addr())
+            })
+            .await
+            .context("path did not switch")?;
+        ping_open(&conn, timeout)
+            .await
+            .context("ping_open after switch")?;
+        conn.close(0u32.into(), b"bye");
+        Ok(())
+    }
+
+    let pair = Pair::new(relay_map);
+    let pair = match switching_side {
+        Side::Client => pair
+            .server(server, async move |_dev, _ep, conn| {
+                do_observe(conn, timeout, kind).await
+            })
+            .client(client, async move |dev, _ep, conn| {
+                do_switch(dev, conn, timeout, to_id).await
+            }),
+        Side::Server => pair
+            .server(server, async move |dev, _ep, conn| {
+                do_switch(dev, conn, timeout, to_id).await
+            })
+            .client(client, async move |_dev, _ep, conn| {
+                do_observe(conn, timeout, kind).await
+            }),
+    };
+    pair.run().await?;
+
+    guard.ok();
+    Ok(())
+}
+
+// --- Client switches uplink ---
+
+#[tokio::test]
+#[traced_test]
+async fn switch_client_v4_to_v4() -> Result {
+    run_switch_uplink(Side::Client, SwitchKind::V4ToV4).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_client_v4_to_v6() -> Result {
+    run_switch_uplink(Side::Client, SwitchKind::V4ToV6).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_client_v6_to_v4() -> Result {
+    run_switch_uplink(Side::Client, SwitchKind::V6ToV4).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_client_v6_to_v6() -> Result {
+    run_switch_uplink(Side::Client, SwitchKind::V6ToV6).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_client_dual_to_dual() -> Result {
+    run_switch_uplink(Side::Client, SwitchKind::DualToDual).await
+}
+
+// --- Server switches uplink ---
+
+#[tokio::test]
+#[traced_test]
+async fn switch_server_v4_to_v4() -> Result {
+    run_switch_uplink(Side::Server, SwitchKind::V4ToV4).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_server_v4_to_v6() -> Result {
+    run_switch_uplink(Side::Server, SwitchKind::V4ToV6).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_server_v6_to_v4() -> Result {
+    run_switch_uplink(Side::Server, SwitchKind::V6ToV4).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_server_v6_to_v6() -> Result {
+    run_switch_uplink(Side::Server, SwitchKind::V6ToV6).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn switch_server_dual_to_dual() -> Result {
+    run_switch_uplink(Side::Server, SwitchKind::DualToDual).await
+}

--- a/iroh/tests/patchbay/switch-uplink.rs
+++ b/iroh/tests/patchbay/switch-uplink.rs
@@ -109,9 +109,6 @@ async fn run_switch_uplink(switching_side: Side, from: IpSupport, to: IpSupport)
         ping_accept(&conn, timeout)
             .await
             .context("ping_accept before switch")?;
-        // TODO(Frando): Without this sleep, some of the server-side tests fail.
-        // Exact reason not yet known, but things are very timing-sensitive atm.
-        tokio::time::sleep(Duration::from_secs(1)).await;
         dev.iface("eth0").unwrap().replug(to_id).await?;
         ping_accept(&conn, timeout)
             .await


### PR DESCRIPTION
## Description

Adds a patchbay test matrix for testing uplink switching across IP family transitions (v4/v6/dual-stack) for both client and server side. Each test holepunches a direct path, replugs the switching side to a different router, and verifies that a new direct path is selected and data flows over it.

The tests all pass. Initially, the server side tests failed, and this uncovered two issues which are now fixed:
* We currently fail to detect the default route when switching to a v6-only interface in netwatch, see https://github.com/n0-computer/net-tools/pull/132. This leads to iroh not forwarding the major network change to quinn, because we only do this if we determine the network to be usable, which fails because the default route check fails. 
*  noq's `handle_network_change` only checks  whether a path is recoverable on the client side; the server side always assumed paths were recoverable, so dead direct paths were never proactively abandoned after a server replug. See https://github.com/n0-computer/noq/pull/579
