### PR TITLE
feat(iroh-relay): Allow multiple hostnames with Let's encrypt TLS

### DIFF
--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -38,6 +38,10 @@ const X_IROH_ENDPOINT_ID: &str = "X-Iroh-NodeId";
 const ENV_HTTP_BEARER_TOKEN: &str = "IROH_RELAY_HTTP_BEARER_TOKEN";
 /// Environment variable to verify relay access (without an external auth service)
 const ENV_RELAY_ACCESS_TOKEN: &str = "IROH_RELAY_ACCESS_TOKEN";
+/// Environment variable to override the ACME directory URL.
+const ENV_ACME_URL: &str = "IROH_RELAY_ACME_URL";
+/// Environment variable to trust an additional CA for the ACME server's TLS certificate.
+const ENV_ACME_CA: &str = "IROH_RELAY_ACME_CA";
 
 /// A relay server for iroh.
 #[derive(Parser, Debug, Clone)]
@@ -641,7 +645,7 @@ async fn load_cert_config(tls: &TlsConfig) -> Result<relay::CertConfig> {
                 .contact
                 .clone()
                 .std_context("LetsEncrypt needs a contact email")?;
-            let acme_config = if let Ok(url) = std::env::var("IROH_RELAY_ACME_URL") {
+            let acme_config = if let Ok(url) = std::env::var(ENV_ACME_URL) {
                 AcmeConfig::new(url)
             } else {
                 AcmeConfig::letsencrypt(tls.prod_tls)
@@ -653,7 +657,7 @@ async fn load_cert_config(tls: &TlsConfig) -> Result<relay::CertConfig> {
             // Trust an additional CA for the ACME server's TLS certificate. Useful for testing
             // against a local ACME server such as pebble, whose certificate is not signed by a
             // publicly trusted CA.
-            if let Ok(ca_path) = std::env::var("IROH_RELAY_ACME_CA") {
+            if let Ok(ca_path) = std::env::var(ENV_ACME_CA) {
                 let extra_roots = CertificateDer::pem_file_iter(&ca_path)
                     .std_context("failed to read IROH_RELAY_ACME_CA")?
                     .collect::<Result<Vec<_>, _>>()

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -640,7 +640,12 @@ async fn load_cert_config(tls: &TlsConfig) -> Result<relay::CertConfig> {
                 .contact
                 .clone()
                 .std_context("LetsEncrypt needs a contact email")?;
-            let acme_config = AcmeConfig::letsencrypt(tls.prod_tls)
+            let acme_config = if let Ok(url) = std::env::var("IROH_RELAY_ACME_URL") {
+                AcmeConfig::new(url)
+            } else {
+                AcmeConfig::letsencrypt(tls.prod_tls)
+            };
+            let acme_config = acme_config
                 .domains(domains)
                 .contact(vec![format!("mailto:{contact}")])
                 .cache_path(tls.cert_dir());

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -21,6 +21,7 @@ use iroh_relay::{
         self as relay, Access, AccessControl, AcmeConfig, ClientRateLimit, ClientRequest,
         DEFAULT_CERT_RELOAD_INTERVAL, QuicConfig, reloading_resolver,
     },
+    tls::CaTlsConfig,
 };
 use n0_error::{AnyError, Result, StdResultExt, bail_any};
 use serde::{Deserialize, Serialize};
@@ -645,10 +646,21 @@ async fn load_cert_config(tls: &TlsConfig) -> Result<relay::CertConfig> {
             } else {
                 AcmeConfig::letsencrypt(tls.prod_tls)
             };
-            let acme_config = acme_config
+            let mut acme_config = acme_config
                 .domains(domains)
                 .contact(vec![format!("mailto:{contact}")])
                 .cache_path(tls.cert_dir());
+            // Trust an additional CA for the ACME server's TLS certificate. Useful for testing
+            // against a local ACME server such as pebble, whose certificate is not signed by a
+            // publicly trusted CA.
+            if let Ok(ca_path) = std::env::var("IROH_RELAY_ACME_CA") {
+                let extra_roots = CertificateDer::pem_file_iter(&ca_path)
+                    .std_context("failed to read IROH_RELAY_ACME_CA")?
+                    .collect::<Result<Vec<_>, _>>()
+                    .std_context("failed to parse IROH_RELAY_ACME_CA")?;
+                acme_config =
+                    acme_config.tls_config(CaTlsConfig::default().with_extra_roots(extra_roots));
+            }
             relay::CertConfig::LetsEncrypt {
                 acme_config,
                 server_config_builder: server_config,

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -400,7 +400,8 @@ struct TlsConfig {
     /// port set to [`iroh_relay::defaults::DEFAULT_RELAY_QUIC_PORT`]
     quic_bind_addr: Option<SocketAddr>,
     /// Certificate hostname when using LetsEncrypt.
-    hostname: Option<String>,
+    #[serde(default, deserialize_with = "string_or_seq")]
+    hostname: Vec<String>,
     /// Mode for getting a cert.
     ///
     /// Possible options: 'Manual', 'LetsEncrypt'.
@@ -477,6 +478,23 @@ impl TlsConfig {
             .clone()
             .unwrap_or_else(|| self.cert_dir().join("default.key"))
     }
+}
+
+fn string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    Ok(match StringOrVec::deserialize(deserializer)? {
+        StringOrVec::One(s) => vec![s],
+        StringOrVec::Many(v) => v,
+    })
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -614,16 +632,16 @@ async fn load_cert_config(tls: &TlsConfig) -> Result<relay::CertConfig> {
             relay::CertConfig::Manual { server_config }
         }
         CertMode::LetsEncrypt => {
-            let hostname = tls
-                .hostname
-                .clone()
-                .std_context("LetsEncrypt needs a hostname")?;
+            let domains = tls.hostname.clone();
+            if domains.is_empty() {
+                bail_any!("LetsEncrypt needs at least one hostname");
+            }
             let contact = tls
                 .contact
                 .clone()
                 .std_context("LetsEncrypt needs a contact email")?;
             let acme_config = AcmeConfig::letsencrypt(tls.prod_tls)
-                .domains(vec![hostname])
+                .domains(domains)
                 .contact(vec![format!("mailto:{contact}")])
                 .cache_path(tls.cert_dir());
             relay::CertConfig::LetsEncrypt {

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -58,6 +58,7 @@ use crate::{
     defaults::DEFAULT_KEY_CACHE_CAPACITY,
     http::{AUTH_TOKEN_URL_QUERY_PARAM, ProtocolVersion, RELAY_PROBE_PATH},
     quic::server::{QuicServer, QuicSpawnError, ServerHandle as QuicServerHandle},
+    tls::CaTlsConfig,
 };
 
 pub mod client;
@@ -549,6 +550,7 @@ pub struct AcmeConfig {
     pub(crate) domains: Vec<String>,
     pub(crate) contact: Vec<String>,
     pub(crate) cache_path: Option<PathBuf>,
+    pub(crate) tls_config: CaTlsConfig,
 }
 
 impl AcmeConfig {
@@ -559,6 +561,7 @@ impl AcmeConfig {
             domains: Vec::new(),
             contact: Vec::new(),
             cache_path: None,
+            tls_config: CaTlsConfig::default(),
         }
     }
 
@@ -591,6 +594,16 @@ impl AcmeConfig {
     /// If not called certificates will not be cached.
     pub fn cache_path(mut self, path: PathBuf) -> Self {
         self.cache_path = Some(path);
+        self
+    }
+
+    /// Sets the [`CaTlsConfig`] used to verify the ACME server's TLS certificate.
+    ///
+    /// Defaults to [`CaTlsConfig::embedded`]. Set a config with extra roots when targeting
+    /// an ACME server whose certificate is not signed by a publicly trusted CA, such as a
+    /// local test server.
+    pub fn tls_config(mut self, tls_config: CaTlsConfig) -> Self {
+        self.tls_config = tls_config;
         self
     }
 }
@@ -636,6 +649,11 @@ pub enum SpawnError {
     TlsHeaderParse { source: InvalidHeaderValue },
     #[error("Failed to bind TcpListener")]
     BindTlsListener { source: std::io::Error },
+    #[error("Failed to build ACME client TLS config")]
+    AcmeClientTlsConfig {
+        #[error(std_err)]
+        source: std::io::Error,
+    },
     #[error("No local address")]
     NoLocalAddr { source: std::io::Error },
     #[error("Failed to bind server socket to {addr}")]
@@ -731,11 +749,20 @@ impl Server {
                                 server_config_builder,
                             } => {
                                 let cache = acme_config.cache_path.map(DirCache::new);
+                                let crypto_provider =
+                                    server_config_builder.crypto_provider().clone();
+                                let client_tls_config = acme_config
+                                    .tls_config
+                                    .client_config(crypto_provider)
+                                    .map_err(|err| e!(SpawnError::AcmeClientTlsConfig, err))?;
                                 let config =
-                                    tokio_rustls_acme::AcmeConfig::new(acme_config.domains)
-                                        .contact(acme_config.contact)
-                                        .directory(acme_config.directory_url)
-                                        .cache_option(cache);
+                                    tokio_rustls_acme::AcmeConfig::new_with_client_tls_config(
+                                        acme_config.domains,
+                                        Arc::new(client_tls_config),
+                                    )
+                                    .contact(acme_config.contact)
+                                    .directory(acme_config.directory_url)
+                                    .cache_option(cache);
                                 let mut state = config.state();
                                 let resolver = state.resolver().clone();
                                 let server_config =

--- a/iroh-relay/tests/multiple-hostnames-pebble.sh
+++ b/iroh-relay/tests/multiple-hostnames-pebble.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for iroh-relay multi-hostname ACME support against a local
+# pebble ACME server, exercising real TLS-ALPN-01 challenge validation.
+#
+# Starts pebble, then iroh-relay in LetsEncrypt cert mode pointed at pebble via
+# IROH_RELAY_ACME_URL / IROH_RELAY_ACME_CA, and checks with curl that:
+#   - every configured hostname is served a cert signed by pebble's CA,
+#   - an unconfigured hostname is refused at the TLS handshake, and
+#   - pebble actually completed a challenge (no PEBBLE_VA_ALWAYS_VALID).
+#
+# pebble's validation authority resolves each hostname and connects back to the
+# relay's TLS-ALPN-01 responder. Two things make that callback reach the relay:
+# pebble's validation TLS port is set to the relay's HTTPS port, and an
+# /etc/hosts mounted into the pebble container maps each hostname to 127.0.0.1
+# (pebble reads it through its system resolver, so no separate DNS server is
+# needed). Host networking lets pebble's loopback reach the relay's listener.
+#
+# Exits 0 if all checks pass, 1 otherwise.
+#
+# Requirements: docker (Linux host networking), curl, jq, the iroh-relay sources.
+
+set -euo pipefail
+
+PEBBLE_IMAGE="${PEBBLE_IMAGE:-ghcr.io/letsencrypt/pebble:latest}"
+RELAY_HTTP_PORT="${RELAY_HTTP_PORT:-8080}"
+RELAY_HTTPS_PORT="${RELAY_HTTPS_PORT:-8443}"
+
+# The workdir is always a fresh mktemp directory, never taken from the
+# environment. This is what keeps cleanup safe: nothing here can ever delete a
+# path the user supplied, no matter how the environment is set. The pebble
+# container name is derived from it, so a run never force-removes a container it
+# did not create.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/iroh-relay-pebble.XXXXXXXX")"
+PEBBLE_NAME="${PEBBLE_NAME:-$(basename "$WORK")}"
+
+# Reject non-numeric ports so a bad value cannot leak into the generated config
+# or the jq program further down.
+case "${RELAY_HTTP_PORT}:${RELAY_HTTPS_PORT}" in
+    *[!0-9:]*) echo "RELAY_HTTP_PORT and RELAY_HTTPS_PORT must be numeric" >&2; exit 1 ;;
+esac
+
+# Hostnames the relay is configured to serve, plus one it is not.
+HOSTS=(relay-a.localhost relay-b.localhost)
+HOST_BAD=relay-evil.localhost
+
+PEBBLE_DIR_URL="https://localhost:14000/dir"
+PEBBLE_MGMT_URL="https://localhost:15000"
+
+log() { printf '\n=== %s ===\n' "$*"; }
+ok()  { printf '  [ ok ] %s\n' "$*"; }
+fail() {
+    printf '\n  [FAIL] %s\n' "$*" >&2
+    [ -f "$WORK/relay.log" ] && { echo "--- relay.log (tail) ---" >&2; tail -n 30 "$WORK/relay.log" >&2; }
+    docker logs "$PEBBLE_NAME" >/dev/null 2>&1 && { echo "--- pebble.log (tail) ---" >&2; docker logs "$PEBBLE_NAME" 2>&1 | tail -20 >&2; }
+    exit 1
+}
+
+RELAY_PID=""
+cleanup() {
+    set +e
+    [ -n "$RELAY_PID" ] && kill "$RELAY_PID" 2>/dev/null
+    docker rm -f "$PEBBLE_NAME" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+# curl the relay over HTTPS for a given hostname. --fail turns a non-2xx or TLS
+# error into a non-zero exit; --resolve pins the SNI hostname to loopback.
+curl_relay() {
+    curl -s --fail --max-time 5 -o /dev/null \
+        --cacert "$WORK/pebble-issuer-root.pem" \
+        --resolve "$1:${RELAY_HTTPS_PORT}:127.0.0.1" \
+        "https://$1:${RELAY_HTTPS_PORT}/healthz"
+}
+
+# --- start pebble ------------------------------------------------------------
+
+mkdir -p "$WORK/certs"
+
+{ echo "127.0.0.1 localhost"; echo "::1 localhost"
+  for host in "${HOSTS[@]}"; do echo "127.0.0.1 $host"; done; } > "$WORK/hosts"
+
+log "starting pebble ($PEBBLE_IMAGE)"
+# Derive pebble's config from the image default, setting its TLS-ALPN-01
+# validation port to the relay's HTTPS port so the callback lands on the relay.
+cid=$(docker create "$PEBBLE_IMAGE")
+docker cp "$cid:/test/config/pebble-config.json" "$WORK/pebble-config.in.json" >/dev/null
+docker rm "$cid" >/dev/null
+jq ".pebble.tlsPort = ${RELAY_HTTPS_PORT}" "$WORK/pebble-config.in.json" > "$WORK/pebble-config.json"
+
+docker run -d --rm --name "$PEBBLE_NAME" --network host \
+    -e PEBBLE_VA_NOSLEEP=1 -e PEBBLE_WFE_NONCEREJECT=0 \
+    -v "$WORK/pebble-config.json:/pebble-config.json:ro" \
+    -v "$WORK/hosts:/etc/hosts:ro" \
+    "$PEBBLE_IMAGE" -config /pebble-config.json >/dev/null
+
+for i in $(seq 1 30); do
+    curl -sk -o /dev/null "$PEBBLE_DIR_URL" && break
+    [ "$i" = 30 ] && fail "pebble did not come up"
+    sleep 0.5
+done
+ok "pebble up (validation port = ${RELAY_HTTPS_PORT})"
+
+# pebble.minica.pem signs pebble's own ACME/management TLS, so the relay must
+# trust it (IROH_RELAY_ACME_CA). The certs pebble *issues* chain to a separate
+# root served by the management interface, which curl needs to verify the relay.
+docker cp "$PEBBLE_NAME:/test/certs/pebble.minica.pem" "$WORK/pebble.minica.pem" >/dev/null
+curl -s --cacert "$WORK/pebble.minica.pem" "$PEBBLE_MGMT_URL/roots/0" -o "$WORK/pebble-issuer-root.pem"
+ok "fetched pebble CAs"
+
+# --- start relay -------------------------------------------------------------
+
+hostnames=$(printf '"%s", ' "${HOSTS[@]}")
+cat > "$WORK/relay.toml" <<EOF
+enable_relay = true
+enable_quic_addr_discovery = false
+enable_metrics = false
+http_bind_addr = "0.0.0.0:${RELAY_HTTP_PORT}"
+
+[tls]
+https_bind_addr = "0.0.0.0:${RELAY_HTTPS_PORT}"
+hostname = [ ${hostnames%, } ]
+cert_mode = "LetsEncrypt"
+contact = "test@iroh.test"
+cert_dir = "${WORK}/certs"
+EOF
+
+log "starting iroh-relay (hostnames: ${HOSTS[*]})"
+IROH_RELAY_ACME_URL="$PEBBLE_DIR_URL" \
+IROH_RELAY_ACME_CA="$WORK/pebble.minica.pem" \
+RUST_LOG="${RUST_LOG:-iroh_relay=debug,rustls_acme=info,warn}" \
+    cargo run --quiet --bin iroh-relay --features server -- \
+    --config-path "$WORK/relay.toml" > "$WORK/relay.log" 2>&1 &
+RELAY_PID=$!
+
+# --- checks ------------------------------------------------------------------
+
+log "waiting for the relay to pass validation and provision a cert"
+for i in $(seq 1 90); do
+    kill -0 "$RELAY_PID" 2>/dev/null || fail "relay exited early"
+    curl_relay "${HOSTS[0]}" 2>/dev/null && break
+    [ "$i" = 90 ] && fail "relay did not provision a cert in time"
+    sleep 1
+done
+ok "relay provisioned a cert"
+
+log "every configured hostname serves a pebble-signed cert"
+for host in "${HOSTS[@]}"; do
+    curl_relay "$host" || fail "$host: expected a valid pebble-signed cert"
+    ok "$host: served a pebble-signed cert, verified by curl"
+done
+
+log "an unconfigured hostname is refused"
+curl_relay "$HOST_BAD" 2>/dev/null && fail "$HOST_BAD: handshake unexpectedly succeeded"
+ok "$HOST_BAD: TLS handshake refused, as expected"
+
+log "pebble ran a real challenge validation"
+docker logs "$PEBBLE_NAME" 2>&1 | grep -q "set VALID by completed challenge" \
+    || fail "pebble recorded no completed challenge (was validation skipped?)"
+docker logs "$PEBBLE_NAME" 2>&1 | grep -E "set VALID by completed challenge|Issued certificate" | tail -4
+ok "pebble validated the TLS-ALPN-01 challenge and issued the cert"
+
+log "ALL CHECKS PASSED"
+echo "artifacts (logs, certs, config) left in $WORK"


### PR DESCRIPTION
## Description

This allows to set `hostname = ["relay.foo.org", "relay.bar.org"]` in the iroh-relay TOML config.
Setting a single string like previously,  `hostname = "relay.foo.org"` , is still accepted as well, so this is not a breaking change to config formats.

It also adds enviroment variables to override the ACME directory URL to allow using the ACME adaptor with other servers than letsencrypt.

Finally, this adds a test script that tests the setup with a locally-running `pebble` ACME server. I confirmed locally that it works. Not sure if we want to run it in CI as well.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
