### PR TITLE
refactor(iroh): toggle unstable item visibility with the visibility crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,6 +2366,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "visibility",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "wasm-tracing",
@@ -5495,6 +5496,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -61,6 +61,7 @@ tokio-stream = { version = "0.1.15", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["io-util", "io", "rt"] }
 tracing = "0.1"
 url = { version = "2.5", features = ["serde"] }
+visibility = "0.1"
 webpki = { package = "rustls-webpki", version = "0.103.7", default-features = false, features = ["std"] }
 webpki_types = { package = "rustls-pki-types", version = "1.12" }
 webpki-roots = "1.0.3"

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -42,17 +42,18 @@ use tracing::{debug, trace, warn};
 use self::reportgen::{ProbeFinished, ProbeReport};
 #[cfg(not(wasm_browser))]
 use self::reportgen::{QadProbeReport, SocketState};
-#[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
-pub use self::{
-    // exported primarily for use in documentation
-    defaults::timeouts::TIMEOUT,
-    metrics::Metrics,
-    probes::Probe,
-    report::{RelayLatencies, Report},
-};
+// Always public: `TIMEOUT` is re-exported as `NET_REPORT_TIMEOUT` (for documentation) and
+// `Metrics` is reachable via `EndpointMetrics`.
+pub use self::{defaults::timeouts::TIMEOUT, metrics::Metrics};
 pub(crate) use self::{
     options::Options,
     reportgen::{IfStateDetails, QuicConfig},
+};
+// Reachable as public API only with the `unstable-net-report` feature.
+#[cfg_attr(feature = "unstable-net-report", visibility::make(pub))]
+pub(crate) use self::{
+    probes::Probe,
+    report::{RelayLatencies, Report},
 };
 
 mod defaults;

--- a/iroh/src/net_report/probes.rs
+++ b/iroh/src/net_report/probes.rs
@@ -20,9 +20,9 @@ const HTTPS_OFFSET: Duration = Duration::from_millis(200);
 /// The protocol used to time an endpoint's latency.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, derive_more::Display)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
+#[cfg_attr(feature = "unstable-net-report", visibility::make(pub))]
 #[non_exhaustive]
-pub enum Probe {
+pub(crate) enum Probe {
     /// HTTPS
     Https,
     /// QUIC Address Discovery Ipv4

--- a/iroh/src/net_report/report.rs
+++ b/iroh/src/net_report/report.rs
@@ -13,9 +13,9 @@ use super::{ProbeReport, probes::Probe};
 
 /// A net_report report.
 #[derive(Default, Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-#[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
+#[cfg_attr(feature = "unstable-net-report", visibility::make(pub))]
 #[non_exhaustive]
-pub struct Report {
+pub(crate) struct Report {
     /// A QAD IPv4 round trip completed.
     pub udp_v4: bool,
     /// A QAD IPv6 round trip completed.
@@ -45,14 +45,14 @@ impl fmt::Display for Report {
 
 impl Report {
     /// Do we have any indication that UDP is working?
-    #[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
-    pub fn has_udp(&self) -> bool {
+    #[cfg_attr(feature = "unstable-net-report", visibility::make(pub))]
+    pub(crate) fn has_udp(&self) -> bool {
         self.udp_v4 || self.udp_v6
     }
 
     /// Whether the reported public address differs when probing different servers.
-    #[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
-    pub fn mapping_varies_by_dest(&self) -> Option<bool> {
+    #[cfg_attr(feature = "unstable-net-report", visibility::make(pub))]
+    pub(crate) fn mapping_varies_by_dest(&self) -> Option<bool> {
         match (
             self.mapping_varies_by_dest_ipv4,
             self.mapping_varies_by_dest_ipv6,
@@ -132,8 +132,8 @@ impl Report {
 
 /// Latencies per relay endpoint.
 #[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize)]
-#[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
-pub struct RelayLatencies {
+#[cfg_attr(feature = "unstable-net-report", visibility::make(pub))]
+pub(crate) struct RelayLatencies {
     #[cfg(not(wasm_browser))]
     ipv4: BTreeMap<RelayUrl, Duration>,
     #[cfg(not(wasm_browser))]
@@ -176,8 +176,8 @@ impl RelayLatencies {
 
     /// Returns an iterator over all the relays and their latencies.
     #[cfg(not(wasm_browser))]
-    #[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
-    pub fn iter(&self) -> impl Iterator<Item = (Probe, &'_ RelayUrl, Duration)> + '_ {
+    #[cfg_attr(feature = "unstable-net-report", visibility::make(pub))]
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (Probe, &'_ RelayUrl, Duration)> + '_ {
         self.https
             .iter()
             .map(|(url, l)| (Probe::Https, url, *l))
@@ -187,8 +187,8 @@ impl RelayLatencies {
 
     /// Returns an iterator over all the relays and their latencies.
     #[cfg(wasm_browser)]
-    #[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
-    pub fn iter(&self) -> impl Iterator<Item = (Probe, &'_ RelayUrl, Duration)> + '_ {
+    #[cfg_attr(feature = "unstable-net-report", visibility::make(pub))]
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (Probe, &'_ RelayUrl, Duration)> + '_ {
         self.https.iter().map(|(k, v)| (Probe::Https, k, *v))
     }
 

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -546,8 +546,8 @@ impl NetworkChangeSender {
 
 /// An outgoing packet
 #[derive(Debug, Clone)]
-#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
-pub struct Transmit<'a> {
+#[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+pub(crate) struct Transmit<'a> {
     pub(crate) ecn: Option<noq_udp::EcnCodepoint>,
     /// Packet contents
     pub contents: &'a [u8],
@@ -584,7 +584,8 @@ impl From<&noq_udp::Transmit<'_>> for OwnedTransmit {
 
 /// Transports address.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Addr {
+#[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+pub(crate) enum Addr {
     /// An IP address, should always be stored in its canonical form.
     Ip(SocketAddr),
     /// A relay address.
@@ -614,9 +615,9 @@ impl fmt::Debug for Addr {
 ///
 /// Custom transport authors construct values via [`RecvInfo::new`], which
 /// only accepts [`CustomAddr`].
-#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
+#[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
 #[derive(Clone, Debug, Default)]
-pub struct RecvInfo {
+pub(crate) struct RecvInfo {
     remote: Addr,
     local: Option<CustomAddr>,
 }
@@ -777,8 +778,8 @@ impl LocalTransportAddr {
 
 /// The kind of a transport address, used for configuring bias.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
-pub enum AddrKind {
+#[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+pub(crate) enum AddrKind {
     /// An IPv4 address.
     IpV4,
     /// An IPv6 address.
@@ -814,8 +815,8 @@ impl PartialEq<TransportAddr> for Addr {
 /// * For custom transports it is a custom transport address, if the transport reports one.
 /// * For relay transports there is no separate local address; the relay URL identifies the path.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
-pub enum FourTuple {
+#[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+pub(crate) enum FourTuple {
     /// A path over an IP transport.
     Ip {
         /// The remote socket address.
@@ -839,7 +840,6 @@ pub enum FourTuple {
     },
 }
 
-#[cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
 impl FourTuple {
     /// Creates a four-tuple from a remote address, with no known local address.
     pub(super) fn from_remote(remote: Addr) -> Self {
@@ -901,7 +901,8 @@ impl FourTuple {
     }
 
     /// Returns the remote transport address.
-    pub fn remote(&self) -> Addr {
+    #[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+    pub(crate) fn remote(&self) -> Addr {
         match self {
             Self::Ip { remote, .. } => Addr::Ip(*remote),
             Self::Relay { url, endpoint_id } => Addr::Relay(url.clone(), *endpoint_id),
@@ -910,7 +911,8 @@ impl FourTuple {
     }
 
     /// Returns the local transport address.
-    pub fn local(&self) -> LocalTransportAddr {
+    #[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+    pub(crate) fn local(&self) -> LocalTransportAddr {
         match self {
             Self::Ip { local, .. } => LocalTransportAddr::Ip(*local),
             Self::Relay { url, .. } => LocalTransportAddr::Relay(url.clone()),
@@ -919,12 +921,14 @@ impl FourTuple {
     }
 
     /// Returns `true` if the remote is an IP address.
-    pub fn is_ip(&self) -> bool {
+    #[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+    pub(crate) fn is_ip(&self) -> bool {
         matches!(self, Self::Ip { .. })
     }
 
     /// Returns `true` if the remote is a relay address.
-    pub fn is_relay(&self) -> bool {
+    #[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+    pub(crate) fn is_relay(&self) -> bool {
         matches!(self, Self::Relay { .. })
     }
 
@@ -957,7 +961,8 @@ impl FourTuple {
     }
 
     /// Returns the kind of address, for configuring bias.
-    pub fn addr_kind(&self) -> AddrKind {
+    #[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+    pub(crate) fn addr_kind(&self) -> AddrKind {
         match self {
             Self::Ip { remote, .. } => match remote {
                 SocketAddr::V4(_) => AddrKind::IpV4,

--- a/iroh/src/socket/transports/custom.rs
+++ b/iroh/src/socket/transports/custom.rs
@@ -1,6 +1,5 @@
 // The items in this module are exported from [`crate::endpoint::transports`] only if
-// the "unstable-custom-transports" feature is enabled
-#![cfg_attr(not(feature = "unstable-custom-transports"), allow(unreachable_pub))]
+// the "unstable-custom-transports" feature is enabled.
 
 use std::{
     io,
@@ -21,7 +20,8 @@ use super::{RecvInfo, Transmit};
 /// A transport is a factory for custom endpoints. Whenever an iroh endpoint is
 /// created using [crate::endpoint::Builder::bind], a new custom endpoint will
 /// be created using [CustomTransport::bind].
-pub trait CustomTransport: std::fmt::Debug + Send + Sync + 'static {
+#[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+pub(crate) trait CustomTransport: std::fmt::Debug + Send + Sync + 'static {
     /// Create a custom endpoint
     ///
     /// Analogously to [std::net::UdpSocket::bind], this is where the actual
@@ -33,7 +33,8 @@ pub trait CustomTransport: std::fmt::Debug + Send + Sync + 'static {
 ///
 /// An endpoint has a local address (or multiple local addresses), can receive
 /// packets, and can create senders to send packets.
-pub trait CustomEndpoint: std::fmt::Debug + Send + Sync + 'static {
+#[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+pub(crate) trait CustomEndpoint: std::fmt::Debug + Send + Sync + 'static {
     /// A watcher for local addresses for this custom endpoint.
     fn watch_local_addrs(&self) -> n0_watcher::Direct<Vec<CustomAddr>>;
     /// Create a custom sender for this custom endpoint.
@@ -81,7 +82,8 @@ pub trait CustomEndpoint: std::fmt::Debug + Send + Sync + 'static {
 /// This is not enforced at type level, but [CustomSender::poll_send] should
 /// only be called with addresses for which [CustomSender::is_valid_send_addr]
 /// returns true.
-pub trait CustomSender: std::fmt::Debug + Send + Sync + 'static {
+#[cfg_attr(feature = "unstable-custom-transports", visibility::make(pub))]
+pub(crate) trait CustomSender: std::fmt::Debug + Send + Sync + 'static {
     /// True if this sender can send to the given address.
     fn is_valid_send_addr(&self, addr: &CustomAddr) -> bool;
     /// poll sending a packet on this sender.


### PR DESCRIPTION
## Description

Based on #4338 

Replace the `cfg_attr(not(feature = ...), allow(unreachable_pub))` suppressions on the `unstable-net-report` and `unstable-custom-transports` items with `cfg_attr(feature = ..., visibility::make(pub))` on a `pub(crate)` base. The items (and the public methods of those types) are now genuinely `pub(crate)` when the feature is off and `pub` when it is on, so no lint suppression is needed.


## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
