### PR TITLE
refactor(iroh-relay)!: remove lru_cache from public API

### DIFF
--- a/iroh-relay/src/key_cache.rs
+++ b/iroh-relay/src/key_cache.rs
@@ -16,7 +16,10 @@ type PublicKeyBytes = [u8; PublicKey::LENGTH];
 ///
 /// The cache stores only successful parse results.
 #[derive(Debug, Clone)]
-pub enum KeyCache {
+pub struct KeyCache(Inner);
+
+#[derive(Debug, Clone)]
+enum Inner {
     /// The key cache is disabled.
     Disabled,
     /// The key cache is enabled with a fixed capacity. It is shared between
@@ -28,23 +31,25 @@ impl KeyCache {
     /// Key cache to be used in tests.
     #[cfg(all(test, feature = "server"))]
     pub fn test() -> Self {
-        Self::Disabled
+        Self(Inner::Disabled)
     }
 
     /// Create a new key cache with the given capacity.
     ///
     /// If the capacity is zero, the cache is disabled and has zero overhead.
     pub fn new(capacity: usize) -> Self {
-        let Some(capacity) = NonZeroUsize::new(capacity) else {
-            return Self::Disabled;
-        };
-        let cache = lru::LruCache::new(capacity);
-        Self::Shared(Arc::new(Mutex::new(cache)))
+        match NonZeroUsize::new(capacity) {
+            None => Self(Inner::Disabled),
+            Some(capacity) => {
+                let cache = lru::LruCache::new(capacity);
+                Self(Inner::Shared(Arc::new(Mutex::new(cache))))
+            }
+        }
     }
 
     /// Get a key from a slice of bytes.
     pub fn key_from_slice(&self, slice: &[u8]) -> Result<PublicKey, SignatureError> {
-        let Self::Shared(cache) = self else {
+        let Inner::Shared(cache) = &self.0 else {
             return PublicKey::try_from(slice);
         };
         let Ok(bytes) = PublicKeyBytes::try_from(slice) else {


### PR DESCRIPTION
## Description

We had `lru_cache` in the public API for iroh-relay (with `server` feature). This removes it by hiding the enum behind a struct.

## Breaking Changes

* changed: `iroh_relay::KeyCache` now is a struct (was an enum). All methods are unchanged.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.