### PR TITLE
fix(iroh): cap max_incoming to 256 to limit half-open connection memory

### DIFF
--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -128,6 +128,13 @@ pub(crate) const RELAY_PATH_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(30)
 /// Pretty arbitrary and high right now.
 pub(crate) const MAX_MULTIPATH_PATHS: u32 = 12;
 
+/// Maximum number of incoming connections in the pre-handshake state.
+///
+/// This limits memory consumption from incomplete QUIC handshakes. The noq default
+/// is 65536, which is excessive for a peer-to-peer application and allows an attacker
+/// to exhaust memory with Initial packets from many source addresses.
+pub(crate) const MAX_INCOMING: usize = 256;
+
 /// Error returned when the endpoint state actor stopped while waiting for a reply.
 #[stack_error(add_meta, derive)]
 #[error("endpoint state actor stopped")]
@@ -233,6 +240,7 @@ impl StaticConfig {
         let mut inner =
             noq::ServerConfig::new(Arc::new(quic_server_config), self.token_key.clone());
         inner.transport_config(self.transport_config.to_inner_arc());
+        inner.max_incoming(MAX_INCOMING);
         inner
     }
 


### PR DESCRIPTION
## Summary

The noq default for `max_incoming` is 65536, which allows an attacker to hold that many connections in the pre-handshake state simultaneously, consuming significant memory. For a peer-to-peer application, 256 is a more appropriate default.

Sets `max_incoming` to 256 in iroh's server config. Users who need a higher limit can override via `ServerConfigBuilder::set_max_incoming`.

## Test plan

- [x] `cargo check -p iroh` clean