### PR TITLE
chore(ci): make sccache fail gracefully

### DIFF
--- a/.github/actions/sccache-probe/action.yml
+++ b/.github/actions/sccache-probe/action.yml
@@ -1,0 +1,32 @@
+name: Probe sccache backend
+description: >
+  Verify the sccache backend is reachable; if not, unset RUSTC_WRAPPER so
+  the job runs without sccache rather than failing. Handles transient
+  outages of GHA cache (Blacksmith proxy 502, GitHub cache hiccups, etc.)
+  without requiring a re-run.
+
+runs:
+  using: composite
+  steps:
+    - name: Probe sccache backend
+      if: env.RUSTC_WRAPPER == 'sccache'
+      shell: bash
+      run: |
+        # sccache --start-server triggers a backend probe (.sccache_check
+        # read). On failure (e.g. Blacksmith's GHA cache proxy returning
+        # 502 Bad Gateway), the daemon won't start and every rustc call
+        # fails. Try a few times in case the outage is brief; if it
+        # persists, fall through to plain rustc — slower, but the job
+        # will still succeed.
+        for attempt in 1 2 3; do
+          if timeout 15 sccache --start-server >/dev/null 2>&1; then
+            echo "sccache backend OK (attempt $attempt)"
+            exit 0
+          fi
+          echo "sccache start failed (attempt $attempt/3)"
+          [ $attempt -lt 3 ] && sleep $((attempt * 3))
+        done
+        echo "::warning::sccache backend unreachable; running this job without sccache"
+        # mozilla-actions/sccache-action exports these via $GITHUB_ENV — override.
+        echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,7 @@ jobs:
           fetch-depth: 0
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache-probe
 
       - name: Setup Environment (PR)
         if: ${{ github.event_name == 'pull_request' }}
@@ -282,6 +283,7 @@ jobs:
         with:
           components: rustfmt
       - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache-probe
       - uses: taiki-e/install-action@cargo-make
       - run: cargo make format-check
 
@@ -302,6 +304,7 @@ jobs:
           toolchain: nightly-2025-10-09
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache-probe
 
       - name: Docs
         run: cargo doc --workspace --all-features --no-deps --document-private-items
@@ -321,6 +324,7 @@ jobs:
           components: clippy
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache-probe
 
       # TODO: We have a bunch of platform-dependent code so should
       #    probably run this job on the full platform matrix
@@ -371,6 +375,7 @@ jobs:
           toolchain: ${{ env.MSRV }}
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache-probe
 
       - name: Check MSRV all features
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
           fetch-depth: 0
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: ./.github/actions/sccache-probe
+      - uses: ./.github/workflows/sccache-probe
 
       - name: Setup Environment (PR)
         if: ${{ github.event_name == 'pull_request' }}
@@ -283,7 +283,7 @@ jobs:
         with:
           components: rustfmt
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: ./.github/actions/sccache-probe
+      - uses: ./.github/workflows/sccache-probe
       - uses: taiki-e/install-action@cargo-make
       - run: cargo make format-check
 
@@ -304,7 +304,7 @@ jobs:
           toolchain: nightly-2025-10-09
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: ./.github/actions/sccache-probe
+      - uses: ./.github/workflows/sccache-probe
 
       - name: Docs
         run: cargo doc --workspace --all-features --no-deps --document-private-items
@@ -324,7 +324,7 @@ jobs:
           components: clippy
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: ./.github/actions/sccache-probe
+      - uses: ./.github/workflows/sccache-probe
 
       # TODO: We have a bunch of platform-dependent code so should
       #    probably run this job on the full platform matrix
@@ -375,7 +375,7 @@ jobs:
           toolchain: ${{ env.MSRV }}
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: ./.github/actions/sccache-probe
+      - uses: ./.github/workflows/sccache-probe
 
       - name: Check MSRV all features
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,7 @@ jobs:
           fetch-depth: 0
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: ./.github/workflows/sccache-probe
 
       - name: Setup Environment (PR)
@@ -283,6 +284,7 @@ jobs:
         with:
           components: rustfmt
       - uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: ./.github/workflows/sccache-probe
       - uses: taiki-e/install-action@cargo-make
       - run: cargo make format-check
@@ -304,6 +306,7 @@ jobs:
           toolchain: nightly-2025-10-09
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: ./.github/workflows/sccache-probe
 
       - name: Docs
@@ -324,6 +327,7 @@ jobs:
           components: clippy
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: ./.github/workflows/sccache-probe
 
       # TODO: We have a bunch of platform-dependent code so should
@@ -375,6 +379,7 @@ jobs:
           toolchain: ${{ env.MSRV }}
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: ./.github/workflows/sccache-probe
 
       - name: Check MSRV all features

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,6 +35,7 @@ jobs:
         toolchain: nightly-2025-10-09
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.9
+    - uses: ./.github/actions/sccache-probe
 
     - name: Generate Docs
       run: cargo doc --workspace --all-features --no-deps

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,7 @@ jobs:
         toolchain: nightly-2025-10-09
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.9
-    - uses: ./.github/actions/sccache-probe
+    - uses: ./.github/workflows/sccache-probe
 
     - name: Generate Docs
       run: cargo doc --workspace --all-features --no-deps

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,6 +35,7 @@ jobs:
         toolchain: nightly-2025-10-09
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.9
+      continue-on-error: true
     - uses: ./.github/workflows/sccache-probe
 
     - name: Generate Docs

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -114,6 +114,8 @@ jobs:
 
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.9
+      continue-on-error: true
+    - uses: ./.github/workflows/sccache-probe
 
     - name: Build iroh
       run: |

--- a/.github/workflows/patchbay.yml
+++ b/.github/workflows/patchbay.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+      - uses: ./.github/workflows/sccache-probe
       - name: Install cargo-make and cargo-nextest
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/sccache-probe/action.yml
+++ b/.github/workflows/sccache-probe/action.yml
@@ -24,6 +24,14 @@ runs:
         # Linux/macOS/Windows bash (no coreutils `timeout` needed).
         SCCACHE_STARTUP_NOTIFY_TIMEOUT: "5"
       run: |
+        # If the sccache binary isn't installed (e.g. mozilla-actions/sccache-action
+        # failed to download from GitHub releases), bail out fast.
+        if ! command -v sccache >/dev/null 2>&1; then
+          echo "::warning::sccache binary not found (install likely failed); running this job without sccache"
+          echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_ENABLED=" >> "$GITHUB_ENV"
+          exit 0
+        fi
         # sccache --start-server triggers a backend probe (.sccache_check
         # read). On failure (e.g. Blacksmith's GHA cache proxy returning
         # 502 Bad Gateway), the daemon won't start and every rustc call

--- a/.github/workflows/sccache-probe/action.yml
+++ b/.github/workflows/sccache-probe/action.yml
@@ -9,7 +9,12 @@ runs:
   using: composite
   steps:
     - name: Probe sccache backend
-      if: env.RUSTC_WRAPPER == 'sccache'
+      # Skip on Windows: our Windows runners are self-hosted hetz with
+      # local-disk sccache (no GHA backend → no 502s to handle), and
+      # `shell: bash` on those runners resolves to the WSL launcher
+      # which fails outright. Probe only matters where SCCACHE_GHA_ENABLED
+      # is in play, i.e. Linux self-hosted (Blacksmith) and ubuntu-latest.
+      if: env.RUSTC_WRAPPER == 'sccache' && runner.os != 'Windows'
       shell: bash
       env:
         # Cap each --start-server attempt at 5s in case sccache hangs on

--- a/.github/workflows/sccache-probe/action.yml
+++ b/.github/workflows/sccache-probe/action.yml
@@ -11,20 +11,25 @@ runs:
     - name: Probe sccache backend
       if: env.RUSTC_WRAPPER == 'sccache'
       shell: bash
+      env:
+        # Cap each --start-server attempt at 5s in case sccache hangs on
+        # backend init. Empirically 502s from Blacksmith's GHA proxy
+        # already fail in ~5s; this just bounds pathological hangs.
+        # Two attempts × 5s = ~10s worst case. Portable across
+        # Linux/macOS/Windows bash (no coreutils `timeout` needed).
+        SCCACHE_STARTUP_NOTIFY_TIMEOUT: "5"
       run: |
         # sccache --start-server triggers a backend probe (.sccache_check
         # read). On failure (e.g. Blacksmith's GHA cache proxy returning
         # 502 Bad Gateway), the daemon won't start and every rustc call
-        # fails. Try a few times in case the outage is brief; if it
-        # persists, fall through to plain rustc — slower, but the job
-        # will still succeed.
-        for attempt in 1 2 3; do
-          if timeout 15 sccache --start-server >/dev/null 2>&1; then
+        # fails. One quick retry, then fall through to plain rustc —
+        # slower, but the job will still succeed.
+        for attempt in 1 2; do
+          if sccache --start-server >/dev/null 2>&1; then
             echo "sccache backend OK (attempt $attempt)"
             exit 0
           fi
-          echo "sccache start failed (attempt $attempt/3)"
-          [ $attempt -lt 3 ] && sleep $((attempt * 3))
+          echo "sccache start failed (attempt $attempt/2)"
         done
         echo "::warning::sccache backend unreachable; running this job without sccache"
         # mozilla-actions/sccache-action exports these via $GITHUB_ENV — override.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: ./.github/actions/sccache-probe
+      - uses: ./.github/workflows/sccache-probe
 
       - name: Select features
         run: |
@@ -263,7 +263,7 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: ./.github/actions/sccache-probe
+      - uses: ./.github/workflows/sccache-probe
 
       - uses: msys2/setup-msys2@v2
         with:
@@ -364,7 +364,7 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: ./.github/actions/sccache-probe
+      - uses: ./.github/workflows/sccache-probe
 
       - uses: msys2/setup-msys2@v2
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,6 +117,7 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: ./.github/workflows/sccache-probe
 
       - name: Select features
@@ -263,6 +264,7 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: ./.github/workflows/sccache-probe
 
       - uses: msys2/setup-msys2@v2
@@ -364,6 +366,7 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: ./.github/workflows/sccache-probe
 
       - uses: msys2/setup-msys2@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,6 +117,7 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache-probe
 
       - name: Select features
         run: |
@@ -262,6 +263,7 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache-probe
 
       - uses: msys2/setup-msys2@v2
         with:
@@ -362,6 +364,7 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache-probe
 
       - uses: msys2/setup-msys2@v2
         with:


### PR DESCRIPTION
## Description

Wraps the sccache config into a check so if infra fails for some reason it retries and if that fails too it moves on to complete the job without it.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
