### PR TITLE
fix(iroh): reduce await points in socket actor loop

### DIFF
--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1283,8 +1283,9 @@ impl EndpointInner {
     /// Returns `None` if no actor is running for the remote.
     pub(crate) async fn remote_info(&self, id: EndpointId) -> Option<RemoteInfo> {
         let (tx, rx) = oneshot::channel();
-        self.actor_sender
-            .send(ActorMessage::RemoteInfo(id, tx))
+        self.remote_actors
+            .get(&id)?
+            .send(RemoteStateMessage::RemoteInfo(tx))
             .await
             .ok()?;
         rx.await.ok()
@@ -1334,8 +1335,6 @@ enum ActorMessage {
         WeakConnectionHandle,
         oneshot::Sender<PathWatchable>,
     ),
-    #[debug("RemoteInfo(..)")]
-    RemoteInfo(EndpointId, oneshot::Sender<RemoteInfo>),
     /// Re-evaluate direct addresses, e.g. after configured external addresses changed.
     DirectAddrRefresh,
     #[cfg(all(test, with_crypto_provider))]
@@ -1471,7 +1470,6 @@ impl Actor {
                     let Some(msg) = msg else {
                         trace!("tick: socket receiver closed");
                         self.sock.metrics.socket.actor_tick_other.inc();
-
                         receiver_closed = true;
                         continue;
                     };
@@ -1556,8 +1554,8 @@ impl Actor {
                     self.sock.metrics.socket.actor_link_change.inc();
                     self.handle_network_change(is_major).await;
                 }
-                eid = poll_fn(|cx| self.remote_map.poll_cleanup(cx)) => {
-                    trace!(%eid, "cleaned up RemoteStateActor");
+                remote_id = poll_fn(|cx| self.remote_map.poll_cleanup(cx)) => {
+                    trace!(%remote_id, "cleaned up RemoteStateActor");
                 }
                 _ = &mut notify_quic_network_change => {
                     let has_network = self.has_usable_network();
@@ -1729,11 +1727,6 @@ impl Actor {
             }
             ActorMessage::ResolveRemote(addr, tx) => {
                 tx.send(self.remote_map.resolve_remote(addr).await).ok();
-            }
-            ActorMessage::RemoteInfo(id, tx) => {
-                if let Some(info) = self.remote_map.remote_info(id).await {
-                    tx.send(info).ok();
-                }
             }
             ActorMessage::AddConnection(remote, conn, tx) => {
                 if let Some(watcher) = self.remote_map.add_connection(remote, conn).await {

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -317,9 +317,13 @@ impl ShutdownState {
 /// possible.
 #[derive(Debug)]
 pub(crate) struct Socket {
-    /// Channels for sending time-crucial messages to `RemoteStateActors`.
+    /// Read-only view of the per-remote `RemoteStateActor` inboxes.
     ///
-    /// Currently only exists to support sending `SendDatagram` messages.
+    /// Lets callers send to an existing `RemoteStateActor` without going through
+    /// the socket actor.
+    ///
+    /// A missing entry means no actor is running for that remote. Spawning new
+    /// `RemoteStateActor`s must go through the socket actor channel.
     remote_actors: ReadOnlyMap<EndpointId, mpsc::Sender<RemoteStateMessage>>,
 
     /// EndpointId of this endpoint.

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1729,9 +1729,10 @@ impl Actor {
                 tx.send(self.remote_map.resolve_remote(addr).await).ok();
             }
             ActorMessage::AddConnection(remote, conn, tx) => {
-                if let Some(watcher) = self.remote_map.add_connection(remote, conn).await {
-                    tx.send(watcher).ok();
-                }
+                // Swallowing the error is fine here; if a send on the channel to the
+                // remote state actor ever fails (which it shouldn't), `tx` will be
+                // dropped and thus the failure will be propagated to the caller.
+                self.remote_map.add_connection(remote, conn, tx).await.ok();
             }
             ActorMessage::DirectAddrRefresh => {
                 #[cfg(not(wasm_browser))]

--- a/iroh/src/socket/concurrent_read_map.rs
+++ b/iroh/src/socket/concurrent_read_map.rs
@@ -41,13 +41,6 @@ impl<K: Hash + Eq, V> ConcurrentReadMap<K, V> {
         self.0.remove(key, &self.0.guard());
     }
 
-    pub(crate) fn get(&self, key: &K) -> Option<V>
-    where
-        V: Clone,
-    {
-        self.0.get(key, &self.0.guard()).cloned()
-    }
-
     pub(crate) fn read_only(&self) -> ReadOnlyMap<K, V> {
         ReadOnlyMap(self.0.clone())
     }

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -244,13 +244,6 @@ impl RemoteMap {
         }
     }
 
-    pub(super) async fn remote_info(&mut self, id: EndpointId) -> Option<RemoteInfo> {
-        let actor = self.remote_state_actor_if_exists(id)?;
-        let (tx, rx) = oneshot::channel();
-        actor.send(RemoteStateMessage::RemoteInfo(tx)).await.ok()?;
-        rx.await.ok()
-    }
-
     pub(super) async fn add_connection(
         &mut self,
         remote: EndpointId,
@@ -288,13 +281,6 @@ impl RemoteMap {
         } else {
             sender.clone()
         }
-    }
-
-    pub(super) fn remote_state_actor_if_exists(
-        &self,
-        eid: EndpointId,
-    ) -> Option<mpsc::Sender<RemoteStateMessage>> {
-        self.senders.get(&eid)
     }
 
     pub(super) fn senders(&self) -> ReadOnlyMap<EndpointId, mpsc::Sender<RemoteStateMessage>> {

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -248,14 +248,13 @@ impl RemoteMap {
         &mut self,
         remote: EndpointId,
         conn: noq::WeakConnectionHandle,
-    ) -> Option<PathWatchable> {
+        tx: oneshot::Sender<PathWatchable>,
+    ) -> Result<(), RemoteStateActorStoppedError> {
         let actor = self.remote_state_actor(remote);
-        let (tx, rx) = oneshot::channel();
         actor
             .send(RemoteStateMessage::AddConnection(conn, tx))
-            .await
-            .ok()?;
-        rx.await.ok()
+            .await?;
+        Ok(())
     }
 
     /// Returns the sender for the [`RemoteStateActor`].


### PR DESCRIPTION
## Description

We needlessly await the return channel from messages sent to `RemoteStateActor`s within the main socket actor loop. This moves the await point out of the actor loop:
- For `remote_info`, we can just use the read-only copy of the remote actor sender map, because this should not start a new actor anyways
- for `add_connection`  we can await the reply channel outside of the actor loop, as in #4138


## Change checklist

- [x] Self-review.