### PR TITLE
fix(iroh): `Endpoint::online` should only return once connected to a relay

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1287,7 +1287,7 @@ impl Endpoint {
         loop {
             if value
                 .into_iter()
-                .filter_map(|x| x)
+                .flatten()
                 .any(|(_url, status)| status.is_connected())
             {
                 return;

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -3802,4 +3802,53 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_endpoint_online_add_relay() -> Result {
+        let ep = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Custom(RelayMap::empty()))
+            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .bind()
+            .await?;
+        // should not come online without relays.
+        let res = tokio::time::timeout(Duration::from_millis(500), ep.online()).await;
+        assert!(res.is_err());
+
+        // should come online after a relay is added.
+        let (relay_map, relay_url, _relay_server_guard) = run_relay_server().await?;
+        ep.insert_relay(relay_url.clone(), relay_map.get(&relay_url).unwrap())
+            .await;
+        let res = tokio::time::timeout(Duration::from_millis(1000), ep.online()).await;
+        assert!(res.is_ok());
+
+        // online should still return after endpoint close, if the endpoint was last online
+        let ep_clone = ep.clone();
+        let task = tokio::task::spawn(async move {
+            tokio::time::timeout(Duration::from_millis(500), ep_clone.online()).await
+        });
+        ep.close().await;
+        let res = task.await.unwrap();
+        assert!(res.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_endpoint_online_close() -> Result {
+        let ep = Endpoint::bind(presets::Minimal).await?;
+        // should not come online without relays.
+        let res = tokio::time::timeout(Duration::from_millis(500), ep.online()).await;
+        assert!(res.is_err());
+
+        // online should remain pending after the endpoint is closed.
+        let ep_clone = ep.clone();
+        let task = tokio::task::spawn(async move {
+            tokio::time::timeout(Duration::from_millis(500), ep_clone.online()).await
+        });
+        ep.close().await;
+        let res = task.await.unwrap();
+        assert!(res.is_err());
+        Ok(())
+    }
 }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1238,11 +1238,11 @@ impl Endpoint {
 
     /// A convenience method that waits for the endpoint to be considered "online".
     ///
-    /// This currently means at least one relay server was connected,
-    /// and at least one local IP address is available.
-    /// Even if no relays are configured, this will still wait for a relay connection.
+    /// This currently means at least one relay server has completed its
+    /// connection handshake (i.e. the endpoint is registered and reachable
+    /// via that relay). Merely selecting a relay URL is not sufficient.
     ///
-    /// Once this has been resolved the first time, this will always immediately resolve.
+    /// If no relays are configured, this will pend forever.
     ///
     /// This has no timeout, so if that is needed, you need to wrap it in a
     /// timeout. We recommend using a timeout close to
@@ -1285,7 +1285,6 @@ impl Endpoint {
         let mut watcher = self.inner.home_relay_status();
         let mut value = watcher.get();
         loop {
-            tracing::info!("home relay status: {value:?}");
             if value
                 .into_iter()
                 .filter_map(|x| x)

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1282,7 +1282,25 @@ impl Endpoint {
     /// }
     /// ```
     pub async fn online(&self) {
-        self.inner.home_relay().initialized().await;
+        let mut watcher = self.inner.home_relay_status();
+        let mut value = watcher.get();
+        loop {
+            tracing::info!("home relay status: {value:?}");
+            if value
+                .into_iter()
+                .filter_map(|x| x)
+                .any(|(_url, status)| status.is_connected())
+            {
+                return;
+            }
+            value = match watcher.updated().await {
+                Ok(value) => value,
+                Err(_disconnected) => {
+                    std::future::pending::<()>().await;
+                    break;
+                }
+            }
+        }
     }
 
     /// Returns a [`Watcher`] for any net-reports run from this [`Endpoint`].

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -74,7 +74,7 @@ use crate::{
     socket::{
         concurrent_read_map::ReadOnlyMap,
         remote_map::{MappedAddrs, PathWatchable, RemoteInfo},
-        transports::{HomeRelayStatus, HomeRelayWatcher, TransportBiasMap},
+        transports::{HomeRelayStatus, HomeRelayWatch, HomeRelayWatcher, TransportBiasMap},
     },
     tls::{
         self,
@@ -870,7 +870,7 @@ impl EndpointInner {
         let ipv6_reported = Arc::new(AtomicBool::new(false));
 
         let relay_actor_config = RelayActorConfig {
-            my_relay: Watchable::new(None),
+            my_relay: HomeRelayWatch::default(),
             secret_key: secret_key.clone(),
             #[cfg(not(wasm_browser))]
             dns_resolver: dns_resolver.clone(),

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -74,7 +74,7 @@ use crate::{
     socket::{
         concurrent_read_map::ReadOnlyMap,
         remote_map::{MappedAddrs, PathWatchable, RemoteInfo},
-        transports::TransportBiasMap,
+        transports::{HomeRelayStatus, HomeRelayWatcher, TransportBiasMap},
     },
     tls::{
         self,
@@ -337,6 +337,7 @@ pub(crate) struct Socket {
 
     /// Local addresses
     local_addrs_watch: LocalAddrsWatch,
+    home_relay_watch: HomeRelayWatcher,
     /// Currently bound IP addresses of all sockets
     #[cfg(not(wasm_browser))]
     ip_bind_addrs: Vec<SocketAddr>,
@@ -475,6 +476,12 @@ impl Socket {
                 })
                 .collect()
         })
+    }
+
+    pub(crate) fn home_relay_status(
+        &self,
+    ) -> impl Watcher<Value = Vec<Option<(RelayUrl, HomeRelayStatus)>>> + use<> {
+        self.home_relay_watch.clone()
     }
 
     /// Stores a new set of direct addresses.
@@ -860,11 +867,10 @@ impl EndpointInner {
             .next()
             .unwrap_or_else(RelayMap::empty);
 
-        let my_relay = Watchable::new(None);
         let ipv6_reported = Arc::new(AtomicBool::new(false));
 
         let relay_actor_config = RelayActorConfig {
-            my_relay: my_relay.clone(),
+            my_relay: Watchable::new(None),
             secret_key: secret_key.clone(),
             #[cfg(not(wasm_browser))]
             dns_resolver: dns_resolver.clone(),
@@ -925,6 +931,8 @@ impl EndpointInner {
             )
         };
 
+        let home_relay_watch = transports.home_relay_watch();
+
         let sock = Arc::new(Socket {
             public_key: secret_key.public(),
             remote_actors: remote_map.senders(),
@@ -941,6 +949,7 @@ impl EndpointInner {
             dns_resolver: dns_resolver.clone(),
             metrics: metrics.clone(),
             local_addrs_watch: transports.local_addrs_watch(),
+            home_relay_watch,
             #[cfg(not(wasm_browser))]
             ip_bind_addrs: transports.ip_bind_addrs(),
             tls_config: tls_config.clone(),

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -33,8 +33,7 @@ use custom::{CustomEndpoint, CustomSender, CustomTransport};
 pub(crate) use self::ip::Config as IpConfig;
 #[cfg(not(wasm_browser))]
 use self::ip::{IpNetworkChangeSender, IpTransports, IpTransportsSender};
-pub(crate) use self::relay::{HomeRelayStatus, RelayActorConfig, RelayTransport};
-pub(crate) use self::relay::HomeRelayWatch;
+pub(crate) use self::relay::{HomeRelayStatus, HomeRelayWatch, RelayActorConfig, RelayTransport};
 
 /// Manages the different underlying data transports that the socket can support.
 #[derive(Debug)]

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -33,7 +33,7 @@ use custom::{CustomEndpoint, CustomSender, CustomTransport};
 pub(crate) use self::ip::Config as IpConfig;
 #[cfg(not(wasm_browser))]
 use self::ip::{IpNetworkChangeSender, IpTransports, IpTransportsSender};
-pub(crate) use self::relay::{RelayActorConfig, RelayTransport};
+pub(crate) use self::relay::{HomeRelayStatus, RelayActorConfig, RelayTransport};
 
 /// Manages the different underlying data transports that the socket can support.
 #[derive(Debug)]
@@ -56,7 +56,15 @@ type CustomTransportsWatcher =
 /// Combined watcher type for all relay transports
 type RelayTransportsWatcher = n0_watcher::Join<
     Option<(RelayUrl, EndpointId)>,
-    n0_watcher::Map<n0_watcher::Direct<Option<RelayUrl>>, Option<(RelayUrl, EndpointId)>>,
+    n0_watcher::Map<
+        n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>,
+        Option<(RelayUrl, EndpointId)>,
+    >,
+>;
+
+pub(super) type HomeRelayWatcher = n0_watcher::Join<
+    Option<(RelayUrl, HomeRelayStatus)>,
+    n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>,
 >;
 
 #[cfg(not(wasm_browser))]
@@ -310,6 +318,10 @@ impl Transports {
     /// for relay transports, this is the home relay.
     pub(crate) fn local_addrs(&self) -> Vec<Addr> {
         self.local_addrs_watch().get()
+    }
+
+    pub(super) fn home_relay_watch(&self) -> HomeRelayWatcher {
+        n0_watcher::Join::new(self.relay.iter().map(|t| t.my_relay_status()))
     }
 
     #[cfg(not(wasm_browser))]

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -34,6 +34,7 @@ pub(crate) use self::ip::Config as IpConfig;
 #[cfg(not(wasm_browser))]
 use self::ip::{IpNetworkChangeSender, IpTransports, IpTransportsSender};
 pub(crate) use self::relay::{HomeRelayStatus, RelayActorConfig, RelayTransport};
+pub(crate) use self::relay::HomeRelayWatch;
 
 /// Manages the different underlying data transports that the socket can support.
 #[derive(Debug)]

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -20,8 +20,7 @@ use super::{Addr, Transmit};
 
 mod actor;
 
-pub(crate) use self::actor::HomeRelayWatch;
-pub(crate) use self::actor::{Config as RelayActorConfig, HomeRelayStatus};
+pub(crate) use self::actor::{Config as RelayActorConfig, HomeRelayStatus, HomeRelayWatch};
 use self::actor::{RelayActor, RelayActorMessage, RelayRecvDatagram, RelaySendItem};
 
 #[derive(Debug)]

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -20,7 +20,7 @@ use super::{Addr, Transmit};
 
 mod actor;
 
-pub(crate) use self::actor::Config as RelayActorConfig;
+pub(crate) use self::actor::{Config as RelayActorConfig, HomeRelayStatus};
 use self::actor::{RelayActor, RelayActorMessage, RelayRecvDatagram, RelaySendItem};
 
 #[derive(Debug)]
@@ -33,7 +33,7 @@ pub(crate) struct RelayTransport {
     pending_item: Option<RelayRecvDatagram>,
     actor_sender: mpsc::Sender<RelayActorMessage>,
     _actor_handle: AbortOnDropHandle<()>,
-    my_relay: Watchable<Option<RelayUrl>>,
+    my_relay: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
     my_endpoint_id: EndpointId,
 }
 
@@ -164,11 +164,20 @@ impl RelayTransport {
 
     pub(super) fn local_addr_watch(
         &self,
-    ) -> n0_watcher::Map<n0_watcher::Direct<Option<RelayUrl>>, Option<(RelayUrl, EndpointId)>> {
+    ) -> n0_watcher::Map<
+        n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>,
+        Option<(RelayUrl, EndpointId)>,
+    > {
         let my_endpoint_id = self.my_endpoint_id;
         self.my_relay
             .watch()
-            .map(move |url| url.map(|url| (url, my_endpoint_id)))
+            .map(move |url| url.map(|url| (url.0, my_endpoint_id)))
+    }
+
+    pub(super) fn my_relay_status(
+        &self,
+    ) -> n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>> {
+        self.my_relay.watch()
     }
 
     pub(super) fn create_network_change_sender(&self) -> RelayNetworkChangeSender {

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -23,6 +23,11 @@ mod actor;
 pub(crate) use self::actor::{Config as RelayActorConfig, HomeRelayStatus, HomeRelayWatch};
 use self::actor::{RelayActor, RelayActorMessage, RelayRecvDatagram, RelaySendItem};
 
+type RelayAddrWatcher = n0_watcher::Map<
+    n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>,
+    Option<(RelayUrl, EndpointId)>,
+>;
+
 #[derive(Debug)]
 pub(crate) struct RelayTransport {
     /// Queue to receive datagrams from relays for [`noq::AsyncUdpSocket::poll_recv`].
@@ -162,12 +167,7 @@ impl RelayTransport {
         }
     }
 
-    pub(super) fn local_addr_watch(
-        &self,
-    ) -> n0_watcher::Map<
-        n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>,
-        Option<(RelayUrl, EndpointId)>,
-    > {
+    pub(super) fn local_addr_watch(&self) -> RelayAddrWatcher {
         let my_endpoint_id = self.my_endpoint_id;
         self.my_relay
             .watch()

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -11,7 +11,7 @@ use n0_future::{
     ready,
     task::{self, AbortOnDropHandle},
 };
-use n0_watcher::{Watchable, Watcher as _};
+use n0_watcher::Watcher as _;
 use tokio::sync::mpsc;
 use tokio_util::sync::{CancellationToken, PollSender};
 use tracing::{Instrument, error, info_span, warn};
@@ -20,6 +20,7 @@ use super::{Addr, Transmit};
 
 mod actor;
 
+pub(crate) use self::actor::HomeRelayWatch;
 pub(crate) use self::actor::{Config as RelayActorConfig, HomeRelayStatus};
 use self::actor::{RelayActor, RelayActorMessage, RelayRecvDatagram, RelaySendItem};
 
@@ -33,7 +34,7 @@ pub(crate) struct RelayTransport {
     pending_item: Option<RelayRecvDatagram>,
     actor_sender: mpsc::Sender<RelayActorMessage>,
     _actor_handle: AbortOnDropHandle<()>,
-    my_relay: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
+    my_relay: HomeRelayWatch,
     my_endpoint_id: EndpointId,
 }
 

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -897,6 +897,8 @@ pub(crate) struct HomeRelayWatch {
     inner: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
 }
 
+pub(super) type HomeRelayWatcher = n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>;
+
 impl Default for HomeRelayWatch {
     fn default() -> Self {
         Self {

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -151,6 +151,7 @@ struct ActiveRelayActor {
     /// Token indicating the [`ActiveRelayActor`] should stop.
     stop_token: CancellationToken,
     metrics: Arc<SocketMetrics>,
+    my_relay: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
 }
 
 #[derive(Debug)]
@@ -194,6 +195,7 @@ struct ActiveRelayActorOptions {
     connection_opts: RelayConnectionOptions,
     stop_token: CancellationToken,
     metrics: Arc<SocketMetrics>,
+    my_relay: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
 }
 
 /// Configuration needed to create a connection to a relay server.
@@ -264,6 +266,7 @@ impl ActiveRelayActor {
             connection_opts,
             stop_token,
             metrics,
+            my_relay,
         } = opts;
         let relay_client_builder = Self::create_relay_builder(url.clone(), connection_opts);
         ActiveRelayActor {
@@ -277,6 +280,7 @@ impl ActiveRelayActor {
             inactive_timeout: Box::pin(time::sleep(RELAY_INACTIVE_CLEANUP_TIME)),
             stop_token,
             metrics,
+            my_relay,
         }
     }
 
@@ -315,6 +319,11 @@ impl ActiveRelayActor {
 
         while let Err(err) = self.run_once().await {
             warn!("{err:#}");
+            if self.is_home_relay {
+                let _ = self
+                    .my_relay
+                    .set(Some((self.url.clone(), HomeRelayStatus::Disconnected)));
+            }
             match err {
                 RelayConnectionError::Dial { .. } | RelayConnectionError::Handshake { .. } => {
                     // If dialing failed, or if the relay connection failed before we received a pong,
@@ -351,10 +360,20 @@ impl ActiveRelayActor {
     /// or if the relay connection failed while connected. In both cases, the connection should
     /// be retried with a backoff.
     async fn run_once(&mut self) -> Result<(), RelayConnectionError> {
+        if self.is_home_relay {
+            let _ = self
+                .my_relay
+                .set(Some((self.url.clone(), HomeRelayStatus::Connecting)));
+        }
         let client = match self.run_dialing().instrument(info_span!("dialing")).await {
             Some(client_res) => client_res.map_err(|err| e!(RelayConnectionError::Dial, err))?,
             None => return Ok(()),
         };
+        if self.is_home_relay {
+            let _ = self
+                .my_relay
+                .set(Some((self.url.clone(), HomeRelayStatus::Connected)));
+        }
         self.run_connected(client)
             .instrument(info_span!("connected"))
             .await
@@ -366,7 +385,7 @@ impl ActiveRelayActor {
             .reset(Instant::now() + RELAY_INACTIVE_CLEANUP_TIME);
     }
 
-    fn set_home_relay(&mut self, is_home: bool) {
+    fn set_home_relay(&mut self, is_home: bool, status: HomeRelayStatus) {
         let prev = std::mem::replace(&mut self.is_home_relay, is_home);
         if self.is_home_relay != prev {
             event!(
@@ -375,6 +394,9 @@ impl ActiveRelayActor {
                 url = %self.url,
                 home_relay = self.is_home_relay,
             );
+        }
+        if self.is_home_relay {
+            let _ = self.my_relay.set(Some((self.url.clone(), status)));
         }
     }
 
@@ -432,7 +454,7 @@ impl ActiveRelayActor {
                     };
                     match msg {
                         ActiveRelayMessage::SetHomeRelay(is_home) => {
-                            self.set_home_relay(is_home);
+                            self.set_home_relay(is_home, HomeRelayStatus::Connecting);
                         }
                         ActiveRelayMessage::CheckConnection { .. } => {}
                         #[cfg(test)]
@@ -558,7 +580,7 @@ impl ActiveRelayActor {
                     };
                     match msg {
                         ActiveRelayMessage::SetHomeRelay(is_home) => {
-                            self.set_home_relay(is_home);
+                            self.set_home_relay(is_home, HomeRelayStatus::Connected);
                         }
                         ActiveRelayMessage::CheckConnection { local_ips } => {
                             match client_stream.local_addr() {
@@ -837,8 +859,8 @@ pub(super) struct RelayActor {
 }
 
 #[derive(Debug, Clone)]
-pub struct Config {
-    pub my_relay: Watchable<Option<RelayUrl>>,
+pub(crate) struct Config {
+    pub my_relay: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
     pub secret_key: SecretKey,
     #[cfg(not(wasm_browser))]
     pub dns_resolver: DnsResolver,
@@ -848,6 +870,19 @@ pub struct Config {
     pub ipv6_reported: Arc<AtomicBool>,
     pub tls_config: rustls::ClientConfig,
     pub metrics: Arc<SocketMetrics>,
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub(crate) enum HomeRelayStatus {
+    Connecting,
+    Connected,
+    Disconnected,
+}
+
+impl HomeRelayStatus {
+    pub(crate) fn is_connected(&self) -> bool {
+        matches!(self, Self::Connected)
+    }
 }
 
 impl RelayActor {
@@ -977,24 +1012,28 @@ impl RelayActor {
     }
 
     async fn on_network_change(&mut self, report: Report) {
-        let my_relay = self.config.my_relay.get();
-        if report.preferred_relay == my_relay {
+        let prev = self.config.my_relay.get();
+        let prev_url = prev.as_ref().map(|p| &p.0);
+        if report.preferred_relay.as_ref() == prev_url {
             // No change.
             return;
         }
-        let old_relay = self
-            .config
-            .my_relay
-            .set(report.preferred_relay.clone())
-            .unwrap_or_else(|e| e);
 
         if let Some(relay_url) = report.preferred_relay {
             self.config.metrics.relay_home_change.inc();
 
             // On change, notify all currently connected relay servers and
             // start connecting to our home relay if we are not already.
-            info!("home is now relay {}, was {:?}", relay_url, old_relay);
+            info!("home is now relay {}, was {:?}", relay_url, prev_url);
+            let status = if self.active_relays.contains_key(&relay_url) {
+                HomeRelayStatus::Connected
+            } else {
+                HomeRelayStatus::Connecting
+            };
+            let _ = self.config.my_relay.set(Some((relay_url.clone(), status)));
             self.set_home_relay(relay_url).await;
+        } else {
+            let _ = self.config.my_relay.set(None);
         }
     }
 
@@ -1066,7 +1105,7 @@ impl RelayActor {
             Some(e) => e.clone(),
             None => {
                 let handle = self.start_active_relay(url.clone());
-                if Some(&url) == self.config.my_relay.get().as_ref()
+                if Some(&url) == self.config.my_relay.get().as_ref().map(|p| &p.0)
                     && let Err(err) = handle
                         .inbox_addr
                         .try_send(ActiveRelayMessage::SetHomeRelay(true))
@@ -1106,6 +1145,7 @@ impl RelayActor {
             connection_opts,
             stop_token: self.cancel_token.child_token(),
             metrics: self.config.metrics.clone(),
+            my_relay: self.config.my_relay.clone(),
         };
         let actor = ActiveRelayActor::new(opts);
         self.active_relay_tasks.spawn(
@@ -1174,7 +1214,7 @@ impl RelayActor {
 
         // Make sure home relay exists
         if let Some(url) = self.config.my_relay.get() {
-            self.active_relay_handle(url);
+            self.active_relay_handle(url.0);
         }
         self.log_active_relay();
     }
@@ -1282,6 +1322,7 @@ mod tests {
             },
             stop_token,
             metrics: Default::default(),
+            my_relay: Default::default(),
         };
         let task = tokio::spawn(ActiveRelayActor::new(opts).run().instrument(span));
         AbortOnDropHandle::new(task)

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -897,8 +897,6 @@ pub(crate) struct HomeRelayWatch {
     inner: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
 }
 
-pub(super) type HomeRelayWatcher = n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>;
-
 impl Default for HomeRelayWatch {
     fn default() -> Self {
         Self {

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -1680,4 +1680,29 @@ mod tests {
         let res = tokio::time::timeout(Duration::from_secs(10), tracker.timeout()).await;
         assert!(res.is_err(), "ping timeout should only happen once");
     }
+
+    #[test]
+    fn test_home_relay_watch_url_guard() {
+        use super::{HomeRelayStatus::*, HomeRelayWatch};
+
+        let watch = HomeRelayWatch::default();
+        let a: RelayUrl = "https://a.example.com".parse().unwrap();
+        let b: RelayUrl = "https://b.example.com".parse().unwrap();
+
+        // Actor A becomes home and connects
+        watch.set(a.clone(), Connecting);
+        watch.set_status(&a, Connected);
+        assert_eq!(watch.get(), Some((a.clone(), Connected)));
+
+        // RelayActor migrates home to B
+        watch.set(b.clone(), Connecting);
+
+        // Old actor A tries to write -- rejected because URL changed
+        watch.set_status(&a, Disconnected);
+        assert_eq!(watch.get(), Some((b.clone(), Connecting)));
+
+        // Actor B writes normally
+        watch.set_status(&b, Connected);
+        assert_eq!(watch.get(), Some((b.clone(), Connected)));
+    }
 }

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -151,7 +151,7 @@ struct ActiveRelayActor {
     /// Token indicating the [`ActiveRelayActor`] should stop.
     stop_token: CancellationToken,
     metrics: Arc<SocketMetrics>,
-    my_relay: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
+    my_relay: HomeRelayWatch,
 }
 
 #[derive(Debug)]
@@ -195,7 +195,7 @@ struct ActiveRelayActorOptions {
     connection_opts: RelayConnectionOptions,
     stop_token: CancellationToken,
     metrics: Arc<SocketMetrics>,
-    my_relay: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
+    my_relay: HomeRelayWatch,
 }
 
 /// Configuration needed to create a connection to a relay server.
@@ -319,11 +319,8 @@ impl ActiveRelayActor {
 
         while let Err(err) = self.run_once().await {
             warn!("{err:#}");
-            if self.is_home_relay {
-                let _ = self
-                    .my_relay
-                    .set(Some((self.url.clone(), HomeRelayStatus::Disconnected)));
-            }
+            self.my_relay
+                .set_status(&self.url, HomeRelayStatus::Disconnected);
             match err {
                 RelayConnectionError::Dial { .. } | RelayConnectionError::Handshake { .. } => {
                     // If dialing failed, or if the relay connection failed before we received a pong,
@@ -360,20 +357,14 @@ impl ActiveRelayActor {
     /// or if the relay connection failed while connected. In both cases, the connection should
     /// be retried with a backoff.
     async fn run_once(&mut self) -> Result<(), RelayConnectionError> {
-        if self.is_home_relay {
-            let _ = self
-                .my_relay
-                .set(Some((self.url.clone(), HomeRelayStatus::Connecting)));
-        }
+        self.my_relay
+            .set_status(&self.url, HomeRelayStatus::Connecting);
         let client = match self.run_dialing().instrument(info_span!("dialing")).await {
             Some(client_res) => client_res.map_err(|err| e!(RelayConnectionError::Dial, err))?,
             None => return Ok(()),
         };
-        if self.is_home_relay {
-            let _ = self
-                .my_relay
-                .set(Some((self.url.clone(), HomeRelayStatus::Connected)));
-        }
+        self.my_relay
+            .set_status(&self.url, HomeRelayStatus::Connected);
         self.run_connected(client)
             .instrument(info_span!("connected"))
             .await
@@ -385,7 +376,7 @@ impl ActiveRelayActor {
             .reset(Instant::now() + RELAY_INACTIVE_CLEANUP_TIME);
     }
 
-    fn set_home_relay(&mut self, is_home: bool, status: HomeRelayStatus) {
+    fn set_home_relay(&mut self, is_home: bool) {
         let prev = std::mem::replace(&mut self.is_home_relay, is_home);
         if self.is_home_relay != prev {
             event!(
@@ -394,9 +385,6 @@ impl ActiveRelayActor {
                 url = %self.url,
                 home_relay = self.is_home_relay,
             );
-        }
-        if self.is_home_relay {
-            let _ = self.my_relay.set(Some((self.url.clone(), status)));
         }
     }
 
@@ -454,7 +442,7 @@ impl ActiveRelayActor {
                     };
                     match msg {
                         ActiveRelayMessage::SetHomeRelay(is_home) => {
-                            self.set_home_relay(is_home, HomeRelayStatus::Connecting);
+                            self.set_home_relay(is_home);
                         }
                         ActiveRelayMessage::CheckConnection { .. } => {}
                         #[cfg(test)]
@@ -580,7 +568,7 @@ impl ActiveRelayActor {
                     };
                     match msg {
                         ActiveRelayMessage::SetHomeRelay(is_home) => {
-                            self.set_home_relay(is_home, HomeRelayStatus::Connected);
+                            self.set_home_relay(is_home);
                         }
                         ActiveRelayMessage::CheckConnection { local_ips } => {
                             match client_stream.local_addr() {
@@ -860,7 +848,7 @@ pub(super) struct RelayActor {
 
 #[derive(Debug, Clone)]
 pub(crate) struct Config {
-    pub my_relay: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
+    pub my_relay: HomeRelayWatch,
     pub secret_key: SecretKey,
     #[cfg(not(wasm_browser))]
     pub dns_resolver: DnsResolver,
@@ -872,16 +860,80 @@ pub(crate) struct Config {
     pub metrics: Arc<SocketMetrics>,
 }
 
+/// Connection status of the home relay.
+///
+/// Published via [`HomeRelayWatch`] so that [`Endpoint::online`] can wait until the
+/// relay is fully connected, not just selected.
+///
+/// [`Endpoint::online`]: crate::Endpoint::online
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub(crate) enum HomeRelayStatus {
+    /// Dialing or performing the relay handshake.
     Connecting,
+    /// Connected and handshaked, the endpoint is registered and reachable.
     Connected,
+    /// Connection lost after having been connected.
     Disconnected,
 }
 
 impl HomeRelayStatus {
     pub(crate) fn is_connected(&self) -> bool {
         matches!(self, Self::Connected)
+    }
+}
+
+/// Shared watchable for the home relay URL and connection status.
+///
+/// Owned by [`RelayActor`] and cloned into each [`ActiveRelayActor`].
+///
+/// # Write discipline
+///
+/// The [`RelayActor`] writes the URL (via [`Self::set`] and [`Self::clear`]).
+/// Each [`ActiveRelayActor`] updates only the status (via [`Self::set_status`]),
+/// which guards against stale writes: if another relay has become home since this actor
+/// was designated, the write is silently dropped.
+#[derive(Debug, Clone)]
+pub(crate) struct HomeRelayWatch {
+    inner: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
+}
+
+impl Default for HomeRelayWatch {
+    fn default() -> Self {
+        Self {
+            inner: Watchable::new(None),
+        }
+    }
+}
+
+impl HomeRelayWatch {
+    /// Set the home relay URL and status. Used by [`RelayActor`] on relay changes.
+    fn set(&self, url: RelayUrl, status: HomeRelayStatus) {
+        let _ = self.inner.set(Some((url, status)));
+    }
+
+    /// Clear the home relay (no preferred relay). Used by [`RelayActor`].
+    fn clear(&self) {
+        let _ = self.inner.set(None);
+    }
+
+    /// Update the status, but only if `url` is still the current home relay.
+    ///
+    /// This is the only write method [`ActiveRelayActor`] should use. It prevents a
+    /// demoted actor from overwriting a newer home relay's status: the [`RelayActor`]
+    /// updates the URL in the watchable *before* sending `SetHomeRelay(false)`, so by
+    /// the time the old actor tries to write, the URL no longer matches.
+    fn set_status(&self, url: &RelayUrl, status: HomeRelayStatus) {
+        if self.inner.get().as_ref().map(|p| &p.0) == Some(url) {
+            let _ = self.inner.set(Some((url.clone(), status)));
+        }
+    }
+
+    fn get(&self) -> Option<(RelayUrl, HomeRelayStatus)> {
+        self.inner.get()
+    }
+
+    pub(crate) fn watch(&self) -> n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>> {
+        self.inner.watch()
     }
 }
 
@@ -1030,10 +1082,10 @@ impl RelayActor {
             } else {
                 HomeRelayStatus::Connecting
             };
-            let _ = self.config.my_relay.set(Some((relay_url.clone(), status)));
+            self.config.my_relay.set(relay_url.clone(), status);
             self.set_home_relay(relay_url).await;
         } else {
-            let _ = self.config.my_relay.set(None);
+            self.config.my_relay.clear();
         }
     }
 

--- a/iroh/tests/integration.rs
+++ b/iroh/tests/integration.rs
@@ -51,7 +51,7 @@ async fn simple_endpoint_id_based_connection_transfer() -> Result {
     // ensure the server has connected to a relay
     // and therefore has enough information to publish
     tracing::info!("waiting for server to go online");
-    time::timeout(Duration::from_secs(12), server.online())
+    time::timeout(Duration::from_secs(20), server.online())
         .await
         .std_context("server endpoint took too long to get online")?;
 

--- a/iroh/tests/integration.rs
+++ b/iroh/tests/integration.rs
@@ -51,7 +51,7 @@ async fn simple_endpoint_id_based_connection_transfer() -> Result {
     // ensure the server has connected to a relay
     // and therefore has enough information to publish
     tracing::info!("waiting for server to go online");
-    time::timeout(Duration::from_secs(20), server.online())
+    time::timeout(Duration::from_secs(12), server.online())
         .await
         .std_context("server endpoint took too long to get online")?;
 


### PR DESCRIPTION
## Description

Currently, `Endpoint::online` returns once *net_report selected the home relay*, not once connected to it. This is unintuitive, and leads to races especially in tests.

This fixes it by exposing the connection status of the home relay to the upper Socket layers. It reuses the existing `my_relay` watchable, but adds a `HomeRelayStatus` to its value.

## Breaking Changes

Behavior change: `Endpoint::online` now returns once the endpoint is connected to its home relay. Previously, it would return once the home relay is selected but before having connected to it.

## Notes & open questions

We have a terminology mix in our code between "my_relay" and "home_relay". We should clean this up, but not in this PR.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
