### PR TITLE
feat(iroh-relay, iroh): inform clients when they are rate-limited and warn log in iroh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,7 +1317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4088,7 +4088,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4181,7 +4181,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4286,7 +4286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4763,7 +4763,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5612,7 +5612,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/iroh-relay/src/protos/relay.rs
+++ b/iroh-relay/src/protos/relay.rs
@@ -128,6 +128,15 @@ pub enum Status {
         "Another endpoint connected with the same endpoint id. No more messages will be received."
     )]
     SameEndpointIdConnected,
+    /// The relay is rate-limiting traffic received from this endpoint.
+    ///
+    /// Sent once per connection when the relay first throttles reading from the client.
+    #[display(
+        "The relay is rate-limiting this endpoint; outbound relay traffic is being throttled. \
+        Send less data over the relay, or, if you operate this relay, raise Limits::client_rx. \
+        Read more about rate limiting at https://docs.iroh.computer/relays/rate-limiting"
+    )]
+    RateLimited,
     /// Placeholder for backwards-compatibility for future new health status variants.
     #[display("Unsupported health message ({_0})")]
     Unknown(u8),
@@ -139,6 +148,7 @@ impl Status {
         match self {
             Status::Healthy => dst.put_u8(0),
             Status::SameEndpointIdConnected => dst.put_u8(1),
+            Status::RateLimited => dst.put_u8(2),
             Status::Unknown(discriminant) => dst.put_u8(*discriminant),
         }
         dst
@@ -155,6 +165,7 @@ impl Status {
         match discriminant {
             0 => Ok(Self::Healthy),
             1 => Ok(Self::SameEndpointIdConnected),
+            2 => Ok(Self::RateLimited),
             n => Ok(Self::Unknown(n)),
         }
     }
@@ -677,6 +688,10 @@ mod tests {
                 RelayToClientMsg::Status(Status::SameEndpointIdConnected).write_to(Vec::new()),
                 "0d 01",
             ),
+            (
+                RelayToClientMsg::Status(Status::RateLimited).write_to(Vec::new()),
+                "0d 02",
+            ),
         ]);
 
         Ok(())
@@ -823,7 +838,12 @@ mod proptests {
                 s.len() < MAX_PACKET_SIZE // a single unicode character can match a regex "." but take up multiple bytes
             })
             .prop_map(|problem| RelayToClientMsg::Health { problem });
-        let health = Just(Status::SameEndpointIdConnected).prop_map(RelayToClientMsg::Status);
+        let health = prop_oneof![
+            Just(Status::Healthy),
+            Just(Status::SameEndpointIdConnected),
+            Just(Status::RateLimited),
+        ]
+        .prop_map(RelayToClientMsg::Status);
         let restarting = (any::<u32>(), any::<u32>()).prop_map(|(reconnect_in, try_for)| {
             RelayToClientMsg::Restarting {
                 reconnect_in: Duration::from_millis(reconnect_in.into()),

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -66,8 +66,9 @@ pub struct Config<S> {
     /// Optional signal to inform the client when it is being rate-limited.
     ///
     /// When set, the connection actor notifies the client once with a
-    /// [`Status::RateLimited`] message when the receiver first flips to `true`.
-    pub rate_limited: Option<watch::Receiver<bool>>,
+    /// [`Status::RateLimited`] message when the rate-limited counter first
+    /// becomes non-zero.
+    pub rate_limited: Option<watch::Receiver<u64>>,
 }
 
 impl<S> Config<S> {
@@ -224,14 +225,13 @@ impl Client {
     }
 }
 
-/// Completes when `rx` observes the connection being rate-limited for the first time.
+/// Completes when `rx` observes the connection being rate-limited.
 ///
-/// Pends forever when `rx` is `None`, so that after the first notification the
-/// caller can disarm its select branch by dropping the receiver.
-async fn rate_limited_signal(rx: &mut Option<watch::Receiver<bool>>) -> bool {
+/// Pends forever when `rx` is `None`, i.e. when no rate-limit signal is configured.
+async fn rate_limited_signal(rx: &mut Option<watch::Receiver<u64>>) -> bool {
     match rx {
         Some(rx) => match rx.changed().await {
-            Ok(()) => *rx.borrow_and_update(),
+            Ok(()) => *rx.borrow_and_update() > 0,
             // The sender lives inside this actor's stream, so it cannot drop while
             // the actor runs. Report not limited to be safe.
             Err(_) => false,
@@ -334,10 +334,8 @@ struct Actor<S> {
     ping_tracker: PingTracker,
     /// Relay protocol version negotiated for this client.
     protocol_version: ProtocolVersion,
-    /// Signal that flips to `true` when the connection is rate-limited for the first time.
-    ///
-    /// Set to `None` after the client has been notified, or when no signal was configured.
-    rate_limited: Option<watch::Receiver<bool>>,
+    /// Optional signal counting how often the connection has been rate-limited.
+    rate_limited: Option<watch::Receiver<u64>>,
     metrics: Arc<Metrics>,
 }
 
@@ -378,6 +376,8 @@ where
         ping_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         ping_interval.tick().await;
 
+        let mut rate_limit_notified = false;
+
         loop {
             tokio::select! {
                 biased;
@@ -388,10 +388,10 @@ where
                     self.stream.flush().await.map_err(|_| e!(RunError::Flush))?;
                     break;
                 }
-                limited = rate_limited_signal(&mut self.rate_limited) => {
-                    // Notify the client once per connection, then disarm this branch.
-                    // V1 clients are are not notified.
-                    self.rate_limited = None;
+                limited = rate_limited_signal(&mut self.rate_limited), if !rate_limit_notified => {
+                    // Notify the client once per connection.
+                    // V1 clients are not notified.
+                    rate_limit_notified = true;
                     if limited && self.protocol_version == ProtocolVersion::V2 {
                         debug!("connection is rate-limited, notifying client");
                         self.write_frame(RelayToClientMsg::Status(Status::RateLimited))

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -68,7 +68,7 @@ pub struct Config<S> {
     /// When set, the connection actor notifies the client once with a
     /// [`Status::RateLimited`] message when the rate-limited counter first
     /// becomes non-zero.
-    pub rate_limited: Option<watch::Receiver<u64>>,
+    pub(crate) rate_limited: Option<watch::Receiver<u64>>,
 }
 
 impl<S> Config<S> {

--- a/iroh-relay/src/server/client.rs
+++ b/iroh-relay/src/server/client.rs
@@ -8,7 +8,10 @@ use n0_future::{SinkExt, StreamExt};
 use rand::RngExt;
 use time::{Date, OffsetDateTime};
 use tokio::{
-    sync::mpsc::{self, error::TrySendError},
+    sync::{
+        mpsc::{self, error::TrySendError},
+        watch,
+    },
     time::MissedTickBehavior,
 };
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
@@ -60,6 +63,11 @@ pub struct Config<S> {
     pub channel_capacity: usize,
     /// Protocol version negotiated for this client
     pub protocol_version: ProtocolVersion,
+    /// Optional signal to inform the client when it is being rate-limited.
+    ///
+    /// When set, the connection actor notifies the client once with a
+    /// [`Status::RateLimited`] message when the receiver first flips to `true`.
+    pub rate_limited: Option<watch::Receiver<bool>>,
 }
 
 impl<S> Config<S> {
@@ -77,6 +85,7 @@ impl<S> Config<S> {
             protocol_version,
             write_timeout: SERVER_WRITE_TIMEOUT,
             channel_capacity: PER_CLIENT_SEND_QUEUE_DEPTH,
+            rate_limited: None,
         }
     }
 }
@@ -121,6 +130,7 @@ impl Client {
             write_timeout,
             channel_capacity,
             protocol_version,
+            rate_limited,
         } = config;
         let endpoint_id = guard.endpoint_id;
         let connection_id = guard.connection_id;
@@ -138,6 +148,8 @@ impl Client {
             clients: clients.clone(),
             client_counter: ClientCounter::default(),
             ping_tracker: PingTracker::default(),
+            protocol_version,
+            rate_limited,
             metrics,
         };
 
@@ -209,6 +221,22 @@ impl Client {
             },
         };
         self.message_queue.try_send(message)
+    }
+}
+
+/// Completes when `rx` observes the connection being rate-limited for the first time.
+///
+/// Pends forever when `rx` is `None`, so that after the first notification the
+/// caller can disarm its select branch by dropping the receiver.
+async fn rate_limited_signal(rx: &mut Option<watch::Receiver<bool>>) -> bool {
+    match rx {
+        Some(rx) => match rx.changed().await {
+            Ok(()) => *rx.borrow_and_update(),
+            // The sender lives inside this actor's stream, so it cannot drop while
+            // the actor runs. Report not limited to be safe.
+            Err(_) => false,
+        },
+        None => std::future::pending().await,
     }
 }
 
@@ -304,6 +332,12 @@ struct Actor<S> {
     /// Statistics about the connected clients
     client_counter: ClientCounter,
     ping_tracker: PingTracker,
+    /// Relay protocol version negotiated for this client.
+    protocol_version: ProtocolVersion,
+    /// Signal that flips to `true` when the connection is rate-limited for the first time.
+    ///
+    /// Set to `None` after the client has been notified, or when no signal was configured.
+    rate_limited: Option<watch::Receiver<bool>>,
     metrics: Arc<Metrics>,
 }
 
@@ -353,6 +387,17 @@ where
                     // final flush
                     self.stream.flush().await.map_err(|_| e!(RunError::Flush))?;
                     break;
+                }
+                limited = rate_limited_signal(&mut self.rate_limited) => {
+                    // Notify the client once per connection, then disarm this branch.
+                    // V1 clients are are not notified.
+                    self.rate_limited = None;
+                    if limited && self.protocol_version == ProtocolVersion::V2 {
+                        debug!("connection is rate-limited, notifying client");
+                        self.write_frame(RelayToClientMsg::Status(Status::RateLimited))
+                            .await
+                            .map_err(|err| e!(RunError::WriteFrame, err))?;
+                    }
                 }
                 maybe_frame = self.stream.next() => {
                     self
@@ -602,6 +647,8 @@ mod tests {
             clients: clients.clone(),
             client_counter: ClientCounter::default(),
             ping_tracker: PingTracker::default(),
+            protocol_version: ProtocolVersion::V2,
+            rate_limited: None,
             metrics,
         };
 
@@ -813,7 +860,7 @@ mod tests {
         let (io_read, io_write) = tokio::io::duplex((LIMIT * MAX_FRAMES) as _);
         let mut frame_writer = Conn::test(io_write, Default::default());
         // Rate limiter allowing LIMIT bytes/s
-        let mut stream = RelayedStream::test_limited(io_read, LIMIT / 10, LIMIT)?;
+        let (mut stream, _limited) = RelayedStream::test_limited(io_read, LIMIT / 10, LIMIT)?;
 
         // Prepare a frame to send, assert its size.
         let data = Datagrams::from(b"hello world!!!!!");
@@ -856,6 +903,42 @@ mod tests {
             .expect("ok");
         assert_eq!(recv_frame, frame);
 
+        Ok(())
+    }
+
+    /// A client whose connection is rate-limited receives a [`Status::RateLimited`] notice.
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn test_rate_limit_notice() -> Result {
+        const LIMIT: u32 = 50;
+
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
+        let key = SecretKey::from_bytes(&rng.random()).public();
+        let target = SecretKey::from_bytes(&rng.random()).public();
+
+        let (server_io, client_io) = tokio::io::duplex(4096);
+        // Rate limiter allowing LIMIT bytes/s with a burst size below a single frame.
+        let (stream, limited) = ServerRelayedStream::test_limited(server_io, LIMIT / 10, LIMIT)?;
+        let mut config = Config::new(OnDisconnectGuard::empty(key), stream, ProtocolVersion::V2);
+        config.write_timeout = Duration::from_secs(1);
+        config.channel_capacity = 10;
+        config.rate_limited = Some(limited);
+        let mut conn = Conn::test(client_io, ProtocolVersion::V2);
+
+        let clients = Clients::default();
+        clients.register(config, Arc::new(Metrics::default()));
+
+        // A single frame larger than the burst size trips the rate limiter.
+        conn.send(ClientToRelayMsg::Datagrams {
+            dst_endpoint_id: target,
+            datagrams: Datagrams::from(b"hello world!!!!!"),
+        })
+        .await?;
+
+        let frame = recv_frame(FrameType::Status, &mut conn).await?;
+        assert_eq!(frame, RelayToClientMsg::Status(Status::RateLimited));
+
+        clients.shutdown().await;
         Ok(())
     }
 }

--- a/iroh-relay/src/server/http_server.rs
+++ b/iroh-relay/src/server/http_server.rs
@@ -855,6 +855,7 @@ impl Inner {
 
         let io = RateLimited::from_watcher(io, self.rate_limit.subscribe(), self.metrics.clone())
             .map_err(|err| e!(AcceptError::RateLimitingMisconfigured, err))?;
+        let limited_watcher = io.limited_watcher();
 
         // Create a server builder with default config
         let websocket = tokio_websockets::ServerBuilder::new()
@@ -887,6 +888,7 @@ impl Inner {
         trace!("accept: build client conn");
         let mut client_conn_builder = Config::new(guard, io, protocol_version);
         client_conn_builder.write_timeout = self.write_timeout;
+        client_conn_builder.rate_limited = Some(limited_watcher);
         trace!(endpoint_id = %request.endpoint_id().fmt_short(), "create client");
 
         // build and register client, starting up read & write loops for the client

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -69,7 +69,7 @@ impl ServerRelayedStream {
         stream: tokio::io::DuplexStream,
         max_burst_bytes: u32,
         bytes_per_second: u32,
-    ) -> Result<Self, InvalidBucketConfig> {
+    ) -> Result<(Self, watch::Receiver<bool>), InvalidBucketConfig> {
         let stream = MaybeTlsStream::Test(stream);
         let stream = RateLimited::new(
             stream,
@@ -77,14 +77,16 @@ impl ServerRelayedStream {
             bytes_per_second,
             Arc::new(Metrics::default()),
         )?;
-        Ok(Self {
+        let limited_watcher = stream.limited_watcher();
+        let stream = Self {
             inner: WsBytesFramed {
                 io: tokio_websockets::ServerBuilder::new()
                     .limits(Self::limits())
                     .serve(stream),
             },
             key_cache: KeyCache::test(),
-        })
+        };
+        Ok((stream, limited_watcher))
     }
 
     fn limits() -> tokio_websockets::Limits {
@@ -336,6 +338,11 @@ pub(crate) struct RateLimited<S> {
     bucket_refilled: Option<Pin<Box<time::Sleep>>>,
     /// Keeps track if this stream was ever rate-limited.
     limited_once: bool,
+    /// Set to `true` when this stream is rate-limited for the first time.
+    ///
+    /// Subscribe via [`RateLimited::limited_watcher`] to be notified about it, e.g. to
+    /// inform the client that it is being throttled.
+    limited_tx: watch::Sender<bool>,
     /// Watcher for the per-client rate limit, if set.
     ///
     /// If set by constructing via [`RateLimited::from_watcher`], we check for
@@ -490,6 +497,7 @@ impl<S> RateLimited<S> {
             bucket,
             bucket_refilled: None,
             limited_once: false,
+            limited_tx: watch::Sender::new(false),
             rate_limit_watcher: Some(rate_limit_watcher),
             metrics,
         })
@@ -511,6 +519,7 @@ impl<S> RateLimited<S> {
             )?),
             bucket_refilled: None,
             limited_once: false,
+            limited_tx: watch::Sender::new(false),
             rate_limit_watcher: None,
             metrics,
         })
@@ -523,9 +532,15 @@ impl<S> RateLimited<S> {
             bucket: None,
             bucket_refilled: None,
             limited_once: false,
+            limited_tx: watch::Sender::new(false),
             rate_limit_watcher: None,
             metrics,
         }
+    }
+
+    /// Returns a watcher that flips to `true` once this stream is rate-limited for the first time.
+    pub(crate) fn limited_watcher(&self) -> watch::Receiver<bool> {
+        self.limited_tx.subscribe()
     }
 
     /// Records metrics about being rate-limited.
@@ -535,6 +550,7 @@ impl<S> RateLimited<S> {
         if !self.limited_once {
             self.metrics.conns_rx_ratelimited_total.inc();
             self.limited_once = true;
+            self.limited_tx.send_replace(true);
         }
     }
 }

--- a/iroh-relay/src/server/streams.rs
+++ b/iroh-relay/src/server/streams.rs
@@ -69,7 +69,7 @@ impl ServerRelayedStream {
         stream: tokio::io::DuplexStream,
         max_burst_bytes: u32,
         bytes_per_second: u32,
-    ) -> Result<(Self, watch::Receiver<bool>), InvalidBucketConfig> {
+    ) -> Result<(Self, watch::Receiver<u64>), InvalidBucketConfig> {
         let stream = MaybeTlsStream::Test(stream);
         let stream = RateLimited::new(
             stream,
@@ -336,13 +336,11 @@ pub(crate) struct RateLimited<S> {
     inner: S,
     bucket: Option<Bucket>,
     bucket_refilled: Option<Pin<Box<time::Sleep>>>,
-    /// Keeps track if this stream was ever rate-limited.
-    limited_once: bool,
-    /// Set to `true` when this stream is rate-limited for the first time.
+    /// Counts how often reads from this stream have been rate-limited.
     ///
     /// Subscribe via [`RateLimited::limited_watcher`] to be notified about it, e.g. to
     /// inform the client that it is being throttled.
-    limited_tx: watch::Sender<bool>,
+    limited_tx: watch::Sender<u64>,
     /// Watcher for the per-client rate limit, if set.
     ///
     /// If set by constructing via [`RateLimited::from_watcher`], we check for
@@ -496,8 +494,7 @@ impl<S> RateLimited<S> {
             inner: io,
             bucket,
             bucket_refilled: None,
-            limited_once: false,
-            limited_tx: watch::Sender::new(false),
+            limited_tx: watch::Sender::new(0),
             rate_limit_watcher: Some(rate_limit_watcher),
             metrics,
         })
@@ -518,8 +515,7 @@ impl<S> RateLimited<S> {
                 time::Duration::from_millis(100),
             )?),
             bucket_refilled: None,
-            limited_once: false,
-            limited_tx: watch::Sender::new(false),
+            limited_tx: watch::Sender::new(0),
             rate_limit_watcher: None,
             metrics,
         })
@@ -531,15 +527,14 @@ impl<S> RateLimited<S> {
             inner,
             bucket: None,
             bucket_refilled: None,
-            limited_once: false,
-            limited_tx: watch::Sender::new(false),
+            limited_tx: watch::Sender::new(0),
             rate_limit_watcher: None,
             metrics,
         }
     }
 
-    /// Returns a watcher that flips to `true` once this stream is rate-limited for the first time.
-    pub(crate) fn limited_watcher(&self) -> watch::Receiver<bool> {
+    /// Returns a watcher that counts how often reads from this stream have been rate-limited.
+    pub(crate) fn limited_watcher(&self) -> watch::Receiver<u64> {
         self.limited_tx.subscribe()
     }
 
@@ -547,11 +542,12 @@ impl<S> RateLimited<S> {
     fn record_rate_limited(&mut self, bytes: usize) {
         // TODO: add a label for the frame type.
         self.metrics.bytes_rx_ratelimited_total.inc_by(bytes as u64);
-        if !self.limited_once {
-            self.metrics.conns_rx_ratelimited_total.inc();
-            self.limited_once = true;
-            self.limited_tx.send_replace(true);
-        }
+        self.limited_tx.send_modify(|count| {
+            if *count == 0 {
+                self.metrics.conns_rx_ratelimited_total.inc();
+            }
+            *count += 1;
+        });
     }
 }
 

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -743,6 +743,8 @@ impl ActiveRelayActor {
             }
             RelayToClientMsg::Status(status) => match status {
                 Status::Healthy => info!("Relay server reports: {status}"),
+                // The relay sends this at most once per connection.
+                Status::RateLimited => warn!("{status}"),
                 _ => warn!("Relay server reports problem: {status}"),
             },
             RelayToClientMsg::Restarting { .. } => {


### PR DESCRIPTION
## Description

When a relay server rate-limits a client connection, we now send a new `Status::RateLimited` message to the client, so that it can inform the user or the application. In iroh, for now we just `warn!` log this.

The message is sent at most once per relay connection.

Fixes #4454 

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

This does not need a protocol version bump because we are using the `Status` frame which is designed to be extensible with new variants. Old clients will see a `WARN: Relay server reports problem: Unsupported health message (2)`.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
