### PR TITLE
refactor: Prefer release assert for locations where a bounds check follows

### DIFF
--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -558,8 +558,8 @@ impl Socket {
         metas: &mut [noq_udp::RecvMeta],
         source_addrs: &[transports::Addr],
     ) {
-        debug_assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
-        debug_assert_eq!(
+        assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
+        assert_eq!(
             bufs.len(),
             source_addrs.len(),
             "non matching bufs & source_addrs"

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -248,8 +248,8 @@ impl Transports {
         metas: &mut [noq_udp::RecvMeta],
         sock: &Socket,
     ) -> Poll<io::Result<usize>> {
-        debug_assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
-        debug_assert!(bufs.len() <= noq_udp::BATCH_SIZE, "too many buffers");
+        assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
+        assert!(bufs.len() <= noq_udp::BATCH_SIZE, "too many buffers");
         if sock.is_closing() {
             return Poll::Pending;
         }
@@ -270,7 +270,7 @@ impl Transports {
         bufs: &mut [IoSliceMut<'_>],
         metas: &mut [noq_udp::RecvMeta],
     ) -> Poll<io::Result<usize>> {
-        debug_assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
+        assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
 
         macro_rules! poll_transport {
             ($socket:expr) => {

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -159,7 +159,7 @@ impl RelayTransport {
 
         // If we have any msgs to report, they are in the first `num_msgs_total` slots
         if num_msgs > 0 {
-            debug_assert!(num_msgs <= metas.len());
+            assert!(num_msgs <= metas.len());
             Poll::Ready(Ok(num_msgs))
         } else {
             Poll::Pending

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -267,8 +267,8 @@ impl CustomEndpoint for TestTransport {
         source_addrs: &mut [Addr],
     ) -> Poll<io::Result<usize>> {
         let n = bufs.len();
-        debug_assert_eq!(n, metas.len());
-        debug_assert_eq!(n, source_addrs.len());
+        assert_eq!(n, metas.len(), "non matching bufs & metas");
+        assert_eq!(n, source_addrs.len(), "non matching bufs & source_addrs");
         if n == 0 {
             return Poll::Ready(Ok(0));
         }


### PR DESCRIPTION
## Description

Prefer release assert for locations where a bounds check follows. The compiler has to insert a bounds check in release mode for the array access if the bounds check is not present, so there is no runtime cost for this.

Also it gives better panic messages in case of a buggy noq_udp UDP socket impl or a very broken custom transport impl.

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
