### PR TITLE
refactor(iroh-relay)!: Make `AccessConfig` non-exhaustive

### DIFF
--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -133,6 +133,7 @@ pub struct RelayConfig {
 
 /// Controls which endpoints are allowed to use the relay.
 #[derive(derive_more::Debug)]
+#[non_exhaustive]
 pub enum AccessConfig {
     /// Everyone
     Everyone,


### PR DESCRIPTION
## Description

This marks the `AccessConfig` enum in `iroh-relay` `non_exhaustive`.

The idea is to enable more types of access configs that are backwards-compatible in terms of API.

## Breaking Changes

- `iroh_relay::server::AccessConfig` is now non-exhaustive.

## Notes & open questions

The motivating change was to pass HTTP headers to the function in `Restricted`, but I think it'd be nice to first get this change out, and then in another PR consider whether we'd want to change the exiting `Restricted` or add another case.

## Change checklist
<!-- Remove any that are not relevant. -->
- [X] Self-review.
