### PR TITLE
docs: update license links to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ Copyright 2025 N0, INC.
 This project is licensed under either of
 
  * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
+   https://www.apache.org/licenses/LICENSE-2.0)
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+   https://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/iroh-base/README.md
+++ b/iroh-base/README.md
@@ -7,9 +7,9 @@ This crate provides base types and utilities used throughout Iroh.
 This project is licensed under either of
 
  * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
+   https://www.apache.org/licenses/LICENSE-2.0)
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+   https://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/iroh-dns-server/README.md
+++ b/iroh-dns-server/README.md
@@ -26,8 +26,8 @@ packet origin will be appended with the origin as configured by this server.
 This project is licensed under either of
 
 - Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+  https://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/iroh-dns/README.md
+++ b/iroh-dns/README.md
@@ -9,9 +9,9 @@ This crate contains the core types for publishing and resolving iroh endpoint in
 This project is licensed under either of
 
  * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
+   https://www.apache.org/licenses/LICENSE-2.0)
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+   https://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -141,9 +141,9 @@ This will start a relay server with a self-signed TLS certificate, listening on 
 This project is licensed under either of
 
  * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
+   https://www.apache.org/licenses/LICENSE-2.0)
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+   https://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/iroh/README.md
+++ b/iroh/README.md
@@ -154,9 +154,9 @@ For notes on iroh's structured events and how to build the documentation, see
 This project is licensed under either of
 
  * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
+   https://www.apache.org/licenses/LICENSE-2.0)
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+   https://opensource.org/licenses/MIT)
 
 at your option.
 


### PR DESCRIPTION
## Description

- Update Apache-2.0 and MIT license URLs in README files from HTTP to HTTPS.
- Keep the local LICENSE links and license text unchanged.

## Breaking Changes

None.

## Notes & open questions

Docs-only change. Verified both HTTPS license URLs resolve successfully, and ran `git diff --check`.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the style guide, if relevant.
- [x] Tests if relevant. Not applicable; link-only documentation update.
- [x] All breaking changes documented. No breaking changes.