### PR TITLE
feat(iroh-relay): Simplify embedding the relay server with a custom accept loop

### DIFF
--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -30,7 +30,7 @@ use std::{
 
 use derive_more::Debug;
 use http::{
-    HeaderMap, HeaderValue, Method, Request, Response, StatusCode,
+    HeaderValue, Method, Request, Response, StatusCode,
     header::{AUTHORIZATION, InvalidHeaderValue},
     response::Builder as ResponseBuilder,
 };
@@ -42,7 +42,6 @@ use iroh_base::RelayUrl;
 use n0_error::{e, stack_error};
 use n0_future::{StreamExt, task::AbortOnDropHandle};
 use rustls::server::WantsServerCert;
-use serde::Serialize;
 use tokio::{
     net::TcpListener,
     task::{JoinError, JoinSet},
@@ -56,7 +55,7 @@ use tracing::{Instrument, debug, error, info, info_span, instrument};
 use self::http_server::{BytesBody, HyperError, HyperResult};
 use crate::{
     defaults::DEFAULT_KEY_CACHE_CAPACITY,
-    http::{AUTH_TOKEN_URL_QUERY_PARAM, ProtocolVersion, RELAY_PROBE_PATH},
+    http::{AUTH_TOKEN_URL_QUERY_PARAM, ProtocolVersion},
     quic::server::{QuicServer, QuicSpawnError, ServerHandle as QuicServerHandle},
     tls::CaTlsConfig,
 };
@@ -71,7 +70,7 @@ pub mod streams;
 pub mod testing;
 
 pub use self::{
-    http_server::{Handlers, RelayService},
+    http_server::{Handlers, RelayService, relay_tls_headers},
     metrics::{Metrics, RelayMetrics},
     resolver::{DEFAULT_CERT_RELOAD_INTERVAL, reloading_resolver},
 };
@@ -79,23 +78,6 @@ pub use self::{
 const NO_CONTENT_CHALLENGE_HEADER: &str = "X-Iroh-Challenge";
 const NO_CONTENT_RESPONSE_HEADER: &str = "X-Iroh-Response";
 const NOTFOUND: &[u8] = b"Not Found";
-const ROBOTS_TXT: &[u8] = b"User-agent: *\nDisallow: /\n";
-const INDEX: &[u8] = br#"<html><body>
-<h1>Iroh Relay</h1>
-<p>
-  This is an <a href="https://iroh.computer/">Iroh</a> Relay server.
-</p>
-"#;
-const TLS_HEADERS: [(&str, &str); 2] = [
-    (
-        "Strict-Transport-Security",
-        "max-age=63072000; includeSubDomains",
-    ),
-    (
-        "Content-Security-Policy",
-        "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'",
-    ),
-];
 
 /// Creates a new [`BytesBody`] with no content.
 fn body_empty() -> BytesBody {
@@ -712,15 +694,6 @@ impl Server {
         let (relay_server, http_addr, tls_config) = match config.relay {
             Some(relay_config) => {
                 debug!("Starting Relay server");
-                let mut headers = HeaderMap::new();
-                for (name, value) in TLS_HEADERS.iter() {
-                    headers.insert(
-                        *name,
-                        value
-                            .parse()
-                            .map_err(|err| e!(SpawnError::TlsHeaderParse, err))?,
-                    );
-                }
                 let relay_bind_addr = match relay_config.tls {
                     Some(ref tls) => tls.https_bind_addr,
                     None => relay_config.http_bind_addr,
@@ -730,14 +703,10 @@ impl Server {
                     .unwrap_or(DEFAULT_KEY_CACHE_CAPACITY);
                 let mut builder = http_server::ServerBuilder::new(relay_bind_addr)
                     .metrics(metrics.server.clone())
-                    .headers(headers)
+                    .headers(http_server::relay_tls_headers())
                     .key_cache_capacity(key_cache_capacity)
                     .access(relay_config.access)
-                    .request_handler(Method::GET, "/", Box::new(root_handler))
-                    .request_handler(Method::GET, "/index.html", Box::new(root_handler))
-                    .request_handler(Method::GET, RELAY_PROBE_PATH, Box::new(probe_handler))
-                    .request_handler(Method::GET, "/robots.txt", Box::new(robots_handler))
-                    .request_handler(Method::GET, "/healthz", Box::new(healthz_handler));
+                    .handlers(http_server::Handlers::relay_defaults());
                 if let Some(cfg) = relay_config.limits.client_rx {
                     builder = builder.client_rx_ratelimit(cfg);
                 }
@@ -1014,41 +983,6 @@ async fn relay_supervisor(
     ret
 }
 
-fn root_handler(
-    _r: Request<Incoming>,
-    response: ResponseBuilder,
-) -> HyperResult<Response<BytesBody>> {
-    let body: BytesBody = Box::new(Full::from(INDEX));
-    response
-        .status(StatusCode::OK)
-        .header("Content-Type", "text/html; charset=utf-8")
-        .body(body)
-        .map_err(|err| Box::new(err) as HyperError)
-}
-
-/// HTTP latency queries
-fn probe_handler(
-    _r: Request<Incoming>,
-    response: ResponseBuilder,
-) -> HyperResult<Response<BytesBody>> {
-    response
-        .status(StatusCode::OK)
-        .header("Access-Control-Allow-Origin", "*")
-        .body(body_empty())
-        .map_err(|err| Box::new(err) as HyperError)
-}
-
-fn robots_handler(
-    _r: Request<Incoming>,
-    response: ResponseBuilder,
-) -> HyperResult<Response<BytesBody>> {
-    let body: BytesBody = Box::new(Full::from(ROBOTS_TXT));
-    response
-        .status(StatusCode::OK)
-        .body(body)
-        .map_err(|err| Box::new(err) as HyperError)
-}
-
 /// For captive portal detection.
 fn serve_no_content_handler<B: hyper::body::Body>(
     r: Request<B>,
@@ -1081,32 +1015,6 @@ fn is_challenge_char(c: char) -> bool {
         || c == '.'
         || c == '-'
         || c == '_'
-}
-
-/// Health check response
-#[derive(Serialize)]
-struct Health {
-    status: &'static str,
-    version: &'static str,
-    git_hash: &'static str,
-}
-
-fn healthz_handler(
-    _r: Request<Incoming>,
-    response: ResponseBuilder,
-) -> HyperResult<Response<BytesBody>> {
-    let health = Health {
-        status: "ok",
-        version: env!("CARGO_PKG_VERSION"),
-        git_hash: option_env!("VERGEN_GIT_SHA").unwrap_or("unknown"),
-    };
-    let body = serde_json::to_string(&health).unwrap_or_else(|_| r#"{"status":"error"}"#.into());
-    let body: BytesBody = Box::new(Full::from(body));
-    response
-        .status(StatusCode::OK)
-        .header("Content-Type", "application/json")
-        .body(body)
-        .map_err(|err| Box::new(err) as HyperError)
 }
 
 /// This is a future that never returns, drop it to cancel/abort.

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -413,6 +413,12 @@ impl ServerBuilder {
         self
     }
 
+    /// Sets the collection of custom request handlers, replacing any already set.
+    pub(super) fn handlers(mut self, handlers: Handlers) -> Self {
+        self.handlers = handlers;
+        self
+    }
+
     /// Adds a custom handler for a specific Method & URI.
     pub(super) fn request_handler(
         mut self,
@@ -1190,6 +1196,112 @@ impl std::ops::DerefMut for Handlers {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
+}
+
+impl Handlers {
+    /// The default relay HTTP endpoints served alongside relay traffic: a landing
+    /// page at `/` and `/index.html`, the latency probe at
+    /// [`RELAY_PROBE_PATH`](crate::http::RELAY_PROBE_PATH), `robots.txt`, and a
+    /// `/healthz` check.
+    ///
+    /// The batteries-included [`Server`](super::Server) installs these. A consumer
+    /// embedding [`RelayService`] with its own accept loop can start from here and
+    /// override or add entries through [`DerefMut`](std::ops::DerefMut) rather than
+    /// re-implementing them.
+    pub fn relay_defaults() -> Self {
+        let mut handlers = Self::default();
+        handlers.insert((Method::GET, "/"), Box::new(root_handler));
+        handlers.insert((Method::GET, "/index.html"), Box::new(root_handler));
+        handlers.insert(
+            (Method::GET, crate::http::RELAY_PROBE_PATH),
+            Box::new(probe_handler),
+        );
+        handlers.insert((Method::GET, "/robots.txt"), Box::new(robots_handler));
+        handlers.insert((Method::GET, "/healthz"), Box::new(healthz_handler));
+        handlers
+    }
+}
+
+const INDEX: &[u8] = br#"<html><body>
+<h1>Iroh Relay</h1>
+<p>
+  This is an <a href="https://iroh.computer/">Iroh</a> Relay server.
+</p>
+"#;
+const ROBOTS_TXT: &[u8] = b"User-agent: *\nDisallow: /\n";
+
+const RELAY_TLS_HEADERS: [(&str, &str); 2] = [
+    (
+        "Strict-Transport-Security",
+        "max-age=63072000; includeSubDomains",
+    ),
+    (
+        "Content-Security-Policy",
+        "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'",
+    ),
+];
+
+/// The security response headers a relay applies to every HTTP response: HSTS to
+/// pin HTTPS across the relay's subdomains and a strict CSP for the served pages.
+///
+/// The batteries-included [`Server`](super::Server) applies these; a consumer
+/// embedding [`RelayService`] passes them as its response headers so responses
+/// carry the same hardening.
+pub fn relay_tls_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for (name, value) in RELAY_TLS_HEADERS {
+        // The static values above are valid header values.
+        if let Ok(value) = HeaderValue::from_str(value) {
+            headers.insert(name, value);
+        }
+    }
+    headers
+}
+
+fn root_handler(_r: Request<Incoming>, response: ResponseBuilder) -> HyperResult<Response<BytesBody>> {
+    response
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/html; charset=utf-8")
+        .body(body_full(INDEX))
+        .map_err(|err| Box::new(err) as HyperError)
+}
+
+/// Latency probe; permissive CORS so it is reachable from a browser.
+fn probe_handler(
+    _r: Request<Incoming>,
+    response: ResponseBuilder,
+) -> HyperResult<Response<BytesBody>> {
+    response
+        .status(StatusCode::OK)
+        .header("Access-Control-Allow-Origin", "*")
+        .body(body_full(Bytes::new()))
+        .map_err(|err| Box::new(err) as HyperError)
+}
+
+fn robots_handler(
+    _r: Request<Incoming>,
+    response: ResponseBuilder,
+) -> HyperResult<Response<BytesBody>> {
+    response
+        .status(StatusCode::OK)
+        .body(body_full(ROBOTS_TXT))
+        .map_err(|err| Box::new(err) as HyperError)
+}
+
+fn healthz_handler(
+    _r: Request<Incoming>,
+    response: ResponseBuilder,
+) -> HyperResult<Response<BytesBody>> {
+    let body = format!(
+        r#"{{"status":"ok","version":"{}","git_hash":"{}"}}"#,
+        env!("CARGO_PKG_VERSION"),
+        option_env!("VERGEN_GIT_SHA").unwrap_or("unknown"),
+    );
+    response
+        .status(StatusCode::OK)
+        .header("Content-Type", "application/json")
+        .body(body_full(body))
+        .map_err(|err| Box::new(err) as HyperError)
 }
 
 /// Requires a future to complete before the specified duration elapses, unless the timeout is cleared.

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -1082,10 +1082,14 @@ impl RelayService {
         // established and handed to the relay protocol, clearing the timeout.
         let on_establish = Arc::new(Notify::new());
         let service = RelayServiceWithNotify::new(self, on_establish.clone());
-        let res = clearable_timeout(establish_timeout, on_establish, service.serve_connection(io))
-            .await
-            .map_err(|_elapsed| e!(ServeConnectionError::EstablishTimeout))
-            .flatten();
+        let res = clearable_timeout(
+            establish_timeout,
+            on_establish,
+            service.serve_connection(io),
+        )
+        .await
+        .map_err(|_elapsed| e!(ServeConnectionError::EstablishTimeout))
+        .flatten();
         Self::log_connection_result(res, &metrics);
     }
 
@@ -1258,7 +1262,10 @@ pub fn relay_tls_headers() -> HeaderMap {
     headers
 }
 
-fn root_handler(_r: Request<Incoming>, response: ResponseBuilder) -> HyperResult<Response<BytesBody>> {
+fn root_handler(
+    _r: Request<Incoming>,
+    response: ResponseBuilder,
+) -> HyperResult<Response<BytesBody>> {
     response
         .status(StatusCode::OK)
         .header("Content-Type", "text/html; charset=utf-8")

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -952,9 +952,10 @@ impl RelayService {
         &self.0.clients
     }
 
-    /// Handle the incoming connection.
+    /// Handle an incoming connection.
     ///
-    /// If a `tls_config` is given, will serve the connection using HTTPS, otherwise HTTP.
+    /// This function takes a [`TcpStream`], terminates TLS, and then serves the connection
+    /// as HTTP(S).
     ///
     /// If the connection did not fully upgrade to a relay WebSocket connection after
     /// `establish_timeout`, the connection is aborted.
@@ -1047,6 +1048,44 @@ impl RelayService {
             .map_err(|_elapsed| e!(ServeConnectionError::EstablishTimeout))
             .flatten();
 
+        Self::log_connection_result(res, &metrics);
+    }
+
+    /// Serves an already-established connection as a relay connection.
+    ///
+    /// Runs the HTTP/1 serve loop with WebSocket upgrades, the relay protocol
+    /// handshake and authentication, and the per-client send/recv loop, over a
+    /// stream whose transport the caller has already established (TLS-terminated
+    /// via [`MaybeTlsStream::tls`] or plain via [`MaybeTlsStream::plain`]).
+    ///
+    /// `establish_timeout` limits the time until the WebSocket upgrade must have
+    /// completed. If the time limit is exceeded, the connection is aborted.
+    /// Once the WebSocket upgrade has completed, the timeout is cleared.
+    ///
+    /// Use this when running a custom accept loop and TLS termination -- for
+    /// example to supply a custom [`rustls`] cert resolver or ALPN handling -- while
+    /// reusing the relay protocol serving. For the batteries-included path that
+    /// also terminates TLS from a raw [`TcpStream`], see
+    /// [`handle_connection`](Self::handle_connection).
+    ///
+    /// [`rustls`]: https://docs.rs/rustls
+    pub async fn serve_connection(self, io: MaybeTlsStream, establish_timeout: Duration) {
+        let metrics = self.0.metrics.clone();
+        metrics.http_connections.inc();
+        // The notification token is triggered once the connection is fully
+        // established and handed to the relay protocol, clearing the timeout.
+        let on_establish = Arc::new(Notify::new());
+        let service = RelayServiceWithNotify::new(self, on_establish.clone());
+        let res = clearable_timeout(establish_timeout, on_establish, service.serve_connection(io))
+            .await
+            .map_err(|_elapsed| e!(ServeConnectionError::EstablishTimeout))
+            .flatten();
+        Self::log_connection_result(res, &metrics);
+    }
+
+    /// Logs the outcome of a served connection: the common peer-disconnect cases
+    /// are downgraded to debug, genuine failures are counted and logged.
+    fn log_connection_result(res: Result<(), ServeConnectionError>, metrics: &Metrics) {
         metrics.http_connections_closed.inc();
 
         if let Err(error) = res {

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -202,6 +202,30 @@ pub enum MaybeTlsStream {
 }
 
 impl MaybeTlsStream {
+    /// Wraps a plain, un-encrypted [`tokio::net::TcpStream`].
+    ///
+    /// For callers that run their own accept loop and hand the accepted stream to
+    /// [`RelayService::serve_connection`]. The enum is `#[non_exhaustive]`, so this
+    /// constructor is the way to build one outside the crate.
+    ///
+    /// [`RelayService::serve_connection`]: super::http_server::RelayService::serve_connection
+    pub fn plain(stream: tokio::net::TcpStream) -> Self {
+        Self::Plain(stream)
+    }
+
+    /// Wraps a TLS stream a caller has already terminated over a
+    /// [`tokio::net::TcpStream`].
+    ///
+    /// For callers that terminate TLS themselves (e.g. to supply their own cert
+    /// resolver or ALPN handling) and hand the decrypted stream to
+    /// [`RelayService::serve_connection`]. The enum is `#[non_exhaustive]`, so this
+    /// constructor is the way to build one outside the crate.
+    ///
+    /// [`RelayService::serve_connection`]: super::http_server::RelayService::serve_connection
+    pub fn tls(stream: tokio_rustls::server::TlsStream<tokio::net::TcpStream>) -> Self {
+        Self::Tls(stream)
+    }
+
     /// Tries to disable the nagle algorithm on the TCP stream.
     ///
     /// This sets the NO_DELAY option on the TCP stream, which turns off the


### PR DESCRIPTION
## Description

* Expose the default handlers iroh-relay has (index, /healthz, /ping)
* Expose the set of HTTP headers we set in all replies
* Expose a fn `RelayService::serve_connection` that takes a TLS-terminated stream and handles the full upgrade from there

## Breaking Changes

None

## Notes & open questions

* This makes it easier to embed iroh-relay while doing your own accept loop.
* Draft for now until I fully validate this with the svc-relay work

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
