### PR TITLE
fix(iroh-dns-server): enable TCP keepalive on HTTP listeners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple-dns",
+ "socket2",
  "strum",
  "tempfile",
  "testdir",

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -42,6 +42,7 @@ redb = "4.1.0"
 regex = "1.10.3"
 rustls = { version = "0.23.33", default-features = false }
 serde = { version = "1", features = ["derive"] }
+socket2 = "0.6"
 n0-error = "1.0.0"
 strum = { version = "0.28", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -3,7 +3,7 @@
 use std::{
     net::{IpAddr, Ipv6Addr, SocketAddr},
     path::PathBuf,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use axum::{
@@ -17,6 +17,7 @@ use axum::{
 };
 use n0_error::{Result, StdResultExt, anyerr, bail_any};
 use serde::{Deserialize, Serialize};
+use socket2::{SockRef, TcpKeepalive};
 use tokio::{net::TcpListener, task::JoinSet};
 use tower_http::{
     cors::{self, CorsLayer},
@@ -32,6 +33,18 @@ mod tls;
 
 pub use self::{rate_limiting::RateLimitConfig, tls::CertMode};
 use crate::state::AppState;
+
+/// How long a connection may be idle before keepalive probing starts.
+const TCP_KEEPALIVE_TIME: Duration = Duration::from_secs(60);
+
+/// Enable TCP keepalive on `listener`, which accepted connections inherit.
+///
+/// Without it, connections whose peer vanished without closing are never
+/// reaped: they accumulate for the lifetime of the process until it is
+/// OOM-killed.
+fn set_keepalive(listener: &std::net::TcpListener) -> std::io::Result<()> {
+    SockRef::from(listener).set_tcp_keepalive(&TcpKeepalive::new().with_time(TCP_KEEPALIVE_TIME))
+}
 
 /// Configuration for the HTTP listener.
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -107,6 +120,7 @@ impl HttpServer {
                 .into_std()
                 .anyerr()?;
             let bound_addr = listener.local_addr().anyerr()?;
+            set_keepalive(&listener).anyerr()?;
             let fut = axum_server::from_tcp(listener)?
                 .serve(app.into_make_service_with_connect_info::<SocketAddr>());
             info!("HTTP server listening on {bind_addr}");
@@ -147,6 +161,7 @@ impl HttpServer {
                 .into_std()
                 .anyerr()?;
             let bound_addr = listener.local_addr().anyerr()?;
+            set_keepalive(&listener).anyerr()?;
             let fut = axum_server::from_tcp(listener)?
                 .acceptor(acceptor)
                 .serve(app.into_make_service_with_connect_info::<SocketAddr>());
@@ -527,5 +542,21 @@ mod tests {
                 .set_certificate_verifier(Arc::new(NoCertificateVerification::default()));
             cfg
         }
+    }
+
+    /// Keepalive is set on the listener, so this asserts that accepted
+    /// connections actually inherit it.
+    #[test]
+    fn keepalive_is_inherited_by_accepted_connections() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        super::set_keepalive(&listener).expect("set keepalive");
+        let _client =
+            std::net::TcpStream::connect(listener.local_addr().expect("addr")).expect("connect");
+        let (accepted, _) = listener.accept().expect("accept");
+        assert!(
+            super::SockRef::from(&accepted)
+                .keepalive()
+                .expect("read keepalive")
+        );
     }
 }

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -35,7 +35,7 @@ pub use self::{rate_limiting::RateLimitConfig, tls::CertMode};
 use crate::state::AppState;
 
 /// How long a connection may be idle before keepalive probing starts.
-const TCP_KEEPALIVE_TIME: Duration = Duration::from_secs(60);
+const TCP_KEEPALIVE_TIME: Duration = Duration::from_mins(1);
 
 /// Interval between keepalive probes once probing starts.
 const TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
@@ -548,21 +548,5 @@ mod tests {
                 .set_certificate_verifier(Arc::new(NoCertificateVerification::default()));
             cfg
         }
-    }
-
-    /// Keepalive is set on the listener, so this asserts that accepted
-    /// connections actually inherit it.
-    #[test]
-    fn keepalive_is_inherited_by_accepted_connections() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
-        super::set_keepalive(&listener).expect("set keepalive");
-        let _client =
-            std::net::TcpStream::connect(listener.local_addr().expect("addr")).expect("connect");
-        let (accepted, _) = listener.accept().expect("accept");
-        assert!(
-            super::SockRef::from(&accepted)
-                .keepalive()
-                .expect("read keepalive")
-        );
     }
 }

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -37,13 +37,19 @@ use crate::state::AppState;
 /// How long a connection may be idle before keepalive probing starts.
 const TCP_KEEPALIVE_TIME: Duration = Duration::from_secs(60);
 
+/// Interval between keepalive probes once probing starts.
+const TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
 /// Enable TCP keepalive on `listener`, which accepted connections inherit.
 ///
 /// Without it, connections whose peer vanished without closing are never
 /// reaped: they accumulate for the lifetime of the process until it is
 /// OOM-killed.
 fn set_keepalive(listener: &std::net::TcpListener) -> std::io::Result<()> {
-    SockRef::from(listener).set_tcp_keepalive(&TcpKeepalive::new().with_time(TCP_KEEPALIVE_TIME))
+    let keepalive = TcpKeepalive::new()
+        .with_time(TCP_KEEPALIVE_TIME)
+        .with_interval(TCP_KEEPALIVE_INTERVAL);
+    SockRef::from(listener).set_tcp_keepalive(&keepalive)
 }
 
 /// Configuration for the HTTP listener.


### PR DESCRIPTION
## Description

Recent usage increases highlighted that we're leaking memory. Turns out we seemingly keep connections around forever. 
The issue is slightly compounded by the fact that our pkarr `DEFAULT_REPUBLISH_INTERVAL` is 5 min while the default reqwest pool_idle_timeout is 90s so essentially we never reuse these connections client side and keep opening new ones. 

Another note is that this just cleans up actually dead connections, a client that also leaks connections would also be infinitely responding with keepalives. To fix that we would need some better logistics and a idle timer on our end.

This cleans up dead connections in roughly 200 sec.
## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
