### PR TITLE
fix(iroh): return Result from Accepting::into_0rtt instead of panicking

### DIFF
--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -619,25 +619,26 @@ impl Accepting {
     /// See also documentation for [`Connecting::into_0rtt`].
     ///
     /// [`RecvStream::is_0rtt`]: crate::endpoint::RecvStream::is_0rtt
-    pub fn into_0rtt(self) -> IncomingZeroRttConnection {
-        let (noq_conn, zrtt_accepted) = self
-            .inner
-            .into_0rtt()
-            .expect("incoming connections can always be converted to 0-RTT");
+    #[allow(clippy::result_large_err)]
+    pub fn into_0rtt(self) -> Result<IncomingZeroRttConnection, Accepting> {
+        match self.inner.into_0rtt() {
+            Ok((noq_conn, zrtt_accepted)) => {
+                let accepted: BoxFuture<_> = Box::pin({
+                    let noq_conn = noq_conn.clone();
+                    async move {
+                        let _ = zrtt_accepted.await;
+                        let conn = conn_from_noq_conn(noq_conn, &self.ep)?.await?;
+                        Ok(conn)
+                    }
+                });
+                let accepted = accepted.shared();
 
-        let accepted: BoxFuture<_> = Box::pin({
-            let noq_conn = noq_conn.clone();
-            async move {
-                let _ = zrtt_accepted.await;
-                let conn = conn_from_noq_conn(noq_conn, &self.ep)?.await?;
-                Ok(conn)
+                Ok(IncomingZeroRttConnection {
+                    inner: noq_conn,
+                    data: IncomingZeroRttData { accepted },
+                })
             }
-        });
-        let accepted = accepted.shared();
-
-        IncomingZeroRttConnection {
-            inner: noq_conn,
-            data: IncomingZeroRttData { accepted },
+            Err(inner) => Err(Self { inner, ..self }),
         }
     }
 
@@ -1299,7 +1300,9 @@ mod tests {
                 .std_context("Failed to accept incoming connection")?;
 
             // accept a possible 0-RTT connection
-            let zrtt_conn = accepting.into_0rtt();
+            let zrtt_conn = accepting
+                .into_0rtt()
+                .expect("incoming connections can always be converted to 0-RTT");
 
             let (mut send, mut recv) = zrtt_conn
                 .accept_bi()


### PR DESCRIPTION
## Summary

`Accepting::into_0rtt()` called `.expect()` on the underlying `noq::Connecting::into_0rtt()`, which could panic if the connection state machine was in an unexpected state. Since this is reachable from unauthenticated incoming connections, a panic here is a potential denial-of-service vector.

Changed the return type to `Result<IncomingZeroRttConnection, Accepting>`, matching the pattern already used by `Connecting::into_0rtt()`.

## Test plan

- [x] `cargo check -p iroh` clean
- [x] Test code updated