### PR TITLE
fix(iroh): error when connecting with an empty ALPN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2216,7 @@ dependencies = [
 name = "iroh"
 version = "1.0.2"
 dependencies = [
+ "assert_matches",
  "axum",
  "backon",
  "blake3",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -105,6 +105,7 @@ chrono = "0.4.43"
 
 # *non*-wasm-in-browser test/dev dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
+assert_matches = "1.5.0"
 axum = { version = "0.8" }
 pretty_assertions = "1.4"
 rand_chacha = "0.10"

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1997,7 +1997,6 @@ fn is_cgi() -> bool {
 #[cfg(all(test, with_crypto_provider))]
 mod tests {
     use std::{
-        assert_matches,
         collections::BTreeMap,
         io,
         net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},
@@ -2006,6 +2005,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
+    use assert_matches::assert_matches;
     use iroh_base::{EndpointAddr, EndpointId, RelayUrl, SecretKey, TransportAddr};
     use iroh_dns::endpoint_info::UserData;
     use iroh_relay::{RelayConfig, RelayQuicConfig, server::Access, tls::CaTlsConfig};

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1997,6 +1997,7 @@ fn is_cgi() -> bool {
 #[cfg(all(test, with_crypto_provider))]
 mod tests {
     use std::{
+        assert_matches,
         collections::BTreeMap,
         io,
         net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},
@@ -2047,6 +2048,31 @@ mod tests {
         assert!(res.is_err());
         let err = res.err().unwrap();
         assert!(err.to_string().starts_with("Connecting to ourself"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_connect_empty_alpn() -> Result {
+        let server = Endpoint::builder(presets::Minimal)
+            .alpns(vec![TEST_ALPN.to_vec()])
+            .bind()
+            .await
+            .unwrap();
+        let server_addr = server.addr();
+
+        let client = Endpoint::builder(presets::Minimal).bind().await.unwrap();
+        let res = client.connect(server_addr, b"").await;
+        assert!(res.is_err());
+        let err = res.err().unwrap();
+        assert_matches!(
+            err,
+            ConnectError::Connect {
+                source: ConnectWithOptsError::InvalidAlpn { .. },
+                ..
+            }
+        );
 
         Ok(())
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -922,6 +922,8 @@ pub enum ConnectWithOptsError {
     LocallyRejected,
     #[error("Endpoint is closed")]
     EndpointClosed,
+    #[error("Incalid ALPN")]
+    InvalidAlpn,
 }
 
 #[allow(missing_docs)]
@@ -1110,6 +1112,7 @@ impl Endpoint {
 
         // Connecting to ourselves is not supported.
         ensure!(endpoint_id != self.id(), ConnectWithOptsError::SelfConnect);
+        ensure!(!alpn.is_empty(), ConnectWithOptsError::InvalidAlpn);
 
         event!(
             target: "iroh::_events::conn::connecting",

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -922,7 +922,7 @@ pub enum ConnectWithOptsError {
     LocallyRejected,
     #[error("Endpoint is closed")]
     EndpointClosed,
-    #[error("Incalid ALPN")]
+    #[error("Invalid ALPN")]
     InvalidAlpn,
 }
 


### PR DESCRIPTION
## Description

When using connect with an empty ALPN rustls throws a panic from
somewhere strange. Catch this early.

Part of #4423 

## Breaking Changes

n/a

## Notes & open questions

When testing what the server does when you connect to it when it has
an empty alpn configured I ran into other yaks... I'll get there but
it'll take a while. Let's do the client in the meantime.

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.