### PR TITLE
ci: run daily jobs earlier & run patchbay in merge queue

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -4,8 +4,8 @@ name: Beta Rust
 
 on:
   schedule:
-    # 06:50 UTC every Monday
-    - cron: '50 6 * * 1'
+    # 04:50 UTC every Monday
+    - cron: '50 4 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -23,7 +23,7 @@ on:
   pull_request:
     types: [ 'labeled', 'unlabeled', 'opened', 'synchronize', 'reopened' ]
   schedule:
-    # 06:30 UTC every day
+    # 04:30 UTC every day
     - cron: '30 6 * * *'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/patchbay.yml
+++ b/.github/workflows/patchbay.yml
@@ -2,6 +2,7 @@ name: Patchbay Tests
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
## Description

This runs the daily jobs earlier because they eat into the entire
Europe morning right now. Which slows down development work a lot.

Also runs patchbay tests in the merge queue, we probably want those to
be required.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.

<!-- Message of single commit: -->