### PR TITLE
feat(iroh-relay)!: pass a ClientRequest to AccessConfig and let the client set query params

### DIFF
--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -150,6 +150,8 @@ pub struct ClientBuilder {
     proxy_url: Option<Url>,
     /// The secret key of this client.
     secret_key: SecretKey,
+    /// Query parameters appended to the dial URL.
+    query_params: Vec<(String, String)>,
     /// The DNS resolver to use.
     #[cfg(not(wasm_browser))]
     dns_resolver: DnsResolver,
@@ -170,6 +172,7 @@ impl ClientBuilder {
             tls_config: None,
             proxy_url: None,
             secret_key,
+            query_params: Vec::new(),
             #[cfg(not(wasm_browser))]
             dns_resolver,
             key_cache: KeyCache::new(128),
@@ -223,6 +226,15 @@ impl ClientBuilder {
         self
     }
 
+    /// Appends a query parameter to the relay URL the client connects to.
+    ///
+    /// Multiple calls append. Calling this with the same key twice keeps
+    /// both values.
+    pub fn query_param(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.query_params.push((key.into(), value.into()));
+        self
+    }
+
     /// Set the capacity of the cache for public keys.
     pub fn key_cache_capacity(mut self, capacity: usize) -> Self {
         self.key_cache = KeyCache::new(capacity);
@@ -256,6 +268,9 @@ impl ClientBuilder {
                     url: dial_url.clone()
                 })
             })?;
+        for (key, value) in &self.query_params {
+            dial_url.query_pairs_mut().append_pair(key, value);
+        }
 
         debug!(%dial_url, "Dialing relay by websocket");
 
@@ -374,6 +389,9 @@ impl ClientBuilder {
                     url: dial_url.clone()
                 })
             })?;
+        for (key, value) in &self.query_params {
+            dial_url.query_pairs_mut().append_pair(key, value);
+        }
 
         debug!(%dial_url, "Dialing relay by websocket");
 

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -188,8 +188,9 @@ impl From<AccessConfig> for iroh_relay::server::AccessConfig {
             AccessConfig::Everyone => iroh_relay::server::AccessConfig::Everyone,
             AccessConfig::Allowlist(allow_list) => {
                 let allow_list = Arc::new(allow_list);
-                iroh_relay::server::AccessConfig::Restricted(Box::new(move |endpoint_id| {
+                iroh_relay::server::AccessConfig::Restricted(Box::new(move |request| {
                     let allow_list = allow_list.clone();
+                    let endpoint_id = request.endpoint_id();
                     async move {
                         if allow_list.contains(&endpoint_id) {
                             iroh_relay::server::Access::Allow
@@ -202,8 +203,9 @@ impl From<AccessConfig> for iroh_relay::server::AccessConfig {
             }
             AccessConfig::Denylist(deny_list) => {
                 let deny_list = Arc::new(deny_list);
-                iroh_relay::server::AccessConfig::Restricted(Box::new(move |endpoint_id| {
+                iroh_relay::server::AccessConfig::Restricted(Box::new(move |request| {
                     let deny_list = deny_list.clone();
+                    let endpoint_id = request.endpoint_id();
                     async move {
                         if deny_list.contains(&endpoint_id) {
                             iroh_relay::server::Access::Deny
@@ -224,9 +226,10 @@ impl From<AccessConfig> for iroh_relay::server::AccessConfig {
                     config.bearer_token = Some(token);
                 }
                 let config = Arc::new(config);
-                iroh_relay::server::AccessConfig::Restricted(Box::new(move |endpoint_id| {
+                iroh_relay::server::AccessConfig::Restricted(Box::new(move |request| {
                     let client = client.clone();
                     let config = config.clone();
+                    let endpoint_id = request.endpoint_id();
                     async move { http_access_check(&client, &config, endpoint_id).await }.boxed()
                 }))
             }

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -145,7 +145,11 @@ pub struct ClientRequest {
 }
 
 impl ClientRequest {
-    pub(crate) fn new(endpoint_id: EndpointId, request: http::request::Parts) -> Self {
+    /// Creates a new [`ClientRequest`] from an [`EndpointId`] and HTTP request parts.
+    ///
+    /// The [`EndpointId`] must be proven by the relay handshake. The request parts
+    /// come from the client's WebSocket request.
+    pub fn new(endpoint_id: EndpointId, request: http::request::Parts) -> Self {
         Self {
             endpoint_id,
             request,

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -15,7 +15,10 @@
 //! - HTTPS `/ping`: Used for net_report probes.
 //! - HTTPS `/generate_204`: Used for net_report probes.
 
-use std::{future::Future, net::SocketAddr, num::NonZeroU32, path::PathBuf, pin::Pin, sync::Arc};
+use std::{
+    borrow::Cow, future::Future, net::SocketAddr, num::NonZeroU32, path::PathBuf, pin::Pin,
+    sync::Arc,
+};
 
 use derive_more::Debug;
 use http::{
@@ -131,24 +134,77 @@ pub struct RelayConfig {
     pub access: AccessConfig,
 }
 
+/// Details about an incoming relay client connection.
+///
+/// Passed to the [`AccessConfig::Restricted`] callback to decide whether to
+/// admit the endpoint.
+#[derive(Debug, Clone)]
+pub struct ClientRequest {
+    endpoint_id: EndpointId,
+    request: http::request::Parts,
+}
+
+impl ClientRequest {
+    pub(crate) fn new(endpoint_id: EndpointId, request: http::request::Parts) -> Self {
+        Self {
+            endpoint_id,
+            request,
+        }
+    }
+
+    /// Returns the [`EndpointId`] of the client.
+    ///
+    /// The relay handshake authenticates this id before the access hook
+    /// is invoked. The client proves possession of the secret key for
+    /// this public key by either signing keying material exported from
+    /// the TLS session or a challenge issued by the server.
+    pub fn endpoint_id(&self) -> EndpointId {
+        self.endpoint_id
+    }
+
+    /// Returns the URI of the HTTP request with which the client connected.
+    pub fn uri(&self) -> &http::Uri {
+        &self.request.uri
+    }
+
+    /// Returns an iterator over the query parameters set in the URI of the HTTP request.
+    ///
+    /// Each item is a `(name, value)` pair. Both names and values are percent-decoded.
+    /// The query string is parsed in order, and the same name may appear more than once.
+    pub fn query_pairs(&self) -> impl Iterator<Item = (Cow<'_, str>, Cow<'_, str>)> {
+        url::form_urlencoded::parse(self.request.uri.query().unwrap_or("").as_bytes())
+    }
+
+    /// Returns the headers of the HTTP request with which the client connected.
+    pub fn headers(&self) -> &http::HeaderMap {
+        &self.request.headers
+    }
+}
+
+/// Access check callback used by [`AccessConfig::Restricted`].
+///
+/// Returns [`Access::Allow`] to admit the endpoint, [`Access::Deny`] to
+/// reject it.
+pub type AccessCheck = Box<dyn Fn(&ClientRequest) -> Boxed<Access> + Send + Sync + 'static>;
+
 /// Controls which endpoints are allowed to use the relay.
 #[derive(derive_more::Debug)]
 #[non_exhaustive]
 pub enum AccessConfig {
-    /// Everyone
+    /// Allows every endpoint.
     Everyone,
-    /// Only endpoints for which the function returns `Access::Allow`.
+    /// Delegates the decision to a callback invoked for every connection.
     #[debug("restricted")]
-    Restricted(Box<dyn Fn(EndpointId) -> Boxed<Access> + Send + Sync + 'static>),
+    Restricted(AccessCheck),
 }
 
 impl AccessConfig {
-    /// Is this endpoint allowed?
-    pub async fn is_allowed(&self, endpoint: EndpointId) -> bool {
+    /// Returns whether the given client request should be admitted.
+    pub async fn is_allowed(&self, request: &ClientRequest) -> bool {
         match self {
             Self::Everyone => true,
             Self::Restricted(check) => {
-                let res = check(endpoint).await;
+                let res = check(request).await;
                 matches!(res, Access::Allow)
             }
         }
@@ -1082,7 +1138,8 @@ mod tests {
                 tls: None,
                 limits: Default::default(),
                 key_cache_capacity: Some(1024),
-                access: AccessConfig::Restricted(Box::new(move |endpoint_id| {
+                access: AccessConfig::Restricted(Box::new(move |request| {
+                    let endpoint_id = request.endpoint_id();
                     async move {
                         info!("checking {}", endpoint_id);
                         // reject endpoint a
@@ -1150,6 +1207,84 @@ mod tests {
         } else {
             panic!("client_c received unexpected message {res:?}");
         }
+
+        Ok(())
+    }
+
+    /// Verifies that [`ClientBuilder::query_param`] forwards URL query
+    /// parameters on the WebSocket upgrade so the [`AccessConfig::Restricted`]
+    /// hook can read them via [`ClientRequest::query_pairs`].
+    #[tokio::test]
+    #[traced_test]
+    async fn test_relay_client_query_param_forwarded() -> Result<()> {
+        const TOKEN: &str = "secret-token";
+
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
+        let client_config = CaRootsConfig::default()
+            .client_config(default_provider())
+            .unwrap();
+
+        let server = Server::spawn(ServerConfig {
+            relay: Some(RelayConfig {
+                http_bind_addr: (Ipv4Addr::LOCALHOST, 0).into(),
+                tls: None,
+                limits: Default::default(),
+                key_cache_capacity: Some(1024),
+                access: AccessConfig::Restricted(Box::new(move |request| {
+                    let token = request
+                        .query_pairs()
+                        .find(|(key, _)| key == "token")
+                        .map(|(_, value)| value.into_owned());
+                    async move {
+                        if token.as_deref() == Some(TOKEN) {
+                            Access::Allow
+                        } else {
+                            Access::Deny
+                        }
+                    }
+                    .boxed()
+                })),
+            }),
+            quic: None,
+            metrics_addr: None,
+        })
+        .await?;
+
+        let relay_url = format!("http://{}", server.http_addr().unwrap());
+        let relay_url: RelayUrl = relay_url.parse()?;
+
+        // No query param: denied.
+        let secret_key = SecretKey::from_bytes(&rng.random());
+        let result = ClientBuilder::new(relay_url.clone(), secret_key, dns_resolver())
+            .tls_client_config(client_config.clone())
+            .connect()
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConnectError::Handshake { source: handshake::Error::ServerDeniedAuth { reason, .. }, .. })
+                if reason == "not authorized"
+        ));
+
+        // Wrong token: denied.
+        let secret_key = SecretKey::from_bytes(&rng.random());
+        let result = ClientBuilder::new(relay_url.clone(), secret_key, dns_resolver())
+            .tls_client_config(client_config.clone())
+            .query_param("token", "wrong-token")
+            .connect()
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConnectError::Handshake { source: handshake::Error::ServerDeniedAuth { reason, .. }, .. })
+                if reason == "not authorized"
+        ));
+
+        // Correct token: connection succeeds.
+        let secret_key = SecretKey::from_bytes(&rng.random());
+        let _client = ClientBuilder::new(relay_url, secret_key, dns_resolver())
+            .tls_client_config(client_config)
+            .query_param("token", TOKEN)
+            .connect()
+            .await?;
 
         Ok(())
     }

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -31,7 +31,9 @@ use tokio_rustls_acme::AcmeAcceptor;
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
 use tracing::{Instrument, debug, error, info, info_span, trace, warn, warn_span};
 
-use super::{AccessConfig, SpawnError, clients::Clients, streams::InvalidBucketConfig};
+use super::{
+    AccessConfig, ClientRequest, SpawnError, clients::Clients, streams::InvalidBucketConfig,
+};
 use crate::{
     KeyCache,
     defaults::{DEFAULT_KEY_CACHE_CAPACITY, timeouts::SERVER_WRITE_TIMEOUT},
@@ -611,8 +613,6 @@ impl RelayServiceWithNotify {
                 })
             })?;
 
-        let client_auth_header = req.headers().get(CLIENT_AUTH_HEADER).cloned();
-
         // Setup a future that will eventually receive the upgraded
         // connection and talk a new protocol, and spawn the future
         // into the runtime.
@@ -625,14 +625,11 @@ impl RelayServiceWithNotify {
             async move {
                 match hyper::upgrade::on(&mut req).await {
                     Ok(upgraded) => {
+                        let (parts, _) = req.into_parts();
                         if let Err(err) = this
                             .service
                             .0
-                            .relay_connection_handler(
-                                upgraded,
-                                client_auth_header,
-                                protocol_version,
-                            )
+                            .relay_connection_handler(upgraded, parts, protocol_version)
                             .await
                         {
                             warn!("error accepting upgraded connection: {err:#}",);
@@ -814,7 +811,7 @@ impl Inner {
     async fn relay_connection_handler(
         &self,
         upgraded: Upgraded,
-        client_auth_header: Option<HeaderValue>,
+        request_parts: http::request::Parts,
         protocol_version: ProtocolVersion,
     ) -> Result<(), ConnectionHandlerError> {
         debug!("relay_connection upgraded");
@@ -823,8 +820,7 @@ impl Inner {
             return Err(e!(ConnectionHandlerError::BufferNotEmpty { buf: read_buf }));
         }
 
-        self.accept(io, client_auth_header, protocol_version)
-            .await?;
+        self.accept(io, request_parts, protocol_version).await?;
         Ok(())
     }
 
@@ -841,7 +837,7 @@ impl Inner {
     async fn accept(
         &self,
         io: MaybeTlsStream,
-        client_auth_header: Option<HeaderValue>,
+        request_parts: http::request::Parts,
         protocol_version: ProtocolVersion,
     ) -> Result<(), AcceptError> {
         trace!("accept: start");
@@ -860,11 +856,13 @@ impl Inner {
 
         let mut io = WsBytesFramed { io: websocket };
 
+        let client_auth_header = request_parts.headers.get(CLIENT_AUTH_HEADER).cloned();
         let authentication = handshake::serverside(&mut io, client_auth_header).await?;
 
         trace!(?authentication.mechanism, "accept: verified authentication");
 
-        let is_authorized = self.access.is_allowed(authentication.client_key).await;
+        let request = ClientRequest::new(authentication.client_key, request_parts);
+        let is_authorized = self.access.is_allowed(&request).await;
         let client_key = authentication.authorize_if(is_authorized, &mut io).await?;
 
         trace!("accept: verified authorization");
@@ -1478,8 +1476,12 @@ mod tests {
         let (client_a, rw_a) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_a), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_a),
+                Request::new(()).into_parts().0,
+                Default::default(),
+            )
+            .await
         });
         let mut client_a = make_test_client(client_a, &key_a).await?;
         handler_task.await.std_context("join")??;
@@ -1490,8 +1492,12 @@ mod tests {
         let (client_b, rw_b) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_b), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_b),
+                Request::new(()).into_parts().0,
+                Default::default(),
+            )
+            .await
         });
         let mut client_b = make_test_client(client_b, &key_b).await?;
         handler_task.await.std_context("join")??;
@@ -1582,8 +1588,12 @@ mod tests {
         let (client_a, rw_a) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_a), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_a),
+                Request::new(()).into_parts().0,
+                Default::default(),
+            )
+            .await
         });
         let mut client_a = make_test_client(client_a, &key_a).await?;
         handler_task.await.std_context("join")??;
@@ -1594,8 +1604,12 @@ mod tests {
         let (client_b, rw_b) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(rw_b), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(rw_b),
+                Request::new(()).into_parts().0,
+                Default::default(),
+            )
+            .await
         });
         let mut client_b = make_test_client(client_b, &key_b).await?;
         handler_task.await.std_context("join")??;
@@ -1646,8 +1660,12 @@ mod tests {
         let (new_client_b, new_rw_b) = tokio::io::duplex(10);
         let s = service.clone();
         let handler_task = tokio::spawn(async move {
-            s.0.accept(MaybeTlsStream::Test(new_rw_b), None, Default::default())
-                .await
+            s.0.accept(
+                MaybeTlsStream::Test(new_rw_b),
+                Request::new(()).into_parts().0,
+                Default::default(),
+            )
+            .await
         });
         let mut new_client_b = make_test_client(new_client_b, &key_b).await?;
         handler_task.await.std_context("join")??;


### PR DESCRIPTION
This adds a `query_param` function to the iroh-relay `ClientBuilder` to set URL query parameters on the URL for the WebSocket request. The indended usecase is to allow optionally setting an authentication token. This replaces #4202 which used HTTP headers for this purpose. However, in the browser you cannot set headers on a WebSocket request, thus this approach would break or Wasm-In-Browser support. So we use URL query parameters now.

To make use of the parameters when authenticating clients on the relay server, the `AccessConfig::Restricted` callback now receives a `ClientRequest` that exposes both the `EndpointId` and some parts from the HTTP request with which the client connected (i.e. the WebSocket request). `ClientRequest` for now exposes the headers, the request URI and a utility function to get the query pairs

# Breaking changes

* changed: `iroh_relay::server::AccessConfig::Restricted` closure now takes `&ClientRequest` instead of `EndpointId`. The boxed closure type is exposed as `iroh_relay::server::AccessCheck`. Existing closures need to read `request.endpoint_id()`.
* changed: `iroh_relay::server::AccessConfig::is_allowed` signature is now `is_allowed(&self, request: &ClientRequest) -> bool`.

## Notes & open questions



## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
