### PR TITLE
docs: clarify relay license notes

### DIFF
--- a/iroh-relay/README.md
+++ b/iroh-relay/README.md
@@ -138,7 +138,7 @@ This will start a relay server with a self-signed TLS certificate, listening on 
 
 # License
 
-This project is licensed under either of
+This crate is licensed under either of
 
  * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
    https://www.apache.org/licenses/LICENSE-2.0)
@@ -146,6 +146,9 @@ This project is licensed under either of
    https://opensource.org/licenses/MIT)
 
 at your option.
+
+Some relay source files also include derived Tailscale code, which is covered by
+the bundled `LICENSE-BSD3` file.
 
 ### Contribution
 


### PR DESCRIPTION
## Description

Clarify relay license notes for the bundled BSD-3 derived code.

## Changes Made

- Kept the crate license statement aligned with the Cargo manifest.
- Added a short note that some relay source files include derived Tailscale code covered by `LICENSE-BSD3`.

## Testing

- [x] Docs-only change; no runtime tests required.
- [x] Reviewed the README diff for license wording.

## Impact

The relay README now explains why the repository includes a BSD-3 license file alongside the crate's MIT/Apache-2.0 metadata.
