### PR TITLE
fix(iroh-relay): prevent integer overflow in duration, segment, and rate limiter

### DIFF
--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -180,7 +180,7 @@ impl Datagrams {
         };
 
         let usize_segment_size = usize::from(u16::from(segment_size));
-        let max_content_len = num_segments * usize_segment_size;
+        let max_content_len = num_segments.saturating_mul(usize_segment_size);
         let contents = self
             .contents
             .split_to(std::cmp::min(max_content_len, self.contents.len()));
@@ -297,8 +297,8 @@ impl RelayToClientMsg {
                 reconnect_in,
                 try_for,
             } => {
-                dst.put_u32(reconnect_in.as_millis() as u32);
-                dst.put_u32(try_for.as_millis() as u32);
+                dst.put_u32(u32::try_from(reconnect_in.as_millis()).unwrap_or(u32::MAX));
+                dst.put_u32(u32::try_from(try_for.as_millis()).unwrap_or(u32::MAX));
             }
         }
         dst

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -394,7 +394,7 @@ impl Bucket {
 
         self.fill = self
             .fill
-            .saturating_add(refill_periods as i64 * self.refill);
+            .saturating_add((refill_periods as i64).saturating_mul(self.refill));
         self.fill = std::cmp::min(self.fill, self.max);
         self.last_fill += self.refill_period * refill_periods;
     }


### PR DESCRIPTION
## Summary

Three defensive arithmetic fixes in iroh-relay:

- **Duration encoding** in `Restarting` frames: replace silent truncation (`as u32`) with saturating conversion via `u32::try_from().unwrap_or(u32::MAX)`. Durations exceeding ~49 days now saturate instead of wrapping.
- **Segment calculation** in datagram batching: replace `*` with `saturating_mul` to prevent wrapping on 32-bit targets when processing attacker-controlled frame fields.
- **Rate limiter refill**: wrap `refill_periods * refill` in `saturating_mul` so it can't overflow before the outer `saturating_add`.

## Test plan

- [x] All iroh-relay tests pass
- [x] `cargo check -p iroh-relay` clean