### PR TITLE
refactor!(iroh): remove AccessLimit and associated tests

### DIFF
--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -47,7 +47,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use iroh_base::EndpointId;
 use n0_error::{AnyError, e, stack_error};
 use n0_future::{
     join_all,
@@ -661,57 +660,6 @@ async fn handle_connection(incoming: crate::endpoint::Incoming, protocols: Arc<P
     }
 }
 
-/// Wraps an existing protocol, limiting its access,
-/// based on the provided function.
-///
-/// Any refused connection will be closed with an error code of `0` and reason `not allowed`.
-#[derive(derive_more::Debug, Clone)]
-pub struct AccessLimit<P: ProtocolHandler + Clone> {
-    proto: P,
-    #[debug("limiter")]
-    limiter: Arc<dyn Fn(EndpointId) -> bool + Send + Sync + 'static>,
-}
-
-impl<P: ProtocolHandler + Clone> AccessLimit<P> {
-    /// Create a new `AccessLimit`.
-    ///
-    /// The function should return `true` for endpoints that are allowed to
-    /// connect, and `false` otherwise.
-    pub fn new<F>(proto: P, limiter: F) -> Self
-    where
-        F: Fn(EndpointId) -> bool + Send + Sync + 'static,
-    {
-        Self {
-            proto,
-            limiter: Arc::new(limiter),
-        }
-    }
-}
-
-impl<P: ProtocolHandler + Clone> ProtocolHandler for AccessLimit<P> {
-    fn on_accepting(
-        &self,
-        accepting: Accepting,
-    ) -> impl Future<Output = Result<Connection, AcceptError>> + Send {
-        self.proto.on_accepting(accepting)
-    }
-
-    async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
-        let remote = conn.remote_id();
-        let is_allowed = (self.limiter)(remote);
-        if !is_allowed {
-            conn.close(0u32.into(), b"not allowed");
-            return Err(e!(AcceptError::NotAllowed));
-        }
-        self.proto.accept(conn).await?;
-        Ok(())
-    }
-
-    fn shutdown(&self) -> impl Future<Output = ()> + Send {
-        self.proto.shutdown()
-    }
-}
-
 #[cfg(all(test, with_crypto_provider))]
 mod tests {
     use std::{sync::Mutex, time::Duration};
@@ -760,31 +708,6 @@ mod tests {
 
             Ok(())
         }
-    }
-
-    #[tokio::test]
-    async fn test_limiter_router() -> Result {
-        // tracing_subscriber::fmt::try_init().ok();
-        let e1 = Endpoint::bind(presets::Minimal).await?;
-        // deny all access
-        let proto = AccessLimit::new(Echo, |_endpoint_id| false);
-        let r1 = Router::builder(e1.clone()).accept(ECHO_ALPN, proto).spawn();
-
-        let addr1 = r1.endpoint().addr();
-        dbg!(&addr1);
-        let e2 = Endpoint::bind(presets::Minimal).await?;
-
-        println!("connecting");
-        let conn = e2.connect(addr1, ECHO_ALPN).await?;
-
-        let (_send, mut recv) = conn.open_bi().await.anyerr()?;
-        let response = recv.read_to_end(1000).await.unwrap_err();
-        assert!(format!("{response:#?}").contains("not allowed"));
-
-        r1.shutdown().await.anyerr()?;
-        e2.close().await;
-
-        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Remove AccessLimit and associated tests. It lives in the new iroh-util crate now.

## Breaking Changes

`iroh::protocol::AccessLimit`: removed, moved to iroh-util crate

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
