### PR TITLE
chore(iroh-dns-server): replace `mainline` with `n0-mainline` and update `lru`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,15 +1231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,17 +1349,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flume"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin 0.9.9",
-]
 
 [[package]]
 name = "fnv"
@@ -2369,10 +2349,10 @@ dependencies = [
  "iroh-base",
  "iroh-dns",
  "iroh-metrics",
- "lru 0.18.0",
- "mainline",
+ "lru",
  "n0-error",
  "n0-future",
+ "n0-mainline",
  "n0-tracing-test",
  "patchbay",
  "rand 0.10.1",
@@ -2459,7 +2439,7 @@ dependencies = [
  "iroh-base",
  "iroh-dns",
  "iroh-metrics",
- "lru 0.18.0",
+ "lru",
  "n0-error",
  "n0-future",
  "n0-tracing-test",
@@ -2674,12 +2654,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,15 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-
-[[package]]
-name = "lru"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -2733,28 +2701,6 @@ name = "mac-addr"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
-
-[[package]]
-name = "mainline"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfad9601b9117218868271c05403853593d4817e7abeab5c95e11eee16382bb"
-dependencies = [
- "crc",
- "document-features",
- "dyn-clone",
- "ed25519-dalek",
- "flume",
- "futures-lite",
- "getrandom 0.4.3",
- "lru 0.16.4",
- "serde",
- "serde_bencode",
- "serde_bytes",
- "sha1_smol",
- "thiserror 2.0.18",
- "tracing",
-]
 
 [[package]]
 name = "matchers"
@@ -2877,6 +2823,28 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "n0-mainline"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1350c6f72a2b3368ebf17779844746f246decd886d610f11b2317148fb9fd4"
+dependencies = [
+ "crc",
+ "dyn-clone",
+ "ed25519-dalek",
+ "futures-core",
+ "lru",
+ "n0-error",
+ "noq-udp",
+ "rand 0.10.1",
+ "serde",
+ "serde_bencode",
+ "serde_bytes",
+ "sha1_smol",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -35,7 +35,7 @@ iroh-base = { version = "1.0.3", path = "../iroh-base", features = ["key"] }
 iroh-metrics = { version = "1.0.1", features = ["service"] }
 iroh-dns = { version = "1.0.3", path = "../iroh-dns" }
 lru = "0.18.0"
-mainline = "7"
+n0-mainline = "0.6"
 n0-future = "0.3"
 rcgen = "0.14"
 redb = "4.1.0"

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -50,8 +50,8 @@ mod tests {
         tls::{CaTlsConfig, default_provider},
     };
     use iroh_dns::pkarr::SignedPacket;
-    use mainline::{DhtBuilder, MutableItem, Testnet};
     use n0_error::{Result, StdResultExt};
+    use n0_mainline::{DhtBuilder, MutableItem, Testnet};
     use n0_tracing_test::traced_test;
     use rand::{CryptoRng, RngExt, SeedableRng};
 
@@ -280,7 +280,7 @@ mod tests {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0u64);
 
         // run a mainline testnet
-        let testnet = Testnet::new_async(5).await.anyerr()?;
+        let testnet = Testnet::new(5).await.anyerr()?;
         let bootstrap = testnet.bootstrap.clone();
 
         // spawn our server with mainline support
@@ -312,11 +312,7 @@ mod tests {
             signed_packet.timestamp().as_micros() as i64,
             None,
         );
-        dht.clone()
-            .as_async()
-            .put_mutable(item, None)
-            .await
-            .anyerr()?;
+        dht.put_mutable(item, None).await.anyerr()?;
 
         // resolve via DNS from our server, which will lookup from our DHT
         let resolver = test_resolver(server.dns_addr());

--- a/iroh-dns-server/src/store.rs
+++ b/iroh-dns-server/src/store.rs
@@ -8,8 +8,8 @@ use hickory_server::proto::{
 };
 use iroh_dns::pkarr::{SignedPacket, SignedPacketVerifyError, Timestamp};
 use lru::LruCache;
-use mainline::{Dht, DhtBuilder, MutableItem};
 use n0_error::{Result, StdResultExt};
+use n0_mainline::{Dht, DhtBuilder, MutableItem};
 pub(crate) use signed_packets::Options;
 use tokio::sync::Mutex;
 use tracing::{debug, trace, warn};
@@ -142,11 +142,7 @@ impl ZoneStore {
 
         if let Some(dht) = self.dht.as_ref() {
             debug!("DHT resolve {}", pubkey.to_z32());
-            let maybe_item = dht
-                .clone()
-                .as_async()
-                .get_mutable_most_recent(pubkey.as_bytes(), None)
-                .await;
+            let maybe_item = dht.get_mutable_most_recent(pubkey.as_bytes(), None).await?;
             if let Some(item) = maybe_item
                 && let Ok(packet) = mutable_item_to_signed_packet(&item)
             {


### PR DESCRIPTION
## Description

Main goal is to update `lru` to avoid `cargo deny` being angry.
While doing so I noticed that we pull in another old version of `lru` via `mainline` on `iroh-dns-server`, so I'm switching it to depend on `n0-mainline` instead.

## Breaking Changes

None.

## Change checklist

- [x] Self-review.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
