### PR TITLE
refactor(iroh)!: Use `FourTuple` in send paths

### DIFF
--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -36,9 +36,7 @@ use crate::{
         Metrics as SocketMetrics, RELAY_PATH_MAX_IDLE_TIMEOUT,
         mapped_addrs::{AddrMap, CustomMappedAddr, RelayMappedAddr},
         remote_map::remote_state::path_watcher::PathStateSender,
-        transports::{
-            self, FourTuple, OwnedTransmit, PathSelectionData, TransportBiasMap, TransportsSender,
-        },
+        transports::{self, OwnedTransmit, PathSelectionData, TransportBiasMap, TransportsSender},
     },
     util::MaybeFuture,
 };
@@ -157,7 +155,7 @@ struct State {
     /// holepunching regularly.
     ///
     /// We only select a path once the path is functional in Noq.
-    selected_path: Option<FourTuple>,
+    selected_path: Option<transports::FourTuple>,
     /// Time at which we should schedule the next holepunch attempt.
     scheduled_holepunch: Option<Instant>,
     /// When to next attempt opening paths in [`Self::pending_open_paths`].
@@ -165,7 +163,7 @@ struct State {
     /// Paths which we still need to open.
     ///
     /// They failed to open because we did not have enough CIDs issued by the remote.
-    pending_open_paths: VecDeque<FourTuple>,
+    pending_open_paths: VecDeque<transports::FourTuple>,
 
     // Internal state - address lookup
     //
@@ -442,7 +440,7 @@ impl RemoteStateActor {
                     .paths
                     .addrs()
                     .filter(|addr| addr.is_relay())
-                    .map(|addr| FourTuple::from_remote(addr.clone()))
+                    .map(|addr| transports::FourTuple::from_remote(addr.clone()))
                     .collect::<Vec<_>>();
                 for open_addr in relays {
                     self.state
@@ -683,7 +681,8 @@ impl RemoteStateActor {
     fn select_path(&mut self) {
         // Find the lowest RTT across all connections for each open path.  The long way, so
         // we get to log *all* RTTs.
-        let mut all_path_rtts: FxHashMap<&FourTuple, Vec<Duration>> = FxHashMap::default();
+        let mut all_path_rtts: FxHashMap<&transports::FourTuple, Vec<Duration>> =
+            FxHashMap::default();
         for conn_state in self.connections.values() {
             let Some(conn) = conn_state.handle.upgrade() else {
                 continue;
@@ -695,7 +694,7 @@ impl RemoteStateActor {
             }
         }
         trace!(?all_path_rtts, "dumping all path RTTs");
-        let path_rtts: FxHashMap<&FourTuple, PathSelectionData> = all_path_rtts
+        let path_rtts: FxHashMap<&transports::FourTuple, PathSelectionData> = all_path_rtts
             .into_iter()
             .filter_map(|(addr, rtts)| rtts.into_iter().min().map(|rtt| (addr, rtt)))
             .map(|(addr, rtt)| {
@@ -737,7 +736,7 @@ impl RemoteStateActor {
     /// - Sets all non-selected paths to [`PathStatus::Backup`]
     /// - Opens the selected path if it does not exist on the connection
     /// - Sets the selected path to [`PathStatus::Available`]
-    fn apply_selected_change(&mut self, selected: &FourTuple) {
+    fn apply_selected_change(&mut self, selected: &transports::FourTuple) {
         for (conn_id, conn_state) in self.connections.iter() {
             let Some(conn) = conn_state.handle.upgrade() else {
                 continue;
@@ -787,7 +786,7 @@ impl RemoteStateActor {
         }
     }
 
-    fn open_path_on_all_conns(&mut self, open_addr: &FourTuple) {
+    fn open_path_on_all_conns(&mut self, open_addr: &transports::FourTuple) {
         for (conn_id, conn_state) in self.connections.iter() {
             let Some(conn) = conn_state.handle.upgrade() else {
                 continue;
@@ -854,7 +853,7 @@ impl State {
             // TODO(Frando): We might want to include a local IP here in the future, if we confidently
             // know that it is the correct one.
             // See https://github.com/n0-computer/iroh/issues/4280.
-            let four_tuple = FourTuple::from_remote(addr.remote());
+            let four_tuple = transports::FourTuple::from_remote(addr.remote());
             if let Err(err) = send_datagram(&mut sender, four_tuple, transmit).await {
                 debug!(?addr, "failed to send datagram on selected_path: {err:#}");
             }
@@ -884,7 +883,7 @@ impl State {
                 // See https://github.com/n0-computer/iroh/issues/4280.
                 } else if let Err(err) = send_datagram(
                     &mut sender,
-                    FourTuple::from_remote(addr.clone()),
+                    transports::FourTuple::from_remote(addr.clone()),
                     transmit.clone(),
                 )
                 .await
@@ -1026,7 +1025,7 @@ impl State {
         conn_id: ConnId,
         conn_state: &mut ConnectionState,
         path: &noq::Path,
-    ) -> Option<FourTuple> {
+    ) -> Option<transports::FourTuple> {
         let network_path = self.transport_tuple_for_path(path)?;
         event!(
             target: "iroh::_events::path::open",
@@ -1049,7 +1048,12 @@ impl State {
         Some(network_path)
     }
 
-    fn set_path_status(&mut self, conn_id: ConnId, path: &noq::Path, network_path: &FourTuple) {
+    fn set_path_status(
+        &mut self,
+        conn_id: ConnId,
+        path: &noq::Path,
+        network_path: &transports::FourTuple,
+    ) {
         let status = self.path_status_for_addr(network_path);
         match path.set_status(status) {
             Err(error) => warn!(?error, ?network_path, ?status, "set_status failed"),
@@ -1074,7 +1078,7 @@ impl State {
         conn_id: ConnId,
         conn_state: &ConnectionState,
         conn: &noq::Connection,
-        open_addr: &FourTuple,
+        open_addr: &transports::FourTuple,
     ) {
         // Only the client opens paths; the server receives them via
         // QUIC frames and reacts to PathOpened events.
@@ -1114,7 +1118,7 @@ impl State {
     ///
     /// Returns [`PathStatus::Available`] if `addr` is the currently-selected path,
     /// or [`PathStatus::Backup`] otherwise.
-    fn path_status_for_addr(&self, addr: &FourTuple) -> PathStatus {
+    fn path_status_for_addr(&self, addr: &transports::FourTuple) -> PathStatus {
         if Some(addr) == self.selected_path.as_ref() {
             PathStatus::Available
         } else {
@@ -1123,9 +1127,9 @@ impl State {
     }
 
     /// Returns the [`transports::FourTuple] for a path.
-    fn transport_tuple_for_path(&self, path: &noq::Path) -> Option<FourTuple> {
+    fn transport_tuple_for_path(&self, path: &noq::Path) -> Option<transports::FourTuple> {
         let noq_network_path = path.network_path().ok()?;
-        FourTuple::from_noq(
+        transports::FourTuple::from_noq(
             noq_network_path,
             &self.relay_mapped_addrs,
             &self.custom_mapped_addrs,
@@ -1145,9 +1149,9 @@ impl State {
 /// Returns `Some` if a new path should be selected, `None` if the `current_path` should
 /// continued to be used.
 fn select_best_path<'a>(
-    all_paths: FxHashMap<&'a FourTuple, PathSelectionData>,
-    current_path: Option<&'a FourTuple>,
-) -> Option<(FourTuple, Duration)> {
+    all_paths: FxHashMap<&'a transports::FourTuple, PathSelectionData>,
+    current_path: Option<&'a transports::FourTuple>,
+) -> Option<(transports::FourTuple, Duration)> {
     // Determine the best new path according to sort_key.
     // If there is no path, return None.
     let (best_addr, best_data) = all_paths.iter().min_by_key(|(_, psd)| psd.sort_key())?;
@@ -1199,7 +1203,7 @@ fn update_qnt_candidates(conn: &noq::Connection, direct_addrs: &BTreeSet<SocketA
 
 fn send_datagram<'a>(
     sender: &'a mut TransportsSender,
-    addr: FourTuple,
+    addr: transports::FourTuple,
     owned_transmit: OwnedTransmit,
 ) -> impl Future<Output = n0_error::Result<()>> + 'a {
     std::future::poll_fn(move |cx| {
@@ -1299,7 +1303,7 @@ struct ConnectionState {
     /// [`Connection`]: crate::endpoint::Connection
     path_state: PathStateSender,
     /// The open paths that exist on this connection.
-    paths: FxHashMap<PathId, FourTuple>,
+    paths: FxHashMap<PathId, transports::FourTuple>,
     /// Whether this connection has ever had a direct path.
     ///
     /// Used for recording metrics.
@@ -1310,14 +1314,14 @@ impl ConnectionState {
     /// Tracks an open path for the connection.
     fn add_open_path(
         &mut self,
-        network_path: FourTuple,
+        network_path: transports::FourTuple,
         path_id: PathId,
         metrics: &Arc<SocketMetrics>,
     ) {
         match network_path {
-            FourTuple::Ip { .. } => metrics.paths_direct.inc(),
-            FourTuple::Relay { .. } => metrics.paths_relay.inc(),
-            FourTuple::Custom { .. } => metrics.paths_custom.inc(),
+            transports::FourTuple::Ip { .. } => metrics.paths_direct.inc(),
+            transports::FourTuple::Relay { .. } => metrics.paths_relay.inc(),
+            transports::FourTuple::Custom { .. } => metrics.paths_custom.inc(),
         };
         if !self.has_been_direct && network_path.is_ip() {
             self.has_been_direct = true;
@@ -1334,7 +1338,11 @@ impl ConnectionState {
     }
 
     /// Removes a path from this connection.
-    fn remove_path(&mut self, path_id: &PathId, conn: &noq::Connection) -> Option<FourTuple> {
+    fn remove_path(
+        &mut self,
+        path_id: &PathId,
+        conn: &noq::Connection,
+    ) -> Option<transports::FourTuple> {
         let addr = self.paths.remove(path_id)?;
         self.path_state.record_abandoned(*path_id, conn);
         Some(addr)

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeSet, VecDeque},
-    net::{IpAddr, SocketAddr},
+    net::SocketAddr,
     pin::Pin,
     sync::Arc,
     task::Poll,
@@ -855,8 +855,8 @@ impl State {
             // TODO(Frando): We might want to include a local IP here in the future, if we confidently
             // know that it is the correct one.
             // See https://github.com/n0-computer/iroh/issues/4280.
-            if let Err(err) = send_datagram(&mut sender, addr.remote.clone(), None, transmit).await
-            {
+            let four_tuple = transports::FourTuple::from_remote(addr.remote.clone());
+            if let Err(err) = send_datagram(&mut sender, four_tuple, transmit).await {
                 debug!(?addr, "failed to send datagram on selected_path: {err:#}");
             }
         } else {
@@ -883,8 +883,12 @@ impl State {
                 // TODO(Frando): We might want to include a local IP here in the future, if we confidently
                 // know that it is the correct one.
                 // See https://github.com/n0-computer/iroh/issues/4280.
-                } else if let Err(err) =
-                    send_datagram(&mut sender, addr.clone(), None, transmit.clone()).await
+                } else if let Err(err) = send_datagram(
+                    &mut sender,
+                    transports::FourTuple::from_remote(addr.clone()),
+                    transmit.clone(),
+                )
+                .await
                 {
                     debug!(?addr, "failed to send datagram: {err:#}");
                 }
@@ -1291,8 +1295,7 @@ fn update_qnt_candidates(conn: &noq::Connection, direct_addrs: &BTreeSet<SocketA
 
 fn send_datagram<'a>(
     sender: &'a mut TransportsSender,
-    addr: transports::Addr,
-    local_ip: Option<IpAddr>,
+    addr: transports::FourTuple,
     owned_transmit: OwnedTransmit,
 ) -> impl Future<Output = n0_error::Result<()>> + 'a {
     std::future::poll_fn(move |cx| {
@@ -1303,7 +1306,7 @@ fn send_datagram<'a>(
         };
 
         Pin::new(&mut *sender)
-            .poll_send(cx, &addr, local_ip, &transmit)
+            .poll_send(cx, &addr, &transmit)
             .map(|res| res.with_context(|_| format!("failed to send datagram to {:?}", addr)))
     })
 }

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -15,7 +15,7 @@ use n0_future::{
     time::{self, Duration, Instant},
 };
 use n0_watcher::Watcher;
-use noq::{Closed, FourTuple, PathStatus, WeakConnectionHandle};
+use noq::{Closed, PathStatus, WeakConnectionHandle};
 use noq_proto::{PathError, PathEvent as NoqPathEvent, PathId, n0_nat_traversal};
 use rustc_hash::FxHashMap;
 use tokio::sync::{mpsc, oneshot};
@@ -34,11 +34,10 @@ use crate::{
     endpoint::DirectAddr,
     socket::{
         Metrics as SocketMetrics, RELAY_PATH_MAX_IDLE_TIMEOUT,
-        mapped_addrs::{AddrMap, CustomMappedAddr, MappedAddr, RelayMappedAddr},
-        remote_map::{remote_state::path_watcher::PathStateSender, to_transport_addr},
+        mapped_addrs::{AddrMap, CustomMappedAddr, RelayMappedAddr},
+        remote_map::remote_state::path_watcher::PathStateSender,
         transports::{
-            self, LocalTransportAddr, OwnedTransmit, PathSelectionData, TransportBiasMap,
-            TransportsSender,
+            self, FourTuple, OwnedTransmit, PathSelectionData, TransportBiasMap, TransportsSender,
         },
     },
     util::MaybeFuture,
@@ -158,7 +157,7 @@ struct State {
     /// holepunching regularly.
     ///
     /// We only select a path once the path is functional in Noq.
-    selected_path: Option<TransportFourTuple>,
+    selected_path: Option<FourTuple>,
     /// Time at which we should schedule the next holepunch attempt.
     scheduled_holepunch: Option<Instant>,
     /// When to next attempt opening paths in [`Self::pending_open_paths`].
@@ -166,7 +165,7 @@ struct State {
     /// Paths which we still need to open.
     ///
     /// They failed to open because we did not have enough CIDs issued by the remote.
-    pending_open_paths: VecDeque<TransportFourTuple>,
+    pending_open_paths: VecDeque<FourTuple>,
 
     // Internal state - address lookup
     //
@@ -443,7 +442,7 @@ impl RemoteStateActor {
                     .paths
                     .addrs()
                     .filter(|addr| addr.is_relay())
-                    .map(|addr| TransportFourTuple::from_remote(addr.clone()))
+                    .map(|addr| FourTuple::from_remote(addr.clone()))
                     .collect::<Vec<_>>();
                 for open_addr in relays {
                     self.state
@@ -617,7 +616,7 @@ impl RemoteStateActor {
                     .values()
                     .any(|tuple| tuple.remote() == network_path.remote())
                 {
-                    self.state.paths.abandoned_path(&network_path.remote);
+                    self.state.paths.abandoned_path(&network_path.remote());
                 }
 
                 event!(
@@ -684,7 +683,7 @@ impl RemoteStateActor {
     fn select_path(&mut self) {
         // Find the lowest RTT across all connections for each open path.  The long way, so
         // we get to log *all* RTTs.
-        let mut all_path_rtts: FxHashMap<&TransportFourTuple, Vec<Duration>> = FxHashMap::default();
+        let mut all_path_rtts: FxHashMap<&FourTuple, Vec<Duration>> = FxHashMap::default();
         for conn_state in self.connections.values() {
             let Some(conn) = conn_state.handle.upgrade() else {
                 continue;
@@ -696,7 +695,7 @@ impl RemoteStateActor {
             }
         }
         trace!(?all_path_rtts, "dumping all path RTTs");
-        let path_rtts: FxHashMap<&TransportFourTuple, PathSelectionData> = all_path_rtts
+        let path_rtts: FxHashMap<&FourTuple, PathSelectionData> = all_path_rtts
             .into_iter()
             .filter_map(|(addr, rtts)| rtts.into_iter().min().map(|rtt| (addr, rtt)))
             .map(|(addr, rtt)| {
@@ -704,7 +703,7 @@ impl RemoteStateActor {
                     addr,
                     self.state
                         .transport_bias
-                        .path_selection_data(&addr.remote, rtt),
+                        .path_selection_data(&addr.remote(), rtt),
                 )
             })
             .collect();
@@ -738,7 +737,7 @@ impl RemoteStateActor {
     /// - Sets all non-selected paths to [`PathStatus::Backup`]
     /// - Opens the selected path if it does not exist on the connection
     /// - Sets the selected path to [`PathStatus::Available`]
-    fn apply_selected_change(&mut self, selected: &TransportFourTuple) {
+    fn apply_selected_change(&mut self, selected: &FourTuple) {
         for (conn_id, conn_state) in self.connections.iter() {
             let Some(conn) = conn_state.handle.upgrade() else {
                 continue;
@@ -788,7 +787,7 @@ impl RemoteStateActor {
         }
     }
 
-    fn open_path_on_all_conns(&mut self, open_addr: &TransportFourTuple) {
+    fn open_path_on_all_conns(&mut self, open_addr: &FourTuple) {
         for (conn_id, conn_state) in self.connections.iter() {
             let Some(conn) = conn_state.handle.upgrade() else {
                 continue;
@@ -855,7 +854,7 @@ impl State {
             // TODO(Frando): We might want to include a local IP here in the future, if we confidently
             // know that it is the correct one.
             // See https://github.com/n0-computer/iroh/issues/4280.
-            let four_tuple = transports::FourTuple::from_remote(addr.remote.clone());
+            let four_tuple = FourTuple::from_remote(addr.remote());
             if let Err(err) = send_datagram(&mut sender, four_tuple, transmit).await {
                 debug!(?addr, "failed to send datagram on selected_path: {err:#}");
             }
@@ -885,7 +884,7 @@ impl State {
                 // See https://github.com/n0-computer/iroh/issues/4280.
                 } else if let Err(err) = send_datagram(
                     &mut sender,
-                    transports::FourTuple::from_remote(addr.clone()),
+                    FourTuple::from_remote(addr.clone()),
                     transmit.clone(),
                 )
                 .await
@@ -1027,8 +1026,8 @@ impl State {
         conn_id: ConnId,
         conn_state: &mut ConnectionState,
         path: &noq::Path,
-    ) -> Option<TransportFourTuple> {
-        let network_path = self.transport_addr_for_path(path)?;
+    ) -> Option<FourTuple> {
+        let network_path = self.transport_tuple_for_path(path)?;
         event!(
             target: "iroh::_events::path::open",
             Level::DEBUG,
@@ -1038,7 +1037,7 @@ impl State {
             path_id=%path.id(),
         );
         conn_state.add_open_path(network_path.clone(), path.id(), &self.metrics);
-        if matches!(network_path.remote(), transports::Addr::Relay(..))
+        if network_path.is_relay()
             && let Err(e) = path.set_max_idle_timeout(Some(RELAY_PATH_MAX_IDLE_TIMEOUT))
         {
             debug!(?e, "failed to set relay path idle timeout");
@@ -1046,16 +1045,11 @@ impl State {
 
         self.set_path_status(conn_id, path, &network_path);
         self.paths
-            .insert_open_path(network_path.remote().clone(), Source::Connection);
+            .insert_open_path(network_path.remote(), Source::Connection);
         Some(network_path)
     }
 
-    fn set_path_status(
-        &mut self,
-        conn_id: ConnId,
-        path: &noq::Path,
-        network_path: &TransportFourTuple,
-    ) {
+    fn set_path_status(&mut self, conn_id: ConnId, path: &noq::Path, network_path: &FourTuple) {
         let status = self.path_status_for_addr(network_path);
         match path.set_status(status) {
             Err(error) => warn!(?error, ?network_path, ?status, "set_status failed"),
@@ -1080,7 +1074,7 @@ impl State {
         conn_id: ConnId,
         conn_state: &ConnectionState,
         conn: &noq::Connection,
-        open_addr: &TransportFourTuple,
+        open_addr: &FourTuple,
     ) {
         // Only the client opens paths; the server receives them via
         // QUIC frames and reacts to PathOpened events.
@@ -1092,7 +1086,8 @@ impl State {
             return;
         }
 
-        let quic_addr = self.quic_mapped_four_tuple(open_addr);
+        let quic_addr =
+            open_addr.to_noq_four_tuple(&self.relay_mapped_addrs, &self.custom_mapped_addrs);
         let path_status = self.path_status_for_addr(open_addr);
 
         let fut = conn.open_path_ensure(quic_addr, path_status);
@@ -1119,7 +1114,7 @@ impl State {
     ///
     /// Returns [`PathStatus::Available`] if `addr` is the currently-selected path,
     /// or [`PathStatus::Backup`] otherwise.
-    fn path_status_for_addr(&self, addr: &TransportFourTuple) -> PathStatus {
+    fn path_status_for_addr(&self, addr: &FourTuple) -> PathStatus {
         if Some(addr) == self.selected_path.as_ref() {
             PathStatus::Available
         } else {
@@ -1127,39 +1122,14 @@ impl State {
         }
     }
 
-    /// Returns the QUIC-mapped [`FourTuple`] for a [`TransportFourTuple`].
-    fn quic_mapped_four_tuple(&self, network_path: &TransportFourTuple) -> FourTuple {
-        let remote = match &network_path.remote {
-            transports::Addr::Ip(socket_addr) => *socket_addr,
-            transports::Addr::Relay(relay_url, eid) => self
-                .relay_mapped_addrs
-                .get(&(relay_url.clone(), *eid))
-                .private_socket_addr(),
-            transports::Addr::Custom(remote) => {
-                self.custom_mapped_addrs.get(remote).private_socket_addr()
-            }
-        };
-        let local = network_path
-            .local
-            .to_noq_local_ip(&self.custom_mapped_addrs);
-        FourTuple::new(remote, local)
-    }
-
-    /// Returns the [`transports::Addr] for a path.
-    fn transport_addr_for_path(&self, path: &noq::Path) -> Option<TransportFourTuple> {
+    /// Returns the [`transports::FourTuple] for a path.
+    fn transport_tuple_for_path(&self, path: &noq::Path) -> Option<FourTuple> {
         let noq_network_path = path.network_path().ok()?;
-        let remote_addr = to_transport_addr(
-            noq_network_path.remote(),
+        FourTuple::from_noq(
+            noq_network_path,
             &self.relay_mapped_addrs,
             &self.custom_mapped_addrs,
-        )?;
-        let local_addr = LocalTransportAddr::from_noq_local_ip(
-            noq_network_path.local_ip(),
-            &remote_addr,
-            &self.custom_mapped_addrs,
-        );
-
-        Some(TransportFourTuple::new(remote_addr, local_addr))
+        )
     }
 
     /// Returns the current set of local direct addresses.
@@ -1172,78 +1142,12 @@ impl State {
     }
 }
 
-/// Identifies a network path by the combination of remote and local addresses.
-///
-/// Mirrors [`noq::FourTuple`] but uses [`transports::Addr`] for the remote address.
-#[derive(Debug, Hash, Eq, PartialEq, Clone)]
-pub(super) struct TransportFourTuple {
-    /// The remote side of this tuple.
-    remote: transports::Addr,
-    /// The local side of this tuple.
-    ///
-    /// This is the IP address, unmodified as returned from [`noq::Path::local_ip`].
-    /// We pass it back to noq as-is when opening paths on other connections.
-    ///
-    /// Its meaning is a bit particular:
-    /// * For IP transports this is the interface IP, if known.
-    /// * For custom transports this is a mapped custom transport address.
-    /// * For relay transports this is never set.
-    local: LocalTransportAddr,
-}
-
-impl std::fmt::Display for TransportFourTuple {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.local {
-            LocalTransportAddr::Ip(Some(ip_addr)) => write!(f, "{ip_addr}->")?,
-            LocalTransportAddr::Custom(Some(addr)) => write!(f, "{addr}->")?,
-            _ => {}
-        }
-        write!(f, "{:?}", self.remote)
-    }
-}
-
-impl TransportFourTuple {
-    /// Creates a new [`TransportFourTuple`].
-    pub(super) fn new(remote: transports::Addr, local: LocalTransportAddr) -> Self {
-        Self { remote, local }
-    }
-
-    fn from_remote(remote: transports::Addr) -> Self {
-        let local = match &remote {
-            transports::Addr::Ip(_) => LocalTransportAddr::Ip(None),
-            transports::Addr::Relay(url, _) => LocalTransportAddr::Relay(url.clone()),
-            transports::Addr::Custom(_) => LocalTransportAddr::Custom(None),
-        };
-        Self::new(remote, local)
-    }
-
-    /// Returns the remote address of the network path.
-    pub(super) fn remote(&self) -> &transports::Addr {
-        &self.remote
-    }
-
-    /// Returns the [`LocalTransportAddr`] for this network path.
-    pub(super) fn local(&self) -> &LocalTransportAddr {
-        &self.local
-    }
-
-    /// Returns whether the remote of this tuple is an IP address.
-    pub(super) fn is_ip(&self) -> bool {
-        self.remote.is_ip()
-    }
-
-    /// Returns whether the remote of this tuple is a relay address.
-    pub(super) fn is_relay(&self) -> bool {
-        self.remote.is_relay()
-    }
-}
-
 /// Returns `Some` if a new path should be selected, `None` if the `current_path` should
 /// continued to be used.
 fn select_best_path<'a>(
-    all_paths: FxHashMap<&'a TransportFourTuple, PathSelectionData>,
-    current_path: Option<&'a TransportFourTuple>,
-) -> Option<(TransportFourTuple, Duration)> {
+    all_paths: FxHashMap<&'a FourTuple, PathSelectionData>,
+    current_path: Option<&'a FourTuple>,
+) -> Option<(FourTuple, Duration)> {
     // Determine the best new path according to sort_key.
     // If there is no path, return None.
     let (best_addr, best_data) = all_paths.iter().min_by_key(|(_, psd)| psd.sort_key())?;
@@ -1295,7 +1199,7 @@ fn update_qnt_candidates(conn: &noq::Connection, direct_addrs: &BTreeSet<SocketA
 
 fn send_datagram<'a>(
     sender: &'a mut TransportsSender,
-    addr: transports::FourTuple,
+    addr: FourTuple,
     owned_transmit: OwnedTransmit,
 ) -> impl Future<Output = n0_error::Result<()>> + 'a {
     std::future::poll_fn(move |cx| {
@@ -1395,7 +1299,7 @@ struct ConnectionState {
     /// [`Connection`]: crate::endpoint::Connection
     path_state: PathStateSender,
     /// The open paths that exist on this connection.
-    paths: FxHashMap<PathId, TransportFourTuple>,
+    paths: FxHashMap<PathId, FourTuple>,
     /// Whether this connection has ever had a direct path.
     ///
     /// Used for recording metrics.
@@ -1406,14 +1310,14 @@ impl ConnectionState {
     /// Tracks an open path for the connection.
     fn add_open_path(
         &mut self,
-        network_path: TransportFourTuple,
+        network_path: FourTuple,
         path_id: PathId,
         metrics: &Arc<SocketMetrics>,
     ) {
-        match &network_path.remote {
-            transports::Addr::Ip(_) => metrics.paths_direct.inc(),
-            transports::Addr::Relay(_, _) => metrics.paths_relay.inc(),
-            transports::Addr::Custom(_) => metrics.paths_custom.inc(),
+        match network_path {
+            FourTuple::Ip { .. } => metrics.paths_direct.inc(),
+            FourTuple::Relay { .. } => metrics.paths_relay.inc(),
+            FourTuple::Custom { .. } => metrics.paths_custom.inc(),
         };
         if !self.has_been_direct && network_path.is_ip() {
             self.has_been_direct = true;
@@ -1430,11 +1334,7 @@ impl ConnectionState {
     }
 
     /// Removes a path from this connection.
-    fn remove_path(
-        &mut self,
-        path_id: &PathId,
-        conn: &noq::Connection,
-    ) -> Option<TransportFourTuple> {
+    fn remove_path(&mut self, path_id: &PathId, conn: &noq::Connection) -> Option<FourTuple> {
         let addr = self.paths.remove(path_id)?;
         self.path_state.record_abandoned(*path_id, conn);
         Some(addr)
@@ -1508,28 +1408,28 @@ mod tests {
     use super::*;
     use crate::socket::transports::TransportType;
 
-    fn v4(port: u16) -> TransportFourTuple {
+    fn v4(port: u16) -> transports::FourTuple {
         let remote =
             transports::Addr::Ip(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)));
-        TransportFourTuple::from_remote(remote)
+        transports::FourTuple::from_remote(remote)
     }
 
-    fn v6(port: u16) -> TransportFourTuple {
+    fn v6(port: u16) -> transports::FourTuple {
         let remote = transports::Addr::Ip(SocketAddr::V6(SocketAddrV6::new(
             Ipv6Addr::LOCALHOST,
             port,
             0,
             0,
         )));
-        TransportFourTuple::from_remote(remote)
+        transports::FourTuple::from_remote(remote)
     }
 
-    fn relay(port: u16) -> TransportFourTuple {
+    fn relay(port: u16) -> transports::FourTuple {
         let url = format!("https://relay{port}.iroh.computer")
             .parse::<RelayUrl>()
             .unwrap();
         let remote = transports::Addr::Relay(url, EndpointId::from_bytes(&[0u8; 32]).unwrap());
-        TransportFourTuple::from_remote(remote)
+        transports::FourTuple::from_remote(remote)
     }
 
     fn psd(transport_type: TransportType, rtt_ms: u64) -> PathSelectionData {
@@ -1566,7 +1466,7 @@ mod tests {
         assert!(result.is_some());
         let (addr, _) = result.unwrap();
         assert!(matches!(
-            addr.remote,
+            addr.remote(),
             transports::Addr::Ip(SocketAddr::V6(_))
         ));
 
@@ -1579,7 +1479,7 @@ mod tests {
         assert!(result.is_some());
         let (addr, _) = result.unwrap();
         assert!(matches!(
-            addr.remote,
+            addr.remote(),
             transports::Addr::Ip(SocketAddr::V6(_))
         ));
 
@@ -1592,7 +1492,7 @@ mod tests {
         assert!(result.is_some());
         let (addr, _) = result.unwrap();
         assert!(matches!(
-            addr.remote,
+            addr.remote(),
             transports::Addr::Ip(SocketAddr::V4(_))
         ));
     }
@@ -1681,11 +1581,11 @@ mod tests {
 
     #[test]
     fn test_empty_paths_returns_none() {
-        let paths: FxHashMap<&TransportFourTuple, PathSelectionData> = FxHashMap::default();
+        let paths: FxHashMap<&transports::FourTuple, PathSelectionData> = FxHashMap::default();
         let result = select_best_path(paths, None);
         assert!(result.is_none());
 
-        let paths: FxHashMap<&TransportFourTuple, PathSelectionData> = FxHashMap::default();
+        let paths: FxHashMap<&transports::FourTuple, PathSelectionData> = FxHashMap::default();
         let result = select_best_path(paths, Some(&v4(1)));
         assert!(result.is_none());
     }

--- a/iroh/src/socket/remote_map/remote_state/path_watcher.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_watcher.rs
@@ -41,8 +41,10 @@ use tokio_stream::{
 };
 use tracing::warn;
 
-use super::TransportFourTuple;
-use crate::{endpoint::PathStats, socket::transports::LocalTransportAddr};
+use crate::{
+    endpoint::PathStats,
+    socket::transports::{self, LocalTransportAddr},
+};
 
 /// Per-connection broadcast channel capacity for path events.
 const BROADCAST_CAPACITY: usize = 8;
@@ -165,10 +167,14 @@ impl PathStateSender {
     }
 
     /// Records a newly-opened path and emits [`PathEvent::Opened`].
-    pub(super) fn record_opened(&self, handle: WeakPathHandle, network_path: TransportFourTuple) {
+    pub(super) fn record_opened(
+        &self,
+        handle: WeakPathHandle,
+        network_path: transports::FourTuple,
+    ) {
         let id = handle.id();
-        let remote_addr: TransportAddr = network_path.remote().clone().into();
-        let local_addr = network_path.local().clone();
+        let remote_addr: TransportAddr = network_path.remote().into();
+        let local_addr = network_path.local();
         {
             let mut state = self.shared.state.lock().expect("poisoned");
             let entry = PathData {
@@ -215,9 +221,9 @@ impl PathStateSender {
     }
 
     /// Updates the selected transmission path.
-    pub(super) fn record_selected(&self, network_path: &TransportFourTuple) {
-        let remote_addr: TransportAddr = network_path.remote().clone().into();
-        let local_addr = network_path.local().clone();
+    pub(super) fn record_selected(&self, network_path: &transports::FourTuple) {
+        let remote_addr: TransportAddr = network_path.remote().into();
+        let local_addr = network_path.local();
         let event = {
             let mut state = self.shared.state.lock().expect("poisoned");
             let selected_path_id = state

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -916,7 +916,7 @@ impl PartialEq<TransportAddr> for Addr {
 
 /// Identifies a network path by the combination of remote and local addresses.
 ///
-/// Mirrors [`noq::FourTuple`] but uses transport-level addresses for the remote side.
+/// Mirrors [`noq::FourTuple`] but uses transport-specific addresses.
 ///
 /// The meaning of the local address is a bit particular:
 /// * For IP transports it is the interface IP, if known.

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -929,6 +929,62 @@ impl PartialEq<TransportAddr> for Addr {
     }
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum FourTuple {
+    Ip {
+        remote: SocketAddr,
+        local: Option<IpAddr>,
+    },
+    Relay {
+        url: RelayUrl,
+        endpoint_id: EndpointId,
+    },
+    Custom {
+        remote: CustomAddr,
+        local: Option<CustomAddr>,
+    },
+}
+
+impl FourTuple {
+    pub(super) fn from_remote(remote: Addr) -> Self {
+        match remote {
+            Addr::Ip(remote) => Self::Ip {
+                remote,
+                local: None,
+            },
+            Addr::Relay(url, endpoint_id) => Self::Relay { url, endpoint_id },
+            Addr::Custom(remote) => Self::Custom {
+                remote,
+                local: None,
+            },
+        }
+    }
+}
+
+impl fmt::Display for FourTuple {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FourTuple::Ip { remote, local } => {
+                if let Some(local) = local {
+                    write!(f, "{local}->{remote}")
+                } else {
+                    write!(f, "{remote}")
+                }
+            }
+            FourTuple::Relay { url, endpoint_id } => {
+                write!(f, "Relay({url})->{}", endpoint_id.fmt_short())
+            }
+            FourTuple::Custom { remote, local } => {
+                if let Some(local) = local {
+                    write!(f, "{local}->{remote}")
+                } else {
+                    write!(f, "{remote}")
+                }
+            }
+        }
+    }
+}
+
 /// A sender that sends to all our transports.
 #[derive(Debug, Clone)]
 pub(crate) struct TransportsSender {
@@ -944,47 +1000,49 @@ impl TransportsSender {
     pub(crate) fn poll_send(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context,
-        dst: &Addr,
-        src: Option<IpAddr>,
+        network_path: &FourTuple,
         transmit: &Transmit<'_>,
     ) -> Poll<io::Result<()>> {
-        match dst {
+        match network_path {
             #[cfg(wasm_browser)]
-            Addr::Ip(..) => {
+            FourTuple::Ip { .. } => {
                 return Poll::Ready(Err(io::Error::other("IP is unsupported in browser")));
             }
             #[cfg(not(wasm_browser))]
-            Addr::Ip(dst_addr) => match dst_addr {
+            FourTuple::Ip {
+                remote: dst_addr,
+                local: src,
+            } => match dst_addr {
                 SocketAddr::V4(_) => {
                     if let Some(sender) = self
                         .ip
                         .v4_iter_mut()
-                        .find(|s| s.is_valid_send_addr(src, dst_addr))
+                        .find(|s| s.is_valid_send_addr(*src, dst_addr))
                     {
-                        return Pin::new(sender).poll_send(cx, *dst_addr, src, transmit);
+                        return Pin::new(sender).poll_send(cx, *dst_addr, *src, transmit);
                     }
                     if let Some(sender) = self.ip.v4_default_mut()
-                        && sender.is_valid_default_addr(src, dst_addr)
+                        && sender.is_valid_default_addr(*src, dst_addr)
                     {
-                        return Pin::new(sender).poll_send(cx, *dst_addr, src, transmit);
+                        return Pin::new(sender).poll_send(cx, *dst_addr, *src, transmit);
                     }
                 }
                 SocketAddr::V6(_) => {
                     if let Some(sender) = self
                         .ip
                         .v6_iter_mut()
-                        .find(|s| s.is_valid_send_addr(src, dst_addr))
+                        .find(|s| s.is_valid_send_addr(*src, dst_addr))
                     {
-                        return Pin::new(sender).poll_send(cx, *dst_addr, src, transmit);
+                        return Pin::new(sender).poll_send(cx, *dst_addr, *src, transmit);
                     }
                     if let Some(sender) = self.ip.v6_default_mut()
-                        && sender.is_valid_default_addr(src, dst_addr)
+                        && sender.is_valid_default_addr(*src, dst_addr)
                     {
-                        return Pin::new(sender).poll_send(cx, *dst_addr, src, transmit);
+                        return Pin::new(sender).poll_send(cx, *dst_addr, *src, transmit);
                     }
                 }
             },
-            Addr::Relay(url, endpoint_id) => {
+            FourTuple::Relay { url, endpoint_id } => {
                 let mut has_valid_sender = false;
                 for sender in self
                     .relay
@@ -1001,10 +1059,10 @@ impl TransportsSender {
                     return Poll::Pending;
                 }
             }
-            Addr::Custom(addr) => {
+            FourTuple::Custom { remote, local } => {
                 for sender in &mut self.custom {
-                    if sender.is_valid_send_addr(addr) {
-                        match sender.poll_send(cx, addr, transmit) {
+                    if sender.is_valid_send_addr(remote) {
+                        match sender.poll_send(cx, remote, local.as_ref(), transmit) {
                             Poll::Pending => {}
                             Poll::Ready(res) => return Poll::Ready(res),
                         }
@@ -1015,7 +1073,7 @@ impl TransportsSender {
 
         // We "blackhole" data that we have not found any usable transport for on
         // to make sure the QUIC stack picks up that currently this data does not arrive.
-        trace!(?src, ?dst, "no valid transport available");
+        trace!(%network_path, "no valid transport available");
         Poll::Ready(Ok(()))
     }
 }
@@ -1154,7 +1212,7 @@ impl noq::UdpSender for Sender {
         // and re-send them.
         let mapped_addr = self.mapped_addr(noq_transmit)?;
 
-        let transport_addr = match mapped_addr {
+        let network_path = match mapped_addr {
             MultipathMappedAddr::Mixed(mapped_addr) => {
                 let Some(endpoint_id) = self.sock.mapped_addrs.endpoint_addrs.lookup(&mapped_addr)
                 else {
@@ -1203,7 +1261,7 @@ impl noq::UdpSender for Sender {
                     .relay_addrs
                     .lookup(&relay_mapped_addr)
                 {
-                    Some((relay_url, endpoint_id)) => Addr::Relay(relay_url, endpoint_id),
+                    Some((url, endpoint_id)) => FourTuple::Relay { url, endpoint_id },
                     None => {
                         error!("unknown RelayMappedAddr, dropped transmit");
                         return Poll::Ready(Ok(()));
@@ -1217,7 +1275,16 @@ impl noq::UdpSender for Sender {
                     .custom_addrs
                     .lookup(&custom_mapped_addr)
                 {
-                    Some(addr) => Addr::Custom(addr),
+                    Some(addr) => {
+                        let local = noq_transmit
+                            .src_ip
+                            .and_then(|ip_addr| CustomMappedAddr::try_from(ip_addr).ok())
+                            .and_then(|addr| self.sock.mapped_addrs.custom_addrs.lookup(&addr));
+                        FourTuple::Custom {
+                            remote: addr,
+                            local,
+                        }
+                    }
                     None => {
                         error!("unknown CustomMappedAddr, dropped transmit");
                         return Poll::Ready(Ok(()));
@@ -1228,7 +1295,10 @@ impl noq::UdpSender for Sender {
                 // Ensure IPv6 mapped addresses are converted back
                 let socket_addr =
                     SocketAddr::new(socket_addr.ip().to_canonical(), socket_addr.port());
-                Addr::Ip(socket_addr)
+                FourTuple::Ip {
+                    remote: socket_addr,
+                    local: noq_transmit.src_ip,
+                }
             }
         };
 
@@ -1239,13 +1309,10 @@ impl noq::UdpSender for Sender {
         };
         let this = self.project();
 
-        match this
-            .sender
-            .poll_send(cx, &transport_addr, noq_transmit.src_ip, &transmit)
-        {
+        match this.sender.poll_send(cx, &network_path, &transmit) {
             Poll::Ready(Ok(())) => {
                 trace!(
-                    dst = ?transport_addr,
+                    dst = %network_path,
                     len = transmit.contents.len(),
                     datagram_count = transmit.datagram_count(),
                     "sent transmit"
@@ -1253,7 +1320,7 @@ impl noq::UdpSender for Sender {
                 Poll::Ready(Ok(()))
             }
             Poll::Ready(Err(ref err)) => {
-                warn!(dst=?transport_addr, "dropped transmit: {err:#}");
+                warn!(dst=%network_path, "dropped transmit: {err:#}");
                 Poll::Ready(Ok(()))
             }
             Poll::Pending => {
@@ -1261,7 +1328,7 @@ impl noq::UdpSender for Sender {
                 // different transport.  Instead we let Noq handle this as a lost
                 // datagram.
                 // TODO: Revisit this: we might want to do something better.
-                trace!(dst=?transport_addr, "transport pending, dropped transmit");
+                trace!(dst=%network_path, "transport pending, dropped transmit");
                 Poll::Ready(Ok(()))
             }
         }

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -23,7 +23,10 @@ use crate::{
     endpoint::RelayStatus,
     metrics::EndpointMetrics,
     net_report::Report,
-    socket::mapped_addrs::{AddrMap, CustomMappedAddr, MappedAddr},
+    socket::{
+        mapped_addrs::{AddrMap, CustomMappedAddr, MappedAddr, RelayMappedAddr},
+        remote_map::to_transport_addr,
+    },
 };
 
 pub(crate) mod custom;
@@ -667,10 +670,6 @@ impl Addr {
         matches!(self, Self::Relay(..))
     }
 
-    pub(crate) fn is_ip(&self) -> bool {
-        matches!(self, Self::Ip(_))
-    }
-
     /// Returns `None` if not an `Ip`.
     pub(crate) fn into_socket_addr(self) -> Option<SocketAddr> {
         match self {
@@ -739,20 +738,6 @@ impl LocalTransportAddr {
                     .and_then(|custom_mapped_addr| custom_mapped_addrs.lookup(&custom_mapped_addr));
                 LocalTransportAddr::Custom(addr)
             }
-        }
-    }
-
-    /// Converts this [`LocalTransportAddr`] into a QUIC-mapped [`IpAddr`] to be passed to noq, if any.
-    pub(super) fn to_noq_local_ip(
-        &self,
-        custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
-    ) -> Option<IpAddr> {
-        match self {
-            LocalTransportAddr::Ip(ip_addr) => *ip_addr,
-            LocalTransportAddr::Relay(_url) => None,
-            LocalTransportAddr::Custom(custom_addr) => custom_addr
-                .as_ref()
-                .map(|addr| custom_mapped_addrs.get(addr).private_socket_addr().ip()),
         }
     }
 }
@@ -929,7 +914,15 @@ impl PartialEq<TransportAddr> for Addr {
     }
 }
 
-#[derive(Debug, Clone)]
+/// Identifies a network path by the combination of remote and local addresses.
+///
+/// Mirrors [`noq::FourTuple`] but uses transport-level addresses for the remote side.
+///
+/// The meaning of the local address is a bit particular:
+/// * For IP transports it is the interface IP, if known.
+/// * For custom transports it is a custom transport address, if the transport reports one.
+/// * For relay transports there is no separate local address; the relay URL identifies the path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum FourTuple {
     Ip {
         remote: SocketAddr,
@@ -946,6 +939,7 @@ pub(crate) enum FourTuple {
 }
 
 impl FourTuple {
+    /// Creates a four-tuple from a remote address, with no known local address.
     pub(super) fn from_remote(remote: Addr) -> Self {
         match remote {
             Addr::Ip(remote) => Self::Ip {
@@ -959,6 +953,106 @@ impl FourTuple {
             },
         }
     }
+
+    /// Creates a four-tuple from a remote and a local transport address.
+    ///
+    /// The variant is determined by `remote`. The `local` address is retained only when
+    /// it matches that variant. A mismatched `local` is dropped, which cannot happen for
+    /// values derived together from the same network path.
+    pub(super) fn new(remote: Addr, local: LocalTransportAddr) -> Self {
+        match remote {
+            Addr::Ip(remote) => Self::Ip {
+                remote,
+                local: match local {
+                    LocalTransportAddr::Ip(local) => local,
+                    _ => None,
+                },
+            },
+            Addr::Relay(url, endpoint_id) => Self::Relay { url, endpoint_id },
+            Addr::Custom(remote) => Self::Custom {
+                remote,
+                local: match local {
+                    LocalTransportAddr::Custom(local) => local,
+                    _ => None,
+                },
+            },
+        }
+    }
+
+    /// Returns the [`FourTuple] for a noq network path by looking up QUIC-mapped addresses.
+    pub(super) fn from_noq(
+        noq_four_tuple: noq::FourTuple,
+        relay_mapped_addrs: &AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
+        custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
+    ) -> Option<Self> {
+        let remote = to_transport_addr(
+            noq_four_tuple.remote(),
+            relay_mapped_addrs,
+            custom_mapped_addrs,
+        )?;
+        let local = LocalTransportAddr::from_noq_local_ip(
+            noq_four_tuple.local_ip(),
+            &remote,
+            custom_mapped_addrs,
+        );
+        Some(Self::new(remote, local))
+    }
+
+    /// Returns the remote transport address.
+    pub(super) fn remote(&self) -> Addr {
+        match self {
+            Self::Ip { remote, .. } => Addr::Ip(*remote),
+            Self::Relay { url, endpoint_id } => Addr::Relay(url.clone(), *endpoint_id),
+            Self::Custom { remote, .. } => Addr::Custom(remote.clone()),
+        }
+    }
+
+    /// Returns the local transport address.
+    pub(super) fn local(&self) -> LocalTransportAddr {
+        match self {
+            Self::Ip { local, .. } => LocalTransportAddr::Ip(*local),
+            Self::Relay { url, .. } => LocalTransportAddr::Relay(url.clone()),
+            Self::Custom { local, .. } => LocalTransportAddr::Custom(local.clone()),
+        }
+    }
+
+    /// Returns `true` if the remote is an IP address.
+    pub(super) fn is_ip(&self) -> bool {
+        matches!(self, Self::Ip { .. })
+    }
+
+    /// Returns `true` if the remote is a relay address.
+    pub(super) fn is_relay(&self) -> bool {
+        matches!(self, Self::Relay { .. })
+    }
+
+    /// Returns the QUIC-mapped [`noq::FourTuple`] for this [`FourTuple`].
+    pub(super) fn to_noq_four_tuple(
+        &self,
+        relay_mapped_addrs: &AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
+        custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
+    ) -> noq::FourTuple {
+        let (remote, local) = match self {
+            FourTuple::Ip { remote, local } => (*remote, *local),
+            FourTuple::Relay { url, endpoint_id } => (
+                relay_mapped_addrs
+                    .get(&(url.clone(), *endpoint_id))
+                    .private_socket_addr(),
+                None,
+            ),
+            FourTuple::Custom { remote, local } => {
+                let remote = custom_mapped_addrs.get(remote).private_socket_addr();
+                let local = local.as_ref().map(|custom_addr| {
+                    custom_mapped_addrs
+                        .get(custom_addr)
+                        .private_socket_addr()
+                        .ip()
+                });
+                (remote, local)
+            }
+        };
+        noq::FourTuple::new(remote, local)
+    }
 }
 
 impl fmt::Display for FourTuple {
@@ -966,19 +1060,19 @@ impl fmt::Display for FourTuple {
         match self {
             FourTuple::Ip { remote, local } => {
                 if let Some(local) = local {
-                    write!(f, "{local}->{remote}")
+                    write!(f, "Ip({local}->{remote})")
                 } else {
-                    write!(f, "{remote}")
+                    write!(f, "Ip({remote})")
                 }
             }
             FourTuple::Relay { url, endpoint_id } => {
-                write!(f, "Relay({url})->{}", endpoint_id.fmt_short())
+                write!(f, "Relay({url}, {})", endpoint_id.fmt_short())
             }
             FourTuple::Custom { remote, local } => {
                 if let Some(local) = local {
-                    write!(f, "{local}->{remote}")
+                    write!(f, "Custom({local}->{remote})")
                 } else {
-                    write!(f, "{remote}")
+                    write!(f, "Custom({remote})")
                 }
             }
         }

--- a/iroh/src/socket/transports/custom.rs
+++ b/iroh/src/socket/transports/custom.rs
@@ -93,6 +93,7 @@ pub trait CustomSender: std::fmt::Debug + Send + Sync + 'static {
         &self,
         cx: &mut std::task::Context,
         dst: &CustomAddr,
+        src: Option<&CustomAddr>,
         transmit: &Transmit<'_>,
     ) -> Poll<io::Result<()>>;
 }

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -234,6 +234,7 @@ impl CustomSender for TestSender {
         &self,
         _cx: &mut std::task::Context,
         dst: &CustomAddr,
+        _src: Option<&CustomAddr>,
         transmit: &Transmit<'_>,
     ) -> Poll<io::Result<()>> {
         let packets = self.split(transmit).collect();


### PR DESCRIPTION
## Description

Use a new `transport::FourTuple` throughout the send path. Adds a src argument to CustomSender::poll_send. Replaces the recently added `TransportFourTuple` with the new `transports::FourTuple`.

Motivations:
* We noted that it would be nicer if the TransportFourTuple introduced in #4273 would be an enum, so that we cannot have mismatches between the transport kinds of local and remote addresses. I agree. What prevented it was that we had to convert to `transports::Addr` many times, which is not free.
* I noticed that custom transports don't get a `src: Option<CustomAddr>` in their `poll_send`. I think it should be there, because custom transports *can* set a CustomAddr on which incoming packets were received, so to mirror the features of the IP transport they should be able to pin to an interface when replying as well, if the transport has a notion of multiple interfaces

This PR fixes both by replacing the `remote_state::TransportFourTuple`   with a `transports::FourTuple`  that is used throughout the send path, including custom transports.


## Breaking Changes

* `iroh::endpoint::transports::CustomSender::poll_send` now has an additional arg `src: Option<&CustomAddr>`


## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.