### PR TITLE
refactor!: mark public types as non_exhaustive

### DIFF
--- a/iroh-relay/src/protos/common.rs
+++ b/iroh-relay/src/protos/common.rs
@@ -16,6 +16,7 @@ use noq_proto::{
     Copy, Clone, PartialEq, Eq, Debug, num_enum::IntoPrimitive, num_enum::TryFromPrimitive,
 )]
 // needs to be pub due to being exposed in error types
+#[non_exhaustive]
 pub enum FrameType {
     /// The server frame type for the challenge response
     ServerChallenge = 0,

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -72,6 +72,7 @@ pub enum Error {
 
 /// The messages that a relay sends to clients or the clients receive from the relay.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RelayToClientMsg {
     /// Represents datagrams sent from relays (originally sent to them by another client).
     Datagrams {
@@ -114,6 +115,7 @@ pub enum RelayToClientMsg {
 
 /// Messages that clients send to relays.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ClientToRelayMsg {
     /// Request from the client to the server to reply to the
     /// other side with a [`RelayToClientMsg::Pong`] with the given payload.

--- a/iroh-relay/src/relay_map.rs
+++ b/iroh-relay/src/relay_map.rs
@@ -214,6 +214,7 @@ impl fmt::Display for RelayMap {
 // Please note that this is documented in the `iroh.computer` repository under
 // `src/app/docs/reference/config/page.mdx`.  Any changes to this need to be updated there.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
+#[non_exhaustive]
 pub struct RelayConfig {
     /// The [`RelayUrl`] where this relay server can be dialed.
     pub url: RelayUrl,
@@ -223,6 +224,13 @@ pub struct RelayConfig {
     /// with this relay server.
     #[serde(default = "quic_config")]
     pub quic: Option<RelayQuicConfig>,
+}
+
+impl RelayConfig {
+    /// Creates a new relay configuration with the given URL and optional QUIC config.
+    pub fn new(url: RelayUrl, quic: Option<RelayQuicConfig>) -> Self {
+        Self { url, quic }
+    }
 }
 
 impl From<RelayUrl> for RelayConfig {
@@ -243,9 +251,17 @@ fn quic_config() -> Option<RelayQuicConfig> {
 ///
 /// Defaults to using [`DEFAULT_RELAY_QUIC_PORT`].
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub struct RelayQuicConfig {
     /// The port on which the connection should be bound to.
     pub port: u16,
+}
+
+impl RelayQuicConfig {
+    /// Creates a new QUIC address discovery configuration with the given port.
+    pub fn new(port: u16) -> Self {
+        Self { port }
+    }
 }
 
 impl Default for RelayQuicConfig {

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -5,6 +5,7 @@ use iroh_metrics::{Counter, MetricsGroup, MetricsGroupSet};
 /// Metrics tracked for the relay server
 #[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "relayserver")]
+#[non_exhaustive]
 pub struct Metrics {
     /*
      * Metrics about packets
@@ -72,6 +73,7 @@ pub struct Metrics {
 /// All metrics tracked in the relay server.
 #[derive(Debug, Default, Clone, MetricsGroupSet)]
 #[metrics(name = "relay")]
+#[non_exhaustive]
 pub struct RelayMetrics {
     /// Metrics tracked for the relay server.
     pub server: Arc<Metrics>,

--- a/iroh/examples/mdns_address_lookup.rs
+++ b/iroh/examples/mdns_address_lookup.rs
@@ -55,6 +55,7 @@ async fn main() -> Result<()> {
                     }
                 }
                 address_lookup::DiscoveryEvent::Expired { .. } => {}
+                _ => {}
             };
         }
     });

--- a/iroh/src/address_lookup/mdns.rs
+++ b/iroh/src/address_lookup/mdns.rs
@@ -242,6 +242,7 @@ impl AddressLookupBuilder for MdnsAddressLookupBuilder {
 
 /// An event emitted from the [`MdnsAddressLookup`] service.
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DiscoveryEvent {
     /// A peer was discovered or it's information was updated.
     Discovered {

--- a/iroh/src/address_lookup/mdns.rs
+++ b/iroh/src/address_lookup/mdns.rs
@@ -37,6 +37,7 @@
 //!             DiscoveryEvent::Expired { endpoint_id } => {
 //!                 println!("MDNS expired: {endpoint_id}");
 //!             }
+//!             _ => {}
 //!         }
 //!     }
 //! }

--- a/iroh/src/defaults.rs
+++ b/iroh/src/defaults.rs
@@ -18,9 +18,10 @@ pub const DEFAULT_METRICS_PORT: u16 = 9090;
 
 /// Production configuration.
 pub mod prod {
-    use iroh_relay::{RelayConfig, RelayMap, RelayQuicConfig};
+    use iroh_relay::{RelayConfig, RelayMap};
 
     use super::*;
+    use crate::RelayUrl;
 
     /// Hostname of the default NA east relay.
     pub const NA_EAST_RELAY_HOSTNAME: &str = "use1-1.relay.n0.iroh-canary.iroh.link.";
@@ -47,10 +48,7 @@ pub mod prod {
         let url: Url = format!("https://{NA_EAST_RELAY_HOSTNAME}")
             .parse()
             .expect("default url");
-        RelayConfig {
-            url: url.into(),
-            quic: Some(RelayQuicConfig::default()),
-        }
+        RelayConfig::from(RelayUrl::from(url))
     }
 
     /// Get the default [`RelayConfig`] for NA west.
@@ -59,10 +57,7 @@ pub mod prod {
         let url: Url = format!("https://{NA_WEST_RELAY_HOSTNAME}")
             .parse()
             .expect("default url");
-        RelayConfig {
-            url: url.into(),
-            quic: Some(RelayQuicConfig::default()),
-        }
+        RelayConfig::from(RelayUrl::from(url))
     }
 
     /// Get the default [`RelayConfig`] for EU.
@@ -71,10 +66,7 @@ pub mod prod {
         let url: Url = format!("https://{EU_RELAY_HOSTNAME}")
             .parse()
             .expect("default_url");
-        RelayConfig {
-            url: url.into(),
-            quic: Some(RelayQuicConfig::default()),
-        }
+        RelayConfig::from(RelayUrl::from(url))
     }
 
     /// Get the default [`RelayConfig`] for Asia-Pacific
@@ -83,10 +75,7 @@ pub mod prod {
         let url: Url = format!("https://{AP_RELAY_HOSTNAME}")
             .parse()
             .expect("default_url");
-        RelayConfig {
-            url: url.into(),
-            quic: Some(RelayQuicConfig::default()),
-        }
+        RelayConfig::from(RelayUrl::from(url))
     }
 }
 
@@ -96,9 +85,10 @@ pub mod prod {
 ///
 /// Note: we have staging servers in EU and NA, but no corresponding staging server for AP at this time.
 pub mod staging {
-    use iroh_relay::{RelayConfig, RelayMap, RelayQuicConfig};
+    use iroh_relay::{RelayConfig, RelayMap};
 
     use super::*;
+    use crate::RelayUrl;
 
     /// Hostname of the default NA relay.
     pub const NA_EAST_RELAY_HOSTNAME: &str = "staging-use1-1.relay.iroh.network.";
@@ -116,10 +106,7 @@ pub mod staging {
         let url: Url = format!("https://{NA_EAST_RELAY_HOSTNAME}")
             .parse()
             .expect("default url");
-        RelayConfig {
-            url: url.into(),
-            quic: Some(RelayQuicConfig::default()),
-        }
+        RelayConfig::from(RelayUrl::from(url))
     }
 
     /// Get the default [`RelayConfig`] for EU.
@@ -128,10 +115,7 @@ pub mod staging {
         let url: Url = format!("https://{EU_RELAY_HOSTNAME}")
             .parse()
             .expect("default_url");
-        RelayConfig {
-            url: url.into(),
-            quic: Some(RelayQuicConfig::default()),
-        }
+        RelayConfig::from(RelayUrl::from(url))
     }
 }
 

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -921,13 +921,11 @@ mod test_utils {
         let server = server::Server::spawn(server::testing::server_config())
             .await
             .expect("should serve relay");
-        let quic = Some(RelayQuicConfig {
-            port: server.quic_addr().expect("server should run quic").port(),
-        });
-        let endpoint_desc = RelayConfig {
-            url: server.https_url().expect("should work as relay"),
-            quic,
-        };
+        let quic = Some(RelayQuicConfig::new(
+            server.quic_addr().expect("server should run quic").port(),
+        ));
+        let endpoint_desc =
+            RelayConfig::new(server.https_url().expect("should work as relay"), quic);
 
         (server, endpoint_desc)
     }

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1980,6 +1980,7 @@ pub struct DirectAddr {
 /// These are the various sources or origins from which an iroh endpoint might have found a
 /// possible [`DirectAddr`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum DirectAddrType {
     /// Not yet determined..
     Unknown,

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -687,6 +687,9 @@ impl ActiveRelayActor {
             RelayToClientMsg::Restarting { .. } => {
                 trace!("Ignoring {msg:?}")
             }
+            _ => {
+                trace!("Ignoring unknown relay message: {msg:?}")
+            }
         }
     }
 

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -688,7 +688,7 @@ impl ActiveRelayActor {
                 trace!("Ignoring {msg:?}")
             }
             _ => {
-                trace!("Ignoring unknown relay message: {msg:?}")
+                warn!("Ignoring unknown relay message: {msg:?}")
             }
         }
     }

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -76,12 +76,8 @@ pub async fn run_relay_server_with(quic: bool) -> Result<(RelayMap, RelayUrl, Se
 
     let quic = server
         .quic_addr()
-        .map(|addr| RelayQuicConfig { port: addr.port() });
-    let n: RelayMap = RelayConfig {
-        url: url.clone(),
-        quic,
-    }
-    .into();
+        .map(|addr| RelayQuicConfig::new(addr.port()));
+    let n: RelayMap = RelayConfig::new(url.clone(), quic).into();
     Ok((n, url, server))
 }
 

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -479,8 +479,8 @@ mod relay {
         let url: RelayUrl = "https://relay.test".parse().expect("valid relay url");
         let quic = server
             .quic_addr()
-            .map(|addr| RelayQuicConfig { port: addr.port() });
-        let relay_map: RelayMap = RelayConfig { url, quic }.into();
+            .map(|addr| RelayQuicConfig::new(addr.port()));
+        let relay_map: RelayMap = RelayConfig::new(url, quic).into();
 
         Ok((relay_map, server))
     }


### PR DESCRIPTION
## Description

Add `#[non_exhaustive]` to various public structs and enums that we might want to extend during 1.0:

- structs: `relay_map::RelayConfig`, `relay_map::RelayQuicConfig`
- enums: `DirectAddrType`, `DiscoveryEvent`: enums
- enums in iroh_relay: `RelayToClientMsg`, `ClientToRelayMsg`, `FrameType`

There's more items in the server-side of iroh-relay, will do those separately.

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

* `iroh_relay::RelayConfig` is now `#[non_exhaustive]`. Use `RelayConfig::from(relay_url)` for the common case, or `RelayConfig::new(url, quic)` to specify a custom QUIC config.
* `iroh_relay::RelayQuicConfig` is now `#[non_exhaustive]`. Use `RelayQuicConfig::new(port)` or `RelayQuicConfig::default()` instead of struct literals.
* `iroh_relay::protos::relay::RelayToClientMsg` is now `#[non_exhaustive]`.
* `iroh_relay::protos::relay::ClientToRelayMsg` is now `#[non_exhaustive]`.
* `iroh_relay::protos::common::FrameType` is now `#[non_exhaustive]`.
* `iroh::DirectAddrType` is now `#[non_exhaustive]`.
* `iroh::address_lookup::mdns::DiscoveryEvent` is now `#[non_exhaustive]`.
* `iroh_relay::server::Metrics` is now `#[non_exhaustive]`. Use `Metrics::default()` instead of struct literals.
* `iroh_relay::server::RelayMetrics` is now `#[non_exhaustive]`. Use `RelayMetrics::default()` instead of struct literals.

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
