### PR TITLE
socket: guard against zero-stride noq metadata to avoid div-by-zero

### DIFF
--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -572,12 +572,21 @@ impl Socket {
             let noq_meta = &mut metas[i];
             let source_addr = &source_addrs[i];
 
-            let datagram_count = noq_meta.len.div_ceil(noq_meta.stride);
+            // Custom transports (e.g. BLE) can surface zero-length metadata
+            // where `stride == 0`, and `u*::div_ceil(0)` panics. Treat a
+            // zero-stride entry as a single datagram for the purposes of
+            // the per-packet metric - there is no GRO fan-out to compute
+            // (iroh#4144).
+            let datagram_count = if noq_meta.stride == 0 {
+                1
+            } else {
+                noq_meta.len.div_ceil(noq_meta.stride)
+            };
             self.metrics
                 .socket
                 .recv_datagrams
                 .inc_by(datagram_count as _);
-            if noq_meta.len > noq_meta.stride {
+            if noq_meta.stride > 0 && noq_meta.len > noq_meta.stride {
                 trace!(
                     src = ?source_addr,
                     len = noq_meta.len,


### PR DESCRIPTION
## Summary

Fixes #4144.

The receive loop in `iroh/src/socket.rs` computes `datagram_count = noq_meta.len.div_ceil(noq_meta.stride)` for per-packet metrics. Custom transports (`iroh-ble-transport` and other non-UDP backends upgrading to iroh 0.98+) occasionally surface zero-length metadata where `stride == 0`, and `u*::div_ceil(0)` panics on the worker:

```
thread 'tokio-rt-worker' panicked at iroh-0.98.1/src/socket.rs:575:47:
attempt to divide by zero
```

The panic cascades into noq's endpoint actor with a `PoisonError` and the connection is effectively dead.

## Fix

Treat `stride == 0` as a single datagram for the metric (there is no GRO fan-out to compute in that case), and gate the GRO trace/metric branch on `stride > 0` so the second `div_ceil` can't re-panic either. UDP paths still go through the normal `div_ceil` computation.

## Test plan

- [x] `cargo check -p iroh`
- [x] `cargo test -p iroh --lib socket` (33/33 pass)
