### PR TITLE
deps: bump crossbeam-epoch for invalid pointer dereference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Description

Another cargo-deny warning we did just get.

## Breaking Changes

none

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.