### PR TITLE
refactor(iroh): use n0_future::MaybeFuture instead of own version

### DIFF
--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -9,7 +9,7 @@ use std::{
 use iroh_base::{CustomAddr, EndpointId, RelayUrl, TransportAddr};
 use n0_error::StackResultExt;
 use n0_future::{
-    FuturesUnordered, MergeUnbounded, Stream, StreamExt,
+    FuturesUnordered, MaybeFuture, MergeUnbounded, Stream, StreamExt,
     boxed::BoxStream,
     task::JoinSet,
     time::{self, Duration, Instant},
@@ -38,7 +38,6 @@ use crate::{
         remote_map::remote_state::path_watcher::PathStateSender,
         transports::{self, OwnedTransmit, TransportsSender},
     },
-    util::MaybeFuture,
 };
 
 mod path_state;

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -46,7 +46,7 @@ use iroh_relay::{
 };
 use n0_error::{AnyError, e, stack_error};
 use n0_future::{
-    FuturesUnorderedBounded, SinkExt, StreamExt,
+    FuturesUnorderedBounded, MaybeFuture, SinkExt, StreamExt,
     task::JoinSet,
     time::{self, Duration, Instant, MissedTickBehavior},
 };
@@ -59,9 +59,7 @@ use url::Url;
 
 #[cfg(not(wasm_browser))]
 use crate::dns::DnsResolver;
-use crate::{
-    endpoint::RelayStatus, net_report::Report, socket::Metrics as SocketMetrics, util::MaybeFuture,
-};
+use crate::{endpoint::RelayStatus, net_report::Report, socket::Metrics as SocketMetrics};
 
 /// How long a non-home relay connection needs to be idle (last written to) before we close it.
 const RELAY_INACTIVE_CLEANUP_TIME: Duration = Duration::from_secs(60);
@@ -1019,7 +1017,7 @@ impl RelayActor {
     ) {
         // When this future is present, it is sending pending datagrams to an
         // ActiveRelayActor.  We can not process further datagrams during this time.
-        let mut datagram_send_fut = std::pin::pin!(MaybeFuture::none());
+        let mut datagram_send_fut = std::pin::pin!(MaybeFuture::None);
 
         loop {
             tokio::select! {

--- a/iroh/src/util.rs
+++ b/iroh/src/util.rs
@@ -1,74 +1,5 @@
 //! Utilities used in [`iroh`][`crate`]
 
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-};
-
-use pin_project::pin_project;
-
-/// A future which may not be present.
-///
-/// This is a single type which may optionally contain a future.  If there is no inner
-/// future polling will always return [`Poll::Pending`].
-///
-/// The [`Default`] impl will create a [`MaybeFuture`] without an inner.
-#[derive(Default, Debug)]
-#[pin_project(project = MaybeFutureProj, project_replace = MaybeFutureProjReplace)]
-pub(crate) enum MaybeFuture<T> {
-    /// Future to be polled.
-    Some(#[pin] T),
-    #[default]
-    None,
-}
-
-impl<T> MaybeFuture<T> {
-    /// Creates a [`MaybeFuture`] without an inner future.
-    pub(crate) fn none() -> Self {
-        Self::default()
-    }
-
-    /// Sets the future to None again.
-    pub(crate) fn set_none(mut self: Pin<&mut Self>) {
-        self.as_mut().project_replace(Self::None);
-    }
-
-    /// Sets a new future.
-    pub(crate) fn set_future(mut self: Pin<&mut Self>, fut: T) {
-        self.as_mut().project_replace(Self::Some(fut));
-    }
-
-    /// Returns `true` if the inner is empty.
-    pub(crate) fn is_none(&self) -> bool {
-        matches!(self, Self::None)
-    }
-
-    /// Returns `true` if the inner contains a future.
-    pub(crate) fn is_some(&self) -> bool {
-        matches!(self, Self::Some(_))
-    }
-}
-
-impl<T: Future> Future for MaybeFuture<T> {
-    type Output = T::Output;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.as_mut().project();
-        let poll_res = match this {
-            MaybeFutureProj::Some(ref mut t) => t.as_mut().poll(cx),
-            MaybeFutureProj::None => Poll::Pending,
-        };
-        match poll_res {
-            Poll::Ready(val) => {
-                self.as_mut().project_replace(Self::None);
-                Poll::Ready(val)
-            }
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
 #[cfg(wasm_browser)]
 pub(crate) fn reqwest_client_builder() -> reqwest::ClientBuilder {
     reqwest::Client::builder()
@@ -123,27 +54,5 @@ mod reqwest_dns_resolver {
                 }
             })
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::pin::pin;
-
-    use n0_future::time::Duration;
-
-    use super::*;
-
-    #[tokio::test]
-    async fn test_maybefuture_poll_after_use() {
-        let fut = async move { "hello" };
-        let mut maybe_fut = pin!(MaybeFuture::Some(fut));
-        let res = (&mut maybe_fut).await;
-
-        assert_eq!(res, "hello");
-
-        // Now poll again
-        let res = tokio::time::timeout(Duration::from_millis(10), maybe_fut).await;
-        assert!(res.is_err());
     }
 }


### PR DESCRIPTION
## Description

We upstreamed `MaybeFuture` to `n0-future`, so let's use it and remove our own version in iroh's util module.

## Change checklist
- [x] Self-review.