### PR TITLE
fix(iroh-dns): use portable_atomic::AtomicU64 for 32-bit targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,6 +2431,7 @@ dependencies = [
  "n0-future",
  "n0-tracing-test",
  "ndk-context",
+ "portable-atomic",
  "rand 0.10.1",
  "reqwest",
  "rustls",

--- a/iroh-dns/Cargo.toml
+++ b/iroh-dns/Cargo.toml
@@ -18,6 +18,7 @@ derive_more = { version = "2.0.1", features = ["debug"] }
 iroh-base = { version = "1.0.0-rc.1", path = "../iroh-base", default-features = false, features = ["key", "relay"] }
 n0-error = "=1.0.0-rc.0"
 n0-future = "0.3"
+portable-atomic = "1"
 rand = "0.10"
 reqwest = { version = "0.13", default-features = false }
 rustls = { version = "0.23.33", default-features = false }

--- a/iroh-dns/src/pkarr.rs
+++ b/iroh-dns/src/pkarr.rs
@@ -6,11 +6,12 @@
 
 use std::{
     fmt::{self, Display, Formatter},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::Ordering,
 };
 
 use iroh_base::{PublicKey, SecretKey, Signature};
 use n0_error::{AnyError, anyerr, e, stack_error};
+use portable_atomic::AtomicU64;
 use simple_dns::{CLASS, Name, Packet, ResourceRecord, rdata::RData};
 
 /// Maximum size of the encoded DNS packet within a signed packet.


### PR DESCRIPTION
## Description

This was an oversight. In general we should prefer potable_atomic since it falls back to normal atomics on 64 bit but also works on 32 bit platforms.

I think this should be uncontroversial since we already use portable atomics elsewhere.

Needed to get iroh to work on esp32 and other 32 bit platforms.

## Breaking Changes

None

## Notes & open questions

Note: this is not a breaking change and does not need to go in before 1.0

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
