### PR TITLE
Add NoRoute error variant to QadProbeError

### DIFF
--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -77,6 +77,8 @@ enum QadProbeError {
     Quic { source: iroh_relay::quic::Error },
     #[error("Receiver dropped")]
     ReceiverDropped,
+    #[error("No route to host")]
+    NoRoute,
 }
 
 /// Configuration for the net report component.
@@ -835,6 +837,13 @@ async fn run_probe_v4(
         .map_err(|source| e!(QadProbeError::GetRelayAddr { source }))?;
 
     trace!(?relay_addr, "resolved relay server address");
+
+    if let Ok(socket) = std::net::UdpSocket::bind("0.0.0.0:0") {
+        if let Err(err) = socket.connect(relay_addr) {
+            debug!(?relay_addr, ?err, "no IPv4 route to host, skipping QAD v4 probe");
+            return Err(e!(QadProbeError::NoRoute));
+        }
+    }
     let host = relay
         .url
         .host_str()
@@ -904,6 +913,13 @@ async fn run_probe_v6(
         .map_err(|source| e!(QadProbeError::GetRelayAddr { source }))?;
 
     trace!(?relay_addr, "resolved relay server address");
+
+    if let Ok(socket) = std::net::UdpSocket::bind("[::]:0") {
+        if let Err(err) = socket.connect(relay_addr) {
+            debug!(?relay_addr, ?err, "no IPv6 route to host, skipping QAD v6 probe");
+            return Err(e!(QadProbeError::NoRoute));
+        }
+    }
     let host = relay
         .url
         .host_str()

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -77,8 +77,6 @@ enum QadProbeError {
     Quic { source: iroh_relay::quic::Error },
     #[error("Receiver dropped")]
     ReceiverDropped,
-    #[error("No route to host")]
-    NoRoute,
 }
 
 /// Configuration for the net report component.
@@ -837,13 +835,6 @@ async fn run_probe_v4(
         .map_err(|source| e!(QadProbeError::GetRelayAddr { source }))?;
 
     trace!(?relay_addr, "resolved relay server address");
-
-    if let Ok(socket) = std::net::UdpSocket::bind("0.0.0.0:0") {
-        if let Err(err) = socket.connect(relay_addr) {
-            debug!(?relay_addr, ?err, "no IPv4 route to host, skipping QAD v4 probe");
-            return Err(e!(QadProbeError::NoRoute));
-        }
-    }
     let host = relay
         .url
         .host_str()
@@ -913,13 +904,6 @@ async fn run_probe_v6(
         .map_err(|source| e!(QadProbeError::GetRelayAddr { source }))?;
 
     trace!(?relay_addr, "resolved relay server address");
-
-    if let Ok(socket) = std::net::UdpSocket::bind("[::]:0") {
-        if let Err(err) = socket.connect(relay_addr) {
-            debug!(?relay_addr, ?err, "no IPv6 route to host, skipping QAD v6 probe");
-            return Err(e!(QadProbeError::NoRoute));
-        }
-    }
     let host = relay
         .url
         .host_str()

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -90,11 +90,37 @@ impl IfStateDetails {
 
 impl From<netwatch::netmon::State> for IfStateDetails {
     fn from(value: netwatch::netmon::State) -> Self {
+        let have_v6 = if let Some(ref default_if) = value.default_route_interface {
+            if let Some(iface) = value.interfaces.get(default_if) {
+                iface.addrs().any(|ip_net| match ip_net {
+                    netwatch::interfaces::IpNet::V6 { net, .. } => is_usable_v6(net.addr()),
+                    _ => false,
+                })
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
         IfStateDetails {
             have_v4: value.have_v4,
-            have_v6: value.have_v6,
+            have_v6: value.have_v6 && have_v6,
         }
     }
+}
+
+fn is_usable_v6(ip: std::net::Ipv6Addr) -> bool {
+    // V6 Global1 2000::/3
+    let mask: u16 = 0b1110_0000_0000_0000;
+    let base: u16 = 0x2000;
+    let segment1 = ip.segments()[0];
+    if (base & mask) == (segment1 & mask) {
+        return true;
+    }
+    // Unique Local Address fc00::/7
+    let ula_mask: u16 = 0xfe00;
+    (segment1 & ula_mask) == 0xfc00
 }
 
 /// Any state that depends on sockets being available in the current environment.


### PR DESCRIPTION

## Description

Added NoRoute error variant for handling routing issues.

run_probe_v4, checks if a local route to the target IPv4 address exists run_probe_v6, checks if a local route to the target IPv6 address exists

if fails it skips the probe and returns QadProbeError::NoRoute

running 6 tests
test net_report::tests::test_add_report_history_set_preferred_relay ... ok test net_report::probes::tests::test_initial_probeplan ... ok test net_report::probes::tests::test_initial_probeplan_some_protocols ... ok test net_report::reportgen::tests::test_measure_https_latency ... ok test net_report::reportgen::tests::test_qad_probe_v4 ... ok test net_report::tests::test_basic ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 103 filtered out; finished in 0.37s
