### PR TITLE
chore(iroh): Update hickory to 0.26.0-beta.4 and use exact-version deps for prereleased crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,7 +4951,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "swarm-discovery"
 version = "0.6.0-alpha.2"
-source = "git+https://github.com/n0-computer/swarm-discovery?branch=matheus23%2Fhickory-0.26-beta.4#ead497b4042870e1ee06db18de7c3579fbba9304"
+source = "git+https://github.com/n0-computer/swarm-discovery?branch=matheus23%2Fhickory-0.26-beta.4#f0d63255073d02dc022e89e8eaf15cfe194d7464"
 dependencies = [
  "acto",
  "hickory-proto 0.26.0-beta.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4950,9 +4950,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swarm-discovery"
-version = "0.6.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737bfdaf732174c48b8193b29158460d8d959dd8e9ce071a5bbda95d8546b68b"
+version = "0.6.0-alpha.2"
+source = "git+https://github.com/n0-computer/swarm-discovery?branch=matheus23%2Fhickory-0.26-beta.4#ead497b4042870e1ee06db18de7c3579fbba9304"
 dependencies = [
  "acto",
  "hickory-proto 0.26.0-beta.4",
@@ -6610,8 +6609,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[patch.unused]]
-name = "swarm-discovery"
-version = "0.6.0-alpha.2"
-source = "git+https://github.com/n0-computer/swarm-discovery?branch=matheus23%2Fhickory-0.26-beta.4#ead497b4042870e1ee06db18de7c3579fbba9304"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,9 +1840,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0-beta.1"
+version = "0.26.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc867c64bc89c63a3b1c34258e3bbbd73eb18f8ab785ff352c81c98ad187f78e"
+checksum = "1e232f503c4cfe3f4ea6594971255ecab9f6a0080c4c8e0e17630cc701322aa4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1852,7 +1852,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "h2",
- "hickory-proto 0.26.0-beta.1",
+ "hickory-proto 0.26.0-beta.4",
  "http",
  "idna",
  "ipnet",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0-beta.1"
+version = "0.26.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91ba40132ef5ec8f1eabddb35d1b5d9fae3699c4545c590401893636097caee"
+checksum = "fcca12171ce774c549f35510be702f4da00ef12ca486f0f2acb2ee96f2f5ca0f"
 dependencies = [
  "data-encoding",
  "idna",
@@ -1944,14 +1944,14 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0-beta.1"
+version = "0.26.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3691451dab87ca2d7e3018ae231347d3a502ef3e8c4430f454f7efefa84b1d"
+checksum = "1e7d2c928fa078e6640f26cf1b537b212e1688829c3944780025c7084e8bbbf6"
 dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.0-beta.1",
+ "hickory-proto 0.26.0-beta.4",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -2382,7 +2382,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "getrandom 0.4.2",
- "hickory-resolver 0.26.0-beta.1",
+ "hickory-resolver 0.26.0-beta.4",
  "http",
  "indicatif",
  "ipnet",
@@ -2580,7 +2580,7 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "getrandom 0.4.2",
- "hickory-resolver 0.26.0-beta.1",
+ "hickory-resolver 0.26.0-beta.4",
  "http",
  "http-body-util",
  "hyper",
@@ -4955,7 +4955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "737bfdaf732174c48b8193b29158460d8d959dd8e9ce071a5bbda95d8546b68b"
 dependencies = [
  "acto",
- "hickory-proto 0.26.0-beta.1",
+ "hickory-proto 0.26.0-beta.4",
  "rand 0.10.1",
  "socket2",
  "thiserror 2.0.18",
@@ -6610,3 +6610,8 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[patch.unused]]
+name = "swarm-discovery"
+version = "0.6.0-alpha.2"
+source = "git+https://github.com/n0-computer/swarm-discovery?branch=matheus23%2Fhickory-0.26-beta.4#ead497b4042870e1ee06db18de7c3579fbba9304"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,7 +4951,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "swarm-discovery"
 version = "0.6.0-alpha.2"
-source = "git+https://github.com/n0-computer/swarm-discovery?branch=matheus23%2Fhickory-0.26-beta.4#f0d63255073d02dc022e89e8eaf15cfe194d7464"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5ccbd3c5abd6e7314768de12649c1b0a29bea38fca4370f9408340c0f364a6"
 dependencies = [
  "acto",
  "hickory-proto 0.26.0-beta.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,3 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
-
-[patch.crates-io]
-swarm-discovery = { git = "https://github.com/n0-computer/swarm-discovery", branch = "matheus23/hickory-0.26-beta.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+swarm-discovery = { git = "https://github.com/n0-computer/swarm-discovery", branch = "matheus23/hickory-0.26-beta.4" }

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -81,14 +81,14 @@ time = { version = "0.3.37", optional = true }
 tokio-rustls-acme = { version = "0.9", optional = true }
 tokio-websockets = { version = "0.13", features = ["rustls-bring-your-own-connector", "getrandom", "rand", "server", "sha1_smol"], optional = true } # server-side websocket implementation
 simdutf8 = { version = "0.1.5", optional = true } # minimal version fix
-sha1 = { version = "0.11.0-rc.2", optional = true }
+sha1 = { version = "=0.11.0-rc.2", optional = true }
 toml = { version = "1.0", optional = true }
 serde_json = { version = "1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = { version = "=0.26.0-beta.1", features = ["tokio", "system-config"] }
+hickory-resolver = { version = "=0.26.0-beta.4", features = ["tokio", "system-config"] }
 tokio = { version = "1", features = [
     "io-util",
     "macros",

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -81,7 +81,7 @@ time = { version = "0.3.37", optional = true }
 tokio-rustls-acme = { version = "0.9", optional = true }
 tokio-websockets = { version = "0.13", features = ["rustls-bring-your-own-connector", "getrandom", "rand", "server", "sha1_smol"], optional = true } # server-side websocket implementation
 simdutf8 = { version = "0.1.5", optional = true } # minimal version fix
-sha1 = { version = "=0.11.0-rc.2", optional = true }
+sha1 = { version = "=0.11.0-rc.5", optional = true }
 toml = { version = "1.0", optional = true }
 serde_json = { version = "1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -585,7 +585,7 @@ impl Resolver for HickoryResolver {
             let lookup = resolver.ipv4_lookup(host).await?;
             let iter: BoxIter<Ipv4Addr> =
                 Box::new(lookup.answers().to_vec().into_iter().filter_map(|record| {
-                    match record.data() {
+                    match &record.data {
                         RData::A(addr) => Some(addr.0),
                         _ => None,
                     }
@@ -600,7 +600,7 @@ impl Resolver for HickoryResolver {
             let lookup = resolver.ipv6_lookup(host).await?;
             let iter: BoxIter<Ipv6Addr> =
                 Box::new(lookup.answers().to_vec().into_iter().filter_map(|record| {
-                    match record.data() {
+                    match &record.data {
                         RData::AAAA(addr) => Some(addr.0),
                         _ => None,
                     }
@@ -615,12 +615,12 @@ impl Resolver for HickoryResolver {
             let lookup = resolver.txt_lookup(host).await?;
             let iter: BoxIter<TxtRecordData> =
                 Box::new(lookup.answers().to_vec().into_iter().filter_map(|record| {
-                    match record.data() {
+                    match &record.data {
                         RData::TXT(txt) => {
                             // I don't know a way of avoiding this deep copy, even if it's agonizing.
                             // The representation of `TxtRecrodData` and `hickory_proto::rr::rdata::TXT`
                             // is identical.
-                            Some(TxtRecordData::from(txt.txt_data().to_vec()))
+                            Some(TxtRecordData::from(txt.txt_data.to_vec()))
                         }
                         _ => None,
                     }

--- a/iroh-relay/src/endpoint_info.rs
+++ b/iroh-relay/src/endpoint_info.rs
@@ -961,8 +961,8 @@ mod tests {
         let lookup = lookup
             .answers()
             .iter()
-            .filter_map(|record| match record.data() {
-                RData::TXT(txt) => Some(TxtRecordData::from(txt.txt_data().to_vec())),
+            .filter_map(|record| match &record.data {
+                RData::TXT(txt) => Some(TxtRecordData::from(txt.txt_data.to_vec())),
                 _ => None,
             });
 

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -69,7 +69,7 @@ pkcs8 = "0.11.0-rc.9"
 iroh-metrics = { version = "0.38", default-features = false }
 
 # mdns
-swarm-discovery = { version = "=0.6.0-alpha.1", optional = true }
+swarm-discovery = { version = "=0.6.0-alpha.2", optional = true }
 futures-util = "0.3"
 
 # test_utils

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -27,7 +27,7 @@ bytes = "1.11"
 ctutils = { version = "0.4.0", default-features = false }
 data-encoding = "2.2"
 derive_more = { version = "2.0.1", features = ["debug", "display", "from", "try_into", "deref", "from_str", "into_iterator"] }
-ed25519-dalek = { version = "=3.0.0-pre.1", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
+ed25519-dalek = { version = "=3.0.0-pre.6", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
 http = "1"
 ipnet = "2"
 iroh-base = { version = "0.97.0", default-features = false, features = ["key", "relay"], path = "../iroh-base" }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -27,7 +27,7 @@ bytes = "1.11"
 ctutils = { version = "0.4.0", default-features = false }
 data-encoding = "2.2"
 derive_more = { version = "2.0.1", features = ["debug", "display", "from", "try_into", "deref", "from_str", "into_iterator"] }
-ed25519-dalek = { version = "3.0.0-pre.1", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
+ed25519-dalek = { version = "=3.0.0-pre.1", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
 http = "1"
 ipnet = "2"
 iroh-base = { version = "0.97.0", default-features = false, features = ["key", "relay"], path = "../iroh-base" }
@@ -69,7 +69,7 @@ pkcs8 = "0.11.0-rc.9"
 iroh-metrics = { version = "0.38", default-features = false }
 
 # mdns
-swarm-discovery = { version = "0.6.0-alpha.1", optional = true }
+swarm-discovery = { version = "=0.6.0-alpha.1", optional = true }
 futures-util = "0.3"
 
 # test_utils
@@ -78,7 +78,8 @@ sync_wrapper = { version = "1.0.2", features = ["futures"] }
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hickory-resolver = { version = "=0.26.0-beta.1", default-features = false }
+
+hickory-resolver = { version = "=0.26.0-beta.4", default-features = false }
 portmapper = { version = "0.16", optional = true, default-features = false }
 noq = { version = "0.18.0", default-features = false, features = ["runtime-tokio", "rustls"] }
 tokio = { version = "1", features = [

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -265,8 +265,8 @@ pub(crate) mod dns_server {
             buf: &[u8],
         ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
             let packet = Message::from_bytes(buf)?;
-            debug!(queries = ?packet.queries(), %from, "received query");
-            let mut reply = packet.to_response();
+            debug!(queries = ?packet.queries, %from, "received query");
+            let mut reply = packet.clone().into_response();
             self.resolver.resolve(&packet, &mut reply).await?;
             debug!(?reply, %from, "send reply");
             let buf = reply.to_vec()?;
@@ -449,7 +449,7 @@ pub(crate) mod pkarr_dns_state {
             reply: &mut hickory_resolver::proto::op::Message,
             ttl: u32,
         ) -> std::io::Result<()> {
-            for query in query.queries() {
+            for query in &query.queries {
                 let domain_name = query.name().to_string();
                 let Some(endpoint_id) = endpoint_id_from_domain_name(&domain_name) else {
                     continue;


### PR DESCRIPTION
## Description

Updates hickory to 0.26.0-beta.4.

Also fixes a bunch of version bounds that were outdated, and some that were not exact version bounds, even though we were depending on a prerelease version.

# Notes

Waiting for https://github.com/rkuhn/swarm-discovery/pull/22 to be merged & released.