### PR TITLE
fix(iroh): add missing item for backwards compatibility

### DIFF
--- a/iroh/src/tls.rs
+++ b/iroh/src/tls.rs
@@ -18,6 +18,8 @@ pub(crate) mod name;
 mod resolver;
 mod verifier;
 
+#[allow(deprecated)] // Re-export of backwards-compatibility item
+pub use iroh_relay::tls::CaRootsConfig;
 pub use iroh_relay::tls::CaTlsConfig;
 #[cfg(with_crypto_provider)]
 pub use iroh_relay::tls::default_provider;


### PR DESCRIPTION
## Description

#4300 renamed `iroh_relay::tls::CaRootsConfig` to `CaTlsConfig` with a type alias preserving backwards compatiblity. However, the type alias was not re-exported from `iroh::tls`, making this a backwards-incompatible change between rc.1 and 1.0. This PR fixes it.

## Change checklist

- [x] Self-review.