### PR TITLE
fix(iroh-relay): Connect IPv4 and IPv6 concurrently (happy eyeballs)

### DIFF
--- a/iroh-dns/Cargo.toml
+++ b/iroh-dns/Cargo.toml
@@ -52,6 +52,7 @@ allowed_external_types = [
     "n0_error::*",
     "rustls::*",
     "url::*",
+    "futures_core::stream::Stream",
     # only type alias
     "futures_lite::future::Boxed",
 ]

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -567,15 +567,15 @@ impl DnsResolver {
                     }
                 }
                 tokio::select! {
+                    // We don't actually care about polling order, but `biased` saves the randomization cost.
+                    biased;
                     res = &mut state.v4_fut => {
-                        state.v4_fut = MaybeFuture::None;
                         match res {
                             Ok(items) => state.queue.extend(items.map(IpAddr::V4)),
                             Err(err) => state.v4_err = Some(err),
                         }
                     }
                     res = &mut state.v6_fut => {
-                        state.v6_fut = MaybeFuture::None;
                         match res {
                             Ok(items) => state.queue.extend(items.map(IpAddr::V6)),
                             Err(err) => state.v6_err = Some(err),

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -479,6 +479,53 @@ impl DnsResolver {
         }
     }
 
+    /// Resolves a hostname from a URL to all of its IP addresses, ordered by preference.
+    ///
+    /// The addresses of the preferred family come first (IPv6 when `prefer_ipv6`,
+    /// otherwise IPv4), followed by the addresses of the other family. Callers can
+    /// dial these in order and fall back across families when the preferred address
+    /// is unreachable.
+    pub async fn resolve_host_all(
+        &self,
+        url: &Url,
+        prefer_ipv6: bool,
+        timeout: Duration,
+    ) -> Result<Vec<IpAddr>, DnsError> {
+        let host = url.host().ok_or_else(|| e!(DnsError::MissingHost))?;
+        match host {
+            url::Host::Domain(domain) => {
+                let lookup = tokio::join!(
+                    self.lookup_ipv4(domain, timeout),
+                    self.lookup_ipv6(domain, timeout)
+                );
+                let addrs: Vec<IpAddr> = match lookup {
+                    (Err(ipv4_err), Err(ipv6_err)) => {
+                        return Err(e!(DnsError::ResolveBoth {
+                            ipv4: Box::new(ipv4_err),
+                            ipv6: Box::new(ipv6_err)
+                        }));
+                    }
+                    (Err(_), Ok(v6)) => v6.collect(),
+                    (Ok(v4), Err(_)) => v4.collect(),
+                    (Ok(v4), Ok(v6)) => {
+                        if prefer_ipv6 {
+                            v6.chain(v4).collect()
+                        } else {
+                            v4.chain(v6).collect()
+                        }
+                    }
+                };
+                if addrs.is_empty() {
+                    Err(e!(DnsError::NoResponse))
+                } else {
+                    Ok(addrs)
+                }
+            }
+            url::Host::Ipv4(ip) => Ok(vec![IpAddr::V4(ip)]),
+            url::Host::Ipv6(ip) => Ok(vec![IpAddr::V6(ip)]),
+        }
+    }
+
     /// Performs an IPv4 lookup with a timeout in a staggered fashion.
     ///
     /// From the moment this function is called, each lookup is scheduled after the delays in

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -495,7 +495,7 @@ impl DnsResolver {
     /// have been yielded.
     pub fn resolve_host_all<'a>(
         &'a self,
-        url: &'a Url,
+        url: &Url,
         timeout: Duration,
     ) -> impl Stream<Item = Result<IpAddr, DnsError>> + Send + 'a {
         let host = match url.host() {

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -487,7 +487,8 @@ impl DnsResolver {
     /// IPv4 and IPv6 are looked up concurrently and each address is yielded as
     /// soon as its lookup completes, so a caller can start dialing without
     /// waiting for both families.
-    /// A lookup failure is swallowedas long as the other family yields an address.
+    ///
+    /// A lookup failure is swallowed as long as the other family yields an address.
     /// Only if both lookups fail does the stream yield a single [`DnsError`].
     ///
     /// The stream ends once both lookups have finished and every address or the error
@@ -495,7 +496,6 @@ impl DnsResolver {
     pub fn resolve_host_all<'a>(
         &'a self,
         url: &'a Url,
-        _prefer_ipv6: bool,
         timeout: Duration,
     ) -> impl Stream<Item = Result<IpAddr, DnsError>> + Send + 'a {
         let host = match url.host() {
@@ -515,8 +515,8 @@ impl DnsResolver {
             Pin<Box<dyn Future<Output = Result<BoxIter<A>, DnsError>> + Send + 'a>>;
 
         struct State<'a> {
-            v4: MaybeFuture<Lookup<'a, Ipv4Addr>>,
-            v6: MaybeFuture<Lookup<'a, Ipv6Addr>>,
+            v4_fut: MaybeFuture<Lookup<'a, Ipv4Addr>>,
+            v6_fut: MaybeFuture<Lookup<'a, Ipv6Addr>>,
             v4_err: Option<DnsError>,
             v6_err: Option<DnsError>,
             queue: VecDeque<IpAddr>,
@@ -525,11 +525,11 @@ impl DnsResolver {
         }
 
         let state = State {
-            v4: MaybeFuture::Some(Box::pin({
+            v4_fut: MaybeFuture::Some(Box::pin({
                 let host = host.clone();
                 self.inner.op(timeout, move |r| r.lookup_ipv4(host.clone()))
             })),
-            v6: MaybeFuture::Some(Box::pin({
+            v6_fut: MaybeFuture::Some(Box::pin({
                 let host = host.clone();
                 self.inner.op(timeout, move |r| r.lookup_ipv6(host.clone()))
             })),
@@ -539,41 +539,43 @@ impl DnsResolver {
             closed: false,
             yielded: false,
         };
+
         Either::Right(stream::unfold(state, async |mut state| {
             loop {
                 if state.closed {
                     return None;
                 }
+
                 if let Some(item) = state.queue.pop_front() {
                     state.yielded = true;
                     return Some((Ok(item), state));
                 }
-                if state.v4_err.is_some() && state.v6_err.is_some() {
+
+                // Return final error item once both futures completed, or None if items were yielded.
+                if state.v4_fut.is_none() && state.v6_fut.is_none() {
                     state.closed = true;
-                    let error = e!(DnsError::ResolveBoth {
-                        ipv4: Box::new(state.v4_err.take().expect("checked to be Some")),
-                        ipv6: Box::new(state.v6_err.take().expect("checked to be Some")),
-                    });
-                    return Some((Err(error), state));
-                }
-                if state.v4.is_none() && state.v6.is_none() {
-                    state.closed = true;
-                    if !state.yielded {
+                    if let (Some(v4), Some(v6)) = (state.v4_err.take(), state.v6_err.take()) {
+                        let error = e!(DnsError::ResolveBoth {
+                            ipv4: Box::new(v4),
+                            ipv6: Box::new(v6),
+                        });
+                        return Some((Err(error), state));
+                    } else if !state.yielded {
                         return Some((Err(e!(DnsError::NoResponse)), state));
                     } else {
                         return None;
                     }
                 }
                 tokio::select! {
-                    res = &mut state.v4 => {
-                        state.v4 = MaybeFuture::None;
+                    res = &mut state.v4_fut => {
+                        state.v4_fut = MaybeFuture::None;
                         match res {
                             Ok(items) => state.queue.extend(items.map(IpAddr::V4)),
                             Err(err) => state.v4_err = Some(err),
                         }
                     }
-                    res = &mut state.v6 => {
-                        state.v6 = MaybeFuture::None;
+                    res = &mut state.v6_fut => {
+                        state.v6_fut = MaybeFuture::None;
                         match res {
                             Ok(items) => state.queue.extend(items.map(IpAddr::V6)),
                             Err(err) => state.v6_err = Some(err),

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -7,9 +7,11 @@
 //! are structured.
 
 use std::{
+    collections::VecDeque,
     fmt,
     future::Future,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    pin::Pin,
     sync::Arc,
 };
 
@@ -23,8 +25,9 @@ use hickory_resolver::{
 use iroh_base::EndpointId;
 use n0_error::{AnyError, StackError, StdResultExt, e, stack_error};
 use n0_future::{
-    StreamExt,
+    Either, MaybeFuture, Stream, StreamExt,
     boxed::BoxFuture,
+    stream,
     time::{self, Duration},
 };
 use tokio::sync::Notify;
@@ -479,51 +482,106 @@ impl DnsResolver {
         }
     }
 
-    /// Resolves a hostname from a URL to all of its IP addresses, ordered by preference.
+    /// Resolves a hostname from a URL to its IP addresses, streamed as they resolve.
     ///
-    /// The addresses of the preferred family come first (IPv6 when `prefer_ipv6`,
-    /// otherwise IPv4), followed by the addresses of the other family. Callers can
-    /// dial these in order and fall back across families when the preferred address
-    /// is unreachable.
-    pub async fn resolve_host_all(
-        &self,
-        url: &Url,
-        prefer_ipv6: bool,
+    /// IPv4 and IPv6 are looked up concurrently and each address is yielded as
+    /// soon as its lookup completes, so a caller can start dialing without
+    /// waiting for both families.
+    /// A lookup failure is swallowedas long as the other family yields an address.
+    /// Only if both lookups fail does the stream yield a single [`DnsError`].
+    ///
+    /// The stream ends once both lookups have finished and every address or the error
+    /// have been yielded.
+    pub fn resolve_host_all<'a>(
+        &'a self,
+        url: &'a Url,
+        _prefer_ipv6: bool,
         timeout: Duration,
-    ) -> Result<Vec<IpAddr>, DnsError> {
-        let host = url.host().ok_or_else(|| e!(DnsError::MissingHost))?;
-        match host {
-            url::Host::Domain(domain) => {
-                let lookup = tokio::join!(
-                    self.lookup_ipv4(domain, timeout),
-                    self.lookup_ipv6(domain, timeout)
-                );
-                let addrs: Vec<IpAddr> = match lookup {
-                    (Err(ipv4_err), Err(ipv6_err)) => {
-                        return Err(e!(DnsError::ResolveBoth {
-                            ipv4: Box::new(ipv4_err),
-                            ipv6: Box::new(ipv6_err)
-                        }));
+    ) -> impl Stream<Item = Result<IpAddr, DnsError>> + Send + 'a {
+        let host = match url.host() {
+            None => {
+                return Either::Left(stream::once(Err(e!(DnsError::MissingHost))));
+            }
+            Some(url::Host::Ipv4(ip)) => {
+                return Either::Left(stream::once(Ok(IpAddr::V4(ip))));
+            }
+            Some(url::Host::Ipv6(ip)) => {
+                return Either::Left(stream::once(Ok(IpAddr::V6(ip))));
+            }
+            Some(url::Host::Domain(domain)) => domain.to_string(),
+        };
+
+        type Lookup<'a, A> =
+            Pin<Box<dyn Future<Output = Result<BoxIter<A>, DnsError>> + Send + 'a>>;
+
+        struct State<'a> {
+            v4: MaybeFuture<Lookup<'a, Ipv4Addr>>,
+            v6: MaybeFuture<Lookup<'a, Ipv6Addr>>,
+            v4_err: Option<DnsError>,
+            v6_err: Option<DnsError>,
+            queue: VecDeque<IpAddr>,
+            closed: bool,
+            yielded: bool,
+        }
+
+        let state = State {
+            v4: MaybeFuture::Some(Box::pin({
+                let host = host.clone();
+                self.inner.op(timeout, move |r| r.lookup_ipv4(host.clone()))
+            })),
+            v6: MaybeFuture::Some(Box::pin({
+                let host = host.clone();
+                self.inner.op(timeout, move |r| r.lookup_ipv6(host.clone()))
+            })),
+            v4_err: None,
+            v6_err: None,
+            queue: VecDeque::new(),
+            closed: false,
+            yielded: false,
+        };
+        Either::Right(stream::unfold(state, async |mut state| {
+            loop {
+                if state.closed {
+                    return None;
+                }
+                if let Some(item) = state.queue.pop_front() {
+                    state.yielded = true;
+                    return Some((Ok(item), state));
+                }
+                if state.v4_err.is_some() && state.v6_err.is_some() {
+                    state.closed = true;
+                    let error = e!(DnsError::ResolveBoth {
+                        ipv4: Box::new(state.v4_err.take().expect("checked to be Some")),
+                        ipv6: Box::new(state.v6_err.take().expect("checked to be Some")),
+                    });
+                    return Some((Err(error), state));
+                }
+                if state.v4.is_none() && state.v6.is_none() {
+                    state.closed = true;
+                    if !state.yielded {
+                        return Some((Err(e!(DnsError::NoResponse)), state));
+                    } else {
+                        return None;
                     }
-                    (Err(_), Ok(v6)) => v6.collect(),
-                    (Ok(v4), Err(_)) => v4.collect(),
-                    (Ok(v4), Ok(v6)) => {
-                        if prefer_ipv6 {
-                            v6.chain(v4).collect()
-                        } else {
-                            v4.chain(v6).collect()
+                }
+                tokio::select! {
+                    res = &mut state.v4 => {
+                        state.v4 = MaybeFuture::None;
+                        match res {
+                            Ok(items) => state.queue.extend(items.map(IpAddr::V4)),
+                            Err(err) => state.v4_err = Some(err),
                         }
                     }
-                };
-                if addrs.is_empty() {
-                    Err(e!(DnsError::NoResponse))
-                } else {
-                    Ok(addrs)
+                    res = &mut state.v6 => {
+                        state.v6 = MaybeFuture::None;
+                        match res {
+                            Ok(items) => state.queue.extend(items.map(IpAddr::V6)),
+                            Err(err) => state.v6_err = Some(err),
+                        }
+                    }
                 }
             }
-            url::Host::Ipv4(ip) => Ok(vec![IpAddr::V4(ip)]),
-            url::Host::Ipv6(ip) => Ok(vec![IpAddr::V6(ip)]),
-        }
+        }))
     }
 
     /// Performs an IPv4 lookup with a timeout in a staggered fashion.

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -210,12 +210,13 @@ impl ClientBuilder {
         self
     }
 
-    /// Returns if we should prefer ipv6
-    /// it replaces the relayhttp.AddressFamilySelector we pass
-    /// It provides the hint as to whether in an IPv4-vs-IPv6 race that
-    /// IPv4 should be held back a bit to give IPv6 a better-than-50/50
-    /// chance of winning. We only return true when we believe IPv6 will
-    /// work anyway, so we don't artificially delay the connection speed.
+    /// Sets a callback hinting whether to prefer IPv6 when dialing the relay.
+    ///
+    /// The callback runs on each dial. When it returns `true`, IPv6 addresses
+    /// are tried first and IPv4 dials are held back slightly, biasing the
+    /// happy-eyeballs race towards IPv6; when it returns `false`, IPv4 is
+    /// preferred. Only return `true` when IPv6 is expected to work, since
+    /// otherwise the bias just delays the connection.
     pub fn address_family_selector<S>(mut self, selector: S) -> Self
     where
         S: Fn() -> bool + Send + Sync + 'static,

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -6,16 +6,21 @@
 
 // Based on tailscale/derp/derphttp/derphttp_client.go
 
+use std::{collections::VecDeque, net::IpAddr};
+
 use bytes::Bytes;
 use data_encoding::BASE64URL;
 use http_body_util::Empty;
 use hyper::{Request, upgrade::Parts};
 use hyper_util::rt::TokioIo;
 use n0_error::e;
-use n0_future::{IterExt, StreamExt, task, time};
+use n0_future::{
+    FuturesUnordered, MaybeFuture, StreamExt, task,
+    time::{self},
+};
 use rustls::client::Resumption;
 use tokio::net::TcpStream;
-use tracing::error;
+use tracing::{Instrument, error, info_span};
 
 use super::{
     streams::{MaybeTlsStream, ProxyStream},
@@ -221,54 +226,135 @@ impl MaybeTlsStreamBuilder {
     }
 }
 
-/// Resolves `url` and races a TCP connection across the resolved addresses.
+/// Resolves `url` and races TCP connections across the resulting addresses,
+/// Happy Eyeballs style (RFC 8305).
 ///
-/// The host is resolved to all of its addresses in preference order (IPv6 first
-/// when `prefer_ipv6`, otherwise IPv4). Each successive dial is started
-/// [`DIAL_STAGGER_DELAY`] after the previous one and capped at
-/// [`DIAL_ENDPOINT_TIMEOUT`], so a slow or unreachable preferred address
-/// does not hold back the rest for the full timeout. The first connection to succeed
-/// is returned. The remaining attempts are cancelled.
+/// IPv4 and IPv6 addresses stream in as their lookups resolve and are appended
+/// to a single queue. The loop dials them one at a time, [`pop_family`] taking
+/// the next address interleaved by family, the preferred one (`prefer_ipv6`)
+/// first:
+///
+/// - the first attempt waits a [`RESOLUTION_DELAY`] head start for the preferred
+///   family while only the other family has resolved, and starts immediately
+///   once the preferred family resolves;
+/// - each later attempt starts [`CONNECTION_ATTEMPT_DELAY`] after the previous
+///   one, or as soon as an attempt fails (fail fast), whichever comes first;
+/// - every attempt is itself capped at [`DIAL_ENDPOINT_TIMEOUT`].
+///
+/// The first connection to succeed is returned; the rest are dropped, which
+/// cancels them.
 async fn dial_happy_eyeballs(
     dns_resolver: &DnsResolver,
     url: &Url,
     prefer_ipv6: bool,
 ) -> Result<TcpStream, DialError> {
     let port = url_port(url).ok_or_else(|| e!(DialError::InvalidTargetPort))?;
-    let addrs = dns_resolver
-        .resolve_host_all(url, prefer_ipv6, DNS_TIMEOUT)
-        .await?;
-    let mut dials = addrs
-        .into_iter()
-        .enumerate()
-        .map(|(i, ip)| {
-            let addr = SocketAddr::new(ip, port);
-            async move {
-                time::sleep(DIAL_STAGGER_DELAY * i as u32).await;
-                trace!("connecting to {}", addr);
-                let tcp_stream = time::timeout(DIAL_ENDPOINT_TIMEOUT, TcpStream::connect(addr))
-                    .await
-                    .map_err(|err| e!(DialError::Timeout, err))
-                    .and_then(|res| res.map_err(|err| e!(DialError::Io, err)))
-                    .inspect_err(|err| {
-                        debug!(%addr, "failed to connect to relay at {addr}: {err:#}");
-                    })?;
-                tcp_stream.set_nodelay(true)?;
-                Ok(tcp_stream)
-            }
-        })
-        .into_unordered_stream();
 
-    let mut last_err = None;
-    while let Some(res) = dials.next().await {
-        match res {
-            Ok(tcp_stream) => return Ok(tcp_stream),
-            Err(err) => last_err = Some(err),
+    // Stream of DNS results, or `None` once the resolver has finished
+    let resolve_stream = dns_resolver.resolve_host_all(url, DNS_TIMEOUT);
+    tokio::pin!(resolve_stream);
+    let mut resolve_stream = Some(resolve_stream);
+
+    // Addresses resolved but not yet tried, in arrival order.
+    let mut queue: VecDeque<IpAddr> = VecDeque::new();
+    // Family to dial next, toggled to interleave.
+    let mut next_prefer_v6 = prefer_ipv6;
+    // In-progress connection attempts.
+    let mut dials = FuturesUnordered::new();
+    // Whether the first attempt has been scheduled yet.
+    let mut started = false;
+    // Last error that occurred, returned if no connection attempt succeeded.
+    let mut last_err: Option<DialError> = None;
+    // Delay after which to start the next connection attempt, or `None` for immediately.
+    let next_dial_delay = MaybeFuture::None;
+    tokio::pin!(next_dial_delay);
+
+    loop {
+        if resolve_stream.is_none() && queue.is_empty() && dials.is_empty() {
+            // Nothing left to resolve, attempt, or wait on.
+            return Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse).into()));
+        }
+
+        let next_addr = match resolve_stream.as_mut() {
+            Some(stream) => MaybeFuture::Some(stream.next()),
+            None => MaybeFuture::None,
+        };
+
+        tokio::select! {
+            biased;
+            Some(res) = dials.next(), if !dials.is_empty() => match res {
+                Ok(stream) => return Ok(stream),
+                Err(err) => {
+                    last_err = Some(err);
+                    // Fail fast: start the next attempt now rather than waiting it out.
+                    next_dial_delay.as_mut().set_none();
+                }
+            },
+            () = &mut next_dial_delay => {},
+            addr = next_addr => match addr {
+                Some(Ok(ip)) => {
+                    queue.push_back(ip);
+                    if !started {
+                        // If no connection attempt has been started, and a non-preferred
+                        // address is resolved, delay the connect by `RESOLUTION_DELAY`.
+                        // If a preferred address arrives later but before this delay expires,
+                        // it will be dialed instead.
+                        if prefer_ipv6 == ip.is_ipv6() {
+                            next_dial_delay.as_mut().set_none()
+                        } else if next_dial_delay.is_none() {
+                            next_dial_delay.as_mut().set_future(time::sleep(RESOLUTION_DELAY));
+                        }
+                    }
+                }
+                Some(Err(err)) => last_err = Some(err.into()),
+                None => {
+                    resolve_stream = None;
+                    if !started {
+                        next_dial_delay.as_mut().set_none()
+                    }
+                }
+            },
+        }
+
+        // The delay has elapsed and an address is waiting: dial the next one
+        // (interleaved by family) and arm the Connection Attempt Delay before
+        // the one after it.
+        if next_dial_delay.as_mut().is_none()
+            && let Some(ip) = pop_family(&mut queue, &mut next_prefer_v6)
+        {
+            let addr = SocketAddr::new(ip, port);
+            dials.push(
+                async move {
+                    trace!("connecting TCP stream");
+                    let stream = time::timeout(DIAL_ENDPOINT_TIMEOUT, TcpStream::connect(addr))
+                        .await
+                        .map_err(DialError::from)
+                        .and_then(|res| res.map_err(DialError::from))
+                        .inspect_err(|err| debug!("failed to connect: {err:#}"))?;
+                    trace!("TCP stream connected");
+                    stream.set_nodelay(true)?;
+                    Ok(stream)
+                }
+                .instrument(info_span!("connect", %addr)),
+            );
+            started = true;
+            next_dial_delay
+                .as_mut()
+                .set_future(time::sleep(CONNECTION_ATTEMPT_DELAY));
         }
     }
+}
 
-    // If we haven't returned yet, last_err is always set unless `addrs` was empty.
-    Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse).into()))
+/// Removes the next address to attempt, preferring `*next_is_v6`'s family and
+/// flipping it so families interleave; falls back to whatever is available.
+fn pop_family(addrs: &mut VecDeque<IpAddr>, next_is_v6: &mut bool) -> Option<IpAddr> {
+    let idx = addrs
+        .iter()
+        .position(|ip| ip.is_ipv6() == *next_is_v6)
+        .unwrap_or(0);
+    let addr = addrs.remove(idx)?;
+    *next_is_v6 = !*next_is_v6;
+    Some(addr)
 }
 
 fn url_port(url: &Url) -> Option<u16> {
@@ -280,5 +366,151 @@ fn url_port(url: &Url) -> Option<u16> {
         "http" | "ws" => Some(80),
         "https" | "wss" => Some(443),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use iroh_dns::dns::{BoxIter, DnsError, DnsResolver, Resolver, TxtRecordData};
+    use n0_future::boxed::BoxFuture;
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    /// Resolver that hands out fixed IPv4 and IPv6 addresses for every host.
+    #[derive(Debug, Clone)]
+    struct StaticResolver {
+        v4: Vec<Ipv4Addr>,
+        v6: Vec<Ipv6Addr>,
+    }
+
+    impl Resolver for StaticResolver {
+        fn lookup_ipv4(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv4Addr>, DnsError>> {
+            let addrs: BoxIter<_> = Box::new(self.v4.clone().into_iter());
+            Box::pin(std::future::ready(Ok(addrs)))
+        }
+
+        fn lookup_ipv6(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv6Addr>, DnsError>> {
+            let addrs: BoxIter<_> = Box::new(self.v6.clone().into_iter());
+            Box::pin(std::future::ready(Ok(addrs)))
+        }
+
+        fn lookup_txt(&self, _host: String) -> BoxFuture<Result<BoxIter<TxtRecordData>, DnsError>> {
+            let records: BoxIter<_> = Box::new(std::iter::empty());
+            Box::pin(std::future::ready(Ok(records)))
+        }
+
+        fn clear_cache(&self) {}
+
+        fn reset(&self) -> Box<dyn Resolver> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn resolver(v4: Vec<Ipv4Addr>, v6: Vec<Ipv6Addr>) -> DnsResolver {
+        DnsResolver::custom(StaticResolver { v4, v6 })
+    }
+
+    fn relay_url(port: u16) -> Url {
+        format!("http://relay.test:{port}")
+            .parse()
+            .expect("valid url")
+    }
+
+    /// An unreachable IPv4 address (RFC 5737 TEST-NET-1): a connection attempt to
+    /// it never succeeds, modelling a stale or dead record.
+    fn dead_v4(n: u8) -> Ipv4Addr {
+        Ipv4Addr::new(192, 0, 2, n)
+    }
+
+    /// An unreachable IPv6 address (RFC 3849 documentation prefix).
+    fn dead_v6(n: u16) -> Ipv6Addr {
+        Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, n)
+    }
+
+    /// Runs the dialer against `relay.test` on `port`. An attempt to an
+    /// unreachable address is capped by [`DIAL_ENDPOINT_TIMEOUT`] internally, so
+    /// the dialer always makes progress; the outer timeout only guards against a
+    /// true hang.
+    async fn dial(
+        resolver: &DnsResolver,
+        port: u16,
+        prefer_ipv6: bool,
+    ) -> Result<TcpStream, DialError> {
+        time::timeout(
+            time::Duration::from_secs(10),
+            dial_happy_eyeballs(resolver, &relay_url(port), prefer_ipv6),
+        )
+        .await
+        .expect("dialer finishes in time")
+    }
+
+    #[tokio::test]
+    async fn connects_to_the_resolved_address() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let stream = dial(&resolver(vec![Ipv4Addr::LOCALHOST], vec![]), port, false)
+            .await
+            .expect("connects to the listener");
+        assert_eq!(
+            stream.peer_addr().unwrap(),
+            (Ipv4Addr::LOCALHOST, port).into()
+        );
+    }
+
+    #[tokio::test]
+    async fn tries_addresses_until_one_connects() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Vary the number of unreachable addresses preceding the reachable one:
+        // the dialer should skip the dead ones and still connect.
+        for dead in [0u8, 1, 3] {
+            let v4 = (1..=dead)
+                .map(dead_v4)
+                .chain([Ipv4Addr::LOCALHOST])
+                .collect();
+            let stream = dial(&resolver(v4, vec![]), port, false)
+                .await
+                .unwrap_or_else(|err| panic!("connects with {dead} dead addresses: {err:#}"));
+            assert_eq!(stream.peer_addr().unwrap().ip(), Ipv4Addr::LOCALHOST);
+        }
+    }
+
+    #[tokio::test]
+    async fn falls_back_from_unreachable_preferred_family() {
+        // IPv6 is preferred but every IPv6 address is unreachable; the dialer must
+        // interleave across families and fall back to the reachable IPv4 address.
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let resolver = resolver(vec![Ipv4Addr::LOCALHOST], vec![dead_v6(1), dead_v6(2)]);
+
+        let stream = dial(&resolver, port, true)
+            .await
+            .expect("falls back to IPv4");
+        assert!(stream.peer_addr().unwrap().is_ipv4());
+    }
+
+    #[tokio::test]
+    async fn errors_when_all_addresses_unreachable() {
+        let resolver = resolver(vec![dead_v4(1), dead_v4(2)], vec![dead_v6(1)]);
+        let err = dial(&resolver, 8080, true)
+            .await
+            .expect_err("nothing reachable");
+        assert!(matches!(
+            err,
+            DialError::Io { .. } | DialError::Timeout { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn errors_when_nothing_resolves() {
+        let err = dial_happy_eyeballs(&resolver(vec![], vec![]), &relay_url(80), false)
+            .await
+            .expect_err("no addresses to dial");
+        assert!(matches!(err, DialError::Dns { .. }));
     }
 }

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -428,7 +428,10 @@ mod tests {
             .await
             .expect_err("nothing reachable");
         dbg!(&err);
-        assert!(matches!(err, DialError::Io { .. }));
+        assert!(matches!(
+            err,
+            DialError::Io { .. } | DialError::Timeout { .. }
+        ));
     }
 
     #[tokio::test]

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -427,6 +427,7 @@ mod tests {
         let err = dial_happy_eyeballs(&resolver, &relay_url(80), true)
             .await
             .expect_err("nothing reachable");
+        dbg!(&err);
         assert!(matches!(err, DialError::Io { .. }));
     }
 

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -10,9 +10,11 @@ use bytes::Bytes;
 use data_encoding::BASE64URL;
 use http_body_util::Empty;
 use hyper::{Request, upgrade::Parts};
+use hyper_util::rt::TokioIo;
 use n0_error::e;
-use n0_future::{task, time};
+use n0_future::{IterExt, StreamExt, task, time};
 use rustls::client::Resumption;
+use tokio::net::TcpStream;
 use tracing::error;
 
 use super::{
@@ -111,31 +113,10 @@ impl MaybeTlsStreamBuilder {
             let stream = self.dial_url_proxy(proxy.clone(), tls_connector).await?;
             Ok(ProxyStream::Proxied(stream))
         } else {
-            let stream = self.dial_url_direct().await?;
+            let stream =
+                dial_happy_eyeballs(&self.dns_resolver, &self.url, self.prefer_ipv6).await?;
             Ok(ProxyStream::Raw(stream))
         }
-    }
-
-    async fn dial_url_direct(&self) -> Result<tokio::net::TcpStream, DialError> {
-        use tokio::net::TcpStream;
-        let dst_ip = self
-            .dns_resolver
-            .resolve_host(&self.url, self.prefer_ipv6, DNS_TIMEOUT)
-            .await?;
-
-        let port = url_port(&self.url).ok_or_else(|| e!(DialError::InvalidTargetPort))?;
-        let addr = SocketAddr::new(dst_ip, port);
-
-        trace!("connecting to {}", addr);
-        let tcp_stream = time::timeout(DIAL_ENDPOINT_TIMEOUT, async move {
-            TcpStream::connect(addr).await
-        })
-        .await
-        .map_err(|err| e!(DialError::Timeout, err))??;
-
-        tcp_stream.set_nodelay(true)?;
-
-        Ok(tcp_stream)
     }
 
     async fn dial_url_proxy(
@@ -144,28 +125,14 @@ impl MaybeTlsStreamBuilder {
         tls_connector: &tokio_rustls::TlsConnector,
     ) -> Result<util::Chain<std::io::Cursor<Bytes>, MaybeTlsStream<tokio::net::TcpStream>>, DialError>
     {
-        use hyper_util::rt::TokioIo;
-        use tokio::net::TcpStream;
         debug!(%self.url, %proxy_url, "dial url via proxy");
 
-        // Resolve proxy DNS
-        let proxy_ip = self
-            .dns_resolver
-            .resolve_host(&proxy_url, self.prefer_ipv6, DNS_TIMEOUT)
-            .await?;
-
-        let proxy_port =
-            url_port(&proxy_url).ok_or_else(|| e!(DialError::ProxyInvalidTargetPort))?;
-        let proxy_addr = SocketAddr::new(proxy_ip, proxy_port);
-
-        debug!(%proxy_addr, "connecting to proxy");
-
-        let tcp_stream = time::timeout(DIAL_ENDPOINT_TIMEOUT, async move {
-            TcpStream::connect(proxy_addr).await
-        })
-        .await??;
-
-        tcp_stream.set_nodelay(true)?;
+        let tcp_stream = dial_happy_eyeballs(&self.dns_resolver, &proxy_url, self.prefer_ipv6)
+            .await
+            .map_err(|err| match err {
+                DialError::InvalidTargetPort { meta } => DialError::ProxyInvalidTargetPort { meta },
+                err @ _ => err,
+            })?;
 
         // Setup TLS if necessary
         let io = if proxy_url.scheme() == "http" {
@@ -252,6 +219,56 @@ impl MaybeTlsStreamBuilder {
 
         Ok(res)
     }
+}
+
+/// Resolves `url` and races a TCP connection across the resolved addresses.
+///
+/// The host is resolved to all of its addresses in preference order (IPv6 first
+/// when `prefer_ipv6`, otherwise IPv4). Each successive dial is started
+/// [`DIAL_STAGGER_DELAY`] after the previous one and capped at
+/// [`DIAL_ENDPOINT_TIMEOUT`], so a slow or unreachable preferred address
+/// does not hold back the rest for the full timeout. The first connection to succeed
+/// is returned. The remaining attempts are cancelled.
+async fn dial_happy_eyeballs(
+    dns_resolver: &DnsResolver,
+    url: &Url,
+    prefer_ipv6: bool,
+) -> Result<TcpStream, DialError> {
+    let port = url_port(url).ok_or_else(|| e!(DialError::InvalidTargetPort))?;
+    let addrs = dns_resolver
+        .resolve_host_all(url, prefer_ipv6, DNS_TIMEOUT)
+        .await?;
+    let mut dials = addrs
+        .into_iter()
+        .enumerate()
+        .map(|(i, ip)| {
+            let addr = SocketAddr::new(ip, port);
+            async move {
+                time::sleep(DIAL_STAGGER_DELAY * i as u32).await;
+                trace!("connecting to {}", addr);
+                let tcp_stream = time::timeout(DIAL_ENDPOINT_TIMEOUT, TcpStream::connect(addr))
+                    .await
+                    .map_err(|err| e!(DialError::Timeout, err))
+                    .and_then(|res| res.map_err(|err| e!(DialError::Io, err)))
+                    .inspect_err(|err| {
+                        debug!(%addr, "failed to connect to relay at {addr}: {err:#}");
+                    })?;
+                tcp_stream.set_nodelay(true)?;
+                Ok(tcp_stream)
+            }
+        })
+        .into_unordered_stream();
+
+    let mut last_err = None;
+    while let Some(res) = dials.next().await {
+        match res {
+            Ok(tcp_stream) => return Ok(tcp_stream),
+            Err(err) => last_err = Some(err),
+        }
+    }
+
+    // If we haven't returned yet, last_err is always set unless `addrs` was empty.
+    Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse).into()))
 }
 
 fn url_port(url: &Url) -> Option<u16> {

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -250,7 +250,7 @@ async fn dial_happy_eyeballs(
 ) -> Result<TcpStream, DialError> {
     let port = url_port(url).ok_or_else(|| e!(DialError::InvalidTargetPort))?;
 
-    // Stream of DNS results, or `None` once the resolver has finished
+    // Stream of resolved addresses.
     let resolve_stream = dns_resolver.resolve_host_all(url, DNS_TIMEOUT);
     tokio::pin!(resolve_stream);
     // Set to `true` once `resolve_stream` yielded `None`, to not poll it again after completion.
@@ -261,7 +261,7 @@ async fn dial_happy_eyeballs(
     let mut next_prefer_v6 = prefer_ipv6;
     // In-progress connection attempts.
     let mut dials = FuturesUnordered::new();
-    // Whether the first attempt has been scheduled yet.
+    // Whether the first connection attempt has been started yet.
     let mut started = false;
     // Last error that occurred, returned if no connection attempt succeeded.
     let mut last_err: Option<DialError> = None;

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -131,7 +131,7 @@ impl MaybeTlsStreamBuilder {
             .await
             .map_err(|err| match err {
                 DialError::InvalidTargetPort { meta } => DialError::ProxyInvalidTargetPort { meta },
-                err @ _ => err,
+                err => err,
             })?;
 
         // Setup TLS if necessary

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -375,9 +375,8 @@ mod tests {
 
     use tokio::net::TcpListener;
 
-    use crate::test_utils::StaticResolver;
-
     use super::*;
+    use crate::test_utils::StaticResolver;
 
     fn relay_url(port: u16) -> Url {
         format!("http://relay.test:{port}")

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -238,7 +238,7 @@ impl MaybeTlsStreamBuilder {
 ///   family while only the other family has resolved, and starts immediately
 ///   once the preferred family resolves;
 /// - each later attempt starts [`CONNECTION_ATTEMPT_DELAY`] after the previous
-///   one, or as soon as an attempt fails (fail fast), whichever comes first;
+///   one, or as soon as the last in-flight attempt fails, whichever comes first;
 /// - every attempt is itself capped at [`DIAL_ENDPOINT_TIMEOUT`].
 ///
 /// The first connection to succeed is returned; the rest are dropped, which
@@ -253,8 +253,8 @@ async fn dial_happy_eyeballs(
     // Stream of DNS results, or `None` once the resolver has finished
     let resolve_stream = dns_resolver.resolve_host_all(url, DNS_TIMEOUT);
     tokio::pin!(resolve_stream);
-    let mut resolve_stream = Some(resolve_stream);
-
+    // Set to `true` once `resolve_stream` yielded `None`, to not poll it again after completion.
+    let mut resolve_stream_finished = false;
     // Addresses resolved but not yet tried, in arrival order.
     let mut queue: VecDeque<IpAddr> = VecDeque::new();
     // Family to dial next, toggled to interleave.
@@ -265,61 +265,19 @@ async fn dial_happy_eyeballs(
     let mut started = false;
     // Last error that occurred, returned if no connection attempt succeeded.
     let mut last_err: Option<DialError> = None;
-    // Delay after which to start the next connection attempt, or `None` for immediately.
-    let next_dial_delay = MaybeFuture::None;
-    tokio::pin!(next_dial_delay);
+    // Timer after which to start the next connection attempt, or `None` for immediately.
+    let next_dial_delayed_until = MaybeFuture::None;
+    tokio::pin!(next_dial_delayed_until);
 
     loop {
-        if resolve_stream.is_none() && queue.is_empty() && dials.is_empty() {
+        if resolve_stream_finished && queue.is_empty() && dials.is_empty() {
             // Nothing left to resolve, attempt, or wait on.
             return Err(last_err.unwrap_or_else(|| e!(DnsError::NoResponse).into()));
         }
 
-        let next_addr = match resolve_stream.as_mut() {
-            Some(stream) => MaybeFuture::Some(stream.next()),
-            None => MaybeFuture::None,
-        };
-
-        tokio::select! {
-            biased;
-            Some(res) = dials.next(), if !dials.is_empty() => match res {
-                Ok(stream) => return Ok(stream),
-                Err(err) => {
-                    last_err = Some(err);
-                    // Fail fast: start the next attempt now rather than waiting it out.
-                    next_dial_delay.as_mut().set_none();
-                }
-            },
-            () = &mut next_dial_delay => {},
-            addr = next_addr => match addr {
-                Some(Ok(ip)) => {
-                    queue.push_back(ip);
-                    if !started {
-                        // If no connection attempt has been started, and a non-preferred
-                        // address is resolved, delay the connect by `RESOLUTION_DELAY`.
-                        // If a preferred address arrives later but before this delay expires,
-                        // it will be dialed instead.
-                        if prefer_ipv6 == ip.is_ipv6() {
-                            next_dial_delay.as_mut().set_none()
-                        } else if next_dial_delay.is_none() {
-                            next_dial_delay.as_mut().set_future(time::sleep(RESOLUTION_DELAY));
-                        }
-                    }
-                }
-                Some(Err(err)) => last_err = Some(err.into()),
-                None => {
-                    resolve_stream = None;
-                    if !started {
-                        next_dial_delay.as_mut().set_none()
-                    }
-                }
-            },
-        }
-
-        // The delay has elapsed and an address is waiting: dial the next one
-        // (interleaved by family) and arm the Connection Attempt Delay before
-        // the one after it.
-        if next_dial_delay.as_mut().is_none()
+        // The next dial is due and an address is waiting: dial the next address,
+        // interleaved by family, and set the timer for the next attempt.
+        if next_dial_delayed_until.is_none()
             && let Some(ip) = pop_family(&mut queue, &mut next_prefer_v6)
         {
             let addr = SocketAddr::new(ip, port);
@@ -338,9 +296,56 @@ async fn dial_happy_eyeballs(
                 .instrument(info_span!("connect", %addr)),
             );
             started = true;
-            next_dial_delay
+            next_dial_delayed_until
                 .as_mut()
                 .set_future(time::sleep(CONNECTION_ATTEMPT_DELAY));
+        }
+
+        // All three arms are guarded, but it is guaranteed that at least one arm
+        // is enabled, otherwise the check at the top of the loop returns.
+        tokio::select! {
+            biased;
+            // Yields when a dial attempt completed.
+            Some(res) = dials.next(), if !dials.is_empty() => match res {
+                Ok(stream) => return Ok(stream),
+                Err(err) => {
+                    last_err = Some(err);
+                    if dials.is_empty() {
+                        // Fail fast: start the next attempt now rather than waiting it out.
+                        next_dial_delayed_until.as_mut().set_none();
+                    }
+                }
+            },
+            // Yields when the next address is resolved.
+            addr = resolve_stream.next(), if !resolve_stream_finished => {
+                match addr {
+                    Some(Ok(ip)) => {
+                        queue.push_back(ip);
+                        if !started {
+                            // If no connection attempt has been started, and a non-preferred
+                            // address is resolved, delay the connect by `RESOLUTION_DELAY`.
+                            // If a preferred address arrives later but before this delay expires,
+                            // it will be dialed instead.
+                            if prefer_ipv6 == ip.is_ipv6() {
+                                next_dial_delayed_until.as_mut().set_none();
+                            } else if next_dial_delayed_until.is_none() {
+                                next_dial_delayed_until.as_mut().set_future(time::sleep(RESOLUTION_DELAY));
+                            }
+                        }
+                    }
+                    Some(Err(err)) => {
+                        last_err = Some(err.into());
+                    }
+                    None => {
+                        resolve_stream_finished = true;
+                        if !started {
+                            next_dial_delayed_until.as_mut().set_none();
+                        }
+                    }
+                }
+            }
+            // Yields when the next dial attempt is due, if the timer is set.
+            () = &mut next_dial_delayed_until, if next_dial_delayed_until.is_some() => {},
         }
     }
 }
@@ -376,7 +381,7 @@ mod tests {
     use tokio::net::TcpListener;
 
     use super::*;
-    use crate::test_utils::StaticResolver;
+    use crate::test_utils::static_resolver;
 
     fn relay_url(port: u16) -> Url {
         format!("http://relay.test:{port}")
@@ -401,7 +406,7 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         let addrs = (1..5).map(dead_v4).chain([Ipv4Addr::LOCALHOST]).collect();
-        let resolver = StaticResolver::new(addrs, vec![]);
+        let resolver = static_resolver(addrs, vec![]);
         let stream = dial_happy_eyeballs(&resolver, &relay_url(port), false)
             .await
             .expect("should skip the invalid addrs and still connect");
@@ -413,7 +418,7 @@ mod tests {
     async fn falls_back_from_unreachable_preferred_family() {
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
         let port = listener.local_addr().unwrap().port();
-        let resolver = StaticResolver::new(vec![Ipv4Addr::LOCALHOST], vec![dead_v6(1), dead_v6(2)]);
+        let resolver = static_resolver(vec![Ipv4Addr::LOCALHOST], vec![dead_v6(1), dead_v6(2)]);
 
         let stream = dial_happy_eyeballs(&resolver, &relay_url(port), true)
             .await
@@ -423,7 +428,7 @@ mod tests {
 
     #[tokio::test]
     async fn errors_when_all_addresses_unreachable() {
-        let resolver = StaticResolver::new(vec![dead_v4(1), dead_v4(2)], vec![dead_v6(1)]);
+        let resolver = static_resolver(vec![dead_v4(1), dead_v4(2)], vec![dead_v6(1)]);
         let err = dial_happy_eyeballs(&resolver, &relay_url(80), true)
             .await
             .expect_err("nothing reachable");
@@ -436,7 +441,7 @@ mod tests {
 
     #[tokio::test]
     async fn errors_when_nothing_resolves() {
-        let resolver = StaticResolver::new(vec![], vec![]);
+        let resolver = static_resolver(vec![], vec![]);
         let err = dial_happy_eyeballs(&resolver, &relay_url(80), false)
             .await
             .expect_err("no addresses to dial");

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -373,45 +373,11 @@ fn url_port(url: &Url) -> Option<u16> {
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
-    use iroh_dns::dns::{BoxIter, DnsError, DnsResolver, Resolver, TxtRecordData};
-    use n0_future::boxed::BoxFuture;
     use tokio::net::TcpListener;
 
+    use crate::test_utils::StaticResolver;
+
     use super::*;
-
-    /// Resolver that hands out fixed IPv4 and IPv6 addresses for every host.
-    #[derive(Debug, Clone)]
-    struct StaticResolver {
-        v4: Vec<Ipv4Addr>,
-        v6: Vec<Ipv6Addr>,
-    }
-
-    impl Resolver for StaticResolver {
-        fn lookup_ipv4(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv4Addr>, DnsError>> {
-            let addrs: BoxIter<_> = Box::new(self.v4.clone().into_iter());
-            Box::pin(std::future::ready(Ok(addrs)))
-        }
-
-        fn lookup_ipv6(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv6Addr>, DnsError>> {
-            let addrs: BoxIter<_> = Box::new(self.v6.clone().into_iter());
-            Box::pin(std::future::ready(Ok(addrs)))
-        }
-
-        fn lookup_txt(&self, _host: String) -> BoxFuture<Result<BoxIter<TxtRecordData>, DnsError>> {
-            let records: BoxIter<_> = Box::new(std::iter::empty());
-            Box::pin(std::future::ready(Ok(records)))
-        }
-
-        fn clear_cache(&self) {}
-
-        fn reset(&self) -> Box<dyn Resolver> {
-            Box::new(self.clone())
-        }
-    }
-
-    fn resolver(v4: Vec<Ipv4Addr>, v6: Vec<Ipv6Addr>) -> DnsResolver {
-        DnsResolver::custom(StaticResolver { v4, v6 })
-    }
 
     fn relay_url(port: u16) -> Url {
         format!("http://relay.test:{port}")
@@ -419,8 +385,7 @@ mod tests {
             .expect("valid url")
     }
 
-    /// An unreachable IPv4 address (RFC 5737 TEST-NET-1): a connection attempt to
-    /// it never succeeds, modelling a stale or dead record.
+    /// An unreachable IPv4 address (RFC 5737 TEST-NET-1).
     fn dead_v4(n: u8) -> Ipv4Addr {
         Ipv4Addr::new(192, 0, 2, n)
     }
@@ -430,65 +395,28 @@ mod tests {
         Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, n)
     }
 
-    /// Runs the dialer against `relay.test` on `port`. An attempt to an
-    /// unreachable address is capped by [`DIAL_ENDPOINT_TIMEOUT`] internally, so
-    /// the dialer always makes progress; the outer timeout only guards against a
-    /// true hang.
-    async fn dial(
-        resolver: &DnsResolver,
-        port: u16,
-        prefer_ipv6: bool,
-    ) -> Result<TcpStream, DialError> {
-        time::timeout(
-            time::Duration::from_secs(10),
-            dial_happy_eyeballs(resolver, &relay_url(port), prefer_ipv6),
-        )
-        .await
-        .expect("dialer finishes in time")
-    }
-
-    #[tokio::test]
-    async fn connects_to_the_resolved_address() {
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-
-        let stream = dial(&resolver(vec![Ipv4Addr::LOCALHOST], vec![]), port, false)
-            .await
-            .expect("connects to the listener");
-        assert_eq!(
-            stream.peer_addr().unwrap(),
-            (Ipv4Addr::LOCALHOST, port).into()
-        );
-    }
-
+    /// Tests that all addresses are tried until one succeeds.
     #[tokio::test]
     async fn tries_addresses_until_one_connects() {
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
-        // Vary the number of unreachable addresses preceding the reachable one:
-        // the dialer should skip the dead ones and still connect.
-        for dead in [0u8, 1, 3] {
-            let v4 = (1..=dead)
-                .map(dead_v4)
-                .chain([Ipv4Addr::LOCALHOST])
-                .collect();
-            let stream = dial(&resolver(v4, vec![]), port, false)
-                .await
-                .unwrap_or_else(|err| panic!("connects with {dead} dead addresses: {err:#}"));
-            assert_eq!(stream.peer_addr().unwrap().ip(), Ipv4Addr::LOCALHOST);
-        }
+        let addrs = (1..5).map(dead_v4).chain([Ipv4Addr::LOCALHOST]).collect();
+        let resolver = StaticResolver::new(addrs, vec![]);
+        let stream = dial_happy_eyeballs(&resolver, &relay_url(port), false)
+            .await
+            .expect("should skip the invalid addrs and still connect");
+        assert_eq!(stream.peer_addr().unwrap().ip(), Ipv4Addr::LOCALHOST);
     }
 
+    /// Tests if the preferred family is unreachable the non-preferred family is used.
     #[tokio::test]
     async fn falls_back_from_unreachable_preferred_family() {
-        // IPv6 is preferred but every IPv6 address is unreachable; the dialer must
-        // interleave across families and fall back to the reachable IPv4 address.
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
         let port = listener.local_addr().unwrap().port();
-        let resolver = resolver(vec![Ipv4Addr::LOCALHOST], vec![dead_v6(1), dead_v6(2)]);
+        let resolver = StaticResolver::new(vec![Ipv4Addr::LOCALHOST], vec![dead_v6(1), dead_v6(2)]);
 
-        let stream = dial(&resolver, port, true)
+        let stream = dial_happy_eyeballs(&resolver, &relay_url(port), true)
             .await
             .expect("falls back to IPv4");
         assert!(stream.peer_addr().unwrap().is_ipv4());
@@ -496,19 +424,17 @@ mod tests {
 
     #[tokio::test]
     async fn errors_when_all_addresses_unreachable() {
-        let resolver = resolver(vec![dead_v4(1), dead_v4(2)], vec![dead_v6(1)]);
-        let err = dial(&resolver, 8080, true)
+        let resolver = StaticResolver::new(vec![dead_v4(1), dead_v4(2)], vec![dead_v6(1)]);
+        let err = dial_happy_eyeballs(&resolver, &relay_url(80), true)
             .await
             .expect_err("nothing reachable");
-        assert!(matches!(
-            err,
-            DialError::Io { .. } | DialError::Timeout { .. }
-        ));
+        assert!(matches!(err, DialError::Io { .. }));
     }
 
     #[tokio::test]
     async fn errors_when_nothing_resolves() {
-        let err = dial_happy_eyeballs(&resolver(vec![], vec![]), &relay_url(80), false)
+        let resolver = StaticResolver::new(vec![], vec![]);
+        let err = dial_happy_eyeballs(&resolver, &relay_url(80), false)
             .await
             .expect_err("no addresses to dial");
         assert!(matches!(err, DialError::Dns { .. }));

--- a/iroh-relay/src/defaults.rs
+++ b/iroh-relay/src/defaults.rs
@@ -31,6 +31,10 @@ pub mod timeouts {
     /// using `TcpStream::connect`
     pub(crate) const DIAL_ENDPOINT_TIMEOUT: Duration = Duration::from_millis(1500);
 
+    /// Delay before starting the next address's dial in the staggered
+    /// "happy eyeballs" connection race.
+    pub(crate) const DIAL_STAGGER_DELAY: Duration = Duration::from_millis(250);
+
     /// Default timeout for DNS queries issued by [`DnsResolver`].
     ///
     /// [`DnsResolver`]: iroh_dns::dns::DnsResolver

--- a/iroh-relay/src/defaults.rs
+++ b/iroh-relay/src/defaults.rs
@@ -31,9 +31,15 @@ pub mod timeouts {
     /// using `TcpStream::connect`
     pub(crate) const DIAL_ENDPOINT_TIMEOUT: Duration = Duration::from_millis(1500);
 
-    /// Delay before starting the next address's dial in the staggered
-    /// "happy eyeballs" connection race.
-    pub(crate) const DIAL_STAGGER_DELAY: Duration = Duration::from_millis(250);
+    /// Happy Eyeballs (RFC 8305) Connection Attempt Delay: the maximum time to
+    /// wait before starting the next connection attempt. A faster failure
+    /// starts the next attempt immediately.
+    pub(crate) const CONNECTION_ATTEMPT_DELAY: Duration = Duration::from_millis(250);
+
+    /// Happy Eyeballs (RFC 8305) Resolution Delay: when the non-preferred
+    /// address family resolves first, wait this long for the preferred family
+    /// before starting to connect, so the preference is honored.
+    pub(crate) const RESOLUTION_DELAY: Duration = Duration::from_millis(50);
 
     /// Default timeout for DNS queries issued by [`DnsResolver`].
     ///

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -33,21 +33,21 @@
 pub mod client;
 pub mod defaults;
 pub mod http;
+mod key_cache;
+mod ping_tracker;
 pub mod protos;
 pub mod quic;
+mod relay_map;
 #[cfg(feature = "server")]
 pub mod server;
+#[cfg(test)]
+pub(crate) mod test_utils;
 pub mod tls;
 
-mod ping_tracker;
-
-mod key_cache;
-mod relay_map;
-pub use key_cache::KeyCache;
-pub use protos::relay::MAX_PACKET_SIZE;
-
 pub use crate::{
+    key_cache::KeyCache,
     ping_tracker::PingTracker,
+    protos::relay::MAX_PACKET_SIZE,
     relay_map::{RelayConfig, RelayMap, RelayQuicConfig},
 };
 

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -1156,17 +1156,13 @@ impl hyper::service::Service<Request<Incoming>> for CaptivePortalService {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        net::{Ipv4Addr, Ipv6Addr},
-        sync::Arc,
-        time::Duration,
-    };
+    use std::{net::Ipv4Addr, sync::Arc, time::Duration};
 
     use http::StatusCode;
     use iroh_base::{EndpointId, RelayUrl, SecretKey};
-    use iroh_dns::dns::{BoxIter, DnsError, DnsResolver, Resolver, TxtRecordData};
+    use iroh_dns::dns::DnsResolver;
     use n0_error::{Result, StackResultExt, StdResultExt};
-    use n0_future::{SinkExt, StreamExt, boxed::BoxFuture};
+    use n0_future::{SinkExt, StreamExt};
     use n0_tracing_test::traced_test;
     use rand::{RngExt, SeedableRng};
     use tracing::{info, instrument};
@@ -1182,6 +1178,7 @@ mod tests {
             handshake,
             relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg},
         },
+        test_utils::StaticResolver,
         tls::{self, CaRootsConfig, default_provider},
     };
 
@@ -1575,38 +1572,8 @@ mod tests {
         Ok(())
     }
 
-    /// A resolver that hands out fixed IPv4 and IPv6 addresses for every host.
-    #[derive(Debug, Clone)]
-    struct StaticResolver {
-        v4: Vec<Ipv4Addr>,
-        v6: Vec<Ipv6Addr>,
-    }
-
-    impl Resolver for StaticResolver {
-        fn lookup_ipv4(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv4Addr>, DnsError>> {
-            let addrs: BoxIter<_> = Box::new(self.v4.clone().into_iter());
-            Box::pin(std::future::ready(Ok(addrs)))
-        }
-
-        fn lookup_ipv6(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv6Addr>, DnsError>> {
-            let addrs: BoxIter<_> = Box::new(self.v6.clone().into_iter());
-            Box::pin(std::future::ready(Ok(addrs)))
-        }
-
-        fn lookup_txt(&self, _host: String) -> BoxFuture<Result<BoxIter<TxtRecordData>, DnsError>> {
-            let records: BoxIter<_> = Box::new(std::iter::empty());
-            Box::pin(std::future::ready(Ok(records)))
-        }
-
-        fn clear_cache(&self) {}
-
-        fn reset(&self) -> Box<dyn Resolver> {
-            Box::new(self.clone())
-        }
-    }
-
-    /// A relay client that prefers IPv6 falls back to IPv4 when the advertised IPv6
-    /// address is unreachable.
+    /// Regression test: A relay client that prefers IPv6 falls back to IPv4
+    /// when the advertised IPv6 address is unreachable.
     #[tokio::test]
     #[traced_test]
     async fn test_relay_client_falls_back_to_ipv4() -> Result {
@@ -1618,21 +1585,18 @@ mod tests {
         let server = Server::spawn(config).await?;
         let addr = server.http_addr().expect("http relay address");
 
-        // `relay.test` resolves to the relay's real IPv4 address alongside an
-        // unreachable IPv6 address from the RFC 3849 documentation prefix, standing
-        // in for the stale AAAA record from the issue.
-        let resolver = DnsResolver::custom(StaticResolver {
-            v4: vec![Ipv4Addr::LOCALHOST],
-            v6: vec!["2001:db8::dead".parse().expect("valid IPv6")],
-        });
+        // Resolves to both the real IPv4 address and an unreachable IPv6 address.
+        let resolver = StaticResolver::new(
+            vec![Ipv4Addr::LOCALHOST],
+            vec!["2001:db8::dead".parse().expect("valid IPv6")],
+        );
         let url: Url = format!("http://relay.test:{}", addr.port())
             .parse()
             .expect("valid relay url");
 
-        // Force the IPv6 preference, as a client with working IPv6 connectivity
-        // would have after a net report.
         let client = ClientBuilder::new(url, SecretKey::generate(), resolver)
             .tls_client_config(tls::make_dangerous_client_config())
+            // Force IPv6 preference
             .address_family_selector(|| true);
 
         tokio::time::timeout(Duration::from_secs(10), client.connect())

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -1156,16 +1156,21 @@ impl hyper::service::Service<Request<Incoming>> for CaptivePortalService {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::Ipv4Addr, sync::Arc, time::Duration};
+    use std::{
+        net::{Ipv4Addr, Ipv6Addr},
+        sync::Arc,
+        time::Duration,
+    };
 
     use http::StatusCode;
     use iroh_base::{EndpointId, RelayUrl, SecretKey};
-    use iroh_dns::dns::DnsResolver;
-    use n0_error::Result;
-    use n0_future::{SinkExt, StreamExt};
+    use iroh_dns::dns::{BoxIter, DnsError, DnsResolver, Resolver, TxtRecordData};
+    use n0_error::{Result, StackResultExt, StdResultExt};
+    use n0_future::{SinkExt, StreamExt, boxed::BoxFuture};
     use n0_tracing_test::traced_test;
     use rand::{RngExt, SeedableRng};
     use tracing::{info, instrument};
+    use url::Url;
 
     use super::{
         Access, AccessControl, ClientRequest, NO_CONTENT_CHALLENGE_HEADER,
@@ -1177,7 +1182,7 @@ mod tests {
             handshake,
             relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg},
         },
-        tls::{CaRootsConfig, default_provider},
+        tls::{self, CaRootsConfig, default_provider},
     };
 
     /// An [`AccessControl`] backed by a closure, for tests.
@@ -1567,6 +1572,72 @@ mod tests {
                 })
                 .await?;
         }
+        Ok(())
+    }
+
+    /// A resolver that hands out fixed IPv4 and IPv6 addresses for every host.
+    #[derive(Debug, Clone)]
+    struct StaticResolver {
+        v4: Vec<Ipv4Addr>,
+        v6: Vec<Ipv6Addr>,
+    }
+
+    impl Resolver for StaticResolver {
+        fn lookup_ipv4(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv4Addr>, DnsError>> {
+            let v4 = self.v4.clone();
+            Box::pin(async move { Ok(Box::new(v4.into_iter()) as BoxIter<Ipv4Addr>) })
+        }
+
+        fn lookup_ipv6(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv6Addr>, DnsError>> {
+            let v6 = self.v6.clone();
+            Box::pin(async move { Ok(Box::new(v6.into_iter()) as BoxIter<Ipv6Addr>) })
+        }
+
+        fn lookup_txt(&self, _host: String) -> BoxFuture<Result<BoxIter<TxtRecordData>, DnsError>> {
+            Box::pin(async move { Ok(Box::new(std::iter::empty()) as BoxIter<TxtRecordData>) })
+        }
+
+        fn clear_cache(&self) {}
+
+        fn reset(&self) -> Box<dyn Resolver> {
+            Box::new(self.clone())
+        }
+    }
+
+    /// A relay client that prefers IPv6 falls back to IPv4 when the advertised IPv6
+    /// address is unreachable.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_relay_client_falls_back_to_ipv4() -> Result {
+        // A relay reachable only over IPv4.
+        let mut config = ServerConfig::default();
+        config.relay = Some(RelayConfig::new((Ipv4Addr::LOCALHOST, 0)));
+        let server = Server::spawn(config).await?;
+        let addr = server.http_addr().expect("http relay address");
+
+        // `relay.test` resolves to the relay's real IPv4 address alongside an
+        // unreachable IPv6 address from the RFC 3849 documentation prefix, standing
+        // in for the stale AAAA record from the issue.
+        let resolver = DnsResolver::custom(StaticResolver {
+            v4: vec![Ipv4Addr::LOCALHOST],
+            v6: vec!["2001:db8::dead".parse().expect("valid IPv6")],
+        });
+        let url: Url = format!("http://relay.test:{}", addr.port())
+            .parse()
+            .expect("valid relay url");
+
+        // Force the IPv6 preference, as a client with working IPv6 connectivity
+        // would have after a net report.
+        let client = ClientBuilder::new(url, SecretKey::generate(), resolver)
+            .tls_client_config(tls::make_dangerous_client_config())
+            .address_family_selector(|| true);
+
+        tokio::time::timeout(Duration::from_secs(10), client.connect())
+            .await
+            .with_std_context(|_| "relay connect timed out")?
+            .context("relay connect")?;
+
+        server.shutdown().await.context("relay server shutdown")?;
         Ok(())
     }
 }

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -1178,7 +1178,7 @@ mod tests {
             handshake,
             relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg},
         },
-        test_utils::StaticResolver,
+        test_utils::static_resolver,
         tls::{self, CaRootsConfig, default_provider},
     };
 
@@ -1586,7 +1586,7 @@ mod tests {
         let addr = server.http_addr().expect("http relay address");
 
         // Resolves to both the real IPv4 address and an unreachable IPv6 address.
-        let resolver = StaticResolver::new(
+        let resolver = static_resolver(
             vec![Ipv4Addr::LOCALHOST],
             vec!["2001:db8::dead".parse().expect("valid IPv6")],
         );

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -1584,17 +1584,18 @@ mod tests {
 
     impl Resolver for StaticResolver {
         fn lookup_ipv4(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv4Addr>, DnsError>> {
-            let v4 = self.v4.clone();
-            Box::pin(async move { Ok(Box::new(v4.into_iter()) as BoxIter<Ipv4Addr>) })
+            let addrs: BoxIter<_> = Box::new(self.v4.clone().into_iter());
+            Box::pin(std::future::ready(Ok(addrs)))
         }
 
         fn lookup_ipv6(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv6Addr>, DnsError>> {
-            let v6 = self.v6.clone();
-            Box::pin(async move { Ok(Box::new(v6.into_iter()) as BoxIter<Ipv6Addr>) })
+            let addrs: BoxIter<_> = Box::new(self.v6.clone().into_iter());
+            Box::pin(std::future::ready(Ok(addrs)))
         }
 
         fn lookup_txt(&self, _host: String) -> BoxFuture<Result<BoxIter<TxtRecordData>, DnsError>> {
-            Box::pin(async move { Ok(Box::new(std::iter::empty()) as BoxIter<TxtRecordData>) })
+            let records: BoxIter<_> = Box::new(std::iter::empty());
+            Box::pin(std::future::ready(Ok(records)))
         }
 
         fn clear_cache(&self) {}

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -1610,8 +1610,10 @@ mod tests {
     #[traced_test]
     async fn test_relay_client_falls_back_to_ipv4() -> Result {
         // A relay reachable only over IPv4.
-        let mut config = ServerConfig::default();
-        config.relay = Some(RelayConfig::new((Ipv4Addr::LOCALHOST, 0)));
+        let config = ServerConfig {
+            relay: Some(RelayConfig::new((Ipv4Addr::LOCALHOST, 0))),
+            ..Default::default()
+        };
         let server = Server::spawn(config).await?;
         let addr = server.http_addr().expect("http relay address");
 

--- a/iroh-relay/src/test_utils.rs
+++ b/iroh-relay/src/test_utils.rs
@@ -3,9 +3,13 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use iroh_dns::dns::{BoxIter, DnsError, DnsResolver, Resolver, TxtRecordData};
 use n0_future::boxed::BoxFuture;
 
-/// Resolver that hands out fixed IPv4 and IPv6 addresses for every host.
+/// Returns a [`DnsResolver`] that hands out fixed IPv4 and IPv6 addresses for every host.
+pub(crate) fn static_resolver(v4: Vec<Ipv4Addr>, v6: Vec<Ipv6Addr>) -> DnsResolver {
+    DnsResolver::custom(StaticResolver { v4, v6 })
+}
+
 #[derive(Debug, Clone)]
-pub(crate) struct StaticResolver {
+struct StaticResolver {
     v4: Vec<Ipv4Addr>,
     v6: Vec<Ipv6Addr>,
 }
@@ -30,11 +34,5 @@ impl Resolver for StaticResolver {
 
     fn reset(&self) -> Box<dyn Resolver> {
         Box::new(self.clone())
-    }
-}
-
-impl StaticResolver {
-    pub(crate) fn new(v4: Vec<Ipv4Addr>, v6: Vec<Ipv6Addr>) -> DnsResolver {
-        DnsResolver::custom(StaticResolver { v4, v6 })
     }
 }

--- a/iroh-relay/src/test_utils.rs
+++ b/iroh-relay/src/test_utils.rs
@@ -1,0 +1,40 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use iroh_dns::dns::{BoxIter, DnsError, DnsResolver, Resolver, TxtRecordData};
+use n0_future::boxed::BoxFuture;
+
+/// Resolver that hands out fixed IPv4 and IPv6 addresses for every host.
+#[derive(Debug, Clone)]
+pub(crate) struct StaticResolver {
+    v4: Vec<Ipv4Addr>,
+    v6: Vec<Ipv6Addr>,
+}
+
+impl Resolver for StaticResolver {
+    fn lookup_ipv4(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv4Addr>, DnsError>> {
+        let addrs: BoxIter<_> = Box::new(self.v4.clone().into_iter());
+        Box::pin(std::future::ready(Ok(addrs)))
+    }
+
+    fn lookup_ipv6(&self, _host: String) -> BoxFuture<Result<BoxIter<Ipv6Addr>, DnsError>> {
+        let addrs: BoxIter<_> = Box::new(self.v6.clone().into_iter());
+        Box::pin(std::future::ready(Ok(addrs)))
+    }
+
+    fn lookup_txt(&self, _host: String) -> BoxFuture<Result<BoxIter<TxtRecordData>, DnsError>> {
+        let records: BoxIter<_> = Box::new(std::iter::empty());
+        Box::pin(std::future::ready(Ok(records)))
+    }
+
+    fn clear_cache(&self) {}
+
+    fn reset(&self) -> Box<dyn Resolver> {
+        Box::new(self.clone())
+    }
+}
+
+impl StaticResolver {
+    pub(crate) fn new(v4: Vec<Ipv4Addr>, v6: Vec<Ipv6Addr>) -> DnsResolver {
+        DnsResolver::custom(StaticResolver { v4, v6 })
+    }
+}


### PR DESCRIPTION
## Description

Currently the relay client resolves a relay's hostname to a single address and dials
only that one. A `prefer_ipv6` flag decides whether we query for an A or AAAA record.
If the DNS query returns an unreachable AAAA record for whatever reason, or we somehow
end in a state where `prefer_ipv6` is true but the machine does not actually support IPv6,
then dialing the relay fails.

This PR fixes this by resolving both A and AAAA records and racing them happy-eyeballs style: the addresses are tried in preference order, each dial starting a short delay after the previous, and the
first connection to succeed wins while the rest are cancelled. The same race
covers both direct and proxied relay connections.

Fixes #4069

## Notes & open questions

Also fixes a unrelated doc comment that was very weirdly written and referred to, I think, some configuration from a very long time ago.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.