### PR TITLE
fix(iroh): don't block socket actor loop on address lookups

### DIFF
--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -827,6 +827,18 @@ mod tests {
         }
     }
 
+    /// An address lookup whose `resolve` stream never yields and never ends.
+    #[derive(Debug, Clone)]
+    struct HangingAddressLookup;
+
+    impl AddressLookup for HangingAddressLookup {
+        fn publish(&self, _data: &EndpointData) {}
+
+        fn resolve(&self, _endpoint_id: EndpointId) -> Option<BoxStream<Result<Item, Error>>> {
+            Some(n0_future::stream::pending().boxed())
+        }
+    }
+
     const TEST_ALPN: &[u8] = b"n0/iroh/test";
 
     /// This is a smoke test for our Address Lookupmechanism.
@@ -967,6 +979,56 @@ mod tests {
             .connect(ep1.id(), TEST_ALPN)
             .await
             .context("connect after other resolver errored")?;
+        Ok(())
+    }
+
+    /// Regression test: a hanging address lookup for one peer must not block
+    /// concurrent `connect()` calls to other peers.
+    ///
+    /// `Socket::handle_actor_message` used to `.await` the per-remote
+    /// `RemoteStateActor` reply when handling `ResolveRemote`, so a slow or
+    /// hanging lookup would serialise every other `connect()` behind it via the
+    /// single socket actor. This tests that we do not serialize here anymore.
+    #[tokio::test]
+    #[traced_test]
+    async fn concurrent_connects_not_blocked_by_slow_lookup() -> Result {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
+        let shared = TestAddressLookupShared::default();
+
+        let (ep_server, _guard_server) =
+            new_endpoint(&mut rng, |ep| shared.create_address_lookup(ep.id())).await;
+
+        // Client uses a working lookup (resolves the server) plus a hanging
+        // lookup. For unknown ids the merged stream pends forever, because
+        // the working lookup ends immediately with no item while the hanging
+        // one never closes.
+        let (ep_client, _guard_client) = new_endpoint_add(&mut rng, |ep| {
+            let lookup = ep.address_lookup().unwrap();
+            lookup.add(shared.create_address_lookup(ep.id()));
+            lookup.add(HangingAddressLookup);
+        })
+        .await;
+
+        // One connect to an unknown id; the socket actor will `.await` its
+        // hanging `ResolveRemote` forever.
+        let offline_id = SecretKey::from_bytes(&rng.random()).public();
+        let _offline_connect = AbortOnDropHandle::new(tokio::spawn({
+            let ep = ep_client.clone();
+            async move {
+                let _ = ep.connect(offline_id, TEST_ALPN).await;
+            }
+        }));
+        // Wait until that `ResolveRemote` is in flight in the socket actor.
+        time::sleep(Duration::from_millis(200)).await;
+
+        // With the bug this connect is queued behind the hanging one and
+        // never makes progress; with the fix it completes promptly.
+        let _conn = time::timeout(
+            Duration::from_secs(1),
+            ep_client.connect(ep_server.id(), TEST_ALPN),
+        )
+        .await
+        .expect("online connect blocked behind hanging lookup")?;
         Ok(())
     }
 

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -989,7 +989,7 @@ mod tests {
     /// `RemoteStateActor` reply when handling `ResolveRemote`, so a slow or
     /// hanging lookup would serialise every other `connect()` behind it via the
     /// single socket actor. This tests that we do not serialize here anymore.
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     #[traced_test]
     async fn concurrent_connects_not_blocked_by_slow_lookup() -> Result {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1271,11 +1271,16 @@ impl EndpointInner {
     ) -> Result<Result<EndpointIdMappedAddr, AddressLookupFailed>, RemoteStateActorStoppedError>
     {
         let (tx, rx) = oneshot::channel();
+        let remote_id = addr.id;
         self.actor_sender
             .send(ActorMessage::ResolveRemote(addr, tx))
             .await
             .ok();
-        rx.await.map_err(|_| RemoteStateActorStoppedError::new())?
+        let reply = rx.await.map_err(|_| RemoteStateActorStoppedError::new())?;
+        match reply {
+            Ok(()) => Ok(Ok(self.mapped_addrs.endpoint_addrs.get(&remote_id))),
+            Err(err) => Ok(Err(err)),
+        }
     }
 
     /// Fetches the [`RemoteInfo`] about a remote from the `RemoteStateActor`.
@@ -1324,9 +1329,7 @@ enum ActorMessage {
     #[debug("ResolveRemote(..)")]
     ResolveRemote(
         EndpointAddr,
-        oneshot::Sender<
-            Result<Result<EndpointIdMappedAddr, AddressLookupFailed>, RemoteStateActorStoppedError>,
-        >,
+        oneshot::Sender<Result<(), AddressLookupFailed>>,
     ),
     #[debug("AddConnection(..)")]
     AddConnection(
@@ -1728,7 +1731,10 @@ impl Actor {
                 self.handle_relay_map_change();
             }
             ActorMessage::ResolveRemote(addr, tx) => {
-                tx.send(self.remote_map.resolve_remote(addr).await).ok();
+                // Swallowing the error is fine here; if a send on the channel to the
+                // remote state actor ever fails (which it shouldn't), `tx` will be
+                // dropped and thus the failure will be propagated to the caller.
+                self.remote_map.resolve_remote(addr, tx).await.ok();
             }
             ActorMessage::RemoteInfo(id, tx) => {
                 if let Some(info) = self.remote_map.remote_info(id).await {

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -228,20 +228,14 @@ impl RemoteMap {
     pub(super) async fn resolve_remote(
         &mut self,
         addr: EndpointAddr,
-    ) -> Result<Result<EndpointIdMappedAddr, AddressLookupFailed>, RemoteStateActorStoppedError>
-    {
+        tx: oneshot::Sender<Result<(), AddressLookupFailed>>,
+    ) -> Result<(), RemoteStateActorStoppedError> {
         let EndpointAddr { id, addrs } = addr;
         let actor = self.remote_state_actor(id);
-        let (tx, rx) = oneshot::channel();
         actor
             .send(RemoteStateMessage::ResolveRemote(addrs, tx))
             .await?;
-
-        match rx.await {
-            Ok(Ok(())) => Ok(Ok(self.mapped_addrs.endpoint_addrs.get(&id))),
-            Ok(Err(err)) => Ok(Err(err)),
-            Err(_) => Err(RemoteStateActorStoppedError::new()),
-        }
+        Ok(())
     }
 
     pub(super) async fn remote_info(&mut self, id: EndpointId) -> Option<RemoteInfo> {


### PR DESCRIPTION
## Description

When calling `Endpoint::connect`, the first thing happening internally is checking if we have *any* address for the endpoint ID, and if not, wait for address lookup to return at least one address (because attempting to connect without any address is worthless). Due to changes in unrelated refactors, we moved the `await` on the return channel from the `RemoteStateActor` (which handles the address lookup) *into the main socket actor loop*. This is a bug, because it means the socket actor loop may be blocked waiting for address lookup, which can take a long time.

This PR fixes this by passing through the return channel and only awaiting it at the call site, i.e. out of the actor loop.

Included is a test that fails without the fix and passes now.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Ideally, the actor loop should not have any `await` points outside of the main `tokio::select!`. However, this is not feasable in the current architecture, because we need to send into bounded channels. This is fine, too, as those sends should all be fast and only apply necessary backpressure in rare conditions. However, it means we need to review all `await` points in the branches of the select most precisely by hand, to be sure to not have any potentially long-running awaits block the actor loop.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Tests if relevant.
