### PR TITLE
fix(iroh): Do not close abandoned paths on all connections

### DIFF
--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -624,30 +624,6 @@ impl RemoteStateActor {
                     ?reason
                 );
 
-                // If one connection abandons a path, close it on all connections.
-                for (conn_id, conn_state) in self.connections.iter() {
-                    let Some(conn) = conn_state.handle.upgrade() else {
-                        continue;
-                    };
-                    // Close all paths with the network paths that was abandoned.
-                    for path in conn_state
-                        .paths
-                        .iter()
-                        .filter(|(_id, addr)| **addr == network_path)
-                        .filter_map(|(id, _addr)| conn.path(*id))
-                    {
-                        trace!(%conn_id, path_id=%path.id(), %network_path, "closing path");
-                        if let Err(err) = path.close() {
-                            trace!(
-                                %conn_id,
-                                path_id=%path.id(),
-                                %network_path,
-                                "path close failed: {err:#}"
-                            );
-                        }
-                    }
-                }
-
                 // If the remote closed our selected path, select a new one.
                 self.select_path();
             }


### PR DESCRIPTION
## Description

If a path is abandoned on one connection we now leave it alone, if the
path is unusable other connections will abandon it in their own time.

Any scheduling on a bad path should be handled better inside
noq. Adding this complexity to iroh does not buy us much.

Supercedes #4245 and #4257.


## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.