### PR TITLE
fix(iroh): drain relay tasks with join_next instead of join_all

### DIFF
--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -1376,8 +1376,11 @@ impl RelayActor {
     /// Stops all [`ActiveRelayActor`]s and awaits for them to finish.
     async fn close_all_active_relays(&mut self) {
         self.cancel_token.cancel();
-        let tasks = std::mem::take(&mut self.active_relay_tasks);
-        tasks.join_all().await;
+        let mut tasks = std::mem::take(&mut self.active_relay_tasks);
+        // Drain rather than `join_all`: `join_all` panics on any `JoinError`,
+        // which includes a merely *cancelled* task, so an actor aborted out
+        // from under us would take this worker thread down during shutdown.
+        while tasks.join_next().await.is_some() {}
 
         self.log_active_relay();
     }

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -1377,9 +1377,7 @@ impl RelayActor {
     async fn close_all_active_relays(&mut self) {
         self.cancel_token.cancel();
         let mut tasks = std::mem::take(&mut self.active_relay_tasks);
-        // Drain rather than `join_all`: `join_all` panics on any `JoinError`,
-        // which includes a merely *cancelled* task, so an actor aborted out
-        // from under us would take this worker thread down during shutdown.
+        // Drain instead of `join_all`, which panics on a cancelled task.
         while tasks.join_next().await.is_some() {}
 
         self.log_active_relay();
@@ -1450,20 +1448,8 @@ mod tests {
     };
     use crate::{dns::DnsResolver, test_utils};
 
-    /// `close_all_active_relays` must survive an [`ActiveRelayActor`] task that
-    /// was cancelled rather than allowed to finish.
-    ///
-    /// It used to await the set with [`JoinSet::join_all`], which panics on any
-    /// [`JoinError`] — including a merely *cancelled* task, not just a panicked
-    /// one — so a cancelled actor took the calling runtime worker down with it.
-    ///
-    /// In the wild this is reached by racing a runtime drop against shutdown,
-    /// which is not something a test can provoke reliably. Aborting the task
-    /// puts the set in the identical state deterministically: `join_next`
-    /// yields `Err(err)` with `err.is_cancelled()` either way.
-    ///
-    /// [`JoinSet::join_all`]: n0_future::task::JoinSet::join_all
-    /// [`JoinError`]: n0_future::task::JoinError
+    /// Abort stands in for the runtime drop that triggers this in the wild:
+    /// `join_next` yields a cancelled `JoinError` either way.
     #[tokio::test]
     async fn close_all_active_relays_survives_a_cancelled_task() {
         let (relay_datagram_recv_queue, _recv_rx) = mpsc::channel(1);
@@ -1482,14 +1468,10 @@ mod tests {
         let mut actor =
             RelayActor::new(config, relay_datagram_recv_queue, CancellationToken::new());
 
-        // A task that never completes on its own, then cancelled — no relay
-        // server and no real actor needed, since the failure is in how the set
-        // is awaited, not in what was spawned into it.
         let handle = actor.active_relay_tasks.spawn(std::future::pending::<()>());
         handle.abort();
 
-        // The assertion is that this returns at all: with `join_all` it panics
-        // with "task N was cancelled".
+        // Panicked with `join_all`.
         actor.close_all_active_relays().await;
 
         assert!(actor.active_relay_tasks.is_empty());

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -47,7 +47,7 @@ use iroh_relay::{
 use n0_error::{AnyError, e, stack_error};
 use n0_future::{
     FuturesUnorderedBounded, MaybeFuture, SinkExt, StreamExt,
-    task::JoinSet,
+    task::{JoinError, JoinSet},
     time::{self, Duration, Instant, MissedTickBehavior},
 };
 use n0_watcher::Watchable;
@@ -1064,16 +1064,7 @@ impl RelayActor {
                     break;
                 }
                 Some(res) = self.active_relay_tasks.join_next() => {
-                    match res {
-                        Ok(()) => (),
-                        Err(err) if err.is_panic() => {
-                            error!("ActiveRelayActor task panicked: {err:#?}");
-                        }
-                        Err(err) if err.is_cancelled() => {
-                            error!("ActiveRelayActor cancelled: {err:#?}");
-                        }
-                        Err(err) => error!("ActiveRelayActor failed: {err:#?}"),
-                    }
+                    log_active_relay_task_result(res);
                     self.reap_active_relays();
                 }
                 msg = receiver.recv() => {
@@ -1377,8 +1368,10 @@ impl RelayActor {
     async fn close_all_active_relays(&mut self) {
         self.cancel_token.cancel();
         let mut tasks = std::mem::take(&mut self.active_relay_tasks);
-        // Drain instead of `join_all`, which panics on a cancelled task.
-        while tasks.join_next().await.is_some() {}
+        // Drain instead of `join_all`, which panics on any `JoinError`.
+        while let Some(res) = tasks.join_next().await {
+            log_active_relay_task_result(res);
+        }
 
         self.log_active_relay();
     }
@@ -1401,6 +1394,16 @@ impl RelayActor {
         ids.sort();
 
         ids.into_iter()
+    }
+}
+
+/// Reports how one [`ActiveRelayActor`] task ended, in the run loop and on shutdown.
+fn log_active_relay_task_result(res: Result<(), JoinError>) {
+    match res {
+        Ok(()) => (),
+        Err(err) if err.is_panic() => error!("ActiveRelayActor task panicked: {err:#?}"),
+        Err(err) if err.is_cancelled() => error!("ActiveRelayActor cancelled: {err:#?}"),
+        Err(err) => error!("ActiveRelayActor failed: {err:#?}"),
     }
 }
 
@@ -1451,6 +1454,7 @@ mod tests {
     /// Abort stands in for the runtime drop that triggers this in the wild:
     /// `join_next` yields a cancelled `JoinError` either way.
     #[tokio::test]
+    #[traced_test]
     async fn close_all_active_relays_survives_a_cancelled_task() {
         let (relay_datagram_recv_queue, _recv_rx) = mpsc::channel(1);
         let config = Config {
@@ -1475,6 +1479,7 @@ mod tests {
         actor.close_all_active_relays().await;
 
         assert!(actor.active_relay_tasks.is_empty());
+        assert!(logs_contain("ActiveRelayActor cancelled"));
     }
 
     /// Starts a new [`ActiveRelayActor`].

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -1445,10 +1445,55 @@ mod tests {
 
     use super::{
         ActiveRelayActor, ActiveRelayActorOptions, ActiveRelayMessage, ActiveRelayPrioMessage,
-        RELAY_INACTIVE_CLEANUP_TIME, RelayConnectionOptions, RelayRecvDatagram, RelaySendItem,
-        UNDELIVERABLE_DATAGRAM_TIMEOUT,
+        Config, RELAY_INACTIVE_CLEANUP_TIME, RelayActor, RelayConnectionOptions, RelayMap,
+        RelayRecvDatagram, RelaySendItem, UNDELIVERABLE_DATAGRAM_TIMEOUT,
     };
     use crate::{dns::DnsResolver, test_utils};
+
+    /// `close_all_active_relays` must survive an [`ActiveRelayActor`] task that
+    /// was cancelled rather than allowed to finish.
+    ///
+    /// It used to await the set with [`JoinSet::join_all`], which panics on any
+    /// [`JoinError`] — including a merely *cancelled* task, not just a panicked
+    /// one — so a cancelled actor took the calling runtime worker down with it.
+    ///
+    /// In the wild this is reached by racing a runtime drop against shutdown,
+    /// which is not something a test can provoke reliably. Aborting the task
+    /// puts the set in the identical state deterministically: `join_next`
+    /// yields `Err(err)` with `err.is_cancelled()` either way.
+    ///
+    /// [`JoinSet::join_all`]: n0_future::task::JoinSet::join_all
+    /// [`JoinError`]: n0_future::task::JoinError
+    #[tokio::test]
+    async fn close_all_active_relays_survives_a_cancelled_task() {
+        let (relay_datagram_recv_queue, _recv_rx) = mpsc::channel(1);
+        let config = Config {
+            my_relay: Default::default(),
+            secret_key: SecretKey::from_bytes(&[0u8; 32]),
+            dns_resolver: DnsResolver::new(),
+            proxy_url: None,
+            ipv6_reported: Arc::new(AtomicBool::new(false)),
+            tls_config: CaTlsConfig::insecure_skip_verify()
+                .client_config(default_provider())
+                .expect("infallible"),
+            metrics: Default::default(),
+            relay_map: RelayMap::empty(),
+        };
+        let mut actor =
+            RelayActor::new(config, relay_datagram_recv_queue, CancellationToken::new());
+
+        // A task that never completes on its own, then cancelled — no relay
+        // server and no real actor needed, since the failure is in how the set
+        // is awaited, not in what was spawned into it.
+        let handle = actor.active_relay_tasks.spawn(std::future::pending::<()>());
+        handle.abort();
+
+        // The assertion is that this returns at all: with `join_all` it panics
+        // with "task N was cancelled".
+        actor.close_all_active_relays().await;
+
+        assert!(actor.active_relay_tasks.is_empty());
+    }
 
     /// Starts a new [`ActiveRelayActor`].
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Description

`RelayActor::close_all_active_relays` awaits its `ActiveRelayActor` tasks with `JoinSet::join_all` ([`actor.rs:1380`](https://github.com/n0-computer/iroh/blob/main/iroh/src/socket/transports/relay/actor.rs#L1380)). `join_all` panics on any `JoinError`, and a `JoinError` can mean the task was cancelled, not just that it panicked. So if an actor gets cancelled while this shutdown is running, it takes the calling runtime worker down with it.

The `cancel_token.cancel()` on the line above isn't the source. That one is cooperative, so tasks awaiting it return `Ok`. What actually triggers this is an embedder dropping its tokio runtime while the shutdown is still in flight: tokio cancels whatever is left, and the join panics on the first one it sees.

I hit it from a consumer that runs an iroh endpoint on its own runtime and drops it on close:

```
thread 'tokio-rt-worker' panicked at tokio-1.52.3/src/task/join_set.rs:453:
task 149 was cancelled
```

Not fatal. The process still finished and flushed. But it's an unwrap-on-cancel in a path every consumer goes through on shutdown.

## Why join_next

tokio documents the hazard and the fix on `join_all` itself:

> If any tasks on the `JoinSet` fail with a `JoinError`, then this call to `join_all` will panic and all remaining tasks on the `JoinSet` are cancelled. To handle errors in any other way, manually call `join_next` in a loop.

The drain is also how tokio implements `JoinSet::shutdown`, so it isn't a new pattern here.

## Test

The second commit adds a test that fails on `main` and passes with the fix:

```
---- close_all_active_relays_survives_a_cancelled_task stdout ----
panicked at tokio-1.53.1/src/task/join_set.rs:453:29: task 1 was cancelled
```

Same line of tokio as the report above.

I didn't try to reproduce the original race. Dropping a runtime concurrently with shutdown would make the test flaky, which rather defeats the point of adding one. Cancelling the task gets the `JoinSet` into the same state anyway: `join_next` yields `Err(err)` with `err.is_cancelled()` either way. So the test targets how the set is awaited rather than the race that happens to expose it. It spawns a `pending()` future and aborts it. No `ActiveRelayActor`, no relay server, runs in 0.01s.

## Notes for review

It can't stall shutdown. The only caller ([`actor.rs:1108`](https://github.com/n0-computer/iroh/blob/main/iroh/src/socket/transports/relay/actor.rs#L1108)) already wraps this in `time::timeout(Duration::from_secs(3), ...)`.

This is the only `JoinSet::join_all` in the crate outside `#[cfg(test)]` code; the other call site is a test helper in `relay.rs`. The `n0_future::join_all` calls elsewhere are the futures combinator rather than the `JoinSet` method, and those don't panic.

Behaviour on a genuine panic is unchanged in practice. `join_next` still yields the `Err`, and this function discards results either way, so nothing that used to be reported is now swallowed. A cancelled task just stops taking the worker with it. If you'd rather keep propagating real panics explicitly, I'm happy to `resume_unwind` on `err.is_panic()`.

One thing I left alone: `n0_future`'s `cfg(wasm_browser)` `JoinSet` shim has its own `join_all` (`n0-future-0.3.2/src/task.rs:222`) with the same shape. Different crate, so I didn't touch it. Happy to file it separately if you think it's worth fixing.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented. (None, internal shutdown path only.)