### PR TITLE
feat(iroh-relay): Add Bearer token access control without an external service

### DIFF
--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -23,6 +23,68 @@ relays, including:
 
 Used in [iroh], created with love by the [n0 team](https://n0.computer/).
 
+## Access control
+
+The relay server supports several access control modes, configured via the
+`access` field in the TOML config file.
+
+### Allow everyone (default)
+
+```toml
+access = "everyone"
+```
+
+### Allowlist / Denylist by node ID
+
+```toml
+# Allow only specific nodes
+access.allowlist = ["<node-id>", "<node-id>"]
+
+# Or block specific nodes and allow everyone else
+access.denylist = ["<node-id>"]
+```
+
+### Bearer token (local, no external service)
+
+Requires connecting clients to present a shared secret via an
+`Authorization: Bearer <token>` header, or a `?token=` URL query parameter.
+
+```toml
+access.token = "my-static-token"
+```
+
+The token can also be supplied via the `IROH_RELAY_ACCESS_TOKEN` environment
+variable, which takes precedence over the config file value.
+
+The token must not be an empty string; the server will fail to start if it is.
+
+On the client side, set the token using
+[`RelayConfig::with_auth_token`](https://docs.rs/iroh-relay/latest/iroh_relay/struct.RelayConfig.html#method.with_auth_token)
+or
+[`RelayMap::with_auth_token`](https://docs.rs/iroh-relay/latest/iroh_relay/struct.RelayMap.html#method.with_auth_token).
+
+> **Note:** a static token has no expiry or revocation. For production
+> deployments that need token lifecycle management, use `AccessConfig::Http`
+> with a dedicated auth service instead. The `AccessControl` trait also
+> supports runtime revocation via `on_connect`/`on_disconnect` and
+> `Clients::disconnect` — see [`tests/runtime_auth.rs`](tests/runtime_auth.rs)
+> for a worked example.
+
+### HTTP callout (external auth service)
+
+The relay calls an external HTTP endpoint for each incoming connection,
+passing the connecting node's ID. The token below authenticates the relay
+to your auth service (machine-to-machine), not the connecting client.
+
+```toml
+access.http.url = "https://your-auth-service.example.com/relay-auth"
+# Optional: authenticate the relay's outbound request to your service
+access.http.bearer_token = "service-to-service-secret"
+```
+
+The bearer token can also be set via the `IROH_RELAY_HTTP_BEARER_TOKEN`
+environment variable.
+
 ## Local testing
 
 Advice for testing your application that uses `iroh` with a locally running `iroh-relay` server

--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -34,23 +34,23 @@ The relay server supports several access control modes, configured via the
 access = "everyone"
 ```
 
-### Allowlist / Denylist by node ID
+### Allowlist / Denylist by endpoint ID
 
 ```toml
-# Allow only specific nodes
-access.allowlist = ["<node-id>", "<node-id>"]
+# Allow only specific endpoints
+access.allowlist = ["<endpoint-id>", "<endpoint-id>"]
 
-# Or block specific nodes and allow everyone else
-access.denylist = ["<node-id>"]
+# Or block specific endpoints and allow everyone else
+access.denylist = ["<endpoint-id>"]
 ```
 
-### Bearer token (local, no external service)
+### Shared token (local, no external service)
 
 Requires connecting clients to present one of the configured shared secrets via an
 `Authorization: Bearer <token>` header, or a `?token=` URL query parameter.
 
 ```toml
-access.token = ["token-a", "token-b"]
+access.shared_token = ["token-a", "token-b"]
 ```
 
 The token list can also be overridden by the `IROH_RELAY_ACCESS_TOKEN` environment
@@ -66,17 +66,12 @@ On the client side, set the token using
 or
 [`RelayMap::with_auth_token`](https://docs.rs/iroh-relay/latest/iroh_relay/struct.RelayMap.html#method.with_auth_token).
 
-> **Note:** a static token has no expiry or revocation. For production
-> deployments that need token lifecycle management, use `AccessConfig::Http`
-> with a dedicated auth service instead. The `AccessControl` trait also
-> supports runtime revocation via `on_connect`/`on_disconnect` and
-> `Clients::disconnect` — see [`tests/runtime_auth.rs`](tests/runtime_auth.rs)
-> for a worked example.
+> **Note:** this shared token does not support revocation other than updating the config and restarting the service.
 
 ### HTTP callout (external auth service)
 
 The relay calls an external HTTP endpoint for each incoming connection,
-passing the connecting node's ID. The token below authenticates the relay
+passing the connecting endpoint's ID. The token below authenticates the relay
 to your auth service (machine-to-machine), not the connecting client.
 
 ```toml

--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -46,17 +46,20 @@ access.denylist = ["<node-id>"]
 
 ### Bearer token (local, no external service)
 
-Requires connecting clients to present a shared secret via an
+Requires connecting clients to present one of the configured shared secrets via an
 `Authorization: Bearer <token>` header, or a `?token=` URL query parameter.
 
 ```toml
-access.token = "my-static-token"
+access.token = ["token-a", "token-b"]
 ```
 
-The token can also be supplied via the `IROH_RELAY_ACCESS_TOKEN` environment
-variable, which takes precedence over the config file value.
+The token list can also be overridden by the `IROH_RELAY_ACCESS_TOKEN` environment
+variable, which sets a single allowed token and takes precedence over the config file
+value. A single value is used (rather than a comma-separated list) to avoid restricting
+the character set of tokens.
 
-The token must not be an empty string; the server will fail to start if it is.
+The token list must not be empty, and no token may be an empty string; the server will
+fail to start if either condition is violated.
 
 On the client side, set the token using
 [`RelayConfig::with_auth_token`](https://docs.rs/iroh-relay/latest/iroh_relay/struct.RelayConfig.html#method.with_auth_token)

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -168,6 +168,7 @@ enum AccessConfig {
     /// To grant access, the HTTP endpoint must return a `200` response with `true` as the response text.
     /// In all other cases, the endpoint will be denied access.
     Http(HttpAccessConfig),
+    #[serde(rename = "shared_token")]
     /// Allows only clients that present one of the configured bearer tokens.
     ///
     /// The token is read from the `Authorization: Bearer <token>` request header,
@@ -185,9 +186,9 @@ enum AccessConfig {
     /// # Example
     ///
     /// ```toml
-    /// access.token = ["token-a", "token-b"]
+    /// access.shared_token = ["token-a", "token-b"]
     /// ```
-    Token(Vec<String>),
+    SharedToken(Vec<String>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -222,16 +223,16 @@ impl TryFrom<AccessConfig> for Arc<dyn iroh_relay::server::DynAccessControl> {
                 }
                 Ok(Arc::new(HttpAccess { client, config }))
             }
-            AccessConfig::Token(mut tokens) => {
+            AccessConfig::SharedToken(mut tokens) => {
                 // A single env var token replaces the entire list. A comma-separated list
                 // is intentionally not supported to avoid restricting the token character set.
                 if let Ok(env_token) = std::env::var(ENV_RELAY_ACCESS_TOKEN) {
                     tokens = vec![env_token];
                 }
                 if tokens.is_empty() || tokens.iter().any(|t| t.is_empty()) {
-                    bail_any!("access.token must not be empty or contain empty strings");
+                    bail_any!("access.shared_token must not be empty or contain empty strings");
                 }
-                Ok(Arc::new(TokenAccess(tokens)))
+                Ok(Arc::new(SharedTokenAccess(tokens)))
             }
         }
     }
@@ -267,9 +268,9 @@ impl AccessControl for DenylistAccess {
 
 /// An [`AccessControl`] admitting only clients that present one of the configured bearer tokens.
 #[derive(Debug)]
-struct TokenAccess(Vec<String>);
+struct SharedTokenAccess(Vec<String>);
 
-impl AccessControl for TokenAccess {
+impl AccessControl for SharedTokenAccess {
     async fn on_connect(&self, request: &ClientRequest) -> Access {
         match request.auth_token() {
             Some(token) if self.0.contains(&token) => Access::Allow,
@@ -859,13 +860,13 @@ mod tests {
         );
 
         let config = r#"
-            access.token = ["token-a", "token-b"]
+            access.shared_token = ["token-a", "token-b"]
         "#
         .to_string();
         let config = Config::from_str(dbg!(&config))?;
         assert_eq!(
             config.access,
-            AccessConfig::Token(vec!["token-a".to_string(), "token-b".to_string()])
+            AccessConfig::SharedToken(vec!["token-a".to_string(), "token-b".to_string()])
         );
 
         Ok(())
@@ -874,7 +875,7 @@ mod tests {
     #[tokio::test]
     async fn test_access_token_empty_is_rejected() -> Result {
         let config = r#"
-            access.token = []
+            access.shared_token = []
         "#;
         let config = Config::from_str(config)?;
         assert!(
@@ -883,7 +884,7 @@ mod tests {
         );
 
         let config = r#"
-            access.token = [""]
+            access.shared_token = [""]
         "#;
         let config = Config::from_str(config)?;
         assert!(

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -217,14 +217,12 @@ impl From<AccessConfig> for Arc<dyn iroh_relay::server::DynAccessControl> {
                 }
                 Arc::new(HttpAccess { client, config })
             },
-           AccessConfig::Token(mut token) => {
+            AccessConfig::Token(mut token) => {
                 if let Ok(env_token) = std::env::var(ENV_RELAY_ACCESS_TOKEN) {
                     token = env_token;
                 }
-                if token.is_empty() {
-                    bail_any!("Access token must not be empty");
-                }
                 Arc::new(TokenAccess(token))
+            }
         }
     }
 }
@@ -717,6 +715,12 @@ async fn build_relay_config(cfg: Config) -> Result<relay::ServerConfig> {
         relay_config.tls = tls_config;
         relay_config.limits = limits;
         relay_config.key_cache_capacity = cfg.key_cache_capacity;
+        if let AccessConfig::Token(ref token) = cfg.access {
+            let effective = std::env::var(ENV_RELAY_ACCESS_TOKEN).unwrap_or_else(|_| token.clone());
+            if effective.is_empty() {
+                bail_any!("Access token must not be an empty string");
+            }
+        }
         relay_config.access = cfg.access.clone().into();
         Some(relay_config)
     } else {
@@ -849,6 +853,27 @@ mod tests {
                 url: "https://example.com/foo".parse().unwrap(),
                 bearer_token: Some("foo".to_string())
             })
+        );
+
+        let config = r#"
+            access.token = "my-static-token"
+        "#
+        .to_string();
+        let config = Config::from_str(dbg!(&config))?;
+        assert_eq!(config.access, AccessConfig::Token("my-static-token".to_string()));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_access_token_empty_is_rejected() -> Result {
+        let config = r#"
+            access.token = ""
+        "#;
+        let config = Config::from_str(config)?;
+        assert!(
+            build_relay_config(config).await.is_err(),
+            "empty access token should be rejected at startup"
         );
         Ok(())
     }

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -182,7 +182,7 @@ enum AccessConfig {
     /// # Example
     ///
     /// ```toml
-    /// access.token = "my-secret"
+    /// access.token = "my-static-token"
     /// ```
     Token(String),
 }
@@ -216,7 +216,7 @@ impl From<AccessConfig> for Arc<dyn iroh_relay::server::DynAccessControl> {
                     config.bearer_token = Some(token);
                 }
                 Arc::new(HttpAccess { client, config })
-            },
+            }
             AccessConfig::Token(mut token) => {
                 if let Ok(env_token) = std::env::var(ENV_RELAY_ACCESS_TOKEN) {
                     token = env_token;
@@ -860,7 +860,10 @@ mod tests {
         "#
         .to_string();
         let config = Config::from_str(dbg!(&config))?;
-        assert_eq!(config.access, AccessConfig::Token("my-static-token".to_string()));
+        assert_eq!(
+            config.access,
+            AccessConfig::Token("my-static-token".to_string())
+        );
 
         Ok(())
     }

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -35,6 +35,8 @@ const DEV_MODE_HTTP_PORT: u16 = 3340;
 const X_IROH_ENDPOINT_ID: &str = "X-Iroh-NodeId";
 /// Environment variable to read a bearer token for HTTP auth requests from.
 const ENV_HTTP_BEARER_TOKEN: &str = "IROH_RELAY_HTTP_BEARER_TOKEN";
+/// Environment variable to verify relay access (without an external auth service)
+const ENV_RELAY_ACCESS_TOKEN: &str = "IROH_RELAY_ACCESS_TOKEN";
 
 /// A relay server for iroh.
 #[derive(Parser, Debug, Clone)]
@@ -166,6 +168,23 @@ enum AccessConfig {
     /// To grant access, the HTTP endpoint must return a `200` response with `true` as the response text.
     /// In all other cases, the endpoint will be denied access.
     Http(HttpAccessConfig),
+    /// Allows only clients that present the configured bearer token.
+    ///
+    /// The token is read from the `Authorization: Bearer <token>` request header,
+    /// or from the `?token=` URL query parameter as a fallback.
+    /// All other connections are denied.
+    ///
+    /// The token can also be set via the `IROH_RELAY_ACCESS_TOKEN` environment
+    /// variable, which takes precedence over the config file value.
+    ///
+    /// The token must not be an empty string; the server will fail to start if it is.
+    ///
+    /// # Example
+    ///
+    /// ```toml
+    /// access.token = "my-secret"
+    /// ```
+    Token(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -197,7 +216,15 @@ impl From<AccessConfig> for Arc<dyn iroh_relay::server::DynAccessControl> {
                     config.bearer_token = Some(token);
                 }
                 Arc::new(HttpAccess { client, config })
-            }
+            },
+           AccessConfig::Token(mut token) => {
+                if let Ok(env_token) = std::env::var(ENV_RELAY_ACCESS_TOKEN) {
+                    token = env_token;
+                }
+                if token.is_empty() {
+                    bail_any!("Access token must not be empty");
+                }
+                Arc::new(TokenAccess(token))
         }
     }
 }
@@ -226,6 +253,20 @@ impl AccessControl for DenylistAccess {
             Access::Deny { reason: None }
         } else {
             Access::Allow
+        }
+    }
+}
+
+/// An [`AccessControl`] admitting only presenting a valid configured access token.
+#[derive(Debug)]
+struct TokenAccess(String);
+
+impl AccessControl for TokenAccess {
+    async fn on_connect(&self, request: &ClientRequest) -> Access {
+        if request.auth_token().as_deref() == Some(self.0.as_str()) {
+            Access::Allow
+        } else {
+            Access::Deny { reason: None }
         }
     }
 }

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -22,7 +22,7 @@ use iroh_relay::{
         DEFAULT_CERT_RELOAD_INTERVAL, QuicConfig, reloading_resolver,
     },
 };
-use n0_error::{Result, StdResultExt, bail_any};
+use n0_error::{AnyError, Result, StdResultExt, bail_any};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 use tracing_subscriber::{EnvFilter, prelude::*};
@@ -168,23 +168,26 @@ enum AccessConfig {
     /// To grant access, the HTTP endpoint must return a `200` response with `true` as the response text.
     /// In all other cases, the endpoint will be denied access.
     Http(HttpAccessConfig),
-    /// Allows only clients that present the configured bearer token.
+    /// Allows only clients that present one of the configured bearer tokens.
     ///
     /// The token is read from the `Authorization: Bearer <token>` request header,
     /// or from the `?token=` URL query parameter as a fallback.
     /// All other connections are denied.
     ///
-    /// The token can also be set via the `IROH_RELAY_ACCESS_TOKEN` environment
-    /// variable, which takes precedence over the config file value.
+    /// The token list can also be overridden by the `IROH_RELAY_ACCESS_TOKEN` environment
+    /// variable, which sets a single allowed token and takes precedence over the config
+    /// file value. A single value is used (rather than a comma-separated list) to avoid
+    /// restricting the character set of tokens.
     ///
-    /// The token must not be an empty string; the server will fail to start if it is.
+    /// The token list must not be empty, and no token may be an empty string;
+    /// the server will fail to start if either condition is violated.
     ///
     /// # Example
     ///
     /// ```toml
-    /// access.token = "my-static-token"
+    /// access.token = ["token-a", "token-b"]
     /// ```
-    Token(String),
+    Token(Vec<String>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -200,12 +203,14 @@ struct HttpAccessConfig {
     bearer_token: Option<String>,
 }
 
-impl From<AccessConfig> for Arc<dyn iroh_relay::server::DynAccessControl> {
-    fn from(cfg: AccessConfig) -> Self {
+impl TryFrom<AccessConfig> for Arc<dyn iroh_relay::server::DynAccessControl> {
+    type Error = AnyError;
+
+    fn try_from(cfg: AccessConfig) -> Result<Self> {
         match cfg {
-            AccessConfig::Everyone => Arc::new(iroh_relay::server::AllowAll),
-            AccessConfig::Allowlist(allow_list) => Arc::new(AllowlistAccess(allow_list)),
-            AccessConfig::Denylist(deny_list) => Arc::new(DenylistAccess(deny_list)),
+            AccessConfig::Everyone => Ok(Arc::new(iroh_relay::server::AllowAll)),
+            AccessConfig::Allowlist(allow_list) => Ok(Arc::new(AllowlistAccess(allow_list))),
+            AccessConfig::Denylist(deny_list) => Ok(Arc::new(DenylistAccess(deny_list))),
             AccessConfig::Http(mut config) => {
                 let client = reqwest::Client::builder()
                     .use_rustls_tls()
@@ -215,13 +220,18 @@ impl From<AccessConfig> for Arc<dyn iroh_relay::server::DynAccessControl> {
                 if let Ok(token) = std::env::var(ENV_HTTP_BEARER_TOKEN) {
                     config.bearer_token = Some(token);
                 }
-                Arc::new(HttpAccess { client, config })
+                Ok(Arc::new(HttpAccess { client, config }))
             }
-            AccessConfig::Token(mut token) => {
+            AccessConfig::Token(mut tokens) => {
+                // A single env var token replaces the entire list. A comma-separated list
+                // is intentionally not supported to avoid restricting the token character set.
                 if let Ok(env_token) = std::env::var(ENV_RELAY_ACCESS_TOKEN) {
-                    token = env_token;
+                    tokens = vec![env_token];
                 }
-                Arc::new(TokenAccess(token))
+                if tokens.is_empty() || tokens.iter().any(|t| t.is_empty()) {
+                    bail_any!("access.token must not be empty or contain empty strings");
+                }
+                Ok(Arc::new(TokenAccess(tokens)))
             }
         }
     }
@@ -255,16 +265,15 @@ impl AccessControl for DenylistAccess {
     }
 }
 
-/// An [`AccessControl`] admitting only presenting a valid configured access token.
+/// An [`AccessControl`] admitting only clients that present one of the configured bearer tokens.
 #[derive(Debug)]
-struct TokenAccess(String);
+struct TokenAccess(Vec<String>);
 
 impl AccessControl for TokenAccess {
     async fn on_connect(&self, request: &ClientRequest) -> Access {
-        if request.auth_token().as_deref() == Some(self.0.as_str()) {
-            Access::Allow
-        } else {
-            Access::Deny { reason: None }
+        match request.auth_token() {
+            Some(token) if self.0.contains(&token) => Access::Allow,
+            _ => Access::Deny { reason: None },
         }
     }
 }
@@ -715,13 +724,7 @@ async fn build_relay_config(cfg: Config) -> Result<relay::ServerConfig> {
         relay_config.tls = tls_config;
         relay_config.limits = limits;
         relay_config.key_cache_capacity = cfg.key_cache_capacity;
-        if let AccessConfig::Token(ref token) = cfg.access {
-            let effective = std::env::var(ENV_RELAY_ACCESS_TOKEN).unwrap_or_else(|_| token.clone());
-            if effective.is_empty() {
-                bail_any!("Access token must not be an empty string");
-            }
-        }
-        relay_config.access = cfg.access.clone().into();
+        relay_config.access = cfg.access.clone().try_into()?;
         Some(relay_config)
     } else {
         None
@@ -856,13 +859,13 @@ mod tests {
         );
 
         let config = r#"
-            access.token = "my-static-token"
+            access.token = ["token-a", "token-b"]
         "#
         .to_string();
         let config = Config::from_str(dbg!(&config))?;
         assert_eq!(
             config.access,
-            AccessConfig::Token("my-static-token".to_string())
+            AccessConfig::Token(vec!["token-a".to_string(), "token-b".to_string()])
         );
 
         Ok(())
@@ -871,12 +874,21 @@ mod tests {
     #[tokio::test]
     async fn test_access_token_empty_is_rejected() -> Result {
         let config = r#"
-            access.token = ""
+            access.token = []
         "#;
         let config = Config::from_str(config)?;
         assert!(
             build_relay_config(config).await.is_err(),
-            "empty access token should be rejected at startup"
+            "empty token list should be rejected at startup"
+        );
+
+        let config = r#"
+            access.token = [""]
+        "#;
+        let config = Config::from_str(config)?;
+        assert!(
+            build_relay_config(config).await.is_err(),
+            "empty string token should be rejected at startup"
         );
         Ok(())
     }


### PR DESCRIPTION
## Description

This PR adds a new `AccessConfig::SharedToken(Vec<String>)` variant to the `iroh-relay` configuration,
allowing self-hosted relays to require a shared bearer token from connecting
clients, without using an external auth service.

- Clients authenticate via `Authorization: Bearer <token>` header or `?token=` query param,
  using the existing `RelayConfig::with_auth_token()` / `RelayMap::with_auth_token()` API;
- Token can be set via config file (`access.shared_token = ["token-a", "token-b"]`) or the
  `IROH_RELAY_ACCESS_TOKEN` environment variable (**the env var takes precedence**);
- Empty token is rejected at startup;
- A token set to the empty string, will make the server fail to start.

[See related discussion](https://github.com/n0-computer/iroh/discussions/4316)

## Breaking Changes

None.

## Notes & open questions

- As we stated in the discussion, using an external service should always be considered the best choice for production. The static token variant is still useful for simpler deployments.
- Supported the token list in config, as suggested by fokx

## Change checklist
- [x] Self-review
- [x] Documentation updates
- [x] Tests

Co-authored-by: fokx <36614441+fokx@users.noreply.github.com>