### PR TITLE
docs: general cleanup and fixes

### DIFF
--- a/iroh-base/src/endpoint_addr.rs
+++ b/iroh-base/src/endpoint_addr.rs
@@ -20,7 +20,7 @@ use crate::{EndpointId, PublicKey, RelayUrl};
 /// contact the endpoint.
 ///
 /// To establish a network connection to an endpoint both the [`EndpointId`] and one or more network
-/// paths are needed.  The network paths can come from various sources, current sources can come from
+/// paths are needed.  The network paths can come from various sources:
 ///
 /// - An [Address Lookup] service which can provide routing information for a given [`EndpointId`].
 ///
@@ -42,7 +42,7 @@ use crate::{EndpointId, PublicKey, RelayUrl};
 pub struct EndpointAddr {
     /// The endpoint's identifier.
     pub id: EndpointId,
-    /// The endpoint's addresses
+    /// The endpoint's addresses.
     pub addrs: BTreeSet<TransportAddr>,
 }
 
@@ -52,10 +52,10 @@ pub struct EndpointAddr {
 )]
 #[non_exhaustive]
 pub enum TransportAddr {
-    /// Relays
+    /// A relay server address.
     #[debug("Relay({_0})")]
     Relay(RelayUrl),
-    /// IP based addresses
+    /// An IP based address.
     Ip(SocketAddr),
     /// Custom transport address
     Custom(CustomAddr),
@@ -128,12 +128,12 @@ impl EndpointAddr {
         self
     }
 
-    /// Returns true, if only a [`EndpointId`] is present.
+    /// Returns true if only an [`EndpointId`] is present.
     pub fn is_empty(&self) -> bool {
         self.addrs.is_empty()
     }
 
-    /// Returns a list of IP addresses of this peer.
+    /// Returns an iterator over the IP addresses of this endpoint.
     pub fn ip_addrs(&self) -> impl Iterator<Item = &SocketAddr> {
         self.addrs.iter().filter_map(|addr| match addr {
             TransportAddr::Ip(addr) => Some(addr),
@@ -141,7 +141,7 @@ impl EndpointAddr {
         })
     }
 
-    /// Returns a list of relay urls of this peer.
+    /// Returns an iterator over the relay URLs of this endpoint.
     ///
     ///  In practice this is expected to be zero or one home relay for all known cases currently.
     pub fn relay_urls(&self) -> impl Iterator<Item = &RelayUrl> {

--- a/iroh-base/src/endpoint_addr.rs
+++ b/iroh-base/src/endpoint_addr.rs
@@ -133,7 +133,7 @@ impl EndpointAddr {
         self.addrs.is_empty()
     }
 
-    /// Returns an iterator over the IP addresses of this endpoint.
+    /// Returns an iterator over the IP addresses of this endpoint address.
     pub fn ip_addrs(&self) -> impl Iterator<Item = &SocketAddr> {
         self.addrs.iter().filter_map(|addr| match addr {
             TransportAddr::Ip(addr) => Some(addr),
@@ -141,7 +141,7 @@ impl EndpointAddr {
         })
     }
 
-    /// Returns an iterator over the relay URLs of this endpoint.
+    /// Returns an iterator over the relay URLs of this endpoint address.
     ///
     ///  In practice this is expected to be zero or one home relay for all known cases currently.
     pub fn relay_urls(&self) -> impl Iterator<Item = &RelayUrl> {

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -23,7 +23,7 @@ const Z_BASE_32: Encoding = new_encoding! {
 
 /// A public key.
 ///
-/// The key itself is stored as the `CompressedEdwards` y coordinate of the public key
+/// The key itself is stored as the compressed Edwards y-coordinate of the public key.
 /// It is verified to decompress into a valid key when created.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
@@ -126,7 +126,7 @@ impl PublicKey {
         Ok(Self(y))
     }
 
-    /// Verify a signature on a message with this secret key's public key.
+    /// Verify a signature on a message with this public key.
     ///
     /// # Return
     ///
@@ -224,7 +224,7 @@ impl Display for PublicKey {
     }
 }
 
-/// Error when deserialising a [`PublicKey`] or a [`SecretKey`].
+/// Error returned when parsing a [`PublicKey`] or a [`SecretKey`].
 #[stack_error(derive, add_meta, from_sources, std_sources)]
 #[allow(missing_docs)]
 #[non_exhaustive]
@@ -238,14 +238,14 @@ pub enum KeyParsingError {
     /// The input has invalid length.
     #[error("invalid length")]
     InvalidLength,
-    /// The decoded data is not a valid Ed25591 public key.
+    /// The decoded data is not a valid Ed25519 public key.
     #[error("data is not a valid public key")]
     InvalidKeyData,
 }
 
-/// Deserialises the [`PublicKey`] from it's base32 encoding.
+/// Parses a [`PublicKey`] from its hex or base32 encoding.
 ///
-/// [`Display`] is capable of serialising this format.
+/// [`Display`] produces the hex encoding.
 impl FromStr for PublicKey {
     type Err = KeyParsingError;
 

--- a/iroh-base/src/key.rs
+++ b/iroh-base/src/key.rs
@@ -23,7 +23,7 @@ const Z_BASE_32: Encoding = new_encoding! {
 
 /// A public key.
 ///
-/// The key itself is stored as the compressed Edwards y-coordinate of the public key.
+/// The key itself is stored as the `CompressedEdwards` y-coordinate of the public key.
 /// It is verified to decompress into a valid key when created.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -13,7 +13,7 @@ pub struct Metrics {
     pub pkarr_publish_noop: Counter,
     /// Total number of DNS requests across all transports.
     pub dns_requests: Counter,
-    /// Number of DNS requests received over UDP or TCP.
+    /// Number of DNS requests received over UDP.
     pub dns_requests_udp: Counter,
     /// Number of DNS requests received over HTTPS (DoH).
     pub dns_requests_https: Counter,
@@ -34,6 +34,8 @@ pub struct Metrics {
     /// Number of signed packets newly inserted into the store.
     pub store_packets_inserted: Counter,
     /// Number of signed packets removed from the store.
+    ///
+    /// Currently always at 0 because the removal API is not used.
     pub store_packets_removed: Counter,
     /// Number of times an existing signed packet was replaced by a newer one.
     pub store_packets_updated: Counter,

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -334,7 +334,7 @@ impl DnsResolver {
     ///
     /// We first try to read the system's resolver from `/etc/resolv.conf`.
     /// This does not work at least on some Androids, therefore we fallback
-    /// to the default `ResolverConfig` which uses eg. to google's `8.8.8.8` or `8.8.4.4`.
+    /// to the default `ResolverConfig` which uses e.g. Google's `8.8.8.8` or `8.8.4.4`.
     pub fn new() -> Self {
         Builder::default().with_system_defaults().build()
     }

--- a/iroh-dns/src/endpoint_info.rs
+++ b/iroh-dns/src/endpoint_info.rs
@@ -3,7 +3,7 @@
 //! Dialing by [`EndpointId`] is supported by iroh endpoints publishing [Pkarr] records to DNS
 //! servers or the Mainline DHT.  This module supports creating and parsing these records.
 //!
-//! [`EndpointInfo`] combines an [`iroh_base::EndpointId`] with [`EndpointData`] —
+//! [`EndpointInfo`] combines an [`iroh_base::EndpointId`] with [`EndpointData`]:
 //! the addressing and metadata that discovery services publish and resolve.
 //! Discovery services use [`AddrFilter`] to control which addresses are published.
 //!
@@ -120,7 +120,7 @@ impl EndpointData {
         self.add_addrs(addresses.into_iter().map(TransportAddr::Ip))
     }
 
-    /// Adds addresses to the endpoint data in the given ordered, but with duplicates filtered.
+    /// Adds addresses to the endpoint data in the given order, but with duplicates filtered.
     pub fn add_addrs(&mut self, addrs: impl IntoIterator<Item = TransportAddr>) {
         let mut addr_set = dedup(&mut self.addrs);
         for addr in addrs.into_iter() {
@@ -131,7 +131,7 @@ impl EndpointData {
         }
     }
 
-    /// Sets the user-defined data and returns the updated endpoint data.
+    /// Sets the user-defined data.
     pub fn set_user_data(&mut self, user_data: Option<UserData>) {
         self.user_data = user_data;
     }
@@ -142,7 +142,7 @@ impl EndpointData {
             .retain(|addr| !matches!(addr, TransportAddr::Ip(_)));
     }
 
-    /// Removes all direct addresses from the endpoint data.
+    /// Removes all relay URLs from the endpoint data.
     pub fn clear_relay_urls(&mut self) {
         self.addrs
             .retain(|addr| !matches!(addr, TransportAddr::Relay(_)));
@@ -169,12 +169,12 @@ impl EndpointData {
         })
     }
 
-    /// Returns the full list of all known addresses
+    /// Returns the full list of all known addresses.
     pub fn addrs(&self) -> impl Iterator<Item = &TransportAddr> {
         self.addrs.iter()
     }
 
-    /// Does this have any addresses?
+    /// Returns whether this has any addresses.
     pub fn has_addrs(&self) -> bool {
         !self.addrs.is_empty()
     }
@@ -294,9 +294,9 @@ impl From<EndpointAddr> for EndpointData {
     }
 }
 
-// User-defined data that can be published and resolved through endpoint discovery.
+/// User-defined data that can be published and resolved through endpoint discovery.
 ///
-/// Under the hood this is a UTF-8 String is no longer than [`UserData::MAX_LENGTH`] bytes.
+/// Under the hood this is a UTF-8 string no longer than [`UserData::MAX_LENGTH`] bytes.
 ///
 /// Iroh does not keep track of or examine the user-defined data.
 ///

--- a/iroh-dns/src/endpoint_info.rs
+++ b/iroh-dns/src/endpoint_info.rs
@@ -8,7 +8,7 @@
 //! Discovery services use [`AddrFilter`] to control which addresses are published.
 //!
 //! This module also provides serialization to and from pkarr signed packets and
-//! DNS TXT records. See the [`crate::attrs`] module for the on-the-wire format.
+//! DNS TXT records.
 //!
 //! DNS records are published under the following names:
 //!

--- a/iroh-relay/src/http.rs
+++ b/iroh-relay/src/http.rs
@@ -77,7 +77,7 @@ impl ProtocolVersion {
         Self::all().collect::<Vec<_>>().join(", ")
     }
 
-    /// Returns all supported protocol versions in a comma-seperated string as an HTTP header value.
+    /// Returns all supported protocol versions in a comma-separated string as an HTTP header value.
     pub fn all_as_header_value() -> HeaderValue {
         HeaderValue::from_bytes(Self::all_joined().as_bytes()).expect("valid header name")
     }

--- a/iroh-relay/src/lib.rs
+++ b/iroh-relay/src/lib.rs
@@ -51,15 +51,13 @@ pub use crate::{
     relay_map::{RelayConfig, RelayMap, RelayQuicConfig},
 };
 
-/// This trait allows anything that ends up potentially
-/// wrapping a TLS stream use the underlying [`export_keying_material`]
-/// function.
-///
-/// [`export_keying_material`]: rustls::ConnectionCommon::export_keying_material
 /// Trait for extracting keying material from a TLS connection.
 ///
-/// This is used during the relay handshake to establish a shared secret
-/// between the client and server for authentication purposes.
+/// This allows anything that ends up potentially wrapping a TLS stream to use the
+/// underlying [`export_keying_material`] function. It is used during the relay handshake
+/// to establish a shared secret between the client and server for authentication purposes.
+///
+/// [`export_keying_material`]: rustls::ConnectionCommon::export_keying_material
 pub trait ExportKeyingMaterial {
     /// If this type ends up wrapping a TLS stream, then this tries
     /// to export keying material by calling the underlying [`export_keying_material`]

--- a/iroh-relay/src/protos/common.rs
+++ b/iroh-relay/src/protos/common.rs
@@ -39,8 +39,7 @@ pub enum FrameType {
     ///
     /// 32B pub key of peer that's gone
     EndpointGone = 8,
-    /// Messages with these frames will be ignored.
-    /// 8 byte ping payload, to be echoed back in FrameType::Pong
+    /// 8 byte ping payload, to be echoed back in a [`FrameType::Pong`].
     Ping = 9,
     /// 8 byte payload, the contents of ping being replied to
     Pong = 10,

--- a/iroh-relay/src/protos/handshake.rs
+++ b/iroh-relay/src/protos/handshake.rs
@@ -377,16 +377,12 @@ pub(crate) async fn clientside(
     }
 }
 
-/// This represents successful authentication for the client with the `client_key` public key
-/// via the authentication [`Mechanism`] `mechanism`.
-///
-/// You must call [`SuccessfulAuthentication::authorize_if`] to finish the protocol.
-#[cfg(feature = "server")]
 /// Result of a successful authentication handshake.
 ///
 /// This struct represents a client that has successfully authenticated itself to the relay
 /// server. The authorization must still be confirmed by calling [`Self::authorize_if`] to
 /// complete the protocol and notify the client of success or failure.
+#[cfg(feature = "server")]
 #[derive(Debug)]
 #[must_use = "the protocol is not finished unless `authorize_if` is called"]
 pub struct SuccessfulAuthentication {

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -486,16 +486,16 @@ impl TlsConfig {
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct Limits {
+    /// Rate limits for incoming traffic from a client connection.
+    pub client_rx: Option<ClientRateLimit>,
     /// Rate limit for accepting new connections. Unlimited if not set.
     ///
-    /// Not currently implemented; setting this has no effect.
+    /// Not currently implemented, setting this has no effect.
     pub accept_conn_limit: Option<f64>,
     /// Burst limit for accepting new connections. Unlimited if not set.
     ///
-    /// Not currently implemented; setting this has no effect.
+    /// Not currently implemented, setting this has no effect.
     pub accept_conn_burst: Option<usize>,
-    /// Rate limits for incoming traffic from a client connection.
-    pub client_rx: Option<ClientRateLimit>,
 }
 
 /// Per-client rate limit configuration.

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -465,7 +465,7 @@ pub struct TlsConfig {
     /// the main relay server this has to be on a different port.  When TLS is not enabled
     /// this is served on the [`RelayConfig::http_bind_addr`] socket address.
     ///
-    /// Normally you'd choose port `80`.
+    /// Normally you'd choose port `443`.
     pub https_bind_addr: SocketAddr,
     /// Mode for getting a cert.
     pub cert: CertConfig,
@@ -486,9 +486,13 @@ impl TlsConfig {
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct Limits {
-    /// Rate limit for accepting new connection. Unlimited if not set.
+    /// Rate limit for accepting new connections. Unlimited if not set.
+    ///
+    /// Not currently implemented; setting this has no effect.
     pub accept_conn_limit: Option<f64>,
-    /// Burst limit for accepting new connection. Unlimited if not set.
+    /// Burst limit for accepting new connections. Unlimited if not set.
+    ///
+    /// Not currently implemented; setting this has no effect.
     pub accept_conn_burst: Option<usize>,
     /// Rate limits for incoming traffic from a client connection.
     pub client_rx: Option<ClientRateLimit>,

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -42,7 +42,7 @@ pub(super) struct Packet {
     data: Datagrams,
 }
 
-/// Configuration for a [`Client`].
+/// Configuration for a client connection.
 ///
 /// Generic over the stream type to support different WebSocket implementations.
 #[derive(Debug)]

--- a/iroh-relay/src/server/clients.rs
+++ b/iroh-relay/src/server/clients.rs
@@ -21,12 +21,11 @@ use crate::{
     server::{client::SendError, metrics::Metrics},
 };
 
-/// Manages the connections to all currently connected clients.
-#[derive(Debug, Clone, Default)]
 /// Registry of connected relay clients.
 ///
 /// This type manages the collection of active client connections and
 /// handles routing messages between them.
+#[derive(Debug, Clone, Default)]
 pub struct Clients(Arc<Inner>);
 
 #[derive(Debug, Default)]

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -10,40 +10,55 @@ pub struct Metrics {
     /*
      * Metrics about packets
      */
-    /// Bytes sent in relayed 'send' packets.
+    /// Bytes sent in [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames.
+    ///
+    /// [`RelayToClientDatagram`]: crate::protos::common::FrameType::RelayToClientDatagram
+    /// [`RelayToClientDatagramBatch`]: crate::protos::common::FrameType::RelayToClientDatagramBatch
     #[metrics(help = "Number of bytes sent.")]
     pub bytes_sent: Counter,
-    /// Bytes received in relayed 'send' packets.
+    /// Bytes received in [`ClientToRelayDatagram`] or [`ClientToRelayDatagramBatch`] frames.
+    ///
+    /// [`ClientToRelayDatagram`]: crate::protos::common::FrameType::ClientToRelayDatagram
+    /// [`ClientToRelayDatagramBatch`]: crate::protos::common::FrameType::ClientToRelayDatagramBatch
     #[metrics(help = "Number of bytes received.")]
     pub bytes_recv: Counter,
 
-    /// Number of 'send' packets sent.
+    /// [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames sent.
+    ///
+    /// [`RelayToClientDatagram`]: crate::protos::common::FrameType::RelayToClientDatagram
+    /// [`RelayToClientDatagramBatch`]: crate::protos::common::FrameType::RelayToClientDatagramBatch
     #[metrics(help = "Number of 'send' packets relayed.")]
     pub send_packets_sent: Counter,
-    /// Number of 'send' packets received.
+    /// [`ClientToRelayDatagram`] or [`ClientToRelayDatagramBatch`] frames received.
+    ///
+    /// [`ClientToRelayDatagram`]: crate::protos::common::FrameType::ClientToRelayDatagram
+    /// [`ClientToRelayDatagramBatch`]: crate::protos::common::FrameType::ClientToRelayDatagramBatch
     #[metrics(help = "Number of 'send' packets received.")]
     pub send_packets_recv: Counter,
-    /// Number of 'send' packets dropped.
+    /// [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames dropped.
+    ///
+    /// [`RelayToClientDatagram`]: crate::protos::common::FrameType::RelayToClientDatagram
+    /// [`RelayToClientDatagramBatch`]: crate::protos::common::FrameType::RelayToClientDatagramBatch
     #[metrics(help = "Number of 'send' packets dropped.")]
     pub send_packets_dropped: Counter,
 
-    /// Packets of other `FrameType`s sent
+    /// Packets of other [`FrameType`](crate::protos::common::FrameType)s sent.
     #[metrics(help = "Number of packets sent that were not 'send' packets")]
     pub other_packets_sent: Counter,
-    /// Packets of other `FrameType`s received
+    /// Packets of other [`FrameType`](crate::protos::common::FrameType)s received.
     #[metrics(help = "Number of packets received that were not 'send' packets")]
     pub other_packets_recv: Counter,
-    /// Packets of other `FrameType`s dropped
+    /// Packets of other [`FrameType`](crate::protos::common::FrameType)s dropped.
     #[metrics(help = "Number of times, non-send packet was dropped.")]
     pub other_packets_dropped: Counter,
 
-    /// Number of `FrameType::Ping`s received
+    /// Number of [`FrameType::Ping`](crate::protos::common::FrameType::Ping)s received.
     #[metrics(help = "Number of times the server has received a Ping from a client.")]
     pub got_ping: Counter,
-    /// Number of `FrameType::Pong`s sent
+    /// Number of [`FrameType::Pong`](crate::protos::common::FrameType::Pong)s sent.
     #[metrics(help = "Number of times the server has sent a Pong to a client.")]
     pub sent_pong: Counter,
-    /// Number of unknown frames received.
+    /// Number of frames with an unknown [`FrameType`](crate::protos::common::FrameType) received.
     #[metrics(help = "Number of unknown frames sent to this server.")]
     pub unknown_frames: Counter,
 

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -36,7 +36,10 @@ pub struct Metrics {
     #[metrics(help = "Number of 'send' packets received.")]
     pub send_packets_recv: Counter,
     /// [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames dropped instead of being
-    /// delivered to a client, because the recipient is not connected or its send queue is full.
+    /// delivered to a client, because the recipient is not connected or writing to its stream failed.
+    ///
+    /// Note that frames dropped because the recipient's send queue is full or closed are not counted
+    /// here.
     ///
     /// [`RelayToClientDatagram`]: crate::protos::common::FrameType::RelayToClientDatagram
     /// [`RelayToClientDatagramBatch`]: crate::protos::common::FrameType::RelayToClientDatagramBatch

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -10,55 +10,57 @@ pub struct Metrics {
     /*
      * Metrics about packets
      */
-    /// Bytes sent in [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames.
+    /// Bytes sent to a client in [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames.
     ///
     /// [`RelayToClientDatagram`]: crate::protos::common::FrameType::RelayToClientDatagram
     /// [`RelayToClientDatagramBatch`]: crate::protos::common::FrameType::RelayToClientDatagramBatch
     #[metrics(help = "Number of bytes sent.")]
     pub bytes_sent: Counter,
-    /// Bytes received in [`ClientToRelayDatagram`] or [`ClientToRelayDatagramBatch`] frames.
+    /// Bytes received from a client in [`ClientToRelayDatagram`] or [`ClientToRelayDatagramBatch`] frames.
     ///
     /// [`ClientToRelayDatagram`]: crate::protos::common::FrameType::ClientToRelayDatagram
     /// [`ClientToRelayDatagramBatch`]: crate::protos::common::FrameType::ClientToRelayDatagramBatch
     #[metrics(help = "Number of bytes received.")]
     pub bytes_recv: Counter,
 
-    /// [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames sent.
+    /// [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames sent to a client.
     ///
     /// [`RelayToClientDatagram`]: crate::protos::common::FrameType::RelayToClientDatagram
     /// [`RelayToClientDatagramBatch`]: crate::protos::common::FrameType::RelayToClientDatagramBatch
     #[metrics(help = "Number of 'send' packets relayed.")]
     pub send_packets_sent: Counter,
-    /// [`ClientToRelayDatagram`] or [`ClientToRelayDatagramBatch`] frames received.
+    /// [`ClientToRelayDatagram`] or [`ClientToRelayDatagramBatch`] frames received from a client.
     ///
     /// [`ClientToRelayDatagram`]: crate::protos::common::FrameType::ClientToRelayDatagram
     /// [`ClientToRelayDatagramBatch`]: crate::protos::common::FrameType::ClientToRelayDatagramBatch
     #[metrics(help = "Number of 'send' packets received.")]
     pub send_packets_recv: Counter,
-    /// [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames dropped.
+    /// [`RelayToClientDatagram`] or [`RelayToClientDatagramBatch`] frames dropped instead of being
+    /// delivered to a client, because the recipient is not connected or its send queue is full.
     ///
     /// [`RelayToClientDatagram`]: crate::protos::common::FrameType::RelayToClientDatagram
     /// [`RelayToClientDatagramBatch`]: crate::protos::common::FrameType::RelayToClientDatagramBatch
     #[metrics(help = "Number of 'send' packets dropped.")]
     pub send_packets_dropped: Counter,
 
-    /// Packets of other [`FrameType`](crate::protos::common::FrameType)s sent.
+    /// Intended to count sent frames other than datagrams, but currently unused (never incremented).
     #[metrics(help = "Number of packets sent that were not 'send' packets")]
     pub other_packets_sent: Counter,
-    /// Packets of other [`FrameType`](crate::protos::common::FrameType)s received.
+    /// Intended to count received frames other than datagrams, but currently unused (never incremented).
     #[metrics(help = "Number of packets received that were not 'send' packets")]
     pub other_packets_recv: Counter,
-    /// Packets of other [`FrameType`](crate::protos::common::FrameType)s dropped.
+    /// Intended to count dropped frames other than datagrams, but currently unused (never incremented).
     #[metrics(help = "Number of times, non-send packet was dropped.")]
     pub other_packets_dropped: Counter,
 
-    /// Number of [`FrameType::Ping`](crate::protos::common::FrameType::Ping)s received.
+    /// Number of [`FrameType::Ping`](crate::protos::common::FrameType::Ping) frames received from a client.
     #[metrics(help = "Number of times the server has received a Ping from a client.")]
     pub got_ping: Counter,
-    /// Number of [`FrameType::Pong`](crate::protos::common::FrameType::Pong)s sent.
+    /// Number of [`FrameType::Pong`](crate::protos::common::FrameType::Pong) frames sent to a client.
     #[metrics(help = "Number of times the server has sent a Pong to a client.")]
     pub sent_pong: Counter,
-    /// Number of frames with an unknown [`FrameType`](crate::protos::common::FrameType) received.
+    /// Intended to count received frames with an unrecognized [`FrameType`](crate::protos::common::FrameType),
+    /// but currently unused (never incremented).
     #[metrics(help = "Number of unknown frames sent to this server.")]
     pub unknown_frames: Counter,
 
@@ -72,7 +74,9 @@ pub struct Metrics {
      */
     /// Number of times this server has accepted a connection.
     pub accepts: Counter,
-    /// Number of connections we have removed because of an error
+    /// Number of times a client connection was disconnected.
+    ///
+    /// Incremented once per connection, paired with [`Self::accepts`].
     #[metrics(help = "Number of clients that have then disconnected.")]
     pub disconnects: Counter,
 

--- a/iroh-relay/src/server/metrics.rs
+++ b/iroh-relay/src/server/metrics.rs
@@ -10,20 +10,20 @@ pub struct Metrics {
     /*
      * Metrics about packets
      */
-    /// Bytes sent from a `FrameType::SendPacket`
+    /// Bytes sent in relayed 'send' packets.
     #[metrics(help = "Number of bytes sent.")]
     pub bytes_sent: Counter,
-    /// Bytes received from a `FrameType::SendPacket`
+    /// Bytes received in relayed 'send' packets.
     #[metrics(help = "Number of bytes received.")]
     pub bytes_recv: Counter,
 
-    /// `FrameType::SendPacket` sent
+    /// Number of 'send' packets sent.
     #[metrics(help = "Number of 'send' packets relayed.")]
     pub send_packets_sent: Counter,
-    /// `FrameType::SendPacket` received
+    /// Number of 'send' packets received.
     #[metrics(help = "Number of 'send' packets received.")]
     pub send_packets_recv: Counter,
-    /// `FrameType::SendPacket` dropped
+    /// Number of 'send' packets dropped.
     #[metrics(help = "Number of 'send' packets dropped.")]
     pub send_packets_dropped: Counter,
 
@@ -43,7 +43,7 @@ pub struct Metrics {
     /// Number of `FrameType::Pong`s sent
     #[metrics(help = "Number of times the server has sent a Pong to a client.")]
     pub sent_pong: Counter,
-    /// Number of `FrameType::Unknown` received
+    /// Number of unknown frames received.
     #[metrics(help = "Number of unknown frames sent to this server.")]
     pub unknown_frames: Counter,
 

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -324,8 +324,8 @@ impl AsyncWrite for MaybeTlsStream {
 ///
 /// The writes to the sink are not rate limited.
 ///
-/// This potentially buffers one frame if the rate limiter does not allows this frame.
-/// While the frame is buffered the undernlying stream is no longer polled.
+/// This potentially buffers one frame if the rate limiter does not allow this frame.
+/// While the frame is buffered the underlying stream is no longer polled.
 #[derive(Debug)]
 pub(crate) struct RateLimited<S> {
     inner: S,

--- a/iroh-relay/src/tls.rs
+++ b/iroh-relay/src/tls.rs
@@ -217,7 +217,7 @@ impl CaTlsConfig {
 
 /// Function to build a [`ServerCertVerifier`] from a [`CryptoProvider`].
 ///
-/// See [`CaTlsConfig::custom_server_cert_verifier].
+/// See [`CaTlsConfig::custom_server_cert_verifier`].
 pub type ServerCertVerifierBuilder = Arc<
     dyn Fn(Arc<CryptoProvider>) -> io::Result<Arc<dyn ServerCertVerifier>> + Send + Sync + 'static,
 >;

--- a/iroh/src/address_lookup.rs
+++ b/iroh/src/address_lookup.rs
@@ -3,10 +3,10 @@
 //! To connect to an iroh endpoint a [`EndpointAddr`] is needed, which may contain a
 //! [`RelayUrl`] or one or more *direct addresses* in addition to the [`EndpointId`].
 //!
-//! Since there is a conversion from [`EndpointId`] to [`EndpointAddr`], you can also use
+//! Since there is a conversion from [`EndpointId`] to [`EndpointAddr`], you can also
 //! connect directly with a [`EndpointId`].
 //!
-//! For this to work however, the endpoint has to get the addressing  information by
+//! For this to work however, the endpoint has to get the addressing information by
 //! other means.
 //!
 //! [`AddressLookup`] is an automated system for an [`Endpoint`] to retrieve this addressing
@@ -50,9 +50,9 @@
 //! [`iroh-mdns-address-lookup`]: https://docs.rs/iroh-mdns-address-lookup
 //! [`iroh-mainline-address-lookup`]: https://docs.rs/iroh-mainline-address-lookup
 //!
-//! To use multiple Address Lookup'ssimultaneously you can call [`Builder::address_lookup`].
+//! To use multiple Address Lookups simultaneously you can call [`Builder::address_lookup`].
 //! This will use [`AddressLookupServices`] under the hood, which performs lookups to all
-//! Address Lookupsystems at the same time.
+//! Address Lookup systems at the same time.
 //!
 //! [`Builder::address_lookup`] takes any type that implements [`AddressLookupBuilder`]. You can
 //! implement that trait on a builder struct if your Address Lookup needs information
@@ -60,8 +60,8 @@
 //! is built by calling [`AddressLookupBuilder::into_address_lookup`], passing the finished [`Endpoint`] to your
 //! builder.
 //!
-//! If your Address Lookupdoes not need any information from its endpoint, you can
-//! pass the Address Lookupservice directly to [`Builder::address_lookup`]: All types that
+//! If your Address Lookup does not need any information from its endpoint, you can
+//! pass the Address Lookup service directly to [`Builder::address_lookup`]: All types that
 //! implement [`AddressLookup`] also have a blanket implementation of [`AddressLookupBuilder`].
 //!
 //! # Examples
@@ -334,7 +334,7 @@ pub trait AddressLookup: std::fmt::Debug + Send + Sync + 'static {
     /// Publishes the given [`EndpointData`] to the Address Lookup mechanism.
     ///
     /// This is fire and forget, since the [`Endpoint`] can not wait for successful
-    /// publishing. If publishing is async, the implementation should start it's own task.
+    /// publishing. If publishing is async, the implementation should start its own task.
     ///
     /// This will be called from a tokio task, so it is safe to spawn new tasks.
     /// These tasks will be run on the runtime of the [`super::Endpoint`].
@@ -369,7 +369,7 @@ impl<T: AddressLookup> AddressLookup for Arc<T> {
 /// directly from [`Item`].
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Item {
-    /// The endpoint info for the endpoint, as discovered by the the Address Lookup.
+    /// The endpoint info for the endpoint, as discovered by the Address Lookup.
     endpoint_info: EndpointInfo,
     /// A static string to identify the Address Lookup source.
     ///
@@ -421,12 +421,12 @@ impl Item {
         self.last_updated
     }
 
-    /// Converts into a [`EndpointAddr`] by cloning the needed fields.
+    /// Returns an [`EndpointAddr`] by cloning the needed fields.
     pub fn to_endpoint_addr(&self) -> EndpointAddr {
         self.endpoint_info.to_endpoint_addr()
     }
 
-    /// Converts into a [`EndpointAddr`] without cloning.
+    /// Converts into an [`EndpointAddr`] without cloning.
     pub fn into_endpoint_addr(self) -> EndpointAddr {
         self.endpoint_info.into_endpoint_addr()
     }
@@ -457,7 +457,7 @@ impl From<Item> for EndpointInfo {
 ///
 /// See [`AddressLookup`] and [`Self::resolve`] for details.
 ///
-/// [`Endpoint]: crate::Endpoint
+/// [`Endpoint`]: crate::Endpoint
 #[derive(Debug, Default, Clone)]
 pub struct AddressLookupServices {
     services: Arc<RwLock<Vec<Box<dyn AddressLookup>>>>,

--- a/iroh/src/address_lookup/dns.rs
+++ b/iroh/src/address_lookup/dns.rs
@@ -82,15 +82,13 @@ impl DnsAddressLookup {
         }
     }
 
-    /// Creates a new DNS discovery using the `iroh.link` domain.
+    /// Creates a new DNS address lookup using the `iroh.link` domain.
     ///
     /// This uses the [`N0_DNS_ENDPOINT_ORIGIN_PROD`] domain.
     ///
-    /// # Usage during tests
-    ///
-    /// For testing it is possible to use the [`N0_DNS_ENDPOINT_ORIGIN_STAGING`] domain
-    /// with [`DnsAddressLookup::builder`].  This would then use a hosted staging discovery
-    /// service for testing purposes.
+    /// When running with the environment variable `IROH_FORCE_STAGING_RELAYS`
+    /// set to any non empty value the [`N0_DNS_ENDPOINT_ORIGIN_STAGING`] domain
+    /// is used instead.
     pub fn n0_dns() -> DnsAddressLookupBuilder {
         if force_staging_infra() {
             Self::builder(N0_DNS_ENDPOINT_ORIGIN_STAGING.to_string())

--- a/iroh/src/address_lookup/memory.rs
+++ b/iroh/src/address_lookup/memory.rs
@@ -3,7 +3,7 @@
 //! Often an application might get endpoint addressing information out-of-band in an
 //! application-specific way.  [`EndpointTicket`]'s are one common way used to achieve this.
 //! This addressing information is often only usable for a limited time so needs to
-//! be able to be removed again once know it is no longer useful.
+//! be able to be removed again once you know it is no longer useful.
 //!
 //! This is where the [`MemoryLookup`] is useful: it allows applications to add and
 //! retract endpoint addressing information that is otherwise out-of-band to iroh.
@@ -29,10 +29,11 @@ use super::{AddressLookup, EndpointData, EndpointInfo, Error, Item};
 /// Often an application might get endpoint addressing information out-of-band in an
 /// application-specific way.  [`EndpointTicket`]'s are one common way used to achieve this.
 /// This addressing information is often only usable for a limited time so needs to
-/// be able to be removed again once know it is no longer useful.
+/// be able to be removed again once you know it is no longer useful.
 ///
 /// This is where the [`MemoryLookup`] is useful: it allows applications to add and
 /// retract endpoint addressing information that is otherwise out-of-band to iroh.
+///
 /// # Examples
 ///
 /// ```no_run
@@ -100,7 +101,7 @@ impl MemoryLookup {
     /// [`Endpoint`]: crate::Endpoint
     pub const PROVENANCE: &'static str = "memory_lookup";
 
-    /// Creates a new static Address Lookup instance.
+    /// Creates a new empty Memory Lookup instance.
     pub fn new() -> Self {
         Self::default()
     }

--- a/iroh/src/address_lookup/pkarr.rs
+++ b/iroh/src/address_lookup/pkarr.rs
@@ -259,7 +259,9 @@ impl AddressLookupBuilder for PkarrPublisherBuilder {
 /// that it only publishes address lookup information, for the corresponding resolver use
 /// the [`PkarrResolver`] together with [`AddressLookupServices`].
 ///
-/// This publisher will **only** publish the [`RelayUrl`] if it is set, otherwise the *direct addresses* are published instead.
+/// By default this publisher only publishes the [`RelayUrl`], to avoid leaking IP addresses to
+/// the public pkarr server.  Which addresses are published is controlled by the [`AddrFilter`]
+/// set via [`PkarrPublisherBuilder::addr_filter`].
 ///
 /// [pkarr]: https://pkarr.org
 /// [module docs]: crate::address_lookup::pkarr
@@ -276,7 +278,7 @@ pub struct PkarrPublisher {
 impl PkarrPublisher {
     /// Returns a [`PkarrPublisherBuilder`] that publishes endpoint info to a [pkarr] relay at `pkarr_relay`.
     ///
-    /// If no further options are set, the pkarr publisher  will use [`DEFAULT_PKARR_TTL`] as the
+    /// If no further options are set, the pkarr publisher will use [`DEFAULT_PKARR_TTL`] as the
     /// time-to-live value for the published packets, and it will republish Address Lookup information
     /// every [`DEFAULT_REPUBLISH_INTERVAL`], even if the information is unchanged.
     ///

--- a/iroh/src/defaults.rs
+++ b/iroh/src/defaults.rs
@@ -69,7 +69,7 @@ pub mod prod {
         RelayConfig::from(RelayUrl::from(url))
     }
 
-    /// Get the default [`RelayConfig`] for Asia-Pacific
+    /// Get the default [`RelayConfig`] for Asia-Pacific.
     pub fn default_ap_relay() -> RelayConfig {
         // The default Asia-Pacific relay server run by number0.
         let url: Url = format!("https://{AP_RELAY_HOSTNAME}")

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1287,18 +1287,18 @@ impl Endpoint {
     /// ```no_run
     /// # #[cfg(with_crypto_provider)]
     /// # {
-    /// # use iroh::Endpoint;
     /// # #[tokio::main]
     /// # async fn main() -> n0_error::Result<()> {
+    /// # use iroh::{Endpoint, endpoint::presets};
     /// // After this await returns, the endpoint is bound to a local socket.
     /// // It can be dialed, but almost certainly hasn't finished picking a
     /// // relay.
-    /// let endpoint = Endpoint::bind(presets::N0).await.unwrap();
+    /// let endpoint = Endpoint::bind(presets::N0).await?;
     ///
     /// // After this await returns we have a connection to at least one relay
     /// // and holepunching should work as expected.
     /// endpoint.online().await;
-    /// # });
+    /// # Ok(()) }
     /// # }
     /// ```
     pub async fn online(&self) {

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1287,6 +1287,7 @@ impl Endpoint {
     /// ```no_run
     /// # #[cfg(with_crypto_provider)]
     /// # {
+    /// # use iroh::Endpoint;
     /// # #[tokio::main]
     /// # async fn main() -> n0_error::Result<()> {
     /// // After this await returns, the endpoint is bound to a local socket.

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -397,7 +397,7 @@ impl Builder {
     /// socket should be bound or the routing will be non-deterministic.
     ///
     /// To use a subnet with a non-zero prefix length as the default route in addition to
-    /// being routed when its prefix matches, use [`BindOpts::set_is_default_route].
+    /// being routed when its prefix matches, use [`BindOpts::set_is_default_route`].
     /// Subnets with a prefix length of zero are always marked as default routes.
     ///
     /// Finally note that most outgoing datagrams are part of an existing network flow. That
@@ -598,7 +598,7 @@ impl Builder {
     ///
     /// This filter is applied once, at the [`AddressLookupServices`] level, before
     /// distributing data to any individual address lookup service. This ensures
-    /// consistent filtering regardless of how the services configured.
+    /// consistent filtering regardless of how the services are configured.
     ///
     /// [`AddressLookupServices`]: crate::address_lookup::AddressLookupServices
     pub fn addr_filter(mut self, filter: AddrFilter) -> Self {
@@ -827,7 +827,7 @@ pub enum EndpointError {
 /// [`Endpoint::connect`] and [`Endpoint::accept`] methods.  Once established, the
 /// [`Connection`] gives access to most [QUIC] features.  Individual streams to send data to
 /// the peer are created using the [`Connection::open_bi`], [`Connection::accept_bi`],
-/// [`Connection::open_uni`] and [`Connection::open_bi`] functions.
+/// [`Connection::open_uni`] and [`Connection::accept_uni`] functions.
 ///
 /// Note that due to the light-weight properties of streams a stream will only be accepted
 /// once the initiating peer has sent some data on it.
@@ -1171,8 +1171,8 @@ impl Endpoint {
     /// understand if the endpoint has ever been considered "online". But after
     /// that initial call to [`Endpoint::online`], to understand if your
     /// endpoint is no longer able to be connected to by endpoints outside
-    /// of the private or local network, watch for changes in it's [`EndpointAddr`].
-    /// If there are no `addrs`in the [`EndpointAddr`], you may not be dialable by other endpoints
+    /// of the private or local network, watch for changes in its [`EndpointAddr`].
+    /// If there are no `addrs` in the [`EndpointAddr`], you may not be dialable by other endpoints
     /// on the internet.
     ///
     /// The `EndpointAddr` will change as:
@@ -1284,20 +1284,23 @@ impl Endpoint {
     ///
     /// # Examples
     ///
-    /// ```no run
-    /// use iroh::Endpoint;
+    /// ```no_run
+    /// # #[cfg(with_crypto_provider)]
+    /// # {
+    /// use iroh::{Endpoint, endpoint::presets};
     ///
-    /// #[tokio::main]
-    /// async fn main() {
+    /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+    /// # rt.block_on(async move {
     /// // After this await returns, the endpoint is bound to a local socket.
     /// // It can be dialed, but almost certainly hasn't finished picking a
     /// // relay.
-    /// let endpoint = Endpoint::bind().await;
+    /// let endpoint = Endpoint::bind(presets::N0).await.unwrap();
     ///
     /// // After this await returns we have a connection to at least one relay
     /// // and holepunching should work as expected.
     /// endpoint.online().await;
-    /// }
+    /// # });
+    /// # }
     /// ```
     pub async fn online(&self) {
         let mut watcher = self.inner.home_relay_status();
@@ -1320,7 +1323,7 @@ impl Endpoint {
     ///
     /// The watched value has one entry per home relay whose URL is known,
     /// and is empty when no relays are configured or before the endpoint has
-    /// selected one the home relay from the list of configured relays.
+    /// selected a home relay from the list of configured relays.
     /// The watcher updates whenever any home relay's connection status changes.
     /// See [`RelayStatus`] for the information available on each entry.
     ///
@@ -1648,7 +1651,7 @@ impl Endpoint {
     /// kernel during the "Time-Wait" period of the TCP socket.
     ///
     /// Be aware however that the underlying UDP sockets are only closed once all clones of
-    /// the the respective [`Endpoint`] are dropped.
+    /// the respective [`Endpoint`] are dropped.
     pub async fn close(&self) {
         self.inner.close().await;
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1287,10 +1287,8 @@ impl Endpoint {
     /// ```no_run
     /// # #[cfg(with_crypto_provider)]
     /// # {
-    /// use iroh::{Endpoint, endpoint::presets};
-    ///
-    /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    /// # rt.block_on(async move {
+    /// # #[tokio::main]
+    /// # async fn main() -> n0_error::Result<()> {
     /// // After this await returns, the endpoint is bound to a local socket.
     /// // It can be dialed, but almost certainly hasn't finished picking a
     /// // relay.

--- a/iroh/src/endpoint/bind.rs
+++ b/iroh/src/endpoint/bind.rs
@@ -111,7 +111,7 @@ impl BindOpts {
     /// Returns whether this is a default route.
     ///
     /// If [`Self::set_is_default_route`] has been called then that value is returned.
-    /// Otherwise, returns `true` if the [`prefix_len`][`Self::prefix_len] is `0` and
+    /// Otherwise, returns `true` if the [`prefix_len`][`Self::prefix_len`] is `0` and
     /// `false` otherwise.
     pub fn is_default_route(&self) -> bool {
         match self.is_default_route {

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -214,7 +214,7 @@ impl Incoming {
         self.inner.remote_address_validated()
     }
 
-    /// Decrypt the Initial packet payload
+    /// Decrypts the Initial packet payload.
     ///
     /// This clones and decrypts the packet payload (~1200 bytes).
     /// Can be used to extract information from the TLS ClientHello without completing the handshake.
@@ -840,7 +840,7 @@ impl<T: ConnectionState> Connection<T> {
         self.inner.accept_uni()
     }
 
-    /// Accept the next incoming bidirectional stream.
+    /// Accepts the next incoming bidirectional stream.
     ///
     /// **Important Note**: The peer that calls [`open_bi`] must write to its [`SendStream`]
     /// before the peer `Connection` is able to accept the stream using
@@ -861,7 +861,7 @@ impl<T: ConnectionState> Connection<T> {
         self.inner.read_datagram()
     }
 
-    /// Wait for the connection to be closed for any reason.
+    /// Waits for the connection to be closed for any reason.
     ///
     /// Despite the return type's name, closed connections are often not an error condition
     /// at the application layer. Cases that might be routine include
@@ -1043,6 +1043,8 @@ impl<T: ConnectionState> Connection<T> {
         self.inner.set_max_concurrent_uni_streams(count)
     }
 
+    /// Sets the connection-level flow control receive window.
+    ///
     /// See [`noq_proto::TransportConfig::receive_window`].
     #[inline]
     pub fn set_receive_window(&self, receive_window: VarInt) {
@@ -1188,10 +1190,10 @@ impl Connection<OutgoingZeroRtt> {
 
     /// Waits until the full handshake occurs and returns a [`ZeroRttStatus`].
     ///
-    /// If `ZeroRttStatus::Accepted` is returned, than any streams created before
+    /// If `ZeroRttStatus::Accepted` is returned, then any streams created before
     /// the handshake has completed can still be used.
     ///
-    /// If `ZeroRttStatus::Rejected` is returned, than any streams created before
+    /// If `ZeroRttStatus::Rejected` is returned, then any streams created before
     /// the handshake will error and any data sent should be re-sent on a
     /// new stream.
     ///

--- a/iroh/src/endpoint/hooks.rs
+++ b/iroh/src/endpoint/hooks.rs
@@ -55,7 +55,7 @@ impl AfterHandshakeOutcome {
 /// For each hook, all installed hooks are invoked in the order they were installed on
 /// the endpoint builder. If a hook returns `Accept`, processing continues with the next
 /// hook. If a hook returns `Reject`, processing is aborted and further hooks
-/// are not invoked for this hook.
+/// are not invoked for this hook point.
 ///
 /// ## Notes to implementers
 ///

--- a/iroh/src/endpoint/presets.rs
+++ b/iroh/src/endpoint/presets.rs
@@ -17,7 +17,7 @@
 
 use crate::endpoint::Builder;
 
-/// Defines a preset
+/// A reusable bundle of endpoint [`Builder`] configuration.
 pub trait Preset {
     /// Applies the configuration to the passed in [`Builder`].
     fn apply(self, builder: Builder) -> Builder;
@@ -86,8 +86,8 @@ impl Preset for Minimal {
 /// - setting the [`rustls::crypto::CryptoProvider`] to [ring] or [aws-lc-rs], depending
 ///   on which feature is enabled in iroh (preferring ring if both are enabled).
 ///
-/// Due to the last point, this preset is only available with the `ring` or
-/// `aws-lc-rs` preset installed.
+/// Due to the last point, this preset is only available with the `tls-ring` or
+/// `tls-aws-lc-rs` feature enabled.
 /// If you want to set your own crypto provider, we recommend copying the
 /// implementation of this preset into your own and setting the appropriate crypto
 /// provider there.
@@ -148,8 +148,8 @@ impl Preset for N0 {
 /// - setting the [`rustls::crypto::CryptoProvider`] to [ring] or [aws-lc-rs], depending
 ///   on which feature is enabled in iroh (preferring ring if both are enabled).
 ///
-/// Due to the last point, this preset is only available with the `ring` or
-/// `aws-lc-rs` preset installed.
+/// Due to the last point, this preset is only available with the `tls-ring` or
+/// `tls-aws-lc-rs` feature enabled.
 /// If you want to set your own crypto provider, we recommend copying the
 /// implementation of this preset into your own and setting the appropriate crypto
 /// provider there.

--- a/iroh/src/endpoint/quic.rs
+++ b/iroh/src/endpoint/quic.rs
@@ -487,7 +487,7 @@ impl QuicTransportConfigBuilder {
     /// interact with the [`QuicTransportConfigBuilder::max_idle_timeout`], if the last path is
     /// abandoned the entire connection will be closed.
     ///
-    /// Note: values higher than [`PATH_MAX_IDLE_TIMEOUT`] are clamped and a warning is logged.
+    /// Note: values higher than `PATH_MAX_IDLE_TIMEOUT` (15 seconds) are clamped and a warning is logged.
     pub fn default_path_max_idle_timeout(mut self, timeout: Duration) -> Self {
         if timeout > PATH_MAX_IDLE_TIMEOUT {
             warn!(

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -1,6 +1,6 @@
 //! Peer-to-peer QUIC connections.
 //!
-//! iroh is a library to establish direct connectivity between peers.  It exposes an
+//! iroh is a library to establish direct connectivity between peers. It exposes an
 //! interface to [QUIC] connections and streams to the user, while implementing direct
 //! connectivity using [hole punching] complemented by relay servers under the hood.
 //!
@@ -73,7 +73,7 @@
 //!
 //! If one of the iroh endpoints can be reached directly, connectivity can also be
 //! established without involving a Relay server.  This is done by using the endpoint's
-//! listening addresses in the connection establishement instead of the [`RelayUrl`] which
+//! listening addresses in the connection establishment instead of the [`RelayUrl`] which
 //! is used to identify a Relay server.  Of course it is also possible to use both a
 //! [`RelayUrl`] and direct addresses at the same time to connect.
 //!

--- a/iroh/src/net_report/report.rs
+++ b/iroh/src/net_report/report.rs
@@ -22,14 +22,13 @@ pub struct Report {
     pub mapping_varies_by_dest_ipv4: Option<bool>,
     /// Whether the reported public address differs when probing different servers (on IPv6).
     pub mapping_varies_by_dest_ipv6: Option<bool>,
-    /// Probe indicating the presence of port mapping protocols on the LAN.
-    /// `None` for unknown
+    /// The relay server with the lowest latency, if any.
     pub preferred_relay: Option<RelayUrl>,
-    /// keyed by relay Url
+    /// The measured latency to each relay, keyed by relay URL.
     pub relay_latency: RelayLatencies,
-    /// ip:port of global IPv4
+    /// The discovered global IPv4 address and port, if any.
     pub global_v4: Option<SocketAddrV4>,
-    /// `[ip]:port` of global IPv6
+    /// The discovered global IPv6 address and port, if any.
     pub global_v6: Option<SocketAddrV6>,
     /// CaptivePortal is set when we think there's a captive portal that is
     /// intercepting HTTP traffic.

--- a/iroh/src/protocol.rs
+++ b/iroh/src/protocol.rs
@@ -174,7 +174,7 @@ pub enum IncomingFilterOutcome {
     ///
     /// What this does depends on the connection type:
     ///
-    /// - **Direct (UDP) connections** : this is QUIC source address
+    /// - **Direct (UDP) connections**: this is QUIC source address
     ///   validation. If the socket address was spoofed, the retry token is
     ///   sent to the spoofed address, so we never hear from the attacker
     ///   again. If the address was real, the client repeats the connection
@@ -182,7 +182,7 @@ pub enum IncomingFilterOutcome {
     ///   [`Incoming::remote_addr_validated`] set to `true`. The token is
     ///   bound to the source address.
     ///
-    /// - **Relay connections** : there is no source address to validate
+    /// - **Relay connections**: there is no source address to validate
     ///   (the relay already vouches for the packet origin), so the
     ///   "validation" itself has no security meaning. However, the retry
     ///   still imposes a real cost on the client: an extra round trip
@@ -491,7 +491,7 @@ impl RouterBuilder {
         self
     }
 
-    /// Returns the [`Endpoint`] of the endpoint.
+    /// Returns the [`Endpoint`] stored in this builder.
     pub fn endpoint(&self) -> &Endpoint {
         &self.endpoint
     }

--- a/iroh/src/socket/metrics.rs
+++ b/iroh/src/socket/metrics.rs
@@ -1,32 +1,41 @@
 use iroh_metrics::{Counter, MetricsGroup};
 use serde::{Deserialize, Serialize};
 
-/// Enum of metrics for the module
-// TODO(frando): Add description doc strings for each metric.
-#[allow(missing_docs)]
+/// Metrics collected by the iroh socket.
 #[derive(Debug, Serialize, Deserialize, MetricsGroup)]
 #[non_exhaustive]
 #[metrics(name = "socket", default)]
 pub struct Metrics {
+    /// Intended to count updates to the local direct address set, but currently unused
+    /// (never incremented).
     pub update_direct_addrs: Counter,
 
-    // Sends (data or disco)
+    /// Number of bytes sent over IPv4 (data or disco).
     pub send_ipv4: Counter,
+    /// Number of bytes sent over IPv6 (data or disco).
     pub send_ipv6: Counter,
+    /// Number of bytes sent over the relay transport (data or disco).
     pub send_relay: Counter,
 
-    // Data packets (non-disco)
+    /// Number of data bytes received over the relay transport.
     pub recv_data_relay: Counter,
-    // Number of bytes received on any custom transport.
+    /// Number of data bytes received over any custom transport.
     pub recv_data_custom: Counter,
+    /// Number of data bytes received over IPv4.
     pub recv_data_ipv4: Counter,
+    /// Number of data bytes received over IPv6.
     pub recv_data_ipv6: Counter,
     /// Number of QUIC datagrams received.
     pub recv_datagrams: Counter,
-    /// Number of datagrams received using GRO
+    /// Number of receive events that used GRO (coalesced datagram batches).
+    ///
+    /// This counts batches, not the individual datagrams within them. See
+    /// [`Self::recv_datagrams`] for the datagram count.
     pub recv_gro_datagrams: Counter,
 
-    // How many times our relay home endpoint DI has changed from non-zero to a different non-zero.
+    /// Number of times the home relay changed to a different relay.
+    ///
+    /// This includes the initial assignment from no home relay to a home relay.
     pub relay_home_change: Counter,
 
     /*
@@ -79,11 +88,18 @@ pub struct Metrics {
     /// Number of custom transport paths closed.
     pub transport_custom_paths_removed: Counter,
 
+    /// Number of iterations of the main socket actor loop.
     pub actor_tick_main: Counter,
+    /// Number of actor messages processed by the socket actor loop.
     pub actor_tick_msg: Counter,
+    /// Number of periodic re-STUN timer ticks handled by the socket actor loop.
     pub actor_tick_re_stun: Counter,
+    /// Number of port-mapping change events handled by the socket actor loop.
     pub actor_tick_portmap_changed: Counter,
+    /// Intended to count direct address heartbeat ticks, but currently unused (never incremented).
     pub actor_tick_direct_addr_heartbeat: Counter,
+    /// Number of local network interface (link) change events handled by the socket actor loop.
     pub actor_link_change: Counter,
+    /// Number of times an input watcher or receiver closed in the socket actor loop.
     pub actor_tick_other: Counter,
 }

--- a/iroh/src/socket/metrics.rs
+++ b/iroh/src/socket/metrics.rs
@@ -10,11 +10,11 @@ pub struct Metrics {
     /// (never incremented).
     pub update_direct_addrs: Counter,
 
-    /// Number of bytes sent over IPv4 (data or disco).
+    /// Number of bytes sent over IPv4.
     pub send_ipv4: Counter,
-    /// Number of bytes sent over IPv6 (data or disco).
+    /// Number of bytes sent over IPv6.
     pub send_ipv6: Counter,
-    /// Number of bytes sent over the relay transport (data or disco).
+    /// Number of bytes sent over the relay transport.
     pub send_relay: Counter,
 
     /// Number of data bytes received over the relay transport.

--- a/iroh/src/tls.rs
+++ b/iroh/src/tls.rs
@@ -1,6 +1,6 @@
 //! TLS configuration for iroh.
 //!
-//! Currently there is one mechanisms available
+//! Currently there is one mechanism available:
 //! - Raw Public Keys, using the TLS extension described in [RFC 7250]
 //!
 //! [RFC 7250]: https://datatracker.ietf.org/doc/html/rfc7250

--- a/iroh/src/tls/verifier.rs
+++ b/iroh/src/tls/verifier.rs
@@ -114,7 +114,7 @@ impl ServerCertVerifier for ServerCertificateVerifier {
 #[derive(Default, Debug)]
 pub(super) struct ClientCertificateVerifier;
 
-/// We requires either following of X.509 client certificate chains:
+/// We require one of the following client certificate configurations:
 ///
 /// - a valid raw public key configuration
 impl ClientCertVerifier for ClientCertificateVerifier {


### PR DESCRIPTION
## Description

This is a cleanup pass over all docs of public items. Fixes typos, odd grammar, non-adherence to doc guidelines, and other minor things.