### PR TITLE
feat(iroh): Add metrics for relay connections

### DIFF
--- a/iroh/src/socket/metrics.rs
+++ b/iroh/src/socket/metrics.rs
@@ -38,6 +38,12 @@ pub struct Metrics {
     /// This includes the initial assignment from no home relay to a home relay.
     pub relay_home_change: Counter,
 
+    /// Number of relay connections on which the relay reported rate limiting.
+    ///
+    /// This is incremented at most once per connection, so it counts the affected
+    /// connections and not how often the relay reported the problem.
+    pub relay_conns_ratelimited: Counter,
+
     /*
      * Holepunching metrics
      */

--- a/iroh/src/socket/metrics.rs
+++ b/iroh/src/socket/metrics.rs
@@ -42,21 +42,21 @@ pub struct Metrics {
     ///
     /// Failed dial attempts are not counted. A relay that is reconnected to is counted
     /// once per connection, so this grows on every reconnect.
-    pub relay_conns_opened: Counter,
+    pub relay_conns_success: Counter,
     /// Number of failed attempts to connect to a relay server.
     ///
     /// Each attempt is counted, so an unreachable relay increments this on every retry.
     pub relay_conns_failed: Counter,
     /// Number of connections to a relay server that ended.
     ///
-    /// Paired with [`Self::relay_conns_opened`], so the number of current connections is
-    /// `relay_conns_opened` - `relay_conns_closed`.
+    /// Paired with [`Self::relay_conns_success`], so the number of current connections is
+    /// `relay_conns_success` - `relay_conns_closed`.
     pub relay_conns_closed: Counter,
     /// Number of relay connections on which the relay reported rate limiting.
     ///
     /// This is incremented at most once per connection, so it counts the affected
     /// connections and not how often the relay reported the problem. Relate it to
-    /// [`Self::relay_conns_opened`] to see how many connections were affected.
+    /// [`Self::relay_conns_success`] to see how many connections were affected.
     pub relay_conns_ratelimited: Counter,
 
     /*

--- a/iroh/src/socket/metrics.rs
+++ b/iroh/src/socket/metrics.rs
@@ -43,6 +43,10 @@ pub struct Metrics {
     /// Failed dial attempts are not counted. A relay that is reconnected to is counted
     /// once per connection, so this grows on every reconnect.
     pub relay_conns_opened: Counter,
+    /// Number of failed attempts to connect to a relay server.
+    ///
+    /// Each attempt is counted, so an unreachable relay increments this on every retry.
+    pub relay_conns_failed: Counter,
     /// Number of connections to a relay server that ended.
     ///
     /// Paired with [`Self::relay_conns_opened`], so the number of current connections is

--- a/iroh/src/socket/metrics.rs
+++ b/iroh/src/socket/metrics.rs
@@ -38,10 +38,21 @@ pub struct Metrics {
     /// This includes the initial assignment from no home relay to a home relay.
     pub relay_home_change: Counter,
 
+    /// Number of connections to a relay server that were established.
+    ///
+    /// Failed dial attempts are not counted. A relay that is reconnected to is counted
+    /// once per connection, so this grows on every reconnect.
+    pub relay_conns_opened: Counter,
+    /// Number of connections to a relay server that ended.
+    ///
+    /// Paired with [`Self::relay_conns_opened`], so the number of current connections is
+    /// `relay_conns_opened` - `relay_conns_closed`.
+    pub relay_conns_closed: Counter,
     /// Number of relay connections on which the relay reported rate limiting.
     ///
     /// This is incremented at most once per connection, so it counts the affected
-    /// connections and not how often the relay reported the problem.
+    /// connections and not how often the relay reported the problem. Relate it to
+    /// [`Self::relay_conns_opened`] to see how many connections were affected.
     pub relay_conns_ratelimited: Counter,
 
     /*

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -559,6 +559,7 @@ impl ActiveRelayActor {
             last_packet_src: None,
             pong_pending: None,
             established: false,
+            rate_limited: false,
             #[cfg(test)]
             test_pong: None,
         };
@@ -743,8 +744,15 @@ impl ActiveRelayActor {
             }
             RelayToClientMsg::Status(status) => match status {
                 Status::Healthy => info!("Relay server reports: {status}"),
-                // The relay sends this at most once per connection.
-                Status::RateLimited => warn!("{status}"),
+                Status::RateLimited => {
+                    warn!("{status}");
+                    // The relay sends this at most once per connection, but do not rely
+                    // on the remote for the metric to count connections.
+                    if !state.rate_limited {
+                        state.rate_limited = true;
+                        self.metrics.relay_conns_ratelimited.inc();
+                    }
+                }
                 _ => warn!("Relay server reports problem: {status}"),
             },
             RelayToClientMsg::Restarting { .. } => {
@@ -853,6 +861,10 @@ struct ConnectedRelayState {
     ///
     /// This is set to `true` once a pong was received from the server.
     established: bool,
+    /// Whether the relay reported that it is rate-limiting this connection.
+    ///
+    /// Used to count each affected connection only once.
+    rate_limited: bool,
     #[cfg(test)]
     test_pong: Option<([u8; 8], oneshot::Sender<()>)>,
 }

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -1615,6 +1615,7 @@ mod tests {
         let (_prio_inbox_tx, prio_inbox_rx) = mpsc::channel(8);
         let (inbox_tx, inbox_rx) = mpsc::channel(16);
         let cancel_token = CancellationToken::new();
+        let metrics = Arc::new(SocketMetrics::default());
         let task = start_active_relay_actor(
             secret_key,
             cancel_token.clone(),
@@ -1623,7 +1624,7 @@ mod tests {
             inbox_rx,
             send_datagram_rx,
             datagram_recv_tx.clone(),
-            Default::default(),
+            metrics.clone(),
             info_span!("actor-under-test"),
         );
 
@@ -1704,6 +1705,15 @@ mod tests {
         cancel_token.cancel();
         task.await.std_context("wait for task to finish")?;
 
+        // The actor connected once at startup and once more after the connection check
+        // failed.
+        assert_eq!(metrics.relay_conns_opened.get(), 2);
+        assert_eq!(
+            metrics.relay_conns_closed.get(),
+            2,
+            "the connections are counted as closed once the actor stops"
+        );
+
         Ok(())
     }
 
@@ -1748,6 +1758,13 @@ mod tests {
         .await
         .std_context("timeout")?;
 
+        assert_eq!(metrics.relay_conns_opened.get(), 1);
+        assert_eq!(
+            metrics.relay_conns_closed.get(),
+            0,
+            "the connection is only counted as closed once it is gone"
+        );
+
         // We now have an idling ActiveRelayActor.  If we advance time just a little it
         // should stay alive.
         info!("Stepping time forwards by RELAY_INACTIVE_CLEANUP_TIME / 2");
@@ -1778,11 +1795,12 @@ mod tests {
             "actor task still running"
         );
 
-        assert_eq!(metrics.relay_conns_opened.get(), 1);
+        // The actor may have reconnected while we advanced time, because a ping to the relay
+        // server can time out while time is frozen, so we do not assert an exact count here.
         assert_eq!(
             metrics.relay_conns_closed.get(),
-            1,
-            "the connection is counted as closed once the actor stops"
+            metrics.relay_conns_opened.get(),
+            "all connections are counted as closed once the actor stops"
         );
 
         cancel_token.cancel();

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -402,7 +402,11 @@ impl ActiveRelayActor {
         self.my_relay
             .set_status(&self.url, RelayConnectionState::Connecting);
         let client = match self.run_dialing().instrument(info_span!("dialing")).await {
-            Some(client_res) => client_res.map_err(|err| e!(RelayConnectionError::Dial, err))?,
+            Some(Ok(client)) => client,
+            Some(Err(err)) => {
+                self.metrics.relay_conns_failed.inc();
+                return Err(e!(RelayConnectionError::Dial, err));
+            }
             None => return Ok(()),
         };
         self.my_relay

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -411,7 +411,7 @@ impl ActiveRelayActor {
         };
         self.my_relay
             .set_status(&self.url, RelayConnectionState::Connected);
-        self.metrics.relay_conns_opened.inc();
+        self.metrics.relay_conns_success.inc();
         let res = self
             .run_connected(client)
             .instrument(info_span!("connected"))
@@ -1707,7 +1707,7 @@ mod tests {
 
         // The actor connected once at startup and once more after the connection check
         // failed.
-        assert_eq!(metrics.relay_conns_opened.get(), 2);
+        assert_eq!(metrics.relay_conns_success.get(), 2);
         assert_eq!(
             metrics.relay_conns_closed.get(),
             2,
@@ -1758,7 +1758,7 @@ mod tests {
         .await
         .std_context("timeout")?;
 
-        assert_eq!(metrics.relay_conns_opened.get(), 1);
+        assert_eq!(metrics.relay_conns_success.get(), 1);
         assert_eq!(
             metrics.relay_conns_closed.get(),
             0,
@@ -1799,7 +1799,7 @@ mod tests {
         // server can time out while time is frozen, so we do not assert an exact count here.
         assert_eq!(
             metrics.relay_conns_closed.get(),
-            metrics.relay_conns_opened.get(),
+            metrics.relay_conns_success.get(),
             "all connections are counted as closed once the actor stops"
         );
 

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -407,9 +407,13 @@ impl ActiveRelayActor {
         };
         self.my_relay
             .set_status(&self.url, RelayConnectionState::Connected);
-        self.run_connected(client)
+        self.metrics.relay_conns_opened.inc();
+        let res = self
+            .run_connected(client)
             .instrument(info_span!("connected"))
-            .await
+            .await;
+        self.metrics.relay_conns_closed.inc();
+        res
     }
 
     fn reset_inactive_timeout(&mut self) {
@@ -1459,7 +1463,7 @@ mod tests {
         RELAY_INACTIVE_CLEANUP_TIME, RelayConnectionOptions, RelayRecvDatagram, RelaySendItem,
         UNDELIVERABLE_DATAGRAM_TIMEOUT,
     };
-    use crate::{dns::DnsResolver, test_utils};
+    use crate::{dns::DnsResolver, metrics::SocketMetrics, test_utils};
 
     /// Starts a new [`ActiveRelayActor`].
     #[allow(clippy::too_many_arguments)]
@@ -1471,6 +1475,7 @@ mod tests {
         inbox_rx: mpsc::Receiver<ActiveRelayMessage>,
         relay_datagrams_send: mpsc::Receiver<RelaySendItem>,
         relay_datagrams_recv: mpsc::Sender<RelayRecvDatagram>,
+        metrics: Arc<SocketMetrics>,
         span: tracing::Span,
     ) -> AbortOnDropHandle<()> {
         let opts = ActiveRelayActorOptions {
@@ -1490,7 +1495,7 @@ mod tests {
                 auth_token: None,
             },
             stop_token,
-            metrics: Default::default(),
+            metrics,
             my_relay: Default::default(),
         };
         let task = tokio::spawn(ActiveRelayActor::new(opts).run().instrument(span));
@@ -1517,6 +1522,7 @@ mod tests {
             inbox_rx,
             send_datagram_rx,
             recv_datagram_tx,
+            Default::default(),
             info_span!("echo-endpoint"),
         );
         let echo_task = tokio::spawn({
@@ -1613,6 +1619,7 @@ mod tests {
             inbox_rx,
             send_datagram_rx,
             datagram_recv_tx.clone(),
+            Default::default(),
             info_span!("actor-under-test"),
         );
 
@@ -1707,6 +1714,7 @@ mod tests {
         let (_prio_inbox_tx, prio_inbox_rx) = mpsc::channel(8);
         let (inbox_tx, inbox_rx) = mpsc::channel(16);
         let cancel_token = CancellationToken::new();
+        let metrics = Arc::new(SocketMetrics::default());
         let mut task = start_active_relay_actor(
             secret_key,
             cancel_token.clone(),
@@ -1715,6 +1723,7 @@ mod tests {
             inbox_rx,
             send_datagram_rx,
             datagram_recv_tx,
+            metrics.clone(),
             info_span!("actor-under-test"),
         );
 
@@ -1763,6 +1772,13 @@ mod tests {
                 .await
                 .is_ok(),
             "actor task still running"
+        );
+
+        assert_eq!(metrics.relay_conns_opened.get(), 1);
+        assert_eq!(
+            metrics.relay_conns_closed.get(),
+            1,
+            "the connection is counted as closed once the actor stops"
         );
 
         cancel_token.cancel();


### PR DESCRIPTION
## Description

This adds counters for relay connections: Number of failed connect attempts, number of opened and closed connection, and number of rate-limited connections.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
