### PR TITLE
[wip] fix(iroh): survive home relay changes on relay-only connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,6 +2239,7 @@ dependencies = [
  "ipnet",
  "iroh-base",
  "iroh-dns",
+ "iroh-dns-server",
  "iroh-metrics",
  "iroh-relay",
  "n0-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,8 +3100,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "noq"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11803df44ac03a30988d61585ea50885d5428e42da944fe1e498799da7886a2"
+source = "git+https://github.com/n0-computer/noq?branch=Frando%2Fabandon-retransmit#630db780d89552f6a8dfbab1ab6f468d1158745d"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3122,8 +3121,7 @@ dependencies = [
 [[package]]
 name = "noq-proto"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334c3c9833f7b2c573cceb9896ddc7aaeb58c8807cbb63211b24d1fe88bf866e"
+source = "git+https://github.com/n0-computer/noq?branch=Frando%2Fabandon-retransmit#630db780d89552f6a8dfbab1ab6f468d1158745d"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3153,8 +3151,7 @@ dependencies = [
 [[package]]
 name = "noq-udp"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde7a5d5102f1cff03d482240f0ed20551661f63663620f4b26112ed751165e9"
+source = "git+https://github.com/n0-computer/noq?branch=Frando%2Fabandon-retransmit#630db780d89552f6a8dfbab1ab6f468d1158745d"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,12 @@ trait_method_marked_deprecated = { required-update = "minor" }
 type_associated_const_marked_deprecated = { required-update = "minor" }
 type_marked_deprecated = { required-update = "minor" }
 type_method_marked_deprecated = { required-update = "minor" }
+
+# Temporary: noq with the abandon-time retransmit fix (immediately declare an
+# abandoned path's in-flight packets lost so their frames retransmit on a live
+# path). PR pending upstream; without it, data in flight on a dying relay path
+# stalls until noq's PathDrained/idle timers fire.
+[patch.crates-io]
+noq = { git = "https://github.com/n0-computer/noq", branch = "Frando/abandon-retransmit" }
+noq-proto = { git = "https://github.com/n0-computer/noq", branch = "Frando/abandon-retransmit" }
+noq-udp = { git = "https://github.com/n0-computer/noq", branch = "Frando/abandon-retransmit" }

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -139,6 +139,7 @@ wasm-bindgen-test = "0.3.62"
 # patchbay netsim test dependencies (linux only)
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 ctor = "1.0"
+iroh-dns-server = { path = "../iroh-dns-server" }
 patchbay = { version = "0.6", features = ["iroh-metrics"] }
 testdir = "0.10"
 

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -144,6 +144,19 @@ pub(crate) const MAX_MULTIPATH_PATHS: u32 = 8;
 /// value.
 pub(crate) const MAX_QNT_ADDRESSES: u8 = 32;
 
+/// How long to wait after the home relay connection is lost before forcing a
+/// full net report.
+///
+/// A brief blip (a single reconnect) should not trigger a report, so the check
+/// is deferred: if the relay reconnects within this window nothing happens.
+const HOME_RELAY_LOST_REPORT_DELAY: Duration = Duration::from_secs(2);
+
+/// Minimum gap between successive forced reports while the home relay stays down.
+///
+/// Once a forced report has run and the relay is still unreachable, wait this
+/// long before forcing another, rather than retrying back to back.
+const HOME_RELAY_LOST_REPORT_RETRY: Duration = Duration::from_secs(5);
+
 /// Error returned when the endpoint state actor stopped while waiting for a reply.
 #[stack_error(add_meta, derive)]
 #[error("endpoint state actor stopped")]
@@ -725,11 +738,20 @@ enum UpdateReason {
     LinkChangeMajor,
     LinkChangeMinor,
     RelayMapChange,
+    /// The home relay connection was lost and has not come back.
+    ///
+    /// This forces a full report so the relay latencies are re-measured
+    /// (incremental reports skip the HTTPS probes), letting another
+    /// reachable relay be promoted to home.
+    HomeRelayLost,
 }
 
 impl UpdateReason {
     fn is_major(self) -> bool {
-        matches!(self, Self::LinkChangeMajor | Self::RelayMapChange)
+        matches!(
+            self,
+            Self::LinkChangeMajor | Self::RelayMapChange | Self::HomeRelayLost
+        )
     }
 }
 
@@ -1501,6 +1523,13 @@ impl Actor {
 
         let mut net_report_watcher = self.sock.net_report.watch();
 
+        // Watch the home relay connection so a lost home relay can force a
+        // full net report (see `UpdateReason::HomeRelayLost`). `home_relay_lost_at`
+        // holds the deadline of a pending deferred report, or `None` when idle.
+        let mut home_relay_watcher = self.sock.home_relay_status();
+        let mut home_relay_connected = home_relay_watcher.get().iter().any(|s| s.is_connected());
+        let mut home_relay_lost_at: Option<Instant> = None;
+
         // ensure we are doing an initial publish of our addresses
         self.sock.publish_my_addr();
 
@@ -1515,6 +1544,12 @@ impl Actor {
                 None => MaybeFuture::None,
             };
             n0_future::pin!(notify_quic_network_change);
+
+            let home_relay_recheck = match home_relay_lost_at {
+                Some(at) => MaybeFuture::Some(n0_future::time::sleep_until(at)),
+                None => MaybeFuture::None,
+            };
+            n0_future::pin!(home_relay_recheck);
 
             tokio::select! {
                 _ = shutdown_token.cancelled() => {
@@ -1563,6 +1598,30 @@ impl Actor {
                         Err(_) => {
                             warn!("net report watcher stopped");
                         }
+                    }
+                }
+                status = home_relay_watcher.updated() => {
+                    if let Ok(status) = status {
+                        let connected = status.iter().any(|s| s.is_connected());
+                        if connected {
+                            // Home relay is up (again); cancel any pending report.
+                            home_relay_lost_at = None;
+                        } else if home_relay_connected && home_relay_lost_at.is_none() {
+                            // Home relay just dropped. Defer a full report so a
+                            // brief reconnect does not trigger one.
+                            debug!("home relay lost, scheduling a full net report");
+                            home_relay_lost_at = Some(Instant::now() + HOME_RELAY_LOST_REPORT_DELAY);
+                        }
+                        home_relay_connected = connected;
+                    }
+                }
+                _ = &mut home_relay_recheck => {
+                    home_relay_lost_at = None;
+                    if !home_relay_connected {
+                        debug!("home relay still down, forcing a full net report");
+                        self.re_stun(UpdateReason::HomeRelayLost);
+                        // Do not retry back to back if it is still failing.
+                        home_relay_lost_at = Some(Instant::now() + HOME_RELAY_LOST_REPORT_RETRY);
                     }
                 }
                 reason = self.direct_addr_done_rx.recv() => {

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -944,6 +944,11 @@ impl EndpointInner {
 
         let ipv6_reported = Arc::new(AtomicBool::new(false));
 
+        // Relay connection loss/restore notifications, from the relay actors
+        // to the remote-state actors (which react to a lost relay by
+        // re-resolving remotes that depend on it).
+        let (relay_conn_events, _) = tokio::sync::broadcast::channel(32);
+
         let relay_actor_config = RelayActorConfig {
             my_relay: HomeRelayWatch::default(),
             secret_key: secret_key.clone(),
@@ -954,6 +959,7 @@ impl EndpointInner {
             tls_config: tls_config.clone(),
             metrics: metrics.socket.clone(),
             relay_map: relay_map.clone(),
+            conn_events: relay_conn_events.clone(),
         };
 
         let shutdown_state = ShutdownState::default();
@@ -1003,6 +1009,7 @@ impl EndpointInner {
                 address_lookup.clone(),
                 shutdown_token.child_token(),
                 path_selector,
+                relay_conn_events,
                 span.clone(),
             )
         };

--- a/iroh/src/socket/biased_rtt_path_selector.rs
+++ b/iroh/src/socket/biased_rtt_path_selector.rs
@@ -141,6 +141,7 @@ impl PathSelector for BiasedRttPathSelector {
         // naturally picks the lowest-RTT instance — no separate aggregation needed.
         let current = ctx.current();
         let mut best: Option<(PathSelectionData<'_>, (TransportType, i128))> = None;
+        let mut best_down: Option<(PathSelectionData<'_>, (TransportType, i128))> = None;
         let mut current_key: Option<(TransportType, i128)> = None;
 
         trace!("dumping path RTTs");
@@ -151,8 +152,19 @@ impl PathSelector for BiasedRttPathSelector {
                 continue;
             };
             let rtt = stats.rtt;
-            trace!(%network_path, ?rtt);
+            trace!(%network_path, ?rtt, transport_down = psd.transport_down());
             let key = self.sort_key(network_path, rtt);
+
+            // A path whose transport is down cannot carry data right now and
+            // its RTT is stale, so it never wins against a live path. It is
+            // still better than no path at all, so it is kept as a fallback
+            // rather than fully excluded.
+            if psd.transport_down() {
+                if best_down.as_ref().is_none_or(|(_, b)| key < *b) {
+                    best_down = Some((psd, key));
+                }
+                continue;
+            }
 
             if Some(network_path) == current && current_key.is_none_or(|c| key < c) {
                 current_key = Some(key);
@@ -163,8 +175,14 @@ impl PathSelector for BiasedRttPathSelector {
         }
 
         let mut selection = PathSelection::none();
-        let Some((best_psd, (best_tier, best_biased))) = best else {
-            return selection;
+        let (best_psd, (best_tier, best_biased)) = match (best, best_down) {
+            (Some(best), _) => best,
+            // Nothing live at all: a down path beats no path.
+            (None, Some(down)) => {
+                selection.set(&down.0);
+                return selection;
+            }
+            (None, None) => return selection,
         };
 
         // If we have no current path or no data for it, switch to the best.
@@ -228,6 +246,10 @@ mod tests {
         let mut stats = PathStats::default();
         stats.rtt = Duration::from_millis(rtt_ms);
         PathSelectionData::for_test(addr, Some(stats))
+    }
+
+    fn psd_down(addr: &transports::FourTuple, rtt_ms: u64) -> PathSelectionData<'_> {
+        psd(addr, rtt_ms).with_transport_down()
     }
 
     /// Runs [`BiasedRttPathSelector::default`] against the given paths and current
@@ -319,5 +341,30 @@ mod tests {
         // Current is set but there are no candidates: keep current (primary() == None).
         let v4 = v4(1);
         assert_eq!(select_with_default(Some(&v4), vec![]), None);
+    }
+
+    #[test]
+    fn down_path_used_as_last_resort() {
+        let relay = relay(1);
+
+        // The only candidate's transport is down: still better than no path.
+        let chosen = select_with_default(Some(&relay), vec![psd_down(&relay, 10)]);
+        assert_eq!(chosen.as_ref(), Some(&relay));
+    }
+
+    #[test]
+    fn live_path_always_preferred_over_down() {
+        let relay_dead = relay(1);
+        let relay_live = relay(2);
+
+        // A live candidate wins even with a much worse RTT than the down
+        // one - the down path's stale RTT must never win a comparison
+        // against a live path, or a replacement relay path could never take
+        // over from a dead relay with a better historical RTT.
+        let chosen = select_with_default(
+            Some(&relay_dead),
+            vec![psd_down(&relay_dead, 1), psd(&relay_live, 500)],
+        );
+        assert_eq!(chosen.as_ref(), Some(&relay_live));
     }
 }

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -9,7 +9,7 @@ use std::{
 use iroh_base::{CustomAddr, EndpointAddr, EndpointId, RelayUrl};
 use n0_future::task::JoinSet;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{Span, error, trace};
 
@@ -34,6 +34,7 @@ use super::{
         AddrMap, CustomMappedAddr, EndpointIdMappedAddr, MultipathMappedAddr, RelayMappedAddr,
     },
     transports,
+    transports::RelayConnEvent,
 };
 use crate::{
     address_lookup::{self, AddressLookupFailed},
@@ -147,6 +148,8 @@ struct Tasks {
     poll_cleanup_waker: Option<Waker>,
     /// The path selector used by all [`RemoteStateActor`]s spawned by this map.
     path_selector: Arc<dyn PathSelector>,
+    /// Relay connection events, subscribed to by each [`RemoteStateActor`].
+    relay_conn_events: broadcast::Sender<RelayConnEvent>,
     /// The tracing span for this endpoint, to be used as parent span for `RemoteStateActor` tasks.
     span: Span,
 }
@@ -159,6 +162,7 @@ impl RemoteMap {
         address_lookup: address_lookup::AddressLookupServices,
         shutdown_token: CancellationToken,
         path_selector: Arc<dyn PathSelector>,
+        relay_conn_events: broadcast::Sender<RelayConnEvent>,
         span: Span,
     ) -> Self {
         Self {
@@ -172,6 +176,7 @@ impl RemoteMap {
                 tasks: Default::default(),
                 poll_cleanup_waker: None,
                 path_selector,
+                relay_conn_events,
                 span,
             },
         }
@@ -335,6 +340,7 @@ impl Tasks {
             self.metrics.clone(),
             self.address_lookup.clone(),
             self.path_selector.clone(),
+            self.relay_conn_events.subscribe(),
         )
         .start(
             initial_msgs,
@@ -401,6 +407,7 @@ mod tests {
             address_lookup::AddressLookupServices::default(),
             shutdown_token.clone(),
             Arc::new(BiasedRttPathSelector::default()),
+            broadcast::channel(16).0,
             Span::none(),
         );
         let guards = (watchable, shutdown_token.clone().drop_guard());

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -18,7 +18,7 @@ use n0_watcher::Watcher;
 use noq::{Closed, PathStats, PathStatus, WeakConnectionHandle};
 use noq_proto::{PathError, PathEvent as NoqPathEvent, PathId, n0_nat_traversal};
 use rustc_hash::FxHashMap;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Level, Span, debug, error, event, info_span, instrument, trace, warn};
 
@@ -36,7 +36,7 @@ use crate::{
         Metrics as SocketMetrics, RELAY_PATH_MAX_IDLE_TIMEOUT,
         mapped_addrs::{AddrMap, CustomMappedAddr, RelayMappedAddr},
         remote_map::remote_state::path_watcher::PathStateSender,
-        transports::{self, OwnedTransmit, TransportsSender},
+        transports::{self, OwnedTransmit, RelayConnEvent, TransportsSender},
     },
 };
 
@@ -63,6 +63,17 @@ const GOOD_ENOUGH_LATENCY: Duration = Duration::from_millis(10);
 ///
 /// Even if we have some non-relay route that works.
 const UPGRADE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Initial backoff between forced address lookup retries.
+///
+/// A forced lookup (e.g. because a connection's only path went suspect) can
+/// race the remote republishing a new address, so it keeps retrying until
+/// something else ends the need for it (a working path, or the path
+/// recovering on its own).
+const ADDRESS_LOOKUP_RETRY_BACKOFF_INITIAL: Duration = Duration::from_millis(500);
+
+/// Maximum backoff between forced address lookup retries.
+const ADDRESS_LOOKUP_RETRY_BACKOFF_MAX: Duration = Duration::from_secs(5);
 
 /// The time after which an idle [`RemoteStateActor`] stops.
 ///
@@ -166,8 +177,52 @@ struct State {
     /// Stream of Address Lookup results, or always pending if Address Lookup is not running.
     address_lookup_stream: Option<BoxStream<Result<AddressLookupItem, AddressLookupFailed>>>,
 
+    /// A forced address lookup still outstanding, if any.
+    ///
+    /// `Some` for as long as something needs the lookup to keep retrying
+    /// until it is no longer needed (see [`State::trigger_address_lookup`]),
+    /// e.g. losing the relay connection carrying a connection's only path.
+    /// Cleared once a replacement path establishes, the relay connection is
+    /// restored, or the last connection closes.
+    address_lookup_retry: Option<AddressLookupRetry>,
+
+    /// Relay connection events from the relay transport.
+    relay_conn_events: broadcast::Receiver<RelayConnEvent>,
+    /// Set once `relay_conn_events` reports closed, to disable its poll arm.
+    relay_conn_events_closed: bool,
+    /// Relays whose connection is currently lost (per [`RelayConnEvent`]).
+    ///
+    /// Paths over these relays are marked down for path selection, so a
+    /// replacement path wins selection despite the dead path's better
+    /// (stale) RTT.
+    lost_relays: BTreeSet<RelayUrl>,
+
     /// The path selector used to pick the preferred path among the candidates.
     path_selector: Arc<dyn PathSelector>,
+}
+
+/// Retry schedule for a forced address lookup that is still needed.
+#[derive(Debug)]
+struct AddressLookupRetry {
+    /// When to start the next address lookup attempt, if one is scheduled.
+    next_lookup: Option<Instant>,
+    /// Backoff applied when the next lookup attempt is scheduled.
+    backoff: Duration,
+}
+
+impl AddressLookupRetry {
+    fn new() -> Self {
+        Self {
+            next_lookup: None,
+            backoff: ADDRESS_LOOKUP_RETRY_BACKOFF_INITIAL,
+        }
+    }
+
+    /// Schedules the next lookup attempt and doubles the backoff, capped.
+    fn schedule_lookup(&mut self) {
+        self.next_lookup = Some(Instant::now() + self.backoff);
+        self.backoff = (self.backoff * 2).min(ADDRESS_LOOKUP_RETRY_BACKOFF_MAX);
+    }
 }
 
 impl RemoteStateActor {
@@ -180,6 +235,7 @@ impl RemoteStateActor {
         metrics: Arc<SocketMetrics>,
         address_lookup: AddressLookupServices,
         path_selector: Arc<dyn PathSelector>,
+        relay_conn_events: broadcast::Receiver<RelayConnEvent>,
     ) -> Self {
         Self {
             connections: FxHashMap::default(),
@@ -200,6 +256,10 @@ impl RemoteStateActor {
                 scheduled_open_path: None,
                 pending_open_paths: VecDeque::new(),
                 address_lookup_stream: None,
+                address_lookup_retry: None,
+                relay_conn_events,
+                relay_conn_events_closed: false,
+                lost_relays: BTreeSet::new(),
                 path_selector,
             },
         }
@@ -263,6 +323,16 @@ impl RemoteStateActor {
                 None => MaybeFuture::None,
             };
             n0_future::pin!(scheduled_hp);
+            let scheduled_lookup_retry = match self
+                .state
+                .address_lookup_retry
+                .as_ref()
+                .and_then(|retry| retry.next_lookup)
+            {
+                Some(when) => MaybeFuture::Some(time::sleep_until(when)),
+                None => MaybeFuture::None,
+            };
+            n0_future::pin!(scheduled_lookup_retry);
             if !self.is_idle(&inbox) {
                 idle_timeout
                     .as_mut()
@@ -315,7 +385,25 @@ impl RemoteStateActor {
                     self.trigger_holepunching();
                 }
                 Some(item) = maybe_next(self.state.address_lookup_stream.as_mut()), if self.state.address_lookup_stream.is_some() => {
-                    self.state.handle_address_lookup_item(item);
+                    self.handle_address_lookup_item(item);
+                }
+                _ = &mut scheduled_lookup_retry => {
+                    if let Some(retry) = self.state.address_lookup_retry.as_mut() {
+                        retry.next_lookup = None;
+                        trace!("retrying forced address lookup");
+                        self.state.start_address_lookup();
+                    }
+                }
+                evt = self.state.relay_conn_events.recv(), if !self.state.relay_conn_events_closed => {
+                    match evt {
+                        Ok(evt) => self.handle_relay_conn_event(evt),
+                        // Events are advisory: on lag we just keep going with
+                        // whatever events still arrive.
+                        Err(broadcast::error::RecvError::Lagged(_)) => {}
+                        Err(broadcast::error::RecvError::Closed) => {
+                            self.state.relay_conn_events_closed = true;
+                        }
+                    }
                 }
                 _ = check_connections.tick() => {
                     self.check_connections();
@@ -470,6 +558,58 @@ impl RemoteStateActor {
         }
     }
 
+    /// Processes an address lookup item, opening any newly found relay addrs and
+    /// continuing a forced retry if one is still outstanding.
+    ///
+    /// Relay addrs from the lookup are opened as paths right away: paths are
+    /// otherwise only opened at connection setup, so a lookup result arriving
+    /// later has to open them itself. When the lookup stream finishes while a
+    /// forced retry is still outstanding, the next attempt is scheduled with
+    /// backoff (see [`State::trigger_address_lookup`]).
+    fn handle_address_lookup_item(
+        &mut self,
+        item: Option<Result<AddressLookupItem, AddressLookupFailed>>,
+    ) {
+        // Collect relay addrs before the state consumes the item.
+        match &item {
+            Some(Ok(item)) if item.endpoint_id() == self.state.endpoint_id => {
+                let relay_addrs: Vec<transports::Addr> = item
+                    .addrs()
+                    .filter_map(|addr| match addr {
+                        TransportAddr::Relay(url) => Some(transports::Addr::from((
+                            url.clone(),
+                            self.state.endpoint_id,
+                        ))),
+                        _ => None,
+                    })
+                    .collect();
+                for addr in relay_addrs {
+                    let open_addr = transports::FourTuple::from_remote(addr);
+                    debug!(?open_addr, "found relay addr, opening path");
+                    self.open_path_on_all_conns(&open_addr);
+                }
+            }
+            _ => {}
+        }
+        let no_service = matches!(
+            &item,
+            Some(Err(AddressLookupFailed::NoServiceConfigured { .. }))
+        );
+
+        let finished = self.state.handle_address_lookup_item(item);
+
+        if finished {
+            if no_service {
+                // No point retrying without a lookup service; whatever wanted the
+                // retry has to be satisfied some other way (e.g. a path
+                // recovering on its own).
+                self.state.address_lookup_retry = None;
+            } else if let Some(retry) = self.state.address_lookup_retry.as_mut() {
+                retry.schedule_lookup();
+            }
+        }
+    }
+
     fn handle_connection_close(&mut self, conn_id: ConnId, closed: Closed) {
         event!(
             target: "iroh::_events::conn::closed",
@@ -486,6 +626,7 @@ impl RemoteStateActor {
         if self.connections.is_empty() {
             trace!("last connection closed - clearing selected_path");
             self.state.selected_path = None;
+            self.state.address_lookup_retry = None;
         }
     }
 
@@ -593,6 +734,14 @@ impl RemoteStateActor {
 
                 self.state
                     .register_and_configure_path(conn_id, conn_state, &path);
+                // A new working path ends any outstanding forced address
+                // lookup. A dead relay path is closed as a redundant relay
+                // path once `select_path` picks the new one (see
+                // `apply_selected_path`). Closing declares whatever was still
+                // queued on it lost, which retransmits it over the new path.
+                if self.state.address_lookup_retry.take().is_some() {
+                    debug!("path established, ending forced address lookup");
+                }
                 self.select_path();
             }
             NoqPathEvent::Abandoned { id, reason, .. } => {
@@ -612,6 +761,7 @@ impl RemoteStateActor {
                 {
                     self.state.paths.abandoned_path(&network_path.remote());
                 }
+                let last_path_gone = conn_state.paths.is_empty();
 
                 event!(
                     target: "iroh::_events::path::abandoned",
@@ -625,6 +775,16 @@ impl RemoteStateActor {
 
                 // If the remote closed our selected path, select a new one.
                 self.select_path();
+
+                // A relay path dying end-to-end without our own relay
+                // connection being lost (the remote lost *its* relay) produces
+                // no relay transport event; the path just idles out and noq
+                // abandons it. Re-resolving the remote is then the only way
+                // back to it.
+                if last_path_gone && network_path.is_relay() {
+                    debug!(%network_path, "last path abandoned, forcing address lookup");
+                    self.state.trigger_address_lookup(true);
+                }
             }
             NoqPathEvent::Discarded { id, path_stats, .. } => {
                 trace!(%id, ?path_stats, "path discarded");
@@ -642,6 +802,54 @@ impl RemoteStateActor {
         }
     }
 
+    /// Handles a [`RelayConnEvent`] from the relay transport.
+    ///
+    /// Losing a relay connection kills all paths over it: their remote ends
+    /// are only reachable through that relay. The relay is recorded in
+    /// [`State::lost_relays`] so path selection treats paths over it as down,
+    /// and if that leaves a connection with no live path, a forced address
+    /// lookup re-resolves the remote (it may have failed over to a different
+    /// home relay and republished). Restoring the connection reverses both.
+    fn handle_relay_conn_event(&mut self, evt: RelayConnEvent) {
+        match evt {
+            RelayConnEvent::Lost(url) => {
+                if !self.state.lost_relays.insert(url.clone()) {
+                    return;
+                }
+                // Re-select so traffic moves off dead paths where possible.
+                self.select_path();
+                // A lookup is only warranted when a connection has no way
+                // around the lost relay.
+                let stranded = self.connections.values().any(|conn_state| {
+                    !conn_state.paths.is_empty()
+                        && conn_state.paths.values().all(
+                            |path| matches!(path, transports::FourTuple::Relay { url: u, .. } if *u == url),
+                        )
+                });
+                if stranded {
+                    debug!(%url, "relay connection lost, forcing address lookup");
+                    self.state.trigger_address_lookup(true);
+                }
+            }
+            RelayConnEvent::Restored(url) => {
+                if !self.state.lost_relays.remove(&url) {
+                    return;
+                }
+                // Paths over this relay work again; any forced lookup started
+                // for its loss is no longer needed.
+                let has_path = self.connections.values().any(|conn_state| {
+                    conn_state.paths.values().any(
+                        |path| matches!(path, transports::FourTuple::Relay { url: u, .. } if *u == url),
+                    )
+                });
+                if has_path && self.state.address_lookup_retry.take().is_some() {
+                    debug!(%url, "relay connection restored, ending forced address lookup");
+                }
+                self.select_path();
+            }
+        }
+    }
+
     /// Selects the preferred path by invoking the configured [`PathSelector`].
     ///
     /// The selected path is added to any connections which do not yet have it.  Any unused
@@ -650,7 +858,8 @@ impl RemoteStateActor {
     fn select_path(&mut self) {
         let current_path = self.state.selected_path.as_ref();
         let selected_addr = {
-            let ctx = PathSelectionContext::new(current_path, &self.connections);
+            let ctx =
+                PathSelectionContext::new(current_path, &self.connections, &self.state.lost_relays);
             self.state.path_selector.select(&ctx).selected().cloned()
         };
 
@@ -675,7 +884,7 @@ impl RemoteStateActor {
     /// Propagates a change of [`State::selected_path`] to noq.
     ///
     /// Iterates over all connections and applies the selected path as follows:
-    /// - Closes non-selected IP paths (but keeps one IP path open still)
+    /// - Closes non-selected IP and relay paths (but keeps one of each kind open still)
     /// - Sets all non-selected paths to [`PathStatus::Backup`]
     /// - Opens the selected path if it does not exist on the connection
     /// - Sets the selected path to [`PathStatus::Available`]
@@ -700,17 +909,24 @@ impl RemoteStateActor {
                     continue;
                 };
 
-                // Closes redundant IP paths so that at most one remains per connection.
+                // Closes redundant IP and relay paths so that at most one of
+                // each kind remains per connection. A second relay path only
+                // ever appears during relay-path recovery (see
+                // `NoqPathEvent::Suspect`); this is what lets the connection
+                // drop a suspect relay path once its replacement works.
                 //
-                // Relay and custom paths are kept open. Only the client closes paths,
-                // to avoid the client and server independently closing different paths
-                // and racing to abandon the last one.
-                if conn.side().is_client()
-                    && path_remote.is_ip()
-                    && path_remote != &selected
-                    && conn_state.paths.values().filter(|a| a.is_ip()).count() > 1
-                {
-                    trace!(?path_remote, %conn_id, %path_id, "closing direct path");
+                // Custom paths are kept open. Only the client closes paths, to
+                // avoid the client and server independently closing different
+                // paths and racing to abandon the last one.
+                let same_kind_count = if path_remote.is_ip() {
+                    conn_state.paths.values().filter(|a| a.is_ip()).count()
+                } else if path_remote.is_relay() {
+                    conn_state.paths.values().filter(|a| a.is_relay()).count()
+                } else {
+                    0
+                };
+                if conn.side().is_client() && path_remote != &selected && same_kind_count > 1 {
+                    trace!(?path_remote, %conn_id, %path_id, "closing redundant path");
                     match path.close() {
                         Err(noq_proto::ClosePathError::MultipathNotNegotiated) => {
                             error!("multipath not negotiated");
@@ -855,16 +1071,35 @@ impl State {
         let addrs = to_transports_addr(self.endpoint_id, addrs);
         self.paths.insert_multiple(addrs, Source::App);
         self.paths.resolve_remote(tx);
-        // Start Address Lookup if we have no selected path.
-        self.trigger_address_lookup();
+        // Start Address Lookup if we have no selected path. Not forced: this
+        // is just an opportunistic lookup, nothing needs it to keep retrying.
+        if self.selected_path.is_none() {
+            self.trigger_address_lookup(false);
+        }
     }
 
-    /// Triggers Address Lookup for the remote endpoint, if needed.
+    /// Triggers Address Lookup for the remote endpoint.
     ///
-    /// Does not start Address Lookup if we have a selected path or if Address Lookup is
-    /// currently running.
-    fn trigger_address_lookup(&mut self) {
-        if self.selected_path.is_some() || self.address_lookup_stream.is_some() {
+    /// If Address Lookup is not currently running, starts it right away regardless of
+    /// `force`. If it is already running: with `force: false` this does nothing; with
+    /// `force: true` it ensures a retry is queued once the current attempt finishes,
+    /// with backoff, repeating for as long as `force` keeps getting requested (e.g. on
+    /// every [`NoqPathEvent::Suspect`] while a connection's only path stays suspect).
+    /// The retry is cleared by whoever no longer needs it (a working path, the suspect
+    /// path recovering on its own, or the last connection closing).
+    fn trigger_address_lookup(&mut self, force: bool) {
+        if force {
+            self.address_lookup_retry
+                .get_or_insert_with(AddressLookupRetry::new);
+        }
+        if self.address_lookup_stream.is_none() {
+            self.start_address_lookup();
+        }
+    }
+
+    /// Starts an Address Lookup stream, unless one is already running.
+    fn start_address_lookup(&mut self) {
+        if self.address_lookup_stream.is_some() {
             return;
         }
         let stream = self.address_lookup.resolve(self.endpoint_id);
@@ -883,14 +1118,17 @@ impl State {
     ///
     /// All address lookup results end up being sent here. It takes care of updating the
     /// [`RemotePathState`] with the results.
+    ///
+    /// Returns whether the lookup stream finished with this item.
     fn handle_address_lookup_item(
         &mut self,
         item: Option<Result<AddressLookupItem, AddressLookupFailed>>,
-    ) {
+    ) -> bool {
         match item {
             None => {
                 self.paths.address_lookup_finished(Ok(()));
                 self.address_lookup_stream = None;
+                true
             }
             Some(Err(err)) => {
                 if let AddressLookupFailed::NoServiceConfigured { .. } = err {
@@ -900,6 +1138,7 @@ impl State {
                 }
                 self.paths.address_lookup_finished(Err(err));
                 self.address_lookup_stream = None;
+                true
             }
             Some(Ok(item)) => {
                 if item.endpoint_id() != self.endpoint_id {
@@ -915,6 +1154,7 @@ impl State {
                         to_transports_addr(self.endpoint_id, item.into_endpoint_addr().addrs);
                     self.paths.insert_multiple(addrs, source);
                 }
+                false
             }
         }
     }
@@ -1288,7 +1528,10 @@ pub struct PathSelectionContext<'a> {
 /// (for unit-testing selectors).
 #[derive(Debug)]
 enum PathsSource<'a> {
-    Live(&'a FxHashMap<ConnId, ConnectionState>),
+    Live {
+        connections: &'a FxHashMap<ConnId, ConnectionState>,
+        lost_relays: &'a BTreeSet<RelayUrl>,
+    },
     #[cfg(test)]
     Test(Vec<PathSelectionData<'a>>),
 }
@@ -1298,10 +1541,14 @@ impl<'a> PathSelectionContext<'a> {
     fn new(
         current: Option<&'a transports::FourTuple>,
         connections: &'a FxHashMap<ConnId, ConnectionState>,
+        lost_relays: &'a BTreeSet<RelayUrl>,
     ) -> Self {
         Self {
             current,
-            source: PathsSource::Live(connections),
+            source: PathsSource::Live {
+                connections,
+                lost_relays,
+            },
         }
     }
 
@@ -1328,16 +1575,32 @@ impl<'a> PathSelectionContext<'a> {
     /// connections to the remote.  Selectors that care should aggregate as appropriate.
     pub fn paths(&self) -> Box<dyn Iterator<Item = PathSelectionData<'a>> + '_> {
         match &self.source {
-            PathsSource::Live(connections) => Box::new(
-                connections
-                    .values()
-                    .filter_map(|state| state.handle.upgrade().map(|conn| (state, conn)))
-                    .flat_map(|(state, conn)| {
-                        state.paths.iter().map(move |(path_id, addr)| {
-                            PathSelectionData::live(addr, *path_id, conn.clone())
-                        })
-                    }),
-            ),
+            PathsSource::Live {
+                connections,
+                lost_relays,
+            } => {
+                let lost_relays: &'a BTreeSet<RelayUrl> = lost_relays;
+                Box::new(
+                    connections
+                        .values()
+                        .filter_map(|state| state.handle.upgrade().map(|conn| (state, conn)))
+                        .flat_map(move |(state, conn)| {
+                            state.paths.iter().map(move |(path_id, addr)| {
+                                let transport_down = matches!(
+                                    addr,
+                                    transports::FourTuple::Relay { url, .. }
+                                        if lost_relays.contains(url)
+                                );
+                                PathSelectionData::live(
+                                    addr,
+                                    *path_id,
+                                    conn.clone(),
+                                    transport_down,
+                                )
+                            })
+                        }),
+                )
+            }
             #[cfg(test)]
             PathsSource::Test(paths) => Box::new(paths.iter().cloned()),
         }
@@ -1353,6 +1616,7 @@ impl<'a> PathSelectionContext<'a> {
 #[derive(derive_more::Debug, Clone)]
 pub struct PathSelectionData<'a> {
     network_path: &'a transports::FourTuple,
+    transport_down: bool,
     #[debug(skip)]
     source: StatsSource,
 }
@@ -1375,9 +1639,11 @@ impl<'a> PathSelectionData<'a> {
         network_path: &'a transports::FourTuple,
         path_id: PathId,
         conn: noq::Connection,
+        transport_down: bool,
     ) -> Self {
         Self {
             network_path,
+            transport_down,
             source: StatsSource::Live { path_id, conn },
         }
     }
@@ -1393,13 +1659,31 @@ impl<'a> PathSelectionData<'a> {
     ) -> Self {
         Self {
             network_path,
+            transport_down: false,
             source: StatsSource::Test(stats.map(Box::new)),
         }
+    }
+
+    /// Marks this candidate's transport as down (testing only).
+    #[cfg(test)]
+    pub(crate) fn with_transport_down(mut self) -> Self {
+        self.transport_down = true;
+        self
     }
 
     /// The network path of the candidate path.
     pub fn network_path(&self) -> &transports::FourTuple {
         self.network_path
+    }
+
+    /// Returns `true` if the transport below this path is known to be down.
+    ///
+    /// Currently this is set for relay paths whose relay connection is lost.
+    /// Such a path cannot carry data right now, but may become usable again;
+    /// its statistics (in particular the RTT) are stale. Selectors should
+    /// only pick it as a last resort.
+    pub fn transport_down(&self) -> bool {
+        self.transport_down
     }
 
     /// Returns path statistics if available.

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -187,9 +187,9 @@ struct State {
     address_lookup_retry: Option<AddressLookupRetry>,
 
     /// Relay connection events from the relay transport.
-    relay_conn_events: broadcast::Receiver<RelayConnEvent>,
-    /// Set once `relay_conn_events` reports closed, to disable its poll arm.
-    relay_conn_events_closed: bool,
+    ///
+    /// `None` once the channel reported closed, disabling its poll arm.
+    relay_conn_events: Option<broadcast::Receiver<RelayConnEvent>>,
     /// Relays whose connection is currently lost (per [`RelayConnEvent`]).
     ///
     /// Paths over these relays are marked down for path selection, so a
@@ -257,8 +257,7 @@ impl RemoteStateActor {
                 pending_open_paths: VecDeque::new(),
                 address_lookup_stream: None,
                 address_lookup_retry: None,
-                relay_conn_events,
-                relay_conn_events_closed: false,
+                relay_conn_events: Some(relay_conn_events),
                 lost_relays: BTreeSet::new(),
                 path_selector,
             },
@@ -394,14 +393,14 @@ impl RemoteStateActor {
                         self.state.start_address_lookup();
                     }
                 }
-                evt = self.state.relay_conn_events.recv(), if !self.state.relay_conn_events_closed => {
+                Some(evt) = maybe_recv(self.state.relay_conn_events.as_mut()), if self.state.relay_conn_events.is_some() => {
                     match evt {
                         Ok(evt) => self.handle_relay_conn_event(evt),
                         // Events are advisory: on lag we just keep going with
                         // whatever events still arrive.
                         Err(broadcast::error::RecvError::Lagged(_)) => {}
                         Err(broadcast::error::RecvError::Closed) => {
-                            self.state.relay_conn_events_closed = true;
+                            self.state.relay_conn_events = None;
                         }
                     }
                 }
@@ -1810,5 +1809,15 @@ async fn maybe_next<S: Stream + Unpin>(maybe_stream: Option<&mut S>) -> Option<O
     match maybe_stream {
         None => None,
         Some(s) => Some(s.next().await),
+    }
+}
+
+/// Receives the next value if `maybe_rx` is `Some`, or returns `None` otherwise.
+async fn maybe_recv<T: Clone>(
+    maybe_rx: Option<&mut broadcast::Receiver<T>>,
+) -> Option<Result<T, broadcast::error::RecvError>> {
+    match maybe_rx {
+        None => None,
+        Some(rx) => Some(rx.recv().await),
     }
 }

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -39,7 +39,7 @@ pub(crate) use self::ip::Config as IpConfig;
 #[cfg(not(wasm_browser))]
 use self::ip::{IpNetworkChangeSender, IpTransports, IpTransportsSender};
 pub(crate) use self::relay::{
-    HomeRelayWatch, RelayActorConfig, RelayConnectionState, RelayTransport,
+    HomeRelayWatch, RelayActorConfig, RelayConnEvent, RelayConnectionState, RelayTransport,
 };
 
 /// How many times all transports may error on `poll_recv` before we give up.

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -21,7 +21,9 @@ use crate::endpoint::RelayStatus;
 
 mod actor;
 
-pub(crate) use self::actor::{Config as RelayActorConfig, HomeRelayWatch, RelayConnectionState};
+pub(crate) use self::actor::{
+    Config as RelayActorConfig, HomeRelayWatch, RelayConnEvent, RelayConnectionState,
+};
 use self::actor::{RelayActor, RelayActorMessage, RelayRecvDatagram, RelaySendItem};
 
 type RelayAddrWatcher =

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -337,7 +337,9 @@ impl ActiveRelayActor {
                     break;
                 };
                 debug!("retry in {delay:?}");
-                time::sleep(delay).await;
+                if !self.sleep_backoff(delay).await {
+                    break;
+                }
             } else {
                 // If the relay connection remained established long enough so that we received a pong
                 // from the relay server, we reset the backoff and attempt to reconnect immediately.
@@ -345,6 +347,41 @@ impl ActiveRelayActor {
             }
         }
         debug!("exiting");
+    }
+
+    /// Waits out a reconnect backoff delay while still answering priority messages.
+    ///
+    /// Other active relays may query [`ActiveRelayPrioMessage::HasEndpointRoute`] on this
+    /// relay while it is backing off, e.g. when [`RelayActor`] is looking for an existing
+    /// relay connection to an endpoint. Answering immediately (with `false`, since a
+    /// disconnected relay cannot have an endpoint route) keeps that lookup from stalling
+    /// for however long is left of this relay's own unrelated backoff.
+    ///
+    /// Returns `false` if the actor should shut down instead of retrying.
+    async fn sleep_backoff(&mut self, delay: Duration) -> bool {
+        let sleep = time::sleep(delay);
+        tokio::pin!(sleep);
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.stop_token.cancelled() => {
+                    debug!("Shutdown.");
+                    return false;
+                }
+                msg = self.prio_inbox.recv() => {
+                    let Some(msg) = msg else {
+                        warn!("Priority inbox closed, shutdown.");
+                        return false;
+                    };
+                    match msg {
+                        ActiveRelayPrioMessage::HasEndpointRoute(_peer, sender) => {
+                            sender.send(false).ok();
+                        }
+                    }
+                }
+                _ = &mut sleep => return true,
+            }
+        }
     }
 
     fn build_backoff() -> impl Backoff {

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -52,7 +52,7 @@ use n0_future::{
 };
 use n0_watcher::Watchable;
 use netwatch::interfaces;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Level, debug, error, event, info, info_span, instrument, trace, warn};
 use url::Url;
@@ -152,6 +152,11 @@ struct ActiveRelayActor {
     stop_token: CancellationToken,
     metrics: Arc<SocketMetrics>,
     my_relay: HomeRelayWatch,
+    /// Broadcasts [`RelayConnEvent`]s for this relay.
+    conn_events: broadcast::Sender<RelayConnEvent>,
+    /// Whether a [`RelayConnEvent::Lost`] was sent and not yet followed by a
+    /// [`RelayConnEvent::Restored`].
+    conn_lost_emitted: bool,
 }
 
 #[derive(Debug)]
@@ -196,6 +201,7 @@ struct ActiveRelayActorOptions {
     stop_token: CancellationToken,
     metrics: Arc<SocketMetrics>,
     my_relay: HomeRelayWatch,
+    conn_events: broadcast::Sender<RelayConnEvent>,
 }
 
 /// Configuration needed to create a connection to a relay server.
@@ -268,6 +274,7 @@ impl ActiveRelayActor {
             stop_token,
             metrics,
             my_relay,
+            conn_events,
         } = opts;
         let relay_client_builder = Self::create_relay_builder(url.clone(), connection_opts);
         ActiveRelayActor {
@@ -282,6 +289,8 @@ impl ActiveRelayActor {
             stop_token,
             metrics,
             my_relay,
+            conn_events,
+            conn_lost_emitted: false,
         }
     }
 
@@ -330,6 +339,20 @@ impl ActiveRelayActor {
             self.my_relay
                 .set_status(&self.url, RelayConnectionState::Disconnected { last_error });
             if !was_established {
+                // A connection attempt failed: the relay is genuinely
+                // unreachable right now, not just briefly disconnected. An
+                // established connection dropping retries immediately without
+                // ending up here, so a spurious disconnect followed by a
+                // successful reconnect never emits this. Connecting and
+                // handshaking take on the order of several round trips, so
+                // this also leaves a dropped connection at least that long to
+                // come back before the loss is announced.
+                if !self.conn_lost_emitted {
+                    self.conn_lost_emitted = true;
+                    self.conn_events
+                        .send(RelayConnEvent::Lost(self.url.clone()))
+                        .ok();
+                }
                 // If dialing failed, or if the relay connection failed before we received a pong,
                 // we wait an exponentially increasing time until we attempt to reconnect again.
                 let Some(delay) = backoff.next() else {
@@ -407,6 +430,12 @@ impl ActiveRelayActor {
         };
         self.my_relay
             .set_status(&self.url, RelayConnectionState::Connected);
+        if self.conn_lost_emitted {
+            self.conn_lost_emitted = false;
+            self.conn_events
+                .send(RelayConnEvent::Restored(self.url.clone()))
+                .ok();
+        }
         self.run_connected(client)
             .instrument(info_span!("connected"))
             .await
@@ -916,6 +945,24 @@ pub(crate) struct Config {
     /// Per-relay configuration. Consulted when starting a connection to
     /// look up the auth token and any future per-relay options.
     pub relay_map: RelayMap,
+    /// Broadcasts [`RelayConnEvent`]s to interested parties (the
+    /// `RemoteStateActor`s, which react to a relay connection loss by
+    /// re-resolving remotes that depend on it).
+    pub conn_events: broadcast::Sender<RelayConnEvent>,
+}
+
+/// A change in an active relay connection, broadcast by the [`ActiveRelayActor`]s.
+///
+/// `Lost` is debounced: it is only sent once an established connection dropped
+/// (or a fresh one could not be made) *and* a reconnect attempt has failed, so
+/// a spurious disconnect with a successful immediate reconnect emits nothing.
+/// One `Restored` follows each `Lost` once the connection is back.
+#[derive(Debug, Clone)]
+pub(crate) enum RelayConnEvent {
+    /// The connection to this relay was lost and a reconnect attempt failed.
+    Lost(RelayUrl),
+    /// The connection to this relay is established again after a `Lost`.
+    Restored(RelayUrl),
 }
 
 /// Connection state of the home relay.
@@ -1300,6 +1347,7 @@ impl RelayActor {
             stop_token: self.cancel_token.child_token(),
             metrics: self.config.metrics.clone(),
             my_relay: self.config.my_relay.clone(),
+            conn_events: self.config.conn_events.clone(),
         };
         let actor = ActiveRelayActor::new(opts);
         self.active_relay_tasks.spawn(
@@ -1436,7 +1484,7 @@ mod tests {
     };
     use n0_error::{AnyError as Error, Result, StackResultExt, StdResultExt};
     use n0_tracing_test::traced_test;
-    use tokio::sync::{mpsc, oneshot};
+    use tokio::sync::{broadcast, mpsc, oneshot};
     use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
     use tracing::{Instrument, info, info_span};
 
@@ -1478,6 +1526,7 @@ mod tests {
             stop_token,
             metrics: Default::default(),
             my_relay: Default::default(),
+            conn_events: broadcast::channel(16).0,
         };
         let task = tokio::spawn(ActiveRelayActor::new(opts).run().instrument(span));
         AbortOnDropHandle::new(task)

--- a/iroh/tests/patchbay/relay.rs
+++ b/iroh/tests/patchbay/relay.rs
@@ -10,16 +10,26 @@
 //! even though IP transports stay enabled, and then break either one
 //! peer's access link or the relay server itself.
 
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 
-use iroh::endpoint::Side;
-use n0_error::{Result, StackResultExt, StdResultExt, anyerr};
+use iroh::{
+    Endpoint, EndpointAddr, RelayMap, RelayMode, RelayUrl, TransportAddr, Watcher,
+    address_lookup::{DnsAddressLookup, PkarrPublisher},
+    dns::DnsResolver,
+    endpoint::{Side, presets},
+    tls::CaTlsConfig,
+};
+use n0_error::{Result, StackResultExt, StdResultExt, anyerr, ensure_any};
 use n0_future::task::AbortOnDropHandle;
 use n0_tracing_test::traced_test;
-use patchbay::{FirewallConfigBuilder, IpSupport, Lab, Nat, OutDir};
+use patchbay::{
+    FirewallConfigBuilder, IfaceConfig, IpSupport, Lab, LinkCondition, LinkDirection, LinkLimits,
+    Nat, OutDir,
+};
 use testdir::testdir;
 use tokio::sync::oneshot;
 use tracing::info;
+use url::Url;
 
 use super::util::{self, Pair, is_relayed, lab_with_relay, ping_accept, ping_open};
 
@@ -345,4 +355,296 @@ async fn relay_reconnect_relay_restart() -> Result {
         .await?;
     guard.ok();
     Ok(())
+}
+
+/// The relay carrying the connection dies; the client re-resolves and recovers.
+///
+/// The peers have disjoint relay maps: the server holds relay-s1 (fast) and
+/// relay-s2 (behind a 100 ms link, so the server homes on s1), the client only
+/// relay-c1. The client dials the server's relay-only addr, so the connection
+/// runs over s1, the server's home relay; relay-c1 plays no role in it. Both
+/// peers block UDP beyond DNS, so the relay is the only possible path.
+///
+/// Address lookup runs through an iroh-dns-server in the lab: the server
+/// publishes its endpoint info over pkarr HTTP, the client resolves the
+/// `_iroh` TXT records over DNS.
+///
+/// s1 is torn down. The server fails over its home relay to s2 and republishes
+/// its endpoint info. The client notices the lost relay connection, re-runs
+/// address lookup for the server, learns s2, and opens a path over it; only
+/// the client can do this. The final ping proves the connection carried across.
+#[tokio::test]
+#[traced_test]
+async fn relay_teardown_failover() -> Result {
+    const ALPN: &[u8] = b"relay-failover";
+    // The default origin served by iroh-dns-server.
+    const LOOKUP_ORIGIN: &str = "irohdns.example";
+
+    let mut builder = Lab::builder().outdir(OutDir::Exact(testdir!()));
+    if let Some(name) = std::thread::current().name() {
+        builder = builder.label(name);
+    }
+    let lab = builder.build().await?;
+    let guard = lab.test_guard();
+
+    let net = lab
+        .add_router("net")
+        .ip_support(IpSupport::DualStack)
+        .build()
+        .await?;
+
+    // The server's relays: s1 fast, s2 behind 100 ms each way. The client's
+    // own relay c1 must never carry the connection.
+    let dev_s1 = lab.add_device("relay-s1").uplink(net.id()).build().await?;
+    let slow = LinkCondition::Manual(LinkLimits {
+        latency_ms: 100,
+        ..Default::default()
+    });
+    let dev_s2 = lab
+        .add_device("relay-s2")
+        .iface(
+            "eth0",
+            IfaceConfig::routed(net.id()).condition(slow, LinkDirection::Both),
+        )
+        .build()
+        .await?;
+    let dev_c1 = lab.add_device("relay-c1").uplink(net.id()).build().await?;
+
+    // The address lookup service: an iroh-dns-server (pkarr relay over HTTP,
+    // DNS server on port 53).
+    let dev_dns = lab.add_device("dns").uplink(net.id()).build().await?;
+
+    // Register DNS before the endpoint devices below; only later devices
+    // resolve it. Only the IPv4 address for dns.test: on this branch the
+    // dns-server's default binds are IPv4-only.
+    let dns = lab.dns_server()?;
+    for (host, dev) in [
+        ("relay-s1.test", &dev_s1),
+        ("relay-s2.test", &dev_s2),
+        ("relay-c1.test", &dev_c1),
+    ] {
+        dns.set_host(host, dev.ip().expect("relay has IPv4").into())?;
+        dns.set_host(host, dev.ip6().expect("relay has IPv6").into())?;
+    }
+    let dns_ip = dev_dns.ip().expect("dns has IPv4");
+    dns.set_host("dns.test", dns_ip.into())?;
+
+    let _dns_guard = util::spawn_dns_server(&dev_dns, testdir!().join("dns-server-data")).await?;
+    let pkarr_url: Url = "http://dns.test:8080/pkarr".parse().expect("valid url");
+    let lookup_nameserver = SocketAddr::new(dns_ip.into(), 53);
+
+    // s1 runs until the test signals a teardown; s2 and c1 run throughout.
+    let (s1_map_tx, s1_map_rx) = oneshot::channel();
+    let (teardown_tx, teardown_rx) = oneshot::channel::<()>();
+    let (down_tx, down_rx) = oneshot::channel::<()>();
+    let s1_task = dev_s1.spawn(async move |_dev| {
+        let (map, server) = util::relay::run_relay_server_named("relay-s1.test")
+            .await
+            .expect("relay-s1 spawn");
+        s1_map_tx.send(map).expect("test task alive");
+        teardown_rx.await.expect("teardown signal");
+        server.shutdown().await.expect("relay-s1 shutdown");
+        down_tx.send(()).expect("test task alive");
+        std::future::pending::<()>().await;
+    })?;
+    let _s1_guard = AbortOnDropHandle::new(s1_task);
+    let s1_map = s1_map_rx
+        .await
+        .std_context("relay-s1 died before binding")?;
+
+    let (s2_map, _s2_guard) = spawn_static_relay(&dev_s2, "relay-s2.test").await?;
+    let (client_map, _c1_guard) = spawn_static_relay(&dev_c1, "relay-c1.test").await?;
+
+    let server_map = RelayMap::empty();
+    for config in s1_map
+        .relays::<Vec<_>>()
+        .into_iter()
+        .chain(s2_map.relays::<Vec<_>>())
+    {
+        server_map.insert(config.url.clone(), config);
+    }
+    let [s1_url, s2_url, c1_url] = ["relay-s1", "relay-s2", "relay-c1"].map(|host| {
+        format!("https://{host}.test")
+            .parse::<RelayUrl>()
+            .expect("valid relay url")
+    });
+
+    // Both peers behind home NATs that block UDP beyond DNS, so the whole
+    // connection runs over the relay.
+    let nat1 = lab
+        .add_router("nat1")
+        .nat(Nat::Home)
+        .firewall_custom(block_udp_except_dns)
+        .build()
+        .await?;
+    let nat2 = lab
+        .add_router("nat2")
+        .nat(Nat::Home)
+        .firewall_custom(block_udp_except_dns)
+        .build()
+        .await?;
+    let dev_server = lab.add_device("server").uplink(nat1.id()).build().await?;
+    let dev_client = lab.add_device("client").uplink(nat2.id()).build().await?;
+
+    let timeout = Duration::from_secs(15);
+    // Recovery spans the server's home failover (deferred full net report), the
+    // republish, and the client's lookup retries; allow generous headroom.
+    let recovery_timeout = Duration::from_secs(30);
+
+    // Both run functions wait here before dropping their endpoint, so neither
+    // side is left waiting out QUIC timeouts on a vanished peer (the same
+    // pattern as `Pair::run`).
+    let barrier_server = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let barrier_client = barrier_server.clone();
+
+    let (addr_tx, addr_rx) = oneshot::channel();
+    let server_task = dev_server.spawn({
+        let s1_url = s1_url.clone();
+        move |_dev| async move {
+            let ep = Endpoint::builder(presets::Minimal)
+                .relay_mode(RelayMode::Custom(server_map))
+                // Publishes the endpoint info (including the home relay) to the
+                // lab dns-server, republished whenever it changes. TTL 1s so
+                // the client's lookup retries are not served stale records
+                // from its resolver cache.
+                .address_lookup(PkarrPublisher::builder(pkarr_url).ttl(1))
+                .ca_tls_config(CaTlsConfig::insecure_skip_verify())
+                .alpns(vec![ALPN.to_vec()])
+                .bind()
+                .await
+                .context("server bind")?;
+            ep.online().await;
+            let home = connected_home_relay(&ep, timeout)
+                .await
+                .context("no home relay")?;
+            ensure_any!(
+                home == s1_url,
+                "server should home on the fast relay, got {home}"
+            );
+
+            let addr = ep.addr();
+            let relay_addr =
+                EndpointAddr::from_parts(addr.id, addr.addrs.into_iter().filter(|a| a.is_relay()));
+            addr_tx.send(relay_addr).ok();
+
+            let incoming = ep.accept().await.context("accept")?;
+            let conn = incoming.accept().anyerr()?.await.context("handshake")?;
+            assert!(is_relayed(&conn), "connection started relayed");
+            ping_accept(&conn, timeout)
+                .await
+                .context("ping before teardown")?;
+            ping_accept(&conn, recovery_timeout)
+                .await
+                .context("ping after relay-s1 teardown")?;
+            barrier_server.wait().await;
+            n0_error::Ok(())
+        }
+    })?;
+
+    let client_task = dev_client.spawn(move |_dev| async move {
+        let ep = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Custom(client_map))
+            // Resolves `_iroh` TXT records at the lab dns-server. The relay
+            // hostnames keep resolving through the system resolver.
+            .address_lookup(
+                DnsAddressLookup::builder(LOOKUP_ORIGIN.to_string())
+                    .dns_resolver(DnsResolver::with_nameserver(lookup_nameserver)),
+            )
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
+            .alpns(vec![ALPN.to_vec()])
+            .bind()
+            .await
+            .context("client bind")?;
+        ep.online().await;
+
+        let addr = addr_rx.await.std_context("server addr")?;
+        let conn = ep.connect(addr, ALPN).await.context("connect")?;
+        let selected = selected_remote_addr(&conn);
+        ensure_any!(
+            matches!(&selected, TransportAddr::Relay(url) if *url == s1_url),
+            "connection should start over the server's home relay, got {selected:?}"
+        );
+        ping_open(&conn, timeout)
+            .await
+            .context("ping before teardown")?;
+
+        info!("tearing down relay-s1 (the relay carrying the connection)");
+        teardown_tx.send(()).map_err(|_| anyerr!("relay-s1 died"))?;
+        down_rx.await.std_context("relay-s1 did not shut down")?;
+
+        info!("relay-s1 down, expecting re-lookup and failover to relay-s2");
+        ping_open(&conn, recovery_timeout)
+            .await
+            .context("ping after relay-s1 teardown")?;
+        let selected = selected_remote_addr(&conn);
+        ensure_any!(
+            matches!(&selected, TransportAddr::Relay(url) if *url == s2_url),
+            "connection should have moved to the server's new home relay, got {selected:?}"
+        );
+        ensure_any!(
+            conn.paths()
+                .iter()
+                .all(|p| !matches!(p.remote_addr(), TransportAddr::Relay(url) if *url == c1_url)),
+            "the client's own relay must not carry a path to the server"
+        );
+        conn.close(0u32.into(), b"bye");
+        barrier_client.wait().await;
+        n0_error::Ok(())
+    })?;
+
+    let (server_res, client_res) = tokio::time::timeout(Duration::from_secs(90), async {
+        tokio::join!(server_task, client_task)
+    })
+    .await
+    .std_context("test timed out")?;
+    server_res.std_context("server task")??;
+    client_res.std_context("client task")??;
+    guard.ok();
+    Ok(())
+}
+
+/// Spawns a relay on `dev` under `host` that runs for the whole test.
+async fn spawn_static_relay(
+    dev: &patchbay::Device,
+    host: &'static str,
+) -> Result<(RelayMap, AbortOnDropHandle<()>)> {
+    let (map_tx, map_rx) = oneshot::channel();
+    let task = dev.spawn(async move |_dev| {
+        let (map, _server) = util::relay::run_relay_server_named(host)
+            .await
+            .expect("relay spawn");
+        map_tx.send(map).expect("test task alive");
+        std::future::pending::<()>().await;
+    })?;
+    let map = map_rx.await.std_context("relay died before binding")?;
+    Ok((map, AbortOnDropHandle::new(task)))
+}
+
+/// Returns the remote address of the connection's selected path.
+fn selected_remote_addr(conn: &iroh::endpoint::Connection) -> TransportAddr {
+    conn.paths()
+        .iter()
+        .find(|p| p.is_selected())
+        .expect("no selected path")
+        .remote_addr()
+        .clone()
+}
+
+/// Waits until the endpoint has a connected home relay and returns its URL.
+async fn connected_home_relay(ep: &Endpoint, timeout: Duration) -> Result<RelayUrl> {
+    tokio::time::timeout(timeout, async move {
+        let mut watcher = ep.home_relay_status();
+        let mut statuses = watcher.get();
+        loop {
+            if let Some(status) = statuses.iter().find(|s| s.is_connected()) {
+                return Ok(status.url().clone());
+            }
+            statuses = watcher
+                .updated()
+                .await
+                .map_err(|_| anyerr!("home relay watcher disconnected"))?;
+        }
+    })
+    .await
+    .std_context("timed out waiting for a connected home relay")?
 }

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -77,6 +77,41 @@ async fn spawn_relay(lab: &Lab) -> Result<(RelayMap, AbortOnDropHandle<()>)> {
     Ok((relay_map, AbortOnDropHandle::new(task_relay)))
 }
 
+/// Spawns an iroh-dns-server on `dev` for address lookup in the lab.
+///
+/// Serves DNS on port 53 (peers behind a UDP-blocking firewall can still reach
+/// it: DNS is the one allowed UDP port) and the pkarr relay over plain HTTP on
+/// port 8080. Returns once the listeners are bound, with a drop handle that
+/// stops the server.
+pub(crate) async fn spawn_dns_server(
+    dev: &Device,
+    data_dir: PathBuf,
+) -> Result<AbortOnDropHandle<()>> {
+    let (ready_tx, ready_rx) = oneshot::channel::<()>();
+    let task = dev.spawn(move |_dev| async move {
+        tokio::fs::create_dir_all(&data_dir)
+            .await
+            .expect("create dns data dir");
+        let mut config = iroh_dns_server::config::Config::default();
+        config.dns.port = 53;
+        config.https = None;
+        config.metrics = Some(iroh_dns_server::config::MetricsConfig::disabled());
+        config.data_dir = Some(data_dir);
+        let server = iroh_dns_server::Server::bind(config)
+            .await
+            .expect("dns-server bind");
+        ready_tx.send(()).expect("test task alive");
+        server
+            .join()
+            .await
+            .expect("dns-server stopped unexpectedly");
+    })?;
+    ready_rx
+        .await
+        .std_context("dns-server died before binding")?;
+    Ok(AbortOnDropHandle::new(task))
+}
+
 /// Type alias for boxed run functions used in [`Pair`].
 type RunFn = Box<dyn 'static + Send + FnOnce(Device, Endpoint, Connection) -> BoxFuture<Result>>;
 
@@ -506,6 +541,18 @@ pub(crate) mod relay {
     /// Callers are responsible for ensuring that a DNS entry for `relay.test`
     /// exists and points to the relay's IP addresses.
     pub(crate) async fn run_relay_server() -> Result<(RelayMap, Server), SpawnError> {
+        run_relay_server_named("relay.test").await
+    }
+
+    /// Like [`run_relay_server`], but with a caller-chosen hostname.
+    ///
+    /// The returned [`RelayMap`] uses `https://<host>` as the relay URL. Use
+    /// this to run several relays in one lab, each on its own device (the
+    /// fixed ports do not clash across network namespaces) with a matching
+    /// DNS entry for its host.
+    pub(crate) async fn run_relay_server_named(
+        host: &str,
+    ) -> Result<(RelayMap, Server), SpawnError> {
         let bind_ip: IpAddr = Ipv6Addr::UNSPECIFIED.into();
 
         let (_certs, server_config) = self_signed_tls_certs_and_config();
@@ -522,7 +569,7 @@ pub(crate) mod relay {
 
         let server = Server::spawn(config).await?;
 
-        let url: RelayUrl = "https://relay.test".parse().expect("valid relay url");
+        let url: RelayUrl = format!("https://{host}").parse().expect("valid relay url");
         let quic = server
             .quic_addr()
             .map(|addr| RelayQuicConfig::new(addr.port()));


### PR DESCRIPTION
## Description


The first commit adds a patchbay test that fails on main: On a relay-only connection with no working IP path, we destroy connectivity to the relay. The test fails on main. However, this doesn't have to be, we can make the connection survive: Breaking the relay connection could  trigger a net report, chose a new home relay, and handle the new relay URL to the client over addr lookup, so that it can open a new path over the new relay. 

This PR explores how to we can do this.

In its current form, it does this:

- a) When the home relay connection dies, trigger a net report, so that we chose a new home relay and publish it in addr lookup
- b) When a relay connection dies and reconnect is not successful, inform the remote state actors about this. If we have any client-side connection where the now-dead relay path is the only path, trigger addr lookup (and retry with backoff) to see if the remote published a *new* relay URL (which it now does thanks to a) above).
- If we discover a new relay URL, establish a new path over this relay URL for all connections that used the previous relay URL, and close the previous relay path (i.e. do as with IP path: close all but one relay path).
- Use n0-computer/noq#770 so that data on the now-dead relay path is retransmitted soonish. Without this noq change, application data sent over the now-dead relay path would stay in that path's send queue for a long time, because its PTO (which eventually triggers draining and declaring all packets lost after) becomes hugely inflated: After the path dies, no data flows for a while, until our new relay path is established, which then delivers acks for the last delivered packets on the now-dead path. Because discovering and establishing the new relay path takes several seconds, the previous path's RTT is inflated to a few seconds, making its PTO be inflated too, which delays the draining and declaring its packets lost to (in the patchbay test measured to be more than 30 seconds). The linked noq change fixes this because packets are now declared lost after 2\*PTO at abandon time, when the PTO is not yet inflated.


Depends on n0-computer/noq#770
Includes #4444

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

Draft. The fix was mostly done by an AI tool and still needs to be reviewed.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
