### PR TITLE
chore: update curve25519-dalek to 5.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.0"
+version = "5.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.91"
 workspace = true
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-rc.0", features = ["serde", "rand_core", "zeroize"], optional = true }
+curve25519-dalek = { version = "=5.0.0-rc.1", features = ["serde", "rand_core", "zeroize"], optional = true }
 data-encoding = { version = "2.6.0", optional = true }
 data-encoding-macro = { version = "0.1.19", optional = true }
 ed25519-dalek = { version = "=3.0.0-rc.0", features = ["serde", "rand_core", "zeroize"], optional = true }


### PR DESCRIPTION
## Description

Updates to the latest rc version of curve25519-dalek . Without that change I can't update Beaver to the latest Servo since Servo switched to rc.1 and cargo does not like having both rc.0 and rc.1together...

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
- [X] Self-review.
