### PR TITLE
refactor(iroh)!: Improve feature-gating for `unstable-custom-transports`

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -769,7 +769,7 @@ impl Builder {
 
     /// Sets the transport bias for a specific address kind.  Test-only: used by
     /// in-crate tests to set up deterministic path-selection scenarios.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "unstable-custom-transports"))]
     pub(crate) fn transport_bias(
         mut self,
         kind: socket::transports::AddrKind,

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -27,12 +27,12 @@ use tracing::{Instrument, Span, debug, event, info_span, instrument, warn};
 use url::Url;
 
 /// Types for defining custom transports
+#[cfg(feature = "unstable-custom-transports")]
 pub mod transports {
-    #[cfg(feature = "unstable-custom-transports")]
-    pub use super::socket::transports::RecvInfo;
-    #[cfg(feature = "unstable-custom-transports")]
-    pub use super::socket::transports::custom::{CustomEndpoint, CustomSender, CustomTransport};
-    pub use super::socket::transports::{Addr, AddrKind, Transmit, TransportBias};
+    pub use super::socket::transports::{
+        Addr, RecvInfo, Transmit,
+        custom::{CustomEndpoint, CustomSender, CustomTransport},
+    };
 }
 
 use self::hooks::EndpointHooksList;
@@ -42,7 +42,9 @@ pub use super::socket::{
         PathInfo, PathInfoList, PathInfoListIter, PathWatcher, RemoteInfo, Source,
         TransportAddrInfo, TransportAddrUsage,
     },
+    transports::{AddrKind, TransportBias},
 };
+
 #[cfg(wasm_browser)]
 use crate::address_lookup::PkarrResolver;
 #[cfg(not(wasm_browser))]
@@ -787,11 +789,7 @@ impl Builder {
     ///     .bind()
     ///     .await?;
     /// ```
-    pub fn transport_bias(
-        mut self,
-        kind: transports::AddrKind,
-        bias: transports::TransportBias,
-    ) -> Self {
+    pub fn transport_bias(mut self, kind: AddrKind, bias: TransportBias) -> Self {
         self.transport_bias = self.transport_bias.with_bias(kind, bias);
         self
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -43,7 +43,6 @@ pub use super::socket::{
         TransportAddrInfo, TransportAddrUsage,
     },
 };
-
 #[cfg(wasm_browser)]
 use crate::address_lookup::PkarrResolver;
 #[cfg(not(wasm_browser))]

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -30,7 +30,7 @@ use url::Url;
 #[cfg(feature = "unstable-custom-transports")]
 pub mod transports {
     pub use super::socket::transports::{
-        Addr, RecvInfo, Transmit,
+        Addr, AddrKind, RecvInfo, Transmit, TransportBias,
         custom::{CustomEndpoint, CustomSender, CustomTransport},
     };
 }
@@ -42,7 +42,6 @@ pub use super::socket::{
         PathInfo, PathInfoList, PathInfoListIter, PathWatcher, RemoteInfo, Source,
         TransportAddrInfo, TransportAddrUsage,
     },
-    transports::{AddrKind, TransportBias},
 };
 
 #[cfg(wasm_browser)]
@@ -789,7 +788,12 @@ impl Builder {
     ///     .bind()
     ///     .await?;
     /// ```
-    pub fn transport_bias(mut self, kind: AddrKind, bias: TransportBias) -> Self {
+    #[cfg(feature = "unstable-custom-transports")]
+    pub fn transport_bias(
+        mut self,
+        kind: transports::AddrKind,
+        bias: transports::TransportBias,
+    ) -> Self {
         self.transport_bias = self.transport_bias.with_bias(kind, bias);
         self
     }

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -739,7 +739,7 @@ impl TransportType {
 /// ```
 /// use std::time::Duration;
 ///
-/// use iroh::endpoint::transports::TransportBias;
+/// use iroh::endpoint::TransportBias;
 ///
 /// // A primary transport with 100ms RTT advantage (will be preferred)
 /// let bias = TransportBias::primary().with_rtt_advantage(Duration::from_millis(100));

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -755,7 +755,7 @@ impl TransportBias {
     }
 
     /// Adds an RTT disadvantage to this transport, making it less preferred.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "unstable-custom-transports"))]
     pub(crate) fn with_rtt_disadvantage(mut self, disadvantage: Duration) -> Self {
         self.rtt_bias += disadvantage.as_nanos() as i128;
         self
@@ -791,7 +791,7 @@ impl Default for TransportBiasMap {
 
 impl TransportBiasMap {
     /// Returns a new map with the given bias added or updated.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "unstable-custom-transports"))]
     pub(crate) fn with_bias(self, kind: AddrKind, bias: TransportBias) -> Self {
         let mut map = (*self.map).clone();
         map.insert(kind, bias);

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -738,6 +738,7 @@ impl TransportType {
 /// # Examples
 ///
 /// ```
+/// # #[cfg(feature = "unstable-custom-transports")] {
 /// use std::time::Duration;
 ///
 /// use iroh::endpoint::transports::TransportBias;
@@ -747,6 +748,7 @@ impl TransportType {
 ///
 /// // A primary transport with 50ms RTT disadvantage (will be less preferred)
 /// let bias = TransportBias::primary().with_rtt_disadvantage(Duration::from_millis(50));
+/// # }
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -691,6 +691,7 @@ impl Addr {
 
 /// The kind of a transport address, used for configuring bias.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
 pub enum AddrKind {
     /// An IPv4 address.
     IpV4,
@@ -739,7 +740,7 @@ impl TransportType {
 /// ```
 /// use std::time::Duration;
 ///
-/// use iroh::endpoint::TransportBias;
+/// use iroh::endpoint::transports::TransportBias;
 ///
 /// // A primary transport with 100ms RTT advantage (will be preferred)
 /// let bias = TransportBias::primary().with_rtt_advantage(Duration::from_millis(100));
@@ -748,6 +749,7 @@ impl TransportType {
 /// let bias = TransportBias::primary().with_rtt_disadvantage(Duration::from_millis(50));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
 pub struct TransportBias {
     /// Whether this is a primary or backup transport.
     pub(crate) transport_type: TransportType,
@@ -755,6 +757,7 @@ pub struct TransportBias {
     pub(crate) rtt_bias: i128,
 }
 
+#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
 impl TransportBias {
     /// Creates a primary transport bias with no RTT advantage.
     ///
@@ -791,6 +794,7 @@ impl TransportBias {
     /// The disadvantage is added to the measured RTT during path selection,
     /// so a transport with a 100ms disadvantage will be avoided in favor of
     /// one with the same measured RTT but no disadvantage.
+    #[cfg_attr(not(feature = "unstable-custom-transports"), allow(dead_code))]
     pub fn with_rtt_disadvantage(mut self, disadvantage: Duration) -> Self {
         self.rtt_bias += disadvantage.as_nanos() as i128;
         self
@@ -826,6 +830,7 @@ impl Default for TransportBiasMap {
 
 impl TransportBiasMap {
     /// Returns a new map with the given bias added or updated.
+    #[cfg_attr(not(feature = "unstable-custom-transports"), allow(dead_code))]
     pub(crate) fn with_bias(self, kind: AddrKind, bias: TransportBias) -> Self {
         let mut map = (*self.map).clone();
         map.insert(kind, bias);

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -494,6 +494,7 @@ impl NetworkChangeSender {
 
 /// An outgoing packet
 #[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
 pub struct Transmit<'a> {
     pub(crate) ecn: Option<noq_udp::EcnCodepoint>,
     /// Packet contents

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -329,7 +329,10 @@ mod tests {
     use super::*;
     use crate::{
         Endpoint, EndpointAddr, RelayMode, SecretKey, TransportAddr,
-        endpoint::{AddrKind, Builder, Connection, TransportBias, presets},
+        endpoint::{
+            Builder, Connection, presets,
+            transports::{AddrKind, TransportBias},
+        },
         protocol::{AcceptError, ProtocolHandler, Router},
         test_utils::run_relay_server,
     };

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -329,10 +329,7 @@ mod tests {
     use super::*;
     use crate::{
         Endpoint, EndpointAddr, RelayMode, SecretKey, TransportAddr,
-        endpoint::{
-            Builder, Connection, presets,
-            transports::{AddrKind, TransportBias},
-        },
+        endpoint::{AddrKind, Builder, Connection, TransportBias, presets},
         protocol::{AcceptError, ProtocolHandler, Router},
         test_utils::run_relay_server,
     };


### PR DESCRIPTION
## Description

Makes the `iroh::endpoint::transports` module gated behind the `custom-transports` feature.

## Breaking Changes

- changed: `iroh::endpoint::transports` is now gated on the `unstable-custom-transports` feature

## Change checklist

- [x] Self-review.
- [x] All breaking changes documented.
