### PR TITLE
chore: remove extensive breaking changes instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,13 +16,6 @@
 - [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
 - [ ] Tests if relevant.
 - [ ] All breaking changes documented.
-  - [ ] List all breaking changes in the above "Breaking Changes" section.
-  - [ ] Open an issue or PR on any number0 repos that are affected by this breaking change. Give guidance on how the updates should be handled or do the actual updates themselves. The major ones are:
-    - [ ] [`quic-rpc`](https://github.com/n0-computer/quic-rpc)
-    - [ ] [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip)
-    - [ ] [`iroh-blobs`](https://github.com/n0-computer/iroh-blobs)
-    - [ ] [`dumbpipe`](https://github.com/n0-computer/dumbpipe)
-    - [ ] [`sendme`](https://github.com/n0-computer/sendme)
 - [ ] This PR was created by a human that thought critically about the
       proposed change and wrote an as clear and concise description as
       they could.


### PR DESCRIPTION
## Description

Now that we're 1.0 we don't break things anymore, we can keep this
section shorter.

## Breaking Changes

none

## Notes & open questions

We could remove this entirely? Or maybe there needs to be a section
for API changes instead where it makes more sense to describe API
additions and deprecations?

## Change checklist

- [x] Self-review.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.