### PR TITLE
fix(iroh): don't kill noq endpoint on first transport recv error

### DIFF
--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -42,6 +42,12 @@ pub(crate) use self::relay::{
     HomeRelayWatch, RelayActorConfig, RelayConnectionState, RelayTransport,
 };
 
+/// How many times all transports may error on `poll_recv` before we give up.
+///
+/// Once all transports errored for this many times in a row, we give up and forward
+/// the error to noq, which will kill the endpoint driver then.
+const MAX_CONSECUTIVE_RECV_ERRORS: usize = 8;
+
 /// Manages the different underlying data transports that the socket can support.
 #[derive(Debug)]
 pub(crate) struct Transports {
@@ -53,6 +59,7 @@ pub(crate) struct Transports {
     poll_recv_counter: usize,
     /// Cache for per-packet recv info, to speed up access
     recv_infos: [RecvInfo; noq_udp::BATCH_SIZE],
+    consecutive_total_recv_failures: usize,
 }
 
 /// Combined watcher type for all ip transports
@@ -243,6 +250,7 @@ impl Transports {
             custom,
             poll_recv_counter: Default::default(),
             recv_infos: Default::default(),
+            consecutive_total_recv_failures: 0,
         })
     }
 
@@ -260,7 +268,8 @@ impl Transports {
         }
 
         match self.inner_poll_recv(cx, bufs, metas)? {
-            Poll::Pending | Poll::Ready(0) => Poll::Pending,
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(0) => Poll::Ready(Ok(0)),
             Poll::Ready(n) => {
                 sock.process_datagrams(&mut bufs[..n], &mut metas[..n], &self.recv_infos[..n]);
                 Poll::Ready(Ok(n))
@@ -277,31 +286,35 @@ impl Transports {
     ) -> Poll<io::Result<usize>> {
         assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
 
+        let mut total_polled = 0;
+        let mut total_errors = 0;
+
         macro_rules! poll_transport {
             ($debug_label:expr, $socket:expr) => {
+                total_polled += 1;
                 match $socket.poll_recv(cx, bufs, metas, &mut self.recv_infos) {
-                    Poll::Pending | Poll::Ready(Ok(0)) => {}
+                    Poll::Pending | Poll::Ready(Ok(0)) => {
+                        self.consecutive_total_recv_failures = 0;
+                    }
                     Poll::Ready(Ok(n)) => {
+                        self.consecutive_total_recv_failures = 0;
                         return Poll::Ready(Ok(n));
                     }
                     Poll::Ready(Err(err)) => {
-                        // noq treats an error returned from poll_recv as unrecoverable and terminates
-                        // its `EndpointDriver`, which silently kills the endpoint.
-                        // As we have multiple transports, and each might recover from errors individually,
-                        // we never forward transport errors to noq and instead only warn-log them.
-                        warn!(transport=$debug_label, "recv error: {err:#}");
+                        total_errors += 1;
+                        warn!(transport = $debug_label, "recv error: {err:#}");
                     }
                 }
             };
         }
 
         // To improve fairness, every other call reverses the ordering of polling.
-
         let counter = self.poll_recv_counter.wrapping_add(1);
-
         if counter.is_multiple_of(2) {
             #[cfg(not(wasm_browser))]
-            poll_transport!("IP", &mut self.ip);
+            for transport in self.ip.iter_mut() {
+                poll_transport!("IP", transport);
+            }
 
             for transport in self.relay.iter_mut() {
                 poll_transport!("relay", transport);
@@ -317,10 +330,25 @@ impl Transports {
                 poll_transport!("relay", transport);
             }
             #[cfg(not(wasm_browser))]
-            poll_transport!("IP", &mut self.ip);
+            for transport in self.ip.iter_mut() {
+                poll_transport!("IP", transport);
+            }
         }
 
-        Poll::Pending
+        if total_polled == total_errors {
+            // All transports errored.
+            self.consecutive_total_recv_failures += 1;
+            if self.consecutive_total_recv_failures >= MAX_CONSECUTIVE_RECV_ERRORS {
+                Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::NetworkDown,
+                    "All transports failed to receive",
+                )))
+            } else {
+                Poll::Ready(Ok(0))
+            }
+        } else {
+            Poll::Pending
+        }
     }
 
     /// Returns a list of all currently known local addresses.

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -278,11 +278,18 @@ impl Transports {
         assert_eq!(bufs.len(), metas.len(), "non matching bufs & metas");
 
         macro_rules! poll_transport {
-            ($socket:expr) => {
-                match $socket.poll_recv(cx, bufs, metas, &mut self.recv_infos)? {
-                    Poll::Pending | Poll::Ready(0) => {}
-                    Poll::Ready(n) => {
+            ($debug_label:expr, $socket:expr) => {
+                match $socket.poll_recv(cx, bufs, metas, &mut self.recv_infos) {
+                    Poll::Pending | Poll::Ready(Ok(0)) => {}
+                    Poll::Ready(Ok(n)) => {
                         return Poll::Ready(Ok(n));
+                    }
+                    Poll::Ready(Err(err)) => {
+                        // noq treats an error returned from poll_recv as unrecoverable and terminates
+                        // its `EndpointDriver`, which silently kills the endpoint.
+                        // As we have multiple transports, and each might recover from errors individually,
+                        // we never forward transport errors to noq and instead only warn-log them.
+                        warn!(transport=$debug_label, "recv error: {err:#}");
                     }
                 }
             };
@@ -294,23 +301,23 @@ impl Transports {
 
         if counter.is_multiple_of(2) {
             #[cfg(not(wasm_browser))]
-            poll_transport!(&mut self.ip);
+            poll_transport!("IP", &mut self.ip);
 
             for transport in self.relay.iter_mut() {
-                poll_transport!(transport);
+                poll_transport!("relay", transport);
             }
             for transport in self.custom.iter_mut() {
-                poll_transport!(transport);
+                poll_transport!("custom", transport);
             }
         } else {
             for transport in self.custom.iter_mut().rev() {
-                poll_transport!(transport);
+                poll_transport!("custom", transport);
             }
             for transport in self.relay.iter_mut().rev() {
-                poll_transport!(transport);
+                poll_transport!("relay", transport);
             }
             #[cfg(not(wasm_browser))]
-            poll_transport!(&mut self.ip);
+            poll_transport!("IP", &mut self.ip);
         }
 
         Poll::Pending

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -288,19 +288,26 @@ impl Transports {
 
         let mut total_polled = 0;
         let mut total_errors = 0;
+        let mut return_ready = false;
 
         macro_rules! poll_transport {
             ($debug_label:expr, $socket:expr) => {
                 total_polled += 1;
                 match $socket.poll_recv(cx, bufs, metas, &mut self.recv_infos) {
-                    Poll::Pending | Poll::Ready(Ok(0)) => {
-                        self.consecutive_total_recv_failures = 0;
+                    Poll::Pending => {}
+                    Poll::Ready(Ok(0)) => {
+                        return_ready = true;
                     }
                     Poll::Ready(Ok(n)) => {
+                        // Once a transport has data ready, we return directly.
                         self.consecutive_total_recv_failures = 0;
                         return Poll::Ready(Ok(n));
                     }
                     Poll::Ready(Err(err)) => {
+                        // We don't set `has_poll_ready` to `true` here, because if we did,
+                        // a single always-failing transport would put us into a hot loop
+                        // where `poll_recv` would be called right away again and again even if
+                        // the non-failing transports are all pending.
                         total_errors += 1;
                         warn!(transport = $debug_label, "recv error: {err:#}");
                     }
@@ -315,7 +322,6 @@ impl Transports {
             for transport in self.ip.iter_mut() {
                 poll_transport!("IP", transport);
             }
-
             for transport in self.relay.iter_mut() {
                 poll_transport!("relay", transport);
             }
@@ -347,7 +353,13 @@ impl Transports {
                 Poll::Ready(Ok(0))
             }
         } else {
-            Poll::Pending
+            // At least one transport is pending or returned Ok(0).
+            self.consecutive_total_recv_failures = 0;
+            if return_ready {
+                Poll::Ready(Ok(0))
+            } else {
+                Poll::Pending
+            }
         }
     }
 

--- a/iroh/src/socket/transports/ip.rs
+++ b/iroh/src/socket/transports/ip.rs
@@ -222,9 +222,7 @@ impl IpTransport {
             Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
         }
     }
-}
 
-impl IpTransport {
     pub(super) fn local_addr_watch(&self) -> n0_watcher::Direct<SocketAddr> {
         self.local_addr.watch()
     }

--- a/iroh/src/socket/transports/ip.rs
+++ b/iroh/src/socket/transports/ip.rs
@@ -11,7 +11,7 @@ use ipnet::{Ipv4Net, Ipv6Net};
 use n0_watcher::Watchable;
 use netwatch::{UdpSender, UdpSocket};
 use pin_project::pin_project;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, trace};
 
 use super::{RecvInfo, Transmit};
 use crate::metrics::{EndpointMetrics, SocketMetrics};
@@ -222,7 +222,9 @@ impl IpTransport {
             Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
         }
     }
+}
 
+impl IpTransport {
     pub(super) fn local_addr_watch(&self) -> n0_watcher::Direct<SocketAddr> {
         self.local_addr.watch()
     }
@@ -465,36 +467,8 @@ impl IpTransports {
         })
     }
 
-    pub(super) fn poll_recv(
-        &mut self,
-        cx: &mut Context,
-        bufs: &mut [io::IoSliceMut<'_>],
-        metas: &mut [noq_udp::RecvMeta],
-        recv_infos: &mut [RecvInfo],
-    ) -> Poll<io::Result<usize>> {
-        macro_rules! poll_transport {
-            ($socket:expr) => {
-                match $socket.poll_recv(cx, bufs, metas, recv_infos) {
-                    Poll::Pending | Poll::Ready(Ok(0)) => {}
-                    Poll::Ready(Ok(n)) => {
-                        return Poll::Ready(Ok(n));
-                    }
-                    Poll::Ready(Err(err)) => {
-                        warn!(socket=%$socket.local_addr.get(), "recv error: {err:#}");
-                    }
-                }
-            };
-        }
-
-        for transport in &mut self.v4 {
-            poll_transport!(transport);
-        }
-
-        for transport in &mut self.v6 {
-            poll_transport!(transport);
-        }
-
-        Poll::Pending
+    pub(super) fn iter_mut(&mut self) -> impl Iterator<Item = &mut IpTransport> {
+        self.v4.iter_mut().chain(self.v6.iter_mut())
     }
 }
 

--- a/iroh/src/socket/transports/ip.rs
+++ b/iroh/src/socket/transports/ip.rs
@@ -11,7 +11,7 @@ use ipnet::{Ipv4Net, Ipv6Net};
 use n0_watcher::Watchable;
 use netwatch::{UdpSender, UdpSocket};
 use pin_project::pin_project;
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use super::{RecvInfo, Transmit};
 use crate::metrics::{EndpointMetrics, SocketMetrics};
@@ -169,20 +169,16 @@ impl IpTransport {
         })?;
         let local_addr = socket.local_addr()?;
         debug!(%addr, %local_addr, "successfully bound");
-        Ok(Self::new(config, Arc::new(socket), metrics.clone()))
-    }
-
-    pub(crate) fn new(config: Config, socket: Arc<UdpSocket>, metrics: Arc<SocketMetrics>) -> Self {
         // Currently gets updated on manual rebind
         // TODO: update when UdpSocket under the hood rebinds automatically
-        let local_addr = Watchable::new(socket.local_addr().expect("invalid socket"));
+        let local_addr = Watchable::new(local_addr);
 
-        Self {
+        Ok(Self {
             config,
-            socket,
+            socket: Arc::new(socket),
             local_addr,
             metrics,
-        }
+        })
     }
 
     /// NOTE: Receiving on a closed socket will return [`Poll::Pending`] indefinitely.
@@ -478,10 +474,13 @@ impl IpTransports {
     ) -> Poll<io::Result<usize>> {
         macro_rules! poll_transport {
             ($socket:expr) => {
-                match $socket.poll_recv(cx, bufs, metas, recv_infos)? {
-                    Poll::Pending | Poll::Ready(0) => {}
-                    Poll::Ready(n) => {
+                match $socket.poll_recv(cx, bufs, metas, recv_infos) {
+                    Poll::Pending | Poll::Ready(Ok(0)) => {}
+                    Poll::Ready(Ok(n)) => {
                         return Poll::Ready(Ok(n));
+                    }
+                    Poll::Ready(Err(err)) => {
+                        warn!(socket=%$socket.local_addr.get(), "recv error: {err:#}");
                     }
                 }
             };


### PR DESCRIPTION
## Description

This changes iroh's implementation of `AsyncUdpSocket::poll_recv` to not forward transport recv errors unconditionally.

When `AsyncUdpSocket::poll_recv` returns an error, noq aborts the `EndpointDriver` (unless the error is `io::ErrorKind::ConnectionReset`, in which case the driver continues). Aborting the `EndpointDriver` is final, there is no recovery path from that in noq. An endpoint with a dead driver will silently fail on most operations thereafter.

In iroh, we have multiple transports. Before this change, a single error in any transport would kill the `noq::Endpoint`. We do not want this: Even if the failure of a transport is real and final, there might still be other transports. Additionally, our IP transports can recover from errors, e.g. when a major network change notification triggers a rebind. Finally, error semantics and whether they are final or transient are obscure and platform-specific, see e.g. #4297.

Instead, we swallow and warn-log errors by default. If *all* configured transports produce an error, we increment a counter. If the counter reaches 8, we give up and return an error from `poll_recv`. We'll have to see in practice if the number 8 is a good compromise here. The idea is to not die on transient errors right away, but also not keep polling a dead system forever.

In any case, with this change the noq Endpoint will survive as long as *any* transport does not produce errors. Whereas before, we would kill the endpoint even if there are healthy transports. 

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
