### PR TITLE
refactor(iroh)!: improve address lookup registry

### DIFF
--- a/iroh/examples/0rtt.rs
+++ b/iroh/examples/0rtt.rs
@@ -4,7 +4,6 @@ use clap::Parser;
 use data_encoding::HEXLOWER;
 use iroh::{
     EndpointId, SecretKey,
-    address_lookup::AddressLookup,
     endpoint::{RecvStream, SendStream, ZeroRttStatus, presets},
 };
 use n0_error::{Result, StackResultExt, StdResultExt};
@@ -71,11 +70,11 @@ async fn connect(args: Args) -> Result<()> {
         .await?;
     // ensure we have resolved the remote_id before connecting
     // so we get a more accurate connection timing
-    let mut address_lookup_stream = endpoint
-        .address_lookup()?
-        .resolve(remote_id)
-        .expect("Address Lookup to be enabled");
-    let _ = address_lookup_stream.next().await;
+    let mut address_lookup_stream = endpoint.address_lookup()?.resolve(remote_id);
+    let _item = address_lookup_stream
+        .next()
+        .await
+        .context("failed to lookup remote")?;
 
     let t0 = Instant::now();
     for i in 0..args.rounds {

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -50,7 +50,7 @@
 //!   records to/from the Mainline DHT. It requires enabling the `address-lookup-pkarr-dht` feature.
 //!
 //! To use multiple Address Lookup'ssimultaneously you can call [`Builder::address_lookup`].
-//! This will use [`ConcurrentAddressLookup`] under the hood, which performs lookups to all
+//! This will use [`AddressLookupServices`] under the hood, which performs lookups to all
 //! Address Lookupsystems at the same time.
 //!
 //! [`Builder::address_lookup`] takes any type that implements [`AddressLookupBuilder`]. You can
@@ -129,13 +129,16 @@
 
 use std::{
     borrow::{Borrow, Cow},
+    pin::Pin,
     sync::{Arc, RwLock},
+    task::{Poll, ready},
 };
 
 use iroh_base::{EndpointAddr, EndpointId};
 pub use iroh_relay::endpoint_info::AddrFilter;
 use n0_error::{AnyError, e, stack_error};
-use n0_future::boxed::BoxStream;
+use n0_future::{MergeBounded, Stream, boxed::BoxStream};
+use tracing::debug;
 
 pub use crate::endpoint_info::{EndpointData, EndpointInfo, ParseError, UserData};
 use crate::{Endpoint, endpoint::EndpointError};
@@ -479,11 +482,16 @@ impl From<Item> for EndpointInfo {
     }
 }
 
-/// An Address Lookup service that combines multiple Address Lookup sources.
+/// Registry for address lookup services for an [`Endpoint`].
 ///
-/// The Address Lookup will resolve concurrently.
+/// The endpoint will use this registry both for publishing its own [`EndpointInfo`]
+/// and for resolving addresses of remote endpoints.
+///
+/// See [`AddressLookup`] and [`Self::resolve`] for details.
+///
+/// [`Endpoint]: crate::Endpoint
 #[derive(Debug, Default, Clone)]
-pub struct ConcurrentAddressLookup {
+pub struct AddressLookupServices {
     services: Arc<RwLock<Vec<Box<dyn AddressLookup>>>>,
     /// The data last published, used to publish when adding a new service.
     last_data: Arc<RwLock<Option<EndpointData>>>,
@@ -491,21 +499,7 @@ pub struct ConcurrentAddressLookup {
     addr_filter: Arc<RwLock<Option<AddrFilter>>>,
 }
 
-impl ConcurrentAddressLookup {
-    /// Creates an empty [`ConcurrentAddressLookup`].
-    pub fn empty() -> Self {
-        Self::default()
-    }
-
-    /// Creates a new [`ConcurrentAddressLookup`].
-    pub fn from_services(services: Vec<Box<dyn AddressLookup>>) -> Self {
-        Self {
-            services: Arc::new(RwLock::new(services)),
-            last_data: Default::default(),
-            addr_filter: Default::default(),
-        }
-    }
-
+impl AddressLookupServices {
     /// Sets the address filter applied before publishing to any service.
     ///
     /// When set, all address data is filtered once before being distributed
@@ -550,24 +544,9 @@ impl ConcurrentAddressLookup {
         let mut services = self.services.write().expect("poisoned");
         services.clear();
     }
-}
 
-impl<T> From<T> for ConcurrentAddressLookup
-where
-    T: IntoIterator<Item = Box<dyn AddressLookup>>,
-{
-    fn from(iter: T) -> Self {
-        let services = iter.into_iter().collect::<Vec<_>>();
-        Self {
-            services: Arc::new(RwLock::new(services)),
-            last_data: Default::default(),
-            addr_filter: Default::default(),
-        }
-    }
-}
-
-impl AddressLookup for ConcurrentAddressLookup {
-    fn publish(&self, data: &EndpointData) {
+    /// Publish endpoint data on all configured services.
+    pub(crate) fn publish(&self, data: &EndpointData) {
         let data = match &*self.addr_filter.read().expect("poisoned") {
             Some(filter) => data.apply_filter(filter),
             None => Cow::Borrowed(data),
@@ -583,17 +562,120 @@ impl AddressLookup for ConcurrentAddressLookup {
             .replace(data.into_owned());
     }
 
-    fn resolve(&self, endpoint_id: EndpointId) -> Option<BoxStream<Result<Item, Error>>> {
+    /// Resolves the addressing information for an [`EndpointId`] across all configured services.
+    ///
+    /// All services are queried concurrently and their results are merged into a
+    /// single stream. Each [`Item`] is yielded as soon as it is produced,
+    /// allowing the caller to act on the first usable address while slower
+    /// services are still working.
+    ///
+    /// Errors from individual services are buffered and do not terminate the
+    /// stream: a single failing service must not hide results from others still
+    /// in flight. The buffered errors only surface as a single
+    /// [`AddressLookupFailed::NoResults`] error once all services have finished
+    /// without yielding any [`Item`]. If at least one [`Item`] was yielded,
+    /// buffered errors are discarded and the stream ends with `None`.
+    ///
+    /// If no services are configured, the stream yields a single
+    /// [`AddressLookupFailed::NoServiceConfigured`] error and then ends.
+    ///
+    /// Dropping the returned stream signals all underlying services to stop any
+    /// pending work, as documented on [`AddressLookup::resolve`].
+    pub fn resolve(
+        &self,
+        endpoint_id: EndpointId,
+    ) -> impl Stream<Item = Result<Item, AddressLookupFailed>> + use<> {
         let services = self.services.read().expect("poisoned");
-        let mut streams = services
-            .iter()
-            .filter_map(|service| service.resolve(endpoint_id))
-            .peekable();
-        if streams.peek().is_none() {
-            None
+        if services.is_empty() {
+            AddressLookupStream::empty()
         } else {
-            let streams = n0_future::MergeBounded::from_iter(streams);
-            Some(Box::pin(streams))
+            let streams = services
+                .iter()
+                .filter_map(|service| service.resolve(endpoint_id));
+            AddressLookupStream::new(streams)
+        }
+    }
+}
+
+/// Stream returned by [`AddressLookupServices::resolve`].
+///
+/// Merges the per-service result streams. Yields each `Ok(_)` item as soon
+/// as it is produced and buffers any `Err(_)` so a single failing service
+/// cannot hide results from others still in flight.
+///
+/// Once all services are done, the stream ends with `None` if at least one
+/// item was yielded; otherwise it yields a single
+/// [`AddressLookupFailed::NoResults`] carrying all buffered errors, then ends.
+///
+/// If no services are configured, the stream yields a single
+/// [`AddressLookupFailed::NoServiceConfigured`] error, then ends.
+struct AddressLookupStream {
+    streams: Option<MergeBounded<BoxStream<Result<Item, Error>>>>,
+    errors: Vec<Error>,
+    did_emit: bool,
+    closed: bool,
+}
+
+impl AddressLookupStream {
+    fn empty() -> Self {
+        Self {
+            streams: None,
+            errors: Vec::new(),
+            did_emit: false,
+            closed: false,
+        }
+    }
+
+    fn new(streams: impl Iterator<Item = BoxStream<Result<Item, Error>>>) -> Self {
+        Self {
+            streams: Some(MergeBounded::from_iter(streams)),
+            errors: Vec::new(),
+            did_emit: false,
+            closed: false,
+        }
+    }
+}
+
+impl Stream for AddressLookupStream {
+    type Item = Result<Item, AddressLookupFailed>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.closed {
+            return Poll::Ready(None);
+        }
+        let mut inner = match this.streams.as_mut() {
+            Some(inner) => inner,
+            None => {
+                this.closed = true;
+                return Poll::Ready(Some(Err(e!(AddressLookupFailed::NoServiceConfigured))));
+            }
+        };
+        loop {
+            let item = match ready!(Pin::new(&mut inner).poll_next(cx)) {
+                Some(Ok(item)) => {
+                    this.did_emit = true;
+                    Some(Ok(item))
+                }
+                Some(Err(error)) => {
+                    debug!("address lookup error: {error:#}");
+                    this.errors.push(error);
+                    continue;
+                }
+                None => {
+                    this.closed = true;
+                    if !this.did_emit {
+                        let errors = std::mem::take(&mut this.errors);
+                        Some(Err(e!(AddressLookupFailed::NoResults { errors })))
+                    } else {
+                        None
+                    }
+                }
+            };
+            return Poll::Ready(item);
         }
     }
 }
@@ -722,7 +804,7 @@ mod tests {
     /// An address lookup that yields a single `Err(_)` after `delay` and then ends.
     ///
     /// Used to reproduce the issue where one resolver's error truncates the merged
-    /// stream of a [`ConcurrentAddressLookup`], hiding subsequent successful results
+    /// stream of a [`AddressLookupServices`], hiding subsequent successful results
     /// from other resolvers.
     #[derive(Debug, Clone)]
     struct FailingAddressLookup {
@@ -833,15 +915,14 @@ mod tests {
         })
         .await;
 
-        let (ep2, _guard2) = new_endpoint(&mut rng, |ep| {
+        let (ep2, _guard2) = new_endpoint_add(&mut rng, |ep| {
             let address_lookup1 = EmptyAddressLookup;
             let address_lookup2 = address_lookup_shared.create_lying_address_lookup(ep.id());
             let address_lookup3 = address_lookup_shared.create_address_lookup(ep.id());
-            let address_lookup = ConcurrentAddressLookup::empty();
+            let address_lookup = ep.address_lookup().unwrap();
             address_lookup.add(address_lookup1);
             address_lookup.add(address_lookup2);
             address_lookup.add(address_lookup3);
-            address_lookup
         })
         .await;
 
@@ -851,7 +932,7 @@ mod tests {
 
     /// Regression test for https://github.com/n0-computer/iroh/issues/4125
     ///
-    /// When one resolver in a [`ConcurrentAddressLookup`] returns `Err(_)` early,
+    /// When one resolver in a [`AddressLookupServices`] returns `Err(_)` early,
     /// the merged stream is currently replaced with `pending()`, hiding any later
     /// `Ok(_)` results from other resolvers. This test verifies that a slow but
     /// successful resolver still delivers its result after a fast failing one errors.
@@ -901,9 +982,9 @@ mod tests {
         })
         .await;
 
-        let (ep2, _guard2) = new_endpoint(&mut rng, |ep| {
+        let (ep2, _guard2) = new_endpoint_add(&mut rng, |ep| {
             let address_lookup1 = address_lookup_shared.create_lying_address_lookup(ep.id());
-            ConcurrentAddressLookup::from_services(vec![Box::new(address_lookup1)])
+            ep.address_lookup().unwrap().add(address_lookup1)
         })
         .await;
 
@@ -966,7 +1047,7 @@ mod tests {
         }
 
         let recorder = RecordingLookup::default();
-        let lookup = ConcurrentAddressLookup::empty();
+        let lookup = AddressLookupServices::default();
         lookup.set_addr_filter(AddrFilter::relay_only());
         lookup.add(recorder.clone());
 

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -565,16 +565,17 @@ impl AddressLookupServices {
     /// Resolves the addressing information for an [`EndpointId`] across all configured services.
     ///
     /// All services are queried concurrently and their results are merged into a
-    /// single stream. Each [`Item`] is yielded as soon as it is produced,
-    /// allowing the caller to act on the first usable address while slower
-    /// services are still working.
+    /// single stream. Each [`Item`] is yielded as `Ok(Ok(item))` as soon as it
+    /// is produced, allowing the caller to act on the first usable address
+    /// while slower services are still working.
     ///
-    /// Errors from individual services are buffered and do not terminate the
-    /// stream: a single failing service must not hide results from others still
-    /// in flight. The buffered errors only surface as a single
-    /// [`AddressLookupFailed::NoResults`] error once all services have finished
-    /// without yielding any [`Item`]. If at least one [`Item`] was yielded,
-    /// buffered errors are discarded and the stream ends with `None`.
+    /// Errors from individual services are yielded inline as `Ok(Err(error))`
+    /// and do not terminate the stream: a single failing service must not hide
+    /// results from others still in flight. Inline errors are also buffered;
+    /// if all services finish without yielding any [`Item`], the stream ends
+    /// with a single [`AddressLookupFailed::NoResults`] carrying the buffered
+    /// errors. If at least one [`Item`] was yielded, buffered errors are
+    /// discarded and the stream ends with `None`.
     ///
     /// If no services are configured, the stream yields a single
     /// [`AddressLookupFailed::NoServiceConfigured`] error and then ends.
@@ -584,7 +585,7 @@ impl AddressLookupServices {
     pub fn resolve(
         &self,
         endpoint_id: EndpointId,
-    ) -> impl Stream<Item = Result<Item, AddressLookupFailed>> + use<> {
+    ) -> impl Stream<Item = Result<Result<Item, Error>, AddressLookupFailed>> + use<> {
         let services = self.services.read().expect("poisoned");
         if services.is_empty() {
             AddressLookupStream::empty()
@@ -599,9 +600,10 @@ impl AddressLookupServices {
 
 /// Stream returned by [`AddressLookupServices::resolve`].
 ///
-/// Merges the per-service result streams. Yields each `Ok(_)` item as soon
-/// as it is produced and buffers any `Err(_)` so a single failing service
-/// cannot hide results from others still in flight.
+/// Merges the per-service result streams. Yields each successful item as
+/// `Ok(Ok(item))` as soon as it is produced, and each per-service error
+/// inline as `Ok(Err(error))`, so a single failing service cannot hide
+/// results from others still in flight. Inline errors are also buffered.
 ///
 /// Once all services are done, the stream ends with `None` if at least one
 /// item was yielded; otherwise it yields a single
@@ -637,7 +639,7 @@ impl AddressLookupStream {
 }
 
 impl Stream for AddressLookupStream {
-    type Item = Result<Item, AddressLookupFailed>;
+    type Item = Result<Result<Item, Error>, AddressLookupFailed>;
 
     fn poll_next(
         self: Pin<&mut Self>,
@@ -654,29 +656,27 @@ impl Stream for AddressLookupStream {
                 return Poll::Ready(Some(Err(e!(AddressLookupFailed::NoServiceConfigured))));
             }
         };
-        loop {
-            let item = match ready!(Pin::new(&mut inner).poll_next(cx)) {
-                Some(Ok(item)) => {
-                    this.did_emit = true;
-                    Some(Ok(item))
+        let item = match ready!(Pin::new(&mut inner).poll_next(cx)) {
+            Some(Ok(item)) => {
+                this.did_emit = true;
+                Some(Ok(Ok(item)))
+            }
+            Some(Err(error)) => {
+                debug!("address lookup error: {error:#}");
+                this.errors.push(error.clone());
+                Some(Ok(Err(error)))
+            }
+            None => {
+                this.closed = true;
+                if !this.did_emit {
+                    let errors = std::mem::take(&mut this.errors);
+                    Some(Err(e!(AddressLookupFailed::NoResults { errors })))
+                } else {
+                    None
                 }
-                Some(Err(error)) => {
-                    debug!("address lookup error: {error:#}");
-                    this.errors.push(error);
-                    continue;
-                }
-                None => {
-                    this.closed = true;
-                    if !this.did_emit {
-                        let errors = std::mem::take(&mut this.errors);
-                        Some(Err(e!(AddressLookupFailed::NoResults { errors })))
-                    } else {
-                        None
-                    }
-                }
-            };
-            return Poll::Ready(item);
-        }
+            }
+        };
+        Poll::Ready(item)
     }
 }
 

--- a/iroh/src/address_lookup/pkarr.rs
+++ b/iroh/src/address_lookup/pkarr.rs
@@ -263,14 +263,14 @@ impl AddressLookupBuilder for PkarrPublisherBuilder {
 ///
 /// This implements the [`AddressLookup`] trait to be used as an address lookup service.  Note
 /// that it only publishes address lookup information, for the corresponding resolver use
-/// the [`PkarrResolver`] together with [`ConcurrentAddressLookup`].
+/// the [`PkarrResolver`] together with [`AddressLookupServices`].
 ///
 /// This publisher will **only** publish the [`RelayUrl`] if it is set, otherwise the *direct addresses* are published instead.
 ///
 /// [pkarr]: https://pkarr.org
 /// [module docs]: crate::address_lookup::pkarr
 /// [`RelayUrl`]: crate::RelayUrl
-/// [`ConcurrentAddressLookup`]: super::ConcurrentAddressLookup
+/// [`AddressLookupServices`]: super::AddressLookupServices
 #[derive(derive_more::Debug, Clone)]
 pub struct PkarrPublisher {
     endpoint_id: EndpointId,
@@ -498,11 +498,11 @@ impl AddressLookupBuilder for PkarrResolverBuilder {
 ///
 /// This implements the [`AddressLookup`] trait to be used as an address lookup service.  Note
 /// that it only resolves address lookup information, for the corresponding publisher use
-/// the [`PkarrPublisher`] together with [`ConcurrentAddressLookup`].
+/// the [`PkarrPublisher`] together with [`AddressLookupServices`].
 ///
 /// [pkarr]: https://pkarr.org
 /// [module docs]: crate::address_lookup::pkarr
-/// [`ConcurrentAddressLookup`]: super::ConcurrentAddressLookup
+/// [`AddressLookupServices`]: super::AddressLookupServices
 #[derive(derive_more::Debug, Clone)]
 pub struct PkarrResolver {
     pkarr_client: PkarrRelayClient,

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -51,7 +51,7 @@ pub use crate::tls::TlsConfigError;
 use crate::{
     NetReport,
     address_lookup::{
-        AddrFilter, AddressLookupBuilder, AddressLookupFailed, ConcurrentAddressLookup,
+        AddrFilter, AddressLookupBuilder, AddressLookupFailed, AddressLookupServices,
         DynAddressLookupBuilder, UserData,
     },
     endpoint::presets::Preset,
@@ -571,7 +571,7 @@ impl Builder {
     ///
     /// This method can be called multiple times and all the Address Lookup's passed in
     /// will be combined using an internal instance of the
-    /// [`crate::address_lookup::ConcurrentAddressLookup`]. To clear all Address Lookup's, use
+    /// [`crate::address_lookup::AddressLookupServices`]. To clear all Address Lookup's, use
     /// [`Self::clear_address_lookup`].
     ///
     /// If no Address Lookup is set, connecting to an endpoint without providing its
@@ -585,11 +585,11 @@ impl Builder {
 
     /// Sets the address filter applied to all address data before publishing.
     ///
-    /// This filter is applied once, at the [`ConcurrentAddressLookup`] level, before
+    /// This filter is applied once, at the [`AddressLookupServices`] level, before
     /// distributing data to any individual address lookup service. This ensures
     /// consistent filtering regardless of how the services configured.
     ///
-    /// [`ConcurrentAddressLookup`]: crate::address_lookup::ConcurrentAddressLookup
+    /// [`AddressLookupServices`]: crate::address_lookup::AddressLookupServices
     pub fn addr_filter(mut self, filter: AddrFilter) -> Self {
         self.addr_filter = Some(filter);
         self
@@ -1406,7 +1406,7 @@ impl Endpoint {
     /// Returns a `EndpointError::Closed` error if the endpoint is closed.
     ///
     /// See [`Builder::address_lookup`].
-    pub fn address_lookup(&self) -> Result<&ConcurrentAddressLookup, EndpointError> {
+    pub fn address_lookup(&self) -> Result<&AddressLookupServices, EndpointError> {
         if self.is_closed() {
             return Err(e!(EndpointError::Closed));
         }

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -67,7 +67,7 @@ use crate::dns::DnsResolver;
 #[cfg(not(wasm_browser))]
 use crate::net_report::QuicConfig;
 use crate::{
-    address_lookup::{self, AddressLookup, AddressLookupFailed, EndpointData, UserData},
+    address_lookup::{self, AddressLookupFailed, EndpointData, UserData},
     defaults::timeouts::NET_REPORT_TIMEOUT,
     endpoint::{hooks::EndpointHooksList, quic::QuicTransportConfig},
     metrics::EndpointMetrics,
@@ -350,7 +350,7 @@ pub(crate) struct Socket {
     relay_map: RelayMap,
 
     /// Optional Address Lookup
-    address_lookup: address_lookup::ConcurrentAddressLookup,
+    address_lookup: address_lookup::AddressLookupServices,
     /// Optional user-defined discover data.
     address_lookup_user_data: RwLock<Option<UserData>>,
     /// Explicitly configured external addresses to advertise.
@@ -525,7 +525,7 @@ impl Socket {
     }
 
     /// Reference to the internal Address Lookup
-    pub(crate) fn address_lookup(&self) -> &address_lookup::ConcurrentAddressLookup {
+    pub(crate) fn address_lookup(&self) -> &address_lookup::AddressLookupServices {
         &self.address_lookup
     }
 
@@ -845,7 +845,7 @@ impl EndpointInner {
             configured_addrs,
         } = opts;
 
-        let address_lookup = address_lookup::ConcurrentAddressLookup::default();
+        let address_lookup = address_lookup::AddressLookupServices::default();
         let port_mapper = portmapper::create_client(&metrics, &portmapper_config);
 
         let relay_transport_configs: Vec<_> = transport_configs

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -128,7 +128,7 @@ struct Tasks {
     metrics: Arc<SocketMetrics>,
     /// The "direct" addresses known for our local endpoint
     local_direct_addrs: n0_watcher::Direct<BTreeSet<DirectAddr>>,
-    address_lookup: address_lookup::ConcurrentAddressLookup,
+    address_lookup: address_lookup::AddressLookupServices,
     shutdown_token: CancellationToken,
 
     //
@@ -152,7 +152,7 @@ impl RemoteMap {
     pub(super) fn new(
         metrics: Arc<SocketMetrics>,
         local_direct_addrs: n0_watcher::Direct<BTreeSet<DirectAddr>>,
-        address_lookup: address_lookup::ConcurrentAddressLookup,
+        address_lookup: address_lookup::AddressLookupServices,
         shutdown_token: CancellationToken,
         transport_bias: TransportBiasMap,
         span: Span,

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -572,6 +572,14 @@ impl RemoteStateActor {
             return;
         }
         let stream = self.address_lookup.resolve(self.endpoint_id);
+        let stream = stream.filter_map(|item| match item {
+            // We don't care about errors from individual services, we just continue.
+            // Indivdual errors are buffered, and if the lookup fails will be returned upstream
+            // with the final `AddressLookupFailed` error.
+            Ok(Err(_err)) => None,
+            Ok(Ok(item)) => Some(Ok(item)),
+            Err(err) => Some(Err(err)),
+        });
         self.address_lookup_stream = Some(Box::pin(stream));
     }
 

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -574,8 +574,8 @@ impl RemoteStateActor {
         let stream = self.address_lookup.resolve(self.endpoint_id);
         let stream = stream.filter_map(|item| match item {
             // We don't care about errors from individual services, we just continue.
-            // Indivdual errors are buffered, and if the lookup fails will be returned upstream
-            // with the final `AddressLookupFailed` error.
+            // Individual errors are buffered into the final error by `AddressLookupServices::resolve`,
+            // and if the lookup fails we return them upstream with the final `AddressLookupFailed` error.
             Ok(Err(_err)) => None,
             Ok(Ok(item)) => Some(Ok(item)),
             Err(err) => Some(Err(err)),

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -3,11 +3,11 @@ use std::{
     net::SocketAddr,
     pin::Pin,
     sync::Arc,
-    task::{Poll, ready},
+    task::Poll,
 };
 
 use iroh_base::{CustomAddr, EndpointId, RelayUrl, TransportAddr};
-use n0_error::{StackResultExt, e};
+use n0_error::StackResultExt;
 use n0_future::{
     FuturesUnordered, MergeUnbounded, Stream, StreamExt,
     boxed::BoxStream,
@@ -30,10 +30,7 @@ pub use self::{
 };
 use super::Source;
 use crate::{
-    address_lookup::{
-        AddressLookup, AddressLookupFailed, ConcurrentAddressLookup, Error as AddressLookupError,
-        Item as AddressLookupItem,
-    },
+    address_lookup::{AddressLookupFailed, AddressLookupServices, Item as AddressLookupItem},
     endpoint::DirectAddr,
     socket::{
         Metrics as SocketMetrics, RELAY_PATH_MAX_IDLE_TIMEOUT,
@@ -119,7 +116,7 @@ pub(super) struct RemoteStateActor {
     /// The mapping between custom transport addresses and their [`CustomMappedAddr`]s.
     custom_mapped_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
     /// Address lookup service, cloned from the socket.
-    address_lookup: ConcurrentAddressLookup,
+    address_lookup: AddressLookupServices,
 
     // Internal state - Noq Connections we are managing.
     //
@@ -163,7 +160,7 @@ pub(super) struct RemoteStateActor {
     // Internal state - address lookup
     //
     /// Stream of Address Lookup results, or always pending if Address Lookup is not running.
-    address_lookup_stream: AddressLookupStream,
+    address_lookup_stream: Option<BoxStream<Result<AddressLookupItem, AddressLookupFailed>>>,
 
     /// Biases for different transport kinds.
     transport_bias: TransportBiasMap,
@@ -177,7 +174,7 @@ impl RemoteStateActor {
         relay_mapped_addrs: AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
         custom_mapped_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
         metrics: Arc<SocketMetrics>,
-        address_lookup: ConcurrentAddressLookup,
+        address_lookup: AddressLookupServices,
         transport_bias: TransportBiasMap,
     ) -> Self {
         Self {
@@ -197,7 +194,7 @@ impl RemoteStateActor {
             scheduled_holepunch: None,
             scheduled_open_path: None,
             pending_open_paths: VecDeque::new(),
-            address_lookup_stream: AddressLookupStream::default(),
+            address_lookup_stream: None,
             transport_bias,
         }
     }
@@ -311,7 +308,7 @@ impl RemoteStateActor {
                     self.scheduled_holepunch = None;
                     self.trigger_holepunching();
                 }
-                Some(item) = self.address_lookup_stream.next(), if !self.address_lookup_stream.is_empty() => {
+                Some(item) = maybe_next(self.address_lookup_stream.as_mut()), if self.address_lookup_stream.is_some() => {
                     self.handle_address_lookup_item(item);
                 }
                 _ = check_connections.tick() => {
@@ -571,28 +568,32 @@ impl RemoteStateActor {
     /// Does not start Address Lookup if we have a selected path or if Address Lookup is
     /// currently running.
     fn trigger_address_lookup(&mut self) {
-        if self.selected_path.get().is_some() || !self.address_lookup_stream.is_empty() {
+        if self.selected_path.get().is_some() || self.address_lookup_stream.is_some() {
             return;
         }
-        match self.address_lookup.resolve(self.endpoint_id) {
-            Some(stream) => self.address_lookup_stream.set(stream),
-            None => self
-                .paths
-                .address_lookup_finished(Err(e!(AddressLookupFailed::NoServiceConfigured))),
-        }
+        let stream = self.address_lookup.resolve(self.endpoint_id);
+        self.address_lookup_stream = Some(Box::pin(stream));
     }
 
     /// Handles an address lookup result.
     ///
     /// All address lookup results end up being sent here. It takes care of updating the
     /// [`RemotePathState`] with the results.
-    fn handle_address_lookup_item(&mut self, item: Result<AddressLookupItem, AddressLookupFailed>) {
+    fn handle_address_lookup_item(
+        &mut self,
+        item: Option<Result<AddressLookupItem, AddressLookupFailed>>,
+    ) {
         match item {
-            Err(err) => {
+            None => {
+                self.paths.address_lookup_finished(Ok(()));
+                self.address_lookup_stream = None;
+            }
+            Some(Err(err)) => {
                 warn!("Address Lookup failed: {err:#}");
                 self.paths.address_lookup_finished(Err(err));
+                self.address_lookup_stream = None;
             }
-            Ok(item) => {
+            Some(Ok(item)) => {
                 if item.endpoint_id() != self.endpoint_id {
                     warn!(
                         ?item,
@@ -1346,84 +1347,11 @@ fn to_transports_addr(
     })
 }
 
-/// Stream wrapper around the result of [`ConcurrentAddressLookup::resolve`].
-///
-/// Holds an optional inner stream and yields only `Ok(_)` items from it.
-/// Errors from the inner stream are buffered internally so a single failing
-/// lookup does not hide results from other lookups still in flight.
-///
-/// # Usage
-///
-/// Construct with [`Default`] and attach the lookup stream via [`Self::set`]
-/// when one is started. Re-attaching with [`Self::set`] replaces the previous
-/// stream and clears any buffered state.
-///
-/// Use [`Self::is_empty`] to check whether a stream is currently attached;
-/// polling without an attached stream immediately yields `Ready(None)`, which
-/// lets the surrounding actor select over this stream unconditionally.
-///
-/// # Output
-///
-/// While the inner stream is live, the wrapper yields each `Ok(item)` and
-/// silently buffers any `Err(_)`. When the inner stream ends:
-///
-/// - If at least one item was yielded, the wrapper ends and buffered errors
-///   are discarded.
-/// - If no item was yielded, the wrapper yields a single
-///   [`AddressLookupFailed::NoResults`] carrying all buffered errors, then ends.
-#[derive(Default)]
-struct AddressLookupStream {
-    inner: Option<BoxStream<Result<AddressLookupItem, AddressLookupError>>>,
-    errors: Option<Vec<AddressLookupError>>,
-    did_emit: bool,
-}
-
-impl AddressLookupStream {
-    fn is_empty(&self) -> bool {
-        self.inner.is_none()
-    }
-
-    fn set(&mut self, stream: BoxStream<Result<AddressLookupItem, AddressLookupError>>) {
-        self.inner = Some(stream);
-        self.errors = None;
-        self.did_emit = false;
-    }
-}
-
-impl Stream for AddressLookupStream {
-    type Item = Result<AddressLookupItem, AddressLookupFailed>;
-
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        loop {
-            let item = match this.inner.as_mut() {
-                None => None,
-                Some(stream) => match ready!(Pin::new(stream).poll_next(cx)) {
-                    Some(Ok(item)) => {
-                        this.did_emit = true;
-                        Some(Ok(item))
-                    }
-                    Some(Err(error)) => {
-                        debug!("address lookup error: {error:#}");
-                        this.errors.get_or_insert_default().push(error);
-                        continue;
-                    }
-                    None => {
-                        this.inner = None;
-                        if !this.did_emit {
-                            let errors = this.errors.take().unwrap_or_default();
-                            Some(Err(e!(AddressLookupFailed::NoResults { errors })))
-                        } else {
-                            None
-                        }
-                    }
-                },
-            };
-            return Poll::Ready(item);
-        }
+/// Returns the next item if `maybe_stream` is `Some`, or `None` otherwise.
+async fn maybe_next<S: Stream + Unpin>(maybe_stream: Option<&mut S>) -> Option<Option<S::Item>> {
+    match maybe_stream {
+        None => None,
+        Some(s) => Some(s.next().await),
     }
 }
 


### PR DESCRIPTION
## Description

While working on #4126 I realized that our `ConcurrentAddressLookup` really is a struct from way back when address lookup configuration on the endpoint worked differently. It now is an integral part of the `Endpoint`, and there's no reason (I think) for users to create one themselves, because they can work on `Endpoint::address_lookup()` directly.

This renames it to `AddressLookupServices` and changes it to no longer implement `AddressLookup` by itself. This allows then for a more sensible return type in `Self::resolve`, basically moving what #4126 did into the correct place.

Also removes a few methods that were unused.

## Breaking Changes

* renamed: `iroh::address_lookup::ConcurrentAddressLookup` -> `iroh::address_lookup::AddressLookupServices`.
* `AddressLookupServices` no longer implements the `AddressLookup` trait. It is owned by the `Endpoint` and used directly via its inherent methods.
* removed: `ConcurrentAddressLookup::empty()` and `ConcurrentAddressLookup::from_services()`. Construct with `AddressLookupServices::default()` and register services with `AddressLookupServices::add` / `AddressLookupServices::add_boxed`.
* removed: `impl<T: IntoIterator<Item = Box<dyn AddressLookup>>> From<T> for ConcurrentAddressLookup`. Construct with `AddressLookupServices::default()` and add services explicitly.
* `iroh::Endpoint::address_lookup` now returns `Result<&AddressLookupServices, EndpointError>` (was `Result<&ConcurrentAddressLookup, EndpointError>`).
* `AddressLookupServices::resolve` now returns `impl Stream<Item = Result<Item, AddressLookupFailed>>` instead of `Option<BoxStream<Result<Item, Error>>>`. The stream is always returned: if no services are configured it yields a single `AddressLookupFailed::NoServiceConfigured` error and then ends. Callers that previously unwrapped the `Option` (e.g. with `.expect("...")`) should drop the unwrap and use the stream directly.


<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.