### PR TITLE
fix: set default crypto provider for iroh-dns-server binary

### DIFF
--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -75,6 +75,11 @@ tempfile = "3.23.0"
 default = ["ring"]
 ring = ["rustls/ring", "tokio-rustls/ring"]
 
+[[bin]]
+name = "iroh-dns-server"
+path = "src/main.rs"
+required-features = ["ring"]
+
 [[bench]]
 name = "write"
 harness = false

--- a/iroh-dns-server/src/main.rs
+++ b/iroh-dns-server/src/main.rs
@@ -15,6 +15,16 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
+
+    // Install `ring` as default crypto provider for rustls.
+    // This helps when both ring and aws-lc-rs rustls features are enabled
+    // (e.g. via `--all-features` in the release build), otherwise rustls
+    // panics because it can't determine a default provider from crate features.
+    // `ring` is enabled by the default `ring` feature of this crate.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to set default crypto provider");
+
     let args = Cli::parse();
 
     let config = if let Some(path) = args.config {


### PR DESCRIPTION
## Description

This fixes the panic in 0.98 on the dns server.

Same fix as in #4087 

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
