### PR TITLE
refactor(iroh)!: remove portmapper metrics from public API

### DIFF
--- a/external-types.toml
+++ b/external-types.toml
@@ -32,7 +32,6 @@ allowed_external_types = [
     "noq::*",
     "noq_proto::*",
     "noq_udp::*",
-    "portmapper::metrics::Metrics",
 
     # non-1.0 crates that we decided to accept in the public API
     "rustls::*",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -150,7 +150,7 @@ cfg_aliases = { version = "0.2.1" }
 [features]
 default = ["metrics", "fast-apple-datapath", "portmapper", "tls-ring"]
 portmapper = ["dep:portmapper"]
-metrics = ["iroh-metrics/metrics", "iroh-relay/metrics", "portmapper?/metrics"]
+metrics = ["iroh-metrics/metrics", "iroh-relay/metrics"]
 test-utils = ["iroh-relay/test-utils", "iroh-relay/server", "dep:axum"]
 # Enables fetching TLS trust anchors from the operating system
 platform-verifier = ["iroh-relay/platform-verifier"]

--- a/iroh/bench/src/bin/bulk.rs
+++ b/iroh/bench/src/bin/bulk.rs
@@ -95,7 +95,6 @@ pub fn run_iroh(opt: Opt) -> Result<()> {
         println!("\nMetrics:");
         collect_and_print("SocketMetrics", &*endpoint_metrics.socket);
         collect_and_print("NetReportMetrics", &*endpoint_metrics.net_report);
-        collect_and_print("PortmapMetrics", &*endpoint_metrics.portmapper);
         #[cfg(feature = "local-relay")]
         if let Some(relay_server) = relay_server.as_ref() {
             collect_and_print("RelayServerMetrics", &*relay_server.metrics().server);

--- a/iroh/src/metrics.rs
+++ b/iroh/src/metrics.rs
@@ -6,10 +6,7 @@ use iroh_metrics::MetricsGroupSet;
 pub use iroh_relay::server::Metrics as RelayMetrics;
 use serde::{Deserialize, Serialize};
 
-pub use crate::{
-    net_report::Metrics as NetReportMetrics, portmapper::Metrics as PortmapMetrics,
-    socket::Metrics as SocketMetrics,
-};
+pub use crate::{net_report::Metrics as NetReportMetrics, socket::Metrics as SocketMetrics};
 
 /// Metrics collected by an [`crate::endpoint::Endpoint`].
 ///
@@ -22,8 +19,6 @@ pub struct EndpointMetrics {
     pub socket: Arc<SocketMetrics>,
     /// Metrics collected by net reports.
     pub net_report: Arc<NetReportMetrics>,
-    /// Metrics collected by the portmapper service.
-    pub portmapper: Arc<PortmapMetrics>,
 }
 
 #[cfg(test)]

--- a/iroh/src/net_report/metrics.rs
+++ b/iroh/src/net_report/metrics.rs
@@ -10,4 +10,8 @@ pub struct Metrics {
     pub reports: Counter,
     /// Number of full reports executed by net_report
     pub reports_full: Counter,
+    /// Number of port mapping attempts.
+    pub portmap_attempts: Counter,
+    /// Number of times an external address was obtained via port mapping.
+    pub portmap_external_address_updated: Counter,
 }

--- a/iroh/src/portmapper.rs
+++ b/iroh/src/portmapper.rs
@@ -1,16 +1,11 @@
 //! Portmapper integration.
 //!
-//! Re-exports the real [`portmapper`] crate when the `portmapper` feature is enabled,
+//! Wraps the real [`portmapper`] crate when the `portmapper` feature is enabled,
 //! or provides a no-op stub otherwise.
 
 use std::net::SocketAddrV4;
 
-#[cfg(all(not(wasm_browser), feature = "portmapper"))]
-pub use ::portmapper::Metrics;
 use tokio::sync::watch;
-
-#[cfg(not(all(not(wasm_browser), feature = "portmapper")))]
-pub use self::stub::Metrics;
 
 /// Configuration for the portmapper service (UPnP, PCP, NAT-PMP).
 ///
@@ -33,18 +28,11 @@ impl Default for PortmapperConfig {
     }
 }
 
-pub(crate) fn create_client(
-    metrics: &crate::metrics::EndpointMetrics,
-    config: &PortmapperConfig,
-) -> Client {
+pub(crate) fn create_client(config: &PortmapperConfig) -> Client {
     match config {
         #[cfg(all(not(wasm_browser), feature = "portmapper"))]
-        PortmapperConfig::Enabled {} => Client::Enabled(::portmapper::Client::with_metrics(
-            Default::default(),
-            metrics.portmapper.clone(),
-        )),
+        PortmapperConfig::Enabled {} => Client::Enabled(::portmapper::Client::default()),
         _ => {
-            let _ = metrics;
             let (tx, rx) = watch::channel(None);
             Client::Disabled { _tx: tx, rx }
         }
@@ -98,39 +86,5 @@ impl Client {
             Client::Enabled(c) => c.watch_external_address(),
             Client::Disabled { rx, .. } => rx.clone(),
         }
-    }
-}
-
-#[cfg(not(all(not(wasm_browser), feature = "portmapper")))]
-mod stub {
-    use iroh_metrics::{Counter, MetricsGroup};
-    use serde::{Deserialize, Serialize};
-
-    /// Stub portmapper metrics used when the `portmapper` feature is disabled.
-    #[derive(Debug, Default, MetricsGroup, Serialize, Deserialize)]
-    #[metrics(name = "portmap")]
-    pub struct Metrics {
-        /// Number of probing tasks started.
-        pub probes_started: Counter,
-        /// Number of updates to the local port.
-        pub local_port_updates: Counter,
-        /// Number of mapping tasks started.
-        pub mapping_attempts: Counter,
-        /// Number of failed mapping tasks.
-        pub mapping_failures: Counter,
-        /// Number of times the external address obtained via port mapping was updated.
-        pub external_address_updated: Counter,
-        /// Number of UPnP probes executed.
-        pub upnp_probes: Counter,
-        /// Number of failed UPnP probes.
-        pub upnp_probes_failed: Counter,
-        /// Number of UPnP probes that found it available.
-        pub upnp_available: Counter,
-        /// Number of UPnP probes that resulted in a gateway different to the previous one.
-        pub upnp_gateway_updated: Counter,
-        /// Number of PCP probes executed.
-        pub pcp_probes: Counter,
-        /// Number of PCP probes that found it available.
-        pub pcp_available: Counter,
     }
 }

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -795,6 +795,7 @@ impl DirectAddrUpdateState {
             return;
         }
 
+        self.sock.metrics.net_report.portmap_attempts.inc();
         self.port_mapper.procure_mapping();
 
         debug!("requesting net_report report");
@@ -887,7 +888,7 @@ impl EndpointInner {
         } = opts;
 
         let address_lookup = address_lookup::AddressLookupServices::default();
-        let port_mapper = portmapper::create_client(&metrics, &portmapper_config);
+        let port_mapper = portmapper::create_client(&portmapper_config);
 
         let relay_transport_configs: Vec<_> = transport_configs
             .iter()
@@ -1578,6 +1579,9 @@ impl Actor {
                     trace!("tick: portmap changed");
                     self.sock.metrics.socket.actor_tick_portmap_changed.inc();
                     let new_external_address = *portmap_watcher.borrow();
+                    if new_external_address.is_some() {
+                        self.sock.metrics.net_report.portmap_external_address_updated.inc();
+                    }
                     debug!("external address updated: {new_external_address:?}");
                     self.re_stun(UpdateReason::PortmapUpdated);
                 },


### PR DESCRIPTION
## Description

Removes the `portmapper` crate from the public API of `iroh`. The `portmapper::Metrics` were re-exported as `iroh::metrics::PortmapMetrics` and held in `EndpointMetrics::portmapper`, which forced the `portmapper` crate into our public API and our `external-types.toml` allow-list.

In its place, `iroh::metrics::NetReportMetrics` gains two minimal counters: `portmap_attempts` and `portmap_external_address_updated`. These are incremented from the socket actor when a port mapping is requested and when the watcher reports a new external address. The internal `portmapper` module no longer takes an `EndpointMetrics` and constructs the underlying portmapper client with its default metrics.

The `metrics` feature no longer toggles the `portmapper/metrics` feature, since portmapper's own metrics are no longer exposed.

## Breaking changes

- removed: `iroh::metrics::PortmapMetrics` re-export.
- removed: `iroh::metrics::EndpointMetrics::portmapper` field.
- added: `iroh::metrics::NetReportMetrics::portmap_attempts` counter.
- added: `iroh::metrics::NetReportMetrics::portmap_external_address_updated` counter.
- changed: the `metrics` feature no longer enables `portmapper/metrics`.

## Change checklist

- [x] Self-review.
- [x] All breaking changes documented.