### PR TITLE
deps(iroh): use new iroh-mainline crate to avoid some deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
  "http",
  "indicatif",
  "ipnet",
- "iroh-base 0.98.0",
+ "iroh-base",
  "iroh-dns",
  "iroh-metrics",
  "iroh-relay",
@@ -2442,28 +2442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-base"
-version = "0.98.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738865784637830fb14204ebd3047922db83bc1816a59027af29579b9c27bd99"
-dependencies = [
- "curve25519-dalek",
- "data-encoding",
- "data-encoding-macro",
- "derive_more",
- "digest",
- "ed25519-dalek",
- "getrandom 0.4.2",
- "n0-error",
- "rand 0.10.1",
- "serde",
- "sha2",
- "url",
- "zeroize",
- "zeroize_derive",
-]
-
-[[package]]
 name = "iroh-bench"
 version = "0.98.0"
 dependencies = [
@@ -2488,7 +2466,7 @@ name = "iroh-dns"
 version = "0.98.0"
 dependencies = [
  "derive_more",
- "iroh-base 0.98.0",
+ "iroh-base",
  "n0-error",
  "n0-future",
  "simple-dns",
@@ -2516,7 +2494,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "iroh",
- "iroh-base 0.98.0",
+ "iroh-base",
  "iroh-dns",
  "iroh-metrics",
  "lru 0.16.3",
@@ -2603,7 +2581,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "iroh-base 0.98.0",
+ "iroh-base",
  "iroh-dns",
  "iroh-metrics",
  "lru 0.16.3",
@@ -2995,18 +2973,18 @@ dependencies = [
 
 [[package]]
 name = "n0-mainline"
-version = "6.4.0"
-source = "git+https://github.com/n0-computer/n0-mainline.git?branch=rename-crate#1bcdb5f5879e9acf58e20e8499c51bf9e01afba0"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9945c678818bd9a0763efa732b36257767734df839399a74cb969a0e9273e7c"
 dependencies = [
  "crc",
  "dyn-clone",
  "ed25519-dalek",
  "futures-core",
- "getrandom 0.3.4",
- "iroh-base 0.98.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.13.0",
  "n0-error",
  "noq-udp",
+ "rand 0.10.1",
  "serde",
  "serde_bencode",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,15 +1267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "dtor"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,17 +1421,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin 0.9.8",
-]
 
 [[package]]
 name = "fnv"
@@ -2387,11 +2367,11 @@ dependencies = [
  "http",
  "indicatif",
  "ipnet",
- "iroh-base",
+ "iroh-base 0.98.0",
  "iroh-dns",
+ "iroh-mainline",
  "iroh-metrics",
  "iroh-relay",
- "mainline",
  "n0-error",
  "n0-future",
  "n0-tracing-test",
@@ -2462,6 +2442,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-base"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738865784637830fb14204ebd3047922db83bc1816a59027af29579b9c27bd99"
+dependencies = [
+ "curve25519-dalek",
+ "data-encoding",
+ "data-encoding-macro",
+ "derive_more",
+ "digest",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "n0-error",
+ "rand 0.10.1",
+ "serde",
+ "sha2",
+ "url",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
 name = "iroh-bench"
 version = "0.98.0"
 dependencies = [
@@ -2486,7 +2488,7 @@ name = "iroh-dns"
 version = "0.98.0"
 dependencies = [
  "derive_more",
- "iroh-base",
+ "iroh-base 0.98.0",
  "n0-error",
  "n0-future",
  "simple-dns",
@@ -2514,11 +2516,11 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "iroh",
- "iroh-base",
+ "iroh-base 0.98.0",
  "iroh-dns",
+ "iroh-mainline",
  "iroh-metrics",
- "lru",
- "mainline",
+ "lru 0.16.3",
  "n0-error",
  "n0-future",
  "n0-tracing-test",
@@ -2548,6 +2550,28 @@ dependencies = [
  "ttl_cache",
  "url",
  "vergen-gitcl",
+]
+
+[[package]]
+name = "iroh-mainline"
+version = "6.4.0"
+source = "git+https://github.com/n0-computer/iroh-mainline.git?branch=rename-crate#0647aea900899fb4b1e8c8cbeb648485afe83284"
+dependencies = [
+ "crc",
+ "dyn-clone",
+ "ed25519-dalek",
+ "futures-core",
+ "getrandom 0.3.4",
+ "iroh-base 0.98.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru 0.13.0",
+ "n0-error",
+ "noq-udp",
+ "serde",
+ "serde_bencode",
+ "serde_bytes",
+ "sha1_smol",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2601,10 +2625,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "iroh-base",
+ "iroh-base 0.98.0",
  "iroh-dns",
  "iroh-metrics",
- "lru",
+ "lru 0.16.3",
  "n0-error",
  "n0-future",
  "n0-tracing-test",
@@ -2814,12 +2838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +2867,12 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+
+[[package]]
+name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
@@ -2867,28 +2891,6 @@ name = "mac-addr"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
-
-[[package]]
-name = "mainline"
-version = "6.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff27d378ca495eaf3be8616d5d7319c1c18e93fd60e13698fcdc7e19448f1a4"
-dependencies = [
- "crc",
- "document-features",
- "dyn-clone",
- "ed25519-dalek",
- "flume",
- "futures-lite",
- "getrandom 0.3.4",
- "lru",
- "serde",
- "serde_bencode",
- "serde_bytes",
- "sha1_smol",
- "thiserror 2.0.18",
- "tracing",
-]
 
 [[package]]
 name = "matchers"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,11 +2369,11 @@ dependencies = [
  "ipnet",
  "iroh-base 0.98.0",
  "iroh-dns",
- "iroh-mainline",
  "iroh-metrics",
  "iroh-relay",
  "n0-error",
  "n0-future",
+ "n0-mainline",
  "n0-tracing-test",
  "n0-watcher",
  "netwatch",
@@ -2518,11 +2518,11 @@ dependencies = [
  "iroh",
  "iroh-base 0.98.0",
  "iroh-dns",
- "iroh-mainline",
  "iroh-metrics",
  "lru 0.16.3",
  "n0-error",
  "n0-future",
+ "n0-mainline",
  "n0-tracing-test",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -2550,28 +2550,6 @@ dependencies = [
  "ttl_cache",
  "url",
  "vergen-gitcl",
-]
-
-[[package]]
-name = "iroh-mainline"
-version = "6.4.0"
-source = "git+https://github.com/n0-computer/iroh-mainline.git?branch=rename-crate#0647aea900899fb4b1e8c8cbeb648485afe83284"
-dependencies = [
- "crc",
- "dyn-clone",
- "ed25519-dalek",
- "futures-core",
- "getrandom 0.3.4",
- "iroh-base 0.98.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru 0.13.0",
- "n0-error",
- "noq-udp",
- "serde",
- "serde_bencode",
- "serde_bytes",
- "sha1_smol",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -3013,6 +2991,28 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "n0-mainline"
+version = "6.4.0"
+source = "git+https://github.com/n0-computer/n0-mainline.git?branch=rename-crate#1bcdb5f5879e9acf58e20e8499c51bf9e01afba0"
+dependencies = [
+ "crc",
+ "dyn-clone",
+ "ed25519-dalek",
+ "futures-core",
+ "getrandom 0.3.4",
+ "iroh-base 0.98.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru 0.13.0",
+ "n0-error",
+ "noq-udp",
+ "serde",
+ "serde_bencode",
+ "serde_bytes",
+ "sha1_smol",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -32,7 +32,7 @@ iroh-base = { version = "0.98", path = "../iroh-base", features = ["key"] }
 iroh-metrics = { version = "0.38", features = ["service"] }
 iroh-dns = { version = "0.98", path = "../iroh-dns" }
 lru = "0.16.3"
-mainline = "6"
+mainline = { package = "iroh-mainline", git = "https://github.com/n0-computer/iroh-mainline.git", branch = "rename-crate" }
 n0-future = "0.3"
 rcgen = "0.14"
 redb = "3.1.0"

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -32,7 +32,7 @@ iroh-base = { version = "0.98", path = "../iroh-base", features = ["key"] }
 iroh-metrics = { version = "0.38", features = ["service"] }
 iroh-dns = { version = "0.98", path = "../iroh-dns" }
 lru = "0.16.3"
-mainline = { package = "n0-mainline", git = "https://github.com/n0-computer/n0-mainline.git", branch = "rename-crate" }
+mainline = { package = "n0-mainline", version = "0.1" }
 n0-future = "0.3"
 rcgen = "0.14"
 redb = "3.1.0"

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -32,7 +32,7 @@ iroh-base = { version = "0.98", path = "../iroh-base", features = ["key"] }
 iroh-metrics = { version = "0.38", features = ["service"] }
 iroh-dns = { version = "0.98", path = "../iroh-dns" }
 lru = "0.16.3"
-mainline = { package = "iroh-mainline", git = "https://github.com/n0-computer/iroh-mainline.git", branch = "rename-crate" }
+mainline = { package = "n0-mainline", git = "https://github.com/n0-computer/n0-mainline.git", branch = "rename-crate" }
 n0-future = "0.3"
 rcgen = "0.14"
 redb = "3.1.0"

--- a/iroh-dns-server/src/server.rs
+++ b/iroh-dns-server/src/server.rs
@@ -31,7 +31,7 @@ pub async fn run_with_config_until_ctrl_c(config: Config) -> Result<()> {
     )?;
     if let Some(bootstrap) = config.mainline_enabled() {
         info!("mainline fallback enabled");
-        store = store.with_mainline_fallback(bootstrap);
+        store = store.with_mainline_fallback(bootstrap).await;
     };
     let server = Server::spawn(config, store, metrics).await?;
     tokio::signal::ctrl_c().await.anyerr()?;
@@ -148,7 +148,7 @@ impl Server {
         let mut store = ZoneStore::in_memory(options.unwrap_or_default(), Default::default())?;
         if let Some(bootstrap) = mainline {
             info!("mainline fallback enabled");
-            store = store.with_mainline_fallback(bootstrap);
+            store = store.with_mainline_fallback(bootstrap).await;
         }
         let server = Self::spawn(config, store, Default::default()).await?;
         Ok(server)

--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -140,7 +140,9 @@ impl ZoneStore {
             debug!("DHT resolve {}", pubkey.to_z32());
             let maybe_item = dht
                 .get_mutable_most_recent(pubkey.as_bytes(), None)
-                .await;
+                .await
+                .ok()
+                .flatten();
             if let Some(item) = maybe_item
                 && let Ok(packet) = mutable_item_to_signed_packet(&item)
             {

--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -70,12 +70,12 @@ impl ZoneStore {
     ///
     /// Optionally set custom bootstrap nodes. If `bootstrap` is empty it will use the default
     /// mainline bootstrap nodes.
-    pub fn with_mainline_fallback(self, bootstrap: BootstrapOption) -> Self {
+    pub async fn with_mainline_fallback(self, bootstrap: BootstrapOption) -> Self {
         let mut builder = DhtBuilder::default();
         if let BootstrapOption::Custom(ref nodes) = bootstrap {
             builder.bootstrap(nodes);
         }
-        let dht = builder.build().expect("failed to build DHT node");
+        let dht = builder.build().await.expect("failed to build DHT node");
         Self {
             dht: Some(dht),
             ..self
@@ -139,8 +139,6 @@ impl ZoneStore {
         if let Some(dht) = self.dht.as_ref() {
             debug!("DHT resolve {}", pubkey.to_z32());
             let maybe_item = dht
-                .clone()
-                .as_async()
                 .get_mutable_most_recent(pubkey.as_bytes(), None)
                 .await;
             if let Some(item) = maybe_item

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -40,7 +40,7 @@ netwatch = "0.16"
 papaya = { version = "0.2.3", default-features = false }
 pin-project = "1"
 portable-atomic = "1"
-mainline = { version = "6", optional = true }
+mainline = { package = "iroh-mainline", git = "https://github.com/n0-computer/iroh-mainline.git", branch = "rename-crate", optional = true }
 noq = { version = "0.18.0", default-features = false, features = ["rustls"] }
 noq-proto = { version = "0.17", default-features = false }
 noq-udp = { version = "0.10", default-features = false }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -40,7 +40,7 @@ netwatch = "0.16"
 papaya = { version = "0.2.3", default-features = false }
 pin-project = "1"
 portable-atomic = "1"
-mainline = { package = "n0-mainline", git = "https://github.com/n0-computer/n0-mainline.git", branch = "rename-crate", optional = true }
+mainline = { package = "n0-mainline", version = "0.1", optional = true }
 noq = { version = "0.18.0", default-features = false, features = ["rustls"] }
 noq-proto = { version = "0.17", default-features = false }
 noq-udp = { version = "0.10", default-features = false }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -40,7 +40,7 @@ netwatch = "0.16"
 papaya = { version = "0.2.3", default-features = false }
 pin-project = "1"
 portable-atomic = "1"
-mainline = { package = "iroh-mainline", git = "https://github.com/n0-computer/iroh-mainline.git", branch = "rename-crate", optional = true }
+mainline = { package = "n0-mainline", git = "https://github.com/n0-computer/n0-mainline.git", branch = "rename-crate", optional = true }
 noq = { version = "0.18.0", default-features = false, features = ["rustls"] }
 noq-proto = { version = "0.17", default-features = false }
 noq-udp = { version = "0.10", default-features = false }

--- a/iroh/examples/dht_address_lookup.rs
+++ b/iroh/examples/dht_address_lookup.rs
@@ -32,7 +32,11 @@ struct Args {
 async fn chat_server() -> Result<()> {
     let secret_key = iroh::SecretKey::generate();
     let endpoint_id = secret_key.public();
-    let address_lookup = DhtAddressLookup::builder().addr_filter(AddrFilter::unfiltered());
+    let address_lookup = DhtAddressLookup::builder()
+        .secret_key(secret_key.clone())
+        .addr_filter(AddrFilter::unfiltered())
+        .build()
+        .await?;
     let endpoint = Endpoint::builder(presets::N0)
         .alpns(vec![CHAT_ALPN.to_vec()])
         .secret_key(secret_key)
@@ -77,7 +81,7 @@ async fn chat_client(args: Args) -> Result<()> {
     let secret_key = iroh::SecretKey::generate();
     let endpoint_id = secret_key.public();
     // note: we don't pass a secret key here, because we don't need to publish our address, don't spam the DHT
-    let address_lookup = DhtAddressLookup::builder().no_publish();
+    let address_lookup = DhtAddressLookup::builder().no_publish().build().await?;
     // we do not need to specify the alpn here, because we are not going to accept connections
     let endpoint = Endpoint::builder(presets::N0)
         .secret_key(secret_key)

--- a/iroh/src/address_lookup/pkarr/dht.rs
+++ b/iroh/src/address_lookup/pkarr/dht.rs
@@ -18,9 +18,8 @@ use n0_future::{
 };
 
 use crate::{
-    Endpoint,
     address_lookup::{
-        AddrFilter, AddressLookup, AddressLookupBuilder, AddressLookupBuilderError, EndpointData,
+        AddrFilter, AddressLookup, AddressLookupBuilderError, EndpointData,
         Error as AddressLookupError, Item as AddressLookupItem, pkarr::DEFAULT_PKARR_TTL,
     },
     endpoint_info::EndpointInfo,
@@ -104,8 +103,6 @@ impl Inner {
 
         let maybe_item = self
             .dht
-            .clone()
-            .as_async()
             .get_mutable_most_recent(public_key.as_bytes(), None)
             .await;
         match maybe_item {
@@ -211,10 +208,17 @@ impl Builder {
     }
 
     /// Builds the address lookup mechanism.
-    pub fn build(self) -> Result<DhtAddressLookup, AddressLookupBuilderError> {
+    ///
+    /// Constructing the DHT is async (it binds a UDP socket and bootstraps the
+    /// routing table), so this must be awaited. The resulting [`DhtAddressLookup`]
+    /// implements [`AddressLookup`], which via the blanket impl also satisfies
+    /// `AddressLookupBuilder` and can be passed directly to
+    /// [`crate::endpoint::Builder::address_lookup`].
+    pub async fn build(self) -> Result<DhtAddressLookup, AddressLookupBuilderError> {
         let dht_builder = self.dht_builder.unwrap_or_default();
         let dht = dht_builder
             .build()
+            .await
             .map_err(|e| AddressLookupBuilderError::from_err("pkarr-dht", e))?;
         let ttl = self.ttl.unwrap_or(DEFAULT_PKARR_TTL);
         let secret_key = self.secret_key.filter(|_| self.enable_publish);
@@ -227,15 +231,6 @@ impl Builder {
             task: Default::default(),
             filter: self.addr_filter,
         })))
-    }
-}
-
-impl AddressLookupBuilder for Builder {
-    fn into_address_lookup(
-        self,
-        endpoint: &Endpoint,
-    ) -> Result<impl AddressLookup, AddressLookupBuilderError> {
-        self.secret_key(endpoint.secret_key().clone()).build()
     }
 }
 
@@ -260,20 +255,12 @@ impl DhtAddressLookup {
         let initial_cas = this
             .0
             .dht
-            .clone()
-            .as_async()
             .get_mutable_most_recent(public_key.as_bytes(), None)
             .await
             .map(|item| item.seq());
         let mut cas = initial_cas;
         loop {
-            let res = this
-                .0
-                .dht
-                .clone()
-                .as_async()
-                .put_mutable(item.clone(), cas)
-                .await;
+            let res = this.0.dht.put_mutable(item.clone(), cas).await;
             match res {
                 Ok(_) => {
                     tracing::debug!("pkarr publish success. published under {z32}");


### PR DESCRIPTION
## Description

This removes the mainline dependency and instead uses iroh-mainline, a new fork of mainline that brings mainline into the n0 ecosystem (noq-udp, n0-error etc.) and has a fully async core instead of a sync core with async bridge.

Most notable deps dropped are:

flume
spin (used from flume)

other than that some harmless compile time deps:

document-features
litrs

But in addition to the dependency redution there are also implementation benefits.

- iroh-mainline uses noq-udp, which means that all the UDP advancements that quinn and we have do can be used by the DHT, which after all is mostly sending and receiving UDP packets. For now it is a straight port, but e.g. taking advantage of GRO/GSO is pretty straightforward.

- iroh-mainline is using a normal tokio actor pattern and tokio queues instead of a sync core that requires std::thread::spawn. Fits better in iroh and should be easier to port to ESP32.

We also have the benefit that iroh-mainline is fully under our control, so we will no longer have unpleasant upstream surprises.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
