### PR TITLE
deps: bump netwatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,8 +3016,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976"
+source = "git+https://github.com/n0-computer/net-tools?branch=main#425a0eaa9f91a577881bfa40fb251b6fa79bb221"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3622,8 +3621,7 @@ dependencies = [
 [[package]]
 name = "portmapper"
 version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721"
+source = "git+https://github.com/n0-computer/net-tools?branch=main#425a0eaa9f91a577881bfa40fb251b6fa79bb221"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ trait_method_marked_deprecated = { required-update = "minor" }
 type_associated_const_marked_deprecated = { required-update = "minor" }
 type_marked_deprecated = { required-update = "minor" }
 type_method_marked_deprecated = { required-update = "minor" }
+
+[patch.crates-io]
+netwatch = { git = "https://github.com/n0-computer/net-tools", branch = "main" }
+portmapper = { git = "https://github.com/n0-computer/net-tools", branch = "main" }


### PR DESCRIPTION
## Description

Bumps netwatch to git main (to be released as netwatch 0.20).

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
