### PR TITLE
[wip] feat(iroh,iroh-relay): add WebTransport relay transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,6 +2552,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "vergen-gitcl",
+ "web-transport-proto",
  "webpki-roots",
  "ws_stream_wasm",
 ]
@@ -4013,6 +4014,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4528,6 +4549,17 @@ checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "sfv"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d471eaefb14f4b30032525bdb124b36e55ba9cb1292080e06f1a236cd10fe87"
+dependencies = [
+ "base64",
+ "indexmap",
+ "ref-cast",
 ]
 
 [[package]]
@@ -5673,6 +5705,20 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-transport-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0225d295c8ac00a2e9a498aefeaf3f3c6186da12a251c938189b15b82ea22808"
+dependencies = [
+ "bytes",
+ "http",
+ "sfv",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/iroh-relay/Cargo.toml
+++ b/iroh-relay/Cargo.toml
@@ -84,6 +84,9 @@ toml = { version = "1.0", optional = true }
 serde_json = { version = "1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
+# WebTransport relay transport
+web-transport-proto = { version = "0.6.0", optional = true }
+
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 hickory-resolver = { version = "0.26.0", features = ["tokio", "system-config"] }
@@ -134,6 +137,7 @@ default = ["metrics", "tls-ring"]
 platform-verifier = ["dep:rustls-platform-verifier"]
 server = [
     "metrics",
+    "h3-transport",
     "tokio/signal",
     "dep:clap",
     "dep:dashmap",
@@ -156,6 +160,10 @@ server = [
 ]
 metrics = ["iroh-metrics/metrics"]
 test-utils = []
+h3-transport = [
+    "dep:web-transport-proto",
+    "noq/runtime-tokio",
+]
 tls-ring = [
     "noq/ring",
     "rustls/ring",

--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -17,14 +17,14 @@ use iroh_dns::dns::{DnsError, DnsResolver};
 use n0_error::StdResultExt;
 use n0_error::{AnyError, e, stack_error};
 use n0_future::{
-    Sink, Stream,
+    Either, Sink, Stream,
     split::{SplitSink, SplitStream, split},
     time,
 };
 use tracing::{debug, trace};
 use url::Url;
 
-pub use self::conn::{RecvError, SendError};
+pub use self::conn::{RecvError, SendError, Transport};
 use crate::{
     KeyCache,
     http::{ProtocolVersion, RELAY_PATH},
@@ -35,6 +35,8 @@ use crate::{
 };
 
 pub(crate) mod conn;
+#[cfg(all(not(wasm_browser), feature = "h3-transport"))]
+pub(crate) mod h3_conn;
 #[cfg(not(wasm_browser))]
 pub(crate) mod streams;
 #[cfg(not(wasm_browser))]
@@ -96,6 +98,12 @@ pub enum ConnectError {
         "No rustls crypto provider configured while both ring and aws-lc-rs feature flags are disabled"
     )]
     MissingCryptoProvider,
+    #[cfg(feature = "h3-transport")]
+    #[error(transparent)]
+    H3 {
+        #[error(std_err)]
+        source: h3_conn::H3ConnectError,
+    },
     #[cfg(wasm_browser)]
     #[error("The relay protocol is not available in browsers")]
     RelayProtoNotAvailable {},
@@ -161,6 +169,11 @@ pub struct ClientBuilder {
     dns_resolver: DnsResolver,
     /// Cache for public keys of remote endpoints.
     key_cache: KeyCache,
+    /// Whether to prefer H3 (QUIC) transport over WebSocket.
+    ///
+    /// When true, the client tries H3 first and falls back to WebSocket on failure.
+    #[cfg(feature = "h3-transport")]
+    enable_h3: bool,
 }
 
 impl ClientBuilder {
@@ -180,6 +193,8 @@ impl ClientBuilder {
             dns_resolver,
             key_cache: KeyCache::new(128),
             auth_token: None,
+            #[cfg(feature = "h3-transport")]
+            enable_h3: false,
         }
     }
 
@@ -252,10 +267,164 @@ impl ClientBuilder {
         self
     }
 
+    /// Enable H3/WebTransport relay connections.
+    ///
+    /// When true, the client races WebTransport and WebSocket connections
+    /// concurrently. The first transport to receive a server response wins;
+    /// the other is aborted.
+    #[cfg(feature = "h3-transport")]
+    pub fn enable_h3(mut self, enable: bool) -> Self {
+        self.enable_h3 = enable;
+        self
+    }
+
     /// Establishes a new connection to the relay server.
+    ///
+    /// When H3 is enabled via [`enable_h3`](Self::enable_h3), races WebTransport
+    /// and WebSocket concurrently. The first to receive a server response wins.
     #[cfg(not(wasm_browser))]
     pub async fn connect(&self) -> Result<Client, ConnectError> {
-        use http::header::{AUTHORIZATION, HeaderValue, SEC_WEBSOCKET_PROTOCOL};
+        #[cfg(feature = "h3-transport")]
+        if self.enable_h3 {
+            return self.connect_race().await;
+        }
+
+        self.connect_ws().await
+    }
+
+    /// Race WebTransport and WebSocket connections concurrently.
+    ///
+    /// DNS is resolved once, then both transports connect in parallel using
+    /// the same IP. The first to complete wins; the loser is dropped.
+    #[cfg(all(not(wasm_browser), feature = "h3-transport"))]
+    async fn connect_race(&self) -> Result<Client, ConnectError> {
+        let url = &*self.url;
+        let host = url
+            .host_str()
+            .ok_or_else(|| e!(ConnectError::InvalidRelayUrl { url: url.clone() }))?;
+
+        let tls_config = self
+            .tls_config
+            .clone()
+            .ok_or_else(|| e!(ConnectError::MissingCryptoProvider))?;
+
+        debug!(%url, "racing WT and WS connections");
+
+        // Race the QUIC handshake against the full WS connect. The QUIC handshake is
+        // 1 RTT; WS needs TCP + TLS + HTTP upgrade (3-4 RTTs). If QUIC succeeds first,
+        // abort WS and complete the WT handshake uncontested. Both dials resolve the
+        // relay URL and race addresses Happy Eyeballs style (RFC 8305).
+        let quic_fut = self.quic_connect_happy_eyeballs(host, tls_config);
+        let ws_fut = self.connect_ws();
+        tokio::pin!(quic_fut);
+        tokio::pin!(ws_fut);
+
+        // Race QUIC handshake (1 RTT) against the full WS connect (3-4 RTTs).
+        // The &mut borrows keep the loser alive for fallback.
+        #[rustfmt::skip]
+        let race = n0_future::future::race(
+            async { Either::Left((&mut quic_fut).await) },
+            async { Either::Right((&mut ws_fut).await) }
+        )
+        .await;
+
+        match race {
+            Either::Left(Ok(quic)) => {
+                debug!("QUIC handshake won the race, completing WT handshake");
+                match h3_conn::wt_handshake(quic, host, &self.secret_key).await {
+                    Ok((io, state, local_addr)) => {
+                        use tracing::{Level, event};
+
+                        event!(
+                            target: "iroh::_events::net::relay::connected",
+                            Level::DEBUG,
+                            url = %self.url,
+                            transport = "h3",
+                        );
+                        let conn = Conn::from_wt(
+                            io,
+                            state,
+                            self.key_cache.clone(),
+                            ProtocolVersion::default(),
+                        );
+                        Ok(Client {
+                            conn,
+                            local_addr: Some(local_addr),
+                        })
+                    }
+                    Err(err) => {
+                        debug!("WT handshake failed ({err:#}), falling back to WS");
+                        ws_fut.await
+                    }
+                }
+            }
+            Either::Left(Err(err)) => {
+                debug!("QUIC failed ({err:#}), waiting for WS");
+                ws_fut.await
+            }
+            Either::Right(Ok(client)) => {
+                debug!("WS won the race");
+                Ok(client)
+            }
+            Either::Right(Err(ws_err)) => {
+                debug!("WS failed ({ws_err:#}), waiting for QUIC");
+                match quic_fut.await {
+                    Ok(quic) => h3_conn::wt_handshake(quic, host, &self.secret_key)
+                        .await
+                        .map(|(io, state, local_addr)| {
+                            let conn = Conn::from_wt(
+                                io,
+                                state,
+                                self.key_cache.clone(),
+                                ProtocolVersion::default(),
+                            );
+                            Client {
+                                conn,
+                                local_addr: Some(local_addr),
+                            }
+                        })
+                        .map_err(|_| ws_err),
+                    Err(err) => {
+                        debug!("QUIC also failed: {err:#}");
+                        Err(ws_err)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Establishes a QUIC connection to the relay, racing the resolved addresses
+    /// Happy Eyeballs style (RFC 8305), the same way the WebSocket path dials.
+    #[cfg(all(not(wasm_browser), feature = "h3-transport"))]
+    async fn quic_connect_happy_eyeballs(
+        &self,
+        server_name: &str,
+        tls_config: rustls::ClientConfig,
+    ) -> Result<h3_conn::QuicConnected, DialError> {
+        tls::race_happy_eyeballs(
+            &self.dns_resolver,
+            &self.url,
+            self.prefer_ipv6(),
+            move |addr| {
+                let tls_config = tls_config.clone();
+                async move {
+                    h3_conn::quic_connect(addr, server_name, tls_config)
+                        .await
+                        .map_err(|err| {
+                            e!(DialError::Io {
+                                source: std::io::Error::other(err)
+                            })
+                        })
+                }
+            },
+        )
+        .await
+    }
+
+    /// Connect via WebSocket.
+    #[cfg(not(wasm_browser))]
+    async fn connect_ws(&self) -> Result<Client, ConnectError> {
+        use http::header::SEC_WEBSOCKET_PROTOCOL;
         use n0_error::StdResultExt;
         use tls::MaybeTlsStreamBuilder;
 
@@ -287,8 +456,7 @@ impl ClientBuilder {
             .clone()
             .ok_or_else(|| e!(ConnectError::MissingCryptoProvider))?;
 
-        #[allow(unused_mut)]
-        let mut builder =
+        let builder =
             MaybeTlsStreamBuilder::new(dial_url.clone(), self.dns_resolver.clone(), tls_config)
                 .prefer_ipv6(self.prefer_ipv6())
                 .proxy_url(self.proxy_url.clone());
@@ -318,6 +486,8 @@ impl ClientBuilder {
             .config(tokio_websockets::Config::default().flush_threshold(usize::MAX));
 
         if let Some(token) = self.auth_token.as_ref() {
+            use http::{HeaderValue, header::AUTHORIZATION};
+
             let value = HeaderValue::from_str(&format!("Bearer {token}"))
                 .map_err(|_| e!(ConnectError::InvalidAuthToken))?;
             builder = builder
@@ -451,6 +621,18 @@ pub struct Client {
 }
 
 impl Client {
+    /// Creates a [`Client`] from a pre-established [`Conn`] and optional local address.
+    #[cfg(all(feature = "h3-transport", test))]
+    pub(crate) fn from_conn(conn: Conn, local_addr: Option<SocketAddr>) -> Self {
+        Self { conn, local_addr }
+    }
+
+    /// Returns which transport protocol this connection uses.
+    #[cfg(not(wasm_browser))]
+    pub fn transport(&self) -> Transport {
+        self.conn.transport()
+    }
+
     /// Splits the client into a sink and a stream.
     pub fn split(self) -> (ClientStream, ClientSink) {
         let (sink, stream) = split(self.conn);

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -61,6 +61,35 @@ pub enum RecvError {
     StreamError { source: AnyError },
 }
 
+/// The transport protocol used by a relay client connection.
+///
+/// Returned by [`Client::transport`](super::Client::transport).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    /// WebSocket over HTTP/1.1 (or browser WebSocket).
+    Ws,
+    /// WebTransport over QUIC.
+    #[cfg(feature = "h3-transport")]
+    H3,
+}
+
+/// Inner transport for the client connection.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum ConnInner {
+    /// WebSocket transport (native).
+    #[cfg(not(wasm_browser))]
+    Ws(WsBytesFramed<MaybeTlsStream<ProxyStream>>),
+    /// WebSocket transport (browser).
+    #[cfg(wasm_browser)]
+    WsBrowser(WsBytesFramed),
+    /// WebTransport over QUIC.
+    #[cfg(feature = "h3-transport")]
+    Wt {
+        stream: crate::protos::h3_streams::WtBytesFramed,
+        _state: super::h3_conn::WtConnState,
+    },
+}
+
 /// A connection to a relay server.
 ///
 /// This holds a connection to a relay server.  It is:
@@ -69,17 +98,25 @@ pub enum RecvError {
 /// - A [`Sink`] for [`ClientToRelayMsg`] to send to the server.
 #[derive(derive_more::Debug)]
 pub(crate) struct Conn {
-    #[cfg(not(wasm_browser))]
-    #[debug("tokio_websockets::WebSocketStream")]
-    pub(crate) conn: WsBytesFramed<MaybeTlsStream<ProxyStream>>,
-    #[cfg(wasm_browser)]
-    #[debug("ws_stream_wasm::WsStream")]
-    pub(crate) conn: WsBytesFramed,
+    #[debug("ConnInner")]
+    pub(crate) conn: ConnInner,
     pub(crate) key_cache: KeyCache,
     pub(crate) protocol_version: ProtocolVersion,
 }
 
 impl Conn {
+    /// Returns which transport protocol this connection uses.
+    pub(crate) fn transport(&self) -> Transport {
+        match &self.conn {
+            #[cfg(not(wasm_browser))]
+            ConnInner::Ws(_) => Transport::Ws,
+            #[cfg(wasm_browser)]
+            ConnInner::WsBrowser(_) => Transport::Ws,
+            #[cfg(feature = "h3-transport")]
+            ConnInner::Wt { .. } => Transport::H3,
+        }
+    }
+
     /// Constructs a new websocket connection, including the initial server handshake.
     pub(crate) async fn new(
         #[cfg(not(wasm_browser))] io: tokio_websockets::WebSocketStream<
@@ -98,28 +135,116 @@ impl Conn {
         trace!("server_handshake: done");
 
         Ok(Self {
-            conn,
+            #[cfg(not(wasm_browser))]
+            conn: ConnInner::Ws(conn),
+            #[cfg(wasm_browser)]
+            conn: ConnInner::WsBrowser(conn),
             key_cache,
             protocol_version,
         })
+    }
+
+    /// Constructs a connection from an already-handshaken [`WtBytesFramed`](crate::protos::h3_streams::WtBytesFramed).
+    #[cfg(feature = "h3-transport")]
+    pub(crate) fn from_wt(
+        stream: crate::protos::h3_streams::WtBytesFramed,
+        state: super::h3_conn::WtConnState,
+        key_cache: KeyCache,
+        protocol_version: ProtocolVersion,
+    ) -> Self {
+        Self {
+            conn: ConnInner::Wt {
+                stream,
+                _state: state,
+            },
+            key_cache,
+            protocol_version,
+        }
     }
 
     #[cfg(all(test, feature = "server"))]
     pub(crate) fn test(io: tokio::io::DuplexStream, protocol_version: ProtocolVersion) -> Self {
         use crate::protos::relay::MAX_FRAME_SIZE;
         Self {
-            conn: WsBytesFramed {
+            conn: ConnInner::Ws(WsBytesFramed {
                 io: tokio_websockets::ClientBuilder::new()
                     .limits(
                         tokio_websockets::Limits::default().max_payload_len(Some(MAX_FRAME_SIZE)),
                     )
                     .take_over(MaybeTlsStream::Test(io)),
-            },
+            }),
             key_cache: KeyCache::test(),
             protocol_version,
         }
     }
 }
+
+// -- ConnInner Stream/Sink impls ----------------------------------------------
+
+impl Stream for ConnInner {
+    type Item = Result<bytes::Bytes, crate::protos::streams::StreamError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.get_mut() {
+            #[cfg(not(wasm_browser))]
+            ConnInner::Ws(ws) => Pin::new(ws).poll_next(cx),
+            #[cfg(wasm_browser)]
+            ConnInner::WsBrowser(ws) => Pin::new(ws).poll_next(cx),
+            #[cfg(feature = "h3-transport")]
+            ConnInner::Wt { stream, .. } => Pin::new(stream).poll_next(cx),
+        }
+    }
+}
+
+impl Sink<bytes::Bytes> for ConnInner {
+    type Error = crate::protos::streams::StreamError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self.get_mut() {
+            #[cfg(not(wasm_browser))]
+            ConnInner::Ws(ws) => Pin::new(ws).poll_ready(cx),
+            #[cfg(wasm_browser)]
+            ConnInner::WsBrowser(ws) => Pin::new(ws).poll_ready(cx),
+            #[cfg(feature = "h3-transport")]
+            ConnInner::Wt { stream, .. } => Pin::new(stream).poll_ready(cx),
+        }
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: bytes::Bytes) -> Result<(), Self::Error> {
+        match self.get_mut() {
+            #[cfg(not(wasm_browser))]
+            ConnInner::Ws(ws) => Pin::new(ws).start_send(item),
+            #[cfg(wasm_browser)]
+            ConnInner::WsBrowser(ws) => Pin::new(ws).start_send(item),
+            #[cfg(feature = "h3-transport")]
+            ConnInner::Wt { stream, .. } => Pin::new(stream).start_send(item),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self.get_mut() {
+            #[cfg(not(wasm_browser))]
+            ConnInner::Ws(ws) => Pin::new(ws).poll_flush(cx),
+            #[cfg(wasm_browser)]
+            ConnInner::WsBrowser(ws) => Pin::new(ws).poll_flush(cx),
+            #[cfg(feature = "h3-transport")]
+            ConnInner::Wt { stream, .. } => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self.get_mut() {
+            #[cfg(not(wasm_browser))]
+            ConnInner::Ws(ws) => Pin::new(ws).poll_close(cx),
+            #[cfg(wasm_browser)]
+            ConnInner::WsBrowser(ws) => Pin::new(ws).poll_close(cx),
+            #[cfg(feature = "h3-transport")]
+            ConnInner::Wt { stream, .. } => Pin::new(stream).poll_close(cx),
+        }
+    }
+}
+
+// -- Conn Stream/Sink impls ---------------------------------------------------
 
 impl Stream for Conn {
     type Item = Result<RelayToClientMsg, RecvError>;

--- a/iroh-relay/src/client/h3_conn.rs
+++ b/iroh-relay/src/client/h3_conn.rs
@@ -1,0 +1,277 @@
+//! WebTransport client connection for the relay protocol.
+//!
+//! This is the QUIC/WebTransport counterpart to the WebSocket transport in the
+//! parent [`client`](super) module. Both speak the same relay protocol and share
+//! the same [`handshake`], so a WebTransport client can relay to a WebSocket peer
+//! and vice versa. WebTransport reaches the first relay byte in ~2 RTTs where
+//! WebSocket needs 3-4 (TCP + TLS + HTTP upgrade + relay auth).
+//!
+//! Connecting happens in two phases so the [`ClientBuilder`] can race the QUIC
+//! handshake against a WebSocket connect and keep whichever wins:
+//!
+//! 1. [`quic_connect`] performs the QUIC handshake (1 RTT, TLS 1.3 included). The
+//!    [`ClientBuilder`] runs this Happy Eyeballs style across the resolved relay
+//!    addresses, the same way the WebSocket path dials.
+//! 2. [`wt_handshake`] completes the WebTransport session on the established
+//!    connection. Per RFC 9114 section 7.2.4.2 it does not wait for the peer's
+//!    settings before sending: client `SETTINGS` (on a uni stream) and the
+//!    WebTransport `CONNECT` request (on a bidi stream) go out in the first
+//!    flight while the server's `SETTINGS` are read concurrently. The `CONNECT`
+//!    carries the relay subprotocol and, when the connection exports keying
+//!    material, an RFC 5705 auth header so the relay [`handshake`] adds no extra
+//!    RTT. Once the server accepts, relay messages flow over [`WtBytesFramed`],
+//!    one QUIC uni stream per message.
+//!
+//! If the server does not speak WebTransport (its settings disable it, or the
+//! `CONNECT` is rejected) the caller falls back to WebSocket.
+//!
+//! [`ClientBuilder`]: super::ClientBuilder
+//! [`handshake`]: crate::protos::handshake
+
+use std::{
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+use iroh_base::SecretKey;
+use n0_error::{AnyError, anyerr, e, stack_error};
+use noq::crypto::rustls::QuicClientConfig;
+use tracing::{debug, trace};
+use web_transport_proto as wt;
+
+use crate::{
+    http::{ALPN_RELAY_H3, CLIENT_AUTH_HEADER, ProtocolVersion, RELAY_PATH},
+    protos::{
+        h3_streams::WtBytesFramed,
+        handshake::{self, KeyMaterialClientAuth},
+    },
+};
+
+/// Timeout for the QUIC handshake when connecting via WebTransport.
+const QUIC_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// WebTransport connection state that must outlive the relay stream.
+///
+/// Dropping this closes the QUIC connection.
+pub(crate) struct WtConnState {
+    _conn: noq::Connection,
+}
+
+/// Errors during WebTransport relay connection establishment.
+#[stack_error(derive, add_meta)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+pub enum H3ConnectError {
+    #[error(transparent)]
+    QuicConnect {
+        #[error(from, std_err)]
+        source: noq::ConnectError,
+    },
+    #[error(transparent)]
+    QuicConnection {
+        #[error(from, std_err)]
+        source: noq::ConnectionError,
+    },
+    /// Error decoding the WebTransport settings sent by the server.
+    ///
+    /// The concrete error type is `web_transport_proto::SettingsError`. Use
+    /// [`AnyError::downcast_ref`] to recover it. Note that the concrete downcast
+    /// type is not covered by any semver guarantees and may change between releases.
+    #[error("WebTransport settings error")]
+    Settings { source: AnyError },
+    /// Error encoding or decoding a WebTransport CONNECT message.
+    ///
+    /// The concrete error type is `web_transport_proto::ConnectError`. Use
+    /// [`AnyError::downcast_ref`] to recover it. Note that the concrete downcast
+    /// type is not covered by any semver guarantees and may change between releases.
+    #[error("WebTransport CONNECT error")]
+    Connect { source: AnyError },
+    /// The server does not support WebTransport.
+    #[error("Server does not support WebTransport")]
+    WebTransportUnsupported {},
+    #[error("Server rejected session: {status}")]
+    Rejected { status: http::StatusCode },
+    #[error(transparent)]
+    Handshake {
+        #[error(from, std_err)]
+        source: handshake::Error,
+    },
+    #[error(transparent)]
+    StreamWrite {
+        #[error(from, std_err)]
+        source: noq::WriteError,
+    },
+    #[error("No local address available")]
+    NoLocalAddr {},
+    #[error(transparent)]
+    EndpointCreate {
+        #[error(from, std_err)]
+        source: std::io::Error,
+    },
+    #[error("QUIC connect timed out")]
+    ConnectTimeout {},
+}
+
+/// Result of the QUIC connect phase. Passed to [`wt_handshake`] to complete
+/// the WebTransport session setup.
+pub(crate) struct QuicConnected {
+    pub conn: noq::Connection,
+    pub local_addr: SocketAddr,
+}
+
+/// Phase 1: establish a QUIC connection (first server response).
+///
+/// Returns as soon as the QUIC handshake completes, confirming the server
+/// speaks QUIC on this port. This is the earliest signal for the WS/WT race.
+pub(crate) async fn quic_connect(
+    server_addr: SocketAddr,
+    server_name: &str,
+    tls_config: rustls::ClientConfig,
+) -> Result<QuicConnected, H3ConnectError> {
+    let bind_addr = if server_addr.is_ipv6() {
+        SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0))
+    } else {
+        SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0))
+    };
+
+    let endpoint = noq::Endpoint::client(bind_addr)?;
+    let local_addr = endpoint
+        .local_addr()
+        .map_err(|_| e!(H3ConnectError::NoLocalAddr))?;
+
+    let mut tls_config = tls_config;
+    tls_config.alpn_protocols = vec![ALPN_RELAY_H3.to_vec()];
+    let quic_client_config = QuicClientConfig::try_from(tls_config).map_err(|_| {
+        e!(H3ConnectError::EndpointCreate {
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "TLS config does not support TLS 1.3 (required for QUIC)",
+            )
+        })
+    })?;
+    let mut client_config = noq::ClientConfig::new(Arc::new(quic_client_config));
+    let mut transport = noq_proto::TransportConfig::default();
+    transport.max_concurrent_uni_streams(256u32.into());
+    client_config.transport_config(Arc::new(transport));
+
+    trace!(%server_addr, %server_name, "WT: QUIC connecting");
+    let connecting = endpoint.connect_with(client_config, server_addr, server_name)?;
+    let conn = tokio::time::timeout(QUIC_CONNECT_TIMEOUT, connecting)
+        .await
+        .map_err(|_| e!(H3ConnectError::ConnectTimeout))??;
+
+    trace!("WT: QUIC handshake complete");
+    Ok(QuicConnected { conn, local_addr })
+}
+
+/// Phase 2: complete the WebTransport handshake on an established QUIC connection.
+///
+/// Sends settings + CONNECT, receives server response, sets up the data stream,
+/// and runs the relay handshake.
+pub(crate) async fn wt_handshake(
+    quic: QuicConnected,
+    server_name: &str,
+    secret_key: &SecretKey,
+) -> Result<(WtBytesFramed, WtConnState, SocketAddr), H3ConnectError> {
+    let QuicConnected { conn, local_addr } = quic;
+
+    // Per RFC 9114 section 7.2.4.2, endpoints must not wait for peer settings
+    // before sending. We pipeline settings + CONNECT in the first flight and
+    // accept server settings concurrently. If the server does not support
+    // WebTransport, the CONNECT will be rejected and we fall back to WS.
+    let mut client_settings = wt::Settings::default();
+    client_settings.enable_webtransport(1);
+
+    // Build CONNECT request with relay subprotocol and auth header.
+    let url = format!("https://{server_name}{RELAY_PATH}");
+    let mut connect_req = wt::ConnectRequest::new(url::Url::parse(&url).expect("valid URL"))
+        .with_protocol(ProtocolVersion::default().to_string());
+
+    // Attach TLS keying material auth to avoid the challenge-response RTT.
+    if let Some(client_auth) = KeyMaterialClientAuth::new(secret_key, &conn) {
+        debug!("using TLS keying material for relay authentication");
+        connect_req = connect_req.with_header(CLIENT_AUTH_HEADER, client_auth.into_header_value());
+    }
+
+    // Pre-encode settings and CONNECT into byte buffers.
+    let mut settings_buf = bytes::BytesMut::new();
+    client_settings.encode(&mut settings_buf);
+
+    let mut connect_buf = bytes::BytesMut::new();
+    connect_req
+        .encode(&mut connect_buf)
+        .map_err(|err| e!(H3ConnectError::Connect, anyerr!(err)))?;
+
+    // Send settings and CONNECT in the same flight.
+    let send_all = async {
+        trace!("WT: opening uni stream for settings");
+        let mut uni = conn.open_uni().await?;
+        uni.write_all(&settings_buf).await?;
+        trace!("WT: settings written");
+
+        trace!("WT: opening bidi stream for CONNECT");
+        let (mut connect_send, connect_recv) = conn.open_bi().await?;
+        let session_id: u64 = connect_send.id().into();
+        connect_send.write_all(&connect_buf).await?;
+        trace!("WT: CONNECT written");
+
+        Ok::<_, H3ConnectError>((connect_recv, session_id))
+    };
+
+    let settings_recv = async {
+        trace!("WT: waiting for server settings");
+        let uni = conn.accept_uni().await?;
+        let mut uni = tokio::io::BufReader::new(uni);
+        let settings = wt::Settings::read(&mut uni)
+            .await
+            .map_err(|err| e!(H3ConnectError::Settings, anyerr!(err)))?;
+        trace!("WT: server settings received");
+        Ok::<_, H3ConnectError>(settings)
+    };
+
+    let (send_result, server_settings) = tokio::join!(send_all, settings_recv);
+    let (mut recv, session_id) = send_result?;
+    let server_settings = server_settings?;
+
+    if server_settings.supports_webtransport() == 0 {
+        return Err(e!(H3ConnectError::WebTransportUnsupported));
+    }
+
+    trace!("WT: pipelined, waiting for CONNECT response");
+
+    let resp = wt::ConnectResponse::read(&mut recv)
+        .await
+        .map_err(|err| e!(H3ConnectError::Connect, anyerr!(err)))?;
+
+    trace!(status = %resp.status, "WT: CONNECT response received");
+
+    if !resp.status.is_success() {
+        return Err(e!(H3ConnectError::Rejected {
+            status: resp.status,
+        }));
+    }
+
+    // Use uni streams for relay messages (one stream per message).
+    let mut io = WtBytesFramed::new(conn.clone(), session_id);
+
+    trace!("WT: starting relay handshake");
+    handshake::clientside(&mut io, secret_key).await?;
+    trace!("WT: relay handshake complete");
+
+    let state = WtConnState { _conn: conn };
+
+    Ok((io, state, local_addr))
+}
+
+/// Convenience: run both phases in sequence. Used in tests.
+#[cfg(test)]
+pub(crate) async fn connect_h3(
+    server_addr: SocketAddr,
+    server_name: &str,
+    tls_config: rustls::ClientConfig,
+    secret_key: &SecretKey,
+) -> Result<(WtBytesFramed, WtConnState, SocketAddr), H3ConnectError> {
+    let quic = quic_connect(server_addr, server_name, tls_config).await?;
+    wt_handshake(quic, server_name, secret_key).await
+}

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -6,7 +6,11 @@
 
 // Based on tailscale/derp/derphttp/derphttp_client.go
 
-use std::{collections::VecDeque, net::IpAddr};
+use std::{
+    collections::VecDeque,
+    future::Future,
+    net::{IpAddr, SocketAddr},
+};
 
 use bytes::Bytes;
 use data_encoding::BASE64URL;
@@ -229,6 +233,31 @@ impl MaybeTlsStreamBuilder {
 /// Resolves `url` and races TCP connections across the resulting addresses,
 /// Happy Eyeballs style (RFC 8305).
 ///
+/// A thin wrapper around [`race_happy_eyeballs`] that dials each address with
+/// [`TcpStream::connect`]. The WebTransport path uses the same racer with a QUIC
+/// dial, see [`ClientBuilder::connect`](super::ClientBuilder::connect).
+async fn dial_happy_eyeballs(
+    dns_resolver: &DnsResolver,
+    url: &Url,
+    prefer_ipv6: bool,
+) -> Result<TcpStream, DialError> {
+    race_happy_eyeballs(dns_resolver, url, prefer_ipv6, |addr| async move {
+        trace!("connecting TCP stream");
+        let stream = time::timeout(DIAL_ENDPOINT_TIMEOUT, TcpStream::connect(addr))
+            .await
+            .map_err(DialError::from)
+            .and_then(|res| res.map_err(DialError::from))
+            .inspect_err(|err| debug!("failed to connect: {err:#}"))?;
+        trace!("TCP stream connected");
+        stream.set_nodelay(true)?;
+        Ok(stream)
+    })
+    .await
+}
+
+/// Resolves `url` and races `dial` attempts across the resulting addresses,
+/// Happy Eyeballs style (RFC 8305).
+///
 /// IPv4 and IPv6 addresses stream in as their lookups resolve and are appended
 /// to a single queue. The loop dials them one at a time, [`pop_family`] taking
 /// the next address interleaved by family, the preferred one (`prefer_ipv6`)
@@ -239,15 +268,20 @@ impl MaybeTlsStreamBuilder {
 ///   once the preferred family resolves;
 /// - each later attempt starts [`CONNECTION_ATTEMPT_DELAY`] after the previous
 ///   one, or as soon as the last in-flight attempt fails, whichever comes first;
-/// - every attempt is itself capped at [`DIAL_ENDPOINT_TIMEOUT`].
+/// - `dial` is responsible for bounding each attempt with its own timeout.
 ///
 /// The first connection to succeed is returned; the rest are dropped, which
 /// cancels them.
-async fn dial_happy_eyeballs(
+pub(super) async fn race_happy_eyeballs<T, F, Fut>(
     dns_resolver: &DnsResolver,
     url: &Url,
     prefer_ipv6: bool,
-) -> Result<TcpStream, DialError> {
+    mut dial: F,
+) -> Result<T, DialError>
+where
+    F: FnMut(SocketAddr) -> Fut,
+    Fut: Future<Output = Result<T, DialError>>,
+{
     let port = url_port(url).ok_or_else(|| e!(DialError::InvalidTargetPort))?;
 
     // Stream of resolved addresses.
@@ -281,20 +315,7 @@ async fn dial_happy_eyeballs(
             && let Some(ip) = pop_family(&mut queue, &mut next_prefer_v6)
         {
             let addr = SocketAddr::new(ip, port);
-            dials.push(
-                async move {
-                    trace!("connecting TCP stream");
-                    let stream = time::timeout(DIAL_ENDPOINT_TIMEOUT, TcpStream::connect(addr))
-                        .await
-                        .map_err(DialError::from)
-                        .and_then(|res| res.map_err(DialError::from))
-                        .inspect_err(|err| debug!("failed to connect: {err:#}"))?;
-                    trace!("TCP stream connected");
-                    stream.set_nodelay(true)?;
-                    Ok(stream)
-                }
-                .instrument(info_span!("connect", %addr)),
-            );
+            dials.push(dial(addr).instrument(info_span!("connect", %addr)));
             started = true;
             next_dial_delayed_until
                 .as_mut()

--- a/iroh-relay/src/http.rs
+++ b/iroh-relay/src/http.rs
@@ -128,3 +128,12 @@ mod tests {
         }
     }
 }
+
+/// ALPN protocol identifier for H3 relay connections.
+///
+/// Uses the standard HTTP/3 ALPN. The relay connection is established with a
+/// WebTransport `CONNECT` request (via `web-transport-proto`); the relay
+/// protocol version is carried in that request's subprotocol field, mirroring
+/// the `Sec-WebSocket-Protocol` header used on the HTTP/1.1 WebSocket path.
+#[cfg(feature = "h3-transport")]
+pub const ALPN_RELAY_H3: &[u8] = b"h3";

--- a/iroh-relay/src/main.rs
+++ b/iroh-relay/src/main.rs
@@ -54,6 +54,14 @@ struct Cli {
     /// Running in dev mode will ignore any config file fields pertaining to TLS.
     #[clap(long, default_value_t = false)]
     dev: bool,
+    /// Run in localhost development mode with TLS (self-signed certs).
+    ///
+    /// This enables HTTPS and H3/QUIC transports using auto-generated self-signed
+    /// certificates for localhost/127.0.0.1. Useful for benchmarking H3 vs WS locally.
+    ///
+    /// Clients must use `--insecure` or equivalent to accept the self-signed certs.
+    #[clap(long, default_value_t = false, conflicts_with = "dev")]
+    dev_tls: bool,
     /// Path to the configuration file.
     #[clap(long, short)]
     config_path: Option<PathBuf>,
@@ -65,6 +73,7 @@ enum CertMode {
     LetsEncrypt,
     #[cfg(feature = "server")]
     Reloading,
+    SelfSigned,
 }
 
 fn load_certs(
@@ -582,7 +591,7 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
     let mut cfg = Config::load(&cli).await?;
-    if cfg.enable_quic_addr_discovery && cfg.tls.is_none() {
+    if cfg.enable_quic_addr_discovery && cfg.tls.is_none() && !cli.dev_tls {
         bail_any!("TLS must be configured in order to spawn a QUIC endpoint");
     }
     if cli.dev {
@@ -590,6 +599,29 @@ async fn main() -> Result<()> {
         if let Some(ref mut tls) = cfg.tls {
             tls.dangerous_http_only = true;
         }
+        if cfg.http_bind_addr.is_none() {
+            cfg.http_bind_addr = Some((Ipv6Addr::UNSPECIFIED, DEV_MODE_HTTP_PORT).into());
+        }
+    }
+    if cli.dev_tls {
+        warn!("Running with self-signed certificates. Do not use --dev-tls in production.");
+        cfg.tls = Some(TlsConfig {
+            https_bind_addr: Some((Ipv6Addr::UNSPECIFIED, 8443).into()),
+            // The H3 relay server binds on the HTTPS port (8443) over UDP, so QAD
+            // gets the default QUIC port to keep the two QUIC endpoints apart.
+            quic_bind_addr: Some((Ipv6Addr::UNSPECIFIED, DEFAULT_RELAY_QUIC_PORT).into()),
+            hostname: vec![],
+            cert_mode: CertMode::SelfSigned,
+            cert_dir: None,
+            manual_cert_path: None,
+            manual_key_path: None,
+            prod_tls: false,
+            contact: None,
+            dangerous_http_only: false,
+        });
+        // QAD (on DEFAULT_RELAY_QUIC_PORT) and the H3 relay server (on the HTTPS
+        // port) now bind distinct UDP ports, so both can run together.
+        cfg.enable_quic_addr_discovery = true;
         if cfg.http_bind_addr.is_none() {
             cfg.http_bind_addr = Some((Ipv6Addr::UNSPECIFIED, DEV_MODE_HTTP_PORT).into());
         }
@@ -679,6 +711,11 @@ async fn load_cert_config(tls: &TlsConfig) -> Result<relay::CertConfig> {
             )
             .await?;
             let server_config = server_config.with_cert_resolver(resolver);
+            relay::CertConfig::Manual { server_config }
+        }
+        CertMode::SelfSigned => {
+            let (_certs, server_config) =
+                iroh_relay::server::testing::self_signed_tls_certs_and_config();
             relay::CertConfig::Manual { server_config }
         }
     };

--- a/iroh-relay/src/protos.rs
+++ b/iroh-relay/src/protos.rs
@@ -1,6 +1,8 @@
 //! Protocols used by the iroh-relay
 
 pub mod common;
+#[cfg(feature = "h3-transport")]
+pub mod h3_streams;
 pub mod handshake;
 pub mod relay;
 pub mod streams;

--- a/iroh-relay/src/protos/h3_streams.rs
+++ b/iroh-relay/src/protos/h3_streams.rs
@@ -1,0 +1,222 @@
+//! WebTransport stream adapter for the relay protocol.
+//!
+//! [`WtBytesFramed`] uses a new unidirectional QUIC stream per relay message.
+//! Each stream carries `[Frame::WEBTRANSPORT][session_id][payload]`. The stream
+//! is finished after the payload, so the receiver reads to EOF. Successive send
+//! streams get increasing priority so the QUIC scheduler prefers newer messages
+//! over retransmissions of older ones.
+//!
+//! [`BytesStreamSink`]: super::streams::BytesStreamSink
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bytes::{Bytes, BytesMut};
+use n0_error::{StdResultExt, anyerr};
+use n0_future::{Sink, Stream, ready};
+use tokio_util::sync::ReusableBoxFuture;
+use web_transport_proto as wt;
+
+use super::streams::StreamError;
+use crate::{ExportKeyingMaterial, MAX_PACKET_SIZE};
+
+/// Maximum bytes to read from a single uni stream before rejecting.
+const MAX_UNI_STREAM_SIZE: usize = MAX_PACKET_SIZE + 64;
+
+/// Relay transport using one unidirectional QUIC stream per message.
+///
+/// Each message is sent on a fresh uni stream with a WT session header and
+/// the raw payload. The receiver accepts uni streams and reads each to EOF.
+/// This eliminates head-of-line blocking: retransmission on one stream does
+/// not delay delivery of later messages on other streams.
+pub struct WtBytesFramed {
+    conn: noq::Connection,
+    session_id: u64,
+    pending_send: Option<Bytes>,
+    send_fut: ReusableBoxFuture<'static, Result<(), StreamError>>,
+    recv_fut: ReusableBoxFuture<'static, Result<Bytes, StreamError>>,
+    send_busy: bool,
+    send_priority: i32,
+}
+
+impl std::fmt::Debug for WtBytesFramed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WtBytesFramed").finish()
+    }
+}
+
+impl WtBytesFramed {
+    /// Create from a QUIC connection and the WebTransport session ID.
+    pub fn new(conn: noq::Connection, session_id: u64) -> Self {
+        let recv_conn = conn.clone();
+        let hdr_len = wt_header_len(session_id);
+        Self {
+            conn,
+            session_id,
+            pending_send: None,
+            send_fut: ReusableBoxFuture::new(std::future::pending()),
+            recv_fut: ReusableBoxFuture::new(recv_one_message(recv_conn, hdr_len)),
+            send_busy: false,
+            send_priority: 0,
+        }
+    }
+}
+
+/// Encode the WT uni stream header for the given session ID.
+fn encode_wt_header(session_id: u64) -> BytesMut {
+    let mut hdr = BytesMut::with_capacity(16);
+    wt::Frame::WEBTRANSPORT.encode(&mut hdr);
+    wt::VarInt::from_u64(session_id)
+        .expect("session ID fits in varint")
+        .encode(&mut hdr);
+    hdr
+}
+
+fn wt_header_len(session_id: u64) -> usize {
+    encode_wt_header(session_id).len()
+}
+
+impl ExportKeyingMaterial for WtBytesFramed {
+    fn export_keying_material<T: AsMut<[u8]>>(
+        &self,
+        mut output: T,
+        label: &[u8],
+        context: Option<&[u8]>,
+    ) -> Option<T> {
+        self.conn
+            .export_keying_material(output.as_mut(), label, context.unwrap_or(&[]))
+            .ok()?;
+        Some(output)
+    }
+}
+
+impl ExportKeyingMaterial for noq::Connection {
+    fn export_keying_material<T: AsMut<[u8]>>(
+        &self,
+        mut output: T,
+        label: &[u8],
+        context: Option<&[u8]>,
+    ) -> Option<T> {
+        noq::Connection::export_keying_material(
+            self,
+            output.as_mut(),
+            label,
+            context.unwrap_or(&[]),
+        )
+        .ok()?;
+        Some(output)
+    }
+}
+
+/// Accept a uni stream, skip the WT header, read the payload to EOF.
+async fn recv_one_message(
+    conn: noq::Connection,
+    wt_header_len: usize,
+) -> Result<Bytes, StreamError> {
+    let mut recv = conn.accept_uni().await.anyerr()?;
+    let data = recv.read_to_end(MAX_UNI_STREAM_SIZE).await.anyerr()?;
+    if data.len() < wt_header_len {
+        return Err(anyerr!("uni stream shorter than WT header",));
+    }
+    Ok(Bytes::from(data).slice(wt_header_len..))
+}
+
+/// Open a uni stream, write WT header and payload, finish the stream.
+async fn send_one_message(
+    conn: noq::Connection,
+    session_id: u64,
+    priority: i32,
+    payload: Bytes,
+) -> Result<(), StreamError> {
+    let mut stream = conn.open_uni().await.anyerr()?;
+    let _ = stream.set_priority(priority);
+    stream
+        .write_chunk(encode_wt_header(session_id).freeze())
+        .await
+        .anyerr()?;
+    stream.write_chunk(payload).await.anyerr()?;
+    stream.finish().anyerr()?;
+    Ok(())
+}
+
+// -- Stream: accept uni streams, read each to EOF -----------------------------
+
+impl Stream for WtBytesFramed {
+    type Item = Result<Bytes, StreamError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        match ready!(this.recv_fut.poll(cx)) {
+            Ok(payload) => {
+                // Immediately set up the next recv.
+                let conn = this.conn.clone();
+                let hdr_len = wt_header_len(this.session_id);
+                this.recv_fut.set(recv_one_message(conn, hdr_len));
+                // The relay protocol never frames an empty message, so an empty
+                // payload is malformed. Yield it and let the frame decoder reject
+                // it; returning `Pending` here would strand the stream, since the
+                // freshly armed `recv_fut` has not been polled to register a waker.
+                Poll::Ready(Some(Ok(payload)))
+            }
+            Err(e) => {
+                // Connection closed or error. Don't set up a new recv.
+                Poll::Ready(Some(Err(e)))
+            }
+        }
+    }
+}
+
+// -- Sink: new uni stream per message -----------------------------------------
+
+impl Sink<Bytes> for WtBytesFramed {
+    type Error = StreamError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+
+        // Flush in-progress send.
+        if this.send_busy {
+            match ready!(this.send_fut.poll(cx)) {
+                Ok(()) => {
+                    this.send_busy = false;
+                }
+                Err(e) => {
+                    this.send_busy = false;
+                    return Poll::Ready(Err(e));
+                }
+            }
+        }
+
+        // Start sending a pending message.
+        if let Some(msg) = this.pending_send.take() {
+            let conn = this.conn.clone();
+            let session_id = this.session_id;
+            let priority = this.send_priority;
+            this.send_priority = this.send_priority.saturating_add(1);
+            this.send_fut
+                .set(send_one_message(conn, session_id, priority, msg));
+            this.send_busy = true;
+            let pin = Pin::new(this);
+            return pin.poll_ready(cx);
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Bytes) -> Result<(), Self::Error> {
+        self.get_mut().pending_send = Some(item);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.poll_ready(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.poll_ready(cx)?);
+        Poll::Ready(Ok(()))
+    }
+}

--- a/iroh-relay/src/protos/handshake.rs
+++ b/iroh-relay/src/protos/handshake.rs
@@ -141,7 +141,7 @@ impl Frame for ServerDeniesAuth {
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub enum Error {
-    /// Error returned from the underlying WebSocket stream during the handshake.
+    /// Error returned from the underlying WebSocket or WebTransport stream during the handshake.
     ///
     /// The concrete error type is `tokio_websockets::Error` on native targets and
     /// `ws_stream_wasm::WsErr` on `wasm_browser` targets. Use [`AnyError::downcast_ref`] to

--- a/iroh-relay/src/relay_map.rs
+++ b/iroh-relay/src/relay_map.rs
@@ -243,6 +243,12 @@ pub struct RelayConfig {
     /// Set via [`RelayConfig::with_auth_token`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_token: Option<String>,
+    /// Whether this relay supports WebTransport (H3) connections.
+    ///
+    /// When true and UDP is available, the client prefers WebTransport over
+    /// WebSocket for lower connection latency. Defaults to true.
+    #[serde(default = "h3_default")]
+    pub h3: bool,
 }
 
 impl RelayConfig {
@@ -252,6 +258,7 @@ impl RelayConfig {
             url,
             quic,
             auth_token: None,
+            h3: h3_default(),
         }
     }
 
@@ -275,12 +282,17 @@ impl From<RelayUrl> for RelayConfig {
             url: value,
             quic: quic_config(),
             auth_token: None,
+            h3: h3_default(),
         }
     }
 }
 
 fn quic_config() -> Option<RelayQuicConfig> {
     Some(RelayQuicConfig::default())
+}
+
+fn h3_default() -> bool {
+    true
 }
 
 /// Configuration for speaking to the QUIC endpoint on the relay

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -63,12 +63,16 @@ use crate::{
 
 pub mod client;
 pub mod clients;
+#[cfg(feature = "h3-transport")]
+pub mod h3_server;
 pub mod http_server;
 mod metrics;
 pub(crate) mod resolver;
 pub mod streams;
-#[cfg(feature = "test-utils")]
 pub mod testing;
+
+#[cfg(all(test, feature = "h3-transport"))]
+mod h3_test;
 
 pub use self::{
     http_server::{Handlers, RelayService},
@@ -624,12 +628,18 @@ pub struct Server {
     https_addr: Option<SocketAddr>,
     /// The address of the QUIC server, if configured.
     quic_addr: Option<SocketAddr>,
+    /// The address of the H3 relay server, if configured.
+    #[cfg(feature = "h3-transport")]
+    h3_addr: Option<SocketAddr>,
     /// Handle to the relay server.
     relay_handle: Option<http_server::ServerHandle>,
     /// Handle to the relay service for runtime control.
     relay_service: Option<http_server::RelayService>,
     /// Handle to the quic server.
     quic_handle: Option<QuicServerHandle>,
+    /// Handle to the H3 relay server.
+    #[cfg(feature = "h3-transport")]
+    h3_handle: Option<h3_server::H3ServerHandle>,
     /// The main task running the server.
     supervisor: AbortOnDropHandle<Result<(), SupervisorError>>,
     metrics: RelayMetrics,
@@ -709,6 +719,9 @@ impl Server {
             None
         };
 
+        #[cfg(feature = "h3-transport")]
+        let mut h3_server: Option<h3_server::H3RelayServer> = None;
+
         let (relay_server, http_addr, tls_config) = match config.relay {
             Some(relay_config) => {
                 debug!("Starting Relay server");
@@ -728,11 +741,12 @@ impl Server {
                 let key_cache_capacity = relay_config
                     .key_cache_capacity
                     .unwrap_or(DEFAULT_KEY_CACHE_CAPACITY);
+                let access = relay_config.access;
                 let mut builder = http_server::ServerBuilder::new(relay_bind_addr)
                     .metrics(metrics.server.clone())
                     .headers(headers)
                     .key_cache_capacity(key_cache_capacity)
-                    .access(relay_config.access)
+                    .access(access.clone())
                     .request_handler(Method::GET, "/", Box::new(root_handler))
                     .request_handler(Method::GET, "/index.html", Box::new(root_handler))
                     .request_handler(Method::GET, RELAY_PROBE_PATH, Box::new(probe_handler))
@@ -741,8 +755,18 @@ impl Server {
                 if let Some(cfg) = relay_config.limits.client_rx {
                     builder = builder.client_rx_ratelimit(cfg);
                 }
+                // The H3 server shares the WS `RelayService`, which only exists once the
+                // builder is spawned. Capture its QUIC bind address and TLS config here and
+                // start it afterwards.
+                #[cfg(feature = "h3-transport")]
+                let mut h3_config: Option<(SocketAddr, rustls::ServerConfig)> = None;
                 let (http_addr, tls_config) = match relay_config.tls {
                     Some(tls_config) => {
+                        // H3 binds on the same port as HTTPS (UDP vs TCP), matching
+                        // standard HTTP/3 deployment (both on port 443 in production).
+                        #[cfg(feature = "h3-transport")]
+                        let h3_quic_bind_addr = tls_config.https_bind_addr;
+
                         let server_tls_config = match tls_config.cert {
                             CertConfig::LetsEncrypt {
                                 acme_config,
@@ -799,6 +823,14 @@ impl Server {
                         };
                         builder = builder.tls_config(Some(server_tls_config.clone()));
 
+                        // Defer the H3 relay server until the WS `RelayService` exists, so both
+                        // transports share one client registry and access control.
+                        #[cfg(feature = "h3-transport")]
+                        {
+                            h3_config =
+                                Some((h3_quic_bind_addr, (*server_tls_config.config).clone()));
+                        }
+
                         // Some services always need to be served over HTTP without TLS.  Run
                         // these standalone.
                         let http_listener = TcpListener::bind(&relay_config.http_bind_addr)
@@ -828,6 +860,27 @@ impl Server {
                     }
                 };
                 let relay_server = builder.spawn().await?;
+
+                // Start the H3 relay server against the same `RelayService`, so a WebSocket
+                // client and a WebTransport client share one registry and can relay to each
+                // other.
+                #[cfg(feature = "h3-transport")]
+                if let Some((bind_addr, server_config)) = h3_config {
+                    match h3_server::H3RelayServer::spawn(
+                        bind_addr,
+                        server_config,
+                        relay_server.service().clone(),
+                    ) {
+                        Ok(server) => {
+                            info!(addr = %server.bind_addr(), "H3 relay server started");
+                            h3_server = Some(server);
+                        }
+                        Err(err) => {
+                            error!("Failed to start H3 relay server: {err:#}");
+                        }
+                    }
+                }
+
                 (Some(relay_server), http_addr, tls_config)
             }
             None => (None, None, None),
@@ -857,15 +910,30 @@ impl Server {
         let quic_addr = quic_server.as_ref().map(|srv| srv.bind_addr());
         let quic_handle = quic_server.as_ref().map(|srv| srv.handle());
 
-        let task = tokio::spawn(relay_supervisor(tasks, relay_server, quic_server));
+        #[cfg(feature = "h3-transport")]
+        let h3_addr = h3_server.as_ref().map(|srv| srv.bind_addr());
+        #[cfg(feature = "h3-transport")]
+        let h3_handle = h3_server.as_ref().map(|srv| srv.handle());
+
+        let task = tokio::spawn(relay_supervisor(
+            tasks,
+            relay_server,
+            quic_server,
+            #[cfg(feature = "h3-transport")]
+            h3_server,
+        ));
 
         Ok(Self {
             http_addr: http_addr.or(relay_addr),
             https_addr: http_addr.and(relay_addr),
             quic_addr,
+            #[cfg(feature = "h3-transport")]
+            h3_addr,
             relay_handle,
             relay_service,
             quic_handle,
+            #[cfg(feature = "h3-transport")]
+            h3_handle,
             supervisor: AbortOnDropHandle::new(task),
             metrics,
             metrics_server,
@@ -876,8 +944,8 @@ impl Server {
     ///
     /// Returns once all server tasks have stopped.
     pub async fn shutdown(self) -> Result<(), SupervisorError> {
-        // Only the Relay server and QUIC server need shutting down, the supervisor will abort the tasks in
-        // the JoinSet when the server terminates.
+        // Only the Relay, QUIC and H3 servers need shutting down, the supervisor will abort the
+        // tasks in the JoinSet when the server terminates.
         if let Some(handle) = self.relay_handle {
             handle.shutdown();
         }
@@ -886,6 +954,11 @@ impl Server {
         }
         if let Some(server) = self.metrics_server {
             server.shutdown().await;
+        }
+
+        #[cfg(feature = "h3-transport")]
+        if let Some(handle) = self.h3_handle {
+            handle.shutdown();
         }
         self.supervisor.await?
     }
@@ -914,6 +987,12 @@ impl Server {
     /// The socket address the QUIC server is listening on.
     pub fn quic_addr(&self) -> Option<SocketAddr> {
         self.quic_addr
+    }
+
+    /// The socket address the H3 relay server is listening on.
+    #[cfg(feature = "h3-transport")]
+    pub fn h3_addr(&self) -> Option<SocketAddr> {
+        self.h3_addr
     }
 
     /// Get the server's https [`RelayUrl`].
@@ -960,6 +1039,7 @@ async fn relay_supervisor(
     mut tasks: JoinSet<Result<(), SupervisorError>>,
     mut relay_http_server: Option<http_server::Server>,
     mut quic_server: Option<QuicServer>,
+    #[cfg(feature = "h3-transport")] mut h3_relay_server: Option<h3_server::H3RelayServer>,
 ) -> Result<(), SupervisorError> {
     let quic_enabled = quic_server.is_some();
     let mut quic_fut = match quic_server {
@@ -971,11 +1051,24 @@ async fn relay_supervisor(
         Some(ref mut server) => n0_future::Either::Left(server.task_handle()),
         None => n0_future::Either::Right(n0_future::future::pending()),
     };
+    // H3 server future: if the feature is not enabled or no server is present, pend forever.
+    #[cfg(feature = "h3-transport")]
+    let h3_enabled = h3_relay_server.is_some();
+    #[cfg(not(feature = "h3-transport"))]
+    let h3_enabled = false;
+    #[cfg(feature = "h3-transport")]
+    let mut h3_fut = match h3_relay_server {
+        Some(ref mut server) => n0_future::Either::Left(server.task_handle()),
+        None => n0_future::Either::Right(n0_future::future::pending()),
+    };
+    #[cfg(not(feature = "h3-transport"))]
+    let mut h3_fut = n0_future::future::pending::<std::result::Result<(), ()>>();
     let res = tokio::select! {
         biased;
         Some(ret) = tasks.join_next() => ret,
         ret = &mut quic_fut, if quic_enabled => ret.map(Ok),
         ret = &mut relay_fut, if relay_enabled => ret.map(Ok),
+        ret = &mut h3_fut, if h3_enabled => ret.map(Ok),
         else => Ok(Err(e!(SupervisorError::NoRelayServicesEnabled))),
     };
     let ret = match res {
@@ -1005,6 +1098,12 @@ async fn relay_supervisor(
 
     // Ensure the QUIC server is closed
     if let Some(server) = quic_server {
+        server.shutdown().await;
+    }
+
+    // Ensure the H3 relay server is closed
+    #[cfg(feature = "h3-transport")]
+    if let Some(server) = h3_relay_server {
         server.shutdown().await;
     }
 

--- a/iroh-relay/src/server/h3_server.rs
+++ b/iroh-relay/src/server/h3_server.rs
@@ -1,0 +1,362 @@
+//! WebTransport server for the relay protocol.
+//!
+//! Accepts relay connections over QUIC/WebTransport, complementing the existing
+//! WebSocket-over-HTTP/1.1 transport.
+
+use std::{net::SocketAddr, sync::Arc};
+
+use n0_error::{AnyError, anyerr, e, stack_error};
+use noq::crypto::rustls::{NoInitialCipherSuite, QuicServerConfig};
+use tokio::task::JoinSet;
+use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
+use tracing::{Instrument, debug, info, info_span, trace, warn};
+use web_transport_proto as wt;
+
+use super::{
+    client::Config, clients::Clients, http_server::RelayService, metrics::Metrics,
+    streams::RelayedStream,
+};
+use crate::{
+    KeyCache,
+    http::{ALPN_RELAY_H3, CLIENT_AUTH_HEADER, ProtocolVersion, RELAY_PATH},
+    protos::{h3_streams::WtBytesFramed, handshake},
+    server::{ClientRequest, DynAccessControl},
+};
+
+/// Errors when spawning the H3 relay server.
+#[allow(missing_docs)]
+#[stack_error(derive, add_meta)]
+#[non_exhaustive]
+pub enum H3SpawnError {
+    #[error(transparent)]
+    NoInitialCipherSuite {
+        #[error(std_err, from)]
+        source: NoInitialCipherSuite,
+    },
+    #[error("Unable to spawn QUIC endpoint for H3 relay")]
+    EndpointServer {
+        #[error(std_err)]
+        source: std::io::Error,
+    },
+    #[error("Unable to get local address from H3 endpoint")]
+    LocalAddr {
+        #[error(std_err)]
+        source: std::io::Error,
+    },
+}
+
+/// A running H3/WebTransport relay server.
+#[derive(Debug)]
+pub struct H3RelayServer {
+    bind_addr: SocketAddr,
+    cancel: CancellationToken,
+    handle: AbortOnDropHandle<()>,
+}
+
+impl H3RelayServer {
+    /// Returns the bound socket address.
+    pub fn bind_addr(&self) -> SocketAddr {
+        self.bind_addr
+    }
+
+    /// Returns a handle for controlling this server.
+    pub fn handle(&self) -> H3ServerHandle {
+        H3ServerHandle {
+            cancel: self.cancel.clone(),
+        }
+    }
+
+    /// Returns a mutable reference to the task handle.
+    pub fn task_handle(&mut self) -> &mut AbortOnDropHandle<()> {
+        &mut self.handle
+    }
+
+    /// Spawns the H3/WebTransport relay server.
+    ///
+    /// The `service` is the same [`RelayService`] that backs the WebSocket server,
+    /// so both transports register into one [`Clients`] registry and share the
+    /// access control, key cache, and metrics. `bind_addr` and `server_config` are
+    /// the QUIC-specific bind address and TLS configuration.
+    pub(crate) fn spawn(
+        bind_addr: SocketAddr,
+        server_config: rustls::ServerConfig,
+        service: RelayService,
+    ) -> Result<Self, H3SpawnError> {
+        let mut server_tls_config = server_config;
+        server_tls_config.alpn_protocols = vec![ALPN_RELAY_H3.to_vec()];
+
+        let quic_server_config = QuicServerConfig::try_from(server_tls_config)?;
+        let mut server_config = noq::ServerConfig::with_crypto(Arc::new(quic_server_config));
+        let transport_config = Arc::get_mut(&mut server_config.transport).expect("not used yet");
+        // Uni streams: high limit for per-message uni streams.
+        // Bidi streams: 1 for the CONNECT session.
+        transport_config
+            .max_concurrent_uni_streams(256u32.into())
+            .max_concurrent_bidi_streams(2_u8.into());
+
+        let endpoint = noq::Endpoint::server(server_config, bind_addr)
+            .map_err(|err| e!(H3SpawnError::EndpointServer, err))?;
+        let bind_addr = endpoint
+            .local_addr()
+            .map_err(|err| e!(H3SpawnError::LocalAddr, err))?;
+
+        info!(?bind_addr, "H3/WT relay server listening");
+
+        let cancel = CancellationToken::new();
+        let cancel_loop = cancel.clone();
+
+        let clients = service.clients().clone();
+        let key_cache = service.key_cache().clone();
+        let access = service.access().clone();
+        let metrics = service.metrics().clone();
+
+        let task = tokio::task::spawn(
+            async move {
+                let mut set = JoinSet::new();
+                debug!("waiting for connections");
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = cancel_loop.cancelled() => {
+                            break;
+                        }
+                        Some(res) = set.join_next() => {
+                            if let Err(err) = res
+                                && err.is_panic()
+                            {
+                                panic!("H3/WT relay task panicked: {err:#?}");
+                            }
+                        }
+                        res = endpoint.accept() => match res {
+                            Some(incoming) => {
+                                let remote_addr = incoming.remote_address();
+                                debug!(%remote_addr, "accepting QUIC connection");
+                                let clients = clients.clone();
+                                let key_cache = key_cache.clone();
+                                let metrics = metrics.clone();
+                                let access = access.clone();
+                                set.spawn(
+                                    async move {
+                                        if let Err(err) = handle_wt_connection(
+                                            incoming, clients, key_cache, access, metrics,
+                                        ).await {
+                                            warn!("WT connection error: {err:#}");
+                                        }
+                                    }
+                                    .instrument(info_span!("wt-relay-conn", %remote_addr))
+                                );
+                            }
+                            None => {
+                                debug!("endpoint closed");
+                                break;
+                            }
+                        }
+                    }
+                }
+                endpoint.close(0u32.into(), b"server shutdown");
+                endpoint.wait_idle().await;
+                set.abort_all();
+                while !set.is_empty() {
+                    _ = set.join_next().await;
+                }
+                debug!("H3/WT relay server shut down");
+            }
+            .instrument(info_span!("h3-wt-relay-serve")),
+        );
+
+        Ok(Self {
+            bind_addr,
+            cancel,
+            handle: AbortOnDropHandle::new(task),
+        })
+    }
+
+    /// Gracefully shuts down the server.
+    pub async fn shutdown(mut self) {
+        self.cancel.cancel();
+        if !self.task_handle().is_finished() {
+            _ = self.task_handle().await;
+        }
+    }
+}
+
+/// Handle for controlling the H3/WT relay server.
+#[derive(Debug, Clone)]
+pub struct H3ServerHandle {
+    cancel: CancellationToken,
+}
+
+impl H3ServerHandle {
+    /// Initiate graceful shutdown.
+    pub fn shutdown(&self) {
+        self.cancel.cancel();
+    }
+}
+
+/// Connection handling errors.
+#[stack_error(derive, add_meta)]
+#[non_exhaustive]
+enum WtConnectionError {
+    #[error(transparent)]
+    Quic {
+        #[error(from, std_err)]
+        source: noq::ConnectionError,
+    },
+    /// Error decoding the WebTransport settings sent by the client.
+    ///
+    /// The concrete error type is `web_transport_proto::SettingsError`. Use
+    /// [`AnyError::downcast_ref`] to recover it. Note that the concrete downcast
+    /// type is not covered by any semver guarantees and may change between releases.
+    #[error("WebTransport settings error")]
+    Settings { source: AnyError },
+    /// Error encoding or decoding a WebTransport CONNECT message.
+    ///
+    /// The concrete error type is `web_transport_proto::ConnectError`. Use
+    /// [`AnyError::downcast_ref`] to recover it. Note that the concrete downcast
+    /// type is not covered by any semver guarantees and may change between releases.
+    #[error("WebTransport CONNECT error")]
+    Connect { source: AnyError },
+    #[error(transparent)]
+    Handshake {
+        #[error(from, std_err)]
+        source: handshake::Error,
+    },
+    #[error(transparent)]
+    StreamWrite {
+        #[error(from, std_err)]
+        source: noq::WriteError,
+    },
+    #[error("invalid WebTransport CONNECT request")]
+    Http {
+        #[error(from, std_err)]
+        source: http::Error,
+    },
+}
+
+/// Handle a single QUIC connection and serve WebTransport relay sessions.
+async fn handle_wt_connection(
+    incoming: noq::Incoming,
+    clients: Clients,
+    key_cache: KeyCache,
+    access: Arc<dyn DynAccessControl>,
+    metrics: Arc<Metrics>,
+) -> Result<(), WtConnectionError> {
+    let conn = incoming.await?;
+
+    trace!("WT srv: QUIC connection established");
+
+    let mut server_settings = wt::Settings::default();
+    server_settings.enable_webtransport(1);
+
+    let mut settings_buf = bytes::BytesMut::new();
+    server_settings.encode(&mut settings_buf);
+
+    let (send_result, recv_result) = tokio::join!(
+        async {
+            trace!("WT srv: sending settings");
+            let mut uni = conn.open_uni().await?;
+            uni.write_all(&settings_buf).await?;
+            trace!("WT srv: settings sent");
+            Ok::<_, WtConnectionError>(())
+        },
+        async {
+            trace!("WT srv: waiting for client settings");
+            let uni = conn.accept_uni().await?;
+            let mut uni = tokio::io::BufReader::new(uni);
+            let s = wt::Settings::read(&mut uni)
+                .await
+                .map_err(|err| e!(WtConnectionError::Settings, anyerr!(err)))?;
+            trace!("WT srv: client settings received");
+            Ok::<_, WtConnectionError>(s)
+        }
+    );
+    send_result?;
+    let client_settings = recv_result?;
+
+    if client_settings.supports_webtransport() == 0 {
+        warn!("client does not support WebTransport");
+        return Ok(());
+    }
+
+    trace!("WT srv: waiting for CONNECT");
+    let (mut send, mut recv) = conn.accept_bi().await?;
+    // Record the CONNECT stream's QUIC stream ID as the session ID.
+    let session_id: u64 = send.id().into();
+    let connect_req = wt::ConnectRequest::read(&mut recv)
+        .await
+        .map_err(|err| e!(WtConnectionError::Connect, anyerr!(err)))?;
+    trace!(url = %connect_req.url, session_id, "WT srv: CONNECT received");
+
+    if connect_req.url.path() != RELAY_PATH {
+        warn!(path = %connect_req.url.path(), "invalid path, expected {RELAY_PATH}");
+        let mut buf = bytes::BytesMut::new();
+        let _ = wt::ConnectResponse::new(http::StatusCode::NOT_FOUND).encode(&mut buf);
+        let _ = send.write_all(&buf).await;
+        return Ok(());
+    }
+
+    let protocol_version = connect_req
+        .protocols
+        .iter()
+        .filter_map(|s| ProtocolVersion::match_from_str(s.as_str()))
+        .max();
+    let Some(protocol_version) = protocol_version else {
+        warn!("unsupported or missing relay subprotocol");
+        let mut buf = bytes::BytesMut::new();
+        let _ = wt::ConnectResponse::new(http::StatusCode::BAD_REQUEST).encode(&mut buf);
+        let _ = send.write_all(&buf).await;
+        return Ok(());
+    };
+
+    let client_auth_header = connect_req
+        .headers
+        .get(CLIENT_AUTH_HEADER.as_str())
+        .cloned();
+
+    let resp = wt::ConnectResponse::OK.with_protocol(protocol_version.to_string());
+    let mut resp_buf = bytes::BytesMut::new();
+    resp.encode(&mut resp_buf)
+        .map_err(|err| e!(WtConnectionError::Connect, anyerr!(err)))?;
+    trace!("WT srv: sending CONNECT response");
+    send.write_all(&resp_buf).await?;
+
+    // Use uni streams for relay messages (one stream per message).
+    let mut io = WtBytesFramed::new(conn.clone(), session_id);
+
+    trace!("WT srv: starting relay handshake");
+    let authentication = handshake::serverside(&mut io, client_auth_header).await?;
+
+    trace!(?authentication.mechanism, "verified authentication");
+
+    // Build a `ClientRequest` from the WebTransport CONNECT request and authorize it
+    // against the configured `AccessControl`, mirroring the WebSocket accept path.
+    let request_parts = {
+        let mut request = http::Request::builder()
+            .uri(connect_req.url.as_str())
+            .body(())?;
+        *request.headers_mut() = connect_req.headers;
+        request.into_parts().0
+    };
+    let request = ClientRequest::new(authentication.client_key, protocol_version, request_parts);
+    let guard = authentication
+        .authorize_with(&request, &access, &mut io)
+        .await?;
+
+    trace!("verified authorization");
+
+    let io = RelayedStream::new(io, key_cache.clone());
+
+    let endpoint_id = request.endpoint_id();
+    let client_conn = Config::new(guard, io, protocol_version);
+
+    trace!(endpoint_id = %endpoint_id.fmt_short(), "registering client");
+
+    clients.register(client_conn, metrics.clone());
+
+    debug!(endpoint_id = %endpoint_id.fmt_short(), "client registered");
+
+    // Keep the connection alive until the client disconnects.
+    conn.closed().await;
+
+    Ok(())
+}

--- a/iroh-relay/src/server/h3_test.rs
+++ b/iroh-relay/src/server/h3_test.rs
@@ -1,0 +1,249 @@
+//! Integration tests for relay connections over HTTP/3.
+
+#[cfg(all(
+    test,
+    feature = "server",
+    feature = "h3-transport",
+    with_crypto_provider
+))]
+mod tests {
+    use std::{net::Ipv4Addr, sync::Arc, time::Duration};
+
+    use iroh_base::{EndpointId, SecretKey};
+    use iroh_dns::dns::DnsResolver;
+    use n0_error::Result;
+    use n0_future::{SinkExt, StreamExt};
+    use n0_tracing_test::traced_test;
+    use rand::{RngExt, SeedableRng};
+    use tracing::{info, instrument};
+
+    use http::HeaderMap;
+
+    use crate::{
+        KeyCache,
+        client::{Client, ClientBuilder, conn::Conn, h3_conn},
+        http::ProtocolVersion,
+        protos::relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg},
+        server::{
+            AllowAll, Metrics, Server,
+            h3_server::H3RelayServer,
+            http_server::{Handlers, RelayService},
+            testing::self_signed_tls_certs_and_config,
+        },
+    };
+
+    /// Spawn an H3-only relay server for testing.
+    fn spawn_h3_relay() -> std::result::Result<H3RelayServer, crate::server::h3_server::H3SpawnError>
+    {
+        let (_, server_config) = self_signed_tls_certs_and_config();
+        let service = RelayService::new(
+            Handlers::default(),
+            HeaderMap::new(),
+            None,
+            KeyCache::new(1024),
+            Arc::new(AllowAll),
+            Arc::new(Metrics::default()),
+        );
+
+        H3RelayServer::spawn((Ipv4Addr::LOCALHOST, 0).into(), server_config, service)
+    }
+
+    /// Connect a relay client over H3 directly (no ClientBuilder).
+    async fn connect_h3_client(
+        server_addr: std::net::SocketAddr,
+        secret_key: SecretKey,
+    ) -> Result<Client> {
+        let tls_config = crate::tls::make_dangerous_client_config();
+
+        let (io, state, local_addr) =
+            h3_conn::connect_h3(server_addr, "localhost", tls_config, &secret_key).await?;
+
+        let conn = Conn::from_wt(io, state, KeyCache::new(128), ProtocolVersion::default());
+        Ok(Client::from_conn(conn, Some(local_addr)))
+    }
+
+    #[instrument]
+    async fn try_send_recv(
+        client_a: &mut Client,
+        client_b: &mut Client,
+        b_key: EndpointId,
+        msg: Datagrams,
+    ) -> Result<RelayToClientMsg> {
+        for _ in 0..10 {
+            client_a
+                .send(ClientToRelayMsg::Datagrams {
+                    dst_endpoint_id: b_key,
+                    datagrams: msg.clone(),
+                })
+                .await?;
+            let Ok(res) = tokio::time::timeout(Duration::from_millis(500), client_b.next()).await
+            else {
+                continue;
+            };
+            let res = res.expect("stream finished")?;
+            return Ok(res);
+        }
+        panic!("failed to send and recv message");
+    }
+
+    fn dns_resolver() -> DnsResolver {
+        DnsResolver::new()
+    }
+
+    /// Test with standalone H3 relay server and direct H3 clients.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_h3_relay_clients() -> Result<()> {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42u64);
+        let server = spawn_h3_relay()?;
+        let server_addr = server.bind_addr();
+
+        info!(%server_addr, "H3 relay server started");
+
+        let a_secret_key = SecretKey::from_bytes(&rng.random());
+        let a_key = a_secret_key.public();
+        let mut client_a = connect_h3_client(server_addr, a_secret_key).await?;
+
+        let b_secret_key = SecretKey::from_bytes(&rng.random());
+        let b_key = b_secret_key.public();
+        let mut client_b = connect_h3_client(server_addr, b_secret_key).await?;
+
+        // A -> B
+        let msg = Datagrams::from("hello over h3, b!");
+        let res = try_send_recv(&mut client_a, &mut client_b, b_key, msg.clone()).await?;
+        let RelayToClientMsg::Datagrams {
+            remote_endpoint_id,
+            datagrams,
+        } = res
+        else {
+            panic!("unexpected message {res:?}");
+        };
+        assert_eq!(a_key, remote_endpoint_id);
+        assert_eq!(msg, datagrams);
+
+        // B -> A
+        let msg = Datagrams::from("howdy over h3, a!");
+        let res = try_send_recv(&mut client_b, &mut client_a, a_key, msg.clone()).await?;
+        let RelayToClientMsg::Datagrams {
+            remote_endpoint_id,
+            datagrams,
+        } = res
+        else {
+            panic!("unexpected message {res:?}");
+        };
+        assert_eq!(b_key, remote_endpoint_id);
+        assert_eq!(msg, datagrams);
+
+        server.shutdown().await;
+        Ok(())
+    }
+
+    /// Test H3 via `ClientBuilder::enable_h3(true)` against the full integrated server.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_h3_via_client_builder() -> Result<()> {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(99u64);
+
+        // Spawn a full server with TLS (which auto-starts H3).
+        let server = Server::spawn(crate::server::testing::server_config()).await?;
+        let h3_addr = server.h3_addr().expect("H3 server should be running");
+
+        info!(?h3_addr, "Full server with H3 started");
+
+        let client_config = crate::tls::make_dangerous_client_config();
+
+        // Use a relay URL pointing at the H3 address.
+        let relay_url: iroh_base::RelayUrl =
+            format!("https://localhost:{}", h3_addr.port()).parse()?;
+
+        // Client A via H3
+        let a_secret_key = SecretKey::from_bytes(&rng.random());
+        let a_key = a_secret_key.public();
+        let mut client_a = ClientBuilder::new(relay_url.clone(), a_secret_key, dns_resolver())
+            .tls_client_config(client_config.clone())
+            .enable_h3(true)
+            .connect()
+            .await?;
+
+        // Verify H3 transport is actually used.
+        assert_eq!(
+            client_a.transport(),
+            crate::client::Transport::H3,
+            "Expected H3 transport"
+        );
+
+        // Client B via H3
+        let b_secret_key = SecretKey::from_bytes(&rng.random());
+        let b_key = b_secret_key.public();
+        let mut client_b = ClientBuilder::new(relay_url.clone(), b_secret_key, dns_resolver())
+            .tls_client_config(client_config)
+            .enable_h3(true)
+            .connect()
+            .await?;
+
+        assert_eq!(
+            client_b.transport(),
+            crate::client::Transport::H3,
+            "Expected H3 transport"
+        );
+
+        // A -> B
+        let msg = Datagrams::from("h3 via builder!");
+        let res = try_send_recv(&mut client_a, &mut client_b, b_key, msg.clone()).await?;
+        let RelayToClientMsg::Datagrams {
+            remote_endpoint_id,
+            datagrams,
+        } = res
+        else {
+            panic!("unexpected message {res:?}");
+        };
+        assert_eq!(a_key, remote_endpoint_id);
+        assert_eq!(msg, datagrams);
+
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// Test that `enable_h3` falls back to WS when no H3 server is available.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_h3_fallback_to_ws() -> Result<()> {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(77u64);
+
+        // Spawn a plain HTTP relay (no TLS, no H3).
+        let server = Server::spawn(crate::server::ServerConfig {
+            relay: Some(crate::server::RelayConfig {
+                http_bind_addr: (Ipv4Addr::LOCALHOST, 0).into(),
+                tls: None,
+                limits: Default::default(),
+                key_cache_capacity: Some(1024),
+                access: Arc::new(AllowAll),
+            }),
+            quic: None,
+            metrics_addr: None,
+        })
+        .await?;
+
+        let relay_url: iroh_base::RelayUrl =
+            format!("http://{}", server.http_addr().unwrap()).parse()?;
+
+        let client_config = crate::tls::make_dangerous_client_config();
+
+        let a_secret_key = SecretKey::from_bytes(&rng.random());
+        // enable_h3 is true but server has no H3, should fall back to WS.
+        let client_a = ClientBuilder::new(relay_url, a_secret_key, dns_resolver())
+            .tls_client_config(client_config)
+            .enable_h3(true)
+            .connect()
+            .await?;
+
+        assert_eq!(
+            client_a.transport(),
+            crate::client::Transport::Ws,
+            "Should have fallen back to WS"
+        );
+
+        server.shutdown().await?;
+        Ok(())
+    }
+}

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -442,13 +442,15 @@ impl ServerBuilder {
     pub(super) async fn spawn(self) -> Result<Server, SpawnError> {
         let cancel_token = CancellationToken::new();
 
+        let metrics = self.metrics.unwrap_or_default();
+        let key_cache = KeyCache::new(self.key_cache_capacity);
         let service = RelayService::new(
             self.handlers,
             self.headers,
             self.client_rx_ratelimit,
-            KeyCache::new(self.key_cache_capacity),
+            key_cache,
             self.access,
-            self.metrics.unwrap_or_default(),
+            metrics,
         );
 
         let addr = self.addr;
@@ -950,6 +952,21 @@ impl RelayService {
     /// connected endpoint via [`Clients::disconnect`].
     pub fn clients(&self) -> &Clients {
         &self.0.clients
+    }
+
+    /// Returns the access control shared by all transports.
+    pub(crate) fn access(&self) -> &Arc<dyn DynAccessControl> {
+        &self.0.access
+    }
+
+    /// Returns the key cache shared by all transports.
+    pub(crate) fn key_cache(&self) -> &KeyCache {
+        &self.0.key_cache
+    }
+
+    /// Returns the metrics shared by all transports.
+    pub(crate) fn metrics(&self) -> &Arc<Metrics> {
+        &self.0.metrics
     }
 
     /// Handle the incoming connection.

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -145,7 +145,9 @@ testdir = "0.10"
 cfg_aliases = { version = "0.2.1" }
 
 [features]
-default = ["metrics", "fast-apple-datapath", "portmapper", "tls-ring"]
+default = ["metrics", "fast-apple-datapath", "portmapper", "tls-ring", "h3-transport"]
+# HTTP/3 relay transport (QUIC-based, preferred when UDP is available)
+h3-transport = ["iroh-relay/h3-transport"]
 portmapper = ["dep:portmapper"]
 metrics = ["iroh-metrics/metrics", "iroh-relay/metrics"]
 test-utils = ["iroh-relay/test-utils", "iroh-relay/server", "dep:axum"]

--- a/iroh/examples/transfer.rs
+++ b/iroh/examples/transfer.rs
@@ -345,6 +345,10 @@ struct EndpointArgs {
     /// Accepts values like "5M", "2000K", etc.
     #[clap(long, value_parser = parse_byte_size)]
     receive_window: Option<u32>,
+    /// Trust any server certificate (for local testing with self-signed certs).
+    #[cfg(feature = "test-utils")]
+    #[clap(long)]
+    insecure: bool,
 }
 
 #[derive(Subcommand, Debug, derive_more::Display)]
@@ -495,7 +499,12 @@ impl EndpointArgs {
             builder = builder.addr_filter(AddrFilter::relay_only());
         }
 
-        if Env::Dev == self.env {
+        #[cfg(feature = "test-utils")]
+        let needs_insecure = Env::Dev == self.env || self.insecure;
+        #[cfg(not(feature = "test-utils"))]
+        let needs_insecure = Env::Dev == self.env;
+
+        if needs_insecure {
             #[cfg(feature = "test-utils")]
             {
                 builder = builder.ca_tls_config(iroh::tls::CaTlsConfig::insecure_skip_verify());
@@ -503,7 +512,7 @@ impl EndpointArgs {
             #[cfg(not(feature = "test-utils"))]
             {
                 n0_error::bail_any!(
-                    "Must have the `test-utils` feature enabled when using the `--env=dev` flag"
+                    "Must have the `test-utils` feature enabled when using --env=dev, --insecure, or --local-relay"
                 )
             }
         }

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -353,6 +353,8 @@ pub(crate) struct Socket {
     net_report: Watchable<(Option<Report>, UpdateReason)>,
     /// If the last net_report report, reports IPv6 to be available.
     ipv6_reported: Arc<AtomicBool>,
+    /// If the last net_report report, reports UDP to be available.
+    udp_available: Arc<AtomicBool>,
     /// Maps for resolving mapped addrs to/from IP and relay addresses.
     mapped_addrs: MappedAddrs,
 
@@ -921,6 +923,7 @@ impl EndpointInner {
             .unwrap_or_else(RelayMap::empty);
 
         let ipv6_reported = Arc::new(AtomicBool::new(false));
+        let udp_available = Arc::new(AtomicBool::new(false));
 
         let relay_actor_config = RelayActorConfig {
             my_relay: HomeRelayWatch::default(),
@@ -929,9 +932,10 @@ impl EndpointInner {
             dns_resolver: dns_resolver.clone(),
             proxy_url: proxy_url.clone(),
             ipv6_reported: ipv6_reported.clone(),
+            udp_available: udp_available.clone(),
             tls_config: tls_config.clone(),
-            metrics: metrics.socket.clone(),
             relay_map: relay_map.clone(),
+            metrics: metrics.socket.clone(),
         };
 
         let shutdown_state = ShutdownState::default();
@@ -991,6 +995,7 @@ impl EndpointInner {
             remote_actors: remote_map.senders(),
             shutdown: shutdown_state,
             ipv6_reported,
+            udp_available,
             mapped_addrs: remote_map.mapped_addrs.clone(),
             address_lookup,
             relay_map: relay_map.clone(),
@@ -1964,6 +1969,9 @@ impl Actor {
     fn handle_net_report_report(&mut self, mut report: Option<net_report::Report>) {
         if let Some(ref mut r) = report {
             self.sock.ipv6_reported.store(r.udp_v6, Ordering::Relaxed);
+            self.sock
+                .udp_available
+                .store(r.has_udp(), Ordering::Relaxed);
             if r.preferred_relay.is_none()
                 && let Some(my_relay) = self.sock.my_relay()
             {

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -206,6 +206,10 @@ struct RelayConnectionOptions {
     dns_resolver: DnsResolver,
     proxy_url: Option<Url>,
     prefer_ipv6: Arc<AtomicBool>,
+    /// Whether UDP is available (from net_report). Used to prefer H3 over WebSocket.
+    udp_available: Arc<AtomicBool>,
+    /// Whether this relay advertises H3/WebTransport support.
+    h3_enabled: bool,
     tls_config: rustls::ClientConfig,
     auth_token: Option<String>,
 }
@@ -295,6 +299,8 @@ impl ActiveRelayActor {
             dns_resolver,
             proxy_url,
             prefer_ipv6,
+            udp_available,
+            h3_enabled,
             tls_config,
             auth_token,
         } = opts;
@@ -307,6 +313,12 @@ impl ActiveRelayActor {
         )
         .tls_client_config(tls_config)
         .address_family_selector(move || prefer_ipv6.load(Ordering::Relaxed));
+        #[cfg(feature = "h3-transport")]
+        {
+            // Use H3/WebTransport if the relay advertises it and UDP is available.
+            // Falls back to WS on failure (timeout or UDP blocked).
+            builder = builder.enable_h3(h3_enabled && udp_available.load(Ordering::Relaxed));
+        }
         if let Some(proxy_url) = proxy_url {
             builder = builder.proxy_url(proxy_url);
         }
@@ -874,11 +886,13 @@ pub(crate) struct Config {
     pub proxy_url: Option<Url>,
     /// If the last net_report report, reports IPv6 to be available.
     pub ipv6_reported: Arc<AtomicBool>,
+    /// Whether the last net_report indicates UDP is available.
+    pub udp_available: Arc<AtomicBool>,
     pub tls_config: rustls::ClientConfig,
-    pub metrics: Arc<SocketMetrics>,
-    /// Per-relay configuration. Consulted when starting a connection to
-    /// look up the auth token and any future per-relay options.
+    /// The relay map. Consulted when starting a connection to look up per-relay
+    /// configuration such as the auth token and H3 support.
     pub relay_map: RelayMap,
+    pub metrics: Arc<SocketMetrics>,
 }
 
 /// Connection state of the home relay.
@@ -1238,12 +1252,22 @@ impl RelayActor {
             .relay_map
             .get(&url)
             .and_then(|cfg| cfg.auth_token.clone());
+
+        let h3_enabled = self
+            .config
+            .relay_map
+            .get(&url)
+            .map(|cfg| cfg.h3)
+            .unwrap_or(true);
+
         let connection_opts = RelayConnectionOptions {
             secret_key: self.config.secret_key.clone(),
             #[cfg(not(wasm_browser))]
             dns_resolver: self.config.dns_resolver.clone(),
             proxy_url: self.config.proxy_url.clone(),
             prefer_ipv6: self.config.ipv6_reported.clone(),
+            udp_available: self.config.udp_available.clone(),
+            h3_enabled,
             tls_config: self.config.tls_config.clone(),
             auth_token,
         };
@@ -1436,6 +1460,8 @@ mod tests {
                 tls_config: CaTlsConfig::insecure_skip_verify()
                     .client_config(default_provider())
                     .expect("infallible"),
+                udp_available: Arc::new(AtomicBool::new(false)),
+                h3_enabled: false,
                 auth_token: None,
             },
             stop_token,

--- a/iroh/src/test_utils.rs
+++ b/iroh/src/test_utils.rs
@@ -76,7 +76,9 @@ pub async fn run_relay_server_with_access(
     let quic = server
         .quic_addr()
         .map(|addr| RelayQuicConfig::new(addr.port()));
-    let n: RelayMap = RelayConfig::new(url.clone(), quic).into();
+    let mut cfg = RelayConfig::new(url.clone(), quic);
+    cfg.h3 = true;
+    let n: RelayMap = cfg.into();
     Ok((n, url, server))
 }
 

--- a/iroh/tests/patchbay.rs
+++ b/iroh/tests/patchbay.rs
@@ -50,6 +50,9 @@ mod switch_uplink;
 #[path = "patchbay/util.rs"]
 mod util;
 
+#[path = "patchbay/relay.rs"]
+mod relay;
+
 /// Init the user namespace before any threads are spawned.
 ///
 /// This gives us all permissions we need for the patchbay tests.

--- a/iroh/tests/patchbay/relay.rs
+++ b/iroh/tests/patchbay/relay.rs
@@ -1,0 +1,252 @@
+//! Relay TTFB measurement tests.
+//!
+//! Two relays: relay-a is the client's home relay (for net_report to set
+//! `udp_available`), relay-b is the server's relay (measured path). The client
+//! discovers relay-b from the server's address and creates a fresh relay actor
+//! that reads the current `udp_available` state and the `h3` flag.
+
+use std::time::{Duration, Instant};
+
+use iroh::{
+    Endpoint, EndpointAddr, RelayMode,
+    endpoint::{Connection, presets},
+    tls::CaTlsConfig,
+};
+use iroh_relay::RelayMap;
+use n0_error::{Result, StdResultExt};
+use n0_tracing_test::traced_test;
+use patchbay::{IpSupport, LinkCondition, LinkDirection, LinkLimits};
+use testdir::testdir;
+use tokio::sync::oneshot;
+
+use super::util;
+
+const ALPN: &[u8] = b"relay-ttfb";
+const PING_DATA: &[u8] = b"relay-ttfb-ping";
+
+async fn ttfb_accept(conn: &Connection) -> Result {
+    let (mut send, mut recv) = conn.accept_bi().await.anyerr()?;
+    let mut buf = vec![0u8; PING_DATA.len()];
+    recv.read_exact(&mut buf).await.anyerr()?;
+    send.write_all(&buf).await.anyerr()?;
+    send.finish().anyerr()?;
+    Ok(())
+}
+
+async fn ttfb_measure(conn: &Connection) -> Result<Duration> {
+    let start = Instant::now();
+    let (mut send, mut recv) = conn.open_bi().await.anyerr()?;
+    send.write_all(PING_DATA).await.anyerr()?;
+    let mut buf = vec![0u8; PING_DATA.len()];
+    recv.read_exact(&mut buf).await.anyerr()?;
+    let elapsed = start.elapsed();
+    assert_eq!(&buf, PING_DATA);
+    Ok(elapsed)
+}
+
+/// Run a TTFB measurement at 60ms RTT with the given `h3` setting on relay-b.
+///
+/// Topology:
+///   relay-a (client home, no latency)
+///   relay-b (server relay, no latency)
+///   server and client (30ms one-way = 60ms RTT)
+///
+/// The client goes online via relay-a (sets `udp_available`), then connects
+/// to the server which is on relay-b. A fresh relay actor is created for
+/// relay-b with the `h3` flag controlling WS vs WT.
+async fn run_relay_ttfb(h3: bool) -> Result {
+    let label = if h3 { "WT" } else { "WS" };
+
+    let mut builder = patchbay::Lab::builder().outdir(patchbay::OutDir::Exact(testdir!()));
+    if let Some(name) = std::thread::current().name() {
+        builder = builder.label(name);
+    }
+    let lab = builder.build().await?;
+    let guard = lab.test_guard();
+
+    let router = lab
+        .add_router("net")
+        .ip_support(IpSupport::DualStack)
+        .build()
+        .await?;
+
+    // Relay A: client's home relay.
+    let relay_a_dev = lab
+        .add_device("relay-a")
+        .uplink(router.id())
+        .build()
+        .await?;
+    let dns = lab.dns_server()?;
+    dns.set_host("relay-a.test", relay_a_dev.ip().expect("v4").into())?;
+    dns.set_host("relay-a.test", relay_a_dev.ip6().expect("v6").into())?;
+
+    let (relay_a_tx, relay_a_rx) = oneshot::channel::<RelayMap>();
+    let _relay_a_task = relay_a_dev.spawn(async move |_ctx| {
+        let (map, _server) = util::relay::run_relay_server_named("relay-a.test")
+            .await
+            .unwrap();
+        relay_a_tx.send(map).unwrap();
+        std::future::pending::<()>().await;
+    })?;
+    let relay_a_map = relay_a_rx.await.std_context("relay-a")?;
+
+    // Relay B: server's relay.
+    let relay_b_dev = lab
+        .add_device("relay-b")
+        .uplink(router.id())
+        .build()
+        .await?;
+    dns.set_host("relay-b.test", relay_b_dev.ip().expect("v4").into())?;
+    dns.set_host("relay-b.test", relay_b_dev.ip6().expect("v6").into())?;
+
+    let (relay_b_tx, relay_b_rx) = oneshot::channel::<RelayMap>();
+    let _relay_b_task = relay_b_dev.spawn(async move |_ctx| {
+        let (map, _server) = util::relay::run_relay_server_named("relay-b.test")
+            .await
+            .unwrap();
+        relay_b_tx.send(map).unwrap();
+        std::future::pending::<()>().await;
+    })?;
+    let relay_b_map = relay_b_rx.await.std_context("relay-b")?;
+
+    // 30ms one-way (60ms RTT).
+    let latency = LinkCondition::Manual(LinkLimits {
+        latency_ms: 30,
+        jitter_ms: 2,
+        loss_pct: 0.0,
+        reorder_pct: 0.0,
+        rate_kbit: 0,
+        duplicate_pct: 0.0,
+        corrupt_pct: 0.0,
+    });
+
+    let server_dev = lab
+        .add_device("server")
+        .iface("eth0", router.id())
+        .build()
+        .await?;
+    server_dev
+        .iface("eth0")
+        .unwrap()
+        .set_condition(latency, LinkDirection::Both)
+        .await?;
+
+    let client_dev = lab
+        .add_device("client")
+        .iface("eth0", router.id())
+        .build()
+        .await?;
+    client_dev
+        .iface("eth0")
+        .unwrap()
+        .set_condition(latency, LinkDirection::Both)
+        .await?;
+
+    let (addr_tx, addr_rx) = oneshot::channel();
+
+    // Server: uses relay-b.
+    let server_relay_b = relay_b_map.clone();
+    let client_relay_b = relay_b_map;
+    let server_task = server_dev.spawn({
+        move |_dev| async move {
+            let ep = Endpoint::builder(presets::Minimal)
+                .relay_mode(RelayMode::Custom(server_relay_b))
+                .ca_tls_config(CaTlsConfig::insecure_skip_verify())
+                .alpns(vec![ALPN.to_vec()])
+                .bind()
+                .await
+                .std_context("server bind")?;
+            ep.online().await;
+
+            let addr = ep.addr();
+            let relay_addr =
+                EndpointAddr::from_parts(addr.id, addr.addrs.into_iter().filter(|a| a.is_relay()));
+            addr_tx.send(relay_addr).unwrap();
+
+            let incoming = ep.accept().await.std_context("accept")?;
+            let conn = incoming
+                .accept()
+                .std_context("handshake")?
+                .await
+                .std_context("await")?;
+            ttfb_accept(&conn).await?;
+
+            // Keep connection alive while the client reads the echo.
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            n0_error::Ok(())
+        }
+    })?;
+
+    // Client: home relay is relay-a. Relay-b is in the map with the h3 flag.
+    let client_task = client_dev.spawn({
+        move |_dev| async move {
+            let server_addr = addr_rx.await.std_context("addr rx")?;
+
+            // Build a relay map with relay-a (home, h3=true) and relay-b
+            // (server's relay, h3 flag from test parameter).
+            let client_map = RelayMap::empty();
+            let relays_a: Vec<_> = relay_a_map.relays();
+            for cfg in relays_a {
+                let mut c = iroh_relay::RelayConfig::clone(&cfg);
+                c.h3 = true;
+                client_map.insert(c.url.clone(), std::sync::Arc::new(c));
+            }
+            let relays_b: Vec<_> = client_relay_b.relays();
+            for cfg in relays_b {
+                let mut c = iroh_relay::RelayConfig::clone(&cfg);
+                c.h3 = h3;
+                client_map.insert(c.url.clone(), std::sync::Arc::new(c));
+            }
+
+            let ep = Endpoint::builder(presets::Minimal)
+                .relay_mode(RelayMode::Custom(client_map))
+                .ca_tls_config(CaTlsConfig::insecure_skip_verify())
+                .alpns(vec![ALPN.to_vec()])
+                .bind()
+                .await
+                .std_context("client bind")?;
+
+            // Go online via relay-a so net_report sets udp_available.
+            ep.online().await;
+
+            // Connect to server on relay-b. This creates a new relay actor
+            // for relay-b that reads udp_available and h3 from the map.
+            let t0 = Instant::now();
+            let conn = ep.connect(server_addr, ALPN).await.std_context("connect")?;
+            let connect_time = t0.elapsed();
+            let echo_time = ttfb_measure(&conn).await?;
+            let total = t0.elapsed();
+
+            println!(
+                "{label} relay TTFB at 60ms RTT: connect={connect_time:?} echo={echo_time:?} total={total:?}"
+            );
+
+            assert!(total < Duration::from_secs(3), "{label} too slow: {total:?}");
+
+            n0_error::Ok(())
+        }
+    })?;
+
+    let (server_res, client_res) = tokio::time::timeout(Duration::from_secs(60), async {
+        tokio::join!(server_task, client_task)
+    })
+    .await
+    .std_context("test timed out")?;
+    server_res.std_context("server")??;
+    client_res.std_context("client")??;
+
+    guard.ok();
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn relay_ttfb_60ms_ws() -> Result {
+    run_relay_ttfb(false).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn relay_ttfb_60ms_wt() -> Result {
+    run_relay_ttfb(true).await
+}

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -475,7 +475,7 @@ fn addr_relay_only(addr: EndpointAddr) -> EndpointAddr {
     EndpointAddr::from_parts(addr.id, addr.addrs.into_iter().filter(|a| a.is_relay()))
 }
 
-mod relay {
+pub(crate) mod relay {
     use std::{
         net::{IpAddr, Ipv6Addr},
         sync::Arc,
@@ -495,7 +495,16 @@ mod relay {
     /// The returned [`RelayMap`] uses `https://relay.test` as the relay URL.
     /// Callers are responsible for ensuring that a DNS entry for `relay.test`
     /// exists and points to the relay's IP addresses.
-    pub(crate) async fn run_relay_server() -> Result<(RelayMap, Server), SpawnError> {
+    pub async fn run_relay_server_named(hostname: &str) -> Result<(RelayMap, Server), SpawnError> {
+        let (map, server) = run_relay_server_inner(hostname).await?;
+        Ok((map, server))
+    }
+
+    pub async fn run_relay_server() -> Result<(RelayMap, Server), SpawnError> {
+        run_relay_server_inner("relay.test").await
+    }
+
+    async fn run_relay_server_inner(hostname: &str) -> Result<(RelayMap, Server), SpawnError> {
         let bind_ip: IpAddr = Ipv6Addr::UNSPECIFIED.into();
 
         let (_certs, server_config) = self_signed_tls_certs_and_config();
@@ -512,11 +521,15 @@ mod relay {
 
         let server = Server::spawn(config).await?;
 
-        let url: RelayUrl = "https://relay.test".parse().expect("valid relay url");
+        let url: RelayUrl = format!("https://{hostname}")
+            .parse()
+            .expect("valid relay url");
         let quic = server
             .quic_addr()
             .map(|addr| RelayQuicConfig::new(addr.port()));
-        let relay_map: RelayMap = RelayConfig::new(url, quic).into();
+        let mut cfg = RelayConfig::new(url, quic);
+        cfg.h3 = true;
+        let relay_map: RelayMap = cfg.into();
 
         Ok((relay_map, server))
     }


### PR DESCRIPTION
## Description

**note: early draft**

Add WebTransport over QUIC as a relay transport alongside WebSocket. On a network where UDP is available it reaches the first relay byte in about two round trips, against three or four for WebSocket, which needs TCP, a TLS handshake, and an HTTP upgrade.

When a relay advertises H3 support and net_report has seen UDP work, the client races a WebTransport (HTTP/3) dial against a WebSocket dial and keeps whichever finishes its handshake first, aborting the other. Both dials resolve the relay and race IPv4 against IPv6 Happy Eyeballs style (RFC 8305). The WebTransport side opens a QUIC connection, which is one round trip including TLS 1.3, then pipelines the settings exchange and WebTransport `CONNECT`. The relay handshake uses the TLS keying material and adds no further round trip.

The `iroh-relay --dev-tls` flag serves HTTPS and H3 from self-signed certificates for local testing, with QUIC address discovery bound to its own UDP port so it does not contend with the H3 server.

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
