### PR TITLE
refactor(iroh-dns): use fallback nameservers if no JNI context is initialized

### DIFF
--- a/iroh-dns/src/android.rs
+++ b/iroh-dns/src/android.rs
@@ -42,28 +42,52 @@ pub(crate) fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), NetEr
     }
 }
 
-/// Publishes a `JavaVM` and `Application` `Context` to [`ndk_context`] so
-/// iroh's system DNS reader can use JNI.
+/// Exposes a JVM to iroh so that we can read the system's DNS configuration.
 ///
-/// The default [`DnsResolver`] reads DNS configuration through JNI and panics
-/// if [`ndk_context`] has not been initialized. Apps that already initialize
-/// the context (directly, or via ndk-glue or android-activity) do not need
-/// this. Apps that don't use either glue crate must call this once at
-/// process startup, before any `DnsResolver` or `Endpoint` is constructed.
+/// This calls [`ndk_context::initialize_android_context`] to expose a
+/// `JavaVM` and Application Context to Rust code so that we can use JNI.
+/// This is required to get the configured nameservers on Android.
 ///
-/// Pass the `JavaVM` from `JNI_OnLoad` (or `JNIEnv::GetJavaVM`) and a JNI
-/// global reference to the singleton `Application` from
-/// `ActivityThread.currentApplication()`. Both pointers must remain valid
-/// until the process exits.
+/// If this function is not called, fetching the configured nameservers will fail
+/// and the default [`DnsResolver`] will use fallback nameservers instead.
+///
+/// If you call [`ndk_context::initialize_android_context`] already somewhere
+/// up the stack in your app, or use a crate like `ndk-glue` or `android-activity`
+/// that do this for you, then there's no need to call this function.
+///
+/// If you don't use a glue crate, a typical way to initialize the context is
+/// via `JNI_OnLoad`:
+///
+/// *Note: `install_android_jni_context` is reexported from `iroh`, so you can substitute
+/// `iroh_dns` for `iroh` below.*
+///
+/// ```ignore
+/// #[cfg(target_os = "android")]
+/// #[no_mangle]
+/// pub extern "C" fn JNI_OnLoad(
+///     vm: jni::JavaVM,
+///     res: *mut std::os::raw::c_void,
+/// ) -> jni::sys::jint {
+///     use std::ffi::c_void;
+///
+///     let vm = vm.get_java_vm_pointer() as *mut c_void;
+///     unsafe {
+///         iroh_dns::install_android_jni_context(vm, res);
+///     }
+///     jni::JNIVersion::V6.into()
+/// }
+/// ```
 ///
 /// # Safety
 ///
-/// See [`ndk_context::initialize_android_context`].
+/// Both the `java_vm` and `context_jobject` pointers must remain valid until the process exits.
+/// See also [`ndk_context::initialize_android_context`].
 ///
 /// [`DnsResolver`]: crate::dns::DnsResolver
 /// [`ndk_context`]: https://docs.rs/ndk-context
-pub unsafe fn install_android_jni_context(java_vm: *mut c_void, application_context: *mut c_void) {
+/// [`ndk_context::initialize_android_context`]: https://docs.rs/ndk-context/latest/ndk_context/fn.initialize_android_context.html
+pub unsafe fn install_android_jni_context(java_vm: *mut c_void, context_jobject: *mut c_void) {
     unsafe {
-        ndk_context::initialize_android_context(java_vm, application_context);
+        ndk_context::initialize_android_context(java_vm, context_jobject);
     }
 }

--- a/iroh-dns/src/android.rs
+++ b/iroh-dns/src/android.rs
@@ -7,17 +7,22 @@
 //! (both do this before `main`) or by an explicit
 //! [`install_android_jni_context`] call.
 //!
-//! Without an initialized [`ndk_context`], the JNI lookup panics. Debug
-//! builds wrap the call in `std::panic::catch_unwind` so unit tests on
-//! Android (where no JVM is in scope) fall back to the resolver's
-//! default servers instead of aborting the test binary. Release builds
-//! let the panic propagate; uninitialized [`ndk_context`] in production
-//! is a programming error and should surface loudly.
+//! Without an initialized [`ndk_context`], the JNI lookup panics internally.
+//! We catch the panic via [`catch_unwind`] and convert the panic into a regular
+//! error, which will then make the [`DnsResolver`] use fallback nameservers.
+//!
+//! This depends on panic unwinding though, so if you set `panic = abort` in
+//! your compilation profile, and don't install the JNI context, your app
+//! would panic and abort on the first DNS lookup.
 //!
 //! [`DnsResolver`]: crate::dns::DnsResolver
 //! [`ndk_context`]: https://docs.rs/ndk-context
+//! [`catch_unwind`]: std::panic::catch_unwind
 
-use std::ffi::c_void;
+use std::{
+    ffi::c_void,
+    panic::{AssertUnwindSafe, catch_unwind},
+};
 
 use hickory_resolver::{
     config::{ResolverConfig, ResolverOpts},
@@ -26,21 +31,15 @@ use hickory_resolver::{
 
 /// Reads the active network's DNS configuration via JNI.
 pub(crate) fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), NetError> {
-    #[cfg(debug_assertions)]
-    {
-        use std::panic::{AssertUnwindSafe, catch_unwind};
-        match catch_unwind(AssertUnwindSafe(
-            hickory_resolver::system_conf::read_system_conf,
-        )) {
-            Ok(Ok(conf)) => Ok(conf),
-            Ok(Err(err)) => Err(NetError::from(err)),
-            Err(_) => Err(NetError::Msg(
-                "ndk_context not initialized; call install_android_jni_context".to_string(),
-            )),
-        }
+    match catch_unwind(AssertUnwindSafe(
+        hickory_resolver::system_conf::read_system_conf,
+    )) {
+        Ok(Ok(conf)) => Ok(conf),
+        Ok(Err(err)) => Err(NetError::from(err)),
+        Err(_) => Err(NetError::Msg(
+            "ndk_context not initialized; call install_android_jni_context".to_string(),
+        )),
     }
-    #[cfg(not(debug_assertions))]
-    Ok(hickory_resolver::system_conf::read_system_conf()?)
 }
 
 /// Publishes a `JavaVM` and `Application` `Context` to [`ndk_context`] so

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -34,6 +34,8 @@ use tokio::sync::Notify;
 use tracing::warn;
 use url::Url;
 
+#[cfg(any(target_os = "android", doc))]
+pub use crate::android::install_android_jni_context;
 use crate::{attrs::ParseError, endpoint_info::EndpointInfo};
 
 /// Default DNS query timeout.
@@ -182,9 +184,9 @@ impl DnsProtocol {
 impl Builder {
     /// Makes the builder respect the host system's DNS configuration.
     ///
-    /// We first try to read the system's resolver from `/etc/resolv.conf`.
-    /// This does not work at least on some Androids, therefore we fallback
-    /// to a default config which uses Google's `8.8.8.8` or `8.8.4.4`.
+    /// We will try to read the system's DNS configuration in a platform-specific
+    /// way. If that fails for whatever reason, the resolver will be configured
+    /// to use Google's DNS servers instead.
     pub fn with_system_defaults(mut self) -> Self {
         self.use_system_defaults = true;
         self
@@ -233,12 +235,18 @@ impl Builder {
 /// The system-defaults reader uses JNI through [`ndk_context`], which must be
 /// initialized with a `JavaVM` and `Application` context before the resolver
 /// is constructed. Glue crates like ndk-glue and android-activity do this
-/// before `main`. Apps that don't use either can call
-/// `iroh_dns::install_android_jni_context` once at startup. Without an
-/// initialized `ndk_context` the JNI lookup panics in release builds. In
-/// debug builds the panic is caught and the resolver falls back to Google's
-/// public DNS.
+/// before `main`. Apps that don't use either should call [`install_android_jni_context`]
+/// once at startup, see docs there for details.
 ///
+/// If `ndk_context` is not initialized, fetching the system config on Android will fail
+/// and the resolver will use Google's fallback DNS servers. Due to how things are
+/// implemented in `ndk_context`, detecting the failure relies on unwinding a panic.
+/// If your app uses `panic = "abort"` in its compilation profile, this doesn't work,
+/// so in that case your app will panic if no JNI context is initialized.
+/// Therefore, either make sure that the JNI context is installed, or don't use
+/// `panic = "abort"`.
+///
+/// [`install_android_jni_context`]: crate::install_android_jni_context
 /// [`ndk_context`]: https://docs.rs/ndk-context
 #[derive(Debug, Clone)]
 pub struct DnsResolver {
@@ -722,8 +730,8 @@ impl HickoryResolver {
         let (mut config, mut options) = if builder.use_system_defaults {
             match Self::system_config() {
                 Ok((config, options)) => (config, options),
-                Err(error) => {
-                    warn!(%error, "Failed to read the system's DNS config, using fallback DNS servers.");
+                Err(reason) => {
+                    warn!(%reason, "Failed to read the system's DNS config, using Google DNS servers as fallback.");
                     (
                         ResolverConfig::udp_and_tcp(&hickory_resolver::config::GOOGLE),
                         ResolverOpts::default(),

--- a/iroh-dns/src/lib.rs
+++ b/iroh-dns/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links, unreachable_pub)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", doc))]
 mod android;
 mod attrs;
 #[cfg(not(wasm_browser))]
@@ -13,6 +13,6 @@ pub mod dns;
 pub mod endpoint_info;
 pub mod pkarr;
 
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", doc))]
 pub use android::install_android_jni_context;
 pub use attrs::{EncodingError, IROH_TXT_NAME, ParseError};

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -877,13 +877,21 @@ pub enum EndpointError {
 ///
 /// The endpoint's default [`DnsResolver`] reads the system DNS configuration
 /// through JNI, which needs a JVM context published to [`ndk_context`]. Apps
-/// must initialize that context before constructing the endpoint, or the
-/// resolver build panics. See [`DnsResolver`] for the supported
-/// initialization paths.
+/// should initialize that context before constructing the endpoint. See
+/// [`iroh_dns::install_android_jni_context`] for details (the function is also
+/// exported as `iroh::dns::install_android_jni_context`).
+///
+/// If no JNI context is installed, iroh relies on panic unwinding to detect
+/// the error, and will then use Google's fallback DNS servers. Note that if
+/// your compilation profile sets `panic = "abort"`, this can't work, and thus
+/// your app will panic if using a default `DnsResolver` without first initializing
+/// the JNI context.
 ///
 /// [QUIC]: https://quicwg.org
 /// [`DnsResolver`]: crate::dns::DnsResolver
 /// [`ndk_context`]: https://docs.rs/ndk-context
+/// [`iroh_dns::install_android_jni_context`]: https://docs.rs/iroh-dns/latest/iroh_dns/fn.install_android_jni_context.html
+// The last link can't be a normal doclink, because #[cfg(doc)] can't cross crate boundaries unfortunately.
 #[derive(Clone, Debug)]
 pub struct Endpoint {
     inner: Arc<EndpointInner>,


### PR DESCRIPTION
## Description

On Android the default DNS resolver reads system DNS through JNI, which panics if `ndk_context` was never initialized. Previously that panic was only caught in debug builds, so a release app without a JNI context would abort on its first lookup.

This PR changes it such that we always try to catch the panic, also in release builds, and thus use the fallback DNS servers (hardcoded to Google currently) if the JNI context was not initialized.

What remains ugly is that this depends on panic unwinding, so iroh will still panic if no JNI context is set and the app is compiled with `panic = "abort"`. Unfortunately there's no way around this currently, unless we decide to not use `ndk_context` and provide our own initialization function (ndk_context provides no way to return an error for unitialized context, it panics unconditionally. I made a PR https://github.com/rust-mobile/ndk-context/pull/4 but I don't expect it to be merged, the crate seems unmaintained, which is quite unfortunate).

The PR also improves the documentation around the Android setup.

Fixes https://github.com/n0-computer/dumbpipe/issues/96 - this change will iroh work in termux (with fallback resolvers, but that was always the case).

## Breaking Changes

None.

## Notes & open questions

* This now actually aligns more to how we handle other platforms: If reading the system configuration fails, we use the fallback servers.
* We might want to make the fallback behavior configurable, but that's for another PR.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
