### PR TITLE
test: Mark a patchbay test as flaky

### DIFF
--- a/iroh/tests/patchbay/degrade.rs
+++ b/iroh/tests/patchbay/degrade.rs
@@ -178,6 +178,7 @@ async fn degrade_server_1_poor() -> Result {
     run_degrade_level(Side::Server, 1).await
 }
 
+#[ignore = "flaky"]
 #[tokio::test]
 #[traced_test]
 async fn degrade_server_2_bad() -> Result {

--- a/iroh/tests/patchbay/degrade.rs
+++ b/iroh/tests/patchbay/degrade.rs
@@ -178,9 +178,9 @@ async fn degrade_server_1_poor() -> Result {
     run_degrade_level(Side::Server, 1).await
 }
 
-#[ignore = "flaky"]
 #[tokio::test]
 #[traced_test]
+#[ignore = "not yet passing reliably"]
 async fn degrade_server_2_bad() -> Result {
     run_degrade_level(Side::Server, 2).await
 }
@@ -220,6 +220,7 @@ async fn degrade_client_1_poor() -> Result {
 
 #[tokio::test]
 #[traced_test]
+#[ignore = "not yet passing reliably"]
 async fn degrade_client_2_bad() -> Result {
     run_degrade_level(Side::Client, 2).await
 }


### PR DESCRIPTION
## Description

This test is flaky because QAD fails to establish a connection within
3s due to the packet loss. At that point there's not relay server
until at least the next net-report which only runs after about 30s.

The right fix for this is for net-report to be more streaming instead
of running on a schedule. So iroh can respond to events from changed
network conditions properly.

## Breaking Changes

n/a

## Notes & open questions

See #4321 to track this.

## Change checklist

- [x] Self-review.