### PR TITLE
feat(iroh): add custom QUIC time source

### DIFF
--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -161,6 +161,8 @@ tls-ring = ["noq/ring", "iroh-relay/tls-ring", "iroh-dns/tls-ring"]
 tls-aws-lc-rs = ["noq/aws-lc-rs", "iroh-relay/tls-aws-lc-rs", "iroh-dns/tls-aws-lc-rs"]
 # Unstable: Custom transport API (may change without notice)
 unstable-custom-transports = []
+# Unstable: Custom QUIC time source API (may change without notice)
+unstable-custom-runtime = []
 # Unstable: API to access an endpoint's NetReport (may change without notice)
 unstable-net-report = []
 

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -47,6 +47,18 @@ pub mod transports {
     };
 }
 
+/// Host-provided QUIC clock and timer factory.
+///
+/// <div class="warning">
+///
+/// This API is unstable and gated behind the `unstable-custom-runtime` feature.
+/// It is not covered by semantic versioning guarantees and may change in any release
+/// without a major version bump.
+///
+/// </div>
+#[cfg(feature = "unstable-custom-runtime")]
+pub use crate::quic_time_source::{QuicInstant, QuicTimeSource};
+
 use self::hooks::EndpointHooksList;
 pub use super::socket::{
     BindError, DirectAddr, DirectAddrType,
@@ -148,6 +160,7 @@ pub struct Builder {
     net_report_config: NetReportConfig,
     crypto_provider: Option<Arc<rustls::crypto::CryptoProvider>>,
     configured_addrs: BTreeSet<SocketAddr>,
+    quic_time_source: Option<Arc<dyn crate::quic_time_source::QuicTimeSource>>,
 }
 
 impl From<RelayMode> for Option<TransportConfig> {
@@ -216,6 +229,7 @@ impl Builder {
             net_report_config: Default::default(),
             crypto_provider: None,
             configured_addrs: Default::default(),
+            quic_time_source: None,
         }
     }
 
@@ -279,6 +293,7 @@ impl Builder {
             net_report_config: self.net_report_config,
             static_config,
             configured_addrs: self.configured_addrs,
+            quic_time_source: self.quic_time_source,
         };
 
         let inner = socket::EndpointInner::bind(sock_opts)
@@ -797,6 +812,24 @@ impl Builder {
     /// Some non-essential features of the net report component can be disabled via this configuration.
     pub fn net_report_config(mut self, config: NetReportConfig) -> Self {
         self.net_report_config = config;
+        self
+    }
+
+    /// Sets the monotonic clock and sleep factory used by this endpoint's QUIC runtime.
+    ///
+    /// Iroh continues to manage task spawning, tracing, and endpoint shutdown. If this
+    /// method is not called, the platform's default clock and timers are used.
+    ///
+    /// <div class="warning">
+    ///
+    /// This API is unstable and gated behind the `unstable-custom-runtime` feature.
+    /// It is not covered by semantic versioning guarantees and may change in any release
+    /// without a major version bump.
+    ///
+    /// </div>
+    #[cfg(feature = "unstable-custom-runtime")]
+    pub fn quic_time_source(mut self, time_source: Arc<dyn QuicTimeSource>) -> Self {
+        self.quic_time_source = Some(time_source);
         self
     }
 

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -278,6 +278,7 @@ pub mod endpoint;
 pub mod metrics;
 mod net_report;
 pub mod protocol;
+mod quic_time_source;
 
 pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{

--- a/iroh/src/quic_time_source.rs
+++ b/iroh/src/quic_time_source.rs
@@ -1,0 +1,32 @@
+//! Host-provided QUIC timing services.
+//!
+//! Public items are re-exported from [`crate::endpoint`] when the
+//! `unstable-custom-runtime` feature is enabled.
+#![cfg_attr(not(feature = "unstable-custom-runtime"), allow(unreachable_pub))]
+
+use std::{fmt::Debug, future::Future, pin::Pin};
+
+#[cfg(wasm_browser)]
+pub use n0_future::time::Instant as QuicInstant;
+#[cfg(not(wasm_browser))]
+pub use std::time::Instant as QuicInstant;
+
+/// Supplies the monotonic clock and sleeps used by an endpoint's QUIC runtime.
+///
+/// Iroh continues to own task spawning, tracing, and endpoint shutdown. A custom
+/// time source only replaces the clock and timer implementation used by noq.
+///
+/// [`Self::now`] and the deadlines passed to [`Self::sleep_until`] must use the
+/// same clock and time origin. Time returned by [`Self::now`] must never move
+/// backwards. A sleep may complete late, but must not complete before its
+/// deadline.
+pub trait QuicTimeSource: Send + Sync + Debug + 'static {
+    /// Returns the current monotonic time.
+    fn now(&self) -> QuicInstant;
+
+    /// Returns a future that completes once `deadline` has been reached.
+    ///
+    /// Iroh may drop this future before it completes when noq resets its timer.
+    /// Dropping the future must cancel any obsolete wakeup associated with it.
+    fn sleep_until(&self, deadline: QuicInstant) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+}

--- a/iroh/src/runtime.rs
+++ b/iroh/src/runtime.rs
@@ -1,4 +1,10 @@
-use std::pin::Pin;
+use std::{
+    fmt,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use iroh_base::EndpointId;
 use portable_atomic::{AtomicU64, Ordering};
@@ -6,9 +12,12 @@ use tokio_util::sync::CancellationToken;
 #[cfg(not(wasm_browser))]
 use tokio_util::task::TaskTracker;
 
+use crate::quic_time_source::{QuicInstant as Instant, QuicTimeSource};
+
 #[derive(Debug)]
 pub(crate) struct Runtime {
     id: EndpointId,
+    time_source: Option<Arc<dyn QuicTimeSource>>,
     #[cfg(not(wasm_browser))]
     tasks: TaskTracker,
     #[cfg(not(wasm_browser))]
@@ -20,9 +29,10 @@ pub(crate) struct Runtime {
 impl Runtime {
     /// Create a new [`Runtime`] that manages shutting down tasks properly,
     /// whether gracefully or un-gracefully.
-    pub(crate) fn new(id: EndpointId) -> Self {
+    pub(crate) fn new(id: EndpointId, time_source: Option<Arc<dyn QuicTimeSource>>) -> Self {
         Self {
             id,
+            time_source,
             #[cfg(not(wasm_browser))]
             tasks: TaskTracker::new(),
             #[cfg(not(wasm_browser))]
@@ -66,11 +76,17 @@ impl Runtime {
 impl noq::Runtime for Runtime {
     #[cfg(not(wasm_browser))]
     fn new_timer(&self, i: std::time::Instant) -> Pin<Box<dyn noq::AsyncTimer>> {
+        if let Some(time_source) = &self.time_source {
+            return Box::pin(TimeSourceTimer::new(time_source.clone(), i));
+        }
         noq::TokioRuntime.new_timer(i)
     }
 
     #[cfg(wasm_browser)]
     fn new_timer(&self, deadline: n0_future::time::Instant) -> Pin<Box<dyn noq::AsyncTimer>> {
+        if let Some(time_source) = &self.time_source {
+            return Box::pin(TimeSourceTimer::new(time_source.clone(), deadline));
+        }
         Box::pin(web::Timer(n0_future::time::sleep_until(deadline)))
     }
 
@@ -100,6 +116,13 @@ impl noq::Runtime for Runtime {
         wasm_bindgen_futures::spawn_local(future);
     }
 
+    fn now(&self) -> Instant {
+        if let Some(time_source) = &self.time_source {
+            return time_source.now();
+        }
+        Instant::now()
+    }
+
     // We're not actually using this function in iroh
     #[cfg(not(wasm_browser))]
     fn wrap_udp_socket(
@@ -107,6 +130,34 @@ impl noq::Runtime for Runtime {
         t: std::net::UdpSocket,
     ) -> std::io::Result<Box<dyn noq::AsyncUdpSocket>> {
         noq::TokioRuntime.wrap_udp_socket(t)
+    }
+}
+
+struct TimeSourceTimer {
+    time_source: Arc<dyn QuicTimeSource>,
+    sleep: Pin<Box<dyn Future<Output = ()> + Send>>,
+}
+
+impl TimeSourceTimer {
+    fn new(time_source: Arc<dyn QuicTimeSource>, deadline: Instant) -> Self {
+        let sleep = time_source.sleep_until(deadline);
+        Self { time_source, sleep }
+    }
+}
+
+impl fmt::Debug for TimeSourceTimer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TimeSourceTimer").finish_non_exhaustive()
+    }
+}
+
+impl noq::AsyncTimer for TimeSourceTimer {
+    fn reset(mut self: Pin<&mut Self>, deadline: Instant) {
+        self.sleep = self.time_source.sleep_until(deadline);
+    }
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        self.sleep.as_mut().poll(cx)
     }
 }
 
@@ -131,5 +182,177 @@ mod web {
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
             Pin::new(&mut self.0).poll(cx)
         }
+    }
+}
+
+#[cfg(all(test, not(wasm_browser)))]
+mod tests {
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, Ordering},
+        },
+        task::{Context, Poll},
+        time::{Duration, Instant},
+    };
+
+    use futures_util::task::AtomicWaker;
+    use iroh_base::SecretKey;
+    use noq::Runtime as _;
+
+    use super::Runtime;
+    use crate::quic_time_source::QuicTimeSource;
+
+    #[derive(Debug)]
+    struct TestTimeSource {
+        now: Instant,
+        sleeps: Mutex<Vec<(Instant, Arc<SleepState>)>>,
+    }
+
+    impl QuicTimeSource for TestTimeSource {
+        fn now(&self) -> Instant {
+            self.now
+        }
+
+        fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            let state = Arc::new(SleepState::default());
+            self.sleeps
+                .lock()
+                .expect("test sleep registry poisoned")
+                .push((deadline, state.clone()));
+            Box::pin(TestSleep { state })
+        }
+    }
+
+    impl TestTimeSource {
+        fn sleep(&self, index: usize) -> (Instant, Arc<SleepState>) {
+            self.sleeps.lock().expect("test sleep registry poisoned")[index].clone()
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct SleepState {
+        ready: AtomicBool,
+        dropped: AtomicBool,
+        waker: AtomicWaker,
+    }
+
+    impl SleepState {
+        fn wake(&self) {
+            self.ready.store(true, Ordering::Relaxed);
+            self.waker.wake();
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestSleep {
+        state: Arc<SleepState>,
+    }
+
+    impl Future for TestSleep {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.state.ready.load(Ordering::Relaxed) {
+                return Poll::Ready(());
+            }
+            self.state.waker.register(cx.waker());
+            if self.state.ready.load(Ordering::Relaxed) {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        }
+    }
+
+    impl Drop for TestSleep {
+        fn drop(&mut self) {
+            self.state.dropped.store(true, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn custom_time_source_drives_noq_clock_and_timers() {
+        let now = Instant::now() + Duration::from_secs(10);
+        let time_source = Arc::new(TestTimeSource {
+            now,
+            sleeps: Mutex::new(Vec::new()),
+        });
+        let runtime = Runtime::new(
+            SecretKey::generate().public(),
+            Some(time_source.clone() as Arc<dyn QuicTimeSource>),
+        );
+
+        assert_eq!(runtime.now(), now);
+        let deadline = now + Duration::from_secs(1);
+        let mut timer = runtime.new_timer(deadline);
+        let (created_deadline, sleep) = time_source.sleep(0);
+        assert_eq!(created_deadline, deadline);
+
+        let waker = futures_util::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(timer.as_mut().poll(&mut cx).is_pending());
+        sleep.wake();
+        assert!(timer.as_mut().poll(&mut cx).is_ready());
+    }
+
+    #[test]
+    fn resetting_custom_timer_replaces_and_cancels_sleep() {
+        let now = Instant::now();
+        let time_source = Arc::new(TestTimeSource {
+            now,
+            sleeps: Mutex::new(Vec::new()),
+        });
+        let runtime = Runtime::new(
+            SecretKey::generate().public(),
+            Some(time_source.clone() as Arc<dyn QuicTimeSource>),
+        );
+        let mut timer = runtime.new_timer(now + Duration::from_secs(1));
+        let (_, first) = time_source.sleep(0);
+
+        let second_deadline = now + Duration::from_secs(2);
+        timer.as_mut().reset(second_deadline);
+        let (created_deadline, second) = time_source.sleep(1);
+        assert_eq!(created_deadline, second_deadline);
+        assert!(first.dropped.load(Ordering::Relaxed));
+
+        first.wake();
+        let waker = futures_util::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(timer.as_mut().poll(&mut cx).is_pending());
+        second.wake();
+        assert!(timer.as_mut().poll(&mut cx).is_ready());
+
+        timer.as_mut().reset(now + Duration::from_secs(3));
+        assert!(second.dropped.load(Ordering::Relaxed));
+        assert!(timer.as_mut().poll(&mut cx).is_pending());
+    }
+
+    #[test]
+    fn dropping_custom_timer_cancels_sleep() {
+        let now = Instant::now();
+        let time_source = Arc::new(TestTimeSource {
+            now,
+            sleeps: Mutex::new(Vec::new()),
+        });
+        let runtime = Runtime::new(
+            SecretKey::generate().public(),
+            Some(time_source.clone() as Arc<dyn QuicTimeSource>),
+        );
+        let timer = runtime.new_timer(now + Duration::from_secs(1));
+        let (_, sleep) = time_source.sleep(0);
+        drop(timer);
+        assert!(sleep.dropped.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn default_runtime_uses_system_clock() {
+        let runtime = Runtime::new(SecretKey::generate().public(), None);
+        let before = Instant::now();
+        let now = runtime.now();
+        let after = Instant::now();
+        assert!(now >= before && now <= after);
     }
 }

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -196,6 +196,9 @@ pub(crate) struct Options {
 
     /// Explicitly configured external addresses to advertise.
     pub(crate) configured_addrs: BTreeSet<SocketAddr>,
+
+    /// Optional host-provided clock and timer factory for the QUIC runtime.
+    pub(crate) quic_time_source: Option<Arc<dyn crate::quic_time_source::QuicTimeSource>>,
 }
 
 /// Inner state for an iroh [`crate::Endpoint`].
@@ -893,6 +896,7 @@ impl EndpointInner {
             net_report_config,
             static_config,
             configured_addrs,
+            quic_time_source,
         } = opts;
 
         let address_lookup = address_lookup::AddressLookupServices::default();
@@ -1022,7 +1026,7 @@ impl EndpointInner {
         let local_addrs_watch = transports.local_addrs_watch();
         let transports_network_change = transports.create_network_change_sender();
 
-        let runtime = Arc::new(Runtime::new(secret_key.public()));
+        let runtime = Arc::new(Runtime::new(secret_key.public(), quic_time_source));
 
         let endpoint = noq::Endpoint::new_with_abstract_socket(
             endpoint_config,
@@ -2184,6 +2188,7 @@ mod tests {
             net_report_config: Default::default(),
             static_config,
             configured_addrs: Default::default(),
+            quic_time_source: None,
         }
     }
 
@@ -2600,6 +2605,7 @@ mod tests {
             net_report_config: Default::default(),
             static_config,
             configured_addrs: Default::default(),
+            quic_time_source: None,
         };
         let sock = EndpointInner::bind(opts).await?;
         Ok(sock)


### PR DESCRIPTION
## Description

Add an unstable endpoint-level QUIC time source with two host-provided operations: monotonic `now()` and a sleep future for a deadline. Iroh adapts that future internally to noq’s `AsyncTimer`; resetting a timer replaces and drops the obsolete sleep. The existing platform runtime remains the default.

This keeps noq types and host-specific behavior out of the public contract. Iroh continues to own task spawning, sockets, tracing, and shutdown.

The tests cover clock delegation, sleep completion, reset cancellation, timer-drop cancellation, and the default runtime.

Closes #4459.

## Breaking Changes

None. The API is gated behind the new `unstable-custom-runtime` feature.

## Notes & open questions

This draft is intended to make the proposed boundary concrete while we discuss whether this is a viable host model. In the Workerd consumer there is no `setTimeout(1ms)` loop: host time is observed at I/O boundaries, and JS arms one generation-tagged timeout for the earliest QUIC deadline.

Feedback is especially welcome on the API location, naming, and boxed `Send` future shape.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the proposed change and wrote as clear and concise a description as possible.
- [x] This PR is carefully crafted to have the intended effect.