### PR TITLE
fix(iroh): only close paths on the client

### DIFF
--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -931,6 +931,9 @@ impl RemoteStateActor {
                     let Some(conn) = conn_state.handle.upgrade() else {
                         continue;
                     };
+                    if conn.side().is_server() {
+                        continue;
+                    }
                     // Close all paths with the remote address that was abandoned.
                     for path in conn_state
                         .paths


### PR DESCRIPTION
## Description

We should only close paths on the client. When closing redundant IP paths we already do this. However when closing paths abandoned in other connections, we currently close indiscriminately of side. This PR changes it to only close if we're the client.

Maybe supersedes to #4245.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Working on a patchbay test that reproduces the original failure firs.t

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
