### PR TITLE
tests(iroh): enable NAT patchbay tests where the server is hard and client is easiest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#be30bc5e2423475787974eb57d329ecb13566992"
+source = "git+https://github.com/n0-computer/noq?branch=main#c20a684349c2efb620f364a7d34df721ece489a5"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#be30bc5e2423475787974eb57d329ecb13566992"
+source = "git+https://github.com/n0-computer/noq?branch=main#c20a684349c2efb620f364a7d34df721ece489a5"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3220,7 +3220,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#be30bc5e2423475787974eb57d329ecb13566992"
+source = "git+https://github.com/n0-computer/noq?branch=main#c20a684349c2efb620f364a7d34df721ece489a5"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/iroh/tests/patchbay/nat.rs
+++ b/iroh/tests/patchbay/nat.rs
@@ -208,14 +208,12 @@ async fn nat_easy_x_hard() -> Result {
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing (but did in iroh 0.35)"]
 async fn nat_hard_x_none() -> Result {
     run_nat_holepunch(NatKind::Hard, NatKind::None).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing (but did in iroh 0.35)"]
 async fn nat_hard_x_easiest() -> Result {
     run_nat_holepunch(NatKind::Hard, NatKind::Easiest).await
 }


### PR DESCRIPTION
## Description

We now pass the NAT tests for hard vs none or easiest both-ways.

This is enabled by https://github.com/n0-computer/noq/pull/672