### PR TITLE
deps: update ed25519-dalek and curve25519-dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,12 +975,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -1321,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
  "curve25519-dalek",
  "ed25519",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -15,14 +15,14 @@ rust-version = "1.91"
 workspace = true
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.6", features = ["serde", "rand_core", "zeroize"], optional = true }
+curve25519-dalek = { version = "=5.0.0-rc.0", features = ["serde", "rand_core", "zeroize"], optional = true }
 data-encoding = { version = "2.6.0", optional = true }
 data-encoding-macro = { version = "0.1.19", optional = true }
 digest = { version = "0.11", optional = true }
 # Pin sha2 & sha1 to fix version incompatibility
 sha2 = { version = "0.11.0", optional = true }
 sha1 = { version = "0.11.0", optional = true }
-ed25519-dalek = { version = "=3.0.0-pre.7", features = ["serde", "rand_core", "zeroize"], optional = true }
+ed25519-dalek = { version = "=3.0.0-rc.0", features = ["serde", "rand_core", "zeroize"], optional = true }
 derive_more = { version = "2.0.1", features = ["debug", "display"], optional = true }
 url = { version = "2.5.3", features = ["serde"], optional = true }
 rand = { version = "0.10", optional = true }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -28,7 +28,7 @@ ctutils = { version = "0.4.0", default-features = false }
 data-encoding = "2.2"
 
 derive_more = { version = "2.0.1", features = ["debug", "display", "from", "try_into", "deref", "from_str", "into_iterator"] }
-ed25519-dalek = { version = "=3.0.0-pre.7", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
+ed25519-dalek = { version = "=3.0.0-rc.0", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
 http = "1"
 ipnet = "2"
 iroh-base = { version = "1.0.0-rc.1", default-features = false, features = ["key", "relay"], path = "../iroh-base" }


### PR DESCRIPTION
## Description

Updates `ed25519-dalek` to `=3.0.0-rc.0` and `curve25519-dalek` to `=5.0.0-rc.0`. Not sure if the final release will be made in time. We can do a minor release though once the final version comes out. It will be "semi-breaking" but there's nothing we can do about it then (builds will break for people who have `=3.0.0-rc.0` in their *own* Cargo.toml).