### PR TITLE
fix(ci): force non-PIE crt1.o for static musl release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,12 @@ jobs:
               # Native build on self-hosted linux runners; use musl-gcc from musl-tools.
               export CARGO_TARGET_$(echo ${{ matrix.cargo_targets }} | tr 'a-z-' 'A-Z_')_LINKER=musl-gcc
               export CC=musl-gcc
-              export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static -C link-arg=-static"
+              # `relocation-model=static` is required so rustc selects the
+              # non-PIE musl crt1.o (not rcrt1.o) to match the ET_EXEC binary
+              # produced by `musl-gcc -static`. Without it the PIE startup
+              # code (rcrt1.o) ends up linked into a non-PIE binary and the
+              # process segfaults in `_start_c` before reaching `main`.
+              export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static -C relocation-model=static -C link-arg=-static"
             fi
             cargo build --profile optimized-release --all-features --target ${{ matrix.cargo_targets }}
 


### PR DESCRIPTION
Fixes https://github.com/n0-computer/iroh/issues/4252

`musl-gcc -static` produces an `ET_EXEC` binary using musl's `Scrt1.o`, but `rustc` with `+crt-static` was linking its bundled `rcrt1.o` (the static-PIE startup) into the same image. The PIE startup code then treats the absent `.dynamic` section as `_DYNAMIC == 0` and segfaults in `_start_c` before reaching `main`.

Adding `-C relocation-model=static` makes rustc pick the non-PIE `crt1.o`, which matches the ET_EXEC output and yields a fully static, truly portable binary. Verified on the x86_64 musl CI runner against Alpine, Ubuntu 22.04, Ubuntu 24.04, and Debian bookworm.

## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
