### PR TITLE
fix(iroh-relay): implement connection accept rate limiting

### DIFF
--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -197,7 +197,6 @@ pub struct TlsConfig<EC: fmt::Debug, EA: fmt::Debug = EC> {
 }
 
 /// Rate limits.
-// TODO: accept_conn_limit and accept_conn_burst are not currently implemented.
 #[derive(Debug, Default)]
 pub struct Limits {
     /// Rate limit for accepting new connection. Unlimited if not set.
@@ -386,6 +385,10 @@ impl Server {
                     .request_handler(Method::GET, "/healthz", Box::new(healthz_handler));
                 if let Some(cfg) = relay_config.limits.client_rx {
                     builder = builder.client_rx_ratelimit(cfg);
+                }
+                if let Some(limit) = relay_config.limits.accept_conn_limit {
+                    let burst = relay_config.limits.accept_conn_burst.unwrap_or(limit.ceil() as usize);
+                    builder = builder.accept_conn_ratelimit(limit, burst);
                 }
                 let http_addr = match relay_config.tls {
                     Some(tls_config) => {

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -338,6 +338,10 @@ pub(super) struct ServerBuilder {
     /// Rate-limiting is enforced on received traffic from individual clients.  This
     /// configuration applies to a single client connection.
     client_rx_ratelimit: Option<ClientRateLimit>,
+    /// Rate limit for accepting new connections (connections per second).
+    accept_conn_limit: Option<f64>,
+    /// Burst limit for accepting new connections.
+    accept_conn_burst: Option<usize>,
     /// The capacity of the key cache.
     key_cache_capacity: usize,
     /// Access config for endpoints.
@@ -355,6 +359,8 @@ impl ServerBuilder {
             handlers: Default::default(),
             headers: HeaderMap::new(),
             client_rx_ratelimit: None,
+            accept_conn_limit: None,
+            accept_conn_burst: None,
             key_cache_capacity: DEFAULT_KEY_CACHE_CAPACITY,
             access: AccessConfig::Everyone,
             metrics: None,
@@ -400,6 +406,16 @@ impl ServerBuilder {
     /// no rate limit is enforced.
     pub(super) fn client_rx_ratelimit(mut self, config: ClientRateLimit) -> Self {
         self.client_rx_ratelimit = Some(config);
+        self
+    }
+
+    /// Sets the rate limit for accepting new connections.
+    ///
+    /// `limit` is the sustained rate in connections per second.
+    /// `burst` is the maximum number of connections accepted in a burst.
+    pub(super) fn accept_conn_ratelimit(mut self, limit: f64, burst: usize) -> Self {
+        self.accept_conn_limit = Some(limit);
+        self.accept_conn_burst = Some(burst);
         self
     }
 
@@ -457,10 +473,25 @@ impl ServerBuilder {
         info!("[{http_str}] relay: serving on {addr}");
 
         let cancel = cancel_token.clone();
+        let accept_conn_limit = self.accept_conn_limit;
+        let accept_conn_burst = self.accept_conn_burst.unwrap_or(1);
         let task = tokio::task::spawn(
             async move {
                 // create a join set to track all our connection tasks
                 let mut set = tokio::task::JoinSet::new();
+
+                // Accept rate limiter: simple token bucket.
+                // `tokens` starts at `burst` and is refilled at `limit` per second.
+                let mut tokens: f64 = accept_conn_burst as f64;
+                let mut refill_interval = accept_conn_limit.map(|limit| {
+                    let period = std::time::Duration::from_secs_f64(1.0 / limit);
+                    tokio::time::interval(period)
+                });
+                // Skip the first immediate tick.
+                if let Some(ref mut interval) = refill_interval {
+                    interval.tick().await;
+                }
+
                 loop {
                     tokio::select! {
                         biased;
@@ -474,8 +505,25 @@ impl ServerBuilder {
                                 panic!("task panicked: {err:#?}");
                             }
                         }
+                        _ = async {
+                            match refill_interval.as_mut() {
+                                Some(interval) => interval.tick().await,
+                                // If no rate limit, never resolve (let accept handle it).
+                                None => std::future::pending().await,
+                            }
+                        } => {
+                            tokens = (tokens + 1.0).min(accept_conn_burst as f64);
+                        }
                         res = listener.accept() => match res {
                             Ok((stream, peer_addr)) => {
+                                // Check rate limit
+                                if refill_interval.is_some() && tokens < 1.0 {
+                                    debug!("rate-limited connection from {peer_addr}, dropping");
+                                    drop(stream);
+                                    continue;
+                                }
+                                tokens -= 1.0;
+
                                 debug!("connection opened from {peer_addr}");
                                 let tls_config = tls_config.clone();
                                 let service = service.clone();


### PR DESCRIPTION
## Summary

The `accept_conn_limit` and `accept_conn_burst` fields on `Limits` were defined but not implemented (marked with a TODO). This left the relay server vulnerable to connection flooding: an attacker could open thousands of TCP connections that each hold resources for up to 30 seconds (the establish timeout), exhausting file descriptors and memory.

Implements a token bucket rate limiter in the accept loop. When configured, incoming connections that exceed the rate are immediately dropped before a handler task is spawned. The bucket refills at `accept_conn_limit` tokens per second and allows bursts up to `accept_conn_burst`.

## Test plan

- [x] All iroh-relay tests pass
- [x] `cargo check -p iroh-relay` clean