### PR TITLE
refactor(iroh)!: Use FourTuple for selected path

### DIFF
--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -961,6 +961,7 @@ fn spawn_path_watcher(
                     id,
                     remote_addr,
                     last_stats,
+                    ..
                 } => {
                     paths.push(PathData {
                         id,

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -42,6 +42,7 @@ pub use super::socket::{
         Path, PathEvent, PathEventStream, PathList, PathListIter, PathListStream, RemoteInfo,
         TransportAddrInfo, TransportAddrUsage,
     },
+    transports::LocalTransportAddr,
 };
 #[cfg(wasm_browser)]
 use crate::address_lookup::PkarrResolver;
@@ -82,7 +83,7 @@ pub use self::{
     connection::{
         Accept, Accepting, AlpnError, AuthenticationError, Connecting, ConnectingError, Connection,
         ConnectionState, HandshakeCompleted, Incoming, IncomingAddr, IncomingZeroRtt,
-        IncomingZeroRttConnection, LocalTransportAddr, OutgoingZeroRtt, OutgoingZeroRttConnection,
+        IncomingZeroRttConnection, OutgoingZeroRtt, OutgoingZeroRttConnection,
         RemoteEndpointIdError, RetryError, WeakConnectionHandle, ZeroRttStatus,
     },
     quic::{
@@ -1680,11 +1681,6 @@ impl Endpoint {
     /// a transport address.
     pub(crate) fn to_transport_addr(&self, addr: SocketAddr) -> crate::socket::transports::Addr {
         self.inner.to_transport_addr(addr)
-    }
-
-    /// Reverse-resolves a custom mapped address back to its [`iroh_base::CustomAddr`].
-    pub(crate) fn lookup_custom_addr(&self, addr: SocketAddr) -> Option<iroh_base::CustomAddr> {
-        self.inner.lookup_custom_addr(addr)
     }
 
     #[cfg(all(test, with_crypto_provider))]

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -81,8 +81,8 @@ pub use self::quic::{QlogConfig, QlogFactory, QlogFileFactory};
 pub use self::{
     connection::{
         Accept, Accepting, AlpnError, AuthenticationError, Connecting, ConnectingError, Connection,
-        ConnectionState, HandshakeCompleted, Incoming, IncomingAddr, IncomingLocalAddr,
-        IncomingZeroRtt, IncomingZeroRttConnection, OutgoingZeroRtt, OutgoingZeroRttConnection,
+        ConnectionState, HandshakeCompleted, Incoming, IncomingAddr, IncomingZeroRtt,
+        IncomingZeroRttConnection, LocalTransportAddr, OutgoingZeroRtt, OutgoingZeroRttConnection,
         RemoteEndpointIdError, RetryError, WeakConnectionHandle, ZeroRttStatus,
     },
     quic::{
@@ -3491,7 +3491,7 @@ mod tests {
                 if let PathEvent::Closed {
                     remote_addr,
                     last_stats,
-                    id: _,
+                    ..
                 } = event
                 {
                     stats.insert(remote_addr, *last_stats);

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -92,10 +92,10 @@ impl From<transports::Addr> for IncomingAddr {
     }
 }
 
-/// The local address that received an incoming connection.
+/// The local address of a network path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum IncomingLocalAddr {
+pub enum LocalTransportAddr {
     /// The local IP, if the OS surfaced it.
     Ip(Option<IpAddr>),
     /// The relay this connection arrived through.
@@ -208,16 +208,16 @@ impl Incoming {
     }
 
     /// Returns the local address that received this incoming connection.
-    pub fn local_addr(&self) -> IncomingLocalAddr {
+    pub fn local_addr(&self) -> LocalTransportAddr {
         match self.ep.to_transport_addr(self.inner.remote_address()) {
-            transports::Addr::Ip(_) => IncomingLocalAddr::Ip(self.inner.local_ip()),
-            transports::Addr::Relay(url, _) => IncomingLocalAddr::Relay { url },
+            transports::Addr::Ip(_) => LocalTransportAddr::Ip(self.inner.local_ip()),
+            transports::Addr::Relay(url, _) => LocalTransportAddr::Relay { url },
             transports::Addr::Custom(_) => {
                 let local = self
                     .inner
                     .local_ip()
                     .and_then(|ip| self.ep.lookup_custom_addr(SocketAddr::new(ip, 0)));
-                IncomingLocalAddr::Custom(local)
+                LocalTransportAddr::Custom(local)
             }
         }
     }

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -19,7 +19,7 @@
 use std::{
     any::Any,
     future::{Future, IntoFuture},
-    net::{IpAddr, SocketAddr},
+    net::SocketAddr,
     pin::Pin,
     sync::Arc,
     task::Poll,
@@ -48,7 +48,7 @@ use crate::{
     socket::{
         RemoteStateActorStoppedError,
         remote_map::{PathEventStream, PathList, PathListStream, PathStateReceiver},
-        transports,
+        transports::{self, LocalTransportAddr},
     },
 };
 
@@ -90,21 +90,6 @@ impl From<transports::Addr> for IncomingAddr {
             transports::Addr::Custom(addr) => Self::Custom(addr),
         }
     }
-}
-
-/// The local address of a network path.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum LocalTransportAddr {
-    /// The local IP, if the OS surfaced it.
-    Ip(Option<IpAddr>),
-    /// The relay this connection arrived through.
-    Relay {
-        /// The URL of the relay.
-        url: RelayUrl,
-    },
-    /// The local custom address, if the transport reports one.
-    Custom(Option<iroh_base::CustomAddr>),
 }
 
 /// Future produced by [`Endpoint::accept`].
@@ -209,17 +194,9 @@ impl Incoming {
 
     /// Returns the local address that received this incoming connection.
     pub fn local_addr(&self) -> LocalTransportAddr {
-        match self.ep.to_transport_addr(self.inner.remote_address()) {
-            transports::Addr::Ip(_) => LocalTransportAddr::Ip(self.inner.local_ip()),
-            transports::Addr::Relay(url, _) => LocalTransportAddr::Relay { url },
-            transports::Addr::Custom(_) => {
-                let local = self
-                    .inner
-                    .local_ip()
-                    .and_then(|ip| self.ep.lookup_custom_addr(SocketAddr::new(ip, 0)));
-                LocalTransportAddr::Custom(local)
-            }
-        }
+        let remote_addr = self.ep.to_transport_addr(self.inner.remote_address());
+        let noq_local_ip = self.inner.local_ip();
+        LocalTransportAddr::from_noq_local_ip(noq_local_ip, &remote_addr, &self.ep.inner)
     }
 
     /// Returns the remote address of this incoming connection.

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -194,9 +194,9 @@ impl Incoming {
 
     /// Returns the local address that received this incoming connection.
     pub fn local_addr(&self) -> LocalTransportAddr {
-        let remote_addr = self.ep.to_transport_addr(self.inner.remote_address());
-        let noq_local_ip = self.inner.local_ip();
-        LocalTransportAddr::from_noq_local_ip(noq_local_ip, &remote_addr, &self.ep.inner)
+        let remote_addr = self.inner.remote_address();
+        let local_ip = self.inner.local_ip();
+        self.ep.inner.to_local_transport_addr(local_ip, remote_addr)
     }
 
     /// Returns the remote address of this incoming connection.

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -533,16 +533,6 @@ impl Socket {
         .unwrap_or(transports::Addr::Ip(addr))
     }
 
-    /// Reverse-resolves a custom mapped address back to its [`iroh_base::CustomAddr`].
-    pub(crate) fn lookup_custom_addr(&self, addr: SocketAddr) -> Option<iroh_base::CustomAddr> {
-        match MultipathMappedAddr::from(addr) {
-            MultipathMappedAddr::Custom(custom_mapped) => {
-                self.mapped_addrs.custom_addrs.lookup(&custom_mapped)
-            }
-            _ => None,
-        }
-    }
-
     /// Reference to the internal Address Lookup
     pub(crate) fn address_lookup(&self) -> &address_lookup::AddressLookupServices {
         &self.address_lookup

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -68,7 +68,9 @@ use crate::net_report::QuicConfig;
 use crate::{
     address_lookup::{self, AddressLookupFailed, EndpointData, UserData},
     defaults::timeouts::NET_REPORT_TIMEOUT,
-    endpoint::{RelayStatus, hooks::EndpointHooksList, quic::QuicTransportConfig},
+    endpoint::{
+        LocalTransportAddr, RelayStatus, hooks::EndpointHooksList, quic::QuicTransportConfig,
+    },
     metrics::EndpointMetrics,
     net_report::{self, IfStateDetails, Report},
     portmapper,
@@ -531,6 +533,19 @@ impl Socket {
             &self.mapped_addrs.custom_addrs,
         )
         .unwrap_or(transports::Addr::Ip(addr))
+    }
+
+    pub(crate) fn to_local_transport_addr(
+        &self,
+        local_ip: Option<IpAddr>,
+        remote_addr: SocketAddr,
+    ) -> LocalTransportAddr {
+        let remote_addr = self.to_transport_addr(remote_addr);
+        LocalTransportAddr::from_noq_local_ip(
+            local_ip,
+            &remote_addr,
+            &self.mapped_addrs.custom_addrs,
+        )
     }
 
     /// Reference to the internal Address Lookup

--- a/iroh/src/socket/mapped_addrs.rs
+++ b/iroh/src/socket/mapped_addrs.rs
@@ -287,6 +287,17 @@ impl MappedAddr for CustomMappedAddr {
     }
 }
 
+impl TryFrom<IpAddr> for CustomMappedAddr {
+    type Error = CustomMappedAddrError;
+
+    fn try_from(value: IpAddr) -> std::result::Result<Self, Self::Error> {
+        match value {
+            IpAddr::V4(_) => Err(e!(CustomMappedAddrError)),
+            IpAddr::V6(addr) => addr.try_into(),
+        }
+    }
+}
+
 impl TryFrom<Ipv6Addr> for CustomMappedAddr {
     type Error = CustomMappedAddrError;
 

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeSet, VecDeque},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::Arc,
     task::Poll,
@@ -31,10 +31,12 @@ pub use self::{
 use super::Source;
 use crate::{
     address_lookup::{AddressLookupFailed, AddressLookupServices, Item as AddressLookupItem},
-    endpoint::DirectAddr,
+    endpoint::{DirectAddr, LocalTransportAddr},
     socket::{
         Metrics as SocketMetrics, RELAY_PATH_MAX_IDLE_TIMEOUT,
-        mapped_addrs::{AddrMap, CustomMappedAddr, MappedAddr, RelayMappedAddr},
+        mapped_addrs::{
+            AddrMap, CustomMappedAddr, MappedAddr, MultipathMappedAddr, RelayMappedAddr,
+        },
         remote_map::{remote_state::path_watcher::PathStateSender, to_transport_addr},
         transports::{self, OwnedTransmit, PathSelectionData, TransportBiasMap, TransportsSender},
     },
@@ -391,7 +393,8 @@ impl RemoteStateActor {
         conn: noq::Connection,
         tx: oneshot::Sender<PathStateReceiver>,
     ) {
-        let (path_state_sender, path_state_receiver) = PathStateSender::new();
+        let (path_state_sender, path_state_receiver) =
+            PathStateSender::new(self.state.custom_mapped_addrs.clone());
         self.state.metrics.num_conns_opened.inc();
         // Remove any conflicting stable_ids from the local state.
         let conn_id = ConnId(conn.stable_id());
@@ -440,7 +443,7 @@ impl RemoteStateActor {
                     .paths
                     .addrs()
                     .filter(|a| a.is_relay())
-                    .map(|remote| TransportFourTuple::from_remote(remote.clone()))
+                    .map(|remote| TransportFourTuple::new(remote.clone(), None))
                     .collect::<Vec<_>>();
                 for open_addr in relays {
                     self.state
@@ -846,7 +849,8 @@ impl State {
         if let Some(addr) = self.selected_path.as_ref() {
             trace!(?addr, "sending datagram to selected path");
 
-            if let Err(err) = send_datagram(&mut sender, addr.clone(), transmit).await {
+            // TODO: We should pass the local addr here, I think.
+            if let Err(err) = send_datagram(&mut sender, addr.remote.clone(), transmit).await {
                 debug!(?addr, "failed to send datagram on selected_path: {err:#}");
             }
         } else {
@@ -869,12 +873,8 @@ impl State {
                         .any(|a| a.addr == *sockaddr)
                 {
                     trace!(%sockaddr, "not sending datagram to our own address");
-                } else if let Err(err) = send_datagram(
-                    &mut sender,
-                    TransportFourTuple::new(addr.clone(), None),
-                    transmit.clone(),
-                )
-                .await
+                } else if let Err(err) =
+                    send_datagram(&mut sender, addr.clone(), transmit.clone()).await
                 {
                     debug!(?addr, "failed to send datagram: {err:#}");
                 }
@@ -1115,16 +1115,7 @@ impl State {
 
     /// Returns the QUIC-mapped [`FourTuple`] for a [`TransportFourTuple`].
     fn quic_mapped_four_tuple(&self, network_path: &TransportFourTuple) -> FourTuple {
-        let remote = self.quic_mapped_addr(network_path.remote());
-        let local = network_path
-            .local()
-            .map(|addr| self.quic_mapped_addr(addr).ip());
-        FourTuple::new(remote, local)
-    }
-
-    /// Returns the QUIC-mapped address for a [`transports::Addr`].
-    fn quic_mapped_addr(&self, addr: &transports::Addr) -> SocketAddr {
-        match addr {
+        let remote = match &network_path.remote {
             transports::Addr::Ip(socket_addr) => *socket_addr,
             transports::Addr::Relay(relay_url, eid) => self
                 .relay_mapped_addrs
@@ -1133,7 +1124,8 @@ impl State {
             transports::Addr::Custom(remote) => {
                 self.custom_mapped_addrs.get(remote).private_socket_addr()
             }
-        }
+        };
+        FourTuple::new(remote, network_path.noq_local_ip)
     }
 
     /// Returns the [`transports::Addr] for a path.
@@ -1145,16 +1137,7 @@ impl State {
             &self.custom_mapped_addrs,
         )?;
 
-        // When mapping the local IP, we set the port to 0. The port is never used.
-        // TODO: Express this cleaner?
-        let local = noq_network_path.local_ip().and_then(|ip| {
-            to_transport_addr(
-                SocketAddr::new(ip, 0),
-                &self.relay_mapped_addrs,
-                &self.custom_mapped_addrs,
-            )
-        });
-        Some(TransportFourTuple::new(remote, local))
+        Some(TransportFourTuple::new(remote, noq_network_path.local_ip()))
     }
 
     /// Returns the current set of local direct addresses.
@@ -1169,37 +1152,36 @@ impl State {
 
 /// Identifies a network path by the combination of remote and local addresses.
 ///
-/// Mirrors [`noq::FourTuple`] but uses [`transports::Addr`] for the remote and local addresses.
+/// Mirrors [`noq::FourTuple`] but uses [`transports::Addr`] for the remote address.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub(super) struct TransportFourTuple {
     /// The remote side of this tuple.
-    pub(super) remote: transports::Addr,
+    remote: transports::Addr,
     /// The local side of this tuple.
     ///
-    /// Note that when this is [`transports::Addr::Ip`], the port carries no significance
-    /// and is always set to 0.
-    pub(super) local: Option<transports::Addr>,
+    /// This is the IP address, unmodified as returned from [`noq::Path::local_ip`].
+    /// We pass it back to noq as-is when opening paths on other connections.
+    ///
+    /// Its meaning is a bit particular:
+    /// * For IP transports this is the interface IP, if known.
+    /// * For custom transports this is a mapped custom transport address.
+    /// * For relay transports this is never set.
+    noq_local_ip: Option<IpAddr>,
 }
 
 impl std::fmt::Display for TransportFourTuple {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(local_ip) = self.local.as_ref() {
-            write!(f, "{:?}->", local_ip)?;
-        }
-        write!(f, "{:?}", self.remote)
+        write!(f, "{:?}->{:?}", self.noq_local_ip, self.remote)
     }
 }
 
 impl TransportFourTuple {
     /// Creates a new [`TransportFourTuple`].
-    pub(super) fn new(remote: transports::Addr, local: Option<transports::Addr>) -> Self {
-        Self { remote, local }
-    }
-
-    /// Creates a new [`TransportFourTuple`] without a known local address.
-    #[allow(dead_code)]
-    pub(super) fn from_remote(remote: transports::Addr) -> Self {
-        Self::new(remote, None)
+    pub(super) fn new(remote: transports::Addr, noq_local_ip: Option<IpAddr>) -> Self {
+        Self {
+            remote,
+            noq_local_ip,
+        }
     }
 
     /// Returns the remote address of the network path.
@@ -1207,9 +1189,34 @@ impl TransportFourTuple {
         &self.remote
     }
 
-    /// Returns the local address of the network path.
-    pub(super) fn local(&self) -> Option<&transports::Addr> {
-        self.local.as_ref()
+    /// Returns the [`LocalTransportAddr`] for this network path.
+    // * For IP transports, it is the address of the local socket.
+    // * For relay transports, we never set the local_ip in the recv meta.
+    //   We take the relay URL of the remote address here instead.
+    // * For custom transports, the custom transport implementation can set a [`CustomAddr`]
+    //   which we convert back into here from the mapped address.
+    pub(super) fn local(
+        &self,
+        custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
+    ) -> LocalTransportAddr {
+        // TODO: Express this cleaner?
+        match &self.remote {
+            transports::Addr::Relay(relay_url, _public_key) => LocalTransportAddr::Relay {
+                url: relay_url.clone(),
+            },
+            transports::Addr::Ip(_) => LocalTransportAddr::Ip(self.noq_local_ip),
+            transports::Addr::Custom(_) => {
+                let addr = self.noq_local_ip.and_then(|ip| {
+                    match MultipathMappedAddr::from(SocketAddr::new(ip, 0)) {
+                        MultipathMappedAddr::Custom(custom_mapped_addr) => {
+                            custom_mapped_addrs.lookup(&custom_mapped_addr)
+                        }
+                        _ => None,
+                    }
+                });
+                LocalTransportAddr::Custom(addr)
+            }
+        }
     }
 
     /// Returns whether the remote of this tuple is an IP address.
@@ -1280,7 +1287,7 @@ fn update_qnt_candidates(conn: &noq::Connection, direct_addrs: &BTreeSet<SocketA
 
 fn send_datagram<'a>(
     sender: &'a mut TransportsSender,
-    network_path: TransportFourTuple,
+    addr: transports::Addr,
     owned_transmit: OwnedTransmit,
 ) -> impl Future<Output = n0_error::Result<()>> + 'a {
     std::future::poll_fn(move |cx| {
@@ -1290,14 +1297,10 @@ fn send_datagram<'a>(
             segment_size: owned_transmit.segment_size,
         };
 
-        // TODO: Add support for source address here.
+        // TODO: Add support for source address here?
         Pin::new(&mut *sender)
-            .poll_send(cx, &network_path.remote, None, &transmit)
-            .map(|res| {
-                res.with_context(|_| {
-                    format!("failed to send datagram to {:?}", network_path.remote)
-                })
-            })
+            .poll_send(cx, &addr, None, &transmit)
+            .map(|res| res.with_context(|_| format!("failed to send datagram to {:?}", addr)))
     })
 }
 
@@ -1415,7 +1418,7 @@ impl ConnectionState {
             && let Some(path) = conn.path(path_id)
         {
             let handle = path.weak_handle();
-            self.path_state.record_opened(handle, network_path.into());
+            self.path_state.record_opened(handle, network_path);
         }
     }
 
@@ -1501,7 +1504,7 @@ mod tests {
     fn v4(port: u16) -> TransportFourTuple {
         let remote =
             transports::Addr::Ip(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)));
-        TransportFourTuple::from_remote(remote)
+        TransportFourTuple::new(remote, None)
     }
 
     fn v6(port: u16) -> TransportFourTuple {
@@ -1511,7 +1514,7 @@ mod tests {
             0,
             0,
         )));
-        TransportFourTuple::from_remote(remote)
+        TransportFourTuple::new(remote, None)
     }
 
     fn relay(port: u16) -> TransportFourTuple {
@@ -1519,7 +1522,7 @@ mod tests {
             .parse::<RelayUrl>()
             .unwrap();
         let remote = transports::Addr::Relay(url, EndpointId::from_bytes(&[0u8; 32]).unwrap());
-        TransportFourTuple::from_remote(remote)
+        TransportFourTuple::new(remote, None)
     }
 
     fn psd(transport_type: TransportType, rtt_ms: u64) -> PathSelectionData {

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -394,8 +394,7 @@ impl RemoteStateActor {
         conn: noq::Connection,
         tx: oneshot::Sender<PathStateReceiver>,
     ) {
-        let (path_state_sender, path_state_receiver) =
-            PathStateSender::new(self.state.custom_mapped_addrs.clone());
+        let (path_state_sender, path_state_receiver) = PathStateSender::new();
         self.state.metrics.num_conns_opened.inc();
         // Remove any conflicting stable_ids from the local state.
         let conn_id = ConnId(conn.stable_id());
@@ -443,8 +442,8 @@ impl RemoteStateActor {
                     .state
                     .paths
                     .addrs()
-                    .filter(|a| a.is_relay())
-                    .map(|remote| TransportFourTuple::new(remote.clone(), None))
+                    .filter(|addr| addr.is_relay())
+                    .map(|addr| TransportFourTuple::from_remote(addr.clone()))
                     .collect::<Vec<_>>();
                 for open_addr in relays {
                     self.state
@@ -1136,19 +1135,27 @@ impl State {
                 self.custom_mapped_addrs.get(remote).private_socket_addr()
             }
         };
-        FourTuple::new(remote, network_path.noq_local_ip)
+        let local = network_path
+            .local
+            .to_noq_local_ip(&self.custom_mapped_addrs);
+        FourTuple::new(remote, local)
     }
 
     /// Returns the [`transports::Addr] for a path.
     fn transport_addr_for_path(&self, path: &noq::Path) -> Option<TransportFourTuple> {
         let noq_network_path = path.network_path().ok()?;
-        let remote = to_transport_addr(
+        let remote_addr = to_transport_addr(
             noq_network_path.remote(),
             &self.relay_mapped_addrs,
             &self.custom_mapped_addrs,
         )?;
+        let local_addr = LocalTransportAddr::from_noq_local_ip(
+            noq_network_path.local_ip(),
+            &remote_addr,
+            &self.custom_mapped_addrs,
+        );
 
-        Some(TransportFourTuple::new(remote, noq_network_path.local_ip()))
+        Some(TransportFourTuple::new(remote_addr, local_addr))
     }
 
     /// Returns the current set of local direct addresses.
@@ -1177,22 +1184,33 @@ pub(super) struct TransportFourTuple {
     /// * For IP transports this is the interface IP, if known.
     /// * For custom transports this is a mapped custom transport address.
     /// * For relay transports this is never set.
-    noq_local_ip: Option<IpAddr>,
+    local: LocalTransportAddr,
 }
 
 impl std::fmt::Display for TransportFourTuple {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}->{:?}", self.noq_local_ip, self.remote)
+        match &self.local {
+            LocalTransportAddr::Ip(Some(ip_addr)) => write!(f, "{ip_addr}->")?,
+            LocalTransportAddr::Custom(Some(addr)) => write!(f, "{addr}->")?,
+            _ => {}
+        }
+        write!(f, "{:?}", self.remote)
     }
 }
 
 impl TransportFourTuple {
     /// Creates a new [`TransportFourTuple`].
-    pub(super) fn new(remote: transports::Addr, noq_local_ip: Option<IpAddr>) -> Self {
-        Self {
-            remote,
-            noq_local_ip,
-        }
+    pub(super) fn new(remote: transports::Addr, local: LocalTransportAddr) -> Self {
+        Self { remote, local }
+    }
+
+    fn from_remote(remote: transports::Addr) -> Self {
+        let local = match &remote {
+            transports::Addr::Ip(_) => LocalTransportAddr::Ip(None),
+            transports::Addr::Relay(url, _) => LocalTransportAddr::Relay(url.clone()),
+            transports::Addr::Custom(_) => LocalTransportAddr::Custom(None),
+        };
+        Self::new(remote, local)
     }
 
     /// Returns the remote address of the network path.
@@ -1201,21 +1219,8 @@ impl TransportFourTuple {
     }
 
     /// Returns the [`LocalTransportAddr`] for this network path.
-    ///
-    /// * For IP transports, it is the address of the local socket.
-    /// * For relay transports, we never set the local_ip in the recv meta.
-    ///   We take the relay URL of the remote address here instead.
-    /// * For custom transports, the custom transport implementation can set a [`CustomAddr`]
-    ///   which we convert back into here from the mapped address.
-    pub(super) fn local(
-        &self,
-        custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
-    ) -> LocalTransportAddr {
-        LocalTransportAddr::from_noq_local_ip_with_custom_addr_map(
-            self.noq_local_ip,
-            &self.remote,
-            custom_mapped_addrs,
-        )
+    pub(super) fn local(&self) -> &LocalTransportAddr {
+        &self.local
     }
 
     /// Returns whether the remote of this tuple is an IP address.
@@ -1503,7 +1508,7 @@ mod tests {
     fn v4(port: u16) -> TransportFourTuple {
         let remote =
             transports::Addr::Ip(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)));
-        TransportFourTuple::new(remote, None)
+        TransportFourTuple::from_remote(remote)
     }
 
     fn v6(port: u16) -> TransportFourTuple {
@@ -1513,7 +1518,7 @@ mod tests {
             0,
             0,
         )));
-        TransportFourTuple::new(remote, None)
+        TransportFourTuple::from_remote(remote)
     }
 
     fn relay(port: u16) -> TransportFourTuple {
@@ -1521,7 +1526,7 @@ mod tests {
             .parse::<RelayUrl>()
             .unwrap();
         let remote = transports::Addr::Relay(url, EndpointId::from_bytes(&[0u8; 32]).unwrap());
-        TransportFourTuple::new(remote, None)
+        TransportFourTuple::from_remote(remote)
     }
 
     fn psd(transport_type: TransportType, rtt_ms: u64) -> PathSelectionData {

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -660,7 +660,7 @@ impl RemoteStateActor {
             NoqPathEvent::Discarded { id, path_stats, .. } => {
                 trace!(%id, ?path_stats, "path discarded");
             }
-            _ => {
+            NoqPathEvent::RemoteStatus { .. } | NoqPathEvent::ObservedAddr { .. } => {
                 // Nothing to do for these events.
             }
             _ => {

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -612,7 +612,7 @@ impl RemoteStateActor {
 
                 // We track all known remote addresses for the peer in `State::paths`. The paths are tracked
                 // by remote address only (we ignore the local IP). Therefore, we mark a remote addr as abandoned
-                // in the remote-global state only once no connections has any path to that remote addr.
+                // in the remote-global state only once no connections have any path to that remote addr.
                 if !conn_state
                     .paths
                     .values()
@@ -855,7 +855,9 @@ impl State {
 
             // TODO(Frando): We might want to include a local IP here in the future, if we confidently
             // know that it is the correct one.
-            if let Err(err) = send_datagram(&mut sender, addr.remote.clone(), transmit).await {
+            // See https://github.com/n0-computer/iroh/issues/4280.
+            if let Err(err) = send_datagram(&mut sender, addr.remote.clone(), None, transmit).await
+            {
                 debug!(?addr, "failed to send datagram on selected_path: {err:#}");
             }
         } else {
@@ -881,8 +883,9 @@ impl State {
 
                 // TODO(Frando): We might want to include a local IP here in the future, if we confidently
                 // know that it is the correct one.
+                // See https://github.com/n0-computer/iroh/issues/4280.
                 } else if let Err(err) =
-                    send_datagram(&mut sender, addr.clone(), transmit.clone()).await
+                    send_datagram(&mut sender, addr.clone(), None, transmit.clone()).await
                 {
                     debug!(?addr, "failed to send datagram: {err:#}");
                 }
@@ -1284,6 +1287,7 @@ fn update_qnt_candidates(conn: &noq::Connection, direct_addrs: &BTreeSet<SocketA
 fn send_datagram<'a>(
     sender: &'a mut TransportsSender,
     addr: transports::Addr,
+    local_ip: Option<IpAddr>,
     owned_transmit: OwnedTransmit,
 ) -> impl Future<Output = n0_error::Result<()>> + 'a {
     std::future::poll_fn(move |cx| {
@@ -1293,9 +1297,8 @@ fn send_datagram<'a>(
             segment_size: owned_transmit.segment_size,
         };
 
-        // TODO: Add support for source address here?
         Pin::new(&mut *sender)
-            .poll_send(cx, &addr, None, &transmit)
+            .poll_send(cx, &addr, local_ip, &transmit)
             .map(|res| res.with_context(|_| format!("failed to send datagram to {:?}", addr)))
     })
 }

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -15,7 +15,7 @@ use n0_future::{
     time::{self, Duration, Instant},
 };
 use n0_watcher::Watcher;
-use noq::{Closed, PathStatus, WeakConnectionHandle};
+use noq::{Closed, FourTuple, PathStatus, WeakConnectionHandle};
 use noq_proto::{PathError, PathEvent as NoqPathEvent, PathId, n0_nat_traversal};
 use rustc_hash::FxHashMap;
 use tokio::sync::{mpsc, oneshot};
@@ -155,7 +155,7 @@ struct State {
     /// holepunching regularly.
     ///
     /// We only select a path once the path is functional in Noq.
-    selected_path: Option<transports::Addr>,
+    selected_path: Option<TransportFourTuple>,
     /// Time at which we should schedule the next holepunch attempt.
     scheduled_holepunch: Option<Instant>,
     /// When to next attempt opening paths in [`Self::pending_open_paths`].
@@ -163,7 +163,7 @@ struct State {
     /// Paths which we still need to open.
     ///
     /// They failed to open because we did not have enough CIDs issued by the remote.
-    pending_open_paths: VecDeque<transports::Addr>,
+    pending_open_paths: VecDeque<TransportFourTuple>,
 
     // Internal state - address lookup
     //
@@ -440,7 +440,7 @@ impl RemoteStateActor {
                     .paths
                     .addrs()
                     .filter(|a| a.is_relay())
-                    .cloned()
+                    .map(|remote| TransportFourTuple::from_remote(remote.clone()))
                     .collect::<Vec<_>>();
                 for open_addr in relays {
                     self.state
@@ -601,18 +601,24 @@ impl RemoteStateActor {
             }
             NoqPathEvent::Abandoned { id, reason, .. } => {
                 // Remove abandoned path from the conn state.
-                let Some(path_remote) = conn_state.remove_path(&id, &conn) else {
+                let Some(network_path) = conn_state.remove_path(&id, &conn) else {
                     debug!(%id, "path not in path_id_map");
                     return;
                 };
                 // Also remove the path from the remote-global path tracking.
-                self.state.paths.abandoned_path(&path_remote);
+                if !conn_state
+                    .paths
+                    .values()
+                    .any(|tuple| tuple.remote() == network_path.remote())
+                {
+                    self.state.paths.abandoned_path(&network_path.remote);
+                }
 
                 event!(
                     target: "iroh::_events::path::abandoned",
                     Level::DEBUG,
                     remote = %self.state.endpoint_id.fmt_short(),
-                    ?path_remote,
+                    %network_path,
                     %conn_id,
                     path_id = ?id,
                     ?reason
@@ -627,15 +633,15 @@ impl RemoteStateActor {
                     for path in conn_state
                         .paths
                         .iter()
-                        .filter(|(_id, addr)| **addr == path_remote)
+                        .filter(|(_id, addr)| **addr == network_path)
                         .filter_map(|(id, _addr)| conn.path(*id))
                     {
-                        trace!(?path_remote, %conn_id, path_id=%path.id(), "closing path");
+                        trace!(%conn_id, path_id=%path.id(), %network_path, "closing path");
                         if let Err(err) = path.close() {
                             trace!(
-                                ?path_remote,
                                 %conn_id,
                                 path_id=%path.id(),
+                                %network_path,
                                 "path close failed: {err:#}"
                             );
                         }
@@ -672,7 +678,7 @@ impl RemoteStateActor {
     fn select_path(&mut self) {
         // Find the lowest RTT across all connections for each open path.  The long way, so
         // we get to log *all* RTTs.
-        let mut all_path_rtts: FxHashMap<&transports::Addr, Vec<Duration>> = FxHashMap::default();
+        let mut all_path_rtts: FxHashMap<&TransportFourTuple, Vec<Duration>> = FxHashMap::default();
         for conn_state in self.connections.values() {
             let Some(conn) = conn_state.handle.upgrade() else {
                 continue;
@@ -684,13 +690,15 @@ impl RemoteStateActor {
             }
         }
         trace!(?all_path_rtts, "dumping all path RTTs");
-        let path_rtts: FxHashMap<&transports::Addr, PathSelectionData> = all_path_rtts
+        let path_rtts: FxHashMap<&TransportFourTuple, PathSelectionData> = all_path_rtts
             .into_iter()
             .filter_map(|(addr, rtts)| rtts.into_iter().min().map(|rtt| (addr, rtt)))
             .map(|(addr, rtt)| {
                 (
                     addr,
-                    self.state.transport_bias.path_selection_data(addr, rtt),
+                    self.state
+                        .transport_bias
+                        .path_selection_data(&addr.remote, rtt),
                 )
             })
             .collect();
@@ -724,7 +732,7 @@ impl RemoteStateActor {
     /// - Sets all non-selected paths to [`PathStatus::Backup`]
     /// - Opens the selected path if it does not exist on the connection
     /// - Sets the selected path to [`PathStatus::Available`]
-    fn apply_selected_change(&mut self, selected: &transports::Addr) {
+    fn apply_selected_change(&mut self, selected: &TransportFourTuple) {
         for (conn_id, conn_state) in self.connections.iter() {
             let Some(conn) = conn_state.handle.upgrade() else {
                 continue;
@@ -770,13 +778,11 @@ impl RemoteStateActor {
             }
 
             // Record the new selected path in the path watcher.
-            conn_state
-                .path_state
-                .record_selected(selected.clone().into());
+            conn_state.path_state.record_selected(selected);
         }
     }
 
-    fn open_path_on_all_conns(&mut self, open_addr: &transports::Addr) {
+    fn open_path_on_all_conns(&mut self, open_addr: &TransportFourTuple) {
         for (conn_id, conn_state) in self.connections.iter() {
             let Some(conn) = conn_state.handle.upgrade() else {
                 continue;
@@ -863,8 +869,12 @@ impl State {
                         .any(|a| a.addr == *sockaddr)
                 {
                     trace!(%sockaddr, "not sending datagram to our own address");
-                } else if let Err(err) =
-                    send_datagram(&mut sender, addr.clone(), transmit.clone()).await
+                } else if let Err(err) = send_datagram(
+                    &mut sender,
+                    TransportFourTuple::new(addr.clone(), None),
+                    transmit.clone(),
+                )
+                .await
                 {
                     debug!(?addr, "failed to send datagram: {err:#}");
                 }
@@ -1003,44 +1013,44 @@ impl State {
         conn_id: ConnId,
         conn_state: &mut ConnectionState,
         path: &noq::Path,
-    ) -> Option<transports::Addr> {
-        let path_remote = self.transport_addr_for_path(path)?;
+    ) -> Option<TransportFourTuple> {
+        let network_path = self.transport_addr_for_path(path)?;
         event!(
             target: "iroh::_events::path::open",
             Level::DEBUG,
             remote = %self.endpoint_id.fmt_short(),
-            ?path_remote,
+            ?network_path,
             %conn_id,
             path_id=%path.id(),
         );
-        conn_state.add_open_path(path_remote.clone(), path.id(), &self.metrics);
-        if matches!(path_remote, transports::Addr::Relay(..))
+        conn_state.add_open_path(network_path.clone(), path.id(), &self.metrics);
+        if matches!(network_path.remote(), transports::Addr::Relay(..))
             && let Err(e) = path.set_max_idle_timeout(Some(RELAY_PATH_MAX_IDLE_TIMEOUT))
         {
             debug!(?e, "failed to set relay path idle timeout");
         }
 
-        self.set_path_status(conn_id, path, &path_remote);
+        self.set_path_status(conn_id, path, &network_path);
         self.paths
-            .insert_open_path(path_remote.clone(), Source::Connection);
-        Some(path_remote)
+            .insert_open_path(network_path.remote().clone(), Source::Connection);
+        Some(network_path)
     }
 
     fn set_path_status(
         &mut self,
         conn_id: ConnId,
         path: &noq::Path,
-        path_remote: &transports::Addr,
+        network_path: &TransportFourTuple,
     ) {
-        let status = self.path_status_for_addr(path_remote);
+        let status = self.path_status_for_addr(network_path);
         match path.set_status(status) {
-            Err(error) => warn!(?error, ?path_remote, ?status, "set_status failed"),
+            Err(error) => warn!(?error, ?network_path, ?status, "set_status failed"),
             Ok(prev_status) if prev_status != status => {
                 event!(
                     target: "iroh::_events::path::set_status",
                     Level::DEBUG,
                     remote = %self.endpoint_id.fmt_short(),
-                    path_remote = ?path_remote,
+                    path_remote = ?network_path,
                     ?status,
                     %conn_id,
                     path_id=%path.id(),
@@ -1056,7 +1066,7 @@ impl State {
         conn_id: ConnId,
         conn_state: &ConnectionState,
         conn: &noq::Connection,
-        open_addr: &transports::Addr,
+        open_addr: &TransportFourTuple,
     ) {
         // Only the client opens paths; the server receives them via
         // QUIC frames and reacts to PathOpened events.
@@ -1068,7 +1078,7 @@ impl State {
             return;
         }
 
-        let quic_addr = self.quic_mapped_addr(open_addr);
+        let quic_addr = self.quic_mapped_four_tuple(open_addr);
         let path_status = self.path_status_for_addr(open_addr);
 
         let fut = conn.open_path_ensure(quic_addr, path_status);
@@ -1095,7 +1105,7 @@ impl State {
     ///
     /// Returns [`PathStatus::Available`] if `addr` is the currently-selected path,
     /// or [`PathStatus::Backup`] otherwise.
-    fn path_status_for_addr(&self, addr: &transports::Addr) -> PathStatus {
+    fn path_status_for_addr(&self, addr: &TransportFourTuple) -> PathStatus {
         if Some(addr) == self.selected_path.as_ref() {
             PathStatus::Available
         } else {
@@ -1103,9 +1113,18 @@ impl State {
         }
     }
 
+    /// Returns the QUIC-mapped [`FourTuple`] for a [`TransportFourTuple`].
+    fn quic_mapped_four_tuple(&self, network_path: &TransportFourTuple) -> FourTuple {
+        let remote = self.quic_mapped_addr(network_path.remote());
+        let local = network_path
+            .local()
+            .map(|addr| self.quic_mapped_addr(addr).ip());
+        FourTuple::new(remote, local)
+    }
+
     /// Returns the QUIC-mapped address for a [`transports::Addr`].
-    fn quic_mapped_addr(&self, open_addr: &transports::Addr) -> SocketAddr {
-        match open_addr {
+    fn quic_mapped_addr(&self, addr: &transports::Addr) -> SocketAddr {
+        match addr {
             transports::Addr::Ip(socket_addr) => *socket_addr,
             transports::Addr::Relay(relay_url, eid) => self
                 .relay_mapped_addrs
@@ -1118,13 +1137,24 @@ impl State {
     }
 
     /// Returns the [`transports::Addr] for a path.
-    fn transport_addr_for_path(&self, path: &noq::Path) -> Option<transports::Addr> {
-        let socketaddr = path.remote_address().ok()?;
-        to_transport_addr(
-            socketaddr,
+    fn transport_addr_for_path(&self, path: &noq::Path) -> Option<TransportFourTuple> {
+        let noq_network_path = path.network_path().ok()?;
+        let remote = to_transport_addr(
+            noq_network_path.remote(),
             &self.relay_mapped_addrs,
             &self.custom_mapped_addrs,
-        )
+        )?;
+
+        // When mapping the local IP, we set the port to 0. The port is never used.
+        // TODO: Express this cleaner?
+        let local = noq_network_path.local_ip().and_then(|ip| {
+            to_transport_addr(
+                SocketAddr::new(ip, 0),
+                &self.relay_mapped_addrs,
+                &self.custom_mapped_addrs,
+            )
+        });
+        Some(TransportFourTuple::new(remote, local))
     }
 
     /// Returns the current set of local direct addresses.
@@ -1137,12 +1167,68 @@ impl State {
     }
 }
 
+/// Identifies a network path by the combination of remote and local addresses.
+///
+/// Mirrors [`noq::FourTuple`] but uses [`transports::Addr`] for the remote and local addresses.
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+pub(super) struct TransportFourTuple {
+    /// The remote side of this tuple.
+    pub(super) remote: transports::Addr,
+    /// The local side of this tuple.
+    ///
+    /// Note that when this is [`transports::Addr::Ip`], the port carries no significance
+    /// and is always set to 0.
+    pub(super) local: Option<transports::Addr>,
+}
+
+impl std::fmt::Display for TransportFourTuple {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(local_ip) = self.local.as_ref() {
+            write!(f, "{:?}->", local_ip)?;
+        }
+        write!(f, "{:?}", self.remote)
+    }
+}
+
+impl TransportFourTuple {
+    /// Creates a new [`TransportFourTuple`].
+    pub(super) fn new(remote: transports::Addr, local: Option<transports::Addr>) -> Self {
+        Self { remote, local }
+    }
+
+    /// Creates a new [`TransportFourTuple`] without a known local address.
+    #[allow(dead_code)]
+    pub(super) fn from_remote(remote: transports::Addr) -> Self {
+        Self::new(remote, None)
+    }
+
+    /// Returns the remote address of the network path.
+    pub(super) fn remote(&self) -> &transports::Addr {
+        &self.remote
+    }
+
+    /// Returns the local address of the network path.
+    pub(super) fn local(&self) -> Option<&transports::Addr> {
+        self.local.as_ref()
+    }
+
+    /// Returns whether the remote of this tuple is an IP address.
+    pub(super) fn is_ip(&self) -> bool {
+        self.remote.is_ip()
+    }
+
+    /// Returns whether the remote of this tuple is a relay address.
+    pub(super) fn is_relay(&self) -> bool {
+        self.remote.is_relay()
+    }
+}
+
 /// Returns `Some` if a new path should be selected, `None` if the `current_path` should
 /// continued to be used.
 fn select_best_path<'a>(
-    all_paths: FxHashMap<&'a transports::Addr, PathSelectionData>,
-    current_path: Option<&'a transports::Addr>,
-) -> Option<(transports::Addr, Duration)> {
+    all_paths: FxHashMap<&'a TransportFourTuple, PathSelectionData>,
+    current_path: Option<&'a TransportFourTuple>,
+) -> Option<(TransportFourTuple, Duration)> {
     // Determine the best new path according to sort_key.
     // If there is no path, return None.
     let (best_addr, best_data) = all_paths.iter().min_by_key(|(_, psd)| psd.sort_key())?;
@@ -1194,7 +1280,7 @@ fn update_qnt_candidates(conn: &noq::Connection, direct_addrs: &BTreeSet<SocketA
 
 fn send_datagram<'a>(
     sender: &'a mut TransportsSender,
-    dst: transports::Addr,
+    network_path: TransportFourTuple,
     owned_transmit: OwnedTransmit,
 ) -> impl Future<Output = n0_error::Result<()>> + 'a {
     std::future::poll_fn(move |cx| {
@@ -1204,9 +1290,14 @@ fn send_datagram<'a>(
             segment_size: owned_transmit.segment_size,
         };
 
+        // TODO: Add support for source address here.
         Pin::new(&mut *sender)
-            .poll_send(cx, &dst, None, &transmit)
-            .map(|res| res.with_context(|_| format!("failed to send datagram to {dst:?}")))
+            .poll_send(cx, &network_path.remote, None, &transmit)
+            .map(|res| {
+                res.with_context(|_| {
+                    format!("failed to send datagram to {:?}", network_path.remote)
+                })
+            })
     })
 }
 
@@ -1294,7 +1385,7 @@ struct ConnectionState {
     /// [`Connection`]: crate::endpoint::Connection
     path_state: PathStateSender,
     /// The open paths that exist on this connection.
-    paths: FxHashMap<PathId, transports::Addr>,
+    paths: FxHashMap<PathId, TransportFourTuple>,
     /// Whether this connection has ever had a direct path.
     ///
     /// Used for recording metrics.
@@ -1305,26 +1396,26 @@ impl ConnectionState {
     /// Tracks an open path for the connection.
     fn add_open_path(
         &mut self,
-        remote: transports::Addr,
+        network_path: TransportFourTuple,
         path_id: PathId,
         metrics: &Arc<SocketMetrics>,
     ) {
-        match remote {
+        match &network_path.remote {
             transports::Addr::Ip(_) => metrics.paths_direct.inc(),
             transports::Addr::Relay(_, _) => metrics.paths_relay.inc(),
             transports::Addr::Custom(_) => metrics.paths_custom.inc(),
         };
-        if !self.has_been_direct && remote.is_ip() {
+        if !self.has_been_direct && network_path.is_ip() {
             self.has_been_direct = true;
             metrics.num_conns_direct.inc();
         }
 
-        self.paths.insert(path_id, remote.clone());
+        self.paths.insert(path_id, network_path.clone());
         if let Some(conn) = self.handle.upgrade()
             && let Some(path) = conn.path(path_id)
         {
             let handle = path.weak_handle();
-            self.path_state.record_opened(handle, remote.into());
+            self.path_state.record_opened(handle, network_path.into());
         }
     }
 
@@ -1333,7 +1424,7 @@ impl ConnectionState {
         &mut self,
         path_id: &PathId,
         conn: &noq::Connection,
-    ) -> Option<transports::Addr> {
+    ) -> Option<TransportFourTuple> {
         let addr = self.paths.remove(path_id)?;
         self.path_state.record_abandoned(*path_id, conn);
         Some(addr)
@@ -1407,24 +1498,28 @@ mod tests {
     use super::*;
     use crate::socket::transports::TransportType;
 
-    fn v4(port: u16) -> transports::Addr {
-        transports::Addr::Ip(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)))
+    fn v4(port: u16) -> TransportFourTuple {
+        let remote =
+            transports::Addr::Ip(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)));
+        TransportFourTuple::from_remote(remote)
     }
 
-    fn v6(port: u16) -> transports::Addr {
-        transports::Addr::Ip(SocketAddr::V6(SocketAddrV6::new(
+    fn v6(port: u16) -> TransportFourTuple {
+        let remote = transports::Addr::Ip(SocketAddr::V6(SocketAddrV6::new(
             Ipv6Addr::LOCALHOST,
             port,
             0,
             0,
-        )))
+        )));
+        TransportFourTuple::from_remote(remote)
     }
 
-    fn relay(port: u16) -> transports::Addr {
+    fn relay(port: u16) -> TransportFourTuple {
         let url = format!("https://relay{port}.iroh.computer")
             .parse::<RelayUrl>()
             .unwrap();
-        transports::Addr::Relay(url, EndpointId::from_bytes(&[0u8; 32]).unwrap())
+        let remote = transports::Addr::Relay(url, EndpointId::from_bytes(&[0u8; 32]).unwrap());
+        TransportFourTuple::from_remote(remote)
     }
 
     fn psd(transport_type: TransportType, rtt_ms: u64) -> PathSelectionData {
@@ -1460,7 +1555,10 @@ mod tests {
         let result = select_best_path(paths, None);
         assert!(result.is_some());
         let (addr, _) = result.unwrap();
-        assert!(matches!(addr, transports::Addr::Ip(SocketAddr::V6(_))));
+        assert!(matches!(
+            addr.remote,
+            transports::Addr::Ip(SocketAddr::V6(_))
+        ));
 
         // IPv6 should still win when it's slightly slower (within bias range)
         let mut paths = FxHashMap::default();
@@ -1470,7 +1568,10 @@ mod tests {
         let result = select_best_path(paths, None);
         assert!(result.is_some());
         let (addr, _) = result.unwrap();
-        assert!(matches!(addr, transports::Addr::Ip(SocketAddr::V6(_))));
+        assert!(matches!(
+            addr.remote,
+            transports::Addr::Ip(SocketAddr::V6(_))
+        ));
 
         // IPv4 should win when IPv6 is significantly slower
         let mut paths = FxHashMap::default();
@@ -1480,7 +1581,10 @@ mod tests {
         let result = select_best_path(paths, None);
         assert!(result.is_some());
         let (addr, _) = result.unwrap();
-        assert!(matches!(addr, transports::Addr::Ip(SocketAddr::V4(_))));
+        assert!(matches!(
+            addr.remote,
+            transports::Addr::Ip(SocketAddr::V4(_))
+        ));
     }
 
     #[test]
@@ -1567,11 +1671,11 @@ mod tests {
 
     #[test]
     fn test_empty_paths_returns_none() {
-        let paths: FxHashMap<&transports::Addr, PathSelectionData> = FxHashMap::default();
+        let paths: FxHashMap<&TransportFourTuple, PathSelectionData> = FxHashMap::default();
         let result = select_best_path(paths, None);
         assert!(result.is_none());
 
-        let paths: FxHashMap<&transports::Addr, PathSelectionData> = FxHashMap::default();
+        let paths: FxHashMap<&TransportFourTuple, PathSelectionData> = FxHashMap::default();
         let result = select_best_path(paths, Some(&v4(1)));
         assert!(result.is_none());
     }

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -31,14 +31,15 @@ pub use self::{
 use super::Source;
 use crate::{
     address_lookup::{AddressLookupFailed, AddressLookupServices, Item as AddressLookupItem},
-    endpoint::{DirectAddr, LocalTransportAddr},
+    endpoint::DirectAddr,
     socket::{
         Metrics as SocketMetrics, RELAY_PATH_MAX_IDLE_TIMEOUT,
-        mapped_addrs::{
-            AddrMap, CustomMappedAddr, MappedAddr, MultipathMappedAddr, RelayMappedAddr,
-        },
+        mapped_addrs::{AddrMap, CustomMappedAddr, MappedAddr, RelayMappedAddr},
         remote_map::{remote_state::path_watcher::PathStateSender, to_transport_addr},
-        transports::{self, OwnedTransmit, PathSelectionData, TransportBiasMap, TransportsSender},
+        transports::{
+            self, LocalTransportAddr, OwnedTransmit, PathSelectionData, TransportBiasMap,
+            TransportsSender,
+        },
     },
     util::MaybeFuture,
 };
@@ -608,7 +609,10 @@ impl RemoteStateActor {
                     debug!(%id, "path not in path_id_map");
                     return;
                 };
-                // Also remove the path from the remote-global path tracking.
+
+                // We track all known remote addresses for the peer in `State::paths`. The paths are tracked
+                // by remote address only (we ignore the local IP). Therefore, we mark a remote addr as abandoned
+                // in the remote-global state only once no connections has any path to that remote addr.
                 if !conn_state
                     .paths
                     .values()
@@ -632,7 +636,7 @@ impl RemoteStateActor {
                     let Some(conn) = conn_state.handle.upgrade() else {
                         continue;
                     };
-                    // Close all paths with the remote address that was abandoned.
+                    // Close all paths with the network paths that was abandoned.
                     for path in conn_state
                         .paths
                         .iter()
@@ -849,7 +853,8 @@ impl State {
         if let Some(addr) = self.selected_path.as_ref() {
             trace!(?addr, "sending datagram to selected path");
 
-            // TODO: We should pass the local addr here, I think.
+            // TODO(Frando): We might want to include a local IP here in the future, if we confidently
+            // know that it is the correct one.
             if let Err(err) = send_datagram(&mut sender, addr.remote.clone(), transmit).await {
                 debug!(?addr, "failed to send datagram on selected_path: {err:#}");
             }
@@ -873,6 +878,9 @@ impl State {
                         .any(|a| a.addr == *sockaddr)
                 {
                     trace!(%sockaddr, "not sending datagram to our own address");
+
+                // TODO(Frando): We might want to include a local IP here in the future, if we confidently
+                // know that it is the correct one.
                 } else if let Err(err) =
                     send_datagram(&mut sender, addr.clone(), transmit.clone()).await
                 {
@@ -1190,33 +1198,21 @@ impl TransportFourTuple {
     }
 
     /// Returns the [`LocalTransportAddr`] for this network path.
-    // * For IP transports, it is the address of the local socket.
-    // * For relay transports, we never set the local_ip in the recv meta.
-    //   We take the relay URL of the remote address here instead.
-    // * For custom transports, the custom transport implementation can set a [`CustomAddr`]
-    //   which we convert back into here from the mapped address.
+    ///
+    /// * For IP transports, it is the address of the local socket.
+    /// * For relay transports, we never set the local_ip in the recv meta.
+    ///   We take the relay URL of the remote address here instead.
+    /// * For custom transports, the custom transport implementation can set a [`CustomAddr`]
+    ///   which we convert back into here from the mapped address.
     pub(super) fn local(
         &self,
         custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
     ) -> LocalTransportAddr {
-        // TODO: Express this cleaner?
-        match &self.remote {
-            transports::Addr::Relay(relay_url, _public_key) => LocalTransportAddr::Relay {
-                url: relay_url.clone(),
-            },
-            transports::Addr::Ip(_) => LocalTransportAddr::Ip(self.noq_local_ip),
-            transports::Addr::Custom(_) => {
-                let addr = self.noq_local_ip.and_then(|ip| {
-                    match MultipathMappedAddr::from(SocketAddr::new(ip, 0)) {
-                        MultipathMappedAddr::Custom(custom_mapped_addr) => {
-                            custom_mapped_addrs.lookup(&custom_mapped_addr)
-                        }
-                        _ => None,
-                    }
-                });
-                LocalTransportAddr::Custom(addr)
-            }
-        }
+        LocalTransportAddr::from_noq_local_ip_with_custom_addr_map(
+            self.noq_local_ip,
+            &self.remote,
+            custom_mapped_addrs,
+        )
     }
 
     /// Returns whether the remote of this tuple is an IP address.

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -661,7 +661,7 @@ impl RemoteStateActor {
             NoqPathEvent::Discarded { id, path_stats, .. } => {
                 trace!(%id, ?path_stats, "path discarded");
             }
-            NoqPathEvent::RemoteStatus { .. } | NoqPathEvent::ObservedAddr { .. } => {
+            _ => {
                 // Nothing to do for these events.
             }
             _ => {

--- a/iroh/src/socket/remote_map/remote_state/path_watcher.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_watcher.rs
@@ -41,7 +41,7 @@ use tokio_stream::{
 };
 use tracing::warn;
 
-use crate::endpoint::PathStats;
+use crate::{endpoint::PathStats, socket::remote_map::remote_state::TransportFourTuple};
 
 /// Per-connection broadcast channel capacity for path events.
 const BROADCAST_CAPACITY: usize = 8;
@@ -92,6 +92,7 @@ pub enum PathEvent {
 struct PathData {
     handle: WeakPathHandle,
     remote_addr: TransportAddr,
+    local_addr: Option<TransportAddr>,
 }
 
 impl PathData {
@@ -150,13 +151,16 @@ impl PathStateSender {
     }
 
     /// Records a newly-opened path and emits [`PathEvent::Opened`].
-    pub(super) fn record_opened(&self, handle: WeakPathHandle, remote_addr: TransportAddr) {
+    pub(super) fn record_opened(&self, handle: WeakPathHandle, network_path: TransportFourTuple) {
         let id = handle.id();
+        let remote_addr: TransportAddr = network_path.remote.into();
+        let local_addr = network_path.local.map(|local| local.into());
         {
             let mut state = self.shared.state.lock().expect("poisoned");
             let entry = PathData {
                 handle,
                 remote_addr: remote_addr.clone(),
+                local_addr,
             };
             match state.list.iter().position(|e| e.handle.id() == id) {
                 Some(idx) => state.list[idx] = entry,
@@ -192,13 +196,16 @@ impl PathStateSender {
     }
 
     /// Updates the selected transmission path.
-    pub(super) fn record_selected(&self, remote_addr: TransportAddr) {
+    pub(super) fn record_selected(&self, network_path: &TransportFourTuple) {
+        // We need to convert from `transports::Addr` to `TransportAddr` here.
+        let remote_addr = network_path.remote.clone().into();
+        let local_addr = network_path.local.clone().map(|addr| addr.into());
         let changed = {
             let mut state = self.shared.state.lock().expect("poisoned");
             let selected_path_id = state
                 .list
                 .iter()
-                .find(|p| p.remote_addr == remote_addr)
+                .find(|p| p.remote_addr == remote_addr && p.local_addr == local_addr)
                 .map(|p| p.handle.id());
             if selected_path_id != state.selected {
                 state.selected = selected_path_id;

--- a/iroh/src/socket/remote_map/remote_state/path_watcher.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_watcher.rs
@@ -43,8 +43,11 @@ use tracing::warn;
 
 use super::TransportFourTuple;
 use crate::{
-    endpoint::{LocalTransportAddr, PathStats},
-    socket::mapped_addrs::{AddrMap, CustomMappedAddr},
+    endpoint::PathStats,
+    socket::{
+        mapped_addrs::{AddrMap, CustomMappedAddr},
+        transports::LocalTransportAddr,
+    },
 };
 
 /// Per-connection broadcast channel capacity for path events.

--- a/iroh/src/socket/remote_map/remote_state/path_watcher.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_watcher.rs
@@ -29,7 +29,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use iroh_base::{CustomAddr, TransportAddr};
+use iroh_base::TransportAddr;
 use n0_future::{StreamExt, time::Duration};
 use noq::WeakPathHandle;
 use noq_proto::PathId;
@@ -42,13 +42,7 @@ use tokio_stream::{
 use tracing::warn;
 
 use super::TransportFourTuple;
-use crate::{
-    endpoint::PathStats,
-    socket::{
-        mapped_addrs::{AddrMap, CustomMappedAddr},
-        transports::LocalTransportAddr,
-    },
-};
+use crate::{endpoint::PathStats, socket::transports::LocalTransportAddr};
 
 /// Per-connection broadcast channel capacity for path events.
 const BROADCAST_CAPACITY: usize = 8;
@@ -136,7 +130,6 @@ struct State {
 struct Shared {
     state: Mutex<State>,
     notify: Notify,
-    custom_mapped_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
 }
 
 /// The writer-side handle for a connection's path state.
@@ -157,14 +150,11 @@ impl PathStateSender {
     ///
     /// Gets passed a clone of the custom address map, so that we can convert local addresses
     /// to the public [`LocalTransportAddr`] exposed to users.
-    pub(super) fn new(
-        custom_mapped_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
-    ) -> (Self, PathStateReceiver) {
+    pub(super) fn new() -> (Self, PathStateReceiver) {
         let (events, _) = broadcast::channel(BROADCAST_CAPACITY);
         let shared = Arc::new(Shared {
             state: Default::default(),
             notify: Notify::new(),
-            custom_mapped_addrs,
         });
         let receiver = PathStateReceiver {
             shared: shared.clone(),
@@ -178,7 +168,7 @@ impl PathStateSender {
     pub(super) fn record_opened(&self, handle: WeakPathHandle, network_path: TransportFourTuple) {
         let id = handle.id();
         let remote_addr: TransportAddr = network_path.remote().clone().into();
-        let local_addr = network_path.local(&self.shared.custom_mapped_addrs);
+        let local_addr = network_path.local().clone();
         {
             let mut state = self.shared.state.lock().expect("poisoned");
             let entry = PathData {
@@ -227,7 +217,7 @@ impl PathStateSender {
     /// Updates the selected transmission path.
     pub(super) fn record_selected(&self, network_path: &TransportFourTuple) {
         let remote_addr: TransportAddr = network_path.remote().clone().into();
-        let local_addr = network_path.local(&self.shared.custom_mapped_addrs);
+        let local_addr = network_path.local().clone();
         let event = {
             let mut state = self.shared.state.lock().expect("poisoned");
             let selected_path_id = state
@@ -239,8 +229,8 @@ impl PathStateSender {
                 state.selected = selected_path_id;
                 selected_path_id.map(|path_id| PathEvent::Selected {
                     id: path_id,
-                    remote_addr: TransportAddr::from(network_path.remote.clone()),
-                    local_addr: network_path.local(&self.shared.custom_mapped_addrs),
+                    remote_addr: remote_addr.clone(),
+                    local_addr: local_addr.clone(),
                 })
             } else {
                 None

--- a/iroh/src/socket/remote_map/remote_state/path_watcher.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_watcher.rs
@@ -466,9 +466,6 @@ impl<'conn> Path<'conn> {
     }
 
     /// Returns the path's local address, if known.
-    ///
-    /// Note that for IP paths, the port of the socket address carries
-    /// no meaning and will always be set to 0.
     pub fn local_addr(&self) -> &LocalTransportAddr {
         &self.data.local_addr
     }

--- a/iroh/src/socket/remote_map/remote_state/path_watcher.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_watcher.rs
@@ -29,7 +29,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use iroh_base::TransportAddr;
+use iroh_base::{CustomAddr, TransportAddr};
 use n0_future::{StreamExt, time::Duration};
 use noq::WeakPathHandle;
 use noq_proto::PathId;
@@ -41,9 +41,11 @@ use tokio_stream::{
 };
 use tracing::warn;
 
-use crate::endpoint::PathStats;
-
 use super::TransportFourTuple;
+use crate::{
+    endpoint::{LocalTransportAddr, PathStats},
+    socket::mapped_addrs::{AddrMap, CustomMappedAddr},
+};
 
 /// Per-connection broadcast channel capacity for path events.
 const BROADCAST_CAPACITY: usize = 8;
@@ -53,27 +55,36 @@ const BROADCAST_CAPACITY: usize = 8;
 #[non_exhaustive]
 pub enum PathEvent {
     /// A new network path was opened.
+    #[non_exhaustive]
     Opened {
         /// Path identifier.
         id: PathId,
         /// Remote transport address.
         remote_addr: TransportAddr,
+        /// Local address of the path, if known.
+        local_addr: LocalTransportAddr,
     },
     /// A network path was closed.
+    #[non_exhaustive]
     Closed {
         /// Path identifier.
         id: PathId,
         /// Remote transport address.
         remote_addr: TransportAddr,
+        /// Local address of the path, if known.
+        local_addr: LocalTransportAddr,
         /// Path statistics captured at close time.
         last_stats: Box<PathStats>,
     },
     /// This path was selected for transmission of application data.
+    #[non_exhaustive]
     Selected {
         /// Path identifier of the newly selected path.
         id: PathId,
         /// Remote transport address of the newly selected path.
         remote_addr: TransportAddr,
+        /// The local address of the newly selected path, if known.
+        local_addr: LocalTransportAddr,
     },
     /// Events were dropped before the subscriber received them.
     ///
@@ -83,6 +94,7 @@ pub enum PathEvent {
     /// [`Connection::paths`].
     ///
     /// [`Connection::paths`]: crate::endpoint::Connection::paths
+    #[non_exhaustive]
     Lagged {
         /// Number of events dropped since the last delivered event.
         missed: u64,
@@ -94,7 +106,7 @@ pub enum PathEvent {
 struct PathData {
     handle: WeakPathHandle,
     remote_addr: TransportAddr,
-    local_addr: Option<TransportAddr>,
+    local_addr: LocalTransportAddr,
 }
 
 impl PathData {
@@ -121,6 +133,7 @@ struct State {
 struct Shared {
     state: Mutex<State>,
     notify: Notify,
+    custom_mapped_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
 }
 
 /// The writer-side handle for a connection's path state.
@@ -138,11 +151,17 @@ pub(super) struct PathStateSender {
 
 impl PathStateSender {
     /// Creates a sender/receiver pair sharing empty state.
-    pub(super) fn new() -> (Self, PathStateReceiver) {
+    ///
+    /// Gets passed a clone of the custom address map, so that we can convert local addresses
+    /// to the public [`LocalTransportAddr`] exposed to users.
+    pub(super) fn new(
+        custom_mapped_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
+    ) -> (Self, PathStateReceiver) {
         let (events, _) = broadcast::channel(BROADCAST_CAPACITY);
         let shared = Arc::new(Shared {
             state: Default::default(),
             notify: Notify::new(),
+            custom_mapped_addrs,
         });
         let receiver = PathStateReceiver {
             shared: shared.clone(),
@@ -155,14 +174,14 @@ impl PathStateSender {
     /// Records a newly-opened path and emits [`PathEvent::Opened`].
     pub(super) fn record_opened(&self, handle: WeakPathHandle, network_path: TransportFourTuple) {
         let id = handle.id();
-        let remote_addr: TransportAddr = network_path.remote.into();
-        let local_addr = network_path.local.map(|local| local.into());
+        let remote_addr: TransportAddr = network_path.remote().clone().into();
+        let local_addr = network_path.local(&self.shared.custom_mapped_addrs);
         {
             let mut state = self.shared.state.lock().expect("poisoned");
             let entry = PathData {
                 handle,
                 remote_addr: remote_addr.clone(),
-                local_addr,
+                local_addr: local_addr.clone(),
             };
             match state.list.iter().position(|e| e.handle.id() == id) {
                 Some(idx) => state.list[idx] = entry,
@@ -170,7 +189,11 @@ impl PathStateSender {
             }
         }
         self.shared.notify.notify_waiters();
-        let _ = self.events.send(PathEvent::Opened { id, remote_addr });
+        let _ = self.events.send(PathEvent::Opened {
+            id,
+            remote_addr,
+            local_addr,
+        });
     }
 
     /// Records that a path was abandoned by `noq`.
@@ -191,7 +214,8 @@ impl PathStateSender {
             self.shared.notify.notify_waiters();
             let _ = self.events.send(PathEvent::Closed {
                 id,
-                remote_addr: data.remote_addr,
+                remote_addr: data.remote_addr.clone(),
+                local_addr: data.local_addr.clone(),
                 last_stats: Box::new(stats),
             });
         }
@@ -199,10 +223,9 @@ impl PathStateSender {
 
     /// Updates the selected transmission path.
     pub(super) fn record_selected(&self, network_path: &TransportFourTuple) {
-        // We need to convert from `transports::Addr` to `TransportAddr` here.
-        let remote_addr = network_path.remote.clone().into();
-        let local_addr = network_path.local.clone().map(|addr| addr.into());
-        let changed = {
+        let remote_addr: TransportAddr = network_path.remote().clone().into();
+        let local_addr = network_path.local(&self.shared.custom_mapped_addrs);
+        let event = {
             let mut state = self.shared.state.lock().expect("poisoned");
             let selected_path_id = state
                 .list
@@ -211,13 +234,17 @@ impl PathStateSender {
                 .map(|p| p.handle.id());
             if selected_path_id != state.selected {
                 state.selected = selected_path_id;
-                selected_path_id.map(|path_id| (path_id, remote_addr))
+                selected_path_id.map(|path_id| PathEvent::Selected {
+                    id: path_id,
+                    remote_addr: TransportAddr::from(network_path.remote.clone()),
+                    local_addr: network_path.local(&self.shared.custom_mapped_addrs),
+                })
             } else {
                 None
             }
         };
-        if let Some((id, remote_addr)) = changed {
-            let _ = self.events.send(PathEvent::Selected { id, remote_addr });
+        if let Some(event) = event {
+            let _ = self.events.send(event);
             self.shared.notify.notify_waiters();
         }
     }
@@ -242,6 +269,7 @@ impl PathStateSender {
                     let _ = self.events.send(PathEvent::Closed {
                         id: path.handle.id(),
                         remote_addr: path.remote_addr.clone(),
+                        local_addr: path.local_addr.clone(),
                         last_stats: Box::new(*stats),
                     });
                 } else {
@@ -438,8 +466,8 @@ impl<'conn> Path<'conn> {
     ///
     /// Note that for IP paths, the port of the socket address carries
     /// no meaning and will always be set to 0.
-    pub fn local_addr(&self) -> Option<&TransportAddr> {
-        self.data.local_addr.as_ref()
+    pub fn local_addr(&self) -> &LocalTransportAddr {
+        &self.data.local_addr
     }
 
     /// Returns `true` if this path is currently selected for application data transmission.

--- a/iroh/src/socket/remote_map/remote_state/path_watcher.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_watcher.rs
@@ -41,7 +41,9 @@ use tokio_stream::{
 };
 use tracing::warn;
 
-use crate::{endpoint::PathStats, socket::remote_map::remote_state::TransportFourTuple};
+use crate::endpoint::PathStats;
+
+use super::TransportFourTuple;
 
 /// Per-connection broadcast channel capacity for path events.
 const BROADCAST_CAPACITY: usize = 8;
@@ -430,6 +432,14 @@ impl<'conn> Path<'conn> {
     /// Returns the path's remote transport address.
     pub fn remote_addr(&self) -> &TransportAddr {
         &self.data.remote_addr
+    }
+
+    /// Returns the path's local address, if known.
+    ///
+    /// Note that for IP paths, the port of the socket address carries
+    /// no meaning and will always be set to 0.
+    pub fn local_addr(&self) -> Option<&TransportAddr> {
+        self.data.local_addr.as_ref()
     }
 
     /// Returns `true` if this path is currently selected for application data transmission.

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -706,8 +706,6 @@ pub enum LocalTransportAddr {
 }
 
 impl LocalTransportAddr {
-    /// Converts a local address from noq into a [`LocalTransportAddr`], via an endpoint reference.
-
     /// Converts a local address from noq into a [`LocalTransportAddr`].
     ///
     /// This also needs the `remote_addr`, because currently the meaning of the local_ip as returned

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -702,11 +702,8 @@ impl Addr {
 pub enum LocalTransportAddr {
     /// The local IP, if the OS surfaced it.
     Ip(Option<IpAddr>),
-    /// The relay this connection arrived through.
-    Relay {
-        /// The URL of the relay.
-        url: RelayUrl,
-    },
+    /// The relay over which this network path is connected.
+    Relay(RelayUrl),
     /// The local custom address, if the transport reports one.
     Custom(Option<iroh_base::CustomAddr>),
 }
@@ -750,7 +747,7 @@ impl LocalTransportAddr {
         match &remote_addr {
             // If the remote is a relay, noq_local_ip will be unset because we never set it for relay transports.
             // We return a [`LocalTransportAddr`] with the relay URL.
-            Addr::Relay(url, _endpoint_id) => LocalTransportAddr::Relay { url: url.clone() },
+            Addr::Relay(url, _endpoint_id) => LocalTransportAddr::Relay(url.clone()),
             // For IP transports, the local_ip as reported from noq is the interface IP (umapped), if known.
             Addr::Ip(_) => LocalTransportAddr::Ip(noq_local_ip),
             // For custom transports, the custom transport implementation can set a `CustomAddr` in `RecvInfo`.

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -19,7 +19,15 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, instrument, trace, warn};
 
 use super::{Socket, mapped_addrs::MultipathMappedAddr};
-use crate::{endpoint::RelayStatus, metrics::EndpointMetrics, net_report::Report};
+use crate::{
+    endpoint::RelayStatus,
+    metrics::EndpointMetrics,
+    net_report::Report,
+    socket::{
+        EndpointInner,
+        mapped_addrs::{AddrMap, CustomMappedAddr},
+    },
+};
 
 pub(crate) mod custom;
 #[cfg(not(wasm_browser))]
@@ -684,6 +692,76 @@ impl Addr {
             },
             Self::Relay(_, _) => AddrKind::Relay,
             Self::Custom(addr) => AddrKind::Custom(addr.id()),
+        }
+    }
+}
+
+/// The local address of a network path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LocalTransportAddr {
+    /// The local IP, if the OS surfaced it.
+    Ip(Option<IpAddr>),
+    /// The relay this connection arrived through.
+    Relay {
+        /// The URL of the relay.
+        url: RelayUrl,
+    },
+    /// The local custom address, if the transport reports one.
+    Custom(Option<iroh_base::CustomAddr>),
+}
+
+impl LocalTransportAddr {
+    /// Converts a local address from noq into a [`LocalTransportAddr`], via an endpoint reference.
+    ///
+    /// This also needs the `remote_addr`, because currently the meaning of the local_ip as returned
+    /// from noq depends on the kind of network path, which we can gather from the remote address.
+    ///
+    /// We also need a reference to the endpoint to access the address map.
+    ///
+    /// The meaning of the local IP is a bit particular:
+    ///
+    /// * For IP transports, it is the address of the local socket.
+    /// * For relay transports, we never set the local_ip in the recv meta.
+    ///   We take the relay URL of the remote address here instead.
+    /// * For custom transports, the custom transport implementation can set a [`CustomAddr`]
+    ///   through [`RecvInfo`], which is passed as a mapped address to noq. So we convert it
+    ///   back into the [`CustomAddr`] here.
+    pub(crate) fn from_noq_local_ip(
+        noq_local_ip: Option<IpAddr>,
+        remote_addr: &Addr,
+        ep: &EndpointInner,
+    ) -> Self {
+        Self::from_noq_local_ip_with_custom_addr_map(
+            noq_local_ip,
+            remote_addr,
+            &ep.mapped_addrs.custom_addrs,
+        )
+    }
+
+    /// Converts a local address from noq into a [`LocalTransportAddr`], via the custom mapped addrs.
+    ///
+    /// See [`Self::from_noq_local_ip_with_endpoint_ref`] for details.
+    pub(super) fn from_noq_local_ip_with_custom_addr_map(
+        noq_local_ip: Option<IpAddr>,
+        remote_addr: &Addr,
+        custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
+    ) -> Self {
+        match &remote_addr {
+            // If the remote is a relay, noq_local_ip will be unset because we never set it for relay transports.
+            // We return a [`LocalTransportAddr`] with the relay URL.
+            Addr::Relay(url, _endpoint_id) => LocalTransportAddr::Relay { url: url.clone() },
+            // For IP transports, the local_ip as reported from noq is the interface IP (umapped), if known.
+            Addr::Ip(_) => LocalTransportAddr::Ip(noq_local_ip),
+            // For custom transports, the custom transport implementation can set a `CustomAddr` in `RecvInfo`.
+            // The custom addr is converted to a mapped address in `super::Socket::process_datagrams`.
+            // We convert back to a `CustomAddr` here.
+            Addr::Custom(_) => {
+                let addr = noq_local_ip
+                    .and_then(|ip_addr| CustomMappedAddr::try_from(ip_addr).ok())
+                    .and_then(|custom_mapped_addr| custom_mapped_addrs.lookup(&custom_mapped_addr));
+                LocalTransportAddr::Custom(addr)
+            }
         }
     }
 }

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -707,7 +707,6 @@ pub enum LocalTransportAddr {
 
 impl LocalTransportAddr {
     /// Converts a local address from noq into a [`LocalTransportAddr`], via an endpoint reference.
-    ///
 
     /// Converts a local address from noq into a [`LocalTransportAddr`].
     ///

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -23,10 +23,7 @@ use crate::{
     endpoint::RelayStatus,
     metrics::EndpointMetrics,
     net_report::Report,
-    socket::{
-        EndpointInner,
-        mapped_addrs::{AddrMap, CustomMappedAddr},
-    },
+    socket::mapped_addrs::{AddrMap, CustomMappedAddr, MappedAddr},
 };
 
 pub(crate) mod custom;
@@ -697,7 +694,7 @@ impl Addr {
 }
 
 /// The local address of a network path.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum LocalTransportAddr {
     /// The local IP, if the OS surfaced it.
@@ -711,10 +708,11 @@ pub enum LocalTransportAddr {
 impl LocalTransportAddr {
     /// Converts a local address from noq into a [`LocalTransportAddr`], via an endpoint reference.
     ///
+
+    /// Converts a local address from noq into a [`LocalTransportAddr`].
+    ///
     /// This also needs the `remote_addr`, because currently the meaning of the local_ip as returned
     /// from noq depends on the kind of network path, which we can gather from the remote address.
-    ///
-    /// We also need a reference to the endpoint to access the address map.
     ///
     /// The meaning of the local IP is a bit particular:
     ///
@@ -724,22 +722,7 @@ impl LocalTransportAddr {
     /// * For custom transports, the custom transport implementation can set a [`CustomAddr`]
     ///   through [`RecvInfo`], which is passed as a mapped address to noq. So we convert it
     ///   back into the [`CustomAddr`] here.
-    pub(crate) fn from_noq_local_ip(
-        noq_local_ip: Option<IpAddr>,
-        remote_addr: &Addr,
-        ep: &EndpointInner,
-    ) -> Self {
-        Self::from_noq_local_ip_with_custom_addr_map(
-            noq_local_ip,
-            remote_addr,
-            &ep.mapped_addrs.custom_addrs,
-        )
-    }
-
-    /// Converts a local address from noq into a [`LocalTransportAddr`], via the custom mapped addrs.
-    ///
-    /// See [`Self::from_noq_local_ip`] for details.
-    pub(super) fn from_noq_local_ip_with_custom_addr_map(
+    pub(super) fn from_noq_local_ip(
         noq_local_ip: Option<IpAddr>,
         remote_addr: &Addr,
         custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
@@ -759,6 +742,20 @@ impl LocalTransportAddr {
                     .and_then(|custom_mapped_addr| custom_mapped_addrs.lookup(&custom_mapped_addr));
                 LocalTransportAddr::Custom(addr)
             }
+        }
+    }
+
+    /// Converts this [`LocalTransportAddr`] into a QUIC-mapped [`IpAddr`] to be passed to noq, if any.
+    pub(super) fn to_noq_local_ip(
+        &self,
+        custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
+    ) -> Option<IpAddr> {
+        match self {
+            LocalTransportAddr::Ip(ip_addr) => *ip_addr,
+            LocalTransportAddr::Relay(_url) => None,
+            LocalTransportAddr::Custom(custom_addr) => custom_addr
+                .as_ref()
+                .map(|addr| custom_mapped_addrs.get(addr).private_socket_addr().ip()),
         }
     }
 }

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -741,7 +741,7 @@ impl LocalTransportAddr {
 
     /// Converts a local address from noq into a [`LocalTransportAddr`], via the custom mapped addrs.
     ///
-    /// See [`Self::from_noq_local_ip_with_endpoint_ref`] for details.
+    /// See [`Self::from_noq_local_ip`] for details.
     pub(super) fn from_noq_local_ip_with_custom_addr_map(
         noq_local_ip: Option<IpAddr>,
         remote_addr: &Addr,

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -503,7 +503,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_custom_transport_local_addr() -> Result<()> {
-        use crate::endpoint::IncomingLocalAddr;
+        use crate::endpoint::LocalTransportAddr;
 
         let network = TestNetwork::new();
         let s1 = SecretKey::generate();
@@ -529,7 +529,7 @@ mod tests {
         let incoming = ep2.accept().await.expect("incoming");
         assert_eq!(
             incoming.local_addr(),
-            IncomingLocalAddr::Custom(Some(to_custom_addr(s2.public()))),
+            LocalTransportAddr::Custom(Some(to_custom_addr(s2.public()))),
         );
         let _conn = incoming.accept().anyerr()?.await.anyerr()?;
 

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -434,7 +434,10 @@ fn watch_selected_path(conn: &Connection) {
     tokio::spawn(
         async move {
             while let Some(event) = events.next().await {
-                if let PathEvent::Selected { id, remote_addr } = event {
+                if let PathEvent::Selected {
+                    id, remote_addr, ..
+                } = event
+                {
                     debug!("selected path: [{id}] {remote_addr}");
                 }
             }


### PR DESCRIPTION
## Description

Track the selected path in the RemoteStateActor by FourTuple.

Handling and exposing the local address is .. weird:

 * For IP transports, it is the address of the local socket, if known
* For relay transports, we never set the local_ip in the recv meta.
* For custom transports, the custom transport implementation can set a `CustomAddr` in `RecvMeta`, which we convert to a mapped addr with port 0 internally in the recv path

The address we get back from noq for a path is this address. We don't want to ever expose mapped addresses, so we need to convert this address into something else. We have a precedent: We recently introduced a `IncomingLocalAddr` which is basically this.

So I decided to reuse this type and renam eit to `LocalTransportAddr`, which mirrors `TransportAddr` nicely.
The conversions are nothing to be happy about, but I don't see a solid alternative right now without larger refactors.


## Breaking Changes

* changed: The variants of `iroh::endpoint::PathEvent` are now marked `#[non_exhaustive]`
* renamed: `iroh::endpoint::IncomingLocalAddr`  -> `iroh::endpoint::LocalTransportAddr`, and the `Relay` variant is now a tuple variant

## Notes & open questions

Instead of reusing and renaming the exisitng `IncomingLocalAddr`, we could also expose local_addr as `Option<LocalTransportAddr>`, with `enum LocalTransportAddr { Ip(IpAddr), Custom(CustomAddr) }`, i.e. remove the `Relay` case. I had this in an earlier version but then found yet another public address type a bit too much so instead went for the existing `IncomingLocalAddr`.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.