### PR TITLE
chore(ci): make sure android cleans up after itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,11 @@ jobs:
       # Replace cargo-ndk-runner with a wrapper that forwards RUST_LOG
       # and RUST_BACKTRACE into the emulator shell. The upstream binary
       # does `adb shell <bin>` without inheriting any host env.
+      #
+      # The wrapper also removes each binary from the guest once it has run.
+      # A full run pushes ~1.25GB of debug test binaries into /data/local/tmp
+      # and the guest data partition is only ~5.8GB, so leaving them behind
+      # accumulates across jobs (see the sweep in the emulator script below).
       - name: Wrap cargo-ndk-runner to forward logging env
         if: matrix.target == 'x86_64-linux-android'
         run: |
@@ -153,7 +158,11 @@ jobs:
           adb push "$1" "$dev" >/dev/null
           adb shell chmod 755 "$dev"
           shift
+          set +e
           adb shell "RUST_LOG=$RUST_LOG RUST_BACKTRACE=$RUST_BACKTRACE $dev $*"
+          rc=$?
+          adb shell rm -f "$dev" >/dev/null 2>&1
+          exit $rc
           WRAPPER
           chmod +x "$(which cargo-ndk-runner)"
 
@@ -220,6 +229,15 @@ jobs:
             adb shell sysctl -w net.ipv6.conf.default.disable_ipv6=1 || true
             adb shell sysctl -w net.ipv6.conf.lo.disable_ipv6=1 || true
             adb shell ip addr
+            # Sweep leftover test binaries out of the guest. `force-avd-creation: false`
+            # keeps the AVD between jobs, and `-no-snapshot` only disables the *RAM*
+            # quickboot snapshot - the userdata qcow2 overlay still persists on disk. A
+            # job that is cancelled or times out leaves its pushed binaries behind, so
+            # without this they accumulate until /data (~5.8G) fills and every `adb push`
+            # fails with ENOSPC. The runner wrapper deletes binaries as it goes; this
+            # catches what it could not.
+            adb shell 'rm -rf /data/local/tmp/*' || true
+            adb shell df -h /data
             cargo ndk test -p iroh-base --all-features
             cargo ndk test -p iroh-dns --features tls-ring
             cargo ndk test -p iroh-relay --features tls-ring,metrics


### PR DESCRIPTION
## Description

The android QEMU VM at creation time was set to the default 6GB which means all android runners got only that for their work. While the VM is recreated on every run, the disk is just re-mounted and not really cleaned up well afterwards.

This should claw back some headroom to work on it. In case it's an issue again we need to go onto all the relevant CI boxes and adjust the config for the disk image and wipe/recreate it.

Tested all the above manually on the linux ci instance 3.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
