### PR TITLE
deps(noq): update noq and adjust for api change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#be30bc5e2423475787974eb57d329ecb13566992"
+source = "git+https://github.com/n0-computer/noq?branch=main#a303cfa60e24ed986e555e3899ab8b0466ef5630"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#be30bc5e2423475787974eb57d329ecb13566992"
+source = "git+https://github.com/n0-computer/noq?branch=main#a303cfa60e24ed986e555e3899ab8b0466ef5630"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3220,7 +3220,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/n0-computer/noq?branch=main#be30bc5e2423475787974eb57d329ecb13566992"
+source = "git+https://github.com/n0-computer/noq?branch=main#a303cfa60e24ed986e555e3899ab8b0466ef5630"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/iroh/src/endpoint/quic.rs
+++ b/iroh/src/endpoint/quic.rs
@@ -158,6 +158,7 @@ impl QuicTransportConfigBuilder {
         cfg.default_path_max_idle_timeout(Some(PATH_MAX_IDLE_TIMEOUT));
         cfg.max_concurrent_multipath_paths(MAX_MULTIPATH_PATHS);
         cfg.max_remote_nat_traversal_addresses(MAX_QNT_ADDRESSES);
+        cfg.server_handshake_migration(true);
         Self(cfg)
     }
 

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -2603,6 +2603,7 @@ mod tests {
     ) -> Result<noq::Connection> {
         // Endpoint::connect sets this, do the same to have similar behaviour.
         let mut transport_config = noq::TransportConfig::default();
+        transport_config.server_handshake_migration(true);
         transport_config.keep_alive_interval(Some(Duration::from_secs(1)));
 
         socket_connect_with_transport_config(
@@ -2800,6 +2801,7 @@ mod tests {
         // with the next handshake, closing it during the handshake.  This makes the test a
         // little slower though.
         let mut transport_config = noq::TransportConfig::default();
+        transport_config.server_handshake_migration(true);
         transport_config.max_idle_timeout(Some(Duration::from_millis(200).try_into().unwrap()));
         let res = socket_connect_with_transport_config(
             sock_1.noq_endpoint().clone(),


### PR DESCRIPTION
## Description

Previously noq always allowed the server to migrate during the handshake. So now we just always override that setting.

## Breaking Changes

n/a

## Notes & open questions

Some tests manually create noq::TransportConfig, they have been manually adjusted. From the public API this isn't possible.

## Change checklist

- [ ] Self-review.