### PR TITLE
fix(deps): update sha2 and sha1 versions in `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4632,12 +4632,12 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
@@ -4649,12 +4649,12 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -20,8 +20,8 @@ data-encoding = { version = "2.6.0", optional = true }
 data-encoding-macro = { version = "0.1.19", optional = true }
 digest = { version = "0.11", optional = true }
 # Pin sha2 & sha1 to fix version incompatibility
-sha2 = { version = "=0.11.0-rc.5", optional = true }
-sha1 = { version = "=0.11.0-rc.5", optional = true }
+sha2 = { version = "0.11.0", optional = true }
+sha1 = { version = "0.11.0", optional = true }
 ed25519-dalek = { version = "=3.0.0-pre.6", features = ["serde", "rand_core", "zeroize"], optional = true }
 derive_more = { version = "2.0.1", features = ["debug", "display"], optional = true }
 url = { version = "2.5.3", features = ["serde"], optional = true }

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -80,7 +80,7 @@ time = { version = "0.3.37", optional = true }
 tokio-rustls-acme = { version = "0.9", optional = true }
 tokio-websockets = { version = "0.13", features = ["rustls-bring-your-own-connector", "getrandom", "rand", "server", "sha1_smol"], optional = true } # server-side websocket implementation
 simdutf8 = { version = "0.1.5", optional = true } # minimal version fix
-sha1 = { version = "=0.11.0-rc.5", optional = true }
+sha1 = { version = "0.11.0", optional = true }
 toml = { version = "1.0", optional = true }
 serde_json = { version = "1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }


### PR DESCRIPTION
Updated sha2 and sha1 dependencies to version 0.11.0.

So I don't need to override in https://github.com/OkuBrowser/oku.

## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
