### PR TITLE
refactor: Don't send SNI

### DIFF
--- a/iroh/src/tls.rs
+++ b/iroh/src/tls.rs
@@ -88,6 +88,11 @@ impl TlsConfig {
         crypto.resumption = rustls::client::Resumption::store(self.session_store.clone());
         crypto.enable_early_data = true;
 
+        // The synthetic server name is used locally to select the expected endpoint ID
+        // and to partition the session cache. Iroh servers do not use SNI, so do not
+        // disclose the endpoint ID in the ClientHello.
+        crypto.enable_sni = false;
+
         if keylog {
             warn!("enabling SSLKEYLOGFILE for TLS pre-master keys");
             crypto.key_log = Arc::new(rustls::KeyLogFile::new());

--- a/iroh/src/tls/name.rs
+++ b/iroh/src/tls/name.rs
@@ -1,5 +1,9 @@
 //! Implementation of encoding iroh EndpointIds as domain names.
 //!
+//! We used to send this name via SNI up until iroh version 1.0.3, but stopped doing so in
+//! versions after that. It is now used only locally by the `ServerCertificateVerifier` and
+//! to separate the buckets for 0-RTT session tickets.
+//!
 //! We used to use a constant "localhost" for the TLS server name - however, that affects
 //! 0-RTT and would put all of the TLS session tickets we receive into the same bucket in
 //! the TLS session ticket cache.


### PR DESCRIPTION
## Description

Do not send the SNI over the wire. We still use it internally as a key for a cache, but setting this option in rustls will prevent the SNI from being put into the ClientHello.

The server currently does nothing with the SNI, not even check if it exists at all. So this should be a backwards and forwards compatible change.

## Breaking Changes

None

## Notes & open questions

Q: will we ever need the SNI in the future? I don't think it is that useful as a way to sneak data into the ClientHello since it is used for token cache purposes and thus has to be somewhat stable.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
