### PR TITLE
refactor: Remove obsolete fn transport_bias from endpoint builder.

### DIFF
--- a/iroh/examples/custom-transport.rs
+++ b/iroh/examples/custom-transport.rs
@@ -3,10 +3,7 @@ use std::{sync::Arc, time::Duration};
 use clap::Parser;
 use iroh::{
     Endpoint, SecretKey, TransportAddr,
-    endpoint::{
-        Builder, Connection, presets,
-        transports::{AddrKind, TransportBias},
-    },
+    endpoint::{Builder, Connection, presets},
     protocol::{AcceptError, ProtocolHandler, Router},
     test_utils::test_transport::{TEST_TRANSPORT_ID, TestNetwork, TestTransport},
 };
@@ -35,20 +32,12 @@ struct Args {
     delay: u64,
 }
 
-/// Strong RTT advantage for the custom transport (100ms) to ensure it wins path selection.
-const CUSTOM_TRANSPORT_RTT_ADVANTAGE: Duration = Duration::from_millis(100);
-
 impl Args {
     /// Configure an endpoint builder with the custom transport and optional IP/relay transports.
     fn configure(&self, secret_key: SecretKey, transport: Arc<TestTransport>) -> Builder {
         let mut builder = Endpoint::builder(presets::N0)
             .secret_key(secret_key)
-            .preset(transport)
-            // Give the custom transport a strong RTT advantage so it always wins path selection
-            .transport_bias(
-                AddrKind::Custom(TEST_TRANSPORT_ID),
-                TransportBias::primary().with_rtt_advantage(CUSTOM_TRANSPORT_RTT_ADVANTAGE),
-            );
+            .preset(transport);
         if !self.keep_ip {
             builder = builder.clear_ip_transports();
         }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -32,7 +32,7 @@ pub mod transports {
     pub use super::socket::transports::RecvInfo;
     #[cfg(feature = "unstable-custom-transports")]
     pub use super::socket::transports::custom::{CustomEndpoint, CustomSender, CustomTransport};
-    pub use super::socket::transports::{Addr, AddrKind, Transmit, TransportBias};
+    pub use super::socket::transports::{Addr, AddrKind, Transmit};
 }
 
 use self::hooks::EndpointHooksList;
@@ -767,30 +767,13 @@ impl Builder {
         self
     }
 
-    /// Sets the transport bias for a specific address kind.
-    ///
-    /// Transport bias controls how different transport types are prioritized during
-    /// path selection. By default:
-    /// - IPv4 and IPv6 are primary transports (IPv6 has a small RTT advantage)
-    /// - Relay is a backup transport (only used when no primary transport is available)
-    ///
-    /// Use this to customize the behavior, for example to add bias for custom transports.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// use std::time::Duration;
-    /// use iroh::endpoint::{Builder, transports::{AddrKind, TransportBias}};
-    ///
-    /// let endpoint = Builder::new(SomePreset)
-    ///     .transport_bias(AddrKind::Custom(42), TransportBias::primary().with_rtt_advantage(Duration::from_millis(10)))
-    ///     .bind()
-    ///     .await?;
-    /// ```
-    pub fn transport_bias(
+    /// Sets the transport bias for a specific address kind.  Test-only: used by
+    /// in-crate tests to set up deterministic path-selection scenarios.
+    #[cfg(all(test, feature = "unstable-custom-transports"))]
+    pub(crate) fn transport_bias(
         mut self,
-        kind: transports::AddrKind,
-        bias: transports::TransportBias,
+        kind: socket::transports::AddrKind,
+        bias: socket::transports::TransportBias,
     ) -> Self {
         self.transport_bias = self.transport_bias.with_bias(kind, bias);
         self

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -732,22 +732,8 @@ impl TransportType {
 /// Bias configuration for a transport type.
 ///
 /// This controls how a transport is prioritized during path selection.
-///
-/// # Examples
-///
-/// ```
-/// use std::time::Duration;
-///
-/// use iroh::endpoint::transports::TransportBias;
-///
-/// // A primary transport with 100ms RTT advantage (will be preferred)
-/// let bias = TransportBias::primary().with_rtt_advantage(Duration::from_millis(100));
-///
-/// // A primary transport with 50ms RTT disadvantage (will be less preferred)
-/// let bias = TransportBias::primary().with_rtt_disadvantage(Duration::from_millis(50));
-/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TransportBias {
+pub(crate) struct TransportBias {
     /// Whether this is a primary or backup transport.
     pub(crate) transport_type: TransportType,
     /// RTT bias in nanoseconds. Negative values make this transport more preferred.
@@ -756,9 +742,7 @@ pub struct TransportBias {
 
 impl TransportBias {
     /// Creates a primary transport bias with no RTT advantage.
-    ///
-    /// Primary transports compete with each other based on biased RTT measurements.
-    pub fn primary() -> Self {
+    pub(crate) fn primary() -> Self {
         Self {
             transport_type: TransportType::Primary,
             rtt_bias: 0,
@@ -766,8 +750,6 @@ impl TransportBias {
     }
 
     /// Creates a backup transport bias with no RTT advantage.
-    ///
-    /// Backup transports are only used when no primary transport is available.
     pub(crate) fn backup() -> Self {
         Self {
             transport_type: TransportType::Backup,
@@ -776,21 +758,14 @@ impl TransportBias {
     }
 
     /// Adds an RTT advantage to this transport, making it more preferred.
-    ///
-    /// The advantage is subtracted from the measured RTT during path selection,
-    /// so a transport with a 100ms advantage will be preferred over one with
-    /// the same measured RTT but no advantage.
-    pub fn with_rtt_advantage(mut self, advantage: Duration) -> Self {
+    pub(crate) fn with_rtt_advantage(mut self, advantage: Duration) -> Self {
         self.rtt_bias -= advantage.as_nanos() as i128;
         self
     }
 
     /// Adds an RTT disadvantage to this transport, making it less preferred.
-    ///
-    /// The disadvantage is added to the measured RTT during path selection,
-    /// so a transport with a 100ms disadvantage will be avoided in favor of
-    /// one with the same measured RTT but no disadvantage.
-    pub fn with_rtt_disadvantage(mut self, disadvantage: Duration) -> Self {
+    #[cfg(all(test, feature = "unstable-custom-transports"))]
+    pub(crate) fn with_rtt_disadvantage(mut self, disadvantage: Duration) -> Self {
         self.rtt_bias += disadvantage.as_nanos() as i128;
         self
     }
@@ -825,6 +800,7 @@ impl Default for TransportBiasMap {
 
 impl TransportBiasMap {
     /// Returns a new map with the given bias added or updated.
+    #[cfg(all(test, feature = "unstable-custom-transports"))]
     pub(crate) fn with_bias(self, kind: AddrKind, bias: TransportBias) -> Self {
         let mut map = (*self.map).clone();
         map.insert(kind, bias);

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -329,11 +329,9 @@ mod tests {
     use super::*;
     use crate::{
         Endpoint, EndpointAddr, RelayMode, SecretKey, TransportAddr,
-        endpoint::{
-            Builder, Connection, presets,
-            transports::{AddrKind, TransportBias},
-        },
+        endpoint::{Builder, Connection, presets, transports::AddrKind},
         protocol::{AcceptError, ProtocolHandler, Router},
+        socket::transports::TransportBias,
         test_utils::run_relay_server,
     };
 


### PR DESCRIPTION
## Description

This is the part of https://github.com/n0-computer/iroh/pull/4232 that removes something from the non feature gated public API.

If (as seems likely) we won't get https://github.com/n0-computer/iroh/pull/4232 in for this release, this would prevent having to break the stable (non feature gated) public API when adding https://github.com/n0-computer/iroh/pull/4232 in the next release.

## Breaking Changes

Removes some public methods on the endpoint builder that are too opinionated if you want to make path selection fully generic:

endpoint::Builder::transport_bias: removed from the public api
endpoint::transports::TransportBias: removed from the public api

## Notes & open questions

Note: I did a quick check in all notable custom transports I am aware of:

n0-computer/iroh-tor-transport
n0-computer/iroh-nym-transport
mcginty/iroh-ble-transport

None of them does use transport_bias, not even in examples. Most of them just remove the ip transport. So this won't break any downstream crate I am aware of.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
