### PR TITLE
chore(deps): Update noq to latest `main`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#7c17ca2b9fbed155700687c9982952752ec37dba"
+source = "git+https://github.com/n0-computer/noq?branch=main#be30bc5e2423475787974eb57d329ecb13566992"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#7c17ca2b9fbed155700687c9982952752ec37dba"
+source = "git+https://github.com/n0-computer/noq?branch=main#be30bc5e2423475787974eb57d329ecb13566992"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3220,7 +3220,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#7c17ca2b9fbed155700687c9982952752ec37dba"
+source = "git+https://github.com/n0-computer/noq?branch=main#be30bc5e2423475787974eb57d329ecb13566992"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -589,7 +589,7 @@ impl RemoteStateActor {
         };
         trace!("path event");
         match event {
-            NoqPathEvent::Established { id: path_id } => {
+            NoqPathEvent::Established { id: path_id, .. } => {
                 let Some(path) = conn.path(path_id) else {
                     trace!("path open event for unknown path");
                     return;
@@ -599,7 +599,7 @@ impl RemoteStateActor {
                     .register_and_configure_path(conn_id, conn_state, &path);
                 self.select_path();
             }
-            NoqPathEvent::Abandoned { id, reason } => {
+            NoqPathEvent::Abandoned { id, reason, .. } => {
                 // Remove abandoned path from the conn state.
                 let Some(path_remote) = conn_state.remove_path(&id, &conn) else {
                     debug!(%id, "path not in path_id_map");
@@ -645,11 +645,18 @@ impl RemoteStateActor {
                 // If the remote closed our selected path, select a new one.
                 self.select_path();
             }
-            NoqPathEvent::Discarded { id, path_stats } => {
+            NoqPathEvent::Discarded { id, path_stats, .. } => {
                 trace!(%id, ?path_stats, "path discarded");
             }
             NoqPathEvent::RemoteStatus { .. } | NoqPathEvent::ObservedAddr { .. } => {
                 // Nothing to do for these events.
+            }
+            _ => {
+                // We expect to keep noq and iroh in sync in all test setups, but in production it's totally possible
+                // that iroh itself is linked against a newer version of noq with additional events we don't yet
+                // know how to handle.
+                #[cfg(test)]
+                panic!("Unhandled path event: {event:?}");
             }
         }
     }


### PR DESCRIPTION
## Description

Updates to the latest main, including `#[non_exhaustive]` changes to `PathEvent`: https://github.com/n0-computer/noq/pull/648

## Notes & open questions

Adding a `#[cfg(test)] panic!()` to ensure we keep the versions in noq and iroh in sync and see iroh tests failing when we add more path events.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
