### PR TITLE
refactor(iroh-relay)!: remove `rustls_cert_reloadable_resolver` from public API

### DIFF
--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -17,10 +17,14 @@ use iroh_relay::{
     defaults::{
         DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT, DEFAULT_METRICS_PORT, DEFAULT_RELAY_QUIC_PORT,
     },
-    server::{self as relay, ClientRateLimit, QuicConfig},
+    server::{
+        self as relay, ClientRateLimit, DEFAULT_CERT_RELOAD_INTERVAL, QuicConfig,
+        reloading_resolver,
+    },
 };
 use n0_error::{Result, StdResultExt, bail_any};
 use n0_future::FutureExt;
+use rustls::{crypto::CryptoProvider, server::ResolvesServerCert};
 use serde::{Deserialize, Serialize};
 use tokio_rustls_acme::{AcmeConfig, caches::DirCache};
 use tracing::{debug, warn};
@@ -585,40 +589,14 @@ async fn maybe_load_tls(
             let server_config = server_config.with_cert_resolver(resolver);
             (relay::CertConfig::LetsEncrypt { state }, server_config)
         }
-        #[cfg(feature = "server")]
         CertMode::Reloading => {
-            use rustls_cert_file_reader::FileReader;
-            use rustls_cert_reloadable_resolver::{CertifiedKeyLoader, key_provider::Dyn};
-            use webpki_types::{CertificateDer, PrivateKeyDer};
-
-            let cert_path = tls.cert_path();
-            let key_path = tls.key_path();
-            let interval = relay::DEFAULT_CERT_RELOAD_INTERVAL;
-
-            let key_reader = rustls_cert_file_reader::FileReader::new(
-                key_path,
-                rustls_cert_file_reader::Format::PEM,
-            );
-            let certs_reader = rustls_cert_file_reader::FileReader::new(
-                cert_path,
-                rustls_cert_file_reader::Format::PEM,
-            );
-
-            let loader: CertifiedKeyLoader<
-                Dyn,
-                FileReader<PrivateKeyDer<'_>>,
-                FileReader<Vec<CertificateDer<'_>>>,
-            > = CertifiedKeyLoader {
-                key_provider: Dyn(server_config.crypto_provider().key_provider),
-                key_reader,
-                certs_reader,
-            };
-
-            let resolver = Arc::new(
-                relay::ReloadingResolver::init(loader, interval)
-                    .await
-                    .std_context("cert loading")?,
-            );
+            let resolver = reloading_resolver(
+                &server_config.crypto_provider(),
+                tls.cert_path(),
+                tls.key_path(),
+                DEFAULT_CERT_RELOAD_INTERVAL,
+            )
+            .await?;
             let server_config = server_config.with_cert_resolver(resolver);
             (relay::CertConfig::Reloading, server_config)
         }

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -24,7 +24,6 @@ use iroh_relay::{
 };
 use n0_error::{Result, StdResultExt, bail_any};
 use n0_future::FutureExt;
-use rustls::{crypto::CryptoProvider, server::ResolvesServerCert};
 use serde::{Deserialize, Serialize};
 use tokio_rustls_acme::{AcmeConfig, caches::DirCache};
 use tracing::{debug, warn};

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -590,7 +590,7 @@ async fn maybe_load_tls(
         }
         CertMode::Reloading => {
             let resolver = reloading_resolver(
-                &server_config.crypto_provider(),
+                server_config.crypto_provider(),
                 tls.cert_path(),
                 tls.key_path(),
                 DEFAULT_CERT_RELOAD_INTERVAL,

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -54,7 +54,7 @@ pub mod testing;
 pub use self::{
     http_server::{Handlers, RelayService},
     metrics::{Metrics, RelayMetrics},
-    resolver::{DEFAULT_CERT_RELOAD_INTERVAL, ReloadingResolver},
+    resolver::{DEFAULT_CERT_RELOAD_INTERVAL, reloading_resolver},
 };
 
 const NO_CONTENT_CHALLENGE_HEADER: &str = "X-Iroh-Challenge";

--- a/iroh-relay/src/server/resolver.rs
+++ b/iroh-relay/src/server/resolver.rs
@@ -1,28 +1,66 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
+use n0_error::{AnyError, StdResultExt};
 use n0_future::{
     task::{self, AbortOnDropHandle},
     time::{self, Duration},
 };
 use reloadable_state::Reloadable;
 use rustls::{
+    crypto::CryptoProvider,
     server::{ClientHello, ResolvesServerCert},
     sign::CertifiedKey,
 };
+use rustls_cert_reloadable_resolver::{CertifiedKeyLoader, key_provider::Dyn};
 use tokio_util::sync::CancellationToken;
 
 /// The default certificate reload interval.
 pub const DEFAULT_CERT_RELOAD_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24);
 
+/// Builds a [`ResolvesServerCert`] that reloads its certificate and key from disk on an interval.
+///
+/// Loads the PEM-encoded certificate chain from `cert_path` and the PEM-encoded private key
+/// from `key_path` using `crypto_provider`'s key provider, then spawns a background task that
+/// re-reads both files every `interval`. The returned resolver hands the most recently loaded
+/// `CertifiedKey` to rustls for each TLS handshake, so certificate rotation takes effect without
+/// restarting the server. See [`DEFAULT_CERT_RELOAD_INTERVAL`] for a sensible default.
+///
+/// The reload task is tied to the returned `Arc` and is aborted when the last reference is
+/// dropped. Reload failures on the interval are silently ignored; the previously loaded
+/// certificate remains in use.
+///
+/// # Errors
+///
+/// Returns an error if the initial certificate or key load fails (for example, the files do not
+/// exist, cannot be read, or cannot be parsed as PEM).
+pub async fn reloading_resolver(
+    crypto_provider: &CryptoProvider,
+    cert_path: PathBuf,
+    key_path: PathBuf,
+    interval: std::time::Duration,
+) -> Result<Arc<dyn ResolvesServerCert>, AnyError> {
+    let key_reader =
+        rustls_cert_file_reader::FileReader::new(key_path, rustls_cert_file_reader::Format::PEM);
+    let certs_reader =
+        rustls_cert_file_reader::FileReader::new(cert_path, rustls_cert_file_reader::Format::PEM);
+    let loader = CertifiedKeyLoader {
+        key_provider: Dyn(crypto_provider.key_provider),
+        key_reader,
+        certs_reader,
+    };
+    let resolver = ReloadingResolver::init(loader, interval)
+        .await
+        .std_context("cert loading")?;
+    Ok(Arc::new(resolver))
+}
+
 /// A Certificate resolver that reloads the certificate every interval
 #[derive(Debug)]
-pub struct ReloadingResolver<Loader: Send + 'static> {
+struct ReloadingResolver<Loader: Send + 'static> {
     /// The inner reloadable value.
     reloadable: Arc<Reloadable<CertifiedKey, Loader>>,
     /// The handle to the task that reloads the certificate.
     _handle: AbortOnDropHandle<()>,
-    /// Cancel token to shutdown the resolver.
-    cancel_token: CancellationToken,
 }
 
 impl<Loader> ReloadingResolver<Loader>
@@ -30,7 +68,7 @@ where
     Loader: Send + reloadable_state::core::Loader<Value = CertifiedKey> + 'static,
 {
     /// Perform the initial load and construct the [`ReloadingResolver`].
-    pub async fn init(loader: Loader, interval: Duration) -> Result<Self, Loader::Error> {
+    async fn init(loader: Loader, interval: Duration) -> Result<Self, Loader::Error> {
         let (reloadable, _) = Reloadable::init_load(loader).await?;
         let reloadable = Arc::new(reloadable);
 
@@ -59,18 +97,7 @@ where
         Ok(Self {
             reloadable,
             _handle,
-            cancel_token,
         })
-    }
-
-    /// Shutdown the resolver.
-    pub fn shutdown(self) {
-        self.cancel_token.cancel();
-    }
-
-    /// Reload the certificate.
-    pub async fn reload(&self) {
-        let _ = self.reloadable.reload().await;
     }
 }
 

--- a/iroh-relay/src/server/resolver.rs
+++ b/iroh-relay/src/server/resolver.rs
@@ -11,6 +11,7 @@ use rustls::{
     server::{ClientHello, ResolvesServerCert},
     sign::CertifiedKey,
 };
+use rustls_cert_file_reader::{FileReader, Format};
 use rustls_cert_reloadable_resolver::{CertifiedKeyLoader, key_provider::Dyn};
 use tokio_util::sync::CancellationToken;
 
@@ -39,10 +40,8 @@ pub async fn reloading_resolver(
     key_path: PathBuf,
     interval: std::time::Duration,
 ) -> Result<Arc<dyn ResolvesServerCert>, AnyError> {
-    let key_reader =
-        rustls_cert_file_reader::FileReader::new(key_path, rustls_cert_file_reader::Format::PEM);
-    let certs_reader =
-        rustls_cert_file_reader::FileReader::new(cert_path, rustls_cert_file_reader::Format::PEM);
+    let key_reader = FileReader::new(key_path, Format::PEM);
+    let certs_reader = FileReader::new(cert_path, Format::PEM);
     let loader = CertifiedKeyLoader {
         key_provider: Dyn(crypto_provider.key_provider),
         key_reader,


### PR DESCRIPTION
## Description

The `rustls_cert_reloadable_resolver::ReloadingResolver` struct and its generic `Loader` type parameter were part of the public API of `iroh_relay::server`. This PR removes it from the API surface and only keeps a single public async factory function `reloading_resolver` that returns an `Arc<dyn rustls::ResolvesServerCert>`.

For more configurability, users can use `rustls_cert_reloadable_resolver` themselves.

## Breaking Changes

* removed: `iroh_relay::server::ReloadingResolver` (and its `init`, `shutdown`, and `reload` methods) is no longer public. The struct is now a private implementation detail of `iroh-relay`.
* added: `iroh_relay::server::reloading_resolver` async factory function returning `Result<Arc<dyn ResolvesServerCert>, n0_error::AnyError>`. It takes a `&CryptoProvider`, `cert_path: PathBuf`, `key_path: PathBuf`, and `interval: std::time::Duration`. Use this in place of constructing a `ReloadingResolver` directly.


## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.