### PR TITLE
feat(iroh-relay): allow disconnecting clients at runtime

### DIFF
--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -461,6 +461,8 @@ pub struct Server {
     quic_addr: Option<SocketAddr>,
     /// Handle to the relay server.
     relay_handle: Option<http_server::ServerHandle>,
+    /// Handle to the relay service for runtime control.
+    relay_service: Option<http_server::RelayService>,
     /// Handle to the quic server.
     quic_handle: Option<QuicServerHandle>,
     /// The main task running the server.
@@ -655,6 +657,7 @@ impl Server {
         // relay_server is serving HTTP, including the /generate_204 service.
         let relay_addr = relay_server.as_ref().map(|srv| srv.addr());
         let relay_handle = relay_server.as_ref().map(|srv| srv.handle());
+        let relay_service = relay_server.as_ref().map(|srv| srv.service().clone());
 
         let quic_server = match config.quic {
             Some(quic_config) => {
@@ -682,6 +685,7 @@ impl Server {
             https_addr: http_addr.and(relay_addr),
             quic_addr,
             relay_handle,
+            relay_service,
             quic_handle,
             supervisor: AbortOnDropHandle::new(task),
             metrics,
@@ -760,6 +764,21 @@ impl Server {
     /// Returns the metrics collected in the relay server.
     pub fn metrics(&self) -> &RelayMetrics {
         &self.metrics
+    }
+
+    /// Returns a handle to the embedded [`RelayService`] for runtime control.
+    ///
+    /// The service handle allows inspecting and mutating the live relay state
+    /// after [`Server::spawn`] returns. In particular, [`RelayService::clients`]
+    /// reaches the [`Clients`] registry which exposes
+    /// [`Clients::retain`] for forcibly disconnecting clients.
+    ///
+    /// Returns `None` if the relay was not enabled in [`ServerConfig`].
+    ///
+    /// [`Clients`]: clients::Clients
+    /// [`Clients::retain`]: clients::Clients::retain
+    pub fn relay_service(&self) -> Option<&RelayService> {
+        self.relay_service.as_ref()
     }
 }
 

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -57,6 +57,8 @@ pub struct Config<S> {
     pub channel_capacity: usize,
     /// Protocol version negotiated for this client
     pub protocol_version: ProtocolVersion,
+    /// The authorization token that the client registered with
+    pub auth_token: Option<String>,
 }
 
 impl<S> Config<S> {
@@ -72,6 +74,7 @@ impl<S> Config<S> {
             protocol_version,
             write_timeout: SERVER_WRITE_TIMEOUT,
             channel_capacity: PER_CLIENT_SEND_QUEUE_DEPTH,
+            auth_token: None,
         }
     }
 }
@@ -96,6 +99,8 @@ pub struct Client {
     message_queue: mpsc::Sender<RelayToClientMsg>,
     /// Relay protocol version negotiated for this client.
     protocol_version: ProtocolVersion,
+    /// The auth token that the client passed when registering.
+    auth_token: Option<String>,
 }
 
 impl Client {
@@ -117,6 +122,7 @@ impl Client {
             write_timeout,
             channel_capacity,
             protocol_version,
+            auth_token,
         } = config;
 
         let (packet_send_queue_s, packet_send_queue_r) = mpsc::channel(channel_capacity);
@@ -152,7 +158,23 @@ impl Client {
             packet_queue: packet_send_queue_s,
             message_queue: message_send_queue_s,
             protocol_version,
+            auth_token,
         }
+    }
+
+    /// Returns the [`EndpointId`] of this client.
+    pub fn endpoint_id(&self) -> EndpointId {
+        self.endpoint_id
+    }
+
+    /// Returns the authorization token this client registered with, if set.
+    pub fn auth_token(&self) -> Option<&str> {
+        self.auth_token.as_deref()
+    }
+
+    /// Returns the protocol version negotiated for this connection.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
     }
 
     pub(super) fn connection_id(&self) -> u64 {
@@ -684,6 +706,7 @@ mod tests {
                 write_timeout: Duration::from_secs(1),
                 channel_capacity: 10,
                 protocol_version,
+                auth_token: None,
             },
             Conn::test(client, protocol_version),
         )

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -72,6 +72,20 @@ impl Clients {
         n0_future::join_all(clients.map(|(_, state)| state.shutdown_all())).await;
     }
 
+    /// Disconnects all clients for which `f` returns `false`.
+    pub fn retain(&self, f: impl Fn(&Client) -> bool) {
+        for state in self.0.clients.iter() {
+            for client in state.inactive.iter() {
+                if !f(client) {
+                    client.start_shutdown();
+                }
+            }
+            if !f(&state.active) {
+                state.active.start_shutdown();
+            }
+        }
+    }
+
     /// Builds the client handler and starts the read & write loops for the connection.
     pub fn register<S>(&self, client_config: Config<S>, metrics: Arc<Metrics>)
     where
@@ -278,6 +292,7 @@ mod tests {
                 write_timeout: Duration::from_secs(1),
                 channel_capacity: 10,
                 protocol_version: Default::default(),
+                auth_token: None,
             },
             Conn::test(client, protocol_version),
         )

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -114,6 +114,7 @@ pub(super) struct Server {
     addr: SocketAddr,
     http_server_task: AbortOnDropHandle<()>,
     cancel_server_loop: CancellationToken,
+    service: RelayService,
 }
 
 impl Server {
@@ -144,6 +145,11 @@ impl Server {
     /// Returns the local address of this server.
     pub(super) fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    /// Returns the [`RelayService`] driving this server.
+    pub(super) fn service(&self) -> &RelayService {
+        &self.service
     }
 }
 
@@ -464,8 +470,10 @@ impl ServerBuilder {
         info!("[{http_str}] relay: serving on {addr}");
 
         let cancel = cancel_token.clone();
+        let loop_service = service.clone();
         let task = tokio::task::spawn(
             async move {
+                let service = loop_service;
                 // create a join set to track all our connection tasks
                 let mut set = tokio::task::JoinSet::new();
                 loop {
@@ -510,6 +518,7 @@ impl ServerBuilder {
             addr,
             http_server_task: AbortOnDropHandle::new(task),
             cancel_server_loop: cancel_token,
+            service,
         })
     }
 }
@@ -881,6 +890,7 @@ impl Inner {
             write_timeout: self.write_timeout,
             channel_capacity: PER_CLIENT_SEND_QUEUE_DEPTH,
             protocol_version,
+            auth_token: request.auth_token(),
         };
         trace!("accept: create client");
         let endpoint_id = client_conn_builder.endpoint_id;
@@ -931,6 +941,16 @@ impl RelayService {
     /// Shuts down the relay service, disconnecting all clients.
     pub async fn shutdown(&self) {
         self.0.clients.shutdown().await;
+    }
+
+    /// Returns a reference to the registry of currently connected clients.
+    ///
+    /// The returned [`Clients`] handle can be used at runtime to disconnect
+    /// connected clients via [`Clients::retain`]. This is the entry point for
+    /// revoking access for endpoints that were admitted by the access hook
+    /// but should no longer be allowed.
+    pub fn clients(&self) -> &Clients {
+        &self.0.clients
     }
 
     /// Handle the incoming connection.

--- a/iroh-relay/tests/runtime_auth.rs
+++ b/iroh-relay/tests/runtime_auth.rs
@@ -1,0 +1,177 @@
+//! Runtime revocation of relay auth tokens.
+//!
+//! Exercises updating the set of allowed auth tokens at runtime and
+//! disconnecting the now-unauthorized clients through the top-level
+//! [`Server`] public API.
+
+#![cfg(feature = "server")]
+
+use std::{
+    collections::HashSet,
+    net::Ipv4Addr,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use iroh_base::{RelayUrl, SecretKey};
+use iroh_dns::dns::DnsResolver;
+use iroh_relay::{
+    client::{Client, ClientBuilder, ConnectError},
+    protos::{
+        handshake,
+        relay::{ClientToRelayMsg, RelayToClientMsg},
+    },
+    server::{Access, AccessConfig, RelayConfig, Server, ServerConfig},
+    tls::{CaRootsConfig, default_provider},
+};
+use n0_error::{Result, StackResultExt, StdResultExt};
+use n0_future::{FutureExt, SinkExt, StreamExt};
+use n0_tracing_test::traced_test;
+use rand::RngExt;
+
+#[tokio::test]
+#[traced_test]
+async fn relay_runtime_revokes_disallowed_tokens() -> Result<()> {
+    let relay = RestrictedServer::spawn(["token-b"]).await?;
+
+    let relay_url: RelayUrl = format!("http://{}", relay.server.http_addr().expect("http addr"))
+        .parse()
+        .expect("valid relay url");
+
+    assert_denied(connect(&relay_url, "token-a").await);
+    // token-a is added at runtime; both clients then connect successfully.
+    relay.add_token("token-a");
+    let mut client_a = connect(&relay_url, "token-a").await?;
+    let mut client_b = connect(&relay_url, "token-b").await?;
+    ping_round_trip(&mut client_a, [1u8; 8]).await?;
+    ping_round_trip(&mut client_b, [2u8; 8]).await?;
+
+    // Revoking token-a evicts client A; client B keeps working.
+    relay.remove_token("token-a");
+    assert_disconnected(&mut client_a).await;
+    ping_round_trip(&mut client_b, [3u8; 8]).await?;
+
+    // New connections honor the updated allow-list.
+    assert_denied(connect(&relay_url, "token-a").await);
+    let mut client_c = connect(&relay_url, "token-b").await?;
+    ping_round_trip(&mut client_c, [4u8; 8]).await?;
+
+    Ok(())
+}
+
+/// Connects a fresh relay client authenticating with `token`.
+async fn connect(relay_url: &RelayUrl, token: &str) -> Result<Client, ConnectError> {
+    let tls = CaRootsConfig::default()
+        .client_config(default_provider())
+        .expect("valid client config");
+    let secret = SecretKey::from_bytes(&rand::rng().random());
+    ClientBuilder::new(relay_url.clone(), secret, DnsResolver::new())
+        .tls_client_config(tls)
+        .auth_token(token)
+        .connect()
+        .await
+}
+
+/// A relay [`Server`] paired with its runtime-mutable auth-token allow-list.
+///
+/// The allow-list is shared with the server's access hook, so mutations take
+/// effect immediately for new connections. [`RestrictedServer::remove_token`]
+/// additionally evicts clients that connected with a token that is no longer
+/// allowed.
+struct RestrictedServer {
+    server: Server,
+    allowed_tokens: Arc<RwLock<HashSet<String>>>,
+}
+
+impl RestrictedServer {
+    /// Spawns a plain-HTTP relay that admits only the given auth `tokens`.
+    async fn spawn(tokens: impl IntoIterator<Item = &'static str>) -> Result<Self> {
+        let allowed_tokens: Arc<RwLock<HashSet<String>>> =
+            Arc::new(RwLock::new(tokens.into_iter().map(String::from).collect()));
+
+        let mut relay = RelayConfig::new((Ipv4Addr::LOCALHOST, 0));
+        relay.access = {
+            let allowed_tokens = allowed_tokens.clone();
+            AccessConfig::Restricted(Box::new(move |request| {
+                let allowed_tokens = allowed_tokens.clone();
+                async move {
+                    let allowed_tokens = allowed_tokens.read().expect("poisoned");
+                    match request.auth_token() {
+                        Some(token) if allowed_tokens.contains(&token) => Access::Allow,
+                        _ => Access::Deny,
+                    }
+                }
+                .boxed()
+            }))
+        };
+        let mut config = ServerConfig::default();
+        config.relay = Some(relay);
+        let server = Server::spawn(config).await?;
+
+        Ok(Self {
+            server,
+            allowed_tokens,
+        })
+    }
+
+    /// Adds `token` to the allow-list.
+    fn add_token(&self, token: &str) {
+        self.allowed_tokens
+            .write()
+            .expect("poisoned")
+            .insert(token.to_string());
+    }
+
+    /// Removes `token` from the allow-list and disconnects every connected
+    /// client whose auth token is no longer allowed.
+    fn remove_token(&self, token: &str) {
+        let allowed = {
+            let mut allowed = self.allowed_tokens.write().expect("poisoned");
+            allowed.remove(token);
+            allowed.clone()
+        };
+        self.server
+            .relay_service()
+            .expect("relay configured")
+            .clients()
+            .retain(|client| client.auth_token().is_some_and(|t| allowed.contains(t)));
+    }
+}
+
+/// Sends a relay-level ping and asserts the matching pong comes back.
+async fn ping_round_trip(client: &mut Client, data: [u8; 8]) -> Result<()> {
+    client.send(ClientToRelayMsg::Ping(data)).await?;
+    let msg = tokio::time::timeout(Duration::from_secs(2), client.next())
+        .await
+        .std_context("ping timeout")?
+        .context("stream ended")??;
+    match msg {
+        RelayToClientMsg::Pong(echo) => {
+            n0_error::ensure_any!(echo == data, "Pong mismatch");
+            Ok(())
+        }
+        other => n0_error::bail_any!("expected Pong, got {other:?}"),
+    }
+}
+
+/// Asserts that `client`'s stream closes within a few seconds.
+async fn assert_disconnected(client: &mut Client) {
+    match tokio::time::timeout(Duration::from_secs(2), client.next()).await {
+        Ok(None) => {}
+        Ok(Some(Err(e))) => panic!("expected stream close, got Err({e:?})"),
+        Ok(Some(Ok(msg))) => panic!("expected stream close, got {msg:?}"),
+        Err(_) => panic!("timeout waiting for disconnect"),
+    }
+}
+
+/// Asserts that a connection attempt was rejected by the access hook.
+fn assert_denied(result: Result<Client, ConnectError>) {
+    assert!(
+        matches!(
+            result,
+            Err(ConnectError::Handshake { source: handshake::Error::ServerDeniedAuth { ref reason, .. }, .. })
+                if reason == "not authorized"
+        ),
+        "expected handshake denial, got {result:?}",
+    );
+}


### PR DESCRIPTION
## Description

Allow to disconnect clients dynamically at runtime from an `iroh_relay::server::Server`

* Expose the `RelayService` and its `Clients` from the `Server`. Both items are already pub, but were so far not reachable from a `Server`.
* Add `Clients::retain` with a callback that determines for each connected client whether it should stay or be shutdown
* Add accessors to `Client` for the EndpointId and the authorization token

## Breaking Changes

None, only API additions.

## Notes & open questions

I initially had `Clients::disconnect(endpoint_id: EndpointId)` but that would mean that the outer layers would need to track the list of endpoint ids, so I opted for `retain` instead and exposing the authorization token from the `Client`.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.