### PR TITLE
refactor: Introduce a struct RecvInfo that has local and remote addresses.

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -29,6 +29,8 @@ use url::Url;
 /// Types for defining custom transports
 pub mod transports {
     #[cfg(feature = "unstable-custom-transports")]
+    pub use super::socket::transports::RecvInfo;
+    #[cfg(feature = "unstable-custom-transports")]
     pub use super::socket::transports::custom::{CustomEndpoint, CustomSender, CustomTransport};
     pub use super::socket::transports::{Addr, AddrKind, Transmit, TransportBias};
 }

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -87,7 +87,7 @@ impl From<transports::Addr> for IncomingAddr {
         match addr {
             transports::Addr::Ip(addr) => Self::Ip(addr),
             transports::Addr::Relay(url, endpoint_id) => Self::Relay { url, endpoint_id },
-            transports::Addr::Custom { remote, .. } => Self::Custom(remote),
+            transports::Addr::Custom(addr) => Self::Custom(addr),
         }
     }
 }
@@ -212,7 +212,7 @@ impl Incoming {
         match self.ep.to_transport_addr(self.inner.remote_address()) {
             transports::Addr::Ip(_) => IncomingLocalAddr::Ip(self.inner.local_ip()),
             transports::Addr::Relay(url, _) => IncomingLocalAddr::Relay { url },
-            transports::Addr::Custom { .. } => {
+            transports::Addr::Custom(_) => {
                 let local = self
                     .inner
                     .local_ip()

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -579,7 +579,7 @@ impl Socket {
         for i in 0..metas.len() {
             let noq_meta = &mut metas[i];
             let recv_info = &recv_infos[i];
-            let remote_addr = &recv_info.remote;
+            let remote_addr = recv_info.remote();
             let datagram_count = if noq_meta.stride == 0 {
                 if noq_meta.len > 0 {
                     warn!(
@@ -639,7 +639,7 @@ impl Socket {
                     // Fill in the correct mapped address
                     let mapped_addr = self.mapped_addrs.custom_addrs.get(remote);
                     noq_meta.addr = mapped_addr.private_socket_addr();
-                    if let Some(local) = &recv_info.local {
+                    if let Some(local) = recv_info.local() {
                         let local_mapped = self.mapped_addrs.custom_addrs.get(local);
                         noq_meta.dst_ip = Some(local_mapped.private_socket_addr().ip());
                     }

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -566,23 +566,24 @@ impl Socket {
         &self,
         bufs: &mut [io::IoSliceMut<'_>],
         metas: &mut [noq_udp::RecvMeta],
-        source_addrs: &[transports::Addr],
+        recv_infos: &[transports::RecvInfo],
     ) {
         debug_assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
         debug_assert_eq!(
             bufs.len(),
-            source_addrs.len(),
-            "non matching bufs & source_addrs"
+            recv_infos.len(),
+            "non matching bufs & recv_infos"
         );
 
         // zip is slow :(
         for i in 0..metas.len() {
             let noq_meta = &mut metas[i];
-            let source_addr = &source_addrs[i];
+            let recv_info = &recv_infos[i];
+            let remote_addr = &recv_info.remote;
             let datagram_count = if noq_meta.stride == 0 {
                 if noq_meta.len > 0 {
                     warn!(
-                        src = ?source_addr,
+                        src = ?remote_addr,
                         len = noq_meta.len,
                         "received datagram with stride=0 but len>0",
                     );
@@ -600,7 +601,7 @@ impl Socket {
                 .inc_by(datagram_count as _);
             if noq_meta.len > noq_meta.stride {
                 trace!(
-                    src = ?source_addr,
+                    src = ?remote_addr,
                     len = noq_meta.len,
                     stride = %noq_meta.stride,
                     datagram_count,
@@ -608,9 +609,9 @@ impl Socket {
                 );
                 self.metrics.socket.recv_gro_datagrams.inc();
             } else {
-                trace!(src = ?source_addr, len = noq_meta.len, "datagram received");
+                trace!(src = ?remote_addr, len = noq_meta.len, "datagram received");
             }
-            match source_addr {
+            match remote_addr {
                 transports::Addr::Ip(SocketAddr::V4(..)) => {
                     self.metrics.socket.recv_data_ipv4.inc_by(noq_meta.len as _);
                 }
@@ -630,7 +631,7 @@ impl Socket {
                         .get(&(src_url.clone(), *src_node));
                     noq_meta.addr = mapped_addr.private_socket_addr();
                 }
-                transports::Addr::Custom { remote, local } => {
+                transports::Addr::Custom(remote) => {
                     self.metrics
                         .socket
                         .recv_data_custom
@@ -638,7 +639,7 @@ impl Socket {
                     // Fill in the correct mapped address
                     let mapped_addr = self.mapped_addrs.custom_addrs.get(remote);
                     noq_meta.addr = mapped_addr.private_socket_addr();
-                    if let Some(local) = local {
+                    if let Some(local) = &recv_info.local {
                         let local_mapped = self.mapped_addrs.custom_addrs.get(local);
                         noq_meta.dst_ip = Some(local_mapped.private_socket_addr().ip());
                     }

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -106,10 +106,7 @@ pub(super) fn to_transport_addr(
         }
         MultipathMappedAddr::Custom(custom_mapped_addr) => {
             match custom_addrs.lookup(&custom_mapped_addr) {
-                Some(custom_addr) => Some(transports::Addr::Custom {
-                    remote: custom_addr,
-                    local: None,
-                }),
+                Some(custom_addr) => Some(transports::Addr::Custom(custom_addr)),
                 None => {
                     error!("Failed to convert addr to transport addr: Unknown custom mapped addr");
                     None

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -810,7 +810,7 @@ impl RemoteStateActor {
                 .relay_mapped_addrs
                 .get(&(relay_url.clone(), *eid))
                 .private_socket_addr(),
-            transports::Addr::Custom { remote, .. } => {
+            transports::Addr::Custom(remote) => {
                 self.custom_mapped_addrs.get(remote).private_socket_addr()
             }
         };
@@ -1285,7 +1285,7 @@ impl ConnectionState {
         match remote {
             transports::Addr::Ip(_) => metrics.paths_direct.inc(),
             transports::Addr::Relay(_, _) => metrics.paths_relay.inc(),
-            transports::Addr::Custom { .. } => metrics.paths_custom.inc(),
+            transports::Addr::Custom(_) => metrics.paths_custom.inc(),
         };
         if !self.has_been_direct && remote.is_ip() {
             self.has_been_direct = true;

--- a/iroh/src/socket/remote_map/remote_state/path_state.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_state.rs
@@ -88,7 +88,7 @@ impl RemotePathState {
         match addr {
             transports::Addr::Ip(_) => self.metrics.transport_ip_paths_added.inc(),
             transports::Addr::Relay(_, _) => self.metrics.transport_relay_paths_added.inc(),
-            transports::Addr::Custom { .. } => self.metrics.transport_custom_paths_added.inc(),
+            transports::Addr::Custom(_) => self.metrics.transport_custom_paths_added.inc(),
         };
         let state = self.paths.entry(addr).or_default();
         state.status = PathStatus::Open;
@@ -109,7 +109,7 @@ impl RemotePathState {
                     transports::Addr::Relay(_, _) => {
                         self.metrics.transport_relay_paths_removed.inc()
                     }
-                    transports::Addr::Custom { .. } => {
+                    transports::Addr::Custom(_) => {
                         self.metrics.transport_custom_paths_removed.inc()
                     }
                 };

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -564,8 +564,27 @@ impl fmt::Debug for Addr {
 #[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
 #[derive(Clone, Debug, Default)]
 pub struct RecvInfo {
-    pub(crate) remote: Addr,
-    pub(crate) local: Option<CustomAddr>,
+    remote: Addr,
+    local: Option<CustomAddr>,
+}
+
+impl RecvInfo {
+    /// Creates a [`RecvInfo`] from an internal [`Addr`], with no local custom
+    /// address. Used by IP and relay recv paths.
+    pub(crate) fn from_addr(remote: Addr) -> Self {
+        Self {
+            remote,
+            local: None,
+        }
+    }
+
+    pub(crate) fn remote(&self) -> &Addr {
+        &self.remote
+    }
+
+    pub(crate) fn local(&self) -> Option<&CustomAddr> {
+        self.local.as_ref()
+    }
 }
 
 #[cfg(feature = "unstable-custom-transports")]

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -46,8 +46,8 @@ pub(crate) struct Transports {
     custom: Vec<Box<dyn CustomEndpoint>>,
 
     poll_recv_counter: usize,
-    /// Cache for source addrs, to speed up access
-    source_addrs: [Addr; noq_udp::BATCH_SIZE],
+    /// Cache for per-packet recv info, to speed up access
+    recv_infos: [RecvInfo; noq_udp::BATCH_SIZE],
 }
 
 /// Combined watcher type for all ip transports
@@ -237,7 +237,7 @@ impl Transports {
             relay,
             custom,
             poll_recv_counter: Default::default(),
-            source_addrs: Default::default(),
+            recv_infos: Default::default(),
         })
     }
 
@@ -257,7 +257,7 @@ impl Transports {
         match self.inner_poll_recv(cx, bufs, metas)? {
             Poll::Pending | Poll::Ready(0) => Poll::Pending,
             Poll::Ready(n) => {
-                sock.process_datagrams(&mut bufs[..n], &mut metas[..n], &self.source_addrs[..n]);
+                sock.process_datagrams(&mut bufs[..n], &mut metas[..n], &self.recv_infos[..n]);
                 Poll::Ready(Ok(n))
             }
         }
@@ -274,7 +274,7 @@ impl Transports {
 
         macro_rules! poll_transport {
             ($socket:expr) => {
-                match $socket.poll_recv(cx, bufs, metas, &mut self.source_addrs)? {
+                match $socket.poll_recv(cx, bufs, metas, &mut self.recv_infos)? {
                     Poll::Pending | Poll::Ready(0) => {}
                     Poll::Ready(n) => {
                         return Poll::Ready(Ok(n));
@@ -537,15 +537,7 @@ pub enum Addr {
     /// A relay address.
     Relay(RelayUrl, EndpointId),
     /// A custom transport address.
-    ///
-    /// `local` is set on incoming packets when the transport reports the local
-    /// address that received the packet, and ignored on outgoing.
-    Custom {
-        /// The remote custom address.
-        remote: CustomAddr,
-        /// The local custom address, if the transport reports one.
-        local: Option<CustomAddr>,
-    },
+    Custom(CustomAddr),
 }
 
 impl fmt::Debug for Addr {
@@ -553,16 +545,40 @@ impl fmt::Debug for Addr {
         match self {
             Addr::Ip(addr) => write!(f, "Ip({addr})"),
             Addr::Relay(url, node_id) => write!(f, "Relay({url}, {})", node_id.fmt_short()),
-            Addr::Custom {
-                remote,
-                local: None,
-            } => write!(f, "Custom({remote:?})"),
-            Addr::Custom {
-                remote,
-                local: Some(local),
-            } => {
-                write!(f, "Custom({remote:?} via {local:?})")
-            }
+            Addr::Custom(custom_addr) => write!(f, "Custom({custom_addr:?})"),
+        }
+    }
+}
+
+/// Per-packet recv data filled in by transports during [`poll_recv`][CustomEndpoint::poll_recv].
+///
+/// This carries the bits of [`noq_udp::RecvMeta`] that custom transports
+/// can't express through `RecvMeta` itself: the remote address as a
+/// [`CustomAddr`] and, optionally, the local custom address that received
+/// the packet. For IP transports the kernel populates `RecvMeta` directly;
+/// for relays the local URL is the remote's relay URL — so for them this
+/// struct is filled in only with the remote variant.
+///
+/// Custom transport authors construct values via [`RecvInfo::new`], which
+/// only accepts [`CustomAddr`].
+#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
+#[derive(Clone, Debug, Default)]
+pub struct RecvInfo {
+    pub(crate) remote: Addr,
+    pub(crate) local: Option<CustomAddr>,
+}
+
+#[cfg(feature = "unstable-custom-transports")]
+impl RecvInfo {
+    /// Creates a new [`RecvInfo`] for an incoming packet on a custom transport.
+    ///
+    /// `remote` is the remote custom address. `local` is the local custom
+    /// address that received this packet, if the transport can identify it;
+    /// pass `None` otherwise.
+    pub fn new(remote: CustomAddr, local: Option<CustomAddr>) -> Self {
+        Self {
+            remote: Addr::Custom(remote),
+            local,
         }
     }
 }
@@ -602,10 +618,7 @@ impl From<&SocketAddr> for Addr {
 
 impl From<CustomAddr> for Addr {
     fn from(value: CustomAddr) -> Self {
-        Self::Custom {
-            remote: value,
-            local: None,
-        }
+        Self::Custom(value)
     }
 }
 
@@ -620,7 +633,7 @@ impl From<Addr> for TransportAddr {
         match value {
             Addr::Ip(addr) => TransportAddr::Ip(addr),
             Addr::Relay(url, _) => TransportAddr::Relay(url),
-            Addr::Custom { remote, .. } => TransportAddr::Custom(remote),
+            Addr::Custom(addr) => TransportAddr::Custom(addr),
         }
     }
 }
@@ -639,7 +652,7 @@ impl Addr {
         match self {
             Self::Ip(ip) => Some(ip),
             Self::Relay(..) => None,
-            Self::Custom { .. } => None,
+            Self::Custom(_) => None,
         }
     }
 
@@ -651,7 +664,7 @@ impl Addr {
                 SocketAddr::V6(_) => AddrKind::IpV6,
             },
             Self::Relay(_, _) => AddrKind::Relay,
-            Self::Custom { remote, .. } => AddrKind::Custom(remote.id()),
+            Self::Custom(addr) => AddrKind::Custom(addr.id()),
         }
     }
 }
@@ -854,8 +867,8 @@ impl PartialEq<TransportAddr> for Addr {
             Addr::Relay(relay_url, _) => {
                 matches!(other, TransportAddr::Relay(a) if a == relay_url)
             }
-            Addr::Custom { remote, .. } => {
-                matches!(other, TransportAddr::Custom(a) if a == remote)
+            Addr::Custom(custom_addr) => {
+                matches!(other, TransportAddr::Custom(a) if a == custom_addr)
             }
         }
     }
@@ -933,10 +946,10 @@ impl TransportsSender {
                     return Poll::Pending;
                 }
             }
-            Addr::Custom { remote, .. } => {
+            Addr::Custom(addr) => {
                 for sender in &mut self.custom {
-                    if sender.is_valid_send_addr(remote) {
-                        match sender.poll_send(cx, remote, transmit) {
+                    if sender.is_valid_send_addr(addr) {
+                        match sender.poll_send(cx, addr, transmit) {
                             Poll::Pending => {}
                             Poll::Ready(res) => return Poll::Ready(res),
                         }
@@ -997,7 +1010,7 @@ impl noq::AsyncUdpSocket for Transport {
                 match addr {
                     Addr::Ip(addr) => addr,
                     Addr::Relay(..) => DEFAULT_FAKE_ADDR.into(),
-                    Addr::Custom { .. } => DEFAULT_FAKE_ADDR.into(),
+                    Addr::Custom(_) => DEFAULT_FAKE_ADDR.into(),
                 }
             })
             .collect();
@@ -1149,10 +1162,7 @@ impl noq::UdpSender for Sender {
                     .custom_addrs
                     .lookup(&custom_mapped_addr)
                 {
-                    Some(addr) => Addr::Custom {
-                        remote: addr,
-                        local: None,
-                    },
+                    Some(addr) => Addr::Custom(addr),
                     None => {
                         error!("unknown CustomMappedAddr, dropped transmit");
                         return Poll::Ready(Ok(()));

--- a/iroh/src/socket/transports/custom.rs
+++ b/iroh/src/socket/transports/custom.rs
@@ -11,7 +11,7 @@ use std::{
 
 use iroh_base::CustomAddr;
 
-use super::{Addr, Transmit};
+use super::{RecvInfo, Transmit};
 
 /// Custom transport.
 ///
@@ -40,7 +40,7 @@ pub trait CustomEndpoint: std::fmt::Debug + Send + Sync + 'static {
     fn create_sender(&self) -> Arc<dyn CustomSender>;
     /// poll receiving a packet on this custom endpoint.
     ///
-    /// This will be called with `bufs`, `metas` and `source_addrs` of the same length.
+    /// This will be called with `bufs`, `metas` and `recv_infos` of the same length.
     /// It is acceptable to panic if this is not the case.
     ///
     /// The maximum length of the slices is [`noq_udp::BATCH_SIZE`].
@@ -51,15 +51,16 @@ pub trait CustomEndpoint: std::fmt::Debug + Send + Sync + 'static {
     ///
     /// It does not make much sense to return addresses unrelated to this transport.
     ///
-    /// Set `local` on each [`Addr::Custom`] if the transport can identify which
-    /// of its local addresses received this packet; it surfaces via
+    /// For each filled slot, write a [`RecvInfo::new`] carrying the remote
+    /// custom address and, if the transport can identify it, the local custom
+    /// address that received the packet. The latter surfaces via
     /// [`crate::endpoint::Incoming::local_addr`].
     fn poll_recv(
         &mut self,
         cx: &mut Context,
         bufs: &mut [io::IoSliceMut<'_>],
         metas: &mut [noq_udp::RecvMeta],
-        source_addrs: &mut [Addr],
+        recv_infos: &mut [RecvInfo],
     ) -> Poll<io::Result<usize>>;
 
     /// Maximum number of segments to transmit (GSO).

--- a/iroh/src/socket/transports/ip.rs
+++ b/iroh/src/socket/transports/ip.rs
@@ -13,7 +13,7 @@ use netwatch::{UdpSender, UdpSocket};
 use pin_project::pin_project;
 use tracing::{debug, info, trace};
 
-use super::{Addr, Transmit};
+use super::{RecvInfo, Transmit};
 use crate::metrics::{EndpointMetrics, SocketMetrics};
 
 #[derive(Debug)]
@@ -191,12 +191,12 @@ impl IpTransport {
         cx: &mut Context,
         bufs: &mut [io::IoSliceMut<'_>],
         metas: &mut [noq_udp::RecvMeta],
-        source_addrs: &mut [Addr],
+        recv_infos: &mut [RecvInfo],
     ) -> Poll<io::Result<usize>> {
         match self.socket.poll_recv_noq(cx, bufs, metas) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok(n)) => {
-                for (source_addr, meta) in source_addrs.iter_mut().zip(metas.iter_mut()).take(n) {
+                for (recv_info, meta) in recv_infos.iter_mut().zip(metas.iter_mut()).take(n) {
                     if meta.addr.is_ipv4() {
                         // The AsyncUdpSocket is an AF_INET6 socket and needs to show this
                         // as coming from an IPv4-mapped IPv6 addresses, since Noq will
@@ -209,8 +209,9 @@ impl IpTransport {
                     }
                     // The transport addresses are internal to iroh and we always want those
                     // to remain the canonical address.
-                    *source_addr =
+                    recv_info.remote =
                         SocketAddr::new(meta.addr.ip().to_canonical(), meta.addr.port()).into();
+                    recv_info.local = None;
                 }
                 Poll::Ready(Ok(n))
             }
@@ -465,11 +466,11 @@ impl IpTransports {
         cx: &mut Context,
         bufs: &mut [io::IoSliceMut<'_>],
         metas: &mut [noq_udp::RecvMeta],
-        source_addrs: &mut [Addr],
+        recv_infos: &mut [RecvInfo],
     ) -> Poll<io::Result<usize>> {
         macro_rules! poll_transport {
             ($socket:expr) => {
-                match $socket.poll_recv(cx, bufs, metas, source_addrs)? {
+                match $socket.poll_recv(cx, bufs, metas, recv_infos)? {
                     Poll::Pending | Poll::Ready(0) => {}
                     Poll::Ready(n) => {
                         return Poll::Ready(Ok(n));

--- a/iroh/src/socket/transports/ip.rs
+++ b/iroh/src/socket/transports/ip.rs
@@ -209,9 +209,9 @@ impl IpTransport {
                     }
                     // The transport addresses are internal to iroh and we always want those
                     // to remain the canonical address.
-                    recv_info.remote =
-                        SocketAddr::new(meta.addr.ip().to_canonical(), meta.addr.port()).into();
-                    recv_info.local = None;
+                    *recv_info = RecvInfo::from_addr(
+                        SocketAddr::new(meta.addr.ip().to_canonical(), meta.addr.port()).into(),
+                    );
                 }
                 Poll::Ready(Ok(n))
             }

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::{CancellationToken, PollSender};
 use tracing::{Instrument, error, info_span, warn};
 
-use super::{Addr, Transmit};
+use super::{RecvInfo, Transmit};
 use crate::endpoint::RelayStatus;
 
 mod actor;
@@ -85,13 +85,13 @@ impl RelayTransport {
         cx: &mut Context,
         bufs: &mut [io::IoSliceMut<'_>],
         metas: &mut [noq_udp::RecvMeta],
-        source_addrs: &mut [Addr],
+        recv_infos: &mut [RecvInfo],
     ) -> Poll<io::Result<usize>> {
         let mut num_msgs = 0;
-        for ((buf_out, meta_out), addr) in bufs
+        for ((buf_out, meta_out), recv_info) in bufs
             .iter_mut()
             .zip(metas.iter_mut())
-            .zip(source_addrs.iter_mut())
+            .zip(recv_infos.iter_mut())
         {
             let dm = match self.poll_recv_queue(cx) {
                 Poll::Ready(Some(recv)) => recv,
@@ -153,7 +153,8 @@ impl RelayTransport {
             meta_out.ecn = None;
             meta_out.dst_ip = None;
 
-            *addr = (dm.url, dm.src).into();
+            recv_info.remote = (dm.url, dm.src).into();
+            recv_info.local = None;
             num_msgs += 1;
         }
 

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -153,8 +153,7 @@ impl RelayTransport {
             meta_out.ecn = None;
             meta_out.dst_ip = None;
 
-            recv_info.remote = (dm.url, dm.src).into();
-            recv_info.local = None;
+            *recv_info = RecvInfo::from_addr((dm.url, dm.src).into());
             num_msgs += 1;
         }
 

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -20,7 +20,7 @@ use crate::{
     endpoint::{
         Builder,
         presets::Preset,
-        transports::{Addr, CustomEndpoint, CustomSender, CustomTransport, Transmit},
+        transports::{CustomEndpoint, CustomSender, CustomTransport, RecvInfo, Transmit},
     },
 };
 
@@ -264,11 +264,11 @@ impl CustomEndpoint for TestTransport {
         cx: &mut std::task::Context,
         bufs: &mut [io::IoSliceMut<'_>],
         metas: &mut [noq_udp::RecvMeta],
-        source_addrs: &mut [Addr],
+        recv_infos: &mut [RecvInfo],
     ) -> Poll<io::Result<usize>> {
         let n = bufs.len();
         debug_assert_eq!(n, metas.len());
-        debug_assert_eq!(n, source_addrs.len());
+        debug_assert_eq!(n, recv_infos.len());
         if n == 0 {
             return Poll::Ready(Ok(0));
         }
@@ -284,8 +284,8 @@ impl CustomEndpoint for TestTransport {
             Poll::Ready(n) => n,
         };
         let mut count = 0;
-        for (((packet, meta), buf), source_addr) in
-            packets.into_iter().zip(metas).zip(bufs).zip(source_addrs)
+        for (((packet, meta), buf), recv_info) in
+            packets.into_iter().zip(metas).zip(bufs).zip(recv_infos)
         {
             if buf.len() < packet.data.len() {
                 break;
@@ -298,10 +298,7 @@ impl CustomEndpoint for TestTransport {
                 packet.data.len()
             );
             buf[..packet.data.len()].copy_from_slice(&packet.data);
-            *source_addr = Addr::Custom {
-                remote: packet.from,
-                local: Some(to_custom_addr(self.id)),
-            };
+            *recv_info = RecvInfo::new(packet.from, Some(to_custom_addr(self.id)));
             meta.len = packet.data.len();
             meta.stride = packet.data.len();
             count += 1;


### PR DESCRIPTION
## Description

Introduce a struct RecvInfo that has local and remote addresses.

This is an internal struct unless you enable custom transports. It internally has remote as Addr, but the only public way to construct it is via new, which takes only a CustomAddr. So the custom transports API becomes a bit more tight.

We could have a separate struct for the custom transports, but that would mean that we would have to copy in a hot path.


## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
