### PR TITLE
fix: add pkarr resolver to n0 preset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -1511,7 +1511,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -1810,7 +1810,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.8",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -4672,18 +4672,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spinning_top"

--- a/iroh/src/endpoint/presets.rs
+++ b/iroh/src/endpoint/presets.rs
@@ -95,8 +95,9 @@ impl Preset for Minimal {
 /// The default address lookup service publishes to and resolves from the
 /// n0.computer dns server `iroh.link`.
 ///
-/// This is equivalent to adding both a [`crate::address_lookup::PkarrPublisher`]
-/// and a [`crate::address_lookup::DnsAddressLookup`], both configured to use the
+/// This is equivalent to adding a [`crate::address_lookup::PkarrPublisher`],
+/// a [`crate::address_lookup::PkarrResolver`], and (outside browsers) a
+/// [`crate::address_lookup::DnsAddressLookup`], all configured to use the
 /// n0.computer dns server.
 ///
 /// This will by default use [`N0_DNS_PKARR_RELAY_PROD`].
@@ -114,20 +115,19 @@ pub struct N0;
 #[cfg(with_crypto_provider)]
 impl Preset for N0 {
     fn apply(self, mut builder: Builder) -> Builder {
-        use crate::{address_lookup::PkarrPublisher, endpoint::default_relay_mode};
+        use crate::{
+            address_lookup::{PkarrPublisher, PkarrResolver},
+            endpoint::default_relay_mode,
+        };
 
         builder = Minimal.apply(builder);
 
         builder = builder.address_lookup(PkarrPublisher::n0_dns());
 
-        // Resolve using HTTPS requests to our DNS server's /pkarr path in browsers
-        #[cfg(wasm_browser)]
-        {
-            use crate::address_lookup::PkarrResolver;
+        // Resolve using HTTPS requests to our DNS server's /pkarr path.
+        builder = builder.address_lookup(PkarrResolver::n0_dns());
 
-            builder = builder.address_lookup(PkarrResolver::n0_dns());
-        }
-        // Resolve using DNS queries outside browsers.
+        // Additionally resolve using DNS queries outside browsers.
         #[cfg(not(wasm_browser))]
         {
             builder = builder.address_lookup(crate::address_lookup::DnsAddressLookup::n0_dns());
@@ -157,8 +157,9 @@ impl Preset for N0 {
 /// The default address lookup service publishes to and resolves from the
 /// n0.computer dns server `iroh.link`.
 ///
-/// This is equivalent to adding both a [`crate::address_lookup::PkarrPublisher`]
-/// and a [`crate::address_lookup::DnsAddressLookup`], both configured to use the
+/// This is equivalent to adding a [`crate::address_lookup::PkarrPublisher`],
+/// a [`crate::address_lookup::PkarrResolver`], and (outside browsers) a
+/// [`crate::address_lookup::DnsAddressLookup`], all configured to use the
 /// n0.computer dns server.
 ///
 /// This will by default use [`N0_DNS_PKARR_RELAY_PROD`].


### PR DESCRIPTION
## Description

Adds the PkarrResolver to the defaults in the n0 preset so we have a fallback in case DNS queries against dns.iroh.link are somehow blocked.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
