### PR TITLE
chore(ci): route Windows jobs to Blacksmith overflow

### DIFF
--- a/.github/workflows/pick-runner.yml
+++ b/.github/workflows/pick-runner.yml
@@ -75,20 +75,17 @@ on:
         type: number
         default: 3
       core_runner:
-        description: JSON array for the `core` class (always this)
+        description: >
+          JSON array for the `core` class (always this). Also the label set
+          used to count idle self-hosted capacity for this platform
+          (case-insensitive). Pass e.g. '["self-hosted","windows","x64"]' to
+          route a Windows batch.
         type: string
         default: '["self-hosted","linux","X64"]'
       overflow_runner:
         description: JSON array for overflow slots that land on Blacksmith
         type: string
         default: '["blacksmith-4vcpu-ubuntu-2204"]'
-      idle_labels:
-        description: >
-          JSON array of runner labels used to count idle self-hosted capacity
-          for this platform. Case-insensitive. Defaults to linux X64; pass e.g.
-          '["self-hosted","windows","x64"]' to route a Windows batch.
-        type: string
-        default: '["self-hosted","linux","x64"]'
       blacksmith_busy_match:
         description: >
           Substring a busy Blacksmith runner's labels must contain to count
@@ -201,7 +198,6 @@ jobs:
           MAX_BLACKSMITH_CONCURRENT: ${{ inputs.max_blacksmith_concurrent }}
           CORE_RUNNER: ${{ inputs.core_runner }}
           OVERFLOW_RUNNER: ${{ inputs.overflow_runner }}
-          IDLE_LABELS: ${{ inputs.idle_labels }}
           BS_MATCH: ${{ inputs.blacksmith_busy_match }}
           ORG: ${{ inputs.org }}
           GH_TOKEN: ${{ secrets.RUNNER_READ_TOKEN || github.token }}
@@ -213,7 +209,7 @@ jobs:
           # One paginated fetch, counted twice. Avoid a second round-trip.
           RUNNERS_JSON="$(gh api "/orgs/${ORG}/actions/runners" --paginate 2>/dev/null || echo '')"
 
-          IDLE="$(echo "$RUNNERS_JSON" | jq -s --argjson want "$IDLE_LABELS" '[.[] | .runners[]?]
+          IDLE="$(echo "$RUNNERS_JSON" | jq -s --argjson want "$CORE_RUNNER" '[.[] | .runners[]?]
                  | [.[] | select(.status=="online" and .busy==false
                                  and ([.labels[].name | ascii_downcase]
                                       | contains($want | map(ascii_downcase))))]

--- a/.github/workflows/pick-runner.yml
+++ b/.github/workflows/pick-runner.yml
@@ -82,6 +82,20 @@ on:
         description: JSON array for overflow slots that land on Blacksmith
         type: string
         default: '["blacksmith-4vcpu-ubuntu-2204"]'
+      idle_labels:
+        description: >
+          JSON array of runner labels used to count idle self-hosted capacity
+          for this platform. Case-insensitive. Defaults to linux X64; pass e.g.
+          '["self-hosted","windows","x64"]' to route a Windows batch.
+        type: string
+        default: '["self-hosted","linux","x64"]'
+      blacksmith_busy_match:
+        description: >
+          Substring a busy Blacksmith runner's labels must contain to count
+          toward THIS platform's cap (e.g. `ubuntu` or `windows`). Keeps the
+          per-platform `max_blacksmith_concurrent` caps independent.
+        type: string
+        default: ubuntu
       max_blacksmith_concurrent:
         description: >
           Soft cap on total Blacksmith runners busy across the org. If the
@@ -187,6 +201,8 @@ jobs:
           MAX_BLACKSMITH_CONCURRENT: ${{ inputs.max_blacksmith_concurrent }}
           CORE_RUNNER: ${{ inputs.core_runner }}
           OVERFLOW_RUNNER: ${{ inputs.overflow_runner }}
+          IDLE_LABELS: ${{ inputs.idle_labels }}
+          BS_MATCH: ${{ inputs.blacksmith_busy_match }}
           ORG: ${{ inputs.org }}
           GH_TOKEN: ${{ secrets.RUNNER_READ_TOKEN || github.token }}
         shell: bash
@@ -197,19 +213,21 @@ jobs:
           # One paginated fetch, counted twice. Avoid a second round-trip.
           RUNNERS_JSON="$(gh api "/orgs/${ORG}/actions/runners" --paginate 2>/dev/null || echo '')"
 
-          IDLE="$(echo "$RUNNERS_JSON" | jq -s '[.[] | .runners[]?]
+          IDLE="$(echo "$RUNNERS_JSON" | jq -s --argjson want "$IDLE_LABELS" '[.[] | .runners[]?]
                  | [.[] | select(.status=="online" and .busy==false
                                  and ([.labels[].name | ascii_downcase]
-                                      | contains(["self-hosted","linux","x64"])))]
+                                      | contains($want | map(ascii_downcase))))]
                  | length' 2>/dev/null || echo "")"
 
-          # Count busy runners whose labels include any "blacksmith-" prefixed
-          # label. Blacksmith runners are ephemeral — they only exist while
-          # executing a job, so busy==true is always the relevant state.
-          BS_BUSY="$(echo "$RUNNERS_JSON" | jq -s '[.[] | .runners[]?]
+          # Count busy runners whose labels include a "blacksmith-" prefixed
+          # label AND a label containing $BS_MATCH (e.g. "ubuntu"/"windows"), so
+          # each platform's cap counts only its own Blacksmith runners.
+          # Blacksmith runners are ephemeral — they only exist while executing a
+          # job, so busy==true is always the relevant state.
+          BS_BUSY="$(echo "$RUNNERS_JSON" | jq -s --arg os "$BS_MATCH" '[.[] | .runners[]?]
                     | [.[] | select(.busy==true
-                                    and ([.labels[].name | ascii_downcase]
-                                         | any(startswith("blacksmith-"))))]
+                                    and ([.labels[].name | ascii_downcase] | any(startswith("blacksmith-")))
+                                    and ([.labels[].name | ascii_downcase] | any(contains($os | ascii_downcase)))) ]
                     | length' 2>/dev/null || echo "")"
 
           # Decide how many slots get self-hosted.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,6 @@ jobs:
   pick-runner-windows:
     uses: "./.github/workflows/pick-runner.yml"
     with:
-      idle_labels: '["self-hosted","windows","x64"]'
       core_runner: '["self-hosted","windows","x64"]'
       overflow_runner: '["blacksmith-4vcpu-windows-2025"]'
       blacksmith_busy_match: windows

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -303,7 +303,9 @@ jobs:
 
       - uses: msys2/setup-msys2@v2
         with:
-          release: false
+          # Blacksmith's Windows image ships no pre-installed MSYS2 (C:\msys64),
+          # so install it there. Self-hosted keeps the pre-installed one (faster).
+          release: ${{ startsWith(runner.name, 'blacksmith-') }}
 
       - name: Install aws-lc-sys build dependencies
         shell: powershell
@@ -417,7 +419,9 @@ jobs:
 
       - uses: msys2/setup-msys2@v2
         with:
-          release: false
+          # Blacksmith's Windows image ships no pre-installed MSYS2 (C:\msys64),
+          # so install it there. Self-hosted keeps the pre-installed one (faster).
+          release: ${{ startsWith(runner.name, 'blacksmith-') }}
 
       - name: Install aws-lc-sys build dependencies
         shell: powershell

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,20 @@ jobs:
     secrets:
       RUNNER_READ_TOKEN: ${{ secrets.RUNNER_READ_TOKEN }}
 
+  # Windows overflow routing onto Blacksmith, with its own idle count and an
+  # independent Blacksmith cap of 4 (see blacksmith_busy_match: windows).
+  pick-runner-windows:
+    uses: "./.github/workflows/pick-runner.yml"
+    with:
+      idle_labels: '["self-hosted","windows","x64"]'
+      core_runner: '["self-hosted","windows","x64"]'
+      overflow_runner: '["blacksmith-4vcpu-windows-2025"]'
+      blacksmith_busy_match: windows
+      max_blacksmith_concurrent: 4
+      min_free_runners: 1
+    secrets:
+      RUNNER_READ_TOKEN: ${{ secrets.RUNNER_READ_TOKEN }}
+
   build_and_test_nix:
     timeout-minutes: 30
     name: "Tests"
@@ -198,7 +212,8 @@ jobs:
   build_and_test_windows:
     timeout-minutes: 30
     name: "Tests"
-    runs-on: ${{ matrix.runner }}
+    needs: pick-runner-windows
+    runs-on: ${{ fromJSON(matrix.runs_on) }}
     strategy:
       fail-fast: false
       matrix:
@@ -208,14 +223,34 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
         include:
+          # windows cells route via pick-runner-windows slots 1-3
           - name: windows-latest
+            features: all
             os: windows
-            runner: [self-hosted, windows, x64]
+            runs_on: ${{ needs.pick-runner-windows.outputs.overflow_1 }}
+          - name: windows-latest
+            features: none
+            os: windows
+            runs_on: ${{ needs.pick-runner-windows.outputs.overflow_2 }}
+          - name: windows-latest
+            features: default
+            os: windows
+            runs_on: ${{ needs.pick-runner-windows.outputs.overflow_3 }}
     env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
+      # sccache backend is selected at runtime in "Configure sccache backend":
+      # local disk on self-hosted, GHA-backed on Blacksmith (ephemeral).
       RUSTC_WRAPPER: "sccache"
     steps:
+      - name: Configure sccache backend
+        shell: bash
+        run: |
+            if [[ "${RUNNER_NAME:-}" == blacksmith-* ]]; then
+              echo "Runner: $RUNNER_NAME → GHA-backed sccache"
+              echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+            else
+              echo "Runner: $RUNNER_NAME → local-disk sccache"
+              # leave SCCACHE_GHA_ENABLED unset; sccache defaults to local disk
+            fi
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -336,7 +371,8 @@ jobs:
   minimal-crates-windows:
     timeout-minutes: 30
     name: "Minimal Crates (Windows)"
-    runs-on: ${{ matrix.runner }}
+    needs: pick-runner-windows
+    runs-on: ${{ fromJSON(matrix.runs_on) }}
     strategy:
       fail-fast: false
       matrix:
@@ -345,14 +381,25 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
         include:
+          # distinct slot (4) so it can run alongside the 3 build cells
           - name: windows-latest
             os: windows
-            runner: [self-hosted, windows, x64]
+            runs_on: ${{ needs.pick-runner-windows.outputs.overflow_4 }}
     env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
+      # sccache backend is selected at runtime in "Configure sccache backend":
+      # local disk on self-hosted, GHA-backed on Blacksmith (ephemeral).
       RUSTC_WRAPPER: "sccache"
     steps:
+      - name: Configure sccache backend
+        shell: bash
+        run: |
+            if [[ "${RUNNER_NAME:-}" == blacksmith-* ]]; then
+              echo "Runner: $RUNNER_NAME → GHA-backed sccache"
+              echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+            else
+              echo "Runner: $RUNNER_NAME → local-disk sccache"
+              # leave SCCACHE_GHA_ENABLED unset; sccache defaults to local disk
+            fi
       - name: Checkout
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Mirror the Linux Blacksmith overflow setup for Windows CI jobs.

Limited to 4 nodes for spillover vs 10 on linux.