### PR TITLE
fix(iroh): Clean up mapped addresses when unused

### DIFF
--- a/iroh/src/socket/mapped_addrs.rs
+++ b/iroh/src/socket/mapped_addrs.rs
@@ -359,10 +359,36 @@ where
         }
     }
 
+    /// Returns the number of entries in this address map.
+    pub(super) fn len(&self) -> usize {
+        self.inner.lock().expect("poisoned").addrs.len()
+    }
+
     /// Performs the reverse lookup.
     pub(super) fn lookup(&self, addr: &V) -> Option<K> {
         let inner = self.inner.lock().expect("poisoned");
         inner.lookup.get(addr).cloned()
+    }
+
+    /// Removes the [`MappedAddr`] if present, returning it.
+    pub(super) fn remove(&self, key: &K) -> Option<V> {
+        let mut inner = self.inner.lock().expect("poisoned");
+        inner.addrs.remove(key).inspect(|addr| {
+            inner.lookup.remove(addr);
+        })
+    }
+
+    /// Retains the elements for which `f` returns `true`.
+    pub(super) fn retain(&self, mut f: impl FnMut(&K, &V) -> bool) {
+        let mut inner = self.inner.lock().expect("poisoned");
+        let AddrMapInner { addrs, lookup } = &mut *inner;
+        addrs.retain(|k: &K, v| {
+            let retain = f(k, v);
+            if !retain {
+                lookup.remove(v);
+            }
+            retain
+        });
     }
 }
 
@@ -379,5 +405,31 @@ impl<K, V> Default for AddrMapInner<K, V> {
             addrs: Default::default(),
             lookup: Default::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_addrmap_remove() {
+        let map: AddrMap<u8, EndpointIdMappedAddr> = AddrMap::default();
+        let addr = map.get(&0);
+        assert!(map.lookup(&addr).is_some(), "reverse lookup not found");
+
+        map.remove(&0);
+        assert!(map.lookup(&addr).is_none(), "reverse lookup not cleared");
+    }
+
+    #[test]
+    fn test_addrmap_retain() {
+        let map: AddrMap<u8, EndpointIdMappedAddr> = AddrMap::default();
+        map.get(&0);
+        let addr1 = map.get(&1);
+        assert!(map.lookup(&addr1).is_some(), "reverse lookup not found");
+
+        map.retain(|k, _a| *k == 0);
+        assert!(map.lookup(&addr1).is_none(), "reverse lookup not cleared");
     }
 }

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -92,7 +92,7 @@ pub(crate) struct MappedAddrs {
 impl MappedAddrs {
     /// Removes all mapped addresses for an [`EndpointId`].
     fn remove(&self, eid: &EndpointId) {
-        self.endpoint_addrs.remove(&eid);
+        self.endpoint_addrs.remove(eid);
         self.relay_addrs.retain(|k, _| k.1 != *eid);
     }
 }

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -42,6 +42,17 @@ use crate::{
 
 mod remote_state;
 
+/// The number of entries after which we'll start pruning unused addresses.
+///
+/// It is nice to keep mapped addresses consistent, but also if we cycle through lots of
+/// connections that keeps requiring memory. So we make a compromise where we start pruning
+/// only once the number has exceeded a certain size. This means we get stable remote
+/// addresses for the many endpoints that don't end up cycling through lots of peers.
+///
+/// The number is pretty arbitrary: there is not that much data stored for each
+/// [`EndpointId`].
+const MAPPED_ADDR_PRUNE_LIMIT: usize = 64;
+
 // TODO: use this
 // /// Number of endpoints that are inactive for which we keep info about. This limit is enforced
 // /// periodically via [`NodeMap::prune_inactive`].
@@ -76,6 +87,14 @@ pub(crate) struct MappedAddrs {
     pub(super) relay_addrs: AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
     /// The mapping between custom transport addresses and their [`CustomMappedAddr`]s.
     pub(super) custom_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
+}
+
+impl MappedAddrs {
+    /// Removes all mapped addresses for an [`EndpointId`].
+    fn remove(&self, eid: &EndpointId) {
+        self.endpoint_addrs.remove(&eid);
+        self.relay_addrs.retain(|k, _| k.1 != *eid);
+    }
 }
 
 /// Converts a mapped socket address to a transport address.
@@ -236,6 +255,9 @@ impl RemoteMap {
         if leftover_msgs.is_empty() {
             // the actor shut down cleanly
             self.senders.remove(&remote_id);
+            if self.mapped_addrs.endpoint_addrs.len() > MAPPED_ADDR_PRUNE_LIMIT {
+                self.mapped_addrs.remove(&remote_id);
+            }
             trace!(%remote_id, "cleaned up RemoteStateActor");
             true
         } else {


### PR DESCRIPTION
## Description

This adds some cleanup for when a mapped address is no longer
used. Cleaning it up immediately would mean we generate new mapped
addresses for endpoints if we come back to them. But also growing them
unlimited does eventually result in a memory leak.

So the compromise is that when an endpoint does not use too many
remote endpoints they are all remembered. But once over the threshold
we start removing unused addresses.

This of course leaves up to the threshold addresses allocated that may
never ever be used again. It's not ideal, but also doing this better
would require a lot more bookkeeping.

## Breaking Changes

n/a

## Notes & open questions

- Maybe 64 is a bit much, 32 would probably also be plenty.

- I'm not sure what to do with custom mapped addrs. It seems like they
  would also need cleanup but they don't currently store an
  EndpointId. Perhaps the generic AddrMap needs to enforce that an
  EndpointId is in the key somehow. I don't really understand how this
  works currently for custom addresses.

- Replaces #4294 that is abandoned.

## Change checklist

- [ ] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.

<!-- Message of single commit: -->