### PR TITLE
feat(iroh-relay)!: add support for bearer auth via HTTP headers

### DIFF
--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -177,6 +177,10 @@ name = "iroh-relay"
 path = "src/main.rs"
 required-features = ["server"]
 
+[[example]]
+name = "multitenant"
+required-features = ["server"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "iroh_docsrs"]

--- a/iroh-relay/examples/multitenant.rs
+++ b/iroh-relay/examples/multitenant.rs
@@ -1,0 +1,171 @@
+//! Multitenant iroh-relay example.
+//!
+//! Stands up a single HTTP listener that fronts three independent
+//! [`RelayService`] instances. The HTTP `Authorization: Bearer <token>` header
+//! on the WebSocket upgrade request selects which `RelayService` handles the
+//! connection, giving each tenant its own metrics, rate limits, and
+//! [`AccessConfig`] hook.
+//!
+//! Run with:
+//!
+//!     cargo run --example multitenant --features=server
+//!
+//! And connect with:
+//!
+//!     cargo run --example transfer -- provide --relay-url http://localhost:8080 --relay-auth-token tenant-alpha-secret
+//!
+//! Notes:
+//! - The example uses plain HTTP, not HTTPS
+//! - QAD is not enabled in this example
+//! - Each tenant's `AccessConfig::Restricted` hook receives the WebSocket
+//!   upgrade request headers, including the bearer credential. This lets the
+//!   tenant additionally bind the bearer to the `EndpointId` proven by the
+//!   relay handshake (e.g. assert that the bearer claims the same key) -
+//!   the example just logs them.
+
+use std::{collections::HashMap, convert::Infallible, net::SocketAddr, sync::Arc};
+
+use bytes::Bytes;
+use http::{HeaderMap, Method, Request, Response, StatusCode, header};
+use http_body_util::Full;
+use hyper::{
+    body::Incoming,
+    server::conn::http1,
+    service::{Service as _, service_fn},
+};
+use hyper_util::rt::TokioIo;
+use iroh_relay::{
+    KeyCache,
+    server::{
+        Access, AccessConfig, Metrics,
+        http_server::{BytesBody, Handlers, RelayService, RelayServiceWithNotify},
+        streams::MaybeTlsStream,
+    },
+};
+use n0_future::FutureExt;
+use tokio::{net::TcpListener, sync::Notify};
+use tracing::{debug, info, warn};
+
+/// Static tenant configuration: `(tenant_name, bearer_token)`.
+const TENANTS: &[(&str, &str)] = &[
+    ("alpha", "tenant-alpha-secret"),
+    ("beta", "tenant-beta-secret"),
+    ("gamma", "tenant-gamma-secret"),
+];
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    // Build one `RelayService` per tenant. Each tenant gets its own `Metrics`
+    // and `AccessConfig` hook.
+    let tenants: HashMap<String, RelayService> = TENANTS
+        .iter()
+        .map(|(name, token)| (token.to_string(), build_tenant(name)))
+        .collect();
+    let tenants = Arc::new(tenants);
+
+    let bind: SocketAddr = "127.0.0.1:8080".parse()?;
+    let listener = TcpListener::bind(bind).await?;
+    info!(
+        "multitenant relay listening on http://{}",
+        listener.local_addr()?
+    );
+    info!("tenants:");
+    for (name, token) in TENANTS {
+        info!("  {name}: Authorization: Bearer {token}");
+    }
+
+    loop {
+        let (stream, peer) = listener.accept().await?;
+        let tenants = tenants.clone();
+        tokio::spawn(async move {
+            let io = TokioIo::new(MaybeTlsStream::Plain(stream));
+            let conn = http1::Builder::new()
+                .serve_connection(
+                    io,
+                    service_fn(move |req| {
+                        let tenants = tenants.clone();
+                        async move { Ok::<_, Infallible>(dispatch(req, tenants).await) }
+                    }),
+                )
+                .with_upgrades();
+            if let Err(err) = conn.await {
+                warn!(%peer, "connection error: {err:#}");
+            }
+        });
+    }
+}
+
+fn build_tenant(name: &'static str) -> RelayService {
+    let access = AccessConfig::Restricted(Box::new(move |endpoint_id, headers| {
+        // Snapshot the bearer for logging. In production this is where the
+        // tenant would verify the credential and assert that it claims
+        // `endpoint_id` (the key proven by the relay handshake).
+        let bearer = headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok().map(str::to_string));
+        info!(
+            tenant = name,
+            endpoint = %endpoint_id.fmt_short(),
+            bearer = ?bearer,
+            "tenant accepting endpoint",
+        );
+        async move { Access::Allow }.boxed()
+    }));
+    RelayService::new(
+        Handlers::default(),
+        HeaderMap::new(),
+        // Per-tenant rate limits would go here.
+        None,
+        KeyCache::new(1024),
+        access,
+        // A fresh `Metrics` per tenant: each tenant gets its own counters.
+        Arc::new(Metrics::default()),
+    )
+}
+
+async fn dispatch(
+    req: Request<Incoming>,
+    tenants: Arc<HashMap<String, RelayService>>,
+) -> Response<BytesBody> {
+    debug!("incoming request: {} {}", req.method(), req.uri());
+    if matches!(
+        (req.method(), req.uri().path()),
+        (&Method::GET, "/" | "/index.html")
+    ) {
+        return simple_response(StatusCode::OK, "iroh multitenant relay");
+    }
+    if (req.method(), req.uri().path()) == (&Method::GET, "/ping") {
+        return simple_response(StatusCode::OK, "");
+    }
+    if (req.method(), req.uri().path()) != (&Method::GET, "/relay") {
+        return simple_response(StatusCode::NOT_FOUND, "not found");
+    }
+    let bearer = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "));
+    let Some(token) = bearer else {
+        return simple_response(StatusCode::UNAUTHORIZED, "missing bearer token");
+    };
+    let Some(service) = tenants.get(token).cloned() else {
+        return simple_response(StatusCode::UNAUTHORIZED, "unknown bearer token");
+    };
+    let service_with_notify = RelayServiceWithNotify::new(service, Arc::new(Notify::new()));
+    match service_with_notify.call(req).await {
+        Ok(resp) => resp,
+        Err(err) => {
+            warn!("relay handler error: {err:#}");
+            simple_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
+        }
+    }
+}
+
+fn simple_response(status: StatusCode, body: &'static str) -> Response<BytesBody> {
+    Response::builder()
+        .status(status)
+        .body(Box::new(Full::new(Bytes::from_static(body.as_bytes()))) as BytesBody)
+        .expect("valid response")
+}

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -94,6 +94,8 @@ pub enum ConnectError {
         "No rustls crypto provider configured while both ring and aws-lc-rs feature flags are disabled"
     )]
     MissingCryptoProvider,
+    #[error("Configured auth token is not a valid HTTP header value")]
+    InvalidAuthToken,
     #[cfg(wasm_browser)]
     #[error("The relay protocol is not available in browsers")]
     RelayProtoNotAvailable {},
@@ -150,6 +152,8 @@ pub struct ClientBuilder {
     proxy_url: Option<Url>,
     /// The secret key of this client.
     secret_key: SecretKey,
+    /// Optional bearer token sent on the WebSocket upgrade request.
+    auth_token: Option<String>,
     /// The DNS resolver to use.
     #[cfg(not(wasm_browser))]
     dns_resolver: DnsResolver,
@@ -170,6 +174,7 @@ impl ClientBuilder {
             tls_config: None,
             proxy_url: None,
             secret_key,
+            auth_token: None,
             #[cfg(not(wasm_browser))]
             dns_resolver,
             key_cache: KeyCache::new(128),
@@ -220,6 +225,16 @@ impl ClientBuilder {
     /// Set an explicit proxy url to proxy all HTTP(S) traffic through.
     pub fn proxy_url(mut self, url: Url) -> Self {
         self.proxy_url.replace(url);
+        self
+    }
+
+    /// Sets a bearer token to authenticate to the relay server.
+    ///
+    /// The token is sent on the WebSocket upgrade request as the credential
+    /// portion of an `Authorization: Bearer <token>` header. Used by
+    /// multitenant relay deployments to attribute and route the connection.
+    pub fn auth_token(mut self, token: impl Into<String>) -> Self {
+        self.auth_token = Some(token.into());
         self
     }
 
@@ -299,6 +314,13 @@ impl ClientBuilder {
                 .expect(
                     "impossible: CLIENT_AUTH_HEADER isn't a disallowed header value for websockets",
                 );
+        }
+        if let Some(token) = &self.auth_token {
+            let value = http::HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|_| e!(ConnectError::InvalidAuthToken))?;
+            builder = builder
+                .add_header(http::header::AUTHORIZATION, value)
+                .expect("AUTHORIZATION isn't a disallowed header value for websockets");
         }
         let (conn, response) = builder.connect_on(stream).await.anyerr()?;
 

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -188,31 +188,35 @@ impl From<AccessConfig> for iroh_relay::server::AccessConfig {
             AccessConfig::Everyone => iroh_relay::server::AccessConfig::Everyone,
             AccessConfig::Allowlist(allow_list) => {
                 let allow_list = Arc::new(allow_list);
-                iroh_relay::server::AccessConfig::Restricted(Box::new(move |endpoint_id| {
-                    let allow_list = allow_list.clone();
-                    async move {
-                        if allow_list.contains(&endpoint_id) {
-                            iroh_relay::server::Access::Allow
-                        } else {
-                            iroh_relay::server::Access::Deny
+                iroh_relay::server::AccessConfig::Restricted(Box::new(
+                    move |endpoint_id, _headers| {
+                        let allow_list = allow_list.clone();
+                        async move {
+                            if allow_list.contains(&endpoint_id) {
+                                iroh_relay::server::Access::Allow
+                            } else {
+                                iroh_relay::server::Access::Deny
+                            }
                         }
-                    }
-                    .boxed()
-                }))
+                        .boxed()
+                    },
+                ))
             }
             AccessConfig::Denylist(deny_list) => {
                 let deny_list = Arc::new(deny_list);
-                iroh_relay::server::AccessConfig::Restricted(Box::new(move |endpoint_id| {
-                    let deny_list = deny_list.clone();
-                    async move {
-                        if deny_list.contains(&endpoint_id) {
-                            iroh_relay::server::Access::Deny
-                        } else {
-                            iroh_relay::server::Access::Allow
+                iroh_relay::server::AccessConfig::Restricted(Box::new(
+                    move |endpoint_id, _headers| {
+                        let deny_list = deny_list.clone();
+                        async move {
+                            if deny_list.contains(&endpoint_id) {
+                                iroh_relay::server::Access::Deny
+                            } else {
+                                iroh_relay::server::Access::Allow
+                            }
                         }
-                    }
-                    .boxed()
-                }))
+                        .boxed()
+                    },
+                ))
             }
             AccessConfig::Http(mut config) => {
                 let client = reqwest::Client::builder()
@@ -224,11 +228,14 @@ impl From<AccessConfig> for iroh_relay::server::AccessConfig {
                     config.bearer_token = Some(token);
                 }
                 let config = Arc::new(config);
-                iroh_relay::server::AccessConfig::Restricted(Box::new(move |endpoint_id| {
-                    let client = client.clone();
-                    let config = config.clone();
-                    async move { http_access_check(&client, &config, endpoint_id).await }.boxed()
-                }))
+                iroh_relay::server::AccessConfig::Restricted(Box::new(
+                    move |endpoint_id, _headers| {
+                        let client = client.clone();
+                        let config = config.clone();
+                        async move { http_access_check(&client, &config, endpoint_id).await }
+                            .boxed()
+                    },
+                ))
             }
         }
     }

--- a/iroh-relay/src/relay_map.rs
+++ b/iroh-relay/src/relay_map.rs
@@ -218,18 +218,38 @@ impl fmt::Display for RelayMap {
 pub struct RelayConfig {
     /// The [`RelayUrl`] where this relay server can be dialed.
     pub url: RelayUrl,
+
     /// Configuration to speak to the QUIC endpoint on the relay server.
     ///
     /// When `None`, we will not attempt to do QUIC address discovery
     /// with this relay server.
     #[serde(default = "quic_config")]
     pub quic: Option<RelayQuicConfig>,
+
+    /// Optional bearer token sent on the WebSocket upgrade request as
+    /// `Authorization: Bearer <token>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<String>,
 }
 
 impl RelayConfig {
     /// Creates a new relay configuration with the given URL and optional QUIC config.
     pub fn new(url: RelayUrl, quic: Option<RelayQuicConfig>) -> Self {
-        Self { url, quic }
+        Self {
+            url,
+            quic,
+            auth_token: None,
+        }
+    }
+
+    /// Sets the bearer token to authenticate to this relay with.
+    ///
+    /// The raw token is sent verbatim as the credential portion of an
+    /// `Authorization: Bearer <token>` header on the WebSocket upgrade
+    /// request.
+    pub fn with_auth_token(mut self, token: impl ToString) -> Self {
+        self.auth_token = Some(token.to_string());
+        self
     }
 }
 
@@ -238,6 +258,7 @@ impl From<RelayUrl> for RelayConfig {
         Self {
             url: value,
             quic: quic_config(),
+            auth_token: None,
         }
     }
 }

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -131,23 +131,37 @@ pub struct RelayConfig {
     pub access: AccessConfig,
 }
 
+/// Access check callback used by [`AccessConfig::Restricted`].
+///
+/// Receives the [`EndpointId`] proven by the relay handshake alongside the
+/// original HTTP request headers from the WebSocket upgrade.  Returning
+/// [`Access::Allow`] admits the endpoint, otherwise it is rejected.
+pub type AccessCheck = Box<dyn Fn(EndpointId, &HeaderMap) -> Boxed<Access> + Send + Sync + 'static>;
+
 /// Controls which endpoints are allowed to use the relay.
 #[derive(derive_more::Debug)]
 pub enum AccessConfig {
     /// Everyone
     Everyone,
     /// Only endpoints for which the function returns `Access::Allow`.
+    ///
+    /// The closure receives the [`EndpointId`] proven by the relay handshake
+    /// alongside the original HTTP request headers from the WebSocket upgrade.
+    /// This makes it possible to bind an `Authorization: Bearer` token (or any
+    /// other header) to the endpoint key actually connecting, e.g. to assert
+    /// the endpoint id described in the bearer credential matches the one
+    /// proven by the handshake.
     #[debug("restricted")]
-    Restricted(Box<dyn Fn(EndpointId) -> Boxed<Access> + Send + Sync + 'static>),
+    Restricted(AccessCheck),
 }
 
 impl AccessConfig {
     /// Is this endpoint allowed?
-    pub async fn is_allowed(&self, endpoint: EndpointId) -> bool {
+    pub async fn is_allowed(&self, endpoint: EndpointId, headers: &HeaderMap) -> bool {
         match self {
             Self::Everyone => true,
             Self::Restricted(check) => {
-                let res = check(endpoint).await;
+                let res = check(endpoint, headers).await;
                 matches!(res, Access::Allow)
             }
         }
@@ -1081,7 +1095,7 @@ mod tests {
                 tls: None,
                 limits: Default::default(),
                 key_cache_capacity: Some(1024),
-                access: AccessConfig::Restricted(Box::new(move |endpoint_id| {
+                access: AccessConfig::Restricted(Box::new(move |endpoint_id, _headers| {
                     async move {
                         info!("checking {}", endpoint_id);
                         // reject endpoint a

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -52,12 +52,14 @@ use crate::{
     },
 };
 
-// type BytesBody = http_body_util::Full<hyper::body::Bytes>;
-pub(super) type BytesBody = Box<
+/// Boxed HTTP response body produced by [`RelayServiceWithNotify`].
+pub type BytesBody = Box<
     dyn 'static + Send + Unpin + hyper::body::Body<Data = hyper::body::Bytes, Error = Infallible>,
 >;
-pub(super) type HyperError = Box<dyn std::error::Error + Send + Sync>;
-pub(super) type HyperResult<T> = std::result::Result<T, HyperError>;
+/// Boxed error type returned from [`RelayServiceWithNotify`]'s [`hyper::service::Service`] impl.
+pub type HyperError = Box<dyn std::error::Error + Send + Sync>;
+/// Result alias for HTTP responses produced by [`RelayServiceWithNotify`].
+pub type HyperResult<T> = std::result::Result<T, HyperError>;
 pub(super) type HyperHandler = Box<
     dyn Fn(Request<Incoming>, ResponseBuilder) -> HyperResult<Response<BytesBody>>
         + Send
@@ -612,6 +614,9 @@ impl RelayServiceWithNotify {
             })?;
 
         let client_auth_header = req.headers().get(CLIENT_AUTH_HEADER).cloned();
+        // Snapshot the full request headers so the `AccessConfig` hook can
+        // inspect them after the WebSocket handshake completes.
+        let request_headers = req.headers().clone();
 
         // Setup a future that will eventually receive the upgraded
         // connection and talk a new protocol, and spawn the future
@@ -631,6 +636,7 @@ impl RelayServiceWithNotify {
                             .relay_connection_handler(
                                 upgraded,
                                 client_auth_header,
+                                request_headers,
                                 protocol_version,
                             )
                             .await
@@ -815,6 +821,7 @@ impl Inner {
         &self,
         upgraded: Upgraded,
         client_auth_header: Option<HeaderValue>,
+        request_headers: HeaderMap,
         protocol_version: ProtocolVersion,
     ) -> Result<(), ConnectionHandlerError> {
         debug!("relay_connection upgraded");
@@ -823,7 +830,7 @@ impl Inner {
             return Err(e!(ConnectionHandlerError::BufferNotEmpty { buf: read_buf }));
         }
 
-        self.accept(io, client_auth_header, protocol_version)
+        self.accept(io, client_auth_header, request_headers, protocol_version)
             .await?;
         Ok(())
     }
@@ -842,6 +849,7 @@ impl Inner {
         &self,
         io: MaybeTlsStream,
         client_auth_header: Option<HeaderValue>,
+        request_headers: HeaderMap,
         protocol_version: ProtocolVersion,
     ) -> Result<(), AcceptError> {
         trace!("accept: start");
@@ -864,7 +872,10 @@ impl Inner {
 
         trace!(?authentication.mechanism, "accept: verified authentication");
 
-        let is_authorized = self.access.is_allowed(authentication.client_key).await;
+        let is_authorized = self
+            .access
+            .is_allowed(authentication.client_key, &request_headers)
+            .await;
         let client_key = authentication.authorize_if(is_authorized, &mut io).await?;
 
         trace!("accept: verified authorization");
@@ -1478,8 +1489,13 @@ mod tests {
         let (client_a, rw_a) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_a), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_a),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut client_a = make_test_client(client_a, &key_a).await?;
         handler_task.await.std_context("join")??;
@@ -1490,8 +1506,13 @@ mod tests {
         let (client_b, rw_b) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_b), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_b),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut client_b = make_test_client(client_b, &key_b).await?;
         handler_task.await.std_context("join")??;
@@ -1582,8 +1603,13 @@ mod tests {
         let (client_a, rw_a) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_a), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_a),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut client_a = make_test_client(client_a, &key_a).await?;
         handler_task.await.std_context("join")??;
@@ -1594,8 +1620,13 @@ mod tests {
         let (client_b, rw_b) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_b), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_b),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut client_b = make_test_client(client_b, &key_b).await?;
         handler_task.await.std_context("join")??;
@@ -1646,8 +1677,13 @@ mod tests {
         let (new_client_b, new_rw_b) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(new_rw_b), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(new_rw_b),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut new_client_b = make_test_client(new_client_b, &key_b).await?;
         handler_task.await.std_context("join")??;

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -39,8 +39,8 @@ use derive_more::{Display, From};
 use indicatif::HumanBytes;
 use ipnet::{Ipv4Net, Ipv6Net};
 use iroh::{
-    Endpoint, EndpointAddr, EndpointId, RelayMap, RelayMode, RelayUrl, SecretKey, TransportAddr,
-    Watcher,
+    Endpoint, EndpointAddr, EndpointId, RelayConfig, RelayMap, RelayMode, RelayUrl, SecretKey,
+    TransportAddr, Watcher,
     address_lookup::{
         AddrFilter,
         dns::DnsAddressLookup,
@@ -277,6 +277,12 @@ struct EndpointArgs {
     /// Set one or more relay servers to use.
     #[clap(long)]
     relay_url: Vec<RelayUrl>,
+    /// Bearer token sent on the WebSocket upgrade to each `--relay-url`.
+    ///
+    /// Used by multitenant relay deployments to attribute and route the
+    /// connection. Has no effect unless `--relay-url` is also set.
+    #[clap(long)]
+    relay_auth_token: Option<String>,
     /// Disable relays completely.
     #[clap(long, conflicts_with = "relay_url")]
     no_relay: bool,
@@ -474,7 +480,15 @@ impl EndpointArgs {
         if self.no_relay {
             // nothing to do
         } else if !self.relay_url.is_empty() {
-            builder = builder.relay_mode(RelayMode::Custom(RelayMap::from_iter(self.relay_url)));
+            let token = self.relay_auth_token.clone();
+            let configs = self.relay_url.into_iter().map(|url| {
+                let mut cfg = RelayConfig::from(url);
+                if let Some(ref token) = token {
+                    cfg = cfg.with_auth_token(token.clone());
+                }
+                cfg
+            });
+            builder = builder.relay_mode(RelayMode::Custom(RelayMap::from_iter(configs)));
         } else {
             builder = builder.relay_mode(self.env.relay_mode());
         };

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -896,6 +896,7 @@ impl EndpointInner {
             ipv6_reported: ipv6_reported.clone(),
             tls_config: tls_config.clone(),
             metrics: metrics.socket.clone(),
+            relay_map: relay_map.clone(),
         };
 
         let shutdown_state = ShutdownState::default();

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -40,7 +40,7 @@ use std::{
 use backon::{Backoff, BackoffBuilder, ExponentialBuilder};
 use iroh_base::{EndpointId, RelayUrl, SecretKey};
 use iroh_relay::{
-    self as relay, PingTracker,
+    self as relay, PingTracker, RelayMap,
     client::{Client, ConnectError, RecvError, SendError},
     protos::relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg, Status},
 };
@@ -209,6 +209,7 @@ struct RelayConnectionOptions {
     proxy_url: Option<Url>,
     prefer_ipv6: Arc<AtomicBool>,
     tls_config: rustls::ClientConfig,
+    auth_token: Option<String>,
 }
 
 /// Possible reasons for a failed relay connection.
@@ -297,6 +298,7 @@ impl ActiveRelayActor {
             proxy_url,
             prefer_ipv6,
             tls_config,
+            auth_token,
         } = opts;
 
         let mut builder = relay::client::ClientBuilder::new(
@@ -309,6 +311,9 @@ impl ActiveRelayActor {
         .address_family_selector(move || prefer_ipv6.load(Ordering::Relaxed));
         if let Some(proxy_url) = proxy_url {
             builder = builder.proxy_url(proxy_url);
+        }
+        if let Some(token) = auth_token {
+            builder = builder.auth_token(token);
         }
         builder
     }
@@ -872,6 +877,9 @@ pub(crate) struct Config {
     pub ipv6_reported: Arc<AtomicBool>,
     pub tls_config: rustls::ClientConfig,
     pub metrics: Arc<SocketMetrics>,
+    /// Per-relay configuration; consulted when starting a connection to look
+    /// up the bearer token (and any other future per-relay knobs).
+    pub relay_map: RelayMap,
 }
 
 /// Connection state of the home relay.
@@ -1226,6 +1234,11 @@ impl RelayActor {
     fn start_active_relay(&mut self, url: RelayUrl) -> ActiveRelayHandle {
         debug!(?url, "Adding relay connection");
 
+        let auth_token = self
+            .config
+            .relay_map
+            .get(&url)
+            .and_then(|cfg| cfg.auth_token.clone());
         let connection_opts = RelayConnectionOptions {
             secret_key: self.config.secret_key.clone(),
             #[cfg(not(wasm_browser))]
@@ -1233,6 +1246,7 @@ impl RelayActor {
             proxy_url: self.config.proxy_url.clone(),
             prefer_ipv6: self.config.ipv6_reported.clone(),
             tls_config: self.config.tls_config.clone(),
+            auth_token,
         };
 
         // TODO: Replace 64 with PER_CLIENT_SEND_QUEUE_DEPTH once that's unused
@@ -1423,6 +1437,7 @@ mod tests {
                 tls_config: CaRootsConfig::insecure_skip_verify()
                     .client_config(default_provider())
                     .expect("infallible"),
+                auth_token: None,
             },
             stop_token,
             metrics: Default::default(),


### PR DESCRIPTION
## Description

Based on #4202 

* iroh: Add `auth_token: Option<String>` to `RelayConfig` to optionally set an auth token per relay map entry. If set, will be set as `Authentication: Bearer <token>` header on the WebSocket request to the relay
* iroh: Add `--relay-auth-token` arg to the transfer example
* iroh-relay: Pass `&HeaderMap` to the `AccessConfig::Restricted` callback
* iroh-relay: Add `multitenant` example

Demo:

```sh
# terminal 1
cargo run --p iroh-relay --features server --example multitenant

# terminal 2
cargo run --example transfer -- provide --relay-url http://localhost:8080 --relay-auth-token tenant-beta-secret
# copy endpoint id

# terminal 3
cargo run --example transfer -- fetch --relay-url http://localhost:8080 --relay-auth-token tenant-beta-secret EP_ID
# -> works
```
if you were to run terminal 3 with
```sh
cargo run --example transfer -- fetch --relay-url http://localhost:8080 --relay-auth-token tenant-alpha-secret EP_ID
```
the connect eventually times out and fails silently: due to the different tenant auth token, the fetch client is connected to a different `RelayService` than the provide node, and thus all packets by the fetch node are dropped. The different `RelayService` nodes are fully distinct, even though they have the same URL. See notes below.

When running without an auth token or with a wrong one, the relay connection fails with `401` and iroh will retry with increasing backoff.

## Notes & open questions

* How do we want people to set the relay auth token? This PR does it via a new field in `RelayConfig`. This works fine for entries in the home relay. But maybe we need a way to inject a token dynamically per relay URL? Right now there wouldn't be a way to set the token for a Relay URL not part of the RelayMap (i.e. when connecting to some endpoint and getting their relay URL from address lookup)
* The example uses the same relay URL but has distinct `RelayService`s under the hood, dispatching by the auth token. I think this is suboptimal, each tenant should have their own URL. But this is just a limitation of the example atm and could be built differently.
* There's no way to surface a failed authentication to the user currently, all you get is warn logs
* The `transfer` example reports `No home relay` - it seems to wait for QAD to time out, and the example multitenant relay has no QAD. Should be fixed/tracked somewhere (will make an issue).


## Breaking Changes

* changed: `iroh_relay::server::AccessConfig::Restricted` closure now takes `(EndpointId, &HeaderMap)` instead of `(EndpointId)`, so it can read the WebSocket upgrade headers (e.g. `Authorization: Bearer`). The boxed closure type is also exposed as `iroh_relay::server::AccessCheck`. Existing closures need an extra `_headers` parameter.
* changed: `iroh_relay::server::AccessConfig::is_allowed` signature is now `is_allowed(&self, endpoint: EndpointId, headers: &HeaderMap) -> bool`.
* added: `iroh_relay::RelayConfig::auth_token: Option<String>` field and `RelayConfig::with_auth_token` builder method. When set, the client sends `Authorization: Bearer <token>` on the WebSocket upgrade. `RelayConfig` is `#[non_exhaustive]`, so the field addition is not breaking.
* added: `iroh_relay::client::ClientBuilder::auth_token` builder method, mirroring `RelayConfig::auth_token` for direct `ClientBuilder` users.
* added: `iroh_relay::client::ConnectError::InvalidAuthToken`, returned from `ClientBuilder::connect` when the configured bearer token isn't a valid HTTP header value. `ConnectError` is `#[non_exhaustive]`, so the variant is not breaking.


## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
