### PR TITLE
fix(iroh): don't abort on a poisoned path-watcher state lock

### DIFF
--- a/iroh/src/socket/remote_map/remote_state/path_watcher.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_watcher.rs
@@ -175,7 +175,7 @@ impl PathStateSender {
         let id = handle.id();
         let remote_addr: TransportAddr = network_path.remote().into();
         let local_addr = network_path.local();
-        {
+        let replaced = {
             let mut state = self.shared.state.lock().expect("poisoned");
             let entry = PathData {
                 handle,
@@ -183,10 +183,16 @@ impl PathStateSender {
                 local_addr: local_addr.clone(),
             };
             match state.list.iter().position(|e| e.handle.id() == id) {
-                Some(idx) => state.list[idx] = entry,
-                None => state.list.push(entry),
+                Some(idx) => Some(std::mem::replace(&mut state.list[idx], entry)),
+                None => {
+                    state.list.push(entry);
+                    None
+                }
             }
-        }
+        };
+        // Dropped outside the guard: `WeakPathHandle::drop` can reach noq's
+        // connection lock, whose own `lock()` panics on poison.
+        drop(replaced);
         self.shared.notify.notify_waiters();
         let _ = self.events.send(PathEvent::Opened {
             id,
@@ -256,39 +262,48 @@ impl PathStateSender {
     ///
     /// [`WeakPathHandle`]: noq::WeakPathHandle
     pub(super) fn close(self, closed: noq::Closed) {
-        let mut state = self.shared.state.lock().expect("poisoned");
-        if !state.closed {
-            for path in state.list.iter() {
-                if let Some(stats) = closed
-                    .path_stats
-                    .iter()
-                    .find(|(id, _stats)| *id == path.handle.id())
-                    .map(|(_id, stats)| stats)
-                {
-                    let _ = self.events.send(PathEvent::Closed {
-                        id: path.handle.id(),
-                        remote_addr: path.remote_addr.clone(),
-                        local_addr: path.local_addr.clone(),
-                        last_stats: Box::new(*stats),
-                    });
-                } else {
-                    warn!(
-                        "Connection close event is missing path stats for path {}",
-                        path.handle.id()
-                    );
-                }
+        // The guard is not held across `events.send` or `warn!`: both run consumer
+        // code, and a panic there would poison this mutex before `Drop` re-enters it.
+        let paths = {
+            let state = self.shared.state.lock().expect("poisoned");
+            if state.closed {
+                return;
             }
-            state.closed = true;
-            self.shared.notify.notify_waiters();
+            state.list.clone()
+        };
+        for path in paths {
+            let id = path.handle.id();
+            if let Some((_id, stats)) = closed.path_stats.iter().find(|(sid, _)| *sid == id) {
+                let _ = self.events.send(PathEvent::Closed {
+                    id,
+                    remote_addr: path.remote_addr,
+                    local_addr: path.local_addr,
+                    last_stats: Box::new(*stats),
+                });
+            } else {
+                warn!("Connection close event is missing path stats for path {id}");
+            }
         }
+        // `closed` is set only once the terminal events are queued, so a
+        // `PathListStream` cannot observe the close and end before them.
+        self.shared.state.lock().expect("poisoned").closed = true;
+        self.shared.notify.notify_waiters();
     }
 }
 
 impl Drop for PathStateSender {
     fn drop(&mut self) {
-        let mut state = self.shared.state.lock().expect("poisoned");
-        if !state.closed {
+        // Recover rather than panic: a panic in a `Drop` during another unwind is
+        // a double panic and aborts the process. This only writes `closed`, never
+        // reads, so a torn snapshot cannot affect it; `notify_waiters` runs
+        // consumer wakers and so stays outside the critical section.
+        let was_open = {
+            let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            let was_open = !state.closed;
             state.closed = true;
+            was_open
+        };
+        if was_open {
             self.shared.notify.notify_waiters();
         }
     }
@@ -552,5 +567,30 @@ impl Stream for PathEventStream {
             Ok(event) => Some(event),
             Err(BroadcastStreamRecvError::Lagged(missed)) => Some(PathEvent::Lagged { missed }),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test: `Drop` must tolerate poison left by a panic elsewhere.
+    #[test]
+    fn drop_tolerates_a_poisoned_state_lock() {
+        let (sender, _receiver) = PathStateSender::new();
+        let shared = sender.shared.clone();
+
+        // Poison the mutex the way a panic under any other lock site would.
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = shared.state.lock().expect("not yet poisoned");
+            panic!("poisoning the state lock");
+        });
+        assert!(shared.state.is_poisoned());
+
+        drop(sender);
+
+        // Still marked closed, so a reader waiting on `notify` is released.
+        let state = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(state.closed);
     }
 }


### PR DESCRIPTION
## Description

I use iroh to sync notes between a user's own devices: phone to desktop, over
QUIC, through a relay I host myself. I tapped "retry sync" on my Android phone
and the app died on the spot. The crash log shows `SIGABRT` on a tokio worker,
`panic_in_cleanup`, inside `RemoteStateActor::handle_msg_add_connection`. The
phone had two active interfaces up at the time, so its paths were churning.

`panic_in_cleanup` is the giveaway: a destructor panicked while an earlier panic
was still unwinding. That's a double panic, and it aborts the process outright —
nothing to catch, no task boundary to stop at. `Drop for PathStateSender` locks
`Shared.state` with `.expect("poisoned")`, so once that mutex is poisoned the
destructor is fatal.

`Shared` and `State` are private to the module, so I could enumerate every
locker. There are seven. Three of them held the guard across something that can
unwind:

1. `close()` held it across `events.send` and a `warn!`. The `warn!` goes into
   whatever `tracing` subscriber the consumer installed, which is code iroh knows
   nothing about. And `close(self, ..)` takes `self` by value, so the guard drops
   before `self` does — the destructor runs inside that same unwind. It now
   snapshots the list, emits outside the guard, and sets `closed` last.
2. `Drop` held it across `notify_waiters()`, which runs consumer wakers. Tokio's
   comment directly above that call reads "One of the wakers may panic". So the
   destructor I was hardening was itself a way to poison the lock. It now takes
   the guard only to flip `closed`.
3. `record_opened` assigned over an existing slot, which dropped the displaced
   `PathData` in place, under the guard. Its `WeakPathHandle::drop` can reach
   noq's connection lock, and noq locks with `.unwrap()`. In practice the only
   caller holds the `Path` and `Connection` alive across the call, so the
   refcount never reaches zero and that lock is never taken — a route that
   happens to be closed rather than a live bug. Still not worth leaving there.
   `mem::replace` moves the entry out so it drops after the block, which is what
   `record_abandoned` already did.

The other four only touch the guarded data: `WeakPathHandle::id` is a field read,
`State::clone` bumps a couple of atomics, `SmallVec::remove` moves rather than
drops. So with those three changed, nothing in the module can poison the mutex.

The destructor still recovers instead of panicking, for poison arriving from
somewhere else:

```rust
let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
```

I'd rather not defend that as a general rule. It's specific to this destructor:
it writes `closed` and reads nothing, so there's no half-updated state for it to
act on, and that write is what lets readers stop waiting — `PathListStream::poll_next`
only ends on `closed`. The worst it does is turn an abort into a panic somewhere
else, which iroh already re-raises deliberately from `RemoteStateActor`.

There's a regression test that poisons the mutex and then drops the sender. It
fails without the destructor change. `cargo test -p iroh --lib` is green,
including the three `endpoint_two_*` tests that drive the path lifecycle over
real connections.

## Breaking Changes

None. It's all inside a `pub(super)` type. I kept the existing ordering:
`close()` still sets `closed` after the `PathEvent::Closed` events are queued and
before `notify_waiters()`, so a `paths_stream()` consumer can't finish before the
events carrying each path's final stats.

## Notes & open questions

- Recovering a poisoned guard goes against the idiom used everywhere else in the
  crate — 19 `.expect("poisoned")` call sites, 7 of them in this file now. I
  think it's only justified in a destructor, where the panic can't be recovered
  from anyway. I didn't reach for `parking_lot`, since #3034 removed it on
  purpose. If you'd rather have one rule everywhere, a small poison-free wrapper
  like tokio's `loom::std::Mutex` would cover all 19 and I'm happy to raise it
  separately.
- The two reader sites still use `expect("poisoned")`. Poison is sticky, so a
  reader this `Drop` releases will panic rather than end cleanly. Better than an
  abort, still not right.
- Change 1 is the separable one, if you'd rather take the destructor fixes first.
  I kept them together because neither half fixes the crash on its own.
- `EndpointInner::drop` in `socket.rs` has the same shape, via `abort()`. Those
  two are the only `impl Drop` in `iroh/src`. Happy to fold it in if you want the
  rule applied consistently.
- I can't tell you what panicked first. I don't have the log for it, and this
  patch is about the abort rather than the cause. Worth saying the abort doesn't
  need iroh to be at fault at all: noq's `Mutex::lock` unwraps, and
  `ConnectionRef::drop`, `OnClosed::drop` and `WeakPathHandle::drop` all take
  that lock. I can file that separately if it's useful.

Hit on iroh 1.0.0; this patch is against `main` (`a05c9c414`).

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
      (Comments stating why each critical section excludes consumer code, and
      why poisoning is tolerated in the destructor.)
- [x] Tests if relevant.
      (Regression test; fails without the change.)
- [x] All breaking changes documented.
      (There are none.)
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
      (Drafted with AI assistance. The app crashed on my Android device; the
      reachability argument for each lock site, the ordering analysis and the
      regression test were reviewed and verified against `main` before
      submitting.)
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
