### PR TITLE
fix(iroh): evict cached mapped addrs when a RemoteStateActor shuts down

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,2 @@
+target/
+.git/

--- a/iroh/src/socket/mapped_addrs.rs
+++ b/iroh/src/socket/mapped_addrs.rs
@@ -364,6 +364,31 @@ where
         let inner = self.inner.lock().expect("poisoned");
         inner.lookup.get(addr).cloned()
     }
+
+    pub(super) fn remove(&self, key: &K) -> Option<V> {
+        let mut inner = self.inner.lock().expect("poisoned");
+        if let Some(v) = inner.addrs.remove(key) {
+            inner.lookup.remove(&v);
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn retain(&self, mut f: impl FnMut(&K, &V) -> bool) {
+        let mut inner = self.inner.lock().expect("poisoned");
+        // Disjoint borrows: `addrs.retain` holds `addrs` mutably while the
+        // closure also needs `lookup` — destructure so they aren't both
+        // routed through `inner` (avoids E0499).
+        let AddrMapInner { addrs, lookup } = &mut *inner;
+        addrs.retain(|k, v| {
+            let keep = f(k, v);
+            if !keep {
+                lookup.remove(v);
+            }
+            keep
+        });
+    }
 }
 
 #[derive(Debug)]
@@ -379,5 +404,39 @@ impl<K, V> Default for AddrMapInner<K, V> {
             addrs: Default::default(),
             lookup: Default::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The map is generic over the key, so a plain `u32` key exercises the
+    // forward/reverse bookkeeping; `EndpointIdMappedAddr::generate()` is a
+    // process-global counter with no other dependencies.
+    #[test]
+    fn remove_clears_forward_and_reverse_maps() {
+        let map: AddrMap<u32, EndpointIdMappedAddr> = AddrMap::default();
+        let addr = map.get(&1);
+        assert_eq!(map.lookup(&addr), Some(1), "reverse lookup present after insert");
+
+        assert_eq!(map.remove(&1), Some(addr), "remove returns the mapped addr");
+        assert_eq!(map.lookup(&addr), None, "reverse lookup cleared on remove");
+
+        // Re-inserting generates a fresh addr, proving the old entry was gone.
+        let addr2 = map.get(&1);
+        assert_ne!(addr, addr2);
+    }
+
+    #[test]
+    fn retain_drops_unmatched_entries_and_their_reverse() {
+        let map: AddrMap<u32, EndpointIdMappedAddr> = AddrMap::default();
+        let kept = map.get(&1);
+        let dropped = map.get(&2);
+
+        map.retain(|k, _| *k == 1);
+
+        assert_eq!(map.lookup(&kept), Some(1), "retained entry keeps its reverse lookup");
+        assert_eq!(map.lookup(&dropped), None, "dropped entry reverse lookup is cleared");
     }
 }

--- a/iroh/src/socket/mapped_addrs.rs
+++ b/iroh/src/socket/mapped_addrs.rs
@@ -377,9 +377,6 @@ where
 
     pub(super) fn retain(&self, mut f: impl FnMut(&K, &V) -> bool) {
         let mut inner = self.inner.lock().expect("poisoned");
-        // Disjoint borrows: `addrs.retain` holds `addrs` mutably while the
-        // closure also needs `lookup` — destructure so they aren't both
-        // routed through `inner` (avoids E0499).
         let AddrMapInner { addrs, lookup } = &mut *inner;
         addrs.retain(|k, v| {
             let keep = f(k, v);
@@ -411,9 +408,6 @@ impl<K, V> Default for AddrMapInner<K, V> {
 mod tests {
     use super::*;
 
-    // The map is generic over the key, so a plain `u32` key exercises the
-    // forward/reverse bookkeeping; `EndpointIdMappedAddr::generate()` is a
-    // process-global counter with no other dependencies.
     #[test]
     fn remove_clears_forward_and_reverse_maps() {
         let map: AddrMap<u32, EndpointIdMappedAddr> = AddrMap::default();

--- a/iroh/src/socket/mapped_addrs.rs
+++ b/iroh/src/socket/mapped_addrs.rs
@@ -412,7 +412,11 @@ mod tests {
     fn remove_clears_forward_and_reverse_maps() {
         let map: AddrMap<u32, EndpointIdMappedAddr> = AddrMap::default();
         let addr = map.get(&1);
-        assert_eq!(map.lookup(&addr), Some(1), "reverse lookup present after insert");
+        assert_eq!(
+            map.lookup(&addr),
+            Some(1),
+            "reverse lookup present after insert"
+        );
 
         assert_eq!(map.remove(&1), Some(addr), "remove returns the mapped addr");
         assert_eq!(map.lookup(&addr), None, "reverse lookup cleared on remove");
@@ -430,7 +434,15 @@ mod tests {
 
         map.retain(|k, _| *k == 1);
 
-        assert_eq!(map.lookup(&kept), Some(1), "retained entry keeps its reverse lookup");
-        assert_eq!(map.lookup(&dropped), None, "dropped entry reverse lookup is cleared");
+        assert_eq!(
+            map.lookup(&kept),
+            Some(1),
+            "retained entry keeps its reverse lookup"
+        );
+        assert_eq!(
+            map.lookup(&dropped),
+            None,
+            "dropped entry reverse lookup is cleared"
+        );
     }
 }

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -236,7 +236,11 @@ impl RemoteMap {
         if leftover_msgs.is_empty() {
             // the actor shut down cleanly
             self.senders.remove(&remote_id);
-            trace!(%remote_id, "cleaned up RemoteStateActor");
+            self.mapped_addrs.endpoint_addrs.remove(&remote_id);
+            self.mapped_addrs
+                .relay_addrs
+                .retain(|k, _| k.1 != remote_id);
+            trace!(%remote_id, "cleaned up RemoteStateActor and mapped_addrs");
             true
         } else {
             // The remote actor got messages while it was closing, so we're restarting


### PR DESCRIPTION
## Description

While running iroh under sustained remote churn (remotes continuously appearing and going away) in
a downstream project, we saw the per-remote address cache grow without bound. `AddrMap` — the cache
of mapped endpoint/relay addresses behind `mapped_addrs` — has no eviction path and is never pruned.
When a `RemoteStateActor` shuts down cleanly, `RemoteMap::remove_or_restart_actor` removes its
`senders` entry but leaves that remote's cached addresses in `mapped_addrs` forever, so
`endpoint_addrs`/`relay_addrs` grow once per remote-ever-seen.

(Also: thank you for iroh — the endpoint/discovery/QUIC stack let us build a multi-node mesh without
hand-rolling NAT traversal or relay handling, which is exactly why we could focus on this one cache.)

### Fix

Add `remove()` and `retain()` to `AddrMap` (keeping the forward `addrs` and reverse `lookup` maps
consistent), and call them in the clean-shutdown branch of `remove_or_restart_actor` to drop the
gone remote's cached endpoint and relay addresses. Eviction happens only on clean shutdown, so
active remotes are untouched. `relay_addrs` is keyed by `(addr, remote_id)`, so it uses `retain` to
drop all entries for the departing remote.

## Breaking Changes

None. `remove`/`retain` are `pub(super)`; behavior change is limited to releasing state for remotes
that have already gone away.

## Notes & open questions

- **Test:** added a unit test for `AddrMap::remove`/`retain` covering forward removal and
  reverse-lookup consistency (the subtle part — keeping `addrs` and `lookup` in sync). The
  end-to-end "cache tracks only live remotes" behavior is churn-dependent; we validated it via a
  downstream heap profile under continuous remote kill/respawn, where the `mapped_addrs` entries
  stopped growing with remotes-ever-seen. A before/after `dhat` capture on your churn harness is the
  cleanest way to quantify it.
- Open question: are there other intended lifetimes for `mapped_addrs` entries (e.g. deliberately
  cached across reconnects)? If so, the eviction point may want to be narrower — guidance welcome.

## Checklist

- [x] Self-review
- [x] Documented the disjoint-borrow reasoning in `retain`
- [x] Tests — unit test for `remove`/`retain`; integration validation noted above
- [x] No breaking changes

## Related

Found together with two other churn-related leak fixes in the iroh stack:
- n0-computer/iroh-gossip#146 — connection-task reaping + peer-state eviction under churn
- n0-computer/noq#682 — close the connection when a `Connecting` is dropped pre-handshake

Resolves #4293
