### PR TITLE
deps(iroh): update patchbay to 0.5

### DIFF
--- a/.github/workflows/patchbay.yml
+++ b/.github/workflows/patchbay.yml
@@ -44,8 +44,8 @@ jobs:
           set -o pipefail
           cargo make patchbay 2>&1 | tee "$RUNNER_TEMP/logs.txt"
         env:
-          PATCHBAY_LOG: trace
-          RUST_LOG: trace
+          PATCHBAY_LOG: ${{ runner.debug && 'trace' || 'debug' }}
+          RUST_LOG: ${{ runner.debug && 'trace' || 'debug' }}
 
       - name: Upload test results
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,7 +3530,8 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "patchbay"
 version = "0.5.0"
-source = "git+https://github.com/n0-computer/patchbay?branch=main#b3c9cf30c6535e19491cfdc78e0afac0112e6adf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3742a2d138befdefff631816140d985988b7e4600dbec986d360d35f0209b2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3529,14 +3529,15 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patchbay"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d93ad32b57e2d0185284b2e73817b3668feb3013ee70e963d1cb01dda53a8a"
+checksum = "1bf9072413442b17c2501d644ae24cf9b51eb042f9ce9a198f0cb18c02ca876f"
 dependencies = [
  "anyhow",
  "chrono",
  "derive_more",
  "futures",
+ "hickory-proto 0.25.2",
  "ipnet",
  "iroh-metrics",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1397,7 +1397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3292,7 +3292,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3529,9 +3529,8 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patchbay"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf9072413442b17c2501d644ae24cf9b51eb042f9ce9a198f0cb18c02ca876f"
+version = "0.5.0"
+source = "git+https://github.com/n0-computer/patchbay?branch=main#b3c9cf30c6535e19491cfdc78e0afac0112e6adf"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4320,7 +4319,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4413,7 +4412,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4518,7 +4517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4788,7 +4787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5028,7 +5027,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5928,7 +5927,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
 noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
 noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
 noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }
+patchbay = { git = "https://github.com/n0-computer/patchbay", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,3 @@ netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
 noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
 noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
 noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }
-patchbay = { git = "https://github.com/n0-computer/patchbay", branch = "main" }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -142,7 +142,7 @@ wasm-bindgen-test = "0.3.62"
 # patchbay netsim test dependencies (linux only)
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 ctor = "0.8"
-patchbay = { version = "0.4", features = ["iroh-metrics"] }
+patchbay = { version = "0.5", features = ["iroh-metrics"] }
 testdir = "0.10"
 
 [build-dependencies]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -142,7 +142,7 @@ wasm-bindgen-test = "0.3.62"
 # patchbay netsim test dependencies (linux only)
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 ctor = "0.8"
-patchbay = { version = "0.3", features = ["iroh-metrics"] }
+patchbay = { version = "0.4", features = ["iroh-metrics"] }
 testdir = "0.10"
 
 [build-dependencies]

--- a/iroh/tests/patchbay.rs
+++ b/iroh/tests/patchbay.rs
@@ -140,7 +140,7 @@ async fn switch_uplink_v4() -> Result {
             // Wait a little more and then switch wifis.
             tokio::time::sleep(Duration::from_secs(1)).await;
             info!("switch IP uplink");
-            dev.replug_iface("eth0", nat3.id()).await?;
+            dev.iface("eth0").unwrap().replug(nat3.id()).await?;
 
             // We don't assert any path changes here, because the remote stays identical,
             // and PathInfo does not contain info on local addrs. Instead, the remote
@@ -232,7 +232,7 @@ async fn switch_uplink_v6() -> Result {
                 .context("ping before switch")?;
 
             info!("switch IP uplink to v6");
-            dev.replug_iface("eth0", mobile.id()).await?;
+            dev.iface("eth0").unwrap().replug(mobile.id()).await?;
 
             // We don't assert any path changes here, because the remote stays identical,
             // and PathInfo does not contain info on local addrs. Instead, the remote
@@ -276,9 +276,11 @@ async fn change_ifaces() -> Result {
         .build()
         .await?;
     client
-        .set_link_condition("eth0", Some(LinkCondition::Mobile4G), LinkDirection::Both)
+        .iface("eth0")
+        .unwrap()
+        .set_condition(LinkCondition::Mobile4G, LinkDirection::Both)
         .await?;
-    client.link_down("eth1").await?;
+    client.iface("eth1").unwrap().link_down().await?;
 
     let timeout = Duration::from_secs(15);
     Pair::new(relay_map)
@@ -300,7 +302,7 @@ async fn change_ifaces() -> Result {
 
             // Bring up the LAN interface to the other ep.
             info!("bring up eth1");
-            dev.link_up("eth1").await?;
+            dev.iface("eth1").unwrap().link_up().await?;
 
             // Wait for a new direct path to be established. We check is_ip() explicitly
             // to avoid triggering on a transient relay fallback during the switch.
@@ -349,9 +351,9 @@ async fn link_outage_recovery() -> Result {
             let downtime = Duration::from_secs(5);
             info!("holepunched, now killing link for {downtime:?}");
             // Take the link down.
-            dev.link_down("eth0").await?;
+            dev.iface("eth0").unwrap().link_down().await?;
             tokio::time::sleep(downtime).await;
-            dev.link_up("eth0").await?;
+            dev.iface("eth0").unwrap().link_up().await?;
             info!("link restored, waiting for recovery");
 
             // After link recovery, we should be able to ping, either via relay
@@ -461,7 +463,7 @@ async fn run_degrade_level(impaired_side: Side, level: usize) -> Result<TestGuar
     let timeout = Duration::from_secs(20 + level as u64 * 10);
 
     let limits = DEGRADE_LEVELS[level];
-    let link_condition = Some(LinkCondition::Manual(limits));
+    let link_condition = LinkCondition::Manual(limits);
 
     let server = lab
         .add_device("server")
@@ -478,8 +480,11 @@ async fn run_degrade_level(impaired_side: Side, level: usize) -> Result<TestGuar
         Side::Server => &server,
     };
     impaired_device
-        .set_link_condition("eth0", link_condition, LinkDirection::Both)
+        .iface("eth0")
+        .unwrap()
+        .set_condition(link_condition, LinkDirection::Both)
         .await?;
+
     info!(?impaired_side, ?limits, %level, ?timeout, "degrade test start");
 
     let result = tokio::time::timeout(

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -55,8 +55,9 @@ async fn spawn_relay(lab: &Lab) -> Result<(RelayMap, AbortOnDropHandle<()>)> {
     // Devices created after this will resolve "relay.test" to both addresses.
     let relay_v4 = dev_relay.ip().expect("relay has IPv4");
     let relay_v6 = dev_relay.ip6().expect("relay has IPv6");
-    lab.dns_entry("relay.test", relay_v4.into())?;
-    lab.dns_entry("relay.test", relay_v6.into())?;
+    let dns = lab.dns_server()?;
+    dns.set_host("relay.test", relay_v4.into())?;
+    dns.set_host("relay.test", relay_v6.into())?;
     info!(%relay_v4, %relay_v6, "DNS entries for relay.test registered");
 
     let (relay_map_tx, relay_map_rx) = oneshot::channel();

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -8,7 +8,7 @@ use iroh::{
 use iroh_metrics::MetricsGroupSet;
 use n0_error::{Result, StackResultExt, StdResultExt, anyerr, ensure_any};
 use n0_future::{boxed::BoxFuture, task::AbortOnDropHandle};
-use patchbay::{Device, IpSupport, Lab, LabOpts, OutDir, TestGuard};
+use patchbay::{Device, IpSupport, Lab, OutDir, TestGuard};
 use tokio::sync::{Barrier, oneshot};
 use tracing::{Instrument, debug, error, error_span, event, info};
 
@@ -24,13 +24,13 @@ const TEST_ALPN: &[u8] = b"test";
 /// The relay binds on `[::]` and is reachable via `https://relay.test`
 /// (resolved through lab-wide DNS entries for both IPv4 and IPv6).
 pub async fn lab_with_relay(
-    path: PathBuf,
+    outdir: PathBuf,
 ) -> Result<(Lab, RelayMap, AbortOnDropHandle<()>, TestGuard)> {
-    let mut opts = LabOpts::default().outdir(OutDir::Exact(path));
+    let mut builder = Lab::builder().outdir(OutDir::Exact(outdir));
     if let Some(name) = std::thread::current().name() {
-        opts = opts.label(name);
+        builder = builder.label(name);
     }
-    let lab = Lab::with_opts(opts).await?;
+    let lab = builder.build().await?;
     let guard = lab.test_guard();
     let (relay_map, relay_guard) = spawn_relay(&lab).await?;
     Ok((lab, relay_map, relay_guard, guard))


### PR DESCRIPTION
## Description

Updates patchbay from 0.3.0 to 0.5.0.
* v0.4 introduced an new `Iface` API.
* v0.5 fixed a nasty bug when running patchbay as root (as CI runners do) where `resolv.conf` would leak to the host, and has a new `Lab::builder` API.


