### PR TITLE
refactor(iroh): adapt for noq::Closed return type of Connection::closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "0.18.0"
-source = "git+https://github.com/n0-computer/noq?branch=Frando%2Fpath-stats-on-close#e07aac8eb4b4b25b77a77c048baa15c8b17987c2"
+source = "git+https://github.com/n0-computer/noq?branch=main#3fc2e28f9e82719a4a425aa33053b34e6842eca9"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "0.17.0"
-source = "git+https://github.com/n0-computer/noq?branch=Frando%2Fpath-stats-on-close#e07aac8eb4b4b25b77a77c048baa15c8b17987c2"
+source = "git+https://github.com/n0-computer/noq?branch=main#3fc2e28f9e82719a4a425aa33053b34e6842eca9"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3235,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "0.10.0"
-source = "git+https://github.com/n0-computer/noq?branch=Frando%2Fpath-stats-on-close#e07aac8eb4b4b25b77a77c048baa15c8b17987c2"
+source = "git+https://github.com/n0-computer/noq?branch=main#3fc2e28f9e82719a4a425aa33053b34e6842eca9"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3259,7 +3259,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4255,7 +4255,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4348,7 +4348,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4369,7 +4369,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4474,7 +4474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4732,7 +4732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4957,7 +4957,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5857,7 +5857,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "0.18.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#9e1f1ad77911fb0c8795d171c26d326c481dce3d"
+source = "git+https://github.com/n0-computer/noq?branch=Frando%2Fpath-stats-on-close#e07aac8eb4b4b25b77a77c048baa15c8b17987c2"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "0.17.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#9e1f1ad77911fb0c8795d171c26d326c481dce3d"
+source = "git+https://github.com/n0-computer/noq?branch=Frando%2Fpath-stats-on-close#e07aac8eb4b4b25b77a77c048baa15c8b17987c2"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3235,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "0.10.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#9e1f1ad77911fb0c8795d171c26d326c481dce3d"
+source = "git+https://github.com/n0-computer/noq?branch=Frando%2Fpath-stats-on-close#e07aac8eb4b4b25b77a77c048baa15c8b17987c2"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3259,7 +3259,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4255,7 +4255,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4348,7 +4348,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4369,7 +4369,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4474,7 +4474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4732,7 +4732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4957,7 +4957,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5857,7 +5857,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 unused-async = "warn"
 
 [patch.crates-io]
-noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
-noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
-noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }
+noq = { git = "https://github.com/n0-computer/noq", branch = "Frando/path-stats-on-close" }
+noq-udp = { git = "https://github.com/n0-computer/noq", branch = "Frando/path-stats-on-close" }
+noq-proto = { git = "https://github.com/n0-computer/noq", branch = "Frando/path-stats-on-close" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 unused-async = "warn"
 
 [patch.crates-io]
-noq = { git = "https://github.com/n0-computer/noq", branch = "Frando/path-stats-on-close" }
-noq-udp = { git = "https://github.com/n0-computer/noq", branch = "Frando/path-stats-on-close" }
-noq-proto = { git = "https://github.com/n0-computer/noq", branch = "Frando/path-stats-on-close" }
+noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
+noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
+noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }

--- a/iroh/examples/monitor-connections.rs
+++ b/iroh/examples/monitor-connections.rs
@@ -2,7 +2,9 @@ use std::{sync::Arc, time::Duration};
 
 use iroh::{
     Endpoint, Watcher,
-    endpoint::{AfterHandshakeOutcome, Connection, EndpointHooks, WeakConnectionHandle, presets},
+    endpoint::{
+        AfterHandshakeOutcome, Closed, Connection, EndpointHooks, WeakConnectionHandle, presets,
+    },
 };
 use n0_error::{Result, StackResultExt, StdResultExt, ensure_any};
 use n0_future::task::AbortOnDropHandle;
@@ -135,9 +137,9 @@ impl Monitor {
                     info!(%remote, %alpn, ?rtt, "new connection");
                     tasks.spawn(async move {
                         match handle.closed().await {
-                            Some((close_reason, stats)) => {
+                            Some(Closed { reason, stats, .. }) => {
                                 // We have access to the final stats of the connection!
-                                info!(%remote, %alpn, ?close_reason, udp_rx=stats.udp_rx.bytes, udp_tx=stats.udp_tx.bytes, "connection closed");
+                                info!(%remote, %alpn, ?reason, udp_rx=stats.udp_rx.bytes, udp_tx=stats.udp_tx.bytes, "connection closed");
                             }
                             None => {
                                 // The connection was closed before we could register our stats-on-close listener.

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -86,7 +86,7 @@ pub use self::{
         RemoteEndpointIdError, RetryError, WeakConnectionHandle, ZeroRttStatus,
     },
     quic::{
-        AcceptBi, AcceptUni, AckFrequencyConfig, ApplicationClose, Chunk, ClosedStream,
+        AcceptBi, AcceptUni, AckFrequencyConfig, ApplicationClose, Chunk, Closed, ClosedStream,
         ConnectionClose, ConnectionError, ConnectionStats, Controller, ControllerFactory,
         ControllerMetrics, CryptoError, DecryptedInitial, Dir, ExportKeyingMaterialError,
         FrameStats, FrameType, HandshakeTokenKey, HeaderKey, IdleTimeout, IncomingAlpns, Keys,

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -40,7 +40,7 @@ use crate::{
     endpoint::{
         AfterHandshakeOutcome,
         quic::{
-            AcceptBi, AcceptUni, ConnectionError, ConnectionStats, Controller,
+            AcceptBi, AcceptUni, Closed, ConnectionError, ConnectionStats, Controller,
             ExportKeyingMaterialError, OpenBi, OpenUni, PathId, ReadDatagram, SendDatagram,
             SendDatagramError, ServerConfig, Side, VarInt,
         },
@@ -1269,9 +1269,7 @@ impl WeakConnectionHandle {
     /// references are dropped before the future is awaited.
     ///
     /// The future does not keep the connection alive.
-    pub fn closed(
-        &self,
-    ) -> impl Future<Output = Option<(ConnectionError, ConnectionStats)>> + Send + 'static {
+    pub fn closed(&self) -> impl Future<Output = Option<Closed>> + Send + 'static {
         let registered = self.inner.upgrade().map(|conn| conn.on_closed());
         async move {
             match registered {

--- a/iroh/src/endpoint/quic.rs
+++ b/iroh/src/endpoint/quic.rs
@@ -16,6 +16,7 @@ pub use noq::{
     AcceptBi,             // iroh::endpoint::Connection
     AcceptUni,            // iroh::endpoint::Connection
     AckFrequencyConfig,   // iroh::endpoint::quic::QuicTransportConfig
+    Closed,               // iroh::endpoint::WeakConnectionHandle
     ClosedStream,         // iroh::protocol::AcceptError, noq::RecvStream, noq::SendStream
     ConnectionError,      // iroh::endpoint::ConnectError
     ConnectionStats,      // iroh::endpoint::Connection

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -1337,8 +1337,8 @@ impl Future for OnClosed {
     type Output = (ConnId, ConnectionError);
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let (close_reason, _stats) = std::task::ready!(Pin::new(&mut self.inner).poll(cx));
-        Poll::Ready((self.conn_id, close_reason))
+        let closed = std::task::ready!(Pin::new(&mut self.inner).poll(cx));
+        Poll::Ready((self.conn_id, closed.reason))
     }
 }
 


### PR DESCRIPTION
## Description

Updates `noq` and adapts iroh to the changes in  https://github.com/n0-computer/noq/pull/617  by reexporting `noq::Closed`.

## Breaking Changes

* changed: The `OnClosed` future returned from `iroh::endpoint::WeakConnectionHandle::closed` now resolves to `iroh::endpoint::Closed`, a struct with public fields for the close reason, connection stats, and path stats.

## Notes & open questions

It would be nice to have the `TransportAddr` available for the path stats, but we don't have that info available for paths that were already closed earlier. Use the new APIs in #4188 instead if this needed.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.