### PR TITLE
docs(iroh): update tls- feature names

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -729,7 +729,8 @@ impl Builder {
     ///
     /// The two most common crypto providers in use today are `ring` as well as `aws-lc-rs`.
     ///
-    /// If either the `ring` or `aws-lc-rs` feature is set in iroh, this function doesn't need to be called.
+    /// If either the `tls-ring` or `tls-aws-lc-rs` feature is set in iroh, this function doesn't
+    /// need to be called.
     ///
     /// If none of these features are set, then calling this function in the builder is mandatory.
     pub fn crypto_provider(mut self, crypto_provider: Arc<rustls::crypto::CryptoProvider>) -> Self {

--- a/iroh/src/endpoint/presets.rs
+++ b/iroh/src/endpoint/presets.rs
@@ -47,7 +47,7 @@ impl Preset for Empty {
 /// At the moment the only mandatory option to set on the endpoint builder is
 /// [`Builder::crypto_provider`]. This preset makes a choice for that based on
 /// the current set of enabled features in iroh, which is why it's only available
-/// with the "ring" or "aws-lc-rs" feature flag.
+/// with the `tls-ring` or `tls-aws-lc-rs` feature flag.
 ///
 /// It uses either [ring] or [aws-lc-rs], depending on which feature is enabled
 /// on iroh (preferring ring if both are enabled).


### PR DESCRIPTION
Fixes 387c2e4fcb41ab24fc922003492ed232fb45aa4e where the features were introduced, but the documentation was wrong.

CC: Philipp Krüger <philipp.krueger1@gmail.com>


Closes https://github.com/n0-computer/iroh/issues/4262