### PR TITLE
refactor(iroh)!: Remove `ipnet`, `hickory_net` and `netmon` from public API surface by replacing their errors with variants or AnyError

### DIFF
--- a/iroh-relay/src/dns.rs
+++ b/iroh-relay/src/dns.rs
@@ -20,7 +20,7 @@ use hickory_resolver::{
     proto::rr::RData,
 };
 use iroh_base::EndpointId;
-use n0_error::{StackError, e, stack_error};
+use n0_error::{AnyError, StackError, StdResultExt, e, stack_error};
 use n0_future::{
     StreamExt,
     boxed::BoxFuture,
@@ -74,22 +74,20 @@ pub type BoxIter<T> = Box<dyn Iterator<Item = T> + Send + 'static>;
 #[stack_error(derive, add_meta, from_sources, std_sources)]
 #[non_exhaustive]
 pub enum DnsError {
-    #[error(transparent)]
-    Timeout { source: tokio::time::error::Elapsed },
+    #[error("Request timed out")]
+    Timeout {},
     #[error("No response")]
     NoResponse {},
-    #[error("Resolve failed ipv4: {ipv4}, ipv6 {ipv6}")]
+    #[error("Resolve failed, IPv4: {ipv4}, IPv6: {ipv6}")]
     ResolveBoth {
         ipv4: Box<DnsError>,
         ipv6: Box<DnsError>,
     },
-    #[error("missing host")]
+    #[error("Missing host")]
     MissingHost {},
-    #[error(transparent)]
-    Resolve {
-        source: hickory_resolver::net::NetError,
-    },
-    #[error("invalid DNS response: not a query for _iroh.z32encodedpubkey")]
+    #[error("Failed to resolve")]
+    Resolve { source: AnyError },
+    #[error("Invalid DNS response: not a query for _iroh.z32encodedpubkey")]
     InvalidResponse {},
 }
 
@@ -274,7 +272,9 @@ impl DnsResolver {
     ) -> Result<impl Iterator<Item = TxtRecordData>, DnsError> {
         let host = host.to_string();
         let fut = self.0.read().await.lookup_txt(host);
-        let res = time::timeout(timeout, fut).await??;
+        let res = time::timeout(timeout, fut)
+            .await
+            .map_err(|_| e!(DnsError::Timeout))??;
         Ok(res)
     }
 
@@ -286,7 +286,9 @@ impl DnsResolver {
     ) -> Result<impl Iterator<Item = IpAddr> + use<T>, DnsError> {
         let host = host.to_string();
         let fut = self.0.read().await.lookup_ipv4(host);
-        let addrs = time::timeout(timeout, fut).await??;
+        let addrs = time::timeout(timeout, fut)
+            .await
+            .map_err(|_| e!(DnsError::Timeout))??;
         Ok(addrs.into_iter().map(IpAddr::V4))
     }
 
@@ -298,7 +300,9 @@ impl DnsResolver {
     ) -> Result<impl Iterator<Item = IpAddr> + use<T>, DnsError> {
         let host = host.to_string();
         let fut = self.0.read().await.lookup_ipv6(host);
-        let addrs = time::timeout(timeout, fut).await??;
+        let addrs = time::timeout(timeout, fut)
+            .await
+            .map_err(|_| e!(DnsError::Timeout))??;
         Ok(addrs.into_iter().map(IpAddr::V6))
     }
 
@@ -564,7 +568,7 @@ impl Resolver for HickoryResolver {
     fn lookup_ipv4(&self, host: String) -> BoxFuture<Result<BoxIter<Ipv4Addr>, DnsError>> {
         let resolver = self.resolver.clone();
         Box::pin(async move {
-            let lookup = resolver.ipv4_lookup(host).await?;
+            let lookup = resolver.ipv4_lookup(host).await.anyerr()?;
             let iter: BoxIter<Ipv4Addr> =
                 Box::new(lookup.answers().to_vec().into_iter().filter_map(|record| {
                     match &record.data {
@@ -579,7 +583,7 @@ impl Resolver for HickoryResolver {
     fn lookup_ipv6(&self, host: String) -> BoxFuture<Result<BoxIter<Ipv6Addr>, DnsError>> {
         let resolver = self.resolver.clone();
         Box::pin(async move {
-            let lookup = resolver.ipv6_lookup(host).await?;
+            let lookup = resolver.ipv6_lookup(host).await.anyerr()?;
             let iter: BoxIter<Ipv6Addr> =
                 Box::new(lookup.answers().to_vec().into_iter().filter_map(|record| {
                     match &record.data {
@@ -594,7 +598,7 @@ impl Resolver for HickoryResolver {
     fn lookup_txt(&self, host: String) -> BoxFuture<Result<BoxIter<TxtRecordData>, DnsError>> {
         let resolver = self.resolver.clone();
         Box::pin(async move {
-            let lookup = resolver.txt_lookup(host).await?;
+            let lookup = resolver.txt_lookup(host).await.anyerr()?;
             let iter: BoxIter<TxtRecordData> =
                 Box::new(lookup.answers().to_vec().into_iter().filter_map(|record| {
                     match &record.data {

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -439,7 +439,8 @@ impl Builder {
                     bail!(InvalidSocketAddr::DuplicateDefaultAddr);
                 }
 
-                let ip_net = Ipv4Net::new(*addr.ip(), opts.prefix_len())?;
+                let ip_net = Ipv4Net::new(*addr.ip(), opts.prefix_len())
+                    .map_err(|_| e!(InvalidSocketAddr::InvalidPrefixLength))?;
                 self.transports.push(TransportConfig::Ip {
                     config: IpConfig::V4 {
                         ip_net,
@@ -459,7 +460,8 @@ impl Builder {
                     bail!(InvalidSocketAddr::DuplicateDefaultAddr);
                 }
 
-                let ip_net = Ipv6Net::new(*addr.ip(), opts.prefix_len())?;
+                let ip_net = Ipv6Net::new(*addr.ip(), opts.prefix_len())
+                    .map_err(|_| e!(InvalidSocketAddr::InvalidPrefixLength))?;
                 self.transports.push(TransportConfig::Ip {
                     config: IpConfig::V6 {
                         ip_net,

--- a/iroh/src/endpoint/bind.rs
+++ b/iroh/src/endpoint/bind.rs
@@ -240,11 +240,8 @@ pub enum InvalidSocketAddr {
         #[error(std_err)]
         source: std::net::AddrParseError,
     },
-    #[error(transparent)]
-    InvalidPrefix {
-        #[error(std_err)]
-        source: ipnet::PrefixLenError,
-    },
+    #[error("Invalid IP prefix length")]
+    InvalidPrefixLength {},
     #[error(transparent)]
     Infallible {
         #[error(std_err)]

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -29,7 +29,7 @@ use std::{
 use iroh_base::{EndpointAddr, EndpointId, PublicKey, RelayUrl, SecretKey, TransportAddr};
 use iroh_relay::{RelayConfig, RelayMap};
 use mapped_addrs::MultipathMappedAddr;
-use n0_error::{bail, e, stack_error};
+use n0_error::{AnyError, anyerr, bail, e, stack_error};
 use n0_future::{
     MaybeFuture,
     task::{self, AbortOnDropHandle},
@@ -803,7 +803,7 @@ pub enum BindError {
     #[error("Failed to create internal QUIC endpoint")]
     CreateQuicEndpoint { source: io::Error },
     #[error("Failed to create netmon monitor")]
-    CreateNetmonMonitor { source: netmon::Error },
+    CreateNetmonMonitor { source: AnyError },
     #[error("Invalid transport configuration")]
     InvalidTransportConfig,
     #[error("Invalid CA root configuration")]
@@ -986,7 +986,7 @@ impl EndpointInner {
 
         let network_monitor = netmon::Monitor::new()
             .await
-            .map_err(|err| e!(BindError::CreateNetmonMonitor, err))?;
+            .map_err(|err| e!(BindError::CreateNetmonMonitor, anyerr!(err)))?;
 
         #[cfg(not(wasm_browser))]
         let net_report_config = {


### PR DESCRIPTION
## Description

This removes a few foreign errors from our public API to reduce semver-relevant API surface.

- Remove `ipnet::PrefixLenError` from public API, just the variant is enough (doesn't add further details anyway)
- Replace `hickory_net::Error` with `AnyError` to not have a dependency on `hickory_net` in public API
- Replace `netmon::Error` with `AnyError` to not have a dependency on `netmon` in public API

## Breaking Changes

* changed: `iroh_relay::dns::DnsError::Timeout`: the `source: tokio::time::error::Elapsed` field has been removed. The variant is now an empty struct variant (`Timeout {}`) and no longer exposes `tokio` in the public API.
* changed: `iroh_relay::dns::DnsError::Resolve { source }`: the `source` field type changed from `hickory_resolver::net::NetError` to `n0_error::AnyError`. `hickory_resolver` is no longer part of the public API surface of this error.
* changed: `iroh::endpoint::BindError::CreateNetmonMonitor { source }`: the `source` field type changed from `netmon::Error` to `n0_error::AnyError`. `netmon` is no longer part of the public API surface of this error.
* removed: `iroh::endpoint::bind::InvalidSocketAddr::InvalidPrefix { source: ipnet::PrefixLenError }` variant.
* added: `iroh::endpoint::bind::InvalidSocketAddr::InvalidPrefixLength {}` variant, replacing `InvalidPrefix`. The underlying `ipnet::PrefixLenError` is no longer exposed.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.