### PR TITLE
fix!: Fix serialization of CustomAddr so that the data serializes the same  as a Vec<u8>

### DIFF
--- a/iroh-base/src/endpoint_addr.rs
+++ b/iroh-base/src/endpoint_addr.rs
@@ -265,7 +265,8 @@ impl<'de> Deserialize<'de> for CustomAddrBytes {
                 Ok(CustomAddrBytes::copy_from_slice(&v))
             }
 
-            /// Self-describing formats deserialize the bytes as a sequence.
+            /// Needed for json, which has no byte type and encodes bytes as a number
+            /// array, so `deserialize_bytes` comes back as a sequence.
             fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
                 // Does not reserve from the attacker-controlled `size_hint`.
                 let mut data = Vec::new();

--- a/iroh-base/src/endpoint_addr.rs
+++ b/iroh-base/src/endpoint_addr.rs
@@ -10,7 +10,7 @@ use std::{collections::BTreeSet, fmt, net::SocketAddr};
 
 use data_encoding::HEXLOWER;
 use n0_error::stack_error;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 use crate::{EndpointId, PublicKey, RelayUrl};
 
@@ -232,10 +232,52 @@ pub enum CustomAddrParseError {
     InvalidData,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Inline or heap storage, chosen by length. Serializes as plain bytes: the cutoff is an
+/// implementation detail, and `copy_from_slice` must stay the only constructor.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum CustomAddrBytes {
     Inline { size: u8, data: [u8; 30] },
     Heap(Box<[u8]>),
+}
+
+impl Serialize for CustomAddrBytes {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(self.as_bytes())
+    }
+}
+
+impl<'de> Deserialize<'de> for CustomAddrBytes {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct BytesVisitor;
+
+        impl<'de> de::Visitor<'de> for BytesVisitor {
+            type Value = CustomAddrBytes;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("custom transport address bytes")
+            }
+
+            fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                Ok(CustomAddrBytes::copy_from_slice(v))
+            }
+
+            fn visit_byte_buf<E: de::Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+                Ok(CustomAddrBytes::copy_from_slice(&v))
+            }
+
+            /// Self-describing formats deserialize the bytes as a sequence.
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                // Does not reserve from the attacker-controlled `size_hint`.
+                let mut data = Vec::new();
+                while let Some(byte) = seq.next_element::<u8>()? {
+                    data.push(byte);
+                }
+                Ok(CustomAddrBytes::copy_from_slice(&data))
+            }
+        }
+
+        deserializer.deserialize_bytes(BytesVisitor)
+    }
 }
 
 impl fmt::Debug for CustomAddrBytes {
@@ -419,6 +461,95 @@ mod tests {
         assert_eq!(s, "deadbeef_0102");
         let parsed: CustomAddr = s.parse().unwrap();
         assert_eq!(addr, parsed);
+    }
+
+    /// The serialized form is just the bytes, so no encoding can disagree with itself.
+    #[test]
+    fn test_custom_addr_serde_roundtrip() {
+        for len in [0usize, 1, 29, 30, 31, 32, 255] {
+            let data: Vec<u8> = (0..len).map(|i| i as u8).collect();
+            let addr = CustomAddr::from_parts(0x544f52, &data);
+            let ser = postcard::to_stdvec(&addr).unwrap();
+            let back: CustomAddr = postcard::from_bytes(&ser).unwrap();
+            assert_eq!(addr, back);
+            assert_eq!(back.data(), &data[..]);
+
+            // The bytes are those of a plain `Vec<u8>`, with no trace of the cutoff.
+            let expected = postcard::to_stdvec(&(0x544f52u64, &data)).unwrap();
+            assert_eq!(ser, expected);
+
+            // Self-describing formats go through `visit_seq`.
+            let json = serde_json::to_string(&addr).unwrap();
+            let back: CustomAddr = serde_json::from_str(&json).unwrap();
+            assert_eq!(addr, back);
+        }
+    }
+
+    /// Equal addresses must be equal whatever route they arrive by.
+    #[test]
+    fn test_custom_addr_deserialize_is_canonical() {
+        for len in [5usize, 30, 31] {
+            let data = vec![9u8; len];
+            let addr = CustomAddr::from_parts(0x544f52, &data);
+            let ser = postcard::to_stdvec(&addr).unwrap();
+            let back: CustomAddr = postcard::from_bytes(&ser).unwrap();
+
+            assert_eq!(back.data(), addr.data());
+            assert_eq!(back, addr);
+            let set: BTreeSet<CustomAddr> = [back, addr].into_iter().collect();
+            assert_eq!(set.len(), 1);
+        }
+    }
+
+    /// The reported crash: an inline `size` larger than the 30-byte buffer, which the
+    /// derived `Deserialize` used to accept and every reader then panicked on.
+    #[test]
+    fn test_custom_addr_deserialize_oversized_inline() {
+        // The old encoding, with the inline size byte set to 255.
+        let mut crafted = postcard::to_stdvec(&(0x544f52u64, 0u32, 30u8, [9u8; 30])).unwrap();
+        let idx = crafted.len() - 31;
+        assert_eq!(crafted[idx], 30);
+        crafted[idx] = 255;
+
+        if let Ok(addr) = postcard::from_bytes::<CustomAddr>(&crafted) {
+            assert_eq!(addr.data().len(), addr.to_vec().len() - 8);
+            let _ = format!("{addr:?}");
+            let _ = format!("{addr:#?}");
+            let _ = addr.to_string();
+        }
+    }
+
+    /// The same, reached the way an attacker would: an [`EndpointAddr`] from a ticket.
+    #[test]
+    fn test_endpoint_addr_deserialize_arbitrary_bytes() {
+        let id = PublicKey::from_bytes(&[0; 32]).unwrap();
+        let addr = EndpointAddr {
+            id,
+            addrs: [TransportAddr::Custom(CustomAddr::from_parts(
+                0x544f52, &[9u8; 30],
+            ))]
+            .into_iter()
+            .collect(),
+        };
+        let ser = postcard::to_stdvec(&addr).unwrap();
+
+        // Flipping any single byte must not make a value that panics when read.
+        for idx in 0..ser.len() {
+            for bit in 0..8 {
+                let mut crafted = ser.clone();
+                crafted[idx] ^= 1 << bit;
+                if let Ok(evil) = postcard::from_bytes::<EndpointAddr>(&crafted) {
+                    let _ = format!("{evil:?}");
+                    for addr in &evil.addrs {
+                        if let TransportAddr::Custom(custom) = addr {
+                            let _ = custom.data();
+                            let _ = custom.to_vec();
+                            let _ = custom.to_string();
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fix serialization of CustomAddr so that the data serializes the same  as a Vec<u8>

This is needed so the inline size remains an implementation detail. It breaks CustomAddr deser, but that is fine since custom addresses, while being stable, are only used in conjunction with a feature cleary marked as experimental.

## Breaking Changes

Does not change the public API, but does change the serialization of CustomAddrs. I think we don't need a iroh-base 2.0 regardless because you only create or use CustomAddrs when working with the experimental custom transports that are explicitly excluded from stability guarantees. YMMV.

## Notes & open questions

Note for next release: we technically break serialization format for CustomAddr, so we should add the rationale for not going to 2.0 to the release notes.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
