### PR TITLE
refactor: improve the new DNS resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -97,9 +97,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -112,15 +112,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -153,9 +153,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -281,9 +281,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -412,9 +412,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-url"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5b428e9fb429c6fda7316e9b006f993e6b4c33005e4659339fb5214479dddec"
+checksum = "d3b761ea69df72d0cc9591ea39adfb0e3b922a27dc535227d7ffbed5702e8809"
 dependencies = [
  "base64",
 ]
@@ -442,22 +442,22 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -504,9 +504,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -531,6 +531,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -585,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -595,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -607,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -619,24 +630,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cobs"
@@ -649,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -665,13 +676,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
@@ -738,6 +748,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -866,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -880,11 +899,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "rand_core",
+ "rand_core 0.9.5",
  "rustc_version",
  "serde",
  "subtle",
@@ -914,12 +933,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -938,11 +957,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -963,11 +981,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1198,7 +1216,7 @@ checksum = "ad207ed88a133091f83224265eac21109930db09bedcad05d5252f2af2de20a1"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.9.5",
  "serde",
  "sha2",
  "signature",
@@ -1280,21 +1298,21 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash 0.2.0",
  "libm",
- "rand",
+ "portable-atomic",
  "siphasher",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
@@ -1551,10 +1569,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1596,7 +1617,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1668,6 +1689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,7 +1743,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustls",
  "serde",
@@ -1741,7 +1768,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "resolv-conf",
  "rustls",
  "serde",
@@ -1843,18 +1870,18 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1867,7 +1894,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1875,15 +1901,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1907,7 +1932,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1939,12 +1964,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1952,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1965,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1979,15 +2005,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1999,15 +2025,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2072,7 +2098,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.9.4",
  "tokio",
  "url",
  "xmltree",
@@ -2080,12 +2106,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2115,14 +2141,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2136,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2186,8 +2213,8 @@ dependencies = [
  "portmapper",
  "postcard",
  "pretty_assertions",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "reqwest 0.13.2",
  "rustc-hash",
  "rustls",
@@ -2225,9 +2252,9 @@ dependencies = [
  "n0-error",
  "postcard",
  "proptest",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
  "serde",
  "serde_json",
  "serde_test",
@@ -2249,7 +2276,7 @@ dependencies = [
  "n0-error",
  "n0-future",
  "noq",
- "rand",
+ "rand 0.9.4",
  "rcgen",
  "rustls",
  "tokio",
@@ -2284,8 +2311,8 @@ dependencies = [
  "n0-future",
  "n0-tracing-test",
  "pkarr",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "rcgen",
  "redb",
  "regex",
@@ -2357,12 +2384,11 @@ dependencies = [
  "dashmap",
  "data-encoding",
  "derive_more",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "http",
  "http-body-util",
  "hyper",
  "hyper-util",
- "ipconfig",
  "iroh-base",
  "iroh-metrics",
  "lru",
@@ -2376,8 +2402,8 @@ dependencies = [
  "pkarr",
  "postcard",
  "proptest",
- "rand",
- "rand_chacha",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rcgen",
  "reloadable-state",
  "reqwest 0.13.2",
@@ -2426,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -2439,7 +2465,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2448,9 +2474,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2464,10 +2512,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2486,9 +2536,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -2498,9 +2548,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -2519,9 +2569,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2559,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2645,9 +2695,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2656,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2853,7 +2903,7 @@ dependencies = [
  "objc2-system-configuration",
  "pin-project-lite",
  "serde",
- "socket2 0.6.3",
+ "socket2",
  "time",
  "tokio",
  "tokio-util",
@@ -2889,16 +2939,17 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "0.17.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#8adda44486fdf33f08ae7481b2c3b3a4db587548"
+source = "git+https://github.com/n0-computer/noq?branch=main#17ce1822764a0e94f957a28cd388c49add99ce66"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "derive_more",
  "noq-proto",
  "noq-udp",
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2909,7 +2960,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "0.16.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#8adda44486fdf33f08ae7481b2c3b3a4db587548"
+source = "git+https://github.com/n0-computer/noq?branch=main#17ce1822764a0e94f957a28cd388c49add99ce66"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -2917,11 +2968,11 @@ dependencies = [
  "derive_more",
  "enum-assoc",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "identity-hash",
  "lru-slab",
  "n0-qlog",
- "rand",
+ "rand 0.10.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2938,11 +2989,11 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "0.9.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#8adda44486fdf33f08ae7481b2c3b3a4db587548"
+source = "git+https://github.com/n0-computer/noq?branch=main#17ce1822764a0e94f957a28cd388c49add99ce66"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -2983,9 +3034,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -3008,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -3018,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3101,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -3135,9 +3186,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "papaya"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
 dependencies = [
  "equivalent",
  "seize",
@@ -3246,12 +3297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkarr"
 version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3341,7 +3386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3373,10 +3418,10 @@ dependencies = [
  "n0-error",
  "netwatch",
  "num_enum",
- "rand",
+ "rand 0.9.4",
  "serde",
  "smallvec",
- "socket2 0.6.3",
+ "socket2",
  "time",
  "tokio",
  "tokio-util",
@@ -3412,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3484,16 +3529,16 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -3544,7 +3589,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3560,7 +3605,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3581,7 +3626,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3609,12 +3654,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3624,7 +3680,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3637,12 +3703,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3656,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3690,9 +3762,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "3.1.1"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef99362319c782aa4639ad3a306b64c3bb90e12874e99b8df124cb679d988611"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
 dependencies = [
  "libc",
 ]
@@ -3863,9 +3935,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3900,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3999,9 +4071,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4104,9 +4176,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "send_wrapper"
@@ -4191,9 +4263,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4221,9 +4293,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -4231,11 +4303,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4248,7 +4320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c777f0a122a53fddb0beb6e706771197000b8eb5c9f42b5b850f450ef48c788"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4265,7 +4337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4344,16 +4416,6 @@ checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -4405,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.8.0-rc.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
@@ -4510,8 +4572,8 @@ checksum = "1a5ab62937edac8b23fa40e55a358ea1924245b17fc1eb20d14929c8f11be98d"
 dependencies = [
  "acto",
  "hickory-proto",
- "rand",
- "socket2 0.6.3",
+ "rand 0.9.4",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4556,9 +4618,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -4652,9 +4714,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4672,9 +4734,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4687,9 +4749,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -4697,16 +4759,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4780,19 +4842,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-websockets"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b6348ebfaaecd771cecb69e832961d277f59845d4220a584701f72728152b7"
+checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
 dependencies = [
  "aws-lc-rs",
  "base64",
  "bytes",
  "futures-core",
  "futures-sink",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "http",
  "httparse",
- "rand",
+ "rand 0.10.1",
  "ring",
  "rustls-pki-types",
  "sha1_smol",
@@ -4804,9 +4866,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4819,18 +4881,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4840,18 +4902,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4962,9 +5024,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5014,9 +5076,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -5079,9 +5141,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5202,9 +5264,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5215,23 +5277,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5239,9 +5297,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5252,18 +5310,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.64"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
 dependencies = [
  "async-trait",
  "cast",
@@ -5283,9 +5341,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.64"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5294,9 +5352,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
 
 [[package]]
 name = "wasm-encoder"
@@ -5358,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5515,6 +5573,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5539,15 +5608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5603,21 +5663,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -5666,12 +5711,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5690,12 +5729,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5711,12 +5744,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5750,12 +5777,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5771,12 +5792,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5798,12 +5813,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5822,12 +5831,6 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -5840,21 +5843,11 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5947,9 +5940,9 @@ dependencies = [
 
 [[package]]
 name = "wmi"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003e65f4934cf9449b9ce913ad822cd054a5af669d24f93db101fdb02856bb23"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
 dependencies = [
  "chrono",
  "futures",
@@ -5962,9 +5955,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -6035,9 +6028,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6046,9 +6039,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6064,18 +6057,18 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6084,18 +6077,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6125,9 +6118,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6136,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6147,9 +6140,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -48,7 +48,7 @@ postcard = { version = "1", default-features = false, features = [
 ] }
 noq = { version = "0.17.0", default-features = false, features = ["rustls"] }
 noq-proto = { version = "0.16.0", default-features = false }
-rand = "0.9.2"
+rand = "0.10"
 reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider"] }
 rustls = { version = "0.23.33", default-features = false }
 rustls-platform-verifier = { version = "0.6.2", optional = true }
@@ -79,7 +79,7 @@ rustls-cert-reloadable-resolver = { version = "0.7.1", optional = true }
 rustls-cert-file-reader = { version = "0.4.2", optional = true }
 time = { version = "0.3.37", optional = true }
 tokio-rustls-acme = { version = "0.9", optional = true }
-tokio-websockets = { version = "0.12", features = ["rustls-bring-your-own-connector", "getrandom", "rand", "server", "sha1_smol"], optional = true } # server-side websocket implementation
+tokio-websockets = { version = "0.13", features = ["rustls-bring-your-own-connector", "getrandom", "rand", "server", "sha1_smol"], optional = true } # server-side websocket implementation
 simdutf8 = { version = "0.1.5", optional = true } # minimal version fix
 sha1 = { version = "0.11.0-rc.2", optional = true }
 toml = { version = "1.0", optional = true }
@@ -98,21 +98,17 @@ tokio = { version = "1", features = [
     "fs",
     "io-std",
 ] }
-tokio-websockets = { version = "0.12", features = ["rustls-bring-your-own-connector", "getrandom", "rand", "client", "sha1_smol"] }
-
-# Windows-only dependencies
-[target.'cfg(windows)'.dependencies]
-ipconfig = "0.3"
+tokio-websockets = { version = "0.13", features = ["rustls-bring-your-own-connector", "getrandom", "rand", "client", "sha1_smol"] }
 
 # wasm-in-browser dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 ws_stream_wasm = { version = "0.7.4", default-features = false }
-getrandom = { version = "0.3.2", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
-proptest = "1.2.0"
-rand_chacha = "0.9"
+proptest = "1.11.0"
+rand_chacha = "0.10"
 tokio = { version = "1", features = [
     "io-util",
     "sync",

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -566,39 +566,51 @@ impl DnsResolverInner {
 /// This contains a list of character strings, as defined in [RFC 1035 Section 3.3.14].
 ///
 /// [`TxtRecordData`] implements [`fmt::Display`], so you can call [`ToString::to_string`] to
-/// convert the record data into a string. This will concatenate all strings without a separator.
+/// convert the record data into a string. This will parse each character string with
+/// [`String::from_utf8_lossy`] and then concatenate all strings without a separator.
 ///
 /// If you want to process each character string individually, use [`Self::iter`].
 ///
 /// [RFC 1035 Section 3.3.14]: https://datatracker.ietf.org/doc/html/rfc1035#section-3.3.14
 #[derive(Debug, Clone)]
-pub struct TxtRecordData(Box<[String]>);
+pub struct TxtRecordData(Box<[Box<[u8]>]>);
 
 impl TxtRecordData {
     /// Returns an iterator over the character strings contained in this TXT record.
-    pub fn iter(&self) -> impl Iterator<Item = &str> {
-        self.0.iter().map(|x| x.as_str())
+    pub fn iter(&self) -> impl Iterator<Item = &[u8]> {
+        self.0.iter().map(|x| x.as_ref())
     }
 }
 
 impl fmt::Display for TxtRecordData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for s in self.iter() {
-            write!(f, "{s}")?
+            write!(f, "{}", &String::from_utf8_lossy(s))?
         }
         Ok(())
     }
 }
 
-impl FromIterator<String> for TxtRecordData {
-    fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
+impl FromIterator<Box<[u8]>> for TxtRecordData {
+    fn from_iter<T: IntoIterator<Item = Box<[u8]>>>(iter: T) -> Self {
         Self(iter.into_iter().collect())
+    }
+}
+
+impl From<Vec<Box<[u8]>>> for TxtRecordData {
+    fn from(value: Vec<Box<[u8]>>) -> Self {
+        Self(value.into_boxed_slice())
     }
 }
 
 impl From<Vec<String>> for TxtRecordData {
     fn from(value: Vec<String>) -> Self {
-        Self(value.into_boxed_slice())
+        Self(
+            value
+                .into_iter()
+                .map(|s| s.into_bytes().into_boxed_slice())
+                .collect(),
+        )
     }
 }
 

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -106,6 +106,8 @@ pub enum DnsError {
     },
     #[error("DNS server returned error: {rcode}")]
     ServerError { rcode: String },
+    #[error("domain name does not exist (NXDOMAIN)")]
+    NxDomain {},
     #[error("invalid DNS response: not a query for _iroh.z32encodedpubkey")]
     InvalidResponse {},
 }

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -106,10 +106,10 @@ pub enum DnsError {
     },
     #[error("DNS server returned error: {rcode}")]
     ServerError { rcode: String },
-    #[error("domain name does not exist (NXDOMAIN)")]
-    NxDomain {},
     #[error("invalid DNS response: not a query for _iroh.z32encodedpubkey")]
     InvalidResponse {},
+    #[error("domain name does not exist (NXDOMAIN)")]
+    NxDomain {},
 }
 
 /// Potential errors related to DNS endpoint address lookups.

--- a/iroh-relay/src/dns/cache.rs
+++ b/iroh-relay/src/dns/cache.rs
@@ -39,7 +39,7 @@ struct CacheEntry {
 
 impl CacheEntry {
     fn is_expired(&self) -> bool {
-        Instant::now() > self.inserted_at + self.ttl
+        self.inserted_at.elapsed() > self.ttl
     }
 }
 

--- a/iroh-relay/src/dns/cache.rs
+++ b/iroh-relay/src/dns/cache.rs
@@ -44,6 +44,15 @@ impl CacheEntry {
 }
 
 /// DNS cache with LRU eviction and TTL-based expiry.
+///
+/// # Allocation notes
+///
+/// - `get()` allocates a `String` for the lookup key because `LruCache::get`
+///   requires `K: Borrow<Q>` and tuples don't implement cross-type `Borrow`.
+///   This is ~20-50 bytes per lookup, negligible vs network I/O.
+/// - `get()` clones the cached record (Vec of addresses). Necessary because
+///   the cache is behind a `std::sync::RwLock` and the borrow can't outlive it.
+/// - `insert()` allocates a `String` for the key. Unavoidable for owned storage.
 #[derive(Debug)]
 pub(super) struct DnsCache {
     inner: LruCache<(String, QueryType), CacheEntry>,

--- a/iroh-relay/src/dns/cache.rs
+++ b/iroh-relay/src/dns/cache.rs
@@ -1,6 +1,7 @@
 //! Simple TTL-based DNS cache using LRU eviction.
 
 use std::{
+    hash::{Hash, Hasher},
     net::{Ipv4Addr, Ipv6Addr},
     time::{Duration, Instant},
 };
@@ -19,6 +20,18 @@ pub(super) enum QueryType {
     A,
     AAAA,
     TXT,
+}
+
+/// Pre-hash `(host, qtype)` into a u64 key for allocation-free cache lookups.
+///
+/// Collisions are benign (worst case: wrong cache entry returned, causing a
+/// re-query). With 64-bit hashes and a 512-entry cache the probability is
+/// negligible.
+fn cache_key(host: &str, qtype: QueryType) -> u64 {
+    let mut hasher = std::hash::DefaultHasher::new();
+    host.hash(&mut hasher);
+    qtype.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// A cached DNS result.
@@ -45,17 +58,12 @@ impl CacheEntry {
 
 /// DNS cache with LRU eviction and TTL-based expiry.
 ///
-/// # Allocation notes
-///
-/// - `get()` allocates a `String` for the lookup key because `LruCache::get`
-///   requires `K: Borrow<Q>` and tuples don't implement cross-type `Borrow`.
-///   This is ~20-50 bytes per lookup, negligible vs network I/O.
-/// - `get()` clones the cached record (Vec of addresses). Necessary because
-///   the cache is behind a `std::sync::RwLock` and the borrow can't outlive it.
-/// - `insert()` allocates a `String` for the key. Unavoidable for owned storage.
+/// Uses pre-hashed u64 keys to avoid allocating a `String` on every lookup.
+/// The only remaining per-hit allocation is the `record.clone()` on cache hit,
+/// which is necessary because the cache is behind a `std::sync::RwLock`.
 #[derive(Debug)]
 pub(super) struct DnsCache {
-    inner: LruCache<(String, QueryType), CacheEntry>,
+    inner: LruCache<u64, CacheEntry>,
 }
 
 impl DnsCache {
@@ -67,16 +75,13 @@ impl DnsCache {
 
     /// Look up a cached record. Returns `None` if not found or expired.
     pub(super) fn get(&mut self, host: &str, qtype: QueryType) -> Option<CachedRecord> {
-        let key = (host.to_string(), qtype);
-        if let Some(entry) = self.inner.get(&key) {
-            if entry.is_expired() {
-                self.inner.pop(&key);
-                return None;
-            }
-            Some(entry.record.clone())
-        } else {
-            None
+        let key = cache_key(host, qtype);
+        let entry = self.inner.get(&key)?;
+        if entry.is_expired() {
+            self.inner.pop(&key);
+            return None;
         }
+        Some(entry.record.clone())
     }
 
     /// Insert a record into the cache with the given TTL.
@@ -99,7 +104,7 @@ impl DnsCache {
             inserted_at: Instant::now(),
             ttl: Duration::from_secs(ttl as u64),
         };
-        self.inner.put((host.to_string(), qtype), entry);
+        self.inner.put(cache_key(host, qtype), entry);
     }
 
     /// Clear all cache entries.

--- a/iroh-relay/src/dns/cache.rs
+++ b/iroh-relay/src/dns/cache.rs
@@ -71,7 +71,16 @@ impl DnsCache {
     }
 
     /// Insert a record into the cache with the given TTL.
-    /// A TTL of 0 means don't cache (negative caching disabled).
+    ///
+    /// A TTL of 0 means don't cache. This also means that negative responses
+    /// (NXDOMAIN, NODATA) are never cached, since empty results have TTL 0.
+    /// This matches the old hickory-resolver configuration which set
+    /// `negative_max_ttl = Some(Duration::ZERO)`.
+    ///
+    /// **Known limitation:** Without negative caching, repeated queries for
+    /// non-existent domains always hit the network. Under high concurrency
+    /// this can become a thundering herd. A future improvement could cache
+    /// negative results for a short duration (e.g. 5-10 seconds).
     pub(super) fn insert(&mut self, host: &str, qtype: QueryType, record: CachedRecord, ttl: u32) {
         if ttl == 0 {
             return;

--- a/iroh-relay/src/dns/cache.rs
+++ b/iroh-relay/src/dns/cache.rs
@@ -3,6 +3,7 @@
 use std::{
     hash::{Hash, Hasher},
     net::{Ipv4Addr, Ipv6Addr},
+    sync::Mutex,
     time::{Duration, Instant},
 };
 
@@ -56,29 +57,32 @@ impl CacheEntry {
     }
 }
 
-/// DNS cache with LRU eviction and TTL-based expiry.
+/// Thread-safe DNS cache with LRU eviction and TTL-based expiry.
 ///
 /// Uses pre-hashed u64 keys to avoid allocating a `String` on every lookup.
 /// The only remaining per-hit allocation is the `record.clone()` on cache hit,
-/// which is necessary because the cache is behind a `std::sync::RwLock`.
+/// necessary because the result must outlive the lock guard.
 #[derive(Debug)]
 pub(super) struct DnsCache {
-    inner: LruCache<u64, CacheEntry>,
+    inner: Mutex<LruCache<u64, CacheEntry>>,
 }
 
 impl DnsCache {
     pub(super) fn new() -> Self {
         Self {
-            inner: LruCache::new(std::num::NonZeroUsize::new(MAX_CACHE_ENTRIES).expect("non-zero")),
+            inner: Mutex::new(LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CACHE_ENTRIES).expect("non-zero"),
+            )),
         }
     }
 
     /// Look up a cached record. Returns `None` if not found or expired.
-    pub(super) fn get(&mut self, host: &str, qtype: QueryType) -> Option<CachedRecord> {
+    pub(super) fn get(&self, host: &str, qtype: QueryType) -> Option<CachedRecord> {
         let key = cache_key(host, qtype);
-        let entry = self.inner.get(&key)?;
+        let mut inner = self.inner.lock().expect("poisoned");
+        let entry = inner.get(&key)?;
         if entry.is_expired() {
-            self.inner.pop(&key);
+            inner.pop(&key);
             return None;
         }
         Some(entry.record.clone())
@@ -95,7 +99,7 @@ impl DnsCache {
     /// non-existent domains always hit the network. Under high concurrency
     /// this can become a thundering herd. A future improvement could cache
     /// negative results for a short duration (e.g. 5-10 seconds).
-    pub(super) fn insert(&mut self, host: &str, qtype: QueryType, record: CachedRecord, ttl: u32) {
+    pub(super) fn insert(&self, host: &str, qtype: QueryType, record: CachedRecord, ttl: u32) {
         if ttl == 0 {
             return;
         }
@@ -104,11 +108,14 @@ impl DnsCache {
             inserted_at: Instant::now(),
             ttl: Duration::from_secs(ttl as u64),
         };
-        self.inner.put(cache_key(host, qtype), entry);
+        self.inner
+            .lock()
+            .expect("poisoned")
+            .put(cache_key(host, qtype), entry);
     }
 
     /// Clear all cache entries.
-    pub(super) fn clear(&mut self) {
-        self.inner.clear();
+    pub(super) fn clear(&self) {
+        self.inner.lock().expect("poisoned").clear();
     }
 }

--- a/iroh-relay/src/dns/query.rs
+++ b/iroh-relay/src/dns/query.rs
@@ -54,18 +54,17 @@ pub(super) const MAX_CNAME_DEPTH: usize = 8;
 fn resolve_cname_chain<'a>(packet: &'a Packet<'a>, start_name: &Name<'a>) -> Name<'a> {
     let mut current = start_name.clone();
     for _ in 0..MAX_CNAME_DEPTH {
-        let next = packet.answers.iter().find_map(|rr| {
-            if rr.name == current {
-                if let RData::CNAME(cname) = &rr.rdata {
-                    return Some(cname.0.clone());
-                }
-            }
-            None
-        });
-        match next {
-            Some(name) => current = name,
-            None => break,
-        }
+        let Some(next) = packet.answers.iter().find_map(|rr| {
+            (rr.name == current)
+                .then(|| match &rr.rdata {
+                    RData::CNAME(cname) => Some(cname.0.clone()),
+                    _ => None,
+                })
+                .flatten()
+        }) else {
+            break;
+        };
+        current = next;
     }
     current
 }
@@ -76,15 +75,9 @@ fn resolve_cname_chain<'a>(packet: &'a Packet<'a>, start_name: &Name<'a>) -> Nam
 /// This is used for recursive CNAME following: when the server returns only a
 /// CNAME without the final record, the caller issues a new query for the target.
 pub(super) fn cname_target(packet: &Packet<'_>, qname: &str) -> Option<String> {
-    let Ok(name) = Name::new(qname) else {
-        return None;
-    };
+    let name = Name::new(qname).ok()?;
     let canonical = resolve_cname_chain(packet, &name);
-    if canonical != name {
-        Some(canonical.to_string())
-    } else {
-        None
-    }
+    (canonical != name).then(|| canonical.to_string())
 }
 
 /// Check response packet for errors (RCODE, ID mismatch).
@@ -209,20 +202,14 @@ pub(super) fn parse_txt_response(
 /// (which uses a HashMap and would lose ordering and deduplicate keys).
 fn extract_txt_record_data(txt: &simple_dns::rdata::TXT<'_>) -> TxtRecordData {
     match String::try_from(txt.clone()) {
-        Ok(s) if !s.is_empty() => {
-            TxtRecordData::from(vec![s.into_bytes().into_boxed_slice()])
-        }
+        Ok(s) if !s.is_empty() => TxtRecordData::from(vec![s.into_bytes().into_boxed_slice()]),
         _ => TxtRecordData::from(Vec::<Box<[u8]>>::new()),
     }
 }
 
 /// Returns true if the response has the TC (truncation) flag set.
 pub(super) fn is_truncated(data: &[u8]) -> bool {
-    if let Ok(packet) = Packet::parse(data) {
-        packet.has_flags(PacketFlag::TRUNCATION)
-    } else {
-        false
-    }
+    Packet::parse(data).is_ok_and(|p| p.has_flags(PacketFlag::TRUNCATION))
 }
 
 #[cfg(test)]

--- a/iroh-relay/src/dns/query.rs
+++ b/iroh-relay/src/dns/query.rs
@@ -94,6 +94,7 @@ fn check_response(packet: &Packet, expected_id: u16) -> Result<(), DnsError> {
     }
     match packet.rcode() {
         RCODE::NoError => Ok(()),
+        RCODE::NameError => Err(e!(DnsError::NxDomain)),
         rcode => Err(e!(DnsError::ServerError {
             rcode: format!("{rcode:?}"),
         })),

--- a/iroh-relay/src/dns/query.rs
+++ b/iroh-relay/src/dns/query.rs
@@ -26,6 +26,49 @@ pub(super) fn build_query(host: &str, qtype: TYPE) -> Result<(u16, Vec<u8>), Dns
     Ok((id, bytes))
 }
 
+/// Maximum CNAME chain depth to prevent infinite loops.
+pub(super) const MAX_CNAME_DEPTH: usize = 8;
+
+/// Resolve the CNAME chain in the answer section starting from `start_name`.
+///
+/// Returns the final canonical name after following all CNAMEs, or the
+/// original name if no CNAME records are present.
+fn resolve_cname_chain<'a>(packet: &'a Packet<'a>, start_name: &Name<'a>) -> Name<'a> {
+    let mut current = start_name.clone();
+    for _ in 0..MAX_CNAME_DEPTH {
+        let next = packet.answers.iter().find_map(|rr| {
+            if rr.name == current {
+                if let RData::CNAME(cname) = &rr.rdata {
+                    return Some(cname.0.clone());
+                }
+            }
+            None
+        });
+        match next {
+            Some(name) => current = name,
+            None => break,
+        }
+    }
+    current
+}
+
+/// Returns the CNAME target for a query name, if the response contains a CNAME
+/// but no final records of the requested type for that name.
+///
+/// This is used for recursive CNAME following: when the server returns only a
+/// CNAME without the final record, the caller issues a new query for the target.
+pub(super) fn cname_target(packet: &Packet<'_>, qname: &str) -> Option<String> {
+    let Ok(name) = Name::new(qname) else {
+        return None;
+    };
+    let canonical = resolve_cname_chain(packet, &name);
+    if canonical != name {
+        Some(canonical.to_string())
+    } else {
+        None
+    }
+}
+
 /// Check response packet for errors (RCODE, ID mismatch).
 fn check_response(packet: &Packet, expected_id: u16) -> Result<(), DnsError> {
     if packet.id() != expected_id {
@@ -39,7 +82,10 @@ fn check_response(packet: &Packet, expected_id: u16) -> Result<(), DnsError> {
     }
 }
 
-/// Parse A (IPv4) records from a DNS response.
+/// Parse A (IPv4) records from a DNS response, following CNAME chains.
+///
+/// If the response contains CNAME records pointing from the queried name to a
+/// canonical name, records for both the original and canonical names are collected.
 pub(super) fn parse_a_response(
     data: &[u8],
     expected_id: u16,
@@ -47,12 +93,23 @@ pub(super) fn parse_a_response(
     let packet = Packet::parse(data)?;
     check_response(&packet, expected_id)?;
 
+    // Resolve the CNAME chain to find the canonical name.
+    let qname = packet
+        .questions
+        .first()
+        .map(|q| q.qname.clone())
+        .unwrap_or_else(|| Name::new_unchecked(""));
+    let canonical = resolve_cname_chain(&packet, &qname);
+
     let mut addrs = Vec::new();
     let mut min_ttl = u32::MAX;
     for rr in &packet.answers {
         if let RData::A(A { address }) = &rr.rdata {
-            addrs.push(Ipv4Addr::from(*address));
-            min_ttl = min_ttl.min(rr.ttl);
+            // Accept records matching either the original or canonical name.
+            if rr.name == qname || rr.name == canonical {
+                addrs.push(Ipv4Addr::from(*address));
+                min_ttl = min_ttl.min(rr.ttl);
+            }
         }
     }
     if min_ttl == u32::MAX {
@@ -61,7 +118,7 @@ pub(super) fn parse_a_response(
     Ok((addrs, min_ttl))
 }
 
-/// Parse AAAA (IPv6) records from a DNS response.
+/// Parse AAAA (IPv6) records from a DNS response, following CNAME chains.
 pub(super) fn parse_aaaa_response(
     data: &[u8],
     expected_id: u16,
@@ -69,12 +126,21 @@ pub(super) fn parse_aaaa_response(
     let packet = Packet::parse(data)?;
     check_response(&packet, expected_id)?;
 
+    let qname = packet
+        .questions
+        .first()
+        .map(|q| q.qname.clone())
+        .unwrap_or_else(|| Name::new_unchecked(""));
+    let canonical = resolve_cname_chain(&packet, &qname);
+
     let mut addrs = Vec::new();
     let mut min_ttl = u32::MAX;
     for rr in &packet.answers {
         if let RData::AAAA(AAAA { address }) = &rr.rdata {
-            addrs.push(Ipv6Addr::from(*address));
-            min_ttl = min_ttl.min(rr.ttl);
+            if rr.name == qname || rr.name == canonical {
+                addrs.push(Ipv6Addr::from(*address));
+                min_ttl = min_ttl.min(rr.ttl);
+            }
         }
     }
     if min_ttl == u32::MAX {
@@ -83,7 +149,7 @@ pub(super) fn parse_aaaa_response(
     Ok((addrs, min_ttl))
 }
 
-/// Parse TXT records from a DNS response.
+/// Parse TXT records from a DNS response, following CNAME chains.
 pub(super) fn parse_txt_response(
     data: &[u8],
     expected_id: u16,
@@ -91,13 +157,22 @@ pub(super) fn parse_txt_response(
     let packet = Packet::parse(data)?;
     check_response(&packet, expected_id)?;
 
+    let qname = packet
+        .questions
+        .first()
+        .map(|q| q.qname.clone())
+        .unwrap_or_else(|| Name::new_unchecked(""));
+    let canonical = resolve_cname_chain(&packet, &qname);
+
     let mut records = Vec::new();
     let mut min_ttl = u32::MAX;
     for rr in &packet.answers {
         if let RData::TXT(txt) = &rr.rdata {
-            let record = extract_txt_record_data(txt);
-            records.push(record);
-            min_ttl = min_ttl.min(rr.ttl);
+            if rr.name == qname || rr.name == canonical {
+                let record = extract_txt_record_data(txt);
+                records.push(record);
+                min_ttl = min_ttl.min(rr.ttl);
+            }
         }
     }
     if min_ttl == u32::MAX {
@@ -135,5 +210,173 @@ pub(super) fn is_truncated(data: &[u8]) -> bool {
         packet.has_flags(PacketFlag::TRUNCATION)
     } else {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use simple_dns::{
+        CLASS, Name, Packet, PacketFlag, QCLASS, QTYPE, Question, ResourceRecord,
+        rdata::{A, RData, CNAME},
+    };
+
+    use super::*;
+
+    /// Build a query packet for `host` with type A, return (id, bytes).
+    fn make_query(host: &str) -> (u16, Vec<u8>) {
+        build_query(host, TYPE::A).unwrap()
+    }
+
+    /// Build a response with A records for `name`.
+    fn a_response(id: u16, name: &str, addrs: &[Ipv4Addr]) -> Vec<u8> {
+        let mut packet = Packet::new_reply(id);
+        packet.set_flags(PacketFlag::RECURSION_DESIRED | PacketFlag::RECURSION_AVAILABLE);
+        // Echo the question back (needed for CNAME resolution in parse functions).
+        packet.questions.push(Question::new(
+            Name::new_unchecked(name),
+            QTYPE::TYPE(TYPE::A),
+            QCLASS::CLASS(CLASS::IN),
+            false,
+        ));
+        for addr in addrs {
+            packet.answers.push(ResourceRecord::new(
+                Name::new_unchecked(name),
+                CLASS::IN,
+                300,
+                RData::A(A { address: u32::from(*addr) }),
+            ));
+        }
+        packet.build_bytes_vec().unwrap()
+    }
+
+    /// Build a response containing a CNAME from `alias` -> `canonical`, plus
+    /// A records under the canonical name (the common "both in one response" case).
+    fn cname_with_a_response(
+        id: u16,
+        alias: &str,
+        canonical: &str,
+        addrs: &[Ipv4Addr],
+    ) -> Vec<u8> {
+        let mut packet = Packet::new_reply(id);
+        packet.set_flags(PacketFlag::RECURSION_DESIRED | PacketFlag::RECURSION_AVAILABLE);
+        packet.questions.push(Question::new(
+            Name::new_unchecked(alias),
+            QTYPE::TYPE(TYPE::A),
+            QCLASS::CLASS(CLASS::IN),
+            false,
+        ));
+        // CNAME record
+        packet.answers.push(ResourceRecord::new(
+            Name::new_unchecked(alias),
+            CLASS::IN,
+            300,
+            RData::CNAME(CNAME(Name::new_unchecked(canonical))),
+        ));
+        // A records for the canonical name
+        for addr in addrs {
+            packet.answers.push(ResourceRecord::new(
+                Name::new_unchecked(canonical),
+                CLASS::IN,
+                300,
+                RData::A(A { address: u32::from(*addr) }),
+            ));
+        }
+        packet.build_bytes_vec().unwrap()
+    }
+
+    /// Build a response containing only a CNAME (no final A record).
+    fn cname_only_response(id: u16, alias: &str, canonical: &str) -> Vec<u8> {
+        let mut packet = Packet::new_reply(id);
+        packet.set_flags(PacketFlag::RECURSION_DESIRED | PacketFlag::RECURSION_AVAILABLE);
+        packet.questions.push(Question::new(
+            Name::new_unchecked(alias),
+            QTYPE::TYPE(TYPE::A),
+            QCLASS::CLASS(CLASS::IN),
+            false,
+        ));
+        packet.answers.push(ResourceRecord::new(
+            Name::new_unchecked(alias),
+            CLASS::IN,
+            300,
+            RData::CNAME(CNAME(Name::new_unchecked(canonical))),
+        ));
+        packet.build_bytes_vec().unwrap()
+    }
+
+    #[test]
+    fn parse_a_no_cname() {
+        let (id, _) = make_query("example.com");
+        let resp = a_response(id, "example.com", &[Ipv4Addr::new(1, 2, 3, 4)]);
+        let (addrs, ttl) = parse_a_response(&resp, id).unwrap();
+        assert_eq!(addrs, [Ipv4Addr::new(1, 2, 3, 4)]);
+        assert_eq!(ttl, 300);
+    }
+
+    #[test]
+    fn parse_a_with_cname_in_response() {
+        let (id, _) = make_query("alias.example.com");
+        let resp = cname_with_a_response(
+            id,
+            "alias.example.com",
+            "real.example.com",
+            &[Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)],
+        );
+        let (addrs, _) = parse_a_response(&resp, id).unwrap();
+        assert_eq!(addrs, [Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)]);
+    }
+
+    #[test]
+    fn parse_a_with_chained_cname() {
+        // alias -> middle -> real, A records on real
+        let (id, _) = make_query("alias.example.com");
+        let mut packet = Packet::new_reply(id);
+        packet.set_flags(PacketFlag::RECURSION_DESIRED | PacketFlag::RECURSION_AVAILABLE);
+        packet.questions.push(Question::new(
+            Name::new_unchecked("alias.example.com"),
+            QTYPE::TYPE(TYPE::A),
+            QCLASS::CLASS(CLASS::IN),
+            false,
+        ));
+        packet.answers.push(ResourceRecord::new(
+            Name::new_unchecked("alias.example.com"),
+            CLASS::IN,
+            300,
+            RData::CNAME(CNAME(Name::new_unchecked("middle.example.com"))),
+        ));
+        packet.answers.push(ResourceRecord::new(
+            Name::new_unchecked("middle.example.com"),
+            CLASS::IN,
+            300,
+            RData::CNAME(CNAME(Name::new_unchecked("real.example.com"))),
+        ));
+        packet.answers.push(ResourceRecord::new(
+            Name::new_unchecked("real.example.com"),
+            CLASS::IN,
+            300,
+            RData::A(A { address: u32::from(Ipv4Addr::new(5, 6, 7, 8)) }),
+        ));
+        let resp = packet.build_bytes_vec().unwrap();
+        let (addrs, _) = parse_a_response(&resp, id).unwrap();
+        assert_eq!(addrs, [Ipv4Addr::new(5, 6, 7, 8)]);
+    }
+
+    #[test]
+    fn cname_target_extracts_target_for_recursive_follow() {
+        let id = 1234;
+        let resp = cname_only_response(id, "alias.example.com", "real.example.com");
+        let packet = Packet::parse(&resp).unwrap();
+        let target = cname_target(&packet, "alias.example.com");
+        assert_eq!(target.as_deref(), Some("real.example.com"));
+    }
+
+    #[test]
+    fn cname_target_returns_none_when_no_cname() {
+        let id = 1234;
+        let resp = a_response(id, "example.com", &[Ipv4Addr::new(1, 2, 3, 4)]);
+        let packet = Packet::parse(&resp).unwrap();
+        let target = cname_target(&packet, "example.com");
+        assert_eq!(target, None);
     }
 }

--- a/iroh-relay/src/dns/query.rs
+++ b/iroh-relay/src/dns/query.rs
@@ -100,6 +100,16 @@ fn check_response(packet: &Packet, expected_id: u16) -> Result<(), DnsError> {
     }
 }
 
+/// Check whether a resource record's name matches the queried name or its
+/// CNAME-resolved canonical name. If no question section is present
+/// (shouldn't happen in practice), accept all records.
+fn name_matches(rr_name: &Name<'_>, qname: Option<&Name<'_>>, canonical: Option<&Name<'_>>) -> bool {
+    match qname {
+        Some(q) => rr_name == q || canonical.is_some_and(|c| rr_name == c),
+        None => true, // No question section -- accept all matching record types.
+    }
+}
+
 /// Parse A (IPv4) records from a DNS response, following CNAME chains.
 ///
 /// If the response contains CNAME records pointing from the queried name to a
@@ -111,20 +121,14 @@ pub(super) fn parse_a_response(
     let packet = Packet::parse(data)?;
     check_response(&packet, expected_id)?;
 
-    // Resolve the CNAME chain to find the canonical name.
-    let qname = packet
-        .questions
-        .first()
-        .map(|q| q.qname.clone())
-        .unwrap_or_else(|| Name::new_unchecked(""));
-    let canonical = resolve_cname_chain(&packet, &qname);
+    let qname = packet.questions.first().map(|q| q.qname.clone());
+    let canonical = qname.as_ref().map(|q| resolve_cname_chain(&packet, q));
 
     let mut addrs = Vec::new();
     let mut min_ttl = u32::MAX;
     for rr in &packet.answers {
         if let RData::A(A { address }) = &rr.rdata {
-            // Accept records matching either the original or canonical name.
-            if rr.name == qname || rr.name == canonical {
+            if name_matches(&rr.name, qname.as_ref(), canonical.as_ref()) {
                 addrs.push(Ipv4Addr::from(*address));
                 min_ttl = min_ttl.min(rr.ttl);
             }
@@ -144,18 +148,14 @@ pub(super) fn parse_aaaa_response(
     let packet = Packet::parse(data)?;
     check_response(&packet, expected_id)?;
 
-    let qname = packet
-        .questions
-        .first()
-        .map(|q| q.qname.clone())
-        .unwrap_or_else(|| Name::new_unchecked(""));
-    let canonical = resolve_cname_chain(&packet, &qname);
+    let qname = packet.questions.first().map(|q| q.qname.clone());
+    let canonical = qname.as_ref().map(|q| resolve_cname_chain(&packet, q));
 
     let mut addrs = Vec::new();
     let mut min_ttl = u32::MAX;
     for rr in &packet.answers {
         if let RData::AAAA(AAAA { address }) = &rr.rdata {
-            if rr.name == qname || rr.name == canonical {
+            if name_matches(&rr.name, qname.as_ref(), canonical.as_ref()) {
                 addrs.push(Ipv6Addr::from(*address));
                 min_ttl = min_ttl.min(rr.ttl);
             }
@@ -175,18 +175,14 @@ pub(super) fn parse_txt_response(
     let packet = Packet::parse(data)?;
     check_response(&packet, expected_id)?;
 
-    let qname = packet
-        .questions
-        .first()
-        .map(|q| q.qname.clone())
-        .unwrap_or_else(|| Name::new_unchecked(""));
-    let canonical = resolve_cname_chain(&packet, &qname);
+    let qname = packet.questions.first().map(|q| q.qname.clone());
+    let canonical = qname.as_ref().map(|q| resolve_cname_chain(&packet, q));
 
     let mut records = Vec::new();
     let mut min_ttl = u32::MAX;
     for rr in &packet.answers {
         if let RData::TXT(txt) = &rr.rdata {
-            if rr.name == qname || rr.name == canonical {
+            if name_matches(&rr.name, qname.as_ref(), canonical.as_ref()) {
                 let record = extract_txt_record_data(txt);
                 records.push(record);
                 min_ttl = min_ttl.min(rr.ttl);

--- a/iroh-relay/src/dns/query.rs
+++ b/iroh-relay/src/dns/query.rs
@@ -97,7 +97,11 @@ fn check_response(packet: &Packet, expected_id: u16) -> Result<(), DnsError> {
 /// Check whether a resource record's name matches the queried name or its
 /// CNAME-resolved canonical name. If no question section is present
 /// (shouldn't happen in practice), accept all records.
-fn name_matches(rr_name: &Name<'_>, qname: Option<&Name<'_>>, canonical: Option<&Name<'_>>) -> bool {
+fn name_matches(
+    rr_name: &Name<'_>,
+    qname: Option<&Name<'_>>,
+    canonical: Option<&Name<'_>>,
+) -> bool {
     match qname {
         Some(q) => rr_name == q || canonical.is_some_and(|c| rr_name == c),
         None => true, // No question section -- accept all matching record types.
@@ -121,11 +125,11 @@ pub(super) fn parse_a_response(
     let mut addrs = Vec::new();
     let mut min_ttl = u32::MAX;
     for rr in &packet.answers {
-        if let RData::A(A { address }) = &rr.rdata {
-            if name_matches(&rr.name, qname.as_ref(), canonical.as_ref()) {
-                addrs.push(Ipv4Addr::from(*address));
-                min_ttl = min_ttl.min(rr.ttl);
-            }
+        if let RData::A(A { address }) = &rr.rdata
+            && name_matches(&rr.name, qname.as_ref(), canonical.as_ref())
+        {
+            addrs.push(Ipv4Addr::from(*address));
+            min_ttl = min_ttl.min(rr.ttl);
         }
     }
     if min_ttl == u32::MAX {
@@ -148,11 +152,11 @@ pub(super) fn parse_aaaa_response(
     let mut addrs = Vec::new();
     let mut min_ttl = u32::MAX;
     for rr in &packet.answers {
-        if let RData::AAAA(AAAA { address }) = &rr.rdata {
-            if name_matches(&rr.name, qname.as_ref(), canonical.as_ref()) {
-                addrs.push(Ipv6Addr::from(*address));
-                min_ttl = min_ttl.min(rr.ttl);
-            }
+        if let RData::AAAA(AAAA { address }) = &rr.rdata
+            && name_matches(&rr.name, qname.as_ref(), canonical.as_ref())
+        {
+            addrs.push(Ipv6Addr::from(*address));
+            min_ttl = min_ttl.min(rr.ttl);
         }
     }
     if min_ttl == u32::MAX {
@@ -175,12 +179,12 @@ pub(super) fn parse_txt_response(
     let mut records = Vec::new();
     let mut min_ttl = u32::MAX;
     for rr in &packet.answers {
-        if let RData::TXT(txt) = &rr.rdata {
-            if name_matches(&rr.name, qname.as_ref(), canonical.as_ref()) {
-                let record = extract_txt_record_data(txt);
-                records.push(record);
-                min_ttl = min_ttl.min(rr.ttl);
-            }
+        if let RData::TXT(txt) = &rr.rdata
+            && name_matches(&rr.name, qname.as_ref(), canonical.as_ref())
+        {
+            let record = extract_txt_record_data(txt);
+            records.push(record);
+            min_ttl = min_ttl.min(rr.ttl);
         }
     }
     if min_ttl == u32::MAX {
@@ -218,7 +222,7 @@ mod tests {
 
     use simple_dns::{
         CLASS, Name, Packet, PacketFlag, QCLASS, QTYPE, Question, ResourceRecord,
-        rdata::{A, RData, CNAME},
+        rdata::{A, CNAME, RData},
     };
 
     use super::*;
@@ -244,7 +248,9 @@ mod tests {
                 Name::new_unchecked(name),
                 CLASS::IN,
                 300,
-                RData::A(A { address: u32::from(*addr) }),
+                RData::A(A {
+                    address: u32::from(*addr),
+                }),
             ));
         }
         packet.build_bytes_vec().unwrap()
@@ -252,12 +258,7 @@ mod tests {
 
     /// Build a response containing a CNAME from `alias` -> `canonical`, plus
     /// A records under the canonical name (the common "both in one response" case).
-    fn cname_with_a_response(
-        id: u16,
-        alias: &str,
-        canonical: &str,
-        addrs: &[Ipv4Addr],
-    ) -> Vec<u8> {
+    fn cname_with_a_response(id: u16, alias: &str, canonical: &str, addrs: &[Ipv4Addr]) -> Vec<u8> {
         let mut packet = Packet::new_reply(id);
         packet.set_flags(PacketFlag::RECURSION_DESIRED | PacketFlag::RECURSION_AVAILABLE);
         packet.questions.push(Question::new(
@@ -279,7 +280,9 @@ mod tests {
                 Name::new_unchecked(canonical),
                 CLASS::IN,
                 300,
-                RData::A(A { address: u32::from(*addr) }),
+                RData::A(A {
+                    address: u32::from(*addr),
+                }),
             ));
         }
         packet.build_bytes_vec().unwrap()
@@ -332,7 +335,10 @@ mod tests {
             &[Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)],
         );
         let (addrs, _) = parse_a_response(&resp, id).unwrap();
-        assert_eq!(addrs, [Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)]);
+        assert_eq!(
+            addrs,
+            [Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)]
+        );
     }
 
     #[test]
@@ -363,7 +369,9 @@ mod tests {
             Name::new_unchecked("real.example.com"),
             CLASS::IN,
             300,
-            RData::A(A { address: u32::from(Ipv4Addr::new(5, 6, 7, 8)) }),
+            RData::A(A {
+                address: u32::from(Ipv4Addr::new(5, 6, 7, 8)),
+            }),
         ));
         let resp = packet.build_bytes_vec().unwrap();
         let (addrs, _) = parse_a_response(&resp, id).unwrap();

--- a/iroh-relay/src/dns/query.rs
+++ b/iroh-relay/src/dns/query.rs
@@ -195,26 +195,23 @@ pub(super) fn parse_txt_response(
     Ok((records, min_ttl))
 }
 
-/// Extract character strings from a TXT record into `TxtRecordData`.
+/// Extract the raw content of a TXT record into `TxtRecordData`.
 ///
-/// For iroh's use case, TXT records contain `key=value` strings
-/// where each DNS character string is one attribute.
+/// Converts the TXT record's character strings into raw bytes. In iroh's
+/// DNS encoding, each TXT record typically contains a single character
+/// string (one `key=value` attribute), and each attribute is published as
+/// a separate TXT ResourceRecord.
+///
+/// We use `String::try_from` which concatenates all character strings in
+/// the record into one byte sequence. This preserves the raw content
+/// without the destructive key=value parsing that `TXT::attributes()` does
+/// (which uses a HashMap and would lose ordering and deduplicate keys).
 fn extract_txt_record_data(txt: &simple_dns::rdata::TXT<'_>) -> TxtRecordData {
-    let attrs = txt.attributes();
-    if !attrs.is_empty() {
-        let strings: Vec<String> = attrs
-            .into_iter()
-            .map(|(k, v)| match v {
-                Some(val) => format!("{k}={val}"),
-                None => k.to_owned(),
-            })
-            .collect();
-        TxtRecordData::from(strings)
-    } else {
-        match String::try_from(txt.clone()) {
-            Ok(s) if !s.is_empty() => TxtRecordData::from(vec![s]),
-            _ => TxtRecordData::from(Vec::<String>::new()),
+    match String::try_from(txt.clone()) {
+        Ok(s) if !s.is_empty() => {
+            TxtRecordData::from(vec![s.into_bytes().into_boxed_slice()])
         }
+        _ => TxtRecordData::from(Vec::<Box<[u8]>>::new()),
     }
 }
 

--- a/iroh-relay/src/dns/query.rs
+++ b/iroh-relay/src/dns/query.rs
@@ -10,7 +10,18 @@ use simple_dns::{
 
 use super::{DnsError, TxtRecordData};
 
+/// EDNS(0) advertised UDP payload size.
+///
+/// 1232 bytes is the current recommended safe value per RFC 6891 and the
+/// DNS flag day 2020 recommendations. This avoids IP fragmentation on
+/// common path MTUs while allowing responses much larger than the
+/// original 512-byte RFC 1035 limit.
+const EDNS_UDP_PAYLOAD_SIZE: u16 = 1232;
+
 /// Build a DNS query packet for the given host and query type.
+///
+/// The query includes an EDNS(0) OPT record advertising support for
+/// responses up to [`EDNS_UDP_PAYLOAD_SIZE`] bytes over UDP.
 ///
 /// Returns `(query_id, wire_bytes)`.
 pub(super) fn build_query(host: &str, qtype: TYPE) -> Result<(u16, Vec<u8>), DnsError> {
@@ -21,6 +32,13 @@ pub(super) fn build_query(host: &str, qtype: TYPE) -> Result<(u16, Vec<u8>), Dns
     let name = Name::new(host)?;
     let question = Question::new(name, QTYPE::TYPE(qtype), QCLASS::CLASS(CLASS::IN), false);
     packet.questions.push(question);
+
+    // Add EDNS(0) OPT record to advertise larger UDP payload support.
+    *packet.opt_mut() = Some(simple_dns::rdata::OPT {
+        udp_packet_size: EDNS_UDP_PAYLOAD_SIZE,
+        version: 0,
+        opt_codes: vec![],
+    });
 
     let bytes = packet.build_bytes_vec()?;
     Ok((id, bytes))
@@ -303,6 +321,15 @@ mod tests {
             RData::CNAME(CNAME(Name::new_unchecked(canonical))),
         ));
         packet.build_bytes_vec().unwrap()
+    }
+
+    #[test]
+    fn build_query_includes_edns_opt() {
+        let (_, bytes) = build_query("example.com", TYPE::A).unwrap();
+        let packet = Packet::parse(&bytes).unwrap();
+        let opt = packet.opt().expect("query should include OPT record");
+        assert_eq!(opt.udp_packet_size, 1232);
+        assert_eq!(opt.version, 0);
     }
 
     #[test]

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -11,7 +11,6 @@ use n0_future::{
     FuturesUnorderedBounded, StreamExt,
     time::{self, Duration},
 };
-use rustls::ClientConfig;
 use simple_dns::TYPE;
 use tracing::{debug, trace};
 
@@ -41,7 +40,8 @@ const DEFAULT_NDOTS: usize = 1;
 pub(super) struct SimpleDnsResolver {
     nameservers: Vec<(SocketAddr, DnsProtocol)>,
     search_domains: Vec<String>,
-    tls_config: Option<Arc<ClientConfig>>,
+    #[cfg(with_crypto_provider)]
+    tls_config: Option<Arc<rustls::ClientConfig>>,
     /// Lazily initialized, cached reqwest client for DNS-over-HTTPS queries.
     https_client: tokio::sync::Mutex<Option<reqwest::Client>>,
     cache: std::sync::RwLock<DnsCache>,
@@ -62,6 +62,7 @@ impl SimpleDnsResolver {
         for domain in &search_domains {
             trace!(%domain, "search domain");
         }
+        #[cfg(with_crypto_provider)]
         let tls_config = builder
             .tls_client_config
             .as_ref()
@@ -69,6 +70,7 @@ impl SimpleDnsResolver {
         Self {
             nameservers,
             search_domains,
+            #[cfg(with_crypto_provider)]
             tls_config,
             https_client: tokio::sync::Mutex::new(None),
             cache: std::sync::RwLock::new(DnsCache::new()),
@@ -137,7 +139,11 @@ impl SimpleDnsResolver {
         if let Some(client) = guard.as_ref() {
             return Ok(client.clone());
         }
-        let client = transport::build_https_client(self.tls_config.as_ref())?;
+        #[cfg(with_crypto_provider)]
+        let tls = self.tls_config.as_ref();
+        #[cfg(not(with_crypto_provider))]
+        let tls = None;
+        let client = transport::build_https_client(tls)?;
         *guard = Some(client.clone());
         Ok(client)
     }
@@ -146,7 +152,7 @@ impl SimpleDnsResolver {
     async fn with_timeout<T>(
         fut: impl std::future::Future<Output = Result<T, DnsError>>,
     ) -> Result<T, DnsError> {
-        Ok(time::timeout(NAMESERVER_TIMEOUT, fut).await??)
+        time::timeout(NAMESERVER_TIMEOUT, fut).await?
     }
 
     /// Query a single nameserver, with UDP retry and truncation fallback.
@@ -164,7 +170,8 @@ impl SimpleDnsResolver {
                     match Self::with_timeout(transport::udp_query(addr, query_bytes)).await {
                         Ok(resp) if query::is_truncated(&resp) => {
                             debug!(%addr, "UDP response truncated, retrying over TCP");
-                            return Self::with_timeout(transport::tcp_query(addr, query_bytes)).await;
+                            return Self::with_timeout(transport::tcp_query(addr, query_bytes))
+                                .await;
                         }
                         Ok(resp) => return Ok(resp),
                         Err(e) => {
@@ -175,9 +182,7 @@ impl SimpleDnsResolver {
                 }
                 Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
             }
-            DnsProtocol::Tcp => {
-                Self::with_timeout(transport::tcp_query(addr, query_bytes)).await
-            }
+            DnsProtocol::Tcp => Self::with_timeout(transport::tcp_query(addr, query_bytes)).await,
             #[cfg(with_crypto_provider)]
             DnsProtocol::Tls => {
                 let tls_config = self.tls_config.as_ref().ok_or_else(|| {
@@ -299,12 +304,7 @@ impl SimpleDnsResolver {
                     if !addrs.is_empty() {
                         debug!(%host, count = addrs.len(), ttl, "resolved A record");
                         if let Ok(mut cache) = self.cache.write() {
-                            cache.insert(
-                                &host,
-                                QueryType::A,
-                                CachedRecord::A(addrs.clone()),
-                                ttl,
-                            );
+                            cache.insert(&host, QueryType::A, CachedRecord::A(addrs.clone()), ttl);
                         }
                         return Ok(addrs.into_iter());
                     }
@@ -406,11 +406,14 @@ impl SimpleDnsResolver {
         let (nameservers, search_domains) = Self::build_config(&self.builder);
         self.nameservers = nameservers;
         self.search_domains = search_domains;
-        self.tls_config = self
-            .builder
-            .tls_client_config
-            .as_ref()
-            .map(|c| Arc::new(c.clone()));
+        #[cfg(with_crypto_provider)]
+        {
+            self.tls_config = self
+                .builder
+                .tls_client_config
+                .as_ref()
+                .map(|c| Arc::new(c.clone()));
+        }
         // Clear cached HTTPS client so it gets rebuilt with the new TLS config on next use
         *self.https_client.get_mut() = None;
         if let Ok(mut cache) = self.cache.write() {
@@ -521,8 +524,7 @@ mod tests {
     }
 
     mod search_names {
-        use super::super::*;
-        use super::super::super::Builder;
+        use super::super::{super::Builder, *};
 
         fn resolver_with_search(domains: &[&str]) -> SimpleDnsResolver {
             let mut r = SimpleDnsResolver::new(Builder::default());
@@ -539,7 +541,10 @@ mod tests {
         #[test]
         fn fqdn_bypasses_search() {
             let r = resolver_with_search(&["example.com"]);
-            assert_eq!(r.search_names("myhost.example.com."), vec!["myhost.example.com."]);
+            assert_eq!(
+                r.search_names("myhost.example.com."),
+                vec!["myhost.example.com."]
+            );
         }
 
         #[test]
@@ -565,10 +570,7 @@ mod tests {
         #[test]
         fn multi_dot_name_tries_bare_first() {
             let r = resolver_with_search(&["example.com"]);
-            assert_eq!(
-                r.search_names("a.b.c"),
-                vec!["a.b.c", "a.b.c.example.com"]
-            );
+            assert_eq!(r.search_names("a.b.c"), vec!["a.b.c", "a.b.c.example.com"]);
         }
     }
 }

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -306,7 +306,8 @@ impl SimpleDnsResolver {
                     let (results, ttl) = parse(&response, id)?;
                     if !results.is_empty() {
                         debug!(%host, count = results.len(), ttl, ?qtype, "resolved");
-                        self.cache.insert(host, qtype, to_cache(results.clone()), ttl);
+                        self.cache
+                            .insert(host, qtype, to_cache(results.clone()), ttl);
                         return Ok(results);
                     }
                 }

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use n0_error::e;
-use n0_future::time::{self, Duration};
+use n0_future::{
+    FuturesUnorderedBounded, StreamExt,
+    time::{self, Duration},
+};
 use rustls::ClientConfig;
 use simple_dns::TYPE;
 use tracing::{debug, trace};
@@ -19,10 +22,16 @@ use super::{
     system_config, transport,
 };
 
-/// Per-nameserver timeout. Ensures we move on to the next nameserver
-/// if one is unresponsive, rather than consuming the entire query budget.
-/// Matches hickory-resolver's default of 5 seconds.
-const NAMESERVER_TIMEOUT: Duration = Duration::from_secs(5);
+/// Per-nameserver timeout for a single attempt.
+const NAMESERVER_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Delay between launching queries to successive nameservers.
+/// Gives the preferred nameserver a head start before trying alternates.
+const NAMESERVER_STAGGER: Duration = Duration::from_millis(100);
+
+/// Number of UDP retry attempts per nameserver before giving up.
+/// UDP is unreliable, so a single dropped packet shouldn't be fatal.
+const UDP_ATTEMPTS: usize = 2;
 
 #[derive(Debug)]
 pub(super) struct SimpleDnsResolver {
@@ -83,63 +92,153 @@ impl SimpleDnsResolver {
         Ok(client)
     }
 
-    /// Send a query to the first responding nameserver.
-    async fn send_query(&self, query_bytes: &[u8]) -> Result<Vec<u8>, DnsError> {
-        let mut last_err = None;
-        for (addr, proto) in &self.nameservers {
-            trace!(%addr, ?proto, "sending DNS query");
-            let result = time::timeout(NAMESERVER_TIMEOUT, async {
-                match proto {
-                    DnsProtocol::Udp => {
-                        let resp = transport::udp_query(*addr, query_bytes).await?;
-                        // Check for truncation, fallback to TCP
-                        if query::is_truncated(&resp) {
-                            debug!(%addr, "UDP response truncated, retrying over TCP");
-                            transport::tcp_query(*addr, query_bytes).await
-                        } else {
-                            Ok(resp)
+    /// Query a single nameserver, with UDP retry and truncation fallback.
+    async fn query_nameserver(
+        &self,
+        addr: SocketAddr,
+        proto: DnsProtocol,
+        query_bytes: &[u8],
+    ) -> Result<Vec<u8>, DnsError> {
+        match proto {
+            DnsProtocol::Udp => {
+                let mut last_err = None;
+                for attempt in 0..UDP_ATTEMPTS {
+                    trace!(%addr, attempt, "sending UDP query");
+                    match time::timeout(NAMESERVER_TIMEOUT, transport::udp_query(addr, query_bytes))
+                        .await
+                    {
+                        Ok(Ok(resp)) => {
+                            if query::is_truncated(&resp) {
+                                debug!(%addr, "UDP response truncated, retrying over TCP");
+                                return time::timeout(
+                                    NAMESERVER_TIMEOUT,
+                                    transport::tcp_query(addr, query_bytes),
+                                )
+                                .await
+                                .unwrap_or_else(|_| {
+                                    Err(e!(DnsError::Transport {
+                                        source: std::io::Error::new(
+                                            std::io::ErrorKind::TimedOut,
+                                            "TCP fallback timed out",
+                                        ),
+                                    }))
+                                });
+                            }
+                            return Ok(resp);
+                        }
+                        Ok(Err(e)) => {
+                            trace!(%addr, attempt, err = %e, "UDP query failed");
+                            last_err = Some(e);
+                        }
+                        Err(_) => {
+                            trace!(%addr, attempt, "UDP query timed out");
+                            last_err = Some(e!(DnsError::Transport {
+                                source: std::io::Error::new(
+                                    std::io::ErrorKind::TimedOut,
+                                    "nameserver query timed out",
+                                ),
+                            }));
                         }
                     }
-                    DnsProtocol::Tcp => transport::tcp_query(*addr, query_bytes).await,
-                    DnsProtocol::Tls => {
-                        let tls_config = self.tls_config.as_ref().ok_or_else(|| {
-                            e!(DnsError::Transport {
-                                source: std::io::Error::new(
-                                    std::io::ErrorKind::InvalidInput,
-                                    "TLS config required for DNS-over-TLS",
-                                ),
-                            })
-                        })?;
-                        transport::tls_query(*addr, query_bytes, tls_config).await
-                    }
-                    DnsProtocol::Https => {
-                        let client = self.get_or_init_https_client().await?;
-                        transport::https_query(*addr, query_bytes, &client).await
-                    }
                 }
-            })
-            .await;
-            let result = match result {
-                Ok(inner) => inner,
-                Err(_elapsed) => {
-                    trace!(%addr, ?proto, "DNS query timed out");
+                Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
+            }
+            DnsProtocol::Tcp => {
+                time::timeout(NAMESERVER_TIMEOUT, transport::tcp_query(addr, query_bytes))
+                    .await
+                    .unwrap_or_else(|_| {
+                        Err(e!(DnsError::Transport {
+                            source: std::io::Error::new(
+                                std::io::ErrorKind::TimedOut,
+                                "nameserver query timed out",
+                            ),
+                        }))
+                    })
+            }
+            #[cfg(with_crypto_provider)]
+            DnsProtocol::Tls => {
+                let tls_config = self.tls_config.as_ref().ok_or_else(|| {
+                    e!(DnsError::Transport {
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "TLS config required for DNS-over-TLS",
+                        ),
+                    })
+                })?;
+                time::timeout(
+                    NAMESERVER_TIMEOUT,
+                    transport::tls_query(addr, query_bytes, tls_config),
+                )
+                .await
+                .unwrap_or_else(|_| {
                     Err(e!(DnsError::Transport {
                         source: std::io::Error::new(
                             std::io::ErrorKind::TimedOut,
                             "nameserver query timed out",
                         ),
                     }))
+                })
+            }
+            #[cfg(with_crypto_provider)]
+            DnsProtocol::Https => {
+                let client = self.get_or_init_https_client().await?;
+                time::timeout(
+                    NAMESERVER_TIMEOUT,
+                    transport::https_query(addr, query_bytes, &client),
+                )
+                .await
+                .unwrap_or_else(|_| {
+                    Err(e!(DnsError::Transport {
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "nameserver query timed out",
+                        ),
+                    }))
+                })
+            }
+        }
+    }
+
+    /// Send a query to all nameservers in parallel with staggered starts.
+    ///
+    /// Each nameserver gets a staggered start delay to give the preferred
+    /// (first) nameserver a head start. The first successful response wins.
+    /// UDP queries are retried once per nameserver on failure.
+    async fn send_query(&self, query_bytes: &[u8]) -> Result<Vec<u8>, DnsError> {
+        if self.nameservers.is_empty() {
+            return Err(e!(DnsError::NoResponse));
+        }
+
+        let count = self.nameservers.len();
+        let mut futures = FuturesUnorderedBounded::new(count);
+
+        for (i, (addr, proto)) in self.nameservers.iter().enumerate() {
+            let addr = *addr;
+            let proto = *proto;
+            let stagger = NAMESERVER_STAGGER * i as u32;
+            futures.push(async move {
+                if !stagger.is_zero() {
+                    time::sleep(stagger).await;
                 }
-            };
+                trace!(%addr, ?proto, "sending DNS query");
+                let result = self.query_nameserver(addr, proto, query_bytes).await;
+                match &result {
+                    Ok(resp) => {
+                        trace!(%addr, ?proto, len = resp.len(), "DNS query succeeded");
+                    }
+                    Err(e) => {
+                        trace!(%addr, ?proto, err = %e, "DNS query failed");
+                    }
+                }
+                result
+            });
+        }
+
+        let mut last_err = None;
+        while let Some(result) = futures.next().await {
             match result {
-                Ok(resp) => {
-                    trace!(%addr, ?proto, len = resp.len(), "DNS query succeeded");
-                    return Ok(resp);
-                }
-                Err(e) => {
-                    trace!(%addr, ?proto, err = %e, "DNS query failed, trying next nameserver");
-                    last_err = Some(e);
-                }
+                Ok(resp) => return Ok(resp),
+                Err(e) => last_err = Some(e),
             }
         }
         Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -1,10 +1,12 @@
 //! Built-in DNS resolver using `simple-dns` for packet construction/parsing
 //! and tokio for transport.
 
+#[cfg(with_crypto_provider)]
+use std::sync::Arc;
 use std::{
     future::Future,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    sync::{Arc, Mutex},
+    sync::Mutex,
 };
 
 use n0_error::e;
@@ -12,7 +14,7 @@ use n0_future::{
     FuturesUnorderedBounded, StreamExt,
     time::{self, Duration},
 };
-use simple_dns::{TYPE, rdata::RData};
+use simple_dns::TYPE;
 use tracing::{debug, trace};
 
 use super::{
@@ -135,16 +137,13 @@ impl SimpleDnsResolver {
     /// Returns a clone of the cached reqwest client, creating it on first use.
     ///
     /// `reqwest::Client` uses an inner `Arc`, so cloning is cheap.
+    #[cfg(with_crypto_provider)]
     fn get_or_init_https_client(&self) -> Result<reqwest::Client, DnsError> {
         let mut guard = self.https_client.lock().expect("poisoned");
         if let Some(client) = guard.as_ref() {
             return Ok(client.clone());
         }
-        #[cfg(with_crypto_provider)]
-        let tls = self.tls_config.as_ref();
-        #[cfg(not(with_crypto_provider))]
-        let tls = None;
-        let client = transport::build_https_client(tls)?;
+        let client = transport::build_https_client(self.tls_config.as_ref())?;
         *guard = Some(client.clone());
         Ok(client)
     }
@@ -246,44 +245,29 @@ impl SimpleDnsResolver {
         for _ in 0..MAX_CNAME_DEPTH {
             let (id, query_bytes) = query::build_query(&current_host, qtype)?;
             let response = self.send_query(&query_bytes).await?;
-
-            // Check if the response only has CNAMEs but no records of the
-            // requested type. If so, follow the CNAME to a new query.
             let packet = simple_dns::Packet::parse(&response)?;
-            let has_target_records = packet.answers.iter().any(|rr| {
-                matches!(
-                    (&rr.rdata, qtype),
-                    (RData::A(_), TYPE::A)
-                        | (RData::AAAA(_), TYPE::AAAA)
-                        | (RData::TXT(_), TYPE::TXT)
-                )
-            });
 
-            if has_target_records {
+            let has_answer = packet
+                .answers
+                .iter()
+                .any(|rr| rr.rdata.type_code() == qtype);
+
+            if has_answer {
                 return Ok((response, id));
             }
 
-            // No target records -- check for a CNAME to follow.
-            match query::cname_target(&packet, &current_host) {
-                Some(target) => {
-                    debug!(
-                        from = %current_host,
-                        to = %target,
-                        "following CNAME"
-                    );
-                    current_host = target;
-                }
-                None => {
-                    // No CNAME either; return the response as-is (empty results).
-                    return Ok((response, id));
-                }
-            }
+            // No records of the requested type -- follow CNAME if present.
+            let Some(target) = query::cname_target(&packet, &current_host) else {
+                return Ok((response, id));
+            };
+            debug!(from = %current_host, to = %target, "following CNAME");
+            current_host = target;
         }
-        // Exceeded max CNAME depth.
         Err(e!(DnsError::InvalidResponse))
     }
 
     /// Shared lookup logic: check cache, try search names, parse response, cache result.
+    #[allow(clippy::type_complexity)]
     async fn lookup<T: Clone>(
         &self,
         host: &str,

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -33,9 +33,14 @@ const NAMESERVER_STAGGER: Duration = Duration::from_millis(100);
 /// UDP is unreliable, so a single dropped packet shouldn't be fatal.
 const UDP_ATTEMPTS: usize = 2;
 
+/// Default value for `ndots`: hostnames with at least this many dots are
+/// tried as absolute names first, before appending search domains.
+const DEFAULT_NDOTS: usize = 1;
+
 #[derive(Debug)]
 pub(super) struct SimpleDnsResolver {
     nameservers: Vec<(SocketAddr, DnsProtocol)>,
+    search_domains: Vec<String>,
     tls_config: Option<Arc<ClientConfig>>,
     /// Lazily initialized, cached reqwest client for DNS-over-HTTPS queries.
     https_client: tokio::sync::Mutex<Option<reqwest::Client>>,
@@ -45,10 +50,17 @@ pub(super) struct SimpleDnsResolver {
 
 impl SimpleDnsResolver {
     pub(super) fn new(builder: Builder) -> Self {
-        let nameservers = Self::build_nameservers(&builder);
-        debug!(count = nameservers.len(), "configured DNS nameservers");
+        let (nameservers, search_domains) = Self::build_config(&builder);
+        debug!(
+            nameservers = nameservers.len(),
+            search_domains = search_domains.len(),
+            "configured DNS resolver"
+        );
         for (addr, proto) in &nameservers {
             trace!(%addr, ?proto, "nameserver");
+        }
+        for domain in &search_domains {
+            trace!(%domain, "search domain");
         }
         let tls_config = builder
             .tls_client_config
@@ -56,6 +68,7 @@ impl SimpleDnsResolver {
             .map(|c: &ClientConfig| Arc::new(c.clone()));
         Self {
             nameservers,
+            search_domains,
             tls_config,
             https_client: tokio::sync::Mutex::new(None),
             cache: std::sync::RwLock::new(DnsCache::new()),
@@ -63,11 +76,14 @@ impl SimpleDnsResolver {
         }
     }
 
-    fn build_nameservers(builder: &Builder) -> Vec<(SocketAddr, DnsProtocol)> {
+    fn build_config(builder: &Builder) -> (Vec<(SocketAddr, DnsProtocol)>, Vec<String>) {
         let mut nameservers = Vec::new();
+        let mut search_domains = Vec::new();
 
         if builder.use_system_defaults {
-            nameservers.extend(system_config::system_nameservers());
+            let config = system_config::system_config();
+            nameservers.extend(config.nameservers);
+            search_domains = config.search_domains;
         }
 
         nameservers.extend(builder.nameservers.iter().copied());
@@ -76,7 +92,41 @@ impl SimpleDnsResolver {
             nameservers.extend(system_config::fallback_nameservers());
         }
 
-        nameservers
+        (nameservers, search_domains)
+    }
+
+    /// Returns the list of candidate names to try for a given hostname,
+    /// applying search domain expansion per resolv.conf(5) semantics.
+    ///
+    /// - If the name ends with `.` (FQDN), it is used as-is.
+    /// - If the name has >= `ndots` dots, try the bare name first, then
+    ///   each search domain suffix.
+    /// - If the name has < `ndots` dots, try each search domain suffix
+    ///   first, then the bare name.
+    fn search_names(&self, host: &str) -> Vec<String> {
+        // Explicit FQDN: no search domain expansion.
+        if host.ends_with('.') || self.search_domains.is_empty() {
+            return vec![host.to_string()];
+        }
+
+        let dot_count = host.chars().filter(|&c| c == '.').count();
+        let mut names = Vec::with_capacity(self.search_domains.len() + 1);
+
+        if dot_count >= DEFAULT_NDOTS {
+            // Likely absolute -- try bare name first.
+            names.push(host.to_string());
+            for domain in &self.search_domains {
+                names.push(format!("{host}.{domain}"));
+            }
+        } else {
+            // Short name -- try search domains first.
+            for domain in &self.search_domains {
+                names.push(format!("{host}.{domain}"));
+            }
+            names.push(host.to_string());
+        }
+
+        names
     }
 
     /// Returns a clone of the cached reqwest client, creating it on first use.
@@ -302,16 +352,34 @@ impl SimpleDnsResolver {
             return Ok(addrs.into_iter());
         }
 
-        trace!(%host, "resolving A record");
-        let (response, id) = self.send_query_following_cnames(&host, TYPE::A).await?;
-        let (addrs, ttl) = query::parse_a_response(&response, id)?;
-        debug!(%host, count = addrs.len(), ttl, "resolved A record");
-
-        if let Ok(mut cache) = self.cache.write() {
-            cache.insert(&host, QueryType::A, CachedRecord::A(addrs.clone()), ttl);
+        let mut last_err = None;
+        for name in self.search_names(&host) {
+            trace!(%name, "resolving A record");
+            match self.send_query_following_cnames(&name, TYPE::A).await {
+                Ok((response, id)) => {
+                    let (addrs, ttl) = query::parse_a_response(&response, id)?;
+                    if !addrs.is_empty() {
+                        debug!(%name, count = addrs.len(), ttl, "resolved A record");
+                        if let Ok(mut cache) = self.cache.write() {
+                            cache.insert(
+                                &host,
+                                QueryType::A,
+                                CachedRecord::A(addrs.clone()),
+                                ttl,
+                            );
+                        }
+                        return Ok(addrs.into_iter());
+                    }
+                }
+                Err(DnsError::NxDomain { .. }) => {
+                    trace!(%name, "NXDOMAIN, trying next search domain");
+                    last_err = Some(e!(DnsError::NxDomain));
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
         }
-
-        Ok(addrs.into_iter())
+        Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
     }
 
     pub(super) async fn lookup_ipv6(
@@ -325,21 +393,34 @@ impl SimpleDnsResolver {
             return Ok(addrs.into_iter());
         }
 
-        trace!(%host, "resolving AAAA record");
-        let (response, id) = self.send_query_following_cnames(&host, TYPE::AAAA).await?;
-        let (addrs, ttl) = query::parse_aaaa_response(&response, id)?;
-        debug!(%host, count = addrs.len(), ttl, "resolved AAAA record");
-
-        if let Ok(mut cache) = self.cache.write() {
-            cache.insert(
-                &host,
-                QueryType::AAAA,
-                CachedRecord::Aaaa(addrs.clone()),
-                ttl,
-            );
+        let mut last_err = None;
+        for name in self.search_names(&host) {
+            trace!(%name, "resolving AAAA record");
+            match self.send_query_following_cnames(&name, TYPE::AAAA).await {
+                Ok((response, id)) => {
+                    let (addrs, ttl) = query::parse_aaaa_response(&response, id)?;
+                    if !addrs.is_empty() {
+                        debug!(%name, count = addrs.len(), ttl, "resolved AAAA record");
+                        if let Ok(mut cache) = self.cache.write() {
+                            cache.insert(
+                                &host,
+                                QueryType::AAAA,
+                                CachedRecord::Aaaa(addrs.clone()),
+                                ttl,
+                            );
+                        }
+                        return Ok(addrs.into_iter());
+                    }
+                }
+                Err(DnsError::NxDomain { .. }) => {
+                    trace!(%name, "NXDOMAIN, trying next search domain");
+                    last_err = Some(e!(DnsError::NxDomain));
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
         }
-
-        Ok(addrs.into_iter())
+        Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
     }
 
     pub(super) async fn lookup_txt(
@@ -353,21 +434,34 @@ impl SimpleDnsResolver {
             return Ok(records.into_iter());
         }
 
-        trace!(%host, "resolving TXT record");
-        let (response, id) = self.send_query_following_cnames(&host, TYPE::TXT).await?;
-        let (records, ttl) = query::parse_txt_response(&response, id)?;
-        debug!(%host, count = records.len(), ttl, "resolved TXT record");
-
-        if let Ok(mut cache) = self.cache.write() {
-            cache.insert(
-                &host,
-                QueryType::TXT,
-                CachedRecord::Txt(records.clone()),
-                ttl,
-            );
+        let mut last_err = None;
+        for name in self.search_names(&host) {
+            trace!(%name, "resolving TXT record");
+            match self.send_query_following_cnames(&name, TYPE::TXT).await {
+                Ok((response, id)) => {
+                    let (records, ttl) = query::parse_txt_response(&response, id)?;
+                    if !records.is_empty() {
+                        debug!(%name, count = records.len(), ttl, "resolved TXT record");
+                        if let Ok(mut cache) = self.cache.write() {
+                            cache.insert(
+                                &host,
+                                QueryType::TXT,
+                                CachedRecord::Txt(records.clone()),
+                                ttl,
+                            );
+                        }
+                        return Ok(records.into_iter());
+                    }
+                }
+                Err(DnsError::NxDomain { .. }) => {
+                    trace!(%name, "NXDOMAIN, trying next search domain");
+                    last_err = Some(e!(DnsError::NxDomain));
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
         }
-
-        Ok(records.into_iter())
+        Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
     }
 
     pub(super) fn clear_cache(&self) {
@@ -377,7 +471,9 @@ impl SimpleDnsResolver {
     }
 
     pub(super) fn reset(&mut self) {
-        self.nameservers = Self::build_nameservers(&self.builder);
+        let (nameservers, search_domains) = Self::build_config(&self.builder);
+        self.nameservers = nameservers;
+        self.search_domains = search_domains;
         self.tls_config = self
             .builder
             .tls_client_config
@@ -489,6 +585,58 @@ mod tests {
         let resolver = DnsResolver::new();
         for host in ["google.com", "cloudflare.com", "example.com"] {
             assert_resolves_ipv4(&resolver, host).await;
+        }
+    }
+
+    mod search_names {
+        use super::super::*;
+        use super::super::super::Builder;
+
+        fn resolver_with_search(domains: &[&str]) -> SimpleDnsResolver {
+            let mut r = SimpleDnsResolver::new(Builder::default());
+            r.search_domains = domains.iter().map(|s| s.to_string()).collect();
+            r
+        }
+
+        #[test]
+        fn no_search_domains() {
+            let r = SimpleDnsResolver::new(Builder::default());
+            assert_eq!(r.search_names("myhost"), vec!["myhost"]);
+        }
+
+        #[test]
+        fn fqdn_bypasses_search() {
+            let r = resolver_with_search(&["example.com"]);
+            assert_eq!(r.search_names("myhost.example.com."), vec!["myhost.example.com."]);
+        }
+
+        #[test]
+        fn short_name_tries_search_first() {
+            let r = resolver_with_search(&["example.com", "test.local"]);
+            // "myhost" has 0 dots (< ndots=1), so search domains come first.
+            assert_eq!(
+                r.search_names("myhost"),
+                vec!["myhost.example.com", "myhost.test.local", "myhost"]
+            );
+        }
+
+        #[test]
+        fn dotted_name_tries_bare_first() {
+            let r = resolver_with_search(&["example.com"]);
+            // "foo.bar" has 1 dot (>= ndots=1), so bare name comes first.
+            assert_eq!(
+                r.search_names("foo.bar"),
+                vec!["foo.bar", "foo.bar.example.com"]
+            );
+        }
+
+        #[test]
+        fn multi_dot_name_tries_bare_first() {
+            let r = resolver_with_search(&["example.com"]);
+            assert_eq!(
+                r.search_names("a.b.c"),
+                vec!["a.b.c", "a.b.c.example.com"]
+            );
         }
     }
 }

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -283,26 +283,31 @@ impl SimpleDnsResolver {
         Err(e!(DnsError::InvalidResponse))
     }
 
-    pub(super) async fn lookup_ipv4(
+    /// Shared lookup logic: check cache, try search names, parse response, cache result.
+    async fn lookup<T: Clone>(
         &self,
-        host: String,
-    ) -> Result<impl Iterator<Item = Ipv4Addr> + use<>, DnsError> {
-        if let Some(CachedRecord::A(addrs)) = self.cache.get(&host, QueryType::A) {
-            trace!(%host, count = addrs.len(), "A lookup cache hit");
-            return Ok(addrs.into_iter());
+        host: &str,
+        qtype: QueryType,
+        dns_type: TYPE,
+        from_cache: fn(&CachedRecord) -> Option<Vec<T>>,
+        parse: fn(&[u8], u16) -> Result<(Vec<T>, u32), DnsError>,
+        to_cache: fn(Vec<T>) -> CachedRecord,
+    ) -> Result<Vec<T>, DnsError> {
+        if let Some(cached) = self.cache.get(host, qtype).and_then(|r| from_cache(&r)) {
+            trace!(%host, count = cached.len(), ?qtype, "cache hit");
+            return Ok(cached);
         }
 
         let mut last_err = None;
-        for name in self.search_names(&host) {
-            trace!(%name, "resolving A record");
-            match self.send_query_following_cnames(name, TYPE::A).await {
+        for name in self.search_names(host) {
+            trace!(%name, ?qtype, "resolving");
+            match self.send_query_following_cnames(name, dns_type).await {
                 Ok((response, id)) => {
-                    let (addrs, ttl) = query::parse_a_response(&response, id)?;
-                    if !addrs.is_empty() {
-                        debug!(%host, count = addrs.len(), ttl, "resolved A record");
-                        self.cache
-                            .insert(&host, QueryType::A, CachedRecord::A(addrs.clone()), ttl);
-                        return Ok(addrs.into_iter());
+                    let (results, ttl) = parse(&response, id)?;
+                    if !results.is_empty() {
+                        debug!(%host, count = results.len(), ttl, ?qtype, "resolved");
+                        self.cache.insert(host, qtype, to_cache(results.clone()), ttl);
+                        return Ok(results);
                     }
                 }
                 Err(DnsError::NxDomain { .. }) => {
@@ -312,78 +317,66 @@ impl SimpleDnsResolver {
             }
         }
         Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
+    }
+
+    pub(super) async fn lookup_ipv4(
+        &self,
+        host: String,
+    ) -> Result<impl Iterator<Item = Ipv4Addr> + use<>, DnsError> {
+        let addrs = self
+            .lookup(
+                &host,
+                QueryType::A,
+                TYPE::A,
+                |r| match r {
+                    CachedRecord::A(v) => Some(v.clone()),
+                    _ => None,
+                },
+                query::parse_a_response,
+                CachedRecord::A,
+            )
+            .await?;
+        Ok(addrs.into_iter())
     }
 
     pub(super) async fn lookup_ipv6(
         &self,
         host: String,
     ) -> Result<impl Iterator<Item = Ipv6Addr> + use<>, DnsError> {
-        if let Some(CachedRecord::Aaaa(addrs)) = self.cache.get(&host, QueryType::AAAA) {
-            trace!(%host, count = addrs.len(), "AAAA lookup cache hit");
-            return Ok(addrs.into_iter());
-        }
-
-        let mut last_err = None;
-        for name in self.search_names(&host) {
-            trace!(%name, "resolving AAAA record");
-            match self.send_query_following_cnames(name, TYPE::AAAA).await {
-                Ok((response, id)) => {
-                    let (addrs, ttl) = query::parse_aaaa_response(&response, id)?;
-                    if !addrs.is_empty() {
-                        debug!(%host, count = addrs.len(), ttl, "resolved AAAA record");
-                        self.cache.insert(
-                            &host,
-                            QueryType::AAAA,
-                            CachedRecord::Aaaa(addrs.clone()),
-                            ttl,
-                        );
-                        return Ok(addrs.into_iter());
-                    }
-                }
-                Err(DnsError::NxDomain { .. }) => {
-                    last_err = Some(e!(DnsError::NxDomain));
-                }
-                Err(e) => return Err(e),
-            }
-        }
-        Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
+        let addrs = self
+            .lookup(
+                &host,
+                QueryType::AAAA,
+                TYPE::AAAA,
+                |r| match r {
+                    CachedRecord::Aaaa(v) => Some(v.clone()),
+                    _ => None,
+                },
+                query::parse_aaaa_response,
+                CachedRecord::Aaaa,
+            )
+            .await?;
+        Ok(addrs.into_iter())
     }
 
     pub(super) async fn lookup_txt(
         &self,
         host: String,
     ) -> Result<impl Iterator<Item = TxtRecordData> + use<>, DnsError> {
-        {
-            if let Some(CachedRecord::Txt(records)) = self.cache.get(&host, QueryType::TXT) {
-                trace!(%host, count = records.len(), "TXT lookup cache hit");
-                return Ok(records.into_iter());
-            }
-        }
-
-        let mut last_err = None;
-        for name in self.search_names(&host) {
-            trace!(%name, "resolving TXT record");
-            match self.send_query_following_cnames(name, TYPE::TXT).await {
-                Ok((response, id)) => {
-                    let (records, ttl) = query::parse_txt_response(&response, id)?;
-                    if !records.is_empty() {
-                        debug!(%host, count = records.len(), ttl, "resolved TXT record");
-                        self.cache.insert(
-                            &host,
-                            QueryType::TXT,
-                            CachedRecord::Txt(records.clone()),
-                            ttl,
-                        );
-                        return Ok(records.into_iter());
-                    }
-                }
-                Err(DnsError::NxDomain { .. }) => {
-                    last_err = Some(e!(DnsError::NxDomain));
-                }
-                Err(e) => return Err(e),
-            }
-        }
-        Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
+        let records = self
+            .lookup(
+                &host,
+                QueryType::TXT,
+                TYPE::TXT,
+                |r| match r {
+                    CachedRecord::Txt(v) => Some(v.clone()),
+                    _ => None,
+                },
+                query::parse_txt_response,
+                CachedRecord::Txt,
+            )
+            .await?;
+        Ok(records.into_iter())
     }
 
     pub(super) fn clear_cache(&self) {

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -65,7 +65,7 @@ impl SimpleDnsResolver {
         let tls_config = builder
             .tls_client_config
             .as_ref()
-            .map(|c: &ClientConfig| Arc::new(c.clone()));
+            .map(|c| Arc::new(c.clone()));
         Self {
             nameservers,
             search_domains,
@@ -109,7 +109,7 @@ impl SimpleDnsResolver {
             return vec![host.to_string()];
         }
 
-        let dot_count = host.chars().filter(|&c| c == '.').count();
+        let dot_count = host.bytes().filter(|&b| b == b'.').count();
         let mut names = Vec::with_capacity(self.search_domains.len() + 1);
 
         if dot_count >= DEFAULT_NDOTS {
@@ -142,6 +142,20 @@ impl SimpleDnsResolver {
         Ok(client)
     }
 
+    /// Run a future with [`NAMESERVER_TIMEOUT`], converting timeout to [`DnsError::Transport`].
+    async fn with_timeout<T>(
+        fut: impl std::future::Future<Output = Result<T, DnsError>>,
+    ) -> Result<T, DnsError> {
+        time::timeout(NAMESERVER_TIMEOUT, fut).await.unwrap_or_else(|_| {
+            Err(e!(DnsError::Transport {
+                source: std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "nameserver query timed out",
+                ),
+            }))
+        })
+    }
+
     /// Query a single nameserver, with UDP retry and truncation fallback.
     async fn query_nameserver(
         &self,
@@ -154,56 +168,22 @@ impl SimpleDnsResolver {
                 let mut last_err = None;
                 for attempt in 0..UDP_ATTEMPTS {
                     trace!(%addr, attempt, "sending UDP query");
-                    match time::timeout(NAMESERVER_TIMEOUT, transport::udp_query(addr, query_bytes))
-                        .await
-                    {
-                        Ok(Ok(resp)) => {
-                            if query::is_truncated(&resp) {
-                                debug!(%addr, "UDP response truncated, retrying over TCP");
-                                return time::timeout(
-                                    NAMESERVER_TIMEOUT,
-                                    transport::tcp_query(addr, query_bytes),
-                                )
-                                .await
-                                .unwrap_or_else(|_| {
-                                    Err(e!(DnsError::Transport {
-                                        source: std::io::Error::new(
-                                            std::io::ErrorKind::TimedOut,
-                                            "TCP fallback timed out",
-                                        ),
-                                    }))
-                                });
-                            }
-                            return Ok(resp);
+                    match Self::with_timeout(transport::udp_query(addr, query_bytes)).await {
+                        Ok(resp) if query::is_truncated(&resp) => {
+                            debug!(%addr, "UDP response truncated, retrying over TCP");
+                            return Self::with_timeout(transport::tcp_query(addr, query_bytes)).await;
                         }
-                        Ok(Err(e)) => {
+                        Ok(resp) => return Ok(resp),
+                        Err(e) => {
                             trace!(%addr, attempt, err = %e, "UDP query failed");
                             last_err = Some(e);
-                        }
-                        Err(_) => {
-                            trace!(%addr, attempt, "UDP query timed out");
-                            last_err = Some(e!(DnsError::Transport {
-                                source: std::io::Error::new(
-                                    std::io::ErrorKind::TimedOut,
-                                    "nameserver query timed out",
-                                ),
-                            }));
                         }
                     }
                 }
                 Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
             }
             DnsProtocol::Tcp => {
-                time::timeout(NAMESERVER_TIMEOUT, transport::tcp_query(addr, query_bytes))
-                    .await
-                    .unwrap_or_else(|_| {
-                        Err(e!(DnsError::Transport {
-                            source: std::io::Error::new(
-                                std::io::ErrorKind::TimedOut,
-                                "nameserver query timed out",
-                            ),
-                        }))
-                    })
+                Self::with_timeout(transport::tcp_query(addr, query_bytes)).await
             }
             #[cfg(with_crypto_provider)]
             DnsProtocol::Tls => {
@@ -215,36 +195,12 @@ impl SimpleDnsResolver {
                         ),
                     })
                 })?;
-                time::timeout(
-                    NAMESERVER_TIMEOUT,
-                    transport::tls_query(addr, query_bytes, tls_config),
-                )
-                .await
-                .unwrap_or_else(|_| {
-                    Err(e!(DnsError::Transport {
-                        source: std::io::Error::new(
-                            std::io::ErrorKind::TimedOut,
-                            "nameserver query timed out",
-                        ),
-                    }))
-                })
+                Self::with_timeout(transport::tls_query(addr, query_bytes, tls_config)).await
             }
             #[cfg(with_crypto_provider)]
             DnsProtocol::Https => {
                 let client = self.get_or_init_https_client().await?;
-                time::timeout(
-                    NAMESERVER_TIMEOUT,
-                    transport::https_query(addr, query_bytes, &client),
-                )
-                .await
-                .unwrap_or_else(|_| {
-                    Err(e!(DnsError::Transport {
-                        source: std::io::Error::new(
-                            std::io::ErrorKind::TimedOut,
-                            "nameserver query timed out",
-                        ),
-                    }))
-                })
+                Self::with_timeout(transport::https_query(addr, query_bytes, &client)).await
             }
         }
     }
@@ -271,16 +227,7 @@ impl SimpleDnsResolver {
                     time::sleep(stagger).await;
                 }
                 trace!(%addr, ?proto, "sending DNS query");
-                let result = self.query_nameserver(addr, proto, query_bytes).await;
-                match &result {
-                    Ok(resp) => {
-                        trace!(%addr, ?proto, len = resp.len(), "DNS query succeeded");
-                    }
-                    Err(e) => {
-                        trace!(%addr, ?proto, err = %e, "DNS query failed");
-                    }
-                }
-                result
+                self.query_nameserver(addr, proto, query_bytes).await
             });
         }
 
@@ -310,11 +257,13 @@ impl SimpleDnsResolver {
             // requested type. If so, follow the CNAME to a new query.
             let packet = simple_dns::Packet::parse(&response)
                 .map_err(|e| e!(DnsError::InvalidPacket { source: e }))?;
-            let has_target_records = packet.answers.iter().any(|rr| match (&rr.rdata, qtype) {
-                (simple_dns::rdata::RData::A(_), TYPE::A) => true,
-                (simple_dns::rdata::RData::AAAA(_), TYPE::AAAA) => true,
-                (simple_dns::rdata::RData::TXT(_), TYPE::TXT) => true,
-                _ => false,
+            let has_target_records = packet.answers.iter().any(|rr| {
+                matches!(
+                    (&rr.rdata, qtype),
+                    (simple_dns::rdata::RData::A(_), TYPE::A)
+                        | (simple_dns::rdata::RData::AAAA(_), TYPE::AAAA)
+                        | (simple_dns::rdata::RData::TXT(_), TYPE::TXT)
+                )
             });
 
             if has_target_records {
@@ -478,7 +427,7 @@ impl SimpleDnsResolver {
             .builder
             .tls_client_config
             .as_ref()
-            .map(|c: &ClientConfig| Arc::new(c.clone()));
+            .map(|c| Arc::new(c.clone()));
         // Clear cached HTTPS client so it gets rebuilt with the new TLS config on next use
         *self.https_client.get_mut() = None;
         if let Ok(mut cache) = self.cache.write() {

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -15,7 +15,8 @@ use tracing::{debug, trace};
 use super::{
     Builder, DnsError, DnsProtocol, TxtRecordData,
     cache::{CachedRecord, DnsCache, QueryType},
-    query, system_config, transport,
+    query::{self, MAX_CNAME_DEPTH},
+    system_config, transport,
 };
 
 /// Per-nameserver timeout. Ensures we move on to the next nameserver
@@ -144,6 +145,53 @@ impl SimpleDnsResolver {
         Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse)))
     }
 
+    /// Send a query and follow CNAME chains recursively if the response contains
+    /// a CNAME but no records of the requested type.
+    async fn send_query_following_cnames(
+        &self,
+        host: &str,
+        qtype: TYPE,
+    ) -> Result<(Vec<u8>, u16), DnsError> {
+        let mut current_host = host.to_string();
+        for _ in 0..MAX_CNAME_DEPTH {
+            let (id, query_bytes) = query::build_query(&current_host, qtype)?;
+            let response = self.send_query(&query_bytes).await?;
+
+            // Check if the response only has CNAMEs but no records of the
+            // requested type. If so, follow the CNAME to a new query.
+            let packet = simple_dns::Packet::parse(&response)
+                .map_err(|e| e!(DnsError::InvalidPacket { source: e }))?;
+            let has_target_records = packet.answers.iter().any(|rr| match (&rr.rdata, qtype) {
+                (simple_dns::rdata::RData::A(_), TYPE::A) => true,
+                (simple_dns::rdata::RData::AAAA(_), TYPE::AAAA) => true,
+                (simple_dns::rdata::RData::TXT(_), TYPE::TXT) => true,
+                _ => false,
+            });
+
+            if has_target_records {
+                return Ok((response, id));
+            }
+
+            // No target records -- check for a CNAME to follow.
+            match query::cname_target(&packet, &current_host) {
+                Some(target) => {
+                    debug!(
+                        from = %current_host,
+                        to = %target,
+                        "following CNAME"
+                    );
+                    current_host = target;
+                }
+                None => {
+                    // No CNAME either; return the response as-is (empty results).
+                    return Ok((response, id));
+                }
+            }
+        }
+        // Exceeded max CNAME depth.
+        Err(e!(DnsError::InvalidResponse))
+    }
+
     pub(super) async fn lookup_ipv4(
         &self,
         host: String,
@@ -156,8 +204,7 @@ impl SimpleDnsResolver {
         }
 
         trace!(%host, "resolving A record");
-        let (id, query_bytes) = query::build_query(&host, TYPE::A)?;
-        let response = self.send_query(&query_bytes).await?;
+        let (response, id) = self.send_query_following_cnames(&host, TYPE::A).await?;
         let (addrs, ttl) = query::parse_a_response(&response, id)?;
         debug!(%host, count = addrs.len(), ttl, "resolved A record");
 
@@ -180,8 +227,7 @@ impl SimpleDnsResolver {
         }
 
         trace!(%host, "resolving AAAA record");
-        let (id, query_bytes) = query::build_query(&host, TYPE::AAAA)?;
-        let response = self.send_query(&query_bytes).await?;
+        let (response, id) = self.send_query_following_cnames(&host, TYPE::AAAA).await?;
         let (addrs, ttl) = query::parse_aaaa_response(&response, id)?;
         debug!(%host, count = addrs.len(), ttl, "resolved AAAA record");
 
@@ -209,8 +255,7 @@ impl SimpleDnsResolver {
         }
 
         trace!(%host, "resolving TXT record");
-        let (id, query_bytes) = query::build_query(&host, TYPE::TXT)?;
-        let response = self.send_query(&query_bytes).await?;
+        let (response, id) = self.send_query_following_cnames(&host, TYPE::TXT).await?;
         let (records, ttl) = query::parse_txt_response(&response, id)?;
         debug!(%host, count = records.len(), ttl, "resolved TXT record");
 

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -2,8 +2,9 @@
 //! and tokio for transport.
 
 use std::{
+    future::Future,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use n0_error::e;
@@ -11,7 +12,7 @@ use n0_future::{
     FuturesUnorderedBounded, StreamExt,
     time::{self, Duration},
 };
-use simple_dns::TYPE;
+use simple_dns::{TYPE, rdata::RData};
 use tracing::{debug, trace};
 
 use super::{
@@ -43,8 +44,8 @@ pub(super) struct SimpleDnsResolver {
     #[cfg(with_crypto_provider)]
     tls_config: Option<Arc<rustls::ClientConfig>>,
     /// Lazily initialized, cached reqwest client for DNS-over-HTTPS queries.
-    https_client: tokio::sync::Mutex<Option<reqwest::Client>>,
-    cache: std::sync::RwLock<DnsCache>,
+    https_client: Mutex<Option<reqwest::Client>>,
+    cache: DnsCache,
     builder: Builder,
 }
 
@@ -72,8 +73,8 @@ impl SimpleDnsResolver {
             search_domains,
             #[cfg(with_crypto_provider)]
             tls_config,
-            https_client: tokio::sync::Mutex::new(None),
-            cache: std::sync::RwLock::new(DnsCache::new()),
+            https_client: Mutex::new(None),
+            cache: DnsCache::new(),
             builder,
         }
     }
@@ -134,8 +135,8 @@ impl SimpleDnsResolver {
     /// Returns a clone of the cached reqwest client, creating it on first use.
     ///
     /// `reqwest::Client` uses an inner `Arc`, so cloning is cheap.
-    async fn get_or_init_https_client(&self) -> Result<reqwest::Client, DnsError> {
-        let mut guard = self.https_client.lock().await;
+    fn get_or_init_https_client(&self) -> Result<reqwest::Client, DnsError> {
+        let mut guard = self.https_client.lock().expect("poisoned");
         if let Some(client) = guard.as_ref() {
             return Ok(client.clone());
         }
@@ -150,7 +151,7 @@ impl SimpleDnsResolver {
 
     /// Run a future with [`NAMESERVER_TIMEOUT`].
     async fn with_timeout<T>(
-        fut: impl std::future::Future<Output = Result<T, DnsError>>,
+        fut: impl Future<Output = Result<T, DnsError>>,
     ) -> Result<T, DnsError> {
         time::timeout(NAMESERVER_TIMEOUT, fut).await?
     }
@@ -194,7 +195,7 @@ impl SimpleDnsResolver {
             }
             #[cfg(with_crypto_provider)]
             DnsProtocol::Https => {
-                let client = self.get_or_init_https_client().await?;
+                let client = self.get_or_init_https_client()?;
                 Self::with_timeout(transport::https_query(addr, query_bytes, &client)).await
             }
         }
@@ -213,9 +214,7 @@ impl SimpleDnsResolver {
         let count = self.nameservers.len();
         let mut futures = FuturesUnorderedBounded::new(count);
 
-        for (i, (addr, proto)) in self.nameservers.iter().enumerate() {
-            let addr = *addr;
-            let proto = *proto;
+        for (i, (addr, proto)) in self.nameservers.iter().copied().enumerate() {
             let stagger = NAMESERVER_STAGGER * i as u32;
             futures.push(async move {
                 if !stagger.is_zero() {
@@ -254,9 +253,9 @@ impl SimpleDnsResolver {
             let has_target_records = packet.answers.iter().any(|rr| {
                 matches!(
                     (&rr.rdata, qtype),
-                    (simple_dns::rdata::RData::A(_), TYPE::A)
-                        | (simple_dns::rdata::RData::AAAA(_), TYPE::AAAA)
-                        | (simple_dns::rdata::RData::TXT(_), TYPE::TXT)
+                    (RData::A(_), TYPE::A)
+                        | (RData::AAAA(_), TYPE::AAAA)
+                        | (RData::TXT(_), TYPE::TXT)
                 )
             });
 
@@ -288,9 +287,7 @@ impl SimpleDnsResolver {
         &self,
         host: String,
     ) -> Result<impl Iterator<Item = Ipv4Addr> + use<>, DnsError> {
-        if let Ok(mut cache) = self.cache.write()
-            && let Some(CachedRecord::A(addrs)) = cache.get(&host, QueryType::A)
-        {
+        if let Some(CachedRecord::A(addrs)) = self.cache.get(&host, QueryType::A) {
             trace!(%host, count = addrs.len(), "A lookup cache hit");
             return Ok(addrs.into_iter());
         }
@@ -303,9 +300,8 @@ impl SimpleDnsResolver {
                     let (addrs, ttl) = query::parse_a_response(&response, id)?;
                     if !addrs.is_empty() {
                         debug!(%host, count = addrs.len(), ttl, "resolved A record");
-                        if let Ok(mut cache) = self.cache.write() {
-                            cache.insert(&host, QueryType::A, CachedRecord::A(addrs.clone()), ttl);
-                        }
+                        self.cache
+                            .insert(&host, QueryType::A, CachedRecord::A(addrs.clone()), ttl);
                         return Ok(addrs.into_iter());
                     }
                 }
@@ -322,9 +318,7 @@ impl SimpleDnsResolver {
         &self,
         host: String,
     ) -> Result<impl Iterator<Item = Ipv6Addr> + use<>, DnsError> {
-        if let Ok(mut cache) = self.cache.write()
-            && let Some(CachedRecord::Aaaa(addrs)) = cache.get(&host, QueryType::AAAA)
-        {
+        if let Some(CachedRecord::Aaaa(addrs)) = self.cache.get(&host, QueryType::AAAA) {
             trace!(%host, count = addrs.len(), "AAAA lookup cache hit");
             return Ok(addrs.into_iter());
         }
@@ -337,14 +331,12 @@ impl SimpleDnsResolver {
                     let (addrs, ttl) = query::parse_aaaa_response(&response, id)?;
                     if !addrs.is_empty() {
                         debug!(%host, count = addrs.len(), ttl, "resolved AAAA record");
-                        if let Ok(mut cache) = self.cache.write() {
-                            cache.insert(
-                                &host,
-                                QueryType::AAAA,
-                                CachedRecord::Aaaa(addrs.clone()),
-                                ttl,
-                            );
-                        }
+                        self.cache.insert(
+                            &host,
+                            QueryType::AAAA,
+                            CachedRecord::Aaaa(addrs.clone()),
+                            ttl,
+                        );
                         return Ok(addrs.into_iter());
                     }
                 }
@@ -361,11 +353,11 @@ impl SimpleDnsResolver {
         &self,
         host: String,
     ) -> Result<impl Iterator<Item = TxtRecordData> + use<>, DnsError> {
-        if let Ok(mut cache) = self.cache.write()
-            && let Some(CachedRecord::Txt(records)) = cache.get(&host, QueryType::TXT)
         {
-            trace!(%host, count = records.len(), "TXT lookup cache hit");
-            return Ok(records.into_iter());
+            if let Some(CachedRecord::Txt(records)) = self.cache.get(&host, QueryType::TXT) {
+                trace!(%host, count = records.len(), "TXT lookup cache hit");
+                return Ok(records.into_iter());
+            }
         }
 
         let mut last_err = None;
@@ -376,14 +368,12 @@ impl SimpleDnsResolver {
                     let (records, ttl) = query::parse_txt_response(&response, id)?;
                     if !records.is_empty() {
                         debug!(%host, count = records.len(), ttl, "resolved TXT record");
-                        if let Ok(mut cache) = self.cache.write() {
-                            cache.insert(
-                                &host,
-                                QueryType::TXT,
-                                CachedRecord::Txt(records.clone()),
-                                ttl,
-                            );
-                        }
+                        self.cache.insert(
+                            &host,
+                            QueryType::TXT,
+                            CachedRecord::Txt(records.clone()),
+                            ttl,
+                        );
                         return Ok(records.into_iter());
                     }
                 }
@@ -397,9 +387,7 @@ impl SimpleDnsResolver {
     }
 
     pub(super) fn clear_cache(&self) {
-        if let Ok(mut cache) = self.cache.write() {
-            cache.clear();
-        }
+        self.cache.clear();
     }
 
     pub(super) fn reset(&mut self) {
@@ -415,10 +403,8 @@ impl SimpleDnsResolver {
                 .map(|c| Arc::new(c.clone()));
         }
         // Clear cached HTTPS client so it gets rebuilt with the new TLS config on next use
-        *self.https_client.get_mut() = None;
-        if let Ok(mut cache) = self.cache.write() {
-            cache.clear();
-        }
+        *self.https_client.lock().expect("poisoned") = None;
+        self.clear_cache();
     }
 }
 

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -235,10 +235,10 @@ impl SimpleDnsResolver {
     /// a CNAME but no records of the requested type.
     async fn send_query_following_cnames(
         &self,
-        host: &str,
+        host: String,
         qtype: TYPE,
     ) -> Result<(Vec<u8>, u16), DnsError> {
-        let mut current_host = host.to_string();
+        let mut current_host = host;
         for _ in 0..MAX_CNAME_DEPTH {
             let (id, query_bytes) = query::build_query(&current_host, qtype)?;
             let response = self.send_query(&query_bytes).await?;
@@ -293,11 +293,11 @@ impl SimpleDnsResolver {
         let mut last_err = None;
         for name in self.search_names(&host) {
             trace!(%name, "resolving A record");
-            match self.send_query_following_cnames(&name, TYPE::A).await {
+            match self.send_query_following_cnames(name, TYPE::A).await {
                 Ok((response, id)) => {
                     let (addrs, ttl) = query::parse_a_response(&response, id)?;
                     if !addrs.is_empty() {
-                        debug!(%name, count = addrs.len(), ttl, "resolved A record");
+                        debug!(%host, count = addrs.len(), ttl, "resolved A record");
                         if let Ok(mut cache) = self.cache.write() {
                             cache.insert(
                                 &host,
@@ -310,9 +310,7 @@ impl SimpleDnsResolver {
                     }
                 }
                 Err(DnsError::NxDomain { .. }) => {
-                    trace!(%name, "NXDOMAIN, trying next search domain");
                     last_err = Some(e!(DnsError::NxDomain));
-                    continue;
                 }
                 Err(e) => return Err(e),
             }
@@ -334,11 +332,11 @@ impl SimpleDnsResolver {
         let mut last_err = None;
         for name in self.search_names(&host) {
             trace!(%name, "resolving AAAA record");
-            match self.send_query_following_cnames(&name, TYPE::AAAA).await {
+            match self.send_query_following_cnames(name, TYPE::AAAA).await {
                 Ok((response, id)) => {
                     let (addrs, ttl) = query::parse_aaaa_response(&response, id)?;
                     if !addrs.is_empty() {
-                        debug!(%name, count = addrs.len(), ttl, "resolved AAAA record");
+                        debug!(%host, count = addrs.len(), ttl, "resolved AAAA record");
                         if let Ok(mut cache) = self.cache.write() {
                             cache.insert(
                                 &host,
@@ -351,9 +349,7 @@ impl SimpleDnsResolver {
                     }
                 }
                 Err(DnsError::NxDomain { .. }) => {
-                    trace!(%name, "NXDOMAIN, trying next search domain");
                     last_err = Some(e!(DnsError::NxDomain));
-                    continue;
                 }
                 Err(e) => return Err(e),
             }
@@ -375,11 +371,11 @@ impl SimpleDnsResolver {
         let mut last_err = None;
         for name in self.search_names(&host) {
             trace!(%name, "resolving TXT record");
-            match self.send_query_following_cnames(&name, TYPE::TXT).await {
+            match self.send_query_following_cnames(name, TYPE::TXT).await {
                 Ok((response, id)) => {
                     let (records, ttl) = query::parse_txt_response(&response, id)?;
                     if !records.is_empty() {
-                        debug!(%name, count = records.len(), ttl, "resolved TXT record");
+                        debug!(%host, count = records.len(), ttl, "resolved TXT record");
                         if let Ok(mut cache) = self.cache.write() {
                             cache.insert(
                                 &host,
@@ -392,9 +388,7 @@ impl SimpleDnsResolver {
                     }
                 }
                 Err(DnsError::NxDomain { .. }) => {
-                    trace!(%name, "NXDOMAIN, trying next search domain");
                     last_err = Some(e!(DnsError::NxDomain));
-                    continue;
                 }
                 Err(e) => return Err(e),
             }

--- a/iroh-relay/src/dns/resolver.rs
+++ b/iroh-relay/src/dns/resolver.rs
@@ -142,18 +142,11 @@ impl SimpleDnsResolver {
         Ok(client)
     }
 
-    /// Run a future with [`NAMESERVER_TIMEOUT`], converting timeout to [`DnsError::Transport`].
+    /// Run a future with [`NAMESERVER_TIMEOUT`].
     async fn with_timeout<T>(
         fut: impl std::future::Future<Output = Result<T, DnsError>>,
     ) -> Result<T, DnsError> {
-        time::timeout(NAMESERVER_TIMEOUT, fut).await.unwrap_or_else(|_| {
-            Err(e!(DnsError::Transport {
-                source: std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "nameserver query timed out",
-                ),
-            }))
-        })
+        Ok(time::timeout(NAMESERVER_TIMEOUT, fut).await??)
     }
 
     /// Query a single nameserver, with UDP retry and truncation fallback.
@@ -189,10 +182,7 @@ impl SimpleDnsResolver {
             DnsProtocol::Tls => {
                 let tls_config = self.tls_config.as_ref().ok_or_else(|| {
                     e!(DnsError::Transport {
-                        source: std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
-                            "TLS config required for DNS-over-TLS",
-                        ),
+                        source: std::io::Error::other("TLS config required for DNS-over-TLS"),
                     })
                 })?;
                 Self::with_timeout(transport::tls_query(addr, query_bytes, tls_config)).await
@@ -255,8 +245,7 @@ impl SimpleDnsResolver {
 
             // Check if the response only has CNAMEs but no records of the
             // requested type. If so, follow the CNAME to a new query.
-            let packet = simple_dns::Packet::parse(&response)
-                .map_err(|e| e!(DnsError::InvalidPacket { source: e }))?;
+            let packet = simple_dns::Packet::parse(&response)?;
             let has_target_records = packet.answers.iter().any(|rr| {
                 matches!(
                     (&rr.rdata, qtype),

--- a/iroh-relay/src/dns/system_config.rs
+++ b/iroh-relay/src/dns/system_config.rs
@@ -32,27 +32,47 @@ const GOOGLE_DNS_IPV6_PRIMARY: Ipv6Addr = Ipv6Addr::new(0x2001, 0x4860, 0x4860, 
 const GOOGLE_DNS_IPV6_SECONDARY: Ipv6Addr =
     Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8844);
 
+/// Parsed system DNS configuration.
+#[derive(Debug, Clone, Default)]
+pub(super) struct SystemDnsConfig {
+    pub(super) nameservers: Vec<(SocketAddr, DnsProtocol)>,
+    /// Search domains from resolv.conf `search` or `domain` directives.
+    ///
+    /// When resolving a short hostname (one with fewer dots than `ndots`,
+    /// default 1), the resolver should try appending each search domain
+    /// before querying the bare name.
+    pub(super) search_domains: Vec<String>,
+}
+
 /// Parse system DNS configuration.
 ///
-/// On Unix, reads `/etc/resolv.conf` for `nameserver` lines.
+/// On Unix, reads `/etc/resolv.conf` for `nameserver` and `search`/`domain` lines.
 /// On Windows, uses the `ipconfig` crate to enumerate network adapters.
 /// Falls back to Google DNS if parsing fails or no servers are found.
-pub(super) fn system_nameservers() -> Vec<(SocketAddr, DnsProtocol)> {
+pub(super) fn system_config() -> SystemDnsConfig {
     match read_system_dns() {
-        Ok(servers) if !servers.is_empty() => servers,
-        _ => fallback_nameservers(),
+        Ok(config) if !config.nameservers.is_empty() => config,
+        _ => SystemDnsConfig {
+            nameservers: fallback_nameservers(),
+            search_domains: Vec::new(),
+        },
     }
+}
+
+/// Backwards-compatible helper that only returns nameservers.
+pub(super) fn system_nameservers() -> Vec<(SocketAddr, DnsProtocol)> {
+    system_config().nameservers
 }
 
 /// Read system DNS configuration using platform-specific mechanisms.
 #[cfg(windows)]
-fn read_system_dns() -> Result<Vec<(SocketAddr, DnsProtocol)>, std::io::Error> {
+fn read_system_dns() -> Result<SystemDnsConfig, std::io::Error> {
     read_from_ipconfig()
 }
 
 /// Read system DNS configuration using platform-specific mechanisms.
 #[cfg(not(windows))]
-fn read_system_dns() -> Result<Vec<(SocketAddr, DnsProtocol)>, std::io::Error> {
+fn read_system_dns() -> Result<SystemDnsConfig, std::io::Error> {
     read_resolv_conf()
 }
 
@@ -80,7 +100,7 @@ pub(super) fn fallback_nameservers() -> Vec<(SocketAddr, DnsProtocol)> {
 
 /// Read DNS servers from Windows network adapter configuration.
 #[cfg(windows)]
-fn read_from_ipconfig() -> Result<Vec<(SocketAddr, DnsProtocol)>, std::io::Error> {
+fn read_from_ipconfig() -> Result<SystemDnsConfig, std::io::Error> {
     let adapters =
         ipconfig::get_adapters().map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
@@ -98,23 +118,37 @@ fn read_from_ipconfig() -> Result<Vec<(SocketAddr, DnsProtocol)>, std::io::Error
         }
     }
 
-    // Deduplicate — multiple adapters may report the same DNS server
+    // Deduplicate -- multiple adapters may report the same DNS server
     servers.dedup_by_key(|(addr, _)| *addr);
 
-    Ok(servers)
+    // Windows does not expose search domains via ipconfig in a
+    // straightforward way, so we leave them empty.
+    Ok(SystemDnsConfig {
+        nameservers: servers,
+        search_domains: Vec::new(),
+    })
 }
 
-/// Read `/etc/resolv.conf` and extract nameserver addresses.
+/// Read `/etc/resolv.conf` and extract nameserver addresses and search domains.
 #[cfg(not(windows))]
-fn read_resolv_conf() -> Result<Vec<(SocketAddr, DnsProtocol)>, std::io::Error> {
+fn read_resolv_conf() -> Result<SystemDnsConfig, std::io::Error> {
     let content = std::fs::read_to_string("/etc/resolv.conf")?;
     Ok(parse_resolv_conf(&content))
 }
 
-/// Parse resolv.conf content and extract nameserver addresses.
+/// Parse resolv.conf content and extract nameserver addresses and search domains.
+///
+/// Recognized directives:
+/// - `nameserver <ip>` -- adds a DNS nameserver
+/// - `search <domain> [<domain> ...]` -- sets the search domain list
+/// - `domain <domain>` -- equivalent to a single-entry search list
+///
+/// The `search` and `domain` directives are mutually exclusive per resolv.conf(5);
+/// the last one seen wins, matching standard resolver behavior.
 #[cfg(any(not(windows), test))]
-fn parse_resolv_conf(content: &str) -> Vec<(SocketAddr, DnsProtocol)> {
+fn parse_resolv_conf(content: &str) -> SystemDnsConfig {
     let mut servers = Vec::new();
+    let mut search_domains = Vec::new();
 
     for line in content.lines() {
         let line = line.trim();
@@ -122,25 +156,41 @@ fn parse_resolv_conf(content: &str) -> Vec<(SocketAddr, DnsProtocol)> {
         if line.starts_with('#') || line.starts_with(';') {
             continue;
         }
-        // Split into keyword and rest, handling any whitespace separator
         let mut parts = line.split_whitespace();
-        if parts.next() == Some("nameserver")
-            && let Some(addr_str) = parts.next()
-            && let Ok(ip) = addr_str.parse::<IpAddr>()
-        {
-            servers.push((SocketAddr::new(ip, DNS_PORT), DnsProtocol::Udp));
+        match parts.next() {
+            Some("nameserver") => {
+                if let Some(addr_str) = parts.next()
+                    && let Ok(ip) = addr_str.parse::<IpAddr>()
+                {
+                    servers.push((SocketAddr::new(ip, DNS_PORT), DnsProtocol::Udp));
+                }
+            }
+            Some("search") => {
+                // `search` replaces any previous search/domain list.
+                search_domains = parts.map(|s| s.to_string()).collect();
+            }
+            Some("domain") => {
+                // `domain` is equivalent to a single-entry search list.
+                if let Some(domain) = parts.next() {
+                    search_domains = vec![domain.to_string()];
+                }
+            }
+            _ => {}
         }
     }
 
-    servers
+    SystemDnsConfig {
+        nameservers: servers,
+        search_domains,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn ips(servers: &[(SocketAddr, DnsProtocol)]) -> Vec<IpAddr> {
-        servers.iter().map(|(a, _)| a.ip()).collect()
+    fn ips(config: &SystemDnsConfig) -> Vec<IpAddr> {
+        config.nameservers.iter().map(|(a, _)| a.ip()).collect()
     }
 
     fn ipv4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
@@ -149,64 +199,88 @@ mod tests {
 
     #[test]
     fn parse_basic() {
-        let servers = parse_resolv_conf("nameserver 8.8.8.8\nnameserver 8.8.4.4\n");
-        assert_eq!(ips(&servers), [ipv4(8, 8, 8, 8), ipv4(8, 8, 4, 4)]);
-        assert!(servers.iter().all(|(_, p)| *p == DnsProtocol::Udp));
+        let config = parse_resolv_conf("nameserver 8.8.8.8\nnameserver 8.8.4.4\n");
+        assert_eq!(ips(&config), [ipv4(8, 8, 8, 8), ipv4(8, 8, 4, 4)]);
+        assert!(config.nameservers.iter().all(|(_, p)| *p == DnsProtocol::Udp));
     }
 
     #[test]
     fn parse_ipv6() {
-        let servers = parse_resolv_conf("nameserver 8.8.8.8\nnameserver 2001:4860:4860::8888\n");
-        assert_eq!(servers.len(), 2);
-        assert!(servers[1].0.ip().is_ipv6());
+        let config = parse_resolv_conf("nameserver 8.8.8.8\nnameserver 2001:4860:4860::8888\n");
+        assert_eq!(config.nameservers.len(), 2);
+        assert!(config.nameservers[1].0.ip().is_ipv6());
     }
 
     #[test]
     fn parse_comments_and_directives() {
-        let servers = parse_resolv_conf(
+        let config = parse_resolv_conf(
             "# comment\n; comment\nsearch example.com\nnameserver 1.1.1.1\noptions ndots:5\nnameserver 1.0.0.1\n",
         );
-        assert_eq!(ips(&servers), [ipv4(1, 1, 1, 1), ipv4(1, 0, 0, 1)]);
+        assert_eq!(ips(&config), [ipv4(1, 1, 1, 1), ipv4(1, 0, 0, 1)]);
+        assert_eq!(config.search_domains, ["example.com"]);
     }
 
     #[test]
     fn parse_skips_invalid_ips() {
-        let servers = parse_resolv_conf("nameserver not-an-ip\nnameserver 8.8.8.8\n");
-        assert_eq!(ips(&servers), [ipv4(8, 8, 8, 8)]);
+        let config = parse_resolv_conf("nameserver not-an-ip\nnameserver 8.8.8.8\n");
+        assert_eq!(ips(&config), [ipv4(8, 8, 8, 8)]);
     }
 
     #[test]
     fn parse_empty() {
-        assert!(parse_resolv_conf("").is_empty());
+        assert!(parse_resolv_conf("").nameservers.is_empty());
     }
 
     #[test]
     fn parse_no_nameservers() {
-        assert!(parse_resolv_conf("search example.com\noptions ndots:1\n").is_empty());
+        let config = parse_resolv_conf("search example.com\noptions ndots:1\n");
+        assert!(config.nameservers.is_empty());
+        assert_eq!(config.search_domains, ["example.com"]);
     }
 
     #[test]
     fn parse_whitespace_variations() {
-        let servers = parse_resolv_conf("  nameserver   8.8.8.8  \n\tnameserver\t1.1.1.1\t\n");
-        assert_eq!(servers.len(), 2);
+        let config = parse_resolv_conf("  nameserver   8.8.8.8  \n\tnameserver\t1.1.1.1\t\n");
+        assert_eq!(config.nameservers.len(), 2);
     }
 
     #[test]
     fn parse_inline_comment() {
-        let servers = parse_resolv_conf("nameserver 8.8.8.8 # primary\nnameserver 1.1.1.1\n");
-        assert_eq!(ips(&servers), [ipv4(8, 8, 8, 8), ipv4(1, 1, 1, 1)]);
+        let config = parse_resolv_conf("nameserver 8.8.8.8 # primary\nnameserver 1.1.1.1\n");
+        assert_eq!(ips(&config), [ipv4(8, 8, 8, 8), ipv4(1, 1, 1, 1)]);
     }
 
     #[test]
     fn parse_no_space_after_keyword() {
-        let servers = parse_resolv_conf("nameserver8.8.8.8\nnameserver 1.1.1.1\n");
-        assert_eq!(ips(&servers), [ipv4(1, 1, 1, 1)]);
+        let config = parse_resolv_conf("nameserver8.8.8.8\nnameserver 1.1.1.1\n");
+        assert_eq!(ips(&config), [ipv4(1, 1, 1, 1)]);
     }
 
     #[test]
     fn parse_scoped_ipv6() {
-        let servers = parse_resolv_conf("nameserver fe80::1%eth0\nnameserver 8.8.8.8\n");
-        assert_eq!(ips(&servers), [ipv4(8, 8, 8, 8)]);
+        let config = parse_resolv_conf("nameserver fe80::1%eth0\nnameserver 8.8.8.8\n");
+        assert_eq!(ips(&config), [ipv4(8, 8, 8, 8)]);
+    }
+
+    #[test]
+    fn parse_search_domains() {
+        let config = parse_resolv_conf("search example.com foo.bar\nnameserver 8.8.8.8\n");
+        assert_eq!(config.search_domains, ["example.com", "foo.bar"]);
+    }
+
+    #[test]
+    fn parse_domain_directive() {
+        let config = parse_resolv_conf("domain example.com\nnameserver 8.8.8.8\n");
+        assert_eq!(config.search_domains, ["example.com"]);
+    }
+
+    #[test]
+    fn search_overrides_domain() {
+        let config = parse_resolv_conf(
+            "domain old.com\nsearch new.com other.com\nnameserver 8.8.8.8\n",
+        );
+        // Last directive wins, per resolv.conf(5).
+        assert_eq!(config.search_domains, ["new.com", "other.com"]);
     }
 
     #[test]

--- a/iroh-relay/src/dns/system_config.rs
+++ b/iroh-relay/src/dns/system_config.rs
@@ -41,7 +41,6 @@ pub(super) struct SystemDnsConfig {
     /// When resolving a short hostname (one with fewer dots than `ndots`,
     /// default 1), the resolver should try appending each search domain
     /// before querying the bare name.
-    ///
     pub(super) search_domains: Vec<String>,
 }
 
@@ -161,15 +160,12 @@ fn parse_resolv_conf(content: &str) -> SystemDnsConfig {
                     // Try parsing as SocketAddr first (supports custom ports like
                     // 8.8.8.8:5353 or [::1]:5353), then fall back to IpAddr with
                     // the default DNS port.
-                    let addr = addr_str
-                        .parse::<SocketAddr>()
-                        .ok()
-                        .or_else(|| {
-                            addr_str
-                                .parse::<IpAddr>()
-                                .ok()
-                                .map(|ip| SocketAddr::new(ip, DNS_PORT))
-                        });
+                    let addr = addr_str.parse::<SocketAddr>().ok().or_else(|| {
+                        addr_str
+                            .parse::<IpAddr>()
+                            .ok()
+                            .map(|ip| SocketAddr::new(ip, DNS_PORT))
+                    });
                     if let Some(addr) = addr {
                         servers.push((addr, DnsProtocol::Udp));
                     }
@@ -211,7 +207,12 @@ mod tests {
     fn parse_basic() {
         let config = parse_resolv_conf("nameserver 8.8.8.8\nnameserver 8.8.4.4\n");
         assert_eq!(ips(&config), [ipv4(8, 8, 8, 8), ipv4(8, 8, 4, 4)]);
-        assert!(config.nameservers.iter().all(|(_, p)| *p == DnsProtocol::Udp));
+        assert!(
+            config
+                .nameservers
+                .iter()
+                .all(|(_, p)| *p == DnsProtocol::Udp)
+        );
     }
 
     #[test]
@@ -288,15 +289,17 @@ mod tests {
     fn parse_custom_port() {
         let config = parse_resolv_conf("nameserver 8.8.8.8:5353\nnameserver 1.1.1.1\n");
         assert_eq!(config.nameservers.len(), 2);
-        assert_eq!(config.nameservers[0].0, "8.8.8.8:5353".parse::<SocketAddr>().unwrap());
+        assert_eq!(
+            config.nameservers[0].0,
+            "8.8.8.8:5353".parse::<SocketAddr>().unwrap()
+        );
         assert_eq!(config.nameservers[1].0.port(), DNS_PORT);
     }
 
     #[test]
     fn search_overrides_domain() {
-        let config = parse_resolv_conf(
-            "domain old.com\nsearch new.com other.com\nnameserver 8.8.8.8\n",
-        );
+        let config =
+            parse_resolv_conf("domain old.com\nsearch new.com other.com\nnameserver 8.8.8.8\n");
         // Last directive wins, per resolv.conf(5).
         assert_eq!(config.search_domains, ["new.com", "other.com"]);
     }

--- a/iroh-relay/src/dns/system_config.rs
+++ b/iroh-relay/src/dns/system_config.rs
@@ -118,8 +118,10 @@ fn read_from_ipconfig() -> Result<SystemDnsConfig, std::io::Error> {
         }
     }
 
-    // Deduplicate -- multiple adapters may report the same DNS server
-    servers.dedup_by_key(|(addr, _)| *addr);
+    // Deduplicate -- multiple adapters may report the same DNS server.
+    // Use a HashSet since dedup_by_key only removes consecutive duplicates.
+    let mut seen = std::collections::HashSet::new();
+    servers.retain(|(addr, _)| seen.insert(*addr));
 
     // Windows does not expose search domains via ipconfig in a
     // straightforward way, so we leave them empty.

--- a/iroh-relay/src/dns/system_config.rs
+++ b/iroh-relay/src/dns/system_config.rs
@@ -159,10 +159,22 @@ fn parse_resolv_conf(content: &str) -> SystemDnsConfig {
         let mut parts = line.split_whitespace();
         match parts.next() {
             Some("nameserver") => {
-                if let Some(addr_str) = parts.next()
-                    && let Ok(ip) = addr_str.parse::<IpAddr>()
-                {
-                    servers.push((SocketAddr::new(ip, DNS_PORT), DnsProtocol::Udp));
+                if let Some(addr_str) = parts.next() {
+                    // Try parsing as SocketAddr first (supports custom ports like
+                    // 8.8.8.8:5353 or [::1]:5353), then fall back to IpAddr with
+                    // the default DNS port.
+                    let addr = addr_str
+                        .parse::<SocketAddr>()
+                        .ok()
+                        .or_else(|| {
+                            addr_str
+                                .parse::<IpAddr>()
+                                .ok()
+                                .map(|ip| SocketAddr::new(ip, DNS_PORT))
+                        });
+                    if let Some(addr) = addr {
+                        servers.push((addr, DnsProtocol::Udp));
+                    }
                 }
             }
             Some("search") => {
@@ -272,6 +284,14 @@ mod tests {
     fn parse_domain_directive() {
         let config = parse_resolv_conf("domain example.com\nnameserver 8.8.8.8\n");
         assert_eq!(config.search_domains, ["example.com"]);
+    }
+
+    #[test]
+    fn parse_custom_port() {
+        let config = parse_resolv_conf("nameserver 8.8.8.8:5353\nnameserver 1.1.1.1\n");
+        assert_eq!(config.nameservers.len(), 2);
+        assert_eq!(config.nameservers[0].0, "8.8.8.8:5353".parse::<SocketAddr>().unwrap());
+        assert_eq!(config.nameservers[1].0.port(), DNS_PORT);
     }
 
     #[test]

--- a/iroh-relay/src/dns/system_config.rs
+++ b/iroh-relay/src/dns/system_config.rs
@@ -42,8 +42,6 @@ pub(super) struct SystemDnsConfig {
     /// default 1), the resolver should try appending each search domain
     /// before querying the bare name.
     ///
-    /// Currently parsed but not yet applied by the resolver.
-    #[allow(dead_code)]
     pub(super) search_domains: Vec<String>,
 }
 
@@ -60,11 +58,6 @@ pub(super) fn system_config() -> SystemDnsConfig {
             search_domains: Vec::new(),
         },
     }
-}
-
-/// Backwards-compatible helper that only returns nameservers.
-pub(super) fn system_nameservers() -> Vec<(SocketAddr, DnsProtocol)> {
-    system_config().nameservers
 }
 
 /// Read system DNS configuration using platform-specific mechanisms.

--- a/iroh-relay/src/dns/system_config.rs
+++ b/iroh-relay/src/dns/system_config.rs
@@ -41,6 +41,9 @@ pub(super) struct SystemDnsConfig {
     /// When resolving a short hostname (one with fewer dots than `ndots`,
     /// default 1), the resolver should try appending each search domain
     /// before querying the bare name.
+    ///
+    /// Currently parsed but not yet applied by the resolver.
+    #[allow(dead_code)]
     pub(super) search_domains: Vec<String>,
 }
 

--- a/iroh-relay/src/dns/transport.rs
+++ b/iroh-relay/src/dns/transport.rs
@@ -1,6 +1,8 @@
 //! DNS transport implementations: UDP, TCP, TLS, and HTTPS.
 
-use std::{net::SocketAddr, sync::Arc};
+use std::net::SocketAddr;
+#[cfg(with_crypto_provider)]
+use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -68,6 +70,7 @@ pub(super) async fn tcp_query(addr: SocketAddr, query: &[u8]) -> Result<Vec<u8>,
 /// (e.g. Google 8.8.8.8, Cloudflare 1.1.1.1), but will fail TLS validation for
 /// servers whose certificates only cover hostnames. A future improvement could
 /// accept an optional hostname for SNI.
+#[cfg(with_crypto_provider)]
 pub(super) async fn tls_query(
     addr: SocketAddr,
     query: &[u8],
@@ -94,6 +97,7 @@ pub(super) async fn tls_query(
 }
 
 /// Build a [`reqwest::Client`] for DNS-over-HTTPS queries.
+#[cfg(with_crypto_provider)]
 pub(super) fn build_https_client(
     tls_config: Option<&Arc<rustls::ClientConfig>>,
 ) -> Result<reqwest::Client, DnsError> {
@@ -111,6 +115,7 @@ pub(super) fn build_https_client(
 /// certificates include the IP address as a SAN, but will fail for servers
 /// that only have hostname-based certificates. A future improvement could
 /// accept an optional hostname for URL construction and TLS SNI.
+#[cfg(with_crypto_provider)]
 pub(super) async fn https_query(
     addr: SocketAddr,
     query: &[u8],

--- a/iroh-relay/src/dns/transport.rs
+++ b/iroh-relay/src/dns/transport.rs
@@ -61,6 +61,12 @@ pub(super) async fn tcp_query(addr: SocketAddr, query: &[u8]) -> Result<Vec<u8>,
 }
 
 /// Send a DNS query over TLS (DNS-over-TLS, RFC 7858).
+///
+/// **Limitation:** The server name for TLS SNI is derived from the IP address.
+/// This works for public DNS providers that include IP SANs in their certificates
+/// (e.g. Google 8.8.8.8, Cloudflare 1.1.1.1), but will fail TLS validation for
+/// servers whose certificates only cover hostnames. A future improvement could
+/// accept an optional hostname for SNI.
 pub(super) async fn tls_query(
     addr: SocketAddr,
     query: &[u8],
@@ -98,6 +104,12 @@ pub(super) fn build_https_client(
 }
 
 /// Send a DNS query over HTTPS (DNS-over-HTTPS, RFC 8484).
+///
+/// **Limitation:** The URL is constructed from the IP address (e.g.
+/// `https://1.1.1.1/dns-query`). This works for providers whose TLS
+/// certificates include the IP address as a SAN, but will fail for servers
+/// that only have hostname-based certificates. A future improvement could
+/// accept an optional hostname for URL construction and TLS SNI.
 pub(super) async fn https_query(
     addr: SocketAddr,
     query: &[u8],

--- a/iroh-relay/src/dns/transport.rs
+++ b/iroh-relay/src/dns/transport.rs
@@ -2,7 +2,6 @@
 
 use std::{net::SocketAddr, sync::Arc};
 
-use n0_error::e;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::DnsError;
@@ -37,12 +36,9 @@ pub(super) async fn udp_query(addr: SocketAddr, query: &[u8]) -> Result<Vec<u8>,
     let mut buf = vec![0u8; 4096];
     let (len, src) = socket.recv_from(&mut buf).await?;
     if src != addr {
-        return Err(e!(DnsError::Transport {
-            source: std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("DNS response from unexpected source {src}, expected {addr}"),
-            ),
-        }));
+        return Err(std::io::Error::other(format!(
+            "DNS response from unexpected source {src}, expected {addr}"
+        )))?;
     }
     buf.truncate(len);
     Ok(buf)

--- a/iroh-relay/src/dns/transport.rs
+++ b/iroh-relay/src/dns/transport.rs
@@ -25,14 +25,12 @@ use super::DnsError;
 /// prevent cache poisoning. The response source address is validated against
 /// the target nameserver.
 pub(super) async fn udp_query(addr: SocketAddr, query: &[u8]) -> Result<Vec<u8>, DnsError> {
-    let bind_addr = SocketAddr::new(
-        if addr.is_ipv6() {
-            std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED)
-        } else {
-            std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED)
-        },
-        0,
-    );
+    let unspecified: std::net::IpAddr = if addr.is_ipv6() {
+        std::net::Ipv6Addr::UNSPECIFIED.into()
+    } else {
+        std::net::Ipv4Addr::UNSPECIFIED.into()
+    };
+    let bind_addr = SocketAddr::new(unspecified, 0);
     let socket = tokio::net::UdpSocket::bind(bind_addr).await?;
     socket.send_to(query, addr).await?;
 

--- a/iroh-relay/src/dns/transport.rs
+++ b/iroh-relay/src/dns/transport.rs
@@ -2,6 +2,7 @@
 
 use std::{net::SocketAddr, sync::Arc};
 
+use n0_error::e;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::DnsError;
@@ -12,6 +13,10 @@ use super::DnsError;
 // cache poisoning).
 
 /// Send a DNS query over UDP and receive the response.
+///
+/// Each query uses a fresh socket with a random ephemeral source port to
+/// prevent cache poisoning. The response source address is validated against
+/// the target nameserver.
 pub(super) async fn udp_query(addr: SocketAddr, query: &[u8]) -> Result<Vec<u8>, DnsError> {
     let bind_addr = SocketAddr::new(
         if addr.is_ipv6() {
@@ -25,7 +30,15 @@ pub(super) async fn udp_query(addr: SocketAddr, query: &[u8]) -> Result<Vec<u8>,
     socket.send_to(query, addr).await?;
 
     let mut buf = vec![0u8; 4096];
-    let len = socket.recv(&mut buf).await?;
+    let (len, src) = socket.recv_from(&mut buf).await?;
+    if src != addr {
+        return Err(e!(DnsError::Transport {
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("DNS response from unexpected source {src}, expected {addr}"),
+            ),
+        }));
+    }
     buf.truncate(len);
     Ok(buf)
 }

--- a/iroh-relay/src/dns/transport.rs
+++ b/iroh-relay/src/dns/transport.rs
@@ -7,10 +7,17 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::DnsError;
 
-// TODO: Consider caching TCP and TLS connections per nameserver for connection reuse,
-// similar to how hickory-resolver multiplexes queries over persistent connections.
-// UDP sockets are intentionally not reused (new random source port per query prevents
-// cache poisoning).
+// Known limitation: TCP and TLS connections are not reused across queries.
+// Each query opens a fresh connection, which means a full TLS handshake per
+// DNS-over-TLS query. This adds significant latency for DoT/DoH workloads.
+// The default UDP-only configuration is not affected.
+//
+// A future improvement could maintain a per-nameserver connection pool for
+// TCP/TLS, similar to how hickory-resolver multiplexes queries over
+// persistent connections.
+//
+// UDP sockets are intentionally not reused (new random source port per query
+// prevents cache poisoning).
 
 /// Send a DNS query over UDP and receive the response.
 ///

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -496,6 +496,16 @@ async fn main() -> Result<()> {
         .with(EnvFilter::from_default_env())
         .init();
 
+    // Install `ring` as default crypto provider for rustls.
+    // This helps when both the tls-ring and tls-aws-lc-rs features are enabled,
+    // otherwise some crypto operations would panic because rustls can't determine
+    // a default provider.
+    // `ring` is enabled by the `tls-ring` feature, which is included in the `server` feature,
+    // which is required for the main.rs binary. Therefore, this does not need any feature flags.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to set default crypto provider");
+
     let cli = Cli::parse();
     let mut cfg = Config::load(&cli).await?;
     if cfg.enable_quic_addr_discovery && cfg.tls.is_none() {
@@ -702,7 +712,7 @@ mod tests {
 
     use iroh_base::SecretKey;
     use n0_error::Result;
-    use rand::SeedableRng;
+    use rand::{RngExt, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 
     use super::*;
@@ -750,7 +760,7 @@ mod tests {
         assert_eq!(config.access, AccessConfig::Everyone);
 
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let endpoint_id = SecretKey::generate(&mut rng).public();
+        let endpoint_id = SecretKey::from_bytes(&rng.random()).public();
 
         let config = format!(
             "


### PR DESCRIPTION
## Description

see individual commits

most prominent changes:
* retry nameserves at least once (its UDP, packets get lost)
* follow CNAME chains
* support EDNS for responses larger than 512bytes (up to ~1200 bytes)
* don't alloc on each cache get

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
