### PR TITLE
fix: forward AWS-LC provider to reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,6 +3786,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,6 +4076,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -158,7 +158,12 @@ fast-apple-datapath = ["noq/fast-apple-datapath"]
 # Use ring as the crypto backend.
 tls-ring = ["noq/ring", "iroh-relay/tls-ring", "iroh-dns/tls-ring"]
 # Use aws-lc-rs as the crypto backend, unless `ring` is also enabled.
-tls-aws-lc-rs = ["noq/aws-lc-rs", "iroh-relay/tls-aws-lc-rs", "iroh-dns/tls-aws-lc-rs"]
+tls-aws-lc-rs = [
+    "noq/aws-lc-rs",
+    "iroh-relay/tls-aws-lc-rs",
+    "iroh-dns/tls-aws-lc-rs",
+    "reqwest/__rustls-aws-lc-rs",
+]
 # Unstable: Custom transport API (may change without notice)
 unstable-custom-transports = []
 # Unstable: API to access an endpoint's NetReport (may change without notice)


### PR DESCRIPTION
## Description

Fixes #4442 by forwarding iroh's `tls-aws-lc-rs` feature to reqwest's `__rustls-aws-lc-rs` provider feature.

Before this change, enabling `iroh/tls-aws-lc-rs` selected AWS-LC for `noq`, `iroh-relay`, and `iroh-dns`, while reqwest remained on `rustls-no-provider`. A reqwest path could therefore reach rustls without the provider selected by the top-level iroh feature.

The lockfile update records the optional reqwest feature graph selected by this configuration.

Validation:

- `cargo metadata --locked --no-deps` confirms `iroh/tls-aws-lc-rs` contains `reqwest/__rustls-aws-lc-rs`.
- `cargo tree -p iroh --no-default-features --features unstable-custom-transports,tls-aws-lc-rs -e features -i reqwest` now shows the AWS-LC provider edge; it was absent before the patch.
- `cargo check --locked -p iroh --no-default-features --features unstable-custom-transports,tls-aws-lc-rs` passes.
- `cargo clippy --locked ... --all-targets -- -D warnings` passes.
- Focused TLS unit tests pass (`2 passed`).
- `cargo fmt --all -- --check` passes.

The complete `iroh --lib` suite was also attempted locally. It reached the real endpoint/socket network tests, where several unrelated network-change and roundtrip tests timed out or failed in the local environment; no failures involved TLS provider selection or feature resolution.

## Breaking Changes

None.

## Notes & open questions

The reqwest feature name is internal by convention, but reqwest 0.13.4 uses `__rustls-aws-lc-rs` as the explicit dependency-facing provider forwarding edge for rustls, matching the issue's proposed fix.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the style guide, if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the proposed change and wrote an as clear and concise description as they could.
- [x] This PR isn't slop, and is carefully crafted to have the intended effect.
