### PR TITLE
fix(iroh): don't falsely report home relay as connected on change

### DIFF
--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -569,6 +569,16 @@ impl ActiveRelayActor {
                     match msg {
                         ActiveRelayMessage::SetHomeRelay(is_home) => {
                             self.set_home_relay(is_home);
+                            // We are in `run_connected`, so if we just became the home
+                            // relay, publish `Connected` (the `RelayActor` only sets
+                            // `Connecting` on the URL change since it cannot know our
+                            // actual state).
+                            if is_home {
+                                self.my_relay.set_status(
+                                    &self.url,
+                                    HomeRelayStatus::Connected,
+                                );
+                            }
                         }
                         ActiveRelayMessage::CheckConnection { local_ips } => {
                             match client_stream.local_addr() {
@@ -1082,12 +1092,13 @@ impl RelayActor {
             // On change, notify all currently connected relay servers and
             // start connecting to our home relay if we are not already.
             info!("home is now relay {}, was {:?}", relay_url, prev_url);
-            let status = if self.active_relays.contains_key(&relay_url) {
-                HomeRelayStatus::Connected
-            } else {
-                HomeRelayStatus::Connecting
-            };
-            self.config.my_relay.set(relay_url.clone(), status);
+            // Publish `Connecting` initially. If an `ActiveRelayActor` already
+            // exists for this URL it will republish its actual status (e.g.
+            // `Connected`) when it receives the `SetHomeRelay(true)` message
+            // sent below.
+            self.config
+                .my_relay
+                .set(relay_url.clone(), HomeRelayStatus::Connecting);
             self.set_home_relay(relay_url).await;
         } else {
             self.config.my_relay.clear();


### PR DESCRIPTION
## Description

Follow-up to #4115. `RelayActor::on_network_change` was inferring `HomeRelayStatus::Connected` from `active_relays.contains_key()`, but a present entry only means the actor task exists, not that it has finished dialing.

If the newly selected home relay already had an `ActiveRelayActor` running as a non-home relay (because we reached a peer via it) and that actor was still dialing or in `Disconnected` backoff, `Endpoint::online` would return immediately, defeating the guarantee added in #4115.

## Change checklist

- [x] Self-review.
