### PR TITLE
chore(iroh): Update to latest noq main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2960,14 +2960,14 @@ dependencies = [
 
 [[package]]
 name = "n0-qlog"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fd2af7d4c68cd5c31fa69e64644e0a778bd1656bb8dfb86f9852f7d02a112e"
+checksum = "bb1c2fc610d1facce51b0bf5d8245b309c91996a933defdf7742c92ac78a58cb"
 dependencies = [
+ "humantime",
  "serde",
  "serde_json",
  "serde_with",
- "smallvec",
  "strum",
 ]
 
@@ -3178,8 +3178,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "1.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
+source = "git+https://github.com/n0-computer/noq?branch=main#a8edb1218edf35abe87c2d0eb203ed44acaf369f"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3200,8 +3199,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "1.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
+source = "git+https://github.com/n0-computer/noq?branch=main#a8edb1218edf35abe87c2d0eb203ed44acaf369f"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3231,8 +3229,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "1.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
+source = "git+https://github.com/n0-computer/noq?branch=main#a8edb1218edf35abe87c2d0eb203ed44acaf369f"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4671,9 +4668,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
+noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
+noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -26,4 +26,6 @@ ignore = [
 ]
 
 [sources]
-allow-git = []
+allow-git = [
+    "https://github.com/n0-computer/noq",
+]


### PR DESCRIPTION
## Description

Updates to the latest noq main, especially due to this bug fix: https://github.com/n0-computer/noq/pull/695

That fix makes `switch_client_dual_to_v4` non-flaky.

## Breaking Changes

None

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
