### PR TITLE
Gate wasm-incompatible optional deps and hyper-using error variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - maint-0.98
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -2,7 +2,7 @@ name: Commits
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, maint-0.98]
     types: [opened, edited, synchronize]
 
 env:

--- a/.github/workflows/netsim.yml
+++ b/.github/workflows/netsim.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - maint-0.98
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -92,7 +92,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
   MSRV: "1.66"
-  SCCACHE_GHA_ENABLED: "true"
+  # SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   IROH_FORCE_STAGING_RELAYS: "1"
 

--- a/.github/workflows/patchbay.yml
+++ b/.github/workflows/patchbay.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - maint-0.98
 
 concurrency:
   group: patchbay-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            name: [ubuntu-latest, ubuntu-arm-latest, macOS-latest, macOS-arm-latest, windows-latest]
+            name: [ubuntu-latest, ubuntu-musl-latest, ubuntu-arm-latest, ubuntu-arm-musl-latest, macOS-latest, macOS-arm-latest, windows-latest]
             rust: [stable]
             experimental: [false]
             include:
@@ -100,13 +100,29 @@ jobs:
                 os: ubuntu-latest
                 release-os: linux
                 release-arch: aarch64
+                libc: gnu
+                cargo_targets: "aarch64-unknown-linux-gnu"
+                runner: [self-hosted, linux, ARM64]
+              - name: ubuntu-arm-musl-latest
+                os: ubuntu-latest
+                release-os: linux
+                release-arch: aarch64
+                libc: musl
                 cargo_targets: "aarch64-unknown-linux-musl"
                 runner: [self-hosted, linux, ARM64]
               - name: ubuntu-latest
                 os: ubuntu-latest
                 release-os: linux
                 release-arch: amd64
+                libc: gnu
                 cargo_targets: "x86_64-unknown-linux-gnu"
+                runner: [self-hosted, linux, X64]
+              - name: ubuntu-musl-latest
+                os: ubuntu-latest
+                release-os: linux
+                release-arch: amd64
+                libc: musl
+                cargo_targets: "x86_64-unknown-linux-musl"
                 runner: [self-hosted, linux, X64]
               - name: macOS-latest
                 os: macOS-latest
@@ -218,7 +234,7 @@ jobs:
             curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o ~/awscli/AWSCLIV2.pkg
 
         - name: Install awscli (linux)
-          if: matrix.os == 'ubuntu-latest' || matrix.name == 'ubuntu-arm-latest'
+          if: matrix.os == 'ubuntu-latest'
           run: sudo ~/awscli/aws/install --update
 
         - name: Install awscli (mac)
@@ -233,13 +249,13 @@ jobs:
               echo "AWS_DEFAULT_REGION=us-west-2" >> $GITHUB_ENV
 
         - name: push release
-          if: matrix.os != 'windows-latest'
+          if: matrix.os != 'windows-latest' && matrix.libc != 'musl'
           run: |
             aws s3 cp ./target/${{ matrix.cargo_targets }}/optimized-release/iroh-relay s3://vorc/iroh-relay-${RELEASE_OS}-${RELEASE_ARCH}-${GITHUB_SHA::7} --no-progress
             aws s3 cp ./target/${{ matrix.cargo_targets }}/optimized-release/iroh-dns-server s3://vorc/iroh-dns-server-${RELEASE_OS}-${RELEASE_ARCH}-${GITHUB_SHA::7} --no-progress
 
         - name: push release latest
-          if: matrix.os != 'windows-latest' && (github.event.inputs.mark_latest == 'true' || github.event_name == 'push')
+          if: matrix.os != 'windows-latest' && matrix.libc != 'musl' && (github.event.inputs.mark_latest == 'true' || github.event_name == 'push')
           run: |
             aws s3 cp ./target/${{ matrix.cargo_targets }}/optimized-release/iroh-relay s3://vorc/iroh-relay-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
             aws s3 cp ./target/${{ matrix.cargo_targets }}/optimized-release/iroh-dns-server s3://vorc/iroh-dns-server-${RELEASE_OS}-${RELEASE_ARCH}-latest --no-progress
@@ -287,7 +303,7 @@ jobs:
           uses: actions/upload-artifact@v7
           if : matrix.os != 'windows-latest'
           with:
-            name: iroh-${{ matrix.release-os }}-${{ matrix.release-arch }}-bundle
+            name: iroh-${{ matrix.release-os }}-${{ matrix.release-arch }}${{ matrix.libc == 'musl' && '-musl' || '' }}-bundle
             path: iroh-*.tar.gz
             compression-level: 0
             retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
                 os: ubuntu-latest
                 release-os: linux
                 release-arch: amd64
-                cargo_targets: "x86_64-unknown-linux-musl"
+                cargo_targets: "x86_64-unknown-linux-gnu"
                 runner: [self-hosted, linux, X64]
               - name: macOS-latest
                 os: macOS-latest

--- a/.github/workflows/wine.yaml
+++ b/.github/workflows/wine.yaml
@@ -2,7 +2,7 @@ name: Wine Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, maint-0.98]
   pull_request:
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to iroh will be documented in this file.
 
+## [0.98.2](https://github.com/n0-computer/iroh/compare/v0.98.1..0.98.2) - 2026-04-28
+
+### 🐛 Bug Fixes
+
+- *(iroh)* Don't abort connection attempts when an empty `EndpointAddr` is added concurrently ([#4177](https://github.com/n0-computer/iroh/issues/4177)) - ([60f6f09](https://github.com/n0-computer/iroh/commit/60f6f092260557840b76b338ed7f85eb45b3db7b))
+- Protect against division by zero in process_datagram ([#4178](https://github.com/n0-computer/iroh/issues/4178)) - ([70cec3d](https://github.com/n0-computer/iroh/commit/70cec3deaa5b007a788243e90d8e3bbe1674edf2))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Fix sccache for netsim ([#4176](https://github.com/n0-computer/iroh/issues/4176)) - ([59e6363](https://github.com/n0-computer/iroh/commit/59e636340a3f75e39e2d5a16dc823975a87dd59c))
+- *(ci)* Fix musl/gnu build setup ([#4184](https://github.com/n0-computer/iroh/issues/4184)) - ([7fe7ffc](https://github.com/n0-computer/iroh/commit/7fe7ffcba53990ebedcee7f81ba289080d14ed14))
+- Enable ci on this branch - ([44b2336](https://github.com/n0-computer/iroh/commit/44b2336bd2d9362c09e2f52aa633db1292f808a5))
+- Fix release build targets ([#4146](https://github.com/n0-computer/iroh/issues/4146)) - ([18f6e2d](https://github.com/n0-computer/iroh/commit/18f6e2dbf80be88f023a40ba4722a94e5e0ea6d4))
+
+### Deps
+
+- Pin pkcs8 and der ([#4197](https://github.com/n0-computer/iroh/issues/4197)) - ([8c1461b](https://github.com/n0-computer/iroh/commit/8c1461b7f8271def0edf677457644178e11bc0d1))
+- Bump rustls-webpki from 0.103.12 to 0.103.13 - ([4baa9b1](https://github.com/n0-computer/iroh/commit/4baa9b1d032e5c2e8208ef22dfe24a19ebb7fd12))
+
 ## [0.98.1](https://github.com/n0-computer/iroh/compare/v0.98.0..0.98.1) - 2026-04-20
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -2379,6 +2379,7 @@ dependencies = [
  "ctor",
  "ctutils",
  "data-encoding",
+ "der",
  "derive_more",
  "ed25519-dalek",
  "futures-util",
@@ -3633,9 +3634,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "b226d2cc389763951db8869584fd800cbbe2962bf454e2edeb5172b31ee99774"
 dependencies = [
  "der",
  "spki",
@@ -4813,9 +4814,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.8.0"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "axum",
  "backon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4410,9 +4410,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -31,8 +31,6 @@ derive_more = { version = "2.0.1", features = [
 ] }
 http = "1"
 http-body-util = "0.1.0"
-hyper = { version = "1", features = ["server", "client", "http1"] }
-hyper-util = "0.1.1"
 iroh-base = { version = "0.98.0", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
 iroh-dns = { version = "0.98.0", path = "../iroh-dns" }
 iroh-metrics = { version = "0.38", default-features = false }
@@ -87,6 +85,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+hyper = { version = "1", features = ["server", "client", "http1"] }
+hyper-util = "0.1.1"
 hickory-resolver = { version = "=0.26.0-beta.4", features = ["tokio", "system-config"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -74,8 +74,10 @@ pub enum ConnectError {
     #[error(transparent)]
     Dial { source: DialError },
     #[error("Unexpected status during upgrade: {code}")]
+    #[cfg(not(wasm_browser))]
     UnexpectedUpgradeStatus { code: hyper::StatusCode },
     #[error("Failed to upgrade response")]
+    #[cfg(not(wasm_browser))]
     Upgrade {
         #[error(std_err)]
         source: hyper::Error,
@@ -121,10 +123,12 @@ pub enum DialError {
     #[error("Invalid URL: {url}")]
     InvalidUrl { url: Url },
     #[error("Failed proxy connection: {status}")]
+    #[cfg(not(wasm_browser))]
     ProxyConnectInvalidStatus { status: hyper::StatusCode },
     #[error("Invalid Proxy URL {proxy_url}")]
     ProxyInvalidUrl { proxy_url: Url },
     #[error("failed to establish proxy connection")]
+    #[cfg(not(wasm_browser))]
     ProxyConnect {
         #[error(std_err)]
         source: hyper::Error,

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh"
-version = "0.98.1"
+version = "0.98.2"
 edition = "2024"
 readme = "README.md"
 description = "p2p quic connections dialed by public key"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -26,6 +26,7 @@ blake3 = { version = "1.8.3", default-features = false }
 bytes = "1.11"
 ctutils = { version = "0.4.0", default-features = false }
 data-encoding = "2.2"
+der = "=0.8.0-rc.10" # only needed for exact version pin (until ed25519-dalek is updated)
 derive_more = { version = "2.0.1", features = ["debug", "display", "from", "try_into", "deref", "from_str", "into_iterator"] }
 ed25519-dalek = { version = "=3.0.0-pre.6", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
 http = "1"
@@ -38,6 +39,7 @@ n0-error = "0.1.3"
 n0-watcher = "0.6"
 netwatch = "0.16"
 papaya = { version = "0.2.3", default-features = false }
+pkcs8 = "=0.11.0-rc.10" # only needed for exact version pin (until ed25519-dalek is updated)
 pin-project = "1"
 portable-atomic = "1"
 mainline = { version = "6", optional = true }
@@ -64,7 +66,6 @@ url = { version = "2.5", features = ["serde"] }
 webpki = { package = "rustls-webpki", version = "0.103.7", default-features = false, features = ["std"] }
 webpki_types = { package = "rustls-pki-types", version = "1.12" }
 webpki-roots = "1.0.3"
-pkcs8 = "0.11.0-rc.9"
 
 # metrics
 iroh-metrics = { version = "0.38", default-features = false }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -70,8 +70,7 @@ webpki-roots = "1.0.3"
 # metrics
 iroh-metrics = { version = "0.38", default-features = false }
 
-# mdns
-swarm-discovery = { version = "=0.6.0-alpha.2", optional = true }
+# mdns (gated to non-wasm below)
 futures-util = "0.3"
 
 # test_utils
@@ -83,6 +82,7 @@ axum = { version = "0.8", optional = true }
 hickory-resolver = { version = "=0.26.0-beta.4", default-features = false }
 portmapper = { version = "0.16", optional = true, default-features = false }
 noq = { version = "0.18.0", default-features = false, features = ["runtime-tokio", "rustls"] }
+swarm-discovery = { version = "=0.6.0-alpha.2", optional = true }
 tokio = { version = "1", features = [
     "io-util",
     "macros",

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -145,14 +145,14 @@ use crate::{Endpoint, endpoint::EndpointError};
 
 #[cfg(not(wasm_browser))]
 pub mod dns;
-#[cfg(feature = "address-lookup-mdns")]
+#[cfg(all(not(wasm_browser), feature = "address-lookup-mdns"))]
 pub mod mdns;
 pub mod memory;
 pub mod pkarr;
 
 #[cfg(not(wasm_browser))]
 pub use dns::*;
-#[cfg(feature = "address-lookup-mdns")]
+#[cfg(all(not(wasm_browser), feature = "address-lookup-mdns"))]
 pub use mdns::*;
 pub use memory::*;
 #[cfg(feature = "address-lookup-pkarr-dht")]

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -1032,6 +1032,59 @@ mod tests {
         Ok(())
     }
 
+    /// Concurrent `connect` calls to the same peer must both wait for the in-flight address lookup.
+    ///
+    /// Reproduces the race where the second `ResolveRemote` for the same
+    /// remote used to drain the first call's pending resolve tx with a
+    /// spurious `NoResults` while the address lookup was still in flight. In
+    /// that state the first call returned `Err(NoAddress)` immediately; the
+    /// second call waited for the lookup and succeeded.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[traced_test]
+    async fn concurrent_connects_do_not_race_on_empty_resolve() -> Result {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
+        let shared = TestAddressLookupShared::default();
+
+        let (ep_server, _guard_server) =
+            new_endpoint(&mut rng, |ep| shared.create_address_lookup(ep.id())).await;
+
+        // Client shares the same lookup, so the server's real address is
+        // discoverable; the 200ms lookup delay opens the race window.
+        let (ep_client, _guard_client) =
+            new_endpoint(&mut rng, |ep| shared.create_address_lookup(ep.id())).await;
+
+        let server_id = ep_server.id();
+        let first = tokio::spawn({
+            let ep = ep_client.clone();
+            async move { ep.connect(server_id, TEST_ALPN).await }
+        });
+
+        // Let the first call register its resolve request and trigger the
+        // address lookup before the second call arrives.
+        time::sleep(Duration::from_millis(10)).await;
+
+        let second = tokio::spawn({
+            let ep = ep_client.clone();
+            async move { ep.connect(server_id, TEST_ALPN).await }
+        });
+
+        let (first, second) = tokio::join!(first, second);
+        let first = first.unwrap();
+        let second = second.unwrap();
+
+        assert!(
+            first.is_ok(),
+            "first connect must wait for lookup, got: {:?}",
+            first.err()
+        );
+        assert!(
+            second.is_ok(),
+            "second connect must wait for lookup, got: {:?}",
+            second.err()
+        );
+        Ok(())
+    }
+
     /// This test only has the "lying" address lookup system. It is here to make sure that this actually fails.
     #[tokio::test]
     #[traced_test]

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -571,8 +571,21 @@ impl Socket {
         for i in 0..metas.len() {
             let noq_meta = &mut metas[i];
             let source_addr = &source_addrs[i];
-
-            let datagram_count = noq_meta.len.div_ceil(noq_meta.stride);
+            let datagram_count = if noq_meta.stride == 0 {
+                if noq_meta.len > 0 {
+                    warn!(
+                        src = ?source_addr,
+                        len = noq_meta.len,
+                        "received datagram with stride=0 but len>0",
+                    );
+                    // fix the weird len
+                    noq_meta.len = 0;
+                }
+                // one empty datagram
+                1
+            } else {
+                noq_meta.len.div_ceil(noq_meta.stride)
+            };
             self.metrics
                 .socket
                 .recv_datagrams
@@ -582,7 +595,7 @@ impl Socket {
                     src = ?source_addr,
                     len = noq_meta.len,
                     stride = %noq_meta.stride,
-                    datagram_count = noq_meta.len.div_ceil(noq_meta.stride),
+                    datagram_count,
                     "GRO datagram received",
                 );
                 self.metrics.socket.recv_gro_datagrams.inc();

--- a/iroh/src/socket/remote_map/remote_state/path_state.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_state.rs
@@ -127,13 +127,18 @@ impl RemotePathState {
 
     /// Inserts multiple addresses of unknown status into our list of potential paths.
     ///
-    /// This will emit pending resolve requests and trigger pruning paths.
+    /// If this caused the path set to transition from empty to non-empty, any
+    /// pending resolve requests are woken with `Ok(())`. Inserts that add no
+    /// new paths (empty iterator, or only duplicates) are a no-op: waking
+    /// pending requests while the path set is still empty would send a bogus
+    /// `AddressLookupFailed::NoResults` while an address lookup is in flight.
     pub(super) fn insert_multiple(
         &mut self,
         addrs: impl Iterator<Item = transports::Addr>,
         source: Source,
     ) {
         let now = Instant::now();
+        let was_empty = self.paths.is_empty();
         for addr in addrs {
             self.paths
                 .entry(addr)
@@ -142,7 +147,9 @@ impl RemotePathState {
                 .insert(source.clone(), now);
         }
         trace!("added addressing information");
-        self.emit_pending_resolve_requests(None);
+        if was_empty && !self.paths.is_empty() {
+            self.emit_pending_resolve_requests(None);
+        }
         self.prune_paths();
     }
 
@@ -622,5 +629,56 @@ mod tests {
         ));
         assert_eq!(metrics.transport_ip_paths_added.get(), 2);
         assert_eq!(metrics.transport_ip_paths_removed.get(), 1);
+    }
+
+    /// An empty `insert_multiple` must not drain pending resolve requests.
+    ///
+    /// This reproduces the race where multiple concurrent `connect_with_opts`
+    /// calls send `ResolveRemote` messages with empty addrs. The first pushes
+    /// a tx, then the second's `insert_multiple([])` used to drain that tx
+    /// with `NoResults { errors: [] }`, even though an address lookup was
+    /// still in flight and would shortly have resolved it.
+    #[test]
+    fn empty_insert_does_not_drain_pending() {
+        let metrics = Arc::new(SocketMetrics::default());
+        let mut state = RemotePathState::new(metrics);
+
+        let (tx, mut rx) = oneshot::channel();
+        state.resolve_remote(tx);
+
+        // Second concurrent resolve arrives with empty addrs (no app-provided
+        // addresses) while address lookup is still running.
+        state.insert_multiple(std::iter::empty(), Source::App);
+
+        assert!(
+            rx.try_recv().is_err(),
+            "pending tx must stay pending while paths are empty and lookup is in flight"
+        );
+
+        // When real addresses arrive, the tx resolves Ok.
+        state.insert_multiple([ip_addr(4242)].into_iter(), Source::App);
+        let resolved = rx.try_recv().expect("tx should have been woken");
+        assert!(resolved.is_ok(), "expected Ok once a path was added");
+    }
+
+    /// `address_lookup_finished(Ok(()))` drains pending requests with `NoResults` when no paths are known.
+    ///
+    /// This is the "lookup done but nothing was found" signal and it must
+    /// still reach callers.
+    #[test]
+    fn address_lookup_finished_empty_emits_no_results() {
+        let metrics = Arc::new(SocketMetrics::default());
+        let mut state = RemotePathState::new(metrics);
+
+        let (tx, mut rx) = oneshot::channel();
+        state.resolve_remote(tx);
+
+        state.address_lookup_finished(Ok(()));
+
+        let resolved = rx.try_recv().expect("tx should have been woken");
+        assert!(matches!(
+            resolved,
+            Err(AddressLookupFailed::NoResults { .. })
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Make `iroh` and `iroh-relay` compile to `wasm32-unknown-unknown` (with `--no-default-features`) by extending the existing `wasm_browser` cfg pattern to two surfaces it currently misses.

## What's currently broken

Even with `default-features = false`, building `iroh` for `wasm32-unknown-unknown` fails today because:

1. `swarm-discovery` is declared in the unconditional `[dependencies]` block of `iroh/Cargo.toml`, despite already being correctly cfg-gated at the source level (`address_lookup.rs` only includes the `mdns` module when the `address-lookup-mdns` feature is on). When a downstream crate enables that feature on a wasm target, swarm-discovery (which transitively pulls tokio's net feature) is force-built.
2. `hyper` and `hyper-util` are likewise unconditional in `iroh-relay/Cargo.toml`, even though `iroh-relay/src/client.rs` already has a wasm path using `ws_stream_wasm` instead of hyper.
3. Several error enum variants in `iroh-relay/src/client.rs` (`UnexpectedUpgradeStatus`, `Upgrade`, `ProxyConnectInvalidStatus`, `ProxyConnect`) reference `hyper::StatusCode` / `hyper::Error` unconditionally. Once hyper isn't available on wasm, these declarations fail to compile.

## What this PR changes

Three small, mechanical changes that mirror existing patterns in the same files:

- `iroh/Cargo.toml`: move `swarm-discovery` from the unconditional `[dependencies]` block into the existing `[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]` block (which already houses `hickory-resolver`, `portmapper`, `noq`, etc.).
- `iroh/src/address_lookup.rs`: add `not(wasm_browser)` to the existing `feature = "address-lookup-mdns"` cfg gates on `pub mod mdns` and `pub use mdns::*`. This mirrors the existing `#[cfg(not(wasm_browser))] pub mod dns;` pattern two lines above.
- `iroh-relay/Cargo.toml`: same Cargo.toml move for `hyper` and `hyper-util`.
- `iroh-relay/src/client.rs`: add `#[cfg(not(wasm_browser))]` to the four hyper-using error enum variants. Mirrors the existing `#[cfg(not(wasm_browser))] Dns { source: DnsError }` variant in the same `DialError` enum.

Total diff: 4 files, ~14 net lines, no behavior changes.

## Verification

```
cargo build --target wasm32-unknown-unknown -p iroh --no-default-features
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.73s
```

Native build is unaffected (existing tests + checks pass).

## Honest scope: what this does *not* fix

This PR does not make `iroh` compile to wasm32 with `--features tls-ring` (or any `tls-*` feature), because the `ring` crate's C build script doesn't target wasm32. That's a separate, larger conversation about crypto backends in browsers (likely involving rustls + a pure-Rust crypto provider, or ring's wasm support). I wanted to flag it so reviewers know what I'm *not* claiming.

What this PR claims is narrower: with these gates in place, `iroh` and `iroh-relay` are correctly architected for wasm32, and downstream crates that opt out of crypto (or ship their own browser TLS path) can build against them.

## Context

I hit this while exploring whether a Flutter+Rust app built on `p2panda-net` (which depends on iroh + iroh-gossip) could compile to wasm32. The walls turned out to be a layered set; iroh was the first one I could meaningfully patch upstream, and the existing `wasm_browser` infrastructure in this repo was clearly designed for exactly this shape — it was just missing these few spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)