### PR TITLE
fix(iroh): Fix race condition in the remote map that can lead to double-spawned RemoteStateActors

### DIFF
--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -1602,7 +1602,7 @@ impl Actor {
                     self.sock.metrics.socket.actor_link_change.inc();
                     self.handle_network_change(is_major);
                 }
-                _remote_id = self.remote_map.cleanup()=> {},
+                _remote_id = self.remote_map.cleanup() => {},
                 _ = &mut notify_quic_network_change => {
                     let has_network = self.has_usable_network();
                     let Some(pending) = self.call_notify_quic_network_change.as_mut() else {

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -17,7 +17,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Display,
-    future::poll_fn,
     io,
     net::{IpAddr, SocketAddr},
     sync::{
@@ -1603,9 +1602,7 @@ impl Actor {
                     self.sock.metrics.socket.actor_link_change.inc();
                     self.handle_network_change(is_major);
                 }
-                remote_id = poll_fn(|cx| self.remote_map.poll_cleanup(cx)) => {
-                    trace!(%remote_id, "cleaned up RemoteStateActor");
-                }
+                _remote_id = self.remote_map.cleanup()=> {},
                 _ = &mut notify_quic_network_change => {
                     let has_network = self.has_usable_network();
                     let Some(pending) = self.call_notify_quic_network_change.as_mut() else {
@@ -1775,16 +1772,10 @@ impl Actor {
                 self.handle_relay_map_change();
             }
             ActorMessage::ResolveRemote(addr, tx) => {
-                // Swallowing the error is fine here; if a send on the channel to the
-                // remote state actor ever fails (which it shouldn't), `tx` will be
-                // dropped and thus the failure will be propagated to the caller.
-                self.remote_map.resolve_remote(addr, tx).await.ok();
+                self.remote_map.resolve_remote(addr, tx).await;
             }
             ActorMessage::AddConnection(remote, conn, tx) => {
-                // Swallowing the error is fine here; if a send on the channel to the
-                // remote state actor ever fails (which it shouldn't), `tx` will be
-                // dropped and thus the failure will be propagated to the caller.
-                self.remote_map.add_connection(remote, conn, tx).await.ok();
+                self.remote_map.add_connection(remote, conn, tx).await;
             }
             ActorMessage::DirectAddrRefresh => {
                 #[cfg(not(wasm_browser))]

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -340,3 +340,103 @@ pub(crate) enum Source {
     /// The address was added as a path within a connection.
     Connection,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{future::poll_fn, net::SocketAddr, time::Duration};
+
+    use iroh_base::{SecretKey, TransportAddr};
+    use n0_future::future::now_or_never;
+    use n0_tracing_test::traced_test;
+    use n0_watcher::Watchable;
+    use tokio::sync::oneshot;
+    use tracing::Span;
+
+    use super::*;
+
+    fn make_remote_map() -> (RemoteMap, CancellationToken, impl Sized) {
+        let metrics = Arc::new(SocketMetrics::default());
+        let watchable: Watchable<BTreeSet<DirectAddr>> = Watchable::new(BTreeSet::new());
+        let local_direct_addrs = watchable.watch();
+        let shutdown_token = CancellationToken::new();
+        let remote_map = RemoteMap::new(
+            metrics,
+            local_direct_addrs,
+            address_lookup::AddressLookupServices::default(),
+            shutdown_token.clone(),
+            TransportBiasMap::default(),
+            Span::none(),
+        );
+        let guards = (watchable, shutdown_token.clone().drop_guard());
+        (remote_map, shutdown_token, guards)
+    }
+
+    /// Regression test: No new RemoteStateActors may be started before
+    /// the task for its previous incarnation was processed.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[traced_test]
+    async fn poll_cleanup_preserves_restarted_sender() {
+        let (mut remote_map, _shutdown_token, _guards) = make_remote_map();
+        let eid = SecretKey::from_bytes(&[0u8; 32]).public();
+
+        // Non-empty addrs so each `resolve_remote` resolves its tx
+        // immediately and does not park in `paths.pending_resolve_requests`;
+        // the actor would never idle out otherwise.
+        let addr_with_ip = |port: u16| {
+            EndpointAddr::from_parts(
+                eid,
+                [TransportAddr::Ip(SocketAddr::from(([127, 0, 0, 1], port)))],
+            )
+        };
+
+        // 1. Spawn A1 and let it process a real `ResolveRemote`.
+        let (tx1, rx1) = oneshot::channel();
+        remote_map
+            .resolve_remote(addr_with_ip(1234), tx1)
+            .await
+            .ok();
+
+        // 2. Advance past idle timeout. The runtime drives A1 to completion
+        //    inside the sleep: it drains the message, becomes idle, exits.
+        tokio::time::sleep(Duration::from_secs(65)).await;
+        assert!(
+            matches!(rx1.await, Ok(Ok(()))),
+            "First resolve completes Ok"
+        );
+
+        // 3. Call `resolve_remote` again. The actor A1 has terminated but its task
+        //    has not yet been cleaned up. A1's sender is still in the sender map
+        //    but is closed.
+        //    Before our fixes, `resolve_remote` would spawn a new actor. When
+        //    `poll_cleanup` was then called, the sender to this new actor would be
+        //    removed again. We fixed this by first processing the tasks for the
+        //    terminated actor.
+
+        //    We resume time so that we don't immediately idle-out again.
+        tokio::time::resume();
+        let (tx2, rx2) = oneshot::channel();
+        remote_map
+            .resolve_remote(addr_with_ip(5678), tx2)
+            .await
+            .ok();
+
+        // 4. Drive `poll_cleanup`, like the socket actor does.
+        //    Before our fixes, this would remove the sender to the just-started A2 from the sender map.
+        now_or_never(poll_fn(|cx| remote_map.poll_cleanup(cx)));
+
+        // 5. A third `resolve_remote`, this time with no addrs.
+        //    With our fix, this reaches the actor spawned above (A2); without
+        //    the fix this would start a new actor because A2 was falsely removed from
+        //    the senders map.
+        let (tx3, rx3) = oneshot::channel();
+        remote_map
+            .resolve_remote(EndpointAddr::new(eid), tx3)
+            .await
+            .ok();
+
+        let outcome2 = rx2.await.expect("the resolve tx must be sent");
+        let outcome3 = rx3.await.expect("the resolve tx must be sent");
+        assert!(outcome2.is_ok(), "expected Ok, but got {outcome2:?}");
+        assert!(outcome3.is_ok(), "expected Ok, but got {outcome3:?}");
+    }
+}

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -11,7 +11,7 @@ use n0_future::task::JoinSet;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
-use tracing::{Span, debug, error, trace};
+use tracing::{Span, error, trace};
 
 pub(crate) use self::remote_state::PathStateReceiver;
 use self::remote_state::RemoteStateActor;
@@ -186,30 +186,25 @@ impl RemoteMap {
     /// This function should be called in a loop to clean up expired tasks.
     /// Only one task is allowed to poll this function concurrently.
     pub(super) async fn cleanup(&mut self) -> EndpointId {
-        poll_fn(|cx| self.poll_cleanup(cx)).await
+        loop {
+            let (remote_id, leftover_messages) = poll_fn(|cx| self.poll_join_next(cx)).await;
+            if self.remove_or_restart_actor(remote_id, leftover_messages) {
+                return remote_id;
+            }
+        }
     }
 
-    /// See [`Self::cleanup`].
-    fn poll_cleanup(&mut self, cx: &mut Context<'_>) -> Poll<EndpointId> {
+    /// Polls for the next joined actor task.
+    ///
+    /// Returns [`Poll::Pending`] if no tasks are running, and is woken when the task set changes.
+    fn poll_join_next(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<(EndpointId, Vec<RemoteStateMessage>)> {
         while let Some(result) = ready!(self.tasks.tasks.poll_join_next(cx)) {
             match result {
                 Ok((remote_id, leftover_msgs)) => {
-                    if leftover_msgs.is_empty() {
-                        // the actor shut down cleanly
-                        self.senders.remove(&remote_id);
-                        trace!(%remote_id, "cleaned up RemoteStateActor");
-                    } else {
-                        // The remote actor got messages while it was closing, so we're restarting
-                        debug!(%remote_id, "restarting terminated RemoteStateActor: messages received during shutdown");
-                        let sender = self.tasks.start_remote_state_actor(
-                            remote_id,
-                            leftover_msgs,
-                            &self.mapped_addrs,
-                        );
-                        // We don't have to be careful about guards - only one thread is modifying this hashmap at a time.
-                        self.senders.insert(remote_id, sender);
-                    }
-                    return Poll::Ready(remote_id);
+                    return Poll::Ready((remote_id, leftover_msgs));
                 }
                 Err(err) => {
                     if let Ok(panic) = err.try_into_panic() {
@@ -225,6 +220,29 @@ impl RemoteMap {
         // properly wait for a task to finish.
         self.tasks.poll_cleanup_waker.replace(cx.waker().clone());
         Poll::Pending
+    }
+
+    /// Removes an actor sender if `leftover_msgs` is empty, or restarts the actor otherwise.
+    fn remove_or_restart_actor(
+        &mut self,
+        remote_id: iroh_base::PublicKey,
+        leftover_msgs: Vec<RemoteStateMessage>,
+    ) -> bool {
+        if leftover_msgs.is_empty() {
+            // the actor shut down cleanly
+            self.senders.remove(&remote_id);
+            trace!(%remote_id, "cleaned up RemoteStateActor");
+            true
+        } else {
+            // The remote actor got messages while it was closing, so we're restarting
+            trace!(%remote_id, "restarting terminated RemoteStateActor: messages received during shutdown");
+            let sender =
+                self.tasks
+                    .start_remote_state_actor(remote_id, leftover_msgs, &self.mapped_addrs);
+            // We don't have to be careful about guards - only one thread is modifying this hashmap at a time.
+            self.senders.insert(remote_id, sender);
+            false
+        }
     }
 
     pub(super) fn on_network_change(&mut self, is_major: bool) {
@@ -261,10 +279,10 @@ impl RemoteMap {
     ///
     /// When sending fails, the actor must be terminating, in which case we wait for its task to
     /// join and then restart the sender.
-    async fn send_to_actor(&mut self, remote: EndpointId, message: RemoteStateMessage) {
-        let sender = self.senders.get_or_insert_with(remote, || {
+    async fn send_to_actor(&mut self, remote_id: EndpointId, message: RemoteStateMessage) {
+        let sender = self.senders.get_or_insert_with(remote_id, || {
             self.tasks
-                .start_remote_state_actor(remote, vec![], &self.mapped_addrs)
+                .start_remote_state_actor(remote_id, vec![], &self.mapped_addrs)
         });
 
         if let Err(mpsc::error::SendError(message)) = sender.send(message).await {
@@ -273,15 +291,17 @@ impl RemoteMap {
             // properly enqueued into a new actor, and that a later cleanup does not reap a newly
             // created sender again.  We can be sure that the task has not been cleaned up yet
             // because we take a `&mut self` reference.
-            while self.cleanup().await != remote {}
-
-            let sender = self.senders.get_or_insert_with(remote, || {
-                self.tasks
-                    .start_remote_state_actor(remote, vec![], &self.mapped_addrs)
-            });
-            sender
-                .try_send(message)
-                .expect("sender just created so it must have capacity")
+            loop {
+                let (id, leftover_messages) = poll_fn(|cx| self.poll_join_next(cx)).await;
+                if id != remote_id {
+                    self.remove_or_restart_actor(id, leftover_messages);
+                } else {
+                    let mut messages = leftover_messages;
+                    messages.push(message);
+                    self.remove_or_restart_actor(id, messages);
+                    break;
+                }
+            }
         }
     }
 

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -51,7 +51,7 @@ mod remote_state;
 #[derive(Debug)]
 pub(crate) struct RemoteMap {
     /// Maps for converting between mapped and IP/relay addrs.
-    pub(crate) mapped_addrs: MappedAddrs,
+    pub(super) mapped_addrs: MappedAddrs,
 
     /// The senders for the inbox of each `RemoteStateActor` that runs.
     ///
@@ -172,15 +172,24 @@ impl RemoteMap {
         }
     }
 
-    /// Potentially removes terminated [`RemoteStateActor`]s from the remote map.
+    /// Cleans up terminated `RemoteStateActor` tasks.
     ///
-    /// Resolves to the endpoint ID that of the remote state actor that got cleaned up
-    /// or restarted.
+    /// This polls for terminated actor tasks, and removes the corresponding actor sender
+    /// from our sender map, or restarts the actor if it has pending messages.
+    ///
+    /// Resolves to the actor's remote endpoint ID whenever a `RemoteStateActor` task joined,
+    /// independent of whether the task was restarted or not.
     ///
     /// Returns pending if there was no actor to be cleaned up right now, and registers
     /// for moments where this could become the case.
     ///
+    /// This function should be called in a loop to clean up expired tasks.
     /// Only one task is allowed to poll this function concurrently.
+    pub(super) async fn cleanup(&mut self) -> EndpointId {
+        poll_fn(|cx| self.poll_cleanup(cx)).await
+    }
+
+    /// See [`Self::cleanup`].
     fn poll_cleanup(&mut self, cx: &mut Context<'_>) -> Poll<EndpointId> {
         while let Some(result) = ready!(self.tasks.tasks.poll_join_next(cx)) {
             match result {
@@ -218,13 +227,6 @@ impl RemoteMap {
         Poll::Pending
     }
 
-    /// Cleanup terminated `RemoteStateActor` tasks.
-    ///
-    /// The future never completes and is cancellation-safe (can be restarted at any point).
-    pub(super) async fn cleanup(&mut self) -> EndpointId {
-        poll_fn(|cx| self.poll_cleanup(cx)).await
-    }
-
     pub(super) fn on_network_change(&mut self, is_major: bool) {
         let read = self.senders.read_only();
         let guard = read.guard();
@@ -241,7 +243,7 @@ impl RemoteMap {
         tx: oneshot::Sender<Result<(), AddressLookupFailed>>,
     ) {
         let EndpointAddr { id, addrs } = addr;
-        self.send_to_remote_state_actor(id, RemoteStateMessage::ResolveRemote(addrs, tx))
+        self.send_to_actor(id, RemoteStateMessage::ResolveRemote(addrs, tx))
             .await
     }
 
@@ -251,15 +253,15 @@ impl RemoteMap {
         conn: noq::Connection,
         tx: oneshot::Sender<PathStateReceiver>,
     ) {
-        self.send_to_remote_state_actor(remote, RemoteStateMessage::AddConnection(conn, tx))
+        self.send_to_actor(remote, RemoteStateMessage::AddConnection(conn, tx))
             .await
     }
 
-    async fn send_to_remote_state_actor(
-        &mut self,
-        remote: EndpointId,
-        message: RemoteStateMessage,
-    ) {
+    /// Sends a message to a `RemoteStateActor`, starting it if not running already.
+    ///
+    /// When sending fails, the actor must be terminating, in which case we wait for its task to
+    /// join and then restart the sender.
+    async fn send_to_actor(&mut self, remote: EndpointId, message: RemoteStateMessage) {
         let sender = self.senders.get_or_insert_with(remote, || {
             self.tasks
                 .start_remote_state_actor(remote, vec![], &self.mapped_addrs)
@@ -267,8 +269,10 @@ impl RemoteMap {
 
         if let Err(mpsc::error::SendError(message)) = sender.send(message).await {
             // The send failed, which means the RemoteStateActor is terminating. We call the cleanup
-            // function so that its task is processed. This ensures that the leftover messages are properly
-            // enqueued into a new actor, and that a later cleanup does not reap a newly created sender again.
+            // function so that its task is processed. This ensures that the leftover messages are
+            // properly enqueued into a new actor, and that a later cleanup does not reap a newly
+            // created sender again.  We can be sure that the task has not been cleaned up yet
+            // because we take a `&mut self` reference.
             while self.cleanup().await != remote {}
 
             let sender = self.senders.get_or_insert_with(remote, || {
@@ -349,7 +353,7 @@ pub(crate) enum Source {
 
 #[cfg(test)]
 mod tests {
-    use std::{future::poll_fn, net::SocketAddr, time::Duration};
+    use std::{net::SocketAddr, time::Duration};
 
     use iroh_base::{SecretKey, TransportAddr};
     use n0_future::future::now_or_never;
@@ -378,7 +382,7 @@ mod tests {
     }
 
     /// Regression test: No new RemoteStateActors may be started before
-    /// the task for its previous incarnation was processed.
+    /// the task of its previous incarnation was processed.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     #[traced_test]
     async fn poll_cleanup_preserves_restarted_sender() {
@@ -398,31 +402,30 @@ mod tests {
         // 1. Spawn A1 and let it process a real `ResolveRemote`.
         let (tx1, rx1) = oneshot::channel();
         remote_map.resolve_remote(addr_with_ip(1234), tx1).await;
-
-        // 2. Advance past idle timeout. The runtime drives A1 to completion
-        //    inside the sleep: it drains the message, becomes idle, exits.
-        tokio::time::sleep(Duration::from_secs(65)).await;
         assert!(
             matches!(rx1.await, Ok(Ok(()))),
             "First resolve completes Ok"
         );
 
+        // 2. Advance past idle timeout.
+        tokio::time::sleep(Duration::from_secs(65)).await;
+
         // 3. Call `resolve_remote` again. The actor A1 has terminated but its task
         //    has not yet been cleaned up. A1's sender is still in the sender map
-        //    but is closed.
-        //    Before our fixes, `resolve_remote` would spawn a new actor. When
-        //    `poll_cleanup` was then called, the sender to this new actor would be
-        //    removed again. We fixed this by first processing the tasks for the
-        //    terminated actor.
-
-        //    We resume time so that we don't immediately idle-out again.
+        //    but is closed. This will spawn a new actor A2.
+        //    Before our fixes, `resolve_remote` would spawn a new actor, and when
+        //    `cleanup` was then called, the sender to this new actor would be
+        //    removed again. We fixed this by first processing the joined task for the
+        //    terminated actor, so that it is removed from our task list *before*
+        //    starting a new actor.
+        //    We also resume time here so that we don't immediately idle-out again.
         tokio::time::resume();
         let (tx2, rx2) = oneshot::channel();
         remote_map.resolve_remote(addr_with_ip(5678), tx2).await;
 
-        // 4. Drive `poll_cleanup`, like the socket actor does.
+        // 4. Drive `cleanup`, like the socket actor does.
         //    Before our fixes, this would remove the sender to the just-started A2 from the sender map.
-        now_or_never(poll_fn(|cx| remote_map.poll_cleanup(cx)));
+        now_or_never(remote_map.cleanup());
 
         // 5. A third `resolve_remote`, this time with no addrs.
         //    With our fix, this reaches the actor spawned above (A2); without

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeSet,
+    future::poll_fn,
     hash::Hash,
     sync::Arc,
     task::{Context, Poll, Waker, ready},
@@ -10,7 +11,7 @@ use n0_future::task::JoinSet;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
-use tracing::{Span, debug, error};
+use tracing::{Span, debug, error, trace};
 
 pub(crate) use self::remote_state::PathStateReceiver;
 use self::remote_state::RemoteStateActor;
@@ -29,7 +30,6 @@ use super::{
 use crate::{
     address_lookup::{self, AddressLookupFailed},
     socket::{
-        RemoteStateActorStoppedError,
         concurrent_read_map::{ConcurrentReadMap, ReadOnlyMap},
         transports::TransportBiasMap,
     },
@@ -174,29 +174,33 @@ impl RemoteMap {
 
     /// Potentially removes terminated [`RemoteStateActor`]s from the remote map.
     ///
-    /// Resolves to the endpoint ID that of the remote state actor that got cleaned up.
+    /// Resolves to the endpoint ID that of the remote state actor that got cleaned up
+    /// or restarted.
     ///
     /// Returns pending if there was no actor to be cleaned up right now, and registers
     /// for moments where this could become the case.
     ///
     /// Only one task is allowed to poll this function concurrently.
-    pub(super) fn poll_cleanup(&mut self, cx: &mut Context<'_>) -> Poll<EndpointId> {
+    fn poll_cleanup(&mut self, cx: &mut Context<'_>) -> Poll<EndpointId> {
         while let Some(result) = ready!(self.tasks.tasks.poll_join_next(cx)) {
             match result {
-                Ok((eid, leftover_msgs)) => {
+                Ok((remote_id, leftover_msgs)) => {
                     if leftover_msgs.is_empty() {
                         // the actor shut down cleanly
-                        self.senders.remove(&eid);
-                        return Poll::Ready(eid);
+                        self.senders.remove(&remote_id);
+                        trace!(%remote_id, "cleaned up RemoteStateActor");
+                    } else {
+                        // The remote actor got messages while it was closing, so we're restarting
+                        debug!(%remote_id, "restarting terminated RemoteStateActor: messages received during shutdown");
+                        let sender = self.tasks.start_remote_state_actor(
+                            remote_id,
+                            leftover_msgs,
+                            &self.mapped_addrs,
+                        );
+                        // We don't have to be careful about guards - only one thread is modifying this hashmap at a time.
+                        self.senders.insert(remote_id, sender);
                     }
-
-                    // The remote actor got messages while it was closing, so we're restarting
-                    debug!(%eid, "restarting terminated remote state actor: messages received during shutdown");
-                    let sender =
-                        self.tasks
-                            .start_remote_state_actor(eid, leftover_msgs, &self.mapped_addrs);
-                    // We don't have to be careful about guards - only one thread is modifying this hashmap at a time.
-                    self.senders.insert(eid, sender);
+                    return Poll::Ready(remote_id);
                 }
                 Err(err) => {
                     if let Ok(panic) = err.try_into_panic() {
@@ -214,6 +218,13 @@ impl RemoteMap {
         Poll::Pending
     }
 
+    /// Cleanup terminated `RemoteStateActor` tasks.
+    ///
+    /// The future never completes and is cancellation-safe (can be restarted at any point).
+    pub(super) async fn cleanup(&mut self) -> EndpointId {
+        poll_fn(|cx| self.poll_cleanup(cx)).await
+    }
+
     pub(super) fn on_network_change(&mut self, is_major: bool) {
         let read = self.senders.read_only();
         let guard = read.guard();
@@ -228,13 +239,10 @@ impl RemoteMap {
         &mut self,
         addr: EndpointAddr,
         tx: oneshot::Sender<Result<(), AddressLookupFailed>>,
-    ) -> Result<(), RemoteStateActorStoppedError> {
+    ) {
         let EndpointAddr { id, addrs } = addr;
-        let actor = self.remote_state_actor(id);
-        actor
-            .send(RemoteStateMessage::ResolveRemote(addrs, tx))
-            .await?;
-        Ok(())
+        self.send_to_remote_state_actor(id, RemoteStateMessage::ResolveRemote(addrs, tx))
+            .await
     }
 
     pub(super) async fn add_connection(
@@ -242,36 +250,34 @@ impl RemoteMap {
         remote: EndpointId,
         conn: noq::Connection,
         tx: oneshot::Sender<PathStateReceiver>,
-    ) -> Result<(), RemoteStateActorStoppedError> {
-        let actor = self.remote_state_actor(remote);
-        actor
-            .send(RemoteStateMessage::AddConnection(conn, tx))
-            .await?;
-        Ok(())
+    ) {
+        self.send_to_remote_state_actor(remote, RemoteStateMessage::AddConnection(conn, tx))
+            .await
     }
 
-    /// Returns the sender for the [`RemoteStateActor`].
-    ///
-    /// If needed a new actor is started on demand.
-    ///
-    /// [`RemoteStateActor`]: remote_state::RemoteStateActor
-    pub(super) fn remote_state_actor(
+    async fn send_to_remote_state_actor(
         &mut self,
-        eid: EndpointId,
-    ) -> mpsc::Sender<RemoteStateMessage> {
-        let sender = self.senders.get_or_insert_with(eid, || {
+        remote: EndpointId,
+        message: RemoteStateMessage,
+    ) {
+        let sender = self.senders.get_or_insert_with(remote, || {
             self.tasks
-                .start_remote_state_actor(eid, vec![], &self.mapped_addrs)
+                .start_remote_state_actor(remote, vec![], &self.mapped_addrs)
         });
-        if sender.is_closed() {
-            // The actor is dead: Start a new actor.
-            let sender = self
-                .tasks
-                .start_remote_state_actor(eid, vec![], &self.mapped_addrs);
-            self.senders.insert(eid, sender.clone());
+
+        if let Err(mpsc::error::SendError(message)) = sender.send(message).await {
+            // The send failed, which means the RemoteStateActor is terminating. We call the cleanup
+            // function so that its task is processed. This ensures that the leftover messages are properly
+            // enqueued into a new actor, and that a later cleanup does not reap a newly created sender again.
+            while self.cleanup().await != remote {}
+
+            let sender = self.senders.get_or_insert_with(remote, || {
+                self.tasks
+                    .start_remote_state_actor(remote, vec![], &self.mapped_addrs)
+            });
             sender
-        } else {
-            sender.clone()
+                .try_send(message)
+                .expect("sender just created so it must have capacity")
         }
     }
 
@@ -391,10 +397,7 @@ mod tests {
 
         // 1. Spawn A1 and let it process a real `ResolveRemote`.
         let (tx1, rx1) = oneshot::channel();
-        remote_map
-            .resolve_remote(addr_with_ip(1234), tx1)
-            .await
-            .ok();
+        remote_map.resolve_remote(addr_with_ip(1234), tx1).await;
 
         // 2. Advance past idle timeout. The runtime drives A1 to completion
         //    inside the sleep: it drains the message, becomes idle, exits.
@@ -415,10 +418,7 @@ mod tests {
         //    We resume time so that we don't immediately idle-out again.
         tokio::time::resume();
         let (tx2, rx2) = oneshot::channel();
-        remote_map
-            .resolve_remote(addr_with_ip(5678), tx2)
-            .await
-            .ok();
+        remote_map.resolve_remote(addr_with_ip(5678), tx2).await;
 
         // 4. Drive `poll_cleanup`, like the socket actor does.
         //    Before our fixes, this would remove the sender to the just-started A2 from the sender map.
@@ -429,10 +429,7 @@ mod tests {
         //    the fix this would start a new actor because A2 was falsely removed from
         //    the senders map.
         let (tx3, rx3) = oneshot::channel();
-        remote_map
-            .resolve_remote(EndpointAddr::new(eid), tx3)
-            .await
-            .ok();
+        remote_map.resolve_remote(EndpointAddr::new(eid), tx3).await;
 
         let outcome2 = rx2.await.expect("the resolve tx must be sent");
         let outcome3 = rx3.await.expect("the resolve tx must be sent");


### PR DESCRIPTION
## Description

Adds a regression test and fix for this bug:

When a RemoteStateActor is terminating, and a new message to the actor is sent *before* `poll_cleanup`  is called, we would check if the sender is closed and, if so, spawn a new RemoteStateActor. When `poll_cleanup` then processes the task of the terminated actor, it would unconditionally remove the sender of the just-spawned actor.


## Notes & open questions

I am pretty sure my solution is fine, but would like an additional set of eyes. I'm also thinking if we can add a small abstraction to make this more foolproof, but not sure. Let's get the fix in first.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.