### PR TITLE
refactor(iroh)!: Make `Source` private and trim its variants

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -39,8 +39,8 @@ use self::hooks::EndpointHooksList;
 pub use super::socket::{
     BindError, DirectAddr, DirectAddrType,
     remote_map::{
-        PathInfo, PathInfoList, PathInfoListIter, PathWatcher, RemoteInfo, Source,
-        TransportAddrInfo, TransportAddrUsage,
+        PathInfo, PathInfoList, PathInfoListIter, PathWatcher, RemoteInfo, TransportAddrInfo,
+        TransportAddrUsage,
     },
 };
 #[cfg(wasm_browser)]

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::BTreeSet,
     hash::Hash,
-    net::{IpAddr, SocketAddr},
     sync::Arc,
     task::{Context, Poll, Waker, ready},
 };
@@ -328,11 +327,8 @@ impl Tasks {
 #[derive(Serialize, Deserialize, strum::Display, Debug, Clone, Eq, PartialEq, Hash)]
 #[strum(serialize_all = "kebab-case")]
 #[allow(private_interfaces)]
-pub enum Source {
-    /// An endpoint communicated with us first via UDP.
-    Udp,
-    /// An endpoint communicated with us first via relay.
-    Relay,
+#[non_exhaustive]
+pub(crate) enum Source {
     /// Application layer added the address directly.
     App,
     /// The address was discovered by an Address Lookup system
@@ -341,69 +337,6 @@ pub enum Source {
         /// The name of the Address Lookup that discovered the address.
         name: String,
     },
-    /// Application layer with a specific name added the endpoint directly.
-    #[strum(serialize = "{name}")]
-    NamedApp {
-        /// The name of the application that added the endpoint
-        name: String,
-    },
-    /// The address was advertised by a call-me-maybe DISCO message.
-    #[strum(serialize = "CallMeMaybe")]
-    CallMeMaybe {
-        /// private marker
-        _0: Private,
-    },
-    /// We received a ping on the path.
-    #[strum(serialize = "Ping")]
-    Ping {
-        /// private marker
-        _0: Private,
-    },
-    /// We established a connection on this address.
-    #[strum(serialize = "Connection")]
-    Connection {
-        /// private marker
-        _0: Private,
-    },
-}
-
-/// Helper to ensure certain `Source` variants can not be constructed externally.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq, Hash)]
-struct Private;
-
-/// An (Ip, Port) pair.
-///
-/// NOTE: storing an [`IpPort`] is safer than storing a [`SocketAddr`] because for IPv6 socket
-/// addresses include fields that can't be assumed consistent even within a single connection.
-#[derive(Debug, derive_more::Display, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[display("{}", SocketAddr::from(*self))]
-pub struct IpPort {
-    ip: IpAddr,
-    port: u16,
-}
-
-impl From<SocketAddr> for IpPort {
-    fn from(socket_addr: SocketAddr) -> Self {
-        Self {
-            ip: socket_addr.ip(),
-            port: socket_addr.port(),
-        }
-    }
-}
-
-impl From<IpPort> for SocketAddr {
-    fn from(ip_port: IpPort) -> Self {
-        let IpPort { ip, port } = ip_port;
-        (ip, port).into()
-    }
-}
-
-impl IpPort {
-    pub fn ip(&self) -> &IpAddr {
-        &self.ip
-    }
-
-    pub fn port(&self) -> u16 {
-        self.port
-    }
+    /// The address was added as a path within a connection.
+    Connection,
 }

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -35,7 +35,7 @@ use crate::{
     socket::{
         Metrics as SocketMetrics, RELAY_PATH_MAX_IDLE_TIMEOUT,
         mapped_addrs::{AddrMap, CustomMappedAddr, MappedAddr, RelayMappedAddr},
-        remote_map::{Private, to_transport_addr},
+        remote_map::to_transport_addr,
         transports::{self, OwnedTransmit, PathSelectionData, TransportBiasMap, TransportsSender},
     },
     util::MaybeFuture,
@@ -487,7 +487,7 @@ impl RemoteStateActor {
                 Self::configure_path(&path, &path_remote);
                 conn_state.add_open_path(path_remote.clone(), PathId::ZERO, &self.metrics);
                 self.paths
-                    .insert_open_path(path_remote.clone(), Source::Connection { _0: Private });
+                    .insert_open_path(path_remote.clone(), Source::Connection);
                 self.select_path();
 
                 if path_remote.is_ip() {
@@ -931,7 +931,7 @@ impl RemoteStateActor {
                     Self::configure_path(&path, &path_remote);
                     conn_state.add_open_path(path_remote.clone(), path_id, &self.metrics);
                     self.paths
-                        .insert_open_path(path_remote.clone(), Source::Connection { _0: Private });
+                        .insert_open_path(path_remote.clone(), Source::Connection);
                 }
 
                 self.select_path();

--- a/iroh/src/socket/remote_map/remote_state/path_state.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_state.rs
@@ -552,7 +552,7 @@ mod tests {
     fn test_insert_open_path() {
         let mut state = RemotePathState::new(Default::default());
         let addr = ip_addr(1000);
-        let source = Source::Udp;
+        let source = Source::Connection;
 
         assert!(state.is_empty());
 
@@ -573,7 +573,7 @@ mod tests {
 
         // Test: Open goes to Inactive
         let addr_open = ip_addr(1000);
-        state.insert_open_path(addr_open.clone(), Source::Udp);
+        state.insert_open_path(addr_open.clone(), Source::Connection);
         assert!(matches!(state.paths[&addr_open].status, PathStatus::Open));
         assert_eq!(metrics.transport_ip_paths_added.get(), 1);
 
@@ -596,7 +596,7 @@ mod tests {
 
         // Test: Unknown goes to Unusable
         let addr_unknown = ip_addr(2000);
-        state.insert_multiple([addr_unknown.clone()].into_iter(), Source::Relay);
+        state.insert_multiple([addr_unknown.clone()].into_iter(), Source::Connection);
         assert!(matches!(
             state.paths[&addr_unknown].status,
             PathStatus::Unknown
@@ -622,7 +622,7 @@ mod tests {
         assert_eq!(metrics.transport_ip_paths_removed.get(), 1);
 
         // Test: Unusable can go to open
-        state.insert_open_path(addr_unknown.clone(), Source::Udp);
+        state.insert_open_path(addr_unknown.clone(), Source::Connection);
         assert!(matches!(
             state.paths[&addr_unknown].status,
             PathStatus::Open


### PR DESCRIPTION
## Description

`iroh::endpoint::Source` wasn't used in any public API anymore, so this makes the enum `pub(crate)`. We also had many unused variants, those are removed. The `_0: Private` marker is removed as well now that the enum is not public anymore.

Also removes the `IpPort` type from `socket::remote_map`, which was `pub` but neither re-exported nor used anywhere.

## Breaking changes

- removed: `iroh::endpoint::Source`. The type is now `pub(crate)` in `iroh::socket::remote_map` and is not part of the public API.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.

