### PR TITLE
fix(iroh): Don't stop the RemoteStateActor if there are pending ResolveRemote requests

### DIFF
--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -1000,6 +1000,35 @@ mod tests {
         Ok(())
     }
 
+    /// Regression test: Pending address lookup must keep the `RemoteStateActor` alive.
+    ///
+    /// Previously, this test failed with an `InternalConsistencyError` because the
+    /// `RemoteStateActor` was marked idle and shut down while there were pending
+    /// `ResolveRemote` requests still queued.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[traced_test]
+    async fn pending_resolve_survives_actor_idle_timeout() -> Result {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
+        let ep = Endpoint::builder(presets::Minimal)
+            .secret_key(SecretKey::from_bytes(&rng.random()))
+            .bind()
+            .await?;
+        ep.address_lookup()
+            .expect("endpoint is still open")
+            .add(HangingAddressLookup);
+
+        let offline_id = SecretKey::from_bytes(&rng.random()).public();
+        let connect_task = tokio::spawn(async move { ep.connect(offline_id, TEST_ALPN).await });
+
+        // `iroh::socket::remote_map::remote_state::ACTOR_MAX_IDLE_TIMEOUT`
+        // is 60s. Sleep for longer so that we are sure that the idle timeout expired.
+        let res = time::timeout(Duration::from_secs(65), connect_task).await;
+        // We expect the timeout to elapse, because the address lookup does not resolve.
+        // Before the fix, this would produce an `InternalConsistencyError` after the actor's idle timeout expired.
+        assert!(res.is_err(), "expected Elapsed, got {res:?}");
+        Ok(())
+    }
+
     /// Concurrent `connect` calls to the same peer must both wait for the in-flight address lookup.
     ///
     /// Reproduces the race where the second `ResolveRemote` for the same

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -104,7 +104,7 @@ pub(super) struct RemoteStateActor {
     connections: FxHashMap<ConnId, ConnectionState>,
     /// State of the actor and hooks into the rest of the remote endpoint.
     ///
-    /// This is on a separate struct so that we can have parallel mutable borrows to `connections` and `state.
+    /// This is on a separate struct so that we can have parallel mutable borrows to `connections` and `state`.
     state: State,
 }
 
@@ -267,7 +267,7 @@ impl RemoteStateActor {
                 None => MaybeFuture::None,
             };
             n0_future::pin!(scheduled_hp);
-            if !inbox.is_empty() || !self.connections.is_empty() {
+            if !self.is_idle(&inbox) {
                 idle_timeout
                     .as_mut()
                     .reset(Instant::now() + ACTOR_MAX_IDLE_TIMEOUT);
@@ -325,7 +325,7 @@ impl RemoteStateActor {
                     self.check_connections();
                 }
                 _ = &mut idle_timeout => {
-                    if self.connections.is_empty() && inbox.is_empty() {
+                    if self.is_idle(&inbox) {
                         trace!("idle timeout expired and still idle: terminate actor");
                         break;
                     } else {
@@ -344,6 +344,13 @@ impl RemoteStateActor {
 
         trace!("actor terminating");
         (self.state.endpoint_id, leftover_msgs)
+    }
+
+    /// Returns `true` if the actor is fully idle.
+    fn is_idle(&self, inbox: &mpsc::Receiver<RemoteStateMessage>) -> bool {
+        self.connections.is_empty()
+            && inbox.is_empty()
+            && self.state.paths.resolve_requests_is_empty()
     }
 
     /// Handles an actor message.

--- a/iroh/src/socket/remote_map/remote_state/path_state.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_state.rs
@@ -166,6 +166,11 @@ impl RemotePathState {
         }
     }
 
+    /// Returns `true` if there are any queued resolve requests from [`Self::resolve_remote`].
+    pub(super) fn resolve_requests_is_empty(&self) -> bool {
+        self.pending_resolve_requests.is_empty()
+    }
+
     /// Notifies that a Address Lookup run has finished.
     ///
     /// This will emit pending resolve requests.


### PR DESCRIPTION
## Description

`Endpoint::connect` starts a RemoteStateActor with a `ResolveRemote` message that contains a oneshot sender as reply channel. The RemoteStateActor starts address lookup, and triggers the reply channel when the first result arrives. The RemoteStateActor has an idle timeout of 60s. Before this fix, we did not check for pending resolve requests when the idle timeout expires: The actor stopped and the reply channel sender are dropped, which propagated as `InternalConsistencyError` back to the caller. 

This PR fixes it such that we only consider a RemoteStateActor to be idle when there are no outstanding `ResolveRemote` requests.

Fixes #4265 and comes with a regression test.

## Notes & open questions

With this change, `Endpoint::connect` will hang forever if the configured AddressLookup services remain pending forever (i.e. don't return any results and don't close their result stream). Will address this in a followup.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
