### PR TITLE
ci: Update semver checks for 1.0 stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,24 +335,11 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.10
         continue-on-error: true
       - uses: ./.github/workflows/sccache-probe
-
-      - name: Setup Environment (PR)
-        if: ${{ github.event_name == 'pull_request' }}
-        shell: bash
-        run: |
-          echo "HEAD_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})" >> ${GITHUB_ENV}
-      - name: Setup Environment (Push)
-        if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
-        shell: bash
-        run: |
-          echo "HEAD_COMMIT_SHA=$(git rev-parse origin/main)" >> ${GITHUB_ENV}
       - name: Check semver
         # uses: obi1kenobi/cargo-semver-checks-action@v2
         uses: n0-computer/cargo-semver-checks-action@feat-baseline
         with:
           package: iroh, iroh-base, iroh-dns, iroh-dns-server, iroh-relay
-          baseline-rev: ${{ env.HEAD_COMMIT_SHA }}
-          use-cache: false
 
   check_external_types:
     timeout-minutes: 30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,20 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(iroh_l
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[workspace.metadata.cargo-semver-checks.lints]
+enum_struct_variant_field_marked_deprecated = { required-update = "minor" }
+enum_tuple_variant_field_marked_deprecated = { required-update = "minor" }
+enum_variant_marked_deprecated = { required-update = "minor" }
+function_marked_deprecated = { required-update = "minor" }
+global_value_marked_deprecated = { required-update = "minor" }
+macro_marked_deprecated = { required-update = "minor" }
+proc_macro_marked_deprecated = { required-update = "minor" }
+struct_field_marked_deprecated = { required-update = "minor" }
+trait_associated_const_marked_deprecated = { required-update = "minor" }
+trait_associated_type_marked_deprecated = { required-update = "minor" }
+trait_marked_deprecated = { required-update = "minor" }
+trait_method_marked_deprecated = { required-update = "minor" }
+type_associated_const_marked_deprecated = { required-update = "minor" }
+type_marked_deprecated = { required-update = "minor" }
+type_method_marked_deprecated = { required-update = "minor" }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/n0-computer/iroh"
 keywords = ["networking", "pkarr", "dns", "dns-server", "iroh"]
 readme = "README.md"
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait = "0.1.77"
 axum = { version = "0.8", features = ["macros"] }

--- a/iroh-dns-server/src/dns.rs
+++ b/iroh-dns-server/src/dns.rs
@@ -86,8 +86,10 @@ impl DnsConfig {
 }
 
 /// A DNS server that serves pkarr signed packets.
+#[derive(derive_more::Debug)]
 pub(crate) struct DnsServer {
     local_addr: SocketAddr,
+    #[debug("hickory_server::Server<DnsHandler>")]
     server: hickory_server::Server<DnsHandler>,
 }
 

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -70,6 +70,7 @@ pub struct HttpsConfig {
 }
 
 /// The HTTP(S) server part of iroh-dns-server
+#[derive(Debug)]
 pub(crate) struct HttpServer {
     tasks: JoinSet<std::io::Result<()>>,
     http_addr: Option<SocketAddr>,

--- a/iroh-dns-server/src/http/tls.rs
+++ b/iroh-dns-server/src/http/tls.rs
@@ -45,7 +45,7 @@ impl CertMode {
     ) -> Result<TlsAcceptor> {
         Ok(match self {
             CertMode::Manual => TlsAcceptor::manual(domains, cert_cache).await?,
-            CertMode::SelfSigned => TlsAcceptor::self_signed(domains).await?,
+            CertMode::SelfSigned => TlsAcceptor::self_signed(domains)?,
             CertMode::LetsEncrypt => {
                 let contact =
                     letsencrypt_contact.context("contact is required for letsencrypt cert mode")?;
@@ -78,7 +78,7 @@ impl<I: AsyncRead + AsyncWrite + Unpin + Send + 'static, S: Send + 'static> Acce
 }
 
 impl TlsAcceptor {
-    async fn self_signed(domains: Vec<String>) -> Result<Self> {
+    fn self_signed(domains: Vec<String>) -> Result<Self> {
         let rcgen::CertifiedKey { cert, signing_key } =
             rcgen::generate_simple_self_signed(domains).anyerr()?;
         let key = PrivateKeyDer::try_from(signing_key.serialize_der())?;

--- a/iroh-dns-server/src/server.rs
+++ b/iroh-dns-server/src/server.rs
@@ -24,6 +24,7 @@ use crate::{
 /// Combines a DNS listener and an HTTP/HTTPS listener into a single handle.
 /// Construct with [`Self::bind`] and drive to completion with [`Self::join`], or
 /// stop the tasks with [`Self::shutdown`].
+#[derive(Debug)]
 pub struct Server {
     http_server: HttpServer,
     dns_server: DnsServer,


### PR DESCRIPTION
## Description

Now that 1.0 is stable we should run our semver checks against the
latest release, which is automatically found on crates.io. This also
means we can enable caching for it.

We do allow for adding deprecations, as per
https://semver.org/#how-should-i-handle-deprecating-functionality

## Breaking Changes

none

## Notes & open questions

- This matches the changes in noq: https://github.com/n0-computer/noq/pull/734

- When there's a semver change that requires a new minor version the
  check will fail. We will have to increment the version number in the
  PR that requires this from now on.

- iroh-dns-server didn't have the workspace lints enabled. I assume this was an
  oversight so added them. They are needed to pick up the semver config from
  the workspace Cargo.toml (there are some alternatives, but we want those lints).
  So this also fixes a few of the new lints and clippy warnings coming with that,
  luckily not much noise.

## Change checklist

- [x] Self-review.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.