### PR TITLE
refactor: Move to_z32/from_z32 into iroh-base and remove EndpointIdExt trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,6 +2442,7 @@ version = "0.97.0"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
+ "data-encoding-macro",
  "derive_more",
  "digest",
  "ed25519-dalek",
@@ -2485,8 +2486,6 @@ dependencies = [
 name = "iroh-dns"
 version = "0.97.0"
 dependencies = [
- "data-encoding",
- "data-encoding-macro",
  "derive_more",
  "iroh-base",
  "n0-error",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [dependencies]
 curve25519-dalek = { version = "=5.0.0-pre.6", features = ["serde", "rand_core", "zeroize"], optional = true }
 data-encoding = { version = "2.3.3", optional = true }
+data-encoding-macro = { version = "0.1.19", optional = true }
 digest = { version = "0.11", optional = true }
 # Pin sha2 & sha1 to fix version incompatibility
 sha2 = { version = "=0.11.0-rc.5", optional = true }
@@ -52,6 +53,7 @@ key = [
   "dep:url",
   "dep:derive_more",
   "dep:data-encoding",
+  "dep:data-encoding-macro",
   "dep:rand",
   "dep:getrandom",
   "dep:zeroize",

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -10,9 +10,16 @@ use std::{
 };
 
 use curve25519_dalek::edwards::CompressedEdwardsY;
+use data_encoding::Encoding;
+use data_encoding_macro::new_encoding;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use n0_error::{e, ensure, stack_error};
 use serde::{Deserialize, Serialize, de, ser};
+
+/// z-base-32 encoding as used by [pkarr](https://pkarr.org) for endpoint id domain names.
+const Z_BASE_32: Encoding = new_encoding! {
+    symbols: "ybndrfg8ejkmcpqxot1uwisza345h769",
+};
 
 /// A public key.
 ///
@@ -150,6 +157,20 @@ impl PublicKey {
     #[doc(hidden)]
     pub fn from_verifying_key(key: VerifyingKey) -> Self {
         Self(CompressedEdwardsY(key.to_bytes()))
+    }
+
+    /// Encodes this key in [z-base-32](https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt),
+    /// the encoding used by [pkarr](https://pkarr.org) domain names.
+    pub fn to_z32(&self) -> String {
+        Z_BASE_32.encode(self.as_bytes())
+    }
+
+    /// Parses a key from its [z-base-32](https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt) encoding.
+    pub fn from_z32(s: &str) -> Result<Self, KeyParsingError> {
+        let bytes = Z_BASE_32
+            .decode(s.as_bytes())
+            .map_err(|_| e!(KeyParsingError::FailedToDecodeBase32))?;
+        Self::try_from(bytes.as_slice())
     }
 }
 

--- a/iroh-dns-server/examples/convert.rs
+++ b/iroh-dns-server/examples/convert.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use clap::Parser;
-use iroh::{EndpointId, endpoint_info::EndpointIdExt};
+use iroh::EndpointId;
 use n0_error::{Result, StdResultExt};
 
 #[derive(Debug, Parser)]

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -8,7 +8,7 @@ use iroh::{
         dns::{N0_DNS_ENDPOINT_ORIGIN_PROD, N0_DNS_ENDPOINT_ORIGIN_STAGING},
         pkarr::{N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING, PkarrRelayClient},
     },
-    endpoint_info::{EndpointIdExt, EndpointInfo, IROH_TXT_NAME},
+    endpoint_info::{EndpointInfo, IROH_TXT_NAME},
     tls::{CaRootsConfig, default_provider},
 };
 use n0_error::{Result, StackResultExt};

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -305,7 +305,6 @@ mod tests {
     use iroh::{
         RelayUrl, SecretKey,
         address_lookup::{EndpointInfo, PkarrRelayClient},
-        endpoint_info::EndpointIdExt,
         tls::{CaRootsConfig, default_provider},
     };
     use n0_error::StdResultExt;

--- a/iroh-dns-server/src/http/pkarr.rs
+++ b/iroh-dns-server/src/http/pkarr.rs
@@ -5,7 +5,7 @@ use axum::{
 use bytes::Bytes;
 use http::{StatusCode, header};
 use iroh_base::PublicKey;
-use iroh_dns::{EndpointIdExt, pkarr::SignedPacket};
+use iroh_dns::pkarr::SignedPacket;
 use tracing::info;
 
 use super::error::AppError;

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -28,7 +28,7 @@ mod tests {
         endpoint_info::EndpointInfo,
         tls::{CaRootsConfig, default_provider},
     };
-    use iroh_dns::{EndpointIdExt, pkarr::SignedPacket};
+    use iroh_dns::pkarr::SignedPacket;
     use mainline::{DhtBuilder, MutableItem, Testnet};
     use n0_error::{Result, StdResultExt};
     use n0_tracing_test::traced_test;

--- a/iroh-dns-server/src/util.rs
+++ b/iroh-dns-server/src/util.rs
@@ -15,7 +15,7 @@ use hickory_server::proto::{
     serialize::binary::BinDecodable,
 };
 use iroh_base::PublicKey;
-use iroh_dns::{EndpointIdExt, pkarr::SignedPacket};
+use iroh_dns::pkarr::SignedPacket;
 use n0_error::{e, stack_error};
 
 /// A lightweight `[u8; 32]` wrapper used as a key for caches and database lookups.

--- a/iroh-dns/Cargo.toml
+++ b/iroh-dns/Cargo.toml
@@ -13,8 +13,6 @@ rust-version = "1.89"
 workspace = true
 
 [dependencies]
-data-encoding = "2.6.0"
-data-encoding-macro = "0.1.19"
 derive_more = { version = "2.0.1", features = ["debug"] }
 iroh-base = { version = "0.97.0", path = "../iroh-base", default-features = false, features = ["key"] }
 n0-error = "0.1"

--- a/iroh-dns/src/attrs.rs
+++ b/iroh-dns/src/attrs.rs
@@ -14,7 +14,7 @@ use std::{collections::BTreeMap, fmt::Display, hash::Hash, str::FromStr};
 use iroh_base::{EndpointId, SecretKey};
 use n0_error::{e, stack_error};
 
-use crate::{EndpointIdExt, pkarr};
+use crate::pkarr;
 
 /// The DNS name for the iroh TXT record.
 pub const IROH_TXT_NAME: &str = "_iroh";
@@ -68,7 +68,7 @@ pub fn endpoint_id_from_txt_name(name: &str) -> Result<EndpointId, ParseError> {
         }));
     }
     let label = labels.next().expect("checked above");
-    let endpoint_id = <EndpointId as EndpointIdExt>::from_z32(label)?;
+    let endpoint_id = EndpointId::from_z32(label)?;
     Ok(endpoint_id)
 }
 

--- a/iroh-dns/src/lib.rs
+++ b/iroh-dns/src/lib.rs
@@ -5,36 +5,3 @@
 
 pub mod attrs;
 pub mod pkarr;
-
-use data_encoding::Encoding;
-use data_encoding_macro::new_encoding;
-use iroh_base::{EndpointId, KeyParsingError};
-use n0_error::e;
-
-/// z-base-32 encoding as used by pkarr.
-const Z_BASE_32: Encoding = new_encoding! {
-    symbols: "ybndrfg8ejkmcpqxot1uwisza345h769",
-};
-
-/// Extension methods for [`EndpointId`] to encode to and decode from z-base-32,
-/// which is the encoding used by [pkarr](https://pkarr.org) domain names.
-pub trait EndpointIdExt {
-    /// Encodes a [`EndpointId`] in [z-base-32](https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt) encoding.
-    fn to_z32(&self) -> String;
-
-    /// Parses a [`EndpointId`] from [z-base-32](https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt) encoding.
-    fn from_z32(s: &str) -> Result<EndpointId, KeyParsingError>;
-}
-
-impl EndpointIdExt for EndpointId {
-    fn to_z32(&self) -> String {
-        Z_BASE_32.encode(self.as_bytes())
-    }
-
-    fn from_z32(s: &str) -> Result<EndpointId, KeyParsingError> {
-        let bytes = Z_BASE_32
-            .decode(s.as_bytes())
-            .map_err(|_| e!(KeyParsingError::FailedToDecodeBase32))?;
-        EndpointId::try_from(bytes.as_slice())
-    }
-}

--- a/iroh-dns/src/pkarr.rs
+++ b/iroh-dns/src/pkarr.rs
@@ -13,8 +13,6 @@ use iroh_base::{PublicKey, SecretKey, Signature};
 use n0_error::{e, stack_error};
 use simple_dns::{CLASS, Name, Packet, ResourceRecord, rdata::RData};
 
-use crate::EndpointIdExt;
-
 /// Maximum size of the encoded DNS packet within a signed packet.
 const MAX_DNS_PACKET_SIZE: usize = 1000;
 

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -32,7 +32,7 @@ use url::Url;
 
 use crate::{
     defaults::timeouts::DNS_TIMEOUT,
-    endpoint_info::{EndpointIdExt, EndpointInfo, ParseError},
+    endpoint_info::{EndpointInfo, ParseError},
 };
 
 /// The n0 address lookup DNS origin, for production.

--- a/iroh-relay/src/endpoint_info.rs
+++ b/iroh-relay/src/endpoint_info.rs
@@ -43,12 +43,9 @@ use std::{
 };
 
 use iroh_base::{EndpointAddr, EndpointId, RelayUrl, SecretKey, TransportAddr};
+pub use iroh_dns::attrs::{EncodingError, IROH_TXT_NAME, ParseError};
 pub(crate) use iroh_dns::attrs::{IrohAttr, TxtAttrs};
 use iroh_dns::pkarr;
-pub use iroh_dns::{
-    EndpointIdExt,
-    attrs::{EncodingError, IROH_TXT_NAME, ParseError},
-};
 use n0_error::{ensure, stack_error};
 use url::Url;
 
@@ -549,7 +546,7 @@ mod tests {
     use iroh_base::{EndpointId, SecretKey, TransportAddr};
     use n0_error::{Result, StdResultExt};
 
-    use super::{EndpointData, EndpointIdExt, EndpointInfo};
+    use super::{EndpointData, EndpointInfo};
     use crate::dns::TxtRecordData;
 
     #[test]

--- a/iroh/examples/dht_address_lookup.rs
+++ b/iroh/examples/dht_address_lookup.rs
@@ -18,7 +18,6 @@ use iroh::{
     address_lookup::{AddrFilter, DhtAddressLookup},
     endpoint::presets,
 };
-use iroh_relay::endpoint_info::EndpointIdExt;
 use n0_error::{Result, StdResultExt};
 use tracing::warn;
 

--- a/iroh/src/address_lookup/pkarr.rs
+++ b/iroh/src/address_lookup/pkarr.rs
@@ -58,7 +58,7 @@ use std::sync::Arc;
 
 use iroh_base::{EndpointId, RelayUrl, SecretKey};
 use iroh_dns::pkarr::{SignedPacket, SignedPacketVerifyError};
-use iroh_relay::endpoint_info::{AddrFilter, EncodingError, EndpointIdExt, EndpointInfo};
+use iroh_relay::endpoint_info::{AddrFilter, EncodingError, EndpointInfo};
 use n0_error::{e, stack_error};
 use n0_future::{
     boxed::BoxStream,

--- a/iroh/src/address_lookup/pkarr/dht.rs
+++ b/iroh/src/address_lookup/pkarr/dht.rs
@@ -9,7 +9,6 @@ use std::sync::{Arc, Mutex};
 
 use iroh_base::{EndpointId, SecretKey};
 use iroh_dns::pkarr::{SignedPacket, SignedPacketVerifyError, Timestamp};
-use iroh_relay::endpoint_info::EndpointIdExt;
 use mainline::{Dht, DhtBuilder, MutableItem};
 use n0_future::{
     boxed::BoxStream,

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -291,7 +291,6 @@ pub(crate) mod pkarr_relay {
     };
     use bytes::Bytes;
     use iroh_base::EndpointId;
-    use iroh_relay::endpoint_info::EndpointIdExt;
     use tokio::sync::oneshot;
     use tracing::{debug, error, warn};
     use url::Url;
@@ -364,7 +363,7 @@ pub(crate) mod pkarr_dns_state {
 
     use iroh_base::EndpointId;
     use iroh_dns::pkarr::SignedPacket;
-    use iroh_relay::endpoint_info::{EndpointIdExt, EndpointInfo, IROH_TXT_NAME};
+    use iroh_relay::endpoint_info::{EndpointInfo, IROH_TXT_NAME};
     use tracing::debug;
 
     use crate::test_utils::dns_server::QueryHandler;


### PR DESCRIPTION
## Description

Move to_z32/from_z32 into iroh-base and remove EndpointIdExt trait

Ext traits are just not very nice for our users.

## Breaking Changes

removed: iroh_relay::endpoint_info::EndpointIdExt trait and its re-export from iroh_dns. The to_z32 / from_z32 methods are now inherent on iroh_base::PublicKey (and therefore EndpointId, which is a type alias). Callers should drop the use iroh_relay::endpoint_info::EndpointIdExt; import — the methods resolve without it.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
