### PR TITLE
chore(ci): pin sccache to 0.16 on windows due to cli len limit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -299,6 +299,10 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
+        with:
+          # Pinned: sccache >= 0.17.0 expands rustc @argfiles and breaks Windows'
+          # 32K command line limit: https://github.com/mozilla/sccache/issues/2397
+          version: "v0.16.0"
       - uses: ./.github/workflows/sccache-probe
 
       - uses: msys2/setup-msys2@v2
@@ -415,6 +419,10 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
+        with:
+          # Pinned: sccache >= 0.17.0 expands rustc @argfiles and breaks Windows'
+          # 32K command line limit: https://github.com/mozilla/sccache/issues/2397
+          version: "v0.16.0"
       - uses: ./.github/workflows/sccache-probe
 
       - uses: msys2/setup-msys2@v2


### PR DESCRIPTION
## Description

Pins sccache to 0.16 as 0.17 expands rustc's @argfiles and results in a command line longer than the 32k limit on windows: https://github.com/mozilla/sccache/issues/2397

## Breaking Changes

n/a

## Notes & open questions

There already is a fix, probably next release will be fine again.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
