### PR TITLE
feat(iroh-relay)!: Allow setting a custom ServerCertVerifier and rename CaRootsConfig to CaTlsConfig

### DIFF
--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -4,7 +4,7 @@ use iroh::{
     address_lookup::pkarr::PkarrRelayClient,
     dns::DnsResolver,
     endpoint_info::EndpointInfo,
-    tls::{CaRootsConfig, default_provider},
+    tls::{CaTlsConfig, default_provider},
 };
 use iroh_dns_server::{Server, config::Config};
 use rand::RngExt;
@@ -29,7 +29,7 @@ fn benchmark_dns_server(c: &mut Criterion) {
                     let secret_key = SecretKey::from_bytes(&rng.random());
                     let endpoint_id = secret_key.public();
 
-                    let tls_config = CaRootsConfig::default()
+                    let tls_config = CaTlsConfig::default()
                         .client_config(default_provider())
                         .expect("infallible");
                     let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -10,7 +10,7 @@ use iroh::{
     },
     dns::DnsResolver,
     endpoint_info::EndpointInfo,
-    tls::{CaRootsConfig, default_provider},
+    tls::{CaTlsConfig, default_provider},
 };
 use iroh_dns::IROH_TXT_NAME;
 use n0_error::{Result, StackResultExt};
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
     println!();
     println!("publish to {pkarr_relay_url} ...");
 
-    let tls_config = CaRootsConfig::default()
+    let tls_config = CaTlsConfig::default()
         .client_config(default_provider())
         .expect("infallible");
     let pkarr = PkarrRelayClient::new(pkarr_relay_url, tls_config, DnsResolver::default());

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -319,7 +319,7 @@ mod tests {
         RelayUrl, SecretKey,
         address_lookup::{EndpointInfo, PkarrRelayClient},
         dns::DnsResolver,
-        tls::{CaRootsConfig, default_provider},
+        tls::{CaTlsConfig, default_provider},
     };
     use n0_error::StdResultExt;
     use n0_tracing_test::traced_test;
@@ -357,7 +357,7 @@ mod tests {
         };
 
         let http_url = server.http_url().expect("http is bound");
-        let tls_config = CaRootsConfig::default()
+        let tls_config = CaTlsConfig::default()
             .client_config(default_provider())
             .expect("infallible");
         let pkarr = PkarrRelayClient::new(

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -47,7 +47,7 @@ mod tests {
         address_lookup::PkarrRelayClient,
         dns::DnsResolver,
         endpoint_info::EndpointInfo,
-        tls::{CaRootsConfig, default_provider},
+        tls::{CaTlsConfig, default_provider},
     };
     use iroh_dns::pkarr::SignedPacket;
     use mainline::{DhtBuilder, MutableItem, Testnet};
@@ -151,7 +151,7 @@ mod tests {
         let signed_packet = SignedPacket::from_bytes(&raw).anyerr()?;
 
         // Publish via relay
-        let tls_config = CaRootsConfig::default()
+        let tls_config = CaTlsConfig::default()
             .client_config(default_provider())
             .expect("infallible");
         let pkarr_client =
@@ -220,7 +220,7 @@ mod tests {
 
         let secret_key = SecretKey::from_bytes(&rng.random());
         let endpoint_id = secret_key.public();
-        let tls_config = CaRootsConfig::default()
+        let tls_config = CaTlsConfig::default()
             .client_config(default_provider())
             .expect("infallible");
         let pkarr = PkarrRelayClient::new(pkarr_relay, tls_config, DnsResolver::default());

--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -74,7 +74,7 @@ iroh = { version = "0.95", features = ["test-utils"] }
 ```
 - Spawn a relay server by calling [`iroh::test_utils::run_relay_server().await`](https://docs.rs/iroh/latest/iroh/test_utils/fn.run_relay_server.html)
 This will start a relay server with a self-signed TLS certificate, listening on a localhost port, and return the server's URL.
-- For the iroh endpoints to successfully connect to the relay, disable TLS certificate verification by calling [`Endpoint::ca_roots_config`](https://docs.rs/iroh/latest/iroh/endpoint/struct.Builder.html#method.ca_roots_config) with  `CaRootConfig::insecure_skip_verify()`.
+- For the iroh endpoints to successfully connect to the relay, disable TLS certificate verification by calling [`Endpoint::ca_tls_config`](https://docs.rs/iroh/latest/iroh/endpoint/struct.Builder.html#method.ca_tls_config) with  `CaRootConfig::insecure_skip_verify()`.
 
 # License
 

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -188,22 +188,22 @@ impl ClientBuilder {
     /// This is a required option.
     ///
     /// You can construct a [`rustls::ClientConfig`] by combining a [`rustls::crypto::CryptoProvider`]
-    /// with a [`tls::CaRootsConfig`] using [`tls::CaRootsConfig::client_config`], for example:
+    /// with a [`tls::CaTlsConfig`] using [`tls::CaTlsConfig::client_config`], for example:
     ///
     /// ```no_run
     /// use std::sync::Arc;
     ///
-    /// use iroh_relay::tls::CaRootsConfig;
+    /// use iroh_relay::tls::CaTlsConfig;
     ///
     /// let crypto_provider: rustls::crypto::CryptoProvider = todo!();
-    /// let client_config = CaRootsConfig::default().client_config(Arc::new(crypto_provider));
+    /// let client_config = CaTlsConfig::default().client_config(Arc::new(crypto_provider));
     /// ```
     ///
     /// If you enable the tls-ring or tls-aws-lc-rs feature, you can use the enabled crypto provider
     /// by using [`tls::default_provider`].
     ///
-    /// [`tls::CaRootsConfig`]: crate::tls::CaRootsConfig
-    /// [`tls::CaRootsConfig::client_config`]: crate::tls::CaRootsConfig::client_config
+    /// [`tls::CaTlsConfig`]: crate::tls::CaTlsConfig
+    /// [`tls::CaTlsConfig::client_config`]: crate::tls::CaTlsConfig::client_config
     /// [`tls::default_provider`]: crate::tls::default_provider
     pub fn tls_client_config(mut self, tls_config: rustls::ClientConfig) -> Self {
         self.tls_config = Some(tls_config);

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -1177,7 +1177,7 @@ mod tests {
             handshake,
             relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg},
         },
-        tls::{CaRootsConfig, default_provider},
+        tls::{CaTlsConfig, default_provider},
     };
 
     /// An [`AccessControl`] backed by a closure, for tests.
@@ -1314,7 +1314,7 @@ mod tests {
         let relay_url = format!("http://{}", server.http_addr().unwrap());
         let relay_url: RelayUrl = relay_url.parse()?;
 
-        let client_config = CaRootsConfig::default()
+        let client_config = CaTlsConfig::default()
             .client_config(default_provider())
             .unwrap();
 
@@ -1379,7 +1379,7 @@ mod tests {
         let current_span = tracing::info_span!("this is a test");
         let _guard = current_span.enter();
 
-        let client_config = CaRootsConfig::default()
+        let client_config = CaTlsConfig::default()
             .client_config(default_provider())
             .unwrap();
 
@@ -1468,7 +1468,7 @@ mod tests {
         const TOKEN: &str = "secret-token";
 
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
-        let client_config = CaRootsConfig::default()
+        let client_config = CaTlsConfig::default()
             .client_config(default_provider())
             .unwrap();
 
@@ -1535,7 +1535,7 @@ mod tests {
         let relay_url = format!("http://{}", server.http_addr().unwrap());
         let relay_url: RelayUrl = relay_url.parse().unwrap();
 
-        let client_config = CaRootsConfig::default()
+        let client_config = CaTlsConfig::default()
             .client_config(default_provider())
             .unwrap();
 

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -1197,7 +1197,7 @@ mod tests {
     use crate::{
         client::{Client, ClientBuilder, ConnectError, conn::Conn},
         protos::relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg},
-        tls::{CaRootsConfig, default_provider},
+        tls::{CaTlsConfig, default_provider},
     };
 
     pub(crate) fn make_tls_config() -> TlsConfig {
@@ -1303,7 +1303,7 @@ mod tests {
     ) -> Result<(PublicKey, Client), ConnectError> {
         let public_key = key.public();
         let client = ClientBuilder::new(server_url, key, DnsResolver::new()).tls_client_config(
-            CaRootsConfig::insecure_skip_verify()
+            CaTlsConfig::insecure_skip_verify()
                 .client_config(default_provider())
                 .expect("infallible"),
         );

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -156,18 +156,21 @@ impl CaTlsConfig {
         self
     }
 
-    /// Builds a [`ClientConfig`] from this config.
-    pub fn client_config(&self, crypto_provider: Arc<CryptoProvider>) -> io::Result<ClientConfig> {
-        let verifier: Arc<dyn ServerCertVerifier> = match self.mode {
+    /// Builds a [`ServerCertVerifier`] from this config.
+    pub fn server_cert_verifier(
+        &self,
+        crypto_provider: Arc<CryptoProvider>,
+    ) -> io::Result<Arc<dyn ServerCertVerifier>> {
+        Ok(match self.mode {
             #[cfg(feature = "platform-verifier")]
             Mode::System => {
                 #[cfg(not(target_os = "android"))]
                 let verifier = rustls_platform_verifier::Verifier::new_with_extra_roots(
                     self.extra_roots.clone(),
-                    crypto_provider.clone(),
+                    crypto_provider,
                 );
                 #[cfg(target_os = "android")]
-                let verifier = rustls_platform_verifier::Verifier::new(crypto_provider.clone());
+                let verifier = rustls_platform_verifier::Verifier::new(crypto_provider);
                 Arc::new(verifier.map_err(io::Error::other)?)
             }
             Mode::EmbeddedWebPki => {
@@ -175,29 +178,28 @@ impl CaTlsConfig {
                     roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
                 };
                 root_store.add_parsable_certificates(self.extra_roots.clone());
-                WebPkiServerVerifier::builder_with_provider(
-                    Arc::new(root_store),
-                    crypto_provider.clone(),
-                )
-                .build()
-                .map_err(io::Error::other)?
+                WebPkiServerVerifier::builder_with_provider(Arc::new(root_store), crypto_provider)
+                    .build()
+                    .map_err(io::Error::other)?
             }
             Mode::ExtraRootsOnly => {
                 let mut root_store = rustls::RootCertStore { roots: vec![] };
                 root_store.add_parsable_certificates(self.extra_roots.clone());
-                WebPkiServerVerifier::builder_with_provider(
-                    Arc::new(root_store),
-                    crypto_provider.clone(),
-                )
-                .build()
-                .map_err(io::Error::other)?
+                WebPkiServerVerifier::builder_with_provider(Arc::new(root_store), crypto_provider)
+                    .build()
+                    .map_err(io::Error::other)?
             }
             #[cfg(any(test, feature = "test-utils"))]
-            Mode::InsecureSkipVerify => Arc::new(no_cert_verifier::NoCertVerifier {
-                crypto_provider: crypto_provider.clone(),
-            }),
+            Mode::InsecureSkipVerify => {
+                Arc::new(no_cert_verifier::NoCertVerifier { crypto_provider })
+            }
             Mode::CustomServerCertVerifier { ref builder } => builder(crypto_provider.clone())?,
-        };
+        })
+    }
+
+    /// Builds a [`ClientConfig`] from this config.
+    pub fn client_config(&self, crypto_provider: Arc<CryptoProvider>) -> io::Result<ClientConfig> {
+        let verifier = self.server_cert_verifier(crypto_provider.clone())?;
         let config = ClientConfig::builder_with_provider(crypto_provider)
             .with_safe_default_protocol_versions()
             .expect("protocols supported by ring")

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -24,7 +24,7 @@ pub struct CaRootsConfig {
     extra_roots: Vec<CertificateDer<'static>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(derive_more::Debug, Clone)]
 enum Mode {
     /// Use a compiled-in copy of the root certificates trusted by Mozilla.
     ///
@@ -42,6 +42,12 @@ enum Mode {
     /// May only be used in tests or local development setups.
     #[cfg(any(test, feature = "test-utils"))]
     InsecureSkipVerify,
+    /// Use a callback to create a [`ClientConfig`] used in all TLS requests.
+    Custom {
+        #[debug("Arc<dyn Fn>")]
+        make_client_config:
+            Arc<dyn 'static + Send + Sync + Fn(Arc<CryptoProvider>) -> io::Result<ClientConfig>>,
+    },
 }
 
 impl Default for CaRootsConfig {
@@ -90,10 +96,49 @@ impl CaRootsConfig {
     }
 
     /// Only trust the explicitly set root certificates.
-    pub fn custom(roots: impl IntoIterator<Item = CertificateDer<'static>>) -> Self {
+    pub fn custom_roots(roots: impl IntoIterator<Item = CertificateDer<'static>>) -> Self {
         Self {
             mode: Mode::ExtraRootsOnly,
             extra_roots: roots.into_iter().collect(),
+        }
+    }
+
+    /// Creates a [`CaRootsConfig`] that uses a callback function to create a [`ClientConfig`].
+    ///
+    /// This is an advanced feature and you should only use this if none of the other constructor
+    /// functions cover your needs. Wrongly implementing the callback may lead to insecure connections
+    /// being accepted.
+    ///
+    /// The [`CryptoProvider`] passed to the callback should be used for all cryptographic operations.
+    ///
+    /// ## Example
+    ///
+    /// This example implements the behavior of [`Self::embedded`] via [`Self::custom`].
+    ///
+    /// ```rust
+    /// # use std::sync::Arc;
+    /// # use iroh_relay::tls::CaRootsConfig;
+    /// let root_store = Arc::new(rustls::RootCertStore {
+    ///     roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    /// });
+    /// let ca_roots_config =
+    ///     CaRootsConfig::custom_client_config_builder(Arc::new(move |crypto_provider| {
+    ///         let client_config = rustls::ClientConfig::builder_with_provider(crypto_provider)
+    ///             .with_safe_default_protocol_versions()
+    ///             .expect("protocols supported by crypto provider")
+    ///             .with_root_certificates(root_store.clone())
+    ///             .with_no_client_auth();
+    ///         Ok(client_config)
+    ///     }));
+    /// ```
+    pub fn custom_client_config_builder(
+        make_client_config: Arc<
+            dyn 'static + Send + Sync + Fn(Arc<CryptoProvider>) -> io::Result<ClientConfig>,
+        >,
+    ) -> Self {
+        Self {
+            mode: Mode::Custom { make_client_config },
+            extra_roots: Vec::new(),
         }
     }
 
@@ -106,21 +151,18 @@ impl CaRootsConfig {
         self
     }
 
-    /// Builds a [`ServerCertVerifier`] from this config.
-    pub fn server_cert_verifier(
-        &self,
-        crypto_provider: Arc<CryptoProvider>,
-    ) -> io::Result<Arc<dyn ServerCertVerifier>> {
-        Ok(match self.mode {
+    /// Build a [`ClientConfig`] from this config.
+    pub fn client_config(&self, crypto_provider: Arc<CryptoProvider>) -> io::Result<ClientConfig> {
+        let verifier: Arc<dyn ServerCertVerifier> = match self.mode {
             #[cfg(feature = "platform-verifier")]
             Mode::System => {
                 #[cfg(not(target_os = "android"))]
                 let verifier = rustls_platform_verifier::Verifier::new_with_extra_roots(
                     self.extra_roots.clone(),
-                    crypto_provider,
+                    crypto_provider.clone(),
                 );
                 #[cfg(target_os = "android")]
-                let verifier = rustls_platform_verifier::Verifier::new(crypto_provider);
+                let verifier = rustls_platform_verifier::Verifier::new(crypto_provider.clone());
                 Arc::new(verifier.map_err(io::Error::other)?)
             }
             Mode::EmbeddedWebPki => {
@@ -128,27 +170,31 @@ impl CaRootsConfig {
                     roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
                 };
                 root_store.add_parsable_certificates(self.extra_roots.clone());
-                WebPkiServerVerifier::builder_with_provider(Arc::new(root_store), crypto_provider)
-                    .build()
-                    .map_err(io::Error::other)?
+                WebPkiServerVerifier::builder_with_provider(
+                    Arc::new(root_store),
+                    crypto_provider.clone(),
+                )
+                .build()
+                .map_err(io::Error::other)?
             }
             Mode::ExtraRootsOnly => {
                 let mut root_store = rustls::RootCertStore { roots: vec![] };
                 root_store.add_parsable_certificates(self.extra_roots.clone());
-                WebPkiServerVerifier::builder_with_provider(Arc::new(root_store), crypto_provider)
-                    .build()
-                    .map_err(io::Error::other)?
+                WebPkiServerVerifier::builder_with_provider(
+                    Arc::new(root_store),
+                    crypto_provider.clone(),
+                )
+                .build()
+                .map_err(io::Error::other)?
             }
             #[cfg(any(test, feature = "test-utils"))]
-            Mode::InsecureSkipVerify => {
-                Arc::new(no_cert_verifier::NoCertVerifier { crypto_provider })
-            }
-        })
-    }
-
-    /// Build a [`ClientConfig`] from this config.
-    pub fn client_config(&self, crypto_provider: Arc<CryptoProvider>) -> io::Result<ClientConfig> {
-        let verifier = self.server_cert_verifier(crypto_provider.clone())?;
+            Mode::InsecureSkipVerify => Arc::new(no_cert_verifier::NoCertVerifier {
+                crypto_provider: crypto_provider.clone(),
+            }),
+            Mode::Custom {
+                ref make_client_config,
+            } => return make_client_config(crypto_provider),
+        };
         let config = ClientConfig::builder_with_provider(crypto_provider)
             .with_safe_default_protocol_versions()
             .expect("protocols supported by ring")

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -118,20 +118,15 @@ impl CaTlsConfig {
     /// # use std::{io, sync::Arc};
     /// # use iroh_relay::tls::CaTlsConfig;
     /// # use rustls::client::WebPkiServerVerifier;
-    /// let root_store = Arc::new(rustls::RootCertStore {
-    ///     roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-    /// });
-    /// let ca_tls_config =
-    ///     CaTlsConfig::custom_server_cert_verifier(Arc::new(move |crypto_provider| {
-    ///         let mut root_store = rustls::RootCertStore {
-    ///             roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-    ///         };
-    ///         let verifier =
-    ///             WebPkiServerVerifier::builder_with_provider(Arc::new(root_store), crypto_provider)
-    ///                 .build()
-    ///                 .map_err(io::Error::other)?;
-    ///         Ok(verifier)
-    ///     }));
+    /// let tls_config = CaTlsConfig::custom_server_cert_verifier(Arc::new(move |crypto_provider| {
+    ///     let root_store = Arc::new(rustls::RootCertStore {
+    ///         roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    ///     });
+    ///     let verifier = WebPkiServerVerifier::builder_with_provider(root_store, crypto_provider)
+    ///         .build()
+    ///         .map_err(io::Error::other)?;
+    ///     Ok(verifier)
+    /// }));
     /// ```
     pub fn custom_server_cert_verifier(builder: ServerCertVerifierBuilder) -> Self {
         Self {

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -60,7 +60,7 @@ impl Default for CaRootsConfig {
 }
 
 impl CaRootsConfig {
-    /// Use the operating system's certificate facilities for verifying the validity of TLS certificates.
+    /// Uses the operating system's certificate facilities for verifying the validity of TLS certificates.
     ///
     /// See [`rustls_platform_verifier`] for details how trust anchors are retrieved on different platforms.
     ///
@@ -74,7 +74,7 @@ impl CaRootsConfig {
         }
     }
 
-    /// Use a compiled-in copy of the root certificates trusted by Mozilla.
+    /// Uses a compiled-in copy of the root certificates trusted by Mozilla.
     ///
     /// See [`webpki_roots`] for details.
     pub fn embedded() -> Self {
@@ -95,7 +95,7 @@ impl CaRootsConfig {
         }
     }
 
-    /// Only trust the explicitly set root certificates.
+    /// Only trusts the explicitly set root certificates.
     pub fn custom_roots(roots: impl IntoIterator<Item = CertificateDer<'static>>) -> Self {
         Self {
             mode: Mode::ExtraRootsOnly,
@@ -113,7 +113,7 @@ impl CaRootsConfig {
     ///
     /// ## Example
     ///
-    /// This example implements the behavior of [`Self::embedded`] via [`Self::custom`].
+    /// This example implements the behavior of [`Self::embedded`] via [`Self::custom_client_config_builder`].
     ///
     /// ```rust
     /// # use std::sync::Arc;
@@ -142,7 +142,9 @@ impl CaRootsConfig {
         }
     }
 
-    /// Add additional root certificates to the list of trusted certificates.
+    /// Adds additional root certificates to the list of trusted certificates.
+    ///
+    /// Ignored when using [`Self::custom_client_config_builder`].
     pub fn with_extra_roots(
         mut self,
         extra_roots: impl IntoIterator<Item = CertificateDer<'static>>,
@@ -151,7 +153,7 @@ impl CaRootsConfig {
         self
     }
 
-    /// Build a [`ClientConfig`] from this config.
+    /// Builds a [`ClientConfig`] from this config.
     pub fn client_config(&self, crypto_provider: Arc<CryptoProvider>) -> io::Result<ClientConfig> {
         let verifier: Arc<dyn ServerCertVerifier> = match self.mode {
             #[cfg(feature = "platform-verifier")]

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -19,7 +19,7 @@ use webpki_types::CertificateDer;
 /// CAs don't need to be trusted for the integrity or authenticity of native
 /// iroh connections, which rely on iroh's own cryptographic authentication mechanisms.
 #[derive(Debug, Clone)]
-pub struct CaRootsConfig {
+pub struct CaTlsConfig {
     mode: Mode,
     extra_roots: Vec<CertificateDer<'static>>,
 }
@@ -54,7 +54,7 @@ enum Mode {
     },
 }
 
-impl Default for CaRootsConfig {
+impl Default for CaTlsConfig {
     fn default() -> Self {
         Self {
             mode: Mode::EmbeddedWebPki,
@@ -63,7 +63,7 @@ impl Default for CaRootsConfig {
     }
 }
 
-impl CaRootsConfig {
+impl CaTlsConfig {
     /// Uses the operating system's certificate facilities for verifying the validity of TLS certificates.
     ///
     /// See [`rustls_platform_verifier`] for details how trust anchors are retrieved on different platforms.
@@ -107,7 +107,7 @@ impl CaRootsConfig {
         }
     }
 
-    /// Creates a [`CaRootsConfig`] that uses a callback function to create a [`ServerCertVerifier`].
+    /// Creates a [`CaTlsConfig`] that uses a callback function to create a [`ServerCertVerifier`].
     ///
     /// This is an advanced feature and you should only use this if none of the other constructor
     /// functions cover your needs. Wrongly implementing the callback may lead to insecure connections
@@ -121,13 +121,13 @@ impl CaRootsConfig {
     ///
     /// ```rust
     /// # use std::{io, sync::Arc};
-    /// # use iroh_relay::tls::CaRootsConfig;
+    /// # use iroh_relay::tls::CaTlsConfig;
     /// # use rustls::client::WebPkiServerVerifier;
     /// let root_store = Arc::new(rustls::RootCertStore {
     ///     roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
     /// });
-    /// let ca_roots_config =
-    ///     CaRootsConfig::custom_server_cert_verifier(Arc::new(move |crypto_provider| {
+    /// let ca_tls_config =
+    ///     CaTlsConfig::custom_server_cert_verifier(Arc::new(move |crypto_provider| {
     ///         let mut root_store = rustls::RootCertStore {
     ///             roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
     ///         };

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -41,16 +41,16 @@ enum Mode {
     System,
     /// Only trust explicitly set root certificates.
     ExtraRootsOnly,
+    /// Use a callback to create a [`ServerCertVerifier`].
+    CustomServerCertVerifier {
+        #[debug("Arc<dyn Fn>")]
+        builder: ServerCertVerifierBuilder,
+    },
     /// INSECURE: Do not verify server certificates at all.
     ///
     /// May only be used in tests or local development setups.
     #[cfg(any(test, feature = "test-utils"))]
     InsecureSkipVerify,
-    /// Use a callback to create a [`ServerCertVerifier`] used in all TLS requests.
-    CustomServerCertVerifier {
-        #[debug("Arc<dyn Fn>")]
-        builder: ServerCertVerifierBuilder,
-    },
 }
 
 impl Default for CaTlsConfig {
@@ -189,11 +189,14 @@ impl CaTlsConfig {
                     .build()
                     .map_err(io::Error::other)?
             }
+            Mode::CustomServerCertVerifier { ref builder } => builder(crypto_provider)?,
             #[cfg(any(test, feature = "test-utils"))]
             Mode::InsecureSkipVerify => {
+                tracing::warn!(
+                    "Insecure TLS config: server certificates will be trusted without verification"
+                );
                 Arc::new(no_cert_verifier::NoCertVerifier { crypto_provider })
             }
-            Mode::CustomServerCertVerifier { ref builder } => builder(crypto_provider.clone())?,
         })
     }
 
@@ -202,7 +205,9 @@ impl CaTlsConfig {
         let verifier = self.server_cert_verifier(crypto_provider.clone())?;
         let config = ClientConfig::builder_with_provider(crypto_provider)
             .with_safe_default_protocol_versions()
-            .expect("protocols supported by ring")
+            .expect(
+                "configured crypto provider is missing support for required TLS protocol versions",
+            )
             .dangerous()
             .with_custom_certificate_verifier(verifier)
             .with_no_client_auth();
@@ -219,7 +224,7 @@ pub type ServerCertVerifierBuilder = Arc<
 
 /// Returns the default crypto provider, if enabled via a feature flag.
 ///
-/// Prefers to ring over aws-lc-rs if both are enabled.
+/// Prefers `ring` over `aws-lc-rs` if both are enabled.
 #[cfg(feature = "tls-ring")]
 pub fn default_provider() -> Arc<CryptoProvider> {
     Arc::new(rustls::crypto::ring::default_provider())
@@ -227,29 +232,20 @@ pub fn default_provider() -> Arc<CryptoProvider> {
 
 /// Returns the default crypto provider, if enabled via a feature flag.
 ///
-/// Prefers to ring over aws-lc-rs if both are enabled.
+/// Prefers `ring` over `aws-lc-rs` if both are enabled.
 #[cfg(all(feature = "tls-aws-lc-rs", not(feature = "tls-ring")))]
 pub fn default_provider() -> Arc<CryptoProvider> {
     Arc::new(rustls::crypto::aws_lc_rs::default_provider())
 }
 
-#[cfg(all(any(test, feature = "test-utils"), with_crypto_provider))]
 /// Creates a client config that trusts any servers without verifying their TLS certificate.
 ///
 /// Should be used for testing local relay setups only.
-pub fn make_dangerous_client_config() -> rustls::ClientConfig {
-    tracing::warn!(
-        "Insecure config: SSL certificates from relay servers will be trusted without verification"
-    );
-    let crypto_provider = crate::tls::default_provider();
-    rustls::client::ClientConfig::builder_with_provider(crypto_provider.clone())
-        .with_protocol_versions(&[&rustls::version::TLS13])
-        .expect("protocols supported by ring")
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(no_cert_verifier::NoCertVerifier {
-            crypto_provider,
-        }))
-        .with_no_client_auth()
+#[cfg(all(any(test, feature = "test-utils"), with_crypto_provider))]
+pub fn make_dangerous_client_config() -> ClientConfig {
+    CaTlsConfig::insecure_skip_verify()
+        .client_config(default_provider())
+        .expect("infallible")
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -279,6 +275,7 @@ mod no_cert_verifier {
         ) -> Result<ServerCertVerified, rustls::Error> {
             Ok(ServerCertVerified::assertion())
         }
+
         fn verify_tls12_signature(
             &self,
             _message: &[u8],

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -45,12 +45,7 @@ enum Mode {
     /// Use a callback to create a [`ServerCertVerifier`] used in all TLS requests.
     CustomServerCertVerifier {
         #[debug("Arc<dyn Fn>")]
-        builder: Arc<
-            dyn 'static
-                + Send
-                + Sync
-                + Fn(Arc<CryptoProvider>) -> io::Result<Arc<dyn ServerCertVerifier>>,
-        >,
+        builder: ServerCertVerifierBuilder,
     },
 }
 
@@ -138,14 +133,7 @@ impl CaTlsConfig {
     ///         Ok(verifier)
     ///     }));
     /// ```
-    pub fn custom_server_cert_verifier(
-        builder: Arc<
-            dyn 'static
-                + Send
-                + Sync
-                + Fn(Arc<CryptoProvider>) -> io::Result<Arc<dyn ServerCertVerifier>>,
-        >,
-    ) -> Self {
+    pub fn custom_server_cert_verifier(builder: ServerCertVerifierBuilder) -> Self {
         Self {
             mode: Mode::CustomServerCertVerifier { builder },
             extra_roots: Vec::new(),
@@ -154,7 +142,7 @@ impl CaTlsConfig {
 
     /// Adds additional root certificates to the list of trusted certificates.
     ///
-    /// Ignored when using [`Self::custom_client_config_builder`].
+    /// Ignored when using [`Self::custom_server_cert_verifier`].
     pub fn with_extra_roots(
         mut self,
         extra_roots: impl IntoIterator<Item = CertificateDer<'static>>,
@@ -214,6 +202,13 @@ impl CaTlsConfig {
         Ok(config)
     }
 }
+
+/// Function to build a [`ServerCertVerifier`] from a [`CryptoProvider`].
+///
+/// See [`CaTlsConfig::custom_server_cert_verifier].
+pub type ServerCertVerifierBuilder = Arc<
+    dyn Fn(Arc<CryptoProvider>) -> io::Result<Arc<dyn ServerCertVerifier>> + Send + Sync + 'static,
+>;
 
 /// Returns the default crypto provider, if enabled via a feature flag.
 ///

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -24,6 +24,10 @@ pub struct CaTlsConfig {
     extra_roots: Vec<CertificateDer<'static>>,
 }
 
+/// Renamed to [`CaTlsConfig`].
+#[deprecated(since = "1.0.0", note = "Renamed to `CaTlsConfig`")]
+pub type CaRootsConfig = CaTlsConfig;
+
 #[derive(derive_more::Debug, Clone)]
 enum Mode {
     /// Use a compiled-in copy of the root certificates trusted by Mozilla.
@@ -100,6 +104,12 @@ impl CaTlsConfig {
             mode: Mode::ExtraRootsOnly,
             extra_roots: roots.into_iter().collect(),
         }
+    }
+
+    /// Renamed to [`Self::custom_roots`].
+    #[deprecated(since = "1.0.0", note = "Renamed to `custom_roots`")]
+    pub fn custom(roots: impl IntoIterator<Item = CertificateDer<'static>>) -> Self {
+        Self::custom_roots(roots)
     }
 
     /// Creates a [`CaTlsConfig`] that uses a callback function to create a [`ServerCertVerifier`].

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -42,11 +42,15 @@ enum Mode {
     /// May only be used in tests or local development setups.
     #[cfg(any(test, feature = "test-utils"))]
     InsecureSkipVerify,
-    /// Use a callback to create a [`ClientConfig`] used in all TLS requests.
-    Custom {
+    /// Use a callback to create a [`ServerCertVerifier`] used in all TLS requests.
+    CustomServerCertVerifier {
         #[debug("Arc<dyn Fn>")]
-        make_client_config:
-            Arc<dyn 'static + Send + Sync + Fn(Arc<CryptoProvider>) -> io::Result<ClientConfig>>,
+        builder: Arc<
+            dyn 'static
+                + Send
+                + Sync
+                + Fn(Arc<CryptoProvider>) -> io::Result<Arc<dyn ServerCertVerifier>>,
+        >,
     },
 }
 
@@ -103,7 +107,7 @@ impl CaRootsConfig {
         }
     }
 
-    /// Creates a [`CaRootsConfig`] that uses a callback function to create a [`ClientConfig`].
+    /// Creates a [`CaRootsConfig`] that uses a callback function to create a [`ServerCertVerifier`].
     ///
     /// This is an advanced feature and you should only use this if none of the other constructor
     /// functions cover your needs. Wrongly implementing the callback may lead to insecure connections
@@ -113,31 +117,37 @@ impl CaRootsConfig {
     ///
     /// ## Example
     ///
-    /// This example implements the behavior of [`Self::embedded`] via [`Self::custom_client_config_builder`].
+    /// This example implements the behavior of [`Self::embedded`] via [`Self::custom_server_cert_verifier`].
     ///
     /// ```rust
-    /// # use std::sync::Arc;
+    /// # use std::{io, sync::Arc};
     /// # use iroh_relay::tls::CaRootsConfig;
+    /// # use rustls::client::WebPkiServerVerifier;
     /// let root_store = Arc::new(rustls::RootCertStore {
     ///     roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
     /// });
     /// let ca_roots_config =
-    ///     CaRootsConfig::custom_client_config_builder(Arc::new(move |crypto_provider| {
-    ///         let client_config = rustls::ClientConfig::builder_with_provider(crypto_provider)
-    ///             .with_safe_default_protocol_versions()
-    ///             .expect("protocols supported by crypto provider")
-    ///             .with_root_certificates(root_store.clone())
-    ///             .with_no_client_auth();
-    ///         Ok(client_config)
+    ///     CaRootsConfig::custom_server_cert_verifier(Arc::new(move |crypto_provider| {
+    ///         let mut root_store = rustls::RootCertStore {
+    ///             roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    ///         };
+    ///         let verifier =
+    ///             WebPkiServerVerifier::builder_with_provider(Arc::new(root_store), crypto_provider)
+    ///                 .build()
+    ///                 .map_err(io::Error::other)?;
+    ///         Ok(verifier)
     ///     }));
     /// ```
-    pub fn custom_client_config_builder(
-        make_client_config: Arc<
-            dyn 'static + Send + Sync + Fn(Arc<CryptoProvider>) -> io::Result<ClientConfig>,
+    pub fn custom_server_cert_verifier(
+        builder: Arc<
+            dyn 'static
+                + Send
+                + Sync
+                + Fn(Arc<CryptoProvider>) -> io::Result<Arc<dyn ServerCertVerifier>>,
         >,
     ) -> Self {
         Self {
-            mode: Mode::Custom { make_client_config },
+            mode: Mode::CustomServerCertVerifier { builder },
             extra_roots: Vec::new(),
         }
     }
@@ -193,9 +203,7 @@ impl CaRootsConfig {
             Mode::InsecureSkipVerify => Arc::new(no_cert_verifier::NoCertVerifier {
                 crypto_provider: crypto_provider.clone(),
             }),
-            Mode::Custom {
-                ref make_client_config,
-            } => return make_client_config(crypto_provider),
+            Mode::CustomServerCertVerifier { ref builder } => builder(crypto_provider.clone())?,
         };
         let config = ClientConfig::builder_with_provider(crypto_provider)
             .with_safe_default_protocol_versions()

--- a/iroh-relay/tests/relay_axum.rs
+++ b/iroh-relay/tests/relay_axum.rs
@@ -39,7 +39,7 @@ use iroh_relay::{
         AllowAll, ClientRequest, DynAccessControl, Metrics, client::Config, clients::Clients,
         streams::RelayedStream,
     },
-    tls::{CaRootsConfig, default_provider},
+    tls::{CaTlsConfig, default_provider},
 };
 use n0_error::{AnyError, Result, StdResultExt};
 use n0_future::{Sink, Stream, task::AbortOnDropHandle};
@@ -217,7 +217,7 @@ async fn relay_embed_axum() -> Result<()> {
     // Connect a relay client to `/relay` on the same axum-fronted port.
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
     let relay_url: RelayUrl = format!("http://{addr}").parse()?;
-    let tls_config = CaRootsConfig::default().client_config(default_provider())?;
+    let tls_config = CaTlsConfig::default().client_config(default_provider())?;
     tokio::time::timeout(
         Duration::from_secs(5),
         ClientBuilder::new(

--- a/iroh-relay/tests/relay_hyper.rs
+++ b/iroh-relay/tests/relay_hyper.rs
@@ -27,7 +27,7 @@ use iroh_relay::{
         http_server::{BytesBody, Handlers, RelayService, RelayServiceWithNotify},
         streams::MaybeTlsStream,
     },
-    tls::{CaRootsConfig, default_provider},
+    tls::{CaTlsConfig, default_provider},
 };
 use n0_error::{Result, StdResultExt};
 use n0_future::task::AbortOnDropHandle;
@@ -106,7 +106,7 @@ async fn relay_embed_hyper() -> Result<()> {
     // Connect a relay client to `/relay`.
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
     let relay_url: RelayUrl = format!("http://{addr}").parse()?;
-    let tls_config = CaRootsConfig::default().client_config(default_provider())?;
+    let tls_config = CaTlsConfig::default().client_config(default_provider())?;
     tokio::time::timeout(
         Duration::from_secs(5),
         ClientBuilder::new(

--- a/iroh-relay/tests/runtime_auth.rs
+++ b/iroh-relay/tests/runtime_auth.rs
@@ -29,7 +29,7 @@ use iroh_relay::{
     server::{
         Access, AccessControl, ClientRequest, ConnectionId, RelayConfig, Server, ServerConfig,
     },
-    tls::{CaRootsConfig, default_provider},
+    tls::{CaTlsConfig, default_provider},
 };
 use n0_error::{Result, StackResultExt, StdResultExt};
 use n0_future::{SinkExt, StreamExt};
@@ -297,7 +297,7 @@ async fn connect_as(
     secret: &SecretKey,
     token: &str,
 ) -> Result<Client, ConnectError> {
-    let tls = CaRootsConfig::default()
+    let tls = CaTlsConfig::default()
         .client_config(default_provider())
         .expect("valid client config");
     ClientBuilder::new(relay_url.clone(), secret.clone(), DnsResolver::new())

--- a/iroh/bench/src/iroh.rs
+++ b/iroh/bench/src/iroh.rs
@@ -38,7 +38,7 @@ pub fn server_endpoint(
         #[cfg(feature = "local-relay")]
         {
             if relay_url.is_some() {
-                builder = builder.ca_roots_config(iroh::tls::CaRootsConfig::insecure_skip_verify());
+                builder = builder.ca_tls_config(iroh::tls::CaTlsConfig::insecure_skip_verify());
             }
             if opt.only_relay {
                 builder = builder.clear_ip_transports();
@@ -103,7 +103,7 @@ pub async fn connect_client(
     #[cfg(feature = "local-relay")]
     {
         if relay_url.is_some() {
-            builder = builder.ca_roots_config(iroh::tls::CaRootsConfig::insecure_skip_verify());
+            builder = builder.ca_tls_config(iroh::tls::CaTlsConfig::insecure_skip_verify());
         }
         if opt.only_relay {
             builder = builder.clear_ip_transports();

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -498,7 +498,7 @@ impl EndpointArgs {
         if Env::Dev == self.env {
             #[cfg(feature = "test-utils")]
             {
-                builder = builder.ca_roots_config(iroh::tls::CaRootsConfig::insecure_skip_verify());
+                builder = builder.ca_tls_config(iroh::tls::CaTlsConfig::insecure_skip_verify());
             }
             #[cfg(not(feature = "test-utils"))]
             {

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -1243,7 +1243,7 @@ mod tests {
 mod test_dns_pkarr {
     use iroh_base::{EndpointAddr, SecretKey, TransportAddr};
     use iroh_dns::endpoint_info::UserData;
-    use iroh_relay::tls::{CaRootsConfig, default_provider};
+    use iroh_relay::tls::{CaTlsConfig, default_provider};
     use n0_error::{Result, StackResultExt};
     use n0_future::time::Duration;
     use n0_tracing_test::traced_test;
@@ -1303,7 +1303,7 @@ mod test_dns_pkarr {
             "https://relay.example".parse().unwrap(),
         ));
 
-        let tls_config = CaRootsConfig::insecure_skip_verify()
+        let tls_config = CaTlsConfig::insecure_skip_verify()
             .client_config(default_provider())
             .expect("infallible");
         let resolver = dns_pkarr_server.dns_resolver();
@@ -1374,7 +1374,7 @@ mod test_dns_pkarr {
         let secret_key = SecretKey::from_bytes(&rng.random());
         let ep = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .secret_key(secret_key.clone())
             .alpns(vec![TEST_ALPN.to_vec()])
             .preset(dns_pkarr_server.preset())

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeSet, net::SocketAddr, pin::Pin, sync::Arc};
 #[cfg(not(wasm_browser))]
 use ipnet::{Ipv4Net, Ipv6Net};
 use iroh_base::{EndpointAddr, EndpointId, RelayUrl, SecretKey, TransportAddr};
-use iroh_relay::{RelayConfig, RelayMap, tls::CaRootsConfig};
+use iroh_relay::{RelayConfig, RelayMap, tls::CaTlsConfig};
 #[cfg(not(wasm_browser))]
 use n0_error::bail;
 use n0_error::{AnyError, e, ensure, stack_error};
@@ -127,7 +127,7 @@ pub struct Builder {
     /// [`Builder::address_lookup`].
     addr_filter: Option<AddrFilter>,
     proxy_url: Option<Url>,
-    ca_roots_config: Option<CaRootsConfig>,
+    ca_tls_config: Option<CaTlsConfig>,
     #[cfg(not(wasm_browser))]
     dns_resolver: Option<DnsResolver>,
     transports: Vec<TransportConfig>,
@@ -194,7 +194,7 @@ impl Builder {
             address_lookup_user_data: Default::default(),
             addr_filter: None,
             proxy_url: None,
-            ca_roots_config: None,
+            ca_tls_config: None,
             #[cfg(not(wasm_browser))]
             dns_resolver: None,
             max_tls_tickets: DEFAULT_MAX_TLS_TICKETS,
@@ -245,7 +245,7 @@ impl Builder {
         let metrics = EndpointMetrics::default();
 
         let tls_config = self
-            .ca_roots_config
+            .ca_tls_config
             .unwrap_or_default()
             .client_config(crypto_provider)
             .map_err(|err| e!(BindError::InvalidCaRootConfig, err))?;
@@ -696,8 +696,8 @@ impl Builder {
     /// iroh relays, pkarr servers, or DNS-over-HTTPS resolvers.
     /// They don't need to be trusted for the integrity or authenticity of native
     /// iroh connections, which rely on iroh's own cryptographic authentication mechanisms.
-    pub fn ca_roots_config(mut self, ca_roots_config: CaRootsConfig) -> Self {
-        self.ca_roots_config = Some(ca_roots_config);
+    pub fn ca_tls_config(mut self, ca_tls_config: CaTlsConfig) -> Self {
+        self.ca_tls_config = Some(ca_tls_config);
         self
     }
 
@@ -1417,7 +1417,7 @@ impl Endpoint {
     /// Note that this TLS config is unrelated to how iroh validates the authenticity
     /// of iroh connections itself.
     ///
-    /// The config is based on the trust anchors set via [`Builder::ca_roots_config`].
+    /// The config is based on the trust anchors set via [`Builder::ca_tls_config`].
     pub fn tls_config(&self) -> &rustls::ClientConfig {
         &self.inner.tls_config
     }
@@ -1946,7 +1946,7 @@ mod tests {
 
     use iroh_base::{EndpointAddr, EndpointId, RelayUrl, SecretKey, TransportAddr};
     use iroh_dns::endpoint_info::UserData;
-    use iroh_relay::{RelayConfig, server::Access, tls::CaRootsConfig};
+    use iroh_relay::{RelayConfig, server::Access, tls::CaTlsConfig};
     use n0_error::{AnyError as Error, Result, StdResultExt};
     use n0_future::{BufferedStreamExt, StreamExt, future::now_or_never, stream, time};
     use n0_tracing_test::traced_test;
@@ -2006,7 +2006,7 @@ mod tests {
             .secret_key(server_secret_key)
             .transport_config(qlog.create("server")?)
             .alpns(vec![TEST_ALPN.to_vec()])
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await?;
         // Wait for the endpoint to be reachable via relay
@@ -2047,7 +2047,7 @@ mod tests {
                 let ep = Endpoint::builder(presets::Minimal)
                     .relay_mode(RelayMode::Custom(relay_map))
                     .alpns(vec![TEST_ALPN.to_vec()])
-                    .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+                    .ca_tls_config(CaTlsConfig::insecure_skip_verify())
                     .transport_config(qlog.create("client")?)
                     .bind()
                     .await?;
@@ -2108,7 +2108,7 @@ mod tests {
         // Make sure the server is bound before having clients connect to it:
         let ep = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .secret_key(server_secret_key)
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
@@ -2174,7 +2174,7 @@ mod tests {
                 let ep = Endpoint::builder(presets::Minimal)
                     .relay_mode(RelayMode::Custom(relay_map.clone()))
                     .alpns(vec![TEST_ALPN.to_vec()])
-                    .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+                    .ca_tls_config(CaTlsConfig::insecure_skip_verify())
                     .secret_key(client_secret_key)
                     .bind()
                     .await?;
@@ -2227,12 +2227,12 @@ mod tests {
         let (relay_map, _relay_url, _guard) = run_relay_server().await?;
         let client = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await?;
         let server = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
             .await?;
@@ -2353,7 +2353,7 @@ mod tests {
             let ep = Endpoint::builder(presets::N0)
                 .secret_key(secret)
                 .alpns(vec![TEST_ALPN.to_vec()])
-                .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+                .ca_tls_config(CaTlsConfig::insecure_skip_verify())
                 .relay_mode(RelayMode::Custom(relay_map))
                 .transport_config(qlog.create("client")?)
                 .bind()
@@ -2400,7 +2400,7 @@ mod tests {
             let ep = Endpoint::builder(presets::N0)
                 .secret_key(secret)
                 .alpns(vec![TEST_ALPN.to_vec()])
-                .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+                .ca_tls_config(CaTlsConfig::insecure_skip_verify())
                 .transport_config(qlog.create("server")?)
                 .relay_mode(RelayMode::Custom(relay_map))
                 .bind()
@@ -2458,7 +2458,7 @@ mod tests {
             let ep = Endpoint::builder(presets::N0)
                 .secret_key(secret)
                 .alpns(vec![TEST_ALPN.to_vec()])
-                .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+                .ca_tls_config(CaTlsConfig::insecure_skip_verify())
                 .relay_mode(RelayMode::Custom(relay_map))
                 .clear_ip_transports() // disable direct
                 .bind()
@@ -2502,7 +2502,7 @@ mod tests {
             let ep = Endpoint::builder(presets::N0)
                 .secret_key(secret)
                 .alpns(vec![TEST_ALPN.to_vec()])
-                .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+                .ca_tls_config(CaTlsConfig::insecure_skip_verify())
                 .relay_mode(RelayMode::Custom(relay_map))
                 .clear_ip_transports()
                 .bind()
@@ -2558,7 +2558,7 @@ mod tests {
             let ep = Endpoint::builder(presets::N0)
                 .secret_key(secret)
                 .alpns(vec![TEST_ALPN.to_vec()])
-                .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+                .ca_tls_config(CaTlsConfig::insecure_skip_verify())
                 .relay_mode(RelayMode::Custom(relay_map))
                 .bind()
                 .await?;
@@ -2608,7 +2608,7 @@ mod tests {
             let ep = Endpoint::builder(presets::N0)
                 .secret_key(secret)
                 .alpns(vec![TEST_ALPN.to_vec()])
-                .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+                .ca_tls_config(CaTlsConfig::insecure_skip_verify())
                 .relay_mode(RelayMode::Custom(relay_map))
                 .bind()
                 .await?;
@@ -2663,12 +2663,12 @@ mod tests {
         let (relay_map, relay_url, _guard1) = run_relay_server().await?;
         let client = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await?;
         let server = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
             .await?;
@@ -2874,7 +2874,7 @@ mod tests {
         let ep = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map))
             .alpns(vec![TEST_ALPN.to_vec()])
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await?;
 
@@ -3505,13 +3505,13 @@ mod tests {
 
         let client = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .transport_config(qlog.create("client")?)
             .bind()
             .await?;
         let server = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .transport_config(qlog.create("server")?)
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
@@ -3589,7 +3589,7 @@ mod tests {
 
         let client = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .instrument(error_span!("ep-client"))
             .await?;
@@ -3600,7 +3600,7 @@ mod tests {
         let ep1 = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .secret_key(secret_key.clone())
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
             .instrument(error_span!("ep1"))
@@ -3630,7 +3630,7 @@ mod tests {
         let ep2 = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map))
             .secret_key(secret_key.clone())
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .alpns(vec![TEST_ALPN.to_vec()])
             .bind()
             .instrument(error_span!("ep2"))
@@ -3867,7 +3867,7 @@ mod tests {
     async fn test_endpoint_online_add_relay() -> Result {
         let ep = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(RelayMap::empty()))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await?;
         // should not come online without relays.
@@ -3943,7 +3943,7 @@ mod tests {
             .into();
         let bad_ep = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(bad_map))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await?;
         let mut stream = bad_ep.home_relay_status().stream();
@@ -3968,7 +3968,7 @@ mod tests {
             .into();
         let good_ep = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(good_map))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await?;
         tokio::time::timeout(Duration::from_secs(5), good_ep.online())

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -701,6 +701,12 @@ impl Builder {
         self
     }
 
+    /// Renamed to [`Builder::ca_tls_config`].
+    #[deprecated(since = "1.0.0", note = "Renamed to `ca_tls_config`")]
+    pub fn ca_roots_config(self, ca_roots_config: CaTlsConfig) -> Self {
+        self.ca_tls_config(ca_roots_config)
+    }
+
     /// Enables saving the TLS pre-master key for connections.
     ///
     /// This key should normally remain secret but can be useful to debug networking issues

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -1274,7 +1274,7 @@ mod tests {
     use std::time::Duration;
 
     use iroh_base::{EndpointAddr, SecretKey};
-    use iroh_relay::tls::CaRootsConfig;
+    use iroh_relay::tls::CaTlsConfig;
     use n0_error::{Result, StackResultExt, StdResultExt};
     use n0_future::{Stream, StreamExt};
     use n0_tracing_test::traced_test;
@@ -1507,7 +1507,7 @@ mod tests {
         let server = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .secret_key(SecretKey::from_bytes(&rng.random()))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .alpns(vec![ALPN.to_vec()])
             .bind()
             .await?;
@@ -1515,7 +1515,7 @@ mod tests {
         let client = Endpoint::builder(presets::Minimal)
             .relay_mode(RelayMode::Custom(relay_map.clone()))
             .secret_key(SecretKey::from_bytes(&rng.random()))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await?;
 

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -950,7 +950,7 @@ mod tests {
 
     use iroh_base::RelayUrl;
     use iroh_dns::dns::DnsResolver;
-    use iroh_relay::tls::{CaRootsConfig, default_provider};
+    use iroh_relay::tls::{CaTlsConfig, default_provider};
     use n0_error::{Result, StdResultExt};
     use n0_tracing_test::traced_test;
     use tokio_util::sync::CancellationToken;
@@ -973,7 +973,7 @@ mod tests {
         let relay_map = RelayMap::from(relay);
 
         let resolver = DnsResolver::new();
-        let tls_config = CaRootsConfig::insecure_skip_verify()
+        let tls_config = CaTlsConfig::insecure_skip_verify()
             .client_config(default_provider())
             .expect("infallible");
         let opts = Options::new(tls_config).quic_config(Some(quic_addr_disc.clone()));
@@ -1177,7 +1177,7 @@ mod tests {
             },
         ];
         let resolver = DnsResolver::new();
-        let tls_config = CaRootsConfig::insecure_skip_verify()
+        let tls_config = CaTlsConfig::insecure_skip_verify()
             .client_config(default_provider())
             .expect("infallible");
         for mut tt in tests {

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -882,7 +882,7 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use iroh_dns::dns::DnsResolver;
-    use iroh_relay::tls::{CaRootsConfig, default_provider};
+    use iroh_relay::tls::{CaTlsConfig, default_provider};
     use n0_error::{Result, StdResultExt};
     use n0_tracing_test::traced_test;
 
@@ -896,7 +896,7 @@ mod tests {
         let report = run_https_probe(
             &dns_resolver,
             relay.url,
-            CaRootsConfig::insecure_skip_verify()
+            CaTlsConfig::insecure_skip_verify()
                 .client_config(default_provider())
                 .expect("infallible"),
         )

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -854,7 +854,7 @@ mod tests {
 
             let e1 = Endpoint::builder(presets::Minimal)
                 .relay_mode(relay_mode.clone())
-                .ca_roots_config(crate::tls::CaRootsConfig::insecure_skip_verify())
+                .ca_tls_config(crate::tls::CaTlsConfig::insecure_skip_verify())
                 .bind()
                 .await?;
             let r1 = Router::builder(e1.clone())
@@ -864,7 +864,7 @@ mod tests {
             let addr = EndpointAddr::new(e1.id()).with_relay_url(relay_url);
             let e2 = Endpoint::builder(presets::Minimal)
                 .relay_mode(relay_mode)
-                .ca_roots_config(crate::tls::CaRootsConfig::insecure_skip_verify())
+                .ca_tls_config(crate::tls::CaTlsConfig::insecure_skip_verify())
                 .bind()
                 .await?;
             Ok((r1, e2, addr, guard))

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -2113,7 +2113,7 @@ mod tests {
 
     use data_encoding::HEXLOWER;
     use iroh_base::{EndpointAddr, EndpointId, TransportAddr};
-    use iroh_relay::tls::{CaRootsConfig, default_provider};
+    use iroh_relay::tls::{CaTlsConfig, default_provider};
     use n0_error::{Result, StackResultExt, StdResultExt};
     use n0_future::{MergeBounded, StreamExt, time};
     use n0_tracing_test::traced_test;
@@ -2163,7 +2163,7 @@ mod tests {
             proxy_url: None,
             dns_resolver: DnsResolver::new(),
             server_config,
-            tls_config: CaRootsConfig::default()
+            tls_config: CaTlsConfig::default()
                 .client_config(crypto_provider.clone())
                 .unwrap(),
             #[cfg(any(test, feature = "test-utils"))]
@@ -2579,7 +2579,7 @@ mod tests {
             dns_resolver,
             proxy_url: None,
             server_config,
-            tls_config: CaRootsConfig::default()
+            tls_config: CaTlsConfig::default()
                 .client_config(crypto_provider.clone())
                 .unwrap(),
             metrics: Default::default(),

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -1397,7 +1397,7 @@ mod tests {
     use iroh_relay::{
         PingTracker,
         protos::relay::Datagrams,
-        tls::{CaRootsConfig, default_provider},
+        tls::{CaTlsConfig, default_provider},
     };
     use n0_error::{AnyError as Error, Result, StackResultExt, StdResultExt};
     use n0_tracing_test::traced_test;
@@ -1435,7 +1435,7 @@ mod tests {
                 dns_resolver: DnsResolver::new(),
                 proxy_url: None,
                 prefer_ipv6: Arc::new(AtomicBool::new(true)),
-                tls_config: CaRootsConfig::insecure_skip_verify()
+                tls_config: CaTlsConfig::insecure_skip_verify()
                     .client_config(default_provider())
                     .expect("infallible"),
                 auth_token: None,

--- a/iroh/src/test_utils/test_transport.rs
+++ b/iroh/src/test_utils/test_transport.rs
@@ -388,7 +388,7 @@ mod tests {
         let mut builder = Endpoint::builder(presets::N0)
             .secret_key(secret_key)
             .relay_mode(relay_mode)
-            .ca_roots_config(crate::tls::CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(crate::tls::CaTlsConfig::insecure_skip_verify())
             .add_custom_transport(transport);
         if let Some(bias) = config.custom_bias {
             builder = builder.path_selector(Arc::new(

--- a/iroh/src/tls.rs
+++ b/iroh/src/tls.rs
@@ -18,7 +18,7 @@ pub(crate) mod name;
 mod resolver;
 mod verifier;
 
-pub use iroh_relay::tls::CaRootsConfig;
+pub use iroh_relay::tls::CaTlsConfig;
 #[cfg(with_crypto_provider)]
 pub use iroh_relay::tls::default_provider;
 

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -3,7 +3,7 @@ use std::{future::Future, path::PathBuf, sync::Arc, time::Duration};
 use iroh::{
     Endpoint, EndpointAddr, RelayMap, RelayMode, TransportAddr,
     endpoint::{Connection, Path, PathEvent, presets},
-    tls::CaRootsConfig,
+    tls::CaTlsConfig,
 };
 use iroh_metrics::MetricsGroupSet;
 use n0_error::{Result, StackResultExt, StdResultExt, anyerr, ensure_any};
@@ -450,7 +450,7 @@ fn endpoint_builder(device: &Device, relay_map: RelayMap) -> iroh::endpoint::Bui
     #[allow(unused_mut)]
     let mut builder = Endpoint::builder(presets::Minimal)
         .relay_mode(RelayMode::Custom(relay_map))
-        .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+        .ca_tls_config(CaTlsConfig::insecure_skip_verify())
         .alpns(vec![TEST_ALPN.to_vec()]);
 
     #[cfg(not(feature = "qlog"))]


### PR DESCRIPTION
## Description

This adds a new mode to fully customize the `rustls::ServerCertVerifier` used for non-iroh TLS requests throughout iroh, and renames `CaRootsConifg` to `CaTlsConfig` (with a deprecated alias to keep backwards compat). A new mode  `CaTlsConfig::custom_server_cert_verifier` allows to supply a callback that gets passed a `CryptoProvider` and returns a `Arc<dyn ServerCertVerifier>`.

It is indended for advanced usecases like those described in #2901.

Fixes #2901
cc @link2xt 

## Breaking Changes

~~None.~~  **Edit:**: There is a single breaking change unfortunately due to an oversight: `iroh::tls::CaRootsConfig`  is removed. Use `CaTlsConfig` instead.

(we wanted to provide a type alias, but missed the re-export. #4346 will fix it and land in iroh 1.0.1)

The following items have been deprecated:

- `iroh_relay::tls::CaRootsConfig` (also re-exported as `iroh::tls::CaRootsConfig`), use `iroh_relay::tls::CaTlsConfig` instead (also re-exported as `iroh::tls::CaTlsConfig`).
- `iroh_relay::tls::CaRootsConfig::custom`, use `CaTlsConfig::custom_roots` instead
- `iroh::endpoint::Builder::ca_roots_config`, use`iroh::endpoint::Builder::ca_tls_config` instead

## Notes & open questions


<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
