### PR TITLE
deps: bump hickory-resolver to 0.26.0-beta.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,9 +1840,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0-beta.1"
+version = "0.26.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc867c64bc89c63a3b1c34258e3bbbd73eb18f8ab785ff352c81c98ad187f78e"
+checksum = "acbafe58dd6a1bfa058c9c3dd3372c54665a1935e504a25783cdcf9bf14b21d6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1852,7 +1852,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "h2",
- "hickory-proto 0.26.0-beta.1",
+ "hickory-proto 0.26.0-beta.3",
  "http",
  "idna",
  "ipnet",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0-beta.1"
+version = "0.26.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91ba40132ef5ec8f1eabddb35d1b5d9fae3699c4545c590401893636097caee"
+checksum = "e7ddac4552e5be0deead6df196824a5964b0797302569ef4686b75d32efad052"
 dependencies = [
  "data-encoding",
  "idna",
@@ -1944,14 +1944,14 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0-beta.1"
+version = "0.26.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3691451dab87ca2d7e3018ae231347d3a502ef3e8c4430f454f7efefa84b1d"
+checksum = "a751e330e7cdf445892d6ce47cb4666a8b127834d2e42cee4db15713b9a27780"
 dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.0-beta.1",
+ "hickory-proto 0.26.0-beta.3",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -2382,7 +2382,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "getrandom 0.4.2",
- "hickory-resolver 0.26.0-beta.1",
+ "hickory-resolver 0.26.0-beta.3",
  "http",
  "indicatif",
  "ipnet",
@@ -2580,7 +2580,7 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "getrandom 0.4.2",
- "hickory-resolver 0.26.0-beta.1",
+ "hickory-resolver 0.26.0-beta.3",
  "http",
  "http-body-util",
  "hyper",
@@ -4937,7 +4937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "737bfdaf732174c48b8193b29158460d8d959dd8e9ce071a5bbda95d8546b68b"
 dependencies = [
  "acto",
- "hickory-proto 0.26.0-beta.1",
+ "hickory-proto 0.26.0-beta.3",
  "rand 0.10.0",
  "socket2",
  "thiserror 2.0.18",

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -88,7 +88,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = { version = "=0.26.0-beta.1", features = ["tokio", "system-config"] }
+hickory-resolver = { version = "=0.26.0-beta.3", features = ["tokio", "system-config"] }
 tokio = { version = "1", features = [
     "io-util",
     "macros",

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -620,7 +620,7 @@ impl Resolver for HickoryResolver {
                             // I don't know a way of avoiding this deep copy, even if it's agonizing.
                             // The representation of `TxtRecrodData` and `hickory_proto::rr::rdata::TXT`
                             // is identical.
-                            Some(TxtRecordData::from(txt.txt_data().to_vec()))
+                            Some(TxtRecordData::from(txt.txt_data.to_vec()))
                         }
                         _ => None,
                     }

--- a/iroh-relay/src/endpoint_info.rs
+++ b/iroh-relay/src/endpoint_info.rs
@@ -962,7 +962,7 @@ mod tests {
             .answers()
             .iter()
             .filter_map(|record| match record.data() {
-                RData::TXT(txt) => Some(TxtRecordData::from(txt.txt_data().to_vec())),
+                RData::TXT(txt) => Some(TxtRecordData::from(txt.txt_data.to_vec())),
                 _ => None,
             });
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -78,7 +78,7 @@ sync_wrapper = { version = "1.0.2", features = ["futures"] }
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = { version = "=0.26.0-beta.1", default-features = false }
+hickory-resolver = { version = "=0.26.0-beta.3", default-features = false }
 portmapper = { version = "0.15", optional = true, default-features = false }
 noq = { version = "0.17.0", default-features = false, features = ["runtime-tokio", "rustls"] }
 tokio = { version = "1", features = [

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -269,8 +269,8 @@ pub(crate) mod dns_server {
             buf: &[u8],
         ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
             let packet = Message::from_bytes(buf)?;
-            debug!(queries = ?packet.queries(), %from, "received query");
-            let mut reply = packet.to_response();
+            debug!(queries = ?packet.queries, %from, "received query");
+            let mut reply = packet.clone().into_response();
             self.resolver.resolve(&packet, &mut reply).await?;
             debug!(?reply, %from, "send reply");
             let buf = reply.to_vec()?;
@@ -453,7 +453,7 @@ pub(crate) mod pkarr_dns_state {
             reply: &mut hickory_resolver::proto::op::Message,
             ttl: u32,
         ) -> std::io::Result<()> {
-            for query in query.queries() {
+            for query in &query.queries {
                 let domain_name = query.name().to_string();
                 let Some(endpoint_id) = endpoint_id_from_domain_name(&domain_name) else {
                     continue;


### PR DESCRIPTION
## Description

bump hickory-resolver from 0.26.0-beta.1 to 0.26.0-beta.3

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
