### PR TITLE
chore(ci): fix musl/gnu build setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            name: [ubuntu-latest, ubuntu-arm-latest, macOS-latest, macOS-arm-latest, windows-latest]
+            name: [ubuntu-latest, ubuntu-musl-latest, ubuntu-arm-latest, ubuntu-arm-musl-latest, macOS-latest, macOS-arm-latest, windows-latest]
             rust: [stable]
             experimental: [false]
             include:
@@ -100,13 +100,29 @@ jobs:
                 os: ubuntu-latest
                 release-os: linux
                 release-arch: aarch64
+                libc: gnu
+                cargo_targets: "aarch64-unknown-linux-gnu"
+                runner: [self-hosted, linux, ARM64]
+              - name: ubuntu-arm-musl-latest
+                os: ubuntu-latest
+                release-os: linux
+                release-arch: aarch64
+                libc: musl
                 cargo_targets: "aarch64-unknown-linux-musl"
                 runner: [self-hosted, linux, ARM64]
               - name: ubuntu-latest
                 os: ubuntu-latest
                 release-os: linux
                 release-arch: amd64
+                libc: gnu
                 cargo_targets: "x86_64-unknown-linux-gnu"
+                runner: [self-hosted, linux, X64]
+              - name: ubuntu-musl-latest
+                os: ubuntu-latest
+                release-os: linux
+                release-arch: amd64
+                libc: musl
+                cargo_targets: "x86_64-unknown-linux-musl"
                 runner: [self-hosted, linux, X64]
               - name: macOS-latest
                 os: macOS-latest
@@ -218,7 +234,7 @@ jobs:
             curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o ~/awscli/AWSCLIV2.pkg
 
         - name: Install awscli (linux)
-          if: matrix.os == 'ubuntu-latest' || matrix.name == 'ubuntu-arm-latest'
+          if: matrix.os == 'ubuntu-latest'
           run: sudo ~/awscli/aws/install --update
 
         - name: Install awscli (mac)
@@ -233,13 +249,13 @@ jobs:
               echo "AWS_DEFAULT_REGION=us-west-2" >> $GITHUB_ENV
 
         - name: push release
-          if: matrix.os != 'windows-latest'
+          if: matrix.os != 'windows-latest' && matrix.libc != 'musl'
           run: |
             aws s3 cp ./target/${{ matrix.cargo_targets }}/optimized-release/iroh-relay s3://vorc/iroh-relay-${RELEASE_OS}-${RELEASE_ARCH}-${GITHUB_SHA::7} --no-progress
             aws s3 cp ./target/${{ matrix.cargo_targets }}/optimized-release/iroh-dns-server s3://vorc/iroh-dns-server-${RELEASE_OS}-${RELEASE_ARCH}-${GITHUB_SHA::7} --no-progress
 
         - name: push release latest
-          if: matrix.os != 'windows-latest' && (github.event.inputs.mark_latest == 'true' || github.event_name == 'push')
+          if: matrix.os != 'windows-latest' && matrix.libc != 'musl' && (github.event.inputs.mark_latest == 'true' || github.event_name == 'push')
           run: |
             aws s3 cp ./target/${{ matrix.cargo_targets }}/optimized-release/iroh-relay s3://vorc/iroh-relay-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
             aws s3 cp ./target/${{ matrix.cargo_targets }}/optimized-release/iroh-dns-server s3://vorc/iroh-dns-server-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
@@ -287,7 +303,7 @@ jobs:
           uses: actions/upload-artifact@v7
           if : matrix.os != 'windows-latest'
           with:
-            name: iroh-${{ matrix.release-os }}-${{ matrix.release-arch }}-bundle
+            name: iroh-${{ matrix.release-os }}-${{ matrix.release-arch }}${{ matrix.libc == 'musl' && '-musl' || '' }}-bundle
             path: iroh-*.tar.gz
             compression-level: 0
             retention-days: 1


### PR DESCRIPTION
## Description

Ensures we independently build for both gnu and musl instead of musl for some and gnu for others.

Closes https://github.com/n0-computer/iroh/pull/4184

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
