### PR TITLE
refactor(iroh): Reduce log levels for connectivity issues

### DIFF
--- a/iroh/src/net_report/reportgen.rs
+++ b/iroh/src/net_report/reportgen.rs
@@ -212,7 +212,7 @@ impl Actor {
                 match time::timeout(OVERALL_REPORT_TIMEOUT, self.run_inner()).await {
                     Ok(()) => trace!("reportgen actor finished"),
                     Err(time::Elapsed { .. }) => {
-                        warn!("reportgen timed out");
+                        debug!("reportgen timed out");
                     }
                 }
             })
@@ -327,12 +327,12 @@ impl Actor {
                                 {
                                     debug!("check_captive_portal failed: {source:#}");
                                 }
-                                err => warn!("check_captive_portal error: {err:#}"),
+                                err => debug!("check_captive_portal error: {err:#}"),
                             }
                             None
                         }
                         Some(Err(time::Elapsed { .. })) => {
-                            warn!("probe timed out");
+                            debug!("probe timed out");
                             None
                         }
                         None => {
@@ -405,7 +405,7 @@ impl Actor {
                         let res = match res {
                             Some(Ok(Ok(report))) => Ok(report),
                             Some(Ok(Err(err))) => {
-                                warn!("probe failed: {:#}", err);
+                                debug!("probe failed: {:#}", err);
                                 Err(e!(ProbesError::ProbeFailure, err))
                             }
                             Some(Err(time::Elapsed { .. })) => Err(e!(ProbesError::Timeout)),

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -324,7 +324,7 @@ impl ActiveRelayActor {
         let mut backoff = Self::build_backoff();
 
         while let Err(err) = self.run_once().await {
-            warn!("{err:#}");
+            debug!("{err:#}");
             let was_established = matches!(err, RelayConnectionError::Established { .. });
             let last_error = Some(Arc::new(AnyError::from(err)));
             self.my_relay
@@ -333,7 +333,7 @@ impl ActiveRelayActor {
                 // If dialing failed, or if the relay connection failed before we received a pong,
                 // we wait an exponentially increasing time until we attempt to reconnect again.
                 let Some(delay) = backoff.next() else {
-                    warn!("retries exceeded");
+                    debug!("retries exceeded");
                     break;
                 };
                 debug!("retry in {delay:?}");


### PR DESCRIPTION
## Description

The relay server disappearing is not a warning. Changing network is
totally normal operation for iroh. This reduces the logging levels
when a relay server disappears: both from a relay actor losing
connectivity as well as from net-report.

## Breaking Changes

none, logs are not part of the api contract.

## Notes & open questions

It could be argued that connecting/disconnecting from the home relay
should be a single info message each time. But let's do that when it's
nice to have. For now I'm just trying to get things to be less noisy.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.