### PR TITLE
refactor(iroh, iroh-relay)!: remove reqwest from public API and enforce our DNS resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,9 +4409,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -45,7 +45,7 @@ fn benchmark_dns_server(c: &mut Criterion) {
                         .client_config(default_provider())
                         .expect("infallible");
                     let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");
-                    let pkarr = PkarrRelayClient::new(pkarr_relay, tls_config);
+                    let pkarr = PkarrRelayClient::new(pkarr_relay, tls_config, Default::default());
                     let relay_url = "http://localhost:8080".parse().unwrap();
                     let endpoint_info = EndpointInfo::new(endpoint_id).with_relay_url(relay_url);
                     let signed_packet = endpoint_info

--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -4,6 +4,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use iroh::{
     SecretKey,
     address_lookup::pkarr::PkarrRelayClient,
+    dns::DnsResolver,
     endpoint_info::EndpointInfo,
     tls::{CaRootsConfig, default_provider},
 };
@@ -45,7 +46,8 @@ fn benchmark_dns_server(c: &mut Criterion) {
                         .client_config(default_provider())
                         .expect("infallible");
                     let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");
-                    let pkarr = PkarrRelayClient::new(pkarr_relay, tls_config, Default::default());
+                    let pkarr =
+                        PkarrRelayClient::new(pkarr_relay, tls_config, DnsResolver::default());
                     let relay_url = "http://localhost:8080".parse().unwrap();
                     let endpoint_info = EndpointInfo::new(endpoint_id).with_relay_url(relay_url);
                     let signed_packet = endpoint_info

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -8,6 +8,7 @@ use iroh::{
         dns::{N0_DNS_ENDPOINT_ORIGIN_PROD, N0_DNS_ENDPOINT_ORIGIN_STAGING},
         pkarr::{N0_DNS_PKARR_RELAY_PROD, N0_DNS_PKARR_RELAY_STAGING, PkarrRelayClient},
     },
+    dns::DnsResolver,
     endpoint_info::{EndpointInfo, IROH_TXT_NAME},
     tls::{CaRootsConfig, default_provider},
 };
@@ -106,7 +107,7 @@ async fn main() -> Result<()> {
     let tls_config = CaRootsConfig::default()
         .client_config(default_provider())
         .expect("infallible");
-    let pkarr = PkarrRelayClient::new(pkarr_relay_url, tls_config, Default::default());
+    let pkarr = PkarrRelayClient::new(pkarr_relay_url, tls_config, DnsResolver::default());
 
     let mut endpoint_info = EndpointInfo::new(endpoint_id);
     if let Some(relay_url) = relay_url {

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
     let tls_config = CaRootsConfig::default()
         .client_config(default_provider())
         .expect("infallible");
-    let pkarr = PkarrRelayClient::new(pkarr_relay_url, tls_config);
+    let pkarr = PkarrRelayClient::new(pkarr_relay_url, tls_config, Default::default());
 
     let mut endpoint_info = EndpointInfo::new(endpoint_id);
     if let Some(relay_url) = relay_url {

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -346,7 +346,11 @@ mod tests {
         let tls_config = CaRootsConfig::default()
             .client_config(default_provider())
             .expect("infallible");
-        let pkarr = PkarrRelayClient::new(format!("{http_url}pkarr").parse().anyerr()?, tls_config);
+        let pkarr = PkarrRelayClient::new(
+            format!("{http_url}pkarr").parse().anyerr()?,
+            tls_config,
+            Default::default(),
+        );
         pkarr.publish(&signed_packet).await?;
 
         // Create a reqwest client that does not verify certificates.

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -305,6 +305,7 @@ mod tests {
     use iroh::{
         RelayUrl, SecretKey,
         address_lookup::{EndpointInfo, PkarrRelayClient},
+        dns::DnsResolver,
         tls::{CaRootsConfig, default_provider},
     };
     use n0_error::StdResultExt;
@@ -349,7 +350,7 @@ mod tests {
         let pkarr = PkarrRelayClient::new(
             format!("{http_url}pkarr").parse().anyerr()?,
             tls_config,
-            Default::default(),
+            DnsResolver::default(),
         );
         pkarr.publish(&signed_packet).await?;
 

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -134,7 +134,7 @@ mod tests {
         let tls_config = CaRootsConfig::default()
             .client_config(default_provider())
             .expect("infallible");
-        let pkarr_client = PkarrRelayClient::new(pkarr_relay_url, tls_config);
+        let pkarr_client = PkarrRelayClient::new(pkarr_relay_url, tls_config, Default::default());
         pkarr_client.publish(&signed_packet).await?;
 
         use hickory_server::proto::rr::Name;
@@ -202,7 +202,7 @@ mod tests {
         let tls_config = CaRootsConfig::default()
             .client_config(default_provider())
             .expect("infallible");
-        let pkarr = PkarrRelayClient::new(pkarr_relay, tls_config);
+        let pkarr = PkarrRelayClient::new(pkarr_relay, tls_config, Default::default());
         let relay_url: RelayUrl = "https://relay.example.".parse()?;
         let endpoint_info = EndpointInfo::new(endpoint_id).with_relay_url(relay_url.clone());
         let signed_packet = endpoint_info.to_pkarr_signed_packet(&secret_key, 30)?;

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -134,7 +134,8 @@ mod tests {
         let tls_config = CaRootsConfig::default()
             .client_config(default_provider())
             .expect("infallible");
-        let pkarr_client = PkarrRelayClient::new(pkarr_relay_url, tls_config, Default::default());
+        let pkarr_client =
+            PkarrRelayClient::new(pkarr_relay_url, tls_config, DnsResolver::default());
         pkarr_client.publish(&signed_packet).await?;
 
         use hickory_server::proto::rr::Name;
@@ -202,7 +203,7 @@ mod tests {
         let tls_config = CaRootsConfig::default()
             .client_config(default_provider())
             .expect("infallible");
-        let pkarr = PkarrRelayClient::new(pkarr_relay, tls_config, Default::default());
+        let pkarr = PkarrRelayClient::new(pkarr_relay, tls_config, DnsResolver::default());
         let relay_url: RelayUrl = "https://relay.example.".parse()?;
         let endpoint_info = EndpointInfo::new(endpoint_id).with_relay_url(relay_url.clone());
         let signed_packet = endpoint_info.to_pkarr_signed_packet(&secret_key, 30)?;

--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -486,27 +486,6 @@ impl Default for DnsResolver {
     }
 }
 
-impl reqwest::dns::Resolve for DnsResolver {
-    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
-        let this = self.clone();
-        let name = name.as_str().to_string();
-        Box::pin(async move {
-            let res = this.lookup_ipv4_ipv6(name, DNS_TIMEOUT).await;
-            match res {
-                Ok(addrs) => {
-                    let addrs: reqwest::dns::Addrs =
-                        Box::new(addrs.map(|addr| SocketAddr::new(addr, 0)));
-                    Ok(addrs)
-                }
-                Err(err) => {
-                    let err: Box<dyn std::error::Error + Send + Sync> = Box::new(err);
-                    Err(err)
-                }
-            }
-        })
-    }
-}
-
 #[derive(Debug)]
 struct HickoryResolver {
     resolver: TokioResolver,

--- a/iroh/src/address_lookup/pkarr.rs
+++ b/iroh/src/address_lookup/pkarr.rs
@@ -59,7 +59,7 @@ use std::sync::Arc;
 use iroh_base::{EndpointId, RelayUrl, SecretKey};
 use iroh_dns::pkarr::{SignedPacket, SignedPacketVerifyError};
 use iroh_relay::endpoint_info::{AddrFilter, EncodingError, EndpointInfo};
-use n0_error::{e, stack_error};
+use n0_error::{AnyError, anyerr, e, stack_error};
 use n0_future::{
     boxed::BoxStream,
     task::{self, AbortOnDropHandle},
@@ -101,17 +101,11 @@ pub enum PkarrError {
     #[error("Invalid relay URL")]
     InvalidRelayUrl { url: RelayUrl },
     #[error("Error sending http request")]
-    HttpSend {
-        #[error(std_err)]
-        source: reqwest::Error,
-    },
+    HttpSend { source: AnyError },
     #[error("Error resolving http request")]
-    HttpRequest { status: reqwest::StatusCode },
+    HttpRequest { status: http::StatusCode },
     #[error("Http payload error")]
-    HttpPayload {
-        #[error(std_err)]
-        source: reqwest::Error,
-    },
+    HttpPayload { source: AnyError },
     #[error("EncodingError")]
     Encoding { source: EncodingError },
 }
@@ -235,7 +229,7 @@ impl PkarrPublisherBuilder {
             self.ttl,
             self.republish_interval,
             #[cfg(not(wasm_browser))]
-            self.dns_resolver,
+            self.dns_resolver.unwrap_or_default(),
             tls_config,
             self.filter,
         )
@@ -304,7 +298,7 @@ impl PkarrPublisher {
         pkarr_relay: Url,
         ttl: u32,
         republish_interval: Duration,
-        #[cfg(not(wasm_browser))] dns_resolver: Option<DnsResolver>,
+        #[cfg(not(wasm_browser))] dns_resolver: DnsResolver,
         tls_config: rustls::ClientConfig,
         addr_filter: AddrFilter,
     ) -> Self {
@@ -312,12 +306,10 @@ impl PkarrPublisher {
         let endpoint_id = secret_key.public();
 
         #[cfg(wasm_browser)]
-        let pkarr_client = PkarrRelayClient::new(pkarr_relay, tls_config);
+        let pkarr_client = PkarrRelayClient::new(pkarr_relay);
 
         #[cfg(not(wasm_browser))]
-        let pkarr_client = PkarrRelayClient::builder(pkarr_relay, tls_config)
-            .set_dns_resolver(dns_resolver)
-            .build();
+        let pkarr_client = PkarrRelayClient::new(pkarr_relay, tls_config, dns_resolver);
 
         let watchable = Watchable::default();
         let service = PublisherService {
@@ -466,12 +458,14 @@ impl PkarrResolverBuilder {
     /// Creates a [`PkarrResolver`] from this builder.
     pub fn build(self, tls_config: rustls::ClientConfig) -> PkarrResolver {
         #[cfg(wasm_browser)]
-        let pkarr_client = PkarrRelayClient::new(self.pkarr_relay, tls_config);
+        let pkarr_client = PkarrRelayClient::new(self.pkarr_relay);
 
         #[cfg(not(wasm_browser))]
-        let pkarr_client = PkarrRelayClient::builder(self.pkarr_relay, tls_config)
-            .set_dns_resolver(self.dns_resolver)
-            .build();
+        let pkarr_client = PkarrRelayClient::new(
+            self.pkarr_relay,
+            tls_config,
+            self.dns_resolver.unwrap_or_default(),
+        );
 
         PkarrResolver { pkarr_client }
     }
@@ -573,39 +567,21 @@ pub struct PkarrRelayClient {
 pub struct PkarrRelayClientBuilder {
     pkarr_relay_url: Url,
     #[cfg(not(wasm_browser))]
-    dns_relay_resolver: Option<DnsResolver>,
+    dns_resolver: DnsResolver,
+    #[cfg(not(wasm_browser))]
     tls_config: rustls::ClientConfig,
 }
 
 impl PkarrRelayClientBuilder {
-    fn new(pkarr_relay_url: Url, tls_config: rustls::ClientConfig) -> Self {
-        Self {
-            pkarr_relay_url,
-            #[cfg(not(wasm_browser))]
-            dns_relay_resolver: None,
-            tls_config,
-        }
-    }
-
-    /// Passes an optional DNS resolver for the client to use.
-    #[cfg(not(wasm_browser))]
-    pub fn set_dns_resolver(mut self, dns_resolver: Option<DnsResolver>) -> Self {
-        self.dns_relay_resolver = dns_resolver;
-        self
-    }
-
     /// Build a [`PkarrRelayClient`].
     pub fn build(self) -> PkarrRelayClient {
-        let mut http_client = reqwest_client_builder(Some(self.tls_config));
-
         #[cfg(not(wasm_browser))]
-        if let Some(dns_resolver) = self.dns_relay_resolver {
-            http_client = http_client.dns_resolver(Arc::new(dns_resolver));
-        };
+        let builder = reqwest_client_builder(self.tls_config, self.dns_resolver);
 
-        let http_client = http_client
-            .build()
-            .expect("failed to create request client");
+        #[cfg(wasm_browser)]
+        let builder = reqwest_client_builder();
+
+        let http_client = builder.build().expect("failed to create reqwest client");
         PkarrRelayClient {
             http_client,
             pkarr_relay_url: self.pkarr_relay_url,
@@ -614,25 +590,32 @@ impl PkarrRelayClientBuilder {
 }
 
 impl PkarrRelayClient {
-    /// Create a new [`PkarrRelayClient`] with default settings.
-    ///
-    /// Use the [`PkarrRelayClient::builder`] to get a builder that allows for
-    /// adding custom settings.
-    pub fn new(pkarr_relay_url: Url, tls_config: rustls::ClientConfig) -> Self {
+    /// Creates a [`PkarrRelayClient`].
+    #[cfg(not(wasm_browser))]
+    pub fn new(
+        pkarr_relay_url: Url,
+        tls_config: rustls::ClientConfig,
+        dns_resolver: DnsResolver,
+    ) -> Self {
+        let http_client = reqwest_client_builder(tls_config, dns_resolver)
+            .build()
+            .expect("failed to create reqwest client");
         Self {
-            http_client: reqwest_client_builder(Some(tls_config))
-                .build()
-                .expect("failed to create request client"),
+            http_client,
             pkarr_relay_url,
         }
     }
 
-    /// Create a [`PkarrRelayClientBuilder`].
-    pub fn builder(
-        pkarr_relay_url: Url,
-        tls_config: rustls::ClientConfig,
-    ) -> PkarrRelayClientBuilder {
-        PkarrRelayClientBuilder::new(pkarr_relay_url, tls_config)
+    /// Creates a [`PkarrRelayClient`].
+    #[cfg(wasm_browser)]
+    pub fn new(pkarr_relay_url: Url) -> Self {
+        let http_client = reqwest_client_builder()
+            .build()
+            .expect("failed to create reqwest client");
+        Self {
+            http_client,
+            pkarr_relay_url,
+        }
     }
 
     /// Resolves a [`SignedPacket`] for the given [`EndpointId`].
@@ -654,7 +637,7 @@ impl PkarrRelayClient {
             .get(url)
             .send()
             .await
-            .map_err(|err| e!(PkarrError::HttpSend, err))?;
+            .map_err(|err| e!(PkarrError::HttpSend, anyerr!(err)))?;
 
         if !response.status().is_success() {
             return Err(e!(PkarrError::HttpRequest {
@@ -666,7 +649,7 @@ impl PkarrRelayClient {
         let payload = response
             .bytes()
             .await
-            .map_err(|source| e!(PkarrError::HttpPayload { source }))?;
+            .map_err(|err| e!(PkarrError::HttpPayload, anyerr!(err)))?;
         let packet = SignedPacket::from_relay_payload(&endpoint_id, &payload)
             .map_err(|err| e!(PkarrError::Verify, err))?;
         Ok(packet)
@@ -689,7 +672,7 @@ impl PkarrRelayClient {
             .body(signed_packet.to_relay_payload())
             .send()
             .await
-            .map_err(|source| e!(PkarrError::HttpSend { source }))?;
+            .map_err(|err| e!(PkarrError::HttpSend, anyerr!(err)))?;
 
         if !response.status().is_success() {
             return Err(e!(PkarrError::HttpRequest {

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -586,8 +586,8 @@ async fn check_captive_portal(
         }
     };
 
-    let mut builder =
-        reqwest_client_builder(Some(tls_config)).redirect(reqwest::redirect::Policy::none());
+    let mut builder = reqwest_client_builder(tls_config, dns_resolver.clone())
+        .redirect(reqwest::redirect::Policy::none());
 
     if let Some(Host::Domain(domain)) = url.host() {
         // Use our own resolver rather than getaddrinfo
@@ -819,9 +819,9 @@ async fn run_https_probe(
     // needs to be more configurable so users can do more crazy things:
     // https://github.com/n0-computer/iroh/issues/2901
     #[cfg(not(wasm_browser))]
-    let mut builder = reqwest_client_builder(Some(tls_config));
+    let mut builder = reqwest_client_builder(tls_config, dns_resolver.clone());
     #[cfg(wasm_browser)]
-    let mut builder = reqwest_client_builder(None);
+    let mut builder = reqwest_client_builder();
 
     #[cfg(not(wasm_browser))]
     {

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -92,7 +92,7 @@ pub(crate) fn reqwest_client_builder(
 
 #[cfg(not(wasm_browser))]
 mod reqwest_dns_resolver {
-    //! Implementation of [`reqwest::dns::Resolver`] for [`DnsResolver`].
+    //! Implementation of [`reqwest::dns::Resolve`] for [`DnsResolver`].
     //!
     //! Wrapped in a newtype to not expose this in the public iroh API.
 

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -69,21 +69,48 @@ impl<T: Future> Future for MaybeFuture<T> {
     }
 }
 
+#[cfg(wasm_browser)]
+pub(crate) fn reqwest_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+}
+
 /// Creates a reqwest client builder that always uses the rustls backend, unless we
 /// are in a browser context, where that is not supported.
+#[cfg(not(wasm_browser))]
 pub(crate) fn reqwest_client_builder(
-    tls_client_config: Option<rustls::ClientConfig>,
+    tls_client_config: rustls::ClientConfig,
+    dns_resolver: crate::dns::DnsResolver,
 ) -> reqwest::ClientBuilder {
-    let mut builder = reqwest::Client::builder();
-    #[cfg(not(wasm_browser))]
-    {
-        builder = if let Some(config) = tls_client_config {
-            builder.use_preconfigured_tls(config)
-        } else {
-            builder.use_rustls_tls()
-        };
+    use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+    use iroh_relay::dns::DnsResolver;
+
+    struct ReqwestDnsResolver(DnsResolver);
+    const DNS_TIMEOUT: Duration = Duration::from_secs(3);
+    impl reqwest::dns::Resolve for ReqwestDnsResolver {
+        fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+            let this = self.0.clone();
+            let name = name.as_str().to_string();
+            Box::pin(async move {
+                let res = this.lookup_ipv4_ipv6(name, DNS_TIMEOUT).await;
+                match res {
+                    Ok(addrs) => {
+                        let addrs: reqwest::dns::Addrs =
+                            Box::new(addrs.map(|addr| SocketAddr::new(addr, 0)));
+                        Ok(addrs)
+                    }
+                    Err(err) => {
+                        let err: Box<dyn std::error::Error + Send + Sync> = Box::new(err);
+                        Err(err)
+                    }
+                }
+            })
+        }
     }
-    builder
+
+    reqwest::Client::builder()
+        .use_preconfigured_tls(tls_client_config)
+        .dns_resolver(Arc::new(ReqwestDnsResolver(dns_resolver)))
 }
 
 #[cfg(test)]

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -81,12 +81,29 @@ pub(crate) fn reqwest_client_builder(
     tls_client_config: rustls::ClientConfig,
     dns_resolver: crate::dns::DnsResolver,
 ) -> reqwest::ClientBuilder {
-    use std::{net::SocketAddr, sync::Arc, time::Duration};
+    use std::sync::Arc;
+
+    use self::reqwest_dns_resolver::ReqwestDnsResolver;
+
+    reqwest::Client::builder()
+        .use_preconfigured_tls(tls_client_config)
+        .dns_resolver(Arc::new(ReqwestDnsResolver(dns_resolver)))
+}
+
+#[cfg(not(wasm_browser))]
+mod reqwest_dns_resolver {
+    //! Implementation of [`reqwest::dns::Resolver`] for [`DnsResolver`].
+    //!
+    //! Wrapped in a newtype to not expose this in the public iroh API.
+
+    use std::{net::SocketAddr, time::Duration};
 
     use iroh_relay::dns::DnsResolver;
 
-    struct ReqwestDnsResolver(DnsResolver);
     const DNS_TIMEOUT: Duration = Duration::from_secs(3);
+
+    pub(super) struct ReqwestDnsResolver(pub(super) DnsResolver);
+
     impl reqwest::dns::Resolve for ReqwestDnsResolver {
         fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
             let this = self.0.clone();
@@ -107,10 +124,6 @@ pub(crate) fn reqwest_client_builder(
             })
         }
     }
-
-    reqwest::Client::builder()
-        .use_preconfigured_tls(tls_client_config)
-        .dns_resolver(Arc::new(ReqwestDnsResolver(dns_resolver)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

This changes our interaction with `reqwest` such that we could swap to another HTTP client library during 1.0.

* Remove the public `impl reqwest::dns::Resolver for DnsResolver`. Instead we now have a private wrapper struct, thus not exposing this as public API
* Remove reqwest errors from our errors, replaced with `AnyError`
* Enforce that we always use the `DnsResolver` configured on the endpoint. In net_report we previously used reqwest's default DNS resolver. Now we always use the one configured on the endpoint
* Streamline the pkarr address lookup constructors to always take a `DnsResolver`. When used outside of iroh's address lookup you can just pass `Default::default` (done in tests or examples).

With this `reqwest`  no longer shows up anywhere in the public API.

## Breaking Changes

changed: `iroh::address_lookup::pkarr::PkarrRelayClient::new` now takes a `DnsResolver` as a third argument (non-`wasm_browser` builds): `PkarrRelayClient::new(pkarr_relay_url, tls_config, dns_resolver)`. Pass `DnsResolver::default()` to preserve previous behavior.
* changed: `iroh::address_lookup::pkarr::PkarrRelayClient::new` in `wasm_browser` builds no longer takes a `tls_config` argument: `PkarrRelayClient::new(pkarr_relay_url)`.
* removed: `iroh::address_lookup::pkarr::PkarrRelayClient::builder`. Construct a `PkarrRelayClient` directly via `PkarrRelayClient::new` and pass the desired `DnsResolver`.
* removed: `iroh::address_lookup::pkarr::PkarrRelayClientBuilder::set_dns_resolver`. The DNS resolver is now a required constructor argument on `PkarrRelayClient::new`.
* changed: `iroh::address_lookup::pkarr::PkarrError::HttpSend { source }`: the `source` field type changed from `reqwest::Error` to `n0_error::AnyError`.
* changed: `iroh::address_lookup::pkarr::PkarrError::HttpPayload { source }`: the `source` field type changed from `reqwest::Error` to `n0_error::AnyError`.
* changed: `iroh::address_lookup::pkarr::PkarrError::HttpRequest { status }`: the `status` field type changed from `reqwest::StatusCode` to `http::StatusCode`.
* removed: `impl reqwest::dns::Resolve for iroh_relay::dns::DnsResolver`. `DnsResolver` is no longer usable directly as a `reqwest` resolver; wrap it yourself if you need that integration

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.