### PR TITLE
docs(iroh-dns-server): Fix link to production config file

### DIFF
--- a/iroh-dns-server/README.md
+++ b/iroh-dns-server/README.md
@@ -7,7 +7,7 @@ This server compiles to a binary `iroh-dns-server`. It needs a config file, of
 which there are two examples included:
 
 - [`config.dev.toml`](./config.dev.toml) - suitable for local development
-- [`config.prod.toml`](./config.dev.toml) - suitable for production, after
+- [`config.prod.toml`](./config.prod.toml) - suitable for production, after
   adjusting the domain names and IP addresses
 
 The server will expose the following services:


### PR DESCRIPTION
Trivial fix to refer to the correct example configuration file.
