### PR TITLE
feat(iroh-base): impl From<&[u8; 32]> for SecretKey

### DIFF
--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -352,6 +352,12 @@ impl From<[u8; 32]> for SecretKey {
     }
 }
 
+impl From<&[u8; 32]> for SecretKey {
+    fn from(value: &[u8; 32]) -> Self {
+        Self::from_bytes(value)
+    }
+}
+
 impl TryFrom<&[u8]> for SecretKey {
     type Error = KeyParsingError;
 


### PR DESCRIPTION
## Description

Add `From<&[u8; 32]>` implementation for `SecretKey`

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
