### PR TITLE
feat(iroh): add ability to configure external addrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1857,7 +1857,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni 0.22.4",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1886,7 +1886,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustls",
  "serde",
@@ -1910,7 +1910,7 @@ dependencies = [
  "jni 0.22.4",
  "once_cell",
  "prefix-trie 0.8.2",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1931,7 +1931,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "resolv-conf",
  "rustls",
  "serde",
@@ -1959,7 +1959,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "resolv-conf",
  "rustls",
  "smallvec",
@@ -2289,7 +2289,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tokio",
  "url",
  "xmltree",
@@ -2407,7 +2407,7 @@ dependencies = [
  "portmapper",
  "postcard",
  "pretty_assertions",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "reqwest 0.13.2",
  "rustc-hash",
@@ -2447,7 +2447,7 @@ dependencies = [
  "n0-error",
  "postcard",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "serde",
  "serde_json",
@@ -2471,7 +2471,7 @@ dependencies = [
  "n0-error",
  "n0-future",
  "noq",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rcgen",
  "rustls",
  "tokio",
@@ -2506,7 +2506,7 @@ dependencies = [
  "n0-future",
  "n0-tracing-test",
  "pkarr",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rcgen",
  "redb",
@@ -2598,7 +2598,7 @@ dependencies = [
  "pkarr",
  "postcard",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rcgen",
  "reloadable-state",
@@ -3236,7 +3236,7 @@ dependencies = [
  "identity-hash",
  "lru-slab",
  "n0-qlog",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3735,7 +3735,7 @@ dependencies = [
  "n0-error",
  "netwatch",
  "num_enum",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "smallvec",
  "socket2",
@@ -3865,7 +3865,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3933,7 +3933,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3982,9 +3982,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3992,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -4938,7 +4938,7 @@ checksum = "737bfdaf732174c48b8193b29158460d8d959dd8e9ce071a5bbda95d8546b68b"
 dependencies = [
  "acto",
  "hickory-proto 0.26.0-beta.1",
- "rand 0.10.0",
+ "rand 0.10.1",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -5270,7 +5270,7 @@ dependencies = [
  "getrandom 0.4.2",
  "http",
  "httparse",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ring",
  "rustls-pki-types",
  "sha1_smol",

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2807,8 +2807,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_external_addr() -> Result {
-        let configured_addr =
-            SocketAddr::from(SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 12345));
+        let configured_addr = SocketAddr::from(SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 12345));
 
         // Test builder-configured external address
         let ep = Endpoint::builder(presets::Minimal)
@@ -2823,8 +2822,7 @@ mod tests {
         );
 
         // Test runtime add
-        let runtime_addr =
-            SocketAddr::from(SocketAddrV4::new(Ipv4Addr::new(5, 6, 7, 8), 54321));
+        let runtime_addr = SocketAddr::from(SocketAddrV4::new(Ipv4Addr::new(5, 6, 7, 8), 54321));
         ep.add_external_addr(runtime_addr).await;
 
         // Give the actor time to process the refresh

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -11,7 +11,7 @@
 //!
 //! [module docs]: crate
 
-use std::{net::SocketAddr, pin::Pin, sync::Arc};
+use std::{collections::BTreeSet, net::SocketAddr, pin::Pin, sync::Arc};
 
 #[cfg(not(wasm_browser))]
 use ipnet::{Ipv4Net, Ipv6Net};
@@ -128,6 +128,7 @@ pub struct Builder {
     transport_bias: socket::transports::TransportBiasMap,
     portmapper_config: PortmapperConfig,
     crypto_provider: Option<Arc<rustls::crypto::CryptoProvider>>,
+    configured_addrs: BTreeSet<SocketAddr>,
 }
 
 impl From<RelayMode> for Option<TransportConfig> {
@@ -194,6 +195,7 @@ impl Builder {
             transport_bias: Default::default(),
             portmapper_config: Default::default(),
             crypto_provider: None,
+            configured_addrs: Default::default(),
         }
     }
 
@@ -254,6 +256,7 @@ impl Builder {
             transport_bias: self.transport_bias,
             portmapper_config: self.portmapper_config,
             static_config,
+            configured_addrs: self.configured_addrs,
         };
 
         let inner = socket::EndpointInner::bind(sock_opts)
@@ -614,6 +617,15 @@ impl Builder {
         self
     }
 
+    /// Adds an external address to advertise to peers as directly reachable.
+    ///
+    /// Can be called multiple times. See also [`Endpoint::add_external_addr`] for
+    /// adding addresses at runtime.
+    pub fn external_addr(mut self, addr: SocketAddr) -> Self {
+        self.configured_addrs.insert(addr);
+        self
+    }
+
     // # Methods for more specialist customisation.
 
     /// Sets a custom [`QuicTransportConfig`] for this endpoint.
@@ -914,6 +926,25 @@ impl Endpoint {
             return None;
         }
         self.inner.remove_relay(relay).await
+    }
+
+    /// Adds an external address to advertise to peers as directly reachable.
+    ///
+    /// See also [`Builder::external_addr`] for setting addresses at build time.
+    pub async fn add_external_addr(&self, addr: SocketAddr) {
+        if self.is_closed() {
+            warn!("Attempting to add external addr for a closed endpoint. Ignoring.");
+            return;
+        }
+        self.inner.add_external_addr(addr).await;
+    }
+
+    /// Removes a configured external address. Returns `true` if it was present.
+    pub async fn remove_external_addr(&self, addr: &SocketAddr) -> bool {
+        if self.is_closed() {
+            return false;
+        }
+        self.inner.remove_external_addr(addr).await
     }
 
     // # Methods for establishing connectivity.
@@ -1831,7 +1862,7 @@ mod tests {
     use std::{
         collections::BTreeMap,
         io,
-        net::{IpAddr, Ipv4Addr, Ipv6Addr},
+        net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},
         str::FromStr,
         sync::Arc,
         time::{Duration, Instant},
@@ -2768,6 +2799,62 @@ mod tests {
 
         assert!(ep.addr().ip_addrs().count() > 0);
 
+        Ok(())
+    }
+
+    /// Test that configured external addresses are included in the endpoint's
+    /// direct addresses, both when set via builder and at runtime.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_external_addr() -> Result {
+        let configured_addr =
+            SocketAddr::from(SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 12345));
+
+        // Test builder-configured external address
+        let ep = Endpoint::builder(presets::Minimal)
+            .external_addr(configured_addr)
+            .bind()
+            .await?;
+
+        let addr = ep.addr();
+        assert!(
+            addr.ip_addrs().any(|a| *a == configured_addr),
+            "builder-configured external addr {configured_addr} not found in endpoint addr: {addr:?}"
+        );
+
+        // Test runtime add
+        let runtime_addr =
+            SocketAddr::from(SocketAddrV4::new(Ipv4Addr::new(5, 6, 7, 8), 54321));
+        ep.add_external_addr(runtime_addr).await;
+
+        // Give the actor time to process the refresh
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let addr = ep.addr();
+        assert!(
+            addr.ip_addrs().any(|a| *a == runtime_addr),
+            "runtime-added external addr {runtime_addr} not found in endpoint addr: {addr:?}"
+        );
+
+        // Test runtime remove
+        let removed = ep.remove_external_addr(&runtime_addr).await;
+        assert!(removed);
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let addr = ep.addr();
+        assert!(
+            !addr.ip_addrs().any(|a| *a == runtime_addr),
+            "removed external addr {runtime_addr} still found in endpoint addr: {addr:?}"
+        );
+
+        // Original configured addr should still be there
+        assert!(
+            addr.ip_addrs().any(|a| *a == configured_addr),
+            "builder-configured external addr {configured_addr} should still be present after removing runtime addr: {addr:?}"
+        );
+
+        ep.close().await;
         Ok(())
     }
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -2804,7 +2804,7 @@ mod tests {
 
     /// Test that configured external addresses are included in the endpoint's
     /// direct addresses, both when set via builder and at runtime.
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     #[traced_test]
     async fn test_external_addr() -> Result {
         let configured_addr = SocketAddr::from(SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 12345));
@@ -2824,8 +2824,6 @@ mod tests {
         // Test runtime add
         let runtime_addr = SocketAddr::from(SocketAddrV4::new(Ipv4Addr::new(5, 6, 7, 8), 54321));
         ep.add_external_addr(runtime_addr).await;
-
-        // Give the actor time to process the refresh
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let addr = ep.addr();
@@ -2837,7 +2835,6 @@ mod tests {
         // Test runtime remove
         let removed = ep.remove_external_addr(&runtime_addr).await;
         assert!(removed);
-
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let addr = ep.addr();
@@ -2845,11 +2842,9 @@ mod tests {
             !addr.ip_addrs().any(|a| *a == runtime_addr),
             "removed external addr {runtime_addr} still found in endpoint addr: {addr:?}"
         );
-
-        // Original configured addr should still be there
         assert!(
             addr.ip_addrs().any(|a| *a == configured_addr),
-            "builder-configured external addr {configured_addr} should still be present after removing runtime addr: {addr:?}"
+            "builder-configured external addr should still be present: {addr:?}"
         );
 
         ep.close().await;

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -617,7 +617,10 @@ impl Builder {
         self
     }
 
-    /// Adds an external address to advertise to peers as directly reachable.
+    /// Adds an external address on which this endpoint is directly reachable.
+    ///
+    /// This address will be advertised to peers together with any discovered external addresses
+    /// and will be used in NAT traversal and to establish direct connections.
     ///
     /// Can be called multiple times. See also [`Endpoint::add_external_addr`] for
     /// adding addresses at runtime.
@@ -928,7 +931,10 @@ impl Endpoint {
         self.inner.remove_relay(relay).await
     }
 
-    /// Adds an external address to advertise to peers as directly reachable.
+    /// Adds an external address on which this endpoint is directly reachable.
+    ///
+    /// This address will be advertised to peers together with any discovered external addresses
+    /// and will be used in NAT traversal and to establish direct connections.
     ///
     /// See also [`Builder::external_addr`] for setting addresses at build time.
     pub async fn add_external_addr(&self, addr: SocketAddr) {

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -176,6 +176,9 @@ pub(crate) struct Options {
 
     /// Static configuration for the endpoint.
     pub(crate) static_config: StaticConfig,
+
+    /// Explicitly configured external addresses to advertise.
+    pub(crate) configured_addrs: BTreeSet<SocketAddr>,
 }
 
 /// Inner state for an iroh [`crate::Endpoint`].
@@ -346,6 +349,8 @@ pub(crate) struct Socket {
     address_lookup: address_lookup::ConcurrentAddressLookup,
     /// Optional user-defined discover data.
     address_lookup_user_data: RwLock<Option<UserData>>,
+    /// Explicitly configured external addresses to advertise.
+    configured_addrs: RwLock<BTreeSet<SocketAddr>>,
 
     pub(crate) tls_config: rustls::ClientConfig,
 
@@ -827,6 +832,7 @@ impl EndpointInner {
             transport_bias,
             portmapper_config,
             static_config,
+            configured_addrs,
         } = opts;
 
         let address_lookup = address_lookup::ConcurrentAddressLookup::default();
@@ -928,6 +934,7 @@ impl EndpointInner {
             address_lookup,
             relay_map: relay_map.clone(),
             address_lookup_user_data: RwLock::new(address_lookup_user_data),
+            configured_addrs: RwLock::new(configured_addrs),
             direct_addrs,
             net_report: Watchable::new((None, UpdateReason::None)),
             #[cfg(not(wasm_browser))]
@@ -1184,6 +1191,36 @@ impl EndpointInner {
         res
     }
 
+    /// Adds an external address to advertise to peers.
+    pub(crate) async fn add_external_addr(&self, addr: SocketAddr) {
+        self.sock
+            .configured_addrs
+            .write()
+            .expect("poisoned")
+            .insert(addr);
+        self.actor_sender
+            .send(ActorMessage::DirectAddrRefresh)
+            .await
+            .ok();
+    }
+
+    /// Removes a configured external address. Returns `true` if it was present.
+    pub(crate) async fn remove_external_addr(&self, addr: &SocketAddr) -> bool {
+        let removed = self
+            .sock
+            .configured_addrs
+            .write()
+            .expect("poisoned")
+            .remove(addr);
+        if removed {
+            self.actor_sender
+                .send(ActorMessage::DirectAddrRefresh)
+                .await
+                .ok();
+        }
+        removed
+    }
+
     /// Call to notify the system of potential network changes.
     pub(crate) async fn network_change(&self) {
         self.actor_sender
@@ -1287,6 +1324,8 @@ enum ActorMessage {
     ),
     #[debug("RemoteInfo(..)")]
     RemoteInfo(EndpointId, oneshot::Sender<RemoteInfo>),
+    /// Re-evaluate direct addresses, e.g. after configured external addresses changed.
+    DirectAddrRefresh,
     #[cfg(all(test, with_crypto_provider))]
     ForceNetworkChange(bool),
 }
@@ -1689,6 +1728,13 @@ impl Actor {
                     tx.send(watcher).ok();
                 }
             }
+            ActorMessage::DirectAddrRefresh => {
+                #[cfg(not(wasm_browser))]
+                {
+                    let (report, _reason) = self.sock.net_report.get();
+                    self.update_direct_addresses(report.as_ref());
+                }
+            }
             #[cfg(all(test, with_crypto_provider))]
             ActorMessage::ForceNetworkChange(is_major) => {
                 self.handle_network_change(is_major).await;
@@ -1758,6 +1804,17 @@ impl Actor {
         }
 
         self.collect_local_addresses(&mut addrs);
+
+        // Add configured external addresses.
+        for addr in self
+            .sock
+            .configured_addrs
+            .read()
+            .expect("poisoned")
+            .iter()
+        {
+            addrs.entry(*addr).or_insert(DirectAddrType::Config);
+        }
 
         // Finally create and store store all these direct addresses and send any
         // queued call-me-maybe messages.
@@ -1950,6 +2007,8 @@ pub enum DirectAddrType {
     /// configure the router to forward this port to the iroh endpoint.  This indicates a
     /// situation like this, which still uses QAD to discover the public address.
     Qad4LocalPort,
+    /// An address explicitly provided by the user via configuration.
+    Config,
 }
 
 impl Display for DirectAddrType {
@@ -1960,6 +2019,7 @@ impl Display for DirectAddrType {
             DirectAddrType::Qad => write!(f, "qad"),
             DirectAddrType::Portmapped => write!(f, "portmap"),
             DirectAddrType::Qad4LocalPort => write!(f, "qad4localport"),
+            DirectAddrType::Config => write!(f, "config"),
         }
     }
 }
@@ -2029,6 +2089,7 @@ mod tests {
             transport_bias: Default::default(),
             portmapper_config: Default::default(),
             static_config,
+            configured_addrs: Default::default(),
         }
     }
 
@@ -2437,6 +2498,7 @@ mod tests {
             transport_bias: Default::default(),
             portmapper_config: Default::default(),
             static_config,
+            configured_addrs: Default::default(),
         };
         let sock = EndpointInner::bind(opts).await?;
         Ok(sock)

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1750,6 +1750,7 @@ impl Actor {
     /// - The portmapper.
     /// - A net_report report.
     /// - The local interfaces IP addresses.
+    /// - User configured addresses.
     #[cfg(not(wasm_browser))]
     fn update_direct_addresses(&mut self, net_report_report: Option<&net_report::Report>) {
         // We only want to have one DirectAddr for each SocketAddr we have.  So we store

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1806,13 +1806,7 @@ impl Actor {
         self.collect_local_addresses(&mut addrs);
 
         // Add configured external addresses.
-        for addr in self
-            .sock
-            .configured_addrs
-            .read()
-            .expect("poisoned")
-            .iter()
-        {
+        for addr in self.sock.configured_addrs.read().expect("poisoned").iter() {
             addrs.entry(*addr).or_insert(DirectAddrType::Config);
         }
 


### PR DESCRIPTION
## Description

This allows configuring known external addresses using the builder and at runtime, to aid in the help of discovery, when they are already known through other processes.

Related to #2552 