### PR TITLE
refactor(iroh-relay)!: Remove `http_body_util` and `tokio_util` from public API surface

### DIFF
--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -531,7 +531,7 @@ async fn main() -> Result<()> {
     tokio::select! {
         biased;
         _ = tokio::signal::ctrl_c() => (),
-        _ = relay.task_handle() => (),
+        _ = relay.join() => (),
     }
 
     relay.shutdown().await?;

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -42,6 +42,8 @@ use crate::{
     quic::server::{QuicServer, QuicSpawnError, ServerHandle as QuicServerHandle},
 };
 
+use self::http_server::{BytesBody, HyperError, HyperResult};
+
 pub mod client;
 pub mod clients;
 pub mod http_server;
@@ -78,13 +80,9 @@ const TLS_HEADERS: [(&str, &str); 2] = [
     ),
 ];
 
-type BytesBody = http_body_util::Full<hyper::body::Bytes>;
-type HyperError = Box<dyn std::error::Error + Send + Sync>;
-type HyperResult<T> = std::result::Result<T, HyperError>;
-
 /// Creates a new [`BytesBody`] with no content.
 fn body_empty() -> BytesBody {
-    http_body_util::Full::new(hyper::body::Bytes::new())
+    Box::new(http_body_util::Full::new(hyper::body::Bytes::new()))
 }
 
 /// Configuration for the full Relay.
@@ -620,10 +618,11 @@ fn root_handler(
     _r: Request<Incoming>,
     response: ResponseBuilder,
 ) -> HyperResult<Response<BytesBody>> {
+    let body: BytesBody = Box::new(Full::from(INDEX));
     response
         .status(StatusCode::OK)
         .header("Content-Type", "text/html; charset=utf-8")
-        .body(INDEX.into())
+        .body(body)
         .map_err(|err| Box::new(err) as HyperError)
 }
 
@@ -643,9 +642,10 @@ fn robots_handler(
     _r: Request<Incoming>,
     response: ResponseBuilder,
 ) -> HyperResult<Response<BytesBody>> {
+    let body: BytesBody = Box::new(Full::from(ROBOTS_TXT));
     response
         .status(StatusCode::OK)
-        .body(ROBOTS_TXT.into())
+        .body(body)
         .map_err(|err| Box::new(err) as HyperError)
 }
 
@@ -701,10 +701,11 @@ fn healthz_handler(
         git_hash: option_env!("VERGEN_GIT_SHA").unwrap_or("unknown"),
     };
     let body = serde_json::to_string(&health).unwrap_or_else(|_| r#"{"status":"error"}"#.into());
+    let body: BytesBody = Box::new(Full::from(body));
     response
         .status(StatusCode::OK)
         .header("Content-Type", "application/json")
-        .body(body.into())
+        .body(body)
         .map_err(|err| Box::new(err) as HyperError)
 }
 
@@ -773,9 +774,10 @@ impl hyper::service::Service<Request<Incoming>> for CaptivePortalService {
             }
             _ => {
                 // Return 404 not found response.
+                let body: BytesBody = Box::new(Full::from(NOTFOUND));
                 let r = Response::builder()
                     .status(StatusCode::NOT_FOUND)
-                    .body(NOTFOUND.into())
+                    .body(body)
                     .map_err(|err| Box::new(err) as HyperError);
                 Box::pin(async move { r })
             }

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -36,13 +36,12 @@ use tokio::{
 };
 use tracing::{Instrument, debug, error, info, info_span, instrument};
 
+use self::http_server::{BytesBody, HyperError, HyperResult};
 use crate::{
     defaults::DEFAULT_KEY_CACHE_CAPACITY,
     http::RELAY_PROBE_PATH,
     quic::server::{QuicServer, QuicSpawnError, ServerHandle as QuicServerHandle},
 };
-
-use self::http_server::{BytesBody, HyperError, HyperResult};
 
 pub mod client;
 pub mod clients;

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -22,18 +22,18 @@ use http::{
     HeaderMap, HeaderValue, Method, Request, Response, StatusCode, header::InvalidHeaderValue,
     response::Builder as ResponseBuilder,
 };
+use http_body_util::Full;
 use hyper::body::Incoming;
 use iroh_base::EndpointId;
 #[cfg(feature = "test-utils")]
 use iroh_base::RelayUrl;
 use n0_error::{e, stack_error};
-use n0_future::{StreamExt, future::Boxed};
+use n0_future::{StreamExt, future::Boxed, task::AbortOnDropHandle};
 use serde::Serialize;
 use tokio::{
     net::TcpListener,
     task::{JoinError, JoinSet},
 };
-use tokio_util::task::AbortOnDropHandle;
 use tracing::{Instrument, debug, error, info, info_span, instrument};
 
 use crate::{
@@ -492,12 +492,15 @@ impl Server {
         self.supervisor.await?
     }
 
-    /// Returns the handle for the task.
+    /// Waits for the server's supervisor task to finish.
     ///
-    /// This allows waiting for the server's supervisor task to finish.  Can be useful in
-    /// case there is an error in the server before it is shut down.
-    pub fn task_handle(&mut self) -> &mut AbortOnDropHandle<Result<(), SupervisorError>> {
-        &mut self.supervisor
+    /// Returns the exit result of the supervisor task. Unlike [`Self::shutdown`], this does
+    /// *not* request shutdown, it only waits for the server to terminate on its own (for
+    /// example, after an internal error or because the supervisor was aborted from
+    /// elsewhere). The outer [`JoinError`] is only produced if the supervisor task itself
+    /// panics or is aborted.
+    pub async fn join(&mut self) -> Result<Result<(), SupervisorError>, JoinError> {
+        (&mut self.supervisor).await
     }
 
     /// The socket address the HTTPS server is listening on.
@@ -866,7 +869,7 @@ mod tests {
         let mut server = Server::spawn(ServerConfig::<(), ()>::default())
             .await
             .unwrap();
-        let res = tokio::time::timeout(Duration::from_secs(5), server.task_handle())
+        let res = tokio::time::timeout(Duration::from_secs(5), server.join())
             .await
             .expect("timeout, server not finished")
             .expect("server task JoinError");
@@ -889,7 +892,7 @@ mod tests {
         })
         .await
         .unwrap();
-        let res = tokio::time::timeout(Duration::from_secs(5), server.task_handle())
+        let res = tokio::time::timeout(Duration::from_secs(5), server.join())
             .await
             .expect("timeout, server not finished")
             .expect("server task JoinError");

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -6,7 +6,7 @@
 //!
 //! For a complete relay server implementation, see the parent [`server`](super) module.
 
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::HashMap, convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use derive_more::Debug;
@@ -52,10 +52,13 @@ use crate::{
     },
 };
 
-type BytesBody = http_body_util::Full<hyper::body::Bytes>;
-type HyperError = Box<dyn std::error::Error + Send + Sync>;
-type HyperResult<T> = std::result::Result<T, HyperError>;
-type HyperHandler = Box<
+// type BytesBody = http_body_util::Full<hyper::body::Bytes>;
+pub(super) type BytesBody = Box<
+    dyn 'static + Send + Unpin + hyper::body::Body<Data = hyper::body::Bytes, Error = Infallible>,
+>;
+pub(super) type HyperError = Box<dyn std::error::Error + Send + Sync>;
+pub(super) type HyperResult<T> = std::result::Result<T, HyperError>;
+pub(super) type HyperHandler = Box<
     dyn Fn(Request<Incoming>, ResponseBuilder) -> HyperResult<Response<BytesBody>>
         + Send
         + Sync
@@ -84,7 +87,7 @@ fn derive_accept_key(client_key: &HeaderValue) -> String {
 
 /// Creates a new [`BytesBody`] with given content.
 fn body_full(content: impl Into<hyper::body::Bytes>) -> BytesBody {
-    http_body_util::Full::new(content.into())
+    Box::new(http_body_util::Full::new(content.into()))
 }
 
 #[allow(clippy::result_large_err)]


### PR DESCRIPTION
## Description

Two small iroh-relay API cleanups that reduce the public API surface:

- `Server::task_handle` returned a mutable reference to an   `AbortOnDropHandle<Result<(), SupervisorError>>`. It is replaced by   `Server::join`, an `async` method that awaits the supervisor task and  returns its result. This removes `tokio_util` from the public API of `iroh_relay::server::Server`.

- The relay's internal `BytesBody` is now a boxed   `hyper::body::Body<Data = Bytes, Error = Infallible>` trait object
  rather than a concrete `http_body_util::Full<Bytes>`. Through this, the non-1.0 crate `http_body_util` no longer is part of the public API for iroh-relay, at the cost of one additional boxing per HTTP response, which I don't think would be observable perf-wise in any way.

## Breaking Changes

* removed: `iroh_relay::server::Server::task_handle(&mut self) -> &mut AbortOnDropHandle<Result<(), SupervisorError>>`. Replaced by `iroh_relay::server::Server::join(&mut self) -> Result<Result<(), SupervisorError>, JoinError>`.   Callers that previously did `(&mut *server.task_handle()).await` can   use `server.join().await` instead. 
* changed: `iroh_relay::server::http_server::BytesBody` is now  `Box<dyn Send + Unpin + hyper::body::Body<Data = hyper::body::Bytes, Error = Infallible>>`  instead of `http_body_util::Full<hyper::body::Bytes>`. `http_body_util`
  is no longer part of the public API surface.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the style guide
- [x] All breaking changes documented.
