### PR TITLE
feat(iroh-dns): Improve error messages

### DIFF
--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -23,7 +23,7 @@ use hickory_resolver::{
     proto::rr::RData,
 };
 use iroh_base::EndpointId;
-use n0_error::{AnyError, StackError, StdResultExt, e, stack_error};
+use n0_error::{AnyError, StackError, StackErrorExt, StdResultExt, e, stack_error};
 use n0_future::{
     Either, MaybeFuture, Stream, StreamExt,
     boxed::BoxFuture,
@@ -80,7 +80,7 @@ pub type BoxIter<T> = Box<dyn Iterator<Item = T> + Send + 'static>;
 
 /// Potential errors related to DNS operations.
 #[allow(missing_docs)]
-#[stack_error(derive, add_meta, std_sources)]
+#[stack_error(derive, add_meta, from_sources, std_sources)]
 #[non_exhaustive]
 pub enum DnsError {
     #[error("Request timed out")]
@@ -95,29 +95,23 @@ pub enum DnsError {
     #[error("Missing host")]
     MissingHost {},
 
-    /// DEPRECATED since v1.1.0. Replaced by [`Self::Resolve2`].
-    // TODO: This triggers warnings in n0_error expansions. Fix in n0_error.
-    // #[deprecated(
-    //     since = "1.1.0",
-    //     note = "No longer constructed, replaced by DnsError::Resolve2"
-    // )]
-    #[error("Failed to resolve")]
-    Resolve {
-        // We keep the `from` here, because pre-1.1.0 the `stack_error` macro call on `DnsError` included
-        // `from_sources`, which expanded to `impl From<AnyError> for `DnsError`. The manual `from` impl
-        // here on the deprecated variant exists only to maintain backwards compatibility.
-        #[error(source, from)]
-        source: AnyError,
-    },
-    #[error("Failed to retrieve {kind} record for {host}")]
-    Resolve2 {
-        #[error(source)]
-        source: AnyError,
-        host: String,
-        kind: QueryKind,
-    },
+    #[error(transparent)]
+    Resolve { source: AnyError },
     #[error("Invalid DNS response: not a query for _iroh.z32encodedpubkey")]
     InvalidResponse {},
+}
+
+/// Error with details about the DNS query that caused it.
+///
+/// The `source` of [`DnsError::Resolve`] can be cast to this type via [`AnyError::downcast_ref`]
+/// to access the details programatically.
+#[stack_error(derive, add_meta)]
+#[error("Failed to retrieve {} record for {}", kind, host)]
+pub struct ErrorWithDetails {
+    #[error(source)]
+    source: AnyError,
+    host: String,
+    kind: QueryKind,
 }
 
 /// DNS query kind, for error reporting.
@@ -836,10 +830,13 @@ impl Resolver for HickoryResolver {
                 .await
                 .anyerr()
                 .map_err(|source| {
-                    e!(DnsError::Resolve2 {
-                        source,
-                        host,
-                        kind: QueryKind::A
+                    e!(DnsError::Resolve {
+                        source: e!(ErrorWithDetails {
+                            source,
+                            host,
+                            kind: QueryKind::A
+                        })
+                        .into_any()
                     })
                 })?;
             let iter: BoxIter<Ipv4Addr> =
@@ -861,10 +858,13 @@ impl Resolver for HickoryResolver {
                 .await
                 .anyerr()
                 .map_err(|source| {
-                    e!(DnsError::Resolve2 {
-                        source,
-                        host,
-                        kind: QueryKind::AAAA
+                    e!(DnsError::Resolve {
+                        source: e!(ErrorWithDetails {
+                            source,
+                            host,
+                            kind: QueryKind::AAAA
+                        })
+                        .into_any()
                     })
                 })?;
             let iter: BoxIter<Ipv6Addr> =
@@ -886,10 +886,13 @@ impl Resolver for HickoryResolver {
                 .await
                 .anyerr()
                 .map_err(|source| {
-                    e!(DnsError::Resolve2 {
-                        source,
-                        host,
-                        kind: QueryKind::TXT
+                    e!(DnsError::Resolve {
+                        source: e!(ErrorWithDetails {
+                            source,
+                            host,
+                            kind: QueryKind::TXT
+                        })
+                        .into_any()
                     })
                 })?;
             let iter: BoxIter<TxtRecordData> =

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -80,7 +80,7 @@ pub type BoxIter<T> = Box<dyn Iterator<Item = T> + Send + 'static>;
 
 /// Potential errors related to DNS operations.
 #[allow(missing_docs)]
-#[stack_error(derive, add_meta, from_sources, std_sources)]
+#[stack_error(derive, add_meta, std_sources)]
 #[non_exhaustive]
 pub enum DnsError {
     #[error("Request timed out")]
@@ -94,10 +94,45 @@ pub enum DnsError {
     },
     #[error("Missing host")]
     MissingHost {},
+
+    /// DEPRECATED since v1.1.0. Replaced by [`Self::Resolve2`].
+    // TODO: This triggers warnings in n0_error expansions. Fix in n0_error.
+    // #[deprecated(
+    //     since = "1.1.0",
+    //     note = "No longer constructed, replaced by DnsError::Resolve2"
+    // )]
     #[error("Failed to resolve")]
-    Resolve { source: AnyError },
+    Resolve {
+        // We keep the `from` here, because pre-1.1.0 the `stack_error` macro call on `DnsError` included
+        // `from_sources`, which expanded to `impl From<AnyError> for `DnsError`. The manual `from` impl
+        // here on the deprecated variant exists only to maintain backwards compatibility.
+        #[error(source, from)]
+        source: AnyError,
+    },
+    #[error("Failed to retrieve {kind} record for {host}")]
+    Resolve2 {
+        #[error(source)]
+        source: AnyError,
+        host: String,
+        kind: QueryKind,
+    },
     #[error("Invalid DNS response: not a query for _iroh.z32encodedpubkey")]
     InvalidResponse {},
+}
+
+/// DNS query kind, for error reporting.
+#[derive(Debug, derive_more::Display)]
+#[non_exhaustive]
+pub enum QueryKind {
+    /// A record (IPv4)
+    #[display("A")]
+    A,
+    /// AAAA record (IPv6)
+    #[display("AAAA")]
+    AAAA,
+    /// TXT record
+    #[display("TXT")]
+    TXT,
 }
 
 /// Potential errors related to DNS endpoint address lookups.
@@ -106,15 +141,16 @@ pub enum DnsError {
 #[stack_error(derive, add_meta, from_sources)]
 #[non_exhaustive]
 pub enum LookupError {
-    #[error("Malformed txt from lookup")]
+    #[error("Received malformed TXT record")]
     ParseError { source: ParseError },
-    #[error("Failed to resolve TXT record")]
+    #[error(transparent)]
     LookupFailed { source: DnsError },
 }
 
 /// Error returned when a staggered call fails.
 #[stack_error(derive, add_meta)]
-#[error("no calls succeeded: [{}]", errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(""))]
+#[error("{}", errors.first().map(|err| format!("{err:#}")).unwrap_or("all resolves failed".to_string()))]
+// #[error("no calls succeeded:\n{}", errors.iter().map(|(delay, e)| format!("[{delay:?}] {e:#}")).collect::<Vec<_>>().join("\n"))]
 pub struct StaggeredError<E: n0_error::StackError + 'static> {
     errors: Vec<E>,
 }
@@ -795,7 +831,17 @@ impl Resolver for HickoryResolver {
     fn lookup_ipv4(&self, host: String) -> BoxFuture<Result<BoxIter<Ipv4Addr>, DnsError>> {
         let resolver = self.resolver.clone();
         Box::pin(async move {
-            let lookup = resolver.ipv4_lookup(host).await.anyerr()?;
+            let lookup = resolver
+                .ipv4_lookup(host.clone())
+                .await
+                .anyerr()
+                .map_err(|source| {
+                    e!(DnsError::Resolve2 {
+                        source,
+                        host,
+                        kind: QueryKind::A
+                    })
+                })?;
             let iter: BoxIter<Ipv4Addr> =
                 Box::new(lookup.answers().to_vec().into_iter().filter_map(|record| {
                     match &record.data {
@@ -810,7 +856,17 @@ impl Resolver for HickoryResolver {
     fn lookup_ipv6(&self, host: String) -> BoxFuture<Result<BoxIter<Ipv6Addr>, DnsError>> {
         let resolver = self.resolver.clone();
         Box::pin(async move {
-            let lookup = resolver.ipv6_lookup(host).await.anyerr()?;
+            let lookup = resolver
+                .ipv6_lookup(host.clone())
+                .await
+                .anyerr()
+                .map_err(|source| {
+                    e!(DnsError::Resolve2 {
+                        source,
+                        host,
+                        kind: QueryKind::AAAA
+                    })
+                })?;
             let iter: BoxIter<Ipv6Addr> =
                 Box::new(lookup.answers().to_vec().into_iter().filter_map(|record| {
                     match &record.data {
@@ -825,7 +881,17 @@ impl Resolver for HickoryResolver {
     fn lookup_txt(&self, host: String) -> BoxFuture<Result<BoxIter<TxtRecordData>, DnsError>> {
         let resolver = self.resolver.clone();
         Box::pin(async move {
-            let lookup = resolver.txt_lookup(host).await.anyerr()?;
+            let lookup = resolver
+                .txt_lookup(host.clone())
+                .await
+                .anyerr()
+                .map_err(|source| {
+                    e!(DnsError::Resolve2 {
+                        source,
+                        host,
+                        kind: QueryKind::TXT
+                    })
+                })?;
             let iter: BoxIter<TxtRecordData> =
                 Box::new(lookup.answers().to_vec().into_iter().filter_map(|record| {
                     match &record.data {

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -906,9 +906,9 @@ pub struct Endpoint {
 pub enum ConnectWithOptsError {
     #[error("Connecting to ourself is not supported")]
     SelfConnect,
-    #[error("No addressing information available")]
+    #[error("Failed to resolve remote address")]
     NoAddress { source: AddressLookupFailed },
-    #[error("Unable to connect to remote")]
+    #[error("Failed to connect to remote")]
     Noq {
         #[error(std_err)]
         source: QuicConnectError,


### PR DESCRIPTION
## Description

This improves the error message we show when calling `endpoint.connect(endpoint_id, alpn)` without internet connectivity, or with DNS blocked or similar.

Before:
```
No addressing information available: All address lookup services failed or produced no results
    Service 'dns' failed: no calls succeeded: [Failed to resolve TXT recordFailed to resolve TXT recordFailed to resolve TXT recordFailed to resolve TXT recordFailed to resolve TXT
 recordFailed to resolve TXT recordFailed to resolve TXT record]
```

After:
```
Failed to resolve remote address: All address lookup services failed or produced no results
    Service 'dns' failed: Failed to retrieve TXT record for _iroh.38g86cenj4anit756ah78o5ea84nmfgsyhmn64ibxosgyc9jku8y.staging-dns.iroh.link.: no connections available
```


## Breaking Changes

None. 


## Notes & open questions

The `no connections available` at the end of the message is, unfortunately, all we get from hickory-resolver. This can be improved once we land #4036 

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
