### PR TITLE
fix: Protect against division by zero in process_datagram

### DIFF
--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -569,8 +569,21 @@ impl Socket {
         for i in 0..metas.len() {
             let noq_meta = &mut metas[i];
             let source_addr = &source_addrs[i];
-
-            let datagram_count = noq_meta.len.div_ceil(noq_meta.stride);
+            let datagram_count = if noq_meta.stride == 0 {
+                if noq_meta.len > 0 {
+                    warn!(
+                        src = ?source_addr,
+                        len = noq_meta.len,
+                        "received datagram with stride=0 but len>0",
+                    );
+                    // fix the weird len
+                    noq_meta.len = 0;
+                }
+                // one empty datagram
+                1
+            } else {
+                noq_meta.len.div_ceil(noq_meta.stride)
+            };
             self.metrics
                 .socket
                 .recv_datagrams
@@ -580,7 +593,7 @@ impl Socket {
                     src = ?source_addr,
                     len = noq_meta.len,
                     stride = %noq_meta.stride,
-                    datagram_count = noq_meta.len.div_ceil(noq_meta.stride),
+                    datagram_count,
                     "GRO datagram received",
                 );
                 self.metrics.socket.recv_gro_datagrams.inc();


### PR DESCRIPTION
## Description

Protect against division by zero in process_datagram

This protects against the valid case of being sent an empty packet, and for completeness sake also handles the weird case where we get stride = 0, len > 0.

I decided to fix and proceed instead of erroring out since this is a loop.

Fixes https://github.com/n0-computer/iroh/issues/4144

## Breaking Changes

None

## Notes & open questions

Throw exception instead, as suggested in the issue? This would mean that we would not process items after the weird RecvMeta, so I don't like it.

This will probably never happen unless we got an error in the udp socket impl, but 1. stranger things have happened and 2. with custom transports people can send us some weird stuff. 

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
