### PR TITLE
feat(iroh-relay)!: bind challenge-response handshake to relay hostname

### DIFF
--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -359,6 +359,7 @@ impl ClientBuilder {
             self.key_cache.clone(),
             &self.secret_key,
             protocol_version,
+            &self.url,
         )
         .await?;
 
@@ -431,6 +432,7 @@ impl ClientBuilder {
             self.key_cache.clone(),
             &self.secret_key,
             protocol_version,
+            &self.url,
         )
         .await?;
 

--- a/iroh-relay/src/client/conn.rs
+++ b/iroh-relay/src/client/conn.rs
@@ -7,7 +7,7 @@ use std::{
     task::{Context, Poll, ready},
 };
 
-use iroh_base::SecretKey;
+use iroh_base::{RelayUrl, SecretKey};
 use n0_error::{AnyError, anyerr, ensure, stack_error};
 use n0_future::{Sink, Stream};
 use tracing::trace;
@@ -89,12 +89,12 @@ impl Conn {
         key_cache: KeyCache,
         secret_key: &SecretKey,
         protocol_version: ProtocolVersion,
+        relay_url: &RelayUrl,
     ) -> Result<Self, handshake::Error> {
         let mut conn = WsBytesFramed { io };
 
-        // exchange information with the server
         trace!("server_handshake: started");
-        handshake::clientside(&mut conn, secret_key).await?;
+        handshake::clientside(&mut conn, secret_key, relay_url).await?;
         trace!("server_handshake: done");
 
         Ok(Self {

--- a/iroh-relay/src/protos/handshake.rs
+++ b/iroh-relay/src/protos/handshake.rs
@@ -33,7 +33,7 @@ use data_encoding::BASE32HEX_NOPAD as HEX;
 use http::HeaderValue;
 #[cfg(feature = "server")]
 use iroh_base::Signature;
-use iroh_base::{PublicKey, SecretKey};
+use iroh_base::{PublicKey, RelayUrl, SecretKey};
 use n0_error::{AnyError, anyerr, e, ensure, stack_error};
 use n0_future::{SinkExt, TryStreamExt};
 #[cfg(feature = "server")]
@@ -207,32 +207,46 @@ impl ServerChallenge {
     }
 
     /// The actual message bytes to sign (and verify against) for this challenge.
-    fn message_to_sign(&self) -> [u8; 32] {
-        // We're signing a key instead of the direct challenge.
-        // This gives us domain separation protecting from multiple possible attacks,
-        // but especially this one:
-        // Assume a malicious relay. If the protocol required the client to sign the
-        // challenge directly, this would allow the relay to obtain an arbitrary 16-byte
-        // signature, if it maliciously choses the challenge instead of generating it
-        // randomly.
-        // Deriving a key to sign instead mitigates this attack.
-        blake3::derive_key(DOMAIN_SEP_CHALLENGE, &self.challenge)
+    fn message_to_sign(&self, relay_url: &RelayUrl) -> [u8; 32] {
+        // Derive a signing key from the challenge rather than signing it
+        // directly. This gives domain separation: a malicious relay can't obtain
+        // arbitrary signatures by choosing specific challenge bytes.
+        // Including the relay hostname also binds the challenge to a specific
+        // relay, preventing cross-relay authentication proxying.
+        let host = relay_url
+            .host_str()
+            .expect("RelayUrl must have a host")
+            .to_ascii_lowercase();
+        let mut hasher = blake3::Hasher::new_derive_key(DOMAIN_SEP_CHALLENGE);
+        hasher.update(&self.challenge);
+        hasher.update(host.as_bytes());
+        hasher.finalize().into()
     }
 }
 
 impl ClientAuth {
     /// Generates a signature for the given challenge from the server.
-    pub(crate) fn new(secret_key: &SecretKey, challenge: &ServerChallenge) -> Self {
+    pub(crate) fn new(
+        secret_key: &SecretKey,
+        challenge: &ServerChallenge,
+        relay_url: &RelayUrl,
+    ) -> Self {
         Self {
             public_key: secret_key.public(),
-            signature: secret_key.sign(&challenge.message_to_sign()).to_bytes(),
+            signature: secret_key
+                .sign(&challenge.message_to_sign(relay_url))
+                .to_bytes(),
         }
     }
 
-    /// Verifies this client's authentication given the challenge this was sent in response to.
+    /// Verifies this client's authentication given the challenge and relay URL.
     #[cfg(feature = "server")]
-    pub(crate) fn verify(&self, challenge: &ServerChallenge) -> Result<(), Box<VerificationError>> {
-        let message = challenge.message_to_sign();
+    pub(crate) fn verify(
+        &self,
+        challenge: &ServerChallenge,
+        relay_url: &RelayUrl,
+    ) -> Result<(), Box<VerificationError>> {
+        let message = challenge.message_to_sign(relay_url);
         self.public_key
             .verify(&message, &Signature::from_bytes(&self.signature))
             .map_err(|err| {
@@ -340,6 +354,7 @@ impl KeyMaterialClientAuth {
 pub(crate) async fn clientside(
     io: &mut (impl BytesStreamSink + ExportKeyingMaterial),
     secret_key: &SecretKey,
+    relay_url: &RelayUrl,
 ) -> Result<ServerConfirmsAuth, Error> {
     let (tag, frame) = read_frame(
         io,
@@ -354,7 +369,7 @@ pub(crate) async fn clientside(
     let (tag, frame) = if tag == ServerChallenge::TAG {
         let challenge: ServerChallenge = deserialize_frame(frame)?;
 
-        let client_info = ClientAuth::new(secret_key, &challenge);
+        let client_info = ClientAuth::new(secret_key, &challenge, relay_url);
         write_frame(io, client_info).await?;
 
         read_frame(io, &[ServerConfirmsAuth::TAG, ServerDeniesAuth::TAG]).await?
@@ -421,6 +436,7 @@ pub enum Mechanism {
 pub async fn serverside(
     io: &mut (impl BytesStreamSink + ExportKeyingMaterial),
     client_auth_header: Option<HeaderValue>,
+    relay_url: &RelayUrl,
 ) -> Result<SuccessfulAuthentication, Error> {
     if let Some(client_auth_header) = client_auth_header {
         let client_auth_bytes = data_encoding::BASE64URL_NOPAD
@@ -455,7 +471,7 @@ pub async fn serverside(
     let (_, frame) = read_frame(io, &[ClientAuth::TAG]).await?;
     let client_auth: ClientAuth = deserialize_frame(frame)?;
 
-    if let Err(err) = client_auth.verify(&challenge) {
+    if let Err(err) = client_auth.verify(&challenge, relay_url) {
         trace!(?client_auth.public_key, ?err, "authentication failed");
         let denial = ServerDeniesAuth {
             reason: "signature invalid".into(),
@@ -606,7 +622,7 @@ fn deserialize_frame<F: Frame + serde::de::DeserializeOwned>(frame: Bytes) -> Re
 #[cfg(all(test, feature = "server"))]
 mod tests {
     use bytes::BytesMut;
-    use iroh_base::{PublicKey, SecretKey};
+    use iroh_base::{PublicKey, RelayUrl, SecretKey};
     use n0_error::{AnyError, Result, StackResultExt, StdResultExt};
     use n0_future::{Sink, SinkExt, Stream, TryStreamExt};
     use n0_tracing_test::traced_test;
@@ -702,6 +718,7 @@ mod tests {
         server_shared_secret: Option<u64>,
         restricted_to: Option<PublicKey>,
     ) -> (Result<ServerConfirmsAuth>, Result<(PublicKey, Mechanism)>) {
+        let relay_url: RelayUrl = "https://relay.example.com".parse().unwrap();
         let (client, server) = tokio::io::duplex(1024);
 
         let mut client_io = Framed::new(client, LengthDelimitedCodec::new())
@@ -720,13 +737,13 @@ mod tests {
 
         n0_future::future::zip(
             async {
-                super::clientside(&mut client_io, secret_key)
+                super::clientside(&mut client_io, secret_key, &relay_url)
                     .await
                     .context("clientside")
             }
             .instrument(info_span!("clientside")),
             async {
-                let auth_n = super::serverside(&mut server_io, client_auth_header)
+                let auth_n = super::serverside(&mut server_io, client_auth_header, &relay_url)
                     .await
                     .context("serverside")?;
                 let mechanism = auth_n.mechanism;
@@ -845,13 +862,15 @@ mod tests {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
         let secret_key = SecretKey::from_bytes(&rng.random());
         let challenge = ServerChallenge::new(&mut rng);
-        let client_auth = ClientAuth::new(&secret_key, &challenge);
+        let relay_url: RelayUrl = "https://relay.example.com".parse().unwrap();
+        let client_auth = ClientAuth::new(&secret_key, &challenge, &relay_url);
 
         let bytes = postcard::to_allocvec(&client_auth).anyerr()?;
         let decoded: ClientAuth = postcard::from_bytes(&bytes).anyerr()?;
 
         assert_eq!(client_auth.public_key, decoded.public_key);
         assert_eq!(client_auth.signature, decoded.signature);
+        assert!(client_auth.verify(&challenge, &relay_url).is_ok());
 
         Ok(())
     }
@@ -883,9 +902,25 @@ mod tests {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
         let secret_key = SecretKey::from_bytes(&rng.random());
         let challenge = ServerChallenge::new(&mut rng);
-        let client_auth = ClientAuth::new(&secret_key, &challenge);
-        assert!(client_auth.verify(&challenge).is_ok());
+        let relay_url: RelayUrl = "https://relay.example.com".parse().unwrap();
+        let client_auth = ClientAuth::new(&secret_key, &challenge, &relay_url);
+        assert!(client_auth.verify(&challenge, &relay_url).is_ok());
 
+        Ok(())
+    }
+
+    /// Verifies that the challenge-response handshake binds to the relay URL.
+    /// A ClientAuth signed for one relay must not be valid on another.
+    #[test]
+    fn test_challenge_relay_binding() -> Result {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
+        let secret_key = SecretKey::from_bytes(&rng.random());
+        let honest_url: RelayUrl = "https://honest.example.com".parse().unwrap();
+        let malicious_url: RelayUrl = "https://malicious.example.com".parse().unwrap();
+        let challenge_h = ServerChallenge::new(&mut rng);
+        let client_auth = ClientAuth::new(&secret_key, &challenge_h, &malicious_url);
+        assert!(client_auth.verify(&challenge_h, &malicious_url).is_ok());
+        assert!(client_auth.verify(&challenge_h, &honest_url).is_err());
         Ok(())
     }
 

--- a/iroh-relay/src/server.rs
+++ b/iroh-relay/src/server.rs
@@ -37,7 +37,6 @@ use http::{
 use http_body_util::Full;
 use hyper::body::Incoming;
 use iroh_base::EndpointId;
-#[cfg(feature = "test-utils")]
 use iroh_base::RelayUrl;
 use n0_error::{e, stack_error};
 use n0_future::{StreamExt, task::AbortOnDropHandle};
@@ -144,6 +143,11 @@ pub struct RelayConfig {
     pub key_cache_capacity: Option<usize>,
     /// Access control for incoming connections.
     pub access: Arc<dyn DynAccessControl>,
+    /// Canonical URL clients use to reach this relay, for challenge-response binding.
+    ///
+    /// When `None`, derived from the bind address. Required when clients connect
+    /// via a hostname that differs from the bind address (e.g. behind a proxy).
+    pub relay_url: Option<RelayUrl>,
 }
 
 impl RelayConfig {
@@ -159,6 +163,7 @@ impl RelayConfig {
             limits: Limits::default(),
             key_cache_capacity: None,
             access: Arc::new(AllowAll),
+            relay_url: None,
         }
     }
 }
@@ -729,6 +734,16 @@ impl Server {
                     .key_cache_capacity
                     .unwrap_or(DEFAULT_KEY_CACHE_CAPACITY);
                 let mut builder = http_server::ServerBuilder::new(relay_bind_addr)
+                    .relay_url(relay_config.relay_url.clone().unwrap_or_else(|| {
+                        let scheme = if relay_config.tls.is_some() {
+                            "https"
+                        } else {
+                            "http"
+                        };
+                        format!("{scheme}://{relay_bind_addr}")
+                            .parse()
+                            .expect("valid relay url")
+                    }))
                     .metrics(metrics.server.clone())
                     .headers(headers)
                     .key_cache_capacity(key_cache_capacity)
@@ -1609,8 +1624,10 @@ mod tests {
     #[traced_test]
     async fn test_relay_client_falls_back_to_ipv4() -> Result {
         // A relay reachable only over IPv4.
+        let mut relay_config = RelayConfig::new((Ipv4Addr::LOCALHOST, 0));
+        relay_config.relay_url = Some("http://relay.test".parse().unwrap());
         let config = ServerConfig {
-            relay: Some(RelayConfig::new((Ipv4Addr::LOCALHOST, 0))),
+            relay: Some(relay_config),
             ..Default::default()
         };
         let server = Server::spawn(config).await?;

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -21,6 +21,7 @@ use hyper::{
     service::Service,
     upgrade::Upgraded,
 };
+use iroh_base::RelayUrl;
 use n0_error::{e, ensure, stack_error};
 use n0_future::MaybeFuture;
 use tokio::{
@@ -354,6 +355,7 @@ pub(super) struct ServerBuilder {
     access: Arc<dyn DynAccessControl>,
     metrics: Option<Arc<Metrics>>,
     establish_timeout: Duration,
+    relay_url: RelayUrl,
 }
 
 impl ServerBuilder {
@@ -361,6 +363,7 @@ impl ServerBuilder {
     pub(super) fn new(addr: SocketAddr) -> Self {
         Self {
             addr,
+            relay_url: "http://127.0.0.1".parse().expect("valid URL"),
             tls_config: None,
             handlers: Default::default(),
             headers: HeaderMap::new(),
@@ -438,6 +441,12 @@ impl ServerBuilder {
         self
     }
 
+    /// Sets the relay's canonical URL, used for challenge binding.
+    pub(super) fn relay_url(mut self, url: RelayUrl) -> Self {
+        self.relay_url = url;
+        self
+    }
+
     /// Builds and spawns an HTTP(S) Relay Server.
     pub(super) async fn spawn(self) -> Result<Server, SpawnError> {
         let cancel_token = CancellationToken::new();
@@ -449,6 +458,7 @@ impl ServerBuilder {
             KeyCache::new(self.key_cache_capacity),
             self.access,
             self.metrics.unwrap_or_default(),
+            self.relay_url,
         );
 
         let addr = self.addr;
@@ -536,6 +546,7 @@ struct Inner {
     key_cache: KeyCache,
     access: Arc<dyn DynAccessControl>,
     metrics: Arc<Metrics>,
+    relay_url: RelayUrl,
 }
 
 #[stack_error(derive, add_meta)]
@@ -697,6 +708,7 @@ impl RelayServiceWithNotify {
 /// #         streams::MaybeTlsStream
 /// #     },
 /// # };
+/// # use iroh_base::RelayUrl;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let service = RelayService::new(
 ///     Handlers::default(),
@@ -705,6 +717,7 @@ impl RelayServiceWithNotify {
 ///     KeyCache::new(1024),
 ///     Arc::new(AllowAll),
 ///     Arc::new(Metrics::default()),
+///     "http://127.0.0.1".parse().unwrap(),
 /// );
 /// let service = RelayServiceWithNotify::new(service, Arc::new(Notify::new()));
 ///
@@ -865,7 +878,8 @@ impl Inner {
         let mut io = WsBytesFramed { io: websocket };
 
         let client_auth_header = request_parts.headers.get(CLIENT_AUTH_HEADER).cloned();
-        let authentication = handshake::serverside(&mut io, client_auth_header).await?;
+        let authentication =
+            handshake::serverside(&mut io, client_auth_header, &self.relay_url).await?;
 
         trace!(?authentication.mechanism, "accept: verified authentication");
 
@@ -918,6 +932,7 @@ impl RelayService {
         key_cache: KeyCache,
         access: Arc<dyn DynAccessControl>,
         metrics: Arc<Metrics>,
+        relay_url: RelayUrl,
     ) -> Self {
         Self(Arc::new(Inner {
             handlers,
@@ -928,6 +943,7 @@ impl RelayService {
             key_cache,
             access,
             metrics,
+            relay_url,
         }))
     }
 
@@ -965,6 +981,7 @@ impl RelayService {
     /// # use std::{sync::Arc, time::Duration};
     /// # use tokio::net::TcpStream;
     /// # use http::HeaderMap;
+    /// # use iroh_base::RelayUrl;
     /// # use iroh_relay::server::http_server::{Handlers, RelayService, TlsConfig};
     /// # use iroh_relay::{KeyCache, server::{AllowAll, Metrics}};
     /// # use webpki_types::{CertificateDer, PrivateKeyDer};
@@ -981,6 +998,7 @@ impl RelayService {
     ///     key_cache,
     ///     Arc::new(AllowAll),
     ///     metrics,
+    ///     "https://localhost".parse().unwrap(),
     /// );
     ///
     /// // Generate a self-signed certificate for HTTPS
@@ -1471,7 +1489,15 @@ mod tests {
     async fn make_test_client(client: tokio::io::DuplexStream, key: &SecretKey) -> Result<Conn> {
         let client = crate::client::streams::MaybeTlsStream::Test(client);
         let client = tokio_websockets::ClientBuilder::new().take_over(client);
-        let client = Conn::new(client, KeyCache::test(), key, Default::default()).await?;
+        let relay_url: RelayUrl = "http://127.0.0.1".parse().unwrap();
+        let client = Conn::new(
+            client,
+            KeyCache::test(),
+            key,
+            Default::default(),
+            &relay_url,
+        )
+        .await?;
         Ok(client)
     }
 
@@ -1489,6 +1515,7 @@ mod tests {
             KeyCache::test(),
             Arc::new(crate::server::AllowAll),
             metrics.clone(),
+            "http://127.0.0.1".parse().unwrap(),
         );
 
         info!("Create client A and connect it to the server.");
@@ -1601,6 +1628,7 @@ mod tests {
             KeyCache::test(),
             Arc::new(crate::server::AllowAll),
             Default::default(),
+            "http://127.0.0.1".parse().unwrap(),
         );
 
         info!("Create client A and connect it to the server.");

--- a/iroh-relay/src/server/testing.rs
+++ b/iroh-relay/src/server/testing.rs
@@ -57,6 +57,7 @@ pub fn relay_config() -> RelayConfig {
         limits: Default::default(),
         key_cache_capacity: Some(1024),
         access: Arc::new(AllowAll),
+        relay_url: None,
     }
 }
 

--- a/iroh-relay/tests/relay_axum.rs
+++ b/iroh-relay/tests/relay_axum.rs
@@ -54,6 +54,7 @@ struct RelayState {
     access: Arc<dyn DynAccessControl>,
     metrics: Arc<Metrics>,
     clients: Clients,
+    relay_url: RelayUrl,
 }
 
 impl RelayState {
@@ -63,6 +64,7 @@ impl RelayState {
             access: Arc::new(AllowAll),
             metrics: Arc::new(Metrics::default()),
             clients: Clients::default(),
+            relay_url: "http://127.0.0.1".parse().unwrap(),
         }
     }
 }
@@ -184,7 +186,8 @@ async fn handle_relay_websocket(
     client_auth_header: Option<http::HeaderValue>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut adapter = AxumWebSocketAdapter::new(socket);
-    let authentication = handshake::serverside(&mut adapter, client_auth_header).await?;
+    let authentication =
+        handshake::serverside(&mut adapter, client_auth_header, &state.relay_url).await?;
     trace!(?authentication.mechanism, "verified authentication");
 
     let request = ClientRequest::new(

--- a/iroh-relay/tests/relay_hyper.rs
+++ b/iroh-relay/tests/relay_hyper.rs
@@ -61,6 +61,7 @@ async fn serve_hyper() -> Result<(SocketAddr, AbortOnDropHandle<()>)> {
         KeyCache::new(1024),
         Arc::new(AllowAll),
         Arc::new(Metrics::default()),
+        "http://127.0.0.1".parse().unwrap(),
     );
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;


### PR DESCRIPTION
## Description

PR #3331 introduced two-path relay authentication. The fast path (`KeyMaterialClientAuth`) binds to the relay TLS session. The slow path (challenge-response) was implemented without relay identity binding. When the fast path is unavailable (behind a TLS-terminating proxy, or in browsers), clients authenticate without cryptographic proof of which relay they are talking to.

Bind the slow path to the relay hostname by hashing blake3(challenge || hostname) instead of just the challenge. No wire format change.

The relay URL is set via the new `RelayConfig::relay_url` field. When `None`, it auto-derives from the bind address. On the client side, the dial URL is reused directly.

## Breaking Changes

- changed: `RelayService::new` takes a new required `relay_url: RelayUrl`
- changed: `handshake::serverside` takes a new required `relay_url: &RelayUrl`
- `RelayConfig` is `#[non_exhaustive]`; the new `relay_url` field defaults to `None`

## Notes & open questions

None.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the proposed change and wrote an as clear and concise description as they could.
- [x] This PR isn't slop, and is carefully crafted to do have the intented effect.
