### PR TITLE
refactor(iroh-relay)!: pass HTTP headers to AccessConfig hook

### DIFF
--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -94,6 +94,8 @@ pub enum ConnectError {
         "No rustls crypto provider configured while both ring and aws-lc-rs feature flags are disabled"
     )]
     MissingCryptoProvider,
+    #[error("Configured request header {name} is not allowed for the WebSocket upgrade")]
+    DisallowedHeader { name: http::HeaderName },
     #[cfg(wasm_browser)]
     #[error("The relay protocol is not available in browsers")]
     RelayProtoNotAvailable {},
@@ -150,6 +152,8 @@ pub struct ClientBuilder {
     proxy_url: Option<Url>,
     /// The secret key of this client.
     secret_key: SecretKey,
+    /// Additional HTTP headers to send on the WebSocket upgrade request.
+    headers: http::HeaderMap,
     /// The DNS resolver to use.
     #[cfg(not(wasm_browser))]
     dns_resolver: DnsResolver,
@@ -170,6 +174,7 @@ impl ClientBuilder {
             tls_config: None,
             proxy_url: None,
             secret_key,
+            headers: http::HeaderMap::new(),
             #[cfg(not(wasm_browser))]
             dns_resolver,
             key_cache: KeyCache::new(128),
@@ -220,6 +225,18 @@ impl ClientBuilder {
     /// Set an explicit proxy url to proxy all HTTP(S) traffic through.
     pub fn proxy_url(mut self, url: Url) -> Self {
         self.proxy_url.replace(url);
+        self
+    }
+
+    /// Adds an HTTP header to the WebSocket upgrade request.
+    ///
+    /// Multiple calls append to the request; calling this with the same name
+    /// twice keeps both values. The standard WebSocket upgrade headers
+    /// (`Upgrade`, `Connection`, `Sec-WebSocket-*`) are reserved and must
+    /// not be set here; passing one of them surfaces as
+    /// [`ConnectError::DisallowedHeader`] from [`ClientBuilder::connect`].
+    pub fn header(mut self, name: http::HeaderName, value: http::HeaderValue) -> Self {
+        self.headers.append(name, value);
         self
     }
 
@@ -299,6 +316,11 @@ impl ClientBuilder {
                 .expect(
                     "impossible: CLIENT_AUTH_HEADER isn't a disallowed header value for websockets",
                 );
+        }
+        for (name, value) in &self.headers {
+            builder = builder
+                .add_header(name.clone(), value.clone())
+                .map_err(|_| e!(ConnectError::DisallowedHeader { name: name.clone() }))?;
         }
         let (conn, response) = builder.connect_on(stream).await.anyerr()?;
 

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -188,31 +188,35 @@ impl From<AccessConfig> for iroh_relay::server::AccessConfig {
             AccessConfig::Everyone => iroh_relay::server::AccessConfig::Everyone,
             AccessConfig::Allowlist(allow_list) => {
                 let allow_list = Arc::new(allow_list);
-                iroh_relay::server::AccessConfig::Restricted(Box::new(move |endpoint_id| {
-                    let allow_list = allow_list.clone();
-                    async move {
-                        if allow_list.contains(&endpoint_id) {
-                            iroh_relay::server::Access::Allow
-                        } else {
-                            iroh_relay::server::Access::Deny
+                iroh_relay::server::AccessConfig::Restricted(Box::new(
+                    move |endpoint_id, _headers| {
+                        let allow_list = allow_list.clone();
+                        async move {
+                            if allow_list.contains(&endpoint_id) {
+                                iroh_relay::server::Access::Allow
+                            } else {
+                                iroh_relay::server::Access::Deny
+                            }
                         }
-                    }
-                    .boxed()
-                }))
+                        .boxed()
+                    },
+                ))
             }
             AccessConfig::Denylist(deny_list) => {
                 let deny_list = Arc::new(deny_list);
-                iroh_relay::server::AccessConfig::Restricted(Box::new(move |endpoint_id| {
-                    let deny_list = deny_list.clone();
-                    async move {
-                        if deny_list.contains(&endpoint_id) {
-                            iroh_relay::server::Access::Deny
-                        } else {
-                            iroh_relay::server::Access::Allow
+                iroh_relay::server::AccessConfig::Restricted(Box::new(
+                    move |endpoint_id, _headers| {
+                        let deny_list = deny_list.clone();
+                        async move {
+                            if deny_list.contains(&endpoint_id) {
+                                iroh_relay::server::Access::Deny
+                            } else {
+                                iroh_relay::server::Access::Allow
+                            }
                         }
-                    }
-                    .boxed()
-                }))
+                        .boxed()
+                    },
+                ))
             }
             AccessConfig::Http(mut config) => {
                 let client = reqwest::Client::builder()
@@ -224,11 +228,14 @@ impl From<AccessConfig> for iroh_relay::server::AccessConfig {
                     config.bearer_token = Some(token);
                 }
                 let config = Arc::new(config);
-                iroh_relay::server::AccessConfig::Restricted(Box::new(move |endpoint_id| {
-                    let client = client.clone();
-                    let config = config.clone();
-                    async move { http_access_check(&client, &config, endpoint_id).await }.boxed()
-                }))
+                iroh_relay::server::AccessConfig::Restricted(Box::new(
+                    move |endpoint_id, _headers| {
+                        let client = client.clone();
+                        let config = config.clone();
+                        async move { http_access_check(&client, &config, endpoint_id).await }
+                            .boxed()
+                    },
+                ))
             }
         }
     }

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -131,6 +131,13 @@ pub struct RelayConfig {
     pub access: AccessConfig,
 }
 
+/// Access check callback used by [`AccessConfig::Restricted`].
+///
+/// Receives the [`EndpointId`] proven by the relay handshake alongside the
+/// original HTTP request headers from the WebSocket upgrade.  Returning
+/// [`Access::Allow`] admits the endpoint, otherwise it is rejected.
+pub type AccessCheck = Box<dyn Fn(EndpointId, &HeaderMap) -> Boxed<Access> + Send + Sync + 'static>;
+
 /// Controls which endpoints are allowed to use the relay.
 #[derive(derive_more::Debug)]
 #[non_exhaustive]
@@ -138,17 +145,24 @@ pub enum AccessConfig {
     /// Everyone
     Everyone,
     /// Only endpoints for which the function returns `Access::Allow`.
+    ///
+    /// The closure receives the [`EndpointId`] proven by the relay handshake
+    /// alongside the original HTTP request headers from the WebSocket upgrade.
+    /// This makes it possible to bind an `Authorization: Bearer` token (or any
+    /// other header) to the endpoint key actually connecting, e.g. to assert
+    /// the endpoint id described in the bearer credential matches the one
+    /// proven by the handshake.
     #[debug("restricted")]
-    Restricted(Box<dyn Fn(EndpointId) -> Boxed<Access> + Send + Sync + 'static>),
+    Restricted(AccessCheck),
 }
 
 impl AccessConfig {
     /// Is this endpoint allowed?
-    pub async fn is_allowed(&self, endpoint: EndpointId) -> bool {
+    pub async fn is_allowed(&self, endpoint: EndpointId, headers: &HeaderMap) -> bool {
         match self {
             Self::Everyone => true,
             Self::Restricted(check) => {
-                let res = check(endpoint).await;
+                let res = check(endpoint, headers).await;
                 matches!(res, Access::Allow)
             }
         }
@@ -1082,7 +1096,7 @@ mod tests {
                 tls: None,
                 limits: Default::default(),
                 key_cache_capacity: Some(1024),
-                access: AccessConfig::Restricted(Box::new(move |endpoint_id| {
+                access: AccessConfig::Restricted(Box::new(move |endpoint_id, _headers| {
                     async move {
                         info!("checking {}", endpoint_id);
                         // reject endpoint a
@@ -1150,6 +1164,88 @@ mod tests {
         } else {
             panic!("client_c received unexpected message {res:?}");
         }
+
+        Ok(())
+    }
+
+    /// Verifies that [`ClientBuilder::header`] forwards an HTTP header on the
+    /// WebSocket upgrade so the [`AccessConfig::Restricted`] hook can read it.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_relay_client_header_forwarded() -> Result<()> {
+        const TOKEN: &str = "secret-token";
+
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
+        let client_config = CaRootsConfig::default()
+            .client_config(default_provider())
+            .unwrap();
+
+        let server = Server::spawn(ServerConfig {
+            relay: Some(RelayConfig {
+                http_bind_addr: (Ipv4Addr::LOCALHOST, 0).into(),
+                tls: None,
+                limits: Default::default(),
+                key_cache_capacity: Some(1024),
+                access: AccessConfig::Restricted(Box::new(move |_endpoint_id, headers| {
+                    let bearer = headers
+                        .get(http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok())
+                        .and_then(|value| value.strip_prefix("Bearer "))
+                        .map(str::to_owned);
+                    async move {
+                        if bearer.as_deref() == Some(TOKEN) {
+                            Access::Allow
+                        } else {
+                            Access::Deny
+                        }
+                    }
+                    .boxed()
+                })),
+            }),
+            quic: None,
+            metrics_addr: None,
+        })
+        .await?;
+
+        let relay_url = format!("http://{}", server.http_addr().unwrap());
+        let relay_url: RelayUrl = relay_url.parse()?;
+
+        let bearer = |token: &str| {
+            http::HeaderValue::try_from(format!("Bearer {token}")).expect("ascii header value")
+        };
+
+        // No header: denied.
+        let secret_key = SecretKey::from_bytes(&rng.random());
+        let result = ClientBuilder::new(relay_url.clone(), secret_key, dns_resolver())
+            .tls_client_config(client_config.clone())
+            .connect()
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConnectError::Handshake { source: handshake::Error::ServerDeniedAuth { reason, .. }, .. })
+                if reason == "not authorized"
+        ));
+
+        // Wrong header value: denied.
+        let secret_key = SecretKey::from_bytes(&rng.random());
+        let result = ClientBuilder::new(relay_url.clone(), secret_key, dns_resolver())
+            .tls_client_config(client_config.clone())
+            .header(http::header::AUTHORIZATION, bearer("wrong-token"))
+            .connect()
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConnectError::Handshake { source: handshake::Error::ServerDeniedAuth { reason, .. }, .. })
+                if reason == "not authorized"
+        ));
+
+        // Correct header value: connection succeeds.
+        let secret_key = SecretKey::from_bytes(&rng.random());
+        let _client = ClientBuilder::new(relay_url, secret_key, dns_resolver())
+            .tls_client_config(client_config)
+            .header(http::header::AUTHORIZATION, bearer(TOKEN))
+            .connect()
+            .await?;
 
         Ok(())
     }

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -612,6 +612,9 @@ impl RelayServiceWithNotify {
             })?;
 
         let client_auth_header = req.headers().get(CLIENT_AUTH_HEADER).cloned();
+        // Snapshot the full request headers so the `AccessConfig` hook can
+        // inspect them after the WebSocket handshake completes.
+        let request_headers = req.headers().clone();
 
         // Setup a future that will eventually receive the upgraded
         // connection and talk a new protocol, and spawn the future
@@ -631,6 +634,7 @@ impl RelayServiceWithNotify {
                             .relay_connection_handler(
                                 upgraded,
                                 client_auth_header,
+                                request_headers,
                                 protocol_version,
                             )
                             .await
@@ -815,6 +819,7 @@ impl Inner {
         &self,
         upgraded: Upgraded,
         client_auth_header: Option<HeaderValue>,
+        request_headers: HeaderMap,
         protocol_version: ProtocolVersion,
     ) -> Result<(), ConnectionHandlerError> {
         debug!("relay_connection upgraded");
@@ -823,7 +828,7 @@ impl Inner {
             return Err(e!(ConnectionHandlerError::BufferNotEmpty { buf: read_buf }));
         }
 
-        self.accept(io, client_auth_header, protocol_version)
+        self.accept(io, client_auth_header, request_headers, protocol_version)
             .await?;
         Ok(())
     }
@@ -842,6 +847,7 @@ impl Inner {
         &self,
         io: MaybeTlsStream,
         client_auth_header: Option<HeaderValue>,
+        request_headers: HeaderMap,
         protocol_version: ProtocolVersion,
     ) -> Result<(), AcceptError> {
         trace!("accept: start");
@@ -864,7 +870,10 @@ impl Inner {
 
         trace!(?authentication.mechanism, "accept: verified authentication");
 
-        let is_authorized = self.access.is_allowed(authentication.client_key).await;
+        let is_authorized = self
+            .access
+            .is_allowed(authentication.client_key, &request_headers)
+            .await;
         let client_key = authentication.authorize_if(is_authorized, &mut io).await?;
 
         trace!("accept: verified authorization");
@@ -1478,8 +1487,13 @@ mod tests {
         let (client_a, rw_a) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_a), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_a),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut client_a = make_test_client(client_a, &key_a).await?;
         handler_task.await.std_context("join")??;
@@ -1490,8 +1504,13 @@ mod tests {
         let (client_b, rw_b) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_b), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_b),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut client_b = make_test_client(client_b, &key_b).await?;
         handler_task.await.std_context("join")??;
@@ -1582,8 +1601,13 @@ mod tests {
         let (client_a, rw_a) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_a), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_a),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut client_a = make_test_client(client_a, &key_a).await?;
         handler_task.await.std_context("join")??;
@@ -1594,8 +1618,13 @@ mod tests {
         let (client_b, rw_b) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_b), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_b),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut client_b = make_test_client(client_b, &key_b).await?;
         handler_task.await.std_context("join")??;
@@ -1646,8 +1675,13 @@ mod tests {
         let (new_client_b, new_rw_b) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(new_rw_b), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(new_rw_b),
+                None,
+                HeaderMap::new(),
+                Default::default(),
+            )
+            .await
         });
         let mut new_client_b = make_test_client(new_client_b, &key_b).await?;
         handler_task.await.std_context("join")??;


### PR DESCRIPTION
## Description

The `AccessConfig::Restricted` callback now receives the HTTP request headers from the WebSocket upgrade alongside the proven `EndpointId`. This enables binding `Authorization: Bearer` (or any other header) to the endpoint key actually connecting, e.g. to assert that the endpoint id described in the bearer credential matches the one proven by the relay handshake.

## Breaking Changes

* changed: `iroh_relay::server::AccessConfig::Restricted` closure now takes `(EndpointId, &HeaderMap)` instead of `(EndpointId)`. The boxed closure type is also exposed as `iroh_relay::server::AccessCheck`. Existing closures need an extra `_headers` parameter.
* changed: `iroh_relay::server::AccessConfig::is_allowed` signature is now `is_allowed(&self, endpoint: EndpointId, headers: &HeaderMap) -> bool`.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.