### PR TITLE
fix(tests): longer timeout to avoid flakyness

### DIFF
--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -2296,7 +2296,7 @@ mod tests {
         payload: &[u8],
         loss: ExpectedLoss,
     ) -> Result<()> {
-        tokio::time::timeout(Duration::from_secs(4), async move {
+        tokio::time::timeout(Duration::from_secs(20), async move {
             let send_endpoint_id = sender.id();
             let recv_endpoint_id = receiver.id();
             info!("\nroundtrip: {send_endpoint_id:#} -> {recv_endpoint_id:#}");


### PR DESCRIPTION
## Description

We keep getting occasional flakes in CI on the android emulator. 4s is
very short, give it a ton more time.

## Breaking Changes

none

## Notes & open questions

none

## Change checklist

- [x] Self-review.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.