### PR TITLE
fix(iroh): log RemoteStateActor panics instead of propagating them

### DIFF
--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -200,10 +200,15 @@ impl RemoteMap {
                     self.senders.insert(eid, sender);
                 }
                 Err(err) => {
-                    if let Ok(panic) = err.try_into_panic() {
-                        error!("RemoteStateActor panicked.");
-                        std::panic::resume_unwind(panic);
+                    if err.is_panic() {
+                        error!("RemoteStateActor panicked. \
+                               This is a bug — please report it.");
+                    } else {
+                        error!("RemoteStateActor terminated unexpectedly: {err}");
                     }
+                    // We can't recover the EndpointId from a JoinError, so we
+                    // can't clean up the sender here. The next message sent to
+                    // this actor will fail on the dead channel and be dropped.
                 }
             }
         }


### PR DESCRIPTION
## Summary

`RemoteStateActor` panics were propagated via `std::panic::resume_unwind`, which crashes the entire endpoint if any single remote state actor panics. This could be triggered by malformed data from a peer or relay.

Replace with error logging. The dead actor's channel sender will naturally fail on subsequent sends, preventing further message delivery without taking down the endpoint.

## Test plan

- [x] `cargo check -p iroh` clean