### PR TITLE
tests(iroh): improve patchbay NAT matrix

### DIFF
--- a/iroh/tests/patchbay/nat.rs
+++ b/iroh/tests/patchbay/nat.rs
@@ -15,17 +15,80 @@ use std::time::Duration;
 
 use n0_error::{Result, StackResultExt};
 use n0_tracing_test::traced_test;
-use patchbay::Nat;
+use patchbay::{Nat, NatConfig, NatFiltering, NatMapping};
 use testdir::testdir;
 use tracing::info;
 
 use super::util::{Pair, PathWatcherExt, lab_with_relay};
 use crate::util::{ping_accept, ping_open};
 
-async fn run_nat_holepunch(nat_server: Nat, nat_client: Nat) -> Result {
+enum NatKind {
+    /// No NAT. The device has a publicly routable address.
+    None,
+    /// Most permissive NAT.
+    ///
+    /// Typical of consumer routers with UPnP or static port forwarding.
+    ///
+    /// RFC 3489: Full Cone NAT.
+    /// RFC 4787: Endpoint-Independent Mapping, Endpoint-Independent Filtering (EIM/EIF).
+    Easiest,
+    /// Moderately restrictive NAT.
+    ///
+    /// The external mapping is stable across destinations, but inbound packets are filtered
+    /// by source address and port. Common in home routers without UPnP.
+    ///
+    /// RFC 3489: Port Restricted Cone NAT.
+    /// RFC 4787: Endpoint-Independent Mapping, Address-and-Port-Dependent Filtering (EIM/APDF).
+    Easy,
+    /// Most restrictive NAT.
+    ///
+    /// Each destination gets a different external mapping, and inbound packets are filtered
+    /// by source address and port. Holepunching between two Hard NATs requires a relay
+    /// (TURN or similar). Typical of corporate firewalls and carrier-grade NAT (CGN).
+    ///
+    /// RFC 3489: Symmetric NAT.
+    /// RFC 4787: Endpoint-Dependent Mapping, Address-and-Port-Dependent Filtering (EDM/APDF).
+    Hard,
+}
+
+impl From<NatKind> for Nat {
+    fn from(value: NatKind) -> Self {
+        let (mapping, filtering) = match value {
+            NatKind::None => return Nat::None,
+            NatKind::Easiest => (
+                NatMapping::EndpointIndependent,
+                NatFiltering::EndpointIndependent,
+            ),
+            NatKind::Easy => (
+                NatMapping::EndpointIndependent,
+                NatFiltering::AddressAndPortDependent,
+            ),
+            NatKind::Hard => (
+                NatMapping::EndpointDependent,
+                NatFiltering::AddressAndPortDependent,
+            ),
+        };
+        Nat::Custom(NatConfig {
+            mapping,
+            filtering,
+            timeouts: Default::default(),
+            hairpin: false,
+        })
+    }
+}
+
+async fn run_nat_holepunch(nat_server: NatKind, nat_client: NatKind) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let router_server = lab.add_router("nat_server").nat(nat_server).build().await?;
-    let router_client = lab.add_router("nat_client").nat(nat_client).build().await?;
+    let router_server = lab
+        .add_router("nat_server")
+        .nat(nat_server.into())
+        .build()
+        .await?;
+    let router_client = lab
+        .add_router("nat_client")
+        .nat(nat_client.into())
+        .build()
+        .await?;
     let server = lab
         .add_device("server")
         .uplink(router_server.id())
@@ -70,60 +133,111 @@ async fn run_nat_holepunch(nat_server: Nat, nat_client: Nat) -> Result {
     Ok(())
 }
 
+// None x *
+
 #[tokio::test]
 #[traced_test]
 async fn nat_none_x_none() -> Result {
-    run_nat_holepunch(Nat::None, Nat::None).await
+    run_nat_holepunch(NatKind::None, NatKind::None).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_none_x_home() -> Result {
-    run_nat_holepunch(Nat::None, Nat::Home).await
+async fn nat_none_x_easiest() -> Result {
+    run_nat_holepunch(NatKind::None, NatKind::Easiest).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_home_x_none() -> Result {
-    run_nat_holepunch(Nat::Home, Nat::None).await
+async fn nat_none_x_easy() -> Result {
+    run_nat_holepunch(NatKind::None, NatKind::Easy).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_none_x_corporate() -> Result {
-    run_nat_holepunch(Nat::None, Nat::Corporate).await
+async fn nat_none_x_hard() -> Result {
+    run_nat_holepunch(NatKind::None, NatKind::Hard).await
+}
+
+// Easiest x *
+
+#[tokio::test]
+#[traced_test]
+async fn nat_easiest_x_none() -> Result {
+    run_nat_holepunch(NatKind::Easiest, NatKind::None).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing"]
-async fn nat_corporate_x_none() -> Result {
-    run_nat_holepunch(Nat::Corporate, Nat::None).await
+async fn nat_easiest_x_easiest() -> Result {
+    run_nat_holepunch(NatKind::Easiest, NatKind::Easiest).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_home_x_home() -> Result {
-    run_nat_holepunch(Nat::Home, Nat::Home).await
+async fn nat_easiest_x_easy() -> Result {
+    run_nat_holepunch(NatKind::Easiest, NatKind::Easy).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing"]
-async fn nat_home_x_corporate() -> Result {
-    run_nat_holepunch(Nat::Home, Nat::Corporate).await
+async fn nat_easiest_x_hard() -> Result {
+    run_nat_holepunch(NatKind::Easiest, NatKind::Hard).await
+}
+
+// Easy x *
+
+#[tokio::test]
+#[traced_test]
+async fn nat_easy_x_none() -> Result {
+    run_nat_holepunch(NatKind::Easy, NatKind::None).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing"]
-async fn nat_corporate_x_home() -> Result {
-    run_nat_holepunch(Nat::Corporate, Nat::Home).await
+async fn nat_easy_x_easiest() -> Result {
+    run_nat_holepunch(NatKind::Easy, NatKind::Easiest).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing"]
-async fn nat_corporate_x_corporate() -> Result {
-    run_nat_holepunch(Nat::Corporate, Nat::Corporate).await
+async fn nat_easy_x_easy() -> Result {
+    run_nat_holepunch(NatKind::Easy, NatKind::Easy).await
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing (and likely can't without port guessing)"]
+async fn nat_easy_x_hard() -> Result {
+    run_nat_holepunch(NatKind::Easy, NatKind::Hard).await
+}
+
+// Hard x *
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing (but did in iroh 0.35)"]
+async fn nat_hard_x_none() -> Result {
+    run_nat_holepunch(NatKind::Hard, NatKind::None).await
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing (but did in iroh 0.35)"]
+async fn nat_hard_x_easiest() -> Result {
+    run_nat_holepunch(NatKind::Hard, NatKind::Easiest).await
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing (and likely can't without port guessing)"]
+async fn nat_hard_x_easy() -> Result {
+    run_nat_holepunch(NatKind::Hard, NatKind::Easy).await
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing (and likely can't without port guessing)"]
+async fn nat_hard_x_hard() -> Result {
+    run_nat_holepunch(NatKind::Hard, NatKind::Hard).await
 }

--- a/iroh/tests/patchbay/nat.rs
+++ b/iroh/tests/patchbay/nat.rs
@@ -29,16 +29,16 @@ enum NatKind {
     ///
     /// Typical of consumer routers with UPnP or static port forwarding.
     ///
-    /// RFC 3489: Full Cone NAT.
     /// RFC 4787: Endpoint-Independent Mapping, Endpoint-Independent Filtering (EIM/EIF).
+    /// RFC 3489: Full Cone NAT.
     Easiest,
     /// Moderately restrictive NAT.
     ///
     /// The external mapping is stable across destinations, but inbound packets are filtered
     /// by source address and port. Common in home routers without UPnP.
     ///
-    /// RFC 3489: Port Restricted Cone NAT.
     /// RFC 4787: Endpoint-Independent Mapping, Address-and-Port-Dependent Filtering (EIM/APDF).
+    /// RFC 3489: Port Restricted Cone NAT.
     Easy,
     /// Most restrictive NAT.
     ///
@@ -46,8 +46,8 @@ enum NatKind {
     /// by source address and port. Holepunching between two Hard NATs requires a relay
     /// (TURN or similar). Typical of corporate firewalls and carrier-grade NAT (CGN).
     ///
-    /// RFC 3489: Symmetric NAT.
     /// RFC 4787: Endpoint-Dependent Mapping, Address-and-Port-Dependent Filtering (EDM/APDF).
+    /// RFC 3489: Symmetric NAT.
     Hard,
 }
 


### PR DESCRIPTION
## Description

This expands the NAT testing matrix, and defines the NAT types inline.

It tests the full matrix for 4 NAT kinds. See the extensive docs for the different kinds. These are, I think, the most widely deployed ones. There are more possible variations, but these are the ones that matter most IMO.

Tests that don't pass are ignored, with a note of which used to pass in iroh 0.35. The ones that we currently regressed ones are where one side is `Hard` and the other is `None` or `Easiest` - those we should get to pass again. `Hard x Hard` and `Hard x Easy` (and reverse) fail on iroh 0.35 as well - they would need port guessing (birthday paradox) which we never did so far. 

I back-ported these tests to iroh 0.35 for a comparison: https://github.com/n0-computer/iroh/tree/patchbay-0.35

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
