### PR TITLE
deps: Upgrade to latest curve/ed25519-dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -968,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1323,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-rc.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -4599,6 +4600,9 @@ name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "simd_cesu8"

--- a/iroh-base/Cargo.toml
+++ b/iroh-base/Cargo.toml
@@ -15,10 +15,10 @@ rust-version = "1.91"
 workspace = true
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-rc.0", features = ["serde", "rand_core", "zeroize"], optional = true }
+curve25519-dalek = { version = "5", features = ["serde", "rand_core", "zeroize"], optional = true }
 data-encoding = { version = "2.6.0", optional = true }
 data-encoding-macro = { version = "0.1.19", optional = true }
-ed25519-dalek = { version = "=3.0.0-rc.0", features = ["serde", "rand_core", "zeroize"], optional = true }
+ed25519-dalek = { version = "3", features = ["serde", "rand_core", "zeroize"], optional = true }
 derive_more = { version = "2.0.1", features = ["debug", "display"], optional = true }
 url = { version = "2.5.3", features = ["serde"], optional = true }
 rand = { version = "0.10", optional = true }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -28,7 +28,7 @@ ctutils = { version = "0.4.0", default-features = false }
 data-encoding = "2.2"
 
 derive_more = { version = "2.0.1", features = ["debug", "display", "from", "try_into", "deref", "from_str", "into_iterator"] }
-ed25519-dalek = { version = "=3.0.0-rc.0", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
+ed25519-dalek = { version = "3", features = ["serde", "rand_core", "zeroize", "pkcs8", "pem"] }
 http = "1"
 ipnet = "2"
 iroh-base = { version = "1.0.2", default-features = false, features = ["key", "relay"], path = "../iroh-base" }


### PR DESCRIPTION
## Description

We just cut a new major release of `curve25519-dalek` and `ed25519-dalek`. This PR upgrades the deps from rc.0 to the new stable release.

## Breaking Changes

None

## Notes & open questions

None

## Change checklist
<!-- Remove any that are not relevant. -->
- [X] Self-review.
- [X] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [X] Tests if relevant.
- [X] All breaking changes documented.
- [X] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [X] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
