### PR TITLE
test(iroh): fix racy connection shutdown

### DIFF
--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -2206,7 +2206,6 @@ mod tests {
 
         info!("finishing");
         send_bi.finish().std_context("finish")?;
-        send_bi.stopped().await.std_context("stopped")?;
 
         let stats = conn.stats();
         info!("stats: {:#?}", stats);
@@ -2247,7 +2246,6 @@ mod tests {
 
         info!("finishing");
         send_bi.finish().std_context("finish")?;
-        send_bi.stopped().await.std_context("stopped")?;
 
         info!("reading_to_end");
         let val = recv_bi


### PR DESCRIPTION
## Description

Waiting for stopped when the peer is about to shutdown is flaky and
not the recommended shutdown protocol. The CONNECTION_CLOSE could be
sent before all packets have been acked. And if the close arrives
before some acks then stopped (on the server) will fail with an
error.

CONNECTION_CLOSE is supposed to include any un-acked packets, but this
is only a best-effort and not a guarantee. This may not include all
packets if an ACK was already considered in-flight.

## Breaking Changes

n/a

## Notes & open questions

QUIC shutdown, it still gets us...

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.