### PR TITLE
fix: suppress HostUnreachable warnings on UDP transmit (fixes #4345)

### DIFF
--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -1326,7 +1326,15 @@ impl noq::UdpSender for Sender {
                 Poll::Ready(Ok(()))
             }
             Poll::Ready(Err(ref err)) => {
-                warn!(dst=%network_path, "dropped transmit: {err:#}");
+                let kind = err.kind();
+                if kind == std::io::ErrorKind::HostUnreachable
+                    || kind == std::io::ErrorKind::NetworkUnreachable
+                    || kind == std::io::ErrorKind::NetworkDown
+                {
+                    trace!(dst=%network_path, "dropped transmit: {err:#}");
+                } else {
+                    warn!(dst=%network_path, "dropped transmit: {err:#}");
+                }
                 Poll::Ready(Ok(()))
             }
             Poll::Pending => {


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
  - [ ] List all breaking changes in the above "Breaking Changes" section.
  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
