### PR TITLE
docs(iroh): clarify repeated stream opens

### DIFF
--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -813,7 +813,9 @@ impl<T: ConnectionState> Connection<T> {
     ///
     /// Streams are cheap and instantaneous to open unless blocked by flow control. As a
     /// consequence, the peer won’t be notified that a stream has been opened until the
-    /// stream is actually used.
+    /// stream is actually used. Each call opens a distinct stream on this connection, so
+    /// it is normal to call this repeatedly when your protocol uses multiple streams.
+    /// Only streams that are still open count against the concurrent stream limit.
     #[inline]
     pub fn open_uni(&self) -> OpenUni<'_> {
         self.inner.open_uni()
@@ -823,8 +825,11 @@ impl<T: ConnectionState> Connection<T> {
     ///
     /// Streams are cheap and instantaneous to open unless blocked by flow control. As a
     /// consequence, the peer won't be notified that a stream has been opened until the
-    /// stream is actually used. Calling [`open_bi`] then waiting on the [`RecvStream`]
-    /// without writing anything to [`SendStream`] will never succeed.
+    /// stream is actually used. Each call opens a distinct stream on this connection, so
+    /// it is normal to call this repeatedly when your protocol uses multiple streams.
+    /// Only streams that are still open count against the concurrent stream limit.
+    /// Calling [`open_bi`] then waiting on the [`RecvStream`] without writing anything to
+    /// [`SendStream`] will never succeed.
     ///
     /// [`open_bi`]: Connection::open_bi
     /// [`SendStream`]: crate::endpoint::SendStream


### PR DESCRIPTION
## Description

Clarify the `Connection::open_uni()` and `Connection::open_bi()` rustdoc for issue #4277.

- state that each call opens a distinct stream on the same connection
- make it explicit that repeated calls are normal when a protocol uses multiple streams
- clarify that the practical cap is on streams that are concurrently open
- keep the existing `open_bi()` warning about needing to write before the peer can receive the stream

## Breaking Changes

None.

## Notes & open questions

Duplicate checks before opening this draft:
- no open PR matched `#4277`
- no open PR matched `open_bi open_uni`
- no closed PR matched `#4277`

Local verification:
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p iroh --doc` was attempted, but the local Windows build ran out of disk space while compiling `iroh` (`os error 112`).

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.