### PR TITLE
chore(ci): enforce external type allow-list in public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,56 @@ jobs:
           baseline-rev: ${{ env.HEAD_COMMIT_SHA }}
           use-cache: false
 
+  check_external_types:
+    timeout-minutes: 30
+    name: Check external types in public API
+    if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
+    needs: pick-runner
+    runs-on: ${{ fromJSON(needs.pick-runner.outputs.overflow_9) }}
+    # Enforces https://github.com/n0-computer/iroh/issues/3177: foreign types
+    # in our public API are gated by `external-types.toml`.
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
+      # Pin to the nightly that the pinned `cargo-check-external-types`
+      # release was last tested against. Update both together.
+      CARGO_CHECK_EXTERNAL_TYPES_VERSION: "0.4.0"
+      CARGO_CHECK_EXTERNAL_TYPES_NIGHTLY: "nightly-2025-10-18"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.CARGO_CHECK_EXTERNAL_TYPES_NIGHTLY }}
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache cargo-check-external-types
+        id: cache-cet
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-check-external-types
+          key: cargo-check-external-types-${{ env.CARGO_CHECK_EXTERNAL_TYPES_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install cargo-check-external-types
+        if: steps.cache-cet.outputs.cache-hit != 'true'
+        run: cargo install --locked --version "$CARGO_CHECK_EXTERNAL_TYPES_VERSION" cargo-check-external-types
+
+      - name: Check external types
+        run: |
+          set -e
+          fail=0
+          for crate in iroh-base iroh-dns iroh-dns-server iroh iroh-relay; do
+            echo "::group::$crate"
+            if ! cargo check-external-types \
+                --manifest-path "$crate/Cargo.toml" \
+                --config external-types.toml \
+                --all-features; then
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $fail
+
   check_fmt:
     timeout-minutes: 30
     name: Checking fmt

--- a/external-types.toml
+++ b/external-types.toml
@@ -1,0 +1,42 @@
+# Allow-list for `cargo-check-external-types`.
+#
+# Used by the `check_external_types` CI job to enforce
+# https://github.com/n0-computer/iroh/issues/3177: each foreign type in the
+# public API blocks a semver-breaking update of that crate during 1.0, so we
+# keep this list as small as possible.
+
+allowed_external_types = [
+    # workspace crates
+    "iroh_base::*",
+    "iroh_dns::*",
+    "iroh_relay::*",
+
+    # 1.0 crates that we deem fine to be part of the public API
+    "bytes::*",
+    "http::*",
+    "http_body::*",
+    "hyper::*",
+    "rustls_pki_types::*",
+    "serde::*",
+    "serde_core::*",
+    "tokio::*",
+    "url::*",
+
+    # crates owned by us that will move to 1.0 as well
+    "iroh_metrics::*",
+    "n0_error::*",
+    "n0_watcher::*",
+    "noq::*",
+    "noq_proto::*",
+    "noq_udp::*",
+    "portmapper::metrics::Metrics",
+
+    # non-1.0 crates that we decided to accept in the public API
+    "rustls::*",
+    "tokio_rustls::*",
+    "futures_core::stream::Stream",
+    "futures_sink::Sink",
+    # these are only type aliases
+    "futures_lite::future::Boxed",
+    "futures_lite::stream::Boxed",
+]


### PR DESCRIPTION
## Description

Foreign types in our public API block semver-breaking updates of those
crates during 1.0. #3177 tracks reducing that surface to a curated
allow list.

This adds a `check_external_types` CI job that runs
[`cargo-check-external-types`] against `iroh-base`, `iroh-dns`,
`iroh-dns-server`, `iroh`, and `iroh-relay` against a shared
`external-types.toml` at the workspace root.

Closes #3177.

[`cargo-check-external-types`]: https://github.com/awslabs/cargo-check-external-types

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.