### PR TITLE
fix(iroh-dns-server): DNS write benchmark measurement

### DIFF
--- a/iroh-dns-server/benches/write.rs
+++ b/iroh-dns-server/benches/write.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use iroh::{
-    SecretKey,
+    RelayUrl, SecretKey,
     address_lookup::pkarr::PkarrRelayClient,
     dns::DnsResolver,
     endpoint_info::EndpointInfo,
@@ -19,38 +19,41 @@ fn benchmark_dns_server(c: &mut Criterion) {
     for iters in [10_u64, 100_u64, 250_u64, 1000_u64].iter() {
         group.throughput(Throughput::Elements(*iters));
         group.bench_with_input(BenchmarkId::from_parameter(iters), iters, |b, &iters| {
-            b.iter(|| {
-                let rt = Runtime::new().unwrap();
-                rt.block_on(async move {
-                    let config = Config::load("./config.dev.toml").await.unwrap();
-                    let server = Server::bind(config).await.unwrap();
+            let rt = Runtime::new().unwrap();
+            let config = rt.block_on(Config::load("./config.dev.toml")).unwrap();
+            let server = rt.block_on(Server::bind(config)).unwrap();
 
-                    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
-                    let secret_key = SecretKey::from_bytes(&rng.random());
-                    let endpoint_id = secret_key.public();
+            let tls_config = CaTlsConfig::default()
+                .client_config(default_provider())
+                .expect("infallible");
+            let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");
+            let pkarr = PkarrRelayClient::new(pkarr_relay, tls_config, DnsResolver::default());
+            let relay_url: RelayUrl = "http://localhost:8080".parse().unwrap();
+            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
 
-                    let tls_config = CaTlsConfig::default()
-                        .client_config(default_provider())
-                        .expect("infallible");
-                    let pkarr_relay = LOCALHOST_PKARR.parse().expect("valid url");
-                    let pkarr =
-                        PkarrRelayClient::new(pkarr_relay, tls_config, DnsResolver::default());
-                    let relay_url = "http://localhost:8080".parse().unwrap();
-                    let endpoint_info = EndpointInfo::new(endpoint_id).with_relay_url(relay_url);
-                    let signed_packet = endpoint_info
-                        .to_pkarr_signed_packet(&secret_key, 30)
-                        .unwrap();
+            b.iter_custom(|criterion_iters| {
+                let signed_packets = (0..criterion_iters * iters)
+                    .map(|_| {
+                        let secret_key = SecretKey::from_bytes(&rng.random());
+                        let endpoint_info = EndpointInfo::new(secret_key.public())
+                            .with_relay_url(relay_url.clone());
+                        endpoint_info
+                            .to_pkarr_signed_packet(&secret_key, 30)
+                            .unwrap()
+                    })
+                    .collect::<Vec<_>>();
 
+                rt.block_on(async {
                     let start = std::time::Instant::now();
-                    for _ in 0..iters {
-                        pkarr.publish(&signed_packet).await.unwrap();
+                    for signed_packet in &signed_packets {
+                        pkarr.publish(signed_packet).await.unwrap();
                     }
-                    let duration = start.elapsed();
-
-                    server.shutdown().await.unwrap();
-
-                    duration
+                    start.elapsed()
                 })
+            });
+
+            rt.block_on(async {
+                server.shutdown().await.unwrap();
             });
         });
     }


### PR DESCRIPTION
Measure only the DNS write loop in the Criterion benchmark.

The old benchmark used `b.iter`, so Criterion measured runtime creation, config loading, server binding, client setup, packet creation, the publish loop, and shutdown. It also republished the same signed packet for every iteration.

This patch moves setup outside the measured duration, switches to `iter_custom`, and generates distinct signed packets for the measured publish batch. This makes `dns_server_writes` report write-path throughput instead of setup-heavy duplicate-publish timing.

```text
   +-------+----------------------+----------------------+---------------------+----------------------+----------------------+--------------------------+
   | iters | before time (median) | after time (median)  | median time delta   | before throughput    | after throughput     | Criterion verdict        |
   +-------+----------------------+----------------------+---------------------+----------------------+----------------------+--------------------------+
   |    10 |            36.372 ms |             4.009 ms |  -32.363 ms / -89.0%|        274.93 elem/s |      2.494 Kelem/s   | improved, p < 0.05       |
   |   100 |            69.348 ms |            37.477 ms |  -31.871 ms / -46.0%|      1.442 Kelem/s   |      2.668 Kelem/s   | improved, p < 0.05       |
   |   250 |           113.170 ms |           102.680 ms |  -10.490 ms /  -9.3%|      2.209 Kelem/s   |      2.435 Kelem/s   | improved, p = 0.05       |
   |  1000 |           364.230 ms |           414.710 ms |  +50.480 ms / +13.9%|      2.746 Kelem/s   |      2.411 Kelem/s   | regressed, p < 0.05      |
   +-------+----------------------+----------------------+---------------------+----------------------+----------------------+--------------------------+
 ```

 Per-element view:

 ```text
   +-------+------------------------+------------------------+----------------------+
   | iters | before median / elem   | after median / elem    | interpretation       |
   +-------+------------------------+------------------------+----------------------+
   |    10 |            3637.20 us  |             400.91 us  | setup dominated old  |
   |   100 |             693.48 us  |             374.77 us  | setup still visible  |
   |   250 |             452.68 us  |             410.72 us  | closer to write path |
   |  1000 |             364.23 us  |             414.71 us  | unique writes cost   |
   +-------+------------------------+------------------------+----------------------+
 ```

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intended effect.
