### PR TITLE
refactor(iroh): express IPv6 ULA constants in hex

### DIFF
--- a/iroh/src/socket/mapped_addrs.rs
+++ b/iroh/src/socket/mapped_addrs.rs
@@ -20,16 +20,16 @@ use tracing::trace;
 const ADDR_PREFIXL: u8 = 0xfd;
 
 /// The Global ID used in n0's Unique Local Addresses.
-const ADDR_GLOBAL_ID: [u8; 5] = [21, 7, 10, 81, 11];
+const ADDR_GLOBAL_ID: [u8; 5] = [0x15, 0x07, 0x0a, 0x51, 0x0b];
 
-/// The Subnet ID for [`RelayMappedAddr].
-const RELAY_MAPPED_SUBNET: [u8; 2] = [0, 1];
+/// The Subnet ID for [`RelayMappedAddr]: fd15:70a:510b:1::/64.
+const RELAY_MAPPED_SUBNET: [u8; 2] = [0x00, 0x01];
 
-/// The Subnet ID for [`CustomMappedAddr`].
-const CUSTOM_MAPPED_SUBNET: [u8; 2] = [0, 3];
+/// The Subnet ID for [`CustomMappedAddr`]: fd15:70a:510b:3::/64.
+const CUSTOM_MAPPED_SUBNET: [u8; 2] = [0x00, 0x03];
 
-/// The Subnet ID for [`EndpointIdMappedAddr`].
-const ENDPOINT_ID_SUBNET: [u8; 2] = [0; 2];
+/// The Subnet ID for [`EndpointIdMappedAddr`]: fd15:70a:510b::/64.
+const ENDPOINT_ID_SUBNET: [u8; 2] = [0x00, 0x00];
 
 /// A default fake addr, using the maximum addr that the internal fake addrs could be using.
 pub(crate) const DEFAULT_FAKE_ADDR: SocketAddrV6 = SocketAddrV6::new(


### PR DESCRIPTION
## Description

We see those as hex in the logs because that is how you display an
IPv6 address. So write them in hex, it's easier to recognise things
that way.

## Breaking Changes

none

## Notes & open questions

Please double check I didn't make any mistakes converting decimal to hex.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.