### PR TITLE
chore: Run daily flaky CI even 2h earlier

### DIFF
--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -24,7 +24,7 @@ on:
     types: [ 'labeled', 'unlabeled', 'opened', 'synchronize', 'reopened' ]
   schedule:
     # 04:30 UTC every day
-    - cron: '30 6 * * *'
+    - cron: '30 4 * * *'
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
## Description

Currently they start finishing around 9 CEST, so they can go 2 hour
earlier.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.