### PR TITLE
chore: update check-external-types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,8 +372,8 @@ jobs:
       RUSTDOCFLAGS: ""
       # Pin to the nightly that the pinned `cargo-check-external-types`
       # release was last tested against. Update both together.
-      CARGO_CHECK_EXTERNAL_TYPES_VERSION: "0.4.0"
-      TOOLCHAIN: "nightly-2025-10-18"
+      CARGO_CHECK_EXTERNAL_TYPES_VERSION: "0.5.0"
+      TOOLCHAIN: "nightly-2026-03-20"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -46,6 +46,7 @@ description = "Run cargo check-external-types on workspace crates"
 workspace = true
 # cargo check-external-types needs a specific nightly toolchain,
 # see https://github.com/awslabs/cargo-check-external-types#how-to-use
-toolchain = "${TOOLCHAIN:nightly-2025-10-18}"
+toolchain = "${TOOLCHAIN:nightly-2026-03-20}"
 command = "cargo"
+install_crate = false
 args = ["check-external-types", "--all-features"]


### PR DESCRIPTION
## Description

Updates `check-external-types` to the latest version and adapt nightly toolchain. Also don't use cargo-make's auto-install feature.
