### PR TITLE
refactor(iroh): improve tracing logs

### DIFF
--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -21,7 +21,7 @@ use n0_future::{
     split::{SplitSink, SplitStream, split},
     time,
 };
-use tracing::{Level, debug, event, trace};
+use tracing::{debug, trace};
 use url::Url;
 
 pub use self::conn::{RecvError, SendError};
@@ -362,12 +362,6 @@ impl ClientBuilder {
         )
         .await?;
 
-        event!(
-            target: "iroh::_events::net::relay::connected",
-            Level::DEBUG,
-            url = %self.url,
-        );
-
         trace!("connect done");
 
         Ok(Client {
@@ -439,12 +433,6 @@ impl ClientBuilder {
             protocol_version,
         )
         .await?;
-
-        event!(
-            target: "iroh::_events::net::relay::connected",
-            Level::DEBUG,
-            url = %self.url,
-        );
 
         trace!("connect done");
 

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -76,7 +76,7 @@ impl MaybeTlsStreamBuilder {
         debug!(server_addr = ?tcp_stream.peer_addr(), %local_addr, "TCP stream connected");
 
         if self.use_tls() {
-            debug!("Starting TLS handshake");
+            trace!("Starting TLS handshake");
             let hostname = self
                 .tls_servername()
                 .ok_or_else(|| e!(ConnectError::InvalidTlsServername))?;
@@ -86,10 +86,10 @@ impl MaybeTlsStreamBuilder {
                 .connect(hostname, tcp_stream)
                 .await
                 .map_err(|err| e!(ConnectError::Tls, err))?;
-            debug!("tls_connector connect success");
+            trace!("tls_connector connect success");
             Ok(MaybeTlsStream::Tls(tls_stream))
         } else {
-            debug!("Starting handshake");
+            trace!("Starting handshake");
             Ok(MaybeTlsStream::Raw(tcp_stream))
         }
     }

--- a/iroh/src/address_lookup/pkarr.rs
+++ b/iroh/src/address_lookup/pkarr.rs
@@ -319,11 +319,7 @@ impl PkarrPublisher {
             pkarr_client,
             republish_interval,
         };
-        let join_handle = task::spawn(
-            service
-                .run()
-                .instrument(error_span!("pkarr_publish", me=%endpoint_id.fmt_short())),
-        );
+        let join_handle = task::spawn(service.run().instrument(error_span!("pkarr_publish")));
         Self {
             watchable,
             endpoint_id,

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -800,7 +800,7 @@ impl DirectAddrUpdateState {
         self.sock.metrics.net_report.portmap_attempts.inc();
         self.port_mapper.procure_mapping();
 
-        debug!("requesting net_report report");
+        trace!("requesting net_report report");
         let sock = self.sock.clone();
 
         let run_done = self.run_done.clone();

--- a/iroh/src/socket/biased_rtt_path_selector.rs
+++ b/iroh/src/socket/biased_rtt_path_selector.rs
@@ -7,6 +7,7 @@
 use std::{sync::Arc, time::Duration};
 
 use rustc_hash::FxHashMap;
+use tracing::trace;
 
 use super::{
     remote_map::{PathSelection, PathSelectionContext, PathSelectionData, PathSelector},
@@ -142,18 +143,18 @@ impl PathSelector for BiasedRttPathSelector {
         let mut best: Option<(PathSelectionData<'_>, (TransportType, i128))> = None;
         let mut current_key: Option<(TransportType, i128)> = None;
 
-        tracing::debug!("dumping path RTTs");
+        trace!("dumping path RTTs");
         for psd in ctx.paths() {
-            let addr = psd.network_path();
+            let network_path = psd.network_path();
             // Skip paths whose stats can't be read (e.g. closed concurrently with select).
             let Some(stats) = psd.stats() else {
                 continue;
             };
             let rtt = stats.rtt;
-            tracing::debug!(?addr, ?rtt);
-            let key = self.sort_key(addr, rtt);
+            trace!(%network_path, ?rtt);
+            let key = self.sort_key(network_path, rtt);
 
-            if Some(addr) == current && current_key.is_none_or(|c| key < c) {
+            if Some(network_path) == current && current_key.is_none_or(|c| key < c) {
                 current_key = Some(key);
             }
             if best.as_ref().is_none_or(|(_, b)| key < *b) {

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -617,9 +617,9 @@ impl RemoteStateActor {
                     target: "iroh::_events::path::abandoned",
                     Level::DEBUG,
                     remote = %self.state.endpoint_id.fmt_short(),
-                    %network_path,
                     %conn_id,
-                    path_id = ?id,
+                    path_id = %id,
+                    %network_path,
                     ?reason
                 );
 
@@ -663,7 +663,7 @@ impl RemoteStateActor {
                 Level::DEBUG,
                 remote = %self.state.endpoint_id.fmt_short(),
                 network_path = %addr,
-                prev_network_path = prev_remote.map(|p| format!("{p}")).unwrap_or("None".to_string()),
+                prev_network_path = %prev_remote.map(|p| format!("{p}")).unwrap_or("None".to_string()),
             );
         } else {
             trace!(?current_path, "keeping current path");
@@ -980,9 +980,9 @@ impl State {
             target: "iroh::_events::path::open",
             Level::DEBUG,
             remote = %self.endpoint_id.fmt_short(),
-            ?network_path,
             %conn_id,
             path_id=%path.id(),
+            %network_path,
         );
         conn_state.add_open_path(network_path.clone(), path.id(), &self.metrics);
         if network_path.is_relay()
@@ -1011,10 +1011,10 @@ impl State {
                     target: "iroh::_events::path::set_status",
                     Level::DEBUG,
                     remote = %self.endpoint_id.fmt_short(),
-                    path_remote = ?network_path,
-                    ?status,
                     %conn_id,
                     path_id=%path.id(),
+                    %network_path,
+                    ?status,
                     ?prev_status,
                 );
             }
@@ -1159,7 +1159,7 @@ pub(crate) enum RemoteStateMessage {
     /// but only update to a strong [`noq::Connection`] for brief moments.
     ///
     /// The actor will actively manage paths on the connection and start holepunching as needed.
-    #[debug("AddConnection(..)")]
+    #[debug("AddConnection({})", _0.stable_id())]
     AddConnection(noq::Connection, oneshot::Sender<PathStateReceiver>),
     /// Asks if there is any possible path that could be used.
     ///

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -505,7 +505,7 @@ impl ActiveRelayActor {
         &mut self,
         client: iroh_relay::client::Client,
     ) -> Result<(), RelayConnectionError> {
-        debug!("Actor loop: connected to relay");
+        trace!("Actor loop: connected to relay");
         event!(
             target: "iroh::_events::relay::connected",
             Level::DEBUG,


### PR DESCRIPTION
## Description

Did a quick pass over tracing logs when running the transfer example with `RUST_LOG=iroh=debug`.

* Remove some nearly-duplicate lines by demoting one of the duplicates to `trace`
* Remove duplicate `iroh::_event` for relay connections
* Remove duplicate span qualifier for pkarr publish


## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.