### PR TITLE
refactor(iroh-relay)!: use AnyError instead of concrete websocket and postcard errors

### DIFF
--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -11,6 +11,8 @@ use std::{
 
 use conn::Conn;
 use iroh_base::{RelayUrl, SecretKey};
+#[cfg(wasm_browser)]
+use n0_error::StdResultExt;
 use n0_error::{AnyError, e, stack_error};
 use n0_future::{
     Sink, Stream,
@@ -379,7 +381,8 @@ impl ClientBuilder {
             dial_url.as_str(),
             Some(ProtocolVersion::all().collect()),
         )
-        .await?;
+        .await
+        .anyerr()?;
 
         let protocol_version =
             ProtocolVersion::match_from_str(&ws_meta.protocol()).ok_or_else(|| {

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -11,7 +11,7 @@ use std::{
 
 use conn::Conn;
 use iroh_base::{RelayUrl, SecretKey};
-use n0_error::{e, stack_error};
+use n0_error::{AnyError, e, stack_error};
 use n0_future::{
     Sink, Stream,
     split::{SplitSink, SplitStream, split},
@@ -53,14 +53,7 @@ pub enum ConnectError {
     #[error("Invalid relay URL: {url}")]
     InvalidRelayUrl { url: Url },
     #[error(transparent)]
-    Websocket {
-        #[cfg(not(wasm_browser))]
-        #[error(std_err)]
-        source: tokio_websockets::Error,
-        #[cfg(wasm_browser)]
-        #[error(std_err)]
-        source: ws_stream_wasm::WsErr,
-    },
+    Websocket { source: AnyError },
     #[error(
         "Server replied with invalid iroh-relay version header: {}",
         server_version.as_deref().unwrap_or("<empty>")
@@ -232,6 +225,7 @@ impl ClientBuilder {
     #[cfg(not(wasm_browser))]
     pub async fn connect(&self) -> Result<Client, ConnectError> {
         use http::header::SEC_WEBSOCKET_PROTOCOL;
+        use n0_error::StdResultExt;
         use tls::MaybeTlsStreamBuilder;
 
         use crate::{
@@ -298,7 +292,7 @@ impl ClientBuilder {
                     "impossible: CLIENT_AUTH_HEADER isn't a disallowed header value for websockets",
                 );
         }
-        let (conn, response) = builder.connect_on(stream).await?;
+        let (conn, response) = builder.connect_on(stream).await.anyerr()?;
 
         n0_error::ensure!(
             response.status() == hyper::StatusCode::SWITCHING_PROTOCOLS,

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -52,6 +52,12 @@ pub enum ConnectError {
     InvalidWebsocketUrl { url: Url },
     #[error("Invalid relay URL: {url}")]
     InvalidRelayUrl { url: Url },
+    /// Error returned from the underlying WebSocket stream while establishing the connection.
+    ///
+    /// The concrete error type is `tokio_websockets::Error` on native targets and
+    /// `ws_stream_wasm::WsErr` on `wasm_browser` targets. Use [`AnyError::downcast_ref`] to
+    /// recover it. Note that the concrete downcast type is not covered by any semver
+    /// guarantees and may change between releases.
     #[error(transparent)]
     Websocket { source: AnyError },
     #[error(

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use iroh_base::SecretKey;
-use n0_error::{ensure, stack_error};
+use n0_error::{AnyError, anyerr, ensure, stack_error};
 use n0_future::{Sink, Stream};
 use tracing::trace;
 
@@ -30,13 +30,8 @@ use crate::{
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub enum SendError {
-    #[error(transparent)]
-    StreamError {
-        #[cfg(not(wasm_browser))]
-        source: tokio_websockets::Error,
-        #[cfg(wasm_browser)]
-        source: ws_stream_wasm::WsErr,
-    },
+    #[error("Stream error")]
+    StreamError { source: AnyError },
     #[error("Exceeds max packet size ({MAX_PACKET_SIZE}): {size}")]
     ExceedsMaxPacketSize { size: usize },
     #[error("Attempted to send empty packet")]
@@ -50,13 +45,8 @@ pub enum SendError {
 pub enum RecvError {
     #[error(transparent)]
     Protocol { source: ProtoError },
-    #[error(transparent)]
-    StreamError {
-        #[cfg(not(wasm_browser))]
-        source: tokio_websockets::Error,
-        #[cfg(wasm_browser)]
-        source: ws_stream_wasm::WsErr,
-    },
+    #[error("Stream error")]
+    StreamError { source: AnyError },
 }
 
 /// A connection to a relay server.
@@ -129,7 +119,7 @@ impl Stream for Conn {
                     RelayToClientMsg::from_bytes(msg, &self.key_cache, self.protocol_version);
                 Poll::Ready(Some(message.map_err(Into::into)))
             }
-            Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),
+            Some(Err(e)) => Poll::Ready(Some(Err(anyerr!(e).into()))),
             None => Poll::Ready(None),
         }
     }

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -30,6 +30,12 @@ use crate::{
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub enum SendError {
+    /// Error returned from the underlying WebSocket stream while sending.
+    ///
+    /// The concrete error type is `tokio_websockets::Error` on native targets and
+    /// `ws_stream_wasm::WsErr` on `wasm_browser` targets. Use [`AnyError::downcast_ref`] to
+    /// recover it. Note that the concrete downcast type is not covered by any semver
+    /// guarantees and may change between releases.
     #[error("Stream error")]
     StreamError { source: AnyError },
     #[error("Exceeds max packet size ({MAX_PACKET_SIZE}): {size}")]
@@ -45,6 +51,12 @@ pub enum SendError {
 pub enum RecvError {
     #[error(transparent)]
     Protocol { source: ProtoError },
+    /// Error returned from the underlying WebSocket stream while receiving.
+    ///
+    /// The concrete error type is `tokio_websockets::Error` on native targets and
+    /// `ws_stream_wasm::WsErr` on `wasm_browser` targets. Use [`AnyError::downcast_ref`] to
+    /// recover it. Note that the concrete downcast type is not covered by any semver
+    /// guarantees and may change between releases.
     #[error("Stream error")]
     StreamError { source: AnyError },
 }

--- a/iroh-relay/src/protos/handshake.rs
+++ b/iroh-relay/src/protos/handshake.rs
@@ -31,7 +31,7 @@ use http::HeaderValue;
 #[cfg(feature = "server")]
 use iroh_base::Signature;
 use iroh_base::{PublicKey, SecretKey};
-use n0_error::{e, ensure, stack_error};
+use n0_error::{AnyError, anyerr, e, ensure, stack_error};
 use n0_future::{SinkExt, TryStreamExt};
 #[cfg(feature = "server")]
 use rand::CryptoRng;
@@ -136,15 +136,9 @@ impl Frame for ServerDeniesAuth {
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub enum Error {
-    #[error(transparent)]
-    Websocket {
-        #[cfg(not(wasm_browser))]
-        #[error(from, std_err)]
-        source: tokio_websockets::Error,
-        #[cfg(wasm_browser)]
-        #[error(from, std_err)]
-        source: ws_stream_wasm::WsErr,
-    },
+    /// or a `ws_stream_wasm::WsErr` (when running in wasm). You can use [`AnyError::downcast_ref`]
+    #[error("WebSocket error")]
+    Websocket { source: AnyError },
     #[error("Handshake stream ended prematurely")]
     UnexpectedEnd {},
     #[error(transparent)]
@@ -162,8 +156,7 @@ pub enum Error {
     #[error("Handshake failed while deserializing {frame_type:?} frame")]
     DeserializationError {
         frame_type: FrameType,
-        #[error(std_err)]
-        source: postcard::Error,
+        source: AnyError,
     },
     #[cfg(feature = "server")]
     /// Failed to deserialize client auth header
@@ -512,8 +505,12 @@ async fn write_frame<F: serde::Serialize + Frame>(
         .expect("serialization failed") // buffer can't become "full" without being a critical failure, datastructures shouldn't ever fail serialization
         .into_inner()
         .freeze();
-    io.send(bytes).await?;
-    io.flush().await?;
+    io.send(bytes)
+        .await
+        .map_err(|err| e!(Error::Websocket, anyerr!(err)))?;
+    io.flush()
+        .await
+        .map_err(|err| e!(Error::Websocket, anyerr!(err)))?;
     Ok(())
 }
 
@@ -523,7 +520,8 @@ async fn read_frame(
 ) -> Result<(FrameType, Bytes), Error> {
     let mut payload = io
         .try_next()
-        .await?
+        .await
+        .map_err(|err| e!(Error::Websocket, anyerr!(err)))?
         .ok_or_else(|| e!(Error::UnexpectedEnd))?;
 
     let frame_type = FrameType::from_bytes(&mut payload)?;
@@ -543,7 +541,7 @@ fn deserialize_frame<F: Frame + serde::de::DeserializeOwned>(frame: Bytes) -> Re
     postcard::from_bytes(&frame).map_err(|err| {
         e!(Error::DeserializationError {
             frame_type: F::TAG,
-            source: err
+            source: anyerr!(err)
         })
     })
 }
@@ -552,7 +550,7 @@ fn deserialize_frame<F: Frame + serde::de::DeserializeOwned>(frame: Bytes) -> Re
 mod tests {
     use bytes::BytesMut;
     use iroh_base::{PublicKey, SecretKey};
-    use n0_error::{Result, StackResultExt, StdResultExt};
+    use n0_error::{AnyError, Result, StackResultExt, StdResultExt};
     use n0_future::{Sink, SinkExt, Stream, TryStreamExt};
     use n0_tracing_test::traced_test;
     use rand::{RngExt, SeedableRng};
@@ -651,13 +649,13 @@ mod tests {
 
         let mut client_io = Framed::new(client, LengthDelimitedCodec::new())
             .map_ok(BytesMut::freeze)
-            .map_err(tokio_websockets::Error::Io)
-            .sink_map_err(tokio_websockets::Error::Io)
+            .map_err(AnyError::from_std)
+            .sink_map_err(AnyError::from_std)
             .with_shared_secret(client_shared_secret);
         let mut server_io = Framed::new(server, LengthDelimitedCodec::new())
             .map_ok(BytesMut::freeze)
-            .map_err(tokio_websockets::Error::Io)
-            .sink_map_err(tokio_websockets::Error::Io)
+            .map_err(AnyError::from_std)
+            .sink_map_err(AnyError::from_std)
             .with_shared_secret(server_shared_secret);
 
         let client_auth_header = KeyMaterialClientAuth::new(secret_key, &client_io)

--- a/iroh-relay/src/protos/handshake.rs
+++ b/iroh-relay/src/protos/handshake.rs
@@ -136,7 +136,12 @@ impl Frame for ServerDeniesAuth {
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub enum Error {
-    /// or a `ws_stream_wasm::WsErr` (when running in wasm). You can use [`AnyError::downcast_ref`]
+    /// Error returned from the underlying WebSocket stream during the handshake.
+    ///
+    /// The concrete error type is `tokio_websockets::Error` on native targets and
+    /// `ws_stream_wasm::WsErr` on `wasm_browser` targets. Use [`AnyError::downcast_ref`] to
+    /// recover it. Note that the concrete downcast type is not covered by any semver
+    /// guarantees and may change between releases.
     #[error("WebSocket error")]
     Websocket { source: AnyError },
     #[error("Handshake stream ended prematurely")]

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -49,11 +49,6 @@ pub enum Error {
     #[error("Frame is too large, has {frame_len} bytes")]
     FrameTooLarge { frame_len: usize },
     #[error(transparent)]
-    SerDe {
-        #[error(std_err)]
-        source: postcard::Error,
-    },
-    #[error(transparent)]
     FrameTypeError { source: FrameTypeError },
     #[error("Invalid public key")]
     InvalidPublicKey { source: KeyParsingError },

--- a/iroh-relay/src/protos/streams.rs
+++ b/iroh-relay/src/protos/streams.rs
@@ -6,6 +6,8 @@ use std::{
 };
 
 use bytes::Bytes;
+#[cfg(not(wasm_browser))]
+use n0_error::{AnyError, anyerr};
 use n0_future::{Sink, Stream, ready};
 #[cfg(not(wasm_browser))]
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -29,21 +31,14 @@ pub(crate) struct WsBytesFramed {
 
 /// Error type for WebSocket stream operations.
 ///
-/// This type alias represents errors that can occur during WebSocket communication.
-/// The underlying error type depends on the platform:
+/// This is a generic [`AnyError`] and represents errors that can occur during WebSocket
+/// communication. The underlying error type depends on the platform:
 /// - On non-browser platforms: `tokio_websockets::Error`
 /// - On browser WASM: `ws_stream_wasm::WsErr`
-#[cfg(not(wasm_browser))]
-pub type StreamError = tokio_websockets::Error;
-
-/// Error type for WebSocket stream operations.
 ///
-/// This type alias represents errors that can occur during WebSocket communication.
-/// The underlying error type depends on the platform:
-/// - On non-browser platforms: `tokio_websockets::Error`
-/// - On browser WASM: `ws_stream_wasm::WsErr`
-#[cfg(wasm_browser)]
-pub type StreamError = ws_stream_wasm::WsErr;
+/// You can use [`AnyError::downcast_ref`] to downcast to the concrete error. However, the
+/// downcast is not covered by any semver guarantees and the underlying error may change.
+pub type StreamError = AnyError;
 
 /// Shorthand for a type that implements both a websocket-based stream & sink for [`Bytes`].
 pub trait BytesStreamSink:
@@ -92,7 +87,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for WsBytesFramed<T> {
         loop {
             match ready!(Pin::new(&mut self.io).poll_next(cx)) {
                 None => return Poll::Ready(None),
-                Some(Err(e)) => return Poll::Ready(Some(Err(e))),
+                Some(Err(e)) => return Poll::Ready(Some(Err(anyerr!(e)))),
                 Some(Ok(msg)) => {
                     if msg.is_close() {
                         // Indicate the stream is done when we receive a close message.
@@ -139,19 +134,27 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sink<Bytes> for WsBytesFramed<T> {
 
     fn start_send(mut self: Pin<&mut Self>, bytes: Bytes) -> Result<(), Self::Error> {
         let msg = tokio_websockets::Message::binary(tokio_websockets::Payload::from(bytes));
-        Pin::new(&mut self.io).start_send(msg)
+        Pin::new(&mut self.io)
+            .start_send(msg)
+            .map_err(AnyError::from_std)
     }
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.io).poll_ready(cx).map_err(Into::into)
+        Pin::new(&mut self.io)
+            .poll_ready(cx)
+            .map_err(AnyError::from_std)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.io).poll_flush(cx).map_err(Into::into)
+        Pin::new(&mut self.io)
+            .poll_flush(cx)
+            .map_err(AnyError::from_std)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.io).poll_close(cx).map_err(Into::into)
+        Pin::new(&mut self.io)
+            .poll_close(cx)
+            .map_err(AnyError::from_std)
     }
 }
 
@@ -161,18 +164,26 @@ impl Sink<Bytes> for WsBytesFramed {
 
     fn start_send(mut self: Pin<&mut Self>, bytes: Bytes) -> Result<(), Self::Error> {
         let msg = ws_stream_wasm::WsMessage::Binary(Vec::from(bytes));
-        Pin::new(&mut self.io).start_send(msg).map_err(Into::into)
+        Pin::new(&mut self.io)
+            .start_send(msg)
+            .map_err(AnyError::from_std)
     }
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.io).poll_ready(cx).map_err(Into::into)
+        Pin::new(&mut self.io)
+            .poll_ready(cx)
+            .map_err(AnyError::from_std)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.io).poll_flush(cx).map_err(Into::into)
+        Pin::new(&mut self.io)
+            .poll_flush(cx)
+            .map_err(AnyError::from_std)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.io).poll_close(cx).map_err(Into::into)
+        Pin::new(&mut self.io)
+            .poll_close(cx)
+            .map_err(AnyError::from_std)
     }
 }

--- a/iroh-relay/src/protos/streams.rs
+++ b/iroh-relay/src/protos/streams.rs
@@ -6,8 +6,9 @@ use std::{
 };
 
 use bytes::Bytes;
+use n0_error::AnyError;
 #[cfg(not(wasm_browser))]
-use n0_error::{AnyError, anyerr};
+use n0_error::anyerr;
 use n0_future::{Sink, Stream, ready};
 #[cfg(not(wasm_browser))]
 use tokio::io::{AsyncRead, AsyncWrite};


### PR DESCRIPTION
## Description

This hides `postcard`, `tokio_websocket` and `ws_wasm_stream` from the public API surface of iroh-relay by replacing their errors with `AnyError` in the public error enums.

## Breaking Changes

* changed: `iroh_relay::protos::streams::StreamError` is now a type alias for `n0_error::AnyError` on all platforms (previously `tokio_websockets::Error` on non-`wasm_browser`, `ws_stream_wasm::WsErr` on `wasm_browser`). The concrete type is still accessible via `AnyError::downcast_ref`, but that downcast is not covered by semver.
* changed: `iroh_relay::client::ConnectError::Websocket { source }`: the `source` field type changed from a cfg-gated `tokio_websockets::Error` / `ws_stream_wasm::WsErr` to `n0_error::AnyError`.
* changed: `iroh_relay::client::conn::SendError::StreamError { source }`: the `source` field type changed from a cfg-gated `tokio_websockets::Error` / `ws_stream_wasm::WsErr` to `n0_error::AnyError`.
* changed: `iroh_relay::client::conn::RecvError::StreamError { source }`: the `source` field type changed from a cfg-gated `tokio_websockets::Error` / `ws_stream_wasm::WsErr` to `n0_error::AnyError`.
* changed: `iroh_relay::protos::handshake::Error::Websocket { source }`: the `source` field type changed from a cfg-gated `tokio_websockets::Error` / `ws_stream_wasm::WsErr` to `n0_error::AnyError`.
* changed: `iroh_relay::protos::handshake::Error::DeserializationError { source, .. }`: the `source` field type changed from `postcard::Error` to `n0_error::AnyError`.
* removed: `iroh_relay::protos::relay::Error::SerDe { source: postcard::Error }` variant. `postcard` is no longer exposed from this error

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.