### PR TITLE
feat(iroh): do not advertise deprecated IPv6 addrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.15.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=feat-net-tools-flags#ad2b61b1e8bfa5573274dfa4c04d3f35a9f45f6e"
+source = "git+https://github.com/n0-computer/net-tools?branch=main#d77c60b12a06ce084e6cb753bb15481da0123f09"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "portmapper"
 version = "0.15.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=feat-net-tools-flags#ad2b61b1e8bfa5573274dfa4c04d3f35a9f45f6e"
+source = "git+https://github.com/n0-computer/net-tools?branch=main#d77c60b12a06ce084e6cb753bb15481da0123f09"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1857,7 +1857,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni 0.22.4",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1886,7 +1886,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustls",
  "serde",
@@ -1910,7 +1910,7 @@ dependencies = [
  "jni 0.22.4",
  "once_cell",
  "prefix-trie 0.8.2",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1931,7 +1931,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "rustls",
  "serde",
@@ -1959,7 +1959,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "resolv-conf",
  "rustls",
  "smallvec",
@@ -2289,7 +2289,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tokio",
  "url",
  "xmltree",
@@ -2407,7 +2407,7 @@ dependencies = [
  "portmapper",
  "postcard",
  "pretty_assertions",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "reqwest 0.13.2",
  "rustc-hash",
@@ -2447,7 +2447,7 @@ dependencies = [
  "n0-error",
  "postcard",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "serde",
  "serde_json",
@@ -2471,7 +2471,7 @@ dependencies = [
  "n0-error",
  "n0-future",
  "noq",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rcgen",
  "rustls",
  "tokio",
@@ -2506,7 +2506,7 @@ dependencies = [
  "n0-future",
  "n0-tracing-test",
  "pkarr",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rcgen",
  "redb",
@@ -2598,7 +2598,7 @@ dependencies = [
  "pkarr",
  "postcard",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rcgen",
  "reloadable-state",
@@ -3236,7 +3236,7 @@ dependencies = [
  "identity-hash",
  "lru-slab",
  "n0-qlog",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3736,7 +3736,7 @@ dependencies = [
  "n0-error",
  "netwatch",
  "num_enum",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "smallvec",
  "socket2",
@@ -3866,7 +3866,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3934,7 +3934,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3983,9 +3983,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3993,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -4939,7 +4939,7 @@ checksum = "737bfdaf732174c48b8193b29158460d8d959dd8e9ce071a5bbda95d8546b68b"
 dependencies = [
  "acto",
  "hickory-proto 0.26.0-beta.1",
- "rand 0.10.0",
+ "rand 0.10.1",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -5025,7 +5025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5271,7 +5271,7 @@ dependencies = [
  "getrandom 0.4.2",
  "http",
  "httparse",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ring",
  "rustls-pki-types",
  "sha1_smol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.3",
+ "rand 0.9.2",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1857,7 +1857,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni 0.22.4",
- "rand 0.10.1",
+ "rand 0.10.0",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1886,7 +1886,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.3",
+ "rand 0.9.2",
  "ring",
  "rustls",
  "serde",
@@ -1910,7 +1910,7 @@ dependencies = [
  "jni 0.22.4",
  "once_cell",
  "prefix-trie 0.8.2",
- "rand 0.10.1",
+ "rand 0.10.0",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1931,7 +1931,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.3",
+ "rand 0.9.2",
  "resolv-conf",
  "rustls",
  "serde",
@@ -1959,7 +1959,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.1",
+ "rand 0.10.0",
  "resolv-conf",
  "rustls",
  "smallvec",
@@ -2289,7 +2289,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.10.1",
+ "rand 0.10.0",
  "tokio",
  "url",
  "xmltree",
@@ -2407,7 +2407,7 @@ dependencies = [
  "portmapper",
  "postcard",
  "pretty_assertions",
- "rand 0.10.1",
+ "rand 0.10.0",
  "rand_chacha 0.10.0",
  "reqwest 0.13.2",
  "rustc-hash",
@@ -2447,7 +2447,7 @@ dependencies = [
  "n0-error",
  "postcard",
  "proptest",
- "rand 0.10.1",
+ "rand 0.10.0",
  "rand_chacha 0.10.0",
  "serde",
  "serde_json",
@@ -2471,7 +2471,7 @@ dependencies = [
  "n0-error",
  "n0-future",
  "noq",
- "rand 0.10.1",
+ "rand 0.10.0",
  "rcgen",
  "rustls",
  "tokio",
@@ -2506,7 +2506,7 @@ dependencies = [
  "n0-future",
  "n0-tracing-test",
  "pkarr",
- "rand 0.10.1",
+ "rand 0.10.0",
  "rand_chacha 0.10.0",
  "rcgen",
  "redb",
@@ -2598,7 +2598,7 @@ dependencies = [
  "pkarr",
  "postcard",
  "proptest",
- "rand 0.10.1",
+ "rand 0.10.0",
  "rand_chacha 0.10.0",
  "rcgen",
  "reloadable-state",
@@ -3134,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.15.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=main#d77c60b12a06ce084e6cb753bb15481da0123f09"
+source = "git+https://github.com/n0-computer/net-tools?branch=feat-net-tools-flags#ad2b61b1e8bfa5573274dfa4c04d3f35a9f45f6e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3203,7 +3203,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "0.17.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#f0ccfc2ece291d88d2d4185df644616dbb9840fe"
+source = "git+https://github.com/n0-computer/noq?branch=main#a0481ac5a17003845bd3755318640b6abf994e6c"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "0.16.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#f0ccfc2ece291d88d2d4185df644616dbb9840fe"
+source = "git+https://github.com/n0-computer/noq?branch=main#a0481ac5a17003845bd3755318640b6abf994e6c"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3236,7 +3236,7 @@ dependencies = [
  "identity-hash",
  "lru-slab",
  "n0-qlog",
- "rand 0.10.1",
+ "rand 0.10.0",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3253,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "0.9.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#f0ccfc2ece291d88d2d4185df644616dbb9840fe"
+source = "git+https://github.com/n0-computer/noq?branch=main#a0481ac5a17003845bd3755318640b6abf994e6c"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "portmapper"
 version = "0.15.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=main#d77c60b12a06ce084e6cb753bb15481da0123f09"
+source = "git+https://github.com/n0-computer/net-tools?branch=feat-net-tools-flags#ad2b61b1e8bfa5573274dfa4c04d3f35a9f45f6e"
 dependencies = [
  "base64",
  "bytes",
@@ -3736,7 +3736,7 @@ dependencies = [
  "n0-error",
  "netwatch",
  "num_enum",
- "rand 0.10.1",
+ "rand 0.10.0",
  "serde",
  "smallvec",
  "socket2",
@@ -3866,7 +3866,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3934,7 +3934,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3983,9 +3983,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3993,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -4939,7 +4939,7 @@ checksum = "737bfdaf732174c48b8193b29158460d8d959dd8e9ce071a5bbda95d8546b68b"
 dependencies = [
  "acto",
  "hickory-proto 0.26.0-beta.1",
- "rand 0.10.1",
+ "rand 0.10.0",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -5025,7 +5025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5271,7 +5271,7 @@ dependencies = [
  "getrandom 0.4.2",
  "http",
  "httparse",
- "rand 0.10.1",
+ "rand 0.10.0",
  "ring",
  "rustls-pki-types",
  "sha1_smol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4424,9 +4424,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5025,7 +5025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 unused-async = "warn"
 
 [patch.crates-io]
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "feat-net-tools-flags" }
-netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "feat-net-tools-flags" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
+netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
 noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
 noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
 noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 unused-async = "warn"
 
 [patch.crates-io]
-portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
-netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "feat-net-tools-flags" }
+netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "feat-net-tools-flags" }
 noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
 noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
 noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -36,9 +36,12 @@ use n0_future::{
     time::{self, Duration, Instant},
 };
 use n0_watcher::{self, Watchable, Watcher};
-#[cfg(not(wasm_browser))]
-use netwatch::ip::LocalAddresses;
 use netwatch::netmon;
+#[cfg(not(wasm_browser))]
+use netwatch::{
+    interfaces::{IpNet, Ipv6AddrFlags},
+    ip::LocalAddresses,
+};
 use noq::{
     NetworkChangeHint, WeakConnectionHandle,
     crypto::rustls::{QuicClientConfig, QuicServerConfig},
@@ -1756,7 +1759,8 @@ impl Actor {
         // We only want to have one DirectAddr for each SocketAddr we have.  So we store
         // this as a map of SocketAddr -> DirectAddrType.  At the end we will construct a
         // DirectAddr from each entry.
-        let mut addrs: BTreeMap<SocketAddr, DirectAddrType> = BTreeMap::new();
+        let mut addrs: BTreeMap<SocketAddr, (DirectAddrType, Option<Ipv6AddrFlags>)> =
+            BTreeMap::new();
 
         // First add PortMapper provided addresses.
         let portmap_watcher = self
@@ -1767,13 +1771,15 @@ impl Actor {
         if let Some(portmap_ext) = maybe_port_mapped.map(SocketAddr::V4) {
             addrs
                 .entry(portmap_ext)
-                .or_insert(DirectAddrType::Portmapped);
+                .or_insert((DirectAddrType::Portmapped, None));
         }
 
         // Next add STUN addresses from the net_report report.
         if let Some(net_report_report) = net_report_report {
             if let Some(global_v4) = net_report_report.global_v4 {
-                addrs.entry(global_v4.into()).or_insert(DirectAddrType::Qad);
+                addrs
+                    .entry(global_v4.into())
+                    .or_insert((DirectAddrType::Qad, None));
 
                 // If they're behind a hard NAT and are using a fixed
                 // port locally, assume they might've added a static
@@ -1796,11 +1802,13 @@ impl Actor {
                     addr.set_port(port);
                     addrs
                         .entry(addr.into())
-                        .or_insert(DirectAddrType::Qad4LocalPort);
+                        .or_insert((DirectAddrType::Qad4LocalPort, None));
                 }
             }
             if let Some(global_v6) = net_report_report.global_v6 {
-                addrs.entry(global_v6.into()).or_insert(DirectAddrType::Qad);
+                addrs
+                    .entry(global_v6.into())
+                    .or_insert((DirectAddrType::Qad, None));
             }
         }
 
@@ -1808,24 +1816,31 @@ impl Actor {
 
         // Add configured external addresses.
         for addr in self.sock.configured_addrs.read().expect("poisoned").iter() {
-            addrs.entry(*addr).or_insert(DirectAddrType::Config);
+            addrs.entry(*addr).or_insert((DirectAddrType::Config, None));
         }
 
-        // Finally create and store store all these direct addresses and send any
-        // queued call-me-maybe messages.
-        self.sock.store_direct_addresses(
-            addrs
-                .iter()
-                .map(|(addr, typ)| DirectAddr {
-                    addr: *addr,
-                    typ: *typ,
-                })
-                .collect(),
-        );
+        // Finally create and store store all these direct addresses
+        let stored_addrs = addrs
+            .into_iter()
+            .filter_map(|(addr, (typ, flags))| {
+                // Filter out depreacted IPs
+                let is_deprecated = flags.map(|f| f.deprecated).unwrap_or(false);
+                if is_deprecated {
+                    return None;
+                }
+                Some(DirectAddr { addr, typ })
+            })
+            .collect();
+        self.sock.store_direct_addresses(stored_addrs);
     }
 
     #[cfg(not(wasm_browser))]
-    fn collect_local_addresses(&mut self, addrs: &mut BTreeMap<SocketAddr, DirectAddrType>) {
+    fn collect_local_addresses(
+        &mut self,
+        addrs: &mut BTreeMap<SocketAddr, (DirectAddrType, Option<Ipv6AddrFlags>)>,
+    ) {
+        let netmon_state = self.local_interfaces_watcher.get();
+
         // Matches the addresses that have been bound vs the requested ones.
         let local_addrs: Vec<(SocketAddr, SocketAddr)> = self
             .sock
@@ -1875,7 +1890,8 @@ impl Actor {
                 };
                 if let Some(port) = port_if_unspecified {
                     let addr = SocketAddr::new(ip, port);
-                    addrs.entry(addr).or_insert(DirectAddrType::Local);
+                    let flags = find_flags(&netmon_state, ip);
+                    addrs.entry(addr).or_insert((DirectAddrType::Local, flags));
                 }
             }
         }
@@ -1883,7 +1899,8 @@ impl Actor {
         // If a socket is bound to a specific address, add it.
         for (bound, local) in local_addrs {
             if !bound.ip().is_unspecified() {
-                addrs.entry(local).or_insert(DirectAddrType::Local);
+                let flags = find_flags(&netmon_state, local.ip());
+                addrs.entry(local).or_insert((DirectAddrType::Local, flags));
             }
         }
     }
@@ -1903,6 +1920,28 @@ impl Actor {
 
         #[cfg(not(wasm_browser))]
         self.update_direct_addresses(report.as_ref());
+    }
+}
+
+#[cfg(not(wasm_browser))]
+fn find_flags(state: &netmon::State, ip: IpAddr) -> Option<Ipv6AddrFlags> {
+    if ip.is_ipv6() {
+        state
+            .interfaces
+            .values()
+            .flat_map(|i| i.addrs())
+            .find_map(|addr| match addr {
+                IpNet::V4(_) => None,
+                IpNet::V6 { net, flags, .. } => {
+                    if net.addr() == ip {
+                        Some(flags)
+                    } else {
+                        None
+                    }
+                }
+            })
+    } else {
+        None
     }
 }
 

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1823,7 +1823,7 @@ impl Actor {
         let stored_addrs = addrs
             .into_iter()
             .filter_map(|(addr, (typ, flags))| {
-                // Filter out depreacted IPs
+                // Filter out deprecated IPs
                 let is_deprecated = flags.map(|f| f.deprecated).unwrap_or(false);
                 if is_deprecated {
                     return None;


### PR DESCRIPTION
## Description

This skips advertising `deprecated` IPv6 addresses in nat traversal, as they are not supposed to be used for new connections.

Fixes https://github.com/n0-computer/iroh/discussions/4071

## Breaking Changes

None

## Notes & open questions

- There are more flags on IPv6 addresses, should we take them into account in some form as well?

