### PR TITLE
test(iroh): add patchbay tests for relay connectivity

### DIFF
--- a/iroh/tests/patchbay.rs
+++ b/iroh/tests/patchbay.rs
@@ -45,6 +45,8 @@ use crate::util::is_relayed;
 mod degrade;
 #[path = "patchbay/nat.rs"]
 mod nat;
+#[path = "patchbay/relay.rs"]
+mod relay;
 #[path = "patchbay/switch-uplink.rs"]
 mod switch_uplink;
 #[path = "patchbay/util.rs"]

--- a/iroh/tests/patchbay/relay.rs
+++ b/iroh/tests/patchbay/relay.rs
@@ -16,7 +16,7 @@ use iroh::endpoint::Side;
 use n0_error::{Result, StackResultExt, StdResultExt, anyerr};
 use n0_future::task::AbortOnDropHandle;
 use n0_tracing_test::traced_test;
-use patchbay::{IpSupport, Lab, Nat, OutDir};
+use patchbay::{Firewall, IpSupport, Lab, Nat, OutDir};
 use testdir::testdir;
 use tokio::sync::oneshot;
 use tracing::info;
@@ -84,6 +84,85 @@ async fn relay_connect_ipv4() -> Result {
 #[traced_test]
 async fn relay_connect_ipv6() -> Result {
     run_relay_connect(IpSupport::V6Only).await
+}
+
+/// Which peers sit behind a UDP-blocking access router.
+#[derive(Debug, Clone, Copy)]
+enum UdpBlocked {
+    Both,
+    ServerOnly,
+    ClientOnly,
+}
+
+/// Connects two peers of which one or both cannot use UDP at all.
+///
+/// The blocked peers sit behind a home NAT with a [`Firewall::CaptivePortal`]
+/// ruleset: outbound TCP is free, but all UDP except DNS is dropped, like
+/// hotel or airport guest WiFi. That rules out QAD and holepunching, so the
+/// endpoints must connect through the relay over TCP and stay there. The
+/// unblocked peer is behind a plain home NAT; a direct path still needs UDP
+/// on both ends, so the connection must remain relayed in every variant.
+async fn run_relay_udp_blocked(blocked: UdpBlocked) -> Result {
+    let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
+    let server_blocked = matches!(blocked, UdpBlocked::Both | UdpBlocked::ServerOnly);
+    let client_blocked = matches!(blocked, UdpBlocked::Both | UdpBlocked::ClientOnly);
+    let mut net1 = lab.add_router("net1").nat(Nat::Home);
+    if server_blocked {
+        net1 = net1.firewall(Firewall::CaptivePortal);
+    }
+    let net1 = net1.build().await?;
+    let mut net2 = lab.add_router("net2").nat(Nat::Home);
+    if client_blocked {
+        net2 = net2.firewall(Firewall::CaptivePortal);
+    }
+    let net2 = net2.build().await?;
+    let server = lab.add_device("server").uplink(net1.id()).build().await?;
+    let client = lab.add_device("client").uplink(net2.id()).build().await?;
+
+    // Long enough for a holepunch to complete if one were possible.
+    let hold = Duration::from_secs(3);
+    let timeout = Duration::from_secs(15);
+    Pair::new(relay_map)
+        .server(server, async move |_dev, _ep, conn| {
+            assert!(is_relayed(&conn), "connection started relayed");
+            ping_accept(&conn, timeout).await.context("ping 1")?;
+            tokio::time::sleep(hold).await;
+            assert!(is_relayed(&conn), "still relayed with UDP blocked");
+            ping_accept(&conn, timeout).await.context("ping 2")?;
+            conn.closed().await;
+            Ok(())
+        })
+        .client(client, async move |_dev, _ep, conn| {
+            assert!(is_relayed(&conn), "connection started relayed");
+            ping_open(&conn, timeout).await.context("ping 1")?;
+            tokio::time::sleep(hold).await;
+            assert!(is_relayed(&conn), "still relayed with UDP blocked");
+            ping_open(&conn, timeout).await.context("ping 2")?;
+            conn.close(0u32.into(), b"bye");
+            Ok(())
+        })
+        .run()
+        .await?;
+    guard.ok();
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn relay_udp_blocked_both() -> Result {
+    run_relay_udp_blocked(UdpBlocked::Both).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn relay_udp_blocked_server() -> Result {
+    run_relay_udp_blocked(UdpBlocked::ServerOnly).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn relay_udp_blocked_client() -> Result {
+    run_relay_udp_blocked(UdpBlocked::ClientOnly).await
 }
 
 /// Takes one peer's link down and verifies the relay path recovers.

--- a/iroh/tests/patchbay/relay.rs
+++ b/iroh/tests/patchbay/relay.rs
@@ -6,8 +6,8 @@
 //! The connect tests place both peers on access networks that support only
 //! one IP family, so all traffic to the relay uses that family. The
 //! reconnect tests pin the connection to the relay by putting both peers
-//! behind symmetric (`Nat::Corporate`) NATs, for which holepunching is
-//! impossible while IP transports stay enabled, and then break either one
+//! behind symmetric (`Nat::Corporate`) NATs, for which holepunching fails
+//! even though IP transports stay enabled, and then break either one
 //! peer's access link or the relay server itself.
 
 use std::time::Duration;
@@ -23,21 +23,26 @@ use tracing::info;
 
 use super::util::{self, Pair, is_relayed, lab_with_relay, ping_accept, ping_open};
 
-/// Connects two peers whose access networks support only one IP family.
+/// Connects two peers through the relay over a single IP family.
 ///
-/// The relay's own network is dual-stack. The connection starts relayed
-/// (the [`Pair`] harness hands out relay-only addresses) and a ping in each
-/// direction proves the relay carries data over the family under test.
+/// The relay's own network is dual-stack; both access routers support only
+/// the family under test. Their firewall drops all UDP except DNS, so QAD
+/// and holepunching are impossible and the relay is the only usable path:
+/// the ping exchange proves the relay carries data over that family.
+/// Direct-path coverage per family lives in the switch_uplink and nat
+/// matrices.
 async fn run_relay_connect(ip_support: IpSupport) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
     let access1 = lab
         .add_router("access1")
         .ip_support(ip_support)
+        .firewall_custom(|f| f.block_inbound().allow_udp(&[53]))
         .build()
         .await?;
     let access2 = lab
         .add_router("access2")
         .ip_support(ip_support)
+        .firewall_custom(|f| f.block_inbound().allow_udp(&[53]))
         .build()
         .await?;
     let server = lab
@@ -50,6 +55,7 @@ async fn run_relay_connect(ip_support: IpSupport) -> Result {
         .uplink(access2.id())
         .build()
         .await?;
+    // Sanity-check the harness: only the family under test is assigned.
     for dev in [&server, &client] {
         assert_eq!(dev.ip().is_some(), ip_support.has_v4(), "IPv4 assignment");
         assert_eq!(dev.ip6().is_some(), ip_support.has_v6(), "IPv6 assignment");
@@ -59,12 +65,14 @@ async fn run_relay_connect(ip_support: IpSupport) -> Result {
         .server(server, async move |_dev, _ep, conn| {
             assert!(is_relayed(&conn), "connection started relayed");
             ping_accept(&conn, timeout).await.context("ping_accept")?;
+            assert!(is_relayed(&conn), "still relayed with UDP blocked");
             conn.closed().await;
             Ok(())
         })
         .client(client, async move |_dev, _ep, conn| {
             assert!(is_relayed(&conn), "connection started relayed");
             ping_open(&conn, timeout).await.context("ping_open")?;
+            assert!(is_relayed(&conn), "still relayed with UDP blocked");
             conn.close(0u32.into(), b"bye");
             Ok(())
         })
@@ -94,15 +102,14 @@ enum UdpBlocked {
     ClientOnly,
 }
 
-/// Connects two peers of which one or both cannot use UDP at all.
+/// Connects two peers of which one or both cannot use UDP beyond DNS.
 ///
-/// The blocked peers sit behind a home NAT whose firewall drops unsolicited
-/// inbound traffic and all outbound UDP except DNS (the lab DNS server is
-/// UDP-only); outbound TCP stays open. This is the hotel or airport guest
-/// WiFi shape. It rules out QAD and holepunching, so the endpoints must
-/// connect through the relay over TCP and stay there. The unblocked peer is
-/// behind a plain home NAT; a direct path still needs UDP on both ends, so
-/// the connection must remain relayed in every variant.
+/// The blocked peers sit behind a home NAT that drops unsolicited inbound and
+/// all outbound UDP except DNS (the lab DNS server is UDP-only), the hotel or
+/// airport guest WiFi shape. That rules out QAD and holepunching, so they must
+/// reach each other through the relay over TCP. Any unblocked peer is behind a
+/// plain home NAT; a direct path needs UDP on both ends, so the connection
+/// stays relayed in every variant.
 async fn run_relay_udp_blocked(blocked: UdpBlocked) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
     let server_blocked = matches!(blocked, UdpBlocked::Both | UdpBlocked::ServerOnly);
@@ -169,7 +176,8 @@ async fn relay_udp_blocked_client() -> Result {
 /// Takes one peer's link down and verifies the relay path recovers.
 ///
 /// Both peers sit behind symmetric NATs, so the connection cannot escape to
-/// a direct path and recovery must happen through a relay reconnect.
+/// a direct path; the affected peer's relay client notices the dead link and
+/// reconnects once the link is back.
 async fn run_relay_reconnect_link_outage(outage_side: Side, downtime: Duration) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
     let nat1 = lab.add_router("nat1").nat(Nat::Corporate).build().await?;
@@ -177,6 +185,10 @@ async fn run_relay_reconnect_link_outage(outage_side: Side, downtime: Duration) 
     let outage = lab.add_device("outage").uplink(nat1.id()).build().await?;
     let peer = lab.add_device("peer").uplink(nat2.id()).build().await?;
     let timeout = Duration::from_secs(15);
+    // The reconnect backoff can sleep through the link returning: dials during
+    // the outage fail fast and grow the backoff to several seconds plus jitter,
+    // so the post-outage pings need generous headroom.
+    let recovery_timeout = Duration::from_secs(30);
     Pair::new(relay_map)
         .left(outage_side, outage, async move |dev, _ep, conn| {
             assert!(is_relayed(&conn), "connection started relayed");
@@ -188,7 +200,7 @@ async fn run_relay_reconnect_link_outage(outage_side: Side, downtime: Duration) 
             tokio::time::sleep(downtime).await;
             dev.iface("eth0").unwrap().link_up().await?;
             info!("link restored, waiting for relay reconnect");
-            ping_open(&conn, timeout)
+            ping_open(&conn, recovery_timeout)
                 .await
                 .context("ping after link restored")?;
             assert!(is_relayed(&conn), "still relayed behind symmetric NAT");
@@ -200,7 +212,7 @@ async fn run_relay_reconnect_link_outage(outage_side: Side, downtime: Duration) 
             ping_accept(&conn, timeout)
                 .await
                 .context("ping before outage")?;
-            ping_accept(&conn, timeout)
+            ping_accept(&conn, recovery_timeout)
                 .await
                 .context("ping after link restored")?;
             conn.closed().await;
@@ -247,6 +259,8 @@ async fn relay_reconnect_relay_restart() -> Result {
         .build()
         .await?;
     let dev_relay = lab.add_device("relay").uplink(dc.id()).build().await?;
+    // Register DNS before the endpoint devices below; only later devices
+    // resolve it.
     let dns = lab.dns_server()?;
     dns.set_host("relay.test", dev_relay.ip().expect("relay has IPv4").into())?;
     dns.set_host(
@@ -263,9 +277,20 @@ async fn relay_reconnect_relay_restart() -> Result {
         restart_rx.await.expect("restart signal");
         server.shutdown().await.expect("relay shutdown");
         info!("relay stopped, starting a new relay on the same ports");
-        let (_relay_map, _server) = util::relay::run_relay_server()
-            .await
-            .expect("relay respawn");
+        // The old server's sockets are released asynchronously after
+        // shutdown() returns; retry briefly if a port is still taken.
+        let mut attempts = 0;
+        let (_relay_map, _server) = loop {
+            match util::relay::run_relay_server().await {
+                Ok(relay) => break relay,
+                Err(err) if attempts < 20 => {
+                    attempts += 1;
+                    info!("relay respawn attempt {attempts} failed: {err:#}");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                Err(err) => panic!("relay respawn: {err:#}"),
+            }
+        };
         restarted_tx.send(()).expect("test task alive");
         std::future::pending::<()>().await;
     })?;

--- a/iroh/tests/patchbay/relay.rs
+++ b/iroh/tests/patchbay/relay.rs
@@ -1,0 +1,234 @@
+//! Relay connectivity and reconnect tests.
+//!
+//! The relay from [`util::relay::run_relay_server`] binds `[::]` and is
+//! reachable as `https://relay.test` through lab-wide DNS A and AAAA records.
+//!
+//! The connect tests place both peers on access networks that support only
+//! one IP family, so all traffic to the relay uses that family. The
+//! reconnect tests pin the connection to the relay by putting both peers
+//! behind symmetric (`Nat::Corporate`) NATs, for which holepunching is
+//! impossible while IP transports stay enabled, and then break either one
+//! peer's access link or the relay server itself.
+
+use std::time::Duration;
+
+use iroh::endpoint::Side;
+use n0_error::{Result, StackResultExt, StdResultExt, anyerr};
+use n0_future::task::AbortOnDropHandle;
+use n0_tracing_test::traced_test;
+use patchbay::{IpSupport, Lab, Nat, OutDir};
+use testdir::testdir;
+use tokio::sync::oneshot;
+use tracing::info;
+
+use super::util::{self, Pair, is_relayed, lab_with_relay, ping_accept, ping_open};
+
+/// Connects two peers whose access networks support only one IP family.
+///
+/// The relay's own network is dual-stack. The connection starts relayed
+/// (the [`Pair`] harness hands out relay-only addresses) and a ping in each
+/// direction proves the relay carries data over the family under test.
+async fn run_relay_connect(ip_support: IpSupport) -> Result {
+    let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
+    let access1 = lab
+        .add_router("access1")
+        .ip_support(ip_support)
+        .build()
+        .await?;
+    let access2 = lab
+        .add_router("access2")
+        .ip_support(ip_support)
+        .build()
+        .await?;
+    let server = lab
+        .add_device("server")
+        .uplink(access1.id())
+        .build()
+        .await?;
+    let client = lab
+        .add_device("client")
+        .uplink(access2.id())
+        .build()
+        .await?;
+    for dev in [&server, &client] {
+        assert_eq!(dev.ip().is_some(), ip_support.has_v4(), "IPv4 assignment");
+        assert_eq!(dev.ip6().is_some(), ip_support.has_v6(), "IPv6 assignment");
+    }
+    let timeout = Duration::from_secs(10);
+    Pair::new(relay_map)
+        .server(server, async move |_dev, _ep, conn| {
+            assert!(is_relayed(&conn), "connection started relayed");
+            ping_accept(&conn, timeout).await.context("ping_accept")?;
+            conn.closed().await;
+            Ok(())
+        })
+        .client(client, async move |_dev, _ep, conn| {
+            assert!(is_relayed(&conn), "connection started relayed");
+            ping_open(&conn, timeout).await.context("ping_open")?;
+            conn.close(0u32.into(), b"bye");
+            Ok(())
+        })
+        .run()
+        .await?;
+    guard.ok();
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn relay_connect_ipv4() -> Result {
+    run_relay_connect(IpSupport::V4Only).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn relay_connect_ipv6() -> Result {
+    run_relay_connect(IpSupport::V6Only).await
+}
+
+/// Takes one peer's link down and verifies the relay path recovers.
+///
+/// Both peers sit behind symmetric NATs, so the connection cannot escape to
+/// a direct path and recovery must happen through a relay reconnect.
+async fn run_relay_reconnect_link_outage(outage_side: Side, downtime: Duration) -> Result {
+    let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
+    let nat1 = lab.add_router("nat1").nat(Nat::Corporate).build().await?;
+    let nat2 = lab.add_router("nat2").nat(Nat::Corporate).build().await?;
+    let outage = lab.add_device("outage").uplink(nat1.id()).build().await?;
+    let peer = lab.add_device("peer").uplink(nat2.id()).build().await?;
+    let timeout = Duration::from_secs(15);
+    Pair::new(relay_map)
+        .left(outage_side, outage, async move |dev, _ep, conn| {
+            assert!(is_relayed(&conn), "connection started relayed");
+            ping_open(&conn, timeout)
+                .await
+                .context("ping before outage")?;
+            info!("killing link for {downtime:?}");
+            dev.iface("eth0").unwrap().link_down().await?;
+            tokio::time::sleep(downtime).await;
+            dev.iface("eth0").unwrap().link_up().await?;
+            info!("link restored, waiting for relay reconnect");
+            ping_open(&conn, timeout)
+                .await
+                .context("ping after link restored")?;
+            assert!(is_relayed(&conn), "still relayed behind symmetric NAT");
+            conn.close(0u32.into(), b"bye");
+            Ok(())
+        })
+        .right(peer, async move |_dev, _ep, conn| {
+            assert!(is_relayed(&conn), "connection started relayed");
+            ping_accept(&conn, timeout)
+                .await
+                .context("ping before outage")?;
+            ping_accept(&conn, timeout)
+                .await
+                .context("ping after link restored")?;
+            conn.closed().await;
+            Ok(())
+        })
+        .run()
+        .await?;
+    guard.ok();
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn relay_reconnect_link_outage_client() -> Result {
+    run_relay_reconnect_link_outage(Side::Client, Duration::from_secs(5)).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn relay_reconnect_link_outage_server() -> Result {
+    run_relay_reconnect_link_outage(Side::Server, Duration::from_secs(5)).await
+}
+
+/// Restarts the relay server underneath an established relay-pinned
+/// connection and verifies data flows again once the clients reconnect.
+///
+/// The replacement relay binds the same ports and is reachable under the
+/// same `https://relay.test` URL, like a relay deployment restarting in
+/// place. Both peers' relay actors must notice the dead connection and
+/// reconnect on their own.
+#[tokio::test]
+#[traced_test]
+async fn relay_reconnect_relay_restart() -> Result {
+    let mut builder = Lab::builder().outdir(OutDir::Exact(testdir!()));
+    if let Some(name) = std::thread::current().name() {
+        builder = builder.label(name);
+    }
+    let lab = builder.build().await?;
+    let guard = lab.test_guard();
+
+    let dc = lab
+        .add_router("dc")
+        .ip_support(IpSupport::DualStack)
+        .build()
+        .await?;
+    let dev_relay = lab.add_device("relay").uplink(dc.id()).build().await?;
+    let dns = lab.dns_server()?;
+    dns.set_host("relay.test", dev_relay.ip().expect("relay has IPv4").into())?;
+    dns.set_host(
+        "relay.test",
+        dev_relay.ip6().expect("relay has IPv6").into(),
+    )?;
+
+    let (map_tx, map_rx) = oneshot::channel();
+    let (restart_tx, restart_rx) = oneshot::channel::<()>();
+    let (restarted_tx, restarted_rx) = oneshot::channel::<()>();
+    let relay_task = dev_relay.spawn(async move |_dev| {
+        let (relay_map, server) = util::relay::run_relay_server().await.expect("relay spawn");
+        map_tx.send(relay_map).expect("test task alive");
+        restart_rx.await.expect("restart signal");
+        server.shutdown().await.expect("relay shutdown");
+        info!("relay stopped, starting a new relay on the same ports");
+        let (_relay_map, _server) = util::relay::run_relay_server()
+            .await
+            .expect("relay respawn");
+        restarted_tx.send(()).expect("test task alive");
+        std::future::pending::<()>().await;
+    })?;
+    let _relay_guard = AbortOnDropHandle::new(relay_task);
+    let relay_map = map_rx.await.std_context("relay task died before binding")?;
+
+    let nat1 = lab.add_router("nat1").nat(Nat::Corporate).build().await?;
+    let nat2 = lab.add_router("nat2").nat(Nat::Corporate).build().await?;
+    let server = lab.add_device("server").uplink(nat1.id()).build().await?;
+    let client = lab.add_device("client").uplink(nat2.id()).build().await?;
+
+    let timeout = Duration::from_secs(20);
+    Pair::new(relay_map)
+        .server(server, async move |_dev, _ep, conn| {
+            assert!(is_relayed(&conn), "connection started relayed");
+            ping_accept(&conn, timeout)
+                .await
+                .context("ping before restart")?;
+            ping_accept(&conn, timeout)
+                .await
+                .context("ping after restart")?;
+            conn.closed().await;
+            Ok(())
+        })
+        .client(client, async move |_dev, _ep, conn| {
+            assert!(is_relayed(&conn), "connection started relayed");
+            ping_open(&conn, timeout)
+                .await
+                .context("ping before restart")?;
+            restart_tx
+                .send(())
+                .map_err(|_| anyerr!("relay task died"))?;
+            restarted_rx.await.std_context("relay did not restart")?;
+            info!("relay restarted, waiting for reconnect");
+            ping_open(&conn, timeout)
+                .await
+                .context("ping after relay restart")?;
+            assert!(is_relayed(&conn), "still relayed behind symmetric NAT");
+            conn.close(0u32.into(), b"bye");
+            Ok(())
+        })
+        .run()
+        .await?;
+    guard.ok();
+    Ok(())
+}

--- a/iroh/tests/patchbay/relay.rs
+++ b/iroh/tests/patchbay/relay.rs
@@ -16,12 +16,21 @@ use iroh::endpoint::Side;
 use n0_error::{Result, StackResultExt, StdResultExt, anyerr};
 use n0_future::task::AbortOnDropHandle;
 use n0_tracing_test::traced_test;
-use patchbay::{IpSupport, Lab, Nat, OutDir};
+use patchbay::{FirewallConfigBuilder, IpSupport, Lab, Nat, OutDir};
 use testdir::testdir;
 use tokio::sync::oneshot;
 use tracing::info;
 
 use super::util::{self, Pair, is_relayed, lab_with_relay, ping_accept, ping_open};
+
+/// Firewall rules that block all outbound UDP except DNS, leaving TCP open.
+///
+/// The lab DNS server is UDP-only, so port 53 must stay open. Everything else
+/// over UDP (QAD, holepunch probes) is dropped, forcing traffic onto the relay
+/// over TCP. Pass to [`RouterBuilder::firewall_custom`](patchbay::RouterBuilder).
+fn block_udp_except_dns(f: &mut FirewallConfigBuilder) -> &mut FirewallConfigBuilder {
+    f.block_inbound().allow_udp(&[53])
+}
 
 /// Connects two peers through the relay over a single IP family.
 ///
@@ -36,13 +45,13 @@ async fn run_relay_connect(ip_support: IpSupport) -> Result {
     let access1 = lab
         .add_router("access1")
         .ip_support(ip_support)
-        .firewall_custom(|f| f.block_inbound().allow_udp(&[53]))
+        .firewall_custom(block_udp_except_dns)
         .build()
         .await?;
     let access2 = lab
         .add_router("access2")
         .ip_support(ip_support)
-        .firewall_custom(|f| f.block_inbound().allow_udp(&[53]))
+        .firewall_custom(block_udp_except_dns)
         .build()
         .await?;
     let server = lab
@@ -116,12 +125,12 @@ async fn run_relay_udp_blocked(blocked: UdpBlocked) -> Result {
     let client_blocked = matches!(blocked, UdpBlocked::Both | UdpBlocked::ClientOnly);
     let mut net1 = lab.add_router("net1").nat(Nat::Home);
     if server_blocked {
-        net1 = net1.firewall_custom(|f| f.block_inbound().allow_udp(&[53]));
+        net1 = net1.firewall_custom(block_udp_except_dns);
     }
     let net1 = net1.build().await?;
     let mut net2 = lab.add_router("net2").nat(Nat::Home);
     if client_blocked {
-        net2 = net2.firewall_custom(|f| f.block_inbound().allow_udp(&[53]));
+        net2 = net2.firewall_custom(block_udp_except_dns);
     }
     let net2 = net2.build().await?;
     let server = lab.add_device("server").uplink(net1.id()).build().await?;

--- a/iroh/tests/patchbay/relay.rs
+++ b/iroh/tests/patchbay/relay.rs
@@ -16,7 +16,7 @@ use iroh::endpoint::Side;
 use n0_error::{Result, StackResultExt, StdResultExt, anyerr};
 use n0_future::task::AbortOnDropHandle;
 use n0_tracing_test::traced_test;
-use patchbay::{Firewall, IpSupport, Lab, Nat, OutDir};
+use patchbay::{IpSupport, Lab, Nat, OutDir};
 use testdir::testdir;
 use tokio::sync::oneshot;
 use tracing::info;
@@ -96,24 +96,25 @@ enum UdpBlocked {
 
 /// Connects two peers of which one or both cannot use UDP at all.
 ///
-/// The blocked peers sit behind a home NAT with a [`Firewall::CaptivePortal`]
-/// ruleset: outbound TCP is free, but all UDP except DNS is dropped, like
-/// hotel or airport guest WiFi. That rules out QAD and holepunching, so the
-/// endpoints must connect through the relay over TCP and stay there. The
-/// unblocked peer is behind a plain home NAT; a direct path still needs UDP
-/// on both ends, so the connection must remain relayed in every variant.
+/// The blocked peers sit behind a home NAT whose firewall drops unsolicited
+/// inbound traffic and all outbound UDP except DNS (the lab DNS server is
+/// UDP-only); outbound TCP stays open. This is the hotel or airport guest
+/// WiFi shape. It rules out QAD and holepunching, so the endpoints must
+/// connect through the relay over TCP and stay there. The unblocked peer is
+/// behind a plain home NAT; a direct path still needs UDP on both ends, so
+/// the connection must remain relayed in every variant.
 async fn run_relay_udp_blocked(blocked: UdpBlocked) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
     let server_blocked = matches!(blocked, UdpBlocked::Both | UdpBlocked::ServerOnly);
     let client_blocked = matches!(blocked, UdpBlocked::Both | UdpBlocked::ClientOnly);
     let mut net1 = lab.add_router("net1").nat(Nat::Home);
     if server_blocked {
-        net1 = net1.firewall(Firewall::CaptivePortal);
+        net1 = net1.firewall_custom(|f| f.block_inbound().allow_udp(&[53]));
     }
     let net1 = net1.build().await?;
     let mut net2 = lab.add_router("net2").nat(Nat::Home);
     if client_blocked {
-        net2 = net2.firewall(Firewall::CaptivePortal);
+        net2 = net2.firewall_custom(|f| f.block_inbound().allow_udp(&[53]));
     }
     let net2 = net2.build().await?;
     let server = lab.add_device("server").uplink(net1.id()).build().await?;

--- a/iroh/tests/patchbay/relay.rs
+++ b/iroh/tests/patchbay/relay.rs
@@ -6,7 +6,7 @@
 //! The connect tests place both peers on access networks that support only
 //! one IP family, so all traffic to the relay uses that family. The
 //! reconnect tests pin the connection to the relay by putting both peers
-//! behind symmetric (`Nat::Corporate`) NATs, for which holepunching fails
+//! behind symmetric (`Nat::Strict`) NATs, for which holepunching fails
 //! even though IP transports stay enabled, and then break either one
 //! peer's access link or the relay server itself.
 
@@ -123,12 +123,12 @@ async fn run_relay_udp_blocked(blocked: UdpBlocked) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
     let server_blocked = matches!(blocked, UdpBlocked::Both | UdpBlocked::ServerOnly);
     let client_blocked = matches!(blocked, UdpBlocked::Both | UdpBlocked::ClientOnly);
-    let mut net1 = lab.add_router("net1").nat(Nat::Home);
+    let mut net1 = lab.add_router("net1").nat(Nat::Moderate);
     if server_blocked {
         net1 = net1.firewall_custom(block_udp_except_dns);
     }
     let net1 = net1.build().await?;
-    let mut net2 = lab.add_router("net2").nat(Nat::Home);
+    let mut net2 = lab.add_router("net2").nat(Nat::Moderate);
     if client_blocked {
         net2 = net2.firewall_custom(block_udp_except_dns);
     }
@@ -189,8 +189,8 @@ async fn relay_udp_blocked_client() -> Result {
 /// reconnects once the link is back.
 async fn run_relay_reconnect_link_outage(outage_side: Side, downtime: Duration) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let nat1 = lab.add_router("nat1").nat(Nat::Corporate).build().await?;
-    let nat2 = lab.add_router("nat2").nat(Nat::Corporate).build().await?;
+    let nat1 = lab.add_router("nat1").nat(Nat::Strict).build().await?;
+    let nat2 = lab.add_router("nat2").nat(Nat::Strict).build().await?;
     let outage = lab.add_device("outage").uplink(nat1.id()).build().await?;
     let peer = lab.add_device("peer").uplink(nat2.id()).build().await?;
     let timeout = Duration::from_secs(15);
@@ -306,8 +306,8 @@ async fn relay_reconnect_relay_restart() -> Result {
     let _relay_guard = AbortOnDropHandle::new(relay_task);
     let relay_map = map_rx.await.std_context("relay task died before binding")?;
 
-    let nat1 = lab.add_router("nat1").nat(Nat::Corporate).build().await?;
-    let nat2 = lab.add_router("nat2").nat(Nat::Corporate).build().await?;
+    let nat1 = lab.add_router("nat1").nat(Nat::Strict).build().await?;
+    let nat2 = lab.add_router("nat2").nat(Nat::Strict).build().await?;
     let server = lab.add_device("server").uplink(nat1.id()).build().await?;
     let client = lab.add_device("client").uplink(nat2.id()).build().await?;
 

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -17,6 +17,12 @@ use self::relay::run_relay_server;
 
 const TEST_ALPN: &[u8] = b"test";
 
+/// Upper bound on waiting for the peer task at the end-of-run barrier in [`Pair::run`].
+///
+/// Generous compared to the run functions' own timeouts; it only triggers when the
+/// peer task died before reaching the barrier.
+const BARRIER_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Creates a lab with a relay server.
 ///
 /// Returns the lab, relay map, a drop guard that keeps the relay alive,
@@ -211,6 +217,10 @@ impl Pair {
         // `Endpoint::close` on both sides. `Endpoint::close` often takes several seconds,
         // which increases test runtime for all tests significantly, and closing behavior
         // should be tested for separately from the tests that use `Pair`.
+        //
+        // The barrier waits are bounded: a task that fails or panics before reaching the
+        // barrier would otherwise hang the healthy side until the nextest timeout kills
+        // the whole test instead of letting it report the failure.
         let barrier_server = Arc::new(Barrier::new(2));
         let barrier_client = barrier_server.clone();
 
@@ -247,7 +257,7 @@ impl Pair {
                 }
 
                 // Wait until the client run function completed before dropping the endpoint.
-                barrier_server.wait().await;
+                let _ = tokio::time::timeout(BARRIER_TIMEOUT, barrier_server.wait()).await;
                 for group in endpoint.metrics().groups() {
                     dev.record_iroh_metrics(group);
                 }
@@ -288,7 +298,7 @@ impl Pair {
                 }
 
                 // Wait until the server run function completed before dropping the endpoint.
-                barrier_client.wait().await;
+                let _ = tokio::time::timeout(BARRIER_TIMEOUT, barrier_client.wait()).await;
                 for group in endpoint.metrics().groups() {
                     dev.record_iroh_metrics(group);
                 }

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -475,7 +475,7 @@ fn addr_relay_only(addr: EndpointAddr) -> EndpointAddr {
     EndpointAddr::from_parts(addr.id, addr.addrs.into_iter().filter(|a| a.is_relay()))
 }
 
-mod relay {
+pub(crate) mod relay {
     use std::{
         net::{IpAddr, Ipv6Addr},
         sync::Arc,


### PR DESCRIPTION
## Description

Adds patchbay coverage for the relay data path. Each test enforces a relay-only connection between two endpoints, either by blocking all UDP except DNS at the endpoint's routers or by placing both behind symmetric NATs, so holepunching and QAD are ruled out and the relay is the only path.

- `relay_connect_ipv4` / `relay_connect_ipv6`: connect two peers through the relay over a single IP family, with UDP blocked so the ping traverses the relay. Asserts dual-stack connectivty of the relay.
- `relay_udp_blocked_both` / `relay_udp_blocked_server` / `relay_udp_blocked_client`: one or both peers block all outbound UDP except DNS; the connection runs over the relay via TCP and stays relayed. Asserts that this works.
- `relay_reconnect_link_outage_client` / `relay_reconnect_link_outage_server`: behind symmetric NATs, take one peer's link down for a few seconds and confirm the relay path recovers when it returns. A
- `relay_reconnect_relay_restart`: restart the relay server on the same ports under a live connection and confirm both peers reconnect

## Breaking Changes

None

## Notes & open questions

Fixes #4405

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
