### PR TITLE
refactor(iroh): Don't log at warn level if the address lookup isn't configured.

### DIFF
--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -894,9 +894,9 @@ impl State {
             }
             Some(Err(err)) => {
                 if let AddressLookupFailed::NoServiceConfigured { .. } = err {
-                    debug!("Address Lookup not configured");
+                    trace!("Address Lookup not configured");
                 } else {
-                    warn!("Address Lookup failed: {err:#}");
+                    debug!("Address Lookup failed: {err:#}");
                 }
                 self.paths.address_lookup_finished(Err(err));
                 self.address_lookup_stream = None;

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -893,7 +893,11 @@ impl State {
                 self.address_lookup_stream = None;
             }
             Some(Err(err)) => {
-                warn!("Address Lookup failed: {err:#}");
+                if let AddressLookupFailed::NoServiceConfigured { .. } = err {
+                    debug!("Address Lookup not configured");
+                } else {
+                    warn!("Address Lookup failed: {err:#}");
+                }
                 self.paths.address_lookup_finished(Err(err));
                 self.address_lookup_stream = None;
             }


### PR DESCRIPTION
## Description

Don't log at warn level if the address lookup isn't configured.

This is a conscious choice that you don't want to be nagged about all the time.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Note: another option would be to remove the AddressLookupFailed::NoServiceConfigured entirely, but that would be breaking a public API. So I just log that particular error at less than warn to get rid of the log spam.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
