### PR TITLE
feat(iroh-relay)!: Allow servers to request re-authorization from clients

### DIFF
--- a/iroh-relay/src/protos/common.rs
+++ b/iroh-relay/src/protos/common.rs
@@ -63,6 +63,9 @@ pub enum FrameType {
     ///
     /// [`Status`]: super::relay::Status
     Status = 13,
+
+    /// Sent from client to server to set the client's authorization token.
+    Authorization = 14,
 }
 
 #[stack_error(derive, add_meta)]

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -128,6 +128,9 @@ pub enum Status {
         "Another endpoint connected with the same endpoint id. No more messages will be received."
     )]
     SameEndpointIdConnected,
+    /// Authorization has expired, re-auth is needed.
+    #[display("The authorization for this endpoint has expired. Re-auth is needed.")]
+    AuthorizationExpired,
     /// Placeholder for backwards-compatibility for future new health status variants.
     #[display("Unsupported health message ({_0})")]
     Unknown(u8),
@@ -139,6 +142,7 @@ impl Status {
         match self {
             Status::Healthy => dst.put_u8(0),
             Status::SameEndpointIdConnected => dst.put_u8(1),
+            Status::AuthorizationExpired => dst.put_u8(2),
             Status::Unknown(discriminant) => dst.put_u8(*discriminant),
         }
         dst
@@ -155,6 +159,7 @@ impl Status {
         match discriminant {
             0 => Ok(Self::Healthy),
             1 => Ok(Self::SameEndpointIdConnected),
+            2 => Ok(Self::AuthorizationExpired),
             n => Ok(Self::Unknown(n)),
         }
     }
@@ -176,6 +181,11 @@ pub enum ClientToRelayMsg {
         dst_endpoint_id: EndpointId,
         /// The datagrams and related metadata to relay.
         datagrams: Datagrams,
+    },
+    /// Update the authorization token.
+    Authorize {
+        /// The updated authorization token.
+        auth_token: String,
     },
 }
 
@@ -480,6 +490,7 @@ impl ClientToRelayMsg {
             }
             Self::Ping { .. } => FrameType::Ping,
             Self::Pong { .. } => FrameType::Pong,
+            Self::Authorize { .. } => FrameType::Authorization,
         }
     }
 
@@ -506,6 +517,9 @@ impl ClientToRelayMsg {
             Self::Pong(data) => {
                 dst.put(&data[..]);
             }
+            Self::Authorize { auth_token } => {
+                dst.put(auth_token.as_bytes());
+            }
         }
         dst
     }
@@ -517,6 +531,7 @@ impl ClientToRelayMsg {
                 32 // endpoint id
                 + datagrams.encoded_len()
             }
+            Self::Authorize { auth_token } => auth_token.len(),
         };
         self.typ().encoded_len() + payload_len
     }
@@ -557,6 +572,10 @@ impl ClientToRelayMsg {
                 let mut data = [0u8; 8];
                 data.copy_from_slice(&content[..8]);
                 Self::Pong(data)
+            }
+            FrameType::Authorization => {
+                let auth_token = std::str::from_utf8(&content)?.to_owned();
+                Self::Authorize { auth_token }
             }
             _ => {
                 return Err(e!(Error::InvalidFrameType { frame_type }));

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -22,6 +22,10 @@ use crate::{KeyCache, http::ProtocolVersion};
 /// including its on-wire framing overhead)
 pub const MAX_PACKET_SIZE: usize = 64 * 1024;
 
+/// The maximum size, in bytes, of an auth token carried in a
+/// [`ClientToRelayMsg::Authorize`] frame.
+pub const MAX_AUTH_TOKEN_SIZE: usize = 256;
+
 /// The maximum frame size.
 ///
 /// This is also the minimum burst size that a rate-limiter has to accept.
@@ -48,6 +52,8 @@ pub enum Error {
     UnexpectedFrame { got: FrameType, expected: FrameType },
     #[error("Frame is too large, has {frame_len} bytes")]
     FrameTooLarge { frame_len: usize },
+    #[error("Auth token is too large, has {size} bytes (max {MAX_AUTH_TOKEN_SIZE})")]
+    AuthTokenTooLarge { size: usize },
     #[error(transparent)]
     FrameTypeError { source: FrameTypeError },
     #[error("Invalid public key")]
@@ -185,6 +191,8 @@ pub enum ClientToRelayMsg {
     /// Update the authorization token.
     Authorize {
         /// The updated authorization token.
+        ///
+        /// Must not exceed [`MAX_AUTH_TOKEN_SIZE`] bytes when UTF-8 encoded.
         auth_token: String,
     },
 }
@@ -574,6 +582,12 @@ impl ClientToRelayMsg {
                 Self::Pong(data)
             }
             FrameType::Authorization => {
+                ensure!(
+                    content.len() <= MAX_AUTH_TOKEN_SIZE,
+                    Error::AuthTokenTooLarge {
+                        size: content.len()
+                    }
+                );
                 let auth_token = std::str::from_utf8(&content)?.to_owned();
                 Self::Authorize { auth_token }
             }
@@ -878,6 +892,31 @@ mod proptests {
         assert!(matches!(
             result,
             Err(Error::FrameNotAllowedInVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn authorize_token_size_limit() {
+        // A token at the size limit round-trips.
+        let token = "a".repeat(MAX_AUTH_TOKEN_SIZE);
+        let encoded = ClientToRelayMsg::Authorize {
+            auth_token: token.clone(),
+        }
+        .to_bytes()
+        .freeze();
+        let decoded = ClientToRelayMsg::from_bytes(encoded, &KeyCache::test()).unwrap();
+        assert_eq!(decoded, ClientToRelayMsg::Authorize { auth_token: token });
+
+        // One byte over the limit is rejected.
+        let encoded = ClientToRelayMsg::Authorize {
+            auth_token: "a".repeat(MAX_AUTH_TOKEN_SIZE + 1),
+        }
+        .to_bytes()
+        .freeze();
+        let result = ClientToRelayMsg::from_bytes(encoded, &KeyCache::test());
+        assert!(matches!(
+            result,
+            Err(Error::AuthTokenTooLarge { size, .. }) if size == MAX_AUTH_TOKEN_SIZE + 1
         ));
     }
 

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -461,6 +461,8 @@ pub struct Server {
     quic_addr: Option<SocketAddr>,
     /// Handle to the relay server.
     relay_handle: Option<http_server::ServerHandle>,
+    /// Handle to the relay service for runtime control.
+    relay_service: Option<http_server::RelayService>,
     /// Handle to the quic server.
     quic_handle: Option<QuicServerHandle>,
     /// The main task running the server.
@@ -655,6 +657,7 @@ impl Server {
         // relay_server is serving HTTP, including the /generate_204 service.
         let relay_addr = relay_server.as_ref().map(|srv| srv.addr());
         let relay_handle = relay_server.as_ref().map(|srv| srv.handle());
+        let relay_service = relay_server.as_ref().map(|srv| srv.service().clone());
 
         let quic_server = match config.quic {
             Some(quic_config) => {
@@ -682,6 +685,7 @@ impl Server {
             https_addr: http_addr.and(relay_addr),
             quic_addr,
             relay_handle,
+            relay_service,
             quic_handle,
             supervisor: AbortOnDropHandle::new(task),
             metrics,
@@ -760,6 +764,21 @@ impl Server {
     /// Returns the metrics collected in the relay server.
     pub fn metrics(&self) -> &RelayMetrics {
         &self.metrics
+    }
+
+    /// Returns a handle to the embedded [`RelayService`] for runtime control.
+    ///
+    /// The service handle allows inspecting and mutating the live relay state
+    /// after [`Server::spawn`] returns. In particular, [`RelayService::clients`]
+    /// reaches the [`Clients`] registry which exposes
+    /// [`Clients::retain`] for forcibly disconnecting clients.
+    ///
+    /// Returns `None` if the relay was not enabled in [`ServerConfig`].
+    ///
+    /// [`Clients`]: clients::Clients
+    /// [`Clients::retain`]: clients::Clients::retain
+    pub fn relay_service(&self) -> Option<&RelayService> {
+        self.relay_service.as_ref()
     }
 }
 

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -757,16 +757,6 @@ impl Server {
     }
 
     /// Returns a handle to the embedded [`RelayService`] for runtime control.
-    ///
-    /// The service handle allows inspecting and mutating the live relay state
-    /// after [`Server::spawn`] returns. In particular, [`RelayService::clients`]
-    /// reaches the [`Clients`] registry which exposes
-    /// [`Clients::retain`] for forcibly disconnecting clients.
-    ///
-    /// Returns `None` if the relay was not enabled in [`ServerConfig`].
-    ///
-    /// [`Clients`]: clients::Clients
-    /// [`Clients::retain`]: clients::Clients::retain
     pub fn relay_service(&self) -> Option<&RelayService> {
         self.relay_service.as_ref()
     }

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -15,10 +15,7 @@
 //! - HTTPS `/ping`: Used for net_report probes.
 //! - HTTPS `/generate_204`: Used for net_report probes.
 
-use std::{
-    borrow::Cow, future::Future, net::SocketAddr, num::NonZeroU32, path::PathBuf, pin::Pin,
-    sync::Arc,
-};
+use std::{future::Future, net::SocketAddr, num::NonZeroU32, path::PathBuf, pin::Pin, sync::Arc};
 
 use derive_more::Debug;
 use http::{
@@ -161,19 +158,25 @@ impl RelayConfig {
 #[derive(Debug, Clone)]
 pub struct ClientRequest {
     endpoint_id: EndpointId,
-    request: http::request::Parts,
+    auth_token: Option<String>,
 }
 
 impl ClientRequest {
+    /// Creates a new [`ClientRequest`] from an [`EndpointId`] and authorization token.
+    pub fn new(endpoint_id: EndpointId, auth_token: Option<String>) -> Self {
+        Self {
+            endpoint_id,
+            auth_token,
+        }
+    }
+
     /// Creates a new [`ClientRequest`] from an [`EndpointId`] and HTTP request parts.
     ///
     /// The [`EndpointId`] must be proven by the relay handshake. The request parts
     /// come from the client's WebSocket request.
-    pub fn new(endpoint_id: EndpointId, request: http::request::Parts) -> Self {
-        Self {
-            endpoint_id,
-            request,
-        }
+    pub fn from_http_request(endpoint_id: EndpointId, request: &http::request::Parts) -> Self {
+        let auth_token = auth_token_from_request(&request);
+        Self::new(endpoint_id, auth_token)
     }
 
     /// Returns the [`EndpointId`] of the client.
@@ -186,49 +189,36 @@ impl ClientRequest {
         self.endpoint_id
     }
 
-    /// Returns the URI of the HTTP request with which the client connected.
-    pub fn uri(&self) -> &http::Uri {
-        &self.request.uri
+    /// Returns the authorization token provided by the client, if any.
+    pub fn auth_token(&self) -> Option<&str> {
+        self.auth_token.as_deref()
     }
+}
 
-    /// Returns an iterator over the query parameters set in the URI of the HTTP request.
-    ///
-    /// Each item is a `(name, value)` pair. Both names and values are percent-decoded.
-    /// The query string is parsed in order, and the same name may appear more than once.
-    pub fn query_pairs(&self) -> impl Iterator<Item = (Cow<'_, str>, Cow<'_, str>)> {
-        url::form_urlencoded::parse(self.request.uri.query().unwrap_or("").as_bytes())
-    }
-
-    /// Returns the headers of the HTTP request with which the client connected.
-    pub fn headers(&self) -> &http::HeaderMap {
-        &self.request.headers
-    }
-
-    /// Returns the authorization token from the client's HTTP request, if any.
-    ///
-    /// Walks the `Authorization` headers in order and returns the value of
-    /// the first one whose scheme is `Bearer` (matched case-insensitively).
-    /// Headers with a different scheme are skipped.
-    ///
-    /// If none of the `Authorization` headers carries a `Bearer` scheme,
-    /// returns the value of the `token` URL query parameter, or `None` if
-    /// the URL has no `token` parameter.
-    ///
-    /// If an `Authorization` header value is not valid UTF-8 the function returns
-    /// `None` immediately, without checking later headers or the URL query.
-    pub fn auth_token(&self) -> Option<String> {
-        for value in self.request.headers.get_all(AUTHORIZATION) {
-            let value = value.to_str().ok()?;
-            if let Some((scheme, token)) = value.split_once(' ')
-                && scheme.eq_ignore_ascii_case("Bearer")
-            {
-                return Some(token.to_string());
-            }
+/// Returns the authorization token from the client's HTTP request, if any.
+///
+/// Walks the `Authorization` headers in order and returns the value of
+/// the first one whose scheme is `Bearer` (matched case-insensitively).
+/// Headers with a different scheme are skipped.
+///
+/// If none of the `Authorization` headers carries a `Bearer` scheme,
+/// returns the value of the `token` URL query parameter, or `None` if
+/// the URL has no `token` parameter.
+///
+/// If an `Authorization` header value is not valid UTF-8 the function returns
+/// `None` immediately, without checking later headers or the URL query.
+fn auth_token_from_request(request: &http::request::Parts) -> Option<String> {
+    for value in request.headers.get_all(AUTHORIZATION) {
+        let value = value.to_str().ok()?;
+        if let Some((scheme, token)) = value.split_once(' ')
+            && scheme.eq_ignore_ascii_case("Bearer")
+        {
+            return Some(token.to_string());
         }
-        self.query_pairs()
-            .find(|(name, _)| name == AUTH_TOKEN_URL_QUERY_PARAM)
-            .map(|(_, value)| value.into_owned())
     }
+    url::form_urlencoded::parse(request.uri.query().unwrap_or("").as_bytes())
+        .find(|(name, _)| name == AUTH_TOKEN_URL_QUERY_PARAM)
+        .map(|(_, value)| value.into_owned())
 }
 
 /// Access check callback used by [`AccessConfig::Restricted`].

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -175,7 +175,7 @@ impl ClientRequest {
     /// The [`EndpointId`] must be proven by the relay handshake. The request parts
     /// come from the client's WebSocket request.
     pub fn from_http_request(endpoint_id: EndpointId, request: &http::request::Parts) -> Self {
-        let auth_token = auth_token_from_request(&request);
+        let auth_token = auth_token_from_request(request);
         Self::new(endpoint_id, auth_token)
     }
 

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -1326,7 +1326,7 @@ mod tests {
                 key_cache_capacity: Some(1024),
                 access: AccessConfig::Restricted(Box::new(move |request| {
                     async move {
-                        if request.auth_token().as_deref() == Some(TOKEN) {
+                        if request.auth_token() == Some(TOKEN) {
                             Access::Allow
                         } else {
                             Access::Deny

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -219,11 +219,12 @@ impl Client {
     pub(super) fn request_reauth(&self) {
         // V1 clients don't support Status messages, disconnect them, they can reconnect.
         if self.protocol_version == ProtocolVersion::V1 {
-            trace!(dst=%self.endpoint_id.fmt_short(), "Reauth requested, disconnecting because client uses V1 protocol");
+            trace!(dst=%self.endpoint_id.fmt_short(), "Reauth requested but client uses V1 protocol, disconnecting");
             self.start_shutdown();
-        } else if let Err(_) = self
+        } else if self
             .message_queue
             .try_send(RelayToClientMsg::Status(Status::AuthorizationExpired))
+            .is_err()
         {
             trace!(dst=%self.endpoint_id.fmt_short(), "Reauth requested but failed to send AuthorizationExpired, disconnecting");
             self.start_shutdown();

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -1,15 +1,15 @@
 //! The server-side representation of an ongoing client relaying connection.
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{collections::HashSet, pin::Pin, sync::Arc, time::Duration};
 
 use iroh_base::EndpointId;
 use n0_error::{e, stack_error};
-use n0_future::{SinkExt, StreamExt};
+use n0_future::{MaybeFuture, SinkExt, StreamExt};
 use rand::RngExt;
 use time::{Date, OffsetDateTime};
 use tokio::{
     sync::mpsc::{self, error::TrySendError},
-    time::MissedTickBehavior,
+    time::{MissedTickBehavior, Sleep},
 };
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
 use tracing::{Instrument, debug, trace, warn};
@@ -26,11 +26,14 @@ use crate::{
         streams::BytesStreamSink,
     },
     server::{
+        AccessConfig, ClientRequest,
         clients::Clients,
         metrics::Metrics,
         streams::{RecvError as RelayRecvError, RelayedStream, SendError as RelaySendError},
     },
 };
+
+const AUTHORIZATION_EXPIRED_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A request to write a dataframe to a Client
 #[derive(Debug, Clone)]
@@ -57,8 +60,8 @@ pub struct Config<S> {
     pub channel_capacity: usize,
     /// Protocol version negotiated for this client
     pub protocol_version: ProtocolVersion,
-    /// The authorization token that the client registered with
-    pub auth_token: Option<String>,
+    /// The access config against which clients are checked in case a re-auth is requested.
+    pub access_config: Arc<AccessConfig>,
 }
 
 impl<S> Config<S> {
@@ -67,6 +70,7 @@ impl<S> Config<S> {
         endpoint_id: EndpointId,
         stream: RelayedStream<S>,
         protocol_version: ProtocolVersion,
+        access_config: Arc<AccessConfig>,
     ) -> Self {
         Self {
             endpoint_id,
@@ -74,7 +78,7 @@ impl<S> Config<S> {
             protocol_version,
             write_timeout: SERVER_WRITE_TIMEOUT,
             channel_capacity: PER_CLIENT_SEND_QUEUE_DEPTH,
-            auth_token: None,
+            access_config,
         }
     }
 }
@@ -99,8 +103,6 @@ pub struct Client {
     message_queue: mpsc::Sender<RelayToClientMsg>,
     /// Relay protocol version negotiated for this client.
     protocol_version: ProtocolVersion,
-    /// The auth token that the client passed when registering.
-    auth_token: Option<String>,
 }
 
 impl Client {
@@ -122,7 +124,7 @@ impl Client {
             write_timeout,
             channel_capacity,
             protocol_version,
-            auth_token,
+            access_config,
         } = config;
 
         let (packet_send_queue_s, packet_send_queue_r) = mpsc::channel(channel_capacity);
@@ -140,6 +142,8 @@ impl Client {
             client_counter: ClientCounter::default(),
             ping_tracker: PingTracker::default(),
             metrics,
+            access_config,
+            auth_expired: Box::pin(MaybeFuture::None),
         };
 
         // start io loop
@@ -158,23 +162,7 @@ impl Client {
             packet_queue: packet_send_queue_s,
             message_queue: message_send_queue_s,
             protocol_version,
-            auth_token,
         }
-    }
-
-    /// Returns the [`EndpointId`] of this client.
-    pub fn endpoint_id(&self) -> EndpointId {
-        self.endpoint_id
-    }
-
-    /// Returns the authorization token this client registered with, if set.
-    pub fn auth_token(&self) -> Option<&str> {
-        self.auth_token.as_deref()
-    }
-
-    /// Returns the protocol version negotiated for this connection.
-    pub fn protocol_version(&self) -> ProtocolVersion {
-        self.protocol_version
     }
 
     pub(super) fn connection_id(&self) -> u64 {
@@ -227,6 +215,20 @@ impl Client {
         };
         self.message_queue.try_send(message)
     }
+
+    pub(super) fn request_reauth(&self) {
+        // V1 clients don't support Status messages, disconnect them, they can reconnect.
+        if self.protocol_version == ProtocolVersion::V1 {
+            trace!(dst=%self.endpoint_id.fmt_short(), "Reauth requested, disconnecting because client uses V1 protocol");
+            self.start_shutdown();
+        } else if let Err(_) = self
+            .message_queue
+            .try_send(RelayToClientMsg::Status(Status::AuthorizationExpired))
+        {
+            trace!(dst=%self.endpoint_id.fmt_short(), "Reauth requested but failed to send AuthorizationExpired, disconnecting");
+            self.start_shutdown();
+        }
+    }
 }
 
 /// Error when handling an incoming frame from a client.
@@ -242,6 +244,8 @@ pub enum HandleFrameError {
     Recv { source: RelayRecvError },
     #[error(transparent)]
     Send { source: WriteFrameError },
+    #[error("Authorization rejected")]
+    AuthorizationRejected,
 }
 
 /// Error when writing a frame to a client.
@@ -283,6 +287,8 @@ pub enum RunError {
     WriteFrame { source: WriteFrameError },
     #[error("Tick flush")]
     TickFlush {},
+    #[error("Authorization expired")]
+    AuthorizationExpired,
 }
 
 /// Manages all the reads and writes to this client. It periodically sends a `KEEP_ALIVE`
@@ -322,6 +328,8 @@ struct Actor<S> {
     client_counter: ClientCounter,
     ping_tracker: PingTracker,
     metrics: Arc<Metrics>,
+    access_config: Arc<AccessConfig>,
+    auth_expired: Pin<Box<MaybeFuture<Sleep>>>,
 }
 
 impl<S> Actor<S>
@@ -388,7 +396,13 @@ where
                 }
                 // Last priority, sending other message
                 message = self.message_send_queue.recv() => {
-                    let message = message .ok_or_else(|| e!(RunError::HandleDropped))?;
+                    let message = message.ok_or_else(|| e!(RunError::HandleDropped))?;
+
+                    // Arm the re-auth timer when sending out an authorization request
+                    if matches!(message, RelayToClientMsg::Status(Status::AuthorizationExpired)) {
+                        self.auth_expired.as_mut().set_future(tokio::time::sleep(AUTHORIZATION_EXPIRED_TIMEOUT));
+                    }
+
                     trace!("send {message:?}");
                     self.write_frame(message)
                         .await
@@ -406,6 +420,15 @@ where
                     self.write_frame(RelayToClientMsg::Ping(data))
                         .await
                         .map_err(|err| e!(RunError::WriteFrame, err))?;
+                }
+                _ = &mut self.auth_expired => {
+                    // Give the client a chance to pass the authorization without a token, otherwise abort.
+                    let is_allowed = self.access_config.is_allowed(&ClientRequest::new(self.endpoint_id, None)).await;
+                    if is_allowed {
+                        self.auth_expired.as_mut().set_none();
+                    } else {
+                        return Err(e!(RunError::AuthorizationExpired))
+                    }
                 }
             }
 
@@ -489,6 +512,15 @@ where
             }
             ClientToRelayMsg::Pong(data) => {
                 self.ping_tracker.pong_received(data);
+            }
+            ClientToRelayMsg::Authorize { auth_token } => {
+                let req = ClientRequest::new(self.endpoint_id, Some(auth_token));
+                let is_allowed = self.access_config.is_allowed(&req).await;
+                if is_allowed {
+                    self.auth_expired.as_mut().set_none();
+                } else {
+                    return Err(e!(HandleFrameError::AuthorizationRejected));
+                }
             }
         }
         Ok(())
@@ -622,6 +654,8 @@ mod tests {
             client_counter: ClientCounter::default(),
             ping_tracker: PingTracker::default(),
             metrics,
+            access_config: Arc::new(AccessConfig::Everyone),
+            auth_expired: Box::pin(MaybeFuture::None),
         };
 
         let done = CancellationToken::new();
@@ -706,7 +740,7 @@ mod tests {
                 write_timeout: Duration::from_secs(1),
                 channel_capacity: 10,
                 protocol_version,
-                auth_token: None,
+                access_config: Arc::new(AccessConfig::Everyone),
             },
             Conn::test(client, protocol_version),
         )

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -57,6 +57,8 @@ pub struct Config<S> {
     pub channel_capacity: usize,
     /// Protocol version negotiated for this client
     pub protocol_version: ProtocolVersion,
+    /// The authorization token that the client registered with
+    pub auth_token: Option<String>,
 }
 
 impl<S> Config<S> {
@@ -72,6 +74,7 @@ impl<S> Config<S> {
             protocol_version,
             write_timeout: SERVER_WRITE_TIMEOUT,
             channel_capacity: PER_CLIENT_SEND_QUEUE_DEPTH,
+            auth_token: None,
         }
     }
 }
@@ -96,6 +99,8 @@ pub struct Client {
     message_queue: mpsc::Sender<RelayToClientMsg>,
     /// Relay protocol version negotiated for this client.
     protocol_version: ProtocolVersion,
+    /// The auth token that the client passed when registering.
+    auth_token: Option<String>,
 }
 
 impl Client {
@@ -117,6 +122,7 @@ impl Client {
             write_timeout,
             channel_capacity,
             protocol_version,
+            auth_token,
         } = config;
 
         let (packet_send_queue_s, packet_send_queue_r) = mpsc::channel(channel_capacity);
@@ -152,7 +158,23 @@ impl Client {
             packet_queue: packet_send_queue_s,
             message_queue: message_send_queue_s,
             protocol_version,
+            auth_token,
         }
+    }
+
+    /// Returns the [`EndpointId`] of this client.
+    pub fn endpoint_id(&self) -> EndpointId {
+        self.endpoint_id
+    }
+
+    /// Returns the authorization token this client registered with, if set.
+    pub fn auth_token(&self) -> Option<&str> {
+        self.auth_token.as_deref()
+    }
+
+    /// Returns the protocol version negotiated for this connection.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
     }
 
     pub(super) fn connection_id(&self) -> u64 {
@@ -684,6 +706,7 @@ mod tests {
                 write_timeout: Duration::from_secs(1),
                 channel_capacity: 10,
                 protocol_version,
+                auth_token: None,
             },
             Conn::test(client, protocol_version),
         )

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -72,20 +72,6 @@ impl Clients {
         n0_future::join_all(clients.map(|(_, state)| state.shutdown_all())).await;
     }
 
-    /// Disconnects all clients for which `f` returns `false`.
-    pub fn retain(&self, f: impl Fn(&Client) -> bool) {
-        for state in self.0.clients.iter() {
-            for client in state.inactive.iter() {
-                if !f(client) {
-                    client.start_shutdown();
-                }
-            }
-            if !f(&state.active) {
-                state.active.start_shutdown();
-            }
-        }
-    }
-
     /// Builds the client handler and starts the read & write loops for the connection.
     pub fn register<S>(&self, client_config: Config<S>, metrics: Arc<Metrics>)
     where
@@ -194,6 +180,15 @@ impl Clients {
         }
     }
 
+    /// Sends a message to all clients, requiring them to re-authorize.
+    pub fn request_reauth(&self) {
+        for state in self.0.clients.iter() {
+            for client in state.inactive.iter().chain([&state.active]) {
+                client.request_reauth();
+            }
+        }
+    }
+
     /// Attempt to send a packet to client with [`EndpointId`] `dst`.
     pub(super) fn send_packet(
         &self,
@@ -292,7 +287,7 @@ mod tests {
                 write_timeout: Duration::from_secs(1),
                 channel_capacity: 10,
                 protocol_version: Default::default(),
-                auth_token: None,
+                access_config: Arc::new(crate::server::AccessConfig::Everyone),
             },
             Conn::test(client, protocol_version),
         )

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -182,11 +182,11 @@ impl Clients {
 
     /// Sends a message to all clients, requesting them to re-authorize.
     ///
-    /// Clients are expected to reply with a [`ClientToRelayMsg::Authorize`].
+    /// Clients are expected to reply with their authorization token.
     /// If they don't reply within 5s, or if the token they provided does not
     /// pass [`Config::access_config`], the client is disconnected.
     ///
-    /// Clients using [`ProtocolVersion::V1`] are disconnected unconditionally.
+    /// Clients using protocol version V1 are disconnected unconditionally.
     pub fn request_reauth(&self) {
         for state in self.0.clients.iter() {
             for client in state.inactive.iter().chain([&state.active]) {

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -72,6 +72,20 @@ impl Clients {
         n0_future::join_all(clients.map(|(_, state)| state.shutdown_all())).await;
     }
 
+    /// Disconnects all clients for which `f` returns `false`.
+    pub fn retain(&self, f: impl Fn(&Client) -> bool) {
+        for state in self.0.clients.iter() {
+            for client in state.inactive.iter() {
+                if !f(client) {
+                    client.start_shutdown();
+                }
+            }
+            if !f(&state.active) {
+                state.active.start_shutdown();
+            }
+        }
+    }
+
     /// Builds the client handler and starts the read & write loops for the connection.
     pub fn register<S>(&self, client_config: Config<S>, metrics: Arc<Metrics>)
     where
@@ -278,6 +292,7 @@ mod tests {
                 write_timeout: Duration::from_secs(1),
                 channel_capacity: 10,
                 protocol_version: Default::default(),
+                auth_token: None,
             },
             Conn::test(client, protocol_version),
         )

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -180,7 +180,13 @@ impl Clients {
         }
     }
 
-    /// Sends a message to all clients, requiring them to re-authorize.
+    /// Sends a message to all clients, requesting them to re-authorize.
+    ///
+    /// Clients are expected to reply with a [`ClientToRelayMsg::Authorize`].
+    /// If they don't reply within 5s, or if the token they provided does not
+    /// pass [`Config::access_config`], the client is disconnected.
+    ///
+    /// Clients using [`ProtocolVersion::V1`] are disconnected unconditionally.
     pub fn request_reauth(&self) {
         for state in self.0.clients.iter() {
             for client in state.inactive.iter().chain([&state.active]) {

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -945,10 +945,8 @@ impl RelayService {
 
     /// Returns a reference to the registry of currently connected clients.
     ///
-    /// The returned [`Clients`] handle can be used at runtime to disconnect
-    /// connected clients via [`Clients::retain`]. This is the entry point for
-    /// revoking access for endpoints that were admitted by the access hook
-    /// but should no longer be allowed.
+    /// The returned [`Clients`] handle can be used at runtime to request
+    /// all clients to re-authorize via [`Clients::request_reauth`].
     pub fn clients(&self) -> &Clients {
         &self.0.clients
     }

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -114,6 +114,7 @@ pub(super) struct Server {
     addr: SocketAddr,
     http_server_task: AbortOnDropHandle<()>,
     cancel_server_loop: CancellationToken,
+    service: RelayService,
 }
 
 impl Server {
@@ -144,6 +145,11 @@ impl Server {
     /// Returns the local address of this server.
     pub(super) fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    /// Returns the [`RelayService`] driving this server.
+    pub(super) fn service(&self) -> &RelayService {
+        &self.service
     }
 }
 
@@ -464,8 +470,10 @@ impl ServerBuilder {
         info!("[{http_str}] relay: serving on {addr}");
 
         let cancel = cancel_token.clone();
+        let loop_service = service.clone();
         let task = tokio::task::spawn(
             async move {
+                let service = loop_service;
                 // create a join set to track all our connection tasks
                 let mut set = tokio::task::JoinSet::new();
                 loop {
@@ -510,6 +518,7 @@ impl ServerBuilder {
             addr,
             http_server_task: AbortOnDropHandle::new(task),
             cancel_server_loop: cancel_token,
+            service,
         })
     }
 }
@@ -881,6 +890,7 @@ impl Inner {
             write_timeout: self.write_timeout,
             channel_capacity: PER_CLIENT_SEND_QUEUE_DEPTH,
             protocol_version,
+            auth_token: request.auth_token(),
         };
         trace!("accept: create client");
         let endpoint_id = client_conn_builder.endpoint_id;
@@ -931,6 +941,16 @@ impl RelayService {
     /// Shuts down the relay service, disconnecting all clients.
     pub async fn shutdown(&self) {
         self.0.clients.shutdown().await;
+    }
+
+    /// Returns a reference to the registry of currently connected clients.
+    ///
+    /// The returned [`Clients`] handle can be used at runtime to disconnect
+    /// connected clients via [`Clients::retain`]. This is the entry point for
+    /// revoking access for endpoints that were admitted by the access hook
+    /// but should no longer be allowed.
+    pub fn clients(&self) -> &Clients {
+        &self.0.clients
     }
 
     /// Handle the incoming connection.

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -537,7 +537,7 @@ struct Inner {
     write_timeout: Duration,
     rate_limit: Option<ClientRateLimit>,
     key_cache: KeyCache,
-    access: AccessConfig,
+    access: Arc<AccessConfig>,
     metrics: Arc<Metrics>,
 }
 
@@ -872,7 +872,7 @@ impl Inner {
 
         trace!(?authentication.mechanism, "accept: verified authentication");
 
-        let request = ClientRequest::new(authentication.client_key, request_parts);
+        let request = ClientRequest::from_http_request(authentication.client_key, &request_parts);
         let is_authorized = self.access.is_allowed(&request).await;
         let client_key = authentication.authorize_if(is_authorized, &mut io).await?;
 
@@ -890,7 +890,7 @@ impl Inner {
             write_timeout: self.write_timeout,
             channel_capacity: PER_CLIENT_SEND_QUEUE_DEPTH,
             protocol_version,
-            auth_token: request.auth_token(),
+            access_config: self.access.clone(),
         };
         trace!("accept: create client");
         let endpoint_id = client_conn_builder.endpoint_id;
@@ -933,7 +933,7 @@ impl RelayService {
             write_timeout: SERVER_WRITE_TIMEOUT,
             rate_limit,
             key_cache,
-            access,
+            access: Arc::new(access),
             metrics,
         }))
     }

--- a/iroh-relay/tests/relay_axum.rs
+++ b/iroh-relay/tests/relay_axum.rs
@@ -187,7 +187,7 @@ async fn handle_relay_websocket(
     let authentication = handshake::serverside(&mut adapter, client_auth_header).await?;
     trace!(?authentication.mechanism, "verified authentication");
 
-    let request = ClientRequest::new(authentication.client_key, request_parts);
+    let request = ClientRequest::from_http_request(authentication.client_key, &request_parts);
     let is_authorized = state.access.is_allowed(&request).await;
     let client_key = authentication
         .authorize_if(is_authorized, &mut adapter)
@@ -195,7 +195,12 @@ async fn handle_relay_websocket(
     trace!("verified authorization");
 
     let stream = RelayedStream::new(adapter, state.key_cache.clone());
-    let config = Config::new(client_key, stream, ProtocolVersion::V2);
+    let config = Config::new(
+        client_key,
+        stream,
+        ProtocolVersion::V2,
+        state.access.clone(),
+    );
     state.clients.register(config, state.metrics.clone());
     Ok(())
 }

--- a/iroh-relay/tests/runtime_auth.rs
+++ b/iroh-relay/tests/runtime_auth.rs
@@ -1,0 +1,177 @@
+//! Runtime revocation of relay auth tokens.
+//!
+//! Exercises updating the set of allowed auth tokens at runtime and
+//! disconnecting the now-unauthorized clients through the top-level
+//! [`Server`] public API.
+
+#![cfg(feature = "server")]
+
+use std::{
+    collections::HashSet,
+    net::Ipv4Addr,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use iroh_base::{RelayUrl, SecretKey};
+use iroh_dns::dns::DnsResolver;
+use iroh_relay::{
+    client::{Client, ClientBuilder, ConnectError},
+    protos::{
+        handshake,
+        relay::{ClientToRelayMsg, RelayToClientMsg},
+    },
+    server::{Access, AccessConfig, RelayConfig, Server, ServerConfig},
+    tls::{CaRootsConfig, default_provider},
+};
+use n0_error::{Result, StackResultExt, StdResultExt};
+use n0_future::{FutureExt, SinkExt, StreamExt};
+use n0_tracing_test::traced_test;
+use rand::RngExt;
+
+#[tokio::test]
+#[traced_test]
+async fn relay_runtime_revokes_disallowed_tokens() -> Result<()> {
+    let relay = RestrictedServer::spawn(["token-b"]).await?;
+
+    let relay_url: RelayUrl = format!("http://{}", relay.server.http_addr().expect("http addr"))
+        .parse()
+        .expect("valid relay url");
+
+    assert_denied(connect(&relay_url, "token-a").await);
+    // token-a is added at runtime; both clients then connect successfully.
+    relay.add_token("token-a");
+    let mut client_a = connect(&relay_url, "token-a").await?;
+    let mut client_b = connect(&relay_url, "token-b").await?;
+    ping_round_trip(&mut client_a, [1u8; 8]).await?;
+    ping_round_trip(&mut client_b, [2u8; 8]).await?;
+
+    // Revoking token-a evicts client A; client B keeps working.
+    relay.remove_token("token-a");
+    assert_disconnected(&mut client_a).await;
+    ping_round_trip(&mut client_b, [3u8; 8]).await?;
+
+    // New connections honor the updated allow-list.
+    assert_denied(connect(&relay_url, "token-a").await);
+    let mut client_c = connect(&relay_url, "token-b").await?;
+    ping_round_trip(&mut client_c, [4u8; 8]).await?;
+
+    Ok(())
+}
+
+/// Connects a fresh relay client authenticating with `token`.
+async fn connect(relay_url: &RelayUrl, token: &str) -> Result<Client, ConnectError> {
+    let tls = CaRootsConfig::default()
+        .client_config(default_provider())
+        .expect("valid client config");
+    let secret = SecretKey::from_bytes(&rand::rng().random());
+    ClientBuilder::new(relay_url.clone(), secret, DnsResolver::new())
+        .tls_client_config(tls)
+        .auth_token(token)
+        .connect()
+        .await
+}
+
+/// A relay [`Server`] paired with its runtime-mutable auth-token allow-list.
+///
+/// The allow-list is shared with the server's access hook, so mutations take
+/// effect immediately for new connections. [`RestrictedServer::remove_token`]
+/// additionally evicts clients that connected with a token that is no longer
+/// allowed.
+struct RestrictedServer {
+    server: Server,
+    allowed_tokens: Arc<RwLock<HashSet<String>>>,
+}
+
+impl RestrictedServer {
+    /// Spawns a plain-HTTP relay that admits only the given auth `tokens`.
+    async fn spawn(tokens: impl IntoIterator<Item = &'static str>) -> Result<Self> {
+        let allowed_tokens: Arc<RwLock<HashSet<String>>> =
+            Arc::new(RwLock::new(tokens.into_iter().map(String::from).collect()));
+
+        let mut relay = RelayConfig::new((Ipv4Addr::LOCALHOST, 0));
+        relay.access = {
+            let allowed_tokens = allowed_tokens.clone();
+            AccessConfig::Restricted(Box::new(move |request| {
+                let allowed_tokens = allowed_tokens.clone();
+                async move {
+                    let allowed_tokens = allowed_tokens.read().expect("poisoned");
+                    match request.auth_token() {
+                        Some(token) if allowed_tokens.contains(&token) => Access::Allow,
+                        _ => Access::Deny,
+                    }
+                }
+                .boxed()
+            }))
+        };
+        let mut config = ServerConfig::default();
+        config.relay = Some(relay);
+        let server = Server::spawn(config).await?;
+
+        Ok(Self {
+            server,
+            allowed_tokens,
+        })
+    }
+
+    /// Adds `token` to the allow-list.
+    fn add_token(&self, token: &str) {
+        self.allowed_tokens
+            .write()
+            .expect("poisoned")
+            .insert(token.to_string());
+    }
+
+    /// Removes `token` from the allow-list and disconnects every connected
+    /// client whose auth token is no longer allowed.
+    fn remove_token(&self, token: &str) {
+        let allowed = {
+            let mut allowed = self.allowed_tokens.write().expect("poisoned");
+            allowed.remove(token);
+            allowed.clone()
+        };
+        self.server
+            .relay_service()
+            .expect("relay configured")
+            .clients()
+            .retain(|client| client.auth_token().is_some_and(|t| allowed.contains(t)));
+    }
+}
+
+/// Sends a relay-level ping and asserts the matching pong comes back.
+async fn ping_round_trip(client: &mut Client, data: [u8; 8]) -> Result<()> {
+    client.send(ClientToRelayMsg::Ping(data)).await?;
+    let msg = tokio::time::timeout(Duration::from_secs(2), client.next())
+        .await
+        .std_context("ping timeout")?
+        .context("stream ended")??;
+    match msg {
+        RelayToClientMsg::Pong(echo) => {
+            n0_error::ensure_any!(echo == data, "Pong mismatch");
+            Ok(())
+        }
+        other => n0_error::bail_any!("expected Pong, got {other:?}"),
+    }
+}
+
+/// Asserts that `client`'s stream closes within a few seconds.
+async fn assert_disconnected(client: &mut Client) {
+    match tokio::time::timeout(Duration::from_secs(2), client.next()).await {
+        Ok(None) => {}
+        Ok(Some(Err(e))) => panic!("expected stream close, got Err({e:?})"),
+        Ok(Some(Ok(msg))) => panic!("expected stream close, got {msg:?}"),
+        Err(_) => panic!("timeout waiting for disconnect"),
+    }
+}
+
+/// Asserts that a connection attempt was rejected by the access hook.
+fn assert_denied(result: Result<Client, ConnectError>) {
+    assert!(
+        matches!(
+            result,
+            Err(ConnectError::Handshake { source: handshake::Error::ServerDeniedAuth { ref reason, .. }, .. })
+                if reason == "not authorized"
+        ),
+        "expected handshake denial, got {result:?}",
+    );
+}

--- a/iroh-relay/tests/runtime_auth.rs
+++ b/iroh-relay/tests/runtime_auth.rs
@@ -19,7 +19,7 @@ use iroh_relay::{
     client::{Client, ClientBuilder, ConnectError},
     protos::{
         handshake,
-        relay::{ClientToRelayMsg, RelayToClientMsg},
+        relay::{ClientToRelayMsg, RelayToClientMsg, Status},
     },
     server::{Access, AccessConfig, RelayConfig, Server, ServerConfig},
     tls::{CaRootsConfig, default_provider},
@@ -28,8 +28,9 @@ use n0_error::{Result, StackResultExt, StdResultExt};
 use n0_future::{FutureExt, SinkExt, StreamExt};
 use n0_tracing_test::traced_test;
 use rand::RngExt;
+use tracing::debug;
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 #[traced_test]
 async fn relay_runtime_revokes_disallowed_tokens() -> Result<()> {
     let relay = RestrictedServer::spawn(["token-b"]).await?;
@@ -43,18 +44,36 @@ async fn relay_runtime_revokes_disallowed_tokens() -> Result<()> {
     relay.add_token("token-a");
     let mut client_a = connect(&relay_url, "token-a").await?;
     let mut client_b = connect(&relay_url, "token-b").await?;
+    let mut client_c = connect(&relay_url, "token-a").await?;
+
     ping_round_trip(&mut client_a, [1u8; 8]).await?;
     ping_round_trip(&mut client_b, [2u8; 8]).await?;
+    ping_round_trip(&mut client_c, [3u8; 8]).await?;
 
     // Revoking token-a evicts client A; client B keeps working.
     relay.remove_token("token-a");
+
+    reauth_reply(&mut client_a, "token-a").await?;
+    reauth_reply(&mut client_b, "token-b").await?;
+    reauth_noreply(&mut client_c).await?;
+
     assert_disconnected(&mut client_a).await;
+    ping_round_trip(&mut client_b, [3u8; 8]).await?;
+
+    assert_disconnected(&mut client_a).await;
+    ping_round_trip(&mut client_b, [3u8; 8]).await?;
+    ping_round_trip(&mut client_c, [3u8; 8]).await?;
+
+    tokio::time::pause();
+    tokio::time::sleep(Duration::from_secs(6)).await;
+    tokio::time::resume();
+    assert_disconnected(&mut client_c).await;
     ping_round_trip(&mut client_b, [3u8; 8]).await?;
 
     // New connections honor the updated allow-list.
     assert_denied(connect(&relay_url, "token-a").await);
-    let mut client_c = connect(&relay_url, "token-b").await?;
-    ping_round_trip(&mut client_c, [4u8; 8]).await?;
+    let mut client_d = connect(&relay_url, "token-b").await?;
+    ping_round_trip(&mut client_d, [4u8; 8]).await?;
 
     Ok(())
 }
@@ -97,7 +116,7 @@ impl RestrictedServer {
                 async move {
                     let allowed_tokens = allowed_tokens.read().expect("poisoned");
                     match request.auth_token() {
-                        Some(token) if allowed_tokens.contains(&token) => Access::Allow,
+                        Some(token) if allowed_tokens.contains(token) => Access::Allow,
                         _ => Access::Deny,
                     }
                 }
@@ -125,43 +144,80 @@ impl RestrictedServer {
     /// Removes `token` from the allow-list and disconnects every connected
     /// client whose auth token is no longer allowed.
     fn remove_token(&self, token: &str) {
-        let allowed = {
-            let mut allowed = self.allowed_tokens.write().expect("poisoned");
-            allowed.remove(token);
-            allowed.clone()
-        };
+        self.allowed_tokens.write().expect("poisoned").remove(token);
         self.server
             .relay_service()
             .expect("relay configured")
             .clients()
-            .retain(|client| client.auth_token().is_some_and(|t| allowed.contains(t)));
+            .request_reauth();
     }
 }
 
 /// Sends a relay-level ping and asserts the matching pong comes back.
 async fn ping_round_trip(client: &mut Client, data: [u8; 8]) -> Result<()> {
     client.send(ClientToRelayMsg::Ping(data)).await?;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let msg = client.next().await.context("stream ended")??;
+            match msg {
+                RelayToClientMsg::Ping(msg) => {
+                    client.send(ClientToRelayMsg::Pong(msg)).await?;
+                }
+                RelayToClientMsg::Status(status) => debug!("got status message: {status:?}"),
+                RelayToClientMsg::Pong(echo) => {
+                    n0_error::ensure_any!(echo == data, "Pong mismatch");
+                    break;
+                }
+                other => n0_error::bail_any!("expected Pong, got {other:?}"),
+            }
+        }
+        n0_error::Ok(())
+    })
+    .await
+    .std_context("ping roundtrip timeout")?
+}
+
+async fn reauth_noreply(client: &mut Client) -> Result<()> {
+    let msg = next_timeout(client).await?;
+    match msg {
+        RelayToClientMsg::Status(Status::AuthorizationExpired) => {}
+        _ => n0_error::bail_any!("Expected AuthorizationExpired message, got {:?}", msg),
+    }
+    Ok(())
+}
+
+async fn reauth_reply(client: &mut Client, auth_token: impl ToString) -> Result<()> {
+    let auth_token = auth_token.to_string();
+    let msg = next_timeout(client).await?;
+    match msg {
+        RelayToClientMsg::Status(Status::AuthorizationExpired) => {
+            client
+                .send(ClientToRelayMsg::Authorize { auth_token })
+                .await?;
+        }
+        _ => n0_error::bail_any!("Expected AuthorizationExpired message, got {:?}", msg),
+    }
+    Ok(())
+}
+
+async fn next_timeout(client: &mut Client) -> Result<RelayToClientMsg> {
     let msg = tokio::time::timeout(Duration::from_secs(2), client.next())
         .await
-        .std_context("ping timeout")?
-        .context("stream ended")??;
-    match msg {
-        RelayToClientMsg::Pong(echo) => {
-            n0_error::ensure_any!(echo == data, "Pong mismatch");
-            Ok(())
-        }
-        other => n0_error::bail_any!("expected Pong, got {other:?}"),
-    }
+        .std_context("timeout")
+        .context("stream ended")?
+        .anyerr()??;
+    Ok(msg)
 }
 
 /// Asserts that `client`'s stream closes within a few seconds.
 async fn assert_disconnected(client: &mut Client) {
-    match tokio::time::timeout(Duration::from_secs(2), client.next()).await {
-        Ok(None) => {}
-        Ok(Some(Err(e))) => panic!("expected stream close, got Err({e:?})"),
-        Ok(Some(Ok(msg))) => panic!("expected stream close, got {msg:?}"),
-        Err(_) => panic!("timeout waiting for disconnect"),
-    }
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while let Some(msg) = client.next().await {
+            let _ = msg.expect("expected message, got error");
+        }
+    })
+    .await
+    .expect("timeout while waiting for disconnect")
 }
 
 /// Asserts that a connection attempt was rejected by the access hook.

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -3919,7 +3919,7 @@ mod tests {
 
         let access = AccessConfig::Restricted(Box::new(|request| {
             Box::pin(async move {
-                if request.auth_token().as_deref() == Some(TOKEN) {
+                if request.auth_token() == Some(TOKEN) {
                     Access::Allow
                 } else {
                     Access::Deny

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -139,6 +139,7 @@ struct ActiveRelayActor {
     url: RelayUrl,
     /// Builder which can repeatedly build a relay client.
     relay_client_builder: relay::client::ClientBuilder,
+    auth_token: Option<String>,
     /// Whether or not this is the home relay server.
     ///
     /// The home relay server needs to maintain it's connection to the relay server, even if
@@ -271,6 +272,7 @@ impl ActiveRelayActor {
             metrics,
             my_relay,
         } = opts;
+        let auth_token = connection_opts.auth_token.clone();
         let relay_client_builder = Self::create_relay_builder(url.clone(), connection_opts);
         ActiveRelayActor {
             prio_inbox,
@@ -279,6 +281,7 @@ impl ActiveRelayActor {
             relay_datagrams_send,
             url,
             relay_client_builder,
+            auth_token,
             is_home_relay: false,
             inactive_timeout: Box::pin(time::sleep(RELAY_INACTIVE_CLEANUP_TIME)),
             stop_token,
@@ -523,6 +526,7 @@ impl ActiveRelayActor {
             endpoints_present: BTreeSet::new(),
             last_packet_src: None,
             pong_pending: None,
+            auth_pending: false,
             established: false,
             #[cfg(test)]
             test_pong: None,
@@ -539,6 +543,14 @@ impl ActiveRelayActor {
         let res = loop {
             if let Some(data) = state.pong_pending.take() {
                 let fut = client_sink.send(ClientToRelayMsg::Pong(data));
+                self.run_sending(fut, &mut state, &mut client_stream)
+                    .await?;
+            }
+            if state.auth_pending
+                && let Some(auth_token) = self.auth_token.clone()
+            {
+                state.auth_pending = false;
+                let fut = client_sink.send(ClientToRelayMsg::Authorize { auth_token });
                 self.run_sending(fut, &mut state, &mut client_stream)
                     .await?;
             }
@@ -708,6 +720,10 @@ impl ActiveRelayActor {
             }
             RelayToClientMsg::Status(status) => match status {
                 Status::Healthy => info!("Relay server reports: {status}"),
+                Status::AuthorizationExpired => {
+                    debug!("Relay server requests re-authorization");
+                    state.auth_pending = true;
+                }
                 _ => warn!("Relay server reports problem: {status}"),
             },
             RelayToClientMsg::Restarting { .. } => {
@@ -812,6 +828,8 @@ struct ConnectedRelayState {
     last_packet_src: Option<EndpointId>,
     /// A pong we need to send ASAP.
     pong_pending: Option<[u8; 8]>,
+    /// Set to `true` if the relay requested us to send our authorization token.
+    auth_pending: bool,
     /// Whether the connection is to be considered established.
     ///
     /// This is set to `true` once a pong was received from the server.

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -722,7 +722,9 @@ impl ActiveRelayActor {
                 Status::Healthy => info!("Relay server reports: {status}"),
                 Status::AuthorizationExpired => {
                     debug!("Relay server requests re-authorization");
-                    state.auth_pending = true;
+                    if self.auth_token.is_some() {
+                        state.auth_pending = true;
+                    }
                 }
                 _ => warn!("Relay server reports problem: {status}"),
             },
@@ -1415,9 +1417,11 @@ mod tests {
     use iroh_relay::{
         PingTracker,
         protos::relay::Datagrams,
+        server::{Access, AccessConfig},
         tls::{CaRootsConfig, default_provider},
     };
     use n0_error::{AnyError as Error, Result, StackResultExt, StdResultExt};
+    use n0_future::FutureExt;
     use n0_tracing_test::traced_test;
     use tokio::sync::{mpsc, oneshot};
     use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
@@ -1440,6 +1444,7 @@ mod tests {
         inbox_rx: mpsc::Receiver<ActiveRelayMessage>,
         relay_datagrams_send: mpsc::Receiver<RelaySendItem>,
         relay_datagrams_recv: mpsc::Sender<RelayRecvDatagram>,
+        auth_token: Option<String>,
         span: tracing::Span,
     ) -> AbortOnDropHandle<()> {
         let opts = ActiveRelayActorOptions {
@@ -1456,7 +1461,7 @@ mod tests {
                 tls_config: CaRootsConfig::insecure_skip_verify()
                     .client_config(default_provider())
                     .expect("infallible"),
-                auth_token: None,
+                auth_token,
             },
             stop_token,
             metrics: Default::default(),
@@ -1486,6 +1491,7 @@ mod tests {
             inbox_rx,
             send_datagram_rx,
             recv_datagram_tx,
+            None,
             info_span!("echo-endpoint"),
         );
         let echo_task = tokio::spawn({
@@ -1582,6 +1588,7 @@ mod tests {
             inbox_rx,
             send_datagram_rx,
             datagram_recv_tx.clone(),
+            None,
             info_span!("actor-under-test"),
         );
 
@@ -1665,6 +1672,101 @@ mod tests {
         Ok(())
     }
 
+    /// Pings the relay server through the actor and waits for the pong.
+    async fn ping_server(inbox_tx: &mpsc::Sender<ActiveRelayMessage>) -> Result {
+        let (tx, rx) = oneshot::channel();
+        inbox_tx
+            .send(ActiveRelayMessage::PingServer(tx))
+            .await
+            .std_context("send ping server message")?;
+        tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .std_context("ping server timeout")?
+            .std_context("ping server channel closed")?;
+        Ok(())
+    }
+
+    /// The [`ActiveRelayActor`] answers a server re-authorization request by
+    /// re-sending its auth token in-band, keeping the connection alive.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_active_relay_reauth() -> Result {
+        // A relay server whose access hook records the endpoint id and token of
+        // every authorization check it performs, and admits everyone.
+        let (auth_tx, mut auth_rx) = mpsc::unbounded_channel::<(EndpointId, Option<String>)>();
+        let access = AccessConfig::Restricted(Box::new(move |request| {
+            let auth_tx = auth_tx.clone();
+            let endpoint_id = request.endpoint_id();
+            let auth_token = request.auth_token().map(String::from);
+            async move {
+                auth_tx.send((endpoint_id, auth_token)).ok();
+                Access::Allow
+            }
+            .boxed()
+        }));
+        let (_relay_map, relay_url, server) =
+            test_utils::run_relay_server_with_access(false, access).await?;
+
+        // Start the actor under test, connecting with an auth token.
+        const TOKEN: &str = "secret-token";
+        let secret_key = SecretKey::from_bytes(&[1u8; 32]);
+        let endpoint_id = secret_key.public();
+        let (datagram_recv_tx, _datagram_recv_rx) = mpsc::channel(16);
+        let (_send_datagram_tx, send_datagram_rx) = mpsc::channel(16);
+        let (_prio_inbox_tx, prio_inbox_rx) = mpsc::channel(8);
+        let (inbox_tx, inbox_rx) = mpsc::channel(16);
+        let cancel_token = CancellationToken::new();
+        let _task = start_active_relay_actor(
+            secret_key,
+            cancel_token.clone(),
+            relay_url,
+            prio_inbox_rx,
+            inbox_rx,
+            send_datagram_rx,
+            datagram_recv_tx,
+            Some(TOKEN.to_string()),
+            info_span!("actor-under-test"),
+        );
+
+        // The connection handshake runs the access hook once, carrying the
+        // token from the HTTP request.
+        let (id, token) = tokio::time::timeout(Duration::from_secs(5), auth_rx.recv())
+            .await
+            .std_context("timeout waiting for handshake authorization")?
+            .context("access hook channel closed")?;
+        assert_eq!(id, endpoint_id);
+        assert_eq!(token.as_deref(), Some(TOKEN));
+
+        // Ping the server so we know the actor is fully connected and the
+        // server-side client is registered before we request a re-auth.
+        ping_server(&inbox_tx).await?;
+
+        // Ask the server to request re-authorization from every connected client.
+        server
+            .relay_service()
+            .expect("relay configured")
+            .clients()
+            .request_reauth();
+
+        // The actor must answer the `AuthorizationExpired` status with an
+        // in-band `Authorize` frame, which runs the access hook a second time
+        // with the same token. The 2s bound is well below the server's 5s
+        // re-auth deadline, so seeing the check this quickly also proves the
+        // token was re-sent in-band rather than via a reconnect.
+        let (id, token) = tokio::time::timeout(Duration::from_secs(2), auth_rx.recv())
+            .await
+            .std_context("timeout waiting for in-band re-authorization")?
+            .context("access hook channel closed")?;
+        assert_eq!(id, endpoint_id);
+        assert_eq!(token.as_deref(), Some(TOKEN));
+
+        // The connection survived the re-auth: the actor is still reachable.
+        ping_server(&inbox_tx).await?;
+
+        cancel_token.cancel();
+        Ok(())
+    }
+
     #[tokio::test]
     #[traced_test]
     async fn test_active_relay_inactive() -> Result {
@@ -1684,6 +1786,7 @@ mod tests {
             inbox_rx,
             send_datagram_rx,
             datagram_recv_tx,
+            None,
             info_span!("actor-under-test"),
         );
 


### PR DESCRIPTION
## Description

Alternative to #4274 

Adds a feature to the relay protocol allowing servers to re-request authorization from the client. Manually triggered from outside through `Clients::request_reauth`, never triggered in the `iroh-relay` binary. When triggered all clients receive a `Status::AuthorizationExpired` message, to which they ought to reply with the new `Authorization` message with their authorization token. The server arms a timeout (set to 5s) and if it expires without receiving the authorization message, the client is disconnected. If the message arrives, it is checked against the server's `AccessConfig`, and if it fails the client is denied.

Other than #4274 this version does not need to keep holding client's auth tokens in server memory.

This has breaking changes: The `ClientRequest` passed to the `AccessCheck` no longer exposes HTTP semantics. It now only exposes the auth token and endpoint id, nothing else - the HTTP request is not stored on the server for the duraiton of the connection. I think it's fine.

## Breaking Changes

* Removed: `iroh_relay::server::ClientRequest` methods `url`, `headers`, `query_params` are no longer available
* Renamed: `iroh_relay::server::ClientRequest::new` is now `ClientRequest::from_http_request`
* Changed: `iroh_relay::server::client::Config` now takes an additional arg `Arc<AccessConfig>`


## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.