### PR TITLE
feat(net-report): public QAD probe and explicit discovery relays

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -146,6 +146,7 @@ pub struct Builder {
     path_selector: Arc<dyn PathSelector>,
     portmapper_config: PortmapperConfig,
     net_report_config: NetReportConfig,
+    discovery_relays: Vec<RelayConfig>,
     crypto_provider: Option<Arc<rustls::crypto::CryptoProvider>>,
     configured_addrs: BTreeSet<SocketAddr>,
 }
@@ -214,6 +215,7 @@ impl Builder {
             path_selector: Arc::new(BiasedRttPathSelector::default()),
             portmapper_config: Default::default(),
             net_report_config: Default::default(),
+            discovery_relays: Default::default(),
             crypto_provider: None,
             configured_addrs: Default::default(),
         }
@@ -277,6 +279,7 @@ impl Builder {
             path_selector: self.path_selector,
             portmapper_config: self.portmapper_config,
             net_report_config: self.net_report_config,
+            discovery_relays: self.discovery_relays,
             static_config,
             configured_addrs: self.configured_addrs,
         };
@@ -797,6 +800,21 @@ impl Builder {
     /// Some non-essential features of the net report component can be disabled via this configuration.
     pub fn net_report_config(mut self, config: NetReportConfig) -> Self {
         self.net_report_config = config;
+        self
+    }
+
+    /// Sets the relays used for QUIC address discovery (QAD) probes.
+    ///
+    /// The endpoint runs address-discovery probes against these relays to
+    /// learn its public (NAT-mapped) address.  When set, these relays are used
+    /// instead of the relay transport's relay map, so a node can discover its
+    /// public address from custom relays while the relay transport stays
+    /// disabled ([`RelayMode::Disabled`]) or is configured independently.
+    ///
+    /// The probes are short-lived QUIC connections: no relay sessions are held
+    /// open and nothing is published to these relays.
+    pub fn discovery_relays(mut self, relays: impl IntoIterator<Item = RelayConfig>) -> Self {
+        self.discovery_relays = relays.into_iter().collect();
         self
     }
 
@@ -3301,6 +3319,44 @@ mod tests {
         // can get a first report
         endpoint.net_report().updated().await.anyerr()?;
 
+        Ok(())
+    }
+
+    /// The endpoint must discover its public address from explicitly configured
+    /// discovery relays even when the relay transport is disabled.
+    #[tokio::test]
+    #[traced_test]
+    #[cfg(feature = "unstable-net-report")]
+    async fn discovery_relays_probe_custom_relays() -> Result {
+        let (relay_map, relay_url, _server) = run_relay_server().await?;
+        let relay = relay_map.get(&relay_url).expect("relay in map").as_ref().clone();
+
+        let endpoint = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            // The test relay uses a self-signed certificate.
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
+            .discovery_relays([relay])
+            .bind()
+            .await?;
+
+        let mut net_report = endpoint.net_report();
+        let report = time::timeout(Duration::from_secs(30), async {
+            loop {
+                if let Some(report) = net_report.get() {
+                    return Ok::<_, Error>(report);
+                }
+                net_report.updated().await.anyerr()?;
+            }
+        })
+        .await
+        .std_context("net report timed out")??;
+
+        assert!(
+            report.global_v4.is_some(),
+            "expected a QAD-discovered global IPv4 address, got {report:?}"
+        );
+
+        endpoint.close().await;
         Ok(())
     }
 

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -298,6 +298,8 @@ pub mod unstable_net_report {
     /// It is not covered by semantic versioning guarantees and may change in any release
     /// without a major version bump.
     pub use crate::net_report::{Probe, RelayLatencies, Report as NetReport};
+    #[cfg(not(wasm_browser))]
+    pub use crate::net_report::{GetRelayAddrError, QadProbeError, QadProbeReport, probe_relay};
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/iroh/src/net_report.rs
+++ b/iroh/src/net_report.rs
@@ -41,7 +41,7 @@ use tracing::{debug, trace, warn};
 
 use self::reportgen::{ProbeFinished, ProbeReport};
 #[cfg(not(wasm_browser))]
-use self::reportgen::{QadProbeReport, SocketState};
+use self::reportgen::SocketState;
 #[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
 pub use self::{
     // exported primarily for use in documentation
@@ -50,6 +50,9 @@ pub use self::{
     probes::Probe,
     report::{RelayLatencies, Report},
 };
+#[cfg(not(wasm_browser))]
+#[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
+pub use self::reportgen::{GetRelayAddrError, QadProbeReport};
 pub(crate) use self::{
     options::Options,
     reportgen::{IfStateDetails, QuicConfig},
@@ -63,14 +66,13 @@ mod report;
 mod reportgen;
 
 #[cfg(not(wasm_browser))]
+#[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
 #[allow(missing_docs)]
 #[stack_error(derive, add_meta)]
 #[non_exhaustive]
-enum QadProbeError {
+pub enum QadProbeError {
     #[error("Failed to resolve relay address")]
-    GetRelayAddr {
-        source: self::reportgen::GetRelayAddrError,
-    },
+    GetRelayAddr { source: GetRelayAddrError },
     #[error("Missing host in relay URL")]
     MissingHost,
     #[error("QUIC connection failed")]
@@ -828,19 +830,43 @@ async fn run_probe_v4(
     dns_resolver: DnsResolver,
     shutdown_token: CancellationToken,
 ) -> n0_error::Result<(QadProbeReport, QadConn), QadProbeError> {
-    use noq_proto::PathId;
-
     let relay_addr = reportgen::get_relay_addr_ipv4(&dns_resolver, &relay)
         .await
         .map_err(|source| e!(QadProbeError::GetRelayAddr { source }))?;
+    run_qad_probe(relay, relay_addr.into(), quic_client, shutdown_token).await
+}
 
-    trace!(?relay_addr, "resolved relay server address");
+#[cfg(not(wasm_browser))]
+async fn run_probe_v6(
+    relay: Arc<RelayConfig>,
+    quic_client: QuicClient,
+    dns_resolver: DnsResolver,
+    shutdown_token: CancellationToken,
+) -> n0_error::Result<(QadProbeReport, QadConn), QadProbeError> {
+    let relay_addr = reportgen::get_relay_addr_ipv6(&dns_resolver, &relay)
+        .await
+        .map_err(|source| e!(QadProbeError::GetRelayAddr { source }))?;
+    run_qad_probe(relay, relay_addr.into(), quic_client, shutdown_token).await
+}
+
+/// Runs a single QUIC address discovery probe against `server_addr` and keeps
+/// the connection alive so later observations update the returned observer.
+#[cfg(not(wasm_browser))]
+async fn run_qad_probe(
+    relay: Arc<RelayConfig>,
+    server_addr: SocketAddr,
+    quic_client: QuicClient,
+    shutdown_token: CancellationToken,
+) -> n0_error::Result<(QadProbeReport, QadConn), QadProbeError> {
+    use noq_proto::PathId;
+
+    trace!(?server_addr, "resolved relay server address");
     let host = relay
         .url
         .host_str()
         .ok_or_else(|| e!(QadProbeError::MissingHost))?;
     let conn = quic_client
-        .create_conn(relay_addr.into(), host)
+        .create_conn(server_addr, host)
         .await
         .map_err(|source| e!(QadProbeError::Quic { source }))?;
 
@@ -890,73 +916,37 @@ async fn run_probe_v4(
     ))
 }
 
+/// Probes `relay` for the node's public (NAT-mapped) address via QUIC address
+/// discovery (QAD).
+///
+/// Opens a short-lived QUIC connection to the relay's address discovery
+/// endpoint at `server_addr`, reports the address the relay observed for it
+/// and closes the connection again.  `server_addr` must be the relay's QUIC
+/// address-discovery endpoint (see [`RelayConfig::quic`]); resolve it from
+/// the relay's hostname with your own DNS resolver so you control which
+/// address family to probe.
+///
+/// This is the same probe the endpoint runs internally for its net reports;
+/// it is exposed so applications can run address discovery against relays of
+/// their choice (e.g. a private relay set) without installing the relay
+/// transport.  The probe must run from a dedicated socket, so the observed
+/// port is the NAT mapping of the *probe* socket; it is only trustworthy when
+/// the NAT preserves ports (cone NAT).
+///
+/// [`RelayConfig::quic`]: iroh_relay::RelayConfig::quic
 #[cfg(not(wasm_browser))]
-async fn run_probe_v6(
-    relay: Arc<RelayConfig>,
-    quic_client: QuicClient,
-    dns_resolver: DnsResolver,
-    shutdown_token: CancellationToken,
-) -> n0_error::Result<(QadProbeReport, QadConn), QadProbeError> {
-    use noq_proto::PathId;
-
-    let relay_addr = reportgen::get_relay_addr_ipv6(&dns_resolver, &relay)
-        .await
-        .map_err(|source| e!(QadProbeError::GetRelayAddr { source }))?;
-
-    trace!(?relay_addr, "resolved relay server address");
-    let host = relay
-        .url
-        .host_str()
-        .ok_or_else(|| e!(QadProbeError::MissingHost))?;
-    let conn = quic_client
-        .create_conn(relay_addr.into(), host)
-        .await
-        .map_err(|source| e!(QadProbeError::Quic { source }))?;
-
-    let mut watcher = conn.observed_external_addr();
-
-    // wait for an addr
-    let addr = watcher
-        .next()
-        .await
-        .ok_or_else(|| e!(QadProbeError::ReceiverDropped))?;
-    let report = QadProbeReport {
-        relay: relay.url.clone(),
-        addr: SocketAddr::new(addr.ip().to_canonical(), addr.port()),
-        latency: conn.rtt(PathId::ZERO).unwrap_or_default(),
-    };
-
-    let observer = Watchable::new(None);
-    let endpoint = relay.url.clone();
-    let handle = task::spawn(shutdown_token.run_until_cancelled_owned({
-        let observer = observer.clone();
-        let conn = conn.clone();
-        async move {
-            while let Some(val) = watcher.next().await {
-                // if we've sent to an ipv4 address, but received an observed address
-                // that is ivp6 then the address is an [IPv4-Mapped IPv6 Addresses](https://doc.rust-lang.org/beta/std/net/struct.Ipv6Addr.html#ipv4-mapped-ipv6-addresses)
-                let val = SocketAddr::new(val.ip().to_canonical(), val.port());
-                let latency = conn.rtt(PathId::ZERO).unwrap_or_default();
-                observer
-                    .set(Some(QadProbeReport {
-                        relay: endpoint.clone(),
-                        addr: val,
-                        latency,
-                    }))
-                    .ok();
-            }
-        }
-    }));
-    let handle = AbortOnDropHandle::new(handle);
-
-    Ok((
-        report,
-        QadConn {
-            conn,
-            observer,
-            _handle: handle,
-        },
-    ))
+#[cfg(feature = "unstable-net-report")]
+pub async fn probe_relay(
+    relay: &RelayConfig,
+    server_addr: SocketAddr,
+    quic_client: &QuicClient,
+    shutdown: CancellationToken,
+) -> Result<QadProbeReport, QadProbeError> {
+    let (report, conn) =
+        run_qad_probe(Arc::new(relay.clone()), server_addr, quic_client.clone(), shutdown).await?;
+    conn.conn
+        .close(QUIC_ADDR_DISC_CLOSE_CODE, QUIC_ADDR_DISC_CLOSE_REASON);
+    Ok(report)
 }
 
 #[cfg(test)]
@@ -1249,6 +1239,36 @@ mod tests {
             assert_eq!(got, want, "preferred_relay");
         }
 
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[traced_test]
+    #[cfg(feature = "unstable-net-report")]
+    async fn test_probe_relay() -> Result<()> {
+        let (server, relay) = test_utils::relay().await;
+        let client_config = iroh_relay::tls::make_dangerous_client_config();
+        let ep = noq::Endpoint::client(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)).anyerr()?;
+        let client_addr = ep.local_addr().anyerr()?;
+        let quic_client = iroh_relay::quic::QuicClient::new(ep.clone(), client_config);
+        let dns_resolver = DnsResolver::default();
+
+        // Resolve the relay's QUIC address-discovery endpoint and probe it.
+        let relay_addr = reportgen::get_relay_addr_ipv4(&dns_resolver, &relay)
+            .await
+            .anyerr()?;
+        let report = probe_relay(&relay, relay_addr.into(), &quic_client, CancellationToken::new())
+            .await
+            .anyerr()?;
+
+        assert_eq!(report.relay, relay.url);
+        assert_eq!(
+            report.addr, client_addr,
+            "observed address must match the probe socket"
+        );
+
+        ep.wait_idle().await;
+        server.shutdown().await?;
         Ok(())
     }
 }

--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -445,14 +445,16 @@ impl ProbeReport {
 }
 
 #[cfg(not(wasm_browser))]
+#[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct QadProbeReport {
+/// The result of a QUIC address discovery (QAD) probe.
+pub struct QadProbeReport {
     /// The relay that was probed
-    pub(super) relay: RelayUrl,
+    pub relay: RelayUrl,
     /// The latency to the relay.
-    pub(super) latency: Duration,
+    pub latency: Duration,
     /// The discovered public address.
-    pub(super) addr: SocketAddr,
+    pub addr: SocketAddr,
 }
 
 #[derive(Debug, Clone)]
@@ -659,9 +661,11 @@ fn get_quic_port(relay: &RelayConfig) -> Option<u16> {
 }
 
 #[cfg(not(wasm_browser))]
+#[cfg_attr(not(feature = "unstable-net-report"), allow(unreachable_pub))]
+#[allow(missing_docs)]
 #[stack_error(derive, add_meta)]
 #[non_exhaustive]
-pub(super) enum GetRelayAddrError {
+pub enum GetRelayAddrError {
     #[error("No valid hostname in the relay URL")]
     InvalidHostname,
     #[error("No suitable relay address found for {url} ({addr_type})")]

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -191,6 +191,14 @@ pub(crate) struct Options {
     pub(crate) portmapper_config: portmapper::PortmapperConfig,
     pub(crate) net_report_config: crate::net_report::NetReportConfig,
 
+    /// Relays used for QUIC address discovery (QAD) probes.
+    ///
+    /// When set, these relays are probed to discover the node's public address
+    /// instead of the relay transport's relay map.  This allows address
+    /// discovery against custom relays while the relay transport stays
+    /// disabled.
+    pub(crate) discovery_relays: Vec<RelayConfig>,
+
     /// Static configuration for the endpoint.
     pub(crate) static_config: StaticConfig,
 
@@ -891,6 +899,7 @@ impl EndpointInner {
             path_selector,
             portmapper_config,
             net_report_config,
+            discovery_relays,
             static_config,
             configured_addrs,
         } = opts;
@@ -1058,10 +1067,19 @@ impl EndpointInner {
         #[cfg(wasm_browser)]
         let net_report_config = net_report::Options::default().net_report_config(net_report_config);
 
+        // The net report probes an explicitly configured discovery relay list
+        // when one is set (address discovery against custom relays without a
+        // relay transport); otherwise it probes the relay transport's map.
+        let net_report_relay_map = if discovery_relays.is_empty() {
+            relay_map.clone()
+        } else {
+            RelayMap::from_iter(discovery_relays)
+        };
+
         let net_reporter = net_report::Client::new(
             #[cfg(not(wasm_browser))]
             dns_resolver,
-            relay_map.clone(),
+            net_report_relay_map.clone(),
             net_report_config,
             metrics.net_report.clone(),
         );
@@ -1071,7 +1089,7 @@ impl EndpointInner {
             sock.clone(),
             port_mapper,
             Arc::new(AsyncMutex::new(net_reporter)),
-            relay_map,
+            net_report_relay_map,
             direct_addr_done_tx,
             sock.shutdown.at_close_start.child_token(),
         );
@@ -2182,6 +2200,7 @@ mod tests {
             path_selector: Arc::new(BiasedRttPathSelector::default()),
             portmapper_config: Default::default(),
             net_report_config: Default::default(),
+            discovery_relays: Default::default(),
             static_config,
             configured_addrs: Default::default(),
         }
@@ -2598,6 +2617,7 @@ mod tests {
             path_selector: Arc::new(BiasedRttPathSelector::default()),
             portmapper_config: Default::default(),
             net_report_config: Default::default(),
+            discovery_relays: Default::default(),
             static_config,
             configured_addrs: Default::default(),
         };


### PR DESCRIPTION
## Description

In my project I need more control over power consumption on mobile platforms and also want to avoid privacy leaks where some of private relays leak into the public n0 servers. Unfortunately, Iroh assumes that there's just one collective set of relays, but for my VPN app I have to support multiple fully independent sets of private relays (for independently operated mesh VPNs) which should not know anything about each other. The only solution seems to be `RelayMode::Disabled`, but that completely disables QAD and net report. I'd rather not keep maintaining too much duplicate code.

Make QUIC address discovery (QAD) usable outside the net report:

- Expose `probe_relay` (plus `QadProbeReport`/`QadProbeError`) so applications can discover their public (NAT-mapped) address from relays of their choice, e.g. a private relay set, without installing the relay transport.  The v4/v6 probe implementations are deduplicated into a shared `run_qad_probe`.
- Add `Builder::discovery_relays`: an explicit relay list used for the endpoint's address-discovery probes instead of the relay transport's relay map.  With `RelayMode::Disabled` plus `discovery_relays` the node still learns its public address, while no relay transport (and no publishing) is installed.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
