### PR TITLE
fix(iroh)!: remove noq Written reexport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1394,7 +1394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3208,7 +3208,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "0.18.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#3fc2e28f9e82719a4a425aa33053b34e6842eca9"
+source = "git+https://github.com/n0-computer/noq?branch=main#a0f988a91db325be0a2ce7e65536016af881951b"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3229,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "0.17.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#3fc2e28f9e82719a4a425aa33053b34e6842eca9"
+source = "git+https://github.com/n0-computer/noq?branch=main#a0f988a91db325be0a2ce7e65536016af881951b"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "0.10.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#3fc2e28f9e82719a4a425aa33053b34e6842eca9"
+source = "git+https://github.com/n0-computer/noq?branch=main#a0f988a91db325be0a2ce7e65536016af881951b"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3283,7 +3283,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4279,7 +4279,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4372,7 +4372,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4393,7 +4393,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4498,7 +4498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4767,7 +4767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4992,7 +4992,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5927,7 +5927,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -189,7 +189,7 @@ async fn drain_stream(
             Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
         ];
 
-        while let Some(n) = stream.read_chunks(&mut bufs[..]).await.anyerr()? {
+        while let Some(n) = stream.read_many_chunks(&mut bufs[..]).await.anyerr()? {
             if first_byte {
                 ttfb = download_start.elapsed();
                 first_byte = false;

--- a/iroh/bench/src/noq.rs
+++ b/iroh/bench/src/noq.rs
@@ -158,7 +158,7 @@ async fn drain_stream(
             Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
         ];
 
-        while let Some(n) = stream.read_chunks(&mut bufs[..]).await.anyerr()? {
+        while let Some(n) = stream.read_many_chunks(&mut bufs[..]).await.anyerr()? {
             if first_byte {
                 ttfb = download_start.elapsed();
                 first_byte = false;

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -841,7 +841,7 @@ async fn drain_stream(
     // These are 32 buffers, for reading approximately 32kB at once
     let mut bufs: [Bytes; 32] = std::array::from_fn(|_| Bytes::new());
 
-    while let Some(n) = recv.read_chunks(&mut bufs[..]).await.anyerr()? {
+    while let Some(n) = recv.read_many_chunks(&mut bufs[..]).await.anyerr()? {
         // Update time to first byte if still empty and started_at is set.
         if let (None, Some(started_at)) = (time_to_first_byte, started_at) {
             time_to_first_byte = Some(started_at.elapsed());
@@ -924,10 +924,8 @@ async fn write_chunk_timeout(
     while !bufs.is_empty() {
         tokio::select! {
             _ = &mut timeout => break,
-            res = send.write_chunks(bufs) => {
-                let written = res?;
-                total += written.bytes;
-                bufs = &mut bufs[written.chunks..]
+            written = send.write_many_chunks(&mut bufs) => {
+                total += written?;
             }
         }
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -96,7 +96,7 @@ pub use self::{
         SendStream, ServerConfig, ServerConfigBuilder, Side, StoppedError, StreamId, TimeSource,
         TokenLog, TokenReuseError, TransportError, TransportErrorCode, TransportParameters,
         UdpStats, UnorderedRecvStream, UnsupportedVersion, ValidationTokenConfig, VarInt,
-        VarIntBoundsExceeded, WriteError, Written,
+        VarIntBoundsExceeded, WriteError,
     },
 };
 pub use crate::portmapper::PortmapperConfig;

--- a/iroh/src/endpoint/quic.rs
+++ b/iroh/src/endpoint/quic.rs
@@ -42,7 +42,6 @@ pub use noq::{
     VarInt,               // various
     VarIntBoundsExceeded, // noq::VarInt, noq::IdleTimeout
     WriteError,           // noq::SendStream
-    Written,              // noq::SendStream
 };
 #[cfg(feature = "qlog")]
 pub use noq::{QlogConfig, QlogFactory, QlogFileFactory};

--- a/iroh/tests/integration.rs
+++ b/iroh/tests/integration.rs
@@ -69,8 +69,8 @@ async fn simple_endpoint_id_based_connection_transfer() -> Result {
                 let (mut send, mut recv) = conn.accept_bi().await.anyerr()?;
                 let mut bytes_sent = 0;
                 while let Some(chunk) = recv.read_chunk(10_000).await.anyerr()? {
-                    bytes_sent += chunk.bytes.len();
-                    send.write_chunk(chunk.bytes).await.anyerr()?;
+                    bytes_sent += chunk.len();
+                    send.write_chunk(chunk).await.anyerr()?;
                 }
                 send.finish().anyerr()?;
                 tracing::info!("Copied over {bytes_sent} byte(s)");


### PR DESCRIPTION
## Description

Remove Written noq reexport

This struct has been removed from the noq public API

## Breaking Changes

`iroh::endpoint::Written`: removed

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
