### PR TITLE
feat: authorize concrete outbound addresses

### DIFF
--- a/iroh-relay/src/client.rs
+++ b/iroh-relay/src/client.rs
@@ -3,11 +3,47 @@
 //! Based on tailscale/derp/derphttp/derphttp_client.go
 
 use std::{
+    fmt, io,
     net::SocketAddr,
     pin::Pin,
     sync::Arc,
     task::{self, Poll},
 };
+
+/// A cloneable policy that authorizes concrete outbound socket addresses.
+///
+/// The policy runs immediately before an outbound socket operation. Returning
+/// an error rejects that operation.
+#[derive(Clone)]
+pub struct OutboundAddressPolicy(Arc<dyn Fn(SocketAddr) -> io::Result<()> + Send + Sync + 'static>);
+
+impl fmt::Debug for OutboundAddressPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("OutboundAddressPolicy")
+            .field(&"<callback>")
+            .finish()
+    }
+}
+
+impl OutboundAddressPolicy {
+    /// Creates a policy from an address authorization callback.
+    pub fn new<F>(policy: F) -> Self
+    where
+        F: Fn(SocketAddr) -> io::Result<()> + Send + Sync + 'static,
+    {
+        Self(Arc::new(policy))
+    }
+
+    /// Authorizes one concrete outbound socket address.
+    pub fn check(&self, addr: SocketAddr) -> io::Result<()> {
+        (self.0)(addr).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "outbound address rejected by policy",
+            )
+        })
+    }
+}
 
 use anyhow::{anyhow, bail, Result};
 use conn::Conn;
@@ -61,6 +97,8 @@ pub struct ClientBuilder {
     dns_resolver: DnsResolver,
     /// Cache for public keys of remote nodes.
     key_cache: KeyCache,
+    /// Policy for concrete outbound socket addresses.
+    outbound_address_policy: Option<OutboundAddressPolicy>,
 }
 
 impl ClientBuilder {
@@ -86,7 +124,17 @@ impl ClientBuilder {
             #[cfg(not(wasm_browser))]
             dns_resolver,
             key_cache: KeyCache::new(128),
+            outbound_address_policy: None,
         }
+    }
+
+    /// Sets the policy for concrete outbound socket addresses.
+    ///
+    /// Configuring a policy also rejects proxy connections, for which the
+    /// relay destination is not the socket address dialed by this client.
+    pub fn outbound_address_policy(mut self, policy: OutboundAddressPolicy) -> Self {
+        self.outbound_address_policy = Some(policy);
+        self
     }
 
     /// Sets whether to connect to the relay via websockets or not.

--- a/iroh-relay/src/client/tls.rs
+++ b/iroh-relay/src/client/tls.rs
@@ -43,6 +43,7 @@ pub struct MaybeTlsStreamBuilder {
     prefer_ipv6: bool,
     #[cfg(any(test, feature = "test-utils"))]
     insecure_skip_cert_verify: bool,
+    outbound_address_policy: Option<OutboundAddressPolicy>,
 }
 
 impl MaybeTlsStreamBuilder {
@@ -54,7 +55,13 @@ impl MaybeTlsStreamBuilder {
             prefer_ipv6: false,
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_cert_verify: false,
+            outbound_address_policy: None,
         }
+    }
+
+    pub(crate) fn outbound_address_policy(mut self, policy: Option<OutboundAddressPolicy>) -> Self {
+        self.outbound_address_policy = policy;
+        self
     }
 
     pub fn proxy_url(mut self, proxy_url: Option<Url>) -> Self {
@@ -74,6 +81,9 @@ impl MaybeTlsStreamBuilder {
     }
 
     pub async fn connect(self) -> Result<MaybeTlsStream<ProxyStream>> {
+        if self.outbound_address_policy.is_some() && self.proxy_url.is_some() {
+            bail!("outbound address policies do not support relay proxies");
+        }
         let roots = rustls::RootCertStore {
             roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
         };
@@ -146,6 +156,9 @@ impl MaybeTlsStreamBuilder {
     async fn dial_url_direct(&self) -> Result<tokio::net::TcpStream> {
         use tokio::net::TcpStream;
         debug!(%self.url, "dial url");
+        if self.outbound_address_policy.is_some() {
+            validate_policy_relay_url(&self.url)?;
+        }
         let dst_ip = self
             .dns_resolver
             .resolve_host(&self.url, self.prefer_ipv6, DNS_TIMEOUT)
@@ -153,6 +166,9 @@ impl MaybeTlsStreamBuilder {
 
         let port = url_port(&self.url).ok_or_else(|| anyhow!("Missing URL port"))?;
         let addr = SocketAddr::new(dst_ip, port);
+        if let Some(policy) = &self.outbound_address_policy {
+            policy.check(addr)?;
+        }
 
         debug!("connecting to {}", addr);
         let tcp_stream = time::timeout(
@@ -264,17 +280,67 @@ impl MaybeTlsStreamBuilder {
     }
 }
 
+fn validate_policy_relay_url(url: &Url) -> Result<()> {
+    if !matches!(url.scheme(), "http" | "https" | "ws" | "wss")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || !matches!(url.path(), "" | "/" | crate::http::RELAY_PATH)
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        bail!("relay URL is not supported with an outbound address policy");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod policy_tests {
+    use super::validate_policy_relay_url;
+    use url::Url;
+
+    #[test]
+    fn policy_relay_url_shape_is_unambiguous() {
+        for url in [
+            "https://relay.example/",
+            "https://relay.example:443/",
+            "wss://relay.example/relay",
+        ] {
+            validate_policy_relay_url(&Url::parse(url).expect("valid URL"))
+                .expect("supported relay URL");
+        }
+
+        for url in [
+            "ftp://relay.example/",
+            "ftp://relay.example/evil",
+            "https://user@relay.example/",
+            "https://relay.example/other",
+            "https://relay.example/?target=other",
+            "https://relay.example/#fragment",
+        ] {
+            assert!(
+                validate_policy_relay_url(&Url::parse(url).expect("valid URL")).is_err(),
+                "{url}"
+            );
+        }
+    }
+}
+
 impl ClientBuilder {
     /// Connects to configured relay using HTTP(S) with an upgrade header
     /// set to [`HTTP_UPGRADE_PROTOCOL`].
     ///
     /// [`HTTP_UPGRADE_PROTOCOL`]: crate::http::HTTP_UPGRADE_PROTOCOL
     pub(super) async fn connect_relay(&self) -> Result<(Conn, SocketAddr)> {
+        if self.outbound_address_policy.is_some() {
+            validate_policy_relay_url(&self.url)?;
+        }
         #[allow(unused_mut)]
         let mut builder =
             MaybeTlsStreamBuilder::new(self.url.clone().into(), self.dns_resolver.clone())
                 .prefer_ipv6(self.prefer_ipv6())
-                .proxy_url(self.proxy_url.clone());
+                .proxy_url(self.proxy_url.clone())
+                .outbound_address_policy(self.outbound_address_policy.clone());
 
         #[cfg(any(test, feature = "test-utils"))]
         if self.insecure_skip_cert_verify {
@@ -307,6 +373,9 @@ impl ClientBuilder {
     }
 
     pub(super) async fn connect_ws(&self) -> Result<(Conn, SocketAddr)> {
+        if self.outbound_address_policy.is_some() {
+            validate_policy_relay_url(&self.url)?;
+        }
         let mut dial_url = (*self.url).clone();
         dial_url.set_path(RELAY_PATH);
         // The relay URL is exchanged with the http(s) scheme in tickets and similar.
@@ -324,7 +393,8 @@ impl ClientBuilder {
         #[allow(unused_mut)]
         let mut builder = MaybeTlsStreamBuilder::new(dial_url.clone(), self.dns_resolver.clone())
             .prefer_ipv6(self.prefer_ipv6())
-            .proxy_url(self.proxy_url.clone());
+            .proxy_url(self.proxy_url.clone())
+            .outbound_address_policy(self.outbound_address_policy.clone());
 
         #[cfg(any(test, feature = "test-utils"))]
         if self.insecure_skip_cert_verify {

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -121,6 +121,7 @@ pub struct Builder {
     #[cfg(any(test, feature = "test-utils"))]
     path_selection: PathSelection,
     tls_auth: tls::Authentication,
+    outbound_address_policy: Option<iroh_relay::client::OutboundAddressPolicy>,
 }
 
 impl Default for Builder {
@@ -147,6 +148,7 @@ impl Default for Builder {
             #[cfg(any(test, feature = "test-utils"))]
             path_selection: PathSelection::default(),
             tls_auth: tls::Authentication::RawPublicKey,
+            outbound_address_policy: None,
         }
     }
 }
@@ -202,6 +204,7 @@ impl Builder {
             #[cfg(any(test, feature = "test-utils"))]
             path_selection: self.path_selection,
             metrics,
+            outbound_address_policy: self.outbound_address_policy,
         };
         Endpoint::bind(static_config, msock_opts).await
     }
@@ -273,6 +276,18 @@ impl Builder {
     /// [number 0]: https://n0.computer
     pub fn relay_mode(mut self, relay_mode: RelayMode) -> Self {
         self.relay_mode = relay_mode;
+        self
+    }
+
+    /// Sets a policy that authorizes every concrete outbound socket address.
+    ///
+    /// The policy is disabled by default. When configured, it runs immediately
+    /// before direct UDP sends and relay TCP connects.
+    pub fn outbound_address_policy(
+        mut self,
+        policy: iroh_relay::client::OutboundAddressPolicy,
+    ) -> Self {
+        self.outbound_address_policy = Some(policy);
         self
     }
 

--- a/iroh/src/lib.rs
+++ b/iroh/src/lib.rs
@@ -257,7 +257,9 @@ pub use endpoint::{Endpoint, RelayMode};
 pub use iroh_base::{
     KeyParsingError, NodeAddr, NodeId, PublicKey, RelayUrl, RelayUrlParseError, SecretKey,
 };
-pub use iroh_relay::{http::Protocol as RelayProtocol, node_info, RelayMap, RelayNode};
+pub use iroh_relay::{
+    client::OutboundAddressPolicy, http::Protocol as RelayProtocol, node_info, RelayMap, RelayNode,
+};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/iroh/src/magicsock.rs
+++ b/iroh/src/magicsock.rs
@@ -152,6 +152,7 @@ pub(crate) struct Options {
     pub(crate) path_selection: PathSelection,
 
     pub(crate) metrics: EndpointMetrics,
+    pub(crate) outbound_address_policy: Option<iroh_relay::client::OutboundAddressPolicy>,
 }
 
 /// Contents of a relay message. Use a SmallVec to avoid allocations for the very
@@ -188,6 +189,8 @@ pub(crate) struct MagicSock {
     me: String,
     /// Proxy
     proxy_url: Option<Url>,
+    /// Policy for concrete outbound socket addresses.
+    outbound_address_policy: Option<iroh_relay::client::OutboundAddressPolicy>,
     /// Queue to receive datagrams from relays for [`AsyncUdpSocket::poll_recv`].
     ///
     /// Relay datagrams received by relays are put into this queue and consumed by
@@ -744,6 +747,9 @@ impl MagicSock {
 
     #[cfg(not(wasm_browser))]
     fn try_send_udp(&self, addr: SocketAddr, transmit: &quinn_udp::Transmit) -> io::Result<()> {
+        if let Some(policy) = &self.outbound_address_policy {
+            policy.check(addr)?;
+        }
         let conn = self.conn_for_addr(addr)?;
         conn.try_send(transmit)?;
         let total_bytes: u64 = transmit.contents.len() as u64;
@@ -1726,6 +1732,7 @@ impl Handle {
             #[cfg(any(test, feature = "test-utils"))]
             path_selection,
             metrics,
+            outbound_address_policy,
         } = opts;
 
         #[cfg(not(wasm_browser))]
@@ -1794,6 +1801,7 @@ impl Handle {
             insecure_skip_relay_cert_verify,
             discovery_subscribers: DiscoverySubscribers::new(),
             metrics,
+            outbound_address_policy,
         });
 
         let mut endpoint_config = quinn::EndpointConfig::default();
@@ -3472,6 +3480,7 @@ mod tests {
                 path_selection: PathSelection::default(),
                 discovery_user_data: None,
                 metrics: Default::default(),
+                outbound_address_policy: None,
             }
         }
     }
@@ -4083,6 +4092,7 @@ mod tests {
             insecure_skip_relay_cert_verify: true,
             path_selection: PathSelection::default(),
             metrics: Default::default(),
+            outbound_address_policy: None,
         };
         let msock = MagicSock::spawn(opts).await?;
         Ok(msock)

--- a/iroh/src/magicsock/relay_actor.rs
+++ b/iroh/src/magicsock/relay_actor.rs
@@ -213,6 +213,7 @@ struct RelayConnectionOptions {
     #[cfg(any(test, feature = "test-utils"))]
     insecure_skip_cert_verify: bool,
     protocol: iroh_relay::http::Protocol,
+    outbound_address_policy: Option<relay::client::OutboundAddressPolicy>,
 }
 
 /// Possible reasons for a failed relay connection.
@@ -266,6 +267,7 @@ impl ActiveRelayActor {
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_cert_verify,
             protocol,
+            outbound_address_policy,
         } = opts;
 
         let mut builder = relay::client::ClientBuilder::new(
@@ -276,6 +278,9 @@ impl ActiveRelayActor {
         )
         .protocol(protocol)
         .address_family_selector(move || prefer_ipv6.load(Ordering::Relaxed));
+        if let Some(policy) = outbound_address_policy {
+            builder = builder.outbound_address_policy(policy);
+        }
         if let Some(proxy_url) = proxy_url {
             builder = builder.proxy_url(proxy_url);
         }
@@ -1043,6 +1048,7 @@ impl RelayActor {
             #[cfg(any(test, feature = "test-utils"))]
             insecure_skip_cert_verify: self.msock.insecure_skip_relay_cert_verify,
             protocol: self.protocol,
+            outbound_address_policy: self.msock.outbound_address_policy.clone(),
         };
 
         // TODO: Replace 64 with PER_CLIENT_SEND_QUEUE_DEPTH once that's unused
@@ -1346,6 +1352,7 @@ mod tests {
                 prefer_ipv6: Arc::new(AtomicBool::new(true)),
                 insecure_skip_cert_verify: true,
                 protocol: iroh_relay::http::Protocol::default(),
+                outbound_address_policy: None,
             },
             stop_token,
             metrics: Default::default(),


### PR DESCRIPTION
*Posted by Tau*

### Summary

Iroh 0.35 accepts peer-provided direct addresses and relay URLs before it authenticates the peer end to end. Previously an application could inspect discovery data, but DNS resolution, later learned direct paths, and the actual socket operation happened afterward; for example, a relay hostname could resolve to a private address at dial time even when an earlier answer looked public. This adds a default-disabled application policy at the exact direct UDP send and relay TCP connect boundaries, so applications can constrain the concrete `SocketAddr` without another DNS lookup or RTT.

### Details

`Endpoint::outbound_address_policy` installs one cloneable callback for both transport paths. `MagicSock::try_send_udp` calls it for every direct packet, covering initial discovery, explicit node addresses, and later path updates. The relay client validates the original relay URL before websocket normalization, rejects proxies when a concrete relay policy is active, and checks the resolver-selected address immediately before `TcpStream::connect`. Rejections return a constant permission error rather than exposing callback details.

No policy is configured by default, so existing applications retain current behavior. Applications define their own classification or allowlist. This hook classifies the address handed to the OS, not the route the host or network ultimately takes; VPN policy, destination NAT, and other routing rewrites still require deployment egress controls as defense in depth.

Reviewers can run:

```
cargo test -p iroh-relay -p iroh --lib
cargo check -p iroh-relay -p iroh
```

### Review

A hostile security review found and drove fixes for two serious issues in the first version: websocket normalization erased hostile original URL components before validation, and a downstream consumer's first IPv4-mapped IPv6 classification was incomplete. The current change validates both original and concrete dial URL shapes. The reviewer also checked central direct-send coverage, final relay-dial timing, proxy fail-closed behavior, sanitized errors, and compatibility defaults, and reported no remaining findings.
