### PR TITLE
deps: pin pkcs8 and der

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -2334,6 +2334,7 @@ dependencies = [
  "ctor",
  "ctutils",
  "data-encoding",
+ "der",
  "derive_more",
  "ed25519-dalek",
  "futures-util",
@@ -3602,9 +3603,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "b226d2cc389763951db8869584fd800cbbe2962bf454e2edeb5172b31ee99774"
 dependencies = [
  "der",
  "spki",
@@ -4766,9 +4767,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.8.0"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
 dependencies = [
  "base64ct",
  "der",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -26,6 +26,7 @@ blake3 = { version = "1.8.3", default-features = false }
 bytes = "1.11"
 ctutils = { version = "0.4.0", default-features = false }
 data-encoding = "2.2"
+der = "=0.8.0-rc.10" # only needed for exact version pin (until ed25519-dalek is updated)
 derive_more = { version = "2.0.1", features = ["debug", "display", "from", "try_into", "deref", "from_str", "into_iterator"] }
 ed25519-dalek = { version = "=3.0.0-pre.6", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
 http = "1"
@@ -38,6 +39,7 @@ n0-error = "0.1.3"
 n0-watcher = "0.6"
 netwatch = "0.16"
 papaya = { version = "0.2.3", default-features = false }
+pkcs8 = "=0.11.0-rc.10" # only needed for exact version pin (until ed25519-dalek is updated)
 pin-project = "1"
 portable-atomic = "1"
 noq = { version = "0.18.0", default-features = false, features = ["rustls"] }
@@ -63,7 +65,6 @@ url = { version = "2.5", features = ["serde"] }
 webpki = { package = "rustls-webpki", version = "0.103.7", default-features = false, features = ["std"] }
 webpki_types = { package = "rustls-pki-types", version = "1.12" }
 webpki-roots = "1.0.3"
-pkcs8 = "0.11.0-rc.9"
 
 # metrics
 iroh-metrics = { version = "0.38", default-features = false }


### PR DESCRIPTION
## Description

We need to pin the exact RC versions that `ed25519-dalek` needs, otherwise a newer `pkcs8` version is being used that has breaking changes.


## Change checklist

- [x] Self-review.
