### PR TITLE
refactor(iroh-base)!: rename PublicKey to EndpointId, remove EndpointId alias

### DIFF
--- a/iroh-base/src/endpoint_addr.rs
+++ b/iroh-base/src/endpoint_addr.rs
@@ -12,7 +12,7 @@ use data_encoding::HEXLOWER;
 use n0_error::stack_error;
 use serde::{Deserialize, Serialize};
 
-use crate::{EndpointId, PublicKey, RelayUrl};
+use crate::{EndpointId, RelayUrl};
 
 /// Network-level addressing information for an iroh endpoint.
 ///
@@ -93,7 +93,7 @@ impl EndpointAddr {
     ///
     /// This still is usable with e.g. an address lookup service to establish a connection,
     /// depending on the situation.
-    pub fn new(id: PublicKey) -> Self {
+    pub fn new(id: EndpointId) -> Self {
         EndpointAddr {
             id,
             addrs: Default::default(),
@@ -101,7 +101,7 @@ impl EndpointAddr {
     }
 
     /// Creates a new [`EndpointAddr`] from its parts.
-    pub fn from_parts(id: PublicKey, addrs: impl IntoIterator<Item = TransportAddr>) -> Self {
+    pub fn from_parts(id: EndpointId, addrs: impl IntoIterator<Item = TransportAddr>) -> Self {
         Self {
             id,
             addrs: addrs.into_iter().collect(),

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -21,21 +21,22 @@ const Z_BASE_32: Encoding = new_encoding! {
     symbols: "ybndrfg8ejkmcpqxot1uwisza345h769",
 };
 
-/// A public key.
+/// The identifier and public key for an endpoint in the (iroh) network.
 ///
-/// The key itself is stored as the `CompressedEdwards` y coordinate of the public key
-/// It is verified to decompress into a valid key when created.
+/// Each endpoint in iroh has a unique identifier created as a cryptographic key.  This can be
+/// used to globally identify an endpoint.  Since it is also a cryptographic key it is also the
+/// mechanism by which all traffic is always encrypted for a specific endpoint only.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct PublicKey(CompressedEdwardsY);
+pub struct EndpointId(CompressedEdwardsY);
 
-impl Borrow<[u8; 32]> for PublicKey {
+impl Borrow<[u8; 32]> for EndpointId {
     fn borrow(&self) -> &[u8; 32] {
         self.as_bytes()
     }
 }
 
-impl Deref for PublicKey {
+impl Deref for EndpointId {
     type Target = [u8; 32];
 
     fn deref(&self) -> &Self::Target {
@@ -43,39 +44,25 @@ impl Deref for PublicKey {
     }
 }
 
-impl PartialOrd for PublicKey {
+impl PartialOrd for EndpointId {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for PublicKey {
+impl Ord for EndpointId {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0.as_bytes().cmp(other.0.as_bytes())
     }
 }
 
-/// The identifier for an endpoint in the (iroh) network.
-///
-/// Each endpoint in iroh has a unique identifier created as a cryptographic key.  This can be
-/// used to globally identify an endpoint.  Since it is also a cryptographic key it is also the
-/// mechanism by which all traffic is always encrypted for a specific endpoint only.
-///
-/// This is equivalent to [`PublicKey`].  By convention we will (or should) use `PublicKey`
-/// as type name when performing cryptographic operations, but use `EndpointId` when referencing
-/// an endpoint.  E.g.:
-///
-/// - `encrypt(key: PublicKey)`
-/// - `send_to(endpoint: EndpointId)`
-pub type EndpointId = PublicKey;
-
-impl Hash for PublicKey {
+impl Hash for EndpointId {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }
 
-impl Serialize for PublicKey {
+impl Serialize for EndpointId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -88,7 +75,7 @@ impl Serialize for PublicKey {
     }
 }
 
-impl<'de> Deserialize<'de> for PublicKey {
+impl<'de> Deserialize<'de> for EndpointId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -103,16 +90,16 @@ impl<'de> Deserialize<'de> for PublicKey {
     }
 }
 
-impl PublicKey {
-    /// The length of an ed25519 `PublicKey`, in bytes.
+impl EndpointId {
+    /// The length of an `EndpointId`, in bytes.
     pub const LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
 
-    /// Get this public key as a byte array.
+    /// Get this `EndpointId` as a byte array.
     pub fn as_bytes(&self) -> &[u8; 32] {
         self.0.as_bytes()
     }
 
-    /// Construct a `PublicKey` from a slice of bytes.
+    /// Construct a `EndpointId` from a slice of bytes.
     ///
     /// # Warning
     ///
@@ -137,8 +124,9 @@ impl PublicKey {
             .map_err(|_| SignatureError::new())
     }
 
-    /// Convert to a hex string limited to the first 5 bytes for a friendly string
-    /// representation of the key.
+    /// Converts to a hex string limited to the first 5 bytes.
+    ///
+    /// This may be used as a short string representation of the key, e.g. in logs.
     pub fn fmt_short(&self) -> impl Display + Copy + 'static {
         PublicKeyShort(
             self.0.as_bytes()[0..5]
@@ -183,7 +171,7 @@ impl Display for PublicKeyShort {
     }
 }
 
-impl TryFrom<&[u8]> for PublicKey {
+impl TryFrom<&[u8]> for EndpointId {
     type Error = KeyParsingError;
 
     #[inline]
@@ -193,7 +181,7 @@ impl TryFrom<&[u8]> for PublicKey {
     }
 }
 
-impl TryFrom<&[u8; 32]> for PublicKey {
+impl TryFrom<&[u8; 32]> for EndpointId {
     type Error = KeyParsingError;
 
     #[inline]
@@ -202,13 +190,13 @@ impl TryFrom<&[u8; 32]> for PublicKey {
     }
 }
 
-impl AsRef<[u8]> for PublicKey {
+impl AsRef<[u8]> for EndpointId {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl Debug for PublicKey {
+impl Debug for EndpointId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -218,13 +206,13 @@ impl Debug for PublicKey {
     }
 }
 
-impl Display for PublicKey {
+impl Display for EndpointId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", data_encoding::HEXLOWER.encode(self.as_bytes()))
     }
 }
 
-/// Error when deserialising a [`PublicKey`] or a [`SecretKey`].
+/// Error when deserialising a [`EndpointId`] or a [`SecretKey`].
 #[stack_error(derive, add_meta, from_sources, std_sources)]
 #[allow(missing_docs)]
 #[non_exhaustive]
@@ -243,10 +231,10 @@ pub enum KeyParsingError {
     InvalidKeyData,
 }
 
-/// Deserialises the [`PublicKey`] from it's base32 encoding.
+/// Deserialises the [`EndpointId`] from its hex or base32 encoding.
 ///
 /// [`Display`] is capable of serialising this format.
-impl FromStr for PublicKey {
+impl FromStr for EndpointId {
     type Err = KeyParsingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -296,9 +284,9 @@ impl<'de> Deserialize<'de> for SecretKey {
 
 impl SecretKey {
     /// The public key of this [`SecretKey`].
-    pub fn public(&self) -> PublicKey {
+    pub fn public(&self) -> EndpointId {
         let key = self.0.verifying_key().to_bytes();
-        PublicKey(CompressedEdwardsY(key))
+        EndpointId(CompressedEdwardsY(key))
     }
 
     /// Generate a new [`SecretKey`] with a randomness generator.
@@ -475,7 +463,7 @@ pub struct SignatureError {}
 fn decode_base32_hex(s: &str) -> Result<[u8; 32], KeyParsingError> {
     let mut bytes = [0u8; 32];
 
-    let len = if s.len() == PublicKey::LENGTH * 2 {
+    let len = if s.len() == EndpointId::LENGTH * 2 {
         // hex
         data_encoding::HEXLOWER
             .decode_mut(s.as_bytes(), &mut bytes)
@@ -491,7 +479,7 @@ fn decode_base32_hex(s: &str) -> Result<[u8; 32], KeyParsingError> {
             .decode_mut(input, &mut bytes)
             .map_err(|_| e!(KeyParsingError::FailedToDecodeBase32))?
     };
-    ensure!(len == PublicKey::LENGTH, KeyParsingError::InvalidLength);
+    ensure!(len == EndpointId::LENGTH, KeyParsingError::InvalidLength);
     Ok(bytes)
 }
 
@@ -504,9 +492,10 @@ mod tests {
 
     #[test]
     fn test_public_key_postcard() {
-        let public_key =
-            PublicKey::from_str("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
-                .unwrap();
+        let public_key = EndpointId::from_str(
+            "ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6",
+        )
+        .unwrap();
         let bytes = postcard::to_stdvec(&public_key).unwrap();
         let expected = HEXLOWER
             .decode(b"ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
@@ -516,17 +505,17 @@ mod tests {
 
     #[test]
     fn public_key_postcard() {
-        let key = PublicKey::from_bytes(&[0; 32]).unwrap();
+        let key = EndpointId::from_bytes(&[0; 32]).unwrap();
         let bytes = postcard::to_stdvec(&key).unwrap();
-        let key2: PublicKey = postcard::from_bytes(&bytes).unwrap();
+        let key2: EndpointId = postcard::from_bytes(&bytes).unwrap();
         assert_eq!(key, key2);
     }
 
     #[test]
     fn public_key_json() {
-        let key = PublicKey::from_bytes(&[0; 32]).unwrap();
+        let key = EndpointId::from_bytes(&[0; 32]).unwrap();
         let bytes = serde_json::to_string(&key).unwrap();
-        let key2: PublicKey = serde_json::from_str(&bytes).unwrap();
+        let key2: EndpointId = serde_json::from_str(&bytes).unwrap();
         assert_eq!(key, key2);
     }
 
@@ -542,7 +531,7 @@ mod tests {
         );
 
         assert_eq!(
-            PublicKey::from_str(&key.public().to_string()).unwrap(),
+            EndpointId::from_str(&key.public().to_string()).unwrap(),
             key.public()
         );
     }
@@ -550,7 +539,7 @@ mod tests {
     #[test]
     fn test_regression_parse_endpoint_id_panic() {
         let not_a_endpoint_id = "foobarbaz";
-        assert!(PublicKey::from_str(not_a_endpoint_id).is_err());
+        assert!(EndpointId::from_str(not_a_endpoint_id).is_err());
     }
 
     #[test]

--- a/iroh-base/src/lib.rs
+++ b/iroh-base/src/lib.rs
@@ -14,8 +14,7 @@ mod relay_url;
 pub use self::endpoint_addr::{CustomAddr, EndpointAddr, TransportAddr};
 #[cfg(feature = "key")]
 pub use self::key::{
-    EndpointId, KeyParsingError, PublicKey, SecretKey, Signature, SignatureError,
-    SignatureParsingError,
+    EndpointId, KeyParsingError, SecretKey, Signature, SignatureError, SignatureParsingError,
 };
 #[cfg(feature = "relay")]
 pub use self::relay_url::{RelayUrl, RelayUrlParseError};

--- a/iroh-dns-server/src/http/pkarr.rs
+++ b/iroh-dns-server/src/http/pkarr.rs
@@ -4,7 +4,7 @@ use axum::{
 };
 use bytes::Bytes;
 use http::{StatusCode, header};
-use iroh_base::PublicKey;
+use iroh_base::EndpointId;
 use iroh_dns::pkarr::SignedPacket;
 use tracing::info;
 
@@ -16,7 +16,7 @@ pub(super) async fn put(
     Path(key): Path<String>,
     body: Bytes,
 ) -> Result<impl IntoResponse, AppError> {
-    let public_key = PublicKey::from_z32(&key)
+    let public_key = EndpointId::from_z32(&key)
         .map_err(|e| AppError::new(StatusCode::BAD_REQUEST, Some(format!("invalid key: {e}"))))?;
     let label = key.get(..10).unwrap_or(&key);
     let signed_packet = SignedPacket::from_relay_payload(&public_key, &body).map_err(|e| {

--- a/iroh-dns-server/src/util.rs
+++ b/iroh-dns-server/src/util.rs
@@ -14,7 +14,7 @@ use hickory_server::proto::{
     },
     serialize::binary::BinDecodable,
 };
-use iroh_base::PublicKey;
+use iroh_base::EndpointId;
 use iroh_dns::pkarr::SignedPacket;
 use n0_error::{e, stack_error};
 
@@ -47,12 +47,12 @@ impl PublicKeyBytes {
     }
 
     pub(crate) fn from_z32(s: &str) -> Result<Self, InvalidPublicKeyBytes> {
-        let pk = PublicKey::from_z32(s).map_err(|_| e!(InvalidPublicKeyBytes::InvalidEncoding))?;
+        let pk = EndpointId::from_z32(s).map_err(|_| e!(InvalidPublicKeyBytes::InvalidEncoding))?;
         Ok(Self(*pk.as_bytes()))
     }
 
     pub(crate) fn to_z32(self) -> String {
-        PublicKey::from_bytes(&self.0).expect("valid key").to_z32()
+        EndpointId::from_bytes(&self.0).expect("valid key").to_z32()
     }
 
     pub(crate) fn as_bytes(&self) -> &[u8; 32] {

--- a/iroh-dns/src/pkarr.rs
+++ b/iroh-dns/src/pkarr.rs
@@ -9,7 +9,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use iroh_base::{PublicKey, SecretKey, Signature};
+use iroh_base::{EndpointId, SecretKey, Signature};
 use n0_error::{AnyError, anyerr, e, stack_error};
 use simple_dns::{CLASS, Name, Packet, ResourceRecord, rdata::RData};
 
@@ -95,7 +95,7 @@ impl SignedPacket {
             return Err(e!(SignedPacketVerifyError::TooLarge { len: bytes.len() }));
         }
 
-        let public_key = PublicKey::try_from(&bytes[..32])
+        let public_key = EndpointId::try_from(&bytes[..32])
             .map_err(|e| e!(SignedPacketVerifyError::InvalidKey, e))?;
         let signature =
             Signature::from_bytes(bytes[32..96].try_into().expect("64 bytes for signature"));
@@ -117,7 +117,7 @@ impl SignedPacket {
 
     /// Create from a public key and relay payload (signature + timestamp + dns).
     pub fn from_relay_payload(
-        public_key: &PublicKey,
+        public_key: &EndpointId,
         payload: &[u8],
     ) -> Result<SignedPacket, SignedPacketVerifyError> {
         let mut bytes = Vec::with_capacity(32 + payload.len());
@@ -154,8 +154,8 @@ impl SignedPacket {
     }
 
     /// Return the public key.
-    pub fn public_key(&self) -> PublicKey {
-        PublicKey::try_from(&self.bytes[..32]).expect("valid public key in SignedPacket")
+    pub fn public_key(&self) -> EndpointId {
+        EndpointId::try_from(&self.bytes[..32]).expect("valid public key in SignedPacket")
     }
 
     /// Return the signature.

--- a/iroh-relay/src/key_cache.rs
+++ b/iroh-relay/src/key_cache.rs
@@ -3,10 +3,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use iroh_base::PublicKey;
+use iroh_base::EndpointId;
 
-type SignatureError = <PublicKey as TryFrom<&'static [u8]>>::Error;
-type PublicKeyBytes = [u8; PublicKey::LENGTH];
+type SignatureError = <EndpointId as TryFrom<&'static [u8]>>::Error;
+type PublicKeyBytes = [u8; EndpointId::LENGTH];
 
 /// A cache for public keys.
 ///
@@ -24,7 +24,7 @@ enum Inner {
     Disabled,
     /// The key cache is enabled with a fixed capacity. It is shared between
     /// multiple threads.
-    Shared(Arc<Mutex<lru::LruCache<PublicKey, ()>>>),
+    Shared(Arc<Mutex<lru::LruCache<EndpointId, ()>>>),
 }
 
 impl KeyCache {
@@ -48,20 +48,20 @@ impl KeyCache {
     }
 
     /// Get a key from a slice of bytes.
-    pub fn key_from_slice(&self, slice: &[u8]) -> Result<PublicKey, SignatureError> {
+    pub fn key_from_slice(&self, slice: &[u8]) -> Result<EndpointId, SignatureError> {
         let Inner::Shared(cache) = &self.0 else {
-            return PublicKey::try_from(slice);
+            return EndpointId::try_from(slice);
         };
         let Ok(bytes) = PublicKeyBytes::try_from(slice) else {
             // if the size is wrong, use PublicKey::try_from to fail with a
             // SignatureError.
-            return Err(PublicKey::try_from(slice).expect_err("invalid length"));
+            return Err(EndpointId::try_from(slice).expect_err("invalid length"));
         };
         let mut cache = cache.lock().expect("not poisoned");
         if let Some((key, _)) = cache.get_key_value(&bytes) {
             return Ok(*key);
         }
-        let key = PublicKey::from_bytes(&bytes)?;
+        let key = EndpointId::from_bytes(&bytes)?;
         cache.put(key, ());
         Ok(key)
     }

--- a/iroh-relay/src/protos/handshake.rs
+++ b/iroh-relay/src/protos/handshake.rs
@@ -33,7 +33,7 @@ use data_encoding::BASE32HEX_NOPAD as HEX;
 use http::HeaderValue;
 #[cfg(feature = "server")]
 use iroh_base::Signature;
-use iroh_base::{PublicKey, SecretKey};
+use iroh_base::{EndpointId, SecretKey};
 use n0_error::{AnyError, anyerr, e, ensure, stack_error};
 use n0_future::{SinkExt, TryStreamExt};
 #[cfg(feature = "server")]
@@ -60,7 +60,7 @@ const DOMAIN_SEP_TLS_EXPORT_LABEL: &[u8] = b"iroh-relay handshake v1";
 #[cfg_attr(wasm_browser, allow(unused))]
 pub(crate) struct KeyMaterialClientAuth {
     /// The client's public key
-    pub(crate) public_key: PublicKey,
+    pub(crate) public_key: EndpointId,
     /// A signature of (a hash of) extracted key material.
     #[serde(with = "serde_bytes")]
     #[debug("{}", HEX.encode(signature))]
@@ -87,7 +87,7 @@ pub(crate) struct ServerChallenge {
 #[derive(derive_more::Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ClientAuth {
     /// The client's public key, a.k.a. the `EndpointId`
-    pub(crate) public_key: PublicKey,
+    pub(crate) public_key: EndpointId,
     /// A signature of (a hash of) the [`ServerChallenge`].
     ///
     /// This is what provides the authentication.
@@ -193,7 +193,7 @@ pub(crate) enum VerificationError {
         source: iroh_base::SignatureError,
         message: Vec<u8>,
         signature: [u8; 64],
-        public_key: PublicKey,
+        public_key: EndpointId,
     },
 }
 
@@ -391,7 +391,7 @@ pub(crate) async fn clientside(
 #[must_use = "the protocol is not finished unless `authorize_if` is called"]
 pub struct SuccessfulAuthentication {
     /// The authenticated client's public key.
-    pub client_key: PublicKey,
+    pub client_key: EndpointId,
     /// The authentication mechanism that was used.
     pub mechanism: Mechanism,
 }
@@ -516,13 +516,13 @@ impl SuccessfulAuthentication {
     /// * `io` - The WebSocket stream to send the authorization response on
     ///
     /// # Returns
-    /// * `Ok(PublicKey)` - The client's public key if authorization was granted
+    /// * `Ok(EndpointId)` - The client's public key if authorization was granted
     /// * `Err(Error)` - If authorization was denied or communication failed
     pub async fn authorize_if(
         self,
         access: Access,
         io: &mut (impl BytesStreamSink + ExportKeyingMaterial),
-    ) -> Result<PublicKey, Error> {
+    ) -> Result<EndpointId, Error> {
         match access {
             Access::Allow => self.accept(io).await,
             Access::Deny { reason } => Err(self.deny(reason, io).await),
@@ -532,7 +532,7 @@ impl SuccessfulAuthentication {
     async fn accept(
         self,
         io: &mut (impl BytesStreamSink + ExportKeyingMaterial),
-    ) -> Result<PublicKey, Error> {
+    ) -> Result<EndpointId, Error> {
         trace!("authorizing client");
         write_frame(io, ServerConfirmsAuth).await?;
         Ok(self.client_key)
@@ -610,7 +610,7 @@ fn deserialize_frame<F: Frame + serde::de::DeserializeOwned>(frame: Bytes) -> Re
 #[cfg(all(test, feature = "server"))]
 mod tests {
     use bytes::BytesMut;
-    use iroh_base::{PublicKey, SecretKey};
+    use iroh_base::{EndpointId, SecretKey};
     use n0_error::{AnyError, Result, StackResultExt, StdResultExt};
     use n0_future::{Sink, SinkExt, Stream, TryStreamExt};
     use n0_tracing_test::traced_test;
@@ -704,8 +704,8 @@ mod tests {
         secret_key: &SecretKey,
         client_shared_secret: Option<u64>,
         server_shared_secret: Option<u64>,
-        restricted_to: Option<PublicKey>,
-    ) -> (Result<ServerConfirmsAuth>, Result<(PublicKey, Mechanism)>) {
+        restricted_to: Option<EndpointId>,
+    ) -> (Result<ServerConfirmsAuth>, Result<(EndpointId, Mechanism)>) {
         let (client, server) = tokio::io::duplex(1024);
 
         let mut client_io = Framed::new(client, LengthDelimitedCodec::new())

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -1183,7 +1183,7 @@ struct Elapsed;
 mod tests {
     use std::sync::Arc;
 
-    use iroh_base::{PublicKey, SecretKey};
+    use iroh_base::{EndpointId, SecretKey};
     use iroh_dns::dns::DnsResolver;
     use n0_error::{Result, StdResultExt, bail_any};
     use n0_future::{SinkExt, StreamExt};
@@ -1300,7 +1300,7 @@ mod tests {
     async fn create_test_client(
         key: SecretKey,
         server_url: Url,
-    ) -> Result<(PublicKey, Client), ConnectError> {
+    ) -> Result<(EndpointId, Client), ConnectError> {
         let public_key = key.public();
         let client = ClientBuilder::new(server_url, key, DnsResolver::new()).tls_client_config(
             CaRootsConfig::insecure_skip_verify()
@@ -1314,7 +1314,7 @@ mod tests {
 
     fn process_msg(
         msg: Option<Result<RelayToClientMsg, crate::client::RecvError>>,
-    ) -> Option<(PublicKey, Datagrams)> {
+    ) -> Option<(EndpointId, Datagrams)> {
         match msg {
             Some(Err(e)) => {
                 info!("client `recv` error {e}");

--- a/iroh/examples/remote-info.rs
+++ b/iroh/examples/remote-info.rs
@@ -427,7 +427,7 @@ mod remote_map {
 
         async fn clear_expired(
             retention_time: Duration,
-            map: Arc<RwLock<HashMap<iroh::PublicKey, RemoteInfo>>>,
+            map: Arc<RwLock<HashMap<iroh::EndpointId, RemoteInfo>>>,
         ) {
             let mut interval = tokio::time::interval(retention_time);
             loop {

--- a/iroh/src/address_lookup/pkarr.rs
+++ b/iroh/src/address_lookup/pkarr.rs
@@ -2,9 +2,8 @@
 //!
 //! Public-Key Addressable Resource Records, [pkarr], is a system which allows publishing
 //! [DNS Resource Records] owned by a particular [`SecretKey`] under a name derived from its
-//! corresponding [`PublicKey`], also known as the [`EndpointId`].  Additionally this pkarr
-//! Resource Record is signed using the same [`SecretKey`], ensuring authenticity of the
-//! record.
+//! corresponding [`EndpointId`].  Additionally this pkarr Resource Record is signed using the
+//! same [`SecretKey`], ensuring authenticity of the record.
 //!
 //! Pkarr normally stores these records on the [Mainline DHT], but also provides two bridges
 //! that do not require clients to directly interact with the DHT:
@@ -45,7 +44,6 @@
 //! [DNS Resource Records]: https://en.wikipedia.org/wiki/Domain_Name_System#Resource_records
 //! [Mainline DHT]: https://en.wikipedia.org/wiki/Mainline_DHT
 //! [`SecretKey`]: crate::SecretKey
-//! [`PublicKey`]: crate::PublicKey
 //! [`EndpointId`]: crate::EndpointId
 //! [`address_lookup::DnsAddressLookup`]: crate::address_lookup::DnsAddressLookup
 //! [`N0` preset]: crate::endpoint::presets::N0

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -501,12 +501,9 @@ impl Builder {
 
     /// Sets a secret key to authenticate with other peers.
     ///
-    /// This secret key's public key will be the [`PublicKey`] of this endpoint and thus
-    /// also its [`EndpointId`]
+    /// This secret key's public key will be the [`EndpointId`] of this endpoint.
     ///
     /// If not set, a new secret key will be generated.
-    ///
-    /// [`PublicKey`]: iroh_base::PublicKey
     pub fn secret_key(mut self, secret_key: SecretKey) -> Self {
         self.secret_key = Some(secret_key);
         self

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -368,12 +368,10 @@ fn static_info_from_conn(conn: &noq::Connection) -> Result<StaticInfo, Authentic
 
 /// Returns the [`EndpointId`] from the peer's TLS certificate.
 ///
-/// The [`PublicKey`] of an endpoint is also known as an [`EndpointId`].  This [`PublicKey`] is
+/// The public key of an endpoint is also known as an [`EndpointId`].  This public key is
 /// included in the TLS certificate presented during the handshake when connecting.
 /// This function allows you to get the [`EndpointId`] of the remote endpoint of this
 /// connection.
-///
-/// [`PublicKey`]: iroh_base::PublicKey
 fn remote_id_from_noq_conn(conn: &noq::Connection) -> Result<EndpointId, RemoteEndpointIdError> {
     let data = conn.peer_identity();
     match data {
@@ -1067,12 +1065,10 @@ impl Connection<HandshakeCompleted> {
 
     /// Returns the [`EndpointId`] from the peer's TLS certificate.
     ///
-    /// The [`PublicKey`] of an endpoint is also known as an [`EndpointId`].  This [`PublicKey`] is
+    /// The public key of an endpoint is known as an [`EndpointId`].  This public key is
     /// included in the TLS certificate presented during the handshake when connecting.
     /// This function allows you to get the [`EndpointId`] of the remote endpoint of this
     /// connection.
-    ///
-    /// [`PublicKey`]: iroh_base::PublicKey
     pub fn remote_id(&self) -> EndpointId {
         self.data.info.endpoint_id
     }
@@ -1169,12 +1165,10 @@ impl Connection<IncomingZeroRtt> {
 
     /// Returns the [`EndpointId`] from the peer's TLS certificate.
     ///
-    /// The [`PublicKey`] of an endpoint is also known as an [`EndpointId`].  This [`PublicKey`] is
+    /// The public key of an endpoint is known as an [`EndpointId`].  This public key is
     /// included in the TLS certificate presented during the handshake when connecting.
     /// This function allows you to get the [`EndpointId`] of the remote endpoint of this
     /// connection.
-    ///
-    /// [`PublicKey`]: iroh_base::PublicKey
     pub fn remote_id(&self) -> Result<EndpointId, RemoteEndpointIdError> {
         remote_id_from_noq_conn(&self.inner)
     }
@@ -1211,12 +1205,10 @@ impl Connection<OutgoingZeroRtt> {
 
     /// Returns the [`EndpointId`] from the peer's TLS certificate.
     ///
-    /// The [`PublicKey`] of an endpoint is also known as an [`EndpointId`].  This [`PublicKey`] is
+    /// The public key of an endpoint is known as an [`EndpointId`].  This public key is
     /// included in the TLS certificate presented during the handshake when connecting.
     /// This function allows you to get the [`EndpointId`] of the remote endpoint of this
     /// connection.
-    ///
-    /// [`PublicKey`]: iroh_base::PublicKey
     pub fn remote_id(&self) -> Result<EndpointId, RemoteEndpointIdError> {
         remote_id_from_noq_conn(&self.inner)
     }

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -83,10 +83,10 @@
 //! The connection is encrypted using TLS, like standard QUIC connections.  Unlike standard
 //! QUIC there is no client, server or server TLS key and certificate chain.  Instead each iroh endpoint has a
 //! unique [`SecretKey`] used to authenticate and encrypt the connection.  When an iroh
-//! endpoint connects, it uses the corresponding [`PublicKey`] to ensure the connection is only
+//! endpoint connects, it uses the corresponding public key to ensure the connection is only
 //! established with the intended peer.
 //!
-//! Since the [`PublicKey`] is also used to identify the iroh endpoint it is also known as
+//! Since the public key  is also used to identify the iroh endpoint it is called
 //! the [`EndpointId`].  As encryption is an integral part of TLS as used in QUIC this
 //! [`EndpointId`] is always a required parameter to establish a connection.
 //!
@@ -249,7 +249,6 @@
 //! [ALPN]: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation
 //! [HTTP3]: https://en.wikipedia.org/wiki/HTTP/3
 //! [`SecretKey`]: crate::SecretKey
-//! [`PublicKey`]: crate::PublicKey
 //! [`RelayUrl`]: crate::RelayUrl
 //! [`address_lookup`]: crate::endpoint::Builder::address_lookup
 //! [`address_lookup::DnsAddressLookup`]: crate::address_lookup::DnsAddressLookup
@@ -281,8 +280,8 @@ pub mod protocol;
 
 pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{
-    EndpointAddr, EndpointId, KeyParsingError, PublicKey, RelayUrl, RelayUrlParseError, SecretKey,
-    Signature, SignatureError, TransportAddr,
+    EndpointAddr, EndpointId, KeyParsingError, RelayUrl, RelayUrlParseError, SecretKey, Signature,
+    SignatureError, TransportAddr,
 };
 #[cfg(not(wasm_browser))]
 pub use iroh_dns::dns;

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -230,7 +230,7 @@ impl RemoteMap {
     /// Removes an actor sender if `leftover_msgs` is empty, or restarts the actor otherwise.
     fn remove_or_restart_actor(
         &mut self,
-        remote_id: iroh_base::PublicKey,
+        remote_id: iroh_base::EndpointId,
         leftover_msgs: Vec<RemoteStateMessage>,
     ) -> bool {
         if leftover_msgs.is_empty() {

--- a/iroh/src/tls/verifier.rs
+++ b/iroh/src/tls/verifier.rs
@@ -3,7 +3,7 @@
 //! This module handles a verification of a client/server certificate chain
 //! and signatures allegedly by the given certificates, or using raw public keys.
 
-use iroh_base::{PublicKey, Signature};
+use iroh_base::{EndpointId, Signature};
 use rustls::{
     CertificateError, DigitallySignedStruct, DistinguishedName, SignatureScheme,
     SupportedProtocolVersion,
@@ -189,7 +189,7 @@ impl webpki_types::SignatureVerificationAlgorithm for Ed25519Dalek {
         signature: &[u8],
     ) -> Result<(), webpki_types::InvalidSignature> {
         let public_key =
-            PublicKey::try_from(public_key).map_err(|_| webpki_types::InvalidSignature)?;
+            EndpointId::try_from(public_key).map_err(|_| webpki_types::InvalidSignature)?;
         let signature =
             Signature::try_from(signature).map_err(|_| webpki_types::InvalidSignature)?;
         public_key


### PR DESCRIPTION
## Description

This renames `iroh_base::PublicKey` to `EndpointId` and removes the `EndpointId` type alias.

Rationale: We pretty much universally use `EndpointId` already. The few cases where we so far recommended to use `PublicKey` directly (when related to crypto operations) were purely internal, where it does not really matter IMO. Having only a single public type for the endpoint id is less confusing to people (and to IDEs, which sometimes arbitrarily use the non-aliased type instead in my experience).

## Breaking Changes

* renamed: `iroh_base::PublicKey` -> `EndpointId`
* changed: `EndpointId` is no longer a type alias, but a concrete type

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.