### PR TITLE
fix(iroh-relay): treat frames not allowed in a protocol version as error

### DIFF
--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -384,7 +384,7 @@ impl ClientBuilder {
         let protocol_version =
             ProtocolVersion::match_from_str(&ws_meta.protocol()).ok_or_else(|| {
                 e!(ConnectError::BadVersionHeader {
-                    server_version: protocol_version_str.map(ToOwned::to_owned)
+                    server_version: Some(ws_meta.protocol())
                 })
             })?;
 

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -61,6 +61,11 @@ pub enum ConnectError {
         #[error(std_err)]
         source: ws_stream_wasm::WsErr,
     },
+    #[error(
+        "Server replied with invalid iroh-relay version header: {}",
+        server_version.as_deref().unwrap_or("<empty>")
+    )]
+    BadVersionHeader { server_version: Option<String> },
     #[error(transparent)]
     Handshake {
         #[error(std_err)]
@@ -302,7 +307,25 @@ impl ClientBuilder {
             }
         );
 
-        let conn = Conn::new(conn, self.key_cache.clone(), &self.secret_key).await?;
+        let protocol_version_str = response
+            .headers()
+            .get(SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|s| s.to_str().ok());
+        let protocol_version = protocol_version_str
+            .and_then(ProtocolVersion::match_from_str)
+            .ok_or_else(|| {
+                e!(ConnectError::BadVersionHeader {
+                    server_version: protocol_version_str.map(ToOwned::to_owned)
+                })
+            })?;
+
+        let conn = Conn::new(
+            conn,
+            self.key_cache.clone(),
+            &self.secret_key,
+            protocol_version,
+        )
+        .await?;
 
         event!(
             target: "iroh::_events::net::relay::connected",

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -375,12 +375,26 @@ impl ClientBuilder {
 
         debug!(%dial_url, "Dialing relay by websocket");
 
-        let (_, ws_stream) = ws_stream_wasm::WsMeta::connect(
+        let (ws_meta, ws_stream) = ws_stream_wasm::WsMeta::connect(
             dial_url.as_str(),
             Some(ProtocolVersion::all().collect()),
         )
         .await?;
-        let conn = Conn::new(ws_stream, self.key_cache.clone(), &self.secret_key).await?;
+
+        let protocol_version =
+            ProtocolVersion::match_from_str(&ws_meta.protocol()).ok_or_else(|| {
+                e!(ConnectError::BadVersionHeader {
+                    server_version: protocol_version_str.map(ToOwned::to_owned)
+                })
+            })?;
+
+        let conn = Conn::new(
+            ws_stream,
+            self.key_cache.clone(),
+            &self.secret_key,
+            protocol_version,
+        )
+        .await?;
 
         event!(
             target: "iroh::_events::net::relay::connected",

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -17,6 +17,7 @@ use super::KeyCache;
 use crate::client::streams::{MaybeTlsStream, ProxyStream};
 use crate::{
     MAX_PACKET_SIZE,
+    http::ProtocolVersion,
     protos::{
         handshake,
         relay::{ClientToRelayMsg, Error as ProtoError, RelayToClientMsg},
@@ -73,6 +74,7 @@ pub(crate) struct Conn {
     #[debug("ws_stream_wasm::WsStream")]
     pub(crate) conn: WsBytesFramed,
     pub(crate) key_cache: KeyCache,
+    pub(crate) protocol_version: ProtocolVersion,
 }
 
 impl Conn {
@@ -84,6 +86,7 @@ impl Conn {
         #[cfg(wasm_browser)] io: ws_stream_wasm::WsStream,
         key_cache: KeyCache,
         secret_key: &SecretKey,
+        protocol_version: ProtocolVersion,
     ) -> Result<Self, handshake::Error> {
         let mut conn = WsBytesFramed { io };
 
@@ -92,11 +95,15 @@ impl Conn {
         handshake::clientside(&mut conn, secret_key).await?;
         trace!("server_handshake: done");
 
-        Ok(Self { conn, key_cache })
+        Ok(Self {
+            conn,
+            key_cache,
+            protocol_version,
+        })
     }
 
     #[cfg(all(test, feature = "server"))]
-    pub(crate) fn test(io: tokio::io::DuplexStream) -> Self {
+    pub(crate) fn test(io: tokio::io::DuplexStream, protocol_version: ProtocolVersion) -> Self {
         use crate::protos::relay::MAX_FRAME_SIZE;
         Self {
             conn: WsBytesFramed {
@@ -107,6 +114,7 @@ impl Conn {
                     .take_over(MaybeTlsStream::Test(io)),
             },
             key_cache: KeyCache::test(),
+            protocol_version,
         }
     }
 }
@@ -117,7 +125,8 @@ impl Stream for Conn {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match ready!(Pin::new(&mut self.conn).poll_next(cx)) {
             Some(Ok(msg)) => {
-                let message = RelayToClientMsg::from_bytes(msg, &self.key_cache);
+                let message =
+                    RelayToClientMsg::from_bytes(msg, &self.key_cache, self.protocol_version);
                 Poll::Ready(Some(message.map_err(Into::into)))
             }
             Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),

--- a/iroh-relay/src/http.rs
+++ b/iroh-relay/src/http.rs
@@ -47,9 +47,7 @@ pub enum ProtocolVersion {
     V1,
     /// Version 2 (added in iroh 0.98.0)
     /// - Removed `Health` frame (id 11)
-    /// - Added new `Status` frame (id 13)
-    /// - Changed behavior such that unknown frames are ignored instead of
-    ///   being treated as an error
+    /// - Added `Status` frame (id 13)
     #[default]
     #[strum(serialize = "iroh-relay-v2")]
     V2,

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -850,7 +850,10 @@ mod proptests {
         };
         let encoded = frame.to_bytes().freeze();
         let result = RelayToClientMsg::from_bytes(encoded, &KeyCache::test(), ProtocolVersion::V2);
-        assert!(matches!(result, Err(Error::FrameNotAllowedInVersion { .. })));
+        assert!(matches!(
+            result,
+            Err(Error::FrameNotAllowedInVersion { .. })
+        ));
     }
 
     #[test]
@@ -858,7 +861,10 @@ mod proptests {
         let frame = RelayToClientMsg::Status(Status::SameEndpointIdConnected);
         let encoded = frame.to_bytes().freeze();
         let result = RelayToClientMsg::from_bytes(encoded, &KeyCache::test(), ProtocolVersion::V1);
-        assert!(matches!(result, Err(Error::FrameNotAllowedInVersion { .. })));
+        assert!(matches!(
+            result,
+            Err(Error::FrameNotAllowedInVersion { .. })
+        ));
     }
 
     proptest! {

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -835,11 +835,38 @@ mod proptests {
         prop_oneof![send_packet, ping, pong]
     }
 
+    /// The earliest protocol version in which `frame` is allowed.
+    fn allowed_version(frame: &RelayToClientMsg) -> ProtocolVersion {
+        match frame {
+            RelayToClientMsg::Health { .. } => ProtocolVersion::V1,
+            _ => ProtocolVersion::V2,
+        }
+    }
+
+    #[test]
+    fn v1health_rejected_in_v2() {
+        let frame = RelayToClientMsg::Health {
+            problem: "test".into(),
+        };
+        let encoded = frame.to_bytes().freeze();
+        let result = RelayToClientMsg::from_bytes(encoded, &KeyCache::test(), ProtocolVersion::V2);
+        assert!(matches!(result, Err(Error::FrameNotAllowedInVersion { .. })));
+    }
+
+    #[test]
+    fn status_rejected_in_v1() {
+        let frame = RelayToClientMsg::Status(Status::SameEndpointIdConnected);
+        let encoded = frame.to_bytes().freeze();
+        let result = RelayToClientMsg::from_bytes(encoded, &KeyCache::test(), ProtocolVersion::V1);
+        assert!(matches!(result, Err(Error::FrameNotAllowedInVersion { .. })));
+    }
+
     proptest! {
         #[test]
         fn server_client_frame_roundtrip(frame in server_client_frame()) {
+            let version = allowed_version(&frame);
             let encoded = frame.to_bytes().freeze();
-            let decoded = RelayToClientMsg::from_bytes(encoded, &KeyCache::test(), Default::default()).unwrap();
+            let decoded = RelayToClientMsg::from_bytes(encoded, &KeyCache::test(), version).unwrap();
             prop_assert_eq!(frame, decoded);
         }
 

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -15,7 +15,7 @@ use n0_error::{e, ensure, stack_error};
 use n0_future::time::Duration;
 
 use super::common::{FrameType, FrameTypeError};
-use crate::KeyCache;
+use crate::{KeyCache, http::ProtocolVersion};
 
 /// The maximum size of a packet sent over relay.
 /// (This only includes the data bytes visible to the socket, not
@@ -66,6 +66,8 @@ pub enum Error {
         #[error(std_err)]
         source: std::str::Utf8Error,
     },
+    #[error("Received a frame not allowed in this protocol version.")]
+    FrameNotAllowedInVersion,
     #[error("Too few bytes")]
     TooSmall {},
 }
@@ -382,8 +384,14 @@ impl RelayToClientMsg {
     /// Tries to decode a frame received over websockets.
     ///
     /// Specifically, bytes received from a binary websocket message frame.
+    ///
+    /// `protocol_version` is the negotiated protocol version for this connection.
     #[allow(clippy::result_large_err)]
-    pub(crate) fn from_bytes(mut content: Bytes, cache: &KeyCache) -> Result<Self, Error> {
+    pub(crate) fn from_bytes(
+        mut content: Bytes,
+        cache: &KeyCache,
+        protocol_version: ProtocolVersion,
+    ) -> Result<Self, Error> {
         let frame_type = FrameType::from_bytes(&mut content)?;
         let frame_len = content.len();
         ensure!(
@@ -423,6 +431,10 @@ impl RelayToClientMsg {
                 Self::Pong(data)
             }
             FrameType::Health => {
+                ensure!(
+                    protocol_version == ProtocolVersion::V1,
+                    Error::FrameNotAllowedInVersion
+                );
                 let problem = std::str::from_utf8(&content)?.to_owned();
                 Self::Health { problem }
             }
@@ -446,6 +458,10 @@ impl RelayToClientMsg {
                 }
             }
             FrameType::Status => {
+                ensure!(
+                    protocol_version >= ProtocolVersion::V2,
+                    Error::FrameNotAllowedInVersion
+                );
                 let status = Status::from_bytes(content)?;
                 Self::Status(status)
             }
@@ -823,7 +839,7 @@ mod proptests {
         #[test]
         fn server_client_frame_roundtrip(frame in server_client_frame()) {
             let encoded = frame.to_bytes().freeze();
-            let decoded = RelayToClientMsg::from_bytes(encoded, &KeyCache::test()).unwrap();
+            let decoded = RelayToClientMsg::from_bytes(encoded, &KeyCache::test(), Default::default()).unwrap();
             prop_assert_eq!(frame, decoded);
         }
 

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -562,7 +562,7 @@ mod tests {
 
         let endpoint_id = SecretKey::from_bytes(&rng.random()).public();
         let (io, io_rw) = tokio::io::duplex(1024);
-        let mut io_rw = Conn::test(io_rw);
+        let mut io_rw = Conn::test(io_rw, Default::default());
         let stream = RelayedStream::test(io);
 
         let clients = Clients::default();
@@ -663,7 +663,7 @@ mod tests {
                 channel_capacity: 10,
                 protocol_version,
             },
-            Conn::test(client),
+            Conn::test(client, Default::default()),
         )
     }
 
@@ -791,7 +791,7 @@ mod tests {
 
         // Build the rate limited stream.
         let (io_read, io_write) = tokio::io::duplex((LIMIT * MAX_FRAMES) as _);
-        let mut frame_writer = Conn::test(io_write);
+        let mut frame_writer = Conn::test(io_write, Default::default());
         // Rate limiter allowing LIMIT bytes/s
         let mut stream = RelayedStream::test_limited(io_read, LIMIT / 10, LIMIT)?;
 

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -663,7 +663,7 @@ mod tests {
                 channel_capacity: 10,
                 protocol_version,
             },
-            Conn::test(client, Default::default()),
+            Conn::test(client, protocol_version),
         )
     }
 

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -270,6 +270,7 @@ mod tests {
         key: EndpointId,
     ) -> (Config<WsBytesFramed<RateLimited<MaybeTlsStream>>>, Conn) {
         let (server, client) = tokio::io::duplex(1024);
+        let protocol_version = Default::default();
         (
             Config {
                 endpoint_id: key,
@@ -278,7 +279,7 @@ mod tests {
                 channel_capacity: 10,
                 protocol_version: Default::default(),
             },
-            Conn::test(client),
+            Conn::test(client, protocol_version),
         )
     }
 

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -1409,7 +1409,7 @@ mod tests {
     async fn make_test_client(client: tokio::io::DuplexStream, key: &SecretKey) -> Result<Conn> {
         let client = crate::client::streams::MaybeTlsStream::Test(client);
         let client = tokio_websockets::ClientBuilder::new().take_over(client);
-        let client = Conn::new(client, KeyCache::test(), key).await?;
+        let client = Conn::new(client, KeyCache::test(), key, Default::default()).await?;
         Ok(client)
     }
 

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -692,9 +692,9 @@ impl ActiveRelayActor {
             RelayToClientMsg::Health { problem } => {
                 warn!("Relay server reports problem: {problem}");
             }
-            frame => {
-                warn!("Ignoring unknown relay message: {frame:?}")
-            }
+            _ => unreachable!(
+                "got unknown RelayToClientMsg but iroh is released in sync with iroh-relay"
+            ),
         }
     }
 


### PR DESCRIPTION
## Description

#3955 added a new relay protocol version. This PR fixes the contract: We should only allow frames that are defined for the negotiated protocol version, and abort if we receive a frame not allowed in the negotiated version.

## Breaking Changes

None

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.