### PR TITLE
fix(iroh-relay): Improve relay protocol proptests & properly handle invalid messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,6 +1136,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive-ex"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba95f299f6b9cd47f68a847eca2ae9060a2713af532dc35c342065544845407"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,6 +2540,7 @@ dependencies = [
  "sha1 0.11.0",
  "simdutf8",
  "strum",
+ "test-strategy",
  "time",
  "tokio",
  "tokio-rustls",
@@ -4704,6 +4717,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4813,6 +4849,19 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f7fd1eb9efb36942b85a290c4201d317980fe09bc88d34dd48aaaae03075c6a"
+dependencies = [
+ "derive-ex",
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ ignore = [
   "RUSTSEC-2024-0436", # paste -> netlink-packet-core
   "RUSTSEC-2023-0089", # unmaintained: postcard -> heapless -> atomic-polyfill
   "RUSTSEC-2026-0194", # netwatch -> netdev -> plist -> quick-xml: remove once https://github.com/ebarnard/rust-plist/pull/191 is released
+  "RUSTSEC-2026-0195", # netwatch -> netdev -> plist -> quick-xml: remove once https://github.com/ebarnard/rust-plist/pull/191 is released
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,7 @@ allow = [
 ignore = [
   "RUSTSEC-2024-0436", # paste -> netlink-packet-core
   "RUSTSEC-2023-0089", # unmaintained: postcard -> heapless -> atomic-polyfill
+  "RUSTSEC-2026-0194", # netwatch -> netdev -> plist -> quick-xml: plist supposedly not affected, see https://github.com/ebarnard/rust-plist/issues/190
 ]
 
 [sources]

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -107,6 +107,7 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 clap = { version = "4", features = ["derive"] }
 proptest = "1.11.0"
 rand_chacha = "0.10"
+test-strategy = "0.4.5"
 tokio = { version = "1", features = [
     "io-util",
     "sync",

--- a/iroh-relay/proptest-regressions/protos/relay.txt
+++ b/iroh-relay/proptest-regressions/protos/relay.txt
@@ -7,3 +7,4 @@
 cc 9295f5287162dfb180e5826e563c2cea08b477b803ef412ff8351eb5c3eb45ef # shrinks to frame = KeepAlive
 cc 753aabcf8ae2b4e4a52f451d58339aab85a4b61108afdf4b9600f97b3a33bf42 # shrinks to frame = Health { problem: None }
 cc 2b45ae945ff922d4c3dfbad31a5e57c535c0ee2739906272f21ed77f8b862528 # shrinks to frame = Datagrams { remote_node_id: PublicKey(3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29), datagrams: Datagrams { ecn: None, segment_size: Some(0), .. } }
+cc 7743257e00e1727bebb7844fe9da77f73763b7e0a6b9e1f239230a3073323840 # shrinks to input = _ClientRelayFrameDecodeNoPanicArgs { bytes: b"\x04" }

--- a/iroh-relay/src/http.rs
+++ b/iroh-relay/src/http.rs
@@ -43,7 +43,7 @@ pub(crate) const AUTH_TOKEN_URL_QUERY_PARAM: &str = "token";
     strum::IntoStaticStr,
 )]
 // Only used by the `all_is_exhaustive` to validate that `Self::ALL` is up to date.
-#[cfg_attr(test, derive(strum::EnumCount))]
+#[cfg_attr(test, derive(strum::EnumCount, test_strategy::Arbitrary))]
 #[strum(parse_err_ty = UnsupportedRelayProtocolVersion, parse_err_fn = strum_err_fn)]
 #[non_exhaustive]
 // Needs to be ordered with newest version last, so that the `Ord` impl orders by latest version as max.

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -971,7 +971,7 @@ mod proptests {
         #[strategy(perturb_encoding(client_relay_frame().boxed().prop_map(|msg| msg.to_bytes())))]
         bytes: Bytes,
     ) {
-        let _ = ClientToRelayMsg::from_bytes(Bytes::from(bytes), &KeyCache::test()); // only assert no panic
+        let _ = ClientToRelayMsg::from_bytes(bytes, &KeyCache::test()); // only assert no panic
     }
 
     #[proptest]
@@ -980,6 +980,6 @@ mod proptests {
         bytes: Bytes,
         version: ProtocolVersion,
     ) {
-        let _ = RelayToClientMsg::from_bytes(Bytes::from(bytes), &KeyCache::test(), version); // only assert no panic
+        let _ = RelayToClientMsg::from_bytes(bytes, &KeyCache::test(), version); // only assert no panic
     }
 }

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -536,6 +536,8 @@ impl ClientToRelayMsg {
 
         let res = match frame_type {
             FrameType::ClientToRelayDatagram | FrameType::ClientToRelayDatagramBatch => {
+                ensure!(content.len() >= EndpointId::LENGTH, Error::InvalidFrame);
+
                 let dst_endpoint_id = cache.key_from_slice(&content[..EndpointId::LENGTH])?;
                 let datagrams = Datagrams::from_bytes(
                     content.slice(EndpointId::LENGTH..),
@@ -593,7 +595,7 @@ mod tests {
     }
 
     #[test]
-    fn test_server_client_frames_snapshot() -> Result {
+    fn test_relay_client_frames_snapshot() -> Result {
         let client_key = SecretKey::from_bytes(&[42u8; 32]);
 
         check_expected_bytes(vec![
@@ -681,7 +683,7 @@ mod tests {
     }
 
     #[test]
-    fn test_client_server_frames_snapshot() -> Result {
+    fn test_client_relay_frames_snapshot() -> Result {
         let client_key = SecretKey::from_bytes(&[42u8; 32]);
 
         check_expected_bytes(vec![
@@ -741,12 +743,33 @@ mod tests {
 
         Ok(())
     }
+
+    /// A datagram frame must contain at least an EndpointId (32 bytes) after
+    /// the frame type. A frame consisting only of the frame type byte used to
+    /// panic when slicing the destination endpoint id.
+    #[test]
+    fn regression_client_to_relay_undersized_datagram_rejected() {
+        for frame_type in [
+            FrameType::ClientToRelayDatagram,
+            FrameType::ClientToRelayDatagramBatch,
+        ] {
+            let encoded = frame_type.write_to(BytesMut::new()).freeze();
+            let result = ClientToRelayMsg::from_bytes(encoded, &KeyCache::test());
+            assert!(
+                matches!(result, Err(Error::InvalidFrame { .. })),
+                "expected InvalidFrame for {:?}, got {:?}",
+                frame_type,
+                result
+            );
+        }
+    }
 }
 
 #[cfg(all(test, feature = "server"))]
 mod proptests {
     use iroh_base::SecretKey;
-    use proptest::prelude::*;
+    use proptest::{collection::vec, prelude::*};
+    use test_strategy::proptest;
 
     use super::*;
 
@@ -773,7 +796,7 @@ mod proptests {
         (
             ecn(),
             prop::option::of(MAX_PAYLOAD_SIZE / 20..MAX_PAYLOAD_SIZE),
-            prop::collection::vec(any::<u8>(), 0..MAX_PAYLOAD_SIZE),
+            vec(any::<u8>(), 0..MAX_PAYLOAD_SIZE),
         )
             .prop_map(|(ecn, segment_size, data)| Datagrams {
                 ecn,
@@ -785,7 +808,7 @@ mod proptests {
     }
 
     /// Generates a random valid frame
-    fn server_client_frame() -> impl Strategy<Value = RelayToClientMsg> {
+    fn relay_client_frame() -> impl Strategy<Value = RelayToClientMsg> {
         let recv_packet = (key(), datagrams()).prop_map(|(remote_endpoint_id, datagrams)| {
             RelayToClientMsg::Datagrams {
                 remote_endpoint_id,
@@ -816,9 +839,10 @@ mod proptests {
             restarting,
             health
         ]
+        .boxed()
     }
 
-    fn client_server_frame() -> impl Strategy<Value = ClientToRelayMsg> {
+    fn client_relay_frame() -> impl Strategy<Value = ClientToRelayMsg> {
         let send_packet = (key(), datagrams()).prop_map(|(dst_endpoint_id, datagrams)| {
             ClientToRelayMsg::Datagrams {
                 dst_endpoint_id,
@@ -862,41 +886,100 @@ mod proptests {
         ));
     }
 
-    proptest! {
-        #[test]
-        fn server_client_frame_roundtrip(frame in server_client_frame()) {
-            let version = allowed_version(&frame);
-            let encoded = frame.to_bytes().freeze();
-            let decoded = RelayToClientMsg::from_bytes(encoded, &KeyCache::test(), version).unwrap();
-            prop_assert_eq!(frame, decoded);
+    #[proptest]
+    fn relay_client_frame_roundtrip(#[strategy(relay_client_frame())] frame: RelayToClientMsg) {
+        let version = allowed_version(&frame);
+        let encoded = frame.to_bytes().freeze();
+        let decoded = RelayToClientMsg::from_bytes(encoded, &KeyCache::test(), version).unwrap();
+        prop_assert_eq!(frame, decoded);
+    }
+
+    #[proptest]
+    fn client_relay_frame_roundtrip(#[strategy(client_relay_frame())] frame: ClientToRelayMsg) {
+        let encoded = frame.to_bytes().freeze();
+        let decoded = ClientToRelayMsg::from_bytes(encoded, &KeyCache::test()).unwrap();
+        prop_assert_eq!(frame, decoded);
+    }
+
+    #[proptest]
+    fn relay_client_frame_encoded_len(#[strategy(relay_client_frame())] frame: RelayToClientMsg) {
+        let claimed_encoded_len = frame.encoded_len();
+        let actual_encoded_len = frame.to_bytes().len();
+        prop_assert_eq!(claimed_encoded_len, actual_encoded_len);
+    }
+
+    #[proptest]
+    fn client_relay_frame_encoded_len(#[strategy(client_relay_frame())] frame: ClientToRelayMsg) {
+        let claimed_encoded_len = frame.encoded_len();
+        let actual_encoded_len = frame.to_bytes().len();
+        prop_assert_eq!(claimed_encoded_len, actual_encoded_len);
+    }
+
+    #[proptest]
+    fn datagrams_encoded_len(#[strategy(datagrams())] datagrams: Datagrams) {
+        let claimed_encoded_len = datagrams.encoded_len();
+        let actual_encoded_len = datagrams.write_to(Vec::new()).len();
+        prop_assert_eq!(claimed_encoded_len, actual_encoded_len);
+    }
+
+    const MAX_TEST_MSG_SIZE: usize = 100_000;
+
+    fn perturb_encoding(
+        inner: impl Strategy<Value = BytesMut> + Clone + 'static,
+    ) -> impl Strategy<Value = Bytes> + 'static {
+        #[derive(Debug, test_strategy::Arbitrary)]
+        enum GenStrategy {
+            ArbitraryBytes,
+            FlipBits,
+            Truncate,
         }
 
-        #[test]
-        fn client_server_frame_roundtrip(frame in client_server_frame()) {
-            let encoded = frame.to_bytes().freeze();
-            let decoded = ClientToRelayMsg::from_bytes(encoded, &KeyCache::test()).unwrap();
-            prop_assert_eq!(frame, decoded);
-        }
+        any::<GenStrategy>().prop_ind_flat_map(move |strategy| match strategy {
+            GenStrategy::ArbitraryBytes => vec(any::<u8>(), 0..MAX_TEST_MSG_SIZE)
+                .prop_map(Bytes::from)
+                .boxed(),
+            GenStrategy::FlipBits => (vec(any::<u16>(), 0..20), any::<u8>(), inner.clone())
+                .prop_map(|(byte_positions, mask, mut bytes)| {
+                    let len = bytes.len();
+                    for pos in byte_positions {
+                        bytes[(pos as usize).min(len.saturating_sub(1))] ^= mask;
+                    }
+                    bytes.freeze()
+                })
+                .boxed(),
+            GenStrategy::Truncate => (vec(any::<u16>(), 0..20), inner.clone())
+                .prop_map(|(mut truncations, mut bytes)| {
+                    truncations.sort();
+                    let mut bytes_truncated = 0;
+                    for [trunc_start, trunc_end] in truncations.as_chunks::<2>().0 {
+                        let len = bytes.len();
+                        let start = usize::from(*trunc_start).saturating_sub(bytes_truncated);
+                        let end = usize::from(*trunc_end).saturating_sub(bytes_truncated);
+                        let rest = bytes.split_off(end.min(len));
+                        bytes.truncate(start.min(len));
+                        bytes.extend_from_slice(&rest);
+                        bytes_truncated += end - start;
+                    }
+                    bytes.freeze()
+                })
+                .boxed(),
+        })
+    }
 
-        #[test]
-        fn server_client_frame_encoded_len(frame in server_client_frame()) {
-            let claimed_encoded_len = frame.encoded_len();
-            let actual_encoded_len = frame.to_bytes().len();
-            prop_assert_eq!(claimed_encoded_len, actual_encoded_len);
-        }
+    #[proptest]
+    fn client_relay_frame_decode_no_panic(
+        #[strategy(perturb_encoding(client_relay_frame().boxed().prop_map(|msg| msg.to_bytes())))]
+        bytes: Bytes,
+    ) {
+        let _ = ClientToRelayMsg::from_bytes(Bytes::from(bytes), &KeyCache::test()); // only assert no panic
+    }
 
-        #[test]
-        fn client_server_frame_encoded_len(frame in client_server_frame()) {
-            let claimed_encoded_len = frame.encoded_len();
-            let actual_encoded_len = frame.to_bytes().len();
-            prop_assert_eq!(claimed_encoded_len, actual_encoded_len);
-        }
-
-        #[test]
-        fn datagrams_encoded_len(datagrams in datagrams()) {
-            let claimed_encoded_len = datagrams.encoded_len();
-            let actual_encoded_len = datagrams.write_to(Vec::new()).len();
-            prop_assert_eq!(claimed_encoded_len, actual_encoded_len);
-        }
+    #[proptest]
+    fn relay_client_frame_decode_no_panic(
+        #[strategy(perturb_encoding(relay_client_frame().boxed().prop_map(|msg| msg.to_bytes())))]
+        bytes: Bytes,
+        version: ProtocolVersion,
+    ) {
+        let _ = RelayToClientMsg::from_bytes(Bytes::from(bytes), &KeyCache::test(), version); // only assert no panic
     }
 }


### PR DESCRIPTION
## Description

- Adds an `ensure!` to make sure that we parse invalid client-to-relay gracefully
- Adds a regression test for the above
- Improves proptests for parsing the protocol
- Moves to using `test_strategy` for proptests instead of the proptest macro
- Renames some test functions to replace "server" with "relay" and improve consistency

## Breaking Changes

None

## Notes

This is 99% test improvements, and a one-line fix.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
