### PR TITLE
feat(iroh): expose home relay connection status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,9 +4409,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -19,7 +19,7 @@ use iroh_base::{EndpointAddr, EndpointId, RelayUrl, SecretKey, TransportAddr};
 use iroh_relay::{RelayConfig, RelayMap, tls::CaRootsConfig};
 #[cfg(not(wasm_browser))]
 use n0_error::bail;
-use n0_error::{e, ensure, stack_error};
+use n0_error::{AnyError, e, ensure, stack_error};
 use n0_watcher::Watcher;
 use pin_project::pin_project;
 use tokio_util::sync::WaitForCancellationFutureOwned;
@@ -58,6 +58,7 @@ use crate::{
     metrics::EndpointMetrics,
     socket::{
         self, EndpointInner, RemoteStateActorStoppedError, StaticConfig, mapped_addrs::MappedAddr,
+        transports::RelayConnectionState,
     },
     tls::{self, DEFAULT_MAX_TLS_TICKETS, misc::RustlsTokenKey},
 };
@@ -1285,11 +1286,7 @@ impl Endpoint {
         let mut watcher = self.inner.home_relay_status();
         let mut value = watcher.get();
         loop {
-            if value
-                .into_iter()
-                .flatten()
-                .any(|(_url, status)| status.is_connected())
-            {
+            if value.into_iter().any(|status| status.is_connected()) {
                 return;
             }
             value = match watcher.updated().await {
@@ -1300,6 +1297,22 @@ impl Endpoint {
                 }
             }
         }
+    }
+
+    /// Returns a [`Watcher`] over the connection status of the endpoint's home relays.
+    ///
+    /// The watched value has one entry per home relay whose URL is known,
+    /// and is empty when no relays are configured or before the endpoint has
+    /// selected one the home relay from the list of configured relays.
+    /// The watcher updates whenever any home relay's connection status changes.
+    /// See [`RelayStatus`] for the information available on each entry.
+    ///
+    /// The returned watcher only becomes disconnected once the last clone of
+    /// the [`Endpoint`] is dropped. Closing the endpoint does not disconnect
+    /// the watcher. To stop a task once the endpoint stops, combine with
+    /// [`Self::closed`].
+    pub fn home_relay_status(&self) -> impl Watcher<Value = Vec<RelayStatus>> + use<> {
+        self.inner.home_relay_status()
     }
 
     /// Returns a [`Watcher`] for any net-reports run from this [`Endpoint`].
@@ -1804,6 +1817,40 @@ fn proxy_url_from_env() -> Option<Url> {
     }
 
     None
+}
+
+/// Connection status of a single home relay.
+///
+/// Observed via [`Endpoint::home_relay_status`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelayStatus {
+    url: RelayUrl,
+    state: RelayConnectionState,
+}
+
+impl RelayStatus {
+    pub(crate) fn new(url: RelayUrl, state: RelayConnectionState) -> Self {
+        Self { url, state }
+    }
+
+    /// Returns the URL of the home relay.
+    pub fn url(&self) -> &RelayUrl {
+        &self.url
+    }
+
+    /// Returns `true` if the endpoint is connected to the relay.
+    pub fn is_connected(&self) -> bool {
+        self.state.is_connected()
+    }
+
+    /// Returns the most recent connection error, if the relay is currently
+    /// disconnected.
+    ///
+    /// Returns `None` when the relay is connected, or when the endpoint has
+    /// not yet observed a failed connection attempt.
+    pub fn last_error(&self) -> Option<&AnyError> {
+        self.state.last_error().map(Arc::as_ref)
+    }
 }
 
 /// Configuration of the relay servers for an [`Endpoint`].

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -69,7 +69,7 @@ use crate::net_report::QuicConfig;
 use crate::{
     address_lookup::{self, AddressLookupFailed, EndpointData, UserData},
     defaults::timeouts::NET_REPORT_TIMEOUT,
-    endpoint::{hooks::EndpointHooksList, quic::QuicTransportConfig},
+    endpoint::{RelayStatus, hooks::EndpointHooksList, quic::QuicTransportConfig},
     metrics::EndpointMetrics,
     net_report::{self, IfStateDetails, Report},
     portmapper,
@@ -77,7 +77,7 @@ use crate::{
     socket::{
         concurrent_read_map::ReadOnlyMap,
         remote_map::{MappedAddrs, PathWatchable, RemoteInfo},
-        transports::{HomeRelayStatus, HomeRelayWatch, HomeRelayWatcher, TransportBiasMap},
+        transports::{HomeRelayWatch, HomeRelayWatcher, TransportBiasMap},
     },
     tls::{
         self,
@@ -485,9 +485,7 @@ impl Socket {
         })
     }
 
-    pub(crate) fn home_relay_status(
-        &self,
-    ) -> impl Watcher<Value = Vec<Option<(RelayUrl, HomeRelayStatus)>>> + use<> {
+    pub(crate) fn home_relay_status(&self) -> impl Watcher<Value = Vec<RelayStatus>> + use<> {
         self.home_relay_watch.clone()
     }
 

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -20,7 +20,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, instrument, trace, warn};
 
 use super::{Socket, mapped_addrs::MultipathMappedAddr};
-use crate::{metrics::EndpointMetrics, net_report::Report};
+use crate::{endpoint::RelayStatus, metrics::EndpointMetrics, net_report::Report};
 
 pub(crate) mod custom;
 #[cfg(not(wasm_browser))]
@@ -33,7 +33,9 @@ use custom::{CustomEndpoint, CustomSender, CustomTransport};
 pub(crate) use self::ip::Config as IpConfig;
 #[cfg(not(wasm_browser))]
 use self::ip::{IpNetworkChangeSender, IpTransports, IpTransportsSender};
-pub(crate) use self::relay::{HomeRelayStatus, HomeRelayWatch, RelayActorConfig, RelayTransport};
+pub(crate) use self::relay::{
+    HomeRelayWatch, RelayActorConfig, RelayConnectionState, RelayTransport,
+};
 
 /// Manages the different underlying data transports that the socket can support.
 #[derive(Debug)]
@@ -56,15 +58,12 @@ type CustomTransportsWatcher =
 /// Combined watcher type for all relay transports
 type RelayTransportsWatcher = n0_watcher::Join<
     Option<(RelayUrl, EndpointId)>,
-    n0_watcher::Map<
-        n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>,
-        Option<(RelayUrl, EndpointId)>,
-    >,
+    n0_watcher::Map<n0_watcher::Direct<Option<RelayStatus>>, Option<(RelayUrl, EndpointId)>>,
 >;
 
-pub(super) type HomeRelayWatcher = n0_watcher::Join<
-    Option<(RelayUrl, HomeRelayStatus)>,
-    n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>,
+pub(super) type HomeRelayWatcher = n0_watcher::Map<
+    n0_watcher::Join<Option<RelayStatus>, n0_watcher::Direct<Option<RelayStatus>>>,
+    Vec<RelayStatus>,
 >;
 
 #[cfg(not(wasm_browser))]
@@ -322,6 +321,7 @@ impl Transports {
 
     pub(super) fn home_relay_watch(&self) -> HomeRelayWatcher {
         n0_watcher::Join::new(self.relay.iter().map(|t| t.my_relay_status()))
+            .map(|v| v.into_iter().flatten().collect())
     }
 
     #[cfg(not(wasm_browser))]

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -17,16 +17,15 @@ use tokio_util::sync::{CancellationToken, PollSender};
 use tracing::{Instrument, error, info_span, warn};
 
 use super::{Addr, Transmit};
+use crate::endpoint::RelayStatus;
 
 mod actor;
 
-pub(crate) use self::actor::{Config as RelayActorConfig, HomeRelayStatus, HomeRelayWatch};
+pub(crate) use self::actor::{Config as RelayActorConfig, HomeRelayWatch, RelayConnectionState};
 use self::actor::{RelayActor, RelayActorMessage, RelayRecvDatagram, RelaySendItem};
 
-type RelayAddrWatcher = n0_watcher::Map<
-    n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>>,
-    Option<(RelayUrl, EndpointId)>,
->;
+type RelayAddrWatcher =
+    n0_watcher::Map<n0_watcher::Direct<Option<RelayStatus>>, Option<(RelayUrl, EndpointId)>>;
 
 #[derive(Debug)]
 pub(crate) struct RelayTransport {
@@ -171,12 +170,10 @@ impl RelayTransport {
         let my_endpoint_id = self.my_endpoint_id;
         self.my_relay
             .watch()
-            .map(move |url| url.map(|url| (url.0, my_endpoint_id)))
+            .map(move |status| status.map(|status| (status.url().clone(), my_endpoint_id)))
     }
 
-    pub(super) fn my_relay_status(
-        &self,
-    ) -> n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>> {
+    pub(super) fn my_relay_status(&self) -> n0_watcher::Direct<Option<RelayStatus>> {
         self.my_relay.watch()
     }
 

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -44,7 +44,7 @@ use iroh_relay::{
     client::{Client, ConnectError, RecvError, SendError},
     protos::relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg, Status},
 };
-use n0_error::{e, stack_error};
+use n0_error::{AnyError, e, stack_error};
 use n0_future::{
     FuturesUnorderedBounded, SinkExt, StreamExt,
     task::JoinSet,
@@ -59,7 +59,9 @@ use url::Url;
 
 #[cfg(not(wasm_browser))]
 use crate::dns::DnsResolver;
-use crate::{net_report::Report, socket::Metrics as SocketMetrics, util::MaybeFuture};
+use crate::{
+    endpoint::RelayStatus, net_report::Report, socket::Metrics as SocketMetrics, util::MaybeFuture,
+};
 
 /// How long a non-home relay connection needs to be idle (last written to) before we close it.
 const RELAY_INACTIVE_CLEANUP_TIME: Duration = Duration::from_secs(60);
@@ -319,24 +321,23 @@ impl ActiveRelayActor {
 
         while let Err(err) = self.run_once().await {
             warn!("{err:#}");
+            let was_established = matches!(err, RelayConnectionError::Established { .. });
+            let last_error = Some(Arc::new(AnyError::from(err)));
             self.my_relay
-                .set_status(&self.url, HomeRelayStatus::Disconnected);
-            match err {
-                RelayConnectionError::Dial { .. } | RelayConnectionError::Handshake { .. } => {
-                    // If dialing failed, or if the relay connection failed before we received a pong,
-                    // we wait an exponentially increasing time until we attempt to reconnect again.
-                    let Some(delay) = backoff.next() else {
-                        warn!("retries exceeded");
-                        break;
-                    };
-                    debug!("retry in {delay:?}");
-                    time::sleep(delay).await;
-                }
-                RelayConnectionError::Established { .. } => {
-                    // If the relay connection remained established long enough so that we received a pong
-                    // from the relay server, we reset the backoff and attempt to reconnect immediately.
-                    backoff = Self::build_backoff();
-                }
+                .set_status(&self.url, RelayConnectionState::Disconnected { last_error });
+            if !was_established {
+                // If dialing failed, or if the relay connection failed before we received a pong,
+                // we wait an exponentially increasing time until we attempt to reconnect again.
+                let Some(delay) = backoff.next() else {
+                    warn!("retries exceeded");
+                    break;
+                };
+                debug!("retry in {delay:?}");
+                time::sleep(delay).await;
+            } else {
+                // If the relay connection remained established long enough so that we received a pong
+                // from the relay server, we reset the backoff and attempt to reconnect immediately.
+                backoff = Self::build_backoff();
             }
         }
         debug!("exiting");
@@ -358,13 +359,13 @@ impl ActiveRelayActor {
     /// be retried with a backoff.
     async fn run_once(&mut self) -> Result<(), RelayConnectionError> {
         self.my_relay
-            .set_status(&self.url, HomeRelayStatus::Connecting);
+            .set_status(&self.url, RelayConnectionState::Connecting);
         let client = match self.run_dialing().instrument(info_span!("dialing")).await {
             Some(client_res) => client_res.map_err(|err| e!(RelayConnectionError::Dial, err))?,
             None => return Ok(()),
         };
         self.my_relay
-            .set_status(&self.url, HomeRelayStatus::Connected);
+            .set_status(&self.url, RelayConnectionState::Connected);
         self.run_connected(client)
             .instrument(info_span!("connected"))
             .await
@@ -574,10 +575,8 @@ impl ActiveRelayActor {
                             // `Connecting` on the URL change since it cannot know our
                             // actual state).
                             if is_home {
-                                self.my_relay.set_status(
-                                    &self.url,
-                                    HomeRelayStatus::Connected,
-                                );
+                                self.my_relay
+                                    .set_status(&self.url, RelayConnectionState::Connected);
                             }
                         }
                         ActiveRelayMessage::CheckConnection { local_ips } => {
@@ -875,27 +874,64 @@ pub(crate) struct Config {
     pub metrics: Arc<SocketMetrics>,
 }
 
-/// Connection status of the home relay.
+/// Connection state of the home relay.
 ///
-/// Published via [`HomeRelayWatch`] so that [`Endpoint::online`] can wait until the
-/// relay is fully connected, not just selected.
+/// Published via [`HomeRelayWatch`] so that [`Endpoint::online`] and the public
+/// [`Endpoint::home_relay_status`] watcher can observe the connection state.
+/// This type is `pub(crate)`; the public surface lives on
+/// [`crate::endpoint::RelayStatus`], and this enum is intentionally free to
+/// evolve without affecting the public API.
 ///
 /// [`Endpoint::online`]: crate::Endpoint::online
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub(crate) enum HomeRelayStatus {
+/// [`Endpoint::home_relay_status`]: crate::Endpoint::home_relay_status
+#[derive(Debug, Clone)]
+pub(crate) enum RelayConnectionState {
     /// Dialing or performing the relay handshake.
     Connecting,
-    /// Connected and handshaked, the endpoint is registered and reachable.
+    /// Connected and handshaked.
     Connected,
-    /// Connection lost after having been connected.
-    Disconnected,
+    /// Not connected. Either the connection was lost after having been
+    /// established, or an attempt to connect failed.
+    ///
+    /// `last_error` carries the most recent connection error, if any. The
+    /// initial transition into this state (before any attempt has produced
+    /// an error) carries `None`.
+    ///
+    /// The `Arc` is compared by pointer identity: each new failure produces
+    /// a fresh allocation, so the watcher fires on every new error.
+    Disconnected { last_error: Option<Arc<AnyError>> },
 }
 
-impl HomeRelayStatus {
+impl RelayConnectionState {
     pub(crate) fn is_connected(&self) -> bool {
         matches!(self, Self::Connected)
     }
+
+    pub(crate) fn last_error(&self) -> Option<&Arc<AnyError>> {
+        match self {
+            Self::Disconnected { last_error } => last_error.as_ref(),
+            _ => None,
+        }
+    }
 }
+
+impl PartialEq for RelayConnectionState {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Connecting, Self::Connecting) | (Self::Connected, Self::Connected) => true,
+            (Self::Disconnected { last_error: a }, Self::Disconnected { last_error: b }) => {
+                match (a, b) {
+                    (None, None) => true,
+                    (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for RelayConnectionState {}
 
 /// Shared watchable for the home relay URL and connection status.
 ///
@@ -909,7 +945,7 @@ impl HomeRelayStatus {
 /// was designated, the write is silently dropped.
 #[derive(Debug, Clone)]
 pub(crate) struct HomeRelayWatch {
-    inner: Watchable<Option<(RelayUrl, HomeRelayStatus)>>,
+    inner: Watchable<Option<RelayStatus>>,
 }
 
 impl Default for HomeRelayWatch {
@@ -922,8 +958,8 @@ impl Default for HomeRelayWatch {
 
 impl HomeRelayWatch {
     /// Set the home relay URL and status. Used by [`RelayActor`] on relay changes.
-    fn set(&self, url: RelayUrl, status: HomeRelayStatus) {
-        let _ = self.inner.set(Some((url, status)));
+    fn set(&self, url: RelayUrl, state: RelayConnectionState) {
+        let _ = self.inner.set(Some(RelayStatus::new(url, state)));
     }
 
     /// Clear the home relay (no preferred relay). Used by [`RelayActor`].
@@ -937,17 +973,17 @@ impl HomeRelayWatch {
     /// demoted actor from overwriting a newer home relay's status: the [`RelayActor`]
     /// updates the URL in the watchable *before* sending `SetHomeRelay(false)`, so by
     /// the time the old actor tries to write, the URL no longer matches.
-    fn set_status(&self, url: &RelayUrl, status: HomeRelayStatus) {
-        if self.inner.get().as_ref().map(|p| &p.0) == Some(url) {
-            let _ = self.inner.set(Some((url.clone(), status)));
+    fn set_status(&self, url: &RelayUrl, state: RelayConnectionState) {
+        if self.inner.get().as_ref().map(RelayStatus::url) == Some(url) {
+            let _ = self.inner.set(Some(RelayStatus::new(url.clone(), state)));
         }
     }
 
-    fn get(&self) -> Option<(RelayUrl, HomeRelayStatus)> {
+    fn get(&self) -> Option<RelayStatus> {
         self.inner.get()
     }
 
-    pub(crate) fn watch(&self) -> n0_watcher::Direct<Option<(RelayUrl, HomeRelayStatus)>> {
+    pub(crate) fn watch(&self) -> n0_watcher::Direct<Option<RelayStatus>> {
         self.inner.watch()
     }
 }
@@ -1080,7 +1116,7 @@ impl RelayActor {
 
     async fn on_network_change(&mut self, report: Report) {
         let prev = self.config.my_relay.get();
-        let prev_url = prev.as_ref().map(|p| &p.0);
+        let prev_url = prev.as_ref().map(RelayStatus::url);
         if report.preferred_relay.as_ref() == prev_url {
             // No change.
             return;
@@ -1098,7 +1134,7 @@ impl RelayActor {
             // sent below.
             self.config
                 .my_relay
-                .set(relay_url.clone(), HomeRelayStatus::Connecting);
+                .set(relay_url.clone(), RelayConnectionState::Connecting);
             self.set_home_relay(relay_url).await;
         } else {
             self.config.my_relay.clear();
@@ -1173,7 +1209,7 @@ impl RelayActor {
             Some(e) => e.clone(),
             None => {
                 let handle = self.start_active_relay(url.clone());
-                if Some(&url) == self.config.my_relay.get().as_ref().map(|p| &p.0)
+                if Some(&url) == self.config.my_relay.get().as_ref().map(RelayStatus::url)
                     && let Err(err) = handle
                         .inbox_addr
                         .try_send(ActiveRelayMessage::SetHomeRelay(true))
@@ -1281,8 +1317,8 @@ impl RelayActor {
             .retain(|_url, handle| !handle.inbox_addr.is_closed());
 
         // Make sure home relay exists
-        if let Some(url) = self.config.my_relay.get() {
-            self.active_relay_handle(url.0);
+        if let Some(status) = self.config.my_relay.get() {
+            self.active_relay_handle(status.url().clone());
         }
         self.log_active_relay();
     }
@@ -1699,26 +1735,39 @@ mod tests {
 
     #[test]
     fn test_home_relay_watch_url_guard() {
-        use super::{HomeRelayStatus::*, HomeRelayWatch};
+        use super::{HomeRelayWatch, RelayConnectionState};
+        use crate::endpoint::RelayStatus;
 
         let watch = HomeRelayWatch::default();
         let a: RelayUrl = "https://a.example.com".parse().unwrap();
         let b: RelayUrl = "https://b.example.com".parse().unwrap();
 
         // Actor A becomes home and connects
-        watch.set(a.clone(), Connecting);
-        watch.set_status(&a, Connected);
-        assert_eq!(watch.get(), Some((a.clone(), Connected)));
+        watch.set(a.clone(), RelayConnectionState::Connecting);
+        watch.set_status(&a, RelayConnectionState::Connected);
+        assert_eq!(
+            watch.get(),
+            Some(RelayStatus::new(a.clone(), RelayConnectionState::Connected)),
+        );
 
         // RelayActor migrates home to B
-        watch.set(b.clone(), Connecting);
+        watch.set(b.clone(), RelayConnectionState::Connecting);
 
         // Old actor A tries to write -- rejected because URL changed
-        watch.set_status(&a, Disconnected);
-        assert_eq!(watch.get(), Some((b.clone(), Connecting)));
+        watch.set_status(&a, RelayConnectionState::Disconnected { last_error: None });
+        assert_eq!(
+            watch.get(),
+            Some(RelayStatus::new(
+                b.clone(),
+                RelayConnectionState::Connecting
+            )),
+        );
 
         // Actor B writes normally
-        watch.set_status(&b, Connected);
-        assert_eq!(watch.get(), Some((b.clone(), Connected)));
+        watch.set_status(&b, RelayConnectionState::Connected);
+        assert_eq!(
+            watch.get(),
+            Some(RelayStatus::new(b, RelayConnectionState::Connected)),
+        );
     }
 }


### PR DESCRIPTION
## Description

Currently, the only API to check whether an endpoint successfully connected to a home relay is `Endpoint::online`. However, this API neither provides a notification in case the connection is lost, nor does it provide any insight in case the connection fails.

This PR adds `Endpoint::home_relay_status`, exposing the connection status of the home relay. It returns a watcher over `Vec<RelayStatus>`. Currently the vec will never have more than one entry, but we're keeping the API aligned to other relay APIs in preparation of a potential multi-home-relays feature during 1.0.

The `RelayStatus` is a struct that internally contains a non-public enum with the actual status. For now, it only provides methods `is_connected() -> bool` and `last_error() -> Option<Arc<AnyError>>`, which should provide reasonable introspectability while allowing us to add more information in the future.

Fixes #3940


## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.