### PR TITLE
refactor(iroh)!: make net_report::Report be non_exhaustive

### DIFF
--- a/iroh/src/net_report/report.rs
+++ b/iroh/src/net_report/report.rs
@@ -13,6 +13,7 @@ use super::{ProbeReport, probes::Probe};
 
 /// A net_report report.
 #[derive(Default, Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Report {
     /// A QAD IPv4 round trip completed.
     pub udp_v4: bool,


### PR DESCRIPTION
## Description

We have a public but `doc_hidden` function `iroh::Endpoint::net_report` that returns the current `Report`. Due to this, our `net_report::Report` struct is public. It has public fields, therefore it needs to be `non_exhaustive` so that we can add more fields to it down the road.

## Breaking Changes

* changed: `iroh::endpoint::net_report::Report` is now `non_exhaustive`

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
