### PR TITLE
fix(iroh): add global address validation token store

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -236,6 +236,7 @@ impl Builder {
             tls_config,
             transport_config: self.transport_config.clone(),
             token_key,
+            token_store: Arc::new(noq::TokenMemoryCache::default()),
         };
         let server_config = static_config.create_server_config(self.alpn_protocols);
 

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -42,7 +42,7 @@ use netwatch::{
     ip::LocalAddresses,
 };
 use noq::{
-    NetworkChangeHint,
+    NetworkChangeHint, TokenStore,
     crypto::rustls::{QuicClientConfig, QuicServerConfig},
 };
 use rand::RngExt;
@@ -238,6 +238,15 @@ pub(crate) struct StaticConfig {
     pub(crate) client_config: QuicClientConfig,
     #[debug("Arc<RustlsTokenKey>")]
     pub(crate) token_key: Arc<RustlsTokenKey>,
+    /// Client-side store for QUIC address-validation tokens (`NEW_TOKEN` frames).
+    ///
+    /// Shared across all connections created from this endpoint so a token issued
+    /// by a server on one connection can be replayed on a later connection to the
+    /// same server, validating the client's address and lifting the 3x
+    /// anti-amplification limit (notably for 0.5-RTT responses to 0-RTT requests).
+    /// This mirrors how `tls_config`'s session store is shared to enable 0-RTT.
+    #[debug("Arc<dyn TokenStore>")]
+    pub(crate) token_store: Arc<dyn TokenStore>,
     pub(crate) transport_config: QuicTransportConfig,
 }
 
@@ -265,6 +274,9 @@ impl StaticConfig {
         quic_client_config.set_alpn_protocols(alpn_protocols);
         let mut inner = noq::ClientConfig::new(Arc::new(quic_client_config));
         inner.transport_config(transport_config);
+        // Share the endpoint-wide token store so NEW_TOKEN tokens survive across
+        // connections (the default would mint a fresh, empty store per connection).
+        inner.token_store(self.token_store.clone());
         inner
     }
 }
@@ -2151,6 +2163,7 @@ mod tests {
             client_config: tls_config.make_client_config(false).unwrap(),
             tls_config,
             token_key: Arc::new(RustlsTokenKey::new(rng, &crypto_provider).unwrap()),
+            token_store: Arc::new(noq::TokenMemoryCache::default()),
             transport_config: QuicTransportConfig::default(),
         };
         let server_config = static_config.create_server_config(vec![]);
@@ -2564,6 +2577,7 @@ mod tests {
             client_config: tls_config.make_client_config(keylog).unwrap(),
             tls_config,
             token_key: Arc::new(RustlsTokenKey::new(&mut rand::rng(), &crypto_provider).unwrap()),
+            token_store: Arc::new(noq::TokenMemoryCache::default()),
             transport_config: QuicTransportConfig::default(),
         };
         let server_config = static_config.create_server_config(vec![ALPN.to_vec()]);

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -238,13 +238,6 @@ pub(crate) struct StaticConfig {
     pub(crate) client_config: QuicClientConfig,
     #[debug("Arc<RustlsTokenKey>")]
     pub(crate) token_key: Arc<RustlsTokenKey>,
-    /// Client-side store for QUIC address-validation tokens (`NEW_TOKEN` frames).
-    ///
-    /// Shared across all connections created from this endpoint so a token issued
-    /// by a server on one connection can be replayed on a later connection to the
-    /// same server, validating the client's address and lifting the 3x
-    /// anti-amplification limit (notably for 0.5-RTT responses to 0-RTT requests).
-    /// This mirrors how `tls_config`'s session store is shared to enable 0-RTT.
     #[debug("Arc<dyn TokenStore>")]
     pub(crate) token_store: Arc<dyn TokenStore>,
     pub(crate) transport_config: QuicTransportConfig,
@@ -274,8 +267,6 @@ impl StaticConfig {
         quic_client_config.set_alpn_protocols(alpn_protocols);
         let mut inner = noq::ClientConfig::new(Arc::new(quic_client_config));
         inner.transport_config(transport_config);
-        // Share the endpoint-wide token store so NEW_TOKEN tokens survive across
-        // connections (the default would mint a fresh, empty store per connection).
         inner.token_store(self.token_store.clone());
         inner
     }


### PR DESCRIPTION
## Description

This makes the validation token store global for the endpoint. Before it was recreated on each connection, which defeats the purpose of the mechanism.

I had to do this to make the example in my blog post ( https://github.com/n0-computer/iroh.computer/pull/464 ) work at all.

For context: This is the client side store for NEW_TOKEN address validation tokens that need to be presented on new connections for the mechanism to work.

The mechanism is currently disabled on the **server side** because we don't set the "bloom" feature flag on noq-proto ( noq-proto = { version = "=1.0.0-rc.1", default-features = false } ). So if we connect to iroh nodes with default features we *never* store any tokens because we never get any.

## Breaking Changes

None

## Notes & open questions

Note: this whole thing feels weird. Since NEW_TOKEN tokens are of very little utility for iroh connections (reason see blog post) I would prefer if we would really disable the mechanism both on the client side and the server side.

To do that I would like to move from the current approach of `Arc<dyn TokenStore>` with a noop impl `NoneTokenStore` to an `Option<Arc<dyn TokenStore>>` which is just `None` if the mechanism is disabled. The same for the server side where we have `Arc<dyn TokenLog>` and `NoneTokenLog`.

Note: we *can* change this without breaking the public API, but that means that we still keep the NoneXXX impls around. See https://github.com/n0-computer/noq/tree/rklaehn/refactor-token-log-2 . But then ideally you would want to remove them and also provide an option via the builder to disable them, which would be a public API change.

Disabling it by default would mean that we would need a new public API to enable it on the client side. This would be used rarely, only in cases where you care about 0-rtt *and* payloads for 0-rtt that are big enough to exceed the 3x amplification limit. I got some real world use cases for this that I personally care about, involving a DHT, but most iroh users would never have to touch this.

Note: when I say we should disable this by default I mean in iroh. In noq as a generic QUIC impl this makes more sense to enable since normal client server QUIC connections frequently have long cert chains that exceed the amplification limit. Again, for context see the blog post draft.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
