### PR TITLE
doc(portmapping): add more context around portmapping config in docs

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -780,7 +780,9 @@ impl Builder {
 
     /// Configures the portmapper service (UPnP, PCP, NAT-PMP).
     ///
-    /// Defaults to [`PortmapperConfig::Enabled`].
+    /// Defaults to [`PortmapperConfig::Enabled`]. Pass
+    /// [`PortmapperConfig::Disabled`] to avoid gateway probing (e.g. if it
+    /// triggers firewall prompts).
     pub fn portmapper_config(mut self, config: PortmapperConfig) -> Self {
         self.portmapper_config = config;
         self

--- a/iroh/src/portmapper.rs
+++ b/iroh/src/portmapper.rs
@@ -9,6 +9,11 @@ use tokio::sync::watch;
 
 /// Configuration for the portmapper service (UPnP, PCP, NAT-PMP).
 ///
+/// Port mapping asks the local router to open an external port so peers can
+/// reach this endpoint directly, improving connectivity behind NATs. The
+/// discovery step (UPnP uses SSDP multicast) can, however, trigger firewall
+/// prompts on some networks — see [`PortmapperConfig::Disabled`].
+///
 /// Used with [`crate::endpoint::Builder::portmapper_config`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -19,6 +24,11 @@ pub enum PortmapperConfig {
     #[non_exhaustive]
     Enabled {},
     /// Disable portmapping.
+    ///
+    /// Skips the UPnP/PCP/NAT-PMP gateway probing. Use this to avoid the
+    /// SSDP multicast discovery that can raise firewall dialogs (notably on
+    /// macOS), at the cost of potentially worse direct connectivity behind
+    /// some NATs.
     Disabled,
 }
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/n0-computer/iroh/issues/4349

Some developers want to disable port mapping on macOS now, because users might not want to see the firewall dialog and rather opt-in to it. We then proactively highlighting this issue in the docs so developers are aware.

## Breaking Changes
None 

## Notes & open questions

The original bug report also suggested changing the default globally, but we want to preserve an out of the box experience that tries to reach direct connections as quickly as possible so we will keep the default the same.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
