### PR TITLE
refactor(iroh): reduce warn logs

### DIFF
--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -291,9 +291,9 @@ impl Transports {
         let mut return_ready = false;
 
         macro_rules! poll_transport {
-            ($debug_label:expr, $socket:expr) => {
+            ($transport:expr) => {
                 total_polled += 1;
-                match $socket.poll_recv(cx, bufs, metas, &mut self.recv_infos) {
+                match $transport.poll_recv(cx, bufs, metas, &mut self.recv_infos) {
                     Poll::Pending => {}
                     Poll::Ready(Ok(0)) => {
                         return_ready = true;
@@ -309,7 +309,7 @@ impl Transports {
                         // where `poll_recv` would be called right away again and again even if
                         // the non-failing transports are all pending.
                         total_errors += 1;
-                        warn!(transport = $debug_label, "recv error: {err:#}");
+                        debug!(transport = %$transport, "recv error: {err:#}");
                     }
                 }
             };
@@ -321,31 +321,36 @@ impl Transports {
         if counter.is_multiple_of(2) {
             #[cfg(not(wasm_browser))]
             for transport in self.ip.iter_mut() {
-                poll_transport!("IP", transport);
+                poll_transport!(transport);
             }
             for transport in self.relay.iter_mut() {
-                poll_transport!("relay", transport);
+                poll_transport!(transport);
             }
             for transport in self.custom.iter_mut() {
-                poll_transport!("custom", transport);
+                poll_transport!(transport);
             }
         } else {
             for transport in self.custom.iter_mut().rev() {
-                poll_transport!("custom", transport);
+                poll_transport!(transport);
             }
             for transport in self.relay.iter_mut().rev() {
-                poll_transport!("relay", transport);
+                poll_transport!(transport);
             }
             #[cfg(not(wasm_browser))]
             for transport in self.ip.iter_mut() {
-                poll_transport!("IP", transport);
+                poll_transport!(transport);
             }
         }
 
         if total_polled == total_errors {
             // All transports errored.
             self.consecutive_total_recv_failures += 1;
+            debug!(
+                "All transports failed to receive ({} remaining)",
+                MAX_CONSECUTIVE_RECV_ERRORS.wrapping_sub(self.consecutive_total_recv_failures)
+            );
             if self.consecutive_total_recv_failures >= MAX_CONSECUTIVE_RECV_ERRORS {
+                warn!("All transports failed to receive. QUIC endpoint will be shutdown.");
                 Poll::Ready(Err(io::Error::new(
                     io::ErrorKind::NetworkDown,
                     "All transports failed to receive",
@@ -1482,7 +1487,7 @@ impl noq::UdpSender for Sender {
                 Poll::Ready(Ok(()))
             }
             Poll::Ready(Err(ref err)) => {
-                warn!(dst=%network_path, "dropped transmit: {err:#}");
+                debug!(dst=%network_path, "dropped transmit: {err:#}");
                 Poll::Ready(Ok(()))
             }
             Poll::Pending => {

--- a/iroh/src/socket/transports/custom.rs
+++ b/iroh/src/socket/transports/custom.rs
@@ -73,6 +73,12 @@ pub trait CustomEndpoint: std::fmt::Debug + Send + Sync + 'static {
     }
 }
 
+impl std::fmt::Display for Box<dyn CustomEndpoint> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CustomTransport")
+    }
+}
+
 /// Custom sender
 ///
 /// A sender provides a poll based interface to send packets to custom addresses.

--- a/iroh/src/socket/transports/ip.rs
+++ b/iroh/src/socket/transports/ip.rs
@@ -24,6 +24,13 @@ pub(crate) struct IpTransport {
     metrics: Arc<SocketMetrics>,
 }
 
+impl std::fmt::Display for IpTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let version = if self.config.is_ipv4() { "v4" } else { "v6" };
+        write!(f, "IpTransport({version})")
+    }
+}
+
 /// IP transport configuration
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum Config {

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -41,6 +41,12 @@ pub(crate) struct RelayTransport {
     my_endpoint_id: EndpointId,
 }
 
+impl std::fmt::Display for RelayTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RelayTransport")
+    }
+}
+
 impl RelayTransport {
     pub(crate) fn new(config: RelayActorConfig, cancel_token: CancellationToken) -> Self {
         let (relay_datagram_send_tx, relay_datagram_send_rx) = mpsc::channel(256);


### PR DESCRIPTION
## Description

Reduce `WARN` logs we emit for failed sends or receives. These are normal under a few circumstances as numerous users reported. Let's demote them to debug under most circumstances.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
