### PR TITLE
fix(socket): bound pending_open_paths to prevent unbounded memory growth

### DIFF
--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -1059,7 +1059,16 @@ impl State {
                     | Some(Err(PathError::MaxPathIdReached)) => {
                         self.scheduled_open_path =
                             Some(Instant::now() + Duration::from_millis(333));
-                        self.pending_open_paths.push_back(open_addr.clone());
+                        // Dedup before scheduling a retry. On a stuck connection
+                        // (persistent `RemoteCidsExhausted` / `MaxPathIdReached`) each
+                        // scheduled retry re-drives `open_path_on_all_conns`, which
+                        // re-attempts the addr on every connection, and each still-failing
+                        // connection pushes it again. Without this guard
+                        // `pending_open_paths` grows without bound (observed reaching
+                        // several GB and OOMing the host on a churning multipath link).
+                        if !self.pending_open_paths.contains(open_addr) {
+                            self.pending_open_paths.push_back(open_addr.clone());
+                        }
                         trace!(?open_addr, ?ret, "scheduling open_path");
                     }
                     _ => warn!(?ret, "Opening path failed"),


### PR DESCRIPTION
While running a long-lived iroh 1.0.1 endpoint (gossip + iroh-blobs) on a multi-interface host with a lossy uplink, the process footprint balloons from ~250 MB to multiple GB in ~60 s and OOMs, repeatedly.

## Root cause

`iroh::socket::remote_map::remote_state`:

- `open_path_on_conn` (remote_state.rs ~L1062): when opening a path fails with `RemoteCidsExhausted` / `MaxPathIdReached` — a *persistent* condition on a churning multipath connection — it schedules a 333 ms retry and `push_back`s the addr into `pending_open_paths` **with no dedup and no bound**.
- The retry (~L307) does `mem::take(&mut pending_open_paths)` and drains via `open_path_on_all_conns`, which re-attempts each addr on **every** connection, and each still-failing connection re-pushes it.

So on a stuck connection the same `FourTuple`s are enqueued faster than they drain (and multiplied per-connection), and the `VecDeque<FourTuple>` grows without bound.

## Evidence

`heaptrack` on an affected node (symbolized), peak consumers:

```
1.51 GB over 8824 calls:
  RawVec<iroh::socket::transports::FourTuple>::grow_one
   in VecDeque<...FourTuple>::grow
   in iroh::socket::remote_map::remote_state::State::open_path_on_conn
   in RemoteStateActor::run
next largest allocation: 55 MB
```

One call site, dominating everything else, climbing until OOM. Reproduces reliably on a host with several local interfaces (incl. dead/virtual ones) and a high-latency/lossy uplink, where paths flap and CIDs get exhausted.

## Fix

Guard the push with `contains()` so a path already queued for retry is not enqueued again. Distinct candidate paths per remote are a handful, so the `O(n)` check is cheap; the retry still fires — it just cannot accumulate duplicates.

```rust
if !self.pending_open_paths.contains(open_addr) {
    self.pending_open_paths.push_back(open_addr.clone());
}
```

Happy to adjust (e.g. a hard cap instead of / in addition to dedup, or logging when the stuck-CID condition persists) if you prefer a different shape. This is effectively an unbounded-growth / remote-triggerable OOM, so some bound seems worthwhile regardless.