### PR TITLE
fix(logging): do not use span levels higher than info

### DIFF
--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -29,7 +29,7 @@ use tokio::{
 };
 use tokio_rustls_acme::AcmeAcceptor;
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-use tracing::{Instrument, debug, error, info, info_span, trace, warn, warn_span};
+use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 
 use super::{
     AllowAll, ClientRequest, DynAccessControl, SpawnError, clients::Clients,
@@ -652,7 +652,7 @@ impl RelayServiceWithNotify {
                     Err(err) => warn!("upgrade error: {err:#}"),
                 }
             }
-            .instrument(warn_span!("handler"))
+            .instrument(info_span!("handler"))
         });
 
         // Now return a 101 Response saying we agree to the upgrade to the

--- a/iroh/src/address_lookup/pkarr.rs
+++ b/iroh/src/address_lookup/pkarr.rs
@@ -69,7 +69,7 @@ use n0_future::{
     time::{self, Duration, Instant},
 };
 use n0_watcher::{Disconnected, Watchable, Watcher as _};
-use tracing::{Instrument, debug, error_span, trace, warn};
+use tracing::{Instrument, debug, info_span, trace, warn};
 use url::Url;
 
 #[cfg(not(wasm_browser))]
@@ -321,7 +321,7 @@ impl PkarrPublisher {
             pkarr_client,
             republish_interval,
         };
-        let join_handle = task::spawn(service.run().instrument(error_span!("pkarr_publish")));
+        let join_handle = task::spawn(service.run().instrument(info_span!("pkarr_publish")));
         Self {
             watchable,
             endpoint_id,

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -446,7 +446,7 @@ impl Client {
         do_full: bool,
         shutdown_token: CancellationToken,
     ) -> Vec<ProbeReport> {
-        use tracing::{Instrument, warn_span};
+        use tracing::{Instrument, info_span};
 
         let Some(ref quic_client) = self.socket_state.quic_client else {
             return Vec::new();
@@ -516,7 +516,7 @@ impl Client {
                             PROBES_TIMEOUT,
                             run_probe_v4(relay, quic_client, dns_resolver, inner_token),
                         ))
-                        .instrument(warn_span!("QADv4", %relay_url)),
+                        .instrument(info_span!("QADv4", %relay_url)),
                 );
             }
             if if_state.have_v6 && needs_v6_probe {
@@ -533,7 +533,7 @@ impl Client {
                             PROBES_TIMEOUT,
                             run_probe_v6(relay, quic_client, dns_resolver, inner_token),
                         ))
-                        .instrument(warn_span!("QADv6", %relay_url)),
+                        .instrument(info_span!("QADv6", %relay_url)),
                 );
             }
         }
@@ -566,7 +566,7 @@ impl Client {
                 }
 
                 val = v4_buf.join_next(), if !v4_buf.is_empty() => {
-                    let span = warn_span!("QADv4");
+                    let span = info_span!("QADv4");
                     let _guard = span.enter();
                     ipv4_pending = false;
                     match val {
@@ -605,7 +605,7 @@ impl Client {
                     }
                 }
                 val = v6_buf.join_next(), if !v6_buf.is_empty() => {
-                    let span = warn_span!("QADv6");
+                    let span = info_span!("QADv6");
                     let _guard = span.enter();
                     ipv6_pending = false;
                     match val {

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -43,7 +43,7 @@ use n0_future::{
 use rand::seq::IteratorRandom;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, error, trace, warn, warn_span};
+use tracing::{Instrument, debug, error, info_span, trace, warn};
 use url::Host;
 
 #[cfg(not(wasm_browser))]
@@ -141,7 +141,7 @@ impl Client {
         let task = task::spawn(
             actor
                 .run(shutdown_token)
-                .instrument(warn_span!("reportgen-actor")),
+                .instrument(info_span!("reportgen-actor")),
         );
         (
             Self {
@@ -337,7 +337,7 @@ impl Actor {
                     };
                     ProbeFinished::CaptivePortal(res)
                 }
-                .instrument(warn_span!("captive-portal")),
+                .instrument(info_span!("captive-portal")),
             );
         }
         token
@@ -408,7 +408,7 @@ impl Actor {
                         };
                         ProbeFinished::Regular(res)
                     }
-                    .instrument(warn_span!(
+                    .instrument(info_span!(
                         "run-probe",
                         ?proto,
                         ?delay,


### PR DESCRIPTION
## Description

Users keep logging span entry and exit events and are than surprised
to see errors and warnings in their logs that aren't. We tried
re-educating users but it is a losing battle. Instead don't use these
levels in spans.

It does mean that we'll be more likely to miss vital span information
from a warning or error making such logs in isolation much less
useful. Maybe we'll have to get into a habit of repeating span
details in logs themselves, more likely we'll just encounter more
places where we have to ask to run with more logging. Info is a good
compromise for this: we haven't had users complain about span events
on info yes, despite having many of them. And it is not unreasonable
to log your production at info all the time, that is something we do
want to support so we do tweak logging there to be reasonable.

Closes #4374 

## Breaking Changes

none, logging is not part of any API or wire-stability contract.

## Notes & open questions

none

## Change checklist

- [x] Self-review.