### PR TITLE
test(iroh): update patchbay to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,8 +3464,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patchbay"
-version = "0.6.0"
-source = "git+https://github.com/n0-computer/patchbay.git?branch=main#8415da55db963fc03a9132475d9d6c1052c5d85a"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07db6594ac62885d28def27f2385d526f16ba4d2edd096d8806072fa81b757f2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,8 +3465,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "patchbay"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543b9acbe630f7745965d8243d3af809370cfad7b12d801b63e085e606349852"
+source = "git+https://github.com/n0-computer/patchbay.git?branch=main#8415da55db963fc03a9132475d9d6c1052c5d85a"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,3 @@ trait_method_marked_deprecated = { required-update = "minor" }
 type_associated_const_marked_deprecated = { required-update = "minor" }
 type_marked_deprecated = { required-update = "minor" }
 type_method_marked_deprecated = { required-update = "minor" }
-
-# Test-only: point patchbay at git main, which carries the reworked NAT
-# taxonomy, the merged LinkCondition API, and the Lab test-setup helpers that
-# are not in a crates.io release yet.
-[patch.crates-io]
-patchbay = { git = "https://github.com/n0-computer/patchbay.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,9 @@ trait_method_marked_deprecated = { required-update = "minor" }
 type_associated_const_marked_deprecated = { required-update = "minor" }
 type_marked_deprecated = { required-update = "minor" }
 type_method_marked_deprecated = { required-update = "minor" }
+
+# Test-only: point patchbay at git main, which carries the reworked NAT
+# taxonomy, the merged LinkCondition API, and the Lab test-setup helpers that
+# are not in a crates.io release yet.
+[patch.crates-io]
+patchbay = { git = "https://github.com/n0-computer/patchbay.git", branch = "main" }

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -76,7 +76,7 @@ tempfile = "3.23.0"
 # patchbay netsim test dependencies (linux only)
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 ctor = "1.0"
-patchbay = "0.6"
+patchbay = "0.7"
 testdir = "0.10"
 
 [features]

--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -139,7 +139,7 @@ wasm-bindgen-test = "0.3.62"
 # patchbay netsim test dependencies (linux only)
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 ctor = "1.0"
-patchbay = { version = "0.6", features = ["iroh-metrics"] }
+patchbay = { version = "0.7", features = ["iroh-metrics"] }
 testdir = "0.10"
 
 [build-dependencies]

--- a/iroh/tests/patchbay.rs
+++ b/iroh/tests/patchbay.rs
@@ -67,8 +67,8 @@ fn userns_ctor() {
 #[traced_test]
 async fn holepunch_simple() -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let nat1 = lab.add_router("nat1").nat(Nat::Home).build().await?;
-    let nat2 = lab.add_router("nat2").nat(Nat::Home).build().await?;
+    let nat1 = lab.add_router("nat1").nat(Nat::Moderate).build().await?;
+    let nat2 = lab.add_router("nat2").nat(Nat::Moderate).build().await?;
     let server = lab.add_device("server").uplink(nat1.id()).build().await?;
     let client = lab.add_device("client").uplink(nat2.id()).build().await?;
     let timeout = Duration::from_secs(10);
@@ -96,14 +96,15 @@ async fn holepunch_simple() -> Result {
 /// the selected path should switch to the faster LAN link.
 async fn run_add_faster_link(active_side: Side) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let nat_a = lab.add_router("nat_a").nat(Nat::Home).build().await?;
-    let nat_b = lab.add_router("nat_b").nat(Nat::Home).build().await?;
+    let nat_a = lab.add_router("nat_a").nat(Nat::Moderate).build().await?;
+    let nat_b = lab.add_router("nat_b").nat(Nat::Moderate).build().await?;
 
     let active = lab
         .add_device("active")
         .iface(
             "eth0",
-            IfaceConfig::routed(nat_a.id()).condition(LinkCondition::Mobile4G, LinkDirection::Both),
+            IfaceConfig::routed(nat_a.id())
+                .condition(LinkCondition::mobile_4g(), LinkDirection::Both),
         )
         .iface("eth1", IfaceConfig::routed(nat_b.id()).down())
         .build()
@@ -189,8 +190,8 @@ async fn add_faster_link_server() -> Result {
 /// direct path), then waits for a direct path to be selected again.
 async fn run_link_outage_recovery(outage_side: Side, downtime: Duration) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let nat1 = lab.add_router("nat1").nat(Nat::Home).build().await?;
-    let nat2 = lab.add_router("nat2").nat(Nat::Home).build().await?;
+    let nat1 = lab.add_router("nat1").nat(Nat::Moderate).build().await?;
+    let nat2 = lab.add_router("nat2").nat(Nat::Moderate).build().await?;
     let outage = lab.add_device("outage").uplink(nat1.id()).build().await?;
     let peer = lab.add_device("peer").uplink(nat2.id()).build().await?;
     let timeout = Duration::from_secs(15);
@@ -245,13 +246,17 @@ async fn link_outage_recovery_server() -> Result {
 /// it to a Home NAT and verifies a direct path is established.
 async fn run_hard_nat_to_holepunchable(replug_side: Side) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let nat_easy = lab.add_router("nat_easy").nat(Nat::Home).build().await?;
-    let nat_hard = lab
-        .add_router("nat_hard")
-        .nat(Nat::Corporate)
+    let nat_easy = lab
+        .add_router("nat_easy")
+        .nat(Nat::Moderate)
         .build()
         .await?;
-    let nat_peer = lab.add_router("nat_peer").nat(Nat::Home).build().await?;
+    let nat_hard = lab.add_router("nat_hard").nat(Nat::Strict).build().await?;
+    let nat_peer = lab
+        .add_router("nat_peer")
+        .nat(Nat::Moderate)
+        .build()
+        .await?;
 
     let replug = lab
         .add_device("replug")
@@ -329,8 +334,8 @@ async fn hard_nat_to_holepunchable_server() -> Result {
 /// Holepunching succeeds despite many unreachable local addresses on one side.
 async fn run_holepunch_many_addrs(many_addrs_side: Side, addr_count: u8) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let nat1 = lab.add_router("nat1").nat(Nat::Home).build().await?;
-    let nat2 = lab.add_router("nat2").nat(Nat::Home).build().await?;
+    let nat1 = lab.add_router("nat1").nat(Nat::Moderate).build().await?;
+    let nat2 = lab.add_router("nat2").nat(Nat::Moderate).build().await?;
 
     let mut builder = lab.add_device("many_addrs").uplink(nat1.id());
     for i in 0..addr_count {

--- a/iroh/tests/patchbay/degrade.rs
+++ b/iroh/tests/patchbay/degrade.rs
@@ -11,54 +11,100 @@ use tracing::info;
 
 use super::util::{Pair, PathConnectionExt, lab_with_relay, ping_accept, ping_open};
 
-/// Increasingly degraded link conditions applied to one side of the connection.
+/// A ladder of increasingly degraded real-world links, used to find where
+/// hole-punching breaks.
 ///
-/// Each level adds more latency, loss, and reordering. The levels are tested
-/// individually for both server-side and client-side impairment.
+/// Each rung models a plausible last-mile scenario rather than a synthetic
+/// ramp. Loss is bursty (Gilbert-Elliott), the way real radio links drop
+/// packets in fades and handovers, rather than independent per-packet loss, and
+/// the mean burst grows as conditions worsen. Every rung is bandwidth-capped
+/// with a buffer sized to its round-trip time (via [`rtt_ms`]), so queueing
+/// delay and congestion loss appear as they do on a real bottleneck.
+///
+/// The first rungs walk through common degraded links, from good wifi to a
+/// congested cellular connection, with loss rates that track measured medians:
+/// good LTE and wifi sit under 1 %, cell-edge and congested links reach a few
+/// percent. The last three cover distinct extremes: a geostationary satellite
+/// (defined by its ~600 ms round trip), a barely-usable link at the edge of
+/// coverage, and an absurd stress case past what any real link sustains, there
+/// to find the point where the connection gives up entirely. Reordering, which
+/// real links rarely exhibit above a fraction of a percent, is dropped.
+///
+/// [`rtt_ms`]: patchbay::LinkCondition::rtt_ms
 const DEGRADE_LEVELS: &[LinkCondition] = &[
-    // The levels keep independent (Bernoulli) loss, so `loss_pct` is used
-    // directly rather than `bursty_loss`. Latency, jitter, and reordering grow
-    // with each step; the links stay uncapped.
-    // 0: mild - good wifi
+    // 0: good home wifi, 5 GHz, close to the access point.
     LinkCondition::new()
-        .latency_ms(10)
-        .jitter_ms(5)
-        .loss_pct(0.5)
-        .label("mild"),
-    // 1: poor - bad wifi or 3G
+        .rate_mbit(100)
+        .rtt_ms(16)
+        .bursty_loss(0.1)
+        .label("good-wifi"),
+    // 1: congested 2.4 GHz wifi, interference and distance.
     LinkCondition::new()
-        .latency_ms(100)
+        .rate_mbit(25)
+        .rtt_ms(40)
+        .jitter_ms(12)
+        .loss_pct(1.0)
+        .loss_burst_pkts(6)
+        .label("congested-wifi"),
+    // 2: LTE at the cell edge, weak signal.
+    LinkCondition::new()
+        .rate_mbit(8)
+        .rtt_ms(90)
+        .jitter_ms(15)
+        .loss_pct(2.0)
+        .loss_burst_pkts(8)
+        .label("weak-4g"),
+    // 3: degraded 3G, deep buffers (bufferbloat).
+    LinkCondition::new()
+        .rate_mbit(3)
+        .rtt_ms(200)
         .jitter_ms(30)
         .loss_pct(3.0)
-        .reorder_pct(3.0)
-        .label("poor"),
-    // 2: bad - congested 3G
+        .loss_burst_pkts(10)
+        .label("slow-3g"),
+    // 4: oversubscribed cellular under load, heavy bufferbloat.
     LinkCondition::new()
-        .latency_ms(200)
-        .jitter_ms(60)
+        .rate_kbit(1500)
+        .rtt_ms(300)
+        .jitter_ms(40)
         .loss_pct(5.0)
-        .reorder_pct(5.0)
-        .label("bad"),
-    // 3: terrible - barely usable
+        .loss_burst_pkts(12)
+        .label("congested-cellular"),
+    // 5: a very bad cellular link, such as a moving vehicle in poor coverage:
+    // low bandwidth, high latency, and heavy bursty loss.
     LinkCondition::new()
-        .latency_ms(300)
-        .jitter_ms(80)
+        .rate_kbit(800)
+        .rtt_ms(450)
+        .jitter_ms(60)
         .loss_pct(8.0)
-        .reorder_pct(8.0)
-        .label("terrible"),
-    // 4: extreme - GEO satellite with heavy loss
+        .loss_burst_pkts(20)
+        .label("very-bad-cellular"),
+    // 6: geostationary satellite (Viasat / HughesNet class). The ~600 ms round
+    // trip is the defining impairment; loss stays modest.
     LinkCondition::new()
-        .latency_ms(500)
-        .jitter_ms(100)
+        .rate_mbit(25)
+        .rtt_ms(600)
+        .jitter_ms(40)
+        .loss_pct(1.5)
+        .loss_burst_pkts(6)
+        .label("satellite"),
+    // 7: barely-usable cellular or wifi at the edge of coverage. Low bandwidth,
+    // heavy bufferbloat, and long loss bursts.
+    LinkCondition::new()
+        .rate_kbit(500)
+        .rtt_ms(450)
+        .jitter_ms(80)
         .loss_pct(12.0)
-        .reorder_pct(12.0)
-        .label("extreme"),
-    // 5: absurd - stress test
+        .loss_burst_pkts(25)
+        .label("barely-usable"),
+    // 8: absurd stress case, past what any real link sustains, to find where the
+    // connection gives up entirely.
     LinkCondition::new()
-        .latency_ms(800)
-        .jitter_ms(200)
-        .loss_pct(20.0)
-        .reorder_pct(20.0)
+        .rate_kbit(256)
+        .rtt_ms(800)
+        .jitter_ms(150)
+        .loss_pct(25.0)
+        .loss_burst_pkts(40)
         .label("absurd"),
 ];
 
@@ -127,7 +173,7 @@ async fn run_degrade_level(impaired_side: Side, level: usize) -> Result<()> {
             level,
             latency_ms = limits.latency_ms,
             loss_pct = limits.loss_pct,
-            reorder_pct = limits.reorder_pct,
+            loss_burst_pkts = ?limits.loss_burst_pkts,
             impaired_side = ?impaired_side,
             "PASSED",
         ),
@@ -137,7 +183,7 @@ async fn run_degrade_level(impaired_side: Side, level: usize) -> Result<()> {
             level,
             latency_ms = limits.latency_ms,
             loss_pct = limits.loss_pct,
-            reorder_pct = limits.reorder_pct,
+            loss_burst_pkts = ?limits.loss_burst_pkts,
             impaired_side = ?impaired_side,
             error = format!("{err:#}"),
             "FAILED",
@@ -151,80 +197,112 @@ async fn run_degrade_level(impaired_side: Side, level: usize) -> Result<()> {
 
 #[tokio::test]
 #[traced_test]
-async fn degrade_server_0_mild() -> Result {
+async fn degrade_server_good_wifi() -> Result {
     run_degrade_level(Side::Server, 0).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn degrade_server_1_poor() -> Result {
+async fn degrade_server_congested_wifi() -> Result {
     run_degrade_level(Side::Server, 1).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing reliably"]
-async fn degrade_server_2_bad() -> Result {
+async fn degrade_server_weak_4g() -> Result {
     run_degrade_level(Side::Server, 2).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing reliably"]
-async fn degrade_server_3_terrible() -> Result {
+async fn degrade_server_slow_3g() -> Result {
     run_degrade_level(Side::Server, 3).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing reliably"]
-async fn degrade_server_4_extreme() -> Result {
+async fn degrade_server_congested_cellular() -> Result {
     run_degrade_level(Side::Server, 4).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing reliably"]
-async fn degrade_server_5_absurd() -> Result {
+async fn degrade_server_very_bad_cellular() -> Result {
     run_degrade_level(Side::Server, 5).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn degrade_client_0_mild() -> Result {
+async fn degrade_server_satellite() -> Result {
+    run_degrade_level(Side::Server, 6).await
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing"]
+async fn degrade_server_barely_usable() -> Result {
+    run_degrade_level(Side::Server, 7).await
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing"]
+async fn degrade_server_absurd() -> Result {
+    run_degrade_level(Side::Server, 8).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn degrade_client_good_wifi() -> Result {
     run_degrade_level(Side::Client, 0).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn degrade_client_1_poor() -> Result {
+async fn degrade_client_congested_wifi() -> Result {
     run_degrade_level(Side::Client, 1).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing reliably"]
-async fn degrade_client_2_bad() -> Result {
+async fn degrade_client_weak_4g() -> Result {
     run_degrade_level(Side::Client, 2).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing reliably"]
-async fn degrade_client_3_terrible() -> Result {
+async fn degrade_client_slow_3g() -> Result {
     run_degrade_level(Side::Client, 3).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing reliably"]
-async fn degrade_client_4_extreme() -> Result {
+async fn degrade_client_congested_cellular() -> Result {
     run_degrade_level(Side::Client, 4).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing reliably"]
-async fn degrade_client_5_absurd() -> Result {
+async fn degrade_client_very_bad_cellular() -> Result {
     run_degrade_level(Side::Client, 5).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn degrade_client_satellite() -> Result {
+    run_degrade_level(Side::Client, 6).await
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing"]
+async fn degrade_client_barely_usable() -> Result {
+    run_degrade_level(Side::Client, 7).await
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing"]
+async fn degrade_client_absurd() -> Result {
+    run_degrade_level(Side::Client, 8).await
 }

--- a/iroh/tests/patchbay/degrade.rs
+++ b/iroh/tests/patchbay/degrade.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use iroh::endpoint::Side;
 use n0_error::{Result, StackResultExt, StdResultExt};
 use n0_tracing_test::traced_test;
-use patchbay::{LinkCondition, LinkDirection, LinkLimits, Nat};
+use patchbay::{LinkCondition, LinkDirection, Nat};
 use testdir::testdir;
 use tracing::info;
 
@@ -15,82 +15,65 @@ use super::util::{Pair, PathConnectionExt, lab_with_relay, ping_accept, ping_ope
 ///
 /// Each level adds more latency, loss, and reordering. The levels are tested
 /// individually for both server-side and client-side impairment.
-const DEGRADE_LEVELS: &[LinkLimits] = &[
+const DEGRADE_LEVELS: &[LinkCondition] = &[
+    // The levels keep independent (Bernoulli) loss, so `loss_pct` is used
+    // directly rather than `bursty_loss`. Latency, jitter, and reordering grow
+    // with each step; the links stay uncapped.
     // 0: mild - good wifi
-    LinkLimits {
-        latency_ms: 10,
-        jitter_ms: 5,
-        loss_pct: 0.5,
-        reorder_pct: 0.0,
-        rate_kbit: 0,
-        duplicate_pct: 0.0,
-        corrupt_pct: 0.0,
-    },
+    LinkCondition::new()
+        .latency_ms(10)
+        .jitter_ms(5)
+        .loss_pct(0.5)
+        .label("mild"),
     // 1: poor - bad wifi or 3G
-    LinkLimits {
-        latency_ms: 100,
-        jitter_ms: 30,
-        loss_pct: 3.0,
-        reorder_pct: 3.0,
-        rate_kbit: 0,
-        duplicate_pct: 0.0,
-        corrupt_pct: 0.0,
-    },
+    LinkCondition::new()
+        .latency_ms(100)
+        .jitter_ms(30)
+        .loss_pct(3.0)
+        .reorder_pct(3.0)
+        .label("poor"),
     // 2: bad - congested 3G
-    LinkLimits {
-        latency_ms: 200,
-        jitter_ms: 60,
-        loss_pct: 5.0,
-        reorder_pct: 5.0,
-        rate_kbit: 0,
-        duplicate_pct: 0.0,
-        corrupt_pct: 0.0,
-    },
+    LinkCondition::new()
+        .latency_ms(200)
+        .jitter_ms(60)
+        .loss_pct(5.0)
+        .reorder_pct(5.0)
+        .label("bad"),
     // 3: terrible - barely usable
-    LinkLimits {
-        latency_ms: 300,
-        jitter_ms: 80,
-        loss_pct: 8.0,
-        reorder_pct: 8.0,
-        rate_kbit: 0,
-        duplicate_pct: 0.0,
-        corrupt_pct: 0.0,
-    },
+    LinkCondition::new()
+        .latency_ms(300)
+        .jitter_ms(80)
+        .loss_pct(8.0)
+        .reorder_pct(8.0)
+        .label("terrible"),
     // 4: extreme - GEO satellite with heavy loss
-    LinkLimits {
-        latency_ms: 500,
-        jitter_ms: 100,
-        loss_pct: 12.0,
-        reorder_pct: 12.0,
-        rate_kbit: 0,
-        duplicate_pct: 0.0,
-        corrupt_pct: 0.0,
-    },
+    LinkCondition::new()
+        .latency_ms(500)
+        .jitter_ms(100)
+        .loss_pct(12.0)
+        .reorder_pct(12.0)
+        .label("extreme"),
     // 5: absurd - stress test
-    LinkLimits {
-        latency_ms: 800,
-        jitter_ms: 200,
-        loss_pct: 20.0,
-        reorder_pct: 20.0,
-        rate_kbit: 0,
-        duplicate_pct: 0.0,
-        corrupt_pct: 0.0,
-    },
+    LinkCondition::new()
+        .latency_ms(800)
+        .jitter_ms(200)
+        .loss_pct(20.0)
+        .reorder_pct(20.0)
+        .label("absurd"),
 ];
 
 /// Runs a single degradation level.
 ///
-/// Creates two devices behind Home NATs, applies the given [`LinkLimits`] to
+/// Creates two devices behind Home NATs, applies the given [`LinkCondition`] to
 /// `impaired_side`, then attempts to holepunch and ping. Returns the
 /// [`TestGuard`] on success so the caller can mark it as passed.
 async fn run_degrade_level(impaired_side: Side, level: usize) -> Result<()> {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let nat1 = lab.add_router("nat1").nat(Nat::Home).build().await?;
-    let nat2 = lab.add_router("nat2").nat(Nat::Home).build().await?;
+    let nat1 = lab.add_router("nat1").nat(Nat::Moderate).build().await?;
+    let nat2 = lab.add_router("nat2").nat(Nat::Moderate).build().await?;
     let timeout = Duration::from_secs(20 + level as u64 * 10);
 
     let limits = DEGRADE_LEVELS[level];
-    let link_condition = LinkCondition::Manual(limits);
 
     let server = lab
         .add_device("server")
@@ -109,7 +92,7 @@ async fn run_degrade_level(impaired_side: Side, level: usize) -> Result<()> {
     impaired_device
         .iface("eth0")
         .unwrap()
-        .set_condition(link_condition, LinkDirection::Both)
+        .set_condition(limits, LinkDirection::Both)
         .await?;
 
     info!(?impaired_side, ?limits, %level, ?timeout, "degrade test start");

--- a/iroh/tests/patchbay/nat.rs
+++ b/iroh/tests/patchbay/nat.rs
@@ -1,12 +1,16 @@
 //! NAT traversal matrix tests.
 //!
-//! Tests holepunching across combinations of NAT types (None, Home, Corporate).
+//! Tests holepunching across combinations of the upstream [`patchbay::Nat`]
+//! behavior tiers:
 //!
-//! - None: no NAT, publicly routable
-//! - Home: endpoint-independent mapping (EIM), address-and-port-dependent
-//!   filtering (APDF), port-preserving (typical home router)
-//! - Corporate: endpoint-dependent mapping (EDM), APDF, random ports per
-//!   destination (enterprise firewall, cloud NAT)
+//! - `None`: no NAT, publicly routable.
+//! - `Open`: endpoint-independent mapping (EIM), endpoint-independent
+//!   filtering (EIF); RFC 3489 full cone. Typical of routers with UPnP or
+//!   static port forwarding.
+//! - `Moderate`: EIM, address-and-port-dependent filtering (APDF); RFC 3489
+//!   port-restricted cone. The typical home router.
+//! - `Strict`: endpoint-dependent mapping (EDM) with random ports, APDF; RFC
+//!   3489 symmetric. Holepunching between two `Strict` NATs requires a relay.
 //!
 //! Every test expects a direct path to be established. Tests where holepunching
 //! is not yet working are marked `#[ignore]`.
@@ -15,80 +19,17 @@ use std::time::Duration;
 
 use n0_error::{Result, StackResultExt};
 use n0_tracing_test::traced_test;
-use patchbay::{Nat, NatConfig, NatFiltering, NatMapping};
+use patchbay::Nat;
 use testdir::testdir;
 use tracing::info;
 
 use super::util::{Pair, PathConnectionExt, lab_with_relay};
 use crate::util::{is_relayed, ping_accept, ping_open};
 
-enum NatKind {
-    /// No NAT. The device has a publicly routable address.
-    None,
-    /// Most permissive NAT.
-    ///
-    /// Typical of consumer routers with UPnP or static port forwarding.
-    ///
-    /// RFC 4787: Endpoint-Independent Mapping, Endpoint-Independent Filtering (EIM/EIF).
-    /// RFC 3489: Full Cone NAT.
-    Easiest,
-    /// Moderately restrictive NAT.
-    ///
-    /// The external mapping is stable across destinations, but inbound packets are filtered
-    /// by source address and port. Common in home routers without UPnP.
-    ///
-    /// RFC 4787: Endpoint-Independent Mapping, Address-and-Port-Dependent Filtering (EIM/APDF).
-    /// RFC 3489: Port Restricted Cone NAT.
-    Easy,
-    /// Most restrictive NAT.
-    ///
-    /// Each destination gets a different external mapping, and inbound packets are filtered
-    /// by source address and port. Holepunching between two Hard NATs requires a relay
-    /// (TURN or similar). Typical of corporate firewalls and carrier-grade NAT (CGN).
-    ///
-    /// RFC 4787: Endpoint-Dependent Mapping, Address-and-Port-Dependent Filtering (EDM/APDF).
-    /// RFC 3489: Symmetric NAT.
-    Hard,
-}
-
-impl From<NatKind> for Nat {
-    fn from(value: NatKind) -> Self {
-        let (mapping, filtering) = match value {
-            NatKind::None => return Nat::None,
-            NatKind::Easiest => (
-                NatMapping::EndpointIndependent,
-                NatFiltering::EndpointIndependent,
-            ),
-            NatKind::Easy => (
-                NatMapping::EndpointIndependent,
-                NatFiltering::AddressAndPortDependent,
-            ),
-            NatKind::Hard => (
-                NatMapping::EndpointDependent,
-                NatFiltering::AddressAndPortDependent,
-            ),
-        };
-        Nat::Custom(NatConfig {
-            mapping,
-            filtering,
-            timeouts: Default::default(),
-            hairpin: false,
-        })
-    }
-}
-
-async fn run_nat_holepunch(nat_server: NatKind, nat_client: NatKind) -> Result {
+async fn run_nat_holepunch(nat_server: Nat, nat_client: Nat) -> Result {
     let (lab, relay_map, _relay_guard, guard) = lab_with_relay(testdir!()).await?;
-    let router_server = lab
-        .add_router("nat_server")
-        .nat(nat_server.into())
-        .build()
-        .await?;
-    let router_client = lab
-        .add_router("nat_client")
-        .nat(nat_client.into())
-        .build()
-        .await?;
+    let router_server = lab.add_router("nat_server").nat(nat_server).build().await?;
+    let router_client = lab.add_router("nat_client").nat(nat_client).build().await?;
     let server = lab
         .add_device("server")
         .uplink(router_server.id())
@@ -130,104 +71,104 @@ async fn run_nat_holepunch(nat_server: NatKind, nat_client: NatKind) -> Result {
 #[tokio::test]
 #[traced_test]
 async fn nat_none_x_none() -> Result {
-    run_nat_holepunch(NatKind::None, NatKind::None).await
+    run_nat_holepunch(Nat::None, Nat::None).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_none_x_easiest() -> Result {
-    run_nat_holepunch(NatKind::None, NatKind::Easiest).await
+async fn nat_none_x_open() -> Result {
+    run_nat_holepunch(Nat::None, Nat::Open).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_none_x_easy() -> Result {
-    run_nat_holepunch(NatKind::None, NatKind::Easy).await
+async fn nat_none_x_moderate() -> Result {
+    run_nat_holepunch(Nat::None, Nat::Moderate).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_none_x_hard() -> Result {
-    run_nat_holepunch(NatKind::None, NatKind::Hard).await
+async fn nat_none_x_strict() -> Result {
+    run_nat_holepunch(Nat::None, Nat::Strict).await
 }
 
-// Easiest x *
+// Open x *
 
 #[tokio::test]
 #[traced_test]
-async fn nat_easiest_x_none() -> Result {
-    run_nat_holepunch(NatKind::Easiest, NatKind::None).await
-}
-
-#[tokio::test]
-#[traced_test]
-async fn nat_easiest_x_easiest() -> Result {
-    run_nat_holepunch(NatKind::Easiest, NatKind::Easiest).await
+async fn nat_open_x_none() -> Result {
+    run_nat_holepunch(Nat::Open, Nat::None).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_easiest_x_easy() -> Result {
-    run_nat_holepunch(NatKind::Easiest, NatKind::Easy).await
+async fn nat_open_x_open() -> Result {
+    run_nat_holepunch(Nat::Open, Nat::Open).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_easiest_x_hard() -> Result {
-    run_nat_holepunch(NatKind::Easiest, NatKind::Hard).await
-}
-
-// Easy x *
-
-#[tokio::test]
-#[traced_test]
-async fn nat_easy_x_none() -> Result {
-    run_nat_holepunch(NatKind::Easy, NatKind::None).await
+async fn nat_open_x_moderate() -> Result {
+    run_nat_holepunch(Nat::Open, Nat::Moderate).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_easy_x_easiest() -> Result {
-    run_nat_holepunch(NatKind::Easy, NatKind::Easiest).await
+async fn nat_open_x_strict() -> Result {
+    run_nat_holepunch(Nat::Open, Nat::Strict).await
+}
+
+// Moderate x *
+
+#[tokio::test]
+#[traced_test]
+async fn nat_moderate_x_none() -> Result {
+    run_nat_holepunch(Nat::Moderate, Nat::None).await
 }
 
 #[tokio::test]
 #[traced_test]
-async fn nat_easy_x_easy() -> Result {
-    run_nat_holepunch(NatKind::Easy, NatKind::Easy).await
+async fn nat_moderate_x_open() -> Result {
+    run_nat_holepunch(Nat::Moderate, Nat::Open).await
 }
 
 #[tokio::test]
 #[traced_test]
-#[ignore = "not yet passing (and likely can't without port guessing)"]
-async fn nat_easy_x_hard() -> Result {
-    run_nat_holepunch(NatKind::Easy, NatKind::Hard).await
-}
-
-// Hard x *
-
-#[tokio::test]
-#[traced_test]
-async fn nat_hard_x_none() -> Result {
-    run_nat_holepunch(NatKind::Hard, NatKind::None).await
-}
-
-#[tokio::test]
-#[traced_test]
-async fn nat_hard_x_easiest() -> Result {
-    run_nat_holepunch(NatKind::Hard, NatKind::Easiest).await
+async fn nat_moderate_x_moderate() -> Result {
+    run_nat_holepunch(Nat::Moderate, Nat::Moderate).await
 }
 
 #[tokio::test]
 #[traced_test]
 #[ignore = "not yet passing (and likely can't without port guessing)"]
-async fn nat_hard_x_easy() -> Result {
-    run_nat_holepunch(NatKind::Hard, NatKind::Easy).await
+async fn nat_moderate_x_strict() -> Result {
+    run_nat_holepunch(Nat::Moderate, Nat::Strict).await
+}
+
+// Strict x *
+
+#[tokio::test]
+#[traced_test]
+async fn nat_strict_x_none() -> Result {
+    run_nat_holepunch(Nat::Strict, Nat::None).await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn nat_strict_x_open() -> Result {
+    run_nat_holepunch(Nat::Strict, Nat::Open).await
 }
 
 #[tokio::test]
 #[traced_test]
 #[ignore = "not yet passing (and likely can't without port guessing)"]
-async fn nat_hard_x_hard() -> Result {
-    run_nat_holepunch(NatKind::Hard, NatKind::Hard).await
+async fn nat_strict_x_moderate() -> Result {
+    run_nat_holepunch(Nat::Strict, Nat::Moderate).await
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "not yet passing (and likely can't without port guessing)"]
+async fn nat_strict_x_strict() -> Result {
+    run_nat_holepunch(Nat::Strict, Nat::Strict).await
 }

--- a/iroh/tests/patchbay/util.rs
+++ b/iroh/tests/patchbay/util.rs
@@ -9,7 +9,7 @@ use iroh_metrics::MetricsGroupSet;
 use n0_error::{Result, StackResultExt, StdResultExt, anyerr, ensure_any};
 use n0_future::{StreamExt, boxed::BoxFuture, task::AbortOnDropHandle};
 use noq::Side;
-use patchbay::{Device, IpSupport, Lab, OutDir, TestGuard};
+use patchbay::{Device, IpSupport, Lab, TestGuard};
 use tokio::sync::{Barrier, oneshot};
 use tracing::{Instrument, debug, error, error_span, event, info};
 
@@ -27,12 +27,10 @@ const TEST_ALPN: &[u8] = b"test";
 pub(crate) async fn lab_with_relay(
     outdir: PathBuf,
 ) -> Result<(Lab, RelayMap, AbortOnDropHandle<()>, TestGuard)> {
-    let mut builder = Lab::builder().outdir(OutDir::Exact(outdir));
-    if let Some(name) = std::thread::current().name() {
-        builder = builder.label(name);
-    }
-    let lab = builder.build().await?;
-    let guard = lab.test_guard();
+    // `for_test` writes into `outdir`, labels the lab with the current thread
+    // (the test name under the default current-thread runtime), and returns the
+    // pass/fail guard.
+    let (lab, guard) = Lab::for_test(outdir).await?;
     let (relay_map, relay_guard) = spawn_relay(&lab).await?;
     Ok((lab, relay_map, relay_guard, guard))
 }


### PR DESCRIPTION
## Description

I merged a couple of breaking changes to patchbay (restructured the NAT presets n0-computer/patchbay#37 and improved the link condition APIs including now modeling more realistic link conditions n0-computer/patchbay#43). This PR updates iroh to this newly released patchbay 0.7.0.

## Breaking Changes

None

## Notes & open questions

This PR does not adjust the degrade tests to make use of the more realistic loss distribution now available in patchbay, that'll be a separate PR.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
