### PR TITLE
fix(socket): skip same conn in cross-conn path dedup

### DIFF
--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -927,7 +927,10 @@ impl RemoteStateActor {
                 );
 
                 // If one connection abandons a path, close it on all connections.
-                for (conn_id, conn_state) in self.connections.iter() {
+                for (other_conn_id, conn_state) in self.connections.iter() {
+                    if *other_conn_id == conn_id {
+                        continue;
+                    }
                     let Some(conn) = conn_state.handle.upgrade() else {
                         continue;
                     };
@@ -938,11 +941,11 @@ impl RemoteStateActor {
                         .filter(|(_id, addr)| **addr == path_remote)
                         .filter_map(|(id, _addr)| conn.path(*id))
                     {
-                        trace!(?path_remote, %conn_id, path_id=%path.id(), "closing path");
+                        trace!(?path_remote, conn_id=%other_conn_id, path_id=%path.id(), "closing path");
                         if let Err(err) = path.close() {
                             trace!(
                                 ?path_remote,
-                                %conn_id,
+                                conn_id=%other_conn_id,
                                 path_id=%path.id(),
                                 "path close failed: {err:#}"
                             );


### PR DESCRIPTION
Apparently this fixes the issue?

The dedup loop in RemoteStateActor::handle_path_event for `Abandoned` events iterates self.connections to close paths sharing the abandoned path's remote address. Its purpose is cross-ALPN cleanup: if address X became unreachable for one conn, close paths to X in our other conns too. The loop wasn't excluding the conn the event came from, so when two path_ids within a single conn happened to share a `transports::Addr` (can occur with NAT-traversal candidate mapping), abandoning one closed the other.

Effect on multi-direct-path scenarios: server receives PATH_ABANDON for path 0, runs the dedup loop within its own conn, closes a still-live path 1 sharing path 0's address. With no remaining paths the server hits the multipath grace timer and the connection ends with `NO_VIABLE_PATH("last path abandoned, no new path opened")`.

Skip the source conn in the iteration; rename the loop variable to `other_conn_id` to make the constraint explicit. Cross-conn dedup behavior is unchanged.

## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
