### PR TITLE
fix(iroh)!: don't stop address lookup when one service errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,7 +2419,6 @@ dependencies = [
  "smallvec",
  "strum 0.28.0",
  "swarm-discovery",
- "sync_wrapper",
  "testdir",
  "time",
  "tokio",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -27,7 +27,7 @@ derive_more = { version = "2.0.1", features = ["debug", "display"], optional = t
 url = { version = "2.5.3", features = ["serde"], optional = true }
 rand = { version = "0.10", optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
-n0-error = "0.1"
+n0-error = "0.1.3"
 zeroize = { version = "1.8.2", optional = true, features = ["derive"] }
 zeroize_derive = { version = "1.4.2", optional = true } # needed for minimal versions
 

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -41,7 +41,7 @@ rustls = { version = "0.23.33", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 struct_iterable = "0.1.1"
-n0-error = "0.1"
+n0-error = "0.1.3"
 strum = { version = "0.28", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging"] }

--- a/iroh-dns/Cargo.toml
+++ b/iroh-dns/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 derive_more = { version = "2.0.1", features = ["debug"] }
 iroh-base = { version = "0.97.0", path = "../iroh-base", default-features = false, features = ["key"] }
-n0-error = "0.1"
+n0-error = "0.1.3"
 n0-future = "0.3"
 simple-dns = "0.9"
 strum = { version = "0.28", features = ["derive"] }

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -37,7 +37,7 @@ iroh-base = { version = "0.97.0", path = "../iroh-base", default-features = fals
 iroh-dns = { version = "0.97.0", path = "../iroh-dns" }
 iroh-metrics = { version = "0.38", default-features = false }
 lru = "0.16.3"
-n0-error = "0.1"
+n0-error = "0.1.3"
 n0-future = "0.3"
 num_enum = "0.7"
 pin-project = "1"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -34,7 +34,7 @@ iroh-base = { version = "0.97.0", default-features = false, features = ["key", "
 iroh-dns = { version = "0.97", path = "../iroh-dns" }
 iroh-relay = { version = "0.97", path = "../iroh-relay", default-features = false }
 n0-future = "0.3"
-n0-error = "0.1"
+n0-error = "0.1.3"
 n0-watcher = "0.6"
 netwatch = "0.16"
 papaya = { version = "0.2.3", default-features = false }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -74,7 +74,6 @@ futures-util = "0.3"
 
 # test_utils
 axum = { version = "0.8", optional = true }
-sync_wrapper = { version = "1.0.2", features = ["futures"] }
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]

--- a/iroh/bench/Cargo.toml
+++ b/iroh/bench/Cargo.toml
@@ -11,7 +11,7 @@ hdrhistogram = { version = "7.2", default-features = false }
 iroh = { path = "..", default-features = false }
 iroh-metrics = { version = "0.38", optional = true }
 n0-future = "0.3"
-n0-error = "0.1"
+n0-error = "0.1.3"
 noq = "0.18.0"
 rand = "0.10"
 rcgen = "0.14"

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -290,7 +290,7 @@ impl AddressLookupBuilderError {
 #[stack_error(derive, add_meta)]
 #[non_exhaustive]
 #[derive(Clone)]
-pub enum LookupFailed {
+pub enum AddressLookupFailed {
     #[error("No address lookup configured")]
     NoServiceConfigured,
     #[error(

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -290,16 +290,31 @@ impl AddressLookupBuilderError {
 #[stack_error(derive, add_meta)]
 #[non_exhaustive]
 #[derive(Clone)]
-pub enum Error {
+pub enum LookupFailed {
     #[error("No address lookup configured")]
     NoServiceConfigured,
-    #[error("Address lookup produced no results")]
-    NoResults,
-    #[error("Service '{provenance}' error")]
-    User {
-        provenance: &'static str,
-        source: Arc<AnyError>,
-    },
+    #[error(
+        "All address lookup services failed or produced no results{}",
+        {
+            let errors = errors.iter().map(|err| format!("{err:#}")).collect::<Vec<_>>();
+            if !errors.is_empty() {
+                format!("\n    {}", errors.join("\n    "))
+            } else {
+                String::new()
+            }
+        }
+    )]
+    NoResults { errors: Vec<Error> },
+}
+
+/// Error returned by address lookup services when failing to perform the lookup.
+#[stack_error(derive, add_meta)]
+#[error("Service '{provenance}' failed")]
+#[derive(Clone)]
+pub struct Error {
+    provenance: &'static str,
+    #[error(source)]
+    source: Arc<AnyError>,
 }
 
 impl Error {
@@ -324,10 +339,7 @@ impl Error {
     /// Creates a new user error from an arbitrary error type that can be converted into [`AnyError`].
     #[track_caller]
     pub fn from_err_any(provenance: &'static str, source: impl Into<AnyError>) -> Self {
-        e!(Error::User {
-            provenance,
-            source: Arc::new(source.into())
-        })
+        Self::new(provenance, Arc::new(source.into()))
     }
 }
 
@@ -573,12 +585,16 @@ impl AddressLookup for ConcurrentAddressLookup {
 
     fn resolve(&self, endpoint_id: EndpointId) -> Option<BoxStream<Result<Item, Error>>> {
         let services = self.services.read().expect("poisoned");
-        let streams = services
+        let mut streams = services
             .iter()
-            .filter_map(|service| service.resolve(endpoint_id));
-
-        let streams = n0_future::MergeBounded::from_iter(streams);
-        Some(Box::pin(streams))
+            .filter_map(|service| service.resolve(endpoint_id))
+            .peekable();
+        if streams.peek().is_none() {
+            None
+        } else {
+            let streams = n0_future::MergeBounded::from_iter(streams);
+            Some(Box::pin(streams))
+        }
     }
 }
 
@@ -703,6 +719,32 @@ mod tests {
         }
     }
 
+    /// An address lookup that yields a single `Err(_)` after `delay` and then ends.
+    ///
+    /// Used to reproduce the issue where one resolver's error truncates the merged
+    /// stream of a [`ConcurrentAddressLookup`], hiding subsequent successful results
+    /// from other resolvers.
+    #[derive(Debug, Clone)]
+    struct FailingAddressLookup {
+        delay: Duration,
+    }
+
+    impl AddressLookup for FailingAddressLookup {
+        fn publish(&self, _data: &EndpointData) {}
+
+        fn resolve(&self, _endpoint_id: EndpointId) -> Option<BoxStream<Result<Item, Error>>> {
+            let delay = self.delay;
+            let fut = async move {
+                time::sleep(delay).await;
+                Err(Error::from_err(
+                    "failing-test",
+                    std::io::Error::other("simulated resolver failure"),
+                ))
+            };
+            Some(n0_future::stream::once_future(fut).boxed())
+        }
+    }
+
     const TEST_ALPN: &[u8] = b"n0/iroh/test";
 
     /// This is a smoke test for our Address Lookupmechanism.
@@ -804,6 +846,46 @@ mod tests {
         .await;
 
         let _conn = ep2.connect(ep1.id(), TEST_ALPN).await?;
+        Ok(())
+    }
+
+    /// Regression test for https://github.com/n0-computer/iroh/issues/4125
+    ///
+    /// When one resolver in a [`ConcurrentAddressLookup`] returns `Err(_)` early,
+    /// the merged stream is currently replaced with `pending()`, hiding any later
+    /// `Ok(_)` results from other resolvers. This test verifies that a slow but
+    /// successful resolver still delivers its result after a fast failing one errors.
+    #[tokio::test]
+    #[traced_test]
+    async fn address_lookup_succeeds_after_other_resolver_errors() -> Result {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
+        let address_lookup_shared = TestAddressLookupShared::default();
+        let (ep1, _guard1) = new_endpoint_add(&mut rng, |ep| {
+            ep.address_lookup()
+                .unwrap()
+                .add(address_lookup_shared.create_address_lookup(ep.id()));
+        })
+        .await;
+
+        let (ep2, _guard2) = new_endpoint_add(&mut rng, |ep| {
+            // Failing resolver errors first (50ms), working resolver delivers later (200ms).
+            // Without the fix, the error from the failing resolver terminates the stream
+            // before the working resolver's result arrives, so connect times out.
+            let failing = FailingAddressLookup {
+                delay: Duration::from_millis(50),
+            };
+            // This lookup has a delay of 200ms (hardcoded).
+            let working = address_lookup_shared.create_address_lookup(ep.id());
+            let address_lookup = ep.address_lookup().unwrap();
+            address_lookup.add(failing);
+            address_lookup.add(working);
+        })
+        .await;
+
+        let _conn = ep2
+            .connect(ep1.id(), TEST_ALPN)
+            .await
+            .context("connect after other resolver errored")?;
         Ok(())
     }
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -52,7 +52,7 @@ use crate::{
     NetReport,
     address_lookup::{
         AddrFilter, AddressLookupBuilder, ConcurrentAddressLookup, DynAddressLookupBuilder,
-        Error as AddressLookupError, UserData,
+        LookupFailed, UserData,
     },
     endpoint::presets::Preset,
     metrics::EndpointMetrics,
@@ -838,7 +838,7 @@ pub enum ConnectWithOptsError {
     #[error("Connecting to ourself is not supported")]
     SelfConnect,
     #[error("No addressing information available")]
-    NoAddress { source: AddressLookupError },
+    NoAddress { source: LookupFailed },
     #[error("Unable to connect to remote")]
     Noq {
         #[error(std_err)]

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -51,8 +51,8 @@ pub use crate::tls::TlsConfigError;
 use crate::{
     NetReport,
     address_lookup::{
-        AddrFilter, AddressLookupBuilder, ConcurrentAddressLookup, DynAddressLookupBuilder,
-        LookupFailed, UserData,
+        AddrFilter, AddressLookupBuilder, AddressLookupFailed, ConcurrentAddressLookup,
+        DynAddressLookupBuilder, UserData,
     },
     endpoint::presets::Preset,
     metrics::EndpointMetrics,
@@ -838,7 +838,7 @@ pub enum ConnectWithOptsError {
     #[error("Connecting to ourself is not supported")]
     SelfConnect,
     #[error("No addressing information available")]
-    NoAddress { source: LookupFailed },
+    NoAddress { source: AddressLookupFailed },
     #[error("Unable to connect to remote")]
     Noq {
         #[error(std_err)]

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -67,7 +67,7 @@ use crate::dns::DnsResolver;
 #[cfg(not(wasm_browser))]
 use crate::net_report::QuicConfig;
 use crate::{
-    address_lookup::{self, AddressLookup, EndpointData, LookupFailed, UserData},
+    address_lookup::{self, AddressLookup, AddressLookupFailed, EndpointData, UserData},
     defaults::timeouts::NET_REPORT_TIMEOUT,
     endpoint::{hooks::EndpointHooksList, quic::QuicTransportConfig},
     metrics::EndpointMetrics,
@@ -1259,7 +1259,8 @@ impl EndpointInner {
     pub(crate) async fn resolve_remote(
         &self,
         addr: EndpointAddr,
-    ) -> Result<Result<EndpointIdMappedAddr, LookupFailed>, RemoteStateActorStoppedError> {
+    ) -> Result<Result<EndpointIdMappedAddr, AddressLookupFailed>, RemoteStateActorStoppedError>
+    {
         let (tx, rx) = oneshot::channel();
         self.actor_sender
             .send(ActorMessage::ResolveRemote(addr, tx))
@@ -1315,7 +1316,7 @@ enum ActorMessage {
     ResolveRemote(
         EndpointAddr,
         oneshot::Sender<
-            Result<Result<EndpointIdMappedAddr, LookupFailed>, RemoteStateActorStoppedError>,
+            Result<Result<EndpointIdMappedAddr, AddressLookupFailed>, RemoteStateActorStoppedError>,
         >,
     ),
     #[debug("AddConnection(..)")]

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -67,7 +67,7 @@ use crate::dns::DnsResolver;
 #[cfg(not(wasm_browser))]
 use crate::net_report::QuicConfig;
 use crate::{
-    address_lookup::{self, AddressLookup, EndpointData, Error as AddressLookupError, UserData},
+    address_lookup::{self, AddressLookup, EndpointData, LookupFailed, UserData},
     defaults::timeouts::NET_REPORT_TIMEOUT,
     endpoint::{hooks::EndpointHooksList, quic::QuicTransportConfig},
     metrics::EndpointMetrics,
@@ -1259,8 +1259,7 @@ impl EndpointInner {
     pub(crate) async fn resolve_remote(
         &self,
         addr: EndpointAddr,
-    ) -> Result<Result<EndpointIdMappedAddr, AddressLookupError>, RemoteStateActorStoppedError>
-    {
+    ) -> Result<Result<EndpointIdMappedAddr, LookupFailed>, RemoteStateActorStoppedError> {
         let (tx, rx) = oneshot::channel();
         self.actor_sender
             .send(ActorMessage::ResolveRemote(addr, tx))
@@ -1316,7 +1315,7 @@ enum ActorMessage {
     ResolveRemote(
         EndpointAddr,
         oneshot::Sender<
-            Result<Result<EndpointIdMappedAddr, AddressLookupError>, RemoteStateActorStoppedError>,
+            Result<Result<EndpointIdMappedAddr, LookupFailed>, RemoteStateActorStoppedError>,
         >,
     ),
     #[debug("AddConnection(..)")]

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -28,7 +28,7 @@ use super::{
     transports,
 };
 use crate::{
-    address_lookup::{self, LookupFailed},
+    address_lookup::{self, AddressLookupFailed},
     socket::{
         RemoteStateActorStoppedError,
         concurrent_read_map::{ConcurrentReadMap, ReadOnlyMap},
@@ -228,7 +228,8 @@ impl RemoteMap {
     pub(super) async fn resolve_remote(
         &mut self,
         addr: EndpointAddr,
-    ) -> Result<Result<EndpointIdMappedAddr, LookupFailed>, RemoteStateActorStoppedError> {
+    ) -> Result<Result<EndpointIdMappedAddr, AddressLookupFailed>, RemoteStateActorStoppedError>
+    {
         let EndpointAddr { id, addrs } = addr;
         let actor = self.remote_state_actor(id);
         let (tx, rx) = oneshot::channel();

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -28,7 +28,7 @@ use super::{
     transports,
 };
 use crate::{
-    address_lookup,
+    address_lookup::{self, LookupFailed},
     socket::{
         RemoteStateActorStoppedError,
         concurrent_read_map::{ConcurrentReadMap, ReadOnlyMap},
@@ -228,8 +228,7 @@ impl RemoteMap {
     pub(super) async fn resolve_remote(
         &mut self,
         addr: EndpointAddr,
-    ) -> Result<Result<EndpointIdMappedAddr, address_lookup::Error>, RemoteStateActorStoppedError>
-    {
+    ) -> Result<Result<EndpointIdMappedAddr, LookupFailed>, RemoteStateActorStoppedError> {
         let EndpointAddr { id, addrs } = addr;
         let actor = self.remote_state_actor(id);
         let (tx, rx) = oneshot::channel();

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -3,13 +3,13 @@ use std::{
     net::SocketAddr,
     pin::Pin,
     sync::Arc,
-    task::Poll,
+    task::{Poll, ready},
 };
 
 use iroh_base::{CustomAddr, EndpointId, RelayUrl, TransportAddr};
-use n0_error::StackResultExt;
+use n0_error::{StackResultExt, e};
 use n0_future::{
-    Either, FuturesUnordered, MergeUnbounded, Stream, StreamExt,
+    FuturesUnordered, MergeUnbounded, Stream, StreamExt,
     boxed::BoxStream,
     task::JoinSet,
     time::{self, Duration, Instant},
@@ -18,7 +18,6 @@ use n0_watcher::{Watchable, Watcher};
 use noq::{ConnectionError, WeakConnectionHandle};
 use noq_proto::{PathError, PathEvent, PathId, n0_nat_traversal};
 use rustc_hash::FxHashMap;
-use sync_wrapper::SyncStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Level, Span, debug, error, event, info_span, instrument, trace, warn};
@@ -33,7 +32,7 @@ use super::Source;
 use crate::{
     address_lookup::{
         AddressLookup, ConcurrentAddressLookup, Error as AddressLookupError,
-        Item as AddressLookupItem,
+        Item as AddressLookupItem, LookupFailed,
     },
     endpoint::DirectAddr,
     socket::{
@@ -97,18 +96,6 @@ type AddrEvents = MergeUnbounded<
             dyn Stream<Item = (ConnId, Result<n0_nat_traversal::Event, noq::Lagged>)> + Send + Sync,
         >,
     >,
->;
-
-/// Either a stream of incoming results from [`ConcurrentAddressLookup::resolve`] or infinitely pending.
-///
-/// Set to [`Either::Left`] with an always-pending stream while address lookup is not running, and to
-/// [`Either::Right`] while Address Lookup is running.
-///
-/// The stream returned from [`ConcurrentAddressLookup::resolve`] is `!Sync`. We use the (safe) [`SyncStream`]
-/// wrapper to make it `Sync` so that the [`RemoteStateActor::run`] future stays `Send`.
-type AddressLookupStream = Either<
-    n0_future::stream::Pending<Result<AddressLookupItem, AddressLookupError>>,
-    SyncStream<BoxStream<Result<AddressLookupItem, AddressLookupError>>>,
 >;
 
 /// The state we need to know about a single remote endpoint.
@@ -210,7 +197,7 @@ impl RemoteStateActor {
             scheduled_holepunch: None,
             scheduled_open_path: None,
             pending_open_paths: VecDeque::new(),
-            address_lookup_stream: Either::Left(n0_future::stream::pending()),
+            address_lookup_stream: AddressLookupStream::default(),
             transport_bias,
         }
     }
@@ -324,7 +311,7 @@ impl RemoteStateActor {
                     self.scheduled_holepunch = None;
                     self.trigger_holepunching();
                 }
-                item = self.address_lookup_stream.next() => {
+                Some(item) = self.address_lookup_stream.next(), if !self.address_lookup_stream.is_empty() => {
                     self.handle_address_lookup_item(item);
                 }
                 _ = check_connections.tick() => {
@@ -531,7 +518,7 @@ impl RemoteStateActor {
     fn handle_msg_resolve_remote(
         &mut self,
         addrs: BTreeSet<TransportAddr>,
-        tx: oneshot::Sender<Result<(), AddressLookupError>>,
+        tx: oneshot::Sender<Result<(), LookupFailed>>,
     ) {
         let addrs = to_transports_addr(self.endpoint_id, addrs);
         self.paths.insert_multiple(addrs, Source::App);
@@ -584,14 +571,14 @@ impl RemoteStateActor {
     /// Does not start Address Lookup if we have a selected path or if Address Lookup is
     /// currently running.
     fn trigger_address_lookup(&mut self) {
-        if self.selected_path.get().is_some()
-            || matches!(self.address_lookup_stream, Either::Right(_))
-        {
+        if self.selected_path.get().is_some() || !self.address_lookup_stream.is_empty() {
             return;
         }
         match self.address_lookup.resolve(self.endpoint_id) {
-            Some(stream) => self.address_lookup_stream = Either::Right(SyncStream::new(stream)),
-            None => self.paths.address_lookup_finished(Ok(())),
+            Some(stream) => self.address_lookup_stream.set(stream),
+            None => self
+                .paths
+                .address_lookup_finished(Err(e!(LookupFailed::NoServiceConfigured))),
         }
     }
 
@@ -599,21 +586,13 @@ impl RemoteStateActor {
     ///
     /// All address lookup results end up being sent here. It takes care of updating the
     /// [`RemotePathState`] with the results.
-    fn handle_address_lookup_item(
-        &mut self,
-        item: Option<Result<AddressLookupItem, AddressLookupError>>,
-    ) {
+    fn handle_address_lookup_item(&mut self, item: Result<AddressLookupItem, LookupFailed>) {
         match item {
-            None => {
-                self.address_lookup_stream = Either::Left(n0_future::stream::pending());
-                self.paths.address_lookup_finished(Ok(()));
-            }
-            Some(Err(err)) => {
+            Err(err) => {
                 warn!("Address Lookup failed: {err:#}");
-                self.address_lookup_stream = Either::Left(n0_future::stream::pending());
                 self.paths.address_lookup_finished(Err(err));
             }
-            Some(Ok(item)) => {
+            Ok(item) => {
                 if item.endpoint_id() != self.endpoint_id {
                     warn!(
                         ?item,
@@ -1217,7 +1196,7 @@ pub(crate) enum RemoteStateMessage {
     #[debug("ResolveRemote(..)")]
     ResolveRemote(
         BTreeSet<TransportAddr>,
-        oneshot::Sender<Result<(), AddressLookupError>>,
+        oneshot::Sender<Result<(), LookupFailed>>,
     ),
     /// Returns information about the remote.
     ///
@@ -1365,6 +1344,87 @@ fn to_transports_addr(
             None
         }
     })
+}
+
+/// Stream wrapper around the result of [`ConcurrentAddressLookup::resolve`].
+///
+/// Holds an optional inner stream and yields only `Ok(_)` items from it.
+/// Errors from the inner stream are buffered internally so a single failing
+/// lookup does not hide results from other lookups still in flight.
+///
+/// # Usage
+///
+/// Construct with [`Default`] and attach the lookup stream via [`Self::set`]
+/// when one is started. Re-attaching with [`Self::set`] replaces the previous
+/// stream and clears any buffered state.
+///
+/// Use [`Self::is_empty`] to check whether a stream is currently attached;
+/// polling without an attached stream immediately yields `Ready(None)`, which
+/// lets the surrounding actor select over this stream unconditionally.
+///
+/// # Output
+///
+/// While the inner stream is live, the wrapper yields each `Ok(item)` and
+/// silently buffers any `Err(_)`. When the inner stream ends:
+///
+/// - If at least one item was yielded, the wrapper ends and buffered errors
+///   are discarded.
+/// - If no item was yielded, the wrapper yields a single
+///   [`LookupFailed::NoResults`] carrying all buffered errors, then ends.
+#[derive(Default)]
+struct AddressLookupStream {
+    inner: Option<BoxStream<Result<AddressLookupItem, AddressLookupError>>>,
+    errors: Option<Vec<AddressLookupError>>,
+    did_emit: bool,
+}
+
+impl AddressLookupStream {
+    fn is_empty(&self) -> bool {
+        self.inner.is_none()
+    }
+
+    fn set(&mut self, stream: BoxStream<Result<AddressLookupItem, AddressLookupError>>) {
+        self.inner = Some(stream);
+        self.errors = None;
+        self.did_emit = false;
+    }
+}
+
+impl Stream for AddressLookupStream {
+    type Item = Result<AddressLookupItem, LookupFailed>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            let item = match this.inner.as_mut() {
+                None => None,
+                Some(stream) => match ready!(Pin::new(stream).poll_next(cx)) {
+                    Some(Ok(item)) => {
+                        this.did_emit = true;
+                        Some(Ok(item))
+                    }
+                    Some(Err(error)) => {
+                        debug!("address lookup error: {error:#}");
+                        this.errors.get_or_insert_default().push(error);
+                        continue;
+                    }
+                    None => {
+                        this.inner = None;
+                        if !this.did_emit {
+                            let errors = this.errors.take().unwrap_or_default();
+                            Some(Err(e!(LookupFailed::NoResults { errors })))
+                        } else {
+                            None
+                        }
+                    }
+                },
+            };
+            return Poll::Ready(item);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -1370,7 +1370,7 @@ fn to_transports_addr(
 /// - If at least one item was yielded, the wrapper ends and buffered errors
 ///   are discarded.
 /// - If no item was yielded, the wrapper yields a single
-///   [`LookupFailed::NoResults`] carrying all buffered errors, then ends.
+///   [`AddressLookupFailed::NoResults`] carrying all buffered errors, then ends.
 #[derive(Default)]
 struct AddressLookupStream {
     inner: Option<BoxStream<Result<AddressLookupItem, AddressLookupError>>>,

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -31,8 +31,8 @@ pub use self::{
 use super::Source;
 use crate::{
     address_lookup::{
-        AddressLookup, ConcurrentAddressLookup, Error as AddressLookupError,
-        Item as AddressLookupItem, LookupFailed,
+        AddressLookup, AddressLookupFailed, ConcurrentAddressLookup, Error as AddressLookupError,
+        Item as AddressLookupItem,
     },
     endpoint::DirectAddr,
     socket::{
@@ -518,7 +518,7 @@ impl RemoteStateActor {
     fn handle_msg_resolve_remote(
         &mut self,
         addrs: BTreeSet<TransportAddr>,
-        tx: oneshot::Sender<Result<(), LookupFailed>>,
+        tx: oneshot::Sender<Result<(), AddressLookupFailed>>,
     ) {
         let addrs = to_transports_addr(self.endpoint_id, addrs);
         self.paths.insert_multiple(addrs, Source::App);
@@ -578,7 +578,7 @@ impl RemoteStateActor {
             Some(stream) => self.address_lookup_stream.set(stream),
             None => self
                 .paths
-                .address_lookup_finished(Err(e!(LookupFailed::NoServiceConfigured))),
+                .address_lookup_finished(Err(e!(AddressLookupFailed::NoServiceConfigured))),
         }
     }
 
@@ -586,7 +586,7 @@ impl RemoteStateActor {
     ///
     /// All address lookup results end up being sent here. It takes care of updating the
     /// [`RemotePathState`] with the results.
-    fn handle_address_lookup_item(&mut self, item: Result<AddressLookupItem, LookupFailed>) {
+    fn handle_address_lookup_item(&mut self, item: Result<AddressLookupItem, AddressLookupFailed>) {
         match item {
             Err(err) => {
                 warn!("Address Lookup failed: {err:#}");
@@ -1196,7 +1196,7 @@ pub(crate) enum RemoteStateMessage {
     #[debug("ResolveRemote(..)")]
     ResolveRemote(
         BTreeSet<TransportAddr>,
-        oneshot::Sender<Result<(), LookupFailed>>,
+        oneshot::Sender<Result<(), AddressLookupFailed>>,
     ),
     /// Returns information about the remote.
     ///
@@ -1391,7 +1391,7 @@ impl AddressLookupStream {
 }
 
 impl Stream for AddressLookupStream {
-    type Item = Result<AddressLookupItem, LookupFailed>;
+    type Item = Result<AddressLookupItem, AddressLookupFailed>;
 
     fn poll_next(
         self: Pin<&mut Self>,
@@ -1415,7 +1415,7 @@ impl Stream for AddressLookupStream {
                         this.inner = None;
                         if !this.did_emit {
                             let errors = this.errors.take().unwrap_or_default();
-                            Some(Err(e!(LookupFailed::NoResults { errors })))
+                            Some(Err(e!(AddressLookupFailed::NoResults { errors })))
                         } else {
                             None
                         }

--- a/iroh/src/socket/remote_map/remote_state/path_state.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_state.rs
@@ -12,7 +12,7 @@ use tokio::sync::oneshot;
 use tracing::trace;
 
 use super::{Source, TransportAddrInfo, TransportAddrUsage};
-use crate::{address_lookup::LookupFailed, metrics::SocketMetrics, socket::transports};
+use crate::{address_lookup::AddressLookupFailed, metrics::SocketMetrics, socket::transports};
 
 /// Maximum number of non-relay paths we keep around per endpoint.
 pub(super) const MAX_NON_RELAY_PATHS: usize = 30;
@@ -34,7 +34,7 @@ pub(super) struct RemotePathState {
     /// mechanisms. The are only potentially usable.
     paths: FxHashMap<transports::Addr, PathState>,
     /// Pending resolve requests from [`Self::resolve_remote`].
-    pending_resolve_requests: VecDeque<oneshot::Sender<Result<(), LookupFailed>>>,
+    pending_resolve_requests: VecDeque<oneshot::Sender<Result<(), AddressLookupFailed>>>,
     metrics: Arc<SocketMetrics>,
 }
 
@@ -150,8 +150,8 @@ impl RemotePathState {
     ///
     /// If there already is a known path, `Ok(())` is returned immediately. Otherwise an
     /// address lookup is performed and the result is sent back once that
-    /// completes. [`AddressLookupError`] is sent if there are no known paths.
-    pub(super) fn resolve_remote(&mut self, tx: oneshot::Sender<Result<(), LookupFailed>>) {
+    /// completes. [`AddressLookupFailed`] is sent if there are no known paths.
+    pub(super) fn resolve_remote(&mut self, tx: oneshot::Sender<Result<(), AddressLookupFailed>>) {
         if !self.paths.is_empty() {
             tx.send(Ok(())).ok();
         } else {
@@ -162,7 +162,7 @@ impl RemotePathState {
     /// Notifies that a Address Lookup run has finished.
     ///
     /// This will emit pending resolve requests.
-    pub(super) fn address_lookup_finished(&mut self, result: Result<(), LookupFailed>) {
+    pub(super) fn address_lookup_finished(&mut self, result: Result<(), AddressLookupFailed>) {
         self.emit_pending_resolve_requests(result.err());
     }
 
@@ -180,14 +180,14 @@ impl RemotePathState {
     ///
     /// This is a no-op if no requests are queued. Replies `Ok` if we have any known paths,
     /// otherwise with the provided `address_lookup_error` or with [`LookupFailed::NoResults`].
-    fn emit_pending_resolve_requests(&mut self, address_lookup_error: Option<LookupFailed>) {
+    fn emit_pending_resolve_requests(&mut self, address_lookup_error: Option<AddressLookupFailed>) {
         if self.pending_resolve_requests.is_empty() {
             return;
         }
         let result = match (self.paths.is_empty(), address_lookup_error) {
             (false, _) => Ok(()),
             (true, Some(err)) => Err(err),
-            (true, None) => Err(e!(LookupFailed::NoResults { errors: Vec::new() })),
+            (true, None) => Err(e!(AddressLookupFailed::NoResults { errors: Vec::new() })),
         };
         for tx in self.pending_resolve_requests.drain(..) {
             tx.send(result.clone()).ok();

--- a/iroh/src/socket/remote_map/remote_state/path_state.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_state.rs
@@ -12,9 +12,7 @@ use tokio::sync::oneshot;
 use tracing::trace;
 
 use super::{Source, TransportAddrInfo, TransportAddrUsage};
-use crate::{
-    address_lookup::Error as AddressLookupError, metrics::SocketMetrics, socket::transports,
-};
+use crate::{address_lookup::LookupFailed, metrics::SocketMetrics, socket::transports};
 
 /// Maximum number of non-relay paths we keep around per endpoint.
 pub(super) const MAX_NON_RELAY_PATHS: usize = 30;
@@ -36,7 +34,7 @@ pub(super) struct RemotePathState {
     /// mechanisms. The are only potentially usable.
     paths: FxHashMap<transports::Addr, PathState>,
     /// Pending resolve requests from [`Self::resolve_remote`].
-    pending_resolve_requests: VecDeque<oneshot::Sender<Result<(), AddressLookupError>>>,
+    pending_resolve_requests: VecDeque<oneshot::Sender<Result<(), LookupFailed>>>,
     metrics: Arc<SocketMetrics>,
 }
 
@@ -153,7 +151,7 @@ impl RemotePathState {
     /// If there already is a known path, `Ok(())` is returned immediately. Otherwise an
     /// address lookup is performed and the result is sent back once that
     /// completes. [`AddressLookupError`] is sent if there are no known paths.
-    pub(super) fn resolve_remote(&mut self, tx: oneshot::Sender<Result<(), AddressLookupError>>) {
+    pub(super) fn resolve_remote(&mut self, tx: oneshot::Sender<Result<(), LookupFailed>>) {
         if !self.paths.is_empty() {
             tx.send(Ok(())).ok();
         } else {
@@ -164,7 +162,7 @@ impl RemotePathState {
     /// Notifies that a Address Lookup run has finished.
     ///
     /// This will emit pending resolve requests.
-    pub(super) fn address_lookup_finished(&mut self, result: Result<(), AddressLookupError>) {
+    pub(super) fn address_lookup_finished(&mut self, result: Result<(), LookupFailed>) {
         self.emit_pending_resolve_requests(result.err());
     }
 
@@ -181,15 +179,15 @@ impl RemotePathState {
     /// Replies to all pending resolve requests.
     ///
     /// This is a no-op if no requests are queued. Replies `Ok` if we have any known paths,
-    /// otherwise with the provided `address_lookup_error` or with [`AddressLookupError::NoResults`].
-    fn emit_pending_resolve_requests(&mut self, address_lookup_error: Option<AddressLookupError>) {
+    /// otherwise with the provided `address_lookup_error` or with [`LookupFailed::NoResults`].
+    fn emit_pending_resolve_requests(&mut self, address_lookup_error: Option<LookupFailed>) {
         if self.pending_resolve_requests.is_empty() {
             return;
         }
         let result = match (self.paths.is_empty(), address_lookup_error) {
             (false, _) => Ok(()),
             (true, Some(err)) => Err(err),
-            (true, None) => Err(e!(AddressLookupError::NoResults)),
+            (true, None) => Err(e!(LookupFailed::NoResults { errors: Vec::new() })),
         };
         for tx in self.pending_resolve_requests.drain(..) {
             tx.send(result.clone()).ok();

--- a/iroh/src/socket/remote_map/remote_state/path_state.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_state.rs
@@ -179,7 +179,7 @@ impl RemotePathState {
     /// Replies to all pending resolve requests.
     ///
     /// This is a no-op if no requests are queued. Replies `Ok` if we have any known paths,
-    /// otherwise with the provided `address_lookup_error` or with [`LookupFailed::NoResults`].
+    /// otherwise with the provided `address_lookup_error` or with [`AddressLookupFailed::NoResults`].
     fn emit_pending_resolve_requests(&mut self, address_lookup_error: Option<AddressLookupFailed>) {
         if self.pending_resolve_requests.is_empty() {
             return;

--- a/iroh/src/socket/remote_map/remote_state/path_state.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_state.rs
@@ -282,7 +282,7 @@ fn prune_non_relay_paths(paths: &mut FxHashMap<transports::Addr, PathState>) {
     }
 
     // sort the potentially prunable from most recently closed to least recently closed
-    inactive.sort_by(|a, b| b.1.cmp(&a.1));
+    inactive.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     // Prune the "oldest" closed paths.
     let old_inactive =


### PR DESCRIPTION
## Description

We currently abort address lookup on the first error from *any* service. This is a bug, we should run each service to completion and only abort once all completed or failed.

Fixes #4125

Turns out our current errors were not equipped to handle this well. Refactored into
a) The error returned from an individual address lookup service. This is just a struct now, because `NoServicesConfigured` didn't ever make sense here, and `NoResults` is expressed by returning `None` without yielding items.
b) The error returned from a lookup across all services now has `NoServicesConfigured` and `NoResults` variants only, where the latter can contain the errors emitted from individual services


## Breaking Changes

* changed: `iroh::address_lookup::Error` is now a struct. Existing constructor methods are unchanged.
* changed: `iroh::endpoint::ConnectWithOptsError::NoAddress { source }`: The `source` field now has type `AddressLookupFailed`, which is a new error type that can hold errors for *all* failed lookup services

## Notes & open questions

It might be more appropriate to move the new format of the stream right into `ConcurrentAddressLookup`. However, with the different error type, it could no longer implement `AddressLookup` - which it arguably doesn't have to. Maybe that would be the cleaner refactor?

See #4130 

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.